### PR TITLE
docs: clarify merge credential policy

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -76,11 +76,11 @@ IDD は Markdown ネイティブですが、依存関係なしではありませ
 必要なコマンドの詳細はワークフロードキュメントを参照してください。無人または
 マージ可能なエージェントへ認証情報を渡す前に、
 [Permissions and threat model](docs/permissions.md) も確認してください。
-リポジトリが merge-capable profile を明示的に選ばない限り、通常の worker
-credential はマージ手前で止める前提にしてください。merge policy は
-[Customizing IDD](docs/customization.md) で `human_merge`、
-`separate_merge_agent`、`fully_autonomous_merge` から選びます。
-`fully_autonomous_merge` は認証情報に関する明示 opt-in です。
+リポジトリが `fully_autonomous_merge` へ明示 opt-in しない限り、通常の
+worker credential はマージ手前で止める前提にしてください。
+`human_merge` と `separate_merge_agent` では、マージ権限を worker session
+の外に置きます。merge policy は [Customizing IDD](docs/customization.md) で
+1 つ選んで記録します。
 
 ## IDD が自動化すること
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -12,8 +12,8 @@
 IDD Skill は、リポジトリへ移植できる Issue-Driven Development
 ワークフローです。エージェントは着手できる issue を探し、担当を宣言し、
 ブランチを切って実装し、PR を開き、レビュー指摘を反映し、CI を待ち、
-マージして後片づけまで進めます。ループ全体は、リポジトリ内の Markdown
-で書かれた指示ファイルとして管理されます。
+選択したマージポリシーに従ってマージと後片づけまで進めます。ループ全体は、
+リポジトリ内の Markdown で書かれた指示ファイルとして管理されます。
 
 ## IDD が選ばれる理由
 
@@ -57,7 +57,7 @@ IDD を導入したいリポジトリで AI エージェントのセッション
 > このリポジトリで IDD ワークフローを開始してください。
 
 エージェントはワークフローガイドを読み、着手できる issue を探して担当を宣言し、
-実装、PR レビュー、CI、マージ、後片づけまでループを進めます。
+実装、PR レビュー、CI、選択したマージポリシー、後片づけまでループを進めます。
 
 ## リアリティチェック
 
@@ -76,21 +76,26 @@ IDD は Markdown ネイティブですが、依存関係なしではありませ
 必要なコマンドの詳細はワークフロードキュメントを参照してください。無人または
 マージ可能なエージェントへ認証情報を渡す前に、
 [Permissions and threat model](docs/permissions.md) も確認してください。
+リポジトリが merge-capable profile を明示的に選ばない限り、通常の worker
+credential はマージ手前で止める前提にしてください。merge policy は
+[Customizing IDD](docs/customization.md) で `human_merge`、
+`separate_merge_agent`、`fully_autonomous_merge` から選びます。
+`fully_autonomous_merge` は認証情報に関する明示 opt-in です。
 
 ## IDD が自動化すること
 
 IDD は、良い意味で退屈なワークフローです。各フェーズには名前付きの役割、
 再開できるマーカー、次の手順があります。
 
-| ステージ    | エージェントが行うこと                                                                 |
-| ----------- | -------------------------------------------------------------------------------------- |
-| Discover    | ロードマップまたは単独 issue から着手できる作業を探し、範囲を勝手に広げません。        |
-| Claim       | 機械可読な担当マーカーで 1 つの issue を予約します。                                   |
-| Work        | ブランチと worktree を作り、計画、実装、セルフレビューを行います。                     |
-| Submit PR   | push して PR を開き、レビューできる状態になるまで検証を待ちます。                      |
-| Review Loop | レビューの動きを記録し、指摘を採用または見送り、採用した指摘を直します。               |
-| Merge       | 最新状態、助言レビュー、CI、未解決スレッド、コメントをもう一度確認します。             |
-| Cleanup     | 検証済み HEAD をマージし、安全な場合は古いマーカーを隠して、次の Discover へ戻ります。 |
+| ステージ    | エージェントが行うこと                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------ |
+| Discover    | ロードマップまたは単独 issue から着手できる作業を探し、範囲を勝手に広げません。            |
+| Claim       | 機械可読な担当マーカーで 1 つの issue を予約します。                                       |
+| Work        | ブランチと worktree を作り、計画、実装、セルフレビューを行います。                         |
+| Submit PR   | push して PR を開き、レビューできる状態になるまで検証を待ちます。                          |
+| Review Loop | レビューの動きを記録し、指摘を採用または見送り、採用した指摘を直します。                   |
+| Merge       | 最新状態、助言レビュー、CI、未解決スレッド、コメント、選択したマージポリシーを確認します。 |
+| Cleanup     | マージ完了後、安全な場合は古いマーカーを隠して、次の Discover へ戻ります。                 |
 
 完全なフェーズ一覧は [docs/idd-workflow.md](docs/idd-workflow.md) と
 `.github/instructions/` にあります。
