### PR TITLE
docs(idd): add explicit issue target path

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -1,8 +1,9 @@
 # IDD — Claim Phase (A5)
 
-Read this file after picking an issue (A4) or after a successful
-re-claim decision in the resume phase. It covers the four pre-checks,
-claim execution, and claim verification.
+Read this file after picking an issue (A4), after verifying an explicit
+issue target (A0-T), or after a successful re-claim decision in the
+resume phase. It covers the four pre-checks, claim execution, and claim
+verification.
 
 ## Pre-checks (all four must pass)
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -1,11 +1,52 @@
-# IDD — Discover Phase (A0–A4)
+# IDD — Discover Phase (A0-T–A4)
 
 Read this file when starting a new task. It covers finding and selecting
-the next issue to work on. After selecting, read
+the next issue to work on, including an operator-provided exact issue
+target. After selecting or verifying a target, read
 `idd-claim.instructions.md` to claim it.
 
-**Abort conditions**: A1, A3 (default; see decision tree). **Early stop
-condition**: A4 (no claim made — see below).
+**Abort conditions**: A0-T, A1, A3 (default; see decision tree).
+**Early stop condition**: A0-T or A4 (no claim made — see below).
+
+## A0-T — Explicit issue target shortcut
+
+Use this shortcut only when the current operator request contains one
+unambiguous issue target in the current repository: either a single issue
+number such as `#123` or a single issue URL whose owner and repository
+match the current repository.
+
+Do not use this shortcut for ambiguous inputs, multiple issue numbers,
+cross-repository issue URLs, closed issues, inaccessible issues, pull
+requests, discussions, commits, or any other non-issue target. Report the
+reason and stop without claiming. Fall back to normal discovery only when
+the operator explicitly asks for normal discovery in the same run; do not
+silently search for another issue.
+
+For a valid open target, skip A0-O, A1, A1.5, A2, and candidate
+selection. Before A5, run targeted readiness and viability checks against
+that issue only:
+
+1. Re-fetch the target issue.
+2. Apply the same readiness intent as A3 to the target:
+   - no `status:blocked-by-human` or `status:needs-decision` label;
+   - no open dependent issues, except parent epics or aggregate issues
+     that are acceptable under A3;
+   - visible `Blocked by #NNN` references resolve to closed or otherwise
+     completed issues, with unresolved references treated as blocked;
+   - hidden `<!-- idd-skill-blocked-by: {roadmap-id} -->` markers
+     resolve through the same scoped body-content lookup used by A3, and
+     the matching roadmap work is closed or otherwise complete;
+   - no external human coordination is required to start.
+3. Run the normal A4 viability gate against the target only.
+
+If any targeted readiness or viability check fails, report the exact
+failed criterion and stop without claiming. Do not fall back to another
+issue unless the operator explicitly asks for normal discovery in the
+same run.
+
+If all checks pass, the target is selected. Continue directly to
+`idd-claim.instructions.md` A5. A5 claim-state, open-PR, takeover,
+branch-collision, and claim-verification rules remain unchanged.
 
 ## A0 — Check issue-scope setting
 
@@ -50,6 +91,8 @@ by the `roadmap` label (project field) or by recognizing it as an
 umbrella issue. If no roadmap issue exists, report and abort.
 
 **Note**: Repo-wide or label-based issue queries are permitted only in
