### PR TITLE
feat(idd): add orphan-first mode to discover phase

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -18,8 +18,13 @@ Read the **issue-scope** value from the Project commands table in
 
 ## A0-O — Discover orphan issues
 
-Search all open issues in the repository. Collect every issue whose
-body satisfies **all** of the following:
+First, check whether any open issue contains a
+`<!-- idd-skill-roadmap-id: … -->` marker. If such an issue exists (a
+roadmap is active), skip A0-O entirely and fall back to **A1**. The
+`orphan-first` path is only active when no roadmap issue exists.
+
+If no roadmap issue exists, search all open issues in the repository.
+Collect every issue whose body satisfies **all** of the following:
 
 - Does NOT contain any `<!-- idd-skill-roadmap-id: … -->` marker
   (the issue is not itself a roadmap).

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -37,8 +37,10 @@ If no orphan issues are found: fall back to the roadmap path. Proceed
 to **A1** and continue with the normal A1 → A2 → A3 → A4 sequence.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
-reached only when both the orphan path and the roadmap fallback return
-zero results.
+reached when the active discovery path(s) produce zero results: when
+`orphan-first` is active, this means both the orphan path and the
+roadmap fallback returned zero; when `issue-scope` is `roadmap`, only
+the roadmap path runs and A3 applies when it returns zero.
 
 ## A1 — Find the roadmap
 
@@ -46,10 +48,12 @@ Use GH CLI or GH MCP to find the roadmap among open issues. Identify it
 by the `roadmap` label (project field) or by recognizing it as an
 umbrella issue. If no roadmap issue exists, report and abort.
 
-**Note**: A1 is the only IDD phase that may use repo-wide or label-based
-issue queries to locate an issue — solely to find the roadmap. The A3
-`idd-skill-blocked-by` dependency check also permits a
-narrow body-content search; see A2 for details.
+**Note**: Repo-wide or label-based issue queries are permitted only in
+**A0-O** (when `issue-scope` is `orphan-first`, to find orphan issues),
+**A1** (to locate the roadmap), and **A3** (narrow body-content lookup
+for `idd-skill-roadmap-id` to resolve `idd-skill-blocked-by`
+dependency markers; see A2 for details). Outside these three contexts,
+repo-wide and label-based queries are prohibited.
 
 ## A2 — Enumerate sub-issues
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -26,6 +26,9 @@ body satisfies **all** of the following:
 - Does NOT contain any `<!-- idd-skill-blocked-by: … -->` marker.
 - Does NOT have a `status:blocked-by-human` or `status:needs-decision`
   label.
+- Does NOT contain visible `Blocked by #NNN` lines where the referenced
+  issue is open (apply the same fail-safe as A3: if a reference cannot
+  be resolved, treat as blocked).
 
 If at least one orphan issue is found: pass the collected set directly
 to **A4** (viability gate). Skip A1–A3 entirely.
@@ -174,7 +177,8 @@ scope:
 
 ### Step 1 — Viability gate
 
-For each issue from A3, evaluate **all three** criteria. Fail any one →
+For each candidate from A0-O or A3, evaluate **all three** criteria.
+Fail any one →
 discard the issue.
 
 | Criterion                 | Pass                                                                                                                | Fail examples                                                                                    |

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -1,4 +1,4 @@
-# IDD — Discover Phase (A1–A4)
+# IDD — Discover Phase (A0–A4)
 
 Read this file when starting a new task. It covers finding and selecting
 the next issue to work on. After selecting, read
@@ -6,6 +6,36 @@ the next issue to work on. After selecting, read
 
 **Abort conditions**: A1, A3 (default; see decision tree). **Early stop
 condition**: A4 (no claim made — see below).
