### PR TITLE
docs: add review thread policy profiles

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -10,14 +10,14 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                           |
-| ----------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                               |
-| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                    |
-| Review threads    | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the triage, review-fix, pre-merge, and merge phase files for stricter profiles. |
-| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                           |
-| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                   |
-| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.  |
+| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                                     |
+| ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                                         |
+| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                              |
+| Review threads    | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles. |
+| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                                     |
+| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                             |
+| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.            |
 
 ## Review Policy
 
@@ -56,13 +56,16 @@ Choose a stricter profile when review culture requires it:
   the reviewer or maintainer owns conversation resolution.
 
 For either non-default profile, update
+`.github/instructions/idd-review-snapshot.instructions.md`,
 `.github/instructions/idd-review-triage.instructions.md`,
 `.github/instructions/idd-review-fix.instructions.md`,
 `.github/instructions/idd-pre-merge.instructions.md`, and
-`.github/instructions/idd-merge.instructions.md` so F2/F3 do not treat
-agent-handled human threads as merge-ready before the selected
-acknowledgement appears. Branch protection conversation-resolution
-requirements still override any local profile.
+`.github/instructions/idd-merge.instructions.md` so E1 does not hide
+human threads that need acknowledgement, E7 verifies the stricter
+resolution rule, and F2/F3 do not treat agent-handled human threads as
+merge-ready before the selected acknowledgement appears. Branch
+protection conversation-resolution requirements still override any local
+profile.
 
 ## Merge Policy and Credentials
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -10,13 +10,14 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                          |
-| ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                              |
-| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                   |
-| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                          |
-| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                  |
-| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal. |
+| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                           |
+| ----------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                               |
+| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                    |
+| Review threads    | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the triage, review-fix, pre-merge, and merge phase files for stricter profiles. |
+| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                           |
+| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                   |
+| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.  |
 
 ## Review Policy
 
@@ -37,6 +38,31 @@ authority:
 
 Changing the profile is a workflow change. Update the phase files named
 by the profile in the same pull request as the local policy note.
+
+## Review Thread Resolution Policy
+
+The distributed default review-thread policy is `fast-agent-resolve`.
+After an agent accepts and fixes feedback, rejects feedback with a
+recorded rationale, or handles PATH B advisory feedback, the agent may
+resolve the corresponding review thread. This keeps the loop moving, but
+some teams reserve thread resolution for the original reviewer.
+
+Choose a stricter profile when review culture requires it:
+
+- `hybrid-reviewer-ack`: agents may resolve bot or advisory threads, but
+  human review threads stay open until the reviewer or maintainer
+  acknowledges the fix or rationale.
+- `strict-reviewer-resolve`: agents never resolve human review threads;
+  the reviewer or maintainer owns conversation resolution.
+
+For either non-default profile, update
+`.github/instructions/idd-review-triage.instructions.md`,
+`.github/instructions/idd-review-fix.instructions.md`,
+`.github/instructions/idd-pre-merge.instructions.md`, and
+`.github/instructions/idd-merge.instructions.md` so F2/F3 do not treat
+agent-handled human threads as merge-ready before the selected
+acknowledgement appears. Branch protection conversation-resolution
+requirements still override any local profile.
 
 ## Merge Policy and Credentials
 

--- a/docs/idd-review-policy-profiles.md
+++ b/docs/idd-review-policy-profiles.md
@@ -8,7 +8,7 @@ before they treat the imported workflow as final.
 This page names the supported policy shapes and the instruction files
 that need customization when a repository does not use the default.
 
-## Profile Summary
+## PR Review Profile Summary
 
 | Profile            | Use when                                                                                      | Review signal                                                                          | Merge gate                                                                                            |
 | ------------------ | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
@@ -90,6 +90,38 @@ If the external bot can produce blocking `CHANGES_REQUESTED` reviews or
 decision-relevant comments, classify those items as PATH A unless the
 operator explicitly narrows them.
 