@@ -163,6 +168,8 @@ Discover -> Claim -> Work の開始には、引き続き明示的な承認が必
   エージェント間の導線。
 - [Review policy profiles](docs/idd-review-policy-profiles.md) — 標準の
   Copilot 助言レビューまたは別の PR ポリシーを選ぶための指針。
+- [Customization](docs/customization.md) — review、merge、CI、discovery の
+  policy surface を選ぶための指針。
 - [Positioning](docs/positioning.md) — 競合との違いと IDD の位置づけ。
 - [Permissions and threat model](docs/permissions.md) — アクセスプロファイル、
   禁止すべき認証情報、安全な運用ガイド。

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ that keeps going until the issue is closed.
 IDD Skill gives a repository a portable Issue-Driven Development
 workflow: agents discover ready issues, claim ownership, implement in a
 branch, open a PR, handle review feedback, wait for CI, merge, and clean
-up. The whole loop lives in your repo as Markdown instruction files.
+up according to the repository's selected merge policy. The whole loop
+lives in your repo as Markdown instruction files.
 
 ## Why Teams Use IDD
 
@@ -55,7 +56,8 @@ After onboarding, start an agent in the target repository and say:
 > Start the IDD workflow in this repository.
 
 The agent reads the workflow guide, discovers a ready issue, claims it,
-and follows the loop through work, PR review, CI, merge, and cleanup.
+and follows the loop through work, PR review, CI, the selected merge
+policy, and cleanup.
 
 ## Reality Check
 
@@ -76,21 +78,26 @@ To run the full loop, an agent needs:
 See the workflow docs for the detailed command contract. Review
 [Permissions and threat model](docs/permissions.md) before granting
 credentials to unattended or merge-capable agents.
+Treat normal worker credentials as stopping before merge unless the
+repository explicitly opts into a merge-capable profile. Choose
+`human_merge`, `separate_merge_agent`, or `fully_autonomous_merge` in
+[Customizing IDD](docs/customization.md); `fully_autonomous_merge` is an
+explicit credential opt-in.
 
 ## What IDD Automates
 
 IDD is intentionally boring in the best way: every phase has a named
 job, a resumable marker, and a next step.
 
-| Stage       | What the agent does                                                              |
-| ----------- | -------------------------------------------------------------------------------- |
-| Discover    | Finds ready roadmap or orphan issues without silently widening scope.            |
-| Claim       | Reserves one issue with a machine-readable ownership marker.                     |
-| Work        | Creates a branch/worktree, plans, implements, and self-reviews.                  |
-| Submit PR   | Pushes, opens a PR, and waits for validation to become reviewable.               |
-| Review Loop | Captures review activity, accepts or rejects feedback, and fixes accepted items. |
-| Merge       | Rechecks freshness, advisory review state, CI, unresolved threads, and comments. |
-| Cleanup     | Merges the validated HEAD, hides stale markers when safe, and loops back.        |
+| Stage       | What the agent does                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------------------- |
+| Discover    | Finds ready roadmap or orphan issues without silently widening scope.                                       |
+| Claim       | Reserves one issue with a machine-readable ownership marker.                                                |
+| Work        | Creates a branch/worktree, plans, implements, and self-reviews.                                             |
+| Submit PR   | Pushes, opens a PR, and waits for validation to become reviewable.                                          |
+| Review Loop | Captures review activity, accepts or rejects feedback, and fixes accepted items.                            |
+| Merge       | Rechecks freshness, advisory review state, CI, unresolved threads, comments, and the selected merge policy. |
+| Cleanup     | After a completed merge, hides stale markers when safe and loops back.                                      |
 
 The full phase map lives in
 [docs/idd-workflow.md](docs/idd-workflow.md) and the
