### PR TITLE
docs(merge): enforce merge policy handoff before f3

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -17,7 +17,26 @@ gate. The active claim must still use your current `{claim-id}`.
    your current `{claim-id}`. If the active claim is missing, released,
    or held by a different `{claim-id}` (even under the same agent ID),
    the claim was lost — report this and stop.
-2. Immediately before executing the merge command, do one final live
+2. Read the repository's recorded merge policy from repository
+   documentation that future IDD sessions read. If no policy is
+   recorded, treat it as `human_merge`.
+
+   If the recorded policy is anything other than
+   `fully_autonomous_merge`, stop before the final freshness fetch and
+   before `gh pr merge`. After the claim revalidation above, report or
+   post a concise handoff summary with the PR number, branch, current
+   HEAD from F2, the F2 readiness evidence, and the actor expected to
+   merge. For `human_merge`, hand off to the human maintainer. For
+   `separate_merge_agent`, hand off to the configured merge-capable
+   session; if that actor or resume condition is not recorded, hold for
+   maintainer direction. Do not run the F3 merge command or F4 cleanup
+   in the same worker session.
+
+   Only a recorded `fully_autonomous_merge` policy lets the same agent
+   session continue through the remaining F3 gates. This policy gate
+   does not relax claim, freshness, unresolved-thread, advisory, CI, or
+   review requirements.
+3. Immediately before executing the merge command, do one final live
    fetch using the **exact same activity-universe scope as E1 Step 1**
    (all review threads, review bodies, and regular PR comments,
    excluding trusted agent operational marker comments only). Compare
@@ -83,7 +102,7 @@ gate. The active claim must still use your current `{claim-id}`.
        the first condition in F2). F2 will reuse the existing same-HEAD
        marker — do not post a new one.
 
-3. Merge the PR using a **merge commit**, binding to the validated SHA
+4. Merge the PR using a **merge commit**, binding to the validated SHA
    to prevent a race where a new push lands after the F3 freshness check
    but before the merge executes:
 
