### PR TITLE
fix(idd): broaden cleanup bot coverage

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -108,7 +108,10 @@ gate. The active claim must still use your current `{claim-id}`.
    - Known review-bot regular PR comments may be minimized only after
      the PR is merged and the comment has a clear completed-review or
      stale-notification signal, such as a CodeRabbit no-action summary
-     or review-trigger acknowledgement with later IDD disposition.
+     or a CodeRabbit summary / review-trigger acknowledgement with a
+     matching later IDD disposition. CodeRabbit summaries may also be
+     minimized when all CodeRabbit review threads are resolved and have
+     fresh IDD dispositions.
    - Bot review parent bodies without associated review threads are
      skipped by default, including Copilot error review bodies, unless a
      future policy explicitly narrows a safe cleanup class for them.

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -105,6 +105,13 @@ gate. The active claim must still use your current `{claim-id}`.
      only after every actionable child review comment/thread under that
      parent has been accepted or rejected, replied to as required, and
      resolved.
+   - Known review-bot regular PR comments may be minimized only after
+     the PR is merged and the comment has a clear completed-review or
+     stale-notification signal, such as a CodeRabbit no-action summary
+     or review-trigger acknowledgement with later IDD disposition.
+   - Bot review parent bodies without associated review threads are
+     skipped by default, including Copilot error review bodies, unless a
+     future policy explicitly narrows a safe cleanup class for them.
    - IDD operational marker comments may be minimized as `OUTDATED`
      only after the PR is merged and the marker is no longer needed for
      resume, advisory wait, or review-currency checks.

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -82,6 +82,22 @@ when all of these are true:
 - the reviewer has no active `CHANGES_REQUESTED` state that still gates
   the PR
 
+Known review-bot regular PR comments may be minimized after merge only
+when they have a clear completed-review or stale-notification signal.
+Current safe classes are:
+
+- CodeRabbit summary / walkthrough comments that explicitly report no
+  actionable comments
+- CodeRabbit summary / walkthrough comments that have a later IDD
+  accept/reject disposition and no unresolved known-bot review threads
+- CodeRabbit review-trigger acknowledgements after a later IDD
+  disposition confirms the requested review completed
+
+Bot review parent bodies with no associated review threads are skipped
+by design, including Copilot error review bodies. They remain visible
+until a narrower policy proves that hiding them cannot obscure advisory
+review state or maintainer-relevant context.
+
 IDD operational marker comments may be minimized as `OUTDATED` only when
 the PR is merged and the marker is no longer needed for resume, advisory
 wait, or review-currency checks. Candidate prefixes are:
@@ -134,7 +150,9 @@ must include the skip reason.
 The helper also reports skipped cleanup-shaped nodes with reasons such
 as already minimized, no minimization permission, unresolved associated
 review threads, missing accept/reject dispositions, unsafe hold or
-decision context, or a non-merged PR.
+decision context, no completed-review signal on a known-bot regular
+comment, no associated review threads on a bot review parent, or a
+non-merged PR.
 
 ## Apply Shape
 

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -88,10 +88,13 @@ Current safe classes are:
 
 - CodeRabbit summary / walkthrough comments that explicitly report no
   actionable comments
-- CodeRabbit summary / walkthrough comments that have a later IDD
-  accept/reject disposition and no unresolved known-bot review threads
+- CodeRabbit summary / walkthrough comments that have no unresolved
+  known-bot review threads and either a later IDD disposition that names
+  CodeRabbit or resolved CodeRabbit review threads with fresh IDD
+  dispositions
 - CodeRabbit review-trigger acknowledgements after a later IDD
-  disposition confirms the requested review completed
+  disposition that names CodeRabbit confirms the requested review
+  completed
 
 Bot review parent bodies with no associated review threads are skipped
 by design, including Copilot error review bodies. They remain visible

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -26,6 +26,8 @@ The cleanup helper is intentionally narrower than E/F gate helpers:
   is requested
 - apply mode is explicit and can re-validate an active claim before
   every minimization mutation
+- known review-bot regular comments are considered only after merge and
+  only when they match a completed-review or stale-notification signal
 - cleanup remains best-effort and never becomes a merge gate
 - direct GraphQL fallback commands remain documented in
   `docs/idd-comment-minimization.md`

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -108,7 +108,10 @@ gate. The active claim must still use your current `{claim-id}`.
    - Known review-bot regular PR comments may be minimized only after
      the PR is merged and the comment has a clear completed-review or
      stale-notification signal, such as a CodeRabbit no-action summary
