### PR TITLE
docs: add getting started guide

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -46,7 +46,8 @@
       "sourceGlobs": [
         "idd-template/.github/instructions/idd-*.instructions.md",
         "idd-template/docs/idd-*.md",
-        "idd-template/docs/permissions.md"
+        "idd-template/docs/permissions.md",
+        "idd-template/docs/getting-started.md"
       ],
       "paths": [
         "idd-template/.github/instructions/idd-overview.instructions.md",
@@ -66,7 +67,8 @@
         "idd-template/docs/idd-review-policy-profiles.md",
         "idd-template/docs/idd-helper-scripts.md",
         "idd-template/docs/idd-comment-minimization.md",
-        "idd-template/docs/permissions.md"
+        "idd-template/docs/permissions.md",
+        "idd-template/docs/getting-started.md"
       ]
     },
     {
@@ -222,6 +224,12 @@
       "id": "permissions-doc",
       "source": "idd-template/docs/permissions.md",
       "target": "docs/permissions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "getting-started-doc",
+      "source": "idd-template/docs/getting-started.md",
+      "target": "docs/getting-started.md",
       "mode": "exact"
     },
     {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,83 @@
+# Getting Started with IDD
+
+Use this guide when you want the shortest safe path from deciding a
+repository should adopt IDD to the first Issue-Driven Development loop.
+It is procedural on purpose. Deeper rules stay in the workflow and
+phase reference files.
+
+## Before You Start
+
+Choose the repository that will adopt IDD and confirm who is allowed to
+grant agent credentials, review pull requests, and merge. Review
+`docs/permissions.md` before giving an unattended or merge-capable agent
+access to GitHub.
+
+The agent that imports or runs IDD needs access to:
+
+- `git`
+- an authenticated `gh` CLI or equivalent GitHub integration
+- `jq`
+- Node.js/npm with `npx`
+- a REST client such as `curl` for reliable operational marker posting
+
+## 1. Import the Template
+
+Open an agent session in the target repository and ask it to import the
+IDD template from the idd-skill source repository. If the template has
+already been copied, start from the local `ONBOARDING.md` file instead.
+
+The onboarding guide copies the portable instruction files, asks for
+project-specific command values, and updates agent entry files such as
+`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, or Copilot instructions.
+
+## 2. Choose the Review Policy
+
+Before the first full loop, decide whether the default Copilot advisory
+review policy applies. If it does not, choose another profile from
+`docs/idd-review-policy-profiles.md` and apply the listed instruction
+file changes before agents reach PR review and merge phases.
+
+Keep this decision explicit. Review policy changes are workflow changes,
+not just documentation preferences.
+
+## 3. Prepare Issues
+
+IDD works from GitHub Issues. At least one issue should be ready before
+the loop starts:
+
+- limited enough for one reviewable change
+- verifiable with lint, tests, CI, or another explicit check
+- autonomous, with no unresolved human decision or external blocker
+
+For broad requests, use the optional issue-authoring companion to draft
+a roadmap and focused child issues before starting the execution loop.
+Use task-list links to group active roadmap work. Reserve
+`idd-skill-blocked-by` markers for true sequential dependencies on a
+separate roadmap.
+
+## 4. Start the Loop
+
+Ask the agent to start the IDD workflow in the target repository. The
+agent should read the repository entry file, then route through
+`docs/idd-workflow.md` and the phase files under `.github/instructions/`.
+
+The normal loop is:
+
+1. Discover a ready roadmap or orphan issue.
+2. Claim exactly one issue with an ownership marker.
+3. Create a branch and worktree.
+4. Implement, validate, and self-review.
+5. Open a pull request.
+6. Triage review feedback and fix accepted items.
+7. Recheck CI, review freshness, advisory state, and claim ownership.
+8. Merge with a merge commit and clean up stale operational markers.
+
+## 5. Know Where to Go Next
+
+Use the repository's broader docs index as the high-level map when one
+exists. Use `docs/idd-workflow.md` when an agent or maintainer needs
+phase routing details, and use `.github/instructions/*.instructions.md`
+as the authoritative execution rules.
+
+Keep the README short. It should help a first-time reader understand
+what IDD is, why it exists, and which guide to read next.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ also serve as the source for a future GitHub Pages site.
 
 | Need                      | Read first                                              | Why it helps                                                    |
 | ------------------------- | ------------------------------------------------------- | --------------------------------------------------------------- |
+| Start adopting IDD        | [Getting started](getting-started.md)                   | Gives the shortest safe path from import to first loop.         |
 | Run the IDD loop          | [IDD workflow guide](idd-workflow.md)                   | Maps agent entry points, phase files, and Copilot advisory use. |
 | Import IDD into a repo    | [Template onboarding][template-onboarding]              | Explains the portable template copy and placeholder flow.       |
 | Grant agent credentials   | [Permissions](permissions.md)                           | Defines access profiles, forbidden scopes, and threat controls. |
@@ -23,6 +24,8 @@ also serve as the source for a future GitHub Pages site.
 
 ### Adoption and Onboarding
 
+- [Getting started](getting-started.md) is the concise first-run path
+  from template import to the first IDD execution loop.
 - [Template onboarding][template-onboarding] is the canonical
   guide for importing the portable IDD template into another
   repository.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -155,6 +155,7 @@ docs/idd-review-policy-profiles.md
 docs/idd-helper-scripts.md
 docs/idd-comment-minimization.md
 docs/permissions.md
+docs/getting-started.md
 ```
 
 <!-- /audit:generated -->
@@ -209,7 +210,8 @@ for FILE in \
   "docs/idd-review-policy-profiles.md" \
   "docs/idd-helper-scripts.md" \
   "docs/idd-comment-minimization.md" \
-  "docs/permissions.md"
+  "docs/permissions.md" \
+  "docs/getting-started.md"
 do
   gh api -H "Accept: application/vnd.github.raw+json" \
     "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
@@ -271,7 +273,8 @@ for FILE in \
   "docs/idd-review-policy-profiles.md" \
   "docs/idd-helper-scripts.md" \
   "docs/idd-comment-minimization.md" \
-  "docs/permissions.md"
+  "docs/permissions.md" \
+  "docs/getting-started.md"
 do
   curl -fsSL "${BASE}/${FILE}" -o "${DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
@@ -478,10 +481,11 @@ After completing the steps above, confirm each item:
 
 - [ ] Every `idd-*.instructions.md` file listed in the generated core
       file list is present in `.github/instructions/`.
-- [ ] `docs/idd-workflow.md`, `docs/idd-review-policy-profiles.md`,
+- [ ] `docs/getting-started.md`, `docs/idd-workflow.md`,
+      `docs/idd-review-policy-profiles.md`,
       `docs/idd-helper-scripts.md`,
-      `docs/idd-comment-minimization.md`, and `docs/permissions.md` are
-      present.
+      `docs/idd-comment-minimization.md`, and `docs/permissions.md`
+      are present.
 - [ ] The operator's selected PR review policy profile is recorded, and
       any non-default profile has matching phase-file customizations.
 - [ ] If the operator opted into issue authoring,

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -9,9 +9,11 @@ multi-agent GitHub automation.
 2. Fill in the placeholders listed in `ONBOARDING.md`.
 3. Update the agent entry files (`CLAUDE.md`, `copilot-instructions.md`,
    etc.) as described in `ONBOARDING.md`.
-4. Review `docs/permissions.md` before granting credentials to
+4. Read `docs/getting-started.md` for the shortest safe path from
+   import to the first IDD loop.
+5. Review `docs/permissions.md` before granting credentials to
    unattended or merge-capable agents.
-5. Optional: install the issue-authoring companion skill if the project
+6. Optional: install the issue-authoring companion skill if the project
    wants pre-execution issue drafting. The canonical source bundle in
    this repository lives at `skills/issue-authoring/`; install copies
    into the agent-specific skill directory your runtime reads.
@@ -80,6 +82,7 @@ profiles require additional files.
   idd-merge.instructions.md          ← F3–F5: merge execution, cleanup, and loop
   idd-resume.instructions.md         ← resume after crash / handoff
 docs/
+  getting-started.md                  ← concise import-to-first-loop guide
   idd-workflow.md                    ← cross-agent entry point and file map
   idd-review-policy-profiles.md      ← default and alternative PR review policies
   idd-helper-scripts.md              ← optional helper-script evaluation and policy

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -1,0 +1,83 @@
+# Getting Started with IDD
+
+Use this guide when you want the shortest safe path from deciding a
+repository should adopt IDD to the first Issue-Driven Development loop.
+It is procedural on purpose. Deeper rules stay in the workflow and
+phase reference files.
+
+## Before You Start
+
+Choose the repository that will adopt IDD and confirm who is allowed to
+grant agent credentials, review pull requests, and merge. Review
+`docs/permissions.md` before giving an unattended or merge-capable agent
+access to GitHub.
+
+The agent that imports or runs IDD needs access to:
+
+- `git`
+- an authenticated `gh` CLI or equivalent GitHub integration
+- `jq`
+- Node.js/npm with `npx`
+- a REST client such as `curl` for reliable operational marker posting
+
+## 1. Import the Template
+
+Open an agent session in the target repository and ask it to import the
+IDD template from the idd-skill source repository. If the template has
+already been copied, start from the local `ONBOARDING.md` file instead.
+
+The onboarding guide copies the portable instruction files, asks for
+project-specific command values, and updates agent entry files such as
+`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, or Copilot instructions.
+
+## 2. Choose the Review Policy
+
+Before the first full loop, decide whether the default Copilot advisory
+review policy applies. If it does not, choose another profile from
+`docs/idd-review-policy-profiles.md` and apply the listed instruction
+file changes before agents reach PR review and merge phases.
+
+Keep this decision explicit. Review policy changes are workflow changes,
+not just documentation preferences.
+
+## 3. Prepare Issues
+
+IDD works from GitHub Issues. At least one issue should be ready before
+the loop starts:
+
+- limited enough for one reviewable change
+- verifiable with lint, tests, CI, or another explicit check
+- autonomous, with no unresolved human decision or external blocker
+
+For broad requests, use the optional issue-authoring companion to draft
+a roadmap and focused child issues before starting the execution loop.
+Use task-list links to group active roadmap work. Reserve
+`idd-skill-blocked-by` markers for true sequential dependencies on a
+separate roadmap.
+
+## 4. Start the Loop
+
+Ask the agent to start the IDD workflow in the target repository. The
+agent should read the repository entry file, then route through
+`docs/idd-workflow.md` and the phase files under `.github/instructions/`.
+
+The normal loop is:
+
+1. Discover a ready roadmap or orphan issue.
+2. Claim exactly one issue with an ownership marker.
+3. Create a branch and worktree.
+4. Implement, validate, and self-review.
+5. Open a pull request.
+6. Triage review feedback and fix accepted items.
+7. Recheck CI, review freshness, advisory state, and claim ownership.
+8. Merge with a merge commit and clean up stale operational markers.
+
+## 5. Know Where to Go Next
+
+Use the repository's broader docs index as the high-level map when one
+exists. Use `docs/idd-workflow.md` when an agent or maintainer needs
+phase routing details, and use `.github/instructions/*.instructions.md`
+as the authoritative execution rules.
+
+Keep the README short. It should help a first-time reader understand
+what IDD is, why it exists, and which guide to read next.


### PR DESCRIPTION
## Summary

- add `docs/getting-started.md` as the concise import-to-first-loop guide
- export the same guide through `idd-template/docs/getting-started.md`
- wire the new page into `docs/index.md`, template README/ONBOARDING, and the documentation audit manifest

Closes #127

## Validation

- npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"
- npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress
- node scripts/audit-docs.mjs --check
- git diff --check origin/main...HEAD

## Follow-up

- Existing roadmap siblings remain in #117: #128, #129, #130, and #131.

## Background

#117 was converted into a documentation-structure roadmap because it mixed multiple independently reviewable documentation tasks. This PR implements the first child: the focused getting-started guide. The guide is exported with the template because adopters need the same first-run path after copying the portable files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive "Getting Started" guide with step-by-step adoption instructions including template import, policy selection, and workflow execution guidance
  * Updated navigation and onboarding materials to direct users to the new guide
  * Improved overall documentation structure with clearer pathways to additional resources and execution rules

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/132)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->