### PR TITLE
feat(docs): add remote-fetch instructions to ONBOARDING.md

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -4,6 +4,11 @@ This document is the entry point for an AI agent tasked with importing
 and configuring the IDD (Issue-Driven Development) workflow template into
 a new repository.
 
+> **Tip for agents invoked via the trigger phrase**: if you arrived here
+> by fetching this URL, you do not need to clone the idd-skill repository.
+> Step 2 below provides raw-content URLs for every template file so you
+> can download them directly.
+
 ## What you are setting up
 
 IDD is a multi-agent GitHub automation workflow. Agents work through a
@@ -16,7 +21,7 @@ every phase.
 
 1. Read this entire document first.
 2. Ask the operator for any placeholder values that are missing.
-3. Copy the template files into the target repository.
+3. Fetch or copy the template files into the target repository.
 4. Replace every placeholder (see table below) with the correct value.
 5. Add IDD references to the repository's agent entry files.
 6. Verify the result with the checklist at the bottom.
@@ -54,10 +59,12 @@ the repo (e.g., the repo name itself).
 
 ---
 
-## Step 2 — Copy template files
+## Step 2 — Fetch or copy template files
 
-Copy the following files from this template into the target repository,
-preserving their relative paths:
+You need the following eleven files in the target repository. Use
+whichever method applies to your situation.
+
+### File list
 
 ```text
 .github/instructions/idd-overview.instructions.md
@@ -74,6 +81,57 @@ docs/idd-workflow.md
 ```
 
 Create the target directories if they do not exist.
+
+### Option A — Remote fetch (no local clone required)
+
+Use `gh api` or `curl` to download each file from the raw-content
+endpoint. Replace `{DEST}` with the root of the target repository.
+
+Base URL: `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/`
+
+Fetch all files with `gh api` (recommended — handles auth automatically):
+
+```sh
+BASE="https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template"
+DEST="."  # root of the target repository
+
+mkdir -p "${DEST}/.github/instructions" "${DEST}/docs"
+
+for FILE in \
+  ".github/instructions/idd-overview.instructions.md" \
+  ".github/instructions/idd-discover.instructions.md" \
+  ".github/instructions/idd-claim.instructions.md" \
+  ".github/instructions/idd-work.instructions.md" \
+  ".github/instructions/idd-pr-submit.instructions.md" \
+  ".github/instructions/idd-ci.instructions.md" \
+  ".github/instructions/idd-review-triage.instructions.md" \
+  ".github/instructions/idd-review-fix.instructions.md" \
+  ".github/instructions/idd-merge.instructions.md" \
+  ".github/instructions/idd-resume.instructions.md" \
+  "docs/idd-workflow.md"
+do
+  gh api --paginate -H "Accept: application/vnd.github.raw+json" \
+    "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
+    > "${DEST}/${FILE}"
+done
+```
+
+Alternatively, use `curl` with a GitHub personal-access token:
+
+```sh
+BASE="https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template"
+# Set GH_TOKEN to a token with 'contents: read' permission if the repo
+# is private; for a public repo the token is optional.
+AUTH="${GH_TOKEN:+-H "Authorization: token ${GH_TOKEN}"}"
+# Then for each FILE in the list above:
+curl -fsSL ${AUTH} "${BASE}/${FILE}" -o "${DEST}/${FILE}"
+```
+
+### Option B — Local copy (idd-skill cloned)
+
+If you have cloned `https://github.com/kurone-kito/idd-skill`, copy
+the files from `idd-template/` into the target repository preserving
+their relative paths.
 
 ---
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -92,6 +92,33 @@ Base URL: `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-temp
 Fetch all files with `gh api` (recommended — handles auth automatically):
 
 ```sh
+DEST="."  # root of the target repository
+
+mkdir -p "${DEST}/.github/instructions" "${DEST}/docs"
+
+for FILE in \
+  ".github/instructions/idd-overview.instructions.md" \
+  ".github/instructions/idd-discover.instructions.md" \
+  ".github/instructions/idd-claim.instructions.md" \
+  ".github/instructions/idd-work.instructions.md" \
+  ".github/instructions/idd-pr-submit.instructions.md" \
+  ".github/instructions/idd-ci.instructions.md" \
+  ".github/instructions/idd-review-triage.instructions.md" \
+  ".github/instructions/idd-review-fix.instructions.md" \
+  ".github/instructions/idd-merge.instructions.md" \
+  ".github/instructions/idd-resume.instructions.md" \
+  "docs/idd-workflow.md"
+do
+  gh api -H "Accept: application/vnd.github.raw+json" \
+    "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
+    > "${DEST}/${FILE}"
+done
+```
+
+Alternatively, use `curl` (no authentication required — idd-skill is a public
+repository):
+
+```sh
 BASE="https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template"
 DEST="."  # root of the target repository
 
@@ -110,21 +137,8 @@ for FILE in \
   ".github/instructions/idd-resume.instructions.md" \
   "docs/idd-workflow.md"
 do
-  gh api --paginate -H "Accept: application/vnd.github.raw+json" \
-    "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
-    > "${DEST}/${FILE}"
+  curl -fsSL "${BASE}/${FILE}" -o "${DEST}/${FILE}"
 done
-```
-
-Alternatively, use `curl` with a GitHub personal-access token:
-
-```sh
-BASE="https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template"
-# Set GH_TOKEN to a token with 'contents: read' permission if the repo
-# is private; for a public repo the token is optional.
-AUTH="${GH_TOKEN:+-H "Authorization: token ${GH_TOKEN}"}"
-# Then for each FILE in the list above:
-curl -fsSL ${AUTH} "${BASE}/${FILE}" -o "${DEST}/${FILE}"
 ```
 
 ### Option B — Local copy (idd-skill cloned)

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -111,7 +111,7 @@ for FILE in \
 do
   gh api -H "Accept: application/vnd.github.raw+json" \
     "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
-    > "${DEST}/${FILE}"
+    > "${DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
 ```
 
@@ -137,7 +137,7 @@ for FILE in \
   ".github/instructions/idd-resume.instructions.md" \
   "docs/idd-workflow.md"
 do
-  curl -fsSL "${BASE}/${FILE}" -o "${DEST}/${FILE}"
+  curl -fsSL "${BASE}/${FILE}" -o "${DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
 ```
 


### PR DESCRIPTION
## Summary

- Adds a "Step 2 Option A" to `idd-template/ONBOARDING.md` with `gh
  api` and `curl` commands to fetch all 11 template files from the
  GitHub raw-content endpoint — no local clone required
- Fixes MD040 (missing code block language tags) in ONBOARDING.md and
  idd-template/README.md
- Rewrites README.md pipeline description line to stay under 80 chars
  and avoid bold-as-heading (MD013 + MD036)
- Disables MD060 (table-column-style) globally since large-cell tables
  cannot be aligned without hurting readability

Closes #4

## Test plan

- [ ] CI (markdownlint + cspell) passes on this branch
- [ ] An AI agent in a fresh repository can follow ONBOARDING.md
      using only the URL — no idd-skill clone needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded onboarding guide with clearer agent setup instructions.
  * Added a tip for agents invoked via the trigger phrase to use raw-content URLs instead of cloning.
  * Clarified that local cloning is optional and described two alternative ways to obtain template files.
  * Rewrote Step 2 to list required files explicitly and adjusted step numbering for clearer flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->