-     or review-trigger acknowledgement with later IDD disposition.
+     or a CodeRabbit summary / review-trigger acknowledgement with a
+     matching later IDD disposition. CodeRabbit summaries may also be
+     minimized when all CodeRabbit review threads are resolved and have
+     fresh IDD dispositions.
    - Bot review parent bodies without associated review threads are
      skipped by default, including Copilot error review bodies, unless a
      future policy explicitly narrows a safe cleanup class for them.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -105,6 +105,13 @@ gate. The active claim must still use your current `{claim-id}`.
      only after every actionable child review comment/thread under that
      parent has been accepted or rejected, replied to as required, and
      resolved.
+   - Known review-bot regular PR comments may be minimized only after
+     the PR is merged and the comment has a clear completed-review or
+     stale-notification signal, such as a CodeRabbit no-action summary
+     or review-trigger acknowledgement with later IDD disposition.
+   - Bot review parent bodies without associated review threads are
+     skipped by default, including Copilot error review bodies, unless a
+     future policy explicitly narrows a safe cleanup class for them.
    - IDD operational marker comments may be minimized as `OUTDATED`
      only after the PR is merged and the marker is no longer needed for
      resume, advisory wait, or review-currency checks.

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -82,6 +82,22 @@ when all of these are true:
 - the reviewer has no active `CHANGES_REQUESTED` state that still gates
   the PR
 
+Known review-bot regular PR comments may be minimized after merge only
+when they have a clear completed-review or stale-notification signal.
+Current safe classes are:
+
+- CodeRabbit summary / walkthrough comments that explicitly report no
+  actionable comments
+- CodeRabbit summary / walkthrough comments that have a later IDD
+  accept/reject disposition and no unresolved known-bot review threads
+- CodeRabbit review-trigger acknowledgements after a later IDD
+  disposition confirms the requested review completed
+
+Bot review parent bodies with no associated review threads are skipped
+by design, including Copilot error review bodies. They remain visible
+until a narrower policy proves that hiding them cannot obscure advisory
+review state or maintainer-relevant context.
+
 IDD operational marker comments may be minimized as `OUTDATED` only when
 the PR is merged and the marker is no longer needed for resume, advisory
 wait, or review-currency checks. Candidate prefixes are:
@@ -134,7 +150,9 @@ must include the skip reason.
 The helper also reports skipped cleanup-shaped nodes with reasons such
 as already minimized, no minimization permission, unresolved associated
 review threads, missing accept/reject dispositions, unsafe hold or
-decision context, or a non-merged PR.
+decision context, no completed-review signal on a known-bot regular
+comment, no associated review threads on a bot review parent, or a
+non-merged PR.
 
 ## Apply Shape
 

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -88,10 +88,13 @@ Current safe classes are:
 
 - CodeRabbit summary / walkthrough comments that explicitly report no
   actionable comments
-- CodeRabbit summary / walkthrough comments that have a later IDD
-  accept/reject disposition and no unresolved known-bot review threads
+- CodeRabbit summary / walkthrough comments that have no unresolved
+  known-bot review threads and either a later IDD disposition that names
+  CodeRabbit or resolved CodeRabbit review threads with fresh IDD
+  dispositions
 - CodeRabbit review-trigger acknowledgements after a later IDD
-  disposition confirms the requested review completed
+  disposition that names CodeRabbit confirms the requested review
+  completed
 
 Bot review parent bodies with no associated review threads are skipped
 by design, including Copilot error review bodies. They remain visible

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -26,6 +26,8 @@ The cleanup helper is intentionally narrower than E/F gate helpers:
   is requested
 - apply mode is explicit and can re-validate an active claim before
   every minimization mutation
+- known review-bot regular comments are considered only after merge and
+  only when they match a completed-review or stale-notification signal
 - cleanup remains best-effort and never becomes a merge gate
 - direct GraphQL fallback commands remain documented in
   `docs/idd-comment-minimization.md`

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -480,10 +480,13 @@ function classifyRegularBotComment(comment, comments, threads) {
         reason: "CodeRabbit completed summary reported no actionable comments",
       };
     }
