### PR TITLE
docs: add phase reference navigation

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -49,7 +49,8 @@
         "idd-template/docs/permissions.md",
         "idd-template/docs/getting-started.md",
         "idd-template/docs/concepts.md",
-        "idd-template/docs/customization.md"
+        "idd-template/docs/customization.md",
+        "idd-template/docs/reference.md"
       ],
       "paths": [
         "idd-template/.github/instructions/idd-overview.instructions.md",
@@ -72,7 +73,8 @@
         "idd-template/docs/permissions.md",
         "idd-template/docs/getting-started.md",
         "idd-template/docs/concepts.md",
-        "idd-template/docs/customization.md"
+        "idd-template/docs/customization.md",
+        "idd-template/docs/reference.md"
       ]
     },
     {
@@ -246,6 +248,12 @@
       "id": "customization-doc",
       "source": "idd-template/docs/customization.md",
       "target": "docs/customization.md",
+      "mode": "exact"
+    },
+    {
+      "id": "reference-doc",
+      "source": "idd-template/docs/reference.md",
+      "target": "docs/reference.md",
       "mode": "exact"
     },
     {

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ also serve as the source for a future GitHub Pages site.
 | Learn IDD vocabulary      | [Core concepts](concepts.md)                            | Explains the loop's claims, review, merge, and cleanup terms.   |
 | Customize IDD safely      | [Customization](customization.md)                       | Names the adopter policy surfaces and workflow edit points.     |
 | Run the IDD loop          | [IDD workflow guide](idd-workflow.md)                   | Maps agent entry points, phase files, and Copilot advisory use. |
+| Find detailed references  | [Detailed reference](reference.md)                      | Lists phase files and policy pages without duplicating rules.   |
 | Import IDD into a repo    | [Template onboarding][template-onboarding]              | Explains the portable template copy and placeholder flow.       |
 | Grant agent credentials   | [Permissions](permissions.md)                           | Defines access profiles, forbidden scopes, and threat controls. |
 | Choose PR review policy   | [Review policy profiles](idd-review-policy-profiles.md) | Names the default Copilot advisory policy and alternatives.     |
@@ -35,8 +36,6 @@ also serve as the source for a future GitHub Pages site.
 - [Template onboarding][template-onboarding] is the canonical
   guide for importing the portable IDD template into another
   repository.
-- [IDD workflow guide](idd-workflow.md) explains where each supported
-  agent starts and which phase file to read next.
 - [Permissions and threat model](permissions.md) describes the minimum
   GitHub access profiles, forbidden credentials, and operating controls
   for unattended or merge-capable agents.
@@ -44,8 +43,12 @@ also serve as the source for a future GitHub Pages site.
   the default Copilot advisory PR policy and non-default customization
   surfaces.
 
-### Workflow Internals
+### Detailed Reference
 
+- [Detailed reference](reference.md) is the compact phase and policy map
+  for maintainers and agents who need an authoritative source link.
+- [IDD workflow guide](idd-workflow.md) explains where each supported
+  agent starts and which phase file to read next.
 - [IDD helper script evaluation](idd-helper-scripts.md) records why the
   current workflow stays portable shell / `gh` / `jq` instructions
   instead of requiring helper scripts.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,46 @@
+# IDD Detailed Reference
+
+Use this page when you already know the IDD loop exists and need the
+authoritative phase file or policy page for a specific operational
+question. It is a navigation surface, not a replacement for the phase
+instructions themselves.
+
+For first-time adoption, start with [Getting started](getting-started.md)
+or [Core concepts](concepts.md) before using this reference.
+
+## Phase Map
+
+| Need                              | Phase  | Authoritative source                                                           |
+| --------------------------------- | ------ | ------------------------------------------------------------------------------ |
+| Shared definitions and commands   | All    | [IDD overview](../.github/instructions/idd-overview.instructions.md)           |
+| Select the next issue             | A0-A4  | [Discover](../.github/instructions/idd-discover.instructions.md)               |
+| Claim an issue safely             | A5     | [Claim](../.github/instructions/idd-claim.instructions.md)                     |
+| Create a worktree and self-review | B-C    | [Work and self-review](../.github/instructions/idd-work.instructions.md)       |
+| Open or update the pull request   | D      | [PR submit](../.github/instructions/idd-pr-submit.instructions.md)             |
+| Interpret CI while waiting        | D/E/F  | [CI polling](../.github/instructions/idd-ci.instructions.md)                   |
+| Snapshot review activity          | E1-E3  | [Review snapshot](../.github/instructions/idd-review-snapshot.instructions.md) |
+| Triage review items               | E4-E8  | [Review triage](../.github/instructions/idd-review-triage.instructions.md)     |
+| Fix accepted review feedback      | E9-E15 | [Review fix](../.github/instructions/idd-review-fix.instructions.md)           |
+| Check pre-merge gates             | F1-F2  | [Pre-merge conditions](../.github/instructions/idd-pre-merge.instructions.md)  |
+| Merge, clean up, and loop         | F3-F5  | [Merge execution](../.github/instructions/idd-merge.instructions.md)           |
+| Resume after a crash or handoff   | Resume | [Resume](../.github/instructions/idd-resume.instructions.md)                   |
+| Wait for Copilot advisory state   | E/F    | [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)     |
+
+## Policy and Support Pages
+
+| Topic                                  | Read                                                        |
+| -------------------------------------- | ----------------------------------------------------------- |
+| Cross-agent entry path                 | [IDD workflow guide](idd-workflow.md)                       |
+| Review policy choices                  | [IDD review policy profiles](idd-review-policy-profiles.md) |
+| Credential boundaries and threat model | [Permissions](permissions.md)                               |
+| Safe adopter customization surfaces    | [Customization](customization.md)                           |
+| Post-merge comment cleanup             | [IDD comment minimization](idd-comment-minimization.md)     |
+| Helper-script adoption policy          | [IDD helper script evaluation](idd-helper-scripts.md)       |
+
+## Maintainer Note
+
+If you maintain an IDD distribution source repository, keep exported
+template files and generated onboarding lists in sync when adding or
+removing reference pages. In this repository, that means updating
+`audit/sync-manifest.json`, `idd-template/ONBOARDING.md`, and
+`idd-template/README.md` in the same change.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -158,6 +158,7 @@ docs/permissions.md
 docs/getting-started.md
 docs/concepts.md
 docs/customization.md
+docs/reference.md
 ```
 
 <!-- /audit:generated -->
@@ -215,7 +216,8 @@ for FILE in \
   "docs/permissions.md" \
   "docs/getting-started.md" \
   "docs/concepts.md" \
-  "docs/customization.md"
+  "docs/customization.md" \
+  "docs/reference.md"
 do
   gh api -H "Accept: application/vnd.github.raw+json" \
     "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
@@ -280,7 +282,8 @@ for FILE in \
   "docs/permissions.md" \
   "docs/getting-started.md" \
   "docs/concepts.md" \
-  "docs/customization.md"
+  "docs/customization.md" \
+  "docs/reference.md"
 do
   curl -fsSL "${BASE}/${FILE}" -o "${DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
@@ -488,7 +491,8 @@ After completing the steps above, confirm each item:
 - [ ] Every `idd-*.instructions.md` file listed in the generated core
       file list is present in `.github/instructions/`.
 - [ ] `docs/getting-started.md`, `docs/concepts.md`,
-      `docs/customization.md`, `docs/idd-workflow.md`,
+      `docs/customization.md`, `docs/reference.md`,
+      `docs/idd-workflow.md`,
       `docs/idd-review-policy-profiles.md`,
       `docs/idd-helper-scripts.md`,
       `docs/idd-comment-minimization.md`, and `docs/permissions.md`

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -86,6 +86,7 @@ profiles require additional files.
 docs/
   getting-started.md                  ← concise import-to-first-loop guide
   customization.md                    ← adopter policy customization guide
+  reference.md                        ← detailed phase and policy navigation
   idd-workflow.md                    ← cross-agent entry point and file map
   idd-review-policy-profiles.md      ← default and alternative PR review policies
   idd-helper-scripts.md              ← optional helper-script evaluation and policy

--- a/idd-template/docs/reference.md
+++ b/idd-template/docs/reference.md
@@ -1,0 +1,46 @@
+# IDD Detailed Reference
+
+Use this page when you already know the IDD loop exists and need the
+authoritative phase file or policy page for a specific operational
+question. It is a navigation surface, not a replacement for the phase
+instructions themselves.
+
+For first-time adoption, start with [Getting started](getting-started.md)
+or [Core concepts](concepts.md) before using this reference.
+
+## Phase Map
+
+| Need                              | Phase  | Authoritative source                                                           |
+| --------------------------------- | ------ | ------------------------------------------------------------------------------ |
+| Shared definitions and commands   | All    | [IDD overview](../.github/instructions/idd-overview.instructions.md)           |
+| Select the next issue             | A0-A4  | [Discover](../.github/instructions/idd-discover.instructions.md)               |
+| Claim an issue safely             | A5     | [Claim](../.github/instructions/idd-claim.instructions.md)                     |
+| Create a worktree and self-review | B-C    | [Work and self-review](../.github/instructions/idd-work.instructions.md)       |
+| Open or update the pull request   | D      | [PR submit](../.github/instructions/idd-pr-submit.instructions.md)             |
+| Interpret CI while waiting        | D/E/F  | [CI polling](../.github/instructions/idd-ci.instructions.md)                   |
+| Snapshot review activity          | E1-E3  | [Review snapshot](../.github/instructions/idd-review-snapshot.instructions.md) |
+| Triage review items               | E4-E8  | [Review triage](../.github/instructions/idd-review-triage.instructions.md)     |
+| Fix accepted review feedback      | E9-E15 | [Review fix](../.github/instructions/idd-review-fix.instructions.md)           |
+| Check pre-merge gates             | F1-F2  | [Pre-merge conditions](../.github/instructions/idd-pre-merge.instructions.md)  |
+| Merge, clean up, and loop         | F3-F5  | [Merge execution](../.github/instructions/idd-merge.instructions.md)           |
+| Resume after a crash or handoff   | Resume | [Resume](../.github/instructions/idd-resume.instructions.md)                   |
+| Wait for Copilot advisory state   | E/F    | [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)     |
+
+## Policy and Support Pages
+
+| Topic                                  | Read                                                        |
+| -------------------------------------- | ----------------------------------------------------------- |
+| Cross-agent entry path                 | [IDD workflow guide](idd-workflow.md)                       |
+| Review policy choices                  | [IDD review policy profiles](idd-review-policy-profiles.md) |
+| Credential boundaries and threat model | [Permissions](permissions.md)                               |
+| Safe adopter customization surfaces    | [Customization](customization.md)                           |
+| Post-merge comment cleanup             | [IDD comment minimization](idd-comment-minimization.md)     |
+| Helper-script adoption policy          | [IDD helper script evaluation](idd-helper-scripts.md)       |
+
+## Maintainer Note
+
+If you maintain an IDD distribution source repository, keep exported
+template files and generated onboarding lists in sync when adding or
+removing reference pages. In this repository, that means updating
+`audit/sync-manifest.json`, `idd-template/ONBOARDING.md`, and
+`idd-template/README.md` in the same change.


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

- Add `docs/reference.md` and exact-synced `idd-template/docs/reference.md` as a detailed phase and policy navigation page.
- Link the reference page from `docs/index.md` under a dedicated detailed-reference section.
- Export the new page through `audit/sync-manifest.json`, template onboarding fetch/checklist entries, and the template README inventory.

Closes #130

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `node scripts/audit-docs.mjs --check`
- `git diff --check`

## Follow-up

- #131 can now update the bilingual root README to point first-time readers to the completed focused docs path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new detailed reference guide providing phase navigation and links to authoritative instruction pages
  * Reorganized documentation index with improved navigation grouping and expanded reference sections
  * Updated template documentation to include reference materials

* **Chores**
  * Updated manifest configuration for documentation synchronization

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/146)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->