### PR TITLE
docs: evaluate optional IDD helper scripts

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1,0 +1,65 @@
+# IDD Helper Script Evaluation
+
+This document records the current decision on optional helper scripts for
+the IDD workflow. It exists so future reviews can reference the trade-off
+directly instead of re-evaluating the same suggestion from scratch.
+
+## Decision
+
+Do not adopt helper scripts yet.
+
+The canonical workflow remains the portable shell / `gh` / `jq`
+instructions embedded in `.github/instructions/*.instructions.md`.
+Optional helpers may be reconsidered later, but adding them now would
+create a second implementation surface while the review, advisory-wait,
+and claim protocols are still changing through dogfooding.
+
+## Friction Inventory
+
+The repeated query patterns most likely to benefit from helpers are:
+
+| Pattern                         | Current friction                                                                                      | Helper risk                                                                                            |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Claim-state parsing             | HTML marker parsing is stateful and easy to simplify incorrectly.                                     | A script would become another parser that must stay exactly aligned with the instruction rules.        |
+| Review activity snapshots       | E1/F2/F3 need the same activity universe and marker exclusions.                                       | Any mismatch between script output and written gates could make merge freshness checks unsound.        |
+| Advisory-wait marker parsing    | AW1/AW2 combine review API state, requested reviewers, marker comments, and elapsed-time rules.       | A helper could hide important decision-table semantics that agents must still understand during holds. |
+| Final pre-merge freshness check | The merge path repeats review, comment, thread, CI, claim, and advisory checks immediately before F3. | A mutating helper would be risky; even a read-only helper needs strict output contracts.               |
+| Branch protection/ruleset reads | Required review and check discovery can be verbose across GitHub APIs.                                | Ruleset coverage varies by repository, so a helper could create false confidence in unsupported cases. |
+
+## Trade-off
+
+Helper scripts would improve copy/paste reliability and make some
+review-state checks easier to audit locally. That benefit is real,
+especially for advisory-wait and review-snapshot commands.
+
+The portability cost is also real. The exported IDD template is meant to
+work in repositories that can copy Markdown instruction files without
+adopting a runtime, package manager, or repository-local script
+directory. If helper scripts are introduced too early, every operational
+rule must be maintained twice: once in the instructions that agents read,
+and once in code that agents run.
+
+For now, the safer balance is to keep the instructions canonical and use
+documentation refactors to centralize repeated logic before introducing
+code.
+
+## Future Adoption Criteria
+
+If helper scripts are revisited, they should satisfy all of the
+following:
+
+- They are optional and never required to execute the exported template.
+- They are read-only by default; mutating actions remain explicit in the
+  phase instructions.
+- They output stable machine-readable JSON that can be inspected and
+  compared by agents.
+- They keep the shell / `gh` / `jq` fallback documented beside the helper
+  path.
+- They have a small test fixture set for marker parsing and snapshot
+  filtering.
+- They are introduced only after the corresponding instruction protocol
+  has stabilized enough that drift risk is lower than command-copy risk.
+
+Good candidates for a future first helper would be read-only snapshot
+commands for review activity, advisory-wait state, or claim-state
+inspection. They should not replace the written decision tables.

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -108,3 +108,14 @@ in later PR phases.
 Non-Copilot agents can still drive the workflow end to end, but they
 should expect those later phases to interact with Copilot as a GitHub
 reviewer because that is part of this repository's current PR policy.
+
+## Optional helper scripts
+
+The current workflow does not require helper scripts. Shell / `gh` /
+`jq` snippets in `.github/instructions/*.instructions.md` remain the
+canonical portable path for adopters.
+
+See [IDD helper script evaluation](idd-helper-scripts.md) for the
+current inventory of high-friction query patterns, the reason helper
+scripts are not adopted yet, and the criteria for reconsidering optional
+read-only helpers later.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -129,6 +129,7 @@ the files are copied in.
 .github/instructions/idd-merge.instructions.md
 .github/instructions/idd-resume.instructions.md
 docs/idd-workflow.md
