### PR TITLE
docs(skill): clarify issue authoring phases

### DIFF
--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -9,6 +9,22 @@ Use this skill to prepare issue-ready work before execution starts.
 Keep the skill concise and treat the repository docs as the canonical
 source for the full contract and schema.
 
+## Stable Phases
+
+Use two stable phases:
+
+1. **Intake and Clarification** — inspect relevant context, identify
+   ambiguity, run a secondary critique or explicit self-critique, and
+   ask only the questions that block safe issue drafting. Keep
+   clarification bounded; the default maximum is 3 rounds.
+2. **Decompose and Draft** — restate the request in implementation
+   terms, split it into atomic tasks, classify readiness, reuse existing
+   issues when safe, and draft the smallest issue shape that preserves
+   dependencies and reviewability.
+
+Preserve low-readiness work in stable buckets: ready, deferred,
+needs-decision, blocked-by-human, and out-of-scope.
+
 ## Workflow
 
 1. Read the bundled contract in

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -37,6 +37,51 @@ Skip it when all of the following are true:
 - no roadmap, dependency marker, or issue split is needed
 - the user did not ask for issue drafting first
 
+## Stable phases
+
+The bundle uses two stable phases. These names mirror the canonical
+contract and should stay stable for copied bundles.
+
+### 1. Intake and Clarification
+
+In this phase, the agent:
+
+- inspects the relevant code, docs, and existing issues
+- identifies assumptions and ambiguity that affect issue quality
+- runs a secondary critique pass before drafting
+- asks the user only the questions that block safe issue drafting
+
+The critique pass is agent-neutral: use a subagent or rubber-duck
+reviewer when available, otherwise run an explicit self-critique
+locally. Clarification must be bounded; the default maximum is 3 rounds.
+If safe drafting is still impossible after that, stop and report the
+remaining blockers instead of looping indefinitely.
+
+### 2. Decompose and Draft
+
+In this phase, the agent:
+
+- restates the clarified request in implementation-facing terms
+- splits work into atomic tasks
+- checks whether each task is suitable for autonomous execution
+- reuses or extends existing issues before creating new ones
+- drafts orphan issues, roadmap packages, sub-issues, or non-ready
+  buckets as appropriate
+
+## Readiness buckets
+
+Do not silently drop low-confidence or low-readiness work. Route each
+candidate task into one stable bucket:
+
+- **ready**: passes limited scope, clear verification, and autonomous
+  completion
+- **deferred**: plausible, but priority, timing, or decomposition is not
+  strong enough for execution
+- **needs-decision**: depends on a product, policy, or design choice
+- **blocked-by-human**: waits on a person, credential, asset, or outside
+  system
+- **out-of-scope**: does not belong in the repository or skill scope
+
 ## Reuse-first issue policy
 
 Before creating any new issue, check whether the work already has a


### PR DESCRIPTION
## Summary

- Adds a concise stable-phase summary to the issue-authoring skill bundle.
- Mirrors the stable phases, bounded critique/clarification guidance, and readiness buckets in the bundled contract reference.
- Leaves the canonical `docs/issue-authoring-skill.md` and workflow boundary unchanged because they already contain the authoritative details.

Closes #87

## Validation

- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`

## Background

This is scoped to the #88 issue-authoring flow clarity roadmap and keeps the portable bundle useful when copied outside this repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed documentation for stable issue-authoring phases: Intake and Clarification, and Decompose and Draft, with specified behaviors and critique bounds.
  * Introduced readiness buckets framework for task routing and handling: ready, deferred, needs-decision, blocked-by-human, and out-of-scope.
  * Specified that low-readiness work is preserved in stable buckets instead of being discarded.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/93)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->