### PR TITLE
docs(review): add visible human-readable note to E-phase markers

### DIFF
--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -12,13 +12,18 @@ Post this HTML comment to an issue to claim it or take it over:
 <!-- claimed-by: {agent-id} {claim-id} supersedes: {prior-claim-id|none} {ISO8601-timestamp} branch: {branch-name} -->
 ```
 
-**Important**: all operational comments (`claimed-by`, `unclaimed-by`,
-`review-watermark`, `review-baseline`) consist entirely of HTML
-comments. Some GitHub client tools (e.g., `gh issue comment`,
-`gh api -f body=`) silently reject such bodies. Always post these using
-a direct HTTP `POST` with a JSON body (e.g., `curl` with
-`-H "Content-Type: application/json"` and
+**Important**: the machine-readable token in every operational comment
+(`claimed-by`, `unclaimed-by`, `review-watermark`, `review-baseline`)
+is an HTML comment. Some GitHub client tools (e.g., `gh issue comment`,
+`gh api -f body=`) silently reject bodies that consist entirely of HTML
+comments. Always post these using a direct HTTP `POST` with a JSON body
+(e.g., `curl` with `-H "Content-Type: application/json"` and
 `-d '{"body":"<!-- ... -->"}'`).
+
+`review-watermark` and `review-baseline` comments must additionally
+include a short visible note after the HTML comment token (see
+`idd-review-triage.instructions.md` for the required format). `claimed-by`
+and `unclaimed-by` comments remain HTML-comment-only.
 
 - `{claim-id}` is an opaque unique token for one active claim lineage.
   Generate a fresh value on every fresh claim or takeover. Reuse the
@@ -183,10 +188,11 @@ without session context can understand the current state and continue
 correctly. Do not rely on session memory alone for information that
 another agent may need.
 
-Operational restore markers (for example `review-watermark` and
-`review-baseline`) must include the current `{claim-id}` and must never
-be restored across a claim change. A takeover starts a new restore
-scope.
+Operational restore markers (`review-watermark` and `review-baseline`)
+must include the current `{claim-id}` and must never be restored across
+a claim change. A takeover starts a new restore scope. These markers
+must also include a visible human-readable note (see
+`idd-review-triage.instructions.md`).
 
 ## Review item classes
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -84,7 +84,7 @@ reject bodies that consist entirely of HTML comments; this format
 includes visible text so that is not an issue, but the HTTP `POST` path
 is still recommended for reliability (`curl` with
 `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->\n\n_note_"}}'`).
+`-d '{"body":"<!-- ... -->\n\n_note_"}'`).
 
 On resume or restart, read the latest
 `<!-- review-watermark:

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -51,11 +51,19 @@ start of Step 1, compute `{max-activity-updatedAt}` as the highest
 the items that will appear in List A). Write `none` if the snapshot is
 empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
-hidden PR comment:
+PR comment with this format:
 
-```html
+```markdown
 <!-- review-watermark: {agent-id} {claim-id} {head-SHA} {max-activity-updatedAt|none} {total-item-count} {latest-ci-completed-at|none} -->
+
+_{agent-id}: review triage snapshot — IDD automation marker. Do not edit._
 ```
+
+The HTML comment is the machine-readable token; the italic line is a
+visible note for human readers. Detect the language of the PR body and
+write the visible note in that language (default to English if
+ambiguous). Example Japanese note:
+`_{agent-id}: レビュートリアージのスナップショット — IDD 自動化マーカー。編集しないでください。_`
 
 - **`{head-SHA}`**: the value read at the very start of Step 1, before
   any fetching. F2 uses this to detect pushes that occurred between E1's
@@ -70,11 +78,13 @@ hidden PR comment:
 
 Use server-reported timestamps, not the local wall clock.
 
