### PR TITLE
docs: add README sync rule to agent entry files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,6 +25,9 @@ unless benchmark results justify a more neutral layout.
   For example, if the user speaks in Japanese, respond in Japanese.
 - However, comments and documentation should be written in English unless
   there is a clear context otherwise.
+- When editing `README.md`, also apply the equivalent change to
+  `README.ja.md`, and vice versa. Keep both files in sync in the same
+  commit.
 - If uncertainties, concerns, or other implementation issues arise while
   running in Agent mode, promptly switch to Plan mode and ask the user
   questions. In such cases, provide one or more recommended response

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ immediately, without depending on a redirect.
 - Match the conversational language to the user's language.
 - Write comments and documentation in English unless there is a clear
   project-specific reason otherwise.
+- When editing `README.md`, also apply the equivalent change to
+  `README.ja.md`, and vice versa. Keep both files in sync in the same
+  commit.
 - If uncertainty, hidden risk, or missing context blocks a safe change,
   stop and ask a concise question before proceeding.
 - Keep changes small and reviewable. If you create commits, follow the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,9 @@ immediately, without depending on a redirect.
 - Match the conversational language to the user's language.
 - Write comments and documentation in English unless there is a clear
   project-specific reason otherwise.
+- When editing `README.md`, also apply the equivalent change to
+  `README.ja.md`, and vice versa. Keep both files in sync in the same
+  commit.
 - If uncertainty, hidden risk, or missing context blocks a safe change,
   stop and ask a concise question before proceeding.
 - Keep changes small and reviewable. If you create commits, follow the

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,6 +13,9 @@ immediately, without depending on a redirect.
 - Match the conversational language to the user's language.
 - Write comments and documentation in English unless there is a clear
   project-specific reason otherwise.
+- When editing `README.md`, also apply the equivalent change to
+  `README.ja.md`, and vice versa. Keep both files in sync in the same
+  commit.
 - If uncertainty, hidden risk, or missing context blocks a safe change,
   stop and ask a concise question before proceeding.
 - Keep changes small and reviewable. If you create commits, follow the


### PR DESCRIPTION
## Summary
- add the same README sync rule to `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`
- add the equivalent guidance to `.github/copilot-instructions.md`
- keep the scope to entry files only so README-facing follow-ups can proceed separately

Closes #48

## Recommended follow-up
- #55 for the remaining README count-drift fixes and future drift guardrail
- #47 for the post-onboarding IDD trigger phrase guidance once that branch is ready

## Background
- the repository now has canonical English and Japanese READMEs, but contributors had no early agent-facing rule requiring the two files to stay aligned
- this PR intentionally skips the optional README note mentioned in the issue body to keep the write set out of the README files themselves


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development guidelines to ensure documentation synchronization practices across multiple instruction files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->