### PR TITLE
docs: add orphan-first approval policy

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -59,6 +59,17 @@ Read the **issue-scope** value from the Project commands table in
 
 ## A0-O — Discover orphan issues
 
+Read the **orphan-first-policy** value from the Project commands table
+in `idd-overview.instructions.md` before any repo-wide orphan issue
+search.
+
+- If `orphan-first-policy` is `public-disabled`, first determine the
+  repository visibility. If the repository is public, skip A0-O without
+  searching open issues and proceed to A1. If visibility cannot be
+  determined, treat it as public and fail safely to A1. For private or
+  internal repositories, continue with A0-O.
+- For `none` and `maintainer-approved`, continue with A0-O.
+
 Search all open issues in the repository. Collect every issue whose
 body satisfies **all** of the following:
 
@@ -71,19 +82,30 @@ body satisfies **all** of the following:
   issue is open (apply the same fail-safe as A3: if a reference cannot
   be resolved, treat as blocked).
 
-Read the **orphan-first-policy** value from the Project commands table
-in `idd-overview.instructions.md` and apply it before passing A0-O
-candidates to A4:
+Apply the configured policy before passing A0-O candidates to A4:
 
 - `none` (the default): apply no extra orphan-first approval gate.
 - `maintainer-approved`: keep only candidates that have at least one
-  maintainer approval signal: the `idd:ready` label, an issue author
-  association of `OWNER`, `COLLABORATOR`, or `MEMBER`, or a visible
-  comment from a trusted marker actor containing the exact phrase
-  `IDD ready`.
-- `public-disabled`: if the repository visibility is public, skip A0-O
-  and fall back to A1. For private or internal repositories, behave the
+  current maintainer approval signal:
+  - the `idd:ready` label, only when repository policy reserves that
+    label to maintainer approval actors;
+  - an issue author who is a repository owner or collaborator with
+    Write, Maintain, or Admin permission, verified with the collaborator
+    permission API; do not treat organization `MEMBER` association alone
+    as approval;
+  - a visible comment from a maintainer approval actor whose trimmed
+    body is exactly `IDD ready` or contains `IDD ready` as a standalone
+    line. The approval comment must be newer than the latest issue
+    title/body edit and any generated-plan update; if freshness cannot
+    be determined, require a fresh approval comment or a reserved label.
+- `public-disabled`: for private or internal repositories, behave the
   same as `none`.
+
+A maintainer approval actor is a human repository owner or collaborator
+with Write, Maintain, or Admin permission. Do not reuse the trusted
+marker actor set for this approval gate, and do not count automation or
+the current agent unless repository policy explicitly grants that actor
+maintainer approval authority.
 
 If at least one orphan issue remains after the configured policy is
 applied: pass the remaining set directly to **A4** (viability gate).

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -71,12 +71,27 @@ body satisfies **all** of the following:
   issue is open (apply the same fail-safe as A3: if a reference cannot
   be resolved, treat as blocked).
 
-If at least one orphan issue is found: pass the collected set directly
-to **A4** (viability gate). Skip A1–A3 entirely.
+Read the **orphan-first-policy** value from the Project commands table
+in `idd-overview.instructions.md` and apply it before passing A0-O
+candidates to A4:
 
-If no orphan issues are found: fall back to the roadmap path. Proceed
-to **A1** and continue with the normal A1 → A1.5 → A2 → A3 → A4
-sequence.
+- `none` (the default): apply no extra orphan-first approval gate.
+- `maintainer-approved`: keep only candidates that have at least one
+  maintainer approval signal: the `idd:ready` label, an issue author
+  association of `OWNER`, `COLLABORATOR`, or `MEMBER`, or a visible
+  comment from a trusted marker actor containing the exact phrase
+  `IDD ready`.
+- `public-disabled`: if the repository visibility is public, skip A0-O
+  and fall back to A1. For private or internal repositories, behave the
+  same as `none`.
+
+If at least one orphan issue remains after the configured policy is
+applied: pass the remaining set directly to **A4** (viability gate).
+Skip A1–A3 entirely.
+
+If no orphan issues remain after the configured policy is applied: fall
+back to the roadmap path. Proceed to **A1** and continue with the normal
+A1 → A1.5 → A2 → A3 → A4 sequence.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: when

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -288,13 +288,18 @@ When a phase refers to a named command set, run the corresponding
 commands. **Adapt this section when applying this workflow to a
 different project.**
 
