### PR TITLE
fix(idd): guard same-agent claims

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -15,17 +15,15 @@ set. If the project is in use, the project status must be "not started".
 **(b) Claim state** — Re-read the issue and parse the **active claim**
 using the shared claim-state rules:
 
-- No active claim → unclaimed, proceed
-- Active claim held by a **different** agent ID and its latest valid
-  `claimed-by` comment has GitHub `created_at` < 24 h → claimed by
-  another agent, go back to A3
-- Active claim held by a **different** agent ID and its latest valid
-  `claimed-by` comment has GitHub `created_at` ≥ 24 h → stale, proceed
-  with takeover
-- Active claim held by **your own** agent ID → same-agent restart or
-  handoff detected. Do **not** silently inherit it; proceed with an
-  explicit takeover that uses a fresh `{claim-id}` and `supersedes:` the
-  current active claim's `{claim-id}`
+- No active claim → unclaimed, proceed.
+- Active claim already uses a `{claim-id}` that this current session has
+  verified and recorded → already claimed; do not post a new claim.
+  Continue with that same `{claim-id}`.
+- Any other active claim whose latest valid `claimed-by` comment has
+  GitHub `created_at` < 24 h → claimed by another live session, even
+  when the `agent-id` matches. Go back to A3.
+- Any other active claim whose latest valid `claimed-by` comment has
+  GitHub `created_at` ≥ 24 h → stale, proceed with takeover.
 
 Only the GitHub `created_at` of the latest **valid** `claimed-by`
 comment in the active claim counts toward the stale calculation.
@@ -39,12 +37,10 @@ claim exists.
 Otherwise, use the latest legacy `claimed-by` comment as a
 **migration-only** decision input:
 
-- Legacy claim held by a **different** agent ID and GitHub `created_at`
-  < 24 h → claimed by another agent, go back to A3
-- Legacy claim held by a **different** agent ID and GitHub `created_at`
-  ≥ 24 h → stale, proceed and replace it with a new-format claim
-- Legacy claim held by **your own** agent ID → same-agent restart or
-  handoff detected. Proceed and replace it with a new-format claim
+- Latest legacy claim has GitHub `created_at` < 24 h → claimed by
+  another live session, even when the `agent-id` matches. Go back to A3.
+- Latest legacy claim has GitHub `created_at` ≥ 24 h → stale, proceed
+  and replace it with a new-format claim.
 
 The migration claim uses a fresh `{claim-id}` and `supersedes: none`.
 
@@ -52,8 +48,8 @@ The migration claim uses a fresh `{claim-id}` and `supersedes: none`.
 that PR's head branch matches the `branch` field in an inheritable claim
 comment. An inheritable claim comment is either:
 
-- the currently active claim you are taking over (same-agent restart or
-  stale claim), or
+- the already verified active claim for this current session, or
+- the currently active stale claim you are taking over, or
 - the latest `claimed-by` comment that was later released by a matching
   `unclaimed-by` comment (the last voluntarily released branch), or
 - the latest legacy `claimed-by` comment when performing a legacy
@@ -72,17 +68,17 @@ field in an inheritable claim comment as defined in (c) above.
 Determine `{branch-name}`:
 
 - **Re-claim / takeover**: use the exact branch name from the
-  inheritable claim comment (the `branch` field of the active same-agent
-  or stale claim, the last-released `claimed-by`, or the legacy claim
-  being migrated). Do not compute a new name.
+  inheritable claim comment (the `branch` field of the active stale
+  claim, the last-released `claimed-by`, or the legacy claim being
+  migrated). Do not compute a new name.
 - **Fresh claim**: compute a new name using the IDD naming convention:
   `issue/<number>-<slug>` where `<slug>` is 2–5 lowercase hyphenated
   words describing the issue.
 
 Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
 
-- **Takeover of an active claim** (same-agent restart or handoff, or
-  stale claim recovery) → the current active claim's `{claim-id}`
+- **Takeover of an active claim** (stale claim recovery) → the current
+  active claim's `{claim-id}`
 - **Migration from a legacy claim** → `none`
 - **Fresh claim** or claim after a released / unclaimed state → `none`
 

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -65,6 +65,11 @@ field in an inheritable claim comment as defined in (c) above.
 
 ## Claim execution
 
+Skip this section if pre-check (b) classified the issue as already
+claimed by this current session. Keep the recorded `{claim-id}` and
+branch, then proceed directly to Claim verification without posting a new
+claim.
+
 Determine `{branch-name}`:
 
 - **Re-claim / takeover**: use the exact branch name from the

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -16,9 +16,10 @@ set. If the project is in use, the project status must be "not started".
 using the shared claim-state rules:
 
 - No active claim → unclaimed, proceed.
