### PR TITLE
docs(template): document issue authoring companion

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -46,9 +46,11 @@ policy, they should plan to customize
 1. Read this entire document first.
 2. Ask the operator for any placeholder values that are missing.
 3. Fetch or copy the template files into the target repository.
-4. Replace every placeholder (see table below) with the correct value.
-5. Add IDD references to the repository's agent entry files.
-6. Verify the result with the checklist at the bottom.
+4. Ask whether the operator wants the optional issue-authoring
+   companion skill for pre-execution issue drafting.
+5. Replace every placeholder (see table below) with the correct value.
+6. Add IDD references to the repository's agent entry files.
+7. Verify the result with the checklist at the bottom.
 
 ---
 
@@ -103,8 +105,13 @@ entire lifetime of the roadmap.
 
 ## Step 2 — Fetch or copy template files
 
-You need the following files in the target repository. Use whichever
-method applies to your situation.
+You need the following core execution files in the target repository.
+Use whichever method applies to your situation.
+
+The issue-authoring skill is available as an optional companion artifact
+from `skills/issue-authoring/` in the source repository. Install it only
+when the operator explicitly wants pre-execution issue drafting or
+roadmap decomposition support.
 
 Before importing, confirm whether the operator wants to keep the default
 Copilot advisory review policy described above. If not, note that they
@@ -130,6 +137,16 @@ the files are copied in.
 .github/instructions/idd-resume.instructions.md
 docs/idd-workflow.md
 docs/idd-helper-scripts.md
+```
+
+Optional companion files:
+
+```text
+skills/issue-authoring/SKILL.md
+skills/issue-authoring/agents/openai.yaml
+skills/issue-authoring/references/contract.md
+skills/issue-authoring/references/draft-patterns.md
+skills/issue-authoring/references/workflow-boundary.md
 ```
 
 Create the target directories if they do not exist.
@@ -171,6 +188,28 @@ do
 done
 ```
 
+If the operator opts into the issue-authoring companion, fetch it
+separately:
+
+```sh
+DEST="."  # root of the target repository
+
+mkdir -p "${DEST}/skills/issue-authoring/agents" \
+  "${DEST}/skills/issue-authoring/references"
+
+for FILE in \
+  "SKILL.md" \
+  "agents/openai.yaml" \
+  "references/contract.md" \
+  "references/draft-patterns.md" \
+  "references/workflow-boundary.md"
+do
+  gh api -H "Accept: application/vnd.github.raw+json" \
+    "repos/kurone-kito/idd-skill/contents/skills/issue-authoring/${FILE}" \
+    > "${DEST}/skills/issue-authoring/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
+done
+```
+
 Alternatively, use `curl` (no authentication required — idd-skill is a public
 repository):
 
@@ -201,11 +240,53 @@ do
 done
 ```
 
+If the operator opts into the issue-authoring companion with `curl`,
+fetch it separately:
+
+```sh
+BASE="https://raw.githubusercontent.com/kurone-kito/idd-skill/main/skills/issue-authoring"
+DEST="."  # root of the target repository
+
+mkdir -p "${DEST}/skills/issue-authoring/agents" \
+  "${DEST}/skills/issue-authoring/references"
+
+for FILE in \
+  "SKILL.md" \
+  "agents/openai.yaml" \
+  "references/contract.md" \
+  "references/draft-patterns.md" \
+  "references/workflow-boundary.md"
+do
+  curl -fsSL "${BASE}/${FILE}" -o "${DEST}/skills/issue-authoring/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
+done
+```
+
 ### Option B — Local copy (idd-skill cloned)
 
 If you have cloned `https://github.com/kurone-kito/idd-skill`, copy
 the files from `idd-template/` into the target repository preserving
 their relative paths.
+
+If the operator opts into the issue-authoring companion, also copy
+`skills/issue-authoring/` from the source repository to
+`skills/issue-authoring/` in the target repository.
+
+### Optional companion boundary
+
+The issue-authoring companion drafts or refines IDD-ready issues,
+roadmaps, and sub-issues before execution starts. It does not authorize
+publishing issues, editing GitHub issues, or starting the Discover →
+Claim → Work loop unless the operator explicitly asks for that next
+step.
+
+Keep the companion separate from the execution instructions:
+
+- `skills/issue-authoring/` is a helper for drafting issue sets.
+- `.github/instructions/*.instructions.md` execute approved issues
+  through the IDD loop.
+- In the source `idd-skill` repository, maintainers must keep
+  `skills/issue-authoring/` and its bundled references aligned with
+  `docs/issue-authoring-skill.md`.
 
 ---
 
