### PR TITLE
docs(readme): document IDD runtime prerequisites

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -63,7 +63,7 @@ GitHub アクセス手段が必要です:
 - このリポジトリの validation command が現在使っている `dprint`、
   `markdownlint-cli2`、`cspell` を `npx` で実行するための Node.js/npm。
 - HTML コメントで始まる operational marker を投稿するときに、
-  `gh issue comment` より信頼できる経路が必要な場合の `curl` または同等の
+  `gh issue comment` より信頼できる経路が必要な場合に使う `curl` または同等の
   REST client。
 
 WorkTrunk、`git-wt`、commit signing alias などの任意ヘルパーはループを

--- a/README.ja.md
+++ b/README.ja.md
@@ -48,6 +48,27 @@ https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOAR
 `.github/instructions/idd-review-fix.instructions.md` と
 `.github/instructions/idd-merge.instructions.md` をカスタマイズしてください。
 
+## 実行前提
+
+IDD ループをエンドツーエンドで実行するには、いくつかのローカルツールと
+GitHub アクセス手段が必要です:
+
+- branch、worktree、fetch、rebase、merge、status、commit 操作のための
+  `git`。
+- 認証済みの `gh` CLI、または同等の GH MCP integration による GitHub issue、
+  pull request、review、checks、comments、branch protection/ruleset、merge への
+  アクセス。ドキュメント内の shell snippet は `gh` を使います。
+- ページネーションされた GitHub API レスポンスを処理するドキュメント内の
+  shell snippet で使う `jq`。
+- このリポジトリの validation command が現在使っている `dprint`、
+  `markdownlint-cli2`、`cspell` を `npx` で実行するための Node.js/npm。
+- HTML コメントで始まる operational marker を投稿するときに、
+  `gh issue comment` より信頼できる経路が必要な場合の `curl` または同等の
+  REST client。
+
+WorkTrunk、`git-wt`、commit signing alias などの任意ヘルパーはループを
+スムーズにできますが、基本要件ではありません。
+
 ## IDD の使い方
 
 オンボーディングが終わったら、対象リポジトリで AI エージェントのセッションを開き、

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ an agent can run it end to end:
   API responses.
 - Node.js/npm with `npx` for the validation commands currently used by
   this repository: `dprint`, `markdownlint-cli2`, and `cspell`.
-- `curl` or an equivalent REST client when posting HTML-comment
-  operational markers needs a path more reliable than `gh issue
-  comment` for comment bodies that start with HTML comments.
+- `curl` or an equivalent REST client for posting HTML-comment
+  operational markers when a path more reliable than `gh issue
+  comment` is needed for comment bodies that start with HTML comments.
 
 Optional helpers such as WorkTrunk, `git-wt`, and commit-signing aliases
 can make the loop smoother, but they are not baseline requirements.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ default. If adopters do not want that PR policy, they can customize
 `.github/instructions/idd-review-fix.instructions.md` and
 `.github/instructions/idd-merge.instructions.md` after onboarding.
 
+## Runtime prerequisites
+
+The IDD loop needs a few local tools and a GitHub access backend before
+an agent can run it end to end:
+
+- `git` for branch, worktree, fetch, rebase, merge, status, and commit
+  operations.
+- GitHub issue, pull request, review, checks, comments, branch
+  protection/ruleset, and merge access through authenticated `gh` CLI or
+  an equivalent GH MCP integration. The documented shell snippets use
+  `gh`.
+- `jq` for the documented shell snippets that parse paginated GitHub
+  API responses.
+- Node.js/npm with `npx` for the validation commands currently used by
+  this repository: `dprint`, `markdownlint-cli2`, and `cspell`.
+- `curl` or an equivalent REST client when posting HTML-comment
+  operational markers needs a path more reliable than `gh issue
+  comment` for comment bodies that start with HTML comments.
+
+Optional helpers such as WorkTrunk, `git-wt`, and commit-signing aliases
+can make the loop smoother, but they are not baseline requirements.
+
 ## Using IDD
 
 After onboarding, open a session in your target repository and tell your


### PR DESCRIPTION
## Summary

- Add a Runtime prerequisites section to README.md near Quick Start.
- Mirror the same guidance in README.ja.md.
- Distinguish local tools, GitHub access backends, validation commands, REST marker posting, and optional helpers.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

Closes #71

Recommended follow-up issues: none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Runtime prerequisites" section to the README files outlining required local tools (git, jq, Node.js/npm, curl or equivalent) and expected GitHub access method to run the end-to-end workflow.
  * Clarified that auxiliary helpers (e.g., WorkTrunk, git-wt, commit-signing aliases) are optional and not required for baseline operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->