### PR TITLE
docs(idd): clarify roadmap and child claim lock roles

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -8,6 +8,9 @@ verification.
 ## Pre-checks (all four must pass)
 
 Re-fetch the issue immediately before running these checks.
+All A5 checks are target-issue local: claims on related roadmap or
+child issues do not block this check unless they appear on the selected
+issue itself.
 
 **(a) Assignee and project status** — The issue must have no assignee
 set. If the project is in use, the project status must be "not started".

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -152,6 +152,9 @@ A1.5 can publish roadmap-level GitHub side effects before a child task
 issue is selected. Before any such side effect, coordinate on the
 roadmap issue itself:
 
+- Roadmap claim ownership gates roadmap-side mutations only. Do not
+  treat a non-stale roadmap claim as a global lock over A2/A3 child
+  discovery or child A5 checks.
 - Run the A5 claim-state, open-PR, and branch-collision checks against
   the roadmap issue. Do not apply A5's assignee or project
   `not started` readiness gate to roadmap-audit claims; roadmap
@@ -176,6 +179,9 @@ roadmap issue itself:
 - If the roadmap remains open and no PR branch will continue from the
   audit, release the roadmap-audit claim before returning to A2 or
   stopping.
+- Example: when another agent holds a non-stale roadmap claim, do not
+  mutate that roadmap in A1.5, but continue to A2/A3 and allow child
+  issues that pass readiness and A5 to proceed.
 
 Immediately before posting any completion summary, creating follow-up
 issues, editing the roadmap body, changing labels, or closing the

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -179,7 +179,9 @@ them from normal implementation claims.
 Roadmap-audit claims are coordination locks for roadmap-side mutations
 only. They must not be treated as global execution locks: child issue
 discovery and A5 checks remain issue-local and are gated by each child's
-own claim state, blockers, and dependencies.
+own claim state, blockers, and dependencies. This does not relax
+roadmap-level blocker gates such as `status:blocked-by-human` or
+`status:needs-decision`, which still stop child selection in Discover.
 
 ## Abort
 

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -176,6 +176,10 @@ commenting, editing, labeling, creating linked follow-up issues, or
 closing it. A1.5 coordination-only claims use a
 `roadmap-audit/<number>-<slug>` branch field so resume can distinguish
 them from normal implementation claims.
+Roadmap-audit claims are coordination locks for roadmap-side mutations
+only. They must not be treated as global execution locks: child issue
+discovery and A5 checks remain issue-local and are gated by each child's
+own claim state, blockers, and dependencies.
 
 ## Abort
 

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -67,6 +67,7 @@ stale active claim you are taking over, or in the latest released claim.
 
 If the active or inherited branch field starts with `roadmap-audit/`,
 the claim is an A1.5 roadmap-audit coordination claim, not a work branch.
+This coordination claim does not lock unrelated child-issue execution.
 After the re-claim or takeover is verified, do not create a branch or
 worktree and do not use the Step 2 worktree table. Re-run A1.5 for that
 roadmap issue, then follow A1.5's close, release, or stop behavior.

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -104,6 +104,9 @@ autonomous follow-up issues or route human-dependent gaps to an explicit
 blocked or needs-decision state. Roadmap-level side effects still use a
 temporary claim on the roadmap issue itself, so concurrent agents do not
 close or edit the same roadmap at the same time.
+This roadmap claim is a coordination lock only: child issue claims stay
+independent execution locks and can proceed in parallel unless blocked
+by their own readiness or dependency rules.
 
 This audit intentionally lives before A2 rather than in F4. F4 is
 limited to the PR that just merged and the local cleanup for that child

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -106,7 +106,8 @@ temporary claim on the roadmap issue itself, so concurrent agents do not
 close or edit the same roadmap at the same time.
 This roadmap claim is a coordination lock only: child issue claims stay
 independent execution locks and can proceed in parallel unless blocked
-by their own readiness or dependency rules.
+by their own readiness or dependency rules. Roadmap-level blocker labels
+still gate selection as described in Discover.
 
 This audit intentionally lives before A2 rather than in F4. F4 is
 limited to the PR that just merged and the local cleanup for that child

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -8,6 +8,9 @@ verification.
 ## Pre-checks (all four must pass)
 
 Re-fetch the issue immediately before running these checks.
