### PR TITLE
docs(idd): add visible claim markers

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -88,10 +88,13 @@ Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
 - **Migration from a legacy claim** → `none`
 - **Fresh claim** or claim after a released / unclaimed state → `none`
 
-Post the claim comment to the issue:
+Post the claim comment to the issue. Keep the HTML token at the start
+of the body, followed by the visible note:
 
-```html
+```markdown
 <!-- claimed-by: {agent-id} {claim-id} supersedes: {prior-claim-id|none} {ISO8601-timestamp} branch: {branch-name} -->
+
+_{agent-id}: issue claim — IDD automation marker. Do not edit._
 ```
 
 ## Claim verification

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -7,24 +7,32 @@ excludeAgent: "code-review"
 
 ## Claim format
 
-Post this HTML comment to an issue to claim it or take it over:
+Post this comment to an issue to claim it, heartbeat it, or take it
+over. The HTML comment token must remain the first bytes of the body;
+the visible note is for humans:
 
-```html
+```markdown
 <!-- claimed-by: {agent-id} {claim-id} supersedes: {prior-claim-id|none} {ISO8601-timestamp} branch: {branch-name} -->
+
+_{agent-id}: issue claim — IDD automation marker. Do not edit._
 ```
 
 **Important**: the machine-readable token in every operational comment
 (`claimed-by`, `unclaimed-by`, `review-watermark`, `review-baseline`)
 is an HTML comment. Some GitHub client tools (e.g., `gh issue comment`,
 `gh api -f body=`) silently reject bodies that consist entirely of HTML
-comments. Always post these using a direct HTTP `POST` with a JSON body
-(e.g., `curl` with `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->"}'`).
+comments. New operational comments include visible text, but agents
+should still post them using a direct HTTP `POST` with a JSON body for
+reliability (e.g., `curl` with `-H "Content-Type: application/json"` and
+`-d '{"body":"<!-- ... -->\n\n_note_"}'`).
 
-`review-watermark` and `review-baseline` comments must additionally
-include a short visible note after the HTML comment token (see
-`idd-review-snapshot.instructions.md` for the required format). `claimed-by`
-and `unclaimed-by` comments remain HTML-comment-only.
+Every new HTML-comment operational marker comment must include a short
+visible note after the HTML comment token. `review-watermark` and
+`review-baseline` use the phase-specific note formats in
+`idd-review-snapshot.instructions.md`; `claimed-by` and `unclaimed-by`
+use the claim and release notes shown here. Hidden-only legacy
+`claimed-by` and `unclaimed-by` comments remain valid for parsing and
+migration, but do not create new hidden-only claim comments.
 
 - `{claim-id}` is an opaque unique token for one active claim lineage
   and is the portable proof that the current session owns that claim.
@@ -43,8 +51,10 @@ and `unclaimed-by` comments remain HTML-comment-only.
 
 Post this comment to release a claim (on abort or voluntary release):
 
-```html
+```markdown
 <!-- unclaimed-by: {agent-id} {claim-id} {ISO8601-timestamp} -->
+
+_{agent-id}: issue claim released — IDD automation marker. Do not edit._
 ```
 
 ## Claim-state parsing
@@ -103,7 +113,7 @@ Treat these legacy comments as **migration-only** inputs:
   staleness. A matching legacy agent ID is not enough to prove same
   live-session ownership.
 - Then immediately post a new-format `claimed-by` comment with a fresh
-  `{claim-id}` before any further side effects.
+  `{claim-id}` and visible note before any further side effects.
 - Use `supersedes: none` for that one-time migration claim, because the
   legacy format has no `{claim-id}` to reference.
 - After a new-format claim exists, ignore all legacy claim and unclaim

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -88,10 +88,13 @@ Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
 - **Migration from a legacy claim** → `none`
 - **Fresh claim** or claim after a released / unclaimed state → `none`
 
-Post the claim comment to the issue:
+Post the claim comment to the issue. Keep the HTML token at the start
+of the body, followed by the visible note:
 
-```html
+```markdown
 <!-- claimed-by: {agent-id} {claim-id} supersedes: {prior-claim-id|none} {ISO8601-timestamp} branch: {branch-name} -->
+
+_{agent-id}: issue claim — IDD automation marker. Do not edit._
 ```
 
 ## Claim verification

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -7,24 +7,32 @@ excludeAgent: "code-review"
 
 ## Claim format
 
-Post this HTML comment to an issue to claim it or take it over:
+Post this comment to an issue to claim it, heartbeat it, or take it
+over. The HTML comment token must remain the first bytes of the body;
+the visible note is for humans:
 
-```html
+```markdown
 <!-- claimed-by: {agent-id} {claim-id} supersedes: {prior-claim-id|none} {ISO8601-timestamp} branch: {branch-name} -->
