### PR TITLE
docs(readme): add IDD usage trigger phrases

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -48,6 +48,21 @@ https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOAR
 `.github/instructions/idd-review-fix.instructions.md` と
 `.github/instructions/idd-merge.instructions.md` をカスタマイズしてください。
 
+## IDD の使い方
+
+オンボーディングが終わったら、対象リポジトリで AI エージェントのセッションを開き、
+ワークフローの開始を依頼してください。エージェントはまず
+[docs/idd-workflow.md](docs/idd-workflow.md) を読み、次に
+`.github/instructions/idd-overview.instructions.md` を開いてから、
+Discover → Claim → Work → ... のループに入ります。
+
+**フレーズ例**:
+
+- `このリポジトリで IDD ワークフローを開始してください。`
+- `docs/idd-workflow.md` を読んで、次に
+  `.github/instructions/idd-overview.instructions.md` を開き、
+  Discover → Claim → Work のループを開始してください。
+
 ## IDD とは？
 
 IDD は、AI エージェントが GitHub Issues によって駆動される繰り返しパイプラインを

--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ default. If adopters do not want that PR policy, they can customize
 `.github/instructions/idd-review-fix.instructions.md` and
 `.github/instructions/idd-merge.instructions.md` after onboarding.
 
+## Using IDD
+
+After onboarding, open a session in your target repository and tell your
+AI agent to start the workflow. The agent should read
+[docs/idd-workflow.md](docs/idd-workflow.md), then
+`.github/instructions/idd-overview.instructions.md`, and continue into
+the Discover → Claim → Work → ... loop.
+
+**Example phrases**:
+
+- `Start the IDD workflow in this repository.`
+- `Read docs/idd-workflow.md`, then
+  `.github/instructions/idd-overview.instructions.md`, and begin the
+  Discover → Claim → Work loop.
+
 ## What is IDD?
 
 IDD is a multi-agent GitHub automation workflow where AI agents work


### PR DESCRIPTION
## Summary

- add a new `Using IDD` section to `README.md`
- add the matching `IDD の使い方` section to `README.ja.md`
- explain the post-onboarding entry path through `docs/idd-workflow.md`
  and `.github/instructions/idd-overview.instructions.md`
- include concrete trigger phrase examples in each README's language

Closes #47

## Follow-up issues

- none

## Background

This keeps the post-onboarding guidance close to the existing Quick
Start section and keeps the English and Japanese READMEs structurally
aligned without mixing prompt languages inside the same page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance section for the IDD workflow, available in both English and Japanese.
  * Included step-by-step instructions for users to initiate the AI agent workflow after onboarding.
  * Provided example phrases to guide users through the Discover → Claim → Work loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->