-- Active claim already uses a `{claim-id}` that this current session has
-  verified and recorded → already claimed; do not post a new claim.
-  Continue with that same `{claim-id}`.
+- Active claim already uses a `{claim-id}` that this current session had
+  recorded before this check and has now verified → already claimed; do
+  not post a new claim. Continue with that same `{claim-id}`. A token
+  first learned by parsing the current issue comments is not enough.
 - Any other active claim whose latest valid `claimed-by` comment has
   GitHub `created_at` < 24 h → claimed by another live session, even
   when the `agent-id` matches. Go back to A3.
@@ -66,7 +67,7 @@ field in an inheritable claim comment as defined in (c) above.
 ## Claim execution
 
 Skip this section if pre-check (b) classified the issue as already
-claimed by this current session. Keep the recorded `{claim-id}` and
+claimed by this current session. Keep the previously recorded `{claim-id}` and
 branch, then proceed directly to Claim verification without posting a new
 claim.
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -156,14 +156,19 @@ roadmap issue itself:
   the roadmap issue. Do not apply A5's assignee or project
   `not started` readiness gate to roadmap-audit claims; roadmap
   ownership and project status may represent parent coordination rather
-  than task readiness. If an active non-stale claim belongs to another
-  agent, do not mutate the roadmap; report the claim and continue to A2
-  or stop according to the normal ready-to-start rules.
-- If the roadmap is unclaimed, stale, or held by the same agent, post
-  and verify a normal `claimed-by` comment for the roadmap issue using a
+  than task readiness. If an active non-stale claim uses any
+  `{claim-id}` other than one already known and verified by this current
+  session, do not mutate the roadmap; report the claim and continue to
+  A2 or stop according to the normal ready-to-start rules. A matching
+  agent ID alone is not ownership proof.
+- If the roadmap is unclaimed or stale, post and verify a normal
+  `claimed-by` comment for the roadmap issue using a
   `roadmap-audit/<number>-<slug>` branch field. This is a logical
   coordination name, not a work branch, and it does not require creating
   a branch or worktree unless the audit also needs git changes.
+- If the active roadmap claim already uses this current session's
+  verified `{claim-id}`, continue with that same claim and do not post a
+  new claim.
 - Re-validate that roadmap claim before every roadmap comment, follow-up
   issue creation, body edit, label change, or close action.
 - If the roadmap remains open and no PR branch will continue from the

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -157,18 +157,20 @@ roadmap issue itself:
   `not started` readiness gate to roadmap-audit claims; roadmap
   ownership and project status may represent parent coordination rather
   than task readiness. If an active non-stale claim uses any
-  `{claim-id}` other than one already known and verified by this current
-  session, do not mutate the roadmap; report the claim and continue to
-  A2 or stop according to the normal ready-to-start rules. A matching
-  agent ID alone is not ownership proof.
+  `{claim-id}` other than one already recorded by this current session
+  before this check and now verified, do not mutate the roadmap; report
+  the claim and continue to A2 or stop according to the normal
+  ready-to-start rules. A matching agent ID alone is not ownership
+  proof, and neither is a token first learned by parsing the current
+  roadmap comments.
 - If the roadmap is unclaimed or stale, post and verify a normal
   `claimed-by` comment for the roadmap issue using a
   `roadmap-audit/<number>-<slug>` branch field. This is a logical
   coordination name, not a work branch, and it does not require creating
   a branch or worktree unless the audit also needs git changes.
 - If the active roadmap claim already uses this current session's
-  verified `{claim-id}`, continue with that same claim and do not post a
-  new claim.
+  previously recorded and verified `{claim-id}`, continue with that same
+  claim and do not post a new claim.
 - Re-validate that roadmap claim before every roadmap comment, follow-up
   issue creation, body edit, label change, or close action.
 - If the roadmap remains open and no PR branch will continue from the

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -26,12 +26,15 @@ include a short visible note after the HTML comment token (see
 `idd-review-snapshot.instructions.md` for the required format). `claimed-by`
 and `unclaimed-by` comments remain HTML-comment-only.
 
-- `{claim-id}` is an opaque unique token for one active claim lineage.
-  Generate a fresh value on every fresh claim or takeover. Reuse the
-  same `{claim-id}` only for heartbeats of that already-verified claim.
+- `{claim-id}` is an opaque unique token for one active claim lineage
+  and is the portable proof that the current session owns that claim.
+  Generate a fresh value on every fresh claim or stale takeover. Reuse
+  the same `{claim-id}` only for heartbeats of that already-verified
+  claim. A matching `{agent-id}` is never ownership proof by itself,
+  because separate live sessions can share the same agent ID.
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
-  For a takeover (same-agent restart, handoff, or stale-claim recovery),
-  set it to the currently active claim's `{claim-id}`.
+  For a stale-claim takeover, set it to the currently active claim's
+  `{claim-id}`.
 
 ## Unclaim format
 
