### PR TITLE
docs(idd): surface default copilot review policy earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ The agent will collect a few project-specific values (repo name,
 validation commands) and then set up the full IDD workflow
 automatically — no manual file copying required.
 
+Note: the distributed default template is cross-agent for execution, but
+its later PR phases include a GitHub Copilot advisory review step by
+default. If adopters do not want that PR policy, they can customize
+`.github/instructions/idd-review-fix.instructions.md` and
+`.github/instructions/idd-merge.instructions.md` after onboarding.
+
 ## What is IDD?
 
 IDD is a multi-agent GitHub automation workflow where AI agents work
@@ -30,7 +36,9 @@ Review Triage → Review Fix → Merge → Loop.
 
 Each phase is encoded as a `.github/instructions/` file that any
 compatible AI agent can load — GitHub Copilot, Claude Code, Codex CLI,
-or Gemini CLI.
+or Gemini CLI. That execution model is cross-agent, even though the
+distributed default review policy still includes the Copilot advisory
+step noted above.
 
 ## Why idd-skill?
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -53,10 +53,11 @@ instruction files. Some older project text may still use "skill files"
 as shorthand, but these documents are not agent-native `SKILL.md`
 bundles.
 
-## Repository-specific Copilot advisory review addendum
+## Default PR policy: Copilot advisory review
 
-The core IDD flow is cross-agent, but later PR phases intentionally
-include a repository-specific GitHub Copilot advisory review step.
+The core IDD flow is cross-agent, but this repository's distributed
+default PR policy still includes a GitHub Copilot advisory review step
+in later PR phases.
 
 - `idd-review-fix.instructions.md` can request a GitHub Copilot
   re-review for the current PR head.
@@ -64,6 +65,8 @@ include a repository-specific GitHub Copilot advisory review step.
   review state.
 - This dependency is on GitHub's review integration, not on every local
   agent using Copilot as its CLI.
+- Adopters who do not want that default PR policy should edit
+  `idd-review-fix.instructions.md` and `idd-merge.instructions.md`.
 
 Non-Copilot agents can still drive the workflow end to end, but they
 should expect those later phases to interact with Copilot as a GitHub

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -24,6 +24,13 @@ Review Triage → Review Fix → Merge → Loop) driven by GitHub Issues.
 The instruction files in `.github/instructions/` encode every rule for
 every phase.
 
+Important: the distributed default workflow is cross-agent for
+execution, but its later PR phases still include a GitHub Copilot
+advisory review step by default. If the operator does not want that PR
+policy, they should plan to customize
+`.github/instructions/idd-review-fix.instructions.md` and
+`.github/instructions/idd-merge.instructions.md` after import.
+
 ## Your task
 
 1. Read this entire document first.
@@ -81,6 +88,11 @@ entire lifetime of the roadmap.
 
 You need the following eleven files in the target repository. Use
 whichever method applies to your situation.
+
+Before importing, confirm whether the operator wants to keep the default
+Copilot advisory review policy described above. If not, note that they
+should customize `idd-review-fix.instructions.md` and
+`idd-merge.instructions.md` after the files are copied in.
 
 ### File list
 

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -14,6 +14,14 @@ multi-agent GitHub automation.
 
 Open `ONBOARDING.md` and follow the instructions there.
 
+## Default PR policy note
+
+The distributed template is cross-agent for execution, but its later PR
+phases include a GitHub Copilot advisory review step by default. If an
+adopter does not want that PR policy, they can customize
+`.github/instructions/idd-review-fix.instructions.md` and
+`.github/instructions/idd-merge.instructions.md` after import.
+
 ## Placeholders
 
 | Placeholder                      | Description                                      |
@@ -44,6 +52,9 @@ docs/
 ONBOARDING.md                        ← AI agent import guide (start here)
 README.md                            ← this file
 ```
+
+See `docs/idd-workflow.md` for the distinction between cross-agent
+execution and the default Copilot-backed PR policy.
 
 ## Origin
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -59,10 +59,11 @@ instruction files. Some older project text may still use "skill files"
 as shorthand, but these documents are not agent-native `SKILL.md`
 bundles.
 
-## Repository-specific Copilot advisory review addendum
+## Default PR policy: Copilot advisory review
 
-The core IDD flow is cross-agent, but later PR phases intentionally
-include a repository-specific GitHub Copilot advisory review step.
+The core IDD flow is cross-agent, but the distributed default PR policy
+still includes a GitHub Copilot advisory review step in later PR
+phases.
 
 - `idd-review-fix.instructions.md` can request a GitHub Copilot
   re-review for the current PR head.
@@ -70,6 +71,8 @@ include a repository-specific GitHub Copilot advisory review step.
   review state.
 - This dependency is on GitHub's review integration, not on every local
   agent using Copilot as its CLI.
+- Adopters who do not want that default PR policy should edit
+  `idd-review-fix.instructions.md` and `idd-merge.instructions.md`.
 
 Non-Copilot agents can still drive the workflow end to end, but they
 should expect those later phases to interact with Copilot as a GitHub


### PR DESCRIPTION
## Summary
- add early adopter-facing disclosure to the top-level and template READMEs
- surface the default Copilot advisory review policy in ONBOARDING before import
- clarify in both workflow guides that this is a default PR policy and point to the customization files

Closes #12

## Recommended follow-up
- none

## Background
- this is a docs-first expectation-setting change and does not alter the underlying later-phase review or merge behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated documentation to clarify that the default Pull Request workflow includes GitHub Copilot advisory review as a built-in step in later phases
* Added guidance for operators on customizing or disabling the Copilot review policy
* Enhanced onboarding materials with clearer instructions on default workflow behavior and customization options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->