### PR TITLE
feat(ci): add documentation audit checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Run documentation audit
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+        run: node scripts/audit-docs.mjs --check
       - name: Run cspell
         uses: streetsidesoftware/cspell-action@v8
       - name: Run markdownlint

--- a/audit/README.md
+++ b/audit/README.md
@@ -29,7 +29,8 @@ manifest has three main responsibilities:
   match. Use this only when prose is intentionally different but the
   navigational shape must stay aligned.
 - `contains`: the target must include each listed text fragment or
-  regular expression.
+  regular expression. An optional `reference` file only asserts that the
+  referenced source exists; it is not a semantic sync check.
 
 ## Intentional Exceptions
 

--- a/audit/README.md
+++ b/audit/README.md
@@ -1,0 +1,41 @@
+# Documentation Audit
+
+The documentation audit keeps repeatable repository rules in CI instead
+of relying only on agent memory.
+
+Run it locally with:
+
+```sh
+node scripts/audit-docs.mjs --check
+```
+
+The audit reads [`sync-manifest.json`](sync-manifest.json). The
+manifest has three main responsibilities:
+
+- README pairs define files that must change together in pull requests,
+  plus lightweight structure and language-link checks.
+- Generated blocks define file lists that are rendered from the current
+  repository state and compared with marked Markdown blocks.
+- Sync pairs define template versus dogfooding files and the comparison
+  mode for each pair.
+
+## Sync Modes
+
+- `exact`: the source and target must match byte-for-byte after line
+  ending normalization.
+- `concreted`: the source is transformed with explicit replacements,
+  then compared exactly with the target.
+- `structure`: Markdown heading levels and normalized heading text must
+  match. Use this only when prose is intentionally different but the
+  navigational shape must stay aligned.
+- `contains`: the target must include each listed text fragment or
+  regular expression.
+
+## Intentional Exceptions
+
+Prefer adding an explicit manifest rule over weakening the script. For a
+new allowed concrete mapping, add a `concreted` sync pair with a
+`replacements` array. For an intentional prose-only difference, use
+`structure` and document why in the pair's `note` field. For generated
+file lists, update the manifest paths or globs first, then rerun the
+audit so the marked block can be refreshed deliberately.

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -31,10 +31,9 @@
     },
     {
       "id": "idd-template-docs-set",
-      "sourceGlob": "idd-template/docs/*.md",
-      "targetGlob": "docs/*.md",
+      "sourceGlob": "idd-template/docs/idd-*.md",
+      "targetGlob": "docs/idd-*.md",
       "match": "basename",
-      "allowExtraTargets": true,
       "requireSyncPairs": true
     }
   ],
@@ -81,6 +80,30 @@
         "skills/issue-authoring/references/draft-patterns.md",
         "skills/issue-authoring/references/workflow-boundary.md"
       ]
