### PR TITLE
docs(idd): add roadmap completion audit flow

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -113,10 +113,10 @@ roadmap issue itself:
   agent, do not mutate the roadmap; report the claim and continue to A2
   or stop according to the normal ready-to-start rules.
 - If the roadmap is unclaimed, stale, or held by the same agent, post
-  and verify a normal `claimed-by` comment for the roadmap issue using
-  the A5 branch naming convention. This is a roadmap-audit coordination
-  claim; it does not require creating a worktree unless the audit also
-  needs git changes.
+  and verify a normal `claimed-by` comment for the roadmap issue using a
+  `roadmap-audit/<number>-<slug>` branch field. This is a logical
+  coordination name, not a work branch, and it does not require creating
+  a branch or worktree unless the audit also needs git changes.
 - Re-validate that roadmap claim before every roadmap comment, follow-up
   issue creation, body edit, label change, or close action.
 - If the roadmap remains open and no PR branch will continue from the
@@ -147,8 +147,10 @@ Apply one outcome:
   next audit can link it before considering duplicates.
 - **Non-autonomous gaps found**: comment with the decision or human
   blocker, apply `status:needs-decision` or `status:blocked-by-human`
-  when those labels exist, and do not close the roadmap. Continue or
-  stop according to the normal Discover readiness rules.
+  when those labels exist, and do not close the roadmap. Stop before A2
+  after applying a roadmap-level blocker or needs-decision state, so the
+  same unattended run cannot select child work under the blocked
+  roadmap.
 
 ## A2 — Enumerate sub-issues
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -51,9 +51,10 @@ umbrella issue. If no roadmap issue exists, report and abort.
 
 **Note**: Repo-wide or label-based issue queries are permitted only in
 **A0-O** (when `issue-scope` is `orphan-first`, to find orphan issues),
-**A1** (to locate the roadmap), and **A3** (narrow body-content lookup
+**A1** (to locate the roadmap), **A1.5** (narrow duplicate/reuse lookup
+for one specific autonomous gap), and **A3** (narrow body-content lookup
 for `idd-skill-roadmap-id` to resolve `idd-skill-blocked-by`
-dependency markers; see A2 for details). Outside these three contexts,
+dependency markers; see A2 for details). Outside these contexts,
 repo-wide and label-based queries are prohibited.
 
 ## A1.5 — Audit completed roadmaps
@@ -89,6 +90,9 @@ candidates.
 - If any referenced child or descendant issue is open, inaccessible, or
   unresolved, report the provenance path and reason, then continue to
   A2.
+- If any referenced child or descendant has an open linked or closing PR
+  that is not merged or otherwise obsolete, treat that child work as
+  unresolved, report the PR, and continue to A2.
 - If any open or unresolved child or descendant has
   `status:blocked-by-human` or `status:needs-decision`, report the
   blocker and continue to A2 or stop according to the normal
@@ -148,9 +152,9 @@ Apply one outcome:
 - **Non-autonomous gaps found**: comment with the decision or human
   blocker, apply `status:needs-decision` or `status:blocked-by-human`
   when those labels exist, and do not close the roadmap. Stop before A2
-  after applying a roadmap-level blocker or needs-decision state, so the
-  same unattended run cannot select child work under the blocked
-  roadmap.
+  after reporting a non-autonomous gap, even if the repository does not
+  have the blocker labels, so the same unattended run cannot select
+  child work under a roadmap that needs human input.
 
 ## A2 — Enumerate sub-issues
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -88,6 +88,25 @@ the roadmap.
   repository state where feasible. Do not infer completion from checkbox
   state alone.
 
+A1.5 can publish roadmap-level GitHub side effects before a child task
+issue is selected. Before any such side effect, coordinate on the
+roadmap issue itself:
+
+- Run the normal A5 claim pre-checks against the roadmap issue. If an
+  active non-stale claim belongs to another agent, do not mutate the
+  roadmap; report the claim and continue to A2 or stop according to the
+  normal ready-to-start rules.
+- If the roadmap is unclaimed, stale, or held by the same agent, post
+  and verify a normal `claimed-by` comment for the roadmap issue using
+  the A5 branch naming convention. This is a roadmap-audit coordination
+  claim; it does not require creating a worktree unless the audit also
+  needs git changes.
+- Re-validate that roadmap claim before every roadmap comment, follow-up
+  issue creation, body edit, label change, or close action.
+- If the roadmap remains open and no PR branch will continue from the
+  audit, release the roadmap-audit claim before returning to A2 or
+  stopping.
+
 Immediately before posting any completion summary, creating follow-up
 issues, editing the roadmap body, changing labels, or closing the
 roadmap, re-fetch the roadmap and child state and confirm the audit
