### PR TITLE
test(protocol): add resume routing fixture coverage

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -304,6 +304,7 @@ export function classifyResumeRoutingCase(input, options = {}) {
   const staleHours = options.staleHours ?? 24;
   const stallMinutes = options.stallMinutes ?? 30;
   const pendingCiStates = new Set(options.pendingCiStates ?? ["queued", "in_progress", "waiting"]);
+  const terminalSafeCiStates = new Set(options.terminalSafeCiStates ?? ["success", "none"]);
 
   if (!input.hasActiveClaim) {
     return {
@@ -351,6 +352,12 @@ export function classifyResumeRoutingCase(input, options = {}) {
     return {
       route: "hold-for-evidence",
       reason: "CI is still pending for the active non-owned claim",
+    };
+  }
+  if (!terminalSafeCiStates.has(ciState)) {
+    return {
+      route: "hold-for-evidence",
+      reason: "CI is not in a terminal-safe state for stalled-claim recovery",
     };
   }
 

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -300,6 +300,73 @@ export function applyClaimEvent(activeClaim, event, isTrustedAuthor = () => true
   return activeClaim;
 }
 
+export function classifyResumeRoutingCase(input, options = {}) {
+  const staleHours = options.staleHours ?? 24;
+  const stallMinutes = options.stallMinutes ?? 30;
+  const pendingCiStates = new Set(options.pendingCiStates ?? ["queued", "in_progress", "waiting"]);
+
+  if (!input.hasActiveClaim) {
+    return {
+      route: "unclaimed-reclaim-required",
+      reason: "resume requires a fresh claim before continuation",
+    };
+  }
+
+  if (input.claimOwnedBySession) {
+    if (input.rebaseInProgress || input.worktreeDirty || input.hasUnpushedCommits) {
+      return {
+        route: "crash-recovery",
+        reason: "owned claim with interrupted local state",
+      };
+    }
+    return {
+      route: "ordinary-continuation",
+      reason: "owned claim with clean local state",
+    };
+  }
+
+  if (typeof input.claimAgeHours !== "number") {
+    return {
+      route: "hold-for-evidence",
+      reason: "claim age is missing for a non-owned claim",
+    };
+  }
+
+  if (input.claimAgeHours >= staleHours) {
+    return {
+      route: "stale-claim-takeover",
+      reason: `non-owned claim is stale at >= ${staleHours}h`,
+    };
+  }
+
+  if (typeof input.latestActivityAgeMinutes !== "number") {
+    return {
+      route: "hold-for-evidence",
+      reason: "activity age is missing for a non-owned active claim",
+    };
+  }
+
+  const ciState = String(input.ciState ?? "none").toLowerCase();
+  if (pendingCiStates.has(ciState)) {
+    return {
+      route: "hold-for-evidence",
+      reason: "CI is still pending for the active non-owned claim",
+    };
+  }
+
+  if (input.latestActivityAgeMinutes >= stallMinutes) {
+    return {
+      route: "progress-stalled-recovery",
+      reason: `non-owned claim is fresh but idle for >= ${stallMinutes}m`,
+    };
+  }
+
+  return {
+    route: "hold-for-evidence",
+    reason: "non-owned claim is still within active freshness windows",
+  };
+}
+
 function hasExplicitDispositionAfter(targetComment, comments) {
   const targetTime = Date.parse(targetComment.createdAt ?? "");
   return comments.some((comment) => {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -301,9 +301,9 @@ export function applyClaimEvent(activeClaim, event, isTrustedAuthor = () => true
 }
 
 export function classifyResumeRoutingCase(input, options = {}) {
-  const staleHours = options.staleHours ?? 24;
-  const stallMinutes = options.stallMinutes ?? 30;
-  const pendingCiStates = new Set(options.pendingCiStates ?? ["queued", "in_progress", "waiting"]);
+  const staleHours = Number.isFinite(options.staleHours) ? options.staleHours : 24;
+  const stallMinutes = Number.isFinite(options.stallMinutes) ? options.stallMinutes : 30;
+  const pendingCiStates = new Set(options.pendingCiStates ?? ["queued", "in_progress", "waiting", "pending"]);
   const terminalSafeCiStates = new Set(options.terminalSafeCiStates ?? ["success", "none"]);
 
   if (!input.hasActiveClaim) {
@@ -314,7 +314,7 @@ export function classifyResumeRoutingCase(input, options = {}) {
   }
 
   if (input.claimOwnedBySession) {
-    if (input.rebaseInProgress || input.worktreeDirty || input.hasUnpushedCommits) {
+    if (input.rebaseInProgress || input.worktreeDirty) {
       return {
         route: "crash-recovery",
         reason: "owned claim with interrupted local state",
@@ -326,7 +326,7 @@ export function classifyResumeRoutingCase(input, options = {}) {
     };
   }
 
-  if (typeof input.claimAgeHours !== "number") {
+  if (!Number.isFinite(input.claimAgeHours)) {
     return {
       route: "hold-for-evidence",
       reason: "claim age is missing for a non-owned claim",
@@ -340,7 +340,7 @@ export function classifyResumeRoutingCase(input, options = {}) {
     };
   }
 
-  if (typeof input.latestActivityAgeMinutes !== "number") {
+  if (!Number.isFinite(input.latestActivityAgeMinutes)) {
     return {
       route: "hold-for-evidence",
       reason: "activity age is missing for a non-owned active claim",
@@ -363,14 +363,14 @@ export function classifyResumeRoutingCase(input, options = {}) {
 
   if (input.latestActivityAgeMinutes >= stallMinutes) {
     return {
-      route: "progress-stalled-recovery",
-      reason: `non-owned claim is fresh but idle for >= ${stallMinutes}m`,
+      route: "hold-for-evidence",
+      reason: `non-owned claim is fresh and idle for >= ${stallMinutes}m, but still non-inheritable`,
     };
   }
 
   return {
     route: "hold-for-evidence",
-    reason: "non-owned claim is still within active freshness windows",
+    reason: "non-owned claim remains non-inheritable until stale",
   };
 }
 

--- a/tests/fixtures/resume-recovery/nonowned-ci-pending.json
+++ b/tests/fixtures/resume-recovery/nonowned-ci-pending.json
@@ -1,0 +1,17 @@
+{
+  "name": "non-owned claim with pending CI holds even when activity is old",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": false,
+    "claimAgeHours": 6,
+    "latestActivityAgeMinutes": 80,
+    "ciState": "in_progress",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "hold-for-evidence",
+    "reasonContains": "CI is still pending"
+  }
+}

--- a/tests/fixtures/resume-recovery/nonowned-ci-unknown-hold.json
+++ b/tests/fixtures/resume-recovery/nonowned-ci-unknown-hold.json
@@ -1,0 +1,17 @@
+{
+  "name": "non-owned claim with unknown CI state holds for evidence",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": false,
+    "claimAgeHours": 3,
+    "latestActivityAgeMinutes": 50,
+    "ciState": "unknown",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "hold-for-evidence",
+    "reasonContains": "terminal-safe"
+  }
+}

--- a/tests/fixtures/resume-recovery/nonowned-missing-activity.json
+++ b/tests/fixtures/resume-recovery/nonowned-missing-activity.json
@@ -1,0 +1,17 @@
+{
+  "name": "non-owned claim with missing activity evidence holds",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": false,
+    "claimAgeHours": 8,
+    "latestActivityAgeMinutes": null,
+    "ciState": "success",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "hold-for-evidence",
+    "reasonContains": "activity age is missing"
+  }
+}

--- a/tests/fixtures/resume-recovery/nonowned-same-agent-unverified.json
+++ b/tests/fixtures/resume-recovery/nonowned-same-agent-unverified.json
@@ -1,0 +1,17 @@
+{
+  "name": "same agent id without verified ownership is still treated as non-owned",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": false,
+    "claimAgeHours": 1,
+    "latestActivityAgeMinutes": 20,
+    "ciState": "success",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "hold-for-evidence",
+    "reasonContains": "freshness windows"
+  }
+}

--- a/tests/fixtures/resume-recovery/nonowned-same-agent-unverified.json
+++ b/tests/fixtures/resume-recovery/nonowned-same-agent-unverified.json
@@ -12,6 +12,6 @@
   },
   "expected": {
     "route": "hold-for-evidence",
-    "reasonContains": "freshness windows"
+    "reasonContains": "non-inheritable"
   }
 }

--- a/tests/fixtures/resume-recovery/nonowned-stale-24h.json
+++ b/tests/fixtures/resume-recovery/nonowned-stale-24h.json
@@ -1,0 +1,17 @@
+{
+  "name": "non-owned claim at stale threshold routes to takeover",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": false,
+    "claimAgeHours": 24,
+    "latestActivityAgeMinutes": 10,
+    "ciState": "success",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "stale-claim-takeover",
+    "reasonContains": ">= 24h"
+  }
+}

--- a/tests/fixtures/resume-recovery/nonowned-stale-below-threshold.json
+++ b/tests/fixtures/resume-recovery/nonowned-stale-below-threshold.json
@@ -1,0 +1,17 @@
+{
+  "name": "non-owned claim below stale threshold does not takeover",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": false,
+    "claimAgeHours": 23.99,
+    "latestActivityAgeMinutes": 15,
+    "ciState": "success",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "hold-for-evidence",
+    "reasonContains": "freshness windows"
+  }
+}

--- a/tests/fixtures/resume-recovery/nonowned-stale-below-threshold.json
+++ b/tests/fixtures/resume-recovery/nonowned-stale-below-threshold.json
@@ -12,6 +12,6 @@
   },
   "expected": {
     "route": "hold-for-evidence",
-    "reasonContains": "freshness windows"
+    "reasonContains": "non-inheritable"
   }
 }

--- a/tests/fixtures/resume-recovery/nonowned-stalled-idle.json
+++ b/tests/fixtures/resume-recovery/nonowned-stalled-idle.json
@@ -1,0 +1,17 @@
+{
+  "name": "non-owned fresh claim with stale activity routes to stalled recovery",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": false,
+    "claimAgeHours": 4,
+    "latestActivityAgeMinutes": 45,
+    "ciState": "success",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "progress-stalled-recovery",
+    "reasonContains": ">= 30m"
+  }
+}

--- a/tests/fixtures/resume-recovery/nonowned-stalled-idle.json
+++ b/tests/fixtures/resume-recovery/nonowned-stalled-idle.json
@@ -1,5 +1,5 @@
 {
-  "name": "non-owned fresh claim with stale activity routes to stalled recovery",
+  "name": "non-owned fresh claim with stale activity still holds ownership",
   "input": {
     "hasActiveClaim": true,
     "claimOwnedBySession": false,
@@ -11,7 +11,7 @@
     "rebaseInProgress": false
   },
   "expected": {
-    "route": "progress-stalled-recovery",
+    "route": "hold-for-evidence",
     "reasonContains": ">= 30m"
   }
 }

--- a/tests/fixtures/resume-recovery/owned-clean-ordinary.json
+++ b/tests/fixtures/resume-recovery/owned-clean-ordinary.json
@@ -1,0 +1,17 @@
+{
+  "name": "owned clean claim continues normally",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": true,
+    "claimAgeHours": 2,
+    "latestActivityAgeMinutes": 5,
+    "ciState": "success",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "ordinary-continuation",
+    "reasonContains": "clean local state"
+  }
+}

--- a/tests/fixtures/resume-recovery/owned-clean-unpushed.json
+++ b/tests/fixtures/resume-recovery/owned-clean-unpushed.json
@@ -1,0 +1,17 @@
+{
+  "name": "owned clean branch with unpushed commits keeps ordinary continuation",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": true,
+    "claimAgeHours": 2,
+    "latestActivityAgeMinutes": 5,
+    "ciState": "success",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": true,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "ordinary-continuation",
+    "reasonContains": "clean local state"
+  }
+}

--- a/tests/fixtures/resume-recovery/owned-crash-dirty.json
+++ b/tests/fixtures/resume-recovery/owned-crash-dirty.json
@@ -1,0 +1,17 @@
+{
+  "name": "owned dirty claim routes to crash recovery",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": true,
+    "claimAgeHours": 2,
+    "latestActivityAgeMinutes": 5,
+    "ciState": "success",
+    "worktreeDirty": true,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "crash-recovery",
+    "reasonContains": "interrupted local state"
+  }
+}

--- a/tests/fixtures/resume-recovery/owned-crash-rebase.json
+++ b/tests/fixtures/resume-recovery/owned-crash-rebase.json
@@ -1,0 +1,17 @@
+{
+  "name": "owned rebase in progress routes to crash recovery",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": true,
+    "claimAgeHours": 2,
+    "latestActivityAgeMinutes": 5,
+    "ciState": "success",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": true
+  },
+  "expected": {
+    "route": "crash-recovery",
+    "reasonContains": "interrupted local state"
+  }
+}

--- a/tests/fixtures/resume-recovery/unclaimed-reclaim-required.json
+++ b/tests/fixtures/resume-recovery/unclaimed-reclaim-required.json
@@ -1,0 +1,17 @@
+{
+  "name": "missing active claim requires reclaim",
+  "input": {
+    "hasActiveClaim": false,
+    "claimOwnedBySession": false,
+    "claimAgeHours": null,
+    "latestActivityAgeMinutes": null,
+    "ciState": "none",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false
+  },
+  "expected": {
+    "route": "unclaimed-reclaim-required",
+    "reasonContains": "fresh claim"
+  }
+}

--- a/tests/resume-recovery.test.mjs
+++ b/tests/resume-recovery.test.mjs
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
@@ -10,11 +11,11 @@ const fixtures = loadFixtures(FIXTURE_DIR);
 
 for (const fixture of fixtures) {
   test(`resume routing: ${fixture.name}`, () => {
-    const result = classifyResumeRoutingCase(fixture.input, {
-      staleHours: 24,
-      stallMinutes: 30,
-      pendingCiStates: ["queued", "in_progress", "waiting"],
-    });
+      const result = classifyResumeRoutingCase(fixture.input, {
+        staleHours: 24,
+        stallMinutes: 30,
+        pendingCiStates: ["queued", "in_progress", "waiting", "pending"],
+      });
 
     assert.equal(result.route, fixture.expected.route);
     assert.match(result.reason, new RegExp(fixture.expected.reasonContains, "i"));
@@ -22,7 +23,7 @@ for (const fixture of fixtures) {
 }
 
 function loadFixtures(url) {
-  const directory = url.pathname;
+  const directory = fileURLToPath(url);
   return readdirSync(directory)
     .filter((fileName) => fileName.endsWith(".json"))
     .sort()

--- a/tests/resume-recovery.test.mjs
+++ b/tests/resume-recovery.test.mjs
@@ -1,0 +1,33 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { classifyResumeRoutingCase } from "../scripts/protocol-helpers.mjs";
+
+const FIXTURE_DIR = new URL("./fixtures/resume-recovery", import.meta.url);
+const fixtures = loadFixtures(FIXTURE_DIR);
+
+for (const fixture of fixtures) {
+  test(`resume routing: ${fixture.name}`, () => {
+    const result = classifyResumeRoutingCase(fixture.input, {
+      staleHours: 24,
+      stallMinutes: 30,
+      pendingCiStates: ["queued", "in_progress", "waiting"],
+    });
+
+    assert.equal(result.route, fixture.expected.route);
+    assert.match(result.reason, new RegExp(fixture.expected.reasonContains, "i"));
+  });
+}
+
+function loadFixtures(url) {
+  const directory = url.pathname;
+  return readdirSync(directory)
+    .filter((fileName) => fileName.endsWith(".json"))
+    .sort()
+    .map((fileName) => {
+      const fullPath = join(directory, fileName);
+      return JSON.parse(readFileSync(fullPath, "utf8"));
+    });
+}


### PR DESCRIPTION
## Summary
- add a shared classifyResumeRoutingCase helper in scripts/protocol-helpers.mjs
- add fixture-backed resume-recovery scenarios under tests/fixtures/resume-recovery/
- add tests/resume-recovery.test.mjs to validate route and reason decisions at key thresholds

## Why this change
Issue #165 asks for explicit, testable resume routing outcomes around stale claims, stalled progress, crash-recovery, and hold paths. These fixtures pin the boundary behavior and make future regressions visible.

## Follow-ups
- none

Closes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added intelligent resume/recovery routing that evaluates claim ownership, local interruption signals, CI status, and staleness to decide ordinary continuation, various hold-for-evidence outcomes, crash recovery, stalled recovery, or stale-claim takeover.

* **Tests**
  * Added a test suite and 11 scenario fixtures covering owned/non‑owned claims, missing activity, CI pending/unknown, crash conditions, stall thresholds, and stale-takeover cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/171)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->