### PR TITLE
docs: define live status digest contract

### DIFF
--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -195,6 +195,21 @@ timing or loop constant, and record local deviations in onboarding or
 repository docs so future sessions can find the selected policy values
 without scanning every phase file.
 
+## Live status digest
+
+The optional live status digest is a human-facing issue or pull request
+comment whose first line is `<!-- idd-live-status: current -->`. It may
+summarize phase, claim, branch, last checked time, blockers, and next
+action, but it is never an authority for IDD state transitions.
+
+Agents must continue to make claim, review, advisory, CI, merge, and
+roadmap decisions from trusted operational markers and GitHub state. If
+the digest is missing or stale, repair it only after claim revalidation
+and authoritative state collection. If multiple marked digests exist,
+preserve them, report the duplicate URLs, and do not choose one as
+authoritative during an unattended run. See
+`docs/idd-comment-minimization.md` for the full digest contract.
+
 ## Abort
 
 On abort, re-validate ownership first. If the active claim still uses

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -56,6 +56,10 @@ Before routing, collect all of the following:
 9. **Unpushed commits** — run `git log @{u}..HEAD` in the worktree. If
    no upstream is configured, treat all local commits as unpushed.
 10. **Current local HEAD SHA** — run `git rev-parse HEAD`.
+11. **Live status digest state** — record whether the issue or PR has
+    zero, one, or multiple comments whose first line is
+    `<!-- idd-live-status: current -->`. Do not use digest text to route
+    resume; it is repairable UI state only.
 
 ## Step 1 — Identify the issue and claim state
 
@@ -106,6 +110,13 @@ worktree and do not use the Step 2 worktree table. Re-run A1.5 for that
 roadmap issue, then follow A1.5's close, release, or stop behavior.
 Treat child issue claims independently; roadmap-audit claim presence
 alone must not block child issue execution.
+
+After Step 1 establishes the route and verifies any current-session
+claim, repair a missing or stale live status digest from the parsed
+claim state, PR state, CI state, and review activity when doing so is
+safe under the claim revalidation gate. If multiple marked digests
+exist, preserve them, report their URLs, and continue routing from
+trusted markers and GitHub state rather than digest text.
 
 ## Step 2 — Locate or restore branch and worktree
 

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -9,6 +9,55 @@ Minimization is UI cleanup. It preserves the audit trail and must never
 replace review triage, conversation resolution, CI, advisory wait, or
 merge gates.
 