@@ -54,11 +57,8 @@ chronologically and apply these rules:
    only if either:
    - there is no active claim AND its `supersedes:` value is `none`, or
    - its `supersedes:` value exactly matches the current active claim's
-     `{claim-id}`, and either:
-     - it uses the **same** agent ID as the current active claim
-       (explicit same-agent takeover), or
-     - the current active claim is already **stale** at the new
-       comment's GitHub `created_at` timestamp.
+     `{claim-id}`, and the current active claim is already **stale** at
+     the new comment's GitHub `created_at` timestamp.
 4. An `unclaimed-by` releases the claim only if its `{agent-id}` AND
    `{claim-id}` both match the current active claim. Otherwise ignore it
    as a stale release from a superseded session.
@@ -67,9 +67,13 @@ chronologically and apply these rules:
    superseded, or whose `supersedes:` value does not match the current
    active claim when one exists, is ignored as a stale or invalid event.
 
-Same-agent restarts never silently inherit an active claim. They must
-perform an explicit takeover with a fresh `{claim-id}` that
-`supersedes:` the currently active claim.
+Same-agent restarts never silently inherit or supersede an active
+non-stale claim. If the current session already knows and has verified
+the active `{claim-id}`, continue with that same token and use
+heartbeats; do not post a fresh takeover claim. If the session cannot
+prove ownership of the active `{claim-id}`, the active claim is treated
+as owned by another live session until it is released or stale, even
+when `{agent-id}` matches.
 
 ## Legacy claim migration
 
@@ -92,8 +96,9 @@ Treat these legacy comments as **migration-only** inputs:
   legacy `unclaimed-by` comment from the same agent. If so, treat the
   issue as **unclaimed**; skip directly to posting a fresh new-format
   claim with `supersedes: none`.
-- Otherwise, use the latest legacy claim to decide branch reuse,
-  staleness, and whether a same-agent resume is occurring.
+- Otherwise, use the latest legacy claim to decide branch reuse and
+  staleness. A matching legacy agent ID is not enough to prove same
+  live-session ownership.
 - Then immediately post a new-format `claimed-by` comment with a fresh
   `{claim-id}` before any further side effects.
 - Use `supersedes: none` for that one-time migration claim, because the
@@ -104,9 +109,9 @@ Treat these legacy comments as **migration-only** inputs:
 ## Thresholds
 
 - **Stale**: an active claim whose latest **valid** `claimed-by`
-  comment's GitHub `created_at` is ≥ 24 h ago. Another agent may take it
-  over by posting a fresh `{claim-id}` whose `supersedes:` value is that
-  active claim's `{claim-id}`.
+  comment's GitHub `created_at` is ≥ 24 h ago. Another session may take
+  it over by posting a fresh `{claim-id}` whose `supersedes:` value is
+  that active claim's `{claim-id}`.
 - **Heartbeat**: after re-validating ownership, re-post the claim
   comment every 12 h while holding or when any phase is expected to
   exceed 12 h. The latest **valid** `claimed-by` comment for the same

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -31,7 +31,10 @@ and `unclaimed-by` comments remain HTML-comment-only.
   Generate a fresh value on every fresh claim or stale takeover. Reuse
   the same `{claim-id}` only for heartbeats of that already-verified
   claim. A matching `{agent-id}` is never ownership proof by itself,
-  because separate live sessions can share the same agent ID.
+  because separate live sessions can share the same agent ID. Reading an
+  existing `{claim-id}` from issue comments during discovery or resume
+  does not by itself prove ownership; the current session must have
+  already recorded that token before the revalidation step.
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
   For a stale-claim takeover, set it to the currently active claim's
   `{claim-id}`.
@@ -68,12 +71,12 @@ chronologically and apply these rules:
    active claim when one exists, is ignored as a stale or invalid event.
 
 Same-agent restarts never silently inherit or supersede an active
-non-stale claim. If the current session already knows and has verified
-the active `{claim-id}`, continue with that same token and use
-heartbeats; do not post a fresh takeover claim. If the session cannot
-prove ownership of the active `{claim-id}`, the active claim is treated
-as owned by another live session until it is released or stale, even
-when `{agent-id}` matches.
+non-stale claim. If the current session already recorded and verified
+the active `{claim-id}` before this check, continue with that same token
+and use heartbeats; do not post a fresh takeover claim. If the session
+cannot prove ownership of the active `{claim-id}`, the active claim is
+treated as owned by another live session until it is released or stale,
+even when `{agent-id}` matches.
 
 ## Legacy claim migration
 

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -45,9 +45,11 @@ Otherwise, determine claim state from the parsed active claim:
 
 - No active claim → **unclaimed**. Re-claim via
   `idd-claim.instructions.md`, then continue to Step 2.
