### PR TITLE
feat(idd): add post-merge cleanup helper

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -115,12 +115,29 @@ gate. The active claim must still use your current `{claim-id}`.
      decisions, active holds, failed-CI context still needed by
      maintainers, non-operational human discussion, or any content that
      still participates in active F2/F3 gates.
-   - Use GitHub GraphQL `minimizeComment` with node IDs. Check
-     `viewerCanMinimize` and `isMinimized` before minimizing; skip
-     already-minimized comments and comments the viewer cannot minimize.
+   - When `scripts/audit-pr-cleanup.mjs` is available, run it first in
+     dry-run mode so eligible and skipped candidates are visible:
 
-   See `docs/idd-comment-minimization.md` for the investigation notes,
-   dry-run shape, and command examples.
+     ```sh
+     node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
+     ```
+
+     To apply the safe candidates during this claimed IDD run, pass the
+     active issue and claim token so the helper re-validates the claim
+     before each minimization mutation:
+
+     ```sh
+     node scripts/audit-pr-cleanup.mjs --pr <pr-number> --apply \
+       --claim-issue <issue-number> --claim-id <claim-id> --format table
+     ```
+
+   - If the helper is unavailable, use GitHub GraphQL `minimizeComment`
+     with node IDs. Check `viewerCanMinimize` and `isMinimized` before
+     minimizing; skip already-minimized comments and comments the viewer
+     cannot minimize. Re-validate the active claim before each mutation.
+
+   See `docs/idd-comment-minimization.md` for the helper report shape,
+   fallback GraphQL commands, and experiment notes.
 2. Delete the local worktree and local branch.
 3. Update the local `main` branch.
 4. If GitHub auto-delete is disabled: delete the remote branch too.

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -133,7 +133,8 @@ must include the skip reason.
 
 The helper also reports skipped cleanup-shaped nodes with reasons such
 as already minimized, no minimization permission, unresolved associated
-review threads, unsafe hold or decision context, or a non-merged PR.
+review threads, missing accept/reject dispositions, unsafe hold or
+decision context, or a non-merged PR.
 
 ## Apply Shape
 

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -105,8 +105,17 @@ Always skip candidates when any of these are true:
 
 ## Dry Run Shape
 
-Before applying minimization, produce a candidate table with at least
-these fields:
+When the repository-local helper is available, start with a dry-run
+report:
+
+```sh
+node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
+```
+
+The helper defaults to JSON output for stable machine inspection; use
+`--format table` for a compact terminal view. Before applying
+minimization, the dry-run report must show candidate or skipped rows
+with at least these fields:
 
 | Field               | Purpose                                                            |
 | ------------------- | ------------------------------------------------------------------ |
@@ -117,6 +126,33 @@ these fields:
 | `viewerCanMinimize` | Must be `true`                                                     |
 | `isMinimized`       | Must be `false`                                                    |
 | `reason`            | Why the candidate is safe                                          |
+
+The helper also reports skipped cleanup-shaped nodes with reasons such
+as already minimized, no minimization permission, unresolved associated
+review threads, unsafe hold or decision context, or a non-merged PR.
+
+## Apply Shape
+
+Apply mode is explicit:
+
+```sh
+node scripts/audit-pr-cleanup.mjs --pr <pr-number> --apply \
+  --claim-issue <issue-number> --claim-id <claim-id> --format table
+```
+
+During an IDD F4 cleanup, pass the active issue and claim id. The helper
+re-reads the issue and verifies the active claim before every
+`minimizeComment` mutation. Maintainer-led audits outside an active IDD
+claim may use `--skip-claim-check`, but ordinary IDD agents should not.
+
+The helper applies only safe candidates and reports applied, skipped,
+and failed rows. A helper failure is still cleanup-only context; it does
+not retroactively block a merge that already passed F3.
+
+## Fallback GraphQL
+
+If the helper is unavailable, use the direct GraphQL capability checks
+below.
 
 Example capability check for one node ID:
 

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -114,7 +114,7 @@ node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
 
 The helper defaults to JSON output for stable machine inspection; use
 `--format table` for a compact terminal view. Before applying
-minimization, the dry-run report must show candidate or skipped rows
+minimization, the dry-run report must show candidate and skipped rows
 with at least these fields:
 
 | Field               | Purpose                                                            |
@@ -123,9 +123,13 @@ with at least these fields:
 | `url`               | Direct audit link                                                  |
 | `type`              | `IssueComment`, `PullRequestReview`, or `PullRequestReviewComment` |
 | `classifier`        | `RESOLVED` or `OUTDATED`                                           |
-| `viewerCanMinimize` | Must be `true`                                                     |
-| `isMinimized`       | Must be `false`                                                    |
+| `viewerCanMinimize` | Capability state used for candidate / skip decisions               |
+| `isMinimized`       | Current minimization state used for candidate / skip decisions     |
 | `reason`            | Why the candidate is safe                                          |
+
+Candidate rows must have `viewerCanMinimize=true` and
+`isMinimized=false`. Skipped rows may report the opposite states and
+must include the skip reason.
 
 The helper also reports skipped cleanup-shaped nodes with reasons such
 as already minimized, no minimization permission, unresolved associated

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -6,14 +6,19 @@ directly instead of re-evaluating the same suggestion from scratch.
 
 ## Decision
 
-Adopt one narrow helper for post-merge comment cleanup auditing:
-`scripts/audit-pr-cleanup.mjs`.
+In this source repository, adopt one narrow helper for post-merge
+comment cleanup auditing: `scripts/audit-pr-cleanup.mjs`.
 
 The canonical workflow remains the portable shell / `gh` / `jq`
 instructions embedded in `.github/instructions/*.instructions.md`.
 Other helper candidates remain deferred because they would create a
 second implementation surface while the review, advisory-wait, and claim
 protocols are still changing through dogfooding.
+
+The exported template remains portable without a `scripts/` directory.
+Adopters can copy the helper separately when they want the same
+repository-local convenience, otherwise the documented GraphQL fallback
+remains the portable path.
 
 The cleanup helper is intentionally narrower than E/F gate helpers:
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -6,31 +6,44 @@ directly instead of re-evaluating the same suggestion from scratch.
 
 ## Decision
 
-Do not adopt helper scripts yet.
+Adopt one narrow helper for post-merge comment cleanup auditing:
+`scripts/audit-pr-cleanup.mjs`.
 
 The canonical workflow remains the portable shell / `gh` / `jq`
 instructions embedded in `.github/instructions/*.instructions.md`.
-Optional helpers may be reconsidered later, but adding them now would
-create a second implementation surface while the review, advisory-wait,
-and claim protocols are still changing through dogfooding.
+Other helper candidates remain deferred because they would create a
+second implementation surface while the review, advisory-wait, and claim
+protocols are still changing through dogfooding.
+
+The cleanup helper is intentionally narrower than E/F gate helpers:
+
+- dry-run is the default and prints stable JSON unless `--format table`
+  is requested
+- apply mode is explicit and can re-validate an active claim before
+  every minimization mutation
+- cleanup remains best-effort and never becomes a merge gate
+- direct GraphQL fallback commands remain documented in
+  `docs/idd-comment-minimization.md`
 
 ## Friction Inventory
 
 The repeated query patterns most likely to benefit from helpers are:
 
-| Pattern                         | Current friction                                                                                      | Helper risk                                                                                            |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Claim-state parsing             | HTML marker parsing is stateful and easy to simplify incorrectly.                                     | A script would become another parser that must stay exactly aligned with the instruction rules.        |
-| Review activity snapshots       | E1/F2/F3 need the same activity universe and marker exclusions.                                       | Any mismatch between script output and written gates could make merge freshness checks unsound.        |
-| Advisory-wait marker parsing    | AW1/AW2 combine review API state, requested reviewers, marker comments, and elapsed-time rules.       | A helper could hide important decision-table semantics that agents must still understand during holds. |
-| Final pre-merge freshness check | The merge path repeats review, comment, thread, CI, claim, and advisory checks immediately before F3. | A mutating helper would be risky; even a read-only helper needs strict output contracts.               |
-| Branch protection/ruleset reads | Required review and check discovery can be verbose across GitHub APIs.                                | Ruleset coverage varies by repository, so a helper could create false confidence in unsupported cases. |
+| Pattern                         | Current friction                                                                                                        | Helper risk                                                                                                   |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Claim-state parsing             | HTML marker parsing is stateful and easy to simplify incorrectly.                                                       | A script would become another parser that must stay exactly aligned with the instruction rules.               |
+| Review activity snapshots       | E1/F2/F3 need the same activity universe and marker exclusions.                                                         | Any mismatch between script output and written gates could make merge freshness checks unsound.               |
+| Advisory-wait marker parsing    | AW1/AW2 combine review API state, requested reviewers, marker comments, and elapsed-time rules.                         | A helper could hide important decision-table semantics that agents must still understand during holds.        |
+| Final pre-merge freshness check | The merge path repeats review, comment, thread, CI, claim, and advisory checks immediately before F3.                   | A mutating helper would be risky; even a read-only helper needs strict output contracts.                      |
+| Post-merge cleanup candidates   | F4 cleanup requires repeat GraphQL checks for marker comments, review parents, permissions, and resolved child threads. | Adopted narrowly as `scripts/audit-pr-cleanup.mjs`; dry-run first, apply only after F3, and never gate merge. |
+| Branch protection/ruleset reads | Required review and check discovery can be verbose across GitHub APIs.                                                  | Ruleset coverage varies by repository, so a helper could create false confidence in unsupported cases.        |
 
 ## Trade-off
 
-Helper scripts would improve copy/paste reliability and make some
+Helper scripts can improve copy/paste reliability and make some
 review-state checks easier to audit locally. That benefit is real,
-especially for advisory-wait and review-snapshot commands.
+especially for advisory-wait, review-snapshot, and post-merge cleanup
+commands.
 
 The portability cost is also real. The exported IDD template is meant to
 work in repositories that can copy Markdown instruction files without
@@ -39,14 +52,14 @@ directory. If helper scripts are introduced too early, every operational
 rule must be maintained twice: once in the instructions that agents read,
 and once in code that agents run.
 
-For now, the safer balance is to keep the instructions canonical and use
-documentation refactors to centralize repeated logic before introducing
-code.
+For now, the safer balance is to keep pre-merge instructions canonical
+and use only a narrow post-merge cleanup helper where mistakes are
+recoverable and do not affect merge safety.
 
 ## Future Adoption Criteria
 
