### PR TITLE
feat(idd): add dprint to fix-validate and pre-push-validate commands

### DIFF
--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -216,13 +216,13 @@ When a phase refers to a named command set, run the corresponding
 commands. **Adapt this section when applying this workflow to a
 different project.**
 
-| Name                  | Commands                                                                                                         |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **fix-validate**      | `npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
-| **pre-push-validate** | `npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                          |
-| **post-fix-validate** | `npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
-| **install-deps**      | `true`                                                                                                           |
-| **issue-scope**       | `roadmap`                                                                                                        |
+| Name                  | Commands                                                                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **fix-validate**      | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
+| **pre-push-validate** | `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                        |
+| **post-fix-validate** | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
+| **install-deps**      | `true`                                                                                                                                       |
+| **issue-scope**       | `roadmap`                                                                                                                                    |
 
 `pre-push-validate` intentionally omits auto-fix — all code should
 already pass lint at the push step. If lint fails, run **fix-validate**


### PR DESCRIPTION
## Summary

Integrates dprint into the Project commands table in
`.github/instructions/idd-overview.instructions.md`:

| Command | Before | After |
| ------- | ------ | ----- |
| **fix-validate** | `npx markdownlint-cli2 --fix …` | `npx dprint fmt … && npx markdownlint-cli2 --fix …` |
| **pre-push-validate** | `npx markdownlint-cli2 … && npx cspell …` | `npx dprint check … && npx markdownlint-cli2 … && npx cspell …` |
| **post-fix-validate** | superset of fix-validate | `npx dprint fmt … &&` prepended |

Template placeholders (`{{FIX_VALIDATE_COMMANDS}}` etc.) are unchanged.
Per the optional-tool convention (#25), dprint can be replaced with
`true` in environments where it is not available.

Closes #27

## Test plan

- [x] `npx dprint check "**/*.md"` — 0 files unformatted
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] `npx cspell lint "**" --no-progress` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project command specifications in developer documentation. Commands now include enhanced validation with additional formatting and linting checks for code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->