### PR TITLE
docs(idd): clarify blocked-by vs task-list semantics

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -118,6 +118,16 @@ scope:
    out): report each candidate and the filter criterion it failed, then
    proceed to step 4.
 
+   **Diagnostic — all candidates blocked by an open roadmap**: if every
+   candidate is blocked because its `<!-- idd-skill-blocked-by: X -->`
+   marker points to a roadmap issue that is still open, the markers are
+   likely misused as grouping tags rather than as true sequential
+   dependencies. Sub-tasks that should be worked on while the roadmap is
+   open belong in the roadmap's task list as `- [ ] #NNN` entries; the
+   `blocked-by` marker is reserved for issues that must wait for a
+   separate, prior roadmap to close. Report this pattern explicitly so
+   the operator can correct the issue setup.
+
 4. **Request explicit opt-in** — ask the operator: "No roadmap-scoped
    issues are available. Do you want to expand the search scope for this
    run? If so, specify the alternate scope." An agent is **unattended**

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -137,7 +137,9 @@ Two hidden HTML comment markers are used in issue bodies to support the
 discover phase:
 
 - **Roadmap identity** (`idd-skill-roadmap-id`): placed in the roadmap
-  issue body. A1 uses this to identify the roadmap.
+  issue body. A3 uses this marker to resolve `blocked-by` dependency
+  lookups. A1 identifies the roadmap by its `roadmap` label or umbrella
+  structure — not by this marker.
 - **Sequential dependency** (`idd-skill-blocked-by`): placed in an
   issue body to express a hard dependency — this issue **cannot start
   until** the roadmap with the matching `roadmap-id` is closed.

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -131,6 +131,25 @@ Keep the claim. Post the hold reason and resume condition to the PR or
 issue comment. After re-validating ownership, re-post the claim comment
 with the same `{claim-id}` every 12 h as heartbeat.
 
+## Roadmap markers
+
+Two hidden HTML comment markers are used in issue bodies to support the
+discover phase:
+
+- **Roadmap identity** (`idd-skill-roadmap-id`): placed in the roadmap
+  issue body. A1 uses this to identify the roadmap.
+- **Sequential dependency** (`idd-skill-blocked-by`): placed in an
+  issue body to express a hard dependency — this issue **cannot start
+  until** the roadmap with the matching `roadmap-id` is closed.
+
+**Do not use `idd-skill-blocked-by` to group sub-tasks under an active
+roadmap.** Sub-tasks that should be worked on while the roadmap is open
+belong in the roadmap's task list as `- [ ] #NNN` entries. The
+`blocked-by` marker is reserved for issues that must wait for a
+separate, prior roadmap to close before they can start (cross-phase
+sequential dependency). Using it for grouping causes A3 to block every
+sub-task for the entire lifetime of the roadmap.
+
 ## Scope invariant
 
 Agents must not widen issue-selection scope beyond what the roadmap

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -118,6 +118,17 @@ scope:
    out): report each candidate and the filter criterion it failed, then
    proceed to step 4.
 
+   **Diagnostic — all candidates blocked by an open roadmap**: if every
+   candidate is blocked because its
+   `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: X -->` marker points to a
+   roadmap issue that is still open, the markers are likely misused as
+   grouping tags rather than as true sequential dependencies. Sub-tasks
+   that should be worked on while the roadmap is open belong in the
+   roadmap's task list as `- [ ] #NNN` entries; the `blocked-by` marker
+   is reserved for issues that must wait for a separate, prior roadmap to
+   close. Report this pattern explicitly so the operator can correct the
+   issue setup.
+
 4. **Request explicit opt-in** — ask the operator: "No roadmap-scoped
    issues are available. Do you want to expand the search scope for this
    run? If so, specify the alternate scope." An agent is **unattended**

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -131,6 +131,26 @@ Keep the claim. Post the hold reason and resume condition to the PR or
 issue comment. After re-validating ownership, re-post the claim comment
 with the same `{claim-id}` every 12 h as heartbeat.
 