-If helper scripts are revisited, they should satisfy all of the
-following:
+If additional helper scripts are revisited, they should satisfy all of
+the following:
 
 - They are optional and never required to execute the exported template.
 - They are read-only by default; mutating actions remain explicit in the
@@ -60,6 +73,6 @@ following:
 - They are introduced only after the corresponding instruction protocol
   has stabilized enough that drift risk is lower than command-copy risk.
 
-Good candidates for a future first helper would be read-only snapshot
-commands for review activity, advisory-wait state, or claim-state
-inspection. They should not replace the written decision tables.
+Good future candidates would be read-only snapshot commands for review
+activity, advisory-wait state, or claim-state inspection. They should
+not replace the written decision tables.

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -123,16 +123,17 @@ reviewer because that is part of this repository's current PR policy.
 
 ## Optional helper scripts
 
-The current workflow does not require helper scripts. Shell / `gh` /
-`jq` snippets in `.github/instructions/*.instructions.md` remain the
-canonical portable path for adopters.
+The current workflow does not require helper scripts for pre-merge
+gates. Shell / `gh` / `jq` snippets in
+`.github/instructions/*.instructions.md` remain the canonical portable
+path for adopters.
 
 See [IDD helper script evaluation](idd-helper-scripts.md) for the
-current inventory of high-friction query patterns, the reason helper
-scripts are not adopted yet, and the criteria for reconsidering optional
-read-only helpers later.
+current inventory of high-friction query patterns, the narrow
+post-merge cleanup helper that is adopted in this source repository, and
+the criteria for reconsidering additional optional helpers later.
 
 See [IDD comment minimization](idd-comment-minimization.md) for the
-post-merge cleanup rule, GraphQL command shape, and merged-PR experiment
-for hiding completed feedback and stale operational markers without
-deleting the audit trail.
+post-merge cleanup helper, GraphQL fallback command shape, and merged-PR
+experiment for hiding completed feedback and stale operational markers
+without deleting the audit trail.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -115,12 +115,29 @@ gate. The active claim must still use your current `{claim-id}`.
      decisions, active holds, failed-CI context still needed by
      maintainers, non-operational human discussion, or any content that
      still participates in active F2/F3 gates.
-   - Use GitHub GraphQL `minimizeComment` with node IDs. Check
-     `viewerCanMinimize` and `isMinimized` before minimizing; skip
-     already-minimized comments and comments the viewer cannot minimize.
+   - When `scripts/audit-pr-cleanup.mjs` is available, run it first in
+     dry-run mode so eligible and skipped candidates are visible:
 
-   See `docs/idd-comment-minimization.md` for the investigation notes,
-   dry-run shape, and command examples.
+     ```sh
+     node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
+     ```
+
+     To apply the safe candidates during this claimed IDD run, pass the
+     active issue and claim token so the helper re-validates the claim
+     before each minimization mutation:
+
+     ```sh
+     node scripts/audit-pr-cleanup.mjs --pr <pr-number> --apply \
+       --claim-issue <issue-number> --claim-id <claim-id> --format table
+     ```
+
+   - If the helper is unavailable, use GitHub GraphQL `minimizeComment`
+     with node IDs. Check `viewerCanMinimize` and `isMinimized` before
+     minimizing; skip already-minimized comments and comments the viewer
+     cannot minimize. Re-validate the active claim before each mutation.
+
+   See `docs/idd-comment-minimization.md` for the helper report shape,
+   fallback GraphQL commands, and experiment notes.
 2. Delete the local worktree and local branch.
 3. Update the local `main` branch.
 4. If GitHub auto-delete is disabled: delete the remote branch too.

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -133,7 +133,8 @@ must include the skip reason.
 
 The helper also reports skipped cleanup-shaped nodes with reasons such
 as already minimized, no minimization permission, unresolved associated
-review threads, unsafe hold or decision context, or a non-merged PR.
+review threads, missing accept/reject dispositions, unsafe hold or
+decision context, or a non-merged PR.
 
 ## Apply Shape
 

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -105,8 +105,17 @@ Always skip candidates when any of these are true:
 
 ## Dry Run Shape
 
-Before applying minimization, produce a candidate table with at least
-these fields:
+When the repository-local helper is available, start with a dry-run
+report:
+
+```sh
+node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
+```
+
+The helper defaults to JSON output for stable machine inspection; use
+`--format table` for a compact terminal view. Before applying
+minimization, the dry-run report must show candidate or skipped rows
+with at least these fields:
 
 | Field               | Purpose                                                            |
 | ------------------- | ------------------------------------------------------------------ |
@@ -117,6 +126,33 @@ these fields:
 | `viewerCanMinimize` | Must be `true`                                                     |
 | `isMinimized`       | Must be `false`                                                    |
 | `reason`            | Why the candidate is safe                                          |
+
+The helper also reports skipped cleanup-shaped nodes with reasons such
+as already minimized, no minimization permission, unresolved associated
+review threads, unsafe hold or decision context, or a non-merged PR.
+
+## Apply Shape
+
+Apply mode is explicit:
+
+```sh
+node scripts/audit-pr-cleanup.mjs --pr <pr-number> --apply \
+  --claim-issue <issue-number> --claim-id <claim-id> --format table
+```
+
+During an IDD F4 cleanup, pass the active issue and claim id. The helper
+re-reads the issue and verifies the active claim before every
+`minimizeComment` mutation. Maintainer-led audits outside an active IDD
+claim may use `--skip-claim-check`, but ordinary IDD agents should not.
+
+The helper applies only safe candidates and reports applied, skipped,
+and failed rows. A helper failure is still cleanup-only context; it does
+not retroactively block a merge that already passed F3.
+
+## Fallback GraphQL
+
+If the helper is unavailable, use the direct GraphQL capability checks
+below.
 
 Example capability check for one node ID:
 

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -114,7 +114,7 @@ node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
 
 The helper defaults to JSON output for stable machine inspection; use
 `--format table` for a compact terminal view. Before applying
-minimization, the dry-run report must show candidate or skipped rows
+minimization, the dry-run report must show candidate and skipped rows
 with at least these fields:
 
 | Field               | Purpose                                                            |
@@ -123,9 +123,13 @@ with at least these fields:
 | `url`               | Direct audit link                                                  |
 | `type`              | `IssueComment`, `PullRequestReview`, or `PullRequestReviewComment` |
 | `classifier`        | `RESOLVED` or `OUTDATED`                                           |
-| `viewerCanMinimize` | Must be `true`                                                     |
-| `isMinimized`       | Must be `false`                                                    |
+| `viewerCanMinimize` | Capability state used for candidate / skip decisions               |
+| `isMinimized`       | Current minimization state used for candidate / skip decisions     |
 | `reason`            | Why the candidate is safe                                          |
+
+Candidate rows must have `viewerCanMinimize=true` and
+`isMinimized=false`. Skipped rows may report the opposite states and
+must include the skip reason.
 
 The helper also reports skipped cleanup-shaped nodes with reasons such
 as already minimized, no minimization permission, unresolved associated

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -6,14 +6,19 @@ directly instead of re-evaluating the same suggestion from scratch.
 
 ## Decision
 
-Adopt one narrow helper for post-merge comment cleanup auditing:
-`scripts/audit-pr-cleanup.mjs`.
+In this source repository, adopt one narrow helper for post-merge
+comment cleanup auditing: `scripts/audit-pr-cleanup.mjs`.
 
 The canonical workflow remains the portable shell / `gh` / `jq`
 instructions embedded in `.github/instructions/*.instructions.md`.
 Other helper candidates remain deferred because they would create a
 second implementation surface while the review, advisory-wait, and claim
 protocols are still changing through dogfooding.
+
+The exported template remains portable without a `scripts/` directory.
+Adopters can copy the helper separately when they want the same
+repository-local convenience, otherwise the documented GraphQL fallback
+remains the portable path.
 
 The cleanup helper is intentionally narrower than E/F gate helpers:
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -6,31 +6,44 @@ directly instead of re-evaluating the same suggestion from scratch.
 
 ## Decision
 
-Do not adopt helper scripts yet.
+Adopt one narrow helper for post-merge comment cleanup auditing:
+`scripts/audit-pr-cleanup.mjs`.
 
 The canonical workflow remains the portable shell / `gh` / `jq`
 instructions embedded in `.github/instructions/*.instructions.md`.
-Optional helpers may be reconsidered later, but adding them now would
-create a second implementation surface while the review, advisory-wait,
-and claim protocols are still changing through dogfooding.
+Other helper candidates remain deferred because they would create a
+second implementation surface while the review, advisory-wait, and claim
+protocols are still changing through dogfooding.
+
+The cleanup helper is intentionally narrower than E/F gate helpers:
+
+- dry-run is the default and prints stable JSON unless `--format table`
+  is requested
+- apply mode is explicit and can re-validate an active claim before
+  every minimization mutation
+- cleanup remains best-effort and never becomes a merge gate
+- direct GraphQL fallback commands remain documented in
+  `docs/idd-comment-minimization.md`
 
 ## Friction Inventory
 
 The repeated query patterns most likely to benefit from helpers are:
 
-| Pattern                         | Current friction                                                                                      | Helper risk                                                                                            |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Claim-state parsing             | HTML marker parsing is stateful and easy to simplify incorrectly.                                     | A script would become another parser that must stay exactly aligned with the instruction rules.        |
-| Review activity snapshots       | E1/F2/F3 need the same activity universe and marker exclusions.                                       | Any mismatch between script output and written gates could make merge freshness checks unsound.        |
-| Advisory-wait marker parsing    | AW1/AW2 combine review API state, requested reviewers, marker comments, and elapsed-time rules.       | A helper could hide important decision-table semantics that agents must still understand during holds. |
-| Final pre-merge freshness check | The merge path repeats review, comment, thread, CI, claim, and advisory checks immediately before F3. | A mutating helper would be risky; even a read-only helper needs strict output contracts.               |
-| Branch protection/ruleset reads | Required review and check discovery can be verbose across GitHub APIs.                                | Ruleset coverage varies by repository, so a helper could create false confidence in unsupported cases. |
+| Pattern                         | Current friction                                                                                                        | Helper risk                                                                                                   |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Claim-state parsing             | HTML marker parsing is stateful and easy to simplify incorrectly.                                                       | A script would become another parser that must stay exactly aligned with the instruction rules.               |
+| Review activity snapshots       | E1/F2/F3 need the same activity universe and marker exclusions.                                                         | Any mismatch between script output and written gates could make merge freshness checks unsound.               |
+| Advisory-wait marker parsing    | AW1/AW2 combine review API state, requested reviewers, marker comments, and elapsed-time rules.                         | A helper could hide important decision-table semantics that agents must still understand during holds.        |
+| Final pre-merge freshness check | The merge path repeats review, comment, thread, CI, claim, and advisory checks immediately before F3.                   | A mutating helper would be risky; even a read-only helper needs strict output contracts.                      |
+| Post-merge cleanup candidates   | F4 cleanup requires repeat GraphQL checks for marker comments, review parents, permissions, and resolved child threads. | Adopted narrowly as `scripts/audit-pr-cleanup.mjs`; dry-run first, apply only after F3, and never gate merge. |
+| Branch protection/ruleset reads | Required review and check discovery can be verbose across GitHub APIs.                                                  | Ruleset coverage varies by repository, so a helper could create false confidence in unsupported cases.        |
 
 ## Trade-off
 