-Note: the watermark comment body consists entirely of an HTML comment.
-Some GitHub client tools (e.g., `gh issue comment`, `gh api -f body=`)
-silently reject such bodies. Post using a direct HTTP `POST` with a JSON
-body (e.g., `curl` with `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->"}'`).
+Note: the comment body begins with an HTML comment token. Some GitHub
+client tools (e.g., `gh issue comment`, `gh api -f body=`) silently
+reject bodies that consist entirely of HTML comments; this format
+includes visible text so that is not an issue, but the HTTP `POST` path
+is still recommended for reliability (`curl` with
+`-H "Content-Type: application/json"` and
+`-d '{"body":"<!-- ... -->\n\n_note_"}}'`).
 
 On resume or restart, read the latest
 `<!-- review-watermark:
@@ -117,20 +127,30 @@ implementation.
 
 **Incremental review**: on the second and later passes **within the same
 claim**, scope the review to the diff since the previous E2 execution's
-head SHA (tracked via
-`<!-- review-baseline: {agent-id} {claim-id} {SHA} -->` PR comments —
-post a new one after each E2 run; use the latest comment with that
-prefix whose embedded `{claim-id}` matches the current active claim).
-Reset to full-branch diff after a rebase, multi-fix batch, when the
-baseline SHA is not an ancestor of the current HEAD, or whenever the
-active `{claim-id}` changed due to restart or takeover. List A is
+head SHA (tracked via `<!-- review-baseline: … -->` PR comments — post
+a new one after each E2 run; use the latest comment with that prefix
+whose embedded `{claim-id}` matches the current active claim). Reset to
+full-branch diff after a rebase, multi-fix batch, when the baseline SHA
+is not an ancestor of the current HEAD, or whenever the active
+`{claim-id}` changed due to restart or takeover. List A is
 session-local; do not inherit a previous claim's critique findings
 unless they were persisted as reviewer-visible comments.
 
-After the critique pass completes, post a new
-`<!-- review-baseline: {agent-id} {claim-id} {SHA} -->` comment with the
-current HEAD SHA. As with the watermark, post using the GitHub REST API
-directly (the body consists entirely of an HTML comment).
+After the critique pass completes, post a new `review-baseline` comment
+with the current HEAD SHA using this format:
+
+```markdown
+<!-- review-baseline: {agent-id} {claim-id} {SHA} -->
+
+_{agent-id}: critique baseline — IDD automation marker. Do not edit._
+```
+
+Use the PR body's language for the visible note (same rule as the
+watermark). Example Japanese note:
+`_{agent-id}: クリティークのベースライン — IDD 自動化マーカー。編集しないでください。_`
+
+Post using the GitHub REST API directly (the body begins with an HTML
+comment token; use the HTTP `POST` path for reliability).
 
 ## E3 — Empty list check
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -12,13 +12,18 @@ Post this HTML comment to an issue to claim it or take it over:
 <!-- claimed-by: {agent-id} {claim-id} supersedes: {prior-claim-id|none} {ISO8601-timestamp} branch: {branch-name} -->
 ```
 
-**Important**: all operational comments (`claimed-by`, `unclaimed-by`,
-`review-watermark`, `review-baseline`) consist entirely of HTML
-comments. Some GitHub client tools (e.g., `gh issue comment`,
-`gh api -f body=`) silently reject such bodies. Always post these using
-a direct HTTP `POST` with a JSON body (e.g., `curl` with
-`-H "Content-Type: application/json"` and
+**Important**: the machine-readable token in every operational comment
+(`claimed-by`, `unclaimed-by`, `review-watermark`, `review-baseline`)
+is an HTML comment. Some GitHub client tools (e.g., `gh issue comment`,
+`gh api -f body=`) silently reject bodies that consist entirely of HTML
+comments. Always post these using a direct HTTP `POST` with a JSON body
+(e.g., `curl` with `-H "Content-Type: application/json"` and
 `-d '{"body":"<!-- ... -->"}'`).
+
+`review-watermark` and `review-baseline` comments must additionally
+include a short visible note after the HTML comment token (see
+`idd-review-triage.instructions.md` for the required format). `claimed-by`
+and `unclaimed-by` comments remain HTML-comment-only.
 
 - `{claim-id}` is an opaque unique token for one active claim lineage.
   Generate a fresh value on every fresh claim or takeover. Reuse the
@@ -184,10 +189,11 @@ without session context can understand the current state and continue
 correctly. Do not rely on session memory alone for information that
 another agent may need.
 
-Operational restore markers (for example `review-watermark` and
-`review-baseline`) must include the current `{claim-id}` and must never
-be restored across a claim change. A takeover starts a new restore
-scope.
+Operational restore markers (`review-watermark` and `review-baseline`)
+must include the current `{claim-id}` and must never be restored across
+a claim change. A takeover starts a new restore scope. These markers
+must also include a visible human-readable note (see
+`idd-review-triage.instructions.md`).
 
 ## Review item classes
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -84,7 +84,7 @@ reject bodies that consist entirely of HTML comments; this format
 includes visible text so that is not an issue, but the HTTP `POST` path
 is still recommended for reliability (`curl` with
 `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->\n\n_note_"}}'`).
+`-d '{"body":"<!-- ... -->\n\n_note_"}'`).
 
 On resume or restart, read the latest
 `<!-- review-watermark:

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -51,11 +51,19 @@ start of Step 1, compute `{max-activity-updatedAt}` as the highest
 the items that will appear in List A). Write `none` if the snapshot is
 empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
-hidden PR comment:
+PR comment with this format:
 
-```html
+```markdown
 <!-- review-watermark: {agent-id} {claim-id} {head-SHA} {max-activity-updatedAt|none} {total-item-count} {latest-ci-completed-at|none} -->
+
+_{agent-id}: review triage snapshot — IDD automation marker. Do not edit._
 ```