+docs/idd-helper-scripts.md
 ```
 
 Create the target directories if they do not exist.
@@ -161,7 +162,8 @@ for FILE in \
   ".github/instructions/idd-pre-merge.instructions.md" \
   ".github/instructions/idd-merge.instructions.md" \
   ".github/instructions/idd-resume.instructions.md" \
-  "docs/idd-workflow.md"
+  "docs/idd-workflow.md" \
+  "docs/idd-helper-scripts.md"
 do
   gh api -H "Accept: application/vnd.github.raw+json" \
     "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
@@ -192,7 +194,8 @@ for FILE in \
   ".github/instructions/idd-pre-merge.instructions.md" \
   ".github/instructions/idd-merge.instructions.md" \
   ".github/instructions/idd-resume.instructions.md" \
-  "docs/idd-workflow.md"
+  "docs/idd-workflow.md" \
+  "docs/idd-helper-scripts.md"
 do
   curl -fsSL "${BASE}/${FILE}" -o "${DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
@@ -355,7 +358,8 @@ After completing the steps above, confirm each item:
 
 - [ ] All thirteen `idd-*.instructions.md` files are present in
       `.github/instructions/`.
-- [ ] `docs/idd-workflow.md` is present.
+- [ ] `docs/idd-workflow.md` and `docs/idd-helper-scripts.md` are
+      present.
 - [ ] No `{{...}}` placeholders remain in any copied file.
 - [ ] `idd-overview.instructions.md` has `applyTo: "**"` and
       `excludeAgent: "code-review"` in its frontmatter.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -103,8 +103,8 @@ entire lifetime of the roadmap.
 
 ## Step 2 — Fetch or copy template files
 
-You need the following fourteen files in the target repository. Use
-whichever method applies to your situation.
+You need the following files in the target repository. Use whichever
+method applies to your situation.
 
 Before importing, confirm whether the operator wants to keep the default
 Copilot advisory review policy described above. If not, note that they

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -60,6 +60,7 @@ adopter does not want that PR policy, they can customize
   idd-resume.instructions.md         ← resume after crash / handoff
 docs/
   idd-workflow.md                    ← cross-agent entry point and file map
+  idd-helper-scripts.md              ← optional helper-script evaluation and policy
 ONBOARDING.md                        ← AI agent import guide (start here)
 README.md                            ← this file
 ```

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1,0 +1,65 @@
+# IDD Helper Script Evaluation
+
+This document records the current decision on optional helper scripts for
+the IDD workflow. It exists so future reviews can reference the trade-off
+directly instead of re-evaluating the same suggestion from scratch.
+
+## Decision
+
+Do not adopt helper scripts yet.
+
+The canonical workflow remains the portable shell / `gh` / `jq`
+instructions embedded in `.github/instructions/*.instructions.md`.
+Optional helpers may be reconsidered later, but adding them now would
+create a second implementation surface while the review, advisory-wait,
+and claim protocols are still changing through dogfooding.
+
+## Friction Inventory
+
+The repeated query patterns most likely to benefit from helpers are:
+
+| Pattern                         | Current friction                                                                                      | Helper risk                                                                                            |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Claim-state parsing             | HTML marker parsing is stateful and easy to simplify incorrectly.                                     | A script would become another parser that must stay exactly aligned with the instruction rules.        |
+| Review activity snapshots       | E1/F2/F3 need the same activity universe and marker exclusions.                                       | Any mismatch between script output and written gates could make merge freshness checks unsound.        |
+| Advisory-wait marker parsing    | AW1/AW2 combine review API state, requested reviewers, marker comments, and elapsed-time rules.       | A helper could hide important decision-table semantics that agents must still understand during holds. |
+| Final pre-merge freshness check | The merge path repeats review, comment, thread, CI, claim, and advisory checks immediately before F3. | A mutating helper would be risky; even a read-only helper needs strict output contracts.               |
+| Branch protection/ruleset reads | Required review and check discovery can be verbose across GitHub APIs.                                | Ruleset coverage varies by repository, so a helper could create false confidence in unsupported cases. |
+
+## Trade-off
+
+Helper scripts would improve copy/paste reliability and make some
+review-state checks easier to audit locally. That benefit is real,
+especially for advisory-wait and review-snapshot commands.
+
+The portability cost is also real. The exported IDD template is meant to
+work in repositories that can copy Markdown instruction files without
+adopting a runtime, package manager, or repository-local script
+directory. If helper scripts are introduced too early, every operational
+rule must be maintained twice: once in the instructions that agents read,
+and once in code that agents run.
+
+For now, the safer balance is to keep the instructions canonical and use
+documentation refactors to centralize repeated logic before introducing
+code.
+
+## Future Adoption Criteria
+
+If helper scripts are revisited, they should satisfy all of the
+following:
+
+- They are optional and never required to execute the exported template.
+- They are read-only by default; mutating actions remain explicit in the
+  phase instructions.
+- They output stable machine-readable JSON that can be inspected and
+  compared by agents.
+- They keep the shell / `gh` / `jq` fallback documented beside the helper
+  path.
+- They have a small test fixture set for marker parsing and snapshot
+  filtering.
+- They are introduced only after the corresponding instruction protocol
+  has stabilized enough that drift risk is lower than command-copy risk.
+
+Good candidates for a future first helper would be read-only snapshot
+commands for review activity, advisory-wait state, or claim-state
+inspection. They should not replace the written decision tables.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -95,3 +95,14 @@ phases.
 Non-Copilot agents can still drive the workflow end to end, but they
 should expect those later phases to interact with Copilot as a GitHub
 reviewer because that is part of this repository's current PR policy.
+
+## Optional helper scripts
+
+The current workflow does not require helper scripts. Shell / `gh` /
+`jq` snippets in `.github/instructions/*.instructions.md` remain the
+canonical portable path for adopters.
+
+See [IDD helper script evaluation](idd-helper-scripts.md) for the
+current inventory of high-friction query patterns, the reason helper
+scripts are not adopted yet, and the criteria for reconsidering optional
+read-only helpers later.


### PR DESCRIPTION
## Summary

- Add an IDD helper-script evaluation document that inventories the highest-friction repeated GitHub state queries.
- Record the current decision not to adopt helper scripts yet, with portability and drift-risk rationale.
- Mirror the policy into the exported template docs and onboarding file list so adopters receive the same guidance.

## Rationale

This intentionally does not add a `scripts/` directory. The workflow is still stabilizing through dogfooding, and helper scripts would create a second implementation surface for claim parsing, review snapshots, and advisory-wait decisions. The doc keeps shell / `gh` / `jq` instructions canonical while defining criteria for future optional read-only helpers.

## Testing

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

## Follow-up

None.

Closes #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance formalizing that optional helper scripts are not adopted at this time.
  * Described high-friction areas where helpers might help in the future.
  * Clarified risks and trade-offs between runnable helpers and copy-paste instructional reliability.
  * Defined criteria and safeguards for any future, read-only helper adoption.
  * Updated workflow and onboarding materials to reference the new helper-script guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->