+All A5 checks are target-issue local: claims on related roadmap or
+child issues do not block this check unless they appear on the selected
+issue itself.
 
 **(a) Assignee and project status** — The issue must have no assignee
 set. If the project is in use, the project status must be "not started".

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -157,6 +157,9 @@ A1.5 can publish roadmap-level GitHub side effects before a child task
 issue is selected. Before any such side effect, coordinate on the
 roadmap issue itself:
 
+- Roadmap claim ownership gates roadmap-side mutations only. Do not
+  treat a non-stale roadmap claim as a global lock over A2/A3 child
+  discovery or child A5 checks.
 - Run the A5 claim-state, open-PR, and branch-collision checks against
   the roadmap issue. Do not apply A5's assignee or project
   `not started` readiness gate to roadmap-audit claims; roadmap
@@ -181,6 +184,9 @@ roadmap issue itself:
 - If the roadmap remains open and no PR branch will continue from the
   audit, release the roadmap-audit claim before returning to A2 or
   stopping.
+- Example: when another agent holds a non-stale roadmap claim, do not
+  mutate that roadmap in A1.5, but continue to A2/A3 and allow child
+  issues that pass readiness and A5 to proceed.
 
 Immediately before posting any completion summary, creating follow-up
 issues, editing the roadmap body, changing labels, or closing the

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -179,7 +179,9 @@ them from normal implementation claims.
 Roadmap-audit claims are coordination locks for roadmap-side mutations
 only. They must not be treated as global execution locks: child issue
 discovery and A5 checks remain issue-local and are gated by each child's
-own claim state, blockers, and dependencies.
+own claim state, blockers, and dependencies. This does not relax
+roadmap-level blocker gates such as `status:blocked-by-human` or
+`status:needs-decision`, which still stop child selection in Discover.
 
 ## Abort
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -176,6 +176,10 @@ commenting, editing, labeling, creating linked follow-up issues, or
 closing it. A1.5 coordination-only claims use a
 `roadmap-audit/<number>-<slug>` branch field so resume can distinguish
 them from normal implementation claims.
+Roadmap-audit claims are coordination locks for roadmap-side mutations
+only. They must not be treated as global execution locks: child issue
+discovery and A5 checks remain issue-local and are gated by each child's
+own claim state, blockers, and dependencies.
 
 ## Abort
 

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -67,6 +67,7 @@ stale active claim you are taking over, or in the latest released claim.
 
 If the active or inherited branch field starts with `roadmap-audit/`,
 the claim is an A1.5 roadmap-audit coordination claim, not a work branch.
+This coordination claim does not lock unrelated child-issue execution.
 After the re-claim or takeover is verified, do not create a branch or
 worktree and do not use the Step 2 worktree table. Re-run A1.5 for that
 roadmap issue, then follow A1.5's close, release, or stop behavior.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -99,7 +99,8 @@ temporary claim on the roadmap issue itself, so concurrent agents do not
 close or edit the same roadmap at the same time.
 This roadmap claim is a coordination lock only: child issue claims stay
 independent execution locks and can proceed in parallel unless blocked
-by their own readiness or dependency rules.
+by their own readiness or dependency rules. Roadmap-level blocker labels
+still gate selection as described in Discover.
 
 This audit intentionally lives before A2 rather than in F4. F4 is
 limited to the PR that just merged and the local cleanup for that child

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -97,6 +97,9 @@ autonomous follow-up issues or route human-dependent gaps to an explicit
 blocked or needs-decision state. Roadmap-level side effects still use a
 temporary claim on the roadmap issue itself, so concurrent agents do not
 close or edit the same roadmap at the same time.
+This roadmap claim is a coordination lock only: child issue claims stay
+independent execution locks and can proceed in parallel unless blocked
+by their own readiness or dependency rules.
 
 This audit intentionally lives before A2 rather than in F4. F4 is
 limited to the PR that just merged and the local cleanup for that child


### PR DESCRIPTION
## Summary

- clarify that `roadmap-audit/*` claims are coordination locks for roadmap-side mutations only
- keep child execution claim logic issue-local across discover/claim/resume guidance
- mirror the same lock-granularity rule into template instruction files and workflow docs

## Validation

- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`

Closes #158

Follow-up: none expected.