### PR TITLE
refactor: extract Copilot advisory-wait protocol into shared helper file

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -1,0 +1,110 @@
+# IDD — Copilot Advisory-Wait Protocol
+
+This file defines the shared commands and decision rules for the Copilot
+advisory-wait check. It is referenced by:
+
+- **E14** (`idd-review-fix.instructions.md`): request a Copilot
+  re-review and wait for the advisory window
+- **F2** (`idd-merge.instructions.md`): gate check before allowing merge
+- **F3** (`idd-merge.instructions.md`): final revalidation immediately
+  before executing the merge command
+
+Callers are responsible for fetching `PR_HEAD_SHA` before invoking these
+steps and for defining their own routing on each outcome.
+
+## AW1 — Fetch Copilot review state
+
+```sh
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+LAST_COPILOT_COMMIT=$(
+  gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
+    --paginate \
+    --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
+               {sa: .submitted_at, cid: .commit_id}' \
+  | jq -rs 'sort_by(.sa) | last | .cid // ""'
+)
+# If LAST_COPILOT_COMMIT == PR_HEAD_SHA → Copilot has reviewed the current HEAD.
+
+COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
+  --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
+# "true" → review still pending; "false" → submitted or cancelled.
+# GitHub uses "Copilot" (capital C) in requested_reviewers and
+# "copilot-pull-request-reviewer[bot]" in the reviews API — both matched here.
+```
+
+If `LAST_COPILOT_COMMIT == PR_HEAD_SHA` → outcome is **SATISFIED**.
+Caller proceeds to its designated next step without running AW2–AW3.
+
+## AW2 — Fetch advisory-wait markers
+
+```sh
+EARLIEST_SAME_HEAD_AT=$(
+  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
+    | jq -r -s "add
+         | [.[] | select(
+               (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
+               (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA} [^ ]+ -->$\"))
+             )]
+         | min_by(.created_at) | .created_at // \"\""
+)
+# Matches plain-text (current) and HTML-comment (legacy) marker formats.
+# Empty → no same-head marker exists.
+# Non-empty → earliest same-head marker createdAt (advisory-clock start).
+
+MARKER_COUNT=$(
+  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
+    | jq -r -s 'add | [.[] | select(.body | test("^advisory-wait:|^<!-- advisory-wait:"))] | length'
+)
+# Total advisory-wait markers for this PR (all HEADs). Used for the 30-per-PR cap.
+```
+
+Refresh `EARLIEST_SAME_HEAD_AT` at the start of each polling iteration —
+its value can change if a parallel session posted a new marker.
+
+Elapsed time = current UTC time − `EARLIEST_SAME_HEAD_AT` as returned by
+the GitHub API. Never use the timestamp inside the marker body.
+
+## AW3 — Decision table
+
+Evaluate in this order (the first matching row wins):
+
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Elapsed  | Outcome                                                           |
+| --------------------- | ----------------- | ------------------- | -------- | ----------------------------------------------------------------- |
+| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)    | **SATISFIED**                                                     |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **HOLD** (inconsistent)                                           |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | ≥ 30 min | **SATISFIED** (window expired)                                    |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | < 30 min | **WAIT**                                                          |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | ≥ 10 min | **SATISFIED**                                                     |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | < 10 min | **WAIT**                                                          |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | —        | cap ≥ 30: **HOLD** (cap exhausted); cap < 30: **REQUEST\_NEEDED** |
+
+Note: evaluate the 30-minute SATISFIED condition before the WAIT
+condition for the `COPILOT_PENDING="true"` rows — the elapsed ≥ 30 min
+case must not be masked by a still-pending state.
+
+## AW4 — Hold comment templates
+
+**Inconsistent state** (COPILOT_PENDING is true, no same-head marker):
+
+> Copilot review is pending for HEAD `{PR_HEAD_SHA}` but no
+> advisory-wait marker was found. E14 may have crashed before posting
+> the marker. A maintainer must verify whether the Copilot review was
+> formally requested and confirm its status before this step can safely
+> continue. Do not merge or post a new advisory-wait marker until the
+> maintainer has resolved this.
+
+**Cap exhausted** (no same-head marker, MARKER_COUNT ≥ 30):
+
+> The 30-per-PR Copilot re-review cap is exhausted. A maintainer must
+> manually request and evaluate a Copilot review before merge.
+
+## AW5 — Missing-marker recovery during active polling
+
+If `EARLIEST_SAME_HEAD_AT` is empty after a mid-poll refresh (marker
+deleted or never posted): post a hold comment and stop:
+
+> Advisory-wait marker for HEAD `{PR_HEAD_SHA}` is missing during
+> polling. Unable to compute elapsed time. A maintainer must verify the
+> Copilot advisory-wait state before this phase can safely continue.

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -70,19 +70,34 @@ the GitHub API. Never use the timestamp inside the marker body.
 
 Evaluate in this order (the first matching row wins):
 
-| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Elapsed  | Outcome                                                           |
-| --------------------- | ----------------- | ------------------- | -------- | ----------------------------------------------------------------- |
-| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)    | **SATISFIED**                                                     |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **HOLD** (inconsistent)                                           |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | ≥ 30 min | **SATISFIED** (window expired)                                    |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | < 30 min | **WAIT**                                                          |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | ≥ 10 min | **SATISFIED**                                                     |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | < 10 min | **WAIT**                                                          |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | —        | cap ≥ 30: **HOLD** (cap exhausted); cap < 30: **REQUEST\_NEEDED** |
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Elapsed  | Outcome                                                     |
+| --------------------- | ----------------- | ------------------- | -------- | ----------------------------------------------------------- |
+| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)    | **SATISFIED**                                               |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **HOLD** (inconsistent)                                     |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | ≥ 30 min | **SATISFIED** (window expired)                              |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | < 30 min | **WAIT**                                                    |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | ≥ 10 min | **SATISFIED**                                               |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | < 10 min | **WAIT**                                                    |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | —        | cap ≥ 30: **CAP\_EXHAUSTED**; cap < 30: **REQUEST\_NEEDED** |
 
 Note: evaluate the 30-minute SATISFIED condition before the WAIT
 condition for the `COPILOT_PENDING="true"` rows — the elapsed ≥ 30 min
 case must not be masked by a still-pending state.
+
+Callers handle outcomes differently:
+
+| Outcome         | E14                                | F2                                   | F3                           |
+| --------------- | ---------------------------------- | ------------------------------------ | ---------------------------- |
+| SATISFIED       | proceed to E15                     | continue to CI check                 | proceed with merge           |
+| HOLD            | post AW4 comment; stop             | post AW4 comment; stop               | post AW4 comment; stop       |
+| CAP\_EXHAUSTED  | skip advisory wait; proceed to E15 | post AW4 cap-exhausted comment; stop | not applicable (see F3 note) |
+| REQUEST\_NEEDED | request Copilot, post marker, poll | return to E14                        | not applicable (see F3 note) |
+| WAIT            | continue polling (active loop)     | poll F2 conditions every 2 min       | return to F2                 |
+
+**F3 note**: F3 only invokes AW3 when `COPILOT_PENDING` is `"true"` AND
+`LAST_COPILOT_COMMIT != PR_HEAD_SHA`. If `COPILOT_PENDING` is `"false"`,
+F3 treats the advisory check as satisfied without running AW2–AW3 — see
+the F3 caller instructions.
 
 ## AW4 — Hold comment templates
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -69,117 +69,32 @@ bracketed action:
     `{latest-ci-completed-at}` in the watermark (a new CI run completed
     after E1's snapshot; if watermark value is `none`, any current CI
     pass triggers re-evaluation).
-- **Advisory bot wait** (restart-safe enforcement): Use the following
-  commands to check the Copilot review state and `requested_reviewers`.
-  Run these at the start of this check and again during any polling
-  loop:
+- **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
+  already available from the review-currency check above. Apply the
+  advisory-wait protocol (`idd-advisory-wait.instructions.md`):
 
