### PR TITLE
docs(readme): localize quick-start prompts

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,16 +29,14 @@ https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOAR
 
 **短縮形** (WebFetch または `gh` CLI アクセスを持つエージェント向け):
 
-> - `github:kurone-kito/idd-skill` の IDD をこのリポジトリにインポート＆オンボーディングして
-> - Import and onboard `github:kurone-kito/idd-skill`'s IDD into this
->   repository.
+> `github:kurone-kito/idd-skill` の IDD をこのリポジトリに
+> インポート＆オンボーディングして
 
 **明示形** (すべてのエージェントで動作):
 
-> I want to use `github:idd-skill`'s Issue-Driven Development in this
-> repository. Read
-> `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md`
-> and onboard me.
+> `github:idd-skill` の Issue-Driven Development をこの
+> リポジトリで使いたいです。`https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md`
+> を読んでオンボーディングしてください。
 
 エージェントはいくつかのプロジェクト固有の値 (リポジトリ名、バリデーション
 コマンド) を収集し、IDD ワークフロー全体を自動的に設定します —

--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ the following:
 
 **Short form** (agents with WebFetch or `gh` CLI access):
 
-> - `github:kurone-kito/idd-skill` の IDD をこのリポジトリにインポート＆オンボーディングして
-> - Import and onboard `github:kurone-kito/idd-skill`'s IDD into this
->   repository.
+> Import and onboard `github:kurone-kito/idd-skill`'s IDD into this
+> repository.
 
 **Explicit form** (works with any agent):
 


### PR DESCRIPTION
## Summary
- make the English README quick-start section English-only for both prompt forms
- make the Japanese README quick-start section Japanese-only for both prompt forms
- keep the trigger phrase semantics and onboarding URL unchanged while improving copy-paste ergonomics

Closes #39

## Recommended follow-up
- none

## Background
- now that the repository has split English and Japanese READMEs, each page should let readers copy prompts in the language of that page without mixed-language prompt blocks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick start section in English README with improved guidance.
  * Updated Quick start section in Japanese README with reformatted multi-line instructions for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->