+
+_{agent-id}: issue claim — IDD automation marker. Do not edit._
 ```
 
 **Important**: the machine-readable token in every operational comment
 (`claimed-by`, `unclaimed-by`, `review-watermark`, `review-baseline`)
 is an HTML comment. Some GitHub client tools (e.g., `gh issue comment`,
 `gh api -f body=`) silently reject bodies that consist entirely of HTML
-comments. Always post these using a direct HTTP `POST` with a JSON body
-(e.g., `curl` with `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->"}'`).
+comments. New operational comments include visible text, but agents
+should still post them using a direct HTTP `POST` with a JSON body for
+reliability (e.g., `curl` with `-H "Content-Type: application/json"` and
+`-d '{"body":"<!-- ... -->\n\n_note_"}'`).
 
-`review-watermark` and `review-baseline` comments must additionally
-include a short visible note after the HTML comment token (see
-`idd-review-snapshot.instructions.md` for the required format). `claimed-by`
-and `unclaimed-by` comments remain HTML-comment-only.
+Every new HTML-comment operational marker comment must include a short
+visible note after the HTML comment token. `review-watermark` and
+`review-baseline` use the phase-specific note formats in
+`idd-review-snapshot.instructions.md`; `claimed-by` and `unclaimed-by`
+use the claim and release notes shown here. Hidden-only legacy
+`claimed-by` and `unclaimed-by` comments remain valid for parsing and
+migration, but do not create new hidden-only claim comments.
 
 - `{claim-id}` is an opaque unique token for one active claim lineage
   and is the portable proof that the current session owns that claim.
@@ -43,8 +51,10 @@ and `unclaimed-by` comments remain HTML-comment-only.
 
 Post this comment to release a claim (on abort or voluntary release):
 
-```html
+```markdown
 <!-- unclaimed-by: {agent-id} {claim-id} {ISO8601-timestamp} -->
+
+_{agent-id}: issue claim released — IDD automation marker. Do not edit._
 ```
 
 ## Claim-state parsing
@@ -103,7 +113,7 @@ Treat these legacy comments as **migration-only** inputs:
   staleness. A matching legacy agent ID is not enough to prove same
   live-session ownership.
 - Then immediately post a new-format `claimed-by` comment with a fresh
-  `{claim-id}` before any further side effects.
+  `{claim-id}` and visible note before any further side effects.
 - Use `supersedes: none` for that one-time migration claim, because the
   legacy format has no `{claim-id}` to reference.
 - After a new-format claim exists, ignore all legacy claim and unclaim

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -3,15 +3,22 @@
 import { execFileSync } from "node:child_process";
 
 const ISO8601_UTC_WITH_OPTIONAL_FRACTION = String.raw`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z`;
+const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
 
 const OPERATIONAL_MARKERS = [
   {
     label: "<!-- review-watermark:",
-    pattern: /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    pattern: new RegExp(
+      `^<!--\\s*review-watermark:\\s+\\S+\\s+\\S+\\s+\\S+\\s+\\S+\\s+\\d+\\s+\\S+\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+      "i",
+    ),
   },
   {
     label: "<!-- review-baseline:",
-    pattern: /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    pattern: new RegExp(
+      `^<!--\\s*review-baseline:\\s+\\S+\\s+\\S+\\s+\\S+\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+      "i",
+    ),
   },
   {
     label: "advisory-wait:",
@@ -915,7 +922,8 @@ function readActiveClaim(owner, repo, issueNumber) {
 function parseClaim(body, createdAt) {
   const match = body.trimEnd().match(
     new RegExp(
-      `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->$`,
+      `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+      "i",
     ),
   );
   if (!match || !isValidIsoTimestamp(match[4])) {
@@ -933,7 +941,8 @@ function parseClaim(body, createdAt) {
 function parseRelease(body) {
   const match = body.trimEnd().match(
     new RegExp(
-      `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->$`,
+      `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+      "i",
     ),
   );
   if (!match || !isValidIsoTimestamp(match[3])) {


### PR DESCRIPTION
## Summary

- add visible human-readable notes to the `claimed-by` and `unclaimed-by` marker formats
- keep hidden-only legacy claim comments parseable while directing new comments to include visible text
- update the PR cleanup helper claim parser to accept both hidden-only and visible-note ownership comments

Closes #119

## Validation

- npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"
- npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress
- node --check scripts/audit-pr-cleanup.mjs
- node scripts/audit-docs.mjs --check
- node scripts/audit-pr-cleanup.mjs --pr 121 --dry-run --format table
- git diff --check

## Follow-up

- None

## Background

The machine-readable claim token still starts the comment body so existing prefix filters continue to work. The visible note avoids empty-looking GitHub issue comments, while parser updates preserve compatibility with old hidden-only claims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions for operational claim and release comments to include visible human-readable notes alongside system markers for improved clarity.

* **Improvements**
  * Enhanced parser and validation logic to support optional visible notes in operational claim and release comments for increased flexibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/126)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->