-- Active claim whose `{claim-id}` is already known and verified by this
-  current session → **already owned**. Continue to Step 2 with that same
-  `{claim-id}`; do not post a new claim.
+- Active claim whose `{claim-id}` was already recorded by this current
+  session before this check and is now verified → **already owned**.
+  Continue to Step 2 with that same `{claim-id}`; do not post a new
+  claim. A token first learned by parsing the current issue comments is
+  not enough.
 - Any other active claim, latest valid `claimed-by` `created_at` < 24 h
   → **not inheritable**, stop. This includes matching `agent-id`; the
   agent ID alone does not prove that this is the same live session.

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -34,34 +34,31 @@ migration-only input. First check whether that latest legacy
 comment from the same agent — if so, treat the issue as **unclaimed**
 and proceed to the re-claim path below. Otherwise:
 
-- Legacy claim, **own agent ID** → migrate it via
-  `idd-claim.instructions.md` using the same branch and a fresh
-  `{claim-id}` with `supersedes: none`, then continue to Step 2.
-- Legacy claim, **other** agent ID, `created_at` < 24 h → **not
-  inheritable**, stop.
-- Legacy claim, **other** agent ID, `created_at` ≥ 24 h → **stale**.
-  Migrate it via `idd-claim.instructions.md` with a fresh `{claim-id}`
-  and `supersedes: none`, then continue to Step 2.
+- Latest legacy claim has `created_at` < 24 h → **not inheritable**,
+  stop. This includes matching `agent-id`; the legacy agent ID alone
+  does not prove same live-session ownership.
+- Latest legacy claim has `created_at` ≥ 24 h → **stale**. Migrate it
+  via `idd-claim.instructions.md` with a fresh `{claim-id}` and
+  `supersedes: none`, then continue to Step 2.
 
 Otherwise, determine claim state from the parsed active claim:
 
 - No active claim → **unclaimed**. Re-claim via
   `idd-claim.instructions.md`, then continue to Step 2.
-- Active claim, **own agent ID** → **takeover required**. Do **not**
-  silently inherit it. Re-enter `idd-claim.instructions.md` using the
-  same branch and a fresh `{claim-id}` whose `supersedes:` value is the
-  current active claim's `{claim-id}`, then continue to Step 2.
-- Active claim, **other** agent ID, latest valid `claimed-by`
-  `created_at` < 24 h → **not inheritable**, stop.
-- Active claim, **other** agent ID, latest valid `claimed-by`
-  `created_at` ≥ 24 h → **stale**. Take it over via
-  `idd-claim.instructions.md` with a fresh `{claim-id}` whose
-  `supersedes:` value is the current active claim's `{claim-id}`, then
-  continue to Step 2.
+- Active claim whose `{claim-id}` is already known and verified by this
+  current session → **already owned**. Continue to Step 2 with that same
+  `{claim-id}`; do not post a new claim.
+- Any other active claim, latest valid `claimed-by` `created_at` < 24 h
+  → **not inheritable**, stop. This includes matching `agent-id`; the
+  agent ID alone does not prove that this is the same live session.
+- Any other active claim, latest valid `claimed-by` `created_at` ≥ 24 h
+  → **stale**. Take it over via `idd-claim.instructions.md` with a fresh
+  `{claim-id}` whose `supersedes:` value is the current active claim's
+  `{claim-id}`, then continue to Step 2.
 
 A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the
-active claim you are taking over, or in the latest released claim.
+stale active claim you are taking over, or in the latest released claim.
 
 If the active or inherited branch field starts with `roadmap-audit/`,
 the claim is an A1.5 roadmap-audit coordination claim, not a work branch.

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -15,17 +15,15 @@ set. If the project is in use, the project status must be "not started".
 **(b) Claim state** — Re-read the issue and parse the **active claim**
 using the shared claim-state rules:
 