@@ -168,6 +175,8 @@ approval.
   cross-agent routing.
 - [Review policy profiles](docs/idd-review-policy-profiles.md) — choose
   the default Copilot advisory PR policy or a documented alternative.
+- [Customization](docs/customization.md) — choose review, merge, CI, and
+  discovery policy surfaces.
 - [Positioning](docs/positioning.md) — competitive landscape and why
   IDD is different.
 - [Permissions and threat model](docs/permissions.md) — access profiles,

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ See the workflow docs for the detailed command contract. Review
 [Permissions and threat model](docs/permissions.md) before granting
 credentials to unattended or merge-capable agents.
 Treat normal worker credentials as stopping before merge unless the
-repository explicitly opts into a merge-capable profile. Choose
-`human_merge`, `separate_merge_agent`, or `fully_autonomous_merge` in
-[Customizing IDD](docs/customization.md); `fully_autonomous_merge` is an
-explicit credential opt-in.
+repository explicitly opts into `fully_autonomous_merge`.
+`human_merge` and `separate_merge_agent` keep merge authority outside
+the worker session. Choose and record one profile in
+[Customizing IDD](docs/customization.md).
 
 ## What IDD Automates
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -14,7 +14,7 @@ behavior change too.
 | ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                              |
 | Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                   |
-| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), then choose `human_merge`, `separate_merge_agent`, or explicit opt-in `fully_autonomous_merge`.                                      |
+| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                          |
 | CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                  |
 | Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal. |
 
@@ -59,6 +59,14 @@ For `human_merge` and `separate_merge_agent`, keep merge-capable
 credentials out of normal worker sessions. The worker should hand off
 the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
+
+Record the selected merge policy in repository documentation that
+future IDD sessions read, not only in local onboarding notes. For
+`human_merge` and `separate_merge_agent`, also add repository-specific
+agent guidance or phase-file customization so normal workers stop before
+F3 and hand off to the human maintainer or separate merge-capable
+session. Documentation alone will not stop F3 if the same worker session
+still has merge-capable credentials.
 
 The distributed workflow expects merge commits. Changing the merge
 method, required review policy, or branch protection behavior is a

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -10,13 +10,13 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface           | Default                                                         | Where to customize                                                                                                                                                                          |
-| ----------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Review policy     | GitHub Copilot advisory review                                  | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                              |
-| Advisory reviewer | Copilot wait and recovery gates                                 | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                   |
-| Merge policy      | Merge commits after CI, review, freshness, and claim gates pass | Review [Permissions and threat model](permissions.md), then decide whether merges are human-run, run by a separate merge-capable agent, or fully autonomous by explicit opt-in.             |
-| CI commands       | Project-specific command rows in the overview file              | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                  |
-| Issue scope       | Roadmap-first discovery                                         | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal. |
+| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                          |
+| ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                              |
+| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                   |
+| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), then choose `human_merge`, `separate_merge_agent`, or explicit opt-in `fully_autonomous_merge`.                                      |
+| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                  |
+| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal. |
 
 ## Review Policy
 
@@ -42,17 +42,23 @@ by the profile in the same pull request as the local policy note.
 
 IDD can describe an end-to-end loop, but that does not mean every worker
 credential should be able to merge. Use
-[Permissions and threat model](permissions.md) to choose one of these
-operating shapes:
+[Permissions and threat model](permissions.md) to record exactly one
+merge policy profile:
 
-- Human merge: the agent stops before merge and a maintainer runs the
-  final merge after reviewing the PR state.
-- Separate merge agent: a worker handles claim, implementation, PR, and
-  review fixes; a trusted merge-capable session runs only the final
+- `human_merge`: the safe default for public or OSS repositories. The
+  worker stops before merge and a maintainer runs the final merge after
+  reviewing the PR state.
+- `separate_merge_agent`: a worker handles claim, implementation, PR,
+  and review fixes; a trusted merge-capable session runs only the final
   merge phase.
