### PR TITLE
docs(readme): sharpen adopter landing page

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,189 +6,150 @@
 
 🌐 Language: [English](./README.md) | **日本語**
 
-あらゆる GitHub プロジェクトに Issue-Driven Development (IDD) の
-マルチエージェントパイプラインを組み込むための、移植可能な
-`.github/instructions/` ファイル群とドキュメントです。
+複数の AI エージェントが GitHub Issues から作業しても、互いの作業を踏まないようにします。
 
-主な配布物は、導入先リポジトリへコピーする移植可能な IDD instruction
-template です。issue-authoring などのネイティブ `SKILL.md` bundle は、主配布物
-ではなく任意の companion です。
+IDD Skill は、リポジトリへ移植できる Issue-Driven Development
+ワークフローです。エージェントは ready な issue を探し、所有権を claim し、
+branch を切って実装し、PR を開き、review feedback を処理し、CI を待ち、
+merge して cleanup します。ループ全体は、リポジトリ内の Markdown
+instruction files として保持されます。
 
-## IDD とは？
+最初の PR を開いたところで AI エージェントが止まるのではなく、その後の
+handoff まで進み続けてほしいチームに向いています。
 
-IDD は、AI エージェントが GitHub Issues によって駆動される繰り返しパイプラインを
-通じて作業するマルチエージェント GitHub 自動化ワークフローです。
+## IDD が選ばれる理由
 
-| 番号   | 名前               | 概要                                                              |
-| ------ | ------------------ | ----------------------------------------------------------------- |
-| A0-A4  | Discover           | 設定されたスコープから ready な issue を探して選びます。          |
-| A5     | Claim              | 機械可読な claim marker で issue を予約します。                   |
-| B-C    | Work & Self-Review | branch/worktree を作り、計画、実装、自己レビューします。          |
-| D1-D4  | PR Submit          | branch を push して PR を開き、E1 前に validation を待ちます。    |
-| E1-E3  | Review Snapshot    | review activity を記録し、critique を実行して List A を作ります。 |
-| E4-E8  | Review Triage      | List A の項目を分類し、accept/reject の判断を記録します。         |
-| E9-E15 | Review Fix         | accepted feedback を反映し、必要に応じて再レビューを依頼します。  |
-| F1-F2  | Pre-Merge          | review、CI、comments、mergeability の鮮度を確認します。           |
-| F3-F5  | Merge              | 検証済み HEAD を merge し、cleanup 後に discovery へ戻ります。    |
+AI coding agent は強力ですが、チームの workflow はすぐに散らかります:
 
-各フェーズは `.github/instructions/` ファイルとしてエンコードされており、
-GitHub Copilot、Claude Code、Codex CLI、Gemini CLI などの互換 AI エージェントが
-読み込めます。実行モデルはクロスエージェントですが、配布される
-デフォルトのレビューポリシーには下記の Copilot アドバイザリーステップが
-含まれています。
+- 2 つの agent が同じ issue を拾ってしまう。
+- review comment を accepted にしたのに、修正が反映されない。
+- CI が終わった時点で、agent がもう見ていない。
+- 新しい review activity が届いている途中で PR が merge される。
+- workflow rule が vendor platform の中に隠れて、repo から監査できない。
 
-## はじめに
+IDD Skill は、これらの動きを GitHub-native で監査可能なループにします。
+Issue comment には claim、review snapshot、判断、hold、cleanup marker が残るため、
+別の agent が再開しても状況を推測する必要がありません。
 
-IDD は、次の 2 つの手順を分けて使います:
+## クイックスタート
 
