### PR TITLE
docs: add customization guide

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -48,7 +48,8 @@
         "idd-template/docs/idd-*.md",
         "idd-template/docs/permissions.md",
         "idd-template/docs/getting-started.md",
-        "idd-template/docs/concepts.md"
+        "idd-template/docs/concepts.md",
+        "idd-template/docs/customization.md"
       ],
       "paths": [
         "idd-template/.github/instructions/idd-overview.instructions.md",
@@ -70,7 +71,8 @@
         "idd-template/docs/idd-comment-minimization.md",
         "idd-template/docs/permissions.md",
         "idd-template/docs/getting-started.md",
-        "idd-template/docs/concepts.md"
+        "idd-template/docs/concepts.md",
+        "idd-template/docs/customization.md"
       ]
     },
     {
@@ -238,6 +240,12 @@
       "id": "concepts-doc",
       "source": "idd-template/docs/concepts.md",
       "target": "docs/concepts.md",
+      "mode": "exact"
+    },
+    {
+      "id": "customization-doc",
+      "source": "idd-template/docs/customization.md",
+      "target": "docs/customization.md",
       "mode": "exact"
     },
     {

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,0 +1,100 @@
+# Customizing IDD
+
+Use this guide after the first template import and before running IDD in
+a production repository. It names the surfaces adopters can change
+safely and points to the authoritative files for each policy.
+
+Keep one rule in mind: documentation can describe a local decision, but
+phase behavior changes only when the instruction files that enforce that
+behavior change too.
+
+## Customization Surfaces
+
+| Surface           | Default                                                         | Where to customize                                                                                                                                                                    |
+| ----------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy     | GitHub Copilot advisory review                                  | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                        |
+| Advisory reviewer | Copilot wait and recovery gates                                 | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.             |
+| Merge policy      | Merge commits after CI, review, freshness, and claim gates pass | Review [Permissions and threat model](permissions.md), then decide whether merges are human-run, run by a separate merge-capable agent, or fully autonomous by explicit opt-in.       |
+| CI commands       | Project-specific command rows in the overview file              | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                            |
+| Issue scope       | Roadmap-first discovery                                         | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues considered before roadmap traversal. |
+
+## Review Policy
+
+Start with [IDD review policy profiles](idd-review-policy-profiles.md).
+The distributed default is `copilot-advisory`, where Copilot is an
+advisory signal and normal CI, branch protection, unresolved-thread,
+review freshness, and claim checks still gate the merge.
+
+Choose a different profile when a repository has a different review
+authority:
+
+- `human-required` when a maintainer, CODEOWNER, or required reviewer is
+  the review gate.
+- `no-advisory` when the repository intentionally relies on CI and
+  branch protection without a bot advisory reviewer.
+- `external-bot` when a non-Copilot reviewer has a stable actor identity
+  and a current-head completion signal.
+
+Changing the profile is a workflow change. Update the phase files named
+by the profile in the same pull request as the local policy note.
+
+## Merge Policy and Credentials
+
+IDD can describe an end-to-end loop, but that does not mean every worker
+credential should be able to merge. Use
+[Permissions and threat model](permissions.md) to choose one of these
+operating shapes:
+
+- Human merge: the agent stops before merge and a maintainer runs the
+  final merge after reviewing the PR state.
+- Separate merge agent: a worker handles claim, implementation, PR, and
+  review fixes; a trusted merge-capable session runs only the final
+  merge phase.
+- Fully autonomous merge: one agent can complete the final merge too.
+  Use this only as an explicit opt-in after the repository accepts the
+  credential risk.
+
+The distributed workflow expects merge commits. Changing the merge
+method, required review policy, or branch protection behavior is a
+repository policy change, not a copy edit.
+
+## CI and Command Placeholders
+
+The `Project commands` table in
+`.github/instructions/idd-overview.instructions.md` is the command
+contract agents follow. During onboarding, replace the template
+placeholders with the target repository's commands:
+
+- `fix-validate`: auto-fix and verify before each commit.
+- `pre-push-validate`: verify before pushing, without auto-fix.
+- `post-fix-validate`: auto-fix and fully verify after review fixes.
+- `install-deps`: prepare dependencies in a fresh worktree.
+
+Use `true` only when a command is intentionally a no-op for the target
+repository. If validation is expensive, prefer an explicit lightweight
+command over leaving the surface ambiguous.
+
+## Issue Scope
+
+The default `issue-scope` is `roadmap`, which keeps discovery inside the
+selected roadmap's explicit task graph. This is the safest mode for
+large initiatives because agents do not silently widen the work queue.
+
+`orphan-first` changes discovery so unblocked orphan issues are
+considered before roadmap traversal. Choose it only when the repository
+intentionally wants small standalone issues to take priority over
+roadmap work. It is a workflow behavior change, so update the overview
+file and record the decision in local onboarding notes or repository
+documentation.
+
+## Documentation-Only vs Workflow Changes
+
+Documentation-only changes are safe when they record how the repository
+already intends to operate, such as the selected profile or the human
+who owns merge escalation.
+
+Edit instruction files when the agent must behave differently. Examples
+include disabling Copilot waits, replacing the advisory reviewer,
+changing merge gates, changing discovery scope, or altering validation
+commands. Keep live instruction files and the exported template in sync
+when the repository is the source of a reusable IDD distribution.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -10,13 +10,13 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface           | Default                                                         | Where to customize                                                                                                                                                                    |
-| ----------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Review policy     | GitHub Copilot advisory review                                  | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                        |
-| Advisory reviewer | Copilot wait and recovery gates                                 | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.             |
-| Merge policy      | Merge commits after CI, review, freshness, and claim gates pass | Review [Permissions and threat model](permissions.md), then decide whether merges are human-run, run by a separate merge-capable agent, or fully autonomous by explicit opt-in.       |
-| CI commands       | Project-specific command rows in the overview file              | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                            |
-| Issue scope       | Roadmap-first discovery                                         | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues considered before roadmap traversal. |
+| Surface           | Default                                                         | Where to customize                                                                                                                                                                          |
+| ----------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy     | GitHub Copilot advisory review                                  | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                              |
+| Advisory reviewer | Copilot wait and recovery gates                                 | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                   |
+| Merge policy      | Merge commits after CI, review, freshness, and claim gates pass | Review [Permissions and threat model](permissions.md), then decide whether merges are human-run, run by a separate merge-capable agent, or fully autonomous by explicit opt-in.             |
+| CI commands       | Project-specific command rows in the overview file              | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                  |
+| Issue scope       | Roadmap-first discovery                                         | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal. |
 
 ## Review Policy
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ also serve as the source for a future GitHub Pages site.
 | ------------------------- | ------------------------------------------------------- | --------------------------------------------------------------- |
 | Start adopting IDD        | [Getting started](getting-started.md)                   | Gives the shortest safe path from import to first loop.         |
 | Learn IDD vocabulary      | [Core concepts](concepts.md)                            | Explains the loop's claims, review, merge, and cleanup terms.   |
+| Customize IDD safely      | [Customization](customization.md)                       | Names the adopter policy surfaces and workflow edit points.     |
 | Run the IDD loop          | [IDD workflow guide](idd-workflow.md)                   | Maps agent entry points, phase files, and Copilot advisory use. |
 | Import IDD into a repo    | [Template onboarding][template-onboarding]              | Explains the portable template copy and placeholder flow.       |
 | Grant agent credentials   | [Permissions](permissions.md)                           | Defines access profiles, forbidden scopes, and threat controls. |
@@ -29,6 +30,8 @@ also serve as the source for a future GitHub Pages site.
   from template import to the first IDD execution loop.
 - [Core IDD concepts](concepts.md) explains the key terms new adopters
   should know before reading strict phase rules.
+- [Customizing IDD](customization.md) names the safe adopter policy
+  surfaces for review, advisory, merge, CI, and discovery behavior.
 - [Template onboarding][template-onboarding] is the canonical
   guide for importing the portable IDD template into another
   repository.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -157,6 +157,7 @@ docs/idd-comment-minimization.md
 docs/permissions.md
 docs/getting-started.md
 docs/concepts.md
+docs/customization.md
 ```
 
 <!-- /audit:generated -->
@@ -213,7 +214,8 @@ for FILE in \
   "docs/idd-comment-minimization.md" \
   "docs/permissions.md" \
   "docs/getting-started.md" \
-  "docs/concepts.md"
+  "docs/concepts.md" \
+  "docs/customization.md"
 do
   gh api -H "Accept: application/vnd.github.raw+json" \
     "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
@@ -277,7 +279,8 @@ for FILE in \
   "docs/idd-comment-minimization.md" \
   "docs/permissions.md" \
   "docs/getting-started.md" \
-  "docs/concepts.md"
+  "docs/concepts.md" \
+  "docs/customization.md"
 do
   curl -fsSL "${BASE}/${FILE}" -o "${DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
@@ -485,7 +488,7 @@ After completing the steps above, confirm each item:
 - [ ] Every `idd-*.instructions.md` file listed in the generated core
       file list is present in `.github/instructions/`.
 - [ ] `docs/getting-started.md`, `docs/concepts.md`,
-      `docs/idd-workflow.md`,
+      `docs/customization.md`, `docs/idd-workflow.md`,
       `docs/idd-review-policy-profiles.md`,
       `docs/idd-helper-scripts.md`,
       `docs/idd-comment-minimization.md`, and `docs/permissions.md`

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -11,9 +11,11 @@ multi-agent GitHub automation.
    etc.) as described in `ONBOARDING.md`.
 4. Read `docs/getting-started.md` for the shortest safe path from
    import to the first IDD loop.
-5. Review `docs/permissions.md` before granting credentials to
+5. Read `docs/customization.md` before changing review, merge, CI, or
+   discovery policy.
+6. Review `docs/permissions.md` before granting credentials to
    unattended or merge-capable agents.
-6. Optional: install the issue-authoring companion skill if the project
+7. Optional: install the issue-authoring companion skill if the project
    wants pre-execution issue drafting. The canonical source bundle in
    this repository lives at `skills/issue-authoring/`; install copies
    into the agent-specific skill directory your runtime reads.
@@ -83,6 +85,7 @@ profiles require additional files.
   idd-resume.instructions.md         ← resume after crash / handoff
 docs/
   getting-started.md                  ← concise import-to-first-loop guide
+  customization.md                    ← adopter policy customization guide
   idd-workflow.md                    ← cross-agent entry point and file map
   idd-review-policy-profiles.md      ← default and alternative PR review policies
   idd-helper-scripts.md              ← optional helper-script evaluation and policy

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1,0 +1,100 @@
+# Customizing IDD
+
+Use this guide after the first template import and before running IDD in
+a production repository. It names the surfaces adopters can change
+safely and points to the authoritative files for each policy.
+
+Keep one rule in mind: documentation can describe a local decision, but
+phase behavior changes only when the instruction files that enforce that
+behavior change too.
+
+## Customization Surfaces
+
+| Surface           | Default                                                         | Where to customize                                                                                                                                                                    |
+| ----------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy     | GitHub Copilot advisory review                                  | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                        |
+| Advisory reviewer | Copilot wait and recovery gates                                 | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.             |
+| Merge policy      | Merge commits after CI, review, freshness, and claim gates pass | Review [Permissions and threat model](permissions.md), then decide whether merges are human-run, run by a separate merge-capable agent, or fully autonomous by explicit opt-in.       |
+| CI commands       | Project-specific command rows in the overview file              | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                            |
+| Issue scope       | Roadmap-first discovery                                         | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues considered before roadmap traversal. |
+
+## Review Policy
+
+Start with [IDD review policy profiles](idd-review-policy-profiles.md).
+The distributed default is `copilot-advisory`, where Copilot is an
+advisory signal and normal CI, branch protection, unresolved-thread,
+review freshness, and claim checks still gate the merge.
+
+Choose a different profile when a repository has a different review
+authority:
+
+- `human-required` when a maintainer, CODEOWNER, or required reviewer is
+  the review gate.
+- `no-advisory` when the repository intentionally relies on CI and
+  branch protection without a bot advisory reviewer.
+- `external-bot` when a non-Copilot reviewer has a stable actor identity
+  and a current-head completion signal.
+
+Changing the profile is a workflow change. Update the phase files named
+by the profile in the same pull request as the local policy note.
+
+## Merge Policy and Credentials
+
+IDD can describe an end-to-end loop, but that does not mean every worker
+credential should be able to merge. Use
+[Permissions and threat model](permissions.md) to choose one of these
+operating shapes:
+
+- Human merge: the agent stops before merge and a maintainer runs the
+  final merge after reviewing the PR state.
+- Separate merge agent: a worker handles claim, implementation, PR, and
+  review fixes; a trusted merge-capable session runs only the final
+  merge phase.
+- Fully autonomous merge: one agent can complete the final merge too.
+  Use this only as an explicit opt-in after the repository accepts the
+  credential risk.
+
+The distributed workflow expects merge commits. Changing the merge
+method, required review policy, or branch protection behavior is a
+repository policy change, not a copy edit.
+
+## CI and Command Placeholders
+
+The `Project commands` table in
+`.github/instructions/idd-overview.instructions.md` is the command
+contract agents follow. During onboarding, replace the template
+placeholders with the target repository's commands:
+
+- `fix-validate`: auto-fix and verify before each commit.
+- `pre-push-validate`: verify before pushing, without auto-fix.
+- `post-fix-validate`: auto-fix and fully verify after review fixes.
+- `install-deps`: prepare dependencies in a fresh worktree.
+
+Use `true` only when a command is intentionally a no-op for the target
+repository. If validation is expensive, prefer an explicit lightweight
+command over leaving the surface ambiguous.
+
+## Issue Scope
+
+The default `issue-scope` is `roadmap`, which keeps discovery inside the
+selected roadmap's explicit task graph. This is the safest mode for
+large initiatives because agents do not silently widen the work queue.
+
+`orphan-first` changes discovery so unblocked orphan issues are
+considered before roadmap traversal. Choose it only when the repository
+intentionally wants small standalone issues to take priority over
+roadmap work. It is a workflow behavior change, so update the overview
+file and record the decision in local onboarding notes or repository
+documentation.
+
+## Documentation-Only vs Workflow Changes
+
+Documentation-only changes are safe when they record how the repository
+already intends to operate, such as the selected profile or the human
+who owns merge escalation.
+
+Edit instruction files when the agent must behave differently. Examples
+include disabling Copilot waits, replacing the advisory reviewer,
+changing merge gates, changing discovery scope, or altering validation
+commands. Keep live instruction files and the exported template in sync
+when the repository is the source of a reusable IDD distribution.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -10,13 +10,13 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface           | Default                                                         | Where to customize                                                                                                                                                                    |
-| ----------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Review policy     | GitHub Copilot advisory review                                  | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                        |
-| Advisory reviewer | Copilot wait and recovery gates                                 | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.             |
-| Merge policy      | Merge commits after CI, review, freshness, and claim gates pass | Review [Permissions and threat model](permissions.md), then decide whether merges are human-run, run by a separate merge-capable agent, or fully autonomous by explicit opt-in.       |
-| CI commands       | Project-specific command rows in the overview file              | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                            |
-| Issue scope       | Roadmap-first discovery                                         | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues considered before roadmap traversal. |
+| Surface           | Default                                                         | Where to customize                                                                                                                                                                          |
+| ----------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy     | GitHub Copilot advisory review                                  | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                              |
+| Advisory reviewer | Copilot wait and recovery gates                                 | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                   |
+| Merge policy      | Merge commits after CI, review, freshness, and claim gates pass | Review [Permissions and threat model](permissions.md), then decide whether merges are human-run, run by a separate merge-capable agent, or fully autonomous by explicit opt-in.             |
+| CI commands       | Project-specific command rows in the overview file              | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                  |
+| Issue scope       | Roadmap-first discovery                                         | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal. |
 
 ## Review Policy
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

- Add `docs/customization.md` as the adopter-facing guide for review policy, advisory reviewer, merge policy, CI commands, and issue-scope customization.
- Export the same guide to `idd-template/docs/customization.md` and wire it into the template README, onboarding import lists, generated block, and audit manifest.
- Link the guide from `docs/index.md` without changing the root README, which remains part of the later #131 landing-page follow-through.

Closes #129

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `node scripts/audit-docs.mjs --check`
- `git diff --check origin/main...HEAD`

## Follow-up

- #128 remains the concepts page sibling task.
- #130 remains the phase reference navigation sibling task.
- #131 should do the bilingual README landing-page follow-through after the focused docs are in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a customization guide explaining safe configuration of review policies, merge strategies, CI placeholders, and issue discovery modes; linked from onboarding and reference materials.
* **Chores**
  * Updated template distribution and sync configuration to include the new customization guide among core template files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/139)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