+## Live Status Digest Contract
+
+A live status digest is an editable, human-facing issue or pull request
+comment that summarizes the current IDD run. It is UI state only. It
+must never replace trusted operational markers, review state, CI state,
+branch protection, or GitHub issue and pull request state as workflow
+evidence.
+
+The first line of every current digest comment is this stable marker:
+
+```html
+<!-- idd-live-status: current -->
+```
+
+At most one current digest may exist per issue or pull request. Agents
+find the digest by searching comments on that issue or PR for the marker
+above. The marker is an identifier, not authority: a digest posted by an
+untrusted actor or a digest whose text disagrees with trusted markers is
+ignored for workflow decisions and repaired only after the authoritative
+state has been re-read.
+
+Each digest should contain these fields in a compact, editable form:
+
+| Field              | Meaning                                                             |
+| ------------------ | ------------------------------------------------------------------- |
+| `Phase`            | The current IDD phase or resume route                               |
+| `Claim`            | Active claim owner and claim age, or `none`                         |
+| `Branch`           | Current work branch or `none`                                       |
+| `Last checked`     | ISO 8601 time when the digest was last refreshed from trusted state |
+| `Open blockers`    | Human decision, CI, review, dependency, or claim blocker summary    |
+| `Next action`      | The next expected agent, maintainer, CI, or reviewer action         |
+| `Authoritative by` | The marker, CI, review, issue, or PR evidence the summary came from |
+
+Only the current claim owner should update the digest during normal IDD
+execution, and only after the claim revalidation gate passes. Maintainers
+may repair a digest outside an active claim, but that repair does not
+claim workflow ownership. Roadmap-audit digests follow the same rule:
+the roadmap-audit claim gates edits to the roadmap issue digest only,
+not child issue execution.
+
+If the digest is missing during resume, recreate it from the parsed
+claim state, PR state, CI state, and review activity after the resume
+route is known. If the digest is stale, update the existing marked
+comment from that same authoritative state. If multiple marked digest
+comments exist, do not delete, minimize, or guess which one is
+authoritative during an unattended run; preserve the audit history,
+report the duplicate URLs, and use trusted markers and GitHub state for
+all workflow decisions until a repair path selects one current digest.
+
 ## Timing
 
 Run minimization only after one of these is true:

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -50,7 +50,7 @@ you are reading this guide first, start at step 1.
 | `.github/instructions/idd-resume.instructions.md`          | Route resume into crash, stalled, stale-takeover, or clean continuation |
 | `.github/instructions/idd-resume-stall.instructions.md`    | Handle stalled-session recovery with a dedicated safety gate            |
 | `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                    |
-| `docs/idd-comment-minimization.md`                         | Post-merge comment minimization policy, commands, and experiment notes  |
+| `docs/idd-comment-minimization.md`                         | Live status digest contract and post-merge comment minimization policy  |
 
 ## Artifact taxonomy and ownership
 
@@ -128,6 +128,21 @@ paths: crash recovery, progress-stalled or rate-limit recovery,
 stale-claim takeover, or ordinary clean continuation. This keeps crash
 and stall handling separate without requiring the stalled session to
 publish a final self-report.
+
+## Live Status Digests
+
+Use the live status digest contract in
+[IDD comment minimization](idd-comment-minimization.md) when an active
+run needs one human-facing current-status comment. Digest text is never
+workflow evidence by itself: claim parsing, review currency, advisory
+waits, CI, merge readiness, and roadmap audits still read trusted
+operational markers and GitHub state.
+
+During resume, repair a missing or stale digest only after the route and
+claim state are known. Duplicate marked digests are preserved as audit
+history and reported for repair; unattended agents must continue from
+the authoritative markers and GitHub state rather than picking a digest
+arbitrarily.
 
 ### Roadmap-claim contention playbook
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -195,6 +195,21 @@ timing or loop constant, and record local deviations in onboarding or
 repository docs so future sessions can find the selected policy values
 without scanning every phase file.
 
+## Live status digest
+
+The optional live status digest is a human-facing issue or pull request
+comment whose first line is `<!-- idd-live-status: current -->`. It may
+summarize phase, claim, branch, last checked time, blockers, and next
+action, but it is never an authority for IDD state transitions.
+
+Agents must continue to make claim, review, advisory, CI, merge, and
+roadmap decisions from trusted operational markers and GitHub state. If
+the digest is missing or stale, repair it only after claim revalidation
+and authoritative state collection. If multiple marked digests exist,
+preserve them, report the duplicate URLs, and do not choose one as
+authoritative during an unattended run. See
+`docs/idd-comment-minimization.md` for the full digest contract.
+
 ## Abort
 
 On abort, re-validate ownership first. If the active claim still uses

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -56,6 +56,10 @@ Before routing, collect all of the following:
 9. **Unpushed commits** — run `git log @{u}..HEAD` in the worktree. If
    no upstream is configured, treat all local commits as unpushed.
 10. **Current local HEAD SHA** — run `git rev-parse HEAD`.
+11. **Live status digest state** — record whether the issue or PR has
+    zero, one, or multiple comments whose first line is
+    `<!-- idd-live-status: current -->`. Do not use digest text to route
+    resume; it is repairable UI state only.
 
 ## Step 1 — Identify the issue and claim state
 
@@ -106,6 +110,13 @@ worktree and do not use the Step 2 worktree table. Re-run A1.5 for that
 roadmap issue, then follow A1.5's close, release, or stop behavior.
 Treat child issue claims independently; roadmap-audit claim presence
 alone must not block child issue execution.
+
+After Step 1 establishes the route and verifies any current-session
+claim, repair a missing or stale live status digest from the parsed
+claim state, PR state, CI state, and review activity when doing so is
+safe under the claim revalidation gate. If multiple marked digests
+exist, preserve them, report their URLs, and continue routing from
+trusted markers and GitHub state rather than digest text.
 
 ## Step 2 — Locate or restore branch and worktree
 

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -9,6 +9,55 @@ Minimization is UI cleanup. It preserves the audit trail and must never
 replace review triage, conversation resolution, CI, advisory wait, or
 merge gates.
 
+## Live Status Digest Contract
+
+A live status digest is an editable, human-facing issue or pull request
+comment that summarizes the current IDD run. It is UI state only. It
+must never replace trusted operational markers, review state, CI state,
+branch protection, or GitHub issue and pull request state as workflow
+evidence.
+
+The first line of every current digest comment is this stable marker:
+
+```html
+<!-- idd-live-status: current -->
+```
+
+At most one current digest may exist per issue or pull request. Agents
+find the digest by searching comments on that issue or PR for the marker
+above. The marker is an identifier, not authority: a digest posted by an
+untrusted actor or a digest whose text disagrees with trusted markers is
+ignored for workflow decisions and repaired only after the authoritative
+state has been re-read.
+
+Each digest should contain these fields in a compact, editable form:
+
+| Field              | Meaning                                                             |
+| ------------------ | ------------------------------------------------------------------- |
+| `Phase`            | The current IDD phase or resume route                               |
+| `Claim`            | Active claim owner and claim age, or `none`                         |
+| `Branch`           | Current work branch or `none`                                       |
+| `Last checked`     | ISO 8601 time when the digest was last refreshed from trusted state |
+| `Open blockers`    | Human decision, CI, review, dependency, or claim blocker summary    |
+| `Next action`      | The next expected agent, maintainer, CI, or reviewer action         |
+| `Authoritative by` | The marker, CI, review, issue, or PR evidence the summary came from |
+
+Only the current claim owner should update the digest during normal IDD
+execution, and only after the claim revalidation gate passes. Maintainers
+may repair a digest outside an active claim, but that repair does not
+claim workflow ownership. Roadmap-audit digests follow the same rule:
+the roadmap-audit claim gates edits to the roadmap issue digest only,
+not child issue execution.
+
+If the digest is missing during resume, recreate it from the parsed
+claim state, PR state, CI state, and review activity after the resume
+route is known. If the digest is stale, update the existing marked
+comment from that same authoritative state. If multiple marked digest
+comments exist, do not delete, minimize, or guess which one is
+authoritative during an unattended run; preserve the audit history,
+report the duplicate URLs, and use trusted markers and GitHub state for
+all workflow decisions until a repair path selects one current digest.
+
 ## Timing
 
 Run minimization only after one of these is true:

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -56,7 +56,7 @@ entry file should be an explicit operator choice, not the default.
 | `.github/instructions/idd-resume.instructions.md`          | Route resume into crash, stalled, stale-takeover, or clean continuation |
 | `.github/instructions/idd-resume-stall.instructions.md`    | Handle stalled-session recovery with a dedicated safety gate            |
 | `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                    |
