### PR TITLE
docs: add deterministic resume routing prelude

### DIFF
--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -51,8 +51,8 @@ Classification thresholds:
 - **Stale takeover threshold**: 24 h from latest valid `claimed-by`
   `created_at`.
 - **Stall quiet window**: require a sustained quiet period from external
-  signals (for example, no newer issue/PR/review/CI activity and no HEAD
-  movement) before declaring progress-stalled; when uncertain, hold
+  signals of `>= 30 min` (no newer issue/PR/review/CI activity and no
+  HEAD movement) before declaring progress-stalled; when uncertain, hold
   rather than take over.
 
 ## Step 1 — Identify the issue and claim state

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -24,6 +24,37 @@ Before routing, collect all of the following:
    no upstream is configured, treat all local commits as unpushed.
 7. **Current HEAD SHA** — run `git rev-parse HEAD`.
 
+## Step 0 — Classify the resume route
+
+Before applying Step 1, classify the resume situation using only
+externally observable signals. Do not rely on the previous session
+posting a graceful shutdown, release, or hold comment.
+
+Use these signals together:
+
+- active claim ownership (`{claim-id}` and `created_at`)
+- issue/PR activity recency (comments, review threads, review bodies)
+- PR HEAD movement and CI state transitions
+- local worktree dirtiness and unpushed commits
+
+Route to one of the following classes:
+
+| Route class                                | Observable signal pattern                                                                                                                                                 | Action                                                                                                   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Crash recovery**                         | Session appears interrupted (missing/released claim, or unfinished local/PR state with no contradictory fresh owner signal).                                              | Continue with Step 1 and the existing restore table in Step 2.                                           |
+| **Progress-stalled / rate-limit recovery** | Active claim is non-stale and not currently provable as owned by this session, PR HEAD/CI and review activity are quiet, and no external signal proves the owner resumed. | Do not take over yet. Post a hold comment with observed signals and the next retry condition, then stop. |
+| **Stale-claim takeover**                   | Active non-owned claim exists and latest valid `claimed-by` `created_at` is `>= 24 h`.                                                                                    | Execute stale takeover flow in Step 1 (`supersedes` required), then continue.                            |
+| **Ordinary clean continuation**            | Active claim is already owned by this session and current state is consistent with normal continuation.                                                                   | Continue with Step 1/Step 2 as a normal resume.                                                          |
+
+Classification thresholds:
+
+- **Stale takeover threshold**: 24 h from latest valid `claimed-by`
+  `created_at`.
+- **Stall quiet window**: require a sustained quiet period from external
+  signals (for example, no newer issue/PR/review/CI activity and no HEAD
+  movement) before declaring progress-stalled; when uncertain, hold
+  rather than take over.
+
 ## Step 1 — Identify the issue and claim state
 
 - If the issue is **closed** or the corresponding PR is **merged**:
@@ -103,7 +134,8 @@ Read the PR's current CI and review status:
 
 | Condition                                                                          | Action                                                         |
 | ---------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| Required CI checks not yet generated                                               | Wait for generation, then apply D4 logic                       |
+| Required CI checks not yet generated, no reviews yet                               | Wait for generation, then apply D4 logic                       |
+| Required CI checks not yet generated, reviews exist                                | Wait for generation, then apply E15 logic                      |
 | CI `queued` or `in_progress`, no reviews yet (first push)                          | Apply D4 CI logic (`idd-ci.instructions.md`, on-success → E1)  |
 | CI `queued` or `in_progress`, reviews exist (post-fix push)                        | Apply E15 CI logic (`idd-ci.instructions.md`, on-success → E1) |
 | CI `failure` / `cancelled` / `timed_out`, no reviews yet                           | Apply D4 failure/cancelled branch                              |

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -33,23 +33,23 @@ you are reading this guide first, start at step 1.
 
 ## IDD file map
 
