### PR TITLE
fix(merge): block f3 on unresolved actionable threads

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -29,6 +29,14 @@ gate. The active claim must still use your current `{claim-id}`.
    - The total item count of the final fetch exceeds
      `{f2-total-item-count}`.
 
+   From that same final fetch, compute `F3_UNRESOLVED_ACTIONABLE_COUNT`
+   using the exact F2 unresolved-thread rule and exceptions
+   (non-awaiting-reviewer unresolved threads only; awaiting-reviewer
+   classification must follow F2 verbatim, including AMD exclusion and
+   conversation-resolution exception handling). If
+   `F3_UNRESOLVED_ACTIONABLE_COUNT > 0`, stop and return to E1. Do not
+   execute `gh pr merge` in this pass.
+
    Execute the merge immediately after this final fetch **and the claim
    re-validation and advisory state revalidation below**, with no other
    actions in between. Re-validate claim: re-read the issue and confirm

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -29,6 +29,14 @@ gate. The active claim must still use your current `{claim-id}`.
    - The total item count of the final fetch exceeds
      `{f2-total-item-count}`.
 
+   From that same final fetch, compute `F3_UNRESOLVED_ACTIONABLE_COUNT`
+   using the exact F2 unresolved-thread rule and exceptions
+   (non-awaiting-reviewer unresolved threads only; awaiting-reviewer
+   classification must follow F2 verbatim, including AMD exclusion and
+   conversation-resolution exception handling). If
+   `F3_UNRESOLVED_ACTIONABLE_COUNT > 0`, stop and return to E1. Do not
+   execute `gh pr merge` in this pass.
+
    Execute the merge immediately after this final fetch **and the claim
    re-validation and advisory state revalidation below**, with no other
    actions in between. Re-validate claim: re-read the issue and confirm


### PR DESCRIPTION
## Summary
- add an explicit F3 hard gate that computes `F3_UNRESOLVED_ACTIONABLE_COUNT` from the final activity-universe fetch
- require the exact F2 unresolved-thread classification/exceptions when computing that count
- return to E1 and skip `gh pr merge` whenever unresolved actionable threads remain
- mirror the same gate in `idd-template/.github/instructions/idd-merge.instructions.md`

## Why this change
Issue #176 requires merge execution to fail closed when actionable threads are unresolved, even at the final pre-merge step. This closes the incident gap where partial checks could still allow merge.

## Follow-ups
- none

Closes #176