### PR TITLE
docs(readme): add idd phase overview table

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,19 +15,17 @@
 IDD は、AI エージェントが GitHub Issues によって駆動される繰り返しパイプラインを
 通じて作業するマルチエージェント GitHub 自動化ワークフローです。
 
-| 番号   | 名前            | 概要                                                              |
-| ------ | --------------- | ----------------------------------------------------------------- |
-| A0-A4  | Discover        | 設定されたスコープから ready な issue を探して選びます。          |
-| A5     | Claim           | 機械可読な claim marker で issue を予約します。                   |
-| B      | Work            | branch/worktree を作り、計画、実装、自己レビューします。          |
-| D1-D3  | PR Submit       | branch を push し、issue に対応する pull request を開きます。     |
-| D4     | CI Wait         | review snapshot 前に必要な validation 完了を待ちます。            |
-| E1-E3  | Review Snapshot | review activity を記録し、critique を実行して List A を作ります。 |
-| E4-E8  | Review Triage   | List A の項目を分類し、accept/reject の判断を記録します。         |
-| E9-E15 | Review Fix      | accepted feedback を反映し、必要に応じて再レビューを依頼します。  |
-| F1-F2  | Pre-Merge       | review、CI、comments、mergeability の鮮度を確認します。           |
-| F3-F4  | Merge           | 検証済み HEAD を merge し、merge 後の cleanup を行います。        |
-| F5     | Loop            | discovery に戻り、次の issue を選びます。                         |
+| 番号   | 名前               | 概要                                                              |
+| ------ | ------------------ | ----------------------------------------------------------------- |
+| A0-A4  | Discover           | 設定されたスコープから ready な issue を探して選びます。          |
+| A5     | Claim              | 機械可読な claim marker で issue を予約します。                   |
+| B-C    | Work & Self-Review | branch/worktree を作り、計画、実装、自己レビューします。          |
+| D1-D4  | PR Submit          | branch を push して PR を開き、E1 前に validation を待ちます。    |
+| E1-E3  | Review Snapshot    | review activity を記録し、critique を実行して List A を作ります。 |
+| E4-E8  | Review Triage      | List A の項目を分類し、accept/reject の判断を記録します。         |
+| E9-E15 | Review Fix         | accepted feedback を反映し、必要に応じて再レビューを依頼します。  |
+| F1-F2  | Pre-Merge          | review、CI、comments、mergeability の鮮度を確認します。           |
+| F3-F5  | Merge              | 検証済み HEAD を merge し、cleanup 後に discovery へ戻ります。    |
 
 各フェーズは `.github/instructions/` ファイルとしてエンコードされており、
 GitHub Copilot、Claude Code、Codex CLI、Gemini CLI などの互換 AI エージェントが

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,8 +14,18 @@
 
 IDD は、AI エージェントが GitHub Issues によって駆動される繰り返しパイプラインを
 通じて作業するマルチエージェント GitHub 自動化ワークフローです。
-フェーズ: Discover → Claim → Work → PR Submit → CI Wait →
-Review Triage → Review Fix → Merge → Loop。
+
+| 番号   | 名前          | 概要                                                             |
+| ------ | ------------- | ---------------------------------------------------------------- |
+| A0-A4  | Discover      | 設定されたスコープから ready な issue を探して選びます。         |
+| A5     | Claim         | 機械可読な claim marker で issue を予約します。                  |
+| B      | Work          | branch/worktree を作り、計画、実装、自己レビューします。         |
+| D1-D3  | PR Submit     | branch を push し、issue に対応する pull request を開きます。    |
+| D4     | CI Wait       | review triage 前に必要な validation 完了を待ちます。             |
+| E1-E8  | Review Triage | review feedback を snapshot し、対応要否を分類します。           |
+| E9-E15 | Review Fix    | accepted feedback を反映し、必要に応じて再レビューを依頼します。 |
+| F1-F4  | Merge         | merge gate を再確認し、安全に merge して cleanup します。        |
+| F5     | Loop          | discovery に戻り、次の issue を選びます。                        |
 
 各フェーズは `.github/instructions/` ファイルとしてエンコードされており、
 GitHub Copilot、Claude Code、Codex CLI、Gemini CLI などの互換 AI エージェントが

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,17 +15,19 @@
 IDD は、AI エージェントが GitHub Issues によって駆動される繰り返しパイプラインを
 通じて作業するマルチエージェント GitHub 自動化ワークフローです。
 
