### PR TITLE
fix(idd): keep orphan-first retry routing on discover path

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -25,7 +25,9 @@ using the shared claim-state rules:
   first learned by parsing the current issue comments is not enough.
 - Any other active claim whose latest valid `claimed-by` comment has
   GitHub `created_at` < 24 h → claimed by another live session, even
-  when the `agent-id` matches. Go back to A3.
+  when the `agent-id` matches. Return to Discover using the same
+  selection mode that produced this target (orphan-first: continue the
+  A0-O capable path; roadmap mode: continue the A3-ready path).
 - Any other active claim whose latest valid `claimed-by` comment has
   GitHub `created_at` ≥ 24 h → stale, proceed with takeover.
 
@@ -42,8 +44,10 @@ Otherwise, use the latest trusted legacy `claimed-by` comment as a
 **migration-only** decision input:
 
 - Latest trusted legacy claim has GitHub `created_at` < 24 h → claimed
-  by another live session, even when the `agent-id` matches. Go back to
-  A3.
+  by another live session, even when the `agent-id` matches. Return to
+  Discover using the same selection mode that produced this target
+  (orphan-first: continue the A0-O capable path; roadmap mode: continue
+  the A3-ready path).
 - Latest trusted legacy claim has GitHub `created_at` ≥ 24 h → stale,
   proceed and replace it with a new-format claim.
 
@@ -105,8 +109,10 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 ## Claim verification
 
 Re-read the issue immediately and parse the active claim. Verify that
-the active claim now uses **your** `{claim-id}`. If it does not, go back
-to A3.
+the active claim now uses **your** `{claim-id}`. If it does not, return
+to Discover using the same selection mode that produced this target
+(orphan-first: continue the A0-O capable path; roadmap mode: continue
+the A3-ready path).
 
 Once verified, record this `{claim-id}` as your current claim token for
 the rest of the workflow, then continue to `idd-work.instructions.md`.

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -25,7 +25,9 @@ using the shared claim-state rules:
   first learned by parsing the current issue comments is not enough.
 - Any other active claim whose latest valid `claimed-by` comment has
   GitHub `created_at` < 24 h → claimed by another live session, even
-  when the `agent-id` matches. Go back to A3.
+  when the `agent-id` matches. Return to Discover using the same
+  selection mode that produced this target (orphan-first: continue the
+  A0-O capable path; roadmap mode: continue the A3-ready path).
 - Any other active claim whose latest valid `claimed-by` comment has
   GitHub `created_at` ≥ 24 h → stale, proceed with takeover.
 
@@ -42,8 +44,10 @@ Otherwise, use the latest trusted legacy `claimed-by` comment as a
 **migration-only** decision input:
 
 - Latest trusted legacy claim has GitHub `created_at` < 24 h → claimed
-  by another live session, even when the `agent-id` matches. Go back to
-  A3.
+  by another live session, even when the `agent-id` matches. Return to
+  Discover using the same selection mode that produced this target
+  (orphan-first: continue the A0-O capable path; roadmap mode: continue
+  the A3-ready path).
 - Latest trusted legacy claim has GitHub `created_at` ≥ 24 h → stale,
   proceed and replace it with a new-format claim.
 
@@ -105,8 +109,10 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 ## Claim verification
 
 Re-read the issue immediately and parse the active claim. Verify that
-the active claim now uses **your** `{claim-id}`. If it does not, go back
-to A3.
+the active claim now uses **your** `{claim-id}`. If it does not, return
+to Discover using the same selection mode that produced this target
+(orphan-first: continue the A0-O capable path; roadmap mode: continue
+the A3-ready path).
 
 Once verified, record this `{claim-id}` as your current claim token for
 the rest of the workflow, then continue to `idd-work.instructions.md`.


### PR DESCRIPTION
## Summary

- update A5 claim-conflict retry wording so retries return through the same discover selection mode that produced the target issue
- remove roadmap-only "Go back to A3" wording for non-stale active claims, legacy claim conflicts, and claim-verification mismatch
- mirror the same retry-routing wording in the template export

## Background

In orphan-first mode, routing claim conflicts to A3 only is ambiguous and can bypass the orphan-capable path. This change preserves selection-mode semantics during retries.

Closes #174

## Follow-up

None.