-- Fully autonomous merge: one agent can complete the final merge too.
-  Use this only as an explicit opt-in after the repository accepts the
-  credential risk.
+- `fully_autonomous_merge`: one agent session can complete the final
+  merge too. Use this only as an explicit opt-in after the repository
+  accepts the credential risk.
+
+For `human_merge` and `separate_merge_agent`, keep merge-capable
+credentials out of normal worker sessions. The worker should hand off
+the current PR state once CI, review, freshness, and claim evidence are
+ready for the merge-capable actor.
 
 The distributed workflow expects merge commits. Changing the merge
 method, required review policy, or branch protection behavior is a

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -31,8 +31,8 @@ production.
 
 ## Merge Policy Profiles
 
-Choose and record one merge policy before granting unattended agent
-credentials:
+Choose and record one merge policy in repository documentation before
+granting unattended agent credentials:
 
 | Merge policy             | Who may merge                                                            | Worker credential boundary                                                                 |
 | ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
@@ -131,8 +131,8 @@ Before enabling IDD in a repository:
   document any replacement reviewer policy before agents reach later PR
   phases.
 - Record the selected merge policy (`human_merge`,
-  `separate_merge_agent`, or `fully_autonomous_merge`) before granting
-  unattended worker credentials.
+  `separate_merge_agent`, or `fully_autonomous_merge`) in repository
+  documentation before granting unattended worker credentials.
 - Review any installed `SKILL.md` bundles or automation scripts before
   allowing them to run shell commands.
 - Make sure the agent can run validation locally without access to

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -29,6 +29,21 @@ to push a branch and update PR discussion, but it should not be able to
 change repository settings, read secrets, publish packages, or deploy to
 production.
 
+## Merge Policy Profiles
+
+Choose and record one merge policy before granting unattended agent
+credentials:
+
+| Merge policy             | Who may merge                                                            | Worker credential boundary                                                                 |
+| ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | Worker sessions stop before merge and report the PR state for human review.                |
+| `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions handle claim, work, PR, CI, and review fixes without merge-capable access. |
+| `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined only by explicit repository opt-in.        |
+
+Use `human_merge` as the safe default for public or OSS repositories.
+Treat `fully_autonomous_merge` as an explicit credential decision, never
+as an automatic consequence of installing IDD.
+
 ## Phase Permissions
 
 Each IDD phase needs a different subset of access:
@@ -58,8 +73,8 @@ actually call.
   suspicious output, command history exposure, or an unexpected agent
   action.
 - Keep merge-capable credentials out of general worker sessions. Escalate
-  only for the merge phase and only after branch freshness, CI, review,
-  and unresolved-thread checks pass.
+  only according to the selected merge policy and only after branch
+  freshness, CI, review, and unresolved-thread checks pass.
 - Do not paste credentials into issues, PRs, prompts, logs, screenshots,
   or generated documentation.
 - Store credentials in the platform's secret store or an approved local
@@ -115,6 +130,9 @@ Before enabling IDD in a repository:
 - Decide whether the default Copilot advisory review policy applies, and
   document any replacement reviewer policy before agents reach later PR
   phases.
+- Record the selected merge policy (`human_merge`,
+  `separate_merge_agent`, or `fully_autonomous_merge`) before granting
+  unattended worker credentials.
 - Review any installed `SKILL.md` bundles or automation scripts before
   allowing them to run shell commands.
 - Make sure the agent can run validation locally without access to

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -48,6 +48,11 @@ additional files after import.
 Before granting credentials to unattended or merge-capable agents, read
 `docs/permissions.md` and choose the narrowest access profile that can
 complete the intended phase.
+Also choose a merge policy before the first unattended run:
+`human_merge`, `separate_merge_agent`, or `fully_autonomous_merge`.
+Treat `human_merge` as the safe default for public repositories;
+`fully_autonomous_merge` is an explicit opt-in that gives one trusted
+agent session merge authority.
 
 ## Your task
 
@@ -56,11 +61,13 @@ complete the intended phase.
 3. Fetch or copy the template files into the target repository.
 4. Review `docs/permissions.md` with the operator before granting agent
    credentials.
-5. Ask whether the operator wants the optional issue-authoring
+5. Choose and record the operator's merge policy before allowing
+   unattended workers to approach the merge phase.
+6. Ask whether the operator wants the optional issue-authoring
    companion skill for pre-execution issue drafting.
-6. Replace every placeholder (see table below) with the correct value.
-7. Add IDD references to the repository's agent entry files.
-8. Verify the result with the checklist at the bottom.
+7. Replace every placeholder (see table below) with the correct value.
+8. Add IDD references to the repository's agent entry files.
+9. Verify the result with the checklist at the bottom.
 
 ---
 
