### PR TITLE
docs: recover missing Copilot advisory markers

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -99,16 +99,18 @@ the GitHub API. Never use the timestamp inside the marker body.
 
 Evaluate in this order (the first matching row wins):
 
-| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof                         | Elapsed  | Outcome                                                             |
-| --------------------- | ----------------- | ------------------- | ---------------------------------- | -------- | ------------------------------------------------------------------- |
-| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)                              | (any)    | **SATISFIED**                                                       |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true` | —        | **RECOVERY_NEEDED**                                                 |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven                         | —        | **HOLD** (unproven current-head coverage)                           |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | ≥ 30 min | **SATISFIED** (window expired)                                      |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | < 30 min | **WAIT**                                                            |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | ≥ 10 min | **SATISFIED**                                                       |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | < 10 min | **WAIT**                                                            |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | (any)                              | —        | request cap ≥ 30: **CAP\_EXHAUSTED**; cap < 30: **REQUEST\_NEEDED** |
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof / cap                   | Elapsed  | Outcome                                                     |
+| --------------------- | ----------------- | ------------------- | ---------------------------------- | -------- | ----------------------------------------------------------- |
+| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)                              | (any)    | **SATISFIED**                                               |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true` | —        | **RECOVERY_NEEDED**                                         |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap < 30       | —        | **REQUEST_NEEDED** (refresh stale/unproven pending request) |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap ≥ 30       | —        | **CAP\_EXHAUSTED**                                          |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | ≥ 30 min | **SATISFIED** (window expired)                              |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | < 30 min | **WAIT**                                                    |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | ≥ 10 min | **SATISFIED**                                               |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | < 10 min | **WAIT**                                                    |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap ≥ 30                   | —        | **CAP\_EXHAUSTED**                                          |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap < 30                   | —        | **REQUEST_NEEDED**                                          |
 
 Note: evaluate the 30-minute SATISFIED condition before the WAIT
 condition for the `COPILOT_PENDING="true"` rows — the elapsed ≥ 30 min
@@ -121,14 +123,15 @@ Callers handle outcomes differently:
 | SATISFIED       | proceed to E15                     | continue to CI check                 | proceed with merge           |
 | HOLD            | post AW4 comment; stop             | post AW4 comment; stop               | post AW4 comment; stop       |
 | RECOVERY_NEEDED | post recovery marker; poll         | post recovery marker; poll           | post marker; return to F2    |
-| CAP\_EXHAUSTED  | skip advisory wait; proceed to E15 | post AW4 cap-exhausted comment; stop | not applicable (see F3 note) |
-| REQUEST\_NEEDED | request Copilot, post marker, poll | return to E14                        | not applicable (see F3 note) |
+| CAP\_EXHAUSTED  | skip advisory wait; proceed to E15 | post AW4 cap-exhausted comment; stop | post AW4 cap-exhausted; stop |
+| REQUEST\_NEEDED | request Copilot, post marker, poll | return to E14                        | return to E14; do not merge  |
 | WAIT            | continue polling (active loop)     | poll F2 conditions every 2 min       | return to F2                 |
 
 **F3 note**: F3 only invokes AW3 when `COPILOT_PENDING` is `"true"` AND
 `LAST_COPILOT_COMMIT != PR_HEAD_SHA`. If `COPILOT_PENDING` is `"false"`,
 F3 treats the advisory check as satisfied without running AW2–AW3 — see
-the F3 caller instructions.
+the F3 caller instructions. If AW3 returns **REQUEST_NEEDED**, F3 must
+return to E14 instead of requesting a review or merging.
 
 ## AW3-R — Recovery marker
 
@@ -165,14 +168,15 @@ it.
 
 ## AW4 — Hold comment templates
 
-**Unproven pending state** (COPILOT_PENDING is true, no same-head marker
-exists, and current-head coverage is not proven):
+**Pending refresh failed** (COPILOT_PENDING is true, no same-head marker
+exists, current-head coverage is not proven, and E14 cannot refresh the
+request):
 
 > Copilot review is pending for this PR, but the PR timeline does not
 > prove that the request was created after HEAD `{PR_HEAD_SHA}` entered
-> the PR. A maintainer must verify or request the Copilot review before
-> this step can safely continue. Do not merge until the maintainer has
-> resolved this.
+> the PR, and E14 could not refresh the pending request. A maintainer
+> must verify or request the Copilot review before this step can safely
+> continue. Do not merge until the maintainer has resolved this.
 
 **Recovery failed** (COPILOT_PENDING is true, a recovery marker was
 attempted, and no same-head marker can be posted or read):

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -5,7 +5,8 @@ advisory-wait check. It is referenced by:
 
 - **E14** (`idd-review-fix.instructions.md`): request a Copilot
   re-review and wait for the advisory window
-- **F2** (`idd-merge.instructions.md`): gate check before allowing merge
+- **F2** (`idd-pre-merge.instructions.md`): gate check before allowing
+  merge
 - **F3** (`idd-merge.instructions.md`): final revalidation immediately
   before executing the merge command
 
@@ -73,7 +74,7 @@ Evaluate in this order (the first matching row wins):
 | `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Elapsed  | Outcome                                                     |
 | --------------------- | ----------------- | ------------------- | -------- | ----------------------------------------------------------- |
 | `== PR_HEAD_SHA`      | (any)             | (any)               | (any)    | **SATISFIED**                                               |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **HOLD** (inconsistent)                                     |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **RECOVERY_NEEDED**                                         |
 | `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | ≥ 30 min | **SATISFIED** (window expired)                              |
 | `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | < 30 min | **WAIT**                                                    |
 | `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | ≥ 10 min | **SATISFIED**                                               |
@@ -90,6 +91,7 @@ Callers handle outcomes differently:
 | --------------- | ---------------------------------- | ------------------------------------ | ---------------------------- |
 | SATISFIED       | proceed to E15                     | continue to CI check                 | proceed with merge           |
 | HOLD            | post AW4 comment; stop             | post AW4 comment; stop               | post AW4 comment; stop       |
