### PR TITLE
docs(reference): add manual index

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -141,6 +141,8 @@ Discover -> Claim -> Work の開始には、引き続き明示的な承認が必
 
 ## 詳細リファレンス
 
+- [リファレンスマニュアル](docs/index.md) — 詳細ドキュメント群への
+  task-oriented な入口。
 - [Workflow guide](docs/idd-workflow.md) — entry points、file map、
   cross-agent routing。
 - [Positioning](docs/positioning.md) — competitive landscape と IDD の違い。

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ approval.
 
 ## Deeper Reference
 
+- [Reference manual](docs/index.md) — a task-oriented entry point for
+  the deeper documentation set.
 - [Workflow guide](docs/idd-workflow.md) — entry points, file map, and
   cross-agent routing.
 - [Positioning](docs/positioning.md) — competitive landscape and why

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,57 @@
+# IDD Reference Manual
+
+This directory is the deeper reference manual for idd-skill. The root
+README is the adopter landing page; use this page when you need the
+operational details, maintenance notes, or background material behind
+that overview.
+
+The reference is Markdown-first and keeps stable file names so it can
+also serve as the source for a future GitHub Pages site.
+
+## Start Here
+
+| Need                      | Read first                                           | Why it helps                                                    |
+| ------------------------- | ---------------------------------------------------- | --------------------------------------------------------------- |
+| Run the IDD loop          | [IDD workflow guide](idd-workflow.md)                | Maps agent entry points, phase files, and Copilot advisory use. |
+| Import IDD into a repo    | [Template onboarding](../idd-template/ONBOARDING.md) | Explains the portable template copy and placeholder flow.       |
+| Understand the value prop | [Positioning](positioning.md)                        | Summarizes where idd-skill fits among adjacent tools.           |
+
+## Reference Map
+
+### Adoption and Onboarding
+
+- [Template onboarding](../idd-template/ONBOARDING.md) is the canonical
+  guide for importing the portable IDD template into another
+  repository.
+- [IDD workflow guide](idd-workflow.md) explains where each supported
+  agent starts and which phase file to read next.
+
+### Workflow Internals
+
+- [IDD helper script evaluation](idd-helper-scripts.md) records why the
+  current workflow stays portable shell / `gh` / `jq` instructions
+  instead of requiring helper scripts.
+- [IDD comment minimization](idd-comment-minimization.md) defines the
+  safe post-merge cleanup policy for stale operational markers and
+  completed feedback.
+
+### Native Companions
+
+- [Issue authoring skill contract](issue-authoring-skill.md) describes
+  the optional pre-execution helper for drafting IDD-ready roadmap and
+  sub-issues before the Discover -> Claim -> Work loop begins.
+
+### Project Strategy
+
+- [Positioning](positioning.md) covers the competitive landscape,
+  differentiators, and known gaps.
+- [AI tooling strategy](ai-strategy.md) records the repository's
+  Copilot-first guidance policy and how compatibility entry files are
+  maintained for other agents.
+
+## Language Policy
+
+The root README is bilingual. Deeper reference pages are English-first
+unless a separate translation issue explicitly adds another language
+surface. This keeps the operational documentation easier to keep in
+sync while README remains friendly for first-time readers.


### PR DESCRIPTION
## Summary

- Add `docs/index.md` as the reference manual entry point for the repository documentation set.
- Categorize existing docs by reader intent: adoption, workflow internals, native companions, and project strategy.
- Link the English and Japanese READMEs to the new reference manual while preserving their aligned heading structure.

Closes #98

## Follow-up issues

- #99 will decide the future GitHub Pages publication strategy and any static-site-generator tradeoffs.

## Rationale

This keeps the change Markdown-first and avoids enabling Pages or moving exported template docs in this issue. The new index gives README readers a stable deeper-docs landing point without breaking existing documentation URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Created a new reference manual introduction page serving as the deeper documentation entry point, with guides and categorized reference links
  * Updated README files with navigation links to the new reference manual

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/103)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->