@@ -131,6 +138,12 @@ Copilot advisory review policy described above. If not, choose the
 closest profile in `docs/idd-review-policy-profiles.md` and note which
 phase files and profile-specific surfaces must be customized after the
 files are copied in.
+
+Also confirm the operator's merge policy:
+`human_merge`, `separate_merge_agent`, or `fully_autonomous_merge`.
+Record the selected policy in local onboarding notes or repository
+documentation. For `human_merge` and `separate_merge_agent`, do not grant
+merge-capable credentials to normal worker sessions.
 
 ### File list
 
@@ -499,6 +512,8 @@ After completing the steps above, confirm each item:
       are present.
 - [ ] The operator's selected PR review policy profile is recorded, and
       any non-default profile has matching phase-file customizations.
+- [ ] The operator's selected merge policy is recorded, and worker
+      credentials match that boundary.
 - [ ] If the operator opted into issue authoring,
       `skills/issue-authoring/SKILL.md`,
       `skills/issue-authoring/agents/openai.yaml`, and the

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -51,8 +51,9 @@ complete the intended phase.
 Also choose a merge policy before the first unattended run:
 `human_merge`, `separate_merge_agent`, or `fully_autonomous_merge`.
 Treat `human_merge` as the safe default for public repositories;
-`fully_autonomous_merge` is an explicit opt-in that gives one trusted
-agent session merge authority.
+`fully_autonomous_merge` is the explicit opt-in that gives one trusted
+agent session merge authority. Record the selected policy in repository
+documentation that future IDD sessions read.
 
 ## Your task
 
@@ -62,7 +63,8 @@ agent session merge authority.
 4. Review `docs/permissions.md` with the operator before granting agent
    credentials.
 5. Choose and record the operator's merge policy before allowing
-   unattended workers to approach the merge phase.
+   unattended workers to approach the merge phase. The record must live
+   in repository documentation that future IDD sessions read.
 6. Ask whether the operator wants the optional issue-authoring
    companion skill for pre-execution issue drafting.
 7. Replace every placeholder (see table below) with the correct value.
@@ -141,9 +143,11 @@ files are copied in.
 
 Also confirm the operator's merge policy:
 `human_merge`, `separate_merge_agent`, or `fully_autonomous_merge`.
-Record the selected policy in local onboarding notes or repository
-documentation. For `human_merge` and `separate_merge_agent`, do not grant
-merge-capable credentials to normal worker sessions.
+Record the selected policy in repository documentation, such as a local
+policy section in the imported docs or agent entry files. For
+`human_merge` and `separate_merge_agent`, do not grant merge-capable
+credentials to normal worker sessions; also add local guidance or
+phase-file customization so workers hand off before F3.
 
 ### File list
 
@@ -512,8 +516,8 @@ After completing the steps above, confirm each item:
       are present.
 - [ ] The operator's selected PR review policy profile is recorded, and
       any non-default profile has matching phase-file customizations.
-- [ ] The operator's selected merge policy is recorded, and worker
-      credentials match that boundary.
+- [ ] The operator's selected merge policy is recorded in repository
+      documentation, and worker credentials match that boundary.
 - [ ] If the operator opted into issue authoring,
       `skills/issue-authoring/SKILL.md`,
       `skills/issue-authoring/agents/openai.yaml`, and the

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -13,7 +13,8 @@ multi-agent GitHub automation.
    import to the first IDD loop.
 5. Read `docs/customization.md` before changing review, merge, CI, or
    discovery policy.
-6. Review `docs/permissions.md` before granting credentials to
+6. Choose and record a merge policy while reviewing
+   `docs/permissions.md` before granting credentials to
    unattended or merge-capable agents.
 7. Optional: install the issue-authoring companion skill if the project
    wants pre-execution issue drafting. The canonical source bundle in
@@ -54,6 +55,14 @@ described there. At minimum, non-default profiles touch
 `.github/instructions/idd-pre-merge.instructions.md`, and
 `.github/instructions/idd-merge.instructions.md` after import; some
 profiles require additional files.