+## Roadmap markers
+
+Two hidden HTML comment markers are used in issue bodies to support the
+discover phase:
+
+- **Roadmap identity** (`{{PROJECT_MARKER_PREFIX}}-roadmap-id`): placed
+  in the roadmap issue body. A1 uses this to identify the roadmap.
+- **Sequential dependency** (`{{PROJECT_MARKER_PREFIX}}-blocked-by`):
+  placed in an issue body to express a hard dependency — this issue
+  **cannot start until** the roadmap with the matching `roadmap-id` is
+  closed.
+
+**Do not use `{{PROJECT_MARKER_PREFIX}}-blocked-by` to group sub-tasks
+under an active roadmap.** Sub-tasks that should be worked on while the
+roadmap is open belong in the roadmap's task list as `- [ ] #NNN`
+entries. The `blocked-by` marker is reserved for issues that must wait
+for a separate, prior roadmap to close before they can start (cross-
+phase sequential dependency). Using it for grouping causes A3 to block
+every sub-task for the entire lifetime of the roadmap.
+
 ## Scope invariant
 
 Agents must not widen issue-selection scope beyond what the roadmap

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -137,7 +137,9 @@ Two hidden HTML comment markers are used in issue bodies to support the
 discover phase:
 
 - **Roadmap identity** (`{{PROJECT_MARKER_PREFIX}}-roadmap-id`): placed
-  in the roadmap issue body. A1 uses this to identify the roadmap.
+  in the roadmap issue body. A3 uses this marker to resolve `blocked-by`
+  dependency lookups. A1 identifies the roadmap by its `roadmap` label
+  or umbrella structure — not by this marker.
 - **Sequential dependency** (`{{PROJECT_MARKER_PREFIX}}-blocked-by`):
   placed in an issue body to express a hard dependency — this issue
   **cannot start until** the roadmap with the matching `roadmap-id` is

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -64,6 +64,17 @@ The prefix makes these markers unique across projects when issues are
 shared or migrated. Choose a short, lowercase, hyphenated name matching
 the repo (e.g., the repo name itself).
 
+**Important — correct use of `blocked-by`**: the `blocked-by` marker
+expresses a hard sequential dependency. Place it in an issue only when
+that issue **must wait for the referenced roadmap to close** before work
+can start (e.g., Phase 2 issues that depend on Phase 1 completing).
+
+Do **not** use it to group sub-tasks under an active roadmap. Sub-tasks
+that should be worked on while the roadmap is open belong in the
+roadmap's task list as `- [ ] #NNN` entries. Using `blocked-by` for
+grouping causes the discover phase to block every sub-task for the
+entire lifetime of the roadmap.
+
 ---
 
 ## Step 2 — Fetch or copy template files


### PR DESCRIPTION
## Summary

- Adds `## Roadmap markers` section to `idd-overview.instructions.md` (live + template) distinguishing the two marker types: `roadmap-id` for identification and `blocked-by` for cross-phase sequential dependencies — with an explicit warning not to use `blocked-by` for grouping sub-tasks
- Adds a diagnostic note to `idd-discover.instructions.md` A3 (live + template) for the failure mode where every candidate is blocked by an open roadmap, helping operators identify and correct misused markers
- Adds the same guidance to `idd-template/ONBOARDING.md` so adopters receive it before creating issues

Closes #15

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] `npx cspell lint "**" --no-progress` — 0 issues
- [x] All 5 files updated atomically in one commit per template-sync rule (#8)
- [x] Template files use `{{PROJECT_MARKER_PREFIX}}` placeholder form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified roadmap marker usage in the discovery process, distinguishing hard sequential dependencies from simple sub-task grouping.
  * Added diagnostic guidance to detect when dependency markers are being misused to group work rather than indicate true prerequisites, with instructions to move sub-tasks into roadmap task lists.
  * Updated onboarding with explicit rules for dependency marker placement and correct usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->