### PR TITLE
docs(idd): document post-merge comment cleanup

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -94,10 +94,35 @@ gate. The active claim must still use your current `{claim-id}`.
 
 ## F4 — Cleanup
 
-1. Delete the local worktree and local branch.
-2. Update the local `main` branch.
-3. If GitHub auto-delete is disabled: delete the remote branch too.
-   (Worktrunk may be used for steps 1–3.)
+1. Run best-effort merged-PR comment cleanup when credentials permit.
+   This cleanup is never a merge gate and must not run before F3
+   succeeds. If cleanup fails, record the failure only if it is useful
+   for a later audit, then continue with local cleanup.
+
+   - Feedback or review parent comments may be minimized as `RESOLVED`
+     only after every actionable child review comment/thread under that
+     parent has been accepted or rejected, replied to as required, and
+     resolved.
+   - IDD operational marker comments may be minimized as `OUTDATED`
+     only after the PR is merged and the marker is no longer needed for
+     resume, advisory wait, or review-currency checks.
+   - Candidate marker prefixes include `<!-- review-watermark:`,
+     `<!-- review-baseline:`, `advisory-wait:`,
+     `advisory-wait-recovery:`, and `<!-- advisory-wait:`.
+   - Do not minimize comments that contain unresolved maintainer
+     decisions, active holds, failed-CI context still needed by
+     maintainers, non-operational human discussion, or any content that
+     still participates in active F2/F3 gates.
+   - Use GitHub GraphQL `minimizeComment` with node IDs. Check
+     `viewerCanMinimize` and `isMinimized` before minimizing; skip
+     already-minimized comments and comments the viewer cannot minimize.
+
+   See `docs/idd-comment-minimization.md` for the investigation notes,
+   dry-run shape, and command examples.
+2. Delete the local worktree and local branch.
+3. Update the local `main` branch.
+4. If GitHub auto-delete is disabled: delete the remote branch too.
+   (Worktrunk may be used for steps 2–4.)
 
 ## F5 — Loop
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -98,6 +98,8 @@ gate. The active claim must still use your current `{claim-id}`.
    This cleanup is never a merge gate and must not run before F3
    succeeds. If cleanup fails, record the failure only if it is useful
    for a later audit, then continue with local cleanup.
