### PR TITLE
docs: scope IDD overview away from code review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -229,5 +229,7 @@ agents. Start with [docs/idd-workflow.md](../docs/idd-workflow.md) for
 the cross-agent entry path and phase routing.
 
 `.github/instructions/idd-overview.instructions.md` loads automatically
-for GitHub Copilot because it has `applyTo: "**"`. Open the routed phase
-file manually when the current step changes.
+for GitHub Copilot execution surfaces because it has `applyTo: "**"`,
+but it is excluded from Copilot code review with
+`excludeAgent: "code-review"` so reviewer-side context stays lighter.
+Open the routed phase file manually when the current step changes.

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -1,5 +1,6 @@
 ---
 applyTo: "**"
+excludeAgent: "code-review"
 ---
 
 # IDD (Issue-Driven Development) — Shared Definitions

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -24,12 +24,12 @@ you are reading this guide first, start at step 1.
 
 ## Entry points and auto-load expectations
 
-| Agent / surface         | Read first                        | Automatically available IDD context                                                                                                         | Open manually                                                                 |
-| ----------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| GitHub Copilot surfaces | `.github/copilot-instructions.md` | `.github/instructions/idd-overview.instructions.md`; package-scoped `.instructions.md` files in VS Code Copilot when editing matching paths | The routed phase file when the current step changes                           |
-| Codex CLI               | `AGENTS.md`                       | None from `.github/instructions/`                                                                                                           | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
-| Claude Code             | `CLAUDE.md`                       | None from `.github/instructions/` by default                                                                                                | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
-| Gemini CLI              | `GEMINI.md`                       | None from `.github/instructions/`                                                                                                           | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
+| Agent / surface         | Read first                        | Automatically available IDD context                                                                                                                                | Open manually                                                                 |
+| ----------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| GitHub Copilot surfaces | `.github/copilot-instructions.md` | `.github/instructions/idd-overview.instructions.md` for execution surfaces; package-scoped `.instructions.md` files in VS Code Copilot when editing matching paths | The routed phase file when the current step changes                           |
+| Codex CLI               | `AGENTS.md`                       | None from `.github/instructions/`                                                                                                                                  | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
+| Claude Code             | `CLAUDE.md`                       | None from `.github/instructions/` by default                                                                                                                       | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
+| Gemini CLI              | `GEMINI.md`                       | None from `.github/instructions/`                                                                                                                                  | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
 
 ## IDD file map
 
@@ -74,6 +74,21 @@ The IDD workflow distributed from this repository is therefore an
 instruction template first. Native skills can sit beside it as helpers,
 but the synchronization contract for the portable workflow remains
 between the live `.github/instructions/` files and `idd-template/`.
+
+## Copilot review instruction scope
+
+The heavy shared overview keeps `applyTo: "**"` so GitHub Copilot
+execution surfaces can receive the IDD entry context automatically.
+However, it also sets `excludeAgent: "code-review"` so Copilot code
+review does not ingest the full operational workflow as reviewer-side
+context.
+
+This is an intentional middle path between the evaluated alternatives:
+keeping review coupled to the full overview, narrowing `applyTo` and
+risking execution-agent discoverability, or splitting a separate
+reviewer-only instruction file. Copilot code review may still use the
+lightweight repository-wide `.github/copilot-instructions.md`; only the
+heavier `idd-overview.instructions.md` is excluded from review.
 
 ## Default PR policy: Copilot advisory review
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -1,5 +1,6 @@
 ---
 applyTo: "**"
+excludeAgent: "code-review"
 ---
 
 # IDD (Issue-Driven Development) — Shared Definitions

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -280,8 +280,11 @@ phase file manually when the current step changes.
 
 ### .github/copilot-instructions.md (if present)
 
-Add a parallel section so GitHub Copilot surfaces also receive the IDD
-context. The content can mirror the CLAUDE.md addition above.
+Add a parallel section so GitHub Copilot execution surfaces also receive
+the IDD context. The content can mirror the CLAUDE.md addition above.
+The template keeps the heavier `idd-overview.instructions.md` out of
+Copilot code review with `excludeAgent: "code-review"`; repository-wide
+`.github/copilot-instructions.md` guidance may still apply to reviews.
 
 ### AGENTS.md (for Codex CLI)
 
@@ -354,8 +357,8 @@ After completing the steps above, confirm each item:
       `.github/instructions/`.
 - [ ] `docs/idd-workflow.md` is present.
 - [ ] No `{{...}}` placeholders remain in any copied file.
