### PR TITLE
feat(docs): document trigger-phrase onboarding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ A portable set of `.github/instructions/` files and documentation that
 wire up an Issue-Driven Development (IDD) multi-agent pipeline for any
 GitHub project.
 
+## Quick start
+
+Open a session in your target repository and tell your AI agent:
+
+> I want to use `github:idd-skill`'s Issue-Driven Development in this
+> repository. Read
+> `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md`
+> and onboard me.
+
+The agent will collect a few project-specific values (repo name,
+validation commands) and then set up the full IDD workflow
+automatically — no manual file copying required.
+
 ## What is IDD?
 
 IDD is a multi-agent GitHub automation workflow where AI agents work
@@ -19,20 +32,7 @@ Each phase is encoded as a `.github/instructions/` file that any
 compatible AI agent can load — GitHub Copilot, Claude Code, Codex CLI,
 or Gemini CLI.
 
-## Importing IDD into your project
-
-### With an AI agent (recommended)
-
-Start a session in your target repository and ask your agent:
-
-> Read `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md`
-> and follow the instructions to import IDD into this repository.
-
-The agent will ask for a few project-specific values (repo name,
-validation commands) and then copy the instruction files and update
-your agent entry files automatically.
-
-### Manually
+## Importing IDD manually
 
 1. Clone or download this repository.
 2. Copy the `idd-template/` directory contents into your target repository.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -4,10 +4,17 @@ This document is the entry point for an AI agent tasked with importing
 and configuring the IDD (Issue-Driven Development) workflow template into
 a new repository.
 
-> **Tip for agents invoked via the trigger phrase**: if you arrived here
-> by fetching this URL, you do not need to clone the idd-skill repository.
-> Step 2 below provides raw-content URLs for every template file so you
-> can download them directly.
+> **Invoked via the trigger phrase?** If the operator told you to read
+> this URL and onboard, you are in the right place. You do not need to
+> clone the idd-skill repository — Step 2 Option A below provides the
+> commands to download every template file directly from GitHub.
+>
+> The canonical trigger phrase users give their AI agent is:
+>
+> _"I want to use `github:idd-skill`'s Issue-Driven Development in this
+> repository. Read
+> `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md`
+> and onboard me."_
 
 ## What you are setting up
 


### PR DESCRIPTION
## Summary

- Adds a "Quick start" section to README.md with the canonical
  trigger phrase users give their AI agent to onboard IDD
- Updates `idd-template/ONBOARDING.md` header to confirm the
  trigger-phrase flow and reference the remote-fetch step

Closes #5

## Dependencies

- Depends on #6 (remote-fetch ONBOARDING.md) which must be merged
  before the trigger phrase works end-to-end
- Both depend on #2 (project onboarding / IDD import setup)

## Test plan

- [ ] CI passes
- [ ] User in a fresh repo can copy-paste the trigger phrase and
      have their AI agent complete a full onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation with Issue-Driven Development (IDD) workflow overview
  * Added Quick Start guide directing users to onboarding resources
  * Included step-by-step instructions for manually importing IDD into projects
  * Enhanced onboarding guidance with trigger phrase-based workflow instructions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->