-Helper scripts would improve copy/paste reliability and make some
+Helper scripts can improve copy/paste reliability and make some
 review-state checks easier to audit locally. That benefit is real,
-especially for advisory-wait and review-snapshot commands.
+especially for advisory-wait, review-snapshot, and post-merge cleanup
+commands.
 
 The portability cost is also real. The exported IDD template is meant to
 work in repositories that can copy Markdown instruction files without
@@ -39,14 +52,14 @@ directory. If helper scripts are introduced too early, every operational
 rule must be maintained twice: once in the instructions that agents read,
 and once in code that agents run.
 
-For now, the safer balance is to keep the instructions canonical and use
-documentation refactors to centralize repeated logic before introducing
-code.
+For now, the safer balance is to keep pre-merge instructions canonical
+and use only a narrow post-merge cleanup helper where mistakes are
+recoverable and do not affect merge safety.
 
 ## Future Adoption Criteria
 
-If helper scripts are revisited, they should satisfy all of the
-following:
+If additional helper scripts are revisited, they should satisfy all of
+the following:
 
 - They are optional and never required to execute the exported template.
 - They are read-only by default; mutating actions remain explicit in the
@@ -60,6 +73,6 @@ following:
 - They are introduced only after the corresponding instruction protocol
   has stabilized enough that drift risk is lower than command-copy risk.
 
-Good candidates for a future first helper would be read-only snapshot
-commands for review activity, advisory-wait state, or claim-state
-inspection. They should not replace the written decision tables.
+Good future candidates would be read-only snapshot commands for review
+activity, advisory-wait state, or claim-state inspection. They should
+not replace the written decision tables.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -117,16 +117,17 @@ reviewer because that is part of this repository's current PR policy.
 
 ## Optional helper scripts
 
-The current workflow does not require helper scripts. Shell / `gh` /
-`jq` snippets in `.github/instructions/*.instructions.md` remain the
-canonical portable path for adopters.
+The current workflow does not require helper scripts for pre-merge
+gates. Shell / `gh` / `jq` snippets in
+`.github/instructions/*.instructions.md` remain the canonical portable
+path for adopters.
 
 See [IDD helper script evaluation](idd-helper-scripts.md) for the
-current inventory of high-friction query patterns, the reason helper
-scripts are not adopted yet, and the criteria for reconsidering optional
-read-only helpers later.
+current inventory of high-friction query patterns, the narrow
+post-merge cleanup helper that is adopted in this source repository, and
+the criteria for reconsidering additional optional helpers later.
 
 See [IDD comment minimization](idd-comment-minimization.md) for the
-post-merge cleanup rule, GraphQL command shape, and merged-PR experiment
-for hiding completed feedback and stale operational markers without
-deleting the audit trail.
+post-merge cleanup helper, GraphQL fallback command shape, and merged-PR
+experiment for hiding completed feedback and stale operational markers
+without deleting the audit trail.

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -47,6 +47,8 @@ const UNSAFE_TEXT_RULES = [
   },
 ];
 
