### PR TITLE
docs: add core IDD concepts guide

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -47,7 +47,8 @@
         "idd-template/.github/instructions/idd-*.instructions.md",
         "idd-template/docs/idd-*.md",
         "idd-template/docs/permissions.md",
-        "idd-template/docs/getting-started.md"
+        "idd-template/docs/getting-started.md",
+        "idd-template/docs/concepts.md"
       ],
       "paths": [
         "idd-template/.github/instructions/idd-overview.instructions.md",
@@ -68,7 +69,8 @@
         "idd-template/docs/idd-helper-scripts.md",
         "idd-template/docs/idd-comment-minimization.md",
         "idd-template/docs/permissions.md",
-        "idd-template/docs/getting-started.md"
+        "idd-template/docs/getting-started.md",
+        "idd-template/docs/concepts.md"
       ]
     },
     {
@@ -230,6 +232,12 @@
       "id": "getting-started-doc",
       "source": "idd-template/docs/getting-started.md",
       "target": "docs/getting-started.md",
+      "mode": "exact"
+    },
+    {
+      "id": "concepts-doc",
+      "source": "idd-template/docs/concepts.md",
+      "target": "docs/concepts.md",
       "mode": "exact"
     },
     {

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,114 @@
+# Core IDD Concepts
+
+Use this page when you want the mental model before reading the phase
+rules. It explains the vocabulary that appears throughout the IDD loop
+without replacing the authoritative instructions in
+`.github/instructions/`.
+
+For the shortest procedural path, start with
+[Getting started](getting-started.md). For phase routing and file
+ownership, use the [IDD workflow guide](idd-workflow.md).
+
+## Claims and Heartbeats
+
+IDD agents coordinate through GitHub issue comments instead of a
+central scheduler. When an agent starts work, it posts a machine-readable
+claim marker that names the issue, branch, agent, and claim identifier.
+Other agents read the issue comment history before starting so they do
+not pick the same work.
+
+The claim identifier is a correlation token for one claim lineage. It is
+not a secret, and an agent must already have recorded and verified that
+token before treating it as its own. Heartbeat comments refresh a live
+claim so long-running sessions do not look abandoned.
+
+Operational details live in
+[claim phase](../.github/instructions/idd-claim.instructions.md) and the
+shared definitions in
+[IDD overview](../.github/instructions/idd-overview.instructions.md).
+
+## Review Snapshots
+
+PR review activity can change while an agent is fixing feedback. IDD
+uses review snapshots to mark the review state that was inspected at a
+specific PR head. A later phase can then tell whether new review
+activity arrived after that point.
+
+Snapshots keep review handling resumable. If a different agent resumes,
+it can compare the recorded snapshot with current PR activity instead of
+guessing which comments were already seen.
+
+See the
+[review snapshot phase](../.github/instructions/idd-review-snapshot.instructions.md)
+for the exact marker format and collection rules.
+
+## PATH A and PATH B
+
+IDD separates review findings into two paths:
+
+- **PATH A** is actionable feedback. Human review comments, requested
+  changes, and critique findings belong here when they may require a
+  code change or maintainer decision.
+- **PATH B** is advisory feedback. Copilot and CI advisory bot comments
+  are tracked for traceability, accepted or rejected during triage, and
+  closed out without entering the review-fix phase.
+
+This split keeps advisory noise visible without letting it block the
+same way as human requested changes. When a source is ambiguous, IDD
+treats it as PATH A until a maintainer narrows it.
+
+See the
+[review triage phase](../.github/instructions/idd-review-triage.instructions.md)
+for scoring, disposition, and marker requirements.
+
+## Advisory Review Waits
+
+The distributed default PR policy includes GitHub Copilot as an
+advisory reviewer. Advisory review can lag behind CI or human review, so
+IDD has a wait protocol that decides when to keep waiting, request a
+re-review, proceed, or hold.
+
+This is a policy choice, not a requirement of the core issue and claim
+model. Repositories that do not want the default Copilot advisory policy
+can choose another review profile and update the listed phase files.
+
+See [review policy profiles](idd-review-policy-profiles.md) and the
+[advisory wait protocol](../.github/instructions/idd-advisory-wait.instructions.md).
+
+## Merge Freshness Gates
+
+Before merge, IDD rechecks the claim, PR head, CI state, review state,
+unresolved conversations, and recent comments. These gates make sure the
+agent merges the same work that was validated and does not race with a
+new review or another session.
+
+The merge phase is also where repository credential policy matters.
+Many teams should let a worker agent prepare the PR, then let a human or
+separate merge-capable agent run the final gate.
+
+See [permissions and threat model](permissions.md),
+[pre-merge conditions](../.github/instructions/idd-pre-merge.instructions.md),
+and [merge execution](../.github/instructions/idd-merge.instructions.md).
+
+## Cleanup Markers
+
+IDD leaves an audit trail in issues and pull requests so another agent
+can resume work. After a PR merges, cleanup can hide stale operational
+markers and completed feedback when it is safe, while preserving the
+history GitHub needs for auditability.
+
+Cleanup is intentionally conservative. It should make active issues and
+PRs easier to read without deleting the evidence needed to understand
+what happened.
+
+See [comment minimization](idd-comment-minimization.md) for the cleanup
+policy and helper notes.
+
+## Where to Read Next
+
+- [Getting started](getting-started.md) for the first adoption path.
+- [IDD workflow guide](idd-workflow.md) for routing and phase ownership.
+- [Permissions and threat model](permissions.md) before granting
+  credentials.
+- [Review policy profiles](idd-review-policy-profiles.md) before
+  changing PR review behavior.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ also serve as the source for a future GitHub Pages site.
 | Need                      | Read first                                              | Why it helps                                                    |
 | ------------------------- | ------------------------------------------------------- | --------------------------------------------------------------- |
 | Start adopting IDD        | [Getting started](getting-started.md)                   | Gives the shortest safe path from import to first loop.         |
+| Learn IDD vocabulary      | [Core concepts](concepts.md)                            | Explains the loop's claims, review, merge, and cleanup terms.   |
 | Run the IDD loop          | [IDD workflow guide](idd-workflow.md)                   | Maps agent entry points, phase files, and Copilot advisory use. |
 | Import IDD into a repo    | [Template onboarding][template-onboarding]              | Explains the portable template copy and placeholder flow.       |
 | Grant agent credentials   | [Permissions](permissions.md)                           | Defines access profiles, forbidden scopes, and threat controls. |
@@ -26,6 +27,8 @@ also serve as the source for a future GitHub Pages site.
 
 - [Getting started](getting-started.md) is the concise first-run path
   from template import to the first IDD execution loop.
+- [Core IDD concepts](concepts.md) explains the key terms new adopters
+  should know before reading strict phase rules.
 - [Template onboarding][template-onboarding] is the canonical
   guide for importing the portable IDD template into another
   repository.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -156,6 +156,7 @@ docs/idd-helper-scripts.md
 docs/idd-comment-minimization.md
 docs/permissions.md
 docs/getting-started.md
+docs/concepts.md
 ```
 
 <!-- /audit:generated -->
@@ -211,7 +212,8 @@ for FILE in \
   "docs/idd-helper-scripts.md" \
   "docs/idd-comment-minimization.md" \
   "docs/permissions.md" \
-  "docs/getting-started.md"
+  "docs/getting-started.md" \
+  "docs/concepts.md"
 do
   gh api -H "Accept: application/vnd.github.raw+json" \
     "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
@@ -274,7 +276,8 @@ for FILE in \
   "docs/idd-helper-scripts.md" \
   "docs/idd-comment-minimization.md" \
   "docs/permissions.md" \
-  "docs/getting-started.md"
+  "docs/getting-started.md" \
+  "docs/concepts.md"
 do
   curl -fsSL "${BASE}/${FILE}" -o "${DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
@@ -481,7 +484,8 @@ After completing the steps above, confirm each item:
 
 - [ ] Every `idd-*.instructions.md` file listed in the generated core
       file list is present in `.github/instructions/`.
-- [ ] `docs/getting-started.md`, `docs/idd-workflow.md`,
+- [ ] `docs/getting-started.md`, `docs/concepts.md`,
+      `docs/idd-workflow.md`,
       `docs/idd-review-policy-profiles.md`,
       `docs/idd-helper-scripts.md`,
       `docs/idd-comment-minimization.md`, and `docs/permissions.md`

--- a/idd-template/docs/concepts.md
+++ b/idd-template/docs/concepts.md
@@ -1,0 +1,114 @@
+# Core IDD Concepts
+
+Use this page when you want the mental model before reading the phase
+rules. It explains the vocabulary that appears throughout the IDD loop
+without replacing the authoritative instructions in
+`.github/instructions/`.
+
+For the shortest procedural path, start with
+[Getting started](getting-started.md). For phase routing and file
+ownership, use the [IDD workflow guide](idd-workflow.md).
+
+## Claims and Heartbeats
+
+IDD agents coordinate through GitHub issue comments instead of a
+central scheduler. When an agent starts work, it posts a machine-readable
+claim marker that names the issue, branch, agent, and claim identifier.
+Other agents read the issue comment history before starting so they do
+not pick the same work.
+
+The claim identifier is a correlation token for one claim lineage. It is
+not a secret, and an agent must already have recorded and verified that
+token before treating it as its own. Heartbeat comments refresh a live
+claim so long-running sessions do not look abandoned.
+
+Operational details live in
+[claim phase](../.github/instructions/idd-claim.instructions.md) and the
+shared definitions in
+[IDD overview](../.github/instructions/idd-overview.instructions.md).
+
+## Review Snapshots
+
+PR review activity can change while an agent is fixing feedback. IDD
+uses review snapshots to mark the review state that was inspected at a
+specific PR head. A later phase can then tell whether new review
+activity arrived after that point.
+
+Snapshots keep review handling resumable. If a different agent resumes,
+it can compare the recorded snapshot with current PR activity instead of
+guessing which comments were already seen.
+
+See the
+[review snapshot phase](../.github/instructions/idd-review-snapshot.instructions.md)
+for the exact marker format and collection rules.
+
+## PATH A and PATH B
+
+IDD separates review findings into two paths:
+
+- **PATH A** is actionable feedback. Human review comments, requested
+  changes, and critique findings belong here when they may require a
+  code change or maintainer decision.
+- **PATH B** is advisory feedback. Copilot and CI advisory bot comments
+  are tracked for traceability, accepted or rejected during triage, and
+  closed out without entering the review-fix phase.
+
+This split keeps advisory noise visible without letting it block the
+same way as human requested changes. When a source is ambiguous, IDD
+treats it as PATH A until a maintainer narrows it.
+
+See the
+[review triage phase](../.github/instructions/idd-review-triage.instructions.md)
+for scoring, disposition, and marker requirements.
+
+## Advisory Review Waits
+
+The distributed default PR policy includes GitHub Copilot as an
+advisory reviewer. Advisory review can lag behind CI or human review, so
+IDD has a wait protocol that decides when to keep waiting, request a
+re-review, proceed, or hold.
+
+This is a policy choice, not a requirement of the core issue and claim
+model. Repositories that do not want the default Copilot advisory policy
+can choose another review profile and update the listed phase files.
+
+See [review policy profiles](idd-review-policy-profiles.md) and the
+[advisory wait protocol](../.github/instructions/idd-advisory-wait.instructions.md).
+
+## Merge Freshness Gates
+
+Before merge, IDD rechecks the claim, PR head, CI state, review state,
+unresolved conversations, and recent comments. These gates make sure the
+agent merges the same work that was validated and does not race with a
+new review or another session.
+
+The merge phase is also where repository credential policy matters.
+Many teams should let a worker agent prepare the PR, then let a human or
+separate merge-capable agent run the final gate.
+
+See [permissions and threat model](permissions.md),
+[pre-merge conditions](../.github/instructions/idd-pre-merge.instructions.md),
+and [merge execution](../.github/instructions/idd-merge.instructions.md).
+
+## Cleanup Markers
+
+IDD leaves an audit trail in issues and pull requests so another agent
+can resume work. After a PR merges, cleanup can hide stale operational
+markers and completed feedback when it is safe, while preserving the
+history GitHub needs for auditability.
+
+Cleanup is intentionally conservative. It should make active issues and
+PRs easier to read without deleting the evidence needed to understand
+what happened.
+
+See [comment minimization](idd-comment-minimization.md) for the cleanup
+policy and helper notes.
+
+## Where to Read Next
+
+- [Getting started](getting-started.md) for the first adoption path.
+- [IDD workflow guide](idd-workflow.md) for routing and phase ownership.
+- [Permissions and threat model](permissions.md) before granting
+  credentials.
+- [Review policy profiles](idd-review-policy-profiles.md) before
+  changing PR review behavior.


### PR DESCRIPTION
## Summary

- add `docs/concepts.md` as a first-reader concept map for IDD vocabulary
- export the same concepts page through `idd-template/docs/concepts.md`
- wire the new page into `docs/index.md`, the onboarding fetch lists, and the docs audit manifest

Closes #128

## Follow-up issues

- Continue #117 with #129 and #130 before the blocked README follow-through in #131.

## Validation

- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`
- `node scripts/audit-docs.mjs --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide explaining core workflow concepts, including claim coordination, review snapshots, feedback pathways, advisory protocols, and merge gates.
  * Updated onboarding materials to reference new concepts documentation.
  * Enhanced documentation index with core concepts entry point for new adopters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/137)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->