@@ -96,8 +115,9 @@ input still matches the evidence.
 Apply one outcome:
 
 - **Audit passes**: post an `IDD roadmap completion audit` comment with
-  a concise evidence summary, then close the roadmap. No task issue is
-  claimed. Return to A1 and select the next open roadmap, if any.
+  a concise evidence summary, then close the roadmap. No child task
+  issue is claimed. Return to A1 and select the next open roadmap, if
+  any.
 - **Autonomous gaps found**: create or link follow-up issues using the
   repository's issue-authoring rules, update the roadmap task list with
   those links, and continue to A2 so the new work can be discovered.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -77,7 +77,11 @@ descendants, GitHub sub-issue children, and linked or closing PR evidence
 for those child issues. Use the same outbound traversal sources as A2,
 including closed umbrella children, so open descendants cannot be hidden
 behind a closed direct child. This step must not use repo-wide search to
-add unrelated work to the roadmap.
+add unrelated work to the roadmap. The only repo-wide search allowed in
+A1.5 is a narrow duplicate/reuse check for a specific autonomous gap
+before creating a follow-up issue; use those results only to link
+existing gap work or avoid creating a duplicate, not to widen A2
+candidates.
 
 - If the roadmap itself has `status:blocked-by-human` or
   `status:needs-decision`, report the blocker and stop before A2. Do not
@@ -101,10 +105,13 @@ A1.5 can publish roadmap-level GitHub side effects before a child task
 issue is selected. Before any such side effect, coordinate on the
 roadmap issue itself:
 
-- Run the normal A5 claim pre-checks against the roadmap issue. If an
-  active non-stale claim belongs to another agent, do not mutate the
-  roadmap; report the claim and continue to A2 or stop according to the
-  normal ready-to-start rules.
+- Run the A5 claim-state, open-PR, and branch-collision checks against
+  the roadmap issue. Do not apply A5's assignee or project
+  `not started` readiness gate to roadmap-audit claims; roadmap
+  ownership and project status may represent parent coordination rather
+  than task readiness. If an active non-stale claim belongs to another
+  agent, do not mutate the roadmap; report the claim and continue to A2
+  or stop according to the normal ready-to-start rules.
 - If the roadmap is unclaimed, stale, or held by the same agent, post
   and verify a normal `claimed-by` comment for the roadmap issue using
   the A5 branch naming convention. This is a roadmap-audit coordination
@@ -130,6 +137,14 @@ Apply one outcome:
 - **Autonomous gaps found**: create or link follow-up issues using the
   repository's issue-authoring rules, update the roadmap task list with
   those links, and continue to A2 so the new work can be discovered.
+  Before creating a new issue, run the narrow A1.5 duplicate/reuse check
+  for that gap and link a matching existing issue instead. New follow-up
+  issue bodies must reference the roadmap (for example `Refs #NNN`) so a
+  later audit can rediscover them. After creating a follow-up issue,
+  update the roadmap task list with that link before creating another.
+  If the roadmap update fails or the roadmap claim is lost after issue
+  creation, create no more issues; report the created issue link so the
+  next audit can link it before considering duplicates.
 - **Non-autonomous gaps found**: comment with the decision or human
   blocker, apply `status:needs-decision` or `status:blocked-by-human`
   when those labels exist, and do not close the roadmap. Continue or
@@ -168,6 +183,10 @@ touch issues outside the roadmap traversal graph:
   markers.
 - **A1 only**: any method (including `gh issue list`, `gh search`, or
   label-based queries) to locate the roadmap issue itself.
+- **A1.5 only**: a narrow duplicate/reuse lookup for one specific
+  autonomous gap before creating a follow-up issue. The result may only
+  be linked to the selected roadmap or used to avoid creating a
+  duplicate; it must not be added to the A2 candidate set.
 - **A3 only**: a body-content search (e.g.,
   `gh search issues --match-body`) to find the issue with a matching
   `idd-skill-roadmap-id` marker when checking

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -34,7 +34,8 @@ If at least one orphan issue is found: pass the collected set directly
 to **A4** (viability gate). Skip A1–A3 entirely.
 
 If no orphan issues are found: fall back to the roadmap path. Proceed
-to **A1** and continue with the normal A1 → A2 → A3 → A4 sequence.
+to **A1** and continue with the normal A1 → A1.5 → A2 → A3 → A4
+sequence.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: when
@@ -55,11 +56,61 @@ for `idd-skill-roadmap-id` to resolve `idd-skill-blocked-by`
 dependency markers; see A2 for details). Outside these three contexts,
 repo-wide and label-based queries are prohibited.
 
