### PR TITLE
docs: add README reality check

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,11 +59,22 @@ IDD を導入したいリポジトリで AI エージェントのセッション
 エージェントはワークフローガイドを読み、着手できる issue を探して担当を宣言し、
 実装、PR レビュー、CI、マージ、後片づけまでループを進めます。
 
-ループを最後まで実行するには、エージェントが `git`、認証済みの `gh` CLI
-または同等の GitHub MCP 連携、`jq`、`npx` を使える Node.js/npm、
-そして運用マーカーを確実に投稿するための `curl` などの REST クライアントに
-アクセスできる必要があります。必要なコマンドの詳細はワークフロードキュメントを
-参照してください。無人またはマージ可能なエージェントへ認証情報を渡す前に、
+## リアリティチェック
+
+IDD は Markdown ネイティブですが、依存関係なしではありません。
+
+ループを最後まで実行するには、エージェントに次が必要です:
+
+- `git`
+- 認証済みの `gh` CLI または同等の GitHub MCP 連携
+- `jq`
+- `curl` などの REST クライアント
+- `npx` を使える Node.js/npm
+- 選択した merge policy に合う repository-scoped GitHub credentials
+- ループで使う場合は、設定済みの branch protection / required review policy
+
+必要なコマンドの詳細はワークフロードキュメントを参照してください。無人または
+マージ可能なエージェントへ認証情報を渡す前に、
 [Permissions and threat model](docs/permissions.md) も確認してください。
 
 ## IDD が自動化すること

--- a/README.md
+++ b/README.md
@@ -57,12 +57,25 @@ After onboarding, start an agent in the target repository and say:
 The agent reads the workflow guide, discovers a ready issue, claims it,
 and follows the loop through work, PR review, CI, merge, and cleanup.
 
-Before an agent can run the loop end to end, it needs access to `git`,
-an authenticated `gh` CLI or equivalent GitHub MCP integration, `jq`,
-Node.js/npm with `npx`, and a REST client such as `curl` for reliable
-operational marker posting. See the workflow docs for the detailed
-command contract. Review [Permissions and threat model](docs/permissions.md)
-before granting credentials to unattended or merge-capable agents.
+## Reality Check
+
+IDD is Markdown-native, not dependency-free.
+
+To run the full loop, an agent needs:
+
+- `git`
+- An authenticated `gh` CLI or equivalent GitHub MCP integration
+- `jq`
+- A REST client such as `curl`
+- Node.js/npm with `npx`
+- Repository-scoped GitHub credentials appropriate for the chosen merge
+  policy
+- Branch protection and required review policy already configured when
+  those gates are part of the loop
+
+See the workflow docs for the detailed command contract. Review
+[Permissions and threat model](docs/permissions.md) before granting
+credentials to unattended or merge-capable agents.
 
 ## What IDD Automates
 


### PR DESCRIPTION
## Summary

- Move the full-loop prerequisites into a dedicated Reality Check section immediately after Quick Start.
- Make the dependency and credential assumptions explicit in both README.md and README.ja.md.
- Keep the existing workflow and permissions links attached to the expectation-setting section.

Closes #143

## Validation

- `npx dprint@0.54.0 fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx dprint@0.54.0 check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `node scripts/audit-docs.mjs --check`
- `git diff --check origin/main...HEAD`

## Follow-up

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Reality Check" section clarifying all prerequisites required to run the workflow loop, including necessary tools, credentials, and configuration conditions
  * Restructured and enhanced prerequisite documentation for improved clarity in both English and Japanese versions
  * Included guidance on permissions and security considerations before granting access credentials

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->