-| Name                  | Commands                                                                                                                                     |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| **fix-validate**      | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
-| **pre-push-validate** | `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                        |
-| **post-fix-validate** | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
-| **install-deps**      | `true`                                                                                                                                       |
-| **issue-scope**       | `roadmap`                                                                                                                                    |
+| Name                    | Commands                                                                                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **fix-validate**        | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
+| **pre-push-validate**   | `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                        |
+| **post-fix-validate**   | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
+| **install-deps**        | `true`                                                                                                                                       |
+| **issue-scope**         | `roadmap`                                                                                                                                    |
+| **orphan-first-policy** | `none`                                                                                                                                       |
+
+Rows whose values are not shell syntax, such as **issue-scope** and
+**orphan-first-policy**, are workflow settings. Read them literally
+instead of executing them.
 
 `pre-push-validate` intentionally omits auto-fix — all code should
 already pass lint at the push step. If lint fails, run **fix-validate**

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -10,14 +10,15 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                                     |
-| ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                                         |
-| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                              |
-| Review threads    | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles. |
-| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                                     |
-| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                             |
-| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.            |
+| Surface               | Default                                                                                      | Where to customize                                                                                                                                                                                              |
+| --------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy         | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                                                  |
+| Advisory reviewer     | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                                       |
+| Review threads        | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles.          |
+| Merge policy          | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                                              |
+| CI commands           | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                                      |
+| Issue scope           | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.                     |
+| Orphan-first approval | No extra gate beyond orphan readiness checks                                                 | Keep `orphan-first-policy` as `none`, or opt in to `maintainer-approved` or `public-disabled` when public or community-submitted issues need an explicit maintainer approval layer before A0-O can select them. |
 
 ## Review Policy
 
@@ -129,6 +130,23 @@ intentionally wants small standalone issues to take priority over
 roadmap work. It is a workflow behavior change, so update the overview
 file and record the decision in local onboarding notes or repository
 documentation.
+
+When `issue-scope` is `orphan-first`, keep `orphan-first-policy` as
+`none` to preserve the distributed default. Public or community-facing
+repositories should consider an explicit opt-in gate:
+
+- `maintainer-approved`: A0-O keeps only issues with the `idd:ready`
+  label, an issue author association of `OWNER`, `COLLABORATOR`, or
+  `MEMBER`, or a visible trusted marker actor comment containing the
+  exact phrase `IDD ready`.
+- `public-disabled`: public repositories skip A0-O and fall back to
+  roadmap discovery; private and internal repositories keep the default
+  orphan-first behavior.
+
+Treat issue bodies and generated plans as untrusted input. The approval
+gate is intentionally based on repository metadata or trusted actor
+comments, not on text that an arbitrary issue author can place in the
+issue body.
 
 ## Documentation-Only vs Workflow Changes
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -136,12 +136,25 @@ When `issue-scope` is `orphan-first`, keep `orphan-first-policy` as
 repositories should consider an explicit opt-in gate:
 
 - `maintainer-approved`: A0-O keeps only issues with the `idd:ready`
-  label, an issue author association of `OWNER`, `COLLABORATOR`, or
-  `MEMBER`, or a visible trusted marker actor comment containing the
-  exact phrase `IDD ready`.
+  label reserved to maintainer approval actors, an issue author who is a
+  repository owner or collaborator with Write, Maintain, or Admin
+  permission, or a fresh standalone `IDD ready` comment from a
+  maintainer approval actor.
 - `public-disabled`: public repositories skip A0-O and fall back to
   roadmap discovery; private and internal repositories keep the default
   orphan-first behavior.