+## A1.5 — Audit completed roadmaps
+
+After A1 selects an open roadmap, inspect whether the roadmap appears
+complete before enumerating more work. This step belongs in Discover
+because Discover owns roadmap selection and global readiness. F4 remains
+scoped to the just-merged PR and local cleanup while holding only the
+child issue claim; it must not close a parent roadmap as a side effect.
+F5 still loops back here, so the next Discover pass can evaluate parent
+roadmap state after child PRs merge.
+
+Run the completion audit only when the selected roadmap has explicit
+child work such as task-list issue references or GitHub sub-issue
+relationships. If the roadmap has no explicit child work, report that
+it is childless or malformed and continue to A2; do not close it based
+on absence of candidates.
+
+Fetch the selected roadmap, its explicit child references, GitHub
+sub-issue children, and linked or closing PR evidence for those child
+issues. This step must not use repo-wide search to add unrelated work to
+the roadmap.
+
+- If any referenced child issue is open, inaccessible, or unresolved,
+  report the reason and continue to A2.
+- If any child or the roadmap itself has `status:blocked-by-human` or
+  `status:needs-decision`, report the blocker and continue to A2 or stop
+  according to the normal ready-to-start rules.
+- If all referenced child work is closed or otherwise complete, compare
+  the roadmap success criteria against the closed child issues, linked
+  merged PRs, task-list state, follow-up comments, and the current
+  repository state where feasible. Do not infer completion from checkbox
+  state alone.
+
+Immediately before posting any completion summary, creating follow-up
+issues, editing the roadmap body, changing labels, or closing the
+roadmap, re-fetch the roadmap and child state and confirm the audit
+input still matches the evidence.
+
+Apply one outcome:
+
+- **Audit passes**: post an `IDD roadmap completion audit` comment with
+  a concise evidence summary, then close the roadmap. No task issue is
+  claimed. Return to A1 and select the next open roadmap, if any.
+- **Autonomous gaps found**: create or link follow-up issues using the
+  repository's issue-authoring rules, update the roadmap task list with
+  those links, and continue to A2 so the new work can be discovered.
+- **Non-autonomous gaps found**: comment with the decision or human
+  blocker, apply `status:needs-decision` or `status:blocked-by-human`
+  when those labels exist, and do not close the roadmap. Continue or
+  stop according to the normal Discover readiness rules.
+
 ## A2 — Enumerate sub-issues
 
-Starting from the roadmap found in A1, recursively collect all issues it
-references. Include transitively referenced issues. Collect only
-**open** issues.
+Starting from the roadmap found in A1 and not closed by A1.5,
+recursively collect all issues it references. Include transitively
+referenced issues. Collect only **open** issues.
 
 **Allowed traversal sources** (outbound references only):
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -72,21 +72,30 @@ relationships. If the roadmap has no explicit child work, report that
 it is childless or malformed and continue to A2; do not close it based
 on absence of candidates.
 
-Fetch the selected roadmap, its explicit child references, GitHub
-sub-issue children, and linked or closing PR evidence for those child
-issues. This step must not use repo-wide search to add unrelated work to
-the roadmap.
+Fetch the selected roadmap, its explicit child references, transitive
+descendants, GitHub sub-issue children, and linked or closing PR evidence
+for those child issues. Use the same outbound traversal sources as A2,
+including closed umbrella children, so open descendants cannot be hidden
+behind a closed direct child. This step must not use repo-wide search to
+add unrelated work to the roadmap.
 
-- If any referenced child issue is open, inaccessible, or unresolved,
-  report the reason and continue to A2.
-- If any child or the roadmap itself has `status:blocked-by-human` or
-  `status:needs-decision`, report the blocker and continue to A2 or stop
-  according to the normal ready-to-start rules.
-- If all referenced child work is closed or otherwise complete, compare
-  the roadmap success criteria against the closed child issues, linked
-  merged PRs, task-list state, follow-up comments, and the current
-  repository state where feasible. Do not infer completion from checkbox
-  state alone.
+- If the roadmap itself has `status:blocked-by-human` or
+  `status:needs-decision`, report the blocker and stop before A2. Do not
+  continue selecting child issues under a blocked roadmap.
+- If any referenced child or descendant issue is open, inaccessible, or
+  unresolved, report the provenance path and reason, then continue to
+  A2.
+- If any open or unresolved child or descendant has
+  `status:blocked-by-human` or `status:needs-decision`, report the
+  blocker and continue to A2 or stop according to the normal
+  ready-to-start rules. Do not treat stale blocker labels on closed
+  children as audit blockers when their referenced descendants are
+  resolved.
+- If all referenced child and descendant work is closed or otherwise
+  complete, compare the roadmap success criteria against the closed child
+  issues, linked merged PRs, task-list state, follow-up comments, and the
+  current repository state where feasible. Do not infer completion from
+  checkbox state alone.
 
 A1.5 can publish roadmap-level GitHub side effects before a child task
 issue is selected. Before any such side effect, coordinate on the

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -176,7 +176,11 @@ operator instruction. Specifically:
   find issues lacking `idd-skill-roadmap-id` and
   `idd-skill-blocked-by` markers), and for the scoped
   `idd-skill-roadmap-id` body-content lookup required by A3's