-  ```sh
-  # Fetch the current PR HEAD SHA from GitHub (authoritative source).
-  PR_HEAD_SHA=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
+  1. Run **AW1**. If **SATISFIED** → this check is **satisfied**;
+     continue to the **CI** check.
+  2. Run **AW2** to fetch markers.
+  3. Apply the **AW3** decision table:
+     - **SATISFIED** → this check is **satisfied**; continue to the CI
+       check.
+     - **HOLD** → post the hold comment from **AW4** and stop.
+     - **REQUEST_NEEDED** → return to E14 to request Copilot review and
+       post a fresh marker. Do not post a new request in F2.
+     - **WAIT** (`COPILOT_PENDING` is `"true"`, elapsed < 30 min) →
+       wait for the remainder of the applicable window (poll every 2
+       min), refreshing `EARLIEST_SAME_HEAD_AT` per **AW2** at each
+       iteration and applying **AW5** if the marker disappears. Then
+       **go back to the first condition in F2** (the 'Review currency'
+       check) to re-evaluate all conditions.
+     - **WAIT** (`COPILOT_PENDING` is `"false"`, elapsed < 10 min) →
+       wait for the remainder of the 10-minute window (same polling
+       rules). Then **go back to the first condition in F2**.
 
-  # Check if Copilot has reviewed the current HEAD SHA.
-  OWNER=$(gh repo view --json owner --jq '.owner.login')
-  REPO=$(gh repo view --json name --jq '.name')
-  LAST_COPILOT_COMMIT=$(
-    gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
-      --paginate \
-      --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
-                  {sa: .submitted_at, cid: .commit_id}' \
-    | jq -rs 'sort_by(.sa) | last | .cid // ""'
-  )
-  # If LAST_COPILOT_COMMIT == PR_HEAD_SHA → Copilot reviewed the current HEAD.
-
-  # Check whether Copilot's review is still pending.
-  COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-    --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
-  # "true" → Copilot is in requested_reviewers (review still pending);
-  # "false" → review was submitted or the request was cancelled.
-  # Note: GitHub uses "Copilot" (capital C) in the requested_reviewers API
-  # and "copilot-pull-request-reviewer[bot]" in the reviews API — both are
-  # matched here for robustness.
-  ```
-
-  If `LAST_COPILOT_COMMIT == PR_HEAD_SHA` (Copilot has reviewed the
-  current HEAD): this check is **satisfied**.
-
-  Otherwise (Copilot has not reviewed current HEAD): collect all
-  `advisory-wait: {any-agent-id} {head-SHA} …` comments from any IDD
-  agent whose `{head-SHA}` matches the current PR HEAD. Use the one with
-  the **earliest** `createdAt` for elapsed time calculation (the
-  advisory clock starts at the first request, not the last). Use these
-  commands to fetch and time the markers:
-
-  ```sh
-  # Fetch same-head advisory-wait markers and find the earliest createdAt.
-  # Match by body format; any IDD agent / prior session may have posted the marker.
-  EARLIEST_SAME_HEAD_AT=$(
-    gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-      | jq -r -s "add
-           | [.[] | select(
-                 (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
-                 (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA} [^ ]+ -->$\"))
-               )]
-           | min_by(.created_at) | .created_at // \"\""
-  )
-  # Matches both plain-text (new) and HTML-comment (legacy) marker formats.
-  # If empty → no same-head marker exists.
-  # If non-empty → earliest same-head marker createdAt (advisory-clock start).
-
-  # Count total advisory-wait markers across all HEADs (for the 30-per-PR cap):
-  MARKER_COUNT=$(
-    gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-      | jq -r -s 'add | [.[] | select(.body | test("^advisory-wait:|^<!-- advisory-wait:"))] | length'
-  )
-  # Matches both plain-text (new) and HTML-comment (legacy) marker formats.
-  # If MARKER_COUNT >= 30 → cap exhausted (see Branch B no-marker case).
-  ```
-
-  Then branch on `COPILOT_PENDING`:
-
-  **Branch A — `COPILOT_PENDING` is `"true"` (review actively
-  pending)**:
-  - No marker exists for current HEAD → this is an inconsistent state.
-    Post a hold comment: "Copilot review is pending for HEAD
-    `{PR_HEAD_SHA}` but no advisory-wait marker was found. E14 may have
-    crashed before posting the marker. A maintainer must verify whether
-    the Copilot review was formally requested and confirm its status
-    before the merge can proceed. Do not merge or post a new
-    advisory-wait marker until the maintainer has resolved this."
-    **Stop.**
-  - Marker exists; elapsed < 10 min: wait for the remainder of the
-    10-minute window (poll every 2 min), then **go back to the first
-    condition in F2 (the 'Review currency' check)** to pick up any
-    activity that arrived during the wait.
-  - Marker exists; elapsed 10–30 min: **go back to the first condition
-    in F2 (the 'Review currency' check) every 2 minutes**. F2 will
-    re-evaluate all conditions including new review activity; if
-    `COPILOT_PENDING` is still `"true"`, it will re-enter this branch.
-  - Marker exists; elapsed ≥ 30 min: this advisory-bot-wait check is
-    **satisfied**. The advisory window has expired. Continue to the next
-    F2 gate (the **CI** check).
-
-  **Branch B — `COPILOT_PENDING` is `"false"` (request completed or
-  manually cancelled)**: GitHub removes a reviewer from
-  `requested_reviewers` when they submit a review OR when the request is
-  manually cancelled by the PR author. Either outcome counts as "no
-  longer pending" for merge purposes — the advisory wait is treated as
-  honored once the pending state is cleared.
-  - Marker exists; elapsed ≥ 10 min: this check is **satisfied**.
-  - Marker exists; elapsed < 10 min: wait for the remainder of the
-    10-minute window (poll every 2 min), then **go back to the first
-    condition in F2** to re-evaluate.
-  - No marker exists: use `MARKER_COUNT` (computed above). If
-    `MARKER_COUNT` ≥ 30 → post hold comment: "The 30-per-PR Copilot
-    re-review cap is exhausted. A maintainer must manually request and
-    evaluate a Copilot review before merge." **Stop.** If `MARKER_COUNT`
-    < 30 → return to E14 to request Copilot review and post a fresh
-    marker.
-
-  'Elapsed time' means the current UTC time minus the `createdAt` of the
-  **earliest** same-head advisory-wait PR comment
-  (`EARLIEST_SAME_HEAD_AT`, computed above) as returned by the GitHub
-  API — not the timestamp inside the marker body.
+  GitHub removes a reviewer from `requested_reviewers` when they submit
+  a review OR when the request is manually cancelled — either counts as
+  no longer pending for merge purposes.
 - **CI**: Current PR head SHA has all required CI checks generated and
   all passing (→ run CI wait per `idd-ci.instructions.md`, on-success →
   re-evaluate F2)
@@ -273,71 +188,23 @@ three values into F3.
    the active claim still uses your current `{claim-id}`. If it does
    not, the claim was lost — report and stop.
 
-   **Advisory state revalidation (blocking)**: fetch fresh state from
-   GitHub with these commands:
+   **Advisory state revalidation (blocking)**: re-fetch the HEAD SHA:
 
    ```sh
-   PR_HEAD_SHA_F3=$(gh pr view {pr-number} --json headRefOid \
-     --jq '.headRefOid')
-   OWNER=$(gh repo view --json owner --jq '.owner.login')
-   REPO=$(gh repo view --json name --jq '.name')
-   LAST_COPILOT_COMMIT_F3=$(
-     gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
-       --paginate \
-       --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
-                   {sa: .submitted_at, cid: .commit_id}' \
-     | jq -rs 'sort_by(.sa) | last | .cid // ""'
-   )
-   COPILOT_PENDING_F3=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-     --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
-   # Note: GitHub uses "Copilot" (capital C) in requested_reviewers and
-   # "copilot-pull-request-reviewer[bot]" in the reviews API — both matched
-   # here for robustness.
+   PR_HEAD_SHA_F3=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
    ```
 
-   If `COPILOT_PENDING_F3` is `"true"` AND
-   `LAST_COPILOT_COMMIT_F3 != PR_HEAD_SHA_F3` (Copilot has not reviewed
-   the current HEAD), fetch the same-head advisory-wait markers to
-   compute elapsed time. Use these commands — do not skip this step even
-   if F2 already computed the value, because F3 is a blocking gate that
-   must be self-contained:
+   Use `PR_HEAD_SHA_F3` as `PR_HEAD_SHA` for the protocol steps. Run
+   **AW1** and **AW2** (`idd-advisory-wait.instructions.md`) — do not
+   skip this even if F2 already ran them; F3 is a self-contained blocking
+   gate. Then apply **AW3**:
 
-   ```sh
-   EARLIEST_SAME_HEAD_AT_F3=$(
-     gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-       | jq -r -s "add
-            | [.[] | select(
-                  (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA_F3}(?: |\$)\")) or
-                  (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA_F3} [^ ]+ -->$\"))
-                )]
-            | min_by(.created_at) | .created_at // \"\""
-   )
-   # Matches both plain-text (new) and HTML-comment (legacy) marker formats.
-   # If empty → no same-head marker; if non-empty → earliest marker createdAt.
-   ```
+   - **SATISFIED** → proceed with the merge.
+   - **HOLD** → post the hold comment from **AW4** and stop.
+   - **WAIT** → Do NOT execute the merge. Return to the **F2 advisory
+     bot wait check** (go back to the first condition in F2). F2 will
+     reuse the existing same-HEAD marker — do not post a new one.
 