-| 番号   | 名前          | 概要                                                             |
-| ------ | ------------- | ---------------------------------------------------------------- |
-| A0-A4  | Discover      | 設定されたスコープから ready な issue を探して選びます。         |
-| A5     | Claim         | 機械可読な claim marker で issue を予約します。                  |
-| B      | Work          | branch/worktree を作り、計画、実装、自己レビューします。         |
-| D1-D3  | PR Submit     | branch を push し、issue に対応する pull request を開きます。    |
-| D4     | CI Wait       | review triage 前に必要な validation 完了を待ちます。             |
-| E1-E8  | Review Triage | review feedback を snapshot し、対応要否を分類します。           |
-| E9-E15 | Review Fix    | accepted feedback を反映し、必要に応じて再レビューを依頼します。 |
-| F1-F4  | Merge         | merge gate を再確認し、安全に merge して cleanup します。        |
-| F5     | Loop          | discovery に戻り、次の issue を選びます。                        |
+| 番号   | 名前            | 概要                                                              |
+| ------ | --------------- | ----------------------------------------------------------------- |
+| A0-A4  | Discover        | 設定されたスコープから ready な issue を探して選びます。          |
+| A5     | Claim           | 機械可読な claim marker で issue を予約します。                   |
+| B      | Work            | branch/worktree を作り、計画、実装、自己レビューします。          |
+| D1-D3  | PR Submit       | branch を push し、issue に対応する pull request を開きます。     |
+| D4     | CI Wait         | review snapshot 前に必要な validation 完了を待ちます。            |
+| E1-E3  | Review Snapshot | review activity を記録し、critique を実行して List A を作ります。 |
+| E4-E8  | Review Triage   | List A の項目を分類し、accept/reject の判断を記録します。         |
+| E9-E15 | Review Fix      | accepted feedback を反映し、必要に応じて再レビューを依頼します。  |
+| F1-F2  | Pre-Merge       | review、CI、comments、mergeability の鮮度を確認します。           |
+| F3-F4  | Merge           | 検証済み HEAD を merge し、merge 後の cleanup を行います。        |
+| F5     | Loop            | discovery に戻り、次の issue を選びます。                         |
 
 各フェーズは `.github/instructions/` ファイルとしてエンコードされており、
 GitHub Copilot、Claude Code、Codex CLI、Gemini CLI などの互換 AI エージェントが

--- a/README.md
+++ b/README.md
@@ -15,17 +15,19 @@ GitHub project.
 IDD is a multi-agent GitHub automation workflow where AI agents work
 through a repeating pipeline driven entirely by GitHub Issues.
 
-| #      | Name          | Summary                                                        |
-| ------ | ------------- | -------------------------------------------------------------- |
-| A0-A4  | Discover      | Find ready issues from the configured scope and pick one task. |
-| A5     | Claim         | Reserve the issue with a machine-readable claim marker.        |
-| B      | Work          | Create a branch/worktree, plan, implement, and self-review.    |
-| D1-D3  | PR Submit     | Push the branch and open a pull request for the issue.         |
-| D4     | CI Wait       | Wait for required validation to finish before review triage.   |
-| E1-E8  | Review Triage | Snapshot review feedback and classify what needs action.       |
-| E9-E15 | Review Fix    | Apply accepted feedback and request fresh review when needed.  |
-| F1-F4  | Merge         | Re-check merge gates, merge safely, and clean up.              |
-| F5     | Loop          | Return to discovery and pick the next issue.                   |
+| #      | Name            | Summary                                                        |
+| ------ | --------------- | -------------------------------------------------------------- |
+| A0-A4  | Discover        | Find ready issues from the configured scope and pick one task. |
+| A5     | Claim           | Reserve the issue with a machine-readable claim marker.        |
+| B      | Work            | Create a branch/worktree, plan, implement, and self-review.    |
+| D1-D3  | PR Submit       | Push the branch and open a pull request for the issue.         |
+| D4     | CI Wait         | Wait for validation to pass before review snapshot.            |
+| E1-E3  | Review Snapshot | Capture review activity, run critique, and build List A.       |
+| E4-E8  | Review Triage   | Classify List A items and record accept/reject decisions.      |
+| E9-E15 | Review Fix      | Apply accepted feedback and request fresh review when needed.  |
+| F1-F2  | Pre-Merge       | Confirm reviews, CI, comments, and mergeability are fresh.     |
+| F3-F4  | Merge           | Merge using the validated HEAD and clean up after merge.       |
+| F5     | Loop            | Return to discovery and pick the next issue.                   |
 
 Each phase is encoded as a `.github/instructions/` file that any
 compatible AI agent can load — GitHub Copilot, Claude Code, Codex CLI,