-  dependency-marker check.
+  dependency-marker check. A1.5 may also run a narrow repo-wide
+  duplicate/reuse check for a specific autonomous gap before creating a
+  follow-up issue; the result may only prevent a duplicate or link an
+  existing issue back to the selected roadmap, not expand the candidate
+  set.
 - After a zero-result report at A3, an operator may grant a one-time
   opt-in for the current run, specifying an alternate scope. See
   `idd-discover.instructions.md` for the full decision tree.

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -126,7 +126,9 @@ A1.5 roadmap completion audit side effects use the roadmap issue itself
 as the claim target. Even when the audit is GitHub-only and does not
 create a worktree, claim and re-validate the roadmap issue before
 commenting, editing, labeling, creating linked follow-up issues, or
-closing it.
+closing it. A1.5 coordination-only claims use a
+`roadmap-audit/<number>-<slug>` branch field so resume can distinguish
+them from normal implementation claims.
 
 ## Abort
 

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -122,6 +122,12 @@ issue and parse the active claim. The active claim must still use your
 current `{claim-id}`. If it does not, the claim was lost. Stop, do not
 post further operational comments, and report the handoff or race.
 
+A1.5 roadmap completion audit side effects use the roadmap issue itself
+as the claim target. Even when the audit is GitHub-only and does not
+create a worktree, claim and re-validate the roadmap issue before
+commenting, editing, labeling, creating linked follow-up issues, or
+closing it.
+
 ## Abort
 
 On abort, re-validate ownership first. If the active claim still uses

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -63,6 +63,12 @@ A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the
 active claim you are taking over, or in the latest released claim.
 
+If the active or inherited branch field starts with `roadmap-audit/`,
+the claim is an A1.5 roadmap-audit coordination claim, not a work branch.
+After the re-claim or takeover is verified, do not create a branch or
+worktree and do not use the Step 2 worktree table. Re-run A1.5 for that
+roadmap issue, then follow A1.5's close, release, or stop behavior.
+
 ## Step 2 — Locate or restore branch and worktree
 
 When any row below requires creating a worktree, follow the B1

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -36,7 +36,7 @@ you are reading this guide first, start at step 1.
 | File                                                       | Role                                                                   |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping |
-| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue to start                                    |
+| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue and audit completed roadmaps                |
 | `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                            |
 | `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                  |
 | `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                   |
@@ -82,6 +82,20 @@ The IDD workflow distributed from this repository is therefore an
 instruction template first. Native skills can sit beside it as helpers,
 but the synchronization contract for the portable workflow remains
 between the live `.github/instructions/` files and `idd-template/`.
+
+## Roadmap completion audits
+
+Discover owns roadmap-level state. After it finds an open roadmap, it
+can audit whether all explicitly referenced child work is complete
+before selecting the next issue. Passing audits post a concise evidence
+summary and close the roadmap; failing audits either add/link
+autonomous follow-up issues or route human-dependent gaps to an explicit
+blocked or needs-decision state.
+
+This audit intentionally lives before A2 rather than in F4. F4 is
+limited to the PR that just merged and the local cleanup for that child
+issue. F5 then loops back to Discover, where roadmap completion can be
+checked with the broader parent context.
 
 ## Copilot review instruction scope
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -90,7 +90,9 @@ can audit whether all explicitly referenced child work is complete
 before selecting the next issue. Passing audits post a concise evidence
 summary and close the roadmap; failing audits either add/link
 autonomous follow-up issues or route human-dependent gaps to an explicit
-blocked or needs-decision state.
+blocked or needs-decision state. Roadmap-level side effects still use a
+temporary claim on the roadmap issue itself, so concurrent agents do not
+close or edit the same roadmap at the same time.
 
 This audit intentionally lives before A2 rather than in F4. F4 is
 limited to the PR that just merged and the local cleanup for that child

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -75,21 +75,30 @@ relationships. If the roadmap has no explicit child work, report that
 it is childless or malformed and continue to A2; do not close it based
 on absence of candidates.
 
-Fetch the selected roadmap, its explicit child references, GitHub
-sub-issue children, and linked or closing PR evidence for those child
-issues. This step must not use repo-wide search to add unrelated work to
-the roadmap.
+Fetch the selected roadmap, its explicit child references, transitive
+descendants, GitHub sub-issue children, and linked or closing PR evidence
+for those child issues. Use the same outbound traversal sources as A2,
+including closed umbrella children, so open descendants cannot be hidden
+behind a closed direct child. This step must not use repo-wide search to
+add unrelated work to the roadmap.
 
-- If any referenced child issue is open, inaccessible, or unresolved,
-  report the reason and continue to A2.
-- If any child or the roadmap itself has `status:blocked-by-human` or
-  `status:needs-decision`, report the blocker and continue to A2 or stop
-  according to the normal ready-to-start rules.
-- If all referenced child work is closed or otherwise complete, compare
-  the roadmap success criteria against the closed child issues, linked
-  merged PRs, task-list state, follow-up comments, and the current
-  repository state where feasible. Do not infer completion from checkbox
-  state alone.
+- If the roadmap itself has `status:blocked-by-human` or
+  `status:needs-decision`, report the blocker and stop before A2. Do not
+  continue selecting child issues under a blocked roadmap.
+- If any referenced child or descendant issue is open, inaccessible, or
+  unresolved, report the provenance path and reason, then continue to
+  A2.
+- If any open or unresolved child or descendant has
+  `status:blocked-by-human` or `status:needs-decision`, report the
+  blocker and continue to A2 or stop according to the normal
+  ready-to-start rules. Do not treat stale blocker labels on closed
+  children as audit blockers when their referenced descendants are
+  resolved.
+- If all referenced child and descendant work is closed or otherwise
+  complete, compare the roadmap success criteria against the closed child
+  issues, linked merged PRs, task-list state, follow-up comments, and the
+  current repository state where feasible. Do not infer completion from
+  checkbox state alone.
 
 A1.5 can publish roadmap-level GitHub side effects before a child task
 issue is selected. Before any such side effect, coordinate on the

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -116,10 +116,10 @@ roadmap issue itself:
   agent, do not mutate the roadmap; report the claim and continue to A2
   or stop according to the normal ready-to-start rules.
 - If the roadmap is unclaimed, stale, or held by the same agent, post
-  and verify a normal `claimed-by` comment for the roadmap issue using
-  the A5 branch naming convention. This is a roadmap-audit coordination
-  claim; it does not require creating a worktree unless the audit also
-  needs git changes.
+  and verify a normal `claimed-by` comment for the roadmap issue using a
+  `roadmap-audit/<number>-<slug>` branch field. This is a logical
+  coordination name, not a work branch, and it does not require creating
+  a branch or worktree unless the audit also needs git changes.
 - Re-validate that roadmap claim before every roadmap comment, follow-up
   issue creation, body edit, label change, or close action.
 - If the roadmap remains open and no PR branch will continue from the
@@ -150,8 +150,10 @@ Apply one outcome:
   next audit can link it before considering duplicates.
 - **Non-autonomous gaps found**: comment with the decision or human
   blocker, apply `status:needs-decision` or `status:blocked-by-human`
-  when those labels exist, and do not close the roadmap. Continue or
-  stop according to the normal Discover readiness rules.
+  when those labels exist, and do not close the roadmap. Stop before A2
+  after applying a roadmap-level blocker or needs-decision state, so the
+  same unattended run cannot select child work under the blocked
+  roadmap.
 
 ## A2 — Enumerate sub-issues
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -80,7 +80,11 @@ descendants, GitHub sub-issue children, and linked or closing PR evidence
 for those child issues. Use the same outbound traversal sources as A2,
 including closed umbrella children, so open descendants cannot be hidden
 behind a closed direct child. This step must not use repo-wide search to
-add unrelated work to the roadmap.
+add unrelated work to the roadmap. The only repo-wide search allowed in
+A1.5 is a narrow duplicate/reuse check for a specific autonomous gap
+before creating a follow-up issue; use those results only to link
+existing gap work or avoid creating a duplicate, not to widen A2
+candidates.
 
 - If the roadmap itself has `status:blocked-by-human` or
   `status:needs-decision`, report the blocker and stop before A2. Do not
@@ -104,10 +108,13 @@ A1.5 can publish roadmap-level GitHub side effects before a child task
 issue is selected. Before any such side effect, coordinate on the
 roadmap issue itself:
 
-- Run the normal A5 claim pre-checks against the roadmap issue. If an
-  active non-stale claim belongs to another agent, do not mutate the
-  roadmap; report the claim and continue to A2 or stop according to the
-  normal ready-to-start rules.
+- Run the A5 claim-state, open-PR, and branch-collision checks against
+  the roadmap issue. Do not apply A5's assignee or project
+  `not started` readiness gate to roadmap-audit claims; roadmap
+  ownership and project status may represent parent coordination rather
+  than task readiness. If an active non-stale claim belongs to another
+  agent, do not mutate the roadmap; report the claim and continue to A2
+  or stop according to the normal ready-to-start rules.
 - If the roadmap is unclaimed, stale, or held by the same agent, post
   and verify a normal `claimed-by` comment for the roadmap issue using
   the A5 branch naming convention. This is a roadmap-audit coordination
@@ -133,6 +140,14 @@ Apply one outcome:
 - **Autonomous gaps found**: create or link follow-up issues using the
   repository's issue-authoring rules, update the roadmap task list with
   those links, and continue to A2 so the new work can be discovered.
+  Before creating a new issue, run the narrow A1.5 duplicate/reuse check
+  for that gap and link a matching existing issue instead. New follow-up
+  issue bodies must reference the roadmap (for example `Refs #NNN`) so a
+  later audit can rediscover them. After creating a follow-up issue,
+  update the roadmap task list with that link before creating another.
+  If the roadmap update fails or the roadmap claim is lost after issue
+  creation, create no more issues; report the created issue link so the
+  next audit can link it before considering duplicates.
 - **Non-autonomous gaps found**: comment with the decision or human
   blocker, apply `status:needs-decision` or `status:blocked-by-human`
   when those labels exist, and do not close the roadmap. Continue or
