### PR TITLE
docs(idd): document optional validation for non-Node environments

### DIFF
--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -232,6 +232,11 @@ If **fix-validate** or **post-fix-validate** produces file changes
 (auto-fixes), stage and commit those changes before any push, rebase, or
 next step that requires no uncommitted changes.
 
+**Tool availability**: the commands above are required when the listed
+tools are present. In repositories without Node.js or a specific tool,
+replace that command with `true` — the same no-op convention used by
+**install-deps** in this project.
+
 ## Phase routing table
 
 Start by reading this file for shared definitions, then load the phase

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -233,6 +233,12 @@ If **fix-validate** or **post-fix-validate** produces file changes
 (auto-fixes), stage and commit those changes before any push, rebase, or
 next step that requires no uncommitted changes.
 
+**Tool availability**: the commands above are required when the listed
+tools are present. In repositories without a specific tool, replace
+that command with `true` — the same no-op convention used by
+**install-deps**. Set `{{INSTALL_DEPS_COMMAND}}` to `true` if the
+project has no install step.
+
 ## Phase routing table
 
 Start by reading this file for shared definitions, then load the phase

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -50,6 +50,13 @@ request missing values.
 | `{{POST_FIX_VALIDATE_COMMANDS}}` | Commands that auto-fix and fully verify after review fixes. Usually a superset of the other two.                                          | `npm run lint:fix && npm run lint && npm run build && npm run test` |
 | `{{INSTALL_DEPS_COMMAND}}`     | Command to install dependencies in a fresh worktree.                                                                                        | `npm install`                                     |
 
+> **No-op substitution**: any command that is not applicable to your
+> project can be set to `true`. For example, a repository without a
+> dependency install step uses `{{INSTALL_DEPS_COMMAND}}` = `true`.
+> The same applies to validation commands in projects that do not use
+> the listed tools — set the relevant placeholder to `true` to skip
+> that step without breaking the workflow.
+
 ### Notes on `{{PROJECT_MARKER_PREFIX}}`
 
 This prefix appears in two places in issue bodies as hidden HTML


### PR DESCRIPTION
## Summary

- Adds a **Tool availability** note to the Project commands section in
  `.github/instructions/idd-overview.instructions.md` and its template
  copy, clarifying that any `npx`-based command can be replaced with
  `true` when the tool is absent
- Adds a no-op substitution blockquote to `idd-template/ONBOARDING.md`
  using the existing `install-deps: true` pattern as the reference
  example

Closes #25

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] `npx cspell lint "**" --no-progress` — 0 issues
- [x] Both idd-overview files and ONBOARDING.md updated (template-sync rule observed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)