+## Review Thread Resolution Profiles
+
+Review-thread resolution is a separate policy from who reviews the PR.
+The distributed default is `fast-agent-resolve`: after an agent accepts
+and fixes feedback, rejects it with a recorded rationale, or handles PATH
+B advisory feedback, the agent may resolve the associated thread. This
+means "the agent acted on the thread," not "the reviewer agreed."
+
+Repositories that use a different review culture can choose a stricter
+profile during onboarding:
+
+| Profile                   | Use when                                                                                  | Agent may resolve                                                                                      | Merge consequence                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `fast-agent-resolve`      | The repository wants the distributed default and values a fast agent-managed review loop. | Human and bot threads after accepted fixes, rejected rationales, or PATH B advisory handling.          | F2/F3 may proceed once remaining unresolved threads are either resolved or classified as awaiting reviewer. |
+| `hybrid-reviewer-ack`     | Human reviewers expect to confirm human-thread fixes, but bot/advisory threads can close. | Bot/advisory threads; human threads only after reviewer or maintainer acknowledgement.                 | F2/F3 must hold human review threads open until acknowledgement appears and branch protection is satisfied. |
+| `strict-reviewer-resolve` | The team treats thread resolution as reviewer-owned.                                      | No human threads; optionally no bot threads unless the repository documents that exception separately. | F2/F3 must wait for reviewer or maintainer resolution before merge.                                         |
+
+Changing away from `fast-agent-resolve` is a workflow change. Update
+these files together with the recorded profile decision:
+
+- `.github/instructions/idd-review-triage.instructions.md`: adjust E6
+  thread-resolution behavior after PATH A and PATH B dispositions.
+- `.github/instructions/idd-review-fix.instructions.md`: adjust E13
+  resolution after accepted feedback fixes.
+- `.github/instructions/idd-pre-merge.instructions.md`: adjust F2
+  unresolved-thread handling and awaiting-reviewer exclusions.
+- `.github/instructions/idd-merge.instructions.md`: adjust F3
+  conversation-resolution fallback behavior.
+- Repository settings: confirm whether branch protection requires
+  conversation resolution, because that setting can make unresolved
+  acknowledged threads block regardless of the selected profile.
+
 ## Selection Checklist
 
 Before considering onboarding complete, record the selected profile in
@@ -102,6 +134,10 @@ the target repository's local documentation or onboarding notes.
   and branch protection as sufficient gates.
 - Choose `external-bot` only after proving the bot's reviewer identity,
   current-head coverage signal, and wait/timeout behavior.
+- Record the review-thread resolution profile separately. Keep
+  `fast-agent-resolve` for the distributed default, or customize the
+  phase files listed above before choosing `hybrid-reviewer-ack` or
+  `strict-reviewer-resolve`.
 
 Changing the profile is a workflow change, not only a documentation
 change. Update the phase files that enforce review and merge behavior in

--- a/docs/idd-review-policy-profiles.md
+++ b/docs/idd-review-policy-profiles.md
@@ -111,7 +111,11 @@ Changing away from `fast-agent-resolve` is a workflow change. Update
 these files together with the recorded profile decision:
 
 - `.github/instructions/idd-review-triage.instructions.md`: adjust E6
-  thread-resolution behavior after PATH A and PATH B dispositions.
+  thread-resolution behavior after PATH A and PATH B dispositions, and
+  E7 verification so stricter profiles do not require the fast default.
+- `.github/instructions/idd-review-snapshot.instructions.md`: adjust E1
+  awaiting-reviewer filtering when human threads must remain visible
+  until reviewer acknowledgement.
 - `.github/instructions/idd-review-fix.instructions.md`: adjust E13
   resolution after accepted feedback fixes.
 - `.github/instructions/idd-pre-merge.instructions.md`: adjust F2

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -45,6 +45,15 @@ minimum, non-default profiles touch
 `.github/instructions/idd-merge.instructions.md`; some profiles require
 additional files after import.
 