--- a/README.md
+++ b/README.md
@@ -15,19 +15,17 @@ GitHub project.
 IDD is a multi-agent GitHub automation workflow where AI agents work
 through a repeating pipeline driven entirely by GitHub Issues.
 
-| #      | Name            | Summary                                                        |
-| ------ | --------------- | -------------------------------------------------------------- |
-| A0-A4  | Discover        | Find ready issues from the configured scope and pick one task. |
-| A5     | Claim           | Reserve the issue with a machine-readable claim marker.        |
-| B      | Work            | Create a branch/worktree, plan, implement, and self-review.    |
-| D1-D3  | PR Submit       | Push the branch and open a pull request for the issue.         |
-| D4     | CI Wait         | Wait for validation to pass before review snapshot.            |
-| E1-E3  | Review Snapshot | Capture review activity, run critique, and build List A.       |
-| E4-E8  | Review Triage   | Classify List A items and record accept/reject decisions.      |
-| E9-E15 | Review Fix      | Apply accepted feedback and request fresh review when needed.  |
-| F1-F2  | Pre-Merge       | Confirm reviews, CI, comments, and mergeability are fresh.     |
-| F3-F4  | Merge           | Merge using the validated HEAD and clean up after merge.       |
-| F5     | Loop            | Return to discovery and pick the next issue.                   |
+| #      | Name               | Summary                                                            |
+| ------ | ------------------ | ------------------------------------------------------------------ |
+| A0-A4  | Discover           | Find ready issues from the configured scope and pick one task.     |
+| A5     | Claim              | Reserve the issue with a machine-readable claim marker.            |
+| B-C    | Work & Self-Review | Create a branch/worktree, plan, implement, and self-review.        |
+| D1-D4  | PR Submit          | Push the branch, open a PR, and wait for validation before E1.     |
+| E1-E3  | Review Snapshot    | Capture review activity, run critique, and build List A.           |
+| E4-E8  | Review Triage      | Classify List A items and record accept/reject decisions.          |
+| E9-E15 | Review Fix         | Apply accepted feedback and request fresh review when needed.      |
+| F1-F2  | Pre-Merge          | Confirm reviews, CI, comments, and mergeability are fresh.         |
+| F3-F5  | Merge              | Merge using the validated HEAD, clean up, and return to discovery. |
 
 Each phase is encoded as a `.github/instructions/` file that any
 compatible AI agent can load — GitHub Copilot, Claude Code, Codex CLI,

--- a/README.md
+++ b/README.md
@@ -13,9 +13,19 @@ GitHub project.
 ## What is IDD?
 
 IDD is a multi-agent GitHub automation workflow where AI agents work
-through a repeating pipeline driven entirely by GitHub Issues. The
-phases are: Discover → Claim → Work → PR Submit → CI Wait →
-Review Triage → Review Fix → Merge → Loop.
+through a repeating pipeline driven entirely by GitHub Issues.
+
+| #      | Name          | Summary                                                        |
+| ------ | ------------- | -------------------------------------------------------------- |
+| A0-A4  | Discover      | Find ready issues from the configured scope and pick one task. |
+| A5     | Claim         | Reserve the issue with a machine-readable claim marker.        |
+| B      | Work          | Create a branch/worktree, plan, implement, and self-review.    |
+| D1-D3  | PR Submit     | Push the branch and open a pull request for the issue.         |
+| D4     | CI Wait       | Wait for required validation to finish before review triage.   |
+| E1-E8  | Review Triage | Snapshot review feedback and classify what needs action.       |
+| E9-E15 | Review Fix    | Apply accepted feedback and request fresh review when needed.  |
+| F1-F4  | Merge         | Re-check merge gates, merge safely, and clean up.              |
+| F5     | Loop          | Return to discovery and pick the next issue.                   |
 
 Each phase is encoded as a `.github/instructions/` file that any
 compatible AI agent can load — GitHub Copilot, Claude Code, Codex CLI,


### PR DESCRIPTION
## Summary

- Replace the inline IDD phase list in `README.md` with a numbered overview table.
- Mirror the same overview in `README.ja.md` with localized summaries and matching phase names.
- Keep the detailed workflow explanation delegated to the existing instruction files.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

## Notes

- Closes #83
- `#82` was skipped because another active claim won the race for that issue.
- No follow-up issues are recommended for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised IDD workflow in English and Japanese READMEs: replaced the single-line phase list with a structured workflow table showing stages (Discover, Claim, Work & Self-Review, PR Submit, Review Snapshot, Review Triage, Review Fix, Pre-Merge, Merge) with explicit substage ranges and brief responsibilities; removed the previous "CI Wait" and "Loop" entries from the table.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/89)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->