-- No active claim → unclaimed, proceed
-- Active claim held by a **different** agent ID and its latest valid
-  `claimed-by` comment has GitHub `created_at` < 24 h → claimed by
-  another agent, go back to A3
-- Active claim held by a **different** agent ID and its latest valid
-  `claimed-by` comment has GitHub `created_at` ≥ 24 h → stale, proceed
-  with takeover
-- Active claim held by **your own** agent ID → same-agent restart or
-  handoff detected. Do **not** silently inherit it; proceed with an
-  explicit takeover that uses a fresh `{claim-id}` and `supersedes:` the
-  current active claim's `{claim-id}`
+- No active claim → unclaimed, proceed.
+- Active claim already uses a `{claim-id}` that this current session has
+  verified and recorded → already claimed; do not post a new claim.
+  Continue with that same `{claim-id}`.
+- Any other active claim whose latest valid `claimed-by` comment has
+  GitHub `created_at` < 24 h → claimed by another live session, even
+  when the `agent-id` matches. Go back to A3.
+- Any other active claim whose latest valid `claimed-by` comment has
+  GitHub `created_at` ≥ 24 h → stale, proceed with takeover.
 
 Only the GitHub `created_at` of the latest **valid** `claimed-by`
 comment in the active claim counts toward the stale calculation.
@@ -39,12 +37,10 @@ claim exists.
 Otherwise, use the latest legacy `claimed-by` comment as a
 **migration-only** decision input:
 
-- Legacy claim held by a **different** agent ID and GitHub `created_at`
-  < 24 h → claimed by another agent, go back to A3
-- Legacy claim held by a **different** agent ID and GitHub `created_at`
-  ≥ 24 h → stale, proceed and replace it with a new-format claim
-- Legacy claim held by **your own** agent ID → same-agent restart or
-  handoff detected. Proceed and replace it with a new-format claim
+- Latest legacy claim has GitHub `created_at` < 24 h → claimed by
+  another live session, even when the `agent-id` matches. Go back to A3.
+- Latest legacy claim has GitHub `created_at` ≥ 24 h → stale, proceed
+  and replace it with a new-format claim.
 
 The migration claim uses a fresh `{claim-id}` and `supersedes: none`.
 
@@ -52,8 +48,8 @@ The migration claim uses a fresh `{claim-id}` and `supersedes: none`.
 that PR's head branch matches the `branch` field in an inheritable claim
 comment. An inheritable claim comment is either:
 
-- the currently active claim you are taking over (same-agent restart or
-  stale claim), or
+- the already verified active claim for this current session, or
+- the currently active stale claim you are taking over, or
 - the latest `claimed-by` comment that was later released by a matching
   `unclaimed-by` comment (the last voluntarily released branch), or
 - the latest legacy `claimed-by` comment when performing a legacy
@@ -72,17 +68,17 @@ field in an inheritable claim comment as defined in (c) above.
 Determine `{branch-name}`:
 
 - **Re-claim / takeover**: use the exact branch name from the
-  inheritable claim comment (the `branch` field of the active same-agent
-  or stale claim, the last-released `claimed-by`, or the legacy claim
-  being migrated). Do not compute a new name.
+  inheritable claim comment (the `branch` field of the active stale
+  claim, the last-released `claimed-by`, or the legacy claim being
+  migrated). Do not compute a new name.
 - **Fresh claim**: compute a new name using the IDD naming convention:
   `issue/<number>-<slug>` where `<slug>` is 2–5 lowercase hyphenated
   words describing the issue.
 
 Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
 
-- **Takeover of an active claim** (same-agent restart or handoff, or
-  stale claim recovery) → the current active claim's `{claim-id}`
+- **Takeover of an active claim** (stale claim recovery) → the current
+  active claim's `{claim-id}`
 - **Migration from a legacy claim** → `none`
 - **Fresh claim** or claim after a released / unclaimed state → `none`
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -65,6 +65,11 @@ field in an inheritable claim comment as defined in (c) above.
 
 ## Claim execution
 
+Skip this section if pre-check (b) classified the issue as already
+claimed by this current session. Keep the recorded `{claim-id}` and
+branch, then proceed directly to Claim verification without posting a new
+claim.
+
 Determine `{branch-name}`:
 
 - **Re-claim / takeover**: use the exact branch name from the

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -16,9 +16,10 @@ set. If the project is in use, the project status must be "not started".
 using the shared claim-state rules:
 
 - No active claim → unclaimed, proceed.
-- Active claim already uses a `{claim-id}` that this current session has
-  verified and recorded → already claimed; do not post a new claim.
-  Continue with that same `{claim-id}`.
+- Active claim already uses a `{claim-id}` that this current session had
+  recorded before this check and has now verified → already claimed; do
+  not post a new claim. Continue with that same `{claim-id}`. A token
+  first learned by parsing the current issue comments is not enough.
 - Any other active claim whose latest valid `claimed-by` comment has
   GitHub `created_at` < 24 h → claimed by another live session, even
   when the `agent-id` matches. Go back to A3.
@@ -66,7 +67,7 @@ field in an inheritable claim comment as defined in (c) above.
 ## Claim execution
 
 Skip this section if pre-check (b) classified the issue as already
