### PR TITLE
feat(deps): add dprint configuration for markdown formatting

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://dprint.dev/schemas/v0.json",
+  "includes": ["**/*.md"],
+  "excludes": [".git", "node_modules"],
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.21.1.wasm"
+  ],
+  "markdown": {}
+}


### PR DESCRIPTION
## Summary

Adds `dprint.json` at the repository root with the Markdown plugin pinned
to v0.21.1. No files are formatted yet — the initial formatting run is
deferred to #26 so that large cosmetic diff is reviewable separately and
does not conflict with concurrent content issues (#12, #25).

Closes #24

## Test plan

- [x] `npx dprint check "**/*.md"` runs (10 files report unformatted — expected at this stage)
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] `npx cspell lint "**" --no-progress` — 0 issues
- [x] Plugin version pinned (0.21.1, not `latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code formatting configuration to maintain consistent code style across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->