-| File                                                       | Role                                                                   |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping |
-| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue and audit completed roadmaps                |
-| `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                            |
-| `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                  |
-| `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                   |
-| `.github/instructions/idd-ci.instructions.md`              | Shared CI polling helper used by later phases                          |
-| `.github/instructions/idd-advisory-wait.instructions.md`   | Shared Copilot advisory-wait protocol (E14, F2, F3)                    |
-| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if List A is empty |
-| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, record dispositions                      |
-| `.github/instructions/idd-review-fix.instructions.md`      | Fix accepted review items and push follow-up commits                   |
-| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions           |
-| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover          |
-| `.github/instructions/idd-resume.instructions.md`          | Recover after a crash, timeout, or handoff                             |
-| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                   |
-| `docs/idd-comment-minimization.md`                         | Post-merge comment minimization policy, commands, and experiment notes |
+| File                                                       | Role                                                                    |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping  |
+| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue and audit completed roadmaps                 |
+| `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                             |
+| `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                   |
+| `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                    |
+| `.github/instructions/idd-ci.instructions.md`              | Shared CI polling helper used by later phases                           |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | Shared Copilot advisory-wait protocol (E14, F2, F3)                     |
+| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if List A is empty  |
+| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, record dispositions                       |
+| `.github/instructions/idd-review-fix.instructions.md`      | Fix accepted review items and push follow-up commits                    |
+| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions            |
+| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover           |
+| `.github/instructions/idd-resume.instructions.md`          | Route resume into crash, stalled, stale-takeover, or clean continuation |
+| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                    |
+| `docs/idd-comment-minimization.md`                         | Post-merge comment minimization policy, commands, and experiment notes  |
 
 ## Artifact taxonomy and ownership
 
@@ -113,6 +113,15 @@ This audit intentionally lives before A2 rather than in F4. F4 is
 limited to the PR that just merged and the local cleanup for that child
 issue. F5 then loops back to Discover, where roadmap completion can be
 checked with the broader parent context.
+
+## Resume routing model
+
+Resume now starts with a deterministic external-signal classifier before
+claim-state branching. The classifier routes each run into one of four
+paths: crash recovery, progress-stalled or rate-limit recovery,
+stale-claim takeover, or ordinary clean continuation. This keeps crash
+and stall handling separate without requiring the stalled session to
+publish a final self-report.
 
 ### Roadmap-claim contention playbook
 

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -51,8 +51,8 @@ Classification thresholds:
 - **Stale takeover threshold**: 24 h from latest valid `claimed-by`
   `created_at`.
 - **Stall quiet window**: require a sustained quiet period from external
-  signals (for example, no newer issue/PR/review/CI activity and no HEAD
-  movement) before declaring progress-stalled; when uncertain, hold
+  signals of `>= 30 min` (no newer issue/PR/review/CI activity and no
+  HEAD movement) before declaring progress-stalled; when uncertain, hold
   rather than take over.
 
 ## Step 1 — Identify the issue and claim state

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -24,6 +24,37 @@ Before routing, collect all of the following:
    no upstream is configured, treat all local commits as unpushed.
 7. **Current HEAD SHA** — run `git rev-parse HEAD`.
 
+## Step 0 — Classify the resume route
+
+Before applying Step 1, classify the resume situation using only
+externally observable signals. Do not rely on the previous session
+posting a graceful shutdown, release, or hold comment.
+
+Use these signals together:
+
+- active claim ownership (`{claim-id}` and `created_at`)
+- issue/PR activity recency (comments, review threads, review bodies)
+- PR HEAD movement and CI state transitions
+- local worktree dirtiness and unpushed commits
+
+Route to one of the following classes:
+
+| Route class                                | Observable signal pattern                                                                                                                                                 | Action                                                                                                   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Crash recovery**                         | Session appears interrupted (missing/released claim, or unfinished local/PR state with no contradictory fresh owner signal).                                              | Continue with Step 1 and the existing restore table in Step 2.                                           |
+| **Progress-stalled / rate-limit recovery** | Active claim is non-stale and not currently provable as owned by this session, PR HEAD/CI and review activity are quiet, and no external signal proves the owner resumed. | Do not take over yet. Post a hold comment with observed signals and the next retry condition, then stop. |
+| **Stale-claim takeover**                   | Active non-owned claim exists and latest valid `claimed-by` `created_at` is `>= 24 h`.                                                                                    | Execute stale takeover flow in Step 1 (`supersedes` required), then continue.                            |
+| **Ordinary clean continuation**            | Active claim is already owned by this session and current state is consistent with normal continuation.                                                                   | Continue with Step 1/Step 2 as a normal resume.                                                          |
+
+Classification thresholds:
+
+- **Stale takeover threshold**: 24 h from latest valid `claimed-by`
+  `created_at`.
+- **Stall quiet window**: require a sustained quiet period from external
+  signals (for example, no newer issue/PR/review/CI activity and no HEAD
+  movement) before declaring progress-stalled; when uncertain, hold
+  rather than take over.
+
 ## Step 1 — Identify the issue and claim state
 
 - If the issue is **closed** or the corresponding PR is **merged**:
@@ -103,7 +134,8 @@ Read the PR's current CI and review status:
 
 | Condition                                                                          | Action                                                         |
 | ---------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| Required CI checks not yet generated                                               | Wait for generation, then apply D4 logic                       |
+| Required CI checks not yet generated, no reviews yet                               | Wait for generation, then apply D4 logic                       |
+| Required CI checks not yet generated, reviews exist                                | Wait for generation, then apply E15 logic                      |
 | CI `queued` or `in_progress`, no reviews yet (first push)                          | Apply D4 CI logic (`idd-ci.instructions.md`, on-success → E1)  |
 | CI `queued` or `in_progress`, reviews exist (post-fix push)                        | Apply E15 CI logic (`idd-ci.instructions.md`, on-success → E1) |
 | CI `failure` / `cancelled` / `timed_out`, no reviews yet                           | Apply D4 failure/cancelled branch                              |

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -39,23 +39,23 @@ entry file should be an explicit operator choice, not the default.
 
 ## IDD file map
 
-| File                                                       | Role                                                                   |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping |
-| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue and audit completed roadmaps                |
-| `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                            |
-| `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                  |
-| `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                   |
-| `.github/instructions/idd-ci.instructions.md`              | Shared CI polling helper used by later phases                          |
-| `.github/instructions/idd-advisory-wait.instructions.md`   | Shared Copilot advisory-wait protocol (E14, F2, F3)                    |
-| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if List A is empty |
-| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, record dispositions                      |
-| `.github/instructions/idd-review-fix.instructions.md`      | Fix accepted review items and push follow-up commits                   |
-| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions           |
-| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover          |
-| `.github/instructions/idd-resume.instructions.md`          | Recover after a crash, timeout, or handoff                             |
-| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                   |
-| `docs/idd-comment-minimization.md`                         | Post-merge comment minimization policy, commands, and experiment notes |
+| File                                                       | Role                                                                    |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping  |
+| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue and audit completed roadmaps                 |
+| `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                             |
+| `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                   |
+| `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                    |
+| `.github/instructions/idd-ci.instructions.md`              | Shared CI polling helper used by later phases                           |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | Shared Copilot advisory-wait protocol (E14, F2, F3)                     |
+| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if List A is empty  |
+| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, record dispositions                       |
+| `.github/instructions/idd-review-fix.instructions.md`      | Fix accepted review items and push follow-up commits                    |
+| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions            |
+| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover           |
+| `.github/instructions/idd-resume.instructions.md`          | Route resume into crash, stalled, stale-takeover, or clean continuation |
+| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                    |
+| `docs/idd-comment-minimization.md`                         | Post-merge comment minimization policy, commands, and experiment notes  |
 
 ## Artifact taxonomy and ownership
 
@@ -106,6 +106,15 @@ This audit intentionally lives before A2 rather than in F4. F4 is
 limited to the PR that just merged and the local cleanup for that child
 issue. F5 then loops back to Discover, where roadmap completion can be
 checked with the broader parent context.
+
+## Resume routing model
+
+Resume now starts with a deterministic external-signal classifier before
+claim-state branching. The classifier routes each run into one of four
+paths: crash recovery, progress-stalled or rate-limit recovery,
+stale-claim takeover, or ordinary clean continuation. This keeps crash
+and stall handling separate without requiring the stalled session to
+publish a final self-report.
 
 ### Roadmap-claim contention playbook
 


### PR DESCRIPTION
## Summary

- add a Step 0 classifier to `idd-resume.instructions.md` that routes resume into crash recovery, progress-stalled recovery, stale-claim takeover, or ordinary continuation using external signals only
- document conservative stall handling (hold when uncertain) and explicit thresholds so takeover logic remains deterministic
- mirror the same changes into `idd-template/` and update workflow docs to describe the new resume routing model
- split the Step 3 row for "required checks not yet generated" into no-reviews (D4) vs reviews-exist (E15) paths

Closes #166

## Follow-up

- none

## Background

This codifies the crash/stall split as an explicit router so stalled sessions are no longer expected to publish final self-report markers before safe routing decisions can be made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new initial classification step that deterministically routes resume situations into four continuation paths (crash recovery, progress-stalled/rate-limit recovery, stale-claim takeover, ordinary clean continuation) using external signals.
  * Clarified resume routing model and file map entries.
  * Refined CI/review routing to distinguish cases with no reviews vs. existing reviews.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/168)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->