-claimed by this current session. Keep the recorded `{claim-id}` and
+claimed by this current session. Keep the previously recorded `{claim-id}` and
 branch, then proceed directly to Claim verification without posting a new
 claim.
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -162,18 +162,20 @@ roadmap issue itself:
   `not started` readiness gate to roadmap-audit claims; roadmap
   ownership and project status may represent parent coordination rather
   than task readiness. If an active non-stale claim uses any
-  `{claim-id}` other than one already known and verified by this current
-  session, do not mutate the roadmap; report the claim and continue to
-  A2 or stop according to the normal ready-to-start rules. A matching
-  agent ID alone is not ownership proof.
+  `{claim-id}` other than one already recorded by this current session
+  before this check and now verified, do not mutate the roadmap; report
+  the claim and continue to A2 or stop according to the normal
+  ready-to-start rules. A matching agent ID alone is not ownership
+  proof, and neither is a token first learned by parsing the current
+  roadmap comments.
 - If the roadmap is unclaimed or stale, post and verify a normal
   `claimed-by` comment for the roadmap issue using a
   `roadmap-audit/<number>-<slug>` branch field. This is a logical
   coordination name, not a work branch, and it does not require creating
   a branch or worktree unless the audit also needs git changes.
 - If the active roadmap claim already uses this current session's
-  verified `{claim-id}`, continue with that same claim and do not post a
-  new claim.
+  previously recorded and verified `{claim-id}`, continue with that same
+  claim and do not post a new claim.
 - Re-validate that roadmap claim before every roadmap comment, follow-up
   issue creation, body edit, label change, or close action.
 - If the roadmap remains open and no PR branch will continue from the

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -161,14 +161,19 @@ roadmap issue itself:
   the roadmap issue. Do not apply A5's assignee or project
   `not started` readiness gate to roadmap-audit claims; roadmap
   ownership and project status may represent parent coordination rather
-  than task readiness. If an active non-stale claim belongs to another
-  agent, do not mutate the roadmap; report the claim and continue to A2
-  or stop according to the normal ready-to-start rules.
-- If the roadmap is unclaimed, stale, or held by the same agent, post
-  and verify a normal `claimed-by` comment for the roadmap issue using a
+  than task readiness. If an active non-stale claim uses any
+  `{claim-id}` other than one already known and verified by this current
+  session, do not mutate the roadmap; report the claim and continue to
+  A2 or stop according to the normal ready-to-start rules. A matching
+  agent ID alone is not ownership proof.
+- If the roadmap is unclaimed or stale, post and verify a normal
+  `claimed-by` comment for the roadmap issue using a
   `roadmap-audit/<number>-<slug>` branch field. This is a logical
   coordination name, not a work branch, and it does not require creating
   a branch or worktree unless the audit also needs git changes.
+- If the active roadmap claim already uses this current session's
+  verified `{claim-id}`, continue with that same claim and do not post a
+  new claim.
 - Re-validate that roadmap claim before every roadmap comment, follow-up
   issue creation, body edit, label change, or close action.
 - If the roadmap remains open and no PR branch will continue from the

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -26,12 +26,15 @@ include a short visible note after the HTML comment token (see
 `idd-review-snapshot.instructions.md` for the required format). `claimed-by`
 and `unclaimed-by` comments remain HTML-comment-only.
 
-- `{claim-id}` is an opaque unique token for one active claim lineage.
-  Generate a fresh value on every fresh claim or takeover. Reuse the
-  same `{claim-id}` only for heartbeats of that already-verified claim.
+- `{claim-id}` is an opaque unique token for one active claim lineage
+  and is the portable proof that the current session owns that claim.
+  Generate a fresh value on every fresh claim or stale takeover. Reuse
+  the same `{claim-id}` only for heartbeats of that already-verified
+  claim. A matching `{agent-id}` is never ownership proof by itself,
+  because separate live sessions can share the same agent ID.
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
-  For a takeover (same-agent restart, handoff, or stale-claim recovery),
-  set it to the currently active claim's `{claim-id}`.
+  For a stale-claim takeover, set it to the currently active claim's
+  `{claim-id}`.
 
 ## Unclaim format
 
@@ -54,11 +57,8 @@ chronologically and apply these rules:
    only if either:
    - there is no active claim AND its `supersedes:` value is `none`, or
    - its `supersedes:` value exactly matches the current active claim's
-     `{claim-id}`, and either:
-     - it uses the **same** agent ID as the current active claim
-       (explicit same-agent takeover), or
-     - the current active claim is already **stale** at the new
-       comment's GitHub `created_at` timestamp.
+     `{claim-id}`, and the current active claim is already **stale** at
+     the new comment's GitHub `created_at` timestamp.
 4. An `unclaimed-by` releases the claim only if its `{agent-id}` AND
    `{claim-id}` both match the current active claim. Otherwise ignore it
    as a stale release from a superseded session.