+| RECOVERY_NEEDED | post recovery marker; poll         | post recovery marker; poll           | post marker; return to F2    |
 | CAP\_EXHAUSTED  | skip advisory wait; proceed to E15 | post AW4 cap-exhausted comment; stop | not applicable (see F3 note) |
 | REQUEST\_NEEDED | request Copilot, post marker, poll | return to E14                        | not applicable (see F3 note) |
 | WAIT            | continue polling (active loop)     | poll F2 conditions every 2 min       | return to F2                 |
@@ -99,16 +101,46 @@ Callers handle outcomes differently:
 F3 treats the advisory check as satisfied without running AW2–AW3 — see
 the F3 caller instructions.
 
+## AW3-R — Recovery marker
+
+Use this only when AW3 returns **RECOVERY_NEEDED**:
+
+1. Do **not** request another Copilot review. GitHub already reports a
+   pending Copilot reviewer for the current HEAD.
+2. Post a plain-text marker for the current HEAD:
+
+   ```text
+   advisory-wait: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time}
+   ```
+
+3. Use the marker comment's GitHub `created_at` as the advisory-clock
+   start. The embedded timestamp is only human-readable context. Do not
+   use an inferred earlier reviewer-request time; recovery deliberately
+   starts a fresh conservative wait window.
+4. Treat the recovery marker as a wait-clock anchor only. It records an
+   already-pending reviewer state; it is not a new Copilot re-review
+   request.
+5. Re-run AW2 immediately. If the marker cannot be read, post the AW4
+   recovery-failed hold comment and stop.
+6. Continue through the caller's normal polling path. F3 must not merge
+   immediately after posting a recovery marker; it returns to F2.
+
+This recovery path covers Copilot reviewer requests created outside the
+current E14 request step, including GitHub auto-assignment, manual
+reviewer assignment, or a restart where the original request source is
+not knowable. A same-run E14 crash is still safe to recover because the
+new marker's `created_at` restarts the wait window instead of shortening
+it.
+
 ## AW4 — Hold comment templates
 
-**Inconsistent state** (COPILOT_PENDING is true, no same-head marker):
+**Recovery failed** (COPILOT_PENDING is true, no same-head marker can be
+posted or read):
 
 > Copilot review is pending for HEAD `{PR_HEAD_SHA}` but no
-> advisory-wait marker was found. E14 may have crashed before posting
-> the marker. A maintainer must verify whether the Copilot review was
-> formally requested and confirm its status before this step can safely
-> continue. Do not merge or post a new advisory-wait marker until the
-> maintainer has resolved this.
+> advisory-wait marker can be posted or read. A maintainer must verify
+> the Copilot advisory-wait state before this step can safely continue.
+> Do not merge until the maintainer has resolved this.
 
 **Cap exhausted** (no same-head marker, MARKER_COUNT ≥ 30):
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -33,10 +33,36 @@ COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_rev
 # "true" → review still pending; "false" → submitted or cancelled.
 # GitHub uses "Copilot" (capital C) in requested_reviewers and
 # "copilot-pull-request-reviewer[bot]" in the reviews API — both matched here.
