### PR TITLE
docs(template): narrow auto-loaded wording for idd-overview

### DIFF
--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -29,8 +29,8 @@ Open `ONBOARDING.md` and follow the instructions there.
 
 ```text
 .github/instructions/
-  idd-overview.instructions.md       ← shared definitions, auto-loaded (applyTo: **)
-  idd-discover.instructions.md       ← A1–A4: find and select next issue
+  idd-overview.instructions.md       ← shared definitions; auto-loaded by Copilot surfaces (applyTo: "**"); see docs/idd-workflow.md for per-agent loading
+  idd-discover.instructions.md       ← A0–A4: find and select next issue
   idd-claim.instructions.md          ← A5: claim pre-checks and execution
   idd-work.instructions.md           ← B+C: branch, plan, implement, self-review
   idd-pr-submit.instructions.md      ← D: rebase, validate, push, open PR, CI wait


### PR DESCRIPTION
## Summary

- Updates `idd-template/README.md` file-map annotation for `idd-overview.instructions.md` from the universal `auto-loaded (applyTo: **)` to Copilot-specific `auto-loaded by Copilot surfaces (applyTo: "**"); see docs/idd-workflow.md for per-agent loading`
- Also updates the `idd-discover.instructions.md` row from `A1–A4` to `A0–A4` to reflect the orphan-first mode added in #9

Closes #13

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] `npx cspell lint "**" --no-progress` — 0 issues
- [x] Replacement wording is accurate for the supported agent set
- [x] Points readers to `docs/idd-workflow.md` for per-agent details

🤖 Generated with [Claude Code](https://claude.com/claude-code)