### PR TITLE
docs: soften positioning wording

### DIFF
--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -52,9 +52,9 @@ coordination at the issue-tracking level.
 ## Strategic position
 
 idd-skill occupies a unique position as a _portable operating system
-for development teams_ — vendor-neutral, infrastructure-free, and a
-GitHub-native framework with explicit multi-agent coordination
-primitives built into the workflow rules themselves.
+for development teams_ — a GitHub-native framework that is
+vendor-neutral, infrastructure-free, and includes explicit multi-agent
+coordination primitives built into the workflow rules themselves.
 
 The key differentiator is the claim/heartbeat protocol. Other tools
 either assume single-agent execution or rely on external orchestration

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -52,9 +52,9 @@ coordination at the issue-tracking level.
 ## Strategic position
 
 idd-skill occupies a unique position as a _portable operating system
-for development teams_ — vendor-neutral, infrastructure-free, and the
-only framework with explicit multi-agent coordination primitives built
-into the workflow rules themselves.
+for development teams_ — vendor-neutral, infrastructure-free, and a
+GitHub-native framework with explicit multi-agent coordination
+primitives built into the workflow rules themselves.
 
 The key differentiator is the claim/heartbeat protocol. Other tools
 either assume single-agent execution or rely on external orchestration


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.zh.md
-->

Summary:
- Replace the risky "only framework" wording in docs/positioning.md with a safer GitHub-native framing.
- Keep the README guidance and linked positioning narrative aligned with the project’s GitHub-native, portable workflow story.

Background:
The change is purely wording and keeps the existing claim/heartbeat positioning intact while avoiding an absolute market claim.

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product positioning documentation to clarify idd-skill as a GitHub-native framework featuring built-in multi-agent coordination capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/125)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->