+
+## Merge credential policy note
+
+IDD can run an end-to-end loop, but normal worker credentials should not
+imply merge authority. Before granting unattended credentials, choose
+`human_merge`, `separate_merge_agent`, or `fully_autonomous_merge` in
+`docs/customization.md` and `docs/permissions.md`. Treat
+`fully_autonomous_merge` as an explicit opt-in.
 
 ## Placeholders
 

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -13,8 +13,8 @@ multi-agent GitHub automation.
    import to the first IDD loop.
 5. Read `docs/customization.md` before changing review, merge, CI, or
    discovery policy.
-6. Choose and record a merge policy while reviewing
-   `docs/permissions.md` before granting credentials to
+6. Choose and record a merge policy in repository documentation while
+   reviewing `docs/permissions.md` before granting credentials to
    unattended or merge-capable agents.
 7. Optional: install the issue-authoring companion skill if the project
    wants pre-execution issue drafting. The canonical source bundle in
@@ -61,8 +61,10 @@ profiles require additional files.
 IDD can run an end-to-end loop, but normal worker credentials should not
 imply merge authority. Before granting unattended credentials, choose
 `human_merge`, `separate_merge_agent`, or `fully_autonomous_merge` in
-`docs/customization.md` and `docs/permissions.md`. Treat
-`fully_autonomous_merge` as an explicit opt-in.
+`docs/customization.md` and `docs/permissions.md`, and record the choice
+in repository documentation that future IDD sessions read. Treat
+`fully_autonomous_merge` as the explicit opt-in; `human_merge` and
+`separate_merge_agent` require a handoff before F3.
 
 ## Placeholders
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -14,7 +14,7 @@ behavior change too.
 | ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                              |
 | Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                   |
-| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), then choose `human_merge`, `separate_merge_agent`, or explicit opt-in `fully_autonomous_merge`.                                      |
+| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                          |
 | CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                  |
 | Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal. |
 
@@ -59,6 +59,14 @@ For `human_merge` and `separate_merge_agent`, keep merge-capable
 credentials out of normal worker sessions. The worker should hand off
 the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
+
+Record the selected merge policy in repository documentation that
+future IDD sessions read, not only in local onboarding notes. For
+`human_merge` and `separate_merge_agent`, also add repository-specific
+agent guidance or phase-file customization so normal workers stop before
+F3 and hand off to the human maintainer or separate merge-capable
+session. Documentation alone will not stop F3 if the same worker session
+still has merge-capable credentials.
 
 The distributed workflow expects merge commits. Changing the merge
 method, required review policy, or branch protection behavior is a

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -10,13 +10,13 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface           | Default                                                         | Where to customize                                                                                                                                                                          |
-| ----------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Review policy     | GitHub Copilot advisory review                                  | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                              |
-| Advisory reviewer | Copilot wait and recovery gates                                 | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                   |
-| Merge policy      | Merge commits after CI, review, freshness, and claim gates pass | Review [Permissions and threat model](permissions.md), then decide whether merges are human-run, run by a separate merge-capable agent, or fully autonomous by explicit opt-in.             |
-| CI commands       | Project-specific command rows in the overview file              | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                  |
-| Issue scope       | Roadmap-first discovery                                         | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal. |
+| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                          |
+| ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                              |
+| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                   |
+| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), then choose `human_merge`, `separate_merge_agent`, or explicit opt-in `fully_autonomous_merge`.                                      |
+| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                  |
+| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal. |
 
 ## Review Policy
 
@@ -42,17 +42,23 @@ by the profile in the same pull request as the local policy note.
 
 IDD can describe an end-to-end loop, but that does not mean every worker
 credential should be able to merge. Use
-[Permissions and threat model](permissions.md) to choose one of these
-operating shapes:
+[Permissions and threat model](permissions.md) to record exactly one
+merge policy profile:
 
-- Human merge: the agent stops before merge and a maintainer runs the
-  final merge after reviewing the PR state.
-- Separate merge agent: a worker handles claim, implementation, PR, and
-  review fixes; a trusted merge-capable session runs only the final
+- `human_merge`: the safe default for public or OSS repositories. The
+  worker stops before merge and a maintainer runs the final merge after
+  reviewing the PR state.
+- `separate_merge_agent`: a worker handles claim, implementation, PR,
+  and review fixes; a trusted merge-capable session runs only the final
   merge phase.