-   Then branch on the marker state:
-
-   - **No same-head marker (`EARLIEST_SAME_HEAD_AT_F3` is empty)**: this
-     is an inconsistent state — Copilot is pending but no advisory-wait
-     marker was ever posted for this HEAD. Do NOT execute the merge.
-     Post a hold comment: "Copilot review is pending for HEAD
-     `{PR_HEAD_SHA_F3}` but no advisory-wait marker was found. E14 may
-     have crashed before posting the marker. A maintainer must verify
-     whether the Copilot review was formally requested and confirm its
-     status before the merge can proceed. Do not merge or post a new
-     advisory-wait marker until the maintainer has resolved this."
-     **Stop.**
-   - **Marker exists; elapsed ≥ 30 minutes** (current UTC −
-     `EARLIEST_SAME_HEAD_AT_F3` ≥ 30 min): the advisory window has
-     already expired — this check is **satisfied**, proceed with the
-     merge.
-   - **Marker exists; elapsed < 30 minutes** (current UTC −
-     `EARLIEST_SAME_HEAD_AT_F3` < 30 min): a review is actively pending
-     within the window. Do NOT execute the merge. Return to the **F2
-     Advisory bot wait check** (go back to the first condition in F2).
-     F2 will reuse the existing same-HEAD advisory-wait marker — do not
-     post a new marker.
 3. Merge the PR using a **merge commit**, binding to the validated SHA
    to prevent a race where a new push lands after the F3 freshness check
    but before the merge executes:

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -194,16 +194,20 @@ three values into F3.
    PR_HEAD_SHA_F3=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
    ```
 
-   Use `PR_HEAD_SHA_F3` as `PR_HEAD_SHA` for the protocol steps. Run
-   **AW1** and **AW2** (`idd-advisory-wait.instructions.md`) — do not
-   skip this even if F2 already ran them; F3 is a self-contained blocking
-   gate. Then apply **AW3**:
-
-   - **SATISFIED** → proceed with the merge.
-   - **HOLD** → post the hold comment from **AW4** and stop.
-   - **WAIT** → Do NOT execute the merge. Return to the **F2 advisory
-     bot wait check** (go back to the first condition in F2). F2 will
-     reuse the existing same-HEAD marker — do not post a new one.
+   Use `PR_HEAD_SHA_F3` as `PR_HEAD_SHA`. Run **AW1**
+   (`idd-advisory-wait.instructions.md`):
+   - If **SATISFIED** (`LAST_COPILOT_COMMIT == PR_HEAD_SHA_F3`) →
+     proceed with the merge.
+   - If `COPILOT_PENDING` is `"false"` (review completed or cancelled) →
+     this check is satisfied; proceed with the merge.
+   - Otherwise (`COPILOT_PENDING` is `"true"`, not yet reviewed): run
+     **AW2** and apply **AW3** — do not skip even if F2 ran them already,
+     as F3 is a self-contained blocking gate:
+     - **SATISFIED** → proceed with the merge.
+     - **HOLD** → post the hold comment from **AW4** and stop.
+     - **WAIT** → Do NOT execute the merge. Return to the **F2 advisory
+       bot wait check** (go back to the first condition in F2). F2 will
+       reuse the existing same-HEAD marker — do not post a new one.
 
 3. Merge the PR using a **merge commit**, binding to the validated SHA
    to prevent a race where a new push lands after the F3 freshness check

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -263,6 +263,11 @@ file that matches your current situation.
 CI polling logic shared by D and E phases lives in
 `idd-ci.instructions.md`; callers declare their own on-success target.
 
+The Copilot advisory-wait protocol (commands, decision table, hold
+comment templates) is defined once in `idd-advisory-wait.instructions.md`
+and referenced by E14 (review-fix) and F2/F3 (merge). Do not duplicate
+these commands in caller files.
+
 ## Critique pass
 
 A **critique pass** is an independent review of a plan or diff that

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -89,6 +89,8 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
 4. Apply the **AW3** decision table:
    - **SATISFIED** → proceed to E15.
    - **HOLD** → post the hold comment from **AW4** and stop.
+   - **CAP_EXHAUSTED** (`MARKER_COUNT` ≥ 30, no same-head marker) →
+     skip the advisory wait entirely; proceed directly to E15.
    - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, cap < 30):
      request Copilot review and immediately post a plain-text marker:
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -77,184 +77,76 @@ request a Copilot re-review if Copilot has not yet reviewed the current
 HEAD SHA. Subject to a **workflow cap of 30 Copilot re-review requests
 per PR** (this is a process limit, not a GitHub-enforced constraint).
 
-Use these commands to check and request:
+1. Fetch `PR_HEAD_SHA`:
 
-```sh
-# Step 1: Fetch the current PR HEAD SHA from GitHub (authoritative source).
-PR_HEAD_SHA=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
+   ```sh
+   PR_HEAD_SHA=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
+   ```
 
-# Step 2: Check if Copilot has reviewed the current HEAD SHA.
-OWNER=$(gh repo view --json owner --jq '.owner.login')
-REPO=$(gh repo view --json name --jq '.name')
-LAST_COPILOT_COMMIT=$(
-  gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
-    --paginate \
-    --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
-               {sa: .submitted_at, cid: .commit_id}' \
-  | jq -rs 'sort_by(.sa) | last | .cid // ""'
-)
-# If LAST_COPILOT_COMMIT == PR_HEAD_SHA → Copilot already reviewed this HEAD;
-# skip request and marker. E14 Copilot processing is done.
+2. Run **AW1** (`idd-advisory-wait.instructions.md`). If **SATISFIED** →
+   E14 Copilot processing is done; proceed to E15.
+3. Run **AW2** to fetch markers.
+4. Apply the **AW3** decision table:
+   - **SATISFIED** → proceed to E15.
+   - **HOLD** → post the hold comment from **AW4** and stop.
+   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, cap < 30):
+     request Copilot review and immediately post a plain-text marker:
 
-# Step 3: Check if Copilot review is already pending.
-COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-  --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
-# "true" → Copilot is in requested_reviewers (review still pending);
-# "false" → review was submitted or the request was cancelled.
-# Note: GitHub uses "Copilot" (capital C) in the requested_reviewers API
-# and "copilot-pull-request-reviewer[bot]" in the reviews API — both are
-# matched here for robustness.
+     ```sh
+     gh pr edit {pr-number} --add-reviewer "@copilot"
+     ```
 
