### PR TITLE
docs: add roadmap claim contention playbook

### DIFF
--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -70,6 +70,8 @@ the claim is an A1.5 roadmap-audit coordination claim, not a work branch.
 After the re-claim or takeover is verified, do not create a branch or
 worktree and do not use the Step 2 worktree table. Re-run A1.5 for that
 roadmap issue, then follow A1.5's close, release, or stop behavior.
+Treat child issue claims independently; roadmap-audit claim presence
+alone must not block child issue execution.
 
 ## Step 2 — Locate or restore branch and worktree
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -161,6 +161,26 @@ gate is intentionally based on repository metadata or trusted actor
 comments, not on text that an arbitrary issue author can place in the
 issue body.
 
+## Roadmap-Claim Contention Policy
+
+If multiple sessions or agents run concurrently, document a
+roadmap-claim contention policy during onboarding:
+
+- Roadmap claims (`roadmap-audit/*`) are coordination claims for
+  roadmap-side effects only.
+- Child issue claims remain independent execution ownership per issue.
+- Roadmap claim presence alone must not block child issue execution.
+- Stale takeover timing and `supersedes` behavior follow shared claim
+  rules; local policy should not weaken them.
+- If a claim is fresh and owned by another live session, treat it as not
+  inheritable and stop or defer under the shared claim-state rules.
+- Operators should release roadmap-audit claims promptly after roadmap
+  mutations complete.
+
+If your repository needs stricter behavior, customize the relevant
+instruction files and mirror those changes to the template export in the
+same pull request.
+
 ## Documentation-Only vs Workflow Changes
 
 Documentation-only changes are safe when they record how the repository

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -110,6 +110,24 @@ limited to the PR that just merged and the local cleanup for that child
 issue. F5 then loops back to Discover, where roadmap completion can be
 checked with the broader parent context.
 
+### Roadmap-claim contention playbook
+
+Use this playbook when multiple sessions are active:
+
+- **Do continue child execution** when a roadmap claim is present, unless
+  a normal readiness gate blocks the child issue. Claims are per issue.
+- **Do treat `roadmap-audit/*` as coordination-only** for roadmap
+  side-effects (comment/edit/label/follow-up/close), not as a global
+  execution lock.
+- **Do stop and defer on fresh non-owned claims**. If a claim is active,
+  non-stale, and not yours, treat it as not inheritable.
+- **Do take over only stale non-owned claims** according to shared stale
+  thresholds and `supersedes` rules; do not force ownership changes.
+- **Do heartbeat only for owned active claims**, and release
+  roadmap-audit claims promptly after roadmap-side effects finish.
+- **Do not bypass blocker labels, dependency checks, or claim
+  revalidation gates** while resolving contention.
+
 ## Copilot review instruction scope
 
 The heavy shared overview keeps `applyTo: "**"` so GitHub Copilot

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -70,6 +70,8 @@ the claim is an A1.5 roadmap-audit coordination claim, not a work branch.
 After the re-claim or takeover is verified, do not create a branch or
 worktree and do not use the Step 2 worktree table. Re-run A1.5 for that
 roadmap issue, then follow A1.5's close, release, or stop behavior.
+Treat child issue claims independently; roadmap-audit claim presence
+alone must not block child issue execution.
 
 ## Step 2 — Locate or restore branch and worktree
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -161,6 +161,26 @@ gate is intentionally based on repository metadata or trusted actor
 comments, not on text that an arbitrary issue author can place in the
 issue body.
 
+## Roadmap-Claim Contention Policy
+
+If multiple sessions or agents run concurrently, document a
+roadmap-claim contention policy during onboarding:
+
+- Roadmap claims (`roadmap-audit/*`) are coordination claims for
+  roadmap-side effects only.
+- Child issue claims remain independent execution ownership per issue.
+- Roadmap claim presence alone must not block child issue execution.
+- Stale takeover timing and `supersedes` behavior follow shared claim
+  rules; local policy should not weaken them.
+- If a claim is fresh and owned by another live session, treat it as not
+  inheritable and stop or defer under the shared claim-state rules.
+- Operators should release roadmap-audit claims promptly after roadmap
+  mutations complete.
+
+If your repository needs stricter behavior, customize the relevant
+instruction files and mirror those changes to the template export in the
+same pull request.
+
 ## Documentation-Only vs Workflow Changes
 
 Documentation-only changes are safe when they record how the repository

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -103,6 +103,24 @@ limited to the PR that just merged and the local cleanup for that child
 issue. F5 then loops back to Discover, where roadmap completion can be
 checked with the broader parent context.
 
+### Roadmap-claim contention playbook
+
+Use this playbook when multiple sessions are active:
+
+- **Do continue child execution** when a roadmap claim is present, unless
+  a normal readiness gate blocks the child issue. Claims are per issue.
+- **Do treat `roadmap-audit/*` as coordination-only** for roadmap
+  side-effects (comment/edit/label/follow-up/close), not as a global
+  execution lock.
+- **Do stop and defer on fresh non-owned claims**. If a claim is active,
+  non-stale, and not yours, treat it as not inheritable.
+- **Do take over only stale non-owned claims** according to shared stale
+  thresholds and `supersedes` rules; do not force ownership changes.
+- **Do heartbeat only for owned active claims**, and release
+  roadmap-audit claims promptly after roadmap-side effects finish.
+- **Do not bypass blocker labels, dependency checks, or claim
+  revalidation gates** while resolving contention.
+
 ## Copilot review instruction scope
 
 The heavy shared overview keeps `applyTo: "**"` so GitHub Copilot


### PR DESCRIPTION
## Summary

- add a roadmap-claim contention playbook to `docs/idd-workflow.md`
- add onboarding policy guidance to `docs/customization.md`
- clarify in resume guidance that `roadmap-audit/*` claims are coordination-only and do not block child issue execution
- mirror all equivalent updates into `idd-template/` docs/instructions

## Why this change

Roadmap claim contention can be misread as a global execution lock in multi-agent or multi-session operation. This update documents explicit do/don't guidance while preserving existing claim parsing, stale-takeover, and revalidation rules.

## Validation

- markdown formatting/lint
- cspell
- docs audit script check

Closes #160
Refs #157