@@ -359,6 +440,9 @@ After completing the steps above, confirm each item:
 - [ ] All thirteen `idd-*.instructions.md` files are present in
       `.github/instructions/`.
 - [ ] `docs/idd-workflow.md` and `docs/idd-helper-scripts.md` are
+      present.
+- [ ] If the operator opted into issue authoring,
+      `skills/issue-authoring/SKILL.md` and its `references/` files are
       present.
 - [ ] No `{{...}}` placeholders remain in any copied file.
 - [ ] `idd-overview.instructions.md` has `applyTo: "**"` and

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -442,8 +442,9 @@ After completing the steps above, confirm each item:
 - [ ] `docs/idd-workflow.md` and `docs/idd-helper-scripts.md` are
       present.
 - [ ] If the operator opted into issue authoring,
-      `skills/issue-authoring/SKILL.md` and its `references/` files are
-      present.
+      `skills/issue-authoring/SKILL.md`,
+      `skills/issue-authoring/agents/openai.yaml`, and the
+      `skills/issue-authoring/references/` files are present.
 - [ ] No `{{...}}` placeholders remain in any copied file.
 - [ ] `idd-overview.instructions.md` has `applyTo: "**"` and
       `excludeAgent: "code-review"` in its frontmatter.

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -9,17 +9,30 @@ multi-agent GitHub automation.
 2. Fill in the placeholders listed in `ONBOARDING.md`.
 3. Update the agent entry files (`CLAUDE.md`, `copilot-instructions.md`,
    etc.) as described in `ONBOARDING.md`.
+4. Optional: install the issue-authoring companion skill if the project
+   wants pre-execution issue drafting.
 
 ## Quick start (AI agent)
 
-Open `ONBOARDING.md` and follow the instructions there.
+Open `ONBOARDING.md`, follow the core import instructions there, and
+install the optional issue-authoring companion only when the operator
+explicitly asks for it.
 
 ## Artifact boundary
 
 This template exports the portable IDD instruction files, onboarding
-docs, and workflow docs that adopters copy into another repository. It
-does not export repository-local native `SKILL.md` bundles; those should
-remain separate helper artifacts when a project chooses to provide them.
+docs, and workflow docs that adopters copy into another repository for
+the execution loop.
+
+The issue-authoring skill is a public optional companion artifact at
+`skills/issue-authoring/` in the source repository. It is not required
+to run the IDD execution loop. Install it intentionally when a project
+wants an agent to draft or decompose IDD-ready issues before execution
+starts.
+
+Keep the boundary clear: issue authoring prepares draft issues and
+roadmaps; `.github/instructions/*.instructions.md` execute approved
+issues through the normal IDD loop.
 
 ## Default PR policy note
 
@@ -63,10 +76,23 @@ docs/
   idd-helper-scripts.md              ← optional helper-script evaluation and policy
 ONBOARDING.md                        ← AI agent import guide (start here)
 README.md                            ← this file
+
+Optional companion artifact:
+skills/issue-authoring/
+  SKILL.md                           ← pre-execution issue drafting skill
+  agents/openai.yaml                 ← optional OpenAI agent metadata
+  references/contract.md             ← bundled issue authoring contract
+  references/draft-patterns.md       ← drafting examples and output chooser
+  references/workflow-boundary.md    ← publication/execution boundary
 ```
 
 See `docs/idd-workflow.md` for the distinction between cross-agent
 execution and the default Copilot-backed PR policy.
+
+When maintaining the source repository, keep `skills/issue-authoring/`
+and its bundled references aligned with `docs/issue-authoring-skill.md`.
+Adopter copies are helper artifacts and should not replace the execution
+instructions.
 
 ## Origin
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

- Document `skills/issue-authoring/` as an optional public companion artifact for adopters.
- Add opt-in install guidance and `gh api` / `curl` fetch examples to `idd-template/ONBOARDING.md`.
- Clarify that issue authoring drafts issues before execution and does not replace the IDD execution instructions.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

## Notes

- The skill files are not duplicated into `idd-template/`; the source `skills/issue-authoring/` bundle remains the public companion path to avoid silent drift.
- Root README usage wording is left to #76 so it can build on the #74 getting-started restructure.

Closes #75

Recommended follow-up issues: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed onboarding guidance for an optional issue‑authoring companion, including an explicit opt‑in prompt during setup.
  * Clarified artifact boundaries between drafting (companion) and execution flows, and updated quick‑start steps for human and AI‑agent workflows.
  * Added conditional verification requirements when the companion is opted in.
  * Included maintenance guidance for keeping bundled references aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->