-1. 対象リポジトリへ
-   [IDD をインストール / オンボーディング](#idd-のインストール--オンボーディング)
-   する。
-2. 対象リポジトリの準備ができてから
-   [オンボーディング後に IDD を実行する](#オンボーディング後に-idd-を実行する)。
+### IDD をインストールする
 
-AI エージェントとして raw onboarding entry point だけが必要な場合は、
-[AI エージェント向け](#ai-エージェント向け) を参照してください。
-
-## 実行前提
-
-IDD ループをエンドツーエンドで実行するには、次のローカルツールと GitHub
-アクセス手段が必要です:
-
-| ツール / アクセス                                   | 要否                | 用途                                                                                                                                     |
-| --------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `git`                                               | 必須                | branch、worktree、fetch、rebase、merge、status、commit 操作。                                                                            |
-| 認証済みの `gh` CLI または同等の GH MCP integration | 必須                | GitHub issue、PR、review、checks、comments、branch protection/ruleset、merge へのアクセス。ドキュメント内の snippet は `gh` を使います。 |
-| `jq`                                                | 必須                | ページネーションされた GitHub API レスポンスを処理するドキュメント内の shell snippet の解析。                                            |
-| `npx` を使える Node.js/npm                          | 必須                | このリポジトリの validation command で使う `dprint`、`markdownlint-cli2`、`cspell` の実行。                                              |
-| `curl` または同等の REST client                     | marker 投稿時に必須 | HTML コメントで始まる operational marker で、`gh issue comment` の信頼性が足りない場合に使います。                                       |
-| WorkTrunk、`git-wt`、commit signing alias           | 任意                | worktree 操作や commit signing をスムーズにします。基本要件ではありません。                                                              |
-
-## IDD のインストール / オンボーディング
-
-対象リポジトリで AI エージェントのセッションを開き、次のいずれかを伝えてください:
-
-**短縮形** (WebFetch または `gh` CLI アクセスを持つエージェント向け):
+IDD を導入したいリポジトリで AI agent の session を開き、次のように依頼します:
 
 > `github:kurone-kito/idd-skill` の IDD をこのリポジトリに
-> インポート＆オンボーディングして
+> import and onboard してください。
 
-**明示形** (すべてのエージェントで動作):
+明示的な URL が必要な agent には、次のように依頼します:
 
-> `github:idd-skill` の Issue-Driven Development をこの
-> リポジトリで使いたいです。`https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md`
-> を読んでオンボーディングしてください。
+> `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md`
+> を読んで、このリポジトリを Issue-Driven Development 用に
+> onboard してください。
 
-エージェントはいくつかのプロジェクト固有の値 (リポジトリ名、バリデーション
-コマンド) を収集し、IDD ワークフロー全体を自動的に設定します —
+Onboarding guide は project-specific な値を集め、portable template をコピーし、
+agent entry files を更新します。agent が必要な GitHub access を持っていれば、
 手動ファイルコピーは不要です。
 
-注: 配布されるデフォルトテンプレートはクロスエージェント実行に対応していますが、
-後半の PR フェーズにはデフォルトで GitHub Copilot アドバイザリーレビューステップが
-含まれます。このポリシーが不要な場合は、オンボーディング後に
-`.github/instructions/idd-review-fix.instructions.md` と
-`.github/instructions/idd-merge.instructions.md` をカスタマイズしてください。
+### ループを実行する
+
+onboarding 後、対象リポジトリで agent を起動して次のように依頼します:
+
+> このリポジトリで IDD workflow を開始してください。
+
+agent は workflow guide を読み、ready な issue を探して claim し、work、PR review、
+CI、merge、cleanup までループを進めます。
+
+ループを end-to-end で実行するには、agent が `git`、認証済みの `gh` CLI
+または同等の GitHub MCP integration、`jq`、`npx` を使える Node.js/npm、
+そして operational marker を確実に投稿するための `curl` などの REST client に
+アクセスできる必要があります。詳細な command contract は workflow docs を
+参照してください。
+
+## IDD が自動化すること
+
+IDD は、良い意味で退屈な workflow です。各 phase には名前付きの役割、
+再開可能な marker、次の手順があります。
+
+| ステージ    | Agent が行うこと                                                                           |
+| ----------- | ------------------------------------------------------------------------------------------ |
+| Discover    | roadmap または orphan issue から ready な作業を探し、scope を勝手に広げません。            |
+| Claim       | 機械可読な ownership marker で 1 つの issue を予約します。                                 |
+| Work        | branch/worktree を作り、plan、implement、self-review を行います。                          |
+| Submit PR   | push して PR を開き、review 可能になるまで validation を待ちます。                         |
+| Review Loop | review activity を記録し、feedback を accept / reject し、accepted items を直します。      |
+| Merge       | freshness、advisory review state、CI、unresolved threads、comments を再確認します。        |
+| Cleanup     | 検証済み HEAD を merge し、安全な場合は stale marker を隠して、次の discovery へ戻ります。 |
+
+完全な phase map は [docs/idd-workflow.md](docs/idd-workflow.md) と
+`.github/instructions/` にあります。
+
+## 得られるもの
+
+- **衝突しにくい並列作業** — claim と heartbeat marker によって、中央
+  coordinator なしで issue ownership が見えるようになります。
+- **止まりにくい PR** — initial pull request を開いた後も、review comment、CI、
+  follow-up fix を追い続けます。
+- **black box ではない portable rule** — workflow は target repo 内の plain
+  Markdown として残り、読めて、fork できて、customize できます。
+- **agent を選べる自由** — core loop は GitHub Copilot、Claude Code、OpenAI
+  Codex CLI、Gemini CLI で動作します。distributed default PR policy には
+  Copilot advisory review step が含まれます。
+- **運用する service が不要** — template files を import すれば始められます。
+  separate server、scheduler、SaaS account は不要です。
+
+より詳しい positioning は
+[docs/positioning.md](docs/positioning.md) を参照してください。
+
+## このリポジトリが配布するもの
+
+主な package は [`idd-template/`](idd-template/) です。これは adopter が自分の
+repository にコピーする portable な `.github/instructions/` files、onboarding
+docs、workflow docs のセットです。
+
+この repository には、異なる agent がここでどこから始めるかを知るための互換 entry
+files として `AGENTS.md`、`CLAUDE.md`、`GEMINI.md`、
+`.github/copilot-instructions.md` も含まれます。
+
+Native `SKILL.md` bundle は optional companion です。issue drafting など
+pre-execution task には役立ちますが、portable instruction template を
+置き換えるものではありません。
 
 ## AI エージェント向け
 
-`github:kurone-kito/idd-skill` のようなトリガーフレーズで誘導されてきた
-AI エージェントは、まずオンボーディングガイドを参照してください:
+ユーザーが `github:kurone-kito/idd-skill` を示して IDD onboarding を依頼したら、
+まずこの file を取得してください:
 
 ```text
 https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md
 ```
 
-そのファイルをフェッチして手順に従ってください。プレースホルダー値の収集、
-テンプレートファイルのコピー、エージェントエントリーファイルの更新まで
-案内されます — リポジトリのクローンは不要です。
+その内容に正確に従ってください。copy する files、埋める placeholders、
+更新する target-repository entry files が説明されています。
 
-## オンボーディング後に IDD を実行する
+## リクエストが大きすぎるとき
 
-オンボーディングが終わったら、対象リポジトリで AI エージェントのセッションを開き、
-ワークフローの開始を依頼してください。エージェントはまず
-[docs/idd-workflow.md](docs/idd-workflow.md) を読み、次に
-`.github/instructions/idd-overview.instructions.md` を開いてから、
-Discover → Claim → Work → ... のループに入ります。
+request の分解、dependency encoding、roadmap / sub-issue drafting が必要な場合は、
+IDD execution loop の前に optional issue-authoring companion を使ってください。
 
-**フレーズ例**:
+この repository では、agent に次のように依頼します:
 
-- `このリポジトリで IDD ワークフローを開始してください。`
-- `docs/idd-workflow.md` を読んで、次に
-  `.github/instructions/idd-overview.instructions.md` を開き、
-  Discover → Claim → Work のループを開始してください。
-
-## 実行前に issue authoring を使う
-
-1 つのレビュー可能な変更には大きすぎる、または曖昧なリクエスト、
-roadmap や sub-issue への分解が必要なリクエスト、あるいは
-エージェントが作業を claim する前に依存関係を明示すべきリクエストでは、
-IDD execution loop の前に optional issue-authoring skill を使ってください。
-
-このリポジトリでは、次のいずれかのプロンプトでエージェントをネイティブ
-bundle にルーティングできます:
-
-- `$issue-authoring skill を使って IDD-ready な issue をドラフトしてください。`
+- `$issue-authoring skill を使って IDD-ready な issue を draft してください。`
 - `skills/issue-authoring/SKILL.md を開いて issue set を準備してください。`
 
-この skill はドラフトと issue hygiene の準備だけを行います。GitHub issue の公開や
-編集、Discover → Claim → Work の開始は別アクションであり、明示的な承認が必要です。
+Issue authoring は issue draft と hygiene を準備するだけです。issue の公開や
+Discover -> Claim -> Work の開始には、引き続き明示的な承認が必要です。
 
-完全な contract と schema は
-[docs/issue-authoring-skill.md](docs/issue-authoring-skill.md) にあります。
-`idd-template/` だけをインポートする adopter には、デフォルトではこの bundle は
-含まれません。必要な場合は [idd-template/README.md](idd-template/README.md) と
-[idd-template/ONBOARDING.md](idd-template/ONBOARDING.md) に従い、
-optional companion としてインストールしてください。
+## 詳細リファレンス
 
-## idd-skill で得られること
-
-- **安全な並列エージェント作業** — claim と heartbeat の marker が issue の
-  所有者を可視化するため、複数の AI エージェントが同じタスクを拾う事故を避けながら、
-  中央オーケストレーターなしで並行作業できます。
-- **handoff の抜け漏れ削減** — workflow は issue discovery から merge までを扱い、
-  CI wait、review triage、review-fix cycle も含みます。PR を開いた後も、
-  エージェントが次に何をするかを見失いにくくなります。
-- **追加インフラなしで運用開始** — `idd-template/` の docs と instruction files を
-  リポジトリへコピーすれば使えます。SaaS アカウント、GitHub Actions runner、
-  server は不要です。
-- **使うエージェントを選べる自由** — core phases は plain Markdown で、GitHub
-  Copilot、Claude Code、OpenAI Codex CLI、Gemini CLI で動作します。default
-  template には後半フェーズに Copilot advisory review step が含まれます。
-- **自分たちで制御できる監査可能な自動化** — すべての rule が repo 内の Markdown
-  として残るため、team は black box に頼らずに読み、fork し、調整できます。
-
-より詳しい比較は [docs/positioning.md](docs/positioning.md) を参照してください。
-
-## IDD の手動インポート
-
-1. このリポジトリをクローンまたはダウンロードします。
-2. `idd-template/` ディレクトリの内容を対象リポジトリにコピーします。
-3. `idd-template/ONBOARDING.md` に従ってプレースホルダーを埋め、
-   エージェントエントリーファイルを更新します。
-
-## アーティファクトモデル
-
-このリポジトリが主に配布しているのは IDD のインストラクションテンプレートであり、
-単一のエージェントネイティブ skill ではありません。`idd-template/` のエクスポート
-パッケージには、導入先リポジトリへコピーする移植可能な `.github/instructions/`
-ファイル、オンボーディングドキュメント、ワークフロードキュメントが含まれます。
-
-`AGENTS.md`、`CLAUDE.md`、`GEMINI.md`、
-`.github/copilot-instructions.md` などのエージェントエントリーファイルは、
-このリポジトリ向けの互換入口です。ネイティブ `SKILL.md` バンドルが存在する場合、
-それらは IDD ドキュメントを参照できる補助機能ですが、インストラクションテンプレート
-そのものを置き換えるものではありません。
-
-## このリポジトリについて
-
-このリポジトリ自体も IDD ワークフローで管理されています。
-アクティブなワークフローガイドは [docs/idd-workflow.md](docs/idd-workflow.md) を、
-完全なインストラクションセットは `.github/instructions/` を参照してください。
-
-あわせて、repo ローカルのネイティブ skill bundle
-`skills/issue-authoring/` も含まれています。ルーティング例と通常の実行ループ前の
-承認境界については
-[実行前に issue authoring を使う](#実行前に-issue-authoring-を使う) を参照してください。
+- [Workflow guide](docs/idd-workflow.md) — entry points、file map、
+  cross-agent routing。
+- [Positioning](docs/positioning.md) — competitive landscape と IDD の違い。
+- [Issue authoring contract](docs/issue-authoring-skill.md) — optional
+  pre-execution issue drafting model。
+- [Comment minimization](docs/idd-comment-minimization.md) —
+  post-merge cleanup policy。
+- [Template import guide](idd-template/ONBOARDING.md) — target repository
+  向けの raw onboarding instructions。
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -6,197 +6,157 @@
 
 🌐 Language: **English** | [日本語](./README.ja.md)
 
-A portable set of `.github/instructions/` files and documentation that
-wire up an Issue-Driven Development (IDD) multi-agent pipeline for any
-GitHub project.
+Let multiple AI agents work from GitHub Issues without stepping on each
+other.
 
-The primary artifact is the portable IDD instruction template that
-adopters copy into a repository. Native `SKILL.md` bundles, including
-issue-authoring, are optional companions rather than the main package.
+IDD Skill gives a repository a portable Issue-Driven Development
+workflow: agents discover ready issues, claim ownership, implement in a
+branch, open a PR, handle review feedback, wait for CI, merge, and clean
+up. The whole loop is encoded as Markdown instruction files that live in
+your repo.
 
-## What is IDD?
+Use it when your team wants AI agents to keep going after the first PR
+instead of stopping at handoff time.
 
-IDD is a multi-agent GitHub automation workflow where AI agents work
-through a repeating pipeline driven entirely by GitHub Issues.
+## Why Teams Use IDD
 
-| #      | Name               | Summary                                                            |
-| ------ | ------------------ | ------------------------------------------------------------------ |
-| A0-A4  | Discover           | Find ready issues from the configured scope and pick one task.     |
-| A5     | Claim              | Reserve the issue with a machine-readable claim marker.            |
-| B-C    | Work & Self-Review | Create a branch/worktree, plan, implement, and self-review.        |
-| D1-D4  | PR Submit          | Push the branch, open a PR, and wait for validation before E1.     |
-| E1-E3  | Review Snapshot    | Capture review activity, run critique, and build List A.           |
-| E4-E8  | Review Triage      | Classify List A items and record accept/reject decisions.          |
-| E9-E15 | Review Fix         | Apply accepted feedback and request fresh review when needed.      |
-| F1-F2  | Pre-Merge          | Confirm reviews, CI, comments, and mergeability are fresh.         |
-| F3-F5  | Merge              | Merge using the validated HEAD, clean up, and return to discovery. |
+AI coding agents are powerful, but team workflows get messy fast:
 
-Each phase is encoded as a `.github/instructions/` file that any
-compatible AI agent can load — GitHub Copilot, Claude Code, Codex CLI,
-or Gemini CLI. That execution model is cross-agent, even though the
-distributed default review policy still includes the Copilot advisory
-step noted below.
+- Two agents can pick the same issue.
+- Review comments can be accepted but never fixed.
+- CI can finish after the agent has already stopped watching.
+- A PR can merge while fresh review activity is still arriving.
+- The workflow rules can hide inside a vendor platform instead of your
+  repository.
 
-## Getting started
+IDD Skill turns those moving parts into an auditable GitHub-native loop.
+Issue comments record claims, review snapshots, decisions, holds, and
+cleanup markers so another agent can resume the work without guessing.
 
-Use IDD in two separate steps:
+## Quick Start
 
-1. [Install / onboard IDD](#install--onboard-idd) into a target
-   repository.
-2. [Run IDD after onboarding](#run-idd-after-onboarding) when the target
-   repository is ready for the execution loop.
+### Install IDD
 
-If you are an AI agent and only need the raw onboarding entry point, use
-[For AI agents](#for-ai-agents).
-
-## Runtime prerequisites
-
-The IDD loop needs the following local tools and GitHub access before an
-agent can run it end-to-end:
-
-| Tool or access                                          | Status                      | Purpose                                                                                                                    |
-| ------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `git`                                                   | Required                    | Branch, worktree, fetch, rebase, merge, status, and commit operations.                                                     |
-| Authenticated `gh` CLI or equivalent GH MCP integration | Required                    | GitHub issue, PR, review, checks, comments, branch protection/ruleset, and merge access. The documented snippets use `gh`. |
-| `jq`                                                    | Required                    | Parse paginated GitHub API responses in the documented shell snippets.                                                     |
-| Node.js/npm with `npx`                                  | Required                    | Run this repository's validation commands: `dprint`, `markdownlint-cli2`, and `cspell`.                                    |
-| `curl` or equivalent REST client                        | Required for marker posting | Post HTML-comment operational markers when `gh issue comment` is not reliable enough for those bodies.                     |
-| WorkTrunk, `git-wt`, and commit-signing aliases         | Optional                    | Smooth repeated worktree and commit-signing steps; they are not baseline requirements.                                     |
-
-## Install / onboard IDD
-
-To install IDD into a target repository, open a session there and tell
-your AI agent one of the following:
-
-**Short form** (agents with WebFetch or `gh` CLI access):
+Open an AI-agent session in the repository that should adopt IDD and say:
 
 > Import and onboard `github:kurone-kito/idd-skill`'s IDD into this
 > repository.
 
-**Explicit form** (works with any agent):
+If the agent needs an explicit URL, use:
 
-> I want to use `github:idd-skill`'s Issue-Driven Development in this
-> repository. Read
+> Read
 > `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md`
-> and onboard me.
+> and onboard this repository for Issue-Driven Development.
 
-The agent will collect a few project-specific values (repo name,
-validation commands) and then set up the full IDD workflow
-automatically — no manual file copying required.
+The onboarding guide collects project-specific values, copies the
+portable template, and updates the agent entry files. No manual file
+copying is required when the agent has the needed GitHub access.
 
-Note: the distributed default template is cross-agent for execution, but
-its later PR phases include a GitHub Copilot advisory review step by
-default. If adopters do not want that PR policy, they can customize
-`.github/instructions/idd-review-fix.instructions.md` and
-`.github/instructions/idd-merge.instructions.md` after onboarding.
+### Run the Loop
 
-## For AI agents
+After onboarding, start an agent in the target repository and say:
 
-If you were pointed here by a trigger phrase such as
-`github:kurone-kito/idd-skill` and asked to onboard IDD, start with the
-onboarding guide:
+> Start the IDD workflow in this repository.
+
+The agent reads the workflow guide, discovers a ready issue, claims it,
+and follows the loop through work, PR review, CI, merge, and cleanup.
+
+Before an agent can run the loop end to end, it needs access to `git`,
+an authenticated `gh` CLI or equivalent GitHub MCP integration, `jq`,
+Node.js/npm with `npx`, and a REST client such as `curl` for reliable
+operational marker posting. See the workflow docs for the detailed
+command contract.
+
+## What IDD Automates
+
+IDD is intentionally boring in the best way: every phase has a named
+job, a resumable marker, and a next step.
+
+| Stage       | What the agent does                                                              |
+| ----------- | -------------------------------------------------------------------------------- |
+| Discover    | Finds ready roadmap or orphan issues without silently widening scope.            |
+| Claim       | Reserves one issue with a machine-readable ownership marker.                     |
+| Work        | Creates a branch/worktree, plans, implements, and self-reviews.                  |
+| Submit PR   | Pushes, opens a PR, and waits for validation to become reviewable.               |
+| Review Loop | Captures review activity, accepts or rejects feedback, and fixes accepted items. |
+| Merge       | Rechecks freshness, advisory review state, CI, unresolved threads, and comments. |
+| Cleanup     | Merges the validated HEAD, hides stale markers when safe, and loops back.        |
+
+The full phase map lives in
+[docs/idd-workflow.md](docs/idd-workflow.md) and the
+`.github/instructions/` files.
+
+## What You Get
+
+- **Collision-resistant parallel work** — Claim and heartbeat markers
+  make issue ownership visible without a central coordinator.
+- **Fewer stalled PRs** — The workflow keeps watching review comments,
+  CI, and follow-up fixes after the initial pull request opens.
+- **Portable rules, not a black box** — The workflow is plain Markdown
+  that can be inspected, forked, and customized in the target repo.
+- **Agent choice** — The core loop works across GitHub Copilot, Claude
+  Code, OpenAI Codex CLI, and Gemini CLI. The distributed default PR
+  policy still includes a Copilot advisory review step.
+- **No service to operate** — Import the template files; no separate
+  server, scheduler, or SaaS account is required to start.
+
+For deeper positioning, see
+[docs/positioning.md](docs/positioning.md).
+
+## What This Repository Ships
+
+The primary package is [`idd-template/`](idd-template/): a portable set
+of `.github/instructions/` files, onboarding docs, and workflow docs
+that adopters copy into their own repositories.
+
+This repository also includes compatibility entry files such as
+`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and
+`.github/copilot-instructions.md` so different agents know where to
+start here.
+
+Native `SKILL.md` bundles are optional companions. They can help with
+pre-execution tasks such as issue drafting, but they do not replace the
+portable instruction template.
+
+## For AI Agents
+
+If a user points you at `github:kurone-kito/idd-skill` and asks you to
+onboard IDD, fetch this file first:
 
 ```text
 https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/ONBOARDING.md
 ```
 
-Fetch that file and follow its instructions. It will walk you through
-collecting placeholder values, copying the template files, and updating
-the repository's agent entry files — no cloning required.
+Follow it exactly. It explains which files to copy, which placeholders
+to fill, and which target-repository entry files to update.
 
-## Run IDD after onboarding
+## When a Request Is Too Big
 
-After onboarding, open a session in your target repository and tell your
-AI agent to start the workflow. The agent should read
-[docs/idd-workflow.md](docs/idd-workflow.md), then
-`.github/instructions/idd-overview.instructions.md`, and continue into
-the Discover → Claim → Work → ... loop.
+Use the optional issue-authoring companion before the IDD execution loop
+when a request needs decomposition, dependency encoding, or roadmap and
+sub-issue drafting.
 
-**Example phrases**:
-
-- `Start the IDD workflow in this repository.`
-- `Read docs/idd-workflow.md`, then
-  `.github/instructions/idd-overview.instructions.md`, and begin the
-  Discover → Claim → Work loop.
-
-## Use issue authoring before execution
-
-Use the optional issue-authoring skill before the IDD execution loop
-when a request is too large or ambiguous for one reviewable change,
-needs roadmap or sub-issue decomposition, or has dependencies that
-should be explicit before any agent claims work.
-
-In this repository, route an agent to the native bundle with one of
-these prompts:
+In this repository, ask an agent to:
 
 - `Use the $issue-authoring skill to draft IDD-ready issues.`
 - `Open skills/issue-authoring/SKILL.md and prepare the issue set.`
 
-The skill prepares drafts and issue hygiene only. Publishing or editing
-GitHub issues, and starting Discover → Claim → Work, are separate
-actions that require explicit approval.
+Issue authoring only prepares issue drafts and hygiene. Publishing
+issues or starting Discover -> Claim -> Work still requires explicit
+approval.
 
-The full contract and schema are in
-[docs/issue-authoring-skill.md](docs/issue-authoring-skill.md).
-Adopters who import only `idd-template/` do not receive this bundle by
-default; install the optional companion with
-[idd-template/README.md](idd-template/README.md) and
-[idd-template/ONBOARDING.md](idd-template/ONBOARDING.md) when they want
-it.
+## Deeper Reference
 
-## What you get with idd-skill
-
-- **Safe parallel agent work** — Claim and heartbeat markers make issue
-  ownership visible, so multiple AI agents can work at once without
-  picking up the same task or needing a central orchestrator.
-- **Fewer handoff gaps** — The workflow covers discovery through merge,
-  including CI waits, review triage, and review-fix cycles, so agents
-  can keep moving after a PR opens instead of stopping at handoff time.
-- **No extra infrastructure to operate** — Copy the `idd-template/`
-  docs and instruction files into a repository. No SaaS account, GitHub
-  Actions runner, or server is required to start using the loop.
-- **Freedom to choose the agent** — The core phases are plain Markdown
-  and work across GitHub Copilot, Claude Code, OpenAI Codex CLI, and
-  Gemini CLI. The default template still includes a Copilot advisory
-  review step in later phases.
-- **Auditable automation you control** — Every rule lives in the repo as
-  Markdown, so teams can inspect it, fork it, and adapt it without a
-  black box.
-
-For deeper competitive comparison, see
-[docs/positioning.md](docs/positioning.md).
-
-## Importing IDD manually
-
-1. Clone or download this repository.
-2. Copy the `idd-template/` directory contents into your target repository.
-3. Follow `idd-template/ONBOARDING.md` to fill in the placeholders and
-   update your agent entry files.
-
-## Artifact model
-
-This repository primarily distributes an IDD instruction template, not a
-single agent-native skill. The exported package in `idd-template/`
-contains the portable `.github/instructions/` files, onboarding docs,
-and workflow docs that adopters copy into another repository.
-
-Agent entry files such as `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and
-`.github/copilot-instructions.md` are compatibility entry points for
-this repository. Native `SKILL.md` bundles, when present, are separate
-helpers that may reference the IDD docs but should not replace the
-instruction template itself.
-
-## This repository
-
-This repository is itself maintained with the IDD workflow. See
-[docs/idd-workflow.md](docs/idd-workflow.md) for the active workflow
-guide and `.github/instructions/` for the full instruction set.
-
-It also ships a repository-local native skill bundle at
-`skills/issue-authoring/`. See
-[Use issue authoring before execution](#use-issue-authoring-before-execution)
-for routing examples and the approval boundary before the normal
-execution loop begins.
+- [Workflow guide](docs/idd-workflow.md) — entry points, file map, and
+  cross-agent routing.
+- [Positioning](docs/positioning.md) — competitive landscape and why
+  IDD is different.
+- [Issue authoring contract](docs/issue-authoring-skill.md) — optional
+  pre-execution issue drafting model.
+- [Comment minimization](docs/idd-comment-minimization.md) —
+  post-merge cleanup policy.
+- [Template import guide](idd-template/ONBOARDING.md) — raw onboarding
+  instructions for target repositories.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rewrite the English and Japanese READMEs around adopter pain, value, and quick-start flow.
- Shorten reference-heavy material into concise summaries with links to the existing docs and template onboarding guide.
- Preserve the artifact boundary: `idd-template/` remains the primary portable package, while native `SKILL.md` bundles stay optional companions.

Closes #97

## Follow-up issues

- #98 will reorganize `docs/` as the reference manual.
- #99 will prepare the low-cost GitHub Pages path.

## Rationale

This PR intentionally keeps the change scoped to README positioning. It does not move or rewrite the deeper reference docs because those are tracked by the remaining roadmap issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Restructured README with improved organization and clarity for multi-agent workflow
  * Added new sections: "Quick Start," "Why Teams Use IDD," and guidance for large requests
  * Enhanced operational procedures and workflow explanations
  * Updated both English and Japanese documentation versions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/102)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->