+Also choose a review-thread resolution policy before treating the import
+as complete. The distributed default is `fast-agent-resolve`, where an
+agent may resolve review threads after it has acted on accepted,
+rejected, or advisory feedback. Repositories that require reviewer
+acknowledgement should choose `hybrid-reviewer-ack` or
+`strict-reviewer-resolve` from `docs/idd-review-policy-profiles.md` and
+customize the listed phase files before running unattended PR review
+loops.
+
 Before granting credentials to unattended or merge-capable agents, read
 `docs/permissions.md` and choose the narrowest access profile that can
 complete the intended phase.
@@ -62,14 +71,15 @@ documentation that future IDD sessions read.
 3. Fetch or copy the template files into the target repository.
 4. Review `docs/permissions.md` with the operator before granting agent
    credentials.
-5. Choose and record the operator's merge policy before allowing
+5. Choose and record the operator's review-thread resolution policy.
+6. Choose and record the operator's merge policy before allowing
    unattended workers to approach the merge phase. The record must live
    in repository documentation that future IDD sessions read.
-6. Ask whether the operator wants the optional issue-authoring
+7. Ask whether the operator wants the optional issue-authoring
    companion skill for pre-execution issue drafting.
-7. Replace every placeholder (see table below) with the correct value.
-8. Add IDD references to the repository's agent entry files.
-9. Verify the result with the checklist at the bottom.
+8. Replace every placeholder (see table below) with the correct value.
+9. Add IDD references to the repository's agent entry files.
+10. Verify the result with the checklist at the bottom.
 
 ---
 
@@ -140,6 +150,14 @@ Copilot advisory review policy described above. If not, choose the
 closest profile in `docs/idd-review-policy-profiles.md` and note which
 phase files and profile-specific surfaces must be customized after the
 files are copied in.
+
+Confirm the review-thread resolution policy as well. Keep
+`fast-agent-resolve` for the distributed default, or choose
+`hybrid-reviewer-ack` / `strict-reviewer-resolve` when human review
+threads must stay open until reviewer or maintainer acknowledgement.
+Record the choice in repository documentation. For non-default profiles,
+customize the review triage, review fix, pre-merge, and merge phase
+files listed in `docs/idd-review-policy-profiles.md`.
 
 Also confirm the operator's merge policy:
 `human_merge`, `separate_merge_agent`, or `fully_autonomous_merge`.
@@ -516,6 +534,9 @@ After completing the steps above, confirm each item:
       are present.
 - [ ] The operator's selected PR review policy profile is recorded, and
       any non-default profile has matching phase-file customizations.
+- [ ] The operator's selected review-thread resolution policy is
+      recorded, and any non-default profile has matching phase-file
+      customizations.
 - [ ] The operator's selected merge policy is recorded in repository
       documentation, and worker credentials match that boundary.
 - [ ] If the operator opted into issue authoring,

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -156,8 +156,8 @@ Confirm the review-thread resolution policy as well. Keep
 `hybrid-reviewer-ack` / `strict-reviewer-resolve` when human review
 threads must stay open until reviewer or maintainer acknowledgement.
 Record the choice in repository documentation. For non-default profiles,
-customize the review triage, review fix, pre-merge, and merge phase
-files listed in `docs/idd-review-policy-profiles.md`.
+customize the review snapshot, review triage, review fix, pre-merge, and
+merge phase files listed in `docs/idd-review-policy-profiles.md`.
 
 Also confirm the operator's merge policy:
 `human_merge`, `separate_merge_agent`, or `fully_autonomous_merge`.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -10,14 +10,14 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                           |
-| ----------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                               |
-| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                    |
-| Review threads    | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the triage, review-fix, pre-merge, and merge phase files for stricter profiles. |
-| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                           |
-| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                   |
-| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.  |
+| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                                     |
+| ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                                         |
+| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                              |
+| Review threads    | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles. |
+| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                                     |
+| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                             |
+| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.            |
 
 ## Review Policy
 
@@ -56,13 +56,16 @@ Choose a stricter profile when review culture requires it:
   the reviewer or maintainer owns conversation resolution.
 
 For either non-default profile, update