@@ -67,9 +67,13 @@ chronologically and apply these rules:
    superseded, or whose `supersedes:` value does not match the current
    active claim when one exists, is ignored as a stale or invalid event.
 
-Same-agent restarts never silently inherit an active claim. They must
-perform an explicit takeover with a fresh `{claim-id}` that
-`supersedes:` the currently active claim.
+Same-agent restarts never silently inherit or supersede an active
+non-stale claim. If the current session already knows and has verified
+the active `{claim-id}`, continue with that same token and use
+heartbeats; do not post a fresh takeover claim. If the session cannot
+prove ownership of the active `{claim-id}`, the active claim is treated
+as owned by another live session until it is released or stale, even
+when `{agent-id}` matches.
 
 ## Legacy claim migration
 
@@ -92,8 +96,9 @@ Treat these legacy comments as **migration-only** inputs:
   legacy `unclaimed-by` comment from the same agent. If so, treat the
   issue as **unclaimed**; skip directly to posting a fresh new-format
   claim with `supersedes: none`.
-- Otherwise, use the latest legacy claim to decide branch reuse,
-  staleness, and whether a same-agent resume is occurring.
+- Otherwise, use the latest legacy claim to decide branch reuse and
+  staleness. A matching legacy agent ID is not enough to prove same
+  live-session ownership.
 - Then immediately post a new-format `claimed-by` comment with a fresh
   `{claim-id}` before any further side effects.
 - Use `supersedes: none` for that one-time migration claim, because the
@@ -104,9 +109,9 @@ Treat these legacy comments as **migration-only** inputs:
 ## Thresholds
 
 - **Stale**: an active claim whose latest **valid** `claimed-by`
-  comment's GitHub `created_at` is ≥ 24 h ago. Another agent may take it
-  over by posting a fresh `{claim-id}` whose `supersedes:` value is that
-  active claim's `{claim-id}`.
+  comment's GitHub `created_at` is ≥ 24 h ago. Another session may take
+  it over by posting a fresh `{claim-id}` whose `supersedes:` value is
+  that active claim's `{claim-id}`.
 - **Heartbeat**: after re-validating ownership, re-post the claim
   comment every 12 h while holding or when any phase is expected to
   exceed 12 h. The latest **valid** `claimed-by` comment for the same

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -31,7 +31,10 @@ and `unclaimed-by` comments remain HTML-comment-only.
   Generate a fresh value on every fresh claim or stale takeover. Reuse
   the same `{claim-id}` only for heartbeats of that already-verified
   claim. A matching `{agent-id}` is never ownership proof by itself,
-  because separate live sessions can share the same agent ID.
+  because separate live sessions can share the same agent ID. Reading an
+  existing `{claim-id}` from issue comments during discovery or resume
+  does not by itself prove ownership; the current session must have
+  already recorded that token before the revalidation step.
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
   For a stale-claim takeover, set it to the currently active claim's
   `{claim-id}`.
@@ -68,12 +71,12 @@ chronologically and apply these rules:
    active claim when one exists, is ignored as a stale or invalid event.
 
 Same-agent restarts never silently inherit or supersede an active
-non-stale claim. If the current session already knows and has verified
-the active `{claim-id}`, continue with that same token and use
-heartbeats; do not post a fresh takeover claim. If the session cannot
-prove ownership of the active `{claim-id}`, the active claim is treated
-as owned by another live session until it is released or stale, even
-when `{agent-id}` matches.
+non-stale claim. If the current session already recorded and verified
+the active `{claim-id}` before this check, continue with that same token
+and use heartbeats; do not post a fresh takeover claim. If the session
+cannot prove ownership of the active `{claim-id}`, the active claim is
+treated as owned by another live session until it is released or stale,
+even when `{agent-id}` matches.
 
 ## Legacy claim migration
 

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -45,9 +45,11 @@ Otherwise, determine claim state from the parsed active claim:
 
 - No active claim → **unclaimed**. Re-claim via
   `idd-claim.instructions.md`, then continue to Step 2.
-- Active claim whose `{claim-id}` is already known and verified by this
-  current session → **already owned**. Continue to Step 2 with that same
-  `{claim-id}`; do not post a new claim.
+- Active claim whose `{claim-id}` was already recorded by this current
+  session before this check and is now verified → **already owned**.
+  Continue to Step 2 with that same `{claim-id}`; do not post a new
+  claim. A token first learned by parsing the current issue comments is
+  not enough.
 - Any other active claim, latest valid `claimed-by` `created_at` < 24 h
   → **not inheritable**, stop. This includes matching `agent-id`; the
   agent ID alone does not prove that this is the same live session.

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -34,34 +34,31 @@ migration-only input. First check whether that latest legacy
 comment from the same agent — if so, treat the issue as **unclaimed**
 and proceed to the re-claim path below. Otherwise:
 