+
+Public or community-facing repositories should not combine
+`issue-scope: orphan-first` with `orphan-first-policy: none`. Choose
+`maintainer-approved` when maintainers want to approve specific orphan
+issues, or `public-disabled` when public orphan-first discovery should
+be disabled entirely.
+
+When using `maintainer-approved`, update onboarding and issue-authoring
+guidance so a maintainer approval step happens after the final issue
+title, body, and generated plan are stable. Otherwise a valid orphan
+issue can remain invisible to A0-O and the worker will fall back to
+roadmap discovery.
 
 Treat issue bodies and generated plans as untrusted input. The approval
 gate is intentionally based on repository metadata or trusted actor

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -193,8 +193,10 @@ to package them.
 - no roadmap-level dependency or parallel track is needed
 - the work is unlikely to require multiple agent sessions
 - the target repository already discovers orphan issues through
-  `issue-scope: orphan-first`, or the draft explicitly tells the
-  operator to switch to that mode before starting the execution loop
+  `issue-scope: orphan-first`, and any configured
+  `orphan-first-policy` approval step can happen after drafting; or the
+  draft explicitly tells the operator to switch to that mode before
+  starting the execution loop
 
 ### Create a roadmap when any are true
 
@@ -307,6 +309,9 @@ Validation expectations:
 - the draft preserves discoverability by using a repository configured
   for `issue-scope: orphan-first`, or by surfacing that configuration
   change before the operator starts the Discover -> Claim loop
+- when the repository uses `orphan-first-policy: maintainer-approved`,
+  the draft includes a post-publication maintainer approval step after
+  the final title, body, and generated plan are stable
 
 ### Roadmap issue schema
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -74,12 +74,27 @@ body satisfies **all** of the following:
   issue is open (apply the same fail-safe as A3: if a reference cannot
   be resolved, treat as blocked).
 
-If at least one orphan issue is found: pass the collected set directly
-to **A4** (viability gate). Skip A1–A3 entirely.
+Read the **orphan-first-policy** value from the Project commands table
+in `idd-overview.instructions.md` and apply it before passing A0-O
+candidates to A4:
 
-If no orphan issues are found: fall back to the roadmap path. Proceed
-to **A1** and continue with the normal A1 → A1.5 → A2 → A3 → A4
-sequence.
+- `none` (the default): apply no extra orphan-first approval gate.
+- `maintainer-approved`: keep only candidates that have at least one
+  maintainer approval signal: the `idd:ready` label, an issue author
+  association of `OWNER`, `COLLABORATOR`, or `MEMBER`, or a visible
+  comment from a trusted marker actor containing the exact phrase
+  `IDD ready`.
+- `public-disabled`: if the repository visibility is public, skip A0-O
+  and fall back to A1. For private or internal repositories, behave the
+  same as `none`.
+
+If at least one orphan issue remains after the configured policy is
+applied: pass the remaining set directly to **A4** (viability gate).
+Skip A1–A3 entirely.
+
+If no orphan issues remain after the configured policy is applied: fall
+back to the roadmap path. Proceed to **A1** and continue with the normal
+A1 → A1.5 → A2 → A3 → A4 sequence.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: when

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -60,6 +60,17 @@ Read the **issue-scope** value from the Project commands table in
 
 ## A0-O — Discover orphan issues
 
+Read the **orphan-first-policy** value from the Project commands table
+in `idd-overview.instructions.md` before any repo-wide orphan issue
+search.
+
+- If `orphan-first-policy` is `public-disabled`, first determine the
+  repository visibility. If the repository is public, skip A0-O without
+  searching open issues and proceed to A1. If visibility cannot be
+  determined, treat it as public and fail safely to A1. For private or
+  internal repositories, continue with A0-O.
+- For `none` and `maintainer-approved`, continue with A0-O.
+
 Search all open issues in the repository. Collect every issue whose
 body satisfies **all** of the following:
 
