### PR TITLE
docs: surface policy defaults

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -11,7 +11,7 @@ advisory-wait check. It is referenced by:
   before executing the merge command
 
 The current policy values for request caps, advisory windows, and
-related defaults are listed in [IDD policy constants](../docs/policy-constants.md).
+related defaults are listed in [IDD policy constants](../../docs/policy-constants.md).
 Use that inventory when you need the named value, not as a place to
 change behavior.
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -10,6 +10,11 @@ advisory-wait check. It is referenced by:
 - **F3** (`idd-merge.instructions.md`): final revalidation immediately
   before executing the merge command
 
+The current policy values for request caps, advisory windows, and
+related defaults are listed in [IDD policy constants](../docs/policy-constants.md).
+Use that inventory when you need the named value, not as a place to
+change behavior.
+
 Callers are responsible for fetching `PR_HEAD_SHA` before invoking these
 steps and for defining their own routing on each outcome.
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -3,6 +3,10 @@
 Read this file when you need to wait for CI after a push. Callers must
 define their own **on-success** target before invoking this algorithm.
 
+The shared CI wait thresholds and retry defaults are listed in
+[IDD policy constants](../docs/policy-constants.md). Use that inventory
+to find the current named values; this helper still owns the behavior.
+
 ## Algorithm
 
 1. Identify the full set of required checks for the current PR head SHA

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -4,7 +4,7 @@ Read this file when you need to wait for CI after a push. Callers must
 define their own **on-success** target before invoking this algorithm.
 
 The shared CI wait thresholds and retry defaults are listed in
-[IDD policy constants](../docs/policy-constants.md). Use that inventory
+[IDD policy constants](../../docs/policy-constants.md). Use that inventory
 to find the current named values; this helper still owns the behavior.
 
 ## Algorithm

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -5,7 +5,7 @@ pre-merge conditions. It covers executing the merge (F3), cleanup (F4),
 and looping back to discover (F5).
 
 The final merge-gate timing defaults are named in
-[IDD policy constants](../docs/policy-constants.md). Use that inventory
+[IDD policy constants](../../docs/policy-constants.md). Use that inventory
 when you need the canonical values; the merge logic itself stays here.
 
 Before any mutating action in F3, apply the shared claim revalidation

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -4,6 +4,10 @@ Read this file after `idd-pre-merge.instructions.md` (F2) satisfies all
 pre-merge conditions. It covers executing the merge (F3), cleanup (F4),
 and looping back to discover (F5).
 
+The final merge-gate timing defaults are named in
+[IDD policy constants](../docs/policy-constants.md). Use that inventory
+when you need the canonical values; the merge logic itself stays here.
+
 Before any mutating action in F3, apply the shared claim revalidation
 gate. The active claim must still use your current `{claim-id}`.
 

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -183,6 +183,14 @@ own claim state, blockers, and dependencies. This does not relax
 roadmap-level blocker gates such as `status:blocked-by-human` or
 `status:needs-decision`, which still stop child selection in Discover.
 
+## Policy Constants
+
+The distributed claim, advisory, CI, and critique-loop defaults are
+named in `docs/policy-constants.md`. Read that page before changing any
+timing or loop constant, and record local deviations in onboarding or
+repository docs so future sessions can find the selected policy values
+without scanning every phase file.
+
 ## Abort
 
 On abort, re-validate ownership first. If the active claim still uses

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -9,7 +9,7 @@ gate. Even when another local agent is driving the workflow, follow it
 because the dependency is on GitHub review state, not on the local CLI.
 
 The merge-gate timing defaults referenced by F2 are named in
-[IDD policy constants](../docs/policy-constants.md). Use that inventory
+[IDD policy constants](../../docs/policy-constants.md). Use that inventory
 for the canonical values, not as a behavior override.
 
 Before any F-phase mutating action, apply the shared claim revalidation

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -8,6 +8,10 @@ This phase includes a repository-specific GitHub Copilot advisory review
 gate. Even when another local agent is driving the workflow, follow it
 because the dependency is on GitHub review state, not on the local CLI.
 
+The merge-gate timing defaults referenced by F2 are named in
+[IDD policy constants](../docs/policy-constants.md). Use that inventory
+for the canonical values, not as a behavior override.
+
 Before any F-phase mutating action, apply the shared claim revalidation
 gate. The active claim must still use your current `{claim-id}`.
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -10,7 +10,7 @@ follow it because the dependency is on GitHub review state, not on the
 local CLI.
 
 The advisory-review timing defaults used by E14 are named in
-[IDD policy constants](../docs/policy-constants.md). Refer there when
+[IDD policy constants](../../docs/policy-constants.md). Refer there when
 you need the values, but keep the phase logic here unchanged.
 
 Apply the shared claim revalidation gate before E9, before the E12 push,

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -9,6 +9,10 @@ review step. Even when another local agent is driving the workflow,
 follow it because the dependency is on GitHub review state, not on the
 local CLI.
 