-- Legacy claim, **own agent ID** → migrate it via
-  `idd-claim.instructions.md` using the same branch and a fresh
-  `{claim-id}` with `supersedes: none`, then continue to Step 2.
-- Legacy claim, **other** agent ID, `created_at` < 24 h → **not
-  inheritable**, stop.
-- Legacy claim, **other** agent ID, `created_at` ≥ 24 h → **stale**.
-  Migrate it via `idd-claim.instructions.md` with a fresh `{claim-id}`
-  and `supersedes: none`, then continue to Step 2.
+- Latest legacy claim has `created_at` < 24 h → **not inheritable**,
+  stop. This includes matching `agent-id`; the legacy agent ID alone
+  does not prove same live-session ownership.
+- Latest legacy claim has `created_at` ≥ 24 h → **stale**. Migrate it
+  via `idd-claim.instructions.md` with a fresh `{claim-id}` and
+  `supersedes: none`, then continue to Step 2.
 
 Otherwise, determine claim state from the parsed active claim:
 
 - No active claim → **unclaimed**. Re-claim via
   `idd-claim.instructions.md`, then continue to Step 2.
-- Active claim, **own agent ID** → **takeover required**. Do **not**
-  silently inherit it. Re-enter `idd-claim.instructions.md` using the
-  same branch and a fresh `{claim-id}` whose `supersedes:` value is the
-  current active claim's `{claim-id}`, then continue to Step 2.
-- Active claim, **other** agent ID, latest valid `claimed-by`
-  `created_at` < 24 h → **not inheritable**, stop.
-- Active claim, **other** agent ID, latest valid `claimed-by`
-  `created_at` ≥ 24 h → **stale**. Take it over via
-  `idd-claim.instructions.md` with a fresh `{claim-id}` whose
-  `supersedes:` value is the current active claim's `{claim-id}`, then
-  continue to Step 2.
+- Active claim whose `{claim-id}` is already known and verified by this
+  current session → **already owned**. Continue to Step 2 with that same
+  `{claim-id}`; do not post a new claim.
+- Any other active claim, latest valid `claimed-by` `created_at` < 24 h
+  → **not inheritable**, stop. This includes matching `agent-id`; the
+  agent ID alone does not prove that this is the same live session.
+- Any other active claim, latest valid `claimed-by` `created_at` ≥ 24 h
+  → **stale**. Take it over via `idd-claim.instructions.md` with a fresh
+  `{claim-id}` whose `supersedes:` value is the current active claim's
+  `{claim-id}`, then continue to Step 2.
 
 A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the
-active claim you are taking over, or in the latest released claim.
+stale active claim you are taking over, or in the latest released claim.
 
 If the active or inherited branch field starts with `roadmap-audit/`,
 the claim is an A1.5 roadmap-audit coordination claim, not a work branch.

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -889,7 +889,7 @@ function readActiveClaim(owner, repo, issueNumber) {
       if (
         active
         && claim.supersedes === active.claimId
-        && (claim.agentId === active.agentId || isStaleAt(active.createdAt, claim.createdAt))
+        && isStaleAt(active.createdAt, claim.createdAt)
       ) {
         retiredClaimIds.add(active.claimId);
         active = claim;


### PR DESCRIPTION
## Summary

- Tightens the IDD claim contract so `agent-id` alone is never ownership proof, and a `claim-id` only proves ownership when the current session had already recorded it before revalidation.
- Blocks non-stale same-agent takeovers in normal claim, resume, and roadmap-audit flows while preserving stale and released-branch recovery.
- Updates the PR cleanup helper's active-claim parser so same-agent supersede events only win after the active claim is stale.
- Mirrors the instruction changes into `idd-template/`.

Closes #122

## Follow-up

- #118 remains the right place to add broader claim-state fixture coverage if/when parser fixture infrastructure is introduced.

## Validation

- `node --check scripts/audit-pr-cleanup.mjs`
- `node scripts/audit-docs.mjs --check`
- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined claim ownership semantics and session-specific verification logic across IDD automation instructions.
  * Updated claim-state parsing rules to improve takeover and migration behavior.
  * Clarified 24-hour staleness threshold for claim inheritance decisions.

* **Bug Fixes**
  * Tightened active-claim selection logic for superseded claims.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/123)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->