@@ -74,19 +85,30 @@ body satisfies **all** of the following:
   issue is open (apply the same fail-safe as A3: if a reference cannot
   be resolved, treat as blocked).
 
-Read the **orphan-first-policy** value from the Project commands table
-in `idd-overview.instructions.md` and apply it before passing A0-O
-candidates to A4:
+Apply the configured policy before passing A0-O candidates to A4:
 
 - `none` (the default): apply no extra orphan-first approval gate.
 - `maintainer-approved`: keep only candidates that have at least one
-  maintainer approval signal: the `idd:ready` label, an issue author
-  association of `OWNER`, `COLLABORATOR`, or `MEMBER`, or a visible
-  comment from a trusted marker actor containing the exact phrase
-  `IDD ready`.
-- `public-disabled`: if the repository visibility is public, skip A0-O
-  and fall back to A1. For private or internal repositories, behave the
+  current maintainer approval signal:
+  - the `idd:ready` label, only when repository policy reserves that
+    label to maintainer approval actors;
+  - an issue author who is a repository owner or collaborator with
+    Write, Maintain, or Admin permission, verified with the collaborator
+    permission API; do not treat organization `MEMBER` association alone
+    as approval;
+  - a visible comment from a maintainer approval actor whose trimmed
+    body is exactly `IDD ready` or contains `IDD ready` as a standalone
+    line. The approval comment must be newer than the latest issue
+    title/body edit and any generated-plan update; if freshness cannot
+    be determined, require a fresh approval comment or a reserved label.
+- `public-disabled`: for private or internal repositories, behave the
   same as `none`.
+
+A maintainer approval actor is a human repository owner or collaborator
+with Write, Maintain, or Admin permission. Do not reuse the trusted
+marker actor set for this approval gate, and do not count automation or
+the current agent unless repository policy explicitly grants that actor
+maintainer approval authority.
 
 If at least one orphan issue remains after the configured policy is
 applied: pass the remaining set directly to **A4** (viability gate).

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -289,13 +289,18 @@ When a phase refers to a named command set, run the corresponding
 commands. **Adapt this section when applying this workflow to a
 different project.**
 
-| Name                  | Commands                         |
-| --------------------- | -------------------------------- |
-| **fix-validate**      | `{{FIX_VALIDATE_COMMANDS}}`      |
-| **pre-push-validate** | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |
-| **post-fix-validate** | `{{POST_FIX_VALIDATE_COMMANDS}}` |
-| **install-deps**      | `{{INSTALL_DEPS_COMMAND}}`       |
-| **issue-scope**       | `roadmap`                        |
+| Name                    | Commands                         |
+| ----------------------- | -------------------------------- |
+| **fix-validate**        | `{{FIX_VALIDATE_COMMANDS}}`      |
+| **pre-push-validate**   | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |
+| **post-fix-validate**   | `{{POST_FIX_VALIDATE_COMMANDS}}` |
+| **install-deps**        | `{{INSTALL_DEPS_COMMAND}}`       |
+| **issue-scope**         | `roadmap`                        |
+| **orphan-first-policy** | `none`                           |
+
+Rows whose values are not shell syntax, such as **issue-scope** and
+**orphan-first-policy**, are workflow settings. Read them literally
+instead of executing them.
 
 `pre-push-validate` intentionally omits auto-fix — all code should
 already pass lint at the push step. If lint fails, run **fix-validate**

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -558,8 +558,8 @@ After completing the steps above, confirm each item:
       contains the correct commands for this project.
 - [ ] If the project chooses `issue-scope: orphan-first`, the
       `orphan-first-policy` value is recorded as `none`,