@@ -172,6 +187,10 @@ touch issues outside the roadmap traversal graph:
   `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers.
 - **A1 only**: any method (including `gh issue list`, `gh search`, or
   label-based queries) to locate the roadmap issue itself.
+- **A1.5 only**: a narrow duplicate/reuse lookup for one specific
+  autonomous gap before creating a follow-up issue. The result may only
+  be linked to the selected roadmap or used to avoid creating a
+  duplicate; it must not be added to the A2 candidate set.
 - **A3 only**: a body-content search (e.g.,
   `gh search issues --match-body`) to find the issue with a matching
   `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker when checking

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -53,11 +53,12 @@ umbrella issue. If no roadmap issue exists, report and abort.
 
 **Note**: Repo-wide or label-based issue queries are permitted only in
 **A0-O** (when `issue-scope` is `orphan-first`, to find orphan issues),
-**A1** (to locate the roadmap), and **A3** (narrow body-content lookup
+**A1** (to locate the roadmap), **A1.5** (narrow duplicate/reuse lookup
+for one specific autonomous gap), and **A3** (narrow body-content lookup
 for `{{PROJECT_MARKER_PREFIX}}-roadmap-id` to resolve
 `{{PROJECT_MARKER_PREFIX}}-blocked-by` dependency markers; see A2 for
-details). Outside these three contexts, repo-wide and label-based
-queries are prohibited.
+details). Outside these contexts, repo-wide and label-based queries are
+prohibited.
 
 ## A1.5 — Audit completed roadmaps
 
@@ -92,6 +93,9 @@ candidates.
 - If any referenced child or descendant issue is open, inaccessible, or
   unresolved, report the provenance path and reason, then continue to
   A2.
+- If any referenced child or descendant has an open linked or closing PR
+  that is not merged or otherwise obsolete, treat that child work as
+  unresolved, report the PR, and continue to A2.
 - If any open or unresolved child or descendant has
   `status:blocked-by-human` or `status:needs-decision`, report the
   blocker and continue to A2 or stop according to the normal
@@ -151,9 +155,9 @@ Apply one outcome:
 - **Non-autonomous gaps found**: comment with the decision or human
   blocker, apply `status:needs-decision` or `status:blocked-by-human`
   when those labels exist, and do not close the roadmap. Stop before A2
-  after applying a roadmap-level blocker or needs-decision state, so the
-  same unattended run cannot select child work under the blocked
-  roadmap.
+  after reporting a non-autonomous gap, even if the repository does not
+  have the blocker labels, so the same unattended run cannot select
+  child work under a roadmap that needs human input.
 
 ## A2 — Enumerate sub-issues
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -91,6 +91,25 @@ the roadmap.
   repository state where feasible. Do not infer completion from checkbox
   state alone.
 
+A1.5 can publish roadmap-level GitHub side effects before a child task
+issue is selected. Before any such side effect, coordinate on the
+roadmap issue itself:
+
+- Run the normal A5 claim pre-checks against the roadmap issue. If an
+  active non-stale claim belongs to another agent, do not mutate the
+  roadmap; report the claim and continue to A2 or stop according to the
+  normal ready-to-start rules.
+- If the roadmap is unclaimed, stale, or held by the same agent, post
+  and verify a normal `claimed-by` comment for the roadmap issue using
+  the A5 branch naming convention. This is a roadmap-audit coordination
+  claim; it does not require creating a worktree unless the audit also
+  needs git changes.
+- Re-validate that roadmap claim before every roadmap comment, follow-up
+  issue creation, body edit, label change, or close action.
+- If the roadmap remains open and no PR branch will continue from the
+  audit, release the roadmap-audit claim before returning to A2 or
+  stopping.
+
 Immediately before posting any completion summary, creating follow-up
 issues, editing the roadmap body, changing labels, or closing the
 roadmap, re-fetch the roadmap and child state and confirm the audit