-| `docs/idd-comment-minimization.md`                         | Post-merge comment minimization policy, commands, and experiment notes  |
+| `docs/idd-comment-minimization.md`                         | Live status digest contract and post-merge comment minimization policy  |
 
 ## Artifact taxonomy and ownership
 
@@ -121,6 +121,21 @@ paths: crash recovery, progress-stalled or rate-limit recovery,
 stale-claim takeover, or ordinary clean continuation. This keeps crash
 and stall handling separate without requiring the stalled session to
 publish a final self-report.
+
+## Live Status Digests
+
+Use the live status digest contract in
+[IDD comment minimization](idd-comment-minimization.md) when an active
+run needs one human-facing current-status comment. Digest text is never
+workflow evidence by itself: claim parsing, review currency, advisory
+waits, CI, merge readiness, and roadmap audits still read trusted
+operational markers and GitHub state.
+
+During resume, repair a missing or stale digest only after the route and
+claim state are known. Duplicate marked digests are preserved as audit
+history and reported for repair; unattended agents must continue from
+the authoritative markers and GitHub state rather than picking a digest
+arbitrarily.
 
 ### Roadmap-claim contention playbook
 


### PR DESCRIPTION
## Summary

- Define the `IDD live status` digest contract and stable marker.
- Document the digest fields, update authority, trust boundary, and resume repair behavior.
- Mirror the contract and resume guidance into the exported template surfaces.

Closes #196

## Follow-up issues

- #197 wires digest update points into the phase instructions.
- #198 adds helper support for repeatable digest upserts.

## Validation

- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`
- `node scripts/audit-docs.mjs --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for the Live Status Digest feature, an optional status summary format that appears as a workflow comment. Documentation specifies the digest structure, required fields (phase, claim, branch, timestamp, blockers, next steps), ownership rules, and procedures for handling duplicate digests during automated runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/201)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->