-- [ ] `idd-overview.instructions.md` has `applyTo: "**"` in its
-      frontmatter.
+- [ ] `idd-overview.instructions.md` has `applyTo: "**"` and
+      `excludeAgent: "code-review"` in its frontmatter.
 - [ ] `CLAUDE.md` exists and references `docs/idd-workflow.md`, unless
       the operator explicitly opted out of creating it.
 - [ ] `AGENTS.md` exists and references `docs/idd-workflow.md`, unless

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -45,7 +45,7 @@ adopter does not want that PR policy, they can customize
 
 ```text
 .github/instructions/
-  idd-overview.instructions.md       ← shared definitions; auto-loaded by Copilot surfaces (applyTo: "**"); see docs/idd-workflow.md for per-agent loading
+  idd-overview.instructions.md       ← shared definitions; auto-loaded by Copilot execution surfaces (applyTo: "**", excludeAgent: "code-review"); see docs/idd-workflow.md for per-agent loading
   idd-discover.instructions.md       ← A0–A4: find and select next issue
   idd-claim.instructions.md          ← A5: claim pre-checks and execution
   idd-work.instructions.md           ← B+C: branch, plan, implement, self-review

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -24,12 +24,12 @@ you are reading this guide first, start at step 1.
 
 ## Entry points and auto-load expectations
 
-| Agent / surface         | Read first                        | Automatically available IDD context                                                                                                         | Open manually                                                                 |
-| ----------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| GitHub Copilot surfaces | `.github/copilot-instructions.md` | `.github/instructions/idd-overview.instructions.md`; package-scoped `.instructions.md` files in VS Code Copilot when editing matching paths | The routed phase file when the current step changes                           |
-| Codex CLI               | `AGENTS.md`                       | None from `.github/instructions/`                                                                                                           | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
-| Claude Code             | `CLAUDE.md`                       | None from `.github/instructions/` by default                                                                                                | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
-| Gemini CLI              | `GEMINI.md`                       | None from `.github/instructions/`                                                                                                           | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
+| Agent / surface         | Read first                        | Automatically available IDD context                                                                                                                                | Open manually                                                                 |
+| ----------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| GitHub Copilot surfaces | `.github/copilot-instructions.md` | `.github/instructions/idd-overview.instructions.md` for execution surfaces; package-scoped `.instructions.md` files in VS Code Copilot when editing matching paths | The routed phase file when the current step changes                           |
+| Codex CLI               | `AGENTS.md`                       | None from `.github/instructions/`                                                                                                                                  | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
+| Claude Code             | `CLAUDE.md`                       | None from `.github/instructions/` by default                                                                                                                       | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
+| Gemini CLI              | `GEMINI.md`                       | None from `.github/instructions/`                                                                                                                                  | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
 
 During onboarding, create or update `CLAUDE.md`, `AGENTS.md`, and
 `GEMINI.md` so each non-Copilot agent listed above has a stable first
@@ -61,6 +61,21 @@ The files in `.github/instructions/*.instructions.md` are repository
 instruction files. Some older project text may still use "skill files"
 as shorthand, but these documents are not agent-native `SKILL.md`
 bundles.
+
+## Copilot review instruction scope
+
+The heavy shared overview keeps `applyTo: "**"` so GitHub Copilot
+execution surfaces can receive the IDD entry context automatically.
+However, it also sets `excludeAgent: "code-review"` so Copilot code
+review does not ingest the full operational workflow as reviewer-side
+context.
+
+This is an intentional middle path between the evaluated alternatives:
+keeping review coupled to the full overview, narrowing `applyTo` and
+risking execution-agent discoverability, or splitting a separate
+reviewer-only instruction file. Copilot code review may still use the
+lightweight repository-wide `.github/copilot-instructions.md`; only the
+heavier `idd-overview.instructions.md` is excluded from review.
 
 ## Default PR policy: Copilot advisory review
 


### PR DESCRIPTION
## Summary

- Add `excludeAgent: "code-review"` to the live and exported IDD overview instructions while keeping `applyTo: "**"`.
- Document the selected policy: execution surfaces keep the heavy overview, while Copilot code review uses only lighter applicable guidance.
- Update template README/onboarding/workflow docs so adopters copy the same frontmatter and understand the trade-off.

## Rationale

GitHub Docs describe `excludeAgent: "code-review"` as the built-in way to keep a path-specific instruction file available to Copilot cloud agent while excluding it from Copilot code review. This preserves the coding-agent entry path better than narrowing `applyTo`, and avoids creating a separate reviewer-only instruction file for this issue.

Reference: https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions

## Testing

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

## Follow-up

None.

Closes #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated IDD workflow documentation to clarify how instruction files load across different Copilot execution contexts and code review scopes.
  * Refined instruction scope configuration to distinguish execution surfaces from code review contexts.
  * Improved onboarding guidance with updated verification requirements for instruction file metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->