### PR TITLE
ci: enforce dprint markdown check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
         env:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
         run: node scripts/audit-docs.mjs --check
+      - name: Run dprint
+        run: npx dprint check "**/*.md"
       - name: Run cspell
         uses: streetsidesoftware/cspell-action@v8
       - name: Run markdownlint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
         run: node scripts/audit-docs.mjs --check
       - name: Run dprint
-        run: npx dprint check "**/*.md"
+        run: npx dprint@0.54.0 check "**/*.md"
       - name: Run cspell
         uses: streetsidesoftware/cspell-action@v8
       - name: Run markdownlint


### PR DESCRIPTION
## Summary

- Add a dprint formatting check to the lint workflow so Markdown formatting is enforced in CI.
- Keep the existing documentation audit, cspell, and markdownlint checks unchanged.

Closes #138

## Validation

- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`
- `node scripts/audit-docs.mjs --check`
- `npx yaml-lint .github/workflows/lint.yml`
- `git diff --check origin/main...HEAD`

## Follow-up

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Markdown formatting checks to the CI lint workflow (runs dprint to verify .md files), enhancing documentation quality checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/145)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/145)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->