+`.github/instructions/idd-review-snapshot.instructions.md`,
 `.github/instructions/idd-review-triage.instructions.md`,
 `.github/instructions/idd-review-fix.instructions.md`,
 `.github/instructions/idd-pre-merge.instructions.md`, and
-`.github/instructions/idd-merge.instructions.md` so F2/F3 do not treat
-agent-handled human threads as merge-ready before the selected
-acknowledgement appears. Branch protection conversation-resolution
-requirements still override any local profile.
+`.github/instructions/idd-merge.instructions.md` so E1 does not hide
+human threads that need acknowledgement, E7 verifies the stricter
+resolution rule, and F2/F3 do not treat agent-handled human threads as
+merge-ready before the selected acknowledgement appears. Branch
+protection conversation-resolution requirements still override any local
+profile.
 
 ## Merge Policy and Credentials
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -10,13 +10,14 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                          |
-| ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                              |
-| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                   |
-| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                          |
-| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                  |
-| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal. |
+| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                           |
+| ----------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                               |
+| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                    |
+| Review threads    | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the triage, review-fix, pre-merge, and merge phase files for stricter profiles. |
+| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                           |
+| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                   |
+| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.  |
 
 ## Review Policy
 
@@ -37,6 +38,31 @@ authority:
 
 Changing the profile is a workflow change. Update the phase files named
 by the profile in the same pull request as the local policy note.
+
+## Review Thread Resolution Policy
+
+The distributed default review-thread policy is `fast-agent-resolve`.
+After an agent accepts and fixes feedback, rejects feedback with a
+recorded rationale, or handles PATH B advisory feedback, the agent may
+resolve the corresponding review thread. This keeps the loop moving, but
+some teams reserve thread resolution for the original reviewer.
+
+Choose a stricter profile when review culture requires it:
+
+- `hybrid-reviewer-ack`: agents may resolve bot or advisory threads, but
+  human review threads stay open until the reviewer or maintainer
+  acknowledges the fix or rationale.
+- `strict-reviewer-resolve`: agents never resolve human review threads;
+  the reviewer or maintainer owns conversation resolution.
+
+For either non-default profile, update
+`.github/instructions/idd-review-triage.instructions.md`,
+`.github/instructions/idd-review-fix.instructions.md`,
+`.github/instructions/idd-pre-merge.instructions.md`, and
+`.github/instructions/idd-merge.instructions.md` so F2/F3 do not treat
+agent-handled human threads as merge-ready before the selected
+acknowledgement appears. Branch protection conversation-resolution
+requirements still override any local profile.
 
 ## Merge Policy and Credentials
 

--- a/idd-template/docs/idd-review-policy-profiles.md
+++ b/idd-template/docs/idd-review-policy-profiles.md
@@ -8,7 +8,7 @@ before they treat the imported workflow as final.
 This page names the supported policy shapes and the instruction files
 that need customization when a repository does not use the default.
 
-## Profile Summary
+## PR Review Profile Summary
 
 | Profile            | Use when                                                                                      | Review signal                                                                          | Merge gate                                                                                            |
 | ------------------ | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
@@ -90,6 +90,38 @@ If the external bot can produce blocking `CHANGES_REQUESTED` reviews or
 decision-relevant comments, classify those items as PATH A unless the
 operator explicitly narrows them.
 