-    if (hasExplicitDispositionAfter(comment, comments)) {
+    if (
+      hasExplicitDispositionAfter(comment, comments)
+      || hasCompletedBotThreadDispositions(threads, isCodeRabbitLogin)
+    ) {
       return {
         classifier: "RESOLVED",
-        reason: "CodeRabbit completed summary has a later IDD disposition and no unresolved bot threads",
+        reason: "CodeRabbit completed summary has matched IDD disposition evidence",
       };
     }
     return null;
@@ -508,16 +511,33 @@ function isCodeRabbitLogin(login) {
 }
 
 function hasExplicitDispositionAfter(targetComment, comments) {
-  const targetTime = Date.parse(targetComment.updatedAt ?? targetComment.createdAt ?? "");
+  const targetTime = Date.parse(targetComment.createdAt ?? "");
   return comments.some((comment) => {
     const author = comment.author?.login ?? "";
     if (isKnownReviewBot(author) || !isDispositionComment(comment)) {
       return false;
     }
-    const dispositionTime = Date.parse(comment.updatedAt ?? comment.createdAt ?? "");
+    if (!/\bCodeRabbit\b/i.test(comment.body ?? "")) {
+      return false;
+    }
+    const dispositionTime = Date.parse(comment.createdAt ?? "");
     return Number.isFinite(targetTime)
       && Number.isFinite(dispositionTime)
       && dispositionTime > targetTime;
+  });
+}
+
+function hasCompletedBotThreadDispositions(threads, loginPredicate) {
+  const botThreads = threads.filter((thread) => {
+    return (thread.comments?.nodes ?? []).some((comment) => {
+      return loginPredicate(comment.author?.login ?? "") && !isDispositionComment(comment);
+    });
+  });
+
+  return botThreads.length > 0 && botThreads.every((thread) => {
+    return thread.isResolved
+      && !thread.comments?.pageInfo?.hasNextPage
+      && hasFreshDisposition(thread);
   });
 }
 

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -2,6 +2,8 @@
 
 import { execFileSync } from "node:child_process";
 
+const ISO8601_UTC_WITH_OPTIONAL_FRACTION = String.raw`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z`;
+
 const OPERATIONAL_MARKERS = [
   {
     label: "<!-- review-watermark:",
@@ -13,11 +15,15 @@ const OPERATIONAL_MARKERS = [
   },
   {
     label: "advisory-wait:",
-    pattern: /^advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*$/,
+    pattern: new RegExp(
+      `^advisory-wait:\\s+\\S+\\s+[0-9a-f]{40}\\s+${ISO8601_UTC_WITH_OPTIONAL_FRACTION}\\s*$`,
+    ),
   },
   {
     label: "advisory-wait-recovery:",
-    pattern: /^advisory-wait-recovery:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*$/,
+    pattern: new RegExp(
+      `^advisory-wait-recovery:\\s+\\S+\\s+[0-9a-f]{40}\\s+${ISO8601_UTC_WITH_OPTIONAL_FRACTION}\\s*$`,
+    ),
   },
   {
     label: "<!-- advisory-wait:",
@@ -160,7 +166,10 @@ async function buildReport(owner, repo, prNumber, options = {}) {
   };
 
   for (const comment of comments) {
-    evaluateOperationalComment(comment, pr, report);
+    if (evaluateOperationalComment(comment, pr, report)) {
+      continue;
+    }
+    evaluateRegularBotComment(comment, comments, threads, pr, report);
   }
 
   for (const thread of threads) {
@@ -177,17 +186,55 @@ async function buildReport(owner, repo, prNumber, options = {}) {
 function evaluateOperationalComment(comment, pr, report) {
   const prefix = operationalMarkerPrefix(comment.body);
   if (!prefix) {
-    return;
+    return false;
   }
 
   const subject = subjectFromNode(comment, "IssueComment", "OUTDATED");
 
   if (!pr.merged) {
     addSkipped(report, subject, "PR is not merged");
-    return;
+    return true;
   }
 
   const unsafeReason = unsafeTextReason(comment.body);
+  if (unsafeReason) {
+    addSkipped(report, subject, unsafeReason);
+    return true;
+  }
+
+  if (comment.isMinimized) {
+    addSkipped(report, subject, "already minimized");
+    return true;
+  }
+
+  if (!comment.viewerCanMinimize) {
+    addSkipped(report, subject, "viewer cannot minimize this comment");
+    return true;
+  }
+
+  report.candidates.push({
+    ...subject,
+    markerPrefix: prefix,
+    reason: "stale IDD operational marker on a merged PR",
+  });
+  return true;
+}
+
+function evaluateRegularBotComment(comment, comments, threads, pr, report) {
+  const author = comment.author?.login ?? "";
+  if (!isKnownReviewBot(author)) {
+    return;
+  }
+
+  const classification = classifyRegularBotComment(comment, comments, threads);
+  const subject = subjectFromNode(comment, "IssueComment", classification?.classifier ?? "RESOLVED");
+
+  if (!pr.merged) {
+    addSkipped(report, subject, "PR is not merged");
+    return;
+  }
+
+  const unsafeReason = unsafeTextReason(comment.body ?? "");
   if (unsafeReason) {
     addSkipped(report, subject, unsafeReason);
     return;
@@ -203,10 +250,15 @@ function evaluateOperationalComment(comment, pr, report) {
     return;
   }
 
+  if (!classification) {
+    addSkipped(report, subject, "known review-bot regular comment lacks a completed-review signal");
+    return;
+  }
+
   report.candidates.push({
     ...subject,
-    markerPrefix: prefix,
-    reason: "stale IDD operational marker on a merged PR",
+    author,
+    reason: classification.reason,
   });
 }
 
@@ -409,6 +461,77 @@ function isKnownReviewBot(login) {
   return REVIEW_BOT_LOGINS.has(normalized) || normalized.startsWith("copilot-pull-request-reviewer");
 }
 
+function classifyRegularBotComment(comment, comments, threads) {
+  const author = comment.author?.login ?? "";
+  if (!isCodeRabbitLogin(author)) {
+    return null;
+  }
+
+  if (hasUnresolvedKnownBotThreads(threads)) {
+    return null;
+  }
+
+  const body = (comment.body ?? "").trimStart();
+
+  if (body.startsWith("<!-- This is an auto-generated comment: summarize by coderabbit.ai -->")) {
+    if (/No actionable comments were generated/i.test(body)) {
+      return {
+        classifier: "RESOLVED",
+        reason: "CodeRabbit completed summary reported no actionable comments",
+      };
+    }
+    if (hasExplicitDispositionAfter(comment, comments)) {
+      return {
+        classifier: "RESOLVED",
+        reason: "CodeRabbit completed summary has a later IDD disposition and no unresolved bot threads",
+      };
+    }
+    return null;
+  }
+
+  if (body.startsWith("<!-- This is an auto-generated reply by CodeRabbit -->")) {
+    if (/\b(Review triggered|Sure! I'll review|I'll review)\b/i.test(body)
+      && hasExplicitDispositionAfter(comment, comments)) {
+      return {
+        classifier: "OUTDATED",
+        reason: "stale CodeRabbit review-trigger acknowledgement after completed review",
+      };
+    }
+  }
+
+  return null;
+}
+
+function isCodeRabbitLogin(login) {
+  const normalized = login.toLowerCase();
+  return normalized === "coderabbitai" || normalized === "coderabbitai[bot]";
+}
+
+function hasExplicitDispositionAfter(targetComment, comments) {
+  const targetTime = targetComment.updatedAt ?? targetComment.createdAt ?? "";
+  return comments.some((comment) => {
+    const author = comment.author?.login ?? "";
+    if (isKnownReviewBot(author) || !isDispositionComment(comment)) {
+      return false;
+    }
+    return (comment.createdAt ?? "") > targetTime;
+  });
+}
+
+function hasUnresolvedKnownBotThreads(threads) {
+  return threads.some((thread) => {
+    if (thread.isResolved) {
+      return false;
+    }
+    if (thread.comments?.pageInfo?.hasNextPage) {
+      return true;
+    }
+    return (thread.comments?.nodes ?? []).some((comment) => {
+      return isKnownReviewBot(comment.author?.login ?? "");
+    });
+  });
+}
+
 function indexLatestGatingReviewsByAuthor(reviews) {
   const index = new Map();
   for (const review of reviews) {
@@ -518,6 +641,7 @@ function fetchIssueComments(owner, repo, number, options = {}) {
             url
             body
             createdAt
+            updatedAt
             isMinimized
             minimizedReason
             viewerCanMinimize

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -508,13 +508,16 @@ function isCodeRabbitLogin(login) {
 }
 
 function hasExplicitDispositionAfter(targetComment, comments) {
-  const targetTime = targetComment.updatedAt ?? targetComment.createdAt ?? "";
+  const targetTime = Date.parse(targetComment.updatedAt ?? targetComment.createdAt ?? "");
   return comments.some((comment) => {
     const author = comment.author?.login ?? "";
     if (isKnownReviewBot(author) || !isDispositionComment(comment)) {
       return false;
     }
-    return (comment.createdAt ?? "") > targetTime;
+    const dispositionTime = Date.parse(comment.updatedAt ?? comment.createdAt ?? "");
+    return Number.isFinite(targetTime)
+      && Number.isFinite(dispositionTime)
+      && dispositionTime > targetTime;
   });
 }
 


### PR DESCRIPTION
## Summary

- recognize advisory-wait markers with optional fractional seconds
- classify safe CodeRabbit regular PR comments after merge
- document regular review-bot cleanup policy and the no-thread bot review parent skip policy

Closes #110

## Validation

- node --check scripts/audit-pr-cleanup.mjs
- node scripts/audit-pr-cleanup.mjs --pr 105 --dry-run --format json
- node scripts/audit-pr-cleanup.mjs --pr 108 --dry-run --format json
- npx dprint check "**/*.md"
- npx markdownlint-cli2 "**/*.md"
- npx cspell lint "**" --no-progress
- node scripts/audit-docs.mjs --check

## Follow-up

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Tightened guidance for minimizing known review-bot comments post-merge, requiring completed-review or stale-notification signals
  * Added explicit skip reasons and clarified helper-script dry-run/reporting behavior

* **Chores**
  * Improved audit and cleanup behavior: more precise bot-comment classification, safer skip rules for bot review parents, better operational-marker handling and timestamp parsing to reduce false positives
<!-- end of auto-generated comment: release notes by coderabbit.ai -->