+The advisory-review timing defaults used by E14 are named in
+[IDD policy constants](../docs/policy-constants.md). Refer there when
+you need the values, but keep the phase logic here unchanged.
+
 Apply the shared claim revalidation gate before E9, before the E12 push,
 and before each E13/E14 GitHub side effect (reply, resolve, reviewer
 request, or hold comment).

--- a/docs/idd-review-policy-profiles.md
+++ b/docs/idd-review-policy-profiles.md
@@ -31,6 +31,10 @@ Use this profile when GitHub Copilot pull request review is available
 and the operator accepts it as an advisory signal rather than a required
 human approval.
 
+The advisory wait windows, request cap, and CI wait defaults are named in
+[IDD policy constants](policy-constants.md), so adopters can record those
+values separately from the review profile choice.
+
 ## Human-Required Profile
 
 Use `human-required` when a person, CODEOWNER, or required reviewer is

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -90,6 +90,11 @@ instruction template first. Native skills can sit beside it as helpers,
 but the synchronization contract for the portable workflow remains
 between the live `.github/instructions/` files and `idd-template/`.
 
+If you need to understand or change distributed timing defaults, start
+with [IDD policy constants](policy-constants.md). It names the claim,
+advisory, CI, and critique-loop defaults and points to the instruction
+files that own each value.
+
 When an operator gives exactly one issue target, Discover can verify that
 target directly before Claim. The shortcut avoids broad roadmap
 enumeration, but it still applies targeted readiness checks and the A4

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -6,6 +6,11 @@ value here does not change runtime behavior, and this page does not
 promise a configuration mechanism that the instruction files have not
 implemented yet.
 
+The values below are the named policy defaults that onboarding and
+customization docs refer to. When a repository keeps the distributed
+default, the instruction files continue to enforce the same behavior; the
+names just make the defaults easier to record and change consistently.
+
 Use it during onboarding to identify which defaults a repository accepts
 as-is and which defaults need a follow-up workflow change.
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -11,7 +11,7 @@ advisory-wait check. It is referenced by:
   before executing the merge command
 
 The current policy values for request caps, advisory windows, and
-related defaults are listed in [IDD policy constants](../docs/policy-constants.md).
+related defaults are listed in [IDD policy constants](../../docs/policy-constants.md).
 Use that inventory when you need the named value, not as a place to
 change behavior.
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -10,6 +10,11 @@ advisory-wait check. It is referenced by:
 - **F3** (`idd-merge.instructions.md`): final revalidation immediately
   before executing the merge command
 
+The current policy values for request caps, advisory windows, and
+related defaults are listed in [IDD policy constants](../docs/policy-constants.md).
+Use that inventory when you need the named value, not as a place to
+change behavior.
+
 Callers are responsible for fetching `PR_HEAD_SHA` before invoking these
 steps and for defining their own routing on each outcome.
 

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -3,6 +3,10 @@
 Read this file when you need to wait for CI after a push. Callers must
 define their own **on-success** target before invoking this algorithm.
 
+The shared CI wait thresholds and retry defaults are listed in
+[IDD policy constants](../docs/policy-constants.md). Use that inventory
+to find the current named values; this helper still owns the behavior.
+
 ## Algorithm
 
 1. Identify the full set of required checks for the current PR head SHA

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -4,7 +4,7 @@ Read this file when you need to wait for CI after a push. Callers must
 define their own **on-success** target before invoking this algorithm.
 
 The shared CI wait thresholds and retry defaults are listed in
-[IDD policy constants](../docs/policy-constants.md). Use that inventory
+[IDD policy constants](../../docs/policy-constants.md). Use that inventory
 to find the current named values; this helper still owns the behavior.
 
 ## Algorithm

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -5,7 +5,7 @@ pre-merge conditions. It covers executing the merge (F3), cleanup (F4),
 and looping back to discover (F5).
 
 The final merge-gate timing defaults are named in
-[IDD policy constants](../docs/policy-constants.md). Use that inventory
+[IDD policy constants](../../docs/policy-constants.md). Use that inventory
 when you need the canonical values; the merge logic itself stays here.
 
 Before any mutating action in F3, apply the shared claim revalidation

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -4,6 +4,10 @@ Read this file after `idd-pre-merge.instructions.md` (F2) satisfies all
 pre-merge conditions. It covers executing the merge (F3), cleanup (F4),
 and looping back to discover (F5).
 
+The final merge-gate timing defaults are named in
+[IDD policy constants](../docs/policy-constants.md). Use that inventory
+when you need the canonical values; the merge logic itself stays here.
+
 Before any mutating action in F3, apply the shared claim revalidation
 gate. The active claim must still use your current `{claim-id}`.
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -183,6 +183,14 @@ own claim state, blockers, and dependencies. This does not relax
 roadmap-level blocker gates such as `status:blocked-by-human` or
 `status:needs-decision`, which still stop child selection in Discover.
 
