### PR TITLE
docs(idd): add template-sync rule to idd-overview

### DIFF
--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -244,3 +244,20 @@ agent; only the mechanism differs.
 When a phase file says "run a critique pass", apply the row for your
 agent above. If no subagent mechanism is available, perform the critique
 as a structured self-review step within the same response.
+
+## Template sync
+
+This repository is the canonical source of the IDD template distributed
+via `idd-template/`. When modifying any `idd-*.instructions.md` file or
+`docs/idd-workflow.md`, apply the equivalent change to the corresponding
+file in `idd-template/`, replacing resolved project-specific values with
+their `{{placeholder}}` forms:
+
+| Live value (`.github/instructions/`) | Template form (`idd-template/`) |
+| ------------------------------------ | -------------------------------- |
+| `idd-skill` | `{{REPO_NAME}}` / `{{PROJECT_MARKER_PREFIX}}` |
+| `npx markdownlint-cli2 …` | `{{FIX_VALIDATE_COMMANDS}}` |
+| _(other resolved values)_ | _(matching placeholder)_ |
+
+Commits that modify live instruction files without updating the template
+are incomplete; include both changes in the same atomic commit.

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -255,9 +255,16 @@ their `{{placeholder}}` forms:
 
 | Live value (`.github/instructions/`) | Template form (`idd-template/`) |
 | ------------------------------------ | -------------------------------- |
-| `idd-skill` | `{{REPO_NAME}}` / `{{PROJECT_MARKER_PREFIX}}` |
-| `npx markdownlint-cli2 …` | `{{FIX_VALIDATE_COMMANDS}}` |
-| _(other resolved values)_ | _(matching placeholder)_ |
+| `idd-skill` in repo-name contexts | `{{REPO_NAME}}` |
+| `idd-skill` in marker-prefix contexts (e.g. `idd-skill-roadmap-id`) | `{{PROJECT_MARKER_PREFIX}}` |
+| **fix-validate** command string | `{{FIX_VALIDATE_COMMANDS}}` |
+| **pre-push-validate** command string | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |
+| **post-fix-validate** command string | `{{POST_FIX_VALIDATE_COMMANDS}}` |
+| **install-deps** command string | `{{INSTALL_DEPS_COMMAND}}` |
+
+Match by the named command row in the Project commands table, not by
+command prefix, to avoid confusing commands that share the same
+executable.
 
 Commits that modify live instruction files without updating the template
 are incomplete; include both changes in the same atomic commit.

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -244,3 +244,15 @@ agent; only the mechanism differs.
 When a phase file says "run a critique pass", apply the row for your
 agent above. If no subagent mechanism is available, perform the critique
 as a structured self-review step within the same response.
+
+## Template sync
+
+If this repository distributes IDD as a template (i.e., it maintains an
+`idd-template/` directory alongside the live `.github/instructions/`
+files), any change to a live `idd-*.instructions.md` file or
+`docs/idd-workflow.md` must be mirrored in the corresponding file under
+`idd-template/`, replacing resolved project-specific values with their
+`{{placeholder}}` forms.
+
+Commits that modify only one copy are incomplete; include both changes in
+the same atomic commit.

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -252,7 +252,20 @@ If this repository distributes IDD as a template (i.e., it maintains an
 files), any change to a live `idd-*.instructions.md` file or
 `docs/idd-workflow.md` must be mirrored in the corresponding file under
 `idd-template/`, replacing resolved project-specific values with their
-`{{placeholder}}` forms.
+`{{placeholder}}` forms:
+
+| In `.github/instructions/` (live) | In `idd-template/` (template) |
+| --------------------------------- | ----------------------------- |
+| Resolved repo name | `{{REPO_NAME}}` |
+| Resolved marker prefix | `{{PROJECT_MARKER_PREFIX}}` |
+| **fix-validate** command string | `{{FIX_VALIDATE_COMMANDS}}` |
+| **pre-push-validate** command string | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |
+| **post-fix-validate** command string | `{{POST_FIX_VALIDATE_COMMANDS}}` |
+| **install-deps** command string | `{{INSTALL_DEPS_COMMAND}}` |
+
+Match by the named command row in the Project commands table, not by
+command prefix, to avoid confusing commands that share the same
+executable.
 
 Commits that modify only one copy are incomplete; include both changes in
 the same atomic commit.


### PR DESCRIPTION
## Summary

- Adds `## Template sync` section to `.github/instructions/idd-overview.instructions.md` with a mapping table of live values → placeholder forms
- Mirrors the rule in `idd-template/.github/instructions/idd-overview.instructions.md` using generic placeholder language (adopter-facing copy)
- Makes the dual-maintenance obligation self-documenting for all agents working on this repo

Closes #8

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] `npx cspell lint "**" --no-progress` — 0 issues
- [x] Both idd-overview files updated atomically in one commit
- [x] Template file uses placeholder language; live file uses resolved values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added template synchronization guidelines to ensure instruction files remain consistent between repository-local and template copies. Requires mirroring edits into the template using placeholders for project-specific values (repo name, markers, command strings from the Project commands table) and mandates that updates to live and template copies be committed together in a single atomic commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->