+
+## A0 — Check issue-scope setting
+
+Read the **issue-scope** value from the Project commands table in
+`idd-overview.instructions.md`.
+
+- If `issue-scope` is `roadmap` (the default): skip A0-O and proceed to
+  A1 as normal.
+- If `issue-scope` is `orphan-first`: proceed to A0-O.
+
+## A0-O — Discover orphan issues
+
+Search all open issues in the repository. Collect every issue whose
+body satisfies **all** of the following:
+
+- Does NOT contain any `<!-- idd-skill-roadmap-id: … -->` marker
+  (the issue is not itself a roadmap).
+- Does NOT contain any `<!-- idd-skill-blocked-by: … -->` marker.
+- Does NOT have a `status:blocked-by-human` or `status:needs-decision`
+  label.
+
+If at least one orphan issue is found: pass the collected set directly
+to **A4** (viability gate). Skip A1–A3 entirely.
+
+If no orphan issues are found: fall back to the roadmap path. Proceed
+to **A1** and continue with the normal A1 → A2 → A3 → A4 sequence.
+
+The A3 decision tree (abort / ask operator in unattended mode) is
+reached only when both the orphan path and the roadmap fallback return
+zero results.
 
 ## A1 — Find the roadmap
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -18,13 +18,8 @@ Read the **issue-scope** value from the Project commands table in
 
 ## A0-O — Discover orphan issues
 
-First, check whether any open issue contains a
-`<!-- idd-skill-roadmap-id: … -->` marker. If such an issue exists (a
-roadmap is active), skip A0-O entirely and fall back to **A1**. The
-`orphan-first` path is only active when no roadmap issue exists.
-
-If no roadmap issue exists, search all open issues in the repository.
-Collect every issue whose body satisfies **all** of the following:
+Search all open issues in the repository. Collect every issue whose
+body satisfies **all** of the following:
 
 - Does NOT contain any `<!-- idd-skill-roadmap-id: … -->` marker
   (the issue is not itself a roadmap).
@@ -88,6 +83,9 @@ include only **open** issues in the A2 candidate set.
 **Permitted repo-wide queries** — only the following scoped lookups may
 touch issues outside the roadmap traversal graph:
 