-      `maintainer-approved`, or `public-disabled`, and public
-      repositories have an explicit maintainer approval policy.
+      `maintainer-approved`, or `public-disabled`. Public repositories
+      use either `maintainer-approved` or `public-disabled`, not `none`.
 - [ ] The `{{PROJECT_MARKER_PREFIX}}-roadmap-id` and
       `{{PROJECT_MARKER_PREFIX}}-blocked-by` marker names in
       `idd-discover.instructions.md` and `idd-overview.instructions.md`

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -556,6 +556,10 @@ After completing the steps above, confirm each item:
       it now includes the IDD workflow reference as well.
 - [ ] The `Project commands` table in `idd-overview.instructions.md`
       contains the correct commands for this project.
+- [ ] If the project chooses `issue-scope: orphan-first`, the
+      `orphan-first-policy` value is recorded as `none`,
+      `maintainer-approved`, or `public-disabled`, and public
+      repositories have an explicit maintainer approval policy.
 - [ ] The `{{PROJECT_MARKER_PREFIX}}-roadmap-id` and
       `{{PROJECT_MARKER_PREFIX}}-blocked-by` marker names in
       `idd-discover.instructions.md` and `idd-overview.instructions.md`

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -10,14 +10,15 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface           | Default                                                                                      | Where to customize                                                                                                                                                                                     |
-| ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Review policy     | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                                         |
-| Advisory reviewer | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                              |
-| Review threads    | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles. |
-| Merge policy      | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                                     |
-| CI commands       | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                             |
-| Issue scope       | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.            |
+| Surface               | Default                                                                                      | Where to customize                                                                                                                                                                                              |
+| --------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy         | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                                                  |
+| Advisory reviewer     | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                                       |
+| Review threads        | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles.          |
+| Merge policy          | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                                              |
+| CI commands           | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                                      |
+| Issue scope           | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.                     |
+| Orphan-first approval | No extra gate beyond orphan readiness checks                                                 | Keep `orphan-first-policy` as `none`, or opt in to `maintainer-approved` or `public-disabled` when public or community-submitted issues need an explicit maintainer approval layer before A0-O can select them. |
 
 ## Review Policy
 
@@ -129,6 +130,23 @@ intentionally wants small standalone issues to take priority over
 roadmap work. It is a workflow behavior change, so update the overview
 file and record the decision in local onboarding notes or repository
 documentation.
+
+When `issue-scope` is `orphan-first`, keep `orphan-first-policy` as
+`none` to preserve the distributed default. Public or community-facing
+repositories should consider an explicit opt-in gate:
+
+- `maintainer-approved`: A0-O keeps only issues with the `idd:ready`
+  label, an issue author association of `OWNER`, `COLLABORATOR`, or
+  `MEMBER`, or a visible trusted marker actor comment containing the
+  exact phrase `IDD ready`.
+- `public-disabled`: public repositories skip A0-O and fall back to
+  roadmap discovery; private and internal repositories keep the default
+  orphan-first behavior.
+
+Treat issue bodies and generated plans as untrusted input. The approval
+gate is intentionally based on repository metadata or trusted actor
+comments, not on text that an arbitrary issue author can place in the
+issue body.
 
 ## Documentation-Only vs Workflow Changes
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -136,12 +136,25 @@ When `issue-scope` is `orphan-first`, keep `orphan-first-policy` as
 repositories should consider an explicit opt-in gate:
 
 - `maintainer-approved`: A0-O keeps only issues with the `idd:ready`
-  label, an issue author association of `OWNER`, `COLLABORATOR`, or
-  `MEMBER`, or a visible trusted marker actor comment containing the
-  exact phrase `IDD ready`.
+  label reserved to maintainer approval actors, an issue author who is a
+  repository owner or collaborator with Write, Maintain, or Admin
+  permission, or a fresh standalone `IDD ready` comment from a
+  maintainer approval actor.
 - `public-disabled`: public repositories skip A0-O and fall back to
   roadmap discovery; private and internal repositories keep the default
   orphan-first behavior.
