### PR TITLE
docs(readme): add focused docs path

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -66,6 +66,22 @@ IDD を導入したいリポジトリで AI エージェントのセッション
 参照してください。無人またはマージ可能なエージェントへ認証情報を渡す前に、
 [Permissions and threat model](docs/permissions.md) も確認してください。
 
+### 5 分で読む導線
+
+IDD を評価または導入するときは、focused docs を次の順に読んでください:
+
+1. [Getting started](docs/getting-started.md) — テンプレートを取り込み、
+   最初のループを実行する。
+2. [Core concepts](docs/concepts.md) — claim、review、merge、cleanup の
+   語彙を把握する。
+3. [Customization](docs/customization.md) — ワークフロー全体を fork せずに
+   policy surface を選ぶ。
+4. [Permissions and threat model](docs/permissions.md) — agent profile ごとに
+   渡す認証情報を決める。
+5. [リファレンスマニュアル](docs/index.md) と
+   [detailed reference](docs/reference.md) — landing page から phase file、
+   policy、maintenance note へ進む。
+
 ## IDD が自動化すること
 
 IDD は、良い意味で退屈なワークフローです。各フェーズには名前付きの役割、
@@ -147,7 +163,15 @@ Discover -> Claim -> Work の開始には、引き続き明示的な承認が必
 
 ## 詳細リファレンス
 
+- [Getting started](docs/getting-started.md) — import から最初の IDD loop までの
+  最短で安全な導線。
+- [Core concepts](docs/concepts.md) — claim、review snapshot、merge gate、
+  cleanup の背景にある語彙。
+- [Customization](docs/customization.md) — adopter が管理する policy surface と
+  workflow edit point。
 - [リファレンスマニュアル](docs/index.md) — 詳細ドキュメント群への目的別の入口。
+- [Detailed reference](docs/reference.md) — phase file、policy docs、
+  template-maintenance link を、ルールの重複なしで辿るための一覧。
 - [Workflow guide](docs/idd-workflow.md) — 入口ファイル、ファイル構成、
   エージェント間の導線。
 - [Review policy profiles](docs/idd-review-policy-profiles.md) — 標準の

--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ operational marker posting. See the workflow docs for the detailed
 command contract. Review [Permissions and threat model](docs/permissions.md)
 before granting credentials to unattended or merge-capable agents.
 
+### 5-Minute Reading Path
+
+Use the focused docs in this order when you are evaluating or adopting
+IDD:
+
+1. [Getting started](docs/getting-started.md) — import the template and
+   run the first loop.
+2. [Core concepts](docs/concepts.md) — learn the claim, review, merge,
+   and cleanup vocabulary.
+3. [Customization](docs/customization.md) — choose policy surfaces
+   without forking the whole workflow.
+4. [Permissions and threat model](docs/permissions.md) — decide which
+   credentials each agent profile should receive.
+5. [Reference manual](docs/index.md) and
+   [detailed reference](docs/reference.md) — jump from the landing page
+   into phase files, policies, and maintenance notes.
+
 ## What IDD Automates
 
 IDD is intentionally boring in the best way: every phase has a named
@@ -149,8 +166,16 @@ approval.
 
 ## Deeper Reference
 
+- [Getting started](docs/getting-started.md) — the shortest safe path
+  from import to the first IDD loop.
+- [Core concepts](docs/concepts.md) — the vocabulary behind claims,
+  review snapshots, merge gates, and cleanup.
+- [Customization](docs/customization.md) — adopter-controlled policy
+  surfaces and workflow edit points.
 - [Reference manual](docs/index.md) — a task-oriented entry point for
   the deeper documentation set.
+- [Detailed reference](docs/reference.md) — phase files, policy docs,
+  and template-maintenance links without duplicating rules.
 - [Workflow guide](docs/idd-workflow.md) — entry points, file map, and
   cross-agent routing.
 - [Review policy profiles](docs/idd-review-policy-profiles.md) — choose


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

- Add a concise 5-minute reading path to both English and Japanese READMEs.
- Link first-time readers to getting started, concepts, customization, permissions, and the detailed reference surfaces delivered under #127-#130.
- Expand the deeper-reference list without introducing count-based wording.

## Validation

- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `node scripts/audit-docs.mjs --check`
- `npx cspell lint "**" --no-progress`
- `git diff --check origin/main...HEAD`

Closes #131
Refs #117

Follow-up: none expected; this is the landing-page follow-through for the documentation-structure roadmap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "5-Minute Reading Path" section to guide users through documentation in the recommended order (Getting Started → Core Concepts → Customization → Permissions and Threat Model → Reference Materials)
  * Reorganized and enhanced reference documentation sections with clear descriptions for improved navigation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/148)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->