@@ -92,7 +111,7 @@ gate. The active claim must still use your current `{claim-id}`.
    ```
 
    Do not use squash merge or rebase merge.
-4. If merge fails:
+5. If merge fails:
    - Base branch updated or conflict → return to
      `idd-pre-merge.instructions.md` F1
    - CI condition no longer met → return to

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -16,7 +16,7 @@ behavior change too.
 | Advisory reviewer     | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                                                                    |
 | Review threads        | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles.                                       |
 | Policy constants      | Distributed timing, wait, and loop defaults                                                  | Review [IDD policy constants](policy-constants.md) before changing claim ownership timing, advisory waits, CI waits, or critique-loop guardrails. Record the selected critique-loop profile in onboarding notes before unattended operation. |
-| Merge policy          | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                                                                           |
+| Merge policy          | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and keep or customize the F3 handoff gate for non-autonomous profiles.                                                                 |
 | Stall recovery safety | 30-minute quiet-window evidence plus 24-hour stale-threshold ownership gate                  | Keep `idd-resume-stall.instructions.md` aligned with `idd-overview` claim rules, and customize both files together if local policy changes quiet-window or takeover timing.                                                                  |
 | CI commands           | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                                                                   |
 | Issue scope           | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.                                                  |
@@ -115,12 +115,18 @@ the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
-future IDD sessions read, not only in local onboarding notes. For
-`human_merge` and `separate_merge_agent`, also add repository-specific
-agent guidance or phase-file customization so normal workers stop before
-F3 and hand off to the human maintainer or separate merge-capable
-session. Documentation alone will not stop F3 if the same worker session
-still has merge-capable credentials.
+future IDD sessions read, not only in local onboarding notes. The
+distributed merge phase treats a missing or unknown policy as
+`human_merge` and stops in F3 unless the recorded policy is exactly
+`fully_autonomous_merge`.
+
+For `human_merge`, keep the default F3 stop gate and hand off to the
+human maintainer. For `separate_merge_agent`, keep the worker stop gate
+and record the merge-capable actor plus the resume condition, or
+customize the local F3 gate so only that separate merge-capable session
+can proceed. `fully_autonomous_merge` is the only profile that lets the
+same agent session continue through F3 after the normal freshness, CI,
+review, advisory, unresolved-thread, and claim gates pass.
 
 The distributed workflow expects merge commits. Changing the merge
 method, required review policy, or branch protection behavior is a

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -34,15 +34,18 @@ production.
 Choose and record one merge policy in repository documentation before
 granting unattended agent credentials:
 
-| Merge policy             | Who may merge                                                            | Worker credential boundary                                                                 |
-| ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | Worker sessions stop before merge and report the PR state for human review.                |
-| `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions handle claim, work, PR, CI, and review fixes without merge-capable access. |
-| `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined only by explicit repository opt-in.        |
+| Merge policy             | Who may merge                                                            | Worker credential boundary                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | The default F3 gate stops worker sessions before merge and reports the PR state for human review.                    |
+| `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions stop at the default F3 gate; repository guidance names the merge-capable actor and resume condition. |
+| `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined only by explicit repository opt-in.                                  |
 
 Use `human_merge` as the safe default for public or OSS repositories.
 Treat `fully_autonomous_merge` as an explicit credential decision, never
-as an automatic consequence of installing IDD.
+as an automatic consequence of installing IDD. The merge phase treats a
+missing or unknown merge policy as `human_merge`, and only a recorded
+`fully_autonomous_merge` policy lets the same agent session continue
+through F3 merge execution.
 
 ## Phase Permissions
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -17,7 +17,26 @@ gate. The active claim must still use your current `{claim-id}`.
    your current `{claim-id}`. If the active claim is missing, released,
    or held by a different `{claim-id}` (even under the same agent ID),
    the claim was lost — report this and stop.
-2. Immediately before executing the merge command, do one final live
+2. Read the repository's recorded merge policy from repository
+   documentation that future IDD sessions read. If no policy is
+   recorded, treat it as `human_merge`.
+
+   If the recorded policy is anything other than
+   `fully_autonomous_merge`, stop before the final freshness fetch and
+   before `gh pr merge`. After the claim revalidation above, report or
+   post a concise handoff summary with the PR number, branch, current
+   HEAD from F2, the F2 readiness evidence, and the actor expected to
+   merge. For `human_merge`, hand off to the human maintainer. For
+   `separate_merge_agent`, hand off to the configured merge-capable
+   session; if that actor or resume condition is not recorded, hold for
+   maintainer direction. Do not run the F3 merge command or F4 cleanup
+   in the same worker session.
+
+   Only a recorded `fully_autonomous_merge` policy lets the same agent
+   session continue through the remaining F3 gates. This policy gate
+   does not relax claim, freshness, unresolved-thread, advisory, CI, or
+   review requirements.
+3. Immediately before executing the merge command, do one final live
    fetch using the **exact same activity-universe scope as E1 Step 1**
    (all review threads, review bodies, and regular PR comments,
    excluding trusted agent operational marker comments only). Compare
@@ -83,7 +102,7 @@ gate. The active claim must still use your current `{claim-id}`.
        the first condition in F2). F2 will reuse the existing same-HEAD
        marker — do not post a new one.
 
-3. Merge the PR using a **merge commit**, binding to the validated SHA
+4. Merge the PR using a **merge commit**, binding to the validated SHA
    to prevent a race where a new push lands after the F3 freshness check
    but before the merge executes:
 
@@ -92,7 +111,7 @@ gate. The active claim must still use your current `{claim-id}`.
    ```
 
    Do not use squash merge or rebase merge.
-4. If merge fails:
+5. If merge fails:
    - Base branch updated or conflict → return to
      `idd-pre-merge.instructions.md` F1
    - CI condition no longer met → return to

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -61,8 +61,11 @@ Also choose a merge policy before the first unattended run:
 `human_merge`, `separate_merge_agent`, or `fully_autonomous_merge`.
 Treat `human_merge` as the safe default for public repositories;
 `fully_autonomous_merge` is the explicit opt-in that gives one trusted
-agent session merge authority. Record the selected policy in repository
-documentation that future IDD sessions read.
+agent session merge authority. The distributed merge phase stops in F3
+unless that exact policy is recorded, so `human_merge` and
+`separate_merge_agent` runs hand off before merge by default. Record the
+selected policy in repository documentation that future IDD sessions
+read.
 
 If you keep the distributed advisory/CI defaults, record that choice
 alongside the merge policy and point operators to
@@ -172,8 +175,11 @@ Also confirm the operator's merge policy:
 Record the selected policy in repository documentation, such as a local
 policy section in the imported docs or agent entry files. For
 `human_merge` and `separate_merge_agent`, do not grant merge-capable
-credentials to normal worker sessions; also add local guidance or
-phase-file customization so workers hand off before F3.
+credentials to normal worker sessions. Keep the default F3 stop gate for
+worker sessions, and record the human maintainer or separate
+merge-capable actor plus the resume condition. Customize the local F3
+gate only when a repository needs that separate merge-capable actor to
+continue through merge execution under repository-specific guidance.
 
 Confirm claim timing policy defaults from `docs/policy-constants.md` as
 well: `claim-stale-age` (default `24 h`) and
