### PR TITLE
docs(readme): clarify artifact model upfront

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,6 +10,10 @@
 マルチエージェントパイプラインを組み込むための、移植可能な
 `.github/instructions/` ファイル群とドキュメントです。
 
+主な配布物は、導入先リポジトリへコピーする移植可能な IDD instruction
+template です。issue-authoring などのネイティブ `SKILL.md` bundle は、主配布物
+ではなく任意の companion です。
+
 ## IDD とは？
 
 IDD は、AI エージェントが GitHub Issues によって駆動される繰り返しパイプラインを

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ A portable set of `.github/instructions/` files and documentation that
 wire up an Issue-Driven Development (IDD) multi-agent pipeline for any
 GitHub project.
 
+The primary artifact is the portable IDD instruction template that
+adopters copy into a repository. Native `SKILL.md` bundles, including
+issue-authoring, are optional companions rather than the main package.
+
 ## What is IDD?
 
 IDD is a multi-agent GitHub automation workflow where AI agents work


### PR DESCRIPTION
## Summary

- Adds a brief intro clarification that the portable IDD instruction template is the primary artifact.
- Notes that native `SKILL.md` bundles such as issue-authoring are optional companion artifacts.
- Mirrors the clarification in `README.ja.md` while leaving the full Artifact model section as the detailed reference.

Closes #84

## Recommended follow-up issues

None.

## Background

This stays within the #86 README onboarding clarity roadmap and keeps the change limited to the README intro.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the primary deliverable positioning: the portable IDD instruction template is the main distribution item, with native SKILL.md bundles positioned as optional companion materials for adopting repositories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/92)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->