+
+COPILOT_PENDING_COVERS_HEAD=$(
+  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \
+    -H "Accept: application/vnd.github+json" \
+    --paginate \
+    | jq -r -s --arg sha "${PR_HEAD_SHA}" '
+        (add // [])
+        | to_entries
+        | (map(select(.value.event == "committed"
+             and ((.value.sha // .value.commit_id // "") == $sha)))
+           | last | .key // null) as $head_index
+        | (map(select(.value.event == "review_requested"
+             and (((.value.requested_reviewer.login // "") == "Copilot")
+                  or ((.value.requested_reviewer.login // "")
+                      | startswith("copilot-pull-request-reviewer")))))
+           | last | .key // null) as $request_index
+        | ($head_index != null and $request_index != null and
+           $request_index > $head_index)
+      '
+)
+# "true" → the PR timeline proves the latest Copilot review request was
+# created after the current PR_HEAD_SHA entered the PR timeline.
+# "false" → pending reviewer exists, but recovery must stay on HOLD.
 ```
 
 If `LAST_COPILOT_COMMIT == PR_HEAD_SHA` → outcome is **SATISFIED**.
 Caller proceeds to its designated next step without running AW2–AW3.
+
+Do not use commit author or committer timestamps as recovery proof; they
+do not prove when a commit entered the PR branch.
 
 ## AW2 — Fetch advisory-wait markers
 
@@ -46,19 +72,21 @@ EARLIEST_SAME_HEAD_AT=$(
     | jq -r -s "add
          | [.[] | select(
                (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
+               (.body | test(\"^advisory-wait-recovery: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
                (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA} [^ ]+ -->$\"))
              )]
          | min_by(.created_at) | .created_at // \"\""
 )
-# Matches plain-text (current) and HTML-comment (legacy) marker formats.
+# Matches request, recovery, and HTML-comment (legacy) marker formats.
 # Empty → no same-head marker exists.
 # Non-empty → earliest same-head marker createdAt (advisory-clock start).
 
-MARKER_COUNT=$(
+REQUEST_MARKER_COUNT=$(
   gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
     | jq -r -s 'add | [.[] | select(.body | test("^advisory-wait:|^<!-- advisory-wait:"))] | length'
 )
-# Total advisory-wait markers for this PR (all HEADs). Used for the 30-per-PR cap.
+# Total Copilot re-review request markers for this PR (all HEADs). Used for
+# the 30-per-PR request cap. Recovery markers are excluded from this count.
 ```
 
 Refresh `EARLIEST_SAME_HEAD_AT` at the start of each polling iteration —
@@ -71,15 +99,16 @@ the GitHub API. Never use the timestamp inside the marker body.
 
 Evaluate in this order (the first matching row wins):
 
-| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Elapsed  | Outcome                                                     |
-| --------------------- | ----------------- | ------------------- | -------- | ----------------------------------------------------------- |
-| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)    | **SATISFIED**                                               |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **RECOVERY_NEEDED**                                         |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | ≥ 30 min | **SATISFIED** (window expired)                              |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | < 30 min | **WAIT**                                                    |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | ≥ 10 min | **SATISFIED**                                               |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | < 10 min | **WAIT**                                                    |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | —        | cap ≥ 30: **CAP\_EXHAUSTED**; cap < 30: **REQUEST\_NEEDED** |
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof                         | Elapsed  | Outcome                                                             |
+| --------------------- | ----------------- | ------------------- | ---------------------------------- | -------- | ------------------------------------------------------------------- |
+| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)                              | (any)    | **SATISFIED**                                                       |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true` | —        | **RECOVERY_NEEDED**                                                 |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven                         | —        | **HOLD** (unproven current-head coverage)                           |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | ≥ 30 min | **SATISFIED** (window expired)                                      |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | < 30 min | **WAIT**                                                            |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | ≥ 10 min | **SATISFIED**                                                       |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | < 10 min | **WAIT**                                                            |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | (any)                              | —        | request cap ≥ 30: **CAP\_EXHAUSTED**; cap < 30: **REQUEST\_NEEDED** |
 
 Note: evaluate the 30-minute SATISFIED condition before the WAIT
 condition for the `COPILOT_PENDING="true"` rows — the elapsed ≥ 30 min
@@ -106,11 +135,13 @@ the F3 caller instructions.
 Use this only when AW3 returns **RECOVERY_NEEDED**:
 
 1. Do **not** request another Copilot review. GitHub already reports a
-   pending Copilot reviewer for the current HEAD.
+   pending Copilot reviewer, and `COPILOT_PENDING_COVERS_HEAD=true`
+   proves the request was created after the current HEAD entered the PR
+   timeline.
 2. Post a plain-text marker for the current HEAD:
 
    ```text
-   advisory-wait: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time}
+   advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time}
    ```
 
 3. Use the marker comment's GitHub `created_at` as the advisory-clock
@@ -134,15 +165,24 @@ it.
 
 ## AW4 — Hold comment templates
 
-**Recovery failed** (COPILOT_PENDING is true, no same-head marker can be
-posted or read):
+**Unproven pending state** (COPILOT_PENDING is true, no same-head marker
+exists, and current-head coverage is not proven):
+
+> Copilot review is pending for this PR, but the PR timeline does not
+> prove that the request was created after HEAD `{PR_HEAD_SHA}` entered
+> the PR. A maintainer must verify or request the Copilot review before
+> this step can safely continue. Do not merge until the maintainer has
+> resolved this.
+
+**Recovery failed** (COPILOT_PENDING is true, a recovery marker was
+attempted, and no same-head marker can be posted or read):
 
 > Copilot review is pending for HEAD `{PR_HEAD_SHA}` but no
 > advisory-wait marker can be posted or read. A maintainer must verify
 > the Copilot advisory-wait state before this step can safely continue.
 > Do not merge until the maintainer has resolved this.
 
-**Cap exhausted** (no same-head marker, MARKER_COUNT ≥ 30):
+**Cap exhausted** (no same-head marker, REQUEST_MARKER_COUNT ≥ 30):
 
 > The 30-per-PR Copilot re-review cap is exhausted. A maintainer must
 > manually request and evaluate a Copilot review before merge.

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -55,7 +55,8 @@ COPILOT_PENDING_COVERS_HEAD=$(
 )
 # "true" → the PR timeline proves the latest Copilot review request was
 # created after the current PR_HEAD_SHA entered the PR timeline.
-# "false" → pending reviewer exists, but recovery must stay on HOLD.
+# "false" → pending reviewer exists, but current-head coverage is unproven;
+# AW3 routes to REQUEST_NEEDED, or CAP_EXHAUSTED when the request cap is hit.
 ```
 
 If `LAST_COPILOT_COMMIT == PR_HEAD_SHA` → outcome is **SATISFIED**.

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -54,6 +54,10 @@ gate. The active claim must still use your current `{claim-id}`.
      - **RECOVERY_NEEDED** → post the recovery marker from **AW3-R** and
        return to the F2 advisory bot wait check. Do not merge in the
        same F3 pass that creates a recovery marker.
+     - **CAP_EXHAUSTED** → post the cap-exhausted hold comment from
+       **AW4** and stop.
+     - **REQUEST_NEEDED** → return to E14 to refresh/request Copilot
+       review and post a request marker. Do not merge.
      - **WAIT** → Do NOT execute the merge. Return to the **F2 advisory
        bot wait check** in `idd-pre-merge.instructions.md` (go back to
        the first condition in F2). F2 will reuse the existing same-HEAD

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -51,6 +51,9 @@ gate. The active claim must still use your current `{claim-id}`.
      as F3 is a self-contained blocking gate:
      - **SATISFIED** → proceed with the merge.
      - **HOLD** → post the hold comment from **AW4** and stop.
+     - **RECOVERY_NEEDED** → post the recovery marker from **AW3-R** and
+       return to the F2 advisory bot wait check. Do not merge in the
+       same F3 pass that creates a recovery marker.
      - **WAIT** → Do NOT execute the merge. Return to the **F2 advisory
        bot wait check** in `idd-pre-merge.instructions.md` (go back to
        the first condition in F2). F2 will reuse the existing same-HEAD

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -80,6 +80,10 @@ bracketed action:
      - **SATISFIED** → this check is **satisfied**; continue to the CI
        check.
      - **HOLD** → post the hold comment from **AW4** and stop.
+     - **RECOVERY_NEEDED** → post the recovery marker from **AW3-R**
+       without requesting another Copilot review, then enter the normal
+       WAIT polling path using refreshed AW2/AW3 state. Then **go back
+       to the first condition in F2**.
      - **REQUEST_NEEDED** → return to E14 to request Copilot review and
        post a fresh marker. Do not post a new request in F2.
      - **WAIT** (`COPILOT_PENDING` is `"true"`, elapsed < 30 min) →

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -84,6 +84,8 @@ bracketed action:
        without requesting another Copilot review, then enter the normal
        WAIT polling path using refreshed AW2/AW3 state. Then **go back
        to the first condition in F2**.
+     - **CAP_EXHAUSTED** → post the cap-exhausted hold comment from
+       **AW4** and stop.
      - **REQUEST_NEEDED** → return to E14 to request Copilot review and
        post a fresh marker. Do not post a new request in F2.
      - **WAIT** (`COPILOT_PENDING` is `"true"`, elapsed < 30 min) →

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -143,7 +143,8 @@ Copilot and CI advisory bot comments are advisory; unanswered ones do
 not block merge.
 
 **Active polling loop** (applies when `COPILOT_PENDING` is `"true"`, or
-immediately after a new request was sent above):
+immediately after posting a marker in the **REQUEST_NEEDED** or
+**RECOVERY_NEEDED** path above):
 
 Do **not** post a new marker if a same-head marker already exists; reuse
 it. If multiple same-head markers exist, always use the one with the

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -108,10 +108,12 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
    - **RECOVERY_NEEDED** (`COPILOT_PENDING` is `"true"`, no same-head
      marker): post the recovery marker from **AW3-R**. Do not request
      another Copilot review.
-   - **CAP_EXHAUSTED** (`MARKER_COUNT` ≥ 30, no same-head marker) →
+   - **CAP_EXHAUSTED** (`REQUEST_MARKER_COUNT` ≥ 30, no same-head
+     marker) →
      skip the advisory wait entirely; proceed directly to E15.
-   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, cap < 30):
-     request Copilot review and immediately post a plain-text marker:
+   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, request cap <
+     30): request Copilot review and immediately post a plain-text
+     marker:
 
      ```sh
      gh pr edit {pr-number} --add-reviewer "@copilot"
@@ -158,9 +160,10 @@ Poll every 2 minutes:
 
 2. Re-read review threads, review bodies, and regular PR comments,
    **excluding any regular PR comment authored by any IDD agent** (covers
-   advisory-wait, review-watermark, review-baseline, claim, hold notes,
-   and other operational comments). If any item has `updatedAt` strictly
-   newer than the polling watermark → return to E1 immediately.
+   advisory-wait, advisory-wait-recovery, review-watermark,
+   review-baseline, claim, hold notes, and other operational comments).
+   If any item has `updatedAt` strictly newer than the polling watermark
+   → return to E1 immediately.
 
 3. Run **AW1** and **AW2** (refresh `COPILOT_PENDING`, `LAST_COPILOT_COMMIT`,
    and `EARLIEST_SAME_HEAD_AT`). Apply **AW5** if `EARLIEST_SAME_HEAD_AT`

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -105,6 +105,9 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
 4. Apply the **AW3** decision table:
    - **SATISFIED** → proceed to E15.
    - **HOLD** → post the hold comment from **AW4** and stop.
+   - **RECOVERY_NEEDED** (`COPILOT_PENDING` is `"true"`, no same-head
+     marker): post the recovery marker from **AW3-R**. Do not request
+     another Copilot review.
    - **CAP_EXHAUSTED** (`MARKER_COUNT` ≥ 30, no same-head marker) →
      skip the advisory wait entirely; proceed directly to E15.
    - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, cap < 30):
@@ -120,8 +123,8 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
 
      Use `PR_HEAD_SHA` as `{head-SHA}`. Post as plain text, not an HTML
      comment block.
-   - **WAIT**, or after **REQUEST_NEEDED** marker is posted: enter the
-     active polling loop below.
+   - **WAIT**, or after a **REQUEST_NEEDED** or **RECOVERY_NEEDED**
+     marker is posted: enter the active polling loop below.
 
 Copilot and CI advisory bot comments are advisory; unanswered ones do
 not block merge.

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -111,9 +111,20 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
    - **CAP_EXHAUSTED** (`REQUEST_MARKER_COUNT` ≥ 30, no same-head
      marker) →
      skip the advisory wait entirely; proceed directly to E15.
-   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, request cap <
-     30): request Copilot review and immediately post a plain-text
-     marker:
+   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, or
+     `COPILOT_PENDING` is `"true"` but current-head coverage is not
+     proven; request cap < 30): request Copilot review and immediately
+     post a plain-text marker. If `COPILOT_PENDING` is `"true"` in this
+     branch, first remove the stale/unproven pending reviewer request:
+
+     ```sh
+     gh pr edit {pr-number} --remove-reviewer "@copilot"
+     ```
+
+     If removal fails because Copilot is no longer pending, re-run
+     AW1–AW3. If removal fails for any other reason, post the AW4
+     pending-refresh-failed hold comment and stop. After removal
+     succeeds, request Copilot review:
 
      ```sh
      gh pr edit {pr-number} --add-reviewer "@copilot"

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -35,6 +35,7 @@ by any IDD agent):
 - `<!-- claimed-by:`
 - `<!-- unclaimed-by:`
 - `advisory-wait:`
+- `advisory-wait-recovery:`
 - `<!-- advisory-wait:`
 
 Additionally, fetch the **current CI state** for `{head-SHA}`:

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -99,16 +99,18 @@ the GitHub API. Never use the timestamp inside the marker body.
 
 Evaluate in this order (the first matching row wins):
 
-| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof                         | Elapsed  | Outcome                                                             |
-| --------------------- | ----------------- | ------------------- | ---------------------------------- | -------- | ------------------------------------------------------------------- |
-| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)                              | (any)    | **SATISFIED**                                                       |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true` | —        | **RECOVERY_NEEDED**                                                 |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven                         | —        | **HOLD** (unproven current-head coverage)                           |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | ≥ 30 min | **SATISFIED** (window expired)                                      |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | < 30 min | **WAIT**                                                            |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | ≥ 10 min | **SATISFIED**                                                       |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | < 10 min | **WAIT**                                                            |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | (any)                              | —        | request cap ≥ 30: **CAP\_EXHAUSTED**; cap < 30: **REQUEST\_NEEDED** |
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof / cap                   | Elapsed  | Outcome                                                     |
+| --------------------- | ----------------- | ------------------- | ---------------------------------- | -------- | ----------------------------------------------------------- |
+| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)                              | (any)    | **SATISFIED**                                               |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true` | —        | **RECOVERY_NEEDED**                                         |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap < 30       | —        | **REQUEST_NEEDED** (refresh stale/unproven pending request) |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap ≥ 30       | —        | **CAP\_EXHAUSTED**                                          |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | ≥ 30 min | **SATISFIED** (window expired)                              |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | < 30 min | **WAIT**                                                    |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | ≥ 10 min | **SATISFIED**                                               |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | < 10 min | **WAIT**                                                    |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap ≥ 30                   | —        | **CAP\_EXHAUSTED**                                          |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap < 30                   | —        | **REQUEST_NEEDED**                                          |
 
 Note: evaluate the 30-minute SATISFIED condition before the WAIT
 condition for the `COPILOT_PENDING="true"` rows — the elapsed ≥ 30 min
@@ -121,14 +123,15 @@ Callers handle outcomes differently:
 | SATISFIED       | proceed to E15                     | continue to CI check                 | proceed with merge           |
 | HOLD            | post AW4 comment; stop             | post AW4 comment; stop               | post AW4 comment; stop       |
 | RECOVERY_NEEDED | post recovery marker; poll         | post recovery marker; poll           | post marker; return to F2    |
-| CAP\_EXHAUSTED  | skip advisory wait; proceed to E15 | post AW4 cap-exhausted comment; stop | not applicable (see F3 note) |
-| REQUEST\_NEEDED | request Copilot, post marker, poll | return to E14                        | not applicable (see F3 note) |
+| CAP\_EXHAUSTED  | skip advisory wait; proceed to E15 | post AW4 cap-exhausted comment; stop | post AW4 cap-exhausted; stop |
+| REQUEST\_NEEDED | request Copilot, post marker, poll | return to E14                        | return to E14; do not merge  |
 | WAIT            | continue polling (active loop)     | poll F2 conditions every 2 min       | return to F2                 |
 
 **F3 note**: F3 only invokes AW3 when `COPILOT_PENDING` is `"true"` AND
 `LAST_COPILOT_COMMIT != PR_HEAD_SHA`. If `COPILOT_PENDING` is `"false"`,
 F3 treats the advisory check as satisfied without running AW2–AW3 — see
-the F3 caller instructions.
+the F3 caller instructions. If AW3 returns **REQUEST_NEEDED**, F3 must
+return to E14 instead of requesting a review or merging.
 
 ## AW3-R — Recovery marker
 
@@ -165,14 +168,15 @@ it.
 
 ## AW4 — Hold comment templates
 
-**Unproven pending state** (COPILOT_PENDING is true, no same-head marker
-exists, and current-head coverage is not proven):
+**Pending refresh failed** (COPILOT_PENDING is true, no same-head marker
+exists, current-head coverage is not proven, and E14 cannot refresh the
+request):
 
 > Copilot review is pending for this PR, but the PR timeline does not
 > prove that the request was created after HEAD `{PR_HEAD_SHA}` entered
-> the PR. A maintainer must verify or request the Copilot review before
-> this step can safely continue. Do not merge until the maintainer has
-> resolved this.
+> the PR, and E14 could not refresh the pending request. A maintainer
+> must verify or request the Copilot review before this step can safely
+> continue. Do not merge until the maintainer has resolved this.
 
 **Recovery failed** (COPILOT_PENDING is true, a recovery marker was
 attempted, and no same-head marker can be posted or read):

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -5,7 +5,8 @@ advisory-wait check. It is referenced by:
 
 - **E14** (`idd-review-fix.instructions.md`): request a Copilot
   re-review and wait for the advisory window
-- **F2** (`idd-merge.instructions.md`): gate check before allowing merge
+- **F2** (`idd-pre-merge.instructions.md`): gate check before allowing
+  merge
 - **F3** (`idd-merge.instructions.md`): final revalidation immediately
   before executing the merge command
 
@@ -73,7 +74,7 @@ Evaluate in this order (the first matching row wins):
 | `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Elapsed  | Outcome                                                     |
 | --------------------- | ----------------- | ------------------- | -------- | ----------------------------------------------------------- |
 | `== PR_HEAD_SHA`      | (any)             | (any)               | (any)    | **SATISFIED**                                               |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **HOLD** (inconsistent)                                     |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **RECOVERY_NEEDED**                                         |
 | `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | ≥ 30 min | **SATISFIED** (window expired)                              |
 | `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | < 30 min | **WAIT**                                                    |
 | `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | ≥ 10 min | **SATISFIED**                                               |
@@ -90,6 +91,7 @@ Callers handle outcomes differently:
 | --------------- | ---------------------------------- | ------------------------------------ | ---------------------------- |
 | SATISFIED       | proceed to E15                     | continue to CI check                 | proceed with merge           |
 | HOLD            | post AW4 comment; stop             | post AW4 comment; stop               | post AW4 comment; stop       |
+| RECOVERY_NEEDED | post recovery marker; poll         | post recovery marker; poll           | post marker; return to F2    |
 | CAP\_EXHAUSTED  | skip advisory wait; proceed to E15 | post AW4 cap-exhausted comment; stop | not applicable (see F3 note) |
 | REQUEST\_NEEDED | request Copilot, post marker, poll | return to E14                        | not applicable (see F3 note) |
 | WAIT            | continue polling (active loop)     | poll F2 conditions every 2 min       | return to F2                 |
@@ -99,16 +101,46 @@ Callers handle outcomes differently:
 F3 treats the advisory check as satisfied without running AW2–AW3 — see
 the F3 caller instructions.
 
+## AW3-R — Recovery marker
+
+Use this only when AW3 returns **RECOVERY_NEEDED**:
+
+1. Do **not** request another Copilot review. GitHub already reports a
+   pending Copilot reviewer for the current HEAD.
+2. Post a plain-text marker for the current HEAD:
+
+   ```text
+   advisory-wait: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time}
+   ```
+
+3. Use the marker comment's GitHub `created_at` as the advisory-clock
+   start. The embedded timestamp is only human-readable context. Do not
+   use an inferred earlier reviewer-request time; recovery deliberately
+   starts a fresh conservative wait window.
+4. Treat the recovery marker as a wait-clock anchor only. It records an
+   already-pending reviewer state; it is not a new Copilot re-review
+   request.
+5. Re-run AW2 immediately. If the marker cannot be read, post the AW4
+   recovery-failed hold comment and stop.
+6. Continue through the caller's normal polling path. F3 must not merge
+   immediately after posting a recovery marker; it returns to F2.
+
+This recovery path covers Copilot reviewer requests created outside the
+current E14 request step, including GitHub auto-assignment, manual
+reviewer assignment, or a restart where the original request source is
+not knowable. A same-run E14 crash is still safe to recover because the
+new marker's `created_at` restarts the wait window instead of shortening
+it.
+
 ## AW4 — Hold comment templates
 
-**Inconsistent state** (COPILOT_PENDING is true, no same-head marker):
+**Recovery failed** (COPILOT_PENDING is true, no same-head marker can be
+posted or read):
 
 > Copilot review is pending for HEAD `{PR_HEAD_SHA}` but no
-> advisory-wait marker was found. E14 may have crashed before posting
-> the marker. A maintainer must verify whether the Copilot review was
-> formally requested and confirm its status before this step can safely
-> continue. Do not merge or post a new advisory-wait marker until the
-> maintainer has resolved this.
+> advisory-wait marker can be posted or read. A maintainer must verify
+> the Copilot advisory-wait state before this step can safely continue.
+> Do not merge until the maintainer has resolved this.
 
 **Cap exhausted** (no same-head marker, MARKER_COUNT ≥ 30):
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -33,10 +33,36 @@ COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_rev
 # "true" → review still pending; "false" → submitted or cancelled.
 # GitHub uses "Copilot" (capital C) in requested_reviewers and
 # "copilot-pull-request-reviewer[bot]" in the reviews API — both matched here.
+
+COPILOT_PENDING_COVERS_HEAD=$(
+  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \
+    -H "Accept: application/vnd.github+json" \
+    --paginate \
+    | jq -r -s --arg sha "${PR_HEAD_SHA}" '
+        (add // [])
+        | to_entries
+        | (map(select(.value.event == "committed"
+             and ((.value.sha // .value.commit_id // "") == $sha)))
+           | last | .key // null) as $head_index
+        | (map(select(.value.event == "review_requested"
+             and (((.value.requested_reviewer.login // "") == "Copilot")
+                  or ((.value.requested_reviewer.login // "")
+                      | startswith("copilot-pull-request-reviewer")))))
+           | last | .key // null) as $request_index
+        | ($head_index != null and $request_index != null and
+           $request_index > $head_index)
+      '
+)
+# "true" → the PR timeline proves the latest Copilot review request was
+# created after the current PR_HEAD_SHA entered the PR timeline.
+# "false" → pending reviewer exists, but recovery must stay on HOLD.
 ```
 
 If `LAST_COPILOT_COMMIT == PR_HEAD_SHA` → outcome is **SATISFIED**.
 Caller proceeds to its designated next step without running AW2–AW3.
+
+Do not use commit author or committer timestamps as recovery proof; they
+do not prove when a commit entered the PR branch.
 
 ## AW2 — Fetch advisory-wait markers
 
@@ -46,19 +72,21 @@ EARLIEST_SAME_HEAD_AT=$(
     | jq -r -s "add
          | [.[] | select(
                (.body | test(\"^advisory-wait: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
+               (.body | test(\"^advisory-wait-recovery: [^ ]+ ${PR_HEAD_SHA}(?: |\$)\")) or
                (.body | test(\"^<!-- advisory-wait: [^ ]+ ${PR_HEAD_SHA} [^ ]+ -->$\"))
              )]
          | min_by(.created_at) | .created_at // \"\""
 )
-# Matches plain-text (current) and HTML-comment (legacy) marker formats.
+# Matches request, recovery, and HTML-comment (legacy) marker formats.
 # Empty → no same-head marker exists.
 # Non-empty → earliest same-head marker createdAt (advisory-clock start).
 
-MARKER_COUNT=$(
+REQUEST_MARKER_COUNT=$(
   gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
     | jq -r -s 'add | [.[] | select(.body | test("^advisory-wait:|^<!-- advisory-wait:"))] | length'
 )
-# Total advisory-wait markers for this PR (all HEADs). Used for the 30-per-PR cap.
+# Total Copilot re-review request markers for this PR (all HEADs). Used for
+# the 30-per-PR request cap. Recovery markers are excluded from this count.
 ```
 
 Refresh `EARLIEST_SAME_HEAD_AT` at the start of each polling iteration —
@@ -71,15 +99,16 @@ the GitHub API. Never use the timestamp inside the marker body.
 
 Evaluate in this order (the first matching row wins):
 
-| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Elapsed  | Outcome                                                     |
-| --------------------- | ----------------- | ------------------- | -------- | ----------------------------------------------------------- |
-| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)    | **SATISFIED**                                               |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | —        | **RECOVERY_NEEDED**                                         |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | ≥ 30 min | **SATISFIED** (window expired)                              |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | < 30 min | **WAIT**                                                    |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | ≥ 10 min | **SATISFIED**                                               |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | < 10 min | **WAIT**                                                    |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | —        | cap ≥ 30: **CAP\_EXHAUSTED**; cap < 30: **REQUEST\_NEEDED** |
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof                         | Elapsed  | Outcome                                                             |
+| --------------------- | ----------------- | ------------------- | ---------------------------------- | -------- | ------------------------------------------------------------------- |
+| `== PR_HEAD_SHA`      | (any)             | (any)               | (any)                              | (any)    | **SATISFIED**                                                       |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true` | —        | **RECOVERY_NEEDED**                                                 |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven                         | —        | **HOLD** (unproven current-head coverage)                           |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | ≥ 30 min | **SATISFIED** (window expired)                                      |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | (any)                              | < 30 min | **WAIT**                                                            |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | ≥ 10 min | **SATISFIED**                                                       |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | (any)                              | < 10 min | **WAIT**                                                            |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | (any)                              | —        | request cap ≥ 30: **CAP\_EXHAUSTED**; cap < 30: **REQUEST\_NEEDED** |
 
 Note: evaluate the 30-minute SATISFIED condition before the WAIT
 condition for the `COPILOT_PENDING="true"` rows — the elapsed ≥ 30 min
@@ -106,11 +135,13 @@ the F3 caller instructions.
 Use this only when AW3 returns **RECOVERY_NEEDED**:
 
 1. Do **not** request another Copilot review. GitHub already reports a
-   pending Copilot reviewer for the current HEAD.
+   pending Copilot reviewer, and `COPILOT_PENDING_COVERS_HEAD=true`
+   proves the request was created after the current HEAD entered the PR
+   timeline.
 2. Post a plain-text marker for the current HEAD:
 
    ```text
-   advisory-wait: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time}
+   advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time}
    ```
 
 3. Use the marker comment's GitHub `created_at` as the advisory-clock
@@ -134,15 +165,24 @@ it.
 
 ## AW4 — Hold comment templates
 
-**Recovery failed** (COPILOT_PENDING is true, no same-head marker can be
-posted or read):
+**Unproven pending state** (COPILOT_PENDING is true, no same-head marker
+exists, and current-head coverage is not proven):
+
+> Copilot review is pending for this PR, but the PR timeline does not
+> prove that the request was created after HEAD `{PR_HEAD_SHA}` entered
+> the PR. A maintainer must verify or request the Copilot review before
+> this step can safely continue. Do not merge until the maintainer has
+> resolved this.
+
+**Recovery failed** (COPILOT_PENDING is true, a recovery marker was
+attempted, and no same-head marker can be posted or read):
 
 > Copilot review is pending for HEAD `{PR_HEAD_SHA}` but no
 > advisory-wait marker can be posted or read. A maintainer must verify
 > the Copilot advisory-wait state before this step can safely continue.
 > Do not merge until the maintainer has resolved this.
 
-**Cap exhausted** (no same-head marker, MARKER_COUNT ≥ 30):
+**Cap exhausted** (no same-head marker, REQUEST_MARKER_COUNT ≥ 30):
 
 > The 30-per-PR Copilot re-review cap is exhausted. A maintainer must
 > manually request and evaluate a Copilot review before merge.

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -55,7 +55,8 @@ COPILOT_PENDING_COVERS_HEAD=$(
 )
 # "true" → the PR timeline proves the latest Copilot review request was
 # created after the current PR_HEAD_SHA entered the PR timeline.
-# "false" → pending reviewer exists, but recovery must stay on HOLD.
+# "false" → pending reviewer exists, but current-head coverage is unproven;
+# AW3 routes to REQUEST_NEEDED, or CAP_EXHAUSTED when the request cap is hit.
 ```
 
 If `LAST_COPILOT_COMMIT == PR_HEAD_SHA` → outcome is **SATISFIED**.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -54,6 +54,10 @@ gate. The active claim must still use your current `{claim-id}`.
      - **RECOVERY_NEEDED** → post the recovery marker from **AW3-R** and
        return to the F2 advisory bot wait check. Do not merge in the
        same F3 pass that creates a recovery marker.
+     - **CAP_EXHAUSTED** → post the cap-exhausted hold comment from
+       **AW4** and stop.
+     - **REQUEST_NEEDED** → return to E14 to refresh/request Copilot
+       review and post a request marker. Do not merge.
      - **WAIT** → Do NOT execute the merge. Return to the **F2 advisory
        bot wait check** in `idd-pre-merge.instructions.md` (go back to
        the first condition in F2). F2 will reuse the existing same-HEAD

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -51,6 +51,9 @@ gate. The active claim must still use your current `{claim-id}`.
      as F3 is a self-contained blocking gate:
      - **SATISFIED** → proceed with the merge.
      - **HOLD** → post the hold comment from **AW4** and stop.
+     - **RECOVERY_NEEDED** → post the recovery marker from **AW3-R** and
+       return to the F2 advisory bot wait check. Do not merge in the
+       same F3 pass that creates a recovery marker.
      - **WAIT** → Do NOT execute the merge. Return to the **F2 advisory
        bot wait check** in `idd-pre-merge.instructions.md` (go back to
        the first condition in F2). F2 will reuse the existing same-HEAD

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -80,6 +80,10 @@ bracketed action:
      - **SATISFIED** → this check is **satisfied**; continue to the CI
        check.
      - **HOLD** → post the hold comment from **AW4** and stop.
+     - **RECOVERY_NEEDED** → post the recovery marker from **AW3-R**
+       without requesting another Copilot review, then enter the normal
+       WAIT polling path using refreshed AW2/AW3 state. Then **go back
+       to the first condition in F2**.
      - **REQUEST_NEEDED** → return to E14 to request Copilot review and
        post a fresh marker. Do not post a new request in F2.
      - **WAIT** (`COPILOT_PENDING` is `"true"`, elapsed < 30 min) →

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -84,6 +84,8 @@ bracketed action:
        without requesting another Copilot review, then enter the normal
        WAIT polling path using refreshed AW2/AW3 state. Then **go back
        to the first condition in F2**.
+     - **CAP_EXHAUSTED** → post the cap-exhausted hold comment from
+       **AW4** and stop.
      - **REQUEST_NEEDED** → return to E14 to request Copilot review and
        post a fresh marker. Do not post a new request in F2.
      - **WAIT** (`COPILOT_PENDING` is `"true"`, elapsed < 30 min) →

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -143,7 +143,8 @@ Copilot and CI advisory bot comments are advisory; unanswered ones do
 not block merge.
 
 **Active polling loop** (applies when `COPILOT_PENDING` is `"true"`, or
-immediately after a new request was sent above):
+immediately after posting a marker in the **REQUEST_NEEDED** or
+**RECOVERY_NEEDED** path above):
 
 Do **not** post a new marker if a same-head marker already exists; reuse
 it. If multiple same-head markers exist, always use the one with the

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -108,10 +108,12 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
    - **RECOVERY_NEEDED** (`COPILOT_PENDING` is `"true"`, no same-head
      marker): post the recovery marker from **AW3-R**. Do not request
      another Copilot review.
-   - **CAP_EXHAUSTED** (`MARKER_COUNT` ≥ 30, no same-head marker) →
+   - **CAP_EXHAUSTED** (`REQUEST_MARKER_COUNT` ≥ 30, no same-head
+     marker) →
      skip the advisory wait entirely; proceed directly to E15.
-   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, cap < 30):
-     request Copilot review and immediately post a plain-text marker:
+   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, request cap <
+     30): request Copilot review and immediately post a plain-text
+     marker:
 
      ```sh
      gh pr edit {pr-number} --add-reviewer "@copilot"
@@ -158,9 +160,10 @@ Poll every 2 minutes:
 
 2. Re-read review threads, review bodies, and regular PR comments,
    **excluding any regular PR comment authored by any IDD agent** (covers
-   advisory-wait, review-watermark, review-baseline, claim, hold notes,
-   and other operational comments). If any item has `updatedAt` strictly
-   newer than the polling watermark → return to E1 immediately.
+   advisory-wait, advisory-wait-recovery, review-watermark,
+   review-baseline, claim, hold notes, and other operational comments).
+   If any item has `updatedAt` strictly newer than the polling watermark
+   → return to E1 immediately.
 
 3. Run **AW1** and **AW2** (refresh `COPILOT_PENDING`, `LAST_COPILOT_COMMIT`,
    and `EARLIEST_SAME_HEAD_AT`). Apply **AW5** if `EARLIEST_SAME_HEAD_AT`

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -105,6 +105,9 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
 4. Apply the **AW3** decision table:
    - **SATISFIED** → proceed to E15.
    - **HOLD** → post the hold comment from **AW4** and stop.
+   - **RECOVERY_NEEDED** (`COPILOT_PENDING` is `"true"`, no same-head
+     marker): post the recovery marker from **AW3-R**. Do not request
+     another Copilot review.
    - **CAP_EXHAUSTED** (`MARKER_COUNT` ≥ 30, no same-head marker) →
      skip the advisory wait entirely; proceed directly to E15.
    - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, cap < 30):
@@ -120,8 +123,8 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
 
      Use `PR_HEAD_SHA` as `{head-SHA}`. Post as plain text, not an HTML
      comment block.
-   - **WAIT**, or after **REQUEST_NEEDED** marker is posted: enter the
-     active polling loop below.
+   - **WAIT**, or after a **REQUEST_NEEDED** or **RECOVERY_NEEDED**
+     marker is posted: enter the active polling loop below.
 
 Copilot and CI advisory bot comments are advisory; unanswered ones do
 not block merge.

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -111,9 +111,20 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
    - **CAP_EXHAUSTED** (`REQUEST_MARKER_COUNT` ≥ 30, no same-head
      marker) →
      skip the advisory wait entirely; proceed directly to E15.
-   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, request cap <
-     30): request Copilot review and immediately post a plain-text
-     marker:
+   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, or
+     `COPILOT_PENDING` is `"true"` but current-head coverage is not
+     proven; request cap < 30): request Copilot review and immediately
+     post a plain-text marker. If `COPILOT_PENDING` is `"true"` in this
+     branch, first remove the stale/unproven pending reviewer request:
+
+     ```sh
+     gh pr edit {pr-number} --remove-reviewer "@copilot"
+     ```
+
+     If removal fails because Copilot is no longer pending, re-run
+     AW1–AW3. If removal fails for any other reason, post the AW4
+     pending-refresh-failed hold comment and stop. After removal
+     succeeds, request Copilot review:
 
      ```sh
      gh pr edit {pr-number} --add-reviewer "@copilot"

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -35,6 +35,7 @@ by any IDD agent):
 - `<!-- claimed-by:`
 - `<!-- unclaimed-by:`
 - `advisory-wait:`
+- `advisory-wait-recovery:`
 - `<!-- advisory-wait:`
 
 Additionally, fetch the **current CI state** for `{head-SHA}`:


### PR DESCRIPTION
## Summary

- Add a `RECOVERY_NEEDED` advisory-wait outcome for `COPILOT_PENDING=true` with no same-head marker.
- Define a conservative recovery marker path that does not request another Copilot review and uses the marker comment `created_at` as the wait-clock start.
- Wire E14, F2, and F3 routing so recovery returns to normal polling and F3 cannot merge in the same pass that creates a marker.
- Mirror the changes into `idd-template` and fix the F2 reference in the advisory-wait overview.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

## Follow-up

- None.

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added RECOVERY_NEEDED outcome and an AW3-R recovery marker procedure to resume advisory waits when review coverage for the current head is unclear.
  * AW1 now uses PR timeline evidence to detect pending-but-unproven coverage; AW2/AW3 recognize recovery markers and exclude them from re-review cap counting.
  * Posting a recovery marker triggers polling and full re-evaluation (F3 must not merge in the same pass).
  * Replaced AW4 “Inconsistent state” template with “Pending refresh failed” and “Recovery failed.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->