### PR TITLE
docs: add roadmap claim guardrails

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -266,6 +266,28 @@
       "mode": "exact"
     },
     {
+      "id": "roadmap-claim-guardrails-customization",
+      "reference": "docs/customization.md",
+      "target": "idd-template/docs/customization.md",
+      "mode": "contains",
+      "requiredText": [
+        "## Roadmap Claim Guardrails",
+        "Roadmap-audit claims are coordination-only.",
+        "claim-staleness rules before continuing."
+      ]
+    },
+    {
+      "id": "roadmap-claim-guardrails-workflow",
+      "reference": "docs/idd-workflow.md",
+      "target": "idd-template/docs/idd-workflow.md",
+      "mode": "contains",
+      "requiredText": [
+        "## Roadmap Claim Guardrails",
+        "Roadmap-audit claims are coordination-only.",
+        "heartbeat or release rather than holding the claim open."
+      ]
+    },
+    {
       "id": "reference-doc",
       "source": "idd-template/docs/reference.md",
       "target": "docs/reference.md",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -284,7 +284,7 @@
       "requiredText": [
         "## Roadmap Claim Guardrails",
         "Roadmap-audit claims are coordination-only.",
-        "heartbeat or release rather than holding the claim open."
+        "heartbeat, release, or take over rather than holding the claim open."
       ]
     },
     {

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -195,6 +195,21 @@ If your repository needs stricter behavior, customize the relevant
 instruction files and mirror those changes to the template export in the
 same pull request.
 
+## Roadmap Claim Guardrails
+
+Roadmap-audit claims are coordination-only. Use them only while editing
+the roadmap issue itself, then release them once the roadmap-side effect
+is complete. They are not an execution lock for child issues.
+
+If a roadmap claim stays open long after the roadmap mutation is done,
+or if it appears to block child work, treat that as a misuse signal:
+re-read the roadmap state, confirm the active claim, and either
+heartbeat, take over, or release it according to the shared
+claim-staleness rules before continuing.
+
+Keep this guidance under the docs audit so unattended runs can detect
+drift between the live docs and the exported template.
+
 ## Documentation-Only vs Workflow Changes
 
 Documentation-only changes are safe when they record how the repository

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -152,7 +152,7 @@ claims.
 If the roadmap claim remains open after the roadmap-side effect is done,
 or if it appears to serialize child execution, treat that as a misuse
 signal: revalidate ownership and stale timing before continuing, then
-heartbeat or release rather than holding the claim open.
+heartbeat, release, or take over rather than holding the claim open.
 
 The docs audit keeps this guidance synchronized with the exported
 template so unattended runs can spot drift.

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -142,6 +142,21 @@ Use this playbook when multiple sessions are active:
 - **Do not bypass blocker labels, dependency checks, or claim
   revalidation gates** while resolving contention.
 
+## Roadmap Claim Guardrails
+
+Roadmap-audit claims are coordination-only. Use them only while the
+roadmap issue itself is being mutated, then release them once that
+roadmap-side effect is complete. They are not a proxy lock for child
+claims.
+
+If the roadmap claim remains open after the roadmap-side effect is done,
+or if it appears to serialize child execution, treat that as a misuse
+signal: revalidate ownership and stale timing before continuing, then
+heartbeat or release rather than holding the claim open.
+
+The docs audit keeps this guidance synchronized with the exported
+template so unattended runs can spot drift.
+
 ## Copilot review instruction scope
 
 The heavy shared overview keeps `applyTo: "**"` so GitHub Copilot

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -195,6 +195,21 @@ If your repository needs stricter behavior, customize the relevant
 instruction files and mirror those changes to the template export in the
 same pull request.
 
+## Roadmap Claim Guardrails
+
+Roadmap-audit claims are coordination-only. Use them only while editing
+the roadmap issue itself, then release them once the roadmap-side effect
+is complete. They are not an execution lock for child issues.
+
+If a roadmap claim stays open long after the roadmap mutation is done,
+or if it appears to block child work, treat that as a misuse signal:
+re-read the roadmap state, confirm the active claim, and either
+heartbeat, take over, or release it according to the shared
+claim-staleness rules before continuing.
+
+Keep this guidance under the docs audit so unattended runs can detect
+drift between the live docs and the exported template.
+
 ## Documentation-Only vs Workflow Changes
 
 Documentation-only changes are safe when they record how the repository

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -145,7 +145,7 @@ claims.
 If the roadmap claim remains open after the roadmap-side effect is done,
 or if it appears to serialize child execution, treat that as a misuse
 signal: revalidate ownership and stale timing before continuing, then
-heartbeat or release rather than holding the claim open.
+heartbeat, release, or take over rather than holding the claim open.
 
 The docs audit keeps this guidance synchronized with the exported
 template so unattended runs can spot drift.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -135,6 +135,21 @@ Use this playbook when multiple sessions are active:
 - **Do not bypass blocker labels, dependency checks, or claim
   revalidation gates** while resolving contention.
 
+## Roadmap Claim Guardrails
+
+Roadmap-audit claims are coordination-only. Use them only while the
+roadmap issue itself is being mutated, then release them once that
+roadmap-side effect is complete. They are not a proxy lock for child
+claims.
+
+If the roadmap claim remains open after the roadmap-side effect is done,
+or if it appears to serialize child execution, treat that as a misuse
+signal: revalidate ownership and stale timing before continuing, then
+heartbeat or release rather than holding the claim open.
+
+The docs audit keeps this guidance synchronized with the exported
+template so unattended runs can spot drift.
+
 ## Copilot review instruction scope
 
 The heavy shared overview keeps `applyTo: "**"` so GitHub Copilot


### PR DESCRIPTION
## Summary\n\n- Add a dedicated roadmap claim guardrails section to the workflow and customization docs, mirrored in the template copy.\n- Pin the new guardrail wording in the docs audit manifest so the live and template guidance stay aligned.\n\nCloses #159\n\n## Background\n\nRoadmap-audit claims are coordination-only locks for roadmap-side effects, not execution locks for child work. The new guidance makes that distinction explicit and gives unattended runs an audit-visible signal when a roadmap claim looks long-lived or misused.\n\n## Follow-up\n\nNone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Roadmap Claim Guardrails" guidance clarifying roadmap-audit claims are coordination-only, must be held only while mutating the roadmap, released after roadmap-side effects complete, and how to handle stale or blocking claims.

* **Chores**
  * Updated docs synchronization to propagate the new guidance into exported templates and ensure detection of drift.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/162)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->