+    }
+  ],
+  "shellFileLists": [
+    {
+      "id": "idd-template-core-gh-api-loop",
+      "file": "idd-template/ONBOARDING.md",
+      "generatedBlock": "idd-template-core-files"
+    },
+    {
+      "id": "issue-authoring-companion-gh-api-loop",
+      "file": "idd-template/ONBOARDING.md",
+      "generatedBlock": "issue-authoring-companion-files",
+      "stripPrefix": "skills/issue-authoring/"
+    },
+    {
+      "id": "idd-template-core-curl-loop",
+      "file": "idd-template/ONBOARDING.md",
+      "generatedBlock": "idd-template-core-files"
+    },
+    {
+      "id": "issue-authoring-companion-curl-loop",
+      "file": "idd-template/ONBOARDING.md",
+      "generatedBlock": "issue-authoring-companion-files",
+      "stripPrefix": "skills/issue-authoring/"
     }
   ],
   "syncPairs": [
@@ -188,7 +211,7 @@
     },
     {
       "id": "issue-authoring-contract-reference",
-      "source": "docs/issue-authoring-skill.md",
+      "reference": "docs/issue-authoring-skill.md",
       "target": "skills/issue-authoring/references/contract.md",
       "mode": "contains",
       "requiredText": [
@@ -199,7 +222,7 @@
     },
     {
       "id": "issue-authoring-boundary-reference",
-      "source": "docs/issue-authoring-skill.md",
+      "reference": "docs/issue-authoring-skill.md",
       "target": "skills/issue-authoring/references/workflow-boundary.md",
       "mode": "contains",
       "requiredText": [

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -1,0 +1,219 @@
+{
+  "_comment": "Documentation audit contract. Use exact for mirrored files, concreted when the source becomes the target after listed replacements, and structure when the files intentionally differ but must keep the same heading map.",
+  "readmePairs": [
+    {
+      "id": "root-readme",
+      "files": [
+        "README.md",
+        "README.ja.md"
+      ],
+      "pairedChange": true,
+      "structure": "heading-levels",
+      "languageLinks": [
+        {
+          "file": "README.md",
+          "text": "[\u65e5\u672c\u8a9e](./README.ja.md)"
+        },
+        {
+          "file": "README.ja.md",
+          "text": "[English](./README.md)"
+        }
+      ]
+    }
+  ],
+  "fileSets": [
+    {
+      "id": "idd-instruction-template-dogfood-set",
+      "sourceGlob": "idd-template/.github/instructions/idd-*.instructions.md",
+      "targetGlob": ".github/instructions/idd-*.instructions.md",
+      "match": "basename",
+      "requireSyncPairs": true
+    },
+    {
+      "id": "idd-template-docs-set",
+      "sourceGlob": "idd-template/docs/*.md",
+      "targetGlob": "docs/*.md",
+      "match": "basename",
+      "allowExtraTargets": true,
+      "requireSyncPairs": true
+    }
+  ],
+  "generatedBlocks": [
+    {
+      "id": "idd-template-core-files",
+      "file": "idd-template/ONBOARDING.md",
+      "language": "text",
+      "stripPrefix": "idd-template/",
+      "sourceGlobs": [
+        "idd-template/.github/instructions/idd-*.instructions.md",
+        "idd-template/docs/idd-*.md"
+      ],
+      "paths": [
+        "idd-template/.github/instructions/idd-overview.instructions.md",
+        "idd-template/.github/instructions/idd-discover.instructions.md",
+        "idd-template/.github/instructions/idd-claim.instructions.md",
+        "idd-template/.github/instructions/idd-work.instructions.md",
+        "idd-template/.github/instructions/idd-pr-submit.instructions.md",
+        "idd-template/.github/instructions/idd-ci.instructions.md",
+        "idd-template/.github/instructions/idd-advisory-wait.instructions.md",
+        "idd-template/.github/instructions/idd-review-snapshot.instructions.md",
+        "idd-template/.github/instructions/idd-review-triage.instructions.md",
+        "idd-template/.github/instructions/idd-review-fix.instructions.md",
+        "idd-template/.github/instructions/idd-pre-merge.instructions.md",
+        "idd-template/.github/instructions/idd-merge.instructions.md",
+        "idd-template/.github/instructions/idd-resume.instructions.md",
+        "idd-template/docs/idd-workflow.md",
+        "idd-template/docs/idd-helper-scripts.md",
+        "idd-template/docs/idd-comment-minimization.md"
+      ]
+    },
+    {
+      "id": "issue-authoring-companion-files",
+      "file": "idd-template/ONBOARDING.md",
+      "language": "text",
+      "sourceGlobs": [
+        "skills/issue-authoring/**"
+      ],
+      "paths": [
+        "skills/issue-authoring/SKILL.md",
+        "skills/issue-authoring/agents/openai.yaml",
+        "skills/issue-authoring/references/contract.md",
+        "skills/issue-authoring/references/draft-patterns.md",
+        "skills/issue-authoring/references/workflow-boundary.md"
+      ]
+    }
+  ],
+  "syncPairs": [
+    {
+      "id": "idd-advisory-wait-instructions",
+      "source": "idd-template/.github/instructions/idd-advisory-wait.instructions.md",
+      "target": ".github/instructions/idd-advisory-wait.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-ci-instructions",
+      "source": "idd-template/.github/instructions/idd-ci.instructions.md",
+      "target": ".github/instructions/idd-ci.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-claim-instructions",
+      "source": "idd-template/.github/instructions/idd-claim.instructions.md",
+      "target": ".github/instructions/idd-claim.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-discover-instructions",
+      "source": "idd-template/.github/instructions/idd-discover.instructions.md",
+      "target": ".github/instructions/idd-discover.instructions.md",
+      "mode": "structure"
+    },
+    {
+      "id": "idd-merge-instructions",
+      "source": "idd-template/.github/instructions/idd-merge.instructions.md",
+      "target": ".github/instructions/idd-merge.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-overview-instructions",
+      "source": "idd-template/.github/instructions/idd-overview.instructions.md",
+      "target": ".github/instructions/idd-overview.instructions.md",
+      "mode": "structure"
+    },
+    {
+      "id": "idd-pr-submit-instructions",
+      "source": "idd-template/.github/instructions/idd-pr-submit.instructions.md",
+      "target": ".github/instructions/idd-pr-submit.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-pre-merge-instructions",
+      "source": "idd-template/.github/instructions/idd-pre-merge.instructions.md",
+      "target": ".github/instructions/idd-pre-merge.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-resume-instructions",
+      "source": "idd-template/.github/instructions/idd-resume.instructions.md",
+      "target": ".github/instructions/idd-resume.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-review-fix-instructions",
+      "source": "idd-template/.github/instructions/idd-review-fix.instructions.md",
+      "target": ".github/instructions/idd-review-fix.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-review-snapshot-instructions",
+      "source": "idd-template/.github/instructions/idd-review-snapshot.instructions.md",
+      "target": ".github/instructions/idd-review-snapshot.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-review-triage-instructions",
+      "source": "idd-template/.github/instructions/idd-review-triage.instructions.md",
+      "target": ".github/instructions/idd-review-triage.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-work-instructions",
+      "source": "idd-template/.github/instructions/idd-work.instructions.md",
+      "target": ".github/instructions/idd-work.instructions.md",
+      "mode": "concreted",
+      "replacements": [
+        {
+          "from": "{{REPO_NAME}}",
+          "to": "idd-skill"
+        }
+      ]
+    },
+    {
+      "id": "idd-comment-minimization-doc",
+      "source": "idd-template/docs/idd-comment-minimization.md",
+      "target": "docs/idd-comment-minimization.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-helper-scripts-doc",
+      "source": "idd-template/docs/idd-helper-scripts.md",
+      "target": "docs/idd-helper-scripts.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-workflow-doc",
+      "source": "idd-template/docs/idd-workflow.md",
+      "target": "docs/idd-workflow.md",
+      "mode": "structure"
+    },
+    {
+      "id": "issue-authoring-contract-reference",
+      "source": "docs/issue-authoring-skill.md",
+      "target": "skills/issue-authoring/references/contract.md",
+      "mode": "contains",
+      "requiredText": [
+        "It mirrors the canonical\ncontract in `docs/issue-authoring-skill.md`.",
+        "## Target marker prefix",
+        "## Publication boundary"
+      ]
+    },
+    {
+      "id": "issue-authoring-boundary-reference",
+      "source": "docs/issue-authoring-skill.md",
+      "target": "skills/issue-authoring/references/workflow-boundary.md",
+      "mode": "contains",
+      "requiredText": [
+        "This bundle handles pre-approval issue drafting only.",
+        "start the Discover -> Claim -> Work loop implicitly"
+      ]
+    }
+  ],
+  "forbiddenPatterns": [
+    {
+      "id": "hard-coded-idd-instruction-file-count",
+      "glob": "**/*.md",
+      "pattern": "\\b(thirteen|13)\\s+`?idd-\\*\\.instructions\\.md`?\\s+files\\b",
+      "message": "Avoid hard-coded IDD instruction file counts. Use a generated block or count-free wording."
+    }
+  ]
+}

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -121,6 +121,8 @@ the files are copied in.
 
 ### File list
 
+<!-- audit:generated id=idd-template-core-files -->
+
 ```text
 .github/instructions/idd-overview.instructions.md
 .github/instructions/idd-discover.instructions.md
@@ -140,7 +142,11 @@ docs/idd-helper-scripts.md
 docs/idd-comment-minimization.md
 ```
 
+<!-- /audit:generated -->
+
 Optional companion files:
+
+<!-- audit:generated id=issue-authoring-companion-files -->
 
 ```text
 skills/issue-authoring/SKILL.md
@@ -149,6 +155,8 @@ skills/issue-authoring/references/contract.md
 skills/issue-authoring/references/draft-patterns.md
 skills/issue-authoring/references/workflow-boundary.md
 ```
+
+<!-- /audit:generated -->
 
 Create the target directories if they do not exist.
 
@@ -440,8 +448,8 @@ phase file manually when the current step changes.
 
 After completing the steps above, confirm each item:
 
-- [ ] All thirteen `idd-*.instructions.md` files are present in
-      `.github/instructions/`.
+- [ ] Every `idd-*.instructions.md` file listed in the generated core
+      file list is present in `.github/instructions/`.
 - [ ] `docs/idd-workflow.md`, `docs/idd-helper-scripts.md`, and
       `docs/idd-comment-minimization.md` are present.
 - [ ] If the operator opted into issue authoring,

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -169,6 +169,8 @@ Base URL: `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-temp
 
 Fetch all files with `gh api` (recommended — handles auth automatically):
 
+<!-- audit:shell-list id=idd-template-core-gh-api-loop -->
+
 ```sh
 DEST="."  # root of the target repository
 
@@ -201,6 +203,8 @@ done
 If the operator opts into the issue-authoring companion, fetch it
 separately:
 
+<!-- audit:shell-list id=issue-authoring-companion-gh-api-loop -->
+
 ```sh
 DEST="."  # root of the target repository
 
@@ -222,6 +226,8 @@ done
 
 Alternatively, use `curl` (no authentication required — idd-skill is a public
 repository):
+
+<!-- audit:shell-list id=idd-template-core-curl-loop -->
 
 ```sh
 BASE="https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template"
@@ -253,6 +259,8 @@ done
 
 If the operator opts into the issue-authoring companion with `curl`,
 fetch it separately:
+
+<!-- audit:shell-list id=issue-authoring-companion-curl-loop -->
 
 ```sh
 BASE="https://raw.githubusercontent.com/kurone-kito/idd-skill/main/skills/issue-authoring"

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -22,6 +22,7 @@ const changedFiles = listChangedFiles();
 checkReadmePairs(manifest.readmePairs ?? []);
 checkFileSets(manifest.fileSets ?? [], manifest.syncPairs ?? []);
 checkGeneratedBlocks(manifest.generatedBlocks ?? []);
+checkShellFileLists(manifest.shellFileLists ?? [], manifest.generatedBlocks ?? []);
 checkSyncPairs(manifest.syncPairs ?? []);
 checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
 
@@ -152,7 +153,45 @@ function checkGeneratedBlocks(blocks) {
   }
 }
 
+function checkShellFileLists(lists, generatedBlocks) {
+  const blockById = new Map(generatedBlocks.map((block) => [block.id, block]));
+
+  for (const list of lists) {
+    const sourceBlock = blockById.get(list.generatedBlock);
+    if (!sourceBlock) {
+      errors.push(`${list.id}: unknown generated block ${list.generatedBlock}`);
+      continue;
+    }
+
+    const text = readText(list.file);
+    const marker = `<!-- audit:shell-list id=${list.id} -->`;
+    const markerIndex = text.indexOf(marker);
+    if (markerIndex === -1) {
+      errors.push(`${list.id}: ${list.file} is missing ${marker}`);
+      continue;
+    }
+
+    const code = nextFencedCodeBlock(text, markerIndex + marker.length, list.id);
+    if (code === null) {
+      continue;
+    }
+
+    const actual = extractShellForFiles(code, list.id);
+    const strip = list.stripPrefix ?? sourceBlock.stripPrefix;
+    const expected = resolveBlockFiles(sourceBlock).map((file) => stripPrefix(file, strip));
+    if (actual.join("\n") !== expected.join("\n")) {
+      errors.push(`${list.id}: shell file list in ${list.file} is stale`);
+    }
+  }
+}
+
 function renderGeneratedBlock(block) {
+  const files = resolveBlockFiles(block);
+  const renderedFiles = files.map((file) => stripPrefix(file, block.stripPrefix));
+  return `\n\n\`\`\`${block.language ?? "text"}\n${renderedFiles.join("\n")}\n\`\`\`\n\n`;
+}
+
+function resolveBlockFiles(block) {
   const files = block.paths
     ? [...block.paths]
     : uniqueSorted((block.sourceGlobs ?? []).flatMap(globFiles));
@@ -172,8 +211,7 @@ function renderGeneratedBlock(block) {
     }
   }
 
-  const renderedFiles = files.map((file) => stripPrefix(file, block.stripPrefix));
-  return `\n\n\`\`\`${block.language ?? "text"}\n${renderedFiles.join("\n")}\n\`\`\`\n\n`;
+  return files;
 }
 
 function checkSyncPairs(pairs) {
@@ -207,8 +245,8 @@ function checkSyncPairs(pairs) {
 }
 
 function checkContainsPair(pair) {
-  if (pair.source) {
-    readText(pair.source);
+  if (pair.reference) {
+    readText(pair.reference);
   }
 
   const target = readText(pair.target);
@@ -243,6 +281,7 @@ function checkForbiddenPatterns(patterns) {
 function listChangedFiles() {
   const candidates = [];
   const eventPath = process.env.GITHUB_EVENT_PATH;
+  let eventBefore = "";
 
   if (eventPath) {
     try {
@@ -251,7 +290,7 @@ function listChangedFiles() {
         candidates.push([`${event.pull_request.base.sha}...HEAD`]);
       }
       if (event.before && !/^0+$/.test(event.before)) {
-        candidates.push([`${event.before}...HEAD`]);
+        eventBefore = event.before;
       }
     } catch (error) {
       notices.push(`could not read GitHub event payload: ${error.message}`);
@@ -261,13 +300,16 @@ function listChangedFiles() {
   if (process.env.GITHUB_BASE_REF) {
     candidates.push([`origin/${process.env.GITHUB_BASE_REF}...HEAD`]);
   }
+  candidates.push(["origin/main...HEAD"]);
+  if (eventBefore) {
+    candidates.push([`${eventBefore}...HEAD`]);
+  }
   if (
     process.env.GITHUB_EVENT_BEFORE &&
     !/^0+$/.test(process.env.GITHUB_EVENT_BEFORE)
   ) {
     candidates.push([`${process.env.GITHUB_EVENT_BEFORE}...HEAD`]);
   }
-  candidates.push(["origin/main...HEAD"]);
 
   for (const args of candidates) {
     try {
@@ -378,6 +420,54 @@ function stripGeneratedBlocks(text) {
   );
 }
 
+function nextFencedCodeBlock(text, startIndex, id) {
+  const fenceStart = text.indexOf("```", startIndex);
+  if (fenceStart === -1) {
+    errors.push(`${id}: missing fenced code block after marker`);
+    return null;
+  }
+  const codeStart = text.indexOf("\n", fenceStart);
+  if (codeStart === -1) {
+    errors.push(`${id}: malformed fenced code block`);
+    return null;
+  }
+  const fenceEnd = text.indexOf("\n```", codeStart + 1);
+  if (fenceEnd === -1) {
+    errors.push(`${id}: fenced code block is not closed`);
+    return null;
+  }
+  return text.slice(codeStart + 1, fenceEnd);
+}
+
+function extractShellForFiles(code, id) {
+  const lines = code.split("\n");
+  const loopStart = lines.findIndex((line) => line.trim() === "for FILE in \\");
+  if (loopStart === -1) {
+    errors.push(`${id}: missing "for FILE in \\" loop`);
+    return [];
+  }
+  const loopEnd = lines.findIndex((line, index) => index > loopStart && line.trim() === "do");
+  if (loopEnd === -1) {
+    errors.push(`${id}: missing "do" after FILE loop`);
+    return [];
+  }
+
+  const files = [];
+  for (const line of lines.slice(loopStart + 1, loopEnd)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const match = /^"([^"]+)"(?:\s+\\)?$/.exec(trimmed);
+    if (!match) {
+      errors.push(`${id}: unsupported FILE entry ${JSON.stringify(trimmed)}`);
+      continue;
+    }
+    files.push(match[1]);
+  }
+  return files;
+}
+
 function stripPrefix(file, prefix) {
   if (!prefix) {
     return file;
@@ -390,7 +480,12 @@ function stripPrefix(file, prefix) {
 }
 
 function readText(file) {
-  return normalizeText(readFileSync(join(root, file), "utf8"));
+  try {
+    return normalizeText(readFileSync(join(root, file), "utf8"));
+  } catch (error) {
+    errors.push(`${file}: could not read file (${error.code ?? error.message})`);
+    return "";
+  }
 }
 
 function normalizeText(text) {

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -1,0 +1,420 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+const manifestPath = "audit/sync-manifest.json";
+const args = new Set(process.argv.slice(2));
+
+if (!args.has("--check")) {
+  console.error("usage: node scripts/audit-docs.mjs --check");
+  process.exit(2);
+}
+
+const errors = [];
+const notices = [];
+const manifest = JSON.parse(readText(manifestPath));
+const repoFiles = listRepoFiles();
+const changedFiles = listChangedFiles();
+
+checkReadmePairs(manifest.readmePairs ?? []);
+checkFileSets(manifest.fileSets ?? [], manifest.syncPairs ?? []);
+checkGeneratedBlocks(manifest.generatedBlocks ?? []);
+checkSyncPairs(manifest.syncPairs ?? []);
+checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
+
+if (errors.length > 0) {
+  console.error("documentation audit failed:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+for (const notice of notices) {
+  console.log(`notice: ${notice}`);
+}
+console.log("documentation audit passed");
+
+function checkReadmePairs(pairs) {
+  for (const pair of pairs) {
+    const [first, second] = pair.files ?? [];
+    if (!first || !second) {
+      errors.push(`${pair.id}: README pair must contain exactly two files`);
+      continue;
+    }
+
+    if (pair.pairedChange) {
+      checkPairedChange(pair.id, first, second);
+    }
+
+    for (const link of pair.languageLinks ?? []) {
+      const text = readText(link.file);
+      if (!text.includes(link.text)) {
+        errors.push(`${pair.id}: ${link.file} is missing ${JSON.stringify(link.text)}`);
+      }
+    }
+
+    if (pair.structure === "heading-levels") {
+      const firstLevels = headingSignature(readText(first), { levelsOnly: true });
+      const secondLevels = headingSignature(readText(second), { levelsOnly: true });
+      if (firstLevels !== secondLevels) {
+        errors.push(`${pair.id}: README heading levels differ between ${first} and ${second}`);
+      }
+    }
+  }
+}
+
+function checkPairedChange(id, first, second) {
+  if (changedFiles === null) {
+    notices.push(`${id}: skipped paired-change check because no git comparison base was available`);
+    return;
+  }
+
+  const firstChanged = changedFiles.has(first);
+  const secondChanged = changedFiles.has(second);
+  if (firstChanged !== secondChanged) {
+    errors.push(`${id}: ${first} and ${second} must be changed together`);
+  }
+}
+
+function checkFileSets(fileSets, syncPairs) {
+  const coveredSyncPairs = new Set(syncPairs.map((pair) => `${pair.source}\0${pair.target}`));
+
+  for (const fileSet of fileSets) {
+    const sourceFiles = globFiles(fileSet.sourceGlob);
+    const targetFiles = globFiles(fileSet.targetGlob);
+
+    if (fileSet.match !== "basename") {
+      errors.push(`${fileSet.id}: unsupported file set match mode ${fileSet.match}`);
+      continue;
+    }
+
+    const sourceNames = new Set(sourceFiles.map((file) => basename(file)));
+    const targetNames = new Set(targetFiles.map((file) => basename(file)));
+    const sourceByName = new Map(sourceFiles.map((file) => [basename(file), file]));
+    const targetByName = new Map(targetFiles.map((file) => [basename(file), file]));
+
+    for (const sourceName of sourceNames) {
+      if (!targetNames.has(sourceName)) {
+        errors.push(`${fileSet.id}: target is missing ${sourceName}`);
+        continue;
+      }
+      if (fileSet.requireSyncPairs) {
+        const source = sourceByName.get(sourceName);
+        const target = targetByName.get(sourceName);
+        if (!coveredSyncPairs.has(`${source}\0${target}`)) {
+          errors.push(`${fileSet.id}: ${sourceName} is missing a syncPairs entry`);
+        }
+      }
+    }
+
+    if (!fileSet.allowExtraTargets) {
+      for (const targetName of targetNames) {
+        if (!sourceNames.has(targetName)) {
+          errors.push(`${fileSet.id}: target has unexpected ${targetName}`);
+        }
+      }
+    }
+
+    for (const requiredName of fileSet.requiredBasenames ?? []) {
+      if (!targetNames.has(requiredName)) {
+        errors.push(`${fileSet.id}: target is missing required ${requiredName}`);
+      }
+    }
+  }
+}
+
+function checkGeneratedBlocks(blocks) {
+  for (const block of blocks) {
+    const text = readText(block.file);
+    const startMarker = `<!-- audit:generated id=${block.id} -->`;
+    const endMarker = "<!-- /audit:generated -->";
+    const start = text.indexOf(startMarker);
+    if (start === -1) {
+      errors.push(`${block.id}: ${block.file} is missing ${startMarker}`);
+      continue;
+    }
+    const innerStart = start + startMarker.length;
+    const end = text.indexOf(endMarker, innerStart);
+    if (end === -1) {
+      errors.push(`${block.id}: ${block.file} is missing ${endMarker}`);
+      continue;
+    }
+
+    const expected = renderGeneratedBlock(block);
+    const actual = normalizeText(text.slice(innerStart, end));
+    if (actual !== expected) {
+      errors.push(`${block.id}: generated block in ${block.file} is stale`);
+    }
+  }
+}
+
+function renderGeneratedBlock(block) {
+  const files = block.paths
+    ? [...block.paths]
+    : uniqueSorted((block.sourceGlobs ?? []).flatMap(globFiles));
+  const actualFiles = uniqueSorted((block.sourceGlobs ?? []).flatMap(globFiles));
+
+  if (block.paths && block.sourceGlobs) {
+    const expectedSet = new Set(block.paths);
+    for (const actual of actualFiles) {
+      if (!expectedSet.has(actual)) {
+        errors.push(`${block.id}: manifest paths omit ${actual}`);
+      }
+    }
+    for (const expected of block.paths) {
+      if (!actualFiles.includes(expected)) {
+        errors.push(`${block.id}: manifest path does not exist or match globs: ${expected}`);
+      }
+    }
+  }
+
+  const renderedFiles = files.map((file) => stripPrefix(file, block.stripPrefix));
+  return `\n\n\`\`\`${block.language ?? "text"}\n${renderedFiles.join("\n")}\n\`\`\`\n\n`;
+}
+
+function checkSyncPairs(pairs) {
+  for (const pair of pairs) {
+    if (pair.mode === "contains") {
+      checkContainsPair(pair);
+      continue;
+    }
+
+    const source = applyReplacements(readText(pair.source), pair.replacements ?? []);
+    const target = readText(pair.target);
+
+    if (pair.mode === "exact" || pair.mode === "concreted") {
+      if (normalizeText(source) !== normalizeText(target)) {
+        errors.push(`${pair.id}: ${pair.source} and ${pair.target} differ in ${pair.mode} mode`);
+      }
+      continue;
+    }
+
+    if (pair.mode === "structure") {
+      const sourceSignature = headingSignature(source, { levelsOnly: false });
+      const targetSignature = headingSignature(target, { levelsOnly: false });
+      if (sourceSignature !== targetSignature) {
+        errors.push(`${pair.id}: heading structure differs between ${pair.source} and ${pair.target}`);
+      }
+      continue;
+    }
+
+    errors.push(`${pair.id}: unsupported sync mode ${pair.mode}`);
+  }
+}
+
+function checkContainsPair(pair) {
+  if (pair.source) {
+    readText(pair.source);
+  }
+
+  const target = readText(pair.target);
+  for (const requiredText of pair.requiredText ?? []) {
+    if (!target.includes(requiredText)) {
+      errors.push(
+        `${pair.id}: ${pair.target} is missing required text ${JSON.stringify(requiredText)}`,
+      );
+    }
+  }
+  for (const requiredPattern of pair.requiredPatterns ?? []) {
+    const regex = new RegExp(requiredPattern, "m");
+    if (!regex.test(target)) {
+      errors.push(`${pair.id}: ${pair.target} does not match /${requiredPattern}/`);
+    }
+  }
+}
+
+function checkForbiddenPatterns(patterns) {
+  for (const pattern of patterns) {
+    const regex = new RegExp(pattern.pattern, "i");
+    const files = globFiles(pattern.glob);
+    for (const file of files) {
+      const text = readText(file);
+      if (regex.test(stripGeneratedBlocks(text))) {
+        errors.push(`${pattern.id}: ${file}: ${pattern.message}`);
+      }
+    }
+  }
+}
+
+function listChangedFiles() {
+  const candidates = [];
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+
+  if (eventPath) {
+    try {
+      const event = JSON.parse(readFileSync(eventPath, "utf8"));
+      if (event.pull_request?.base?.sha) {
+        candidates.push([`${event.pull_request.base.sha}...HEAD`]);
+      }
+      if (event.before && !/^0+$/.test(event.before)) {
+        candidates.push([`${event.before}...HEAD`]);
+      }
+    } catch (error) {
+      notices.push(`could not read GitHub event payload: ${error.message}`);
+    }
+  }
+
+  if (process.env.GITHUB_BASE_REF) {
+    candidates.push([`origin/${process.env.GITHUB_BASE_REF}...HEAD`]);
+  }
+  if (
+    process.env.GITHUB_EVENT_BEFORE &&
+    !/^0+$/.test(process.env.GITHUB_EVENT_BEFORE)
+  ) {
+    candidates.push([`${process.env.GITHUB_EVENT_BEFORE}...HEAD`]);
+  }
+  candidates.push(["origin/main...HEAD"]);
+
+  for (const args of candidates) {
+    try {
+      const output = git(["diff", "--name-only", ...args]);
+      return withWorkingTreeChanges(new Set(output.split(/\r?\n/).filter(Boolean)));
+    } catch {
+      // Try the next comparison base.
+    }
+  }
+
+  return null;
+}
+
+function withWorkingTreeChanges(files) {
+  for (const args of [
+    ["diff", "--name-only"],
+    ["diff", "--cached", "--name-only"],
+  ]) {
+    try {
+      const output = git(args);
+      for (const file of output.split(/\r?\n/).filter(Boolean)) {
+        files.add(file);
+      }
+    } catch {
+      // Keep the comparison result if a local worktree diff is unavailable.
+    }
+  }
+  return files;
+}
+
+function listRepoFiles() {
+  const output = git(["ls-files", "--cached", "--others", "--exclude-standard"]);
+  return output.split(/\r?\n/).filter(Boolean).sort();
+}
+
+function globFiles(pattern) {
+  const regex = globToRegExp(pattern);
+  return repoFiles.filter((file) => regex.test(file)).sort();
+}
+
+function globToRegExp(pattern) {
+  let source = "^";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === "*") {
+      if (pattern[index + 1] === "*") {
+        if (pattern[index + 2] === "/") {
+          source += "(?:.*/)?";
+          index += 2;
+        } else {
+          source += ".*";
+          index += 1;
+        }
+      } else {
+        source += "[^/]*";
+      }
+      continue;
+    }
+    source += escapeRegExp(char);
+  }
+  return new RegExp(`${source}$`);
+}
+
+function headingSignature(text, { levelsOnly }) {
+  const headings = [];
+  let inFence = false;
+
+  for (const line of normalizeText(text).split("\n")) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      continue;
+    }
+    const match = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
+    if (!match) {
+      continue;
+    }
+    const level = match[1].length;
+    const heading = normalizeHeading(match[2]);
+    headings.push(levelsOnly ? `${level}` : `${level}:${heading}`);
+  }
+
+  return headings.join("\n");
+}
+
+function normalizeHeading(heading) {
+  return heading
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function applyReplacements(text, replacements) {
+  let result = text;
+  for (const replacement of replacements) {
+    result = result.split(replacement.from).join(replacement.to);
+  }
+  return result;
+}
+
+function stripGeneratedBlocks(text) {
+  return normalizeText(text).replace(
+    /<!-- audit:generated id=[^>]+ -->[\s\S]*?<!-- \/audit:generated -->/g,
+    "",
+  );
+}
+
+function stripPrefix(file, prefix) {
+  if (!prefix) {
+    return file;
+  }
+  if (!file.startsWith(prefix)) {
+    errors.push(`${file}: expected prefix ${prefix}`);
+    return file;
+  }
+  return file.slice(prefix.length);
+}
+
+function readText(file) {
+  return normalizeText(readFileSync(join(root, file), "utf8"));
+}
+
+function normalizeText(text) {
+  return text.replace(/\r\n?/g, "\n");
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function basename(file) {
+  return file.slice(file.lastIndexOf("/") + 1);
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[\\^$+?.()|[\]{}]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary

- Add a lightweight Node-based documentation audit command backed by a manifest.
- Enforce README paired edits, README structure/link checks, generated onboarding file lists, and template/dogfooding sync coverage.
- Run the audit in the existing lint workflow with full history available for PR diff checks.

Closes #81

## Follow-up issues

None recommended.

## Rationale

The audit stays mechanical and manifest-driven: it checks structure, file lists, and explicit sync contracts while leaving Japanese/English prose quality to reviewers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now runs an automated documentation audit to validate README sync, generated blocks, and shell-file lists.
  * Added a local CLI to run the same documentation audit checks.

* **Documentation**
  * Added a Documentation Audit guide describing how to run and configure the audit, sync modes, and exception guidance.
  * Updated onboarding docs to mark and verify generated documentation sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->