+**A0-T** (the scoped `idd-skill-roadmap-id` lookup needed to resolve the
+explicit target's `idd-skill-blocked-by` markers),
 **A0-O** (when `issue-scope` is `orphan-first`, to find orphan issues),
 **A1** (to locate the roadmap), **A1.5** (narrow duplicate/reuse lookup
 for one specific autonomous gap), and **A3** (narrow body-content lookup
@@ -184,6 +227,10 @@ include only **open** issues in the A2 candidate set.
 **Permitted repo-wide queries** — only the following scoped lookups may
 touch issues outside the roadmap traversal graph:
 
+- **A0-T only**: the scoped body-content lookup needed to resolve
+  `idd-skill-blocked-by` markers on the explicit target. The result is
+  used solely to determine targeted readiness and is not added to any
+  candidate set.
 - **A0-O only** (when `issue-scope` is `orphan-first`): a repo-wide
   open-issue query to find issues without `roadmap-id` or `blocked-by`
   markers.

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -172,8 +172,14 @@ Agents must not widen issue-selection scope beyond what the roadmap
 explicitly references (directly or transitively) without explicit
 operator instruction. Specifically:
 
+- A single explicit issue target provided by the operator in the current
+  run is explicit operator instruction for that one issue only. Use the
+  A0-T path in `idd-discover.instructions.md`; do not use the target as
+  permission to search for alternate issues.
 - Repo-wide searches (`gh issue list`, `gh search`, label-based queries)
   are permitted only in **A1** (to locate the roadmap itself), in
+  **A0-T** for the scoped body-content lookup needed to resolve the
+  explicit target's `idd-skill-blocked-by` markers, in
   **A0-O** when `issue-scope` is `orphan-first` (body-content filter to
   find issues lacking `idd-skill-roadmap-id` and
   `idd-skill-blocked-by` markers), and for the scoped
@@ -261,19 +267,20 @@ replace that command with `true` — the same no-op convention used by
 Start by reading this file for shared definitions, then load the phase
 file that matches your current situation.
 
-| Situation                                   | Read this file                                                   |
-| ------------------------------------------- | ---------------------------------------------------------------- |
-| Starting fresh (no active claim)            | `idd-discover.instructions.md`, then `idd-claim.instructions.md` |
-| Resuming after crash / rate-limit / handoff | `idd-resume.instructions.md`                                     |
-| Claimed, branch exists, no PR yet           | `idd-work.instructions.md`                                       |
-| PR open, CI running, no reviews yet         | `idd-pr-submit.instructions.md`                                  |
-| PR open, CI running, reviews exist          | `idd-review-snapshot.instructions.md` (E1–E3)                    |
-| PR open, CI passed, no reviews yet          | `idd-review-snapshot.instructions.md` (E3 empty-list → merge)    |
-| PR open, CI passed, reviews pending         | `idd-review-snapshot.instructions.md`                            |
-| Snapshot done, List A non-empty             | `idd-review-triage.instructions.md` (E4–E8)                      |
-| Review feedback accepted, pushing fixes     | `idd-review-fix.instructions.md`                                 |
-| Ready for pre-merge gate check              | `idd-pre-merge.instructions.md`                                  |
-| All pre-merge conditions satisfied          | `idd-merge.instructions.md`                                      |
+| Situation                                     | Read this file                                                        |
+| --------------------------------------------- | --------------------------------------------------------------------- |
+| Starting fresh (no active claim)              | `idd-discover.instructions.md`, then `idd-claim.instructions.md`      |
+| Starting fresh with one explicit issue target | `idd-discover.instructions.md` A0-T, then `idd-claim.instructions.md` |
+| Resuming after crash / rate-limit / handoff   | `idd-resume.instructions.md`                                          |
+| Claimed, branch exists, no PR yet             | `idd-work.instructions.md`                                            |
+| PR open, CI running, no reviews yet           | `idd-pr-submit.instructions.md`                                       |
+| PR open, CI running, reviews exist            | `idd-review-snapshot.instructions.md` (E1–E3)                         |
+| PR open, CI passed, no reviews yet            | `idd-review-snapshot.instructions.md` (E3 empty-list → merge)         |
+| PR open, CI passed, reviews pending           | `idd-review-snapshot.instructions.md`                                 |
+| Snapshot done, List A non-empty               | `idd-review-triage.instructions.md` (E4–E8)                           |
+| Review feedback accepted, pushing fixes       | `idd-review-fix.instructions.md`                                      |
+| Ready for pre-merge gate check                | `idd-pre-merge.instructions.md`                                       |
+| All pre-merge conditions satisfied            | `idd-merge.instructions.md`                                           |
 
 CI polling logic shared by D and E phases lives in
 `idd-ci.instructions.md`; callers declare their own on-success target.

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -83,6 +83,11 @@ instruction template first. Native skills can sit beside it as helpers,
 but the synchronization contract for the portable workflow remains
 between the live `.github/instructions/` files and `idd-template/`.
 
+When an operator gives exactly one issue target, Discover can verify that
+target directly before Claim. The shortcut avoids broad roadmap
+enumeration, but it still applies targeted readiness checks and the A4
+viability gate before the normal A5 claim safety checks.
+
 ## Roadmap completion audits
 
 Discover owns roadmap-level state. After it finds an open roadmap, it

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -1,8 +1,9 @@
 # IDD — Claim Phase (A5)
 
-Read this file after picking an issue (A4) or after a successful
-re-claim decision in the resume phase. It covers the four pre-checks,
-claim execution, and claim verification.
+Read this file after picking an issue (A4), after verifying an explicit
+issue target (A0-T), or after a successful re-claim decision in the
+resume phase. It covers the four pre-checks, claim execution, and claim
+verification.
 
 ## Pre-checks (all four must pass)
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -1,11 +1,53 @@
-# IDD — Discover Phase (A0–A4)
+# IDD — Discover Phase (A0-T–A4)
 
 Read this file when starting a new task. It covers finding and selecting
-the next issue to work on. After selecting, read
+the next issue to work on, including an operator-provided exact issue
+target. After selecting or verifying a target, read
 `idd-claim.instructions.md` to claim it.
 
-**Abort conditions**: A1, A3 (default; see decision tree). **Early stop
-condition**: A4 (no claim made — see below).
+**Abort conditions**: A0-T, A1, A3 (default; see decision tree).
+**Early stop condition**: A0-T or A4 (no claim made — see below).
+
+## A0-T — Explicit issue target shortcut
+
+Use this shortcut only when the current operator request contains one
+unambiguous issue target in the current repository: either a single issue
+number such as `#123` or a single issue URL whose owner and repository
+match the current repository.
+
+Do not use this shortcut for ambiguous inputs, multiple issue numbers,
+cross-repository issue URLs, closed issues, inaccessible issues, pull
+requests, discussions, commits, or any other non-issue target. Report the
+reason and stop without claiming. Fall back to normal discovery only when
+the operator explicitly asks for normal discovery in the same run; do not
+silently search for another issue.
+
+For a valid open target, skip A0-O, A1, A1.5, A2, and candidate
+selection. Before A5, run targeted readiness and viability checks against
+that issue only:
+
+1. Re-fetch the target issue.
+2. Apply the same readiness intent as A3 to the target:
+   - no `status:blocked-by-human` or `status:needs-decision` label;
+   - no open dependent issues, except parent epics or aggregate issues
+     that are acceptable under A3;
+   - visible `Blocked by #NNN` references resolve to closed or otherwise
+     completed issues, with unresolved references treated as blocked;
+   - hidden
+     `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: {roadmap-id} -->`
+     markers resolve through the same scoped body-content lookup used by
+     A3, and the matching roadmap work is closed or otherwise complete;
+   - no external human coordination is required to start.
+3. Run the normal A4 viability gate against the target only.
+
+If any targeted readiness or viability check fails, report the exact
+failed criterion and stop without claiming. Do not fall back to another
+issue unless the operator explicitly asks for normal discovery in the
+same run.
+
+If all checks pass, the target is selected. Continue directly to
+`idd-claim.instructions.md` A5. A5 claim-state, open-PR, takeover,
+branch-collision, and claim-verification rules remain unchanged.
 
 ## A0 — Check issue-scope setting
 
@@ -52,6 +94,9 @@ by the `roadmap` label (project field) or by recognizing it as an
 umbrella issue. If no roadmap issue exists, report and abort.
 
 **Note**: Repo-wide or label-based issue queries are permitted only in
+**A0-T** (the scoped `{{PROJECT_MARKER_PREFIX}}-roadmap-id` lookup
+needed to resolve the explicit target's
+`{{PROJECT_MARKER_PREFIX}}-blocked-by` markers),
 **A0-O** (when `issue-scope` is `orphan-first`, to find orphan issues),
 **A1** (to locate the roadmap), **A1.5** (narrow duplicate/reuse lookup
 for one specific autonomous gap), and **A3** (narrow body-content lookup
@@ -187,6 +232,10 @@ include only **open** issues in the A2 candidate set.
 **Permitted repo-wide queries** — only the following scoped lookups may
 touch issues outside the roadmap traversal graph:
 
+- **A0-T only**: the scoped body-content lookup needed to resolve
+  `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers on the explicit target.
+  The result is used solely to determine targeted readiness and is not
+  added to any candidate set.
 - **A0-O only** (when `issue-scope` is `orphan-first`): a repo-wide
   open-issue query to find issues without
   `{{PROJECT_MARKER_PREFIX}}-roadmap-id` or

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -173,8 +173,14 @@ Agents must not widen issue-selection scope beyond what the roadmap
 explicitly references (directly or transitively) without explicit
 operator instruction. Specifically:
 
+- A single explicit issue target provided by the operator in the current
+  run is explicit operator instruction for that one issue only. Use the
+  A0-T path in `idd-discover.instructions.md`; do not use the target as
+  permission to search for alternate issues.
 - Repo-wide searches (`gh issue list`, `gh search`, label-based queries)
   are permitted only in **A1** (to locate the roadmap itself), in
+  **A0-T** for the scoped body-content lookup needed to resolve the
+  explicit target's `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers, in
   **A0-O** when `issue-scope` is `orphan-first` (body-content filter to
   find issues lacking `{{PROJECT_MARKER_PREFIX}}-roadmap-id` and
   `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers), and for the scoped
@@ -263,19 +269,20 @@ project has no install step.
 Start by reading this file for shared definitions, then load the phase
 file that matches your current situation.
 
-| Situation                                   | Read this file                                                   |
-| ------------------------------------------- | ---------------------------------------------------------------- |
-| Starting fresh (no active claim)            | `idd-discover.instructions.md`, then `idd-claim.instructions.md` |
-| Resuming after crash / rate-limit / handoff | `idd-resume.instructions.md`                                     |
-| Claimed, branch exists, no PR yet           | `idd-work.instructions.md`                                       |
-| PR open, CI running, no reviews yet         | `idd-pr-submit.instructions.md`                                  |
-| PR open, CI running, reviews exist          | `idd-review-snapshot.instructions.md` (E1–E3)                    |
-| PR open, CI passed, no reviews yet          | `idd-review-snapshot.instructions.md` (E3 empty-list → merge)    |
-| PR open, CI passed, reviews pending         | `idd-review-snapshot.instructions.md`                            |
-| Snapshot done, List A non-empty             | `idd-review-triage.instructions.md` (E4–E8)                      |
-| Review feedback accepted, pushing fixes     | `idd-review-fix.instructions.md`                                 |
-| Ready for pre-merge gate check              | `idd-pre-merge.instructions.md`                                  |
-| All pre-merge conditions satisfied          | `idd-merge.instructions.md`                                      |
+| Situation                                     | Read this file                                                        |
+| --------------------------------------------- | --------------------------------------------------------------------- |
+| Starting fresh (no active claim)              | `idd-discover.instructions.md`, then `idd-claim.instructions.md`      |
+| Starting fresh with one explicit issue target | `idd-discover.instructions.md` A0-T, then `idd-claim.instructions.md` |
+| Resuming after crash / rate-limit / handoff   | `idd-resume.instructions.md`                                          |
+| Claimed, branch exists, no PR yet             | `idd-work.instructions.md`                                            |
+| PR open, CI running, no reviews yet           | `idd-pr-submit.instructions.md`                                       |
+| PR open, CI running, reviews exist            | `idd-review-snapshot.instructions.md` (E1–E3)                         |
+| PR open, CI passed, no reviews yet            | `idd-review-snapshot.instructions.md` (E3 empty-list → merge)         |
+| PR open, CI passed, reviews pending           | `idd-review-snapshot.instructions.md`                                 |
+| Snapshot done, List A non-empty               | `idd-review-triage.instructions.md` (E4–E8)                           |
+| Review feedback accepted, pushing fixes       | `idd-review-fix.instructions.md`                                      |
+| Ready for pre-merge gate check                | `idd-pre-merge.instructions.md`                                       |
+| All pre-merge conditions satisfied            | `idd-merge.instructions.md`                                           |
 
 CI polling logic shared by D and E phases lives in
 `idd-ci.instructions.md`; callers declare their own on-success target.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -81,6 +81,11 @@ The distributed workflow remains an instruction template first. Native
 skills can sit beside it as optional helpers, but they do not replace
 these execution-layer files.
 
+When an operator gives exactly one issue target, Discover can verify that
+target directly before Claim. The shortcut avoids broad roadmap
+enumeration, but it still applies targeted readiness checks and the A4
+viability gate before the normal A5 claim safety checks.
+
 ## Roadmap completion audits
 
 Discover owns roadmap-level state. After it finds an open roadmap, it


### PR DESCRIPTION
## Summary

- add an A0-T explicit issue target path before normal discovery
- keep targeted readiness and A4 viability checks before A5 claim safety
- mirror the route in overview, claim entry wording, workflow docs, and idd-template

Closes #107

## Validation

- npx dprint check "**/*.md"
- npx markdownlint-cli2 "**/*.md"
- npx cspell lint "**" --no-progress
- node scripts/audit-docs.mjs --check

## Follow-up

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced explicit issue target shortcut workflow enabling direct verification when operator provides a single issue target
  * Enhanced blocked-by dependency handling with new targeted readiness and viability checks
  * Clarified scope invariants specifying that operator-provided targets authorize only that specific issue
  * Expanded phase routing table with updated guidance for improved workflow decision-making

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->