+const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
+
 const args = parseArgs(process.argv.slice(2));
 
 if (args.help) {
@@ -75,10 +77,7 @@ if (args.apply && !args.skipClaimCheck && (!args.claimIssue || !args.claimId)) {
 }
 
 const repository = args.repo ?? detectRepository();
-const [owner, repo] = repository.split("/");
-if (!owner || !repo) {
-  fail(`invalid repository ${repository}`);
-}
+const [owner, repo] = parseRepository(repository);
 
 const prNumber = parsePositiveInteger(args.pr, "--pr");
 
@@ -654,29 +653,40 @@ function readActiveClaim(owner, repo, issueNumber) {
 
 function parseClaim(body, createdAt) {
   const match = body.trim().match(
-    /^<!--\s*claimed-by:\s+(\S+)\s+(\S+)\s+supersedes:\s+(\S+)\s+\S+\s+branch:\s+([^\s>]+)\s*-->$/,
+    new RegExp(
+      `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->$`,
+    ),
   );
-  if (!match) {
+  if (!match || !isValidIsoTimestamp(match[4])) {
     return null;
   }
   return {
     agentId: match[1],
     claimId: match[2],
     supersedes: match[3],
-    branch: match[4],
+    branch: match[5],
     createdAt,
   };
 }
 
 function parseRelease(body) {
-  const match = body.trim().match(/^<!--\s*unclaimed-by:\s+(\S+)\s+(\S+)\s+\S+\s*-->$/);
-  if (!match) {
+  const match = body.trim().match(
+    new RegExp(
+      `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->$`,
+    ),
+  );
+  if (!match || !isValidIsoTimestamp(match[3])) {
     return null;
   }
   return {
     agentId: match[1],
     claimId: match[2],
   };
+}
+
+function isValidIsoTimestamp(value) {
+  const time = Date.parse(value);
+  return Number.isFinite(time) && new Date(time).toISOString().replace(".000Z", "Z") === value;
 }
 
 function isStaleAt(activeCreatedAt, nextCreatedAt) {
@@ -738,6 +748,17 @@ function detectRepository() {
   return execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"], {
     encoding: "utf8",
   }).trim();
+}
+
+function parseRepository(value) {
+  const parts = value.split("/");
+  if (
+    parts.length !== 2
+    || parts.some((part) => part.length === 0 || /\s/.test(part))
+  ) {
+    fail(`invalid repository ${value}; expected owner/name`);
+  }
+  return parts;
 }
 
 function writeReport(report, format) {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -102,9 +102,13 @@ if (args.apply) {
       }
     }
     try {
-      const minimized = minimizeComment(candidate.subjectId, candidate.classifier);
+      const freshCandidate = await revalidateCandidate(owner, repo, prNumber, candidate, report);
+      if (!freshCandidate) {
+        continue;
+      }
+      const minimized = minimizeComment(freshCandidate.subjectId, freshCandidate.classifier);
       report.applied.push({
-        ...candidate,
+        ...freshCandidate,
         isMinimized: minimized.isMinimized,
         minimizedReason: minimized.minimizedReason,
       });
@@ -304,8 +308,8 @@ function addSkipped(report, subject, reason) {
 }
 
 function operationalMarkerPrefix(body) {
-  const trimmed = body.trimStart();
-  return OPERATIONAL_MARKERS.find((marker) => marker.pattern.test(trimmed))?.label ?? null;
+  const normalized = body.trimEnd();
+  return OPERATIONAL_MARKERS.find((marker) => marker.pattern.test(normalized))?.label ?? null;
 }
 
 function unsafeTextReason(body) {
@@ -572,6 +576,26 @@ function minimizeComment(subjectId, classifier) {
   return minimized;
 }
 
+async function revalidateCandidate(owner, repo, prNumber, candidate, report) {
+  const freshReport = await buildReport(owner, repo, prNumber);
+  const freshCandidate = freshReport.candidates.find((current) => {
+    return current.subjectId === candidate.subjectId && current.classifier === candidate.classifier;
+  });
+  if (freshCandidate) {
+    return freshCandidate;
+  }
+
+  const skipped = freshReport.skipped.find((current) => {
+    return current.subjectId === candidate.subjectId && current.classifier === candidate.classifier;
+  });
+  addSkipped(
+    report,
+    candidate,
+    `pre-minimize revalidation failed: ${skipped?.skipReason ?? "candidate is no longer eligible"}`,
+  );
+  return null;
+}
+
 function assertActiveClaim(owner, repo, issueNumber, agentId, claimId) {
   const active = readActiveClaim(owner, repo, issueNumber);
   if (!active || active.claimId !== claimId || (agentId && active.agentId !== agentId)) {
@@ -652,7 +676,7 @@ function readActiveClaim(owner, repo, issueNumber) {
 }
 
 function parseClaim(body, createdAt) {
-  const match = body.trim().match(
+  const match = body.trimEnd().match(
     new RegExp(
       `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->$`,
     ),
@@ -670,7 +694,7 @@ function parseClaim(body, createdAt) {
 }
 
 function parseRelease(body) {
-  const match = body.trim().match(
+  const match = body.trimEnd().match(
     new RegExp(
       `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->$`,
     ),

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -77,7 +77,15 @@ if (args.apply) {
   report.mode = "apply";
   for (const candidate of report.candidates) {
     if (!args.skipClaimCheck) {
-      assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+      try {
+        assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+      } catch (error) {
+        report.failed.push({
+          ...candidate,
+          error: error.message,
+        });
+        break;
+      }
     }
     try {
       const minimized = minimizeComment(candidate.subjectId, candidate.classifier);
@@ -203,6 +211,20 @@ function evaluateReviewParent(review, pr, threadIndex, report) {
     return;
   }
 
+  if (associated.incomplete) {
+    addSkipped(
+      report,
+      {
+        ...subject,
+        associatedThreads: associated.total,
+        unresolvedThreads: associated.unresolved,
+        missingDispositionThreads: associated.missingDisposition,
+      },
+      "associated review threads have truncated comment data",
+    );
+    return;
+  }
+
   if (associated.unresolved > 0) {
     addSkipped(
       report,
@@ -293,6 +315,7 @@ function indexThreadsByReview(threads) {
         total: 0,
         unresolved: 0,
         missingDisposition: 0,
+        incomplete: false,
         threadIds: [],
       };
       current.total += 1;
@@ -301,6 +324,9 @@ function indexThreadsByReview(threads) {
       }
       if (!hasDisposition(thread)) {
         current.missingDisposition += 1;
+      }
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        current.incomplete = true;
       }
       current.threadIds.push(thread.id);
       index.set(reviewId, current);
@@ -395,6 +421,7 @@ function fetchReviewThreads(owner, repo, number) {
             id
             isResolved
             comments(first:100){
+              pageInfo{hasNextPage}
               nodes{
                 id
                 url
@@ -451,7 +478,7 @@ function assertActiveClaim(owner, repo, issueNumber, agentId, claimId) {
   const active = readActiveClaim(owner, repo, issueNumber);
   if (!active || active.claimId !== claimId || (agentId && active.agentId !== agentId)) {
     const activeLabel = active ? `${active.agentId} ${active.claimId}` : "none";
-    fail(`claim check failed for #${issueNumber}: active claim is ${activeLabel}`);
+    throw new Error(`claim check failed for #${issueNumber}: active claim is ${activeLabel}`);
   }
 }
 

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -106,6 +106,17 @@ if (args.apply) {
       if (!freshCandidate) {
         continue;
       }
+      if (!args.skipClaimCheck) {
+        try {
+          assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+        } catch (error) {
+          report.failed.push({
+            ...freshCandidate,
+            error: error.message,
+          });
+          break;
+        }
+      }
       const minimized = minimizeComment(freshCandidate.subjectId, freshCandidate.classifier);
       report.applied.push({
         ...freshCandidate,
@@ -150,6 +161,10 @@ async function buildReport(owner, repo, prNumber) {
 
   for (const comment of comments) {
     evaluateOperationalComment(comment, pr, report);
+  }
+
+  for (const thread of threads) {
+    evaluateReviewComments(thread, pr, report);
   }
 
   for (const review of reviews) {
@@ -288,6 +303,68 @@ function evaluateReviewParent(review, pr, threadIndex, latestGatingReviews, repo
   });
 }
 
+function evaluateReviewComments(thread, pr, report) {
+  for (const comment of thread.comments?.nodes ?? []) {
+    evaluateReviewComment(comment, thread, pr, report);
+  }
+}
+
+function evaluateReviewComment(comment, thread, pr, report) {
+  const author = comment.author?.login ?? "";
+  if (!isKnownReviewBot(author) || isDispositionComment(comment)) {
+    return;
+  }
+
+  const subject = subjectFromNode(comment, "PullRequestReviewComment", "RESOLVED");
+
+  if (!pr.merged) {
+    addSkipped(report, subject, "PR is not merged");
+    return;
+  }
+
+  const unsafeReason = unsafeTextReason(comment.body ?? "");
+  if (unsafeReason) {
+    addSkipped(report, subject, unsafeReason);
+    return;
+  }
+
+  if (comment.isMinimized) {
+    addSkipped(report, subject, "already minimized");
+    return;
+  }
+
+  if (!comment.viewerCanMinimize) {
+    addSkipped(report, subject, "viewer cannot minimize this review comment");
+    return;
+  }
+
+  if (!thread.isResolved) {
+    addSkipped(report, { ...subject, threadId: thread.id }, "review thread is unresolved");
+    return;
+  }
+
+  if (thread.comments?.pageInfo?.hasNextPage) {
+    addSkipped(report, { ...subject, threadId: thread.id }, "review thread comment data is truncated");
+    return;
+  }
+
+  if (!hasFreshDisposition(thread)) {
+    addSkipped(
+      report,
+      { ...subject, threadId: thread.id },
+      "review thread is missing an IDD accept/reject disposition",
+    );
+    return;
+  }
+
+  report.candidates.push({
+    ...subject,
+    author,
+    threadId: thread.id,
+    reason: "known bot feedback comment in a resolved review thread",
+  });
+}
+
 function subjectFromNode(node, type, classifier) {
   return {
     subjectId: node.id,
@@ -322,7 +399,8 @@ function unsafeTextReason(body) {
 }
 
 function isKnownReviewBot(login) {
-  return REVIEW_BOT_LOGINS.has(login.toLowerCase());
+  const normalized = login.toLowerCase();
+  return REVIEW_BOT_LOGINS.has(normalized) || normalized.startsWith("copilot-pull-request-reviewer");
 }
 
 function indexLatestGatingReviewsByAuthor(reviews) {
@@ -402,7 +480,7 @@ function isIddDispositionComment(comment) {
 }
 
 function isDispositionComment(comment) {
-  const body = (comment.body ?? "").trimStart();
+  const body = (comment.body ?? "").trimEnd();
   return body.startsWith("**Accepted**") || body.startsWith("**Rejected**");
 }
 
@@ -490,6 +568,9 @@ function fetchReviewThreads(owner, repo, number) {
                 url
                 body
                 createdAt
+                isMinimized
+                minimizedReason
+                viewerCanMinimize
                 author{login}
                 pullRequestReview{id}
               }

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -116,6 +116,7 @@ async function buildReport(owner, repo, prNumber) {
   const reviews = fetchReviews(owner, repo, prNumber);
   const threads = fetchReviewThreads(owner, repo, prNumber);
   const threadIndex = indexThreadsByReview(threads);
+  const latestReviews = indexLatestReviewsByAuthor(reviews);
 
   const report = {
     repository: `${owner}/${repo}`,
@@ -134,7 +135,7 @@ async function buildReport(owner, repo, prNumber) {
   }
 
   for (const review of reviews) {
-    evaluateReviewParent(review, pr, threadIndex, report);
+    evaluateReviewParent(review, pr, threadIndex, latestReviews, report);
   }
 
   return report;
@@ -176,7 +177,7 @@ function evaluateOperationalComment(comment, pr, report) {
   });
 }
 
-function evaluateReviewParent(review, pr, threadIndex, report) {
+function evaluateReviewParent(review, pr, threadIndex, latestReviews, report) {
   const author = review.author?.login ?? "";
   if (!isKnownReviewBot(author)) {
     return;
@@ -184,6 +185,7 @@ function evaluateReviewParent(review, pr, threadIndex, report) {
 
   const subject = subjectFromNode(review, "PullRequestReview", "RESOLVED");
   const associated = threadIndex.get(review.id) ?? { total: 0, unresolved: 0, threadIds: [] };
+  const latestReview = latestReviews.get(author.toLowerCase());
 
   if (!pr.merged) {
     addSkipped(report, subject, "PR is not merged");
@@ -203,6 +205,11 @@ function evaluateReviewParent(review, pr, threadIndex, report) {
 
   if (!review.viewerCanMinimize) {
     addSkipped(report, subject, "viewer cannot minimize this review");
+    return;
+  }
+
+  if (review.state === "CHANGES_REQUESTED" || latestReview?.state === "CHANGES_REQUESTED") {
+    addSkipped(report, subject, "review author still has an active changes-requested state");
     return;
   }
 
@@ -300,6 +307,22 @@ function isKnownReviewBot(login) {
   return REVIEW_BOT_LOGINS.has(login.toLowerCase());
 }
 
+function indexLatestReviewsByAuthor(reviews) {
+  const index = new Map();
+  for (const review of reviews) {
+    const author = review.author?.login?.toLowerCase();
+    if (!author) {
+      continue;
+    }
+    const current = index.get(author);
+    const submittedAt = review.submittedAt ?? "";
+    if (!current || submittedAt > (current.submittedAt ?? "")) {
+      index.set(author, review);
+    }
+  }
+  return index;
+}
+
 function indexThreadsByReview(threads) {
   const index = new Map();
 
@@ -322,7 +345,7 @@ function indexThreadsByReview(threads) {
       if (!thread.isResolved) {
         current.unresolved += 1;
       }
-      if (!hasDisposition(thread)) {
+      if (!hasFreshDisposition(thread)) {
         current.missingDisposition += 1;
       }
       if (thread.comments?.pageInfo?.hasNextPage) {
@@ -336,11 +359,25 @@ function indexThreadsByReview(threads) {
   return index;
 }
 
-function hasDisposition(thread) {
-  return (thread.comments?.nodes ?? []).some((comment) => {
-    const body = (comment.body ?? "").trimStart();
-    return body.startsWith("**Accepted**") || body.startsWith("**Rejected**");
+function hasFreshDisposition(thread) {
+  const comments = thread.comments?.nodes ?? [];
+  const latestFeedbackAt = comments
+    .filter((comment) => !isDispositionComment(comment))
+    .map((comment) => comment.createdAt)
+    .sort()
+    .at(-1);
+
+  return comments.some((comment) => {
+    if (!isDispositionComment(comment)) {
+      return false;
+    }
+    return !latestFeedbackAt || comment.createdAt > latestFeedbackAt;
   });
+}
+
+function isDispositionComment(comment) {
+  const body = (comment.body ?? "").trimStart();
+  return body.startsWith("**Accepted**") || body.startsWith("**Rejected**");
 }
 
 function fetchPullRequest(owner, repo, number) {
@@ -537,6 +574,10 @@ function readActiveClaim(owner, repo, issueNumber) {
     if (claim) {
       if (active && claim.agentId === active.agentId && claim.claimId === active.claimId) {
         active.createdAt = claim.createdAt;
+        continue;
+      }
+
+      if (active && claim.claimId === active.claimId) {
         continue;
       }
 

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -614,7 +614,29 @@ function ghGraphql(query, variables) {
     }
   }
 
-  return JSON.parse(execFileSync("gh", commandArgs, { encoding: "utf8" }));
+  try {
+    return JSON.parse(execFileSync("gh", commandArgs, { encoding: "utf8" }));
+  } catch (error) {
+    const stdout = String(error.stdout ?? "").trim();
+    const stderr = String(error.stderr ?? "").trim();
+    const response = parseJsonOrNull(stdout);
+    if (response?.errors?.length) {
+      fail(
+        `GraphQL request failed: ${formatGraphqlErrors(response.errors)}; ${formatGraphqlContext(query, variables)}`,
+      );
+    }
+    fail(
+      `gh api graphql failed: ${stderr || error.message}; ${formatGraphqlContext(query, variables)}`,
+    );
+  }
+}
+
+function parseJsonOrNull(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
 }
 
 function detectRepository() {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -65,9 +65,10 @@ if (!owner || !repo) {
   fail(`invalid repository ${repository}`);
 }
 
-const prNumber = Number.parseInt(args.pr, 10);
-if (!Number.isInteger(prNumber) || prNumber < 1) {
-  fail(`invalid --pr value ${args.pr}`);
+const prNumber = parsePositiveInteger(args.pr, "--pr");
+
+if (args.claimIssue) {
+  args.claimIssue = String(parsePositiveInteger(args.claimIssue, "--claim-issue"));
 }
 
 const report = await buildReport(owner, repo, prNumber);
@@ -209,8 +210,23 @@ function evaluateReviewParent(review, pr, threadIndex, report) {
         ...subject,
         associatedThreads: associated.total,
         unresolvedThreads: associated.unresolved,
+        missingDispositionThreads: associated.missingDisposition,
       },
       "review has unresolved associated review threads",
+    );
+    return;
+  }
+
+  if (associated.missingDisposition > 0) {
+    addSkipped(
+      report,
+      {
+        ...subject,
+        associatedThreads: associated.total,
+        unresolvedThreads: 0,
+        missingDispositionThreads: associated.missingDisposition,
+      },
+      "associated review threads are missing IDD accept/reject dispositions",
     );
     return;
   }
@@ -220,6 +236,7 @@ function evaluateReviewParent(review, pr, threadIndex, report) {
     author,
     associatedThreads: associated.total,
     unresolvedThreads: 0,
+    missingDispositionThreads: 0,
     reason: "known bot review parent with all associated review threads resolved",
   });
 }
@@ -272,10 +289,18 @@ function indexThreadsByReview(threads) {
     );
 
     for (const reviewId of reviewIds) {
-      const current = index.get(reviewId) ?? { total: 0, unresolved: 0, threadIds: [] };
+      const current = index.get(reviewId) ?? {
+        total: 0,
+        unresolved: 0,
+        missingDisposition: 0,
+        threadIds: [],
+      };
       current.total += 1;
       if (!thread.isResolved) {
         current.unresolved += 1;
+      }
+      if (!hasDisposition(thread)) {
+        current.missingDisposition += 1;
       }
       current.threadIds.push(thread.id);
       index.set(reviewId, current);
@@ -283,6 +308,13 @@ function indexThreadsByReview(threads) {
   }
 
   return index;
+}
+
+function hasDisposition(thread) {
+  return (thread.comments?.nodes ?? []).some((comment) => {
+    const body = (comment.body ?? "").trimStart();
+    return body.startsWith("**Accepted**") || body.startsWith("**Rejected**");
+  });
 }
 
 function fetchPullRequest(owner, repo, number) {
@@ -484,8 +516,8 @@ function readActiveClaim(owner, repo, issueNumber) {
 }
 
 function parseClaim(body, createdAt) {
-  const match = body.match(
-    /<!--\s*claimed-by:\s+(\S+)\s+(\S+)\s+supersedes:\s+(\S+)\s+\S+\s+branch:\s+([^\s>]+)\s*-->/,
+  const match = body.trim().match(
+    /^<!--\s*claimed-by:\s+(\S+)\s+(\S+)\s+supersedes:\s+(\S+)\s+\S+\s+branch:\s+([^\s>]+)\s*-->$/,
   );
   if (!match) {
     return null;
@@ -500,7 +532,7 @@ function parseClaim(body, createdAt) {
 }
 
 function parseRelease(body) {
-  const match = body.match(/<!--\s*unclaimed-by:\s+(\S+)\s+(\S+)\s+\S+\s*-->/);
+  const match = body.trim().match(/^<!--\s*unclaimed-by:\s+(\S+)\s+(\S+)\s+\S+\s*-->$/);
   if (!match) {
     return null;
   }
@@ -645,6 +677,13 @@ function readValue(argv, index, flag) {
     fail(`${flag} requires a value`);
   }
   return value;
+}
+
+function parsePositiveInteger(value, flag) {
+  if (!/^[1-9]\d*$/.test(value)) {
+    fail(`${flag} must be a positive integer`);
+  }
+  return Number.parseInt(value, 10);
 }
 
 function printUsage() {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -1,0 +1,667 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const OPERATIONAL_MARKER_PREFIXES = [
+  "<!-- review-watermark:",
+  "<!-- review-baseline:",
+  "advisory-wait:",
+  "advisory-wait-recovery:",
+  "<!-- advisory-wait:",
+];
+
+const REVIEW_BOT_LOGINS = new Set([
+  "coderabbitai",
+  "coderabbitai[bot]",
+  "chatgpt-codex-connector",
+  "chatgpt-codex-connector[bot]",
+]);
+
+const UNSAFE_TEXT_RULES = [
+  {
+    pattern: /\*\*Awaiting maintainer decision\*\*/i,
+    reason: "contains an awaiting-maintainer-decision marker",
+  },
+  {
+    pattern: /\bactive hold\b/i,
+    reason: "contains active hold context",
+  },
+  {
+    pattern: /\bfailed[- ]ci\b|\bfailing ci\b|\bci failure\b|\bci failed\b|\bfailed checks?\b/i,
+    reason: "contains failed-CI context",
+  },
+];
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+  printUsage();
+  process.exit(0);
+}
+
+if (!args.pr) {
+  fail("missing required --pr <number>");
+}
+
+if (args.apply && args.dryRun) {
+  fail("choose only one of --dry-run or --apply");
+}
+
+if (!args.apply) {
+  args.dryRun = true;
+}
+
+if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
+  fail("--skip-claim-check cannot be combined with --claim-issue or --claim-id");
+}
+
+if (args.apply && !args.skipClaimCheck && (!args.claimIssue || !args.claimId)) {
+  fail("--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check");
+}
+
+const repository = args.repo ?? detectRepository();
+const [owner, repo] = repository.split("/");
+if (!owner || !repo) {
+  fail(`invalid repository ${repository}`);
+}
+
+const prNumber = Number.parseInt(args.pr, 10);
+if (!Number.isInteger(prNumber) || prNumber < 1) {
+  fail(`invalid --pr value ${args.pr}`);
+}
+
+const report = await buildReport(owner, repo, prNumber);
+
+if (args.apply) {
+  report.mode = "apply";
+  for (const candidate of report.candidates) {
+    if (!args.skipClaimCheck) {
+      assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+    }
+    try {
+      const minimized = minimizeComment(candidate.subjectId, candidate.classifier);
+      report.applied.push({
+        ...candidate,
+        isMinimized: minimized.isMinimized,
+        minimizedReason: minimized.minimizedReason,
+      });
+    } catch (error) {
+      report.failed.push({
+        ...candidate,
+        error: error.message,
+      });
+    }
+  }
+
+  if (report.failed.length > 0) {
+    writeReport(report, args.format);
+    process.exit(1);
+  }
+}
+
+writeReport(report, args.format);
+
+async function buildReport(owner, repo, prNumber) {
+  const pr = fetchPullRequest(owner, repo, prNumber);
+  const comments = fetchIssueComments(owner, repo, prNumber);
+  const reviews = fetchReviews(owner, repo, prNumber);
+  const threads = fetchReviewThreads(owner, repo, prNumber);
+  const threadIndex = indexThreadsByReview(threads);
+
+  const report = {
+    repository: `${owner}/${repo}`,
+    pr: prNumber,
+    prUrl: pr.url,
+    merged: pr.merged,
+    mode: "dry-run",
+    candidates: [],
+    skipped: [],
+    applied: [],
+    failed: [],
+  };
+
+  for (const comment of comments) {
+    evaluateOperationalComment(comment, pr, report);
+  }
+
+  for (const review of reviews) {
+    evaluateReviewParent(review, pr, threadIndex, report);
+  }
+
+  return report;
+}
+
+function evaluateOperationalComment(comment, pr, report) {
+  const prefix = operationalMarkerPrefix(comment.body);
+  if (!prefix) {
+    return;
+  }
+
+  const subject = subjectFromNode(comment, "IssueComment", "OUTDATED");
+
+  if (!pr.merged) {
+    addSkipped(report, subject, "PR is not merged");
+    return;
+  }
+
+  const unsafeReason = unsafeTextReason(comment.body);
+  if (unsafeReason) {
+    addSkipped(report, subject, unsafeReason);
+    return;
+  }
+
+  if (comment.isMinimized) {
+    addSkipped(report, subject, "already minimized");
+    return;
+  }
+
+  if (!comment.viewerCanMinimize) {
+    addSkipped(report, subject, "viewer cannot minimize this comment");
+    return;
+  }
+
+  report.candidates.push({
+    ...subject,
+    markerPrefix: prefix,
+    reason: "stale IDD operational marker on a merged PR",
+  });
+}
+
+function evaluateReviewParent(review, pr, threadIndex, report) {
+  const author = review.author?.login ?? "";
+  if (!isKnownReviewBot(author)) {
+    return;
+  }
+
+  const subject = subjectFromNode(review, "PullRequestReview", "RESOLVED");
+  const associated = threadIndex.get(review.id) ?? { total: 0, unresolved: 0, threadIds: [] };
+
+  if (!pr.merged) {
+    addSkipped(report, subject, "PR is not merged");
+    return;
+  }
+
+  const unsafeReason = unsafeTextReason(review.body ?? "");
+  if (unsafeReason) {
+    addSkipped(report, subject, unsafeReason);
+    return;
+  }
+
+  if (review.isMinimized) {
+    addSkipped(report, subject, "already minimized");
+    return;
+  }
+
+  if (!review.viewerCanMinimize) {
+    addSkipped(report, subject, "viewer cannot minimize this review");
+    return;
+  }
+
+  if (associated.total === 0) {
+    addSkipped(report, subject, "review has no associated review threads");
+    return;
+  }
+
+  if (associated.unresolved > 0) {
+    addSkipped(
+      report,
+      {
+        ...subject,
+        associatedThreads: associated.total,
+        unresolvedThreads: associated.unresolved,
+      },
+      "review has unresolved associated review threads",
+    );
+    return;
+  }
+
+  report.candidates.push({
+    ...subject,
+    author,
+    associatedThreads: associated.total,
+    unresolvedThreads: 0,
+    reason: "known bot review parent with all associated review threads resolved",
+  });
+}
+
+function subjectFromNode(node, type, classifier) {
+  return {
+    subjectId: node.id,
+    url: node.url,
+    type,
+    classifier,
+    isMinimized: Boolean(node.isMinimized),
+    minimizedReason: node.minimizedReason || null,
+  };
+}
+
+function addSkipped(report, subject, reason) {
+  report.skipped.push({
+    ...subject,
+    skipReason: reason,
+  });
+}
+
+function operationalMarkerPrefix(body) {
+  const trimmed = body.trimStart();
+  return OPERATIONAL_MARKER_PREFIXES.find((prefix) => trimmed.startsWith(prefix)) ?? null;
+}
+
+function unsafeTextReason(body) {
+  for (const rule of UNSAFE_TEXT_RULES) {
+    if (rule.pattern.test(body)) {
+      return rule.reason;
+    }
+  }
+  return null;
+}
+
+function isKnownReviewBot(login) {
+  return REVIEW_BOT_LOGINS.has(login.toLowerCase());
+}
+
+function indexThreadsByReview(threads) {
+  const index = new Map();
+
+  for (const thread of threads) {
+    const reviewIds = new Set(
+      (thread.comments?.nodes ?? [])
+        .map((comment) => comment.pullRequestReview?.id)
+        .filter(Boolean),
+    );
+
+    for (const reviewId of reviewIds) {
+      const current = index.get(reviewId) ?? { total: 0, unresolved: 0, threadIds: [] };
+      current.total += 1;
+      if (!thread.isResolved) {
+        current.unresolved += 1;
+      }
+      current.threadIds.push(thread.id);
+      index.set(reviewId, current);
+    }
+  }
+
+  return index;
+}
+
+function fetchPullRequest(owner, repo, number) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        number
+        url
+        merged
+      }
+    }
+  }`;
+  const result = ghGraphql(query, { owner, repo, number });
+  const pr = result.data?.repository?.pullRequest;
+  if (!pr) {
+    fail(`PR #${number} was not found`);
+  }
+  return pr;
+}
+
+function fetchIssueComments(owner, repo, number) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        comments(first:100,after:$after){
+          nodes{
+            id
+            url
+            body
+            createdAt
+            isMinimized
+            minimizedReason
+            viewerCanMinimize
+            author{login}
+          }
+          pageInfo{hasNextPage endCursor}
+        }
+      }
+    }
+  }`;
+  return fetchConnection(query, { owner, repo, number }, (data) => {
+    return data.repository.pullRequest.comments;
+  });
+}
+
+function fetchReviews(owner, repo, number) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        reviews(first:100,after:$after){
+          nodes{
+            id
+            url
+            body
+            state
+            submittedAt
+            isMinimized
+            minimizedReason
+            viewerCanMinimize
+            author{login}
+          }
+          pageInfo{hasNextPage endCursor}
+        }
+      }
+    }
+  }`;
+  return fetchConnection(query, { owner, repo, number }, (data) => {
+    return data.repository.pullRequest.reviews;
+  });
+}
+
+function fetchReviewThreads(owner, repo, number) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        reviewThreads(first:100,after:$after){
+          nodes{
+            id
+            isResolved
+            comments(first:100){
+              nodes{
+                id
+                url
+                body
+                author{login}
+                pullRequestReview{id}
+              }
+            }
+          }
+          pageInfo{hasNextPage endCursor}
+        }
+      }
+    }
+  }`;
+  return fetchConnection(query, { owner, repo, number }, (data) => {
+    return data.repository.pullRequest.reviewThreads;
+  });
+}
+
+function fetchConnection(query, baseVariables, pickConnection) {
+  const nodes = [];
+  let after = null;
+
+  do {
+    const variables = { ...baseVariables };
+    if (after) {
+      variables.after = after;
+    }
+    const result = ghGraphql(query, variables);
+    const connection = pickConnection(result.data);
+    nodes.push(...(connection.nodes ?? []));
+    after = connection.pageInfo?.hasNextPage ? connection.pageInfo.endCursor : null;
+  } while (after);
+
+  return nodes;
+}
+
+function minimizeComment(subjectId, classifier) {
+  const query = `mutation($id:ID!,$classifier:ReportedContentClassifiers!){
+    minimizeComment(input:{subjectId:$id,classifier:$classifier}){
+      minimizedComment{
+        __typename
+        ... on IssueComment{id url isMinimized minimizedReason}
+        ... on PullRequestReview{id url isMinimized minimizedReason}
+        ... on PullRequestReviewComment{id url isMinimized minimizedReason}
+      }
+    }
+  }`;
+  const result = ghGraphql(query, { id: subjectId, classifier });
+  return result.data.minimizeComment.minimizedComment;
+}
+
+function assertActiveClaim(owner, repo, issueNumber, agentId, claimId) {
+  const active = readActiveClaim(owner, repo, issueNumber);
+  if (!active || active.agentId !== agentId || active.claimId !== claimId) {
+    const activeLabel = active ? `${active.agentId} ${active.claimId}` : "none";
+    fail(`claim check failed for #${issueNumber}: active claim is ${activeLabel}`);
+  }
+}
+
+function readActiveClaim(owner, repo, issueNumber) {
+  const result = JSON.parse(
+    execFileSync(
+      "gh",
+      [
+        "issue",
+        "view",
+        String(issueNumber),
+        "--repo",
+        `${owner}/${repo}`,
+        "--json",
+        "comments",
+      ],
+      { encoding: "utf8" },
+    ),
+  );
+
+  const comments = [...(result.comments ?? [])].sort((left, right) => {
+    return new Date(left.createdAt) - new Date(right.createdAt);
+  });
+
+  let active = null;
+
+  for (const comment of comments) {
+    const claim = parseClaim(comment.body, comment.createdAt);
+    if (claim) {
+      if (active && claim.agentId === active.agentId && claim.claimId === active.claimId) {
+        active.createdAt = claim.createdAt;
+        continue;
+      }
+
+      if (!active && claim.supersedes === "none") {
+        active = claim;
+        continue;
+      }
+
+      if (
+        active
+        && claim.supersedes === active.claimId
+        && (claim.agentId === active.agentId || isStaleAt(active.createdAt, claim.createdAt))
+      ) {
+        active = claim;
+      }
+      continue;
+    }
+
+    const release = parseRelease(comment.body);
+    if (
+      release
+      && active
+      && release.agentId === active.agentId
+      && release.claimId === active.claimId
+    ) {
+      active = null;
+    }
+  }
+
+  return active;
+}
+
+function parseClaim(body, createdAt) {
+  const match = body.match(
+    /<!--\s*claimed-by:\s+(\S+)\s+(\S+)\s+supersedes:\s+(\S+)\s+\S+\s+branch:\s+([^\s>]+)\s*-->/,
+  );
+  if (!match) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    supersedes: match[3],
+    branch: match[4],
+    createdAt,
+  };
+}
+
+function parseRelease(body) {
+  const match = body.match(/<!--\s*unclaimed-by:\s+(\S+)\s+(\S+)\s+\S+\s*-->/);
+  if (!match) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+  };
+}
+
+function isStaleAt(activeCreatedAt, nextCreatedAt) {
+  const staleMs = 24 * 60 * 60 * 1000;
+  return new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >= staleMs;
+}
+
+function ghGraphql(query, variables) {
+  const commandArgs = ["api", "graphql", "-f", `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (Number.isInteger(value)) {
+      commandArgs.push("-F", `${key}=${value}`);
+    } else {
+      commandArgs.push("-f", `${key}=${value}`);
+    }
+  }
+
+  return JSON.parse(execFileSync("gh", commandArgs, { encoding: "utf8" }));
+}
+
+function detectRepository() {
+  if (process.env.GITHUB_REPOSITORY) {
+    return process.env.GITHUB_REPOSITORY;
+  }
+  return execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function writeReport(report, format) {
+  if (format === "json") {
+    console.log(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+
+  printRows("candidates", report.candidates);
+  printRows("skipped", report.skipped);
+  if (report.applied.length > 0) {
+    printRows("applied", report.applied);
+  }
+  if (report.failed.length > 0) {
+    printRows("failed", report.failed);
+  }
+}
+
+function printRows(label, rows) {
+  console.log(`${label}: ${rows.length}`);
+  if (rows.length === 0) {
+    return;
+  }
+  console.log(
+    [
+      "subjectId",
+      "type",
+      "classifier",
+      "isMinimized",
+      "minimizedReason",
+      "reason",
+      "url",
+    ].join("\t"),
+  );
+  for (const row of rows) {
+    console.log(
+      [
+        row.subjectId,
+        row.type,
+        row.classifier,
+        row.isMinimized,
+        row.minimizedReason ?? "",
+        row.error ?? row.skipReason ?? row.reason ?? "",
+        row.url,
+      ].join("\t"),
+    );
+  }
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    agentId: "codex-cli",
+    format: "json",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--pr":
+        parsed.pr = readValue(argv, ++index, arg);
+        break;
+      case "--repo":
+        parsed.repo = readValue(argv, ++index, arg);
+        break;
+      case "--dry-run":
+        parsed.dryRun = true;
+        break;
+      case "--apply":
+        parsed.apply = true;
+        break;
+      case "--format":
+        parsed.format = readValue(argv, ++index, arg);
+        if (!["json", "table"].includes(parsed.format)) {
+          fail("--format must be json or table");
+        }
+        break;
+      case "--claim-issue":
+        parsed.claimIssue = readValue(argv, ++index, arg);
+        break;
+      case "--claim-id":
+        parsed.claimId = readValue(argv, ++index, arg);
+        break;
+      case "--agent-id":
+        parsed.agentId = readValue(argv, ++index, arg);
+        break;
+      case "--skip-claim-check":
+        parsed.skipClaimCheck = true;
+        break;
+      default:
+        fail(`unknown argument ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function readValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    fail(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function printUsage() {
+  console.log(`usage: node scripts/audit-pr-cleanup.mjs --pr <number> [options]
+
+Options:
+  --dry-run                         list candidates without mutating (default)
+  --apply                           minimize safe candidates
+  --claim-issue <number>            issue whose active claim protects apply mode
+  --claim-id <id>                   active claim id required for apply mode
+  --agent-id <id>                   claim agent id (default: codex-cli)
+  --skip-claim-check                explicit maintainer override for apply mode
+  --repo <owner/name>               repository override
+  --format <json|table>             output format (default: json)
+  --help                            show this help
+`);
+}
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(2);
+}

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -230,6 +230,7 @@ function subjectFromNode(node, type, classifier) {
     url: node.url,
     type,
     classifier,
+    viewerCanMinimize: Boolean(node.viewerCanMinimize),
     isMinimized: Boolean(node.isMinimized),
     minimizedReason: node.minimizedReason || null,
   };
@@ -416,7 +417,7 @@ function minimizeComment(subjectId, classifier) {
 
 function assertActiveClaim(owner, repo, issueNumber, agentId, claimId) {
   const active = readActiveClaim(owner, repo, issueNumber);
-  if (!active || active.agentId !== agentId || active.claimId !== claimId) {
+  if (!active || active.claimId !== claimId || (agentId && active.agentId !== agentId)) {
     const activeLabel = active ? `${active.agentId} ${active.claimId}` : "none";
     fail(`claim check failed for #${issueNumber}: active claim is ${activeLabel}`);
   }
@@ -565,6 +566,7 @@ function printRows(label, rows) {
       "subjectId",
       "type",
       "classifier",
+      "viewerCanMinimize",
       "isMinimized",
       "minimizedReason",
       "reason",
@@ -577,6 +579,7 @@ function printRows(label, rows) {
         row.subjectId,
         row.type,
         row.classifier,
+        row.viewerCanMinimize,
         row.isMinimized,
         row.minimizedReason ?? "",
         row.error ?? row.skipReason ?? row.reason ?? "",
@@ -588,7 +591,6 @@ function printRows(label, rows) {
 
 function parseArgs(argv) {
   const parsed = {
-    agentId: "codex-cli",
     format: "json",
   };
 
@@ -653,7 +655,7 @@ Options:
   --apply                           minimize safe candidates
   --claim-issue <number>            issue whose active claim protects apply mode
   --claim-id <id>                   active claim id required for apply mode
-  --agent-id <id>                   claim agent id (default: codex-cli)
+  --agent-id <id>                   optionally require this claim agent id
   --skip-claim-check                explicit maintainer override for apply mode
   --repo <owner/name>               repository override
   --format <json|table>             output format (default: json)

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -5,11 +5,11 @@ import { execFileSync } from "node:child_process";
 const OPERATIONAL_MARKERS = [
   {
     label: "<!-- review-watermark:",
-    pattern: /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->/,
+    pattern: /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
   },
   {
     label: "<!-- review-baseline:",
-    pattern: /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->/,
+    pattern: /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
   },
   {
     label: "advisory-wait:",
@@ -139,11 +139,11 @@ if (args.apply) {
 
 writeReport(report, args.format);
 
-async function buildReport(owner, repo, prNumber) {
-  const pr = fetchPullRequest(owner, repo, prNumber);
-  const comments = fetchIssueComments(owner, repo, prNumber);
-  const reviews = fetchReviews(owner, repo, prNumber);
-  const threads = fetchReviewThreads(owner, repo, prNumber);
+async function buildReport(owner, repo, prNumber, options = {}) {
+  const pr = fetchPullRequest(owner, repo, prNumber, options);
+  const comments = fetchIssueComments(owner, repo, prNumber, options);
+  const reviews = fetchReviews(owner, repo, prNumber, options);
+  const threads = fetchReviewThreads(owner, repo, prNumber, options);
   const threadIndex = indexThreadsByReview(threads);
   const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
 
@@ -164,7 +164,7 @@ async function buildReport(owner, repo, prNumber) {
   }
 
   for (const thread of threads) {
-    evaluateReviewComments(thread, pr, report);
+    evaluateReviewComments(thread, pr, latestGatingReviews, report);
   }
 
   for (const review of reviews) {
@@ -303,19 +303,20 @@ function evaluateReviewParent(review, pr, threadIndex, latestGatingReviews, repo
   });
 }
 
-function evaluateReviewComments(thread, pr, report) {
+function evaluateReviewComments(thread, pr, latestGatingReviews, report) {
   for (const comment of thread.comments?.nodes ?? []) {
-    evaluateReviewComment(comment, thread, pr, report);
+    evaluateReviewComment(comment, thread, pr, latestGatingReviews, report);
   }
 }
 
-function evaluateReviewComment(comment, thread, pr, report) {
+function evaluateReviewComment(comment, thread, pr, latestGatingReviews, report) {
   const author = comment.author?.login ?? "";
   if (!isKnownReviewBot(author) || isDispositionComment(comment)) {
     return;
   }
 
   const subject = subjectFromNode(comment, "PullRequestReviewComment", "RESOLVED");
+  const latestGatingReview = latestGatingReviews.get(author.toLowerCase());
 
   if (!pr.merged) {
     addSkipped(report, subject, "PR is not merged");
@@ -335,6 +336,11 @@ function evaluateReviewComment(comment, thread, pr, report) {
 
   if (!comment.viewerCanMinimize) {
     addSkipped(report, subject, "viewer cannot minimize this review comment");
+    return;
+  }
+
+  if (latestGatingReview?.state === "CHANGES_REQUESTED") {
+    addSkipped(report, subject, "review author still has an active changes-requested state");
     return;
   }
 
@@ -484,7 +490,7 @@ function isDispositionComment(comment) {
   return body.startsWith("**Accepted**") || body.startsWith("**Rejected**");
 }
 
-function fetchPullRequest(owner, repo, number) {
+function fetchPullRequest(owner, repo, number, options = {}) {
   const query = `query($owner:String!,$repo:String!,$number:Int!){
     repository(owner:$owner,name:$repo){
       pullRequest(number:$number){
@@ -494,15 +500,15 @@ function fetchPullRequest(owner, repo, number) {
       }
     }
   }`;
-  const result = ghGraphql(query, { owner, repo, number });
+  const result = ghGraphql(query, { owner, repo, number }, options);
   const pr = result.data?.repository?.pullRequest;
   if (!pr) {
-    fail(`PR #${number} was not found`);
+    handleGraphqlFailure(`PR #${number} was not found`, options);
   }
   return pr;
 }
 
-function fetchIssueComments(owner, repo, number) {
+function fetchIssueComments(owner, repo, number, options = {}) {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
     repository(owner:$owner,name:$repo){
       pullRequest(number:$number){
@@ -524,10 +530,10 @@ function fetchIssueComments(owner, repo, number) {
   }`;
   return fetchConnection(query, { owner, repo, number }, (data) => {
     return data.repository.pullRequest.comments;
-  });
+  }, options);
 }
 
-function fetchReviews(owner, repo, number) {
+function fetchReviews(owner, repo, number, options = {}) {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
     repository(owner:$owner,name:$repo){
       pullRequest(number:$number){
@@ -550,10 +556,10 @@ function fetchReviews(owner, repo, number) {
   }`;
   return fetchConnection(query, { owner, repo, number }, (data) => {
     return data.repository.pullRequest.reviews;
-  });
+  }, options);
 }
 
-function fetchReviewThreads(owner, repo, number) {
+function fetchReviewThreads(owner, repo, number, options = {}) {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
     repository(owner:$owner,name:$repo){
       pullRequest(number:$number){
@@ -583,10 +589,10 @@ function fetchReviewThreads(owner, repo, number) {
   }`;
   return fetchConnection(query, { owner, repo, number }, (data) => {
     return data.repository.pullRequest.reviewThreads;
-  });
+  }, options);
 }
 
-function fetchConnection(query, baseVariables, pickConnection) {
+function fetchConnection(query, baseVariables, pickConnection, options = {}) {
   const nodes = [];
   let after = null;
 
@@ -595,21 +601,24 @@ function fetchConnection(query, baseVariables, pickConnection) {
     if (after) {
       variables.after = after;
     }
-    const result = ghGraphql(query, variables);
+    const result = ghGraphql(query, variables, options);
     if (result.errors?.length) {
-      fail(
+      handleGraphqlFailure(
         `GraphQL connection query failed: ${formatGraphqlErrors(result.errors)}; ${formatGraphqlContext(query, variables)}`,
+        options,
       );
     }
     if (!result.data) {
-      fail(
+      handleGraphqlFailure(
         `GraphQL connection query returned no data; ${formatGraphqlContext(query, variables)}`,
+        options,
       );
     }
     const connection = pickConnection(result.data);
     if (!connection) {
-      fail(
+      handleGraphqlFailure(
         `GraphQL connection query returned no connection; ${formatGraphqlContext(query, variables)}`,
+        options,
       );
     }
     nodes.push(...(connection.nodes ?? []));
@@ -658,7 +667,7 @@ function minimizeComment(subjectId, classifier) {
 }
 
 async function revalidateCandidate(owner, repo, prNumber, candidate, report) {
-  const freshReport = await buildReport(owner, repo, prNumber);
+  const freshReport = await buildReport(owner, repo, prNumber, { throwOnError: true });
   const freshCandidate = freshReport.candidates.find((current) => {
     return current.subjectId === candidate.subjectId && current.classifier === candidate.classifier;
   });

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -451,12 +451,39 @@ function fetchConnection(query, baseVariables, pickConnection) {
       variables.after = after;
     }
     const result = ghGraphql(query, variables);
+    if (result.errors?.length) {
+      fail(
+        `GraphQL connection query failed: ${formatGraphqlErrors(result.errors)}; ${formatGraphqlContext(query, variables)}`,
+      );
+    }
+    if (!result.data) {
+      fail(
+        `GraphQL connection query returned no data; ${formatGraphqlContext(query, variables)}`,
+      );
+    }
     const connection = pickConnection(result.data);
+    if (!connection) {
+      fail(
+        `GraphQL connection query returned no connection; ${formatGraphqlContext(query, variables)}`,
+      );
+    }
     nodes.push(...(connection.nodes ?? []));
     after = connection.pageInfo?.hasNextPage ? connection.pageInfo.endCursor : null;
   } while (after);
 
   return nodes;
+}
+
+function formatGraphqlErrors(errors) {
+  return errors.map((error) => error.message ?? JSON.stringify(error)).join("; ");
+}
+
+function formatGraphqlContext(query, variables) {
+  const compactQuery = query.replace(/\s+/g, " ").trim();
+  const queryPreview = compactQuery.length > 240
+    ? `${compactQuery.slice(0, 237)}...`
+    : compactQuery;
+  return `query=${queryPreview}; variables=${JSON.stringify(variables)}`;
 }
 
 function minimizeComment(subjectId, classifier) {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -2,12 +2,27 @@
 
 import { execFileSync } from "node:child_process";
 
-const OPERATIONAL_MARKER_PREFIXES = [
-  "<!-- review-watermark:",
-  "<!-- review-baseline:",
-  "advisory-wait:",
-  "advisory-wait-recovery:",
-  "<!-- advisory-wait:",
+const OPERATIONAL_MARKERS = [
+  {
+    label: "<!-- review-watermark:",
+    pattern: /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->/,
+  },
+  {
+    label: "<!-- review-baseline:",
+    pattern: /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->/,
+  },
+  {
+    label: "advisory-wait:",
+    pattern: /^advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*$/,
+  },
+  {
+    label: "advisory-wait-recovery:",
+    pattern: /^advisory-wait-recovery:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*$/,
+  },
+  {
+    label: "<!-- advisory-wait:",
+    pattern: /^<!--\s*advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\S+\s*-->\s*$/,
+  },
 ];
 
 const REVIEW_BOT_LOGINS = new Set([
@@ -291,7 +306,7 @@ function addSkipped(report, subject, reason) {
 
 function operationalMarkerPrefix(body) {
   const trimmed = body.trimStart();
-  return OPERATIONAL_MARKER_PREFIXES.find((prefix) => trimmed.startsWith(prefix)) ?? null;
+  return OPERATIONAL_MARKERS.find((marker) => marker.pattern.test(trimmed))?.label ?? null;
 }
 
 function unsafeTextReason(body) {
@@ -463,6 +478,7 @@ function fetchReviewThreads(owner, repo, number) {
                 id
                 url
                 body
+                createdAt
                 author{login}
                 pullRequestReview{id}
               }
@@ -534,8 +550,19 @@ function minimizeComment(subjectId, classifier) {
       }
     }
   }`;
-  const result = ghGraphql(query, { id: subjectId, classifier });
-  return result.data.minimizeComment.minimizedComment;
+  const result = ghGraphql(query, { id: subjectId, classifier }, { throwOnError: true });
+  if (result.errors?.length) {
+    throw new Error(
+      `GraphQL mutation failed: ${formatGraphqlErrors(result.errors)}; ${formatGraphqlContext(query, { id: subjectId, classifier })}`,
+    );
+  }
+  const minimized = result.data?.minimizeComment?.minimizedComment;
+  if (!minimized) {
+    throw new Error(
+      `GraphQL mutation returned no minimized comment; ${formatGraphqlContext(query, { id: subjectId, classifier })}`,
+    );
+  }
+  return minimized;
 }
 
 function assertActiveClaim(owner, repo, issueNumber, agentId, claimId) {
@@ -568,10 +595,15 @@ function readActiveClaim(owner, repo, issueNumber) {
   });
 
   let active = null;
+  const supersededClaimIds = new Set();
 
   for (const comment of comments) {
     const claim = parseClaim(comment.body, comment.createdAt);
     if (claim) {
+      if (supersededClaimIds.has(claim.claimId)) {
+        continue;
+      }
+
       if (active && claim.agentId === active.agentId && claim.claimId === active.claimId) {
         active.createdAt = claim.createdAt;
         continue;
@@ -591,6 +623,7 @@ function readActiveClaim(owner, repo, issueNumber) {
         && claim.supersedes === active.claimId
         && (claim.agentId === active.agentId || isStaleAt(active.createdAt, claim.createdAt))
       ) {
+        supersededClaimIds.add(active.claimId);
         active = claim;
       }
       continue;
@@ -642,7 +675,7 @@ function isStaleAt(activeCreatedAt, nextCreatedAt) {
   return new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >= staleMs;
 }
 
-function ghGraphql(query, variables) {
+function ghGraphql(query, variables, options = {}) {
   const commandArgs = ["api", "graphql", "-f", `query=${query}`];
   for (const [key, value] of Object.entries(variables)) {
     if (value === undefined || value === null) {
@@ -662,14 +695,23 @@ function ghGraphql(query, variables) {
     const stderr = String(error.stderr ?? "").trim();
     const response = parseJsonOrNull(stdout);
     if (response?.errors?.length) {
-      fail(
+      handleGraphqlFailure(
         `GraphQL request failed: ${formatGraphqlErrors(response.errors)}; ${formatGraphqlContext(query, variables)}`,
+        options,
       );
     }
-    fail(
+    handleGraphqlFailure(
       `gh api graphql failed: ${stderr || error.message}; ${formatGraphqlContext(query, variables)}`,
+      options,
     );
   }
+}
+
+function handleGraphqlFailure(message, options) {
+  if (options.throwOnError) {
+    throw new Error(message);
+  }
+  fail(message);
 }
 
 function parseJsonOrNull(value) {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -131,7 +131,7 @@ async function buildReport(owner, repo, prNumber) {
   const reviews = fetchReviews(owner, repo, prNumber);
   const threads = fetchReviewThreads(owner, repo, prNumber);
   const threadIndex = indexThreadsByReview(threads);
-  const latestReviews = indexLatestReviewsByAuthor(reviews);
+  const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
 
   const report = {
     repository: `${owner}/${repo}`,
@@ -150,7 +150,7 @@ async function buildReport(owner, repo, prNumber) {
   }
 
   for (const review of reviews) {
-    evaluateReviewParent(review, pr, threadIndex, latestReviews, report);
+    evaluateReviewParent(review, pr, threadIndex, latestGatingReviews, report);
   }
 
   return report;
@@ -192,7 +192,7 @@ function evaluateOperationalComment(comment, pr, report) {
   });
 }
 
-function evaluateReviewParent(review, pr, threadIndex, latestReviews, report) {
+function evaluateReviewParent(review, pr, threadIndex, latestGatingReviews, report) {
   const author = review.author?.login ?? "";
   if (!isKnownReviewBot(author)) {
     return;
@@ -200,7 +200,7 @@ function evaluateReviewParent(review, pr, threadIndex, latestReviews, report) {
 
   const subject = subjectFromNode(review, "PullRequestReview", "RESOLVED");
   const associated = threadIndex.get(review.id) ?? { total: 0, unresolved: 0, threadIds: [] };
-  const latestReview = latestReviews.get(author.toLowerCase());
+  const latestGatingReview = latestGatingReviews.get(author.toLowerCase());
 
   if (!pr.merged) {
     addSkipped(report, subject, "PR is not merged");
@@ -223,7 +223,7 @@ function evaluateReviewParent(review, pr, threadIndex, latestReviews, report) {
     return;
   }
 
-  if (review.state === "CHANGES_REQUESTED" || latestReview?.state === "CHANGES_REQUESTED") {
+  if (review.state === "CHANGES_REQUESTED" || latestGatingReview?.state === "CHANGES_REQUESTED") {
     addSkipped(report, subject, "review author still has an active changes-requested state");
     return;
   }
@@ -322,9 +322,12 @@ function isKnownReviewBot(login) {
   return REVIEW_BOT_LOGINS.has(login.toLowerCase());
 }
 
-function indexLatestReviewsByAuthor(reviews) {
+function indexLatestGatingReviewsByAuthor(reviews) {
   const index = new Map();
   for (const review of reviews) {
+    if (review.state === "COMMENTED") {
+      continue;
+    }
     const author = review.author?.login?.toLowerCase();
     if (!author) {
       continue;
@@ -377,17 +380,22 @@ function indexThreadsByReview(threads) {
 function hasFreshDisposition(thread) {
   const comments = thread.comments?.nodes ?? [];
   const latestFeedbackAt = comments
-    .filter((comment) => !isDispositionComment(comment))
+    .filter((comment) => !isIddDispositionComment(comment))
     .map((comment) => comment.createdAt)
     .sort()
     .at(-1);
 
   return comments.some((comment) => {
-    if (!isDispositionComment(comment)) {
+    if (!isIddDispositionComment(comment)) {
       return false;
     }
     return !latestFeedbackAt || comment.createdAt > latestFeedbackAt;
   });
+}
+
+function isIddDispositionComment(comment) {
+  const author = comment.author?.login ?? "";
+  return isDispositionComment(comment) && !isKnownReviewBot(author);
 }
 
 function isDispositionComment(comment) {
@@ -595,12 +603,12 @@ function readActiveClaim(owner, repo, issueNumber) {
   });
 
   let active = null;
-  const supersededClaimIds = new Set();
+  const retiredClaimIds = new Set();
 
   for (const comment of comments) {
     const claim = parseClaim(comment.body, comment.createdAt);
     if (claim) {
-      if (supersededClaimIds.has(claim.claimId)) {
+      if (retiredClaimIds.has(claim.claimId)) {
         continue;
       }
 
@@ -623,7 +631,7 @@ function readActiveClaim(owner, repo, issueNumber) {
         && claim.supersedes === active.claimId
         && (claim.agentId === active.agentId || isStaleAt(active.createdAt, claim.createdAt))
       ) {
-        supersededClaimIds.add(active.claimId);
+        retiredClaimIds.add(active.claimId);
         active = claim;
       }
       continue;
@@ -636,6 +644,7 @@ function readActiveClaim(owner, repo, issueNumber) {
       && release.agentId === active.agentId
       && release.claimId === active.claimId
     ) {
+      retiredClaimIds.add(active.claimId);
       active = null;
     }
   }


### PR DESCRIPTION
## Summary

- Add `scripts/audit-pr-cleanup.mjs` for post-merge IDD cleanup dry-runs and explicit apply mode.
- Detect stale IDD operational markers as `OUTDATED` and resolved bot review parent comments as `RESOLVED`.
- Update F4 and helper documentation to use the helper while preserving GraphQL fallback and best-effort cleanup semantics.

Closes #95

## Validation

- `node --check scripts/audit-pr-cleanup.mjs`
- `node scripts/audit-pr-cleanup.mjs --pr 94 --dry-run --format json`
- `node scripts/audit-pr-cleanup.mjs --pr 94 --apply --format table` (expected safety failure without claim args)
- `node scripts/audit-pr-cleanup.mjs --pr 94 --apply --claim-issue 95 --claim-id wrong --format table` (expected claim-check failure before mutation)
- `node scripts/audit-docs.mjs --check`
- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`

## Follow-up issues

None.

## Notes

The helper defaults to dry-run JSON output. Apply mode requires `--claim-issue` and `--claim-id` unless a maintainer explicitly passes `--skip-claim-check`, so ordinary IDD cleanup can revalidate the active claim before each minimization mutation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional post-merge cleanup helper CLI: dry-run preview of candidate comment minimizations, explicit apply mode that re-validates active claims before each minimization, best-effort non-gating minimizations, detailed per-item reporting, and direct GraphQL fallback when the helper is unavailable.

* **Documentation**
  * Clarified workflow, adopter guidance, dry-run/apply report shapes (table/JSON), explicit eligibility/skip rules, claim-validation requirements, and fallback instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->