@@ -559,7 +565,8 @@ After completing the steps above, confirm each item:
 - [ ] The operator's selected critique-loop policy is recorded, and any
       non-default profile has matching phase-file customizations.
 - [ ] The operator's selected merge policy is recorded in repository
-      documentation, and worker credentials match that boundary.
+      documentation, the F3 handoff behavior matches that policy, and
+      worker credentials match that boundary.
 - [ ] Ownership timing policy values `claim-stale-age` and
       `claim-heartbeat-interval` are explicitly recorded for the target
       repository.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -16,7 +16,7 @@ behavior change too.
 | Advisory reviewer     | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                                                                    |
 | Review threads        | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles.                                       |
 | Policy constants      | Distributed timing, wait, and loop defaults                                                  | Review [IDD policy constants](policy-constants.md) before changing claim ownership timing, advisory waits, CI waits, or critique-loop guardrails. Record the selected critique-loop profile in onboarding notes before unattended operation. |
-| Merge policy          | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and customize handoff before F3 for non-autonomous profiles.                                                                           |
+| Merge policy          | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and keep or customize the F3 handoff gate for non-autonomous profiles.                                                                 |
 | Stall recovery safety | 30-minute quiet-window evidence plus 24-hour stale-threshold ownership gate                  | Keep `idd-resume-stall.instructions.md` aligned with `idd-overview` claim rules, and customize both files together if local policy changes quiet-window or takeover timing.                                                                  |
 | CI commands           | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                                                                   |
 | Issue scope           | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.                                                  |
@@ -115,12 +115,18 @@ the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
-future IDD sessions read, not only in local onboarding notes. For
-`human_merge` and `separate_merge_agent`, also add repository-specific
-agent guidance or phase-file customization so normal workers stop before
-F3 and hand off to the human maintainer or separate merge-capable
-session. Documentation alone will not stop F3 if the same worker session
-still has merge-capable credentials.
+future IDD sessions read, not only in local onboarding notes. The
+distributed merge phase treats a missing or unknown policy as
+`human_merge` and stops in F3 unless the recorded policy is exactly
+`fully_autonomous_merge`.
+
+For `human_merge`, keep the default F3 stop gate and hand off to the
+human maintainer. For `separate_merge_agent`, keep the worker stop gate
+and record the merge-capable actor plus the resume condition, or
+customize the local F3 gate so only that separate merge-capable session
+can proceed. `fully_autonomous_merge` is the only profile that lets the
+same agent session continue through F3 after the normal freshness, CI,
+review, advisory, unresolved-thread, and claim gates pass.
 
 The distributed workflow expects merge commits. Changing the merge
 method, required review policy, or branch protection behavior is a

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -34,15 +34,18 @@ production.
 Choose and record one merge policy in repository documentation before
 granting unattended agent credentials:
 
-| Merge policy             | Who may merge                                                            | Worker credential boundary                                                                 |
-| ------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | Worker sessions stop before merge and report the PR state for human review.                |
-| `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions handle claim, work, PR, CI, and review fixes without merge-capable access. |
-| `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined only by explicit repository opt-in.        |
+| Merge policy             | Who may merge                                                            | Worker credential boundary                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | The default F3 gate stops worker sessions before merge and reports the PR state for human review.                    |
+| `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions stop at the default F3 gate; repository guidance names the merge-capable actor and resume condition. |
+| `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined only by explicit repository opt-in.                                  |
 
 Use `human_merge` as the safe default for public or OSS repositories.
 Treat `fully_autonomous_merge` as an explicit credential decision, never
-as an automatic consequence of installing IDD.
+as an automatic consequence of installing IDD. The merge phase treats a
+missing or unknown merge policy as `human_merge`, and only a recorded
+`fully_autonomous_merge` policy lets the same agent session continue
+through F3 merge execution.
 
 ## Phase Permissions
 


### PR DESCRIPTION
## Summary

- Add a default F3 merge-policy gate that treats missing or non-`fully_autonomous_merge` policies as handoff states.
- Mirror the gate into the exported template merge instruction.
- Update customization, permissions, and onboarding docs so adopters record merge policy and handoff behavior together.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `node scripts/audit-docs.mjs --check`
- `node --test tests/*.test.mjs`

## Follow-up Issues

None.

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated merge policy configuration documentation to define repository-level merge policy specifications and their impact on merge automation gates
  * Clarified default merge policy handling and credential boundary behavior
  * Added guidance on merge policy profiles and their interaction with distributed merge execution flow

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/202)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->