### PR TITLE
docs(readme): add why-idd-skill section and competitive positioning

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -24,6 +24,7 @@ version: '0.2'
 words:
   - idd
   - kito
+  - Kiro
   - kuron
   - kurone
   - kuroné

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ or Gemini CLI.
 - **Zero infrastructure** — No SaaS account, no GitHub Actions runner,
   no server required. Copy 11 Markdown files into any repository and the
   workflow is ready.
-- **Agent-agnostic** — Works identically across GitHub Copilot, Claude
-  Code, OpenAI Codex CLI, and Gemini CLI. Switch or combine tools without
-  rewriting any instructions.
+- **Agent-agnostic** — Core phases work across GitHub Copilot, Claude
+  Code, OpenAI Codex CLI, and Gemini CLI without rewriting any
+  instructions. (The default template includes a Copilot advisory review
+  step in later phases; see [docs/positioning.md](docs/positioning.md)
+  for details.)
 - **Fully auditable** — Every rule is plain Markdown. Read it, fork it,
   adapt it. No black box.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ Each phase is encoded as a `.github/instructions/` file that any
 compatible AI agent can load — GitHub Copilot, Claude Code, Codex CLI,
 or Gemini CLI.
 
+## Why idd-skill?
+
+- **Parallel agent coordination** — A built-in claim/heartbeat protocol
+  (HTML comment markers in issue bodies) prevents multiple AI agents from
+  picking up the same issue simultaneously, making true parallel
+  development safe without a central orchestrator.
+- **End-to-end phase coverage** — 10 instruction files encode every step
+  from issue discovery to merge, including CI wait loops, review triage,
+  and review-fix cycles. Most tools stop at "open a PR".
+- **Zero infrastructure** — No SaaS account, no GitHub Actions runner,
+  no server required. Copy 11 Markdown files into any repository and the
+  workflow is ready.
+- **Agent-agnostic** — Works identically across GitHub Copilot, Claude
+  Code, OpenAI Codex CLI, and Gemini CLI. Switch or combine tools without
+  rewriting any instructions.
+- **Fully auditable** — Every rule is plain Markdown. Read it, fork it,
+  adapt it. No black box.
+
+See [docs/positioning.md](docs/positioning.md) for a detailed
+competitive landscape and strategic positioning analysis.
+
 ## Importing IDD manually
 
 1. Clone or download this repository.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,97 @@