+## Review Thread Resolution Profiles
+
+Review-thread resolution is a separate policy from who reviews the PR.
+The distributed default is `fast-agent-resolve`: after an agent accepts
+and fixes feedback, rejects it with a recorded rationale, or handles PATH
+B advisory feedback, the agent may resolve the associated thread. This
+means "the agent acted on the thread," not "the reviewer agreed."
+
+Repositories that use a different review culture can choose a stricter
+profile during onboarding:
+
+| Profile                   | Use when                                                                                  | Agent may resolve                                                                                      | Merge consequence                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `fast-agent-resolve`      | The repository wants the distributed default and values a fast agent-managed review loop. | Human and bot threads after accepted fixes, rejected rationales, or PATH B advisory handling.          | F2/F3 may proceed once remaining unresolved threads are either resolved or classified as awaiting reviewer. |
+| `hybrid-reviewer-ack`     | Human reviewers expect to confirm human-thread fixes, but bot/advisory threads can close. | Bot/advisory threads; human threads only after reviewer or maintainer acknowledgement.                 | F2/F3 must hold human review threads open until acknowledgement appears and branch protection is satisfied. |
+| `strict-reviewer-resolve` | The team treats thread resolution as reviewer-owned.                                      | No human threads; optionally no bot threads unless the repository documents that exception separately. | F2/F3 must wait for reviewer or maintainer resolution before merge.                                         |
+
+Changing away from `fast-agent-resolve` is a workflow change. Update
+these files together with the recorded profile decision:
+
+- `.github/instructions/idd-review-triage.instructions.md`: adjust E6
+  thread-resolution behavior after PATH A and PATH B dispositions.
+- `.github/instructions/idd-review-fix.instructions.md`: adjust E13
+  resolution after accepted feedback fixes.
+- `.github/instructions/idd-pre-merge.instructions.md`: adjust F2
+  unresolved-thread handling and awaiting-reviewer exclusions.
+- `.github/instructions/idd-merge.instructions.md`: adjust F3
+  conversation-resolution fallback behavior.
+- Repository settings: confirm whether branch protection requires
+  conversation resolution, because that setting can make unresolved
+  acknowledged threads block regardless of the selected profile.
+
 ## Selection Checklist
 
 Before considering onboarding complete, record the selected profile in
@@ -102,6 +134,10 @@ the target repository's local documentation or onboarding notes.
   and branch protection as sufficient gates.
 - Choose `external-bot` only after proving the bot's reviewer identity,
   current-head coverage signal, and wait/timeout behavior.
+- Record the review-thread resolution profile separately. Keep
+  `fast-agent-resolve` for the distributed default, or customize the
+  phase files listed above before choosing `hybrid-reviewer-ack` or
+  `strict-reviewer-resolve`.
 
 Changing the profile is a workflow change, not only a documentation
 change. Update the phase files that enforce review and merge behavior in

--- a/idd-template/docs/idd-review-policy-profiles.md
+++ b/idd-template/docs/idd-review-policy-profiles.md
@@ -111,7 +111,11 @@ Changing away from `fast-agent-resolve` is a workflow change. Update
 these files together with the recorded profile decision:
 
 - `.github/instructions/idd-review-triage.instructions.md`: adjust E6
-  thread-resolution behavior after PATH A and PATH B dispositions.
+  thread-resolution behavior after PATH A and PATH B dispositions, and
+  E7 verification so stricter profiles do not require the fast default.
+- `.github/instructions/idd-review-snapshot.instructions.md`: adjust E1
+  awaiting-reviewer filtering when human threads must remain visible
+  until reviewer acknowledgement.
 - `.github/instructions/idd-review-fix.instructions.md`: adjust E13
   resolution after accepted feedback fixes.
 - `.github/instructions/idd-pre-merge.instructions.md`: adjust F2


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/template/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

- Add `fast-agent-resolve`, `hybrid-reviewer-ack`, and `strict-reviewer-resolve` review-thread resolution profiles.
- Surface review-thread resolution as a customization decision without changing the distributed default behavior.
- Update template onboarding so adopters record the selected resolution policy during import.

## Validation

- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `node scripts/audit-docs.mjs --check`
- `npx cspell lint "**" --no-progress`
- `git diff --check origin/main...HEAD`

Closes #140

Follow-up: none expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated customization guidance for issue scope and related surfaces.
  * Added a Review Thread Resolution Policy section describing three profiles: fast-agent-resolve (default), hybrid-reviewer-ack, strict-reviewer-resolve.
  * Clarified which phase instruction files and repository settings must be updated when choosing stricter thread-resolution behavior.
  * Updated onboarding checklist to require selecting and recording the review-thread resolution policy and verifying related customizations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/154)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->