@@ -99,8 +118,9 @@ input still matches the evidence.
 Apply one outcome:
 
 - **Audit passes**: post an `IDD roadmap completion audit` comment with
-  a concise evidence summary, then close the roadmap. No task issue is
-  claimed. Return to A1 and select the next open roadmap, if any.
+  a concise evidence summary, then close the roadmap. No child task
+  issue is claimed. Return to A1 and select the next open roadmap, if
+  any.
 - **Autonomous gaps found**: create or link follow-up issues using the
   repository's issue-authoring rules, update the roadmap task list with
   those links, and continue to A2 so the new work can be discovered.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -36,7 +36,8 @@ If at least one orphan issue is found: pass the collected set directly
 to **A4** (viability gate). Skip A1–A3 entirely.
 
 If no orphan issues are found: fall back to the roadmap path. Proceed
-to **A1** and continue with the normal A1 → A2 → A3 → A4 sequence.
+to **A1** and continue with the normal A1 → A1.5 → A2 → A3 → A4
+sequence.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: when
@@ -58,11 +59,61 @@ for `{{PROJECT_MARKER_PREFIX}}-roadmap-id` to resolve
 details). Outside these three contexts, repo-wide and label-based
 queries are prohibited.
 
+## A1.5 — Audit completed roadmaps
+
+After A1 selects an open roadmap, inspect whether the roadmap appears
+complete before enumerating more work. This step belongs in Discover
+because Discover owns roadmap selection and global readiness. F4 remains
+scoped to the just-merged PR and local cleanup while holding only the
+child issue claim; it must not close a parent roadmap as a side effect.
+F5 still loops back here, so the next Discover pass can evaluate parent
+roadmap state after child PRs merge.
+
+Run the completion audit only when the selected roadmap has explicit
+child work such as task-list issue references or GitHub sub-issue
+relationships. If the roadmap has no explicit child work, report that
+it is childless or malformed and continue to A2; do not close it based
+on absence of candidates.
+
+Fetch the selected roadmap, its explicit child references, GitHub
+sub-issue children, and linked or closing PR evidence for those child
+issues. This step must not use repo-wide search to add unrelated work to
+the roadmap.
+
+- If any referenced child issue is open, inaccessible, or unresolved,
+  report the reason and continue to A2.
+- If any child or the roadmap itself has `status:blocked-by-human` or
+  `status:needs-decision`, report the blocker and continue to A2 or stop
+  according to the normal ready-to-start rules.
+- If all referenced child work is closed or otherwise complete, compare
+  the roadmap success criteria against the closed child issues, linked
+  merged PRs, task-list state, follow-up comments, and the current
+  repository state where feasible. Do not infer completion from checkbox
+  state alone.
+
+Immediately before posting any completion summary, creating follow-up
+issues, editing the roadmap body, changing labels, or closing the
+roadmap, re-fetch the roadmap and child state and confirm the audit
+input still matches the evidence.
+
+Apply one outcome:
+
+- **Audit passes**: post an `IDD roadmap completion audit` comment with
+  a concise evidence summary, then close the roadmap. No task issue is
+  claimed. Return to A1 and select the next open roadmap, if any.
+- **Autonomous gaps found**: create or link follow-up issues using the
+  repository's issue-authoring rules, update the roadmap task list with
+  those links, and continue to A2 so the new work can be discovered.
+- **Non-autonomous gaps found**: comment with the decision or human
+  blocker, apply `status:needs-decision` or `status:blocked-by-human`
+  when those labels exist, and do not close the roadmap. Continue or
+  stop according to the normal Discover readiness rules.
+
 ## A2 — Enumerate sub-issues
 