+# IDD Skill — Competitive Landscape and Positioning
+
+Analysis date: 2026-05-07
+
+## Overview
+
+This document summarises the competitive landscape for idd-skill as of
+the analysis date, provides a comparison matrix, and describes the
+strategic position of the project relative to adjacent tools.
+
+## Competitive landscape
+
+The space of AI-driven development workflow tools can be grouped into
+four broad categories:
+
+**Platform-native agentic workflows** — GitHub Agentic Workflows
+(gh-aw) is a server-side feature that triggers AI agents via GitHub
+events (issues, pull requests, labels). It provides deep GitHub
+integration and persistent execution but requires GitHub infrastructure
+and ties adopters to the GitHub platform.
+
+**Skill/prompt collections** — Projects such as awesome-copilot host
+curated collections of prompts or instruction files that extend AI
+agents. These are adoption-friendly but lack coordination primitives;
+each prompt is independent and there is no built-in mechanism to
+prevent multiple agents from picking up the same task.
+
+**Commercial AI development platforms** — Tools such as Kiro (AWS) and
+Factory.ai provide managed AI coding environments with proprietary
+orchestration. They offer polished UX but require accounts, introduce
+vendor lock-in, and are not portable across agent runtimes.
+
+**Open-source agent frameworks** — Projects such as OpenHands
+(formerly OpenDevin) provide full-featured agent runtimes with tool
+access, sandboxed execution, and multi-step task planning. They are
+powerful but heavyweight; they require infrastructure, are
+single-agent by design, and do not address parallel multi-agent
+coordination at the issue-tracking level.
+
+## Comparison matrix
+
+| Criterion | idd-skill | GitHub Agentic Workflows | Awesome-Copilot skills | Kiro / Factory.ai | OpenHands |
+| --------- | --------- | ----------------------- | --------------------- | ----------------- | --------- |
+| Parallel agent coordination | ✓ (claim/heartbeat) | ✗ | ✗ | Varies | ✗ |
+| End-to-end phase coverage | ✓ (10 files, discovery to merge) | Partial | ✗ | ✓ (proprietary) | Partial |
+| Zero infrastructure | ✓ (Markdown files only) | ✗ (GitHub servers) | ✓ | ✗ (SaaS account) | ✗ (runtime required) |
+| Agent-agnostic | ✓ (Copilot, Claude, Codex, Gemini) | ✗ (GitHub Copilot only) | ✓ | ✗ (proprietary) | ✗ (own runtime) |
+| Fully auditable rules | ✓ (plain Markdown) | ✗ | ✓ | ✗ | ✓ (open source) |
+| GitHub-hosted CI integration | ✓ (CI wait loop) | ✓ | ✗ | ✓ | Varies |
+| No vendor account required | ✓ | ✗ (GitHub account) | ✓ | ✗ | ✓ |
+
+## Strategic position
+
+idd-skill occupies a unique position as a _portable operating system
+for development teams_ — vendor-neutral, infrastructure-free, and the
+only framework with explicit multi-agent coordination primitives built
+into the workflow rules themselves.
+
+The key differentiator is the claim/heartbeat protocol. Other tools
+either assume single-agent execution or rely on external orchestration
+services to prevent task duplication. idd-skill encodes the
+coordination rules directly in the instruction files that agents read,
+making parallel execution safe across heterogeneous agent runtimes with
+no additional infrastructure.
+
+## Relationship to adjacent tools
+
+**idd-skill and GitHub Agentic Workflows are complementary, not
+competing.** GitHub Agentic Workflows excels at the server-side
+trigger layer: reacting to GitHub events, maintaining persistent state
+between agent runs, and integrating deeply with GitHub Projects.
+idd-skill governs _what agents do_ once they are running — the
+coordination rules, phase routing, review triage, and merge
+conditions. A team can use gh-aw to start an agent session in response
+to a new issue, and idd-skill to define how that session should
+proceed.
+
+**idd-skill and prompt collections are additive.** Adopters can import
+idd-skill alongside existing Copilot skill collections; the instruction
+files occupy a different namespace and are concerned with workflow
+orchestration rather than task-specific capabilities.
+
+## Known gaps
+
+- **No server-side persistent execution.** idd-skill requires a human
+  or an external scheduler to start each agent session. It does not
+  include a daemon or event-driven trigger mechanism.
+- **Copilot advisory review dependency in the default template.** The
+  distributed default PR policy includes a GitHub Copilot advisory
+  review step in the review-fix and merge phases. Adopters who do not
+  use GitHub Copilot must customise `idd-review-fix.instructions.md`
+  and `idd-merge.instructions.md` to remove or replace this step.
+- **Requires issue hygiene.** The workflow assumes that issues carry
+  correct dependency markers (`blocked-by`, `roadmap-id`) and that
+  roadmaps reference sub-issues via task lists. Silent misuse of these
+  mechanisms causes the discover phase to stall without a clear error
+  message (mitigated by diagnostic notes added in #15).


### PR DESCRIPTION
## Summary

- Adds `## Why idd-skill?` section to `README.md` (after "What is IDD?") with five factual, verifiable bullets: parallel agent coordination, end-to-end phase coverage, zero infrastructure, agent-agnostic design, and full auditability
- Creates `docs/positioning.md` with competitive landscape summary, comparison matrix (6 tools), strategic position statement, relationship-to-adjacent-tools section, and known-gaps section with datestamp
- Links `docs/positioning.md` from `README.md`
- Adds `Kiro` to cspell words list

Closes #14

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] `npx cspell lint "**" --no-progress` — 0 issues
- [x] No competitor names or "the only X" language in `README.md`
- [x] `docs/positioning.md` linked from `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive positioning guide outlining competitive advantages and comparison matrix
  * Enhanced README with key capabilities: claim/heartbeat coordination, zero-infrastructure setup, GitHub AI compatibility, and auditable ruleset

<!-- end of auto-generated comment: release notes by coderabbit.ai -->