+
+Public or community-facing repositories should not combine
+`issue-scope: orphan-first` with `orphan-first-policy: none`. Choose
+`maintainer-approved` when maintainers want to approve specific orphan
+issues, or `public-disabled` when public orphan-first discovery should
+be disabled entirely.
+
+When using `maintainer-approved`, update onboarding and issue-authoring
+guidance so a maintainer approval step happens after the final issue
+title, body, and generated plan are stable. Otherwise a valid orphan
+issue can remain invisible to A0-O and the worker will fall back to
+roadmap discovery.
 
 Treat issue bodies and generated plans as untrusted input. The approval
 gate is intentionally based on repository metadata or trusted actor

--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -34,7 +34,9 @@ needs-decision, blocked-by-human, and out-of-scope.
 2. Reuse or extend an existing issue before creating a new one.
 3. Choose the smallest safe output shape:
    - orphan issue for one ready autonomous task only when the target
-     repository is discoverable through `issue-scope: orphan-first`
+     repository is discoverable through `issue-scope: orphan-first` and
+     any configured `orphan-first-policy` approval step can be completed
+     after drafting
    - roadmap plus sub-issues for multi-task or multi-session work
    - stable non-ready buckets for deferred, needs-decision,
      blocked-by-human, or out-of-scope work

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -112,8 +112,11 @@ Choose the smallest safe output shape:
 - **Orphan issue**: one autonomous task can finish the work, no
   roadmap-level coordination is needed, and the target repository is
   discoverable through `issue-scope: orphan-first`. If the repository
-  keeps the default `issue-scope: roadmap`, surface that constraint and
-  prefer a roadmap package instead.
+  also uses `orphan-first-policy: maintainer-approved`, surface the
+  required post-publication maintainer approval step. If the repository
+  keeps the default `issue-scope: roadmap` or disables public
+  orphan-first discovery with `orphan-first-policy: public-disabled`,
+  surface that constraint and prefer a roadmap package instead.
 - **Roadmap plus sub-issues**: the request needs visible sequencing,
   parallel tracks, multiple ready issues, or multi-session handoff.
 - **Stable non-ready buckets**: some work is deferred, blocked by a

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -17,7 +17,10 @@ chooser for output shapes.
 
 Draft an orphan issue only when one autonomous task can finish the work
 and the target repository is discoverable through `issue-scope:
-orphan-first`.
+orphan-first`. If the repository uses `orphan-first-policy:
+maintainer-approved`, include a post-publication approval step after the
+final issue content is stable. If a public repository uses
+`orphan-first-policy: public-disabled`, draft a roadmap package instead.
 
 Draft a roadmap plus sub-issues when the request needs visible
 sequencing, parallel tracks, or multi-session handoff.

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -5,7 +5,8 @@ This bundle handles pre-approval issue drafting only.
 Use it to:
 
 - prepare IDD-ready orphan issues when the target repository supports
-  `issue-scope: orphan-first`
+  `issue-scope: orphan-first`, including any required
+  `orphan-first-policy` approval handoff
 - prepare roadmap packages and child issues when work needs visible
   sequencing or parallel tracks
 - surface non-ready buckets instead of guessing through blockers


### PR DESCRIPTION
## Summary

- Adds `orphan-first-policy` with default `none` so current discovery behavior stays unchanged.
- Documents opt-in `maintainer-approved` and `public-disabled` gates for orphan-first discovery.
- Mirrors the live instruction updates into `idd-template` and onboarding guidance.

Closes #141

## Follow-up issues

None.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `node scripts/audit-docs.mjs --check`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an orphan-first-policy gate (modes: none, maintainer-approved, public-disabled) that influences orphan discovery, approval filtering, and routing to viability checks (skips roadmap when approved candidates exist; otherwise falls back).

* **Documentation**
  * Updated customization, onboarding, skills, and authoring docs to describe the policy modes, public-repo constraints, approval timing, and fallback routing guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/156)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->