+- **A0-O only** (when `issue-scope` is `orphan-first`): a repo-wide
+  open-issue query to find issues without `roadmap-id` or `blocked-by`
+  markers.
 - **A1 only**: any method (including `gh issue list`, `gh search`, or
   label-based queries) to locate the roadmap issue itself.
 - **A3 only**: a body-content search (e.g.,

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -159,9 +159,12 @@ explicitly references (directly or transitively) without explicit
 operator instruction. Specifically:
 
 - Repo-wide searches (`gh issue list`, `gh search`, label-based queries)
-  are permitted only in **A1** (to locate the roadmap itself) and for
-  the scoped `idd-skill-roadmap-id` body-content lookup
-  required by A3's dependency-marker check.
+  are permitted only in **A1** (to locate the roadmap itself), in
+  **A0-O** when `issue-scope` is `orphan-first` (body-content filter to
+  find issues lacking `idd-skill-roadmap-id` and
+  `idd-skill-blocked-by` markers), and for the scoped
+  `idd-skill-roadmap-id` body-content lookup required by A3's
+  dependency-marker check.
 - After a zero-result report at A3, an operator may grant a one-time
   opt-in for the current run, specifying an alternate scope. See
   `idd-discover.instructions.md` for the full decision tree.
@@ -219,6 +222,7 @@ different project.**
 | **pre-push-validate** | `npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
 | **post-fix-validate** | `npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
 | **install-deps**      | `true`     |
+| **issue-scope**       | `roadmap`  |
 
 `pre-push-validate` intentionally omits auto-fix — all code should
 already pass lint at the push step. If lint fails, run **fix-validate**

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -18,8 +18,14 @@ Read the **issue-scope** value from the Project commands table in
 
 ## A0-O — Discover orphan issues
 
-Search all open issues in the repository. Collect every issue whose
-body satisfies **all** of the following:
+First, check whether any open issue contains a
+`<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: … -->` marker. If such an
+issue exists (a roadmap is active), skip A0-O entirely and fall back
+to **A1**. The `orphan-first` path is only active when no roadmap issue
+exists.
+
+If no roadmap issue exists, search all open issues in the repository.
+Collect every issue whose body satisfies **all** of the following:
 
 - Does NOT contain any
   `<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: … -->` marker (the issue

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -28,6 +28,9 @@ body satisfies **all** of the following:
   `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: … -->` marker.
 - Does NOT have a `status:blocked-by-human` or `status:needs-decision`
   label.
+- Does NOT contain visible `Blocked by #NNN` lines where the referenced
+  issue is open (apply the same fail-safe as A3: if a reference cannot
+  be resolved, treat as blocked).
 
 If at least one orphan issue is found: pass the collected set directly
 to **A4** (viability gate). Skip A1–A3 entirely.
@@ -177,7 +180,8 @@ scope:
 
 ### Step 1 — Viability gate
 
-For each issue from A3, evaluate **all three** criteria. Fail any one →
+For each candidate from A0-O or A3, evaluate **all three** criteria.
+Fail any one →
 discard the issue.
 
 | Criterion                 | Pass                                                                                                                | Fail examples                                                                                    |

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -1,4 +1,4 @@
-# IDD — Discover Phase (A1–A4)
+# IDD — Discover Phase (A0–A4)
 
 Read this file when starting a new task. It covers finding and selecting
 the next issue to work on. After selecting, read
@@ -6,6 +6,38 @@ the next issue to work on. After selecting, read
 
 **Abort conditions**: A1, A3 (default; see decision tree). **Early stop
 condition**: A4 (no claim made — see below).
+
+## A0 — Check issue-scope setting
+
+Read the **issue-scope** value from the Project commands table in
+`idd-overview.instructions.md`.
+
+- If `issue-scope` is `roadmap` (the default): skip A0-O and proceed to
+  A1 as normal.
+- If `issue-scope` is `orphan-first`: proceed to A0-O.
+
+## A0-O — Discover orphan issues
+
+Search all open issues in the repository. Collect every issue whose
+body satisfies **all** of the following:
+
+- Does NOT contain any
+  `<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: … -->` marker (the issue
+  is not itself a roadmap).
+- Does NOT contain any
+  `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: … -->` marker.
+- Does NOT have a `status:blocked-by-human` or `status:needs-decision`
+  label.
+
+If at least one orphan issue is found: pass the collected set directly
+to **A4** (viability gate). Skip A1–A3 entirely.
+
+If no orphan issues are found: fall back to the roadmap path. Proceed
+to **A1** and continue with the normal A1 → A2 → A3 → A4 sequence.
+
+The A3 decision tree (abort / ask operator in unattended mode) is
+reached only when both the orphan path and the roadmap fallback return
+zero results.
 
 ## A1 — Find the roadmap
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -39,8 +39,10 @@ If no orphan issues are found: fall back to the roadmap path. Proceed
 to **A1** and continue with the normal A1 → A2 → A3 → A4 sequence.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
-reached only when both the orphan path and the roadmap fallback return
-zero results.
+reached when the active discovery path(s) produce zero results: when
+`orphan-first` is active, this means both the orphan path and the
+roadmap fallback returned zero; when `issue-scope` is `roadmap`, only
+the roadmap path runs and A3 applies when it returns zero.
 
 ## A1 — Find the roadmap
 
@@ -48,10 +50,13 @@ Use GH CLI or GH MCP to find the roadmap among open issues. Identify it
 by the `roadmap` label (project field) or by recognizing it as an
 umbrella issue. If no roadmap issue exists, report and abort.
 
-**Note**: A1 is the only IDD phase that may use repo-wide or label-based
-issue queries to locate an issue — solely to find the roadmap. The A3
-`{{PROJECT_MARKER_PREFIX}}-blocked-by` dependency check also permits a
-narrow body-content search; see A2 for details.
+**Note**: Repo-wide or label-based issue queries are permitted only in
+**A0-O** (when `issue-scope` is `orphan-first`, to find orphan issues),
+**A1** (to locate the roadmap), and **A3** (narrow body-content lookup
+for `{{PROJECT_MARKER_PREFIX}}-roadmap-id` to resolve
+`{{PROJECT_MARKER_PREFIX}}-blocked-by` dependency markers; see A2 for
+details). Outside these three contexts, repo-wide and label-based
+queries are prohibited.
 
 ## A2 — Enumerate sub-issues
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -18,14 +18,8 @@ Read the **issue-scope** value from the Project commands table in
 
 ## A0-O — Discover orphan issues
 
-First, check whether any open issue contains a
-`<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: … -->` marker. If such an
-issue exists (a roadmap is active), skip A0-O entirely and fall back
-to **A1**. The `orphan-first` path is only active when no roadmap issue
-exists.
-
-If no roadmap issue exists, search all open issues in the repository.
-Collect every issue whose body satisfies **all** of the following:
+Search all open issues in the repository. Collect every issue whose
+body satisfies **all** of the following:
 
 - Does NOT contain any
   `<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: … -->` marker (the issue
@@ -92,6 +86,10 @@ include only **open** issues in the A2 candidate set.
 **Permitted repo-wide queries** — only the following scoped lookups may
 touch issues outside the roadmap traversal graph:
 
+- **A0-O only** (when `issue-scope` is `orphan-first`): a repo-wide
+  open-issue query to find issues without
+  `{{PROJECT_MARKER_PREFIX}}-roadmap-id` or
+  `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers.
 - **A1 only**: any method (including `gh issue list`, `gh search`, or
   label-based queries) to locate the roadmap issue itself.
 - **A3 only**: a body-content search (e.g.,

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -160,9 +160,12 @@ explicitly references (directly or transitively) without explicit
 operator instruction. Specifically:
 
 - Repo-wide searches (`gh issue list`, `gh search`, label-based queries)
-  are permitted only in **A1** (to locate the roadmap itself) and for
-  the scoped `{{PROJECT_MARKER_PREFIX}}-roadmap-id` body-content lookup
-  required by A3's dependency-marker check.
+  are permitted only in **A1** (to locate the roadmap itself), in
+  **A0-O** when `issue-scope` is `orphan-first` (body-content filter to
+  find issues lacking `{{PROJECT_MARKER_PREFIX}}-roadmap-id` and
+  `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers), and for the scoped
+  `{{PROJECT_MARKER_PREFIX}}-roadmap-id` body-content lookup required by
+  A3's dependency-marker check.
 - After a zero-result report at A3, an operator may grant a one-time
   opt-in for the current run, specifying an alternate scope. See
   `idd-discover.instructions.md` for the full decision tree.
@@ -220,6 +223,7 @@ different project.**
 | **pre-push-validate** | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |
 | **post-fix-validate** | `{{POST_FIX_VALIDATE_COMMANDS}}` |
 | **install-deps**      | `{{INSTALL_DEPS_COMMAND}}`     |
+| **issue-scope**       | `roadmap`                      |
 
 `pre-push-validate` intentionally omits auto-fix — all code should
 already pass lint at the push step. If lint fails, run **fix-validate**


### PR DESCRIPTION
## Summary

- Adds `A0` and `A0-O` steps to `idd-discover.instructions.md` (live + template) that execute before A1 when `issue-scope` is set to `orphan-first`
- A0-O searches for open issues that carry neither `roadmap-id` nor `blocked-by` markers and passes them directly to the A4 viability gate, bypassing A1–A3
- Falls back transparently to the normal roadmap path (A1→A2→A3→A4) when no orphan issues exist
- Adds `issue-scope` row (default: `roadmap`) to the Project commands table in `idd-overview.instructions.md` (live + template)
- Updates the Scope invariant to permit the A0-O repo-wide query
- Default behaviour (`issue-scope: roadmap`) is completely unchanged

Closes #9

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] `npx cspell lint "**" --no-progress` — 0 issues
- [x] All 4 instruction files updated atomically per template-sync rule (#8)
- [x] Template files use `{{PROJECT_MARKER_PREFIX}}` placeholder form
- [x] `issue-scope` default value is `roadmap` — no behaviour change for existing deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Discovery workflow expanded to A0–A4 with a new A0 decision driven by an issue-scope setting.
  * Added an orphan-driven A0-O path that scans open issues lacking roadmap/blocked markers and short-circuits to A4 when orphans are found.
  * Clarified that repo-wide/label-based queries are permitted in A0-O, A1, and A3 only.
  * Broadened A4 viability wording to apply to candidates from A0-O or A3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->