-Starting from the roadmap found in A1, recursively collect all issues it
-references. Include transitively referenced issues. Collect only
-**open** issues.
+Starting from the roadmap found in A1 and not closed by A1.5,
+recursively collect all issues it references. Include transitively
+referenced issues. Collect only **open** issues.
 
 **Allowed traversal sources** (outbound references only):
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -177,7 +177,11 @@ operator instruction. Specifically:
   find issues lacking `{{PROJECT_MARKER_PREFIX}}-roadmap-id` and
   `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers), and for the scoped
   `{{PROJECT_MARKER_PREFIX}}-roadmap-id` body-content lookup required by
-  A3's dependency-marker check.
+  A3's dependency-marker check. A1.5 may also run a narrow repo-wide
+  duplicate/reuse check for a specific autonomous gap before creating a
+  follow-up issue; the result may only prevent a duplicate or link an
+  existing issue back to the selected roadmap, not expand the candidate
+  set.
 - After a zero-result report at A3, an operator may grant a one-time
   opt-in for the current run, specifying an alternate scope. See
   `idd-discover.instructions.md` for the full decision tree.

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -126,7 +126,9 @@ A1.5 roadmap completion audit side effects use the roadmap issue itself
 as the claim target. Even when the audit is GitHub-only and does not
 create a worktree, claim and re-validate the roadmap issue before
 commenting, editing, labeling, creating linked follow-up issues, or
-closing it.
+closing it. A1.5 coordination-only claims use a
+`roadmap-audit/<number>-<slug>` branch field so resume can distinguish
+them from normal implementation claims.
 
 ## Abort
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -122,6 +122,12 @@ issue and parse the active claim. The active claim must still use your
 current `{claim-id}`. If it does not, the claim was lost. Stop, do not
 post further operational comments, and report the handoff or race.
 
+A1.5 roadmap completion audit side effects use the roadmap issue itself
+as the claim target. Even when the audit is GitHub-only and does not
+create a worktree, claim and re-validate the roadmap issue before
+commenting, editing, labeling, creating linked follow-up issues, or
+closing it.
+
 ## Abort
 
 On abort, re-validate ownership first. If the active claim still uses

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -63,6 +63,12 @@ A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the
 active claim you are taking over, or in the latest released claim.
 
+If the active or inherited branch field starts with `roadmap-audit/`,
+the claim is an A1.5 roadmap-audit coordination claim, not a work branch.
+After the re-claim or takeover is verified, do not create a branch or
+worktree and do not use the Step 2 worktree table. Re-run A1.5 for that
+roadmap issue, then follow A1.5's close, release, or stop behavior.
+
 ## Step 2 — Locate or restore branch and worktree
 
 When any row below requires creating a worktree, follow the B1

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -88,7 +88,9 @@ can audit whether all explicitly referenced child work is complete
 before selecting the next issue. Passing audits post a concise evidence
 summary and close the roadmap; failing audits either add/link
 autonomous follow-up issues or route human-dependent gaps to an explicit
-blocked or needs-decision state.
+blocked or needs-decision state. Roadmap-level side effects still use a
+temporary claim on the roadmap issue itself, so concurrent agents do not
+close or edit the same roadmap at the same time.
 
 This audit intentionally lives before A2 rather than in F4. F4 is
 limited to the PR that just merged and the local cleanup for that child

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -42,7 +42,7 @@ entry file should be an explicit operator choice, not the default.
 | File                                                       | Role                                                                   |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping |
-| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue to start                                    |
+| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue and audit completed roadmaps                |
 | `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                            |
 | `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                  |
 | `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                   |
@@ -80,6 +80,20 @@ these instruction files are not agent-native `SKILL.md` bundles.
 The distributed workflow remains an instruction template first. Native
 skills can sit beside it as optional helpers, but they do not replace
 these execution-layer files.
+
+## Roadmap completion audits
+
+Discover owns roadmap-level state. After it finds an open roadmap, it
+can audit whether all explicitly referenced child work is complete
+before selecting the next issue. Passing audits post a concise evidence
+summary and close the roadmap; failing audits either add/link
+autonomous follow-up issues or route human-dependent gaps to an explicit
+blocked or needs-decision state.
+
+This audit intentionally lives before A2 rather than in F4. F4 is
+limited to the PR that just merged and the local cleanup for that child
+issue. F5 then loops back to Discover, where roadmap completion can be
+checked with the broader parent context.
 
 ## Copilot review instruction scope
 


### PR DESCRIPTION
## Summary

- Add an A1.5 roadmap completion audit step between Discover A1 and A2.
- Define safe pass, autonomous-gap, and non-autonomous-gap outcomes for completed roadmap audits.
- Mirror the discover flow update into `idd-template/` and update workflow docs to explain why the audit belongs in Discover rather than F4.

## Verification

- `npx dprint fmt "**/*.md"`
- `npx markdownlint-cli2 --fix "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx dprint check "**/*.md"`
- `node scripts/audit-docs.mjs --check`
- `npx cspell lint "**" --no-progress`
- `git diff --check`

## Follow-up issues

None.

Closes #101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a Discover roadmap completion audit step (A1.5) between roadmap selection and A2 that audits explicit child work and results in: pass (post audit and close), autonomous follow-ups (create/link follow-ups and update roadmap), or non-autonomous blockers (post decision and keep open). A2 runs only if the roadmap wasn’t closed by A1.5.

* **Documentation**
  * Workflow docs updated to specify A1.5 placement, evidence-based audits, claim re-validation, re-fetching state before actions, and an A1.5-scoped narrow duplicate/reuse check.

* **Chores**
  * Resume logic treats branches prefixed with roadmap-audit/ as coordination claims (no worktree creation).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/105)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->