-- Fully autonomous merge: one agent can complete the final merge too.
-  Use this only as an explicit opt-in after the repository accepts the
-  credential risk.
+- `fully_autonomous_merge`: one agent session can complete the final
+  merge too. Use this only as an explicit opt-in after the repository
+  accepts the credential risk.
+
+For `human_merge` and `separate_merge_agent`, keep merge-capable
+credentials out of normal worker sessions. The worker should hand off
+the current PR state once CI, review, freshness, and claim evidence are
+ready for the merge-capable actor.
 
 The distributed workflow expects merge commits. Changing the merge
 method, required review policy, or branch protection behavior is a

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -31,8 +31,8 @@ production.
 
 ## Merge Policy Profiles
 
-Choose and record one merge policy before granting unattended agent
-credentials:
+Choose and record one merge policy in repository documentation before
+granting unattended agent credentials:
 
 | Merge policy             | Who may merge                                                            | Worker credential boundary                                                                 |
 | ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
@@ -131,8 +131,8 @@ Before enabling IDD in a repository:
   document any replacement reviewer policy before agents reach later PR
   phases.
 - Record the selected merge policy (`human_merge`,
-  `separate_merge_agent`, or `fully_autonomous_merge`) before granting
-  unattended worker credentials.
+  `separate_merge_agent`, or `fully_autonomous_merge`) in repository
+  documentation before granting unattended worker credentials.
 - Review any installed `SKILL.md` bundles or automation scripts before
   allowing them to run shell commands.
 - Make sure the agent can run validation locally without access to

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -29,6 +29,21 @@ to push a branch and update PR discussion, but it should not be able to
 change repository settings, read secrets, publish packages, or deploy to
 production.
 
+## Merge Policy Profiles
+
+Choose and record one merge policy before granting unattended agent
+credentials:
+
+| Merge policy             | Who may merge                                                            | Worker credential boundary                                                                 |
+| ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | Worker sessions stop before merge and report the PR state for human review.                |
+| `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions handle claim, work, PR, CI, and review fixes without merge-capable access. |
+| `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined only by explicit repository opt-in.        |
+
+Use `human_merge` as the safe default for public or OSS repositories.
+Treat `fully_autonomous_merge` as an explicit credential decision, never
+as an automatic consequence of installing IDD.
+
 ## Phase Permissions
 
 Each IDD phase needs a different subset of access:
@@ -58,8 +73,8 @@ actually call.
   suspicious output, command history exposure, or an unexpected agent
   action.
 - Keep merge-capable credentials out of general worker sessions. Escalate
-  only for the merge phase and only after branch freshness, CI, review,
-  and unresolved-thread checks pass.
+  only according to the selected merge policy and only after branch
+  freshness, CI, review, and unresolved-thread checks pass.
 - Do not paste credentials into issues, PRs, prompts, logs, screenshots,
   or generated documentation.
 - Store credentials in the platform's secret store or an approved local
@@ -115,6 +130,9 @@ Before enabling IDD in a repository:
 - Decide whether the default Copilot advisory review policy applies, and
   document any replacement reviewer policy before agents reach later PR
   phases.
+- Record the selected merge policy (`human_merge`,
+  `separate_merge_agent`, or `fully_autonomous_merge`) before granting
+  unattended worker credentials.
 - Review any installed `SKILL.md` bundles or automation scripts before
   allowing them to run shell commands.
 - Make sure the agent can run validation locally without access to


### PR DESCRIPTION
## Summary

- Clarify in the English and Japanese READMEs that the loop follows the selected merge policy rather than implying every worker credential can merge.
- Add explicit `human_merge`, `separate_merge_agent`, and `fully_autonomous_merge` merge policy profiles to permissions and customization docs.
- Update template onboarding docs so adopters choose and record merge policy before granting unattended worker credentials.

Closes #135

## Follow-up issues

None.

## Rationale

The distributed IDD workflow can still run end to end when the selected policy allows it, but normal worker credentials should not imply merge authority. The docs now make `fully_autonomous_merge` an explicit opt-in and keep the safer handoff profiles visible during onboarding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified and formalized merge policy profiles (human_merge, separate_merge_agent, fully_autonomous_merge) with explicit selection and recording requirements
  * Added credential/merge-authority gating guidance so worker sessions stop before merge unless repository opts into autonomous merge
  * Expanded IDD loop docs to detail merge checks, safe cleanup behavior, onboarding verification, and links to customization guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/149)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->