-# Step 4a: If COPILOT_PENDING is "true" — do NOT request again (avoids
-# resetting the advisory-wait clock). Use these commands to detect
-# whether a same-head advisory-wait marker exists and find the earliest.
-# Match by body format only (any IDD agent / prior session may have posted it).
-EARLIEST_SAME_HEAD_AT=$(
-  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-    | jq -r -s "add
-         | [.[] | select(
-               (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
-               (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA} [^ ]+ -->$\"))
-             )]
-         | min_by(.created_at) | .created_at // \"\""
-)
-# Matches both plain-text (new) and HTML-comment (legacy) marker formats.
-# If EARLIEST_SAME_HEAD_AT is empty → no same-head marker exists (see below).
-# If EARLIEST_SAME_HEAD_AT is non-empty → marker exists; value is the
-# earliest marker createdAt (use for all elapsed-time checks).
-#   - Marker exists: do NOT post a new marker. Skip to the polling
-#     section below; use EARLIEST_SAME_HEAD_AT as the advisory-clock start.
-#   - No marker exists: this is an inconsistent state (Copilot is
-#     pending but no marker was ever posted for this HEAD). Post a hold
-#     comment: "Copilot review is pending for HEAD {PR_HEAD_SHA} but no
-#     advisory-wait marker was found. E14 may have crashed before posting
-#     the marker. A maintainer must verify whether the Copilot review was
-#     formally requested and confirm its status before E14 can safely
-#     continue." **Stop.**
+     ```text
+     advisory-wait: {agent-id} {head-SHA} {ISO8601-requested-at}
+     ```
 
-# Step 4b: If COPILOT_PENDING is "false" — check the cap before requesting.
-# Count total advisory-wait markers for the 30-per-PR cap (all agents):
-MARKER_COUNT=$(
-  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-    | jq -r -s 'add | [.[] | select(.body | test("^advisory-wait:|^<!-- advisory-wait:"))] | length'
-)
-# Each marker represents one --add-reviewer "@copilot" request.
-# If MARKER_COUNT >= 30 → do NOT request; skip the advisory wait entirely
-#   and proceed directly to E15.
-# If MARKER_COUNT < 30 → request Copilot review:
-gh pr edit {pr-number} --add-reviewer "@copilot"
-```
+     Use `PR_HEAD_SHA` as `{head-SHA}`. Post as plain text, not an HTML
+     comment block.
+   - **WAIT**, or after **REQUEST_NEEDED** marker is posted: enter the
+     active polling loop below.
 
-- Copilot and CI advisory bot comments are advisory; unanswered ones do
-  not block merge.
+Copilot and CI advisory bot comments are advisory; unanswered ones do
+not block merge.
 
-**Waiting for advisory bot re-reviews**: this section applies only when
-Step 4b ran (`COPILOT_PENDING` was `"false"` and the request was sent),
-or when Step 4a ran (`COPILOT_PENDING` was `"true"` and a same-head
-marker was found). **If `LAST_COPILOT_COMMIT == PR_HEAD_SHA` (Copilot
-already reviewed the current HEAD at Step 2), skip this entire section —
-E14 Copilot processing is complete.**
+**Active polling loop** (applies when `COPILOT_PENDING` is `"true"`, or
+immediately after a new request was sent above):
 
-For the Step 4b case (request just sent): persist the advisory wait
-start time by posting a plain-text marker comment:
+Do **not** post a new marker if a same-head marker already exists; reuse
+it. If multiple same-head markers exist, always use the one with the
+**earliest** `createdAt` — the advisory clock starts at the first
+request, not the last.
 
-```text
-advisory-wait: {agent-id} {head-SHA} {ISO8601-requested-at}
-```
-
-**Important**: post this as plain text, not as an HTML comment block.
-Use `PR_HEAD_SHA` as the `{head-SHA}` value so F2 and resume logic can
-distinguish waits for different pushes.
-
-For the Step 4a case (pending, marker already exists): do **not** post a
-new marker; reuse the existing same-head advisory-wait markers. If
-multiple same-head markers exist, use the one with the **earliest**
-`createdAt` (the advisory clock starts at the first request, not the
-last).
-
-For both Step 4b and Step 4a (marker-exists) cases: take a fresh
-snapshot of the activity universe (same scope as E1 Step 1: all threads,
+Take a fresh activity snapshot (same scope as E1 Step 1: all threads,
 review bodies, and regular comments, excluding agent operational
-markers). Record the highest `updatedAt` across all fetched items —
-including your own recent actions — as the **temporary polling
-watermark**. Do **not** post this as a `<!-- review-watermark -->` PR
-comment; it is ephemeral. (If the snapshot is empty, use the `createdAt`
-of the latest `<!-- review-watermark: {agent-id} {claim-id} … -->`
-comment whose embedded `{claim-id}` matches the current active claim. If
-no such same-claim watermark exists, stop waiting and return to E1 to
-create one — do not borrow another claim's watermark.) Then poll until
-an exit condition below is met:
+markers). Record the highest `updatedAt` as the **temporary polling
+watermark** — do **not** post it as a `<!-- review-watermark -->` PR
+comment. If the snapshot is empty, use the `createdAt` of the latest
+`<!-- review-watermark: {agent-id} {claim-id} … -->` comment whose
+`{claim-id}` matches the current active claim. If no same-claim
+watermark exists, stop and return to E1 to create one.
 
-- Poll every 2 minutes: at the start of each iteration, first re-fetch
-  `PR_HEAD_SHA` to detect if a push happened during the wait:
+Poll every 2 minutes:
 
-  ```sh
-  CURRENT_HEAD=$(gh pr view {pr-number} --json headRefOid \
-    --jq '.headRefOid')
-  # If CURRENT_HEAD != PR_HEAD_SHA → HEAD changed; a new push happened.
-  # Exit immediately to E1. A new advisory-wait marker will be needed
-  # for the new HEAD.
-  ```
+1. Re-fetch `PR_HEAD_SHA`:
 
-  If `CURRENT_HEAD != PR_HEAD_SHA` → stop waiting and return to E1. The
-  new HEAD must be re-evaluated; if Copilot has not reviewed it, E14/F2
-  will need a new advisory-wait marker for that HEAD.
+   ```sh
+   CURRENT_HEAD=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
+   ```
 
-  Otherwise read all review threads, review bodies, and regular PR
-  comments, **excluding any regular PR comment authored by any IDD
-  agent** (this covers advisory-wait, review-watermark, review-baseline,
-  claim, hold notes, and any other operational comments an agent may
-  post); compare `updatedAt` against the polling watermark. Also check
-  `requested_reviewers` (via REST API) to determine whether Copilot's
-  review is still pending:
+   If `CURRENT_HEAD != PR_HEAD_SHA` → HEAD changed; return to E1.
 
-  ```sh
-  COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-    --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
-  # "true" → review still pending; "false" → submitted or cancelled.
-  # Note: "Copilot" (capital C) is used in requested_reviewers; the OR
-  # condition also covers "copilot-pull-request-reviewer[bot]" for robustness.
-  ```
+2. Re-read review threads, review bodies, and regular PR comments,
+   **excluding any regular PR comment authored by any IDD agent** (covers
+   advisory-wait, review-watermark, review-baseline, claim, hold notes,
+   and other operational comments). If any item has `updatedAt` strictly
+   newer than the polling watermark → return to E1 immediately.
 
-  'Elapsed time' in all conditions below means the current UTC time
-  minus the `createdAt` of the **earliest** same-head advisory-wait PR
-  comment as returned by the GitHub API — not the timestamp inside the
-  marker body. If multiple same-head markers exist, always use the one
-  with the earliest `createdAt`. At the start of each poll iteration,
-  refresh the value with:
-
-  ```sh
-  EARLIEST_SAME_HEAD_AT=$(
-    gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-      | jq -r -s "add
-           | [.[] | select(
-                 (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
-                 (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA} [^ ]+ -->$\"))
-               )]
-           | min_by(.created_at) | .created_at // \"\""
-  )
-  # Matches both plain-text (new) and HTML-comment (legacy) marker formats.
-  # Elapsed time = (current UTC time) − EARLIEST_SAME_HEAD_AT.
-  ```
-
-  If `EARLIEST_SAME_HEAD_AT` is empty after this refresh (marker deleted
-  or never posted): post a hold comment: "Advisory-wait marker for HEAD
-  `{PR_HEAD_SHA}` is missing during polling. Unable to compute elapsed
-  time. A maintainer must verify the Copilot advisory-wait state before
-  E14 can safely continue." **Stop.**
-
-- If **any** item has `updatedAt` strictly newer than the polling
-  watermark → stop waiting and return to E1 immediately to process it.
-- If elapsed time ≥ 30 minutes (hard cap) → proceed to E15 regardless of
-  `COPILOT_PENDING`. The advisory window has expired. (Evaluate this
-  before the 10-minute conditions; otherwise the pending-true branch
-  below masks this exit for a Haiku-level reader.)
-- If elapsed time ≥ 10 minutes AND `COPILOT_PENDING` is `"false"` →
-  proceed to E15. (Copilot submitted the review or the request was
-  cancelled; either counts as no longer pending.)
-- If elapsed time ≥ 10 minutes AND `COPILOT_PENDING` is `"true"` →
-  **continue polling**. Do NOT exit to E15 while the review is still
-  pending.
+3. Run **AW1** and **AW2** (refresh `COPILOT_PENDING`, `LAST_COPILOT_COMMIT`,
+   and `EARLIEST_SAME_HEAD_AT`). Apply **AW5** if `EARLIEST_SAME_HEAD_AT`
+   is empty. Then apply **AW3**:
+   - **SATISFIED** → exit polling; proceed to E15.
+   - **HOLD** → post hold comment from **AW4** or **AW5**; stop.
+   - **WAIT** → continue polling.
 
 Note: "advisory" means the agent is not obligated to accept every
 suggestion — it does **not** mean the agent can skip waiting for a

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -1,0 +1,110 @@
+# IDD — Copilot Advisory-Wait Protocol
+
+This file defines the shared commands and decision rules for the Copilot
+advisory-wait check. It is referenced by:
+
+- **E14** (`idd-review-fix.instructions.md`): request a Copilot
+  re-review and wait for the advisory window
+- **F2** (`idd-merge.instructions.md`): gate check before allowing merge
+- **F3** (`idd-merge.instructions.md`): final revalidation immediately
+  before executing the merge command
+
+Callers are responsible for fetching `PR_HEAD_SHA` before invoking these
+steps and for defining their own routing on each outcome.
+
+## AW1 — Fetch Copilot review state
+
+```sh
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+LAST_COPILOT_COMMIT=$(
+  gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
+    --paginate \
+    --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
+               {sa: .submitted_at, cid: .commit_id}' \
+  | jq -rs 'sort_by(.sa) | last | .cid // ""'
+)
+# If LAST_COPILOT_COMMIT == PR_HEAD_SHA → Copilot has reviewed the current HEAD.
+
+COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
+  --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
+# "true" → review still pending; "false" → submitted or cancelled.
+# GitHub uses "Copilot" (capital C) in requested_reviewers and
+# "copilot-pull-request-reviewer[bot]" in the reviews API — both matched here.
+```
+
+If `LAST_COPILOT_COMMIT == PR_HEAD_SHA` → outcome is **SATISFIED**.
+Caller proceeds to its designated next step without running AW2–AW3.
+
+## AW2 — Fetch advisory-wait markers
+
+```sh
+EARLIEST_SAME_HEAD_AT=$(
+  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
+    | jq -r -s "add
+         | [.[] | select(
+               (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
+               (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA} [^ ]+ -->$\"))
+             )]
+         | min_by(.created_at) | .created_at // \"\""
+)
+# Matches plain-text (current) and HTML-comment (legacy) marker formats.
+# Empty → no same-head marker exists.
+# Non-empty → earliest same-head marker createdAt (advisory-clock start).
+
+MARKER_COUNT=$(
+  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
+    | jq -r -s 'add | [.[] | select(.body | test("^advisory-wait:|^<!-- advisory-wait:"))] | length'
+)
+# Total advisory-wait markers for this PR (all HEADs). Used for the 30-per-PR cap.
+```
+
+Refresh `EARLIEST_SAME_HEAD_AT` at the start of each polling iteration —
+its value can change if a parallel session posted a new marker.
+
+Elapsed time = current UTC time − `EARLIEST_SAME_HEAD_AT` as returned by
+the GitHub API. Never use the timestamp inside the marker body.
+
+## AW3 — Decision table
+
+Evaluate in this order (the first matching row wins):
+
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Elapsed  | Outcome                                                           |
+| --------------------- | ----------------- | ------------------- | -------- | ----------------------------------------------------------------- |
+| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)    | **SATISFIED**                                                     |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **HOLD** (inconsistent)                                           |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | ≥ 30 min | **SATISFIED** (window expired)                                    |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | < 30 min | **WAIT**                                                          |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | ≥ 10 min | **SATISFIED**                                                     |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | < 10 min | **WAIT**                                                          |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | —        | cap ≥ 30: **HOLD** (cap exhausted); cap < 30: **REQUEST\_NEEDED** |
+
+Note: evaluate the 30-minute SATISFIED condition before the WAIT
+condition for the `COPILOT_PENDING="true"` rows — the elapsed ≥ 30 min
+case must not be masked by a still-pending state.
+
+## AW4 — Hold comment templates
+
+**Inconsistent state** (COPILOT_PENDING is true, no same-head marker):
+
+> Copilot review is pending for HEAD `{PR_HEAD_SHA}` but no
+> advisory-wait marker was found. E14 may have crashed before posting
+> the marker. A maintainer must verify whether the Copilot review was
+> formally requested and confirm its status before this step can safely
+> continue. Do not merge or post a new advisory-wait marker until the
+> maintainer has resolved this.
+
+**Cap exhausted** (no same-head marker, MARKER_COUNT ≥ 30):
+
+> The 30-per-PR Copilot re-review cap is exhausted. A maintainer must
+> manually request and evaluate a Copilot review before merge.
+
+## AW5 — Missing-marker recovery during active polling
+
+If `EARLIEST_SAME_HEAD_AT` is empty after a mid-poll refresh (marker
+deleted or never posted): post a hold comment and stop:
+
+> Advisory-wait marker for HEAD `{PR_HEAD_SHA}` is missing during
+> polling. Unable to compute elapsed time. A maintainer must verify the
+> Copilot advisory-wait state before this phase can safely continue.

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -70,19 +70,34 @@ the GitHub API. Never use the timestamp inside the marker body.
 
 Evaluate in this order (the first matching row wins):
 
-| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Elapsed  | Outcome                                                           |
-| --------------------- | ----------------- | ------------------- | -------- | ----------------------------------------------------------------- |
-| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)    | **SATISFIED**                                                     |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **HOLD** (inconsistent)                                           |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | ≥ 30 min | **SATISFIED** (window expired)                                    |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | < 30 min | **WAIT**                                                          |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | ≥ 10 min | **SATISFIED**                                                     |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | < 10 min | **WAIT**                                                          |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | —        | cap ≥ 30: **HOLD** (cap exhausted); cap < 30: **REQUEST\_NEEDED** |
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Elapsed  | Outcome                                                     |
+| --------------------- | ----------------- | ------------------- | -------- | ----------------------------------------------------------- |
+| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)    | **SATISFIED**                                               |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **HOLD** (inconsistent)                                     |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | ≥ 30 min | **SATISFIED** (window expired)                              |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | < 30 min | **WAIT**                                                    |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | ≥ 10 min | **SATISFIED**                                               |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | < 10 min | **WAIT**                                                    |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | —        | cap ≥ 30: **CAP\_EXHAUSTED**; cap < 30: **REQUEST\_NEEDED** |
 
 Note: evaluate the 30-minute SATISFIED condition before the WAIT
 condition for the `COPILOT_PENDING="true"` rows — the elapsed ≥ 30 min
 case must not be masked by a still-pending state.
+
+Callers handle outcomes differently:
+
+| Outcome         | E14                                | F2                                   | F3                           |
+| --------------- | ---------------------------------- | ------------------------------------ | ---------------------------- |
+| SATISFIED       | proceed to E15                     | continue to CI check                 | proceed with merge           |
+| HOLD            | post AW4 comment; stop             | post AW4 comment; stop               | post AW4 comment; stop       |
+| CAP\_EXHAUSTED  | skip advisory wait; proceed to E15 | post AW4 cap-exhausted comment; stop | not applicable (see F3 note) |
+| REQUEST\_NEEDED | request Copilot, post marker, poll | return to E14                        | not applicable (see F3 note) |
+| WAIT            | continue polling (active loop)     | poll F2 conditions every 2 min       | return to F2                 |
+
+**F3 note**: F3 only invokes AW3 when `COPILOT_PENDING` is `"true"` AND
+`LAST_COPILOT_COMMIT != PR_HEAD_SHA`. If `COPILOT_PENDING` is `"false"`,
+F3 treats the advisory check as satisfied without running AW2–AW3 — see
+the F3 caller instructions.
 
 ## AW4 — Hold comment templates
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -69,117 +69,32 @@ bracketed action:
     `{latest-ci-completed-at}` in the watermark (a new CI run completed
     after E1's snapshot; if watermark value is `none`, any current CI
     pass triggers re-evaluation).
-- **Advisory bot wait** (restart-safe enforcement): Use the following
-  commands to check the Copilot review state and `requested_reviewers`.
-  Run these at the start of this check and again during any polling
-  loop:
+- **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
+  already available from the review-currency check above. Apply the
+  advisory-wait protocol (`idd-advisory-wait.instructions.md`):
 
-  ```sh
-  # Fetch the current PR HEAD SHA from GitHub (authoritative source).
-  PR_HEAD_SHA=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
+  1. Run **AW1**. If **SATISFIED** → this check is **satisfied**;
+     continue to the **CI** check.
+  2. Run **AW2** to fetch markers.
+  3. Apply the **AW3** decision table:
+     - **SATISFIED** → this check is **satisfied**; continue to the CI
+       check.
+     - **HOLD** → post the hold comment from **AW4** and stop.
+     - **REQUEST_NEEDED** → return to E14 to request Copilot review and
+       post a fresh marker. Do not post a new request in F2.
+     - **WAIT** (`COPILOT_PENDING` is `"true"`, elapsed < 30 min) →
+       wait for the remainder of the applicable window (poll every 2
+       min), refreshing `EARLIEST_SAME_HEAD_AT` per **AW2** at each
+       iteration and applying **AW5** if the marker disappears. Then
+       **go back to the first condition in F2** (the 'Review currency'
+       check) to re-evaluate all conditions.
+     - **WAIT** (`COPILOT_PENDING` is `"false"`, elapsed < 10 min) →
+       wait for the remainder of the 10-minute window (same polling
+       rules). Then **go back to the first condition in F2**.
 
-  # Check if Copilot has reviewed the current HEAD SHA.
-  OWNER=$(gh repo view --json owner --jq '.owner.login')
-  REPO=$(gh repo view --json name --jq '.name')
-  LAST_COPILOT_COMMIT=$(
-    gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
-      --paginate \
-      --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
-                  {sa: .submitted_at, cid: .commit_id}' \
-    | jq -rs 'sort_by(.sa) | last | .cid // ""'
-  )
-  # If LAST_COPILOT_COMMIT == PR_HEAD_SHA → Copilot reviewed the current HEAD.
-
-  # Check whether Copilot's review is still pending.
-  COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-    --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
-  # "true" → Copilot is in requested_reviewers (review still pending);
-  # "false" → review was submitted or the request was cancelled.
-  # Note: GitHub uses "Copilot" (capital C) in the requested_reviewers API
-  # and "copilot-pull-request-reviewer[bot]" in the reviews API — both are
-  # matched here for robustness.
-  ```
-
-  If `LAST_COPILOT_COMMIT == PR_HEAD_SHA` (Copilot has reviewed the
-  current HEAD): this check is **satisfied**.
-
-  Otherwise (Copilot has not reviewed current HEAD): collect all
-  `advisory-wait: {any-agent-id} {head-SHA} …` comments from any IDD
-  agent whose `{head-SHA}` matches the current PR HEAD. Use the one with
-  the **earliest** `createdAt` for elapsed time calculation (the
-  advisory clock starts at the first request, not the last). Use these
-  commands to fetch and time the markers:
-
-  ```sh
-  # Fetch same-head advisory-wait markers and find the earliest createdAt.
-  # Match by body format; any IDD agent / prior session may have posted the marker.
-  EARLIEST_SAME_HEAD_AT=$(
-    gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-      | jq -r -s "add
-           | [.[] | select(
-                 (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
-                 (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA} [^ ]+ -->$\"))
-               )]
-           | min_by(.created_at) | .created_at // \"\""
-  )
-  # Matches both plain-text (new) and HTML-comment (legacy) marker formats.
-  # If empty → no same-head marker exists.
-  # If non-empty → earliest same-head marker createdAt (advisory-clock start).
-
-  # Count total advisory-wait markers across all HEADs (for the 30-per-PR cap):
-  MARKER_COUNT=$(
-    gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-      | jq -r -s 'add | [.[] | select(.body | test("^advisory-wait:|^<!-- advisory-wait:"))] | length'
-  )
-  # Matches both plain-text (new) and HTML-comment (legacy) marker formats.
-  # If MARKER_COUNT >= 30 → cap exhausted (see Branch B no-marker case).
-  ```
-
-  Then branch on `COPILOT_PENDING`:
-
-  **Branch A — `COPILOT_PENDING` is `"true"` (review actively
-  pending)**:
-  - No marker exists for current HEAD → this is an inconsistent state.
-    Post a hold comment: "Copilot review is pending for HEAD
-    `{PR_HEAD_SHA}` but no advisory-wait marker was found. E14 may have
-    crashed before posting the marker. A maintainer must verify whether
-    the Copilot review was formally requested and confirm its status
-    before the merge can proceed. Do not merge or post a new
-    advisory-wait marker until the maintainer has resolved this."
-    **Stop.**
-  - Marker exists; elapsed < 10 min: wait for the remainder of the
-    10-minute window (poll every 2 min), then **go back to the first
-    condition in F2 (the 'Review currency' check)** to pick up any
-    activity that arrived during the wait.
-  - Marker exists; elapsed 10–30 min: **go back to the first condition
-    in F2 (the 'Review currency' check) every 2 minutes**. F2 will
-    re-evaluate all conditions including new review activity; if
-    `COPILOT_PENDING` is still `"true"`, it will re-enter this branch.
-  - Marker exists; elapsed ≥ 30 min: this advisory-bot-wait check is
-    **satisfied**. The advisory window has expired. Continue to the next
-    F2 gate (the **CI** check).
-
-  **Branch B — `COPILOT_PENDING` is `"false"` (request completed or
-  manually cancelled)**: GitHub removes a reviewer from
-  `requested_reviewers` when they submit a review OR when the request is
-  manually cancelled by the PR author. Either outcome counts as "no
-  longer pending" for merge purposes — the advisory wait is treated as
-  honored once the pending state is cleared.
-  - Marker exists; elapsed ≥ 10 min: this check is **satisfied**.
-  - Marker exists; elapsed < 10 min: wait for the remainder of the
-    10-minute window (poll every 2 min), then **go back to the first
-    condition in F2** to re-evaluate.
-  - No marker exists: use `MARKER_COUNT` (computed above). If
-    `MARKER_COUNT` ≥ 30 → post hold comment: "The 30-per-PR Copilot
-    re-review cap is exhausted. A maintainer must manually request and
-    evaluate a Copilot review before merge." **Stop.** If `MARKER_COUNT`
-    < 30 → return to E14 to request Copilot review and post a fresh
-    marker.
-
-  'Elapsed time' means the current UTC time minus the `createdAt` of the
-  **earliest** same-head advisory-wait PR comment
-  (`EARLIEST_SAME_HEAD_AT`, computed above) as returned by the GitHub
-  API — not the timestamp inside the marker body.
+  GitHub removes a reviewer from `requested_reviewers` when they submit
+  a review OR when the request is manually cancelled — either counts as
+  no longer pending for merge purposes.
 - **CI**: Current PR head SHA has all required CI checks generated and
   all passing (→ run CI wait per `idd-ci.instructions.md`, on-success →
   re-evaluate F2)
@@ -273,71 +188,23 @@ three values into F3.
    the active claim still uses your current `{claim-id}`. If it does
    not, the claim was lost — report and stop.
 
-   **Advisory state revalidation (blocking)**: fetch fresh state from
-   GitHub with these commands:
+   **Advisory state revalidation (blocking)**: re-fetch the HEAD SHA:
 
    ```sh
-   PR_HEAD_SHA_F3=$(gh pr view {pr-number} --json headRefOid \
-     --jq '.headRefOid')
-   OWNER=$(gh repo view --json owner --jq '.owner.login')
-   REPO=$(gh repo view --json name --jq '.name')
-   LAST_COPILOT_COMMIT_F3=$(
-     gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
-       --paginate \
-       --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
-                   {sa: .submitted_at, cid: .commit_id}' \
-     | jq -rs 'sort_by(.sa) | last | .cid // ""'
-   )
-   COPILOT_PENDING_F3=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-     --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
-   # Note: GitHub uses "Copilot" (capital C) in requested_reviewers and
-   # "copilot-pull-request-reviewer[bot]" in the reviews API — both matched
-   # here for robustness.
+   PR_HEAD_SHA_F3=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
    ```
 
-   If `COPILOT_PENDING_F3` is `"true"` AND
-   `LAST_COPILOT_COMMIT_F3 != PR_HEAD_SHA_F3` (Copilot has not reviewed
-   the current HEAD), fetch the same-head advisory-wait markers to
-   compute elapsed time. Use these commands — do not skip this step even
-   if F2 already computed the value, because F3 is a blocking gate that
-   must be self-contained:
+   Use `PR_HEAD_SHA_F3` as `PR_HEAD_SHA` for the protocol steps. Run
+   **AW1** and **AW2** (`idd-advisory-wait.instructions.md`) — do not
+   skip this even if F2 already ran them; F3 is a self-contained blocking
+   gate. Then apply **AW3**:
 
-   ```sh
-   EARLIEST_SAME_HEAD_AT_F3=$(
-     gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-       | jq -r -s "add
-            | [.[] | select(
-                  (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA_F3}(?: |\$)\")) or
-                  (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA_F3} [^ ]+ -->$\"))
-                )]
-            | min_by(.created_at) | .created_at // \"\""
-   )
-   # Matches both plain-text (new) and HTML-comment (legacy) marker formats.
-   # If empty → no same-head marker; if non-empty → earliest marker createdAt.
-   ```
+   - **SATISFIED** → proceed with the merge.
+   - **HOLD** → post the hold comment from **AW4** and stop.
+   - **WAIT** → Do NOT execute the merge. Return to the **F2 advisory
+     bot wait check** (go back to the first condition in F2). F2 will
+     reuse the existing same-HEAD marker — do not post a new one.
 
-   Then branch on the marker state:
-
-   - **No same-head marker (`EARLIEST_SAME_HEAD_AT_F3` is empty)**: this
-     is an inconsistent state — Copilot is pending but no advisory-wait
-     marker was ever posted for this HEAD. Do NOT execute the merge.
-     Post a hold comment: "Copilot review is pending for HEAD
-     `{PR_HEAD_SHA_F3}` but no advisory-wait marker was found. E14 may
-     have crashed before posting the marker. A maintainer must verify
-     whether the Copilot review was formally requested and confirm its
-     status before the merge can proceed. Do not merge or post a new
-     advisory-wait marker until the maintainer has resolved this."
-     **Stop.**
-   - **Marker exists; elapsed ≥ 30 minutes** (current UTC −
-     `EARLIEST_SAME_HEAD_AT_F3` ≥ 30 min): the advisory window has
-     already expired — this check is **satisfied**, proceed with the
-     merge.
-   - **Marker exists; elapsed < 30 minutes** (current UTC −
-     `EARLIEST_SAME_HEAD_AT_F3` < 30 min): a review is actively pending
-     within the window. Do NOT execute the merge. Return to the **F2
-     Advisory bot wait check** (go back to the first condition in F2).
-     F2 will reuse the existing same-HEAD advisory-wait marker — do not
-     post a new marker.
 3. Merge the PR using a **merge commit**, binding to the validated SHA
    to prevent a race where a new push lands after the F3 freshness check
    but before the merge executes:

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -194,16 +194,20 @@ three values into F3.
    PR_HEAD_SHA_F3=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
    ```
 
-   Use `PR_HEAD_SHA_F3` as `PR_HEAD_SHA` for the protocol steps. Run
-   **AW1** and **AW2** (`idd-advisory-wait.instructions.md`) — do not
-   skip this even if F2 already ran them; F3 is a self-contained blocking
-   gate. Then apply **AW3**:
-
-   - **SATISFIED** → proceed with the merge.
-   - **HOLD** → post the hold comment from **AW4** and stop.
-   - **WAIT** → Do NOT execute the merge. Return to the **F2 advisory
-     bot wait check** (go back to the first condition in F2). F2 will
-     reuse the existing same-HEAD marker — do not post a new one.
+   Use `PR_HEAD_SHA_F3` as `PR_HEAD_SHA`. Run **AW1**
+   (`idd-advisory-wait.instructions.md`):
+   - If **SATISFIED** (`LAST_COPILOT_COMMIT == PR_HEAD_SHA_F3`) →
+     proceed with the merge.
+   - If `COPILOT_PENDING` is `"false"` (review completed or cancelled) →
+     this check is satisfied; proceed with the merge.
+   - Otherwise (`COPILOT_PENDING` is `"true"`, not yet reviewed): run
+     **AW2** and apply **AW3** — do not skip even if F2 ran them already,
+     as F3 is a self-contained blocking gate:
+     - **SATISFIED** → proceed with the merge.
+     - **HOLD** → post the hold comment from **AW4** and stop.
+     - **WAIT** → Do NOT execute the merge. Return to the **F2 advisory
+       bot wait check** (go back to the first condition in F2). F2 will
+       reuse the existing same-HEAD marker — do not post a new one.
 
 3. Merge the PR using a **merge commit**, binding to the validated SHA
    to prevent a race where a new push lands after the F3 freshness check

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -265,6 +265,11 @@ file that matches your current situation.
 CI polling logic shared by D and E phases lives in
 `idd-ci.instructions.md`; callers declare their own on-success target.
 
+The Copilot advisory-wait protocol (commands, decision table, hold
+comment templates) is defined once in `idd-advisory-wait.instructions.md`
+and referenced by E14 (review-fix) and F2/F3 (merge). Do not duplicate
+these commands in caller files.
+
 ## Critique pass
 
 A **critique pass** is an independent review of a plan or diff that

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -89,6 +89,8 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
 4. Apply the **AW3** decision table:
    - **SATISFIED** → proceed to E15.
    - **HOLD** → post the hold comment from **AW4** and stop.
+   - **CAP_EXHAUSTED** (`MARKER_COUNT` ≥ 30, no same-head marker) →
+     skip the advisory wait entirely; proceed directly to E15.
    - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, cap < 30):
      request Copilot review and immediately post a plain-text marker:
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -77,184 +77,76 @@ request a Copilot re-review if Copilot has not yet reviewed the current
 HEAD SHA. Subject to a **workflow cap of 30 Copilot re-review requests
 per PR** (this is a process limit, not a GitHub-enforced constraint).
 
-Use these commands to check and request:
+1. Fetch `PR_HEAD_SHA`:
 
-```sh
-# Step 1: Fetch the current PR HEAD SHA from GitHub (authoritative source).
-PR_HEAD_SHA=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
+   ```sh
+   PR_HEAD_SHA=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
+   ```
 
-# Step 2: Check if Copilot has reviewed the current HEAD SHA.
-OWNER=$(gh repo view --json owner --jq '.owner.login')
-REPO=$(gh repo view --json name --jq '.name')
-LAST_COPILOT_COMMIT=$(
-  gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
-    --paginate \
-    --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
-               {sa: .submitted_at, cid: .commit_id}' \
-  | jq -rs 'sort_by(.sa) | last | .cid // ""'
-)
-# If LAST_COPILOT_COMMIT == PR_HEAD_SHA → Copilot already reviewed this HEAD;
-# skip request and marker. E14 Copilot processing is done.
+2. Run **AW1** (`idd-advisory-wait.instructions.md`). If **SATISFIED** →
+   E14 Copilot processing is done; proceed to E15.
+3. Run **AW2** to fetch markers.
+4. Apply the **AW3** decision table:
+   - **SATISFIED** → proceed to E15.
+   - **HOLD** → post the hold comment from **AW4** and stop.
+   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, cap < 30):
+     request Copilot review and immediately post a plain-text marker:
 
-# Step 3: Check if Copilot review is already pending.
-COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-  --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
-# "true" → Copilot is in requested_reviewers (review still pending);
-# "false" → review was submitted or the request was cancelled.
-# Note: GitHub uses "Copilot" (capital C) in the requested_reviewers API
-# and "copilot-pull-request-reviewer[bot]" in the reviews API — both are
-# matched here for robustness.
+     ```sh
+     gh pr edit {pr-number} --add-reviewer "@copilot"
+     ```
 
-# Step 4a: If COPILOT_PENDING is "true" — do NOT request again (avoids
-# resetting the advisory-wait clock). Use these commands to detect
-# whether a same-head advisory-wait marker exists and find the earliest.
-# Match by body format only (any IDD agent / prior session may have posted it).
-EARLIEST_SAME_HEAD_AT=$(
-  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-    | jq -r -s "add
-         | [.[] | select(
-               (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
-               (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA} [^ ]+ -->$\"))
-             )]
-         | min_by(.created_at) | .created_at // \"\""
-)
-# Matches both plain-text (new) and HTML-comment (legacy) marker formats.
-# If EARLIEST_SAME_HEAD_AT is empty → no same-head marker exists (see below).
-# If EARLIEST_SAME_HEAD_AT is non-empty → marker exists; value is the
-# earliest marker createdAt (use for all elapsed-time checks).
-#   - Marker exists: do NOT post a new marker. Skip to the polling
-#     section below; use EARLIEST_SAME_HEAD_AT as the advisory-clock start.
-#   - No marker exists: this is an inconsistent state (Copilot is
-#     pending but no marker was ever posted for this HEAD). Post a hold
-#     comment: "Copilot review is pending for HEAD {PR_HEAD_SHA} but no
-#     advisory-wait marker was found. E14 may have crashed before posting
-#     the marker. A maintainer must verify whether the Copilot review was
-#     formally requested and confirm its status before E14 can safely
-#     continue." **Stop.**
+     ```text
+     advisory-wait: {agent-id} {head-SHA} {ISO8601-requested-at}
+     ```
 
-# Step 4b: If COPILOT_PENDING is "false" — check the cap before requesting.
-# Count total advisory-wait markers for the 30-per-PR cap (all agents):
-MARKER_COUNT=$(
-  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-    | jq -r -s 'add | [.[] | select(.body | test("^advisory-wait:|^<!-- advisory-wait:"))] | length'
-)
-# Each marker represents one --add-reviewer "@copilot" request.
-# If MARKER_COUNT >= 30 → do NOT request; skip the advisory wait entirely
-#   and proceed directly to E15.
-# If MARKER_COUNT < 30 → request Copilot review:
-gh pr edit {pr-number} --add-reviewer "@copilot"
-```
+     Use `PR_HEAD_SHA` as `{head-SHA}`. Post as plain text, not an HTML
+     comment block.
+   - **WAIT**, or after **REQUEST_NEEDED** marker is posted: enter the
+     active polling loop below.
 
-- Copilot and CI advisory bot comments are advisory; unanswered ones do
-  not block merge.
+Copilot and CI advisory bot comments are advisory; unanswered ones do
+not block merge.
 
-**Waiting for advisory bot re-reviews**: this section applies only when
-Step 4b ran (`COPILOT_PENDING` was `"false"` and the request was sent),
-or when Step 4a ran (`COPILOT_PENDING` was `"true"` and a same-head
-marker was found). **If `LAST_COPILOT_COMMIT == PR_HEAD_SHA` (Copilot
-already reviewed the current HEAD at Step 2), skip this entire section —
-E14 Copilot processing is complete.**
+**Active polling loop** (applies when `COPILOT_PENDING` is `"true"`, or
+immediately after a new request was sent above):
 
-For the Step 4b case (request just sent): persist the advisory wait
-start time by posting a plain-text marker comment:
+Do **not** post a new marker if a same-head marker already exists; reuse
+it. If multiple same-head markers exist, always use the one with the
+**earliest** `createdAt` — the advisory clock starts at the first
+request, not the last.
 
-```text
-advisory-wait: {agent-id} {head-SHA} {ISO8601-requested-at}
-```
-
-**Important**: post this as plain text, not as an HTML comment block.
-Use `PR_HEAD_SHA` as the `{head-SHA}` value so F2 and resume logic can
-distinguish waits for different pushes.
-
-For the Step 4a case (pending, marker already exists): do **not** post a
-new marker; reuse the existing same-head advisory-wait markers. If
-multiple same-head markers exist, use the one with the **earliest**
-`createdAt` (the advisory clock starts at the first request, not the
-last).
-
-For both Step 4b and Step 4a (marker-exists) cases: take a fresh
-snapshot of the activity universe (same scope as E1 Step 1: all threads,
+Take a fresh activity snapshot (same scope as E1 Step 1: all threads,
 review bodies, and regular comments, excluding agent operational
-markers). Record the highest `updatedAt` across all fetched items —
-including your own recent actions — as the **temporary polling
-watermark**. Do **not** post this as a `<!-- review-watermark -->` PR
-comment; it is ephemeral. (If the snapshot is empty, use the `createdAt`
-of the latest `<!-- review-watermark: {agent-id} {claim-id} … -->`
-comment whose embedded `{claim-id}` matches the current active claim. If
-no such same-claim watermark exists, stop waiting and return to E1 to
-create one — do not borrow another claim's watermark.) Then poll until
-an exit condition below is met:
+markers). Record the highest `updatedAt` as the **temporary polling
+watermark** — do **not** post it as a `<!-- review-watermark -->` PR
+comment. If the snapshot is empty, use the `createdAt` of the latest
+`<!-- review-watermark: {agent-id} {claim-id} … -->` comment whose
+`{claim-id}` matches the current active claim. If no same-claim
+watermark exists, stop and return to E1 to create one.
 
-- Poll every 2 minutes: at the start of each iteration, first re-fetch
-  `PR_HEAD_SHA` to detect if a push happened during the wait:
+Poll every 2 minutes:
 
-  ```sh
-  CURRENT_HEAD=$(gh pr view {pr-number} --json headRefOid \
-    --jq '.headRefOid')
-  # If CURRENT_HEAD != PR_HEAD_SHA → HEAD changed; a new push happened.
-  # Exit immediately to E1. A new advisory-wait marker will be needed
-  # for the new HEAD.
-  ```
+1. Re-fetch `PR_HEAD_SHA`:
 
-  If `CURRENT_HEAD != PR_HEAD_SHA` → stop waiting and return to E1. The
-  new HEAD must be re-evaluated; if Copilot has not reviewed it, E14/F2
-  will need a new advisory-wait marker for that HEAD.
+   ```sh
+   CURRENT_HEAD=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')
+   ```
 
-  Otherwise read all review threads, review bodies, and regular PR
-  comments, **excluding any regular PR comment authored by any IDD
-  agent** (this covers advisory-wait, review-watermark, review-baseline,
-  claim, hold notes, and any other operational comments an agent may
-  post); compare `updatedAt` against the polling watermark. Also check
-  `requested_reviewers` (via REST API) to determine whether Copilot's
-  review is still pending:
+   If `CURRENT_HEAD != PR_HEAD_SHA` → HEAD changed; return to E1.
 
-  ```sh
-  COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-    --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
-  # "true" → review still pending; "false" → submitted or cancelled.
-  # Note: "Copilot" (capital C) is used in requested_reviewers; the OR
-  # condition also covers "copilot-pull-request-reviewer[bot]" for robustness.
-  ```
+2. Re-read review threads, review bodies, and regular PR comments,
+   **excluding any regular PR comment authored by any IDD agent** (covers
+   advisory-wait, review-watermark, review-baseline, claim, hold notes,
+   and other operational comments). If any item has `updatedAt` strictly
+   newer than the polling watermark → return to E1 immediately.
 
-  'Elapsed time' in all conditions below means the current UTC time
-  minus the `createdAt` of the **earliest** same-head advisory-wait PR
-  comment as returned by the GitHub API — not the timestamp inside the
-  marker body. If multiple same-head markers exist, always use the one
-  with the earliest `createdAt`. At the start of each poll iteration,
-  refresh the value with:
-
-  ```sh
-  EARLIEST_SAME_HEAD_AT=$(
-    gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-      | jq -r -s "add
-           | [.[] | select(
-                 (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
-                 (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA} [^ ]+ -->$\"))
-               )]
-           | min_by(.created_at) | .created_at // \"\""
-  )
-  # Matches both plain-text (new) and HTML-comment (legacy) marker formats.
-  # Elapsed time = (current UTC time) − EARLIEST_SAME_HEAD_AT.
-  ```
-
-  If `EARLIEST_SAME_HEAD_AT` is empty after this refresh (marker deleted
-  or never posted): post a hold comment: "Advisory-wait marker for HEAD
-  `{PR_HEAD_SHA}` is missing during polling. Unable to compute elapsed
-  time. A maintainer must verify the Copilot advisory-wait state before
-  E14 can safely continue." **Stop.**
-
-- If **any** item has `updatedAt` strictly newer than the polling
-  watermark → stop waiting and return to E1 immediately to process it.
-- If elapsed time ≥ 30 minutes (hard cap) → proceed to E15 regardless of
-  `COPILOT_PENDING`. The advisory window has expired. (Evaluate this
-  before the 10-minute conditions; otherwise the pending-true branch
-  below masks this exit for a Haiku-level reader.)
-- If elapsed time ≥ 10 minutes AND `COPILOT_PENDING` is `"false"` →
-  proceed to E15. (Copilot submitted the review or the request was
-  cancelled; either counts as no longer pending.)
-- If elapsed time ≥ 10 minutes AND `COPILOT_PENDING` is `"true"` →
-  **continue polling**. Do NOT exit to E15 while the review is still
-  pending.
+3. Run **AW1** and **AW2** (refresh `COPILOT_PENDING`, `LAST_COPILOT_COMMIT`,
+   and `EARLIEST_SAME_HEAD_AT`). Apply **AW5** if `EARLIEST_SAME_HEAD_AT`
+   is empty. Then apply **AW3**:
+   - **SATISFIED** → exit polling; proceed to E15.
+   - **HOLD** → post hold comment from **AW4** or **AW5**; stop.
+   - **WAIT** → continue polling.
 
 Note: "advisory" means the agent is not obligated to accept every
 suggestion — it does **not** mean the agent can skip waiting for a

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -103,7 +103,7 @@ entire lifetime of the roadmap.
 
 ## Step 2 — Fetch or copy template files
 
-You need the following eleven files in the target repository. Use
+You need the following twelve files in the target repository. Use
 whichever method applies to your situation.
 
 Before importing, confirm whether the operator wants to keep the default
@@ -120,6 +120,7 @@ should customize `idd-review-fix.instructions.md` and
 .github/instructions/idd-work.instructions.md
 .github/instructions/idd-pr-submit.instructions.md
 .github/instructions/idd-ci.instructions.md
+.github/instructions/idd-advisory-wait.instructions.md
 .github/instructions/idd-review-triage.instructions.md
 .github/instructions/idd-review-fix.instructions.md
 .github/instructions/idd-merge.instructions.md
@@ -150,6 +151,7 @@ for FILE in \
   ".github/instructions/idd-work.instructions.md" \
   ".github/instructions/idd-pr-submit.instructions.md" \
   ".github/instructions/idd-ci.instructions.md" \
+  ".github/instructions/idd-advisory-wait.instructions.md" \
   ".github/instructions/idd-review-triage.instructions.md" \
   ".github/instructions/idd-review-fix.instructions.md" \
   ".github/instructions/idd-merge.instructions.md" \
@@ -178,6 +180,7 @@ for FILE in \
   ".github/instructions/idd-work.instructions.md" \
   ".github/instructions/idd-pr-submit.instructions.md" \
   ".github/instructions/idd-ci.instructions.md" \
+  ".github/instructions/idd-advisory-wait.instructions.md" \
   ".github/instructions/idd-review-triage.instructions.md" \
   ".github/instructions/idd-review-fix.instructions.md" \
   ".github/instructions/idd-merge.instructions.md" \
@@ -340,7 +343,7 @@ phase file manually when the current step changes.
 
 After completing the steps above, confirm each item:
 
-- [ ] All ten `idd-*.instructions.md` files are present in
+- [ ] All eleven `idd-*.instructions.md` files are present in
       `.github/instructions/`.
 - [ ] `docs/idd-workflow.md` is present.
 - [ ] No `{{...}}` placeholders remain in any copied file.


### PR DESCRIPTION
## Summary

Creates `idd-advisory-wait.instructions.md` as a single canonical source for the Copilot advisory-wait protocol, which was previously duplicated across three files.

**Before:** E14 (~185 lines), F2 advisory section (~120 lines), F3 advisory revalidation (~60 lines) — 365 lines of nearly-identical `jq` commands and branching logic.

**After:**
- `idd-advisory-wait.instructions.md` (new, 110 lines): AW1 (fetch state), AW2 (fetch markers), AW3 (decision table), AW4 (hold comment templates), AW5 (missing-marker recovery)
- `idd-review-fix.instructions.md`: 286 → 178 lines (−108)
- `idd-merge.instructions.md`: 378 → 245 lines (−133)
- Net removal: **241 lines** of duplication

Callers (E14, F2, F3) now reference the helper by step code (AW1–AW5) and add only their caller-specific routing (3–10 lines each).

Also updates `ONBOARDING.md` file list from eleven to twelve files, and mirrors all changes to `idd-template/`.

## Test plan

- [ ] `idd-advisory-wait.instructions.md` present in both live and template directories
- [ ] E14 in review-fix references AW1–AW5; no duplicate `jq` commands remain
- [ ] F2 and F3 in merge reference AW1–AW5; no duplicate `jq` commands remain
- [ ] Decision table in AW3 covers all original branches (pending/not-pending × marker/no-marker × elapsed-time ranges)
- [ ] Hold comment templates in AW4 match original exact wording
- [ ] ONBOARDING.md file count updated to twelve; new file added to fetch scripts
- [ ] All files pass dprint + markdownlint + cspell

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated Copilot advisory-wait protocol into a single, reusable spec consumed by review and merge gates.
  * Reworked advisory polling and merge revalidation to be restart-safe with deterministic decision outcomes (SATISFIED/WAIT/HOLD/REQUEST_NEEDED) and templated hold behavior.
* **Documentation**
  * Updated instructions and onboarding to reference the shared protocol and to include the new instruction in the file checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->