### PR TITLE
docs(readme): document issue authoring usage

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -110,6 +110,29 @@ Discover → Claim → Work → ... のループに入ります。
   `.github/instructions/idd-overview.instructions.md` を開き、
   Discover → Claim → Work のループを開始してください。
 
+## 実行前に issue authoring を使う
+
+1 つのレビュー可能な変更には大きすぎる、または曖昧なリクエスト、
+roadmap や sub-issue への分解が必要なリクエスト、あるいは
+エージェントが作業を claim する前に依存関係を明示すべきリクエストでは、
+IDD execution loop の前に optional issue-authoring skill を使ってください。
+
+このリポジトリでは、次のいずれかのプロンプトでエージェントをネイティブ
+bundle にルーティングできます:
+
+- `$issue-authoring skill を使って IDD-ready な issue をドラフトしてください。`
+- `skills/issue-authoring/SKILL.md を開いて issue set を準備してください。`
+
+この skill はドラフトと issue hygiene の準備だけを行います。GitHub issue の公開や
+編集、Discover → Claim → Work の開始は別アクションであり、明示的な承認が必要です。
+
+完全な contract と schema は
+[docs/issue-authoring-skill.md](docs/issue-authoring-skill.md) にあります。
+`idd-template/` だけをインポートする adopter には、デフォルトではこの bundle は
+含まれません。必要な場合は [idd-template/README.md](idd-template/README.md) と
+[idd-template/ONBOARDING.md](idd-template/ONBOARDING.md) に従い、
+optional companion としてインストールしてください。
+
 ## なぜ idd-skill？
 
 - **並列エージェント協調** — Issue ボディに埋め込まれた HTML コメントマーカーによる
@@ -159,11 +182,9 @@ Discover → Claim → Work → ... のループに入ります。
 完全なインストラクションセットは `.github/instructions/` を参照してください。
 
 あわせて、repo ローカルのネイティブ skill bundle
-`skills/issue-authoring/` も含まれています。実行前に IDD-ready な
-issue や roadmap をドラフト・分解したいときはその bundle を使い、
-issue セットの承認後に通常の実行ループへ入るときは
-[docs/idd-workflow.md](docs/idd-workflow.md) と
-`.github/instructions/` を使ってください。
+`skills/issue-authoring/` も含まれています。ルーティング例と通常の実行ループ前の
+承認境界については
+[実行前に issue authoring を使う](#実行前に-issue-authoring-を使う) を参照してください。
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,31 @@ the Discover → Claim → Work → ... loop.
   `.github/instructions/idd-overview.instructions.md`, and begin the
   Discover → Claim → Work loop.
 
+## Use issue authoring before execution
+
+Use the optional issue-authoring skill before the IDD execution loop
+when a request is too large or ambiguous for one reviewable change,
+needs roadmap or sub-issue decomposition, or has dependencies that
+should be explicit before any agent claims work.
+
+In this repository, route an agent to the native bundle with one of
+these prompts:
+
+- `Use the $issue-authoring skill to draft IDD-ready issues.`
+- `Open skills/issue-authoring/SKILL.md and prepare the issue set.`
+
+The skill prepares drafts and issue hygiene only. Publishing or editing
+GitHub issues, and starting Discover → Claim → Work, are separate
+actions that require explicit approval.
+
+The full contract and schema are in
+[docs/issue-authoring-skill.md](docs/issue-authoring-skill.md).
+Adopters who import only `idd-template/` do not receive this bundle by
+default; install the optional companion with
+[idd-template/README.md](idd-template/README.md) and
+[idd-template/ONBOARDING.md](idd-template/ONBOARDING.md) when they want
+it.
+
 ## Why idd-skill?
 
 - **Parallel agent coordination** — A built-in claim/heartbeat protocol
@@ -163,11 +188,10 @@ This repository is itself maintained with the IDD workflow. See
 guide and `.github/instructions/` for the full instruction set.
 
 It also ships a repository-local native skill bundle at
-`skills/issue-authoring/`. Use that bundle when you want an agent to
-draft or decompose IDD-ready issues before execution starts; use
-[docs/idd-workflow.md](docs/idd-workflow.md) plus
-`.github/instructions/` once the issue set is approved and the normal
-execution loop should begin.
+`skills/issue-authoring/`. See
+[Use issue authoring before execution](#use-issue-authoring-before-execution)
+for routing examples and the approval boundary before the normal
+execution loop begins.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add a README section that explains when to use the optional issue-authoring skill before IDD execution.
- Give concrete AI-agent routing examples for `$issue-authoring` and `skills/issue-authoring/SKILL.md`.
- Clarify the approval boundary and the optional adopter install path, mirrored in `README.ja.md`.

Closes #76

## Follow-up issues

None.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on using the optional issue-authoring companion skill before execution, including prompt routing examples and clarification that this phase handles drafting and hygiene only.
  * Updated repository overview to reference the new issue-authoring section and explain how to include the issue-authoring bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->