### PR TITLE
docs: simplify onboarding trigger phrase to github:owner/repo short form

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,30 @@ A portable set of `.github/instructions/` files and documentation that
 wire up an Issue-Driven Development (IDD) multi-agent pipeline for any
 GitHub project.
 
+## For AI agents
+
+If you were pointed here by a trigger phrase such as
+`github:kurone-kito/idd-skill` and asked to onboard IDD, start with the
+onboarding guide:
+
+```text
+https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md
+```
+
+Fetch that file and follow its instructions. It will walk you through
+collecting placeholder values, copying the template files, and updating
+the repository's agent entry files — no cloning required.
+
 ## Quick start
 
-Open a session in your target repository and tell your AI agent:
+Open a session in your target repository and tell your AI agent one of
+the following:
+
+**Short form** (agents with WebFetch or `gh` CLI access):
+
+> `github:kurone-kito/idd-skill` の IDD をこのリポジトリにインポート＆オンボーディングして
+
+**Explicit form** (works with any agent):
 
 > I want to use `github:idd-skill`'s Issue-Driven Development in this
 > repository. Read

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ the following:
 
 **Short form** (agents with WebFetch or `gh` CLI access):
 
-> `github:kurone-kito/idd-skill` の IDD をこのリポジトリにインポート＆オンボーディングして
+> - `github:kurone-kito/idd-skill` の IDD をこのリポジトリにインポート＆オンボーディングして
+> - Import and onboard `github:kurone-kito/idd-skill`'s IDD into this
+>   repository.
 
 **Explicit form** (works with any agent):
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -9,12 +9,22 @@ a new repository.
 > clone the idd-skill repository — Step 2 Option A below provides the
 > commands to download every template file directly from GitHub.
 >
-> The canonical trigger phrase users give their AI agent is:
+> Recognized trigger phrases:
 >
-> _"I want to use `github:idd-skill`'s Issue-Driven Development in this
-> repository. Read
-> `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md`
-> and onboard me."_
+> - Short form (Japanese):
+>   _"`github:kurone-kito/idd-skill` の IDD をこのリポジトリにインポート＆オンボーディングして"_
+> - Short form (English):
+>   _"Import and onboard `github:kurone-kito/idd-skill`'s IDD into this
+>   repository."_
+> - Explicit form (works with any agent):
+>   _"I want to use `github:idd-skill`'s Issue-Driven Development in this
+>   repository. Read
+>   `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md`
+>   and onboard me."_
+>
+> All forms lead here. Agents that received only a `github:owner/repo`
+> reference and resolved this file by fetching the repository README are
+> also in the right place.
 
 ## What you are setting up
 


### PR DESCRIPTION
## Summary

- Adds a `## For AI agents` section to `README.md` with the raw ONBOARDING.md URL, so agents that fetch the README from a `github:owner/repo` reference find the entry point immediately
- Expands the Quick Start section to show both a short-form trigger phrase (Japanese + English) and the original explicit URL form
- Updates `idd-template/ONBOARDING.md` callout to list all recognized trigger phrase forms, including the short form and a note that agents who resolved this file via the README are in the right place

## Test plan

- [ ] Verify no `{{...}}` placeholders remain in copied files
- [ ] Confirm `README.md` and `idd-template/ONBOARDING.md` pass dprint + markdownlint + cspell
- [ ] Manually check that the "For AI agents" section appears near the top of README.md and contains a fetchable URL

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a dedicated “For AI agents” onboarding section with instructions to fetch the onboarding guide.
  * Revised Quick Start to specify two prompt formats: a short-form for agents with web access and an explicit form that works universally.
  * Expanded recognized trigger phrases (including English and Japanese short forms) and clarified all entry points resolve to the same onboarding flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->