+   Re-validate the active claim before each GitHub minimization
+   mutation.
 
    - Feedback or review parent comments may be minimized as `RESOLVED`
      only after every actionable child review comment/thread under that

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -1,0 +1,202 @@
+# IDD Comment Minimization
+
+<!-- cspell:words AAAAB Unminimize Wpaqs unminimized -->
+
+This note defines the safe path for hiding completed IDD review feedback
+and stale operational marker comments after a pull request has merged.
+
+Minimization is UI cleanup. It preserves the audit trail and must never
+replace review triage, conversation resolution, CI, advisory wait, or
+merge gates.
+
+## Timing
+
+Run minimization only after one of these is true:
+
+- the PR has already merged
+- a maintainer explicitly starts a merged-PR audit
+
+Do not minimize comments during active E or F gates. In particular, do
+not minimize comments that still determine review currency, advisory
+wait state, unresolved-thread state, unreplied-comment state, hold
+state, or a pending maintainer decision.
+
+## GitHub mechanism
+
+GitHub GraphQL exposes `minimizeComment`:
+
+```graphql
+mutation($id: ID!, $classifier: ReportedContentClassifiers!) {
+  minimizeComment(input: { subjectId: $id, classifier: $classifier }) {
+    minimizedComment {
+      __typename
+      ... on IssueComment {
+        id
+        url
+        isMinimized
+        minimizedReason
+        viewerCanUnminimize
+      }
+      ... on PullRequestReview {
+        id
+        url
+        isMinimized
+        minimizedReason
+        viewerCanUnminimize
+      }
+      ... on PullRequestReviewComment {
+        id
+        url
+        isMinimized
+        minimizedReason
+        viewerCanUnminimize
+      }
+    }
+  }
+}
+```
+
+The mutation requires a node ID and a `ReportedContentClassifiers`
+value. The relevant classifiers are:
+
+- `RESOLVED` for completed feedback or review parent comments
+- `OUTDATED` for stale IDD operational markers
+
+Schema checks on 2026-05-09 confirmed that `IssueComment`,
+`PullRequestReview`, and `PullRequestReviewComment` expose
+`isMinimized`, `minimizedReason`, `viewerCanMinimize`, and
+`viewerCanUnminimize`. The `gh pr` command group did not expose a
+first-class minimize/hide command, so the portable path is
+`gh api graphql`.
+
+## Candidate Rules
+
+Feedback or review parent comments may be minimized as `RESOLVED` only
+when all of these are true:
+
+- the PR is merged or the cleanup is part of an explicit merged-PR audit
+- every actionable child review comment or thread under that parent has
+  been accepted or rejected under IDD rules
+- required replies have been posted
+- all child threads are resolved
+- the reviewer has no active `CHANGES_REQUESTED` state that still gates
+  the PR
+
+IDD operational marker comments may be minimized as `OUTDATED` only when
+the PR is merged and the marker is no longer needed for resume, advisory
+wait, or review-currency checks. Candidate prefixes are:
+
+- `<!-- review-watermark:`
+- `<!-- review-baseline:`
+- `advisory-wait:`
+- `advisory-wait-recovery:`
+- `<!-- advisory-wait:`
+
+Always skip candidates when any of these are true:
+
+- `viewerCanMinimize=false`
+- `isMinimized=true`
+- the comment contains an active hold or
+  `**Awaiting maintainer decision**`
+- the comment contains failed-CI or reviewer context still needed by
+  maintainers
+- the comment is non-operational human discussion
+- the comment still participates in an active F2 or F3 gate
+
+## Dry Run Shape
+
+Before applying minimization, produce a candidate table with at least
+these fields:
+
+| Field               | Purpose                                                            |
+| ------------------- | ------------------------------------------------------------------ |
+| `subjectId`         | GraphQL node ID passed to `minimizeComment`                        |
+| `url`               | Direct audit link                                                  |
+| `type`              | `IssueComment`, `PullRequestReview`, or `PullRequestReviewComment` |
+| `classifier`        | `RESOLVED` or `OUTDATED`                                           |
+| `viewerCanMinimize` | Must be `true`                                                     |
+| `isMinimized`       | Must be `false`                                                    |
+| `reason`            | Why the candidate is safe                                          |
+
+Example capability check for one node ID:
+
+```sh
+gh api graphql \
+  -f query='query($id:ID!){
+    node(id:$id){
+      __typename
+      ... on IssueComment{id url isMinimized minimizedReason viewerCanMinimize}
+      ... on PullRequestReview{id url isMinimized minimizedReason viewerCanMinimize}
+      ... on PullRequestReviewComment{id url isMinimized minimizedReason viewerCanMinimize}
+    }
+  }' \
+  -f id="$SUBJECT_ID"
+```
+
+Call `minimizeComment` only after the dry run shows
+`viewerCanMinimize=true` and `isMinimized=false`.
+
+Example mutation call:
+
+```sh
+gh api graphql \
+  -f query='mutation($id:ID!,$classifier:ReportedContentClassifiers!){
+    minimizeComment(input:{subjectId:$id,classifier:$classifier}){
+      minimizedComment{
+        __typename
+        ... on IssueComment{id url isMinimized minimizedReason viewerCanUnminimize}
+        ... on PullRequestReview{id url isMinimized minimizedReason viewerCanUnminimize}
+        ... on PullRequestReviewComment{id url isMinimized minimizedReason viewerCanUnminimize}
+      }
+    }
+  }' \
+  -f id="$SUBJECT_ID" \
+  -f classifier="$CLASSIFIER"
+```
+
+## Experiment
+
+Experiment date: 2026-05-09.
+
+Target: merged PR
+[#78](https://github.com/kurone-kito/idd-skill/pull/78), merged at
+2026-05-09T05:36:33Z.
+
+Dry-run selection:
+
+| Subject                     | Type                | Classifier | Reason                                                        |
+| --------------------------- | ------------------- | ---------- | ------------------------------------------------------------- |
+| `IC_kwDOSWpaqs8AAAABBvMrqA` | `IssueComment`      | `OUTDATED` | `review-watermark` marker on merged PR #78                    |
+| `IC_kwDOSWpaqs8AAAABBvM34w` | `IssueComment`      | `OUTDATED` | `review-baseline` marker on merged PR #78                     |
+| `IC_kwDOSWpaqs8AAAABBvNZCw` | `IssueComment`      | `OUTDATED` | `advisory-wait` marker on merged PR #78                       |
+| `PRR_kwDOSWpaqs79uxOa`      | `PullRequestReview` | `RESOLVED` | CodeRabbit parent review body whose child thread was resolved |
+
+All four dry-run candidates had `viewerCanMinimize=true` and
+`isMinimized=false`.
+
+Applied results:
+
+| Subject                     | URL                                                                             | API result                                                                 |
+| --------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `IC_kwDOSWpaqs8AAAABBvMrqA` | <https://github.com/kurone-kito/idd-skill/pull/78#issuecomment-4411567016>      | `isMinimized=true`, `minimizedReason=outdated`, `viewerCanUnminimize=true` |
+| `IC_kwDOSWpaqs8AAAABBvM34w` | <https://github.com/kurone-kito/idd-skill/pull/78#issuecomment-4411570147>      | `isMinimized=true`, `minimizedReason=outdated`, `viewerCanUnminimize=true` |
+| `IC_kwDOSWpaqs8AAAABBvNZCw` | <https://github.com/kurone-kito/idd-skill/pull/78#issuecomment-4411578635>      | `isMinimized=true`, `minimizedReason=outdated`, `viewerCanUnminimize=true` |
+| `PRR_kwDOSWpaqs79uxOa`      | <https://github.com/kurone-kito/idd-skill/pull/78#pullrequestreview-4256895898> | `isMinimized=true`, `minimizedReason=resolved`, `viewerCanUnminimize=true` |
+
+Skipped examples:
+
+- active or non-operational human discussion
+- CodeRabbit walkthrough comments that were informational rather than
+  stale IDD markers
+- accepted/rejected disposition comments, because they are part of the
+  review audit trail
+- child review comments, because the experiment only needed to prove
+  parent review body and operational marker behavior
+
+The API observation confirms that minimized comments remain addressable
+by URL and can be unminimized by a viewer with permission.
+
+Public GitHub UI observation for PR #78 showed minimized operational
+comments collapsed behind a minimized-comment placeholder and the
+resolved feedback area marked as resolved. The underlying comment URLs
+remained addressable.

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -48,6 +48,7 @@ you are reading this guide first, start at step 1.
 | `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions           |
 | `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover          |
 | `.github/instructions/idd-resume.instructions.md`          | Recover after a crash, timeout, or handoff                             |
+| `docs/idd-comment-minimization.md`                         | Post-merge comment minimization policy, commands, and experiment notes |
 
 ## Artifact taxonomy and ownership
 
@@ -130,3 +131,8 @@ See [IDD helper script evaluation](idd-helper-scripts.md) for the
 current inventory of high-friction query patterns, the reason helper
 scripts are not adopted yet, and the criteria for reconsidering optional
 read-only helpers later.
+
+See [IDD comment minimization](idd-comment-minimization.md) for the
+post-merge cleanup rule, GraphQL command shape, and merged-PR experiment
+for hiding completed feedback and stale operational markers without
+deleting the audit trail.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -94,10 +94,35 @@ gate. The active claim must still use your current `{claim-id}`.
 
 ## F4 — Cleanup
 
-1. Delete the local worktree and local branch.
-2. Update the local `main` branch.
-3. If GitHub auto-delete is disabled: delete the remote branch too.
-   (Worktrunk may be used for steps 1–3.)
+1. Run best-effort merged-PR comment cleanup when credentials permit.
+   This cleanup is never a merge gate and must not run before F3
+   succeeds. If cleanup fails, record the failure only if it is useful
+   for a later audit, then continue with local cleanup.
+
+   - Feedback or review parent comments may be minimized as `RESOLVED`
+     only after every actionable child review comment/thread under that
+     parent has been accepted or rejected, replied to as required, and
+     resolved.
+   - IDD operational marker comments may be minimized as `OUTDATED`
+     only after the PR is merged and the marker is no longer needed for
+     resume, advisory wait, or review-currency checks.
+   - Candidate marker prefixes include `<!-- review-watermark:`,
+     `<!-- review-baseline:`, `advisory-wait:`,
+     `advisory-wait-recovery:`, and `<!-- advisory-wait:`.
+   - Do not minimize comments that contain unresolved maintainer
+     decisions, active holds, failed-CI context still needed by
+     maintainers, non-operational human discussion, or any content that
+     still participates in active F2/F3 gates.
+   - Use GitHub GraphQL `minimizeComment` with node IDs. Check
+     `viewerCanMinimize` and `isMinimized` before minimizing; skip
+     already-minimized comments and comments the viewer cannot minimize.
+
+   See `docs/idd-comment-minimization.md` for the investigation notes,
+   dry-run shape, and command examples.
+2. Delete the local worktree and local branch.
+3. Update the local `main` branch.
+4. If GitHub auto-delete is disabled: delete the remote branch too.
+   (Worktrunk may be used for steps 2–4.)
 
 ## F5 — Loop
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -98,6 +98,8 @@ gate. The active claim must still use your current `{claim-id}`.
    This cleanup is never a merge gate and must not run before F3
    succeeds. If cleanup fails, record the failure only if it is useful
    for a later audit, then continue with local cleanup.
+   Re-validate the active claim before each GitHub minimization
+   mutation.
 
    - Feedback or review parent comments may be minimized as `RESOLVED`
      only after every actionable child review comment/thread under that

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -137,6 +137,7 @@ the files are copied in.
 .github/instructions/idd-resume.instructions.md
 docs/idd-workflow.md
 docs/idd-helper-scripts.md
+docs/idd-comment-minimization.md
 ```
 
 Optional companion files:
@@ -180,7 +181,8 @@ for FILE in \
   ".github/instructions/idd-merge.instructions.md" \
   ".github/instructions/idd-resume.instructions.md" \
   "docs/idd-workflow.md" \
-  "docs/idd-helper-scripts.md"
+  "docs/idd-helper-scripts.md" \
+  "docs/idd-comment-minimization.md"
 do
   gh api -H "Accept: application/vnd.github.raw+json" \
     "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
@@ -234,7 +236,8 @@ for FILE in \
   ".github/instructions/idd-merge.instructions.md" \
   ".github/instructions/idd-resume.instructions.md" \
   "docs/idd-workflow.md" \
-  "docs/idd-helper-scripts.md"
+  "docs/idd-helper-scripts.md" \
+  "docs/idd-comment-minimization.md"
 do
   curl -fsSL "${BASE}/${FILE}" -o "${DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
@@ -439,8 +442,8 @@ After completing the steps above, confirm each item:
 
 - [ ] All thirteen `idd-*.instructions.md` files are present in
       `.github/instructions/`.
-- [ ] `docs/idd-workflow.md` and `docs/idd-helper-scripts.md` are
-      present.
+- [ ] `docs/idd-workflow.md`, `docs/idd-helper-scripts.md`, and
+      `docs/idd-comment-minimization.md` are present.
 - [ ] If the operator opted into issue authoring,
       `skills/issue-authoring/SKILL.md`,
       `skills/issue-authoring/agents/openai.yaml`, and the

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -74,6 +74,7 @@ adopter does not want that PR policy, they can customize
 docs/
   idd-workflow.md                    ← cross-agent entry point and file map
   idd-helper-scripts.md              ← optional helper-script evaluation and policy
+  idd-comment-minimization.md        ← post-merge comment cleanup policy and experiment
 ONBOARDING.md                        ← AI agent import guide (start here)
 README.md                            ← this file
 

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -1,0 +1,202 @@
+# IDD Comment Minimization
+
+<!-- cspell:words AAAAB Unminimize Wpaqs unminimized -->
+
+This note defines the safe path for hiding completed IDD review feedback
+and stale operational marker comments after a pull request has merged.
+
+Minimization is UI cleanup. It preserves the audit trail and must never
+replace review triage, conversation resolution, CI, advisory wait, or
+merge gates.
+
+## Timing
+
+Run minimization only after one of these is true:
+
+- the PR has already merged
+- a maintainer explicitly starts a merged-PR audit
+
+Do not minimize comments during active E or F gates. In particular, do
+not minimize comments that still determine review currency, advisory
+wait state, unresolved-thread state, unreplied-comment state, hold
+state, or a pending maintainer decision.
+
+## GitHub mechanism
+
+GitHub GraphQL exposes `minimizeComment`:
+
+```graphql
+mutation($id: ID!, $classifier: ReportedContentClassifiers!) {
+  minimizeComment(input: { subjectId: $id, classifier: $classifier }) {
+    minimizedComment {
+      __typename
+      ... on IssueComment {
+        id
+        url
+        isMinimized
+        minimizedReason
+        viewerCanUnminimize
+      }
+      ... on PullRequestReview {
+        id
+        url
+        isMinimized
+        minimizedReason
+        viewerCanUnminimize
+      }
+      ... on PullRequestReviewComment {
+        id
+        url
+        isMinimized
+        minimizedReason
+        viewerCanUnminimize
+      }
+    }
+  }
+}
+```
+
+The mutation requires a node ID and a `ReportedContentClassifiers`
+value. The relevant classifiers are:
+
+- `RESOLVED` for completed feedback or review parent comments
+- `OUTDATED` for stale IDD operational markers
+
+Schema checks on 2026-05-09 confirmed that `IssueComment`,
+`PullRequestReview`, and `PullRequestReviewComment` expose
+`isMinimized`, `minimizedReason`, `viewerCanMinimize`, and
+`viewerCanUnminimize`. The `gh pr` command group did not expose a
+first-class minimize/hide command, so the portable path is
+`gh api graphql`.
+
+## Candidate Rules
+
+Feedback or review parent comments may be minimized as `RESOLVED` only
+when all of these are true:
+
+- the PR is merged or the cleanup is part of an explicit merged-PR audit
+- every actionable child review comment or thread under that parent has
+  been accepted or rejected under IDD rules
+- required replies have been posted
+- all child threads are resolved
+- the reviewer has no active `CHANGES_REQUESTED` state that still gates
+  the PR
+
+IDD operational marker comments may be minimized as `OUTDATED` only when
+the PR is merged and the marker is no longer needed for resume, advisory
+wait, or review-currency checks. Candidate prefixes are:
+
+- `<!-- review-watermark:`
+- `<!-- review-baseline:`
+- `advisory-wait:`
+- `advisory-wait-recovery:`
+- `<!-- advisory-wait:`
+
+Always skip candidates when any of these are true:
+
+- `viewerCanMinimize=false`
+- `isMinimized=true`
+- the comment contains an active hold or
+  `**Awaiting maintainer decision**`
+- the comment contains failed-CI or reviewer context still needed by
+  maintainers
+- the comment is non-operational human discussion
+- the comment still participates in an active F2 or F3 gate
+
+## Dry Run Shape
+
+Before applying minimization, produce a candidate table with at least
+these fields:
+
+| Field               | Purpose                                                            |
+| ------------------- | ------------------------------------------------------------------ |
+| `subjectId`         | GraphQL node ID passed to `minimizeComment`                        |
+| `url`               | Direct audit link                                                  |
+| `type`              | `IssueComment`, `PullRequestReview`, or `PullRequestReviewComment` |
+| `classifier`        | `RESOLVED` or `OUTDATED`                                           |
+| `viewerCanMinimize` | Must be `true`                                                     |
+| `isMinimized`       | Must be `false`                                                    |
+| `reason`            | Why the candidate is safe                                          |
+
+Example capability check for one node ID:
+
+```sh
+gh api graphql \
+  -f query='query($id:ID!){
+    node(id:$id){
+      __typename
+      ... on IssueComment{id url isMinimized minimizedReason viewerCanMinimize}
+      ... on PullRequestReview{id url isMinimized minimizedReason viewerCanMinimize}
+      ... on PullRequestReviewComment{id url isMinimized minimizedReason viewerCanMinimize}
+    }
+  }' \
+  -f id="$SUBJECT_ID"
+```
+
+Call `minimizeComment` only after the dry run shows
+`viewerCanMinimize=true` and `isMinimized=false`.
+
+Example mutation call:
+
+```sh
+gh api graphql \
+  -f query='mutation($id:ID!,$classifier:ReportedContentClassifiers!){
+    minimizeComment(input:{subjectId:$id,classifier:$classifier}){
+      minimizedComment{
+        __typename
+        ... on IssueComment{id url isMinimized minimizedReason viewerCanUnminimize}
+        ... on PullRequestReview{id url isMinimized minimizedReason viewerCanUnminimize}
+        ... on PullRequestReviewComment{id url isMinimized minimizedReason viewerCanUnminimize}
+      }
+    }
+  }' \
+  -f id="$SUBJECT_ID" \
+  -f classifier="$CLASSIFIER"
+```
+
+## Experiment
+
+Experiment date: 2026-05-09.
+
+Target: merged PR
+[#78](https://github.com/kurone-kito/idd-skill/pull/78), merged at
+2026-05-09T05:36:33Z.
+
+Dry-run selection:
+
+| Subject                     | Type                | Classifier | Reason                                                        |
+| --------------------------- | ------------------- | ---------- | ------------------------------------------------------------- |
+| `IC_kwDOSWpaqs8AAAABBvMrqA` | `IssueComment`      | `OUTDATED` | `review-watermark` marker on merged PR #78                    |
+| `IC_kwDOSWpaqs8AAAABBvM34w` | `IssueComment`      | `OUTDATED` | `review-baseline` marker on merged PR #78                     |
+| `IC_kwDOSWpaqs8AAAABBvNZCw` | `IssueComment`      | `OUTDATED` | `advisory-wait` marker on merged PR #78                       |
+| `PRR_kwDOSWpaqs79uxOa`      | `PullRequestReview` | `RESOLVED` | CodeRabbit parent review body whose child thread was resolved |
+
+All four dry-run candidates had `viewerCanMinimize=true` and
+`isMinimized=false`.
+
+Applied results:
+
+| Subject                     | URL                                                                             | API result                                                                 |
+| --------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `IC_kwDOSWpaqs8AAAABBvMrqA` | <https://github.com/kurone-kito/idd-skill/pull/78#issuecomment-4411567016>      | `isMinimized=true`, `minimizedReason=outdated`, `viewerCanUnminimize=true` |
+| `IC_kwDOSWpaqs8AAAABBvM34w` | <https://github.com/kurone-kito/idd-skill/pull/78#issuecomment-4411570147>      | `isMinimized=true`, `minimizedReason=outdated`, `viewerCanUnminimize=true` |
+| `IC_kwDOSWpaqs8AAAABBvNZCw` | <https://github.com/kurone-kito/idd-skill/pull/78#issuecomment-4411578635>      | `isMinimized=true`, `minimizedReason=outdated`, `viewerCanUnminimize=true` |
+| `PRR_kwDOSWpaqs79uxOa`      | <https://github.com/kurone-kito/idd-skill/pull/78#pullrequestreview-4256895898> | `isMinimized=true`, `minimizedReason=resolved`, `viewerCanUnminimize=true` |
+
+Skipped examples:
+
+- active or non-operational human discussion
+- CodeRabbit walkthrough comments that were informational rather than
+  stale IDD markers
+- accepted/rejected disposition comments, because they are part of the
+  review audit trail
+- child review comments, because the experiment only needed to prove
+  parent review body and operational marker behavior
+
+The API observation confirms that minimized comments remain addressable
+by URL and can be unminimized by a viewer with permission.
+
+Public GitHub UI observation for PR #78 showed minimized operational
+comments collapsed behind a minimized-comment placeholder and the
+resolved feedback area marked as resolved. The underlying comment URLs
+remained addressable.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -54,6 +54,7 @@ entry file should be an explicit operator choice, not the default.
 | `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions           |
 | `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover          |
 | `.github/instructions/idd-resume.instructions.md`          | Recover after a crash, timeout, or handoff                             |
+| `docs/idd-comment-minimization.md`                         | Post-merge comment minimization policy, commands, and experiment notes |
 
 ## Artifact taxonomy and ownership
 
@@ -124,3 +125,8 @@ See [IDD helper script evaluation](idd-helper-scripts.md) for the
 current inventory of high-friction query patterns, the reason helper
 scripts are not adopted yet, and the criteria for reconsidering optional
 read-only helpers later.
+
+See [IDD comment minimization](idd-comment-minimization.md) for the
+post-merge cleanup rule, GraphQL command shape, and merged-PR experiment
+for hiding completed feedback and stale operational markers without
+deleting the audit trail.


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

- Add a post-merge F4 cleanup rule for minimizing completed review parent comments and stale IDD operational markers.
- Document the GraphQL `minimizeComment` path, dry-run requirements, skip rules, and command examples using node IDs plus `viewerCanMinimize` / `isMinimized` checks.
- Mirror the rule and new documentation into `idd-template/`, including onboarding fetch lists and template file maps.

## Experiment

- Ran a controlled merged-PR experiment on #78 after it merged.
- Minimized three stale operational marker comments as `OUTDATED` and one resolved CodeRabbit parent review body as `RESOLVED`.
- Verified API results: each applied candidate reports `isMinimized=true`, the expected `minimizedReason`, and `viewerCanUnminimize=true`; public GitHub UI renders them as collapsed/minimized or resolved while preserving URLs.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

## Notes

- Cleanup is explicitly best-effort and non-blocking; it cannot run before merge and cannot bypass active F2/F3 gates.
- The F4 rule requires claim revalidation before GitHub minimization mutations.

Closes #72

Recommended follow-up issues: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new post-merge comment minimization policy documentation defining when and how completed review feedback and operational marker comments can be safely hidden after pull request merge.
  * Updated workflow guides to reference the new comment minimization process and include it in the merge cleanup phase.
  * Updated onboarding instructions to include the new documentation artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->