+## Policy Constants
+
+The distributed claim, advisory, CI, and critique-loop defaults are
+named in `docs/policy-constants.md`. Read that page before changing any
+timing or loop constant, and record local deviations in onboarding or
+repository docs so future sessions can find the selected policy values
+without scanning every phase file.
+
 ## Abort
 
 On abort, re-validate ownership first. If the active claim still uses

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -9,7 +9,7 @@ gate. Even when another local agent is driving the workflow, follow it
 because the dependency is on GitHub review state, not on the local CLI.
 
 The merge-gate timing defaults referenced by F2 are named in
-[IDD policy constants](../docs/policy-constants.md). Use that inventory
+[IDD policy constants](../../docs/policy-constants.md). Use that inventory
 for the canonical values, not as a behavior override.
 
 Before any F-phase mutating action, apply the shared claim revalidation

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -8,6 +8,10 @@ This phase includes a repository-specific GitHub Copilot advisory review
 gate. Even when another local agent is driving the workflow, follow it
 because the dependency is on GitHub review state, not on the local CLI.
 
+The merge-gate timing defaults referenced by F2 are named in
+[IDD policy constants](../docs/policy-constants.md). Use that inventory
+for the canonical values, not as a behavior override.
+
 Before any F-phase mutating action, apply the shared claim revalidation
 gate. The active claim must still use your current `{claim-id}`.
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -10,7 +10,7 @@ follow it because the dependency is on GitHub review state, not on the
 local CLI.
 
 The advisory-review timing defaults used by E14 are named in
-[IDD policy constants](../docs/policy-constants.md). Refer there when
+[IDD policy constants](../../docs/policy-constants.md). Refer there when
 you need the values, but keep the phase logic here unchanged.
 
 Apply the shared claim revalidation gate before E9, before the E12 push,

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -9,6 +9,10 @@ review step. Even when another local agent is driving the workflow,
 follow it because the dependency is on GitHub review state, not on the
 local CLI.
 
+The advisory-review timing defaults used by E14 are named in
+[IDD policy constants](../docs/policy-constants.md). Refer there when
+you need the values, but keep the phase logic here unchanged.
+
 Apply the shared claim revalidation gate before E9, before the E12 push,
 and before each E13/E14 GitHub side effect (reply, resolve, reviewer
 request, or hold comment).

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -64,6 +64,11 @@ Treat `human_merge` as the safe default for public repositories;
 agent session merge authority. Record the selected policy in repository
 documentation that future IDD sessions read.
 
+If you keep the distributed advisory/CI defaults, record that choice
+alongside the merge policy and point operators to
+[IDD policy constants](docs/policy-constants.md) so the named values are
+easy to find later.
+
 ## Your task
 
 1. Read this entire document first.

--- a/idd-template/docs/idd-review-policy-profiles.md
+++ b/idd-template/docs/idd-review-policy-profiles.md
@@ -31,6 +31,10 @@ Use this profile when GitHub Copilot pull request review is available
 and the operator accepts it as an advisory signal rather than a required
 human approval.
 
+The advisory wait windows, request cap, and CI wait defaults are named in
+[IDD policy constants](policy-constants.md), so adopters can record those
+values separately from the review profile choice.
+
 ## Human-Required Profile
 
 Use `human-required` when a person, CODEOWNER, or required reviewer is

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -83,6 +83,11 @@ The distributed workflow remains an instruction template first. Native
 skills can sit beside it as optional helpers, but they do not replace
 these execution-layer files.
 
+If you need to understand or change distributed timing defaults, start
+with [IDD policy constants](policy-constants.md). It names the claim,
+advisory, CI, and critique-loop defaults and points to the instruction
+files that own each value.
+
 When an operator gives exactly one issue target, Discover can verify that
 target directly before Claim. The shortcut avoids broad roadmap
 enumeration, but it still applies targeted readiness checks and the A4

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -6,6 +6,11 @@ value here does not change runtime behavior, and this page does not
 promise a configuration mechanism that the instruction files have not
 implemented yet.
 
+The values below are the named policy defaults that onboarding and
+customization docs refer to. When a repository keeps the distributed
+default, the instruction files continue to enforce the same behavior; the
+names just make the defaults easier to record and change consistently.
+
 Use it during onboarding to identify which defaults a repository accepts
 as-is and which defaults need a follow-up workflow change.
 


### PR DESCRIPTION
Summarize and name the distributed policy defaults across the live instructions and template mirrors.\n\nThis change adds discoverability pointers for the advisory, CI, claim, and critique-loop timing defaults without changing the workflow behavior.\n\nCloses #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Centralized references to policy constants across instruction and onboarding docs.
  * Added clear guidance for locating and recording distributed timing defaults in a dedicated policy-constants document.
  * Clarified which instruction files own specific timing/default values so users can customize workflow defaults without editing individual phase instructions.
  * Updated workflow and onboarding guidance to reflect the centralized policy-constants source.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/187)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->