### PR TITLE
docs(readme): reframe benefits for adopters

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -136,27 +136,24 @@ bundle にルーティングできます:
 [idd-template/ONBOARDING.md](idd-template/ONBOARDING.md) に従い、
 optional companion としてインストールしてください。
 
-## なぜ idd-skill？
+## idd-skill で得られること
 
-- **並列エージェント協調** — Issue ボディに埋め込まれた HTML コメントマーカーによる
-  クレーム/ハートビートプロトコルにより、複数の AI エージェントが同じ Issue を
-  同時に拾うことを防ぎ、中央オーケストレーターなしで安全な並列開発を実現します。
-- **エンドツーエンドのフェーズカバレッジ** — インストラクションセットが
-  Issue 発見からマージまでのすべてのステップをエンコードします。CI 待機ループ、
-  レビュートリアージ、レビュー修正サイクルを含みます。ほとんどのツールは「PR を開く」
-  で止まります。
-- **インフラ不要** — SaaS アカウント、GitHub Actions ランナー、サーバーは不要です。
-  `idd-template/` のドキュメントとインストラクションファイルを任意のリポジトリに
-  コピーするだけでワークフローが使えます。
-- **エージェント非依存** — コアフェーズは GitHub Copilot、Claude Code、
-  OpenAI Codex CLI、Gemini CLI でインストラクションを書き直すことなく動作します。
-  (デフォルトテンプレートには後半フェーズに Copilot アドバイザリーレビューステップが
-  含まれます。詳細は [docs/positioning.md](docs/positioning.md) を参照。)
-- **完全監査可能** — すべてのルールはプレーン Markdown です。読んで、フォークして、
-  適応させてください。ブラックボックスはありません。
+- **安全な並列エージェント作業** — claim と heartbeat の marker が issue の
+  所有者を可視化するため、複数の AI エージェントが同じタスクを拾う事故を避けながら、
+  中央オーケストレーターなしで並行作業できます。
+- **handoff の抜け漏れ削減** — workflow は issue discovery から merge までを扱い、
+  CI wait、review triage、review-fix cycle も含みます。PR を開いた後も、
+  エージェントが次に何をするかを見失いにくくなります。
+- **追加インフラなしで運用開始** — `idd-template/` の docs と instruction files を
+  リポジトリへコピーすれば使えます。SaaS アカウント、GitHub Actions runner、
+  server は不要です。
+- **使うエージェントを選べる自由** — core phases は plain Markdown で、GitHub
+  Copilot、Claude Code、OpenAI Codex CLI、Gemini CLI で動作します。default
+  template には後半フェーズに Copilot advisory review step が含まれます。
+- **自分たちで制御できる監査可能な自動化** — すべての rule が repo 内の Markdown
+  として残るため、team は black box に頼らずに読み、fork し、調整できます。
 
-詳細な競合状況と戦略的ポジショニング分析については
-[docs/positioning.md](docs/positioning.md) を参照してください。
+より詳しい比較は [docs/positioning.md](docs/positioning.md) を参照してください。
 
 ## IDD の手動インポート
 

--- a/README.md
+++ b/README.md
@@ -140,28 +140,27 @@ default; install the optional companion with
 [idd-template/ONBOARDING.md](idd-template/ONBOARDING.md) when they want
 it.
 
-## Why idd-skill?
+## What you get with idd-skill
 
-- **Parallel agent coordination** — A built-in claim/heartbeat protocol
-  (HTML comment markers in issue bodies) prevents multiple AI agents from
-  picking up the same issue simultaneously, making true parallel
-  development safe without a central orchestrator.
-- **End-to-end phase coverage** — The instruction set encodes every
-  step from issue discovery to merge, including CI wait loops, review
-  triage, and review-fix cycles. Most tools stop at "open a PR".
-- **Zero infrastructure** — No SaaS account, no GitHub Actions runner,
-  no server required. Copy the `idd-template/` docs and instruction
-  files into any repository and the workflow is ready.
-- **Agent-agnostic** — Core phases work across GitHub Copilot, Claude
-  Code, OpenAI Codex CLI, and Gemini CLI without rewriting any
-  instructions. (The default template includes a Copilot advisory review
-  step in later phases; see [docs/positioning.md](docs/positioning.md)
-  for details.)
-- **Fully auditable** — Every rule is plain Markdown. Read it, fork it,
-  adapt it. No black box.
+- **Safe parallel agent work** — Claim and heartbeat markers make issue
+  ownership visible, so multiple AI agents can work at once without
+  picking up the same task or needing a central orchestrator.
+- **Fewer handoff gaps** — The workflow covers discovery through merge,
+  including CI waits, review triage, and review-fix cycles, so agents
+  can keep moving after a PR opens instead of stopping at handoff time.
+- **No extra infrastructure to operate** — Copy the `idd-template/`
+  docs and instruction files into a repository. No SaaS account, GitHub
+  Actions runner, or server is required to start using the loop.
+- **Freedom to choose the agent** — The core phases are plain Markdown
+  and work across GitHub Copilot, Claude Code, OpenAI Codex CLI, and
+  Gemini CLI. The default template still includes a Copilot advisory
+  review step in later phases.
+- **Auditable automation you control** — Every rule lives in the repo as
+  Markdown, so teams can inspect it, fork it, and adapt it without a
+  black box.
 
-See [docs/positioning.md](docs/positioning.md) for a detailed
-competitive landscape and strategic positioning analysis.
+For deeper competitive comparison, see
+[docs/positioning.md](docs/positioning.md).
 
 ## Importing IDD manually
 


### PR DESCRIPTION
## Summary

- Reframes the README benefits section around adopter outcomes instead of a feature inventory.
- Mirrors the updated benefit-focused section in `README.ja.md`.
- Keeps the deeper positioning link for competitive comparison.

Closes #85

## Validation

- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`

## Background

This is scoped to the #86 README onboarding clarity roadmap and intentionally avoids unrelated README sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README sections for improved clarity and readability
  * Streamlined content presentation with concise, bullet-point formatting in both English and Japanese versions
  * Updated documentation structure while preserving all core messaging and external resource links

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/91)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->