### PR TITLE
docs(merge): require explicit F2 evidence checklist

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -54,6 +54,11 @@ minimum, capture:
 4. Reviewer-state evidence: latest `CHANGES_REQUESTED` status for human,
    required, and CODEOWNER reviewers, plus required approval/CODEOWNER
    satisfaction status.
+5. Advisory-wait evidence: current AW outcome (`SATISFIED`/`WAIT`/etc),
+   marker presence (`EARLIEST_SAME_HEAD_AT`), and whether the current
+   state satisfies the advisory gate for merge.
+6. CI evidence: required-check generation state and pass/fail status for
+   all required checks on the current PR HEAD.
 
 Do not treat "one bot says clean" as sufficient evidence. The checklist
 must cover the full activity universe (human reviewers plus advisory bot

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -40,6 +40,26 @@ If `mergeable` is `CONFLICTING` or `mergeStateStatus` is `BEHIND` or
 Verify **all** of the following. If any condition is not met, follow the
 bracketed action:
 
+Before running F3, record explicit F2 evidence for this pass. At
+minimum, capture:
+
+1. Activity-universe snapshot evidence:
+   `{head-SHA}`, `{max-activity-updatedAt|none}`,
+   `{total-item-count}`, `{latest-ci-completed-at|none}`.
+2. Unresolved-thread evidence: total unresolved thread count, the
+   non-awaiting-reviewer unresolved count used by the gate, and whether
+   any AMD (`**Awaiting maintainer decision**`) threads remain.
+3. Unreplied regular-comment evidence: the count of non-IDD-agent
+   comments that still lack a later IDD-agent reply.
+4. Reviewer-state evidence: latest `CHANGES_REQUESTED` status for human,
+   required, and CODEOWNER reviewers, plus required approval/CODEOWNER
+   satisfaction status.
+
+Do not treat "one bot says clean" as sufficient evidence. The checklist
+must cover the full activity universe (human reviewers plus advisory bot
+surfaces such as Copilot, CodeRabbit, Codex connectors, and CI bots) and
+must align with every F2 condition below.
+
 - **Review currency** (live re-fetch required, freshness gate): read the
   most recent `<!-- review-watermark: {agent-id} {claim-id} … -->`
   comment whose embedded `{claim-id}` matches the current active claim

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -161,6 +161,29 @@ Some older project text may still use "skill files" as shorthand for
 instructions, but the native skill bundle and execution instructions are
 related rather than interchangeable surfaces.
 
+## F2 merge-readiness evidence checklist
+
+Before executing F3 merge, F2 must record concrete evidence for merge
+readiness rather than relying on a single reviewer signal.
+
+Required evidence fields:
+
+1. Activity-universe snapshot values:
+   `{head-SHA}`, `{max-activity-updatedAt|none}`,
+   `{total-item-count}`, `{latest-ci-completed-at|none}`.
+2. Unresolved-thread evidence: total unresolved threads, actionable
+   unresolved count (non-awaiting-reviewer), and AMD thread presence.
+3. Unreplied regular-comment evidence: count of non-IDD-agent comments
+   without a later IDD-agent reply.
+4. Reviewer-state evidence: latest `CHANGES_REQUESTED` states for human,
+   required, and CODEOWNER reviewers, plus required approval/CODEOWNER
+   satisfaction.
+
+Mixed reviewer ecosystems are expected. The same checklist applies
+across human reviews and advisory bot surfaces (Copilot, CodeRabbit,
+Codex connectors, CI bots); "one bot says clean" is never sufficient by
+itself.
+
 ## Review Policy Profiles
 
 The execution loop is cross-agent, while PR review policy is a

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -178,6 +178,10 @@ Required evidence fields:
 4. Reviewer-state evidence: latest `CHANGES_REQUESTED` states for human,
    required, and CODEOWNER reviewers, plus required approval/CODEOWNER
    satisfaction.
+5. Advisory-wait evidence: AW outcome for the current HEAD, marker
+   coverage (`EARLIEST_SAME_HEAD_AT`), and merge-gate satisfaction.
+6. CI evidence: required-check generation and pass status for all
+   required checks on the current HEAD.
 
 Mixed reviewer ecosystems are expected. The same checklist applies
 across human reviews and advisory bot surfaces (Copilot, CodeRabbit,

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -54,6 +54,11 @@ minimum, capture:
 4. Reviewer-state evidence: latest `CHANGES_REQUESTED` status for human,
    required, and CODEOWNER reviewers, plus required approval/CODEOWNER
    satisfaction status.
+5. Advisory-wait evidence: current AW outcome (`SATISFIED`/`WAIT`/etc),
+   marker presence (`EARLIEST_SAME_HEAD_AT`), and whether the current
+   state satisfies the advisory gate for merge.
+6. CI evidence: required-check generation state and pass/fail status for
+   all required checks on the current PR HEAD.
 
 Do not treat "one bot says clean" as sufficient evidence. The checklist
 must cover the full activity universe (human reviewers plus advisory bot

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -40,6 +40,26 @@ If `mergeable` is `CONFLICTING` or `mergeStateStatus` is `BEHIND` or
 Verify **all** of the following. If any condition is not met, follow the
 bracketed action:
 
+Before running F3, record explicit F2 evidence for this pass. At
+minimum, capture:
+
+1. Activity-universe snapshot evidence:
+   `{head-SHA}`, `{max-activity-updatedAt|none}`,
+   `{total-item-count}`, `{latest-ci-completed-at|none}`.
+2. Unresolved-thread evidence: total unresolved thread count, the
+   non-awaiting-reviewer unresolved count used by the gate, and whether
+   any AMD (`**Awaiting maintainer decision**`) threads remain.
+3. Unreplied regular-comment evidence: the count of non-IDD-agent
+   comments that still lack a later IDD-agent reply.
+4. Reviewer-state evidence: latest `CHANGES_REQUESTED` status for human,
+   required, and CODEOWNER reviewers, plus required approval/CODEOWNER
+   satisfaction status.
+
+Do not treat "one bot says clean" as sufficient evidence. The checklist
+must cover the full activity universe (human reviewers plus advisory bot
+surfaces such as Copilot, CodeRabbit, Codex connectors, and CI bots) and
+must align with every F2 condition below.
+
 - **Review currency** (live re-fetch required, freshness gate): read the
   most recent `<!-- review-watermark: {agent-id} {claim-id} … -->`
   comment whose embedded `{claim-id}` matches the current active claim

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -167,6 +167,10 @@ Required evidence fields:
 4. Reviewer-state evidence: latest `CHANGES_REQUESTED` states for human,
    required, and CODEOWNER reviewers, plus required approval/CODEOWNER
    satisfaction.
+5. Advisory-wait evidence: AW outcome for the current HEAD, marker
+   coverage (`EARLIEST_SAME_HEAD_AT`), and merge-gate satisfaction.
+6. CI evidence: required-check generation and pass status for all
+   required checks on the current HEAD.
 
 Mixed reviewer ecosystems are expected. The same checklist applies
 across human reviews and advisory bot surfaces (Copilot, CodeRabbit,

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -150,6 +150,29 @@ reviewer-only instruction file. Copilot code review may still use the
 lightweight repository-wide `.github/copilot-instructions.md`; only the
 heavier `idd-overview.instructions.md` is excluded from review.
 
+## F2 merge-readiness evidence checklist
+
+Before executing F3 merge, F2 must record concrete evidence for merge
+readiness rather than relying on a single reviewer signal.
+
+Required evidence fields:
+
+1. Activity-universe snapshot values:
+   `{head-SHA}`, `{max-activity-updatedAt|none}`,
+   `{total-item-count}`, `{latest-ci-completed-at|none}`.
+2. Unresolved-thread evidence: total unresolved threads, actionable
+   unresolved count (non-awaiting-reviewer), and AMD thread presence.
+3. Unreplied regular-comment evidence: count of non-IDD-agent comments
+   without a later IDD-agent reply.
+4. Reviewer-state evidence: latest `CHANGES_REQUESTED` states for human,
+   required, and CODEOWNER reviewers, plus required approval/CODEOWNER
+   satisfaction.
+
+Mixed reviewer ecosystems are expected. The same checklist applies
+across human reviews and advisory bot surfaces (Copilot, CodeRabbit,
+Codex connectors, CI bots); "one bot says clean" is never sufficient by
+itself.
+
 ## Review Policy Profiles
 
 The execution loop is cross-agent, while PR review policy is a


### PR DESCRIPTION
## Summary
- add an explicit F2 merge-readiness evidence checklist to idd-pre-merge instructions
- require recorded evidence for snapshot fields, unresolved-thread counts, unreplied regular comments, and reviewer-state gates
- clarify that one advisory bot signal is never sufficient and the full reviewer ecosystem must be covered
- mirror the same checklist into docs/idd-workflow.md and idd-template/docs/idd-workflow.md

## Why
The unresolved-feedback incident showed that merge decisions can be shortcut when operators treat a single bot response as complete review evidence.

## Notes
- the checklist aligns with existing F2 gate semantics and does not add new merge rules
- live/template instruction and workflow surfaces are updated together to keep distributed guidance aligned

Closes #178

Refs #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an explicit F2 "merge-readiness evidence" checklist across the IDD workflow and templates. Requires recording an activity snapshot, unresolved-thread and unreplied-comment metrics, reviewer-state evidence, advisory-wait coverage/outcome, and CI required-check generation/pass status before proceeding to merge. Clarifies that a single bot signal is not sufficient.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/183)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->