+
+The HTML comment is the machine-readable token; the italic line is a
+visible note for human readers. Detect the language of the PR body and
+write the visible note in that language (default to English if
+ambiguous). Example Japanese note:
+`_{agent-id}: レビュートリアージのスナップショット — IDD 自動化マーカー。編集しないでください。_`
 
 - **`{head-SHA}`**: the value read at the very start of Step 1, before
   any fetching. F2 uses this to detect pushes that occurred between E1's
@@ -70,11 +78,13 @@ hidden PR comment:
 
 Use server-reported timestamps, not the local wall clock.
 
-Note: the watermark comment body consists entirely of an HTML comment.
-Some GitHub client tools (e.g., `gh issue comment`, `gh api -f body=`)
-silently reject such bodies. Post using a direct HTTP `POST` with a JSON
-body (e.g., `curl` with `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->"}'`).
+Note: the comment body begins with an HTML comment token. Some GitHub
+client tools (e.g., `gh issue comment`, `gh api -f body=`) silently
+reject bodies that consist entirely of HTML comments; this format
+includes visible text so that is not an issue, but the HTTP `POST` path
+is still recommended for reliability (`curl` with
+`-H "Content-Type: application/json"` and
+`-d '{"body":"<!-- ... -->\n\n_note_"}}'`).
 
 On resume or restart, read the latest
 `<!-- review-watermark:
@@ -117,20 +127,30 @@ implementation.
 
 **Incremental review**: on the second and later passes **within the same
 claim**, scope the review to the diff since the previous E2 execution's
-head SHA (tracked via
-`<!-- review-baseline: {agent-id} {claim-id} {SHA} -->` PR comments —
-post a new one after each E2 run; use the latest comment with that
-prefix whose embedded `{claim-id}` matches the current active claim).
-Reset to full-branch diff after a rebase, multi-fix batch, when the
-baseline SHA is not an ancestor of the current HEAD, or whenever the
-active `{claim-id}` changed due to restart or takeover. List A is
+head SHA (tracked via `<!-- review-baseline: … -->` PR comments — post
+a new one after each E2 run; use the latest comment with that prefix
+whose embedded `{claim-id}` matches the current active claim). Reset to
+full-branch diff after a rebase, multi-fix batch, when the baseline SHA
+is not an ancestor of the current HEAD, or whenever the active
+`{claim-id}` changed due to restart or takeover. List A is
 session-local; do not inherit a previous claim's critique findings
 unless they were persisted as reviewer-visible comments.
 
-After the critique pass completes, post a new
-`<!-- review-baseline: {agent-id} {claim-id} {SHA} -->` comment with the
-current HEAD SHA. As with the watermark, post using the GitHub REST API
-directly (the body consists entirely of an HTML comment).
+After the critique pass completes, post a new `review-baseline` comment
+with the current HEAD SHA using this format:
+
+```markdown
+<!-- review-baseline: {agent-id} {claim-id} {SHA} -->
+
+_{agent-id}: critique baseline — IDD automation marker. Do not edit._
+```
+
+Use the PR body's language for the visible note (same rule as the
+watermark). Example Japanese note:
+`_{agent-id}: クリティークのベースライン — IDD 自動化マーカー。編集しないでください。_`
+
+Post using the GitHub REST API directly (the body begins with an HTML
+comment token; use the HTTP `POST` path for reliability).
 
 ## E3 — Empty list check
 


### PR DESCRIPTION
## Summary

- `review-watermark` and `review-baseline` PR comments previously consisted entirely of HTML comments, appearing as blank/empty comments to human readers
- Both markers now include a short visible italic note after the HTML token, identifying the posting agent and explaining the marker's purpose
- Agents detect the PR body's language and write the note in that language (English default; Japanese example included)
- `claimed-by` and `unclaimed-by` remain HTML-comment-only (they are issue comments, not PR comments, and are typically seen only in the context of claim management)

## Files changed

- `.github/instructions/idd-overview.instructions.md` — updated "Important" note and restore marker paragraph
- `.github/instructions/idd-review-triage.instructions.md` — updated E1 Step 2 watermark format and E2 baseline format
- Template sync for both files under `idd-template/`

## Test plan

- [ ] `review-watermark` format shows HTML comment + visible note
- [ ] `review-baseline` format shows HTML comment + visible note
- [ ] E1 Step 1 exclusion filter (`<!-- review-watermark:` prefix) still matches the new format (prefix unchanged)
- [ ] All four files pass dprint + markdownlint + cspell

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified operational marker requirements: review-watermark and review-baseline comments must include a visible human-readable note and the current claim ID, and must not be restored across claim changes.
  * Recommended using direct HTTP JSON POST for posting markers to avoid client/tools rejecting HTML-comment-only bodies.
  * Expanded E-phase triage guidance on marker persistence and baseline SHA tracking across restarts and claim changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->