### PR TITLE
feat(template): add review profile artifacts

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -51,7 +51,8 @@
         "idd-template/docs/concepts.md",
         "idd-template/docs/customization.md",
         "idd-template/docs/policy-constants.md",
-        "idd-template/docs/reference.md"
+        "idd-template/docs/reference.md",
+        "idd-template/profiles/**/*.md"
       ],
       "paths": [
         "idd-template/.github/instructions/idd-overview.instructions.md",
@@ -77,7 +78,11 @@
         "idd-template/docs/concepts.md",
         "idd-template/docs/customization.md",
         "idd-template/docs/policy-constants.md",
-        "idd-template/docs/reference.md"
+        "idd-template/docs/reference.md",
+        "idd-template/profiles/README.md",
+        "idd-template/profiles/human-required/README.md",
+        "idd-template/profiles/no-advisory/README.md",
+        "idd-template/profiles/external-bot/README.md"
       ]
     },
     {

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -39,6 +39,12 @@ authority:
 - `external-bot` when a non-Copilot reviewer has a stable actor identity
   and a current-head completion signal.
 
+When importing the template, keep the `profiles/` directory with the
+copied docs. For any non-default PR review profile, use the matching
+`profiles/<profile>/README.md` artifact as the reusable patch surface.
+The artifact records adopter-owned values, the files to edit, and the
+verification evidence to capture after applying the profile.
+
 Changing the profile is a workflow change. Update the phase files named
 by the profile in the same pull request as the local policy note. Use
 the PR review profile edit-surface checklist in

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,8 +34,9 @@ project-specific command values, and updates agent entry files such as
 
 Before the first full loop, decide whether the default Copilot advisory
 review policy applies. If it does not, choose another profile from
-`docs/idd-review-policy-profiles.md` and apply the listed instruction
-file changes before agents reach PR review and merge phases.
+`docs/idd-review-policy-profiles.md`, apply the matching
+`profiles/<profile>/README.md` artifact, and capture its verification
+evidence before agents reach PR review and merge phases.
 
 Keep this decision explicit. Review policy changes are workflow changes,
 not just documentation preferences.

--- a/docs/idd-review-policy-profiles.md
+++ b/docs/idd-review-policy-profiles.md
@@ -35,6 +35,19 @@ The advisory wait windows, request cap, and CI wait defaults are named in
 [IDD policy constants](policy-constants.md), so adopters can record those
 values separately from the review profile choice.
 
+## Profile Artifacts
+
+The exported template includes profile artifacts under `profiles/`.
+When working in this source repository, maintain those artifacts under
+`idd-template/profiles/`. Each non-default artifact is a documented
+patch surface that records adopter-owned values, files to edit, and
+verification evidence for the selected profile.
+
+Use the artifact when choosing `human-required`, `no-advisory`, or
+`external-bot` instead of reconstructing the edit surface from memory.
+The checklist below remains the policy contract; the artifact packages
+that checklist into a reusable onboarding unit.
+
 ## Human-Required Profile
 
 Use `human-required` when a person, CODEOWNER, or required reviewer is
@@ -262,6 +275,8 @@ the target repository's local documentation or onboarding notes.
   and branch protection as sufficient gates.
 - Choose `external-bot` only after proving the bot's reviewer identity,
   current-head coverage signal, and wait/timeout behavior.
+- For any non-default PR review profile, apply the matching artifact
+  from `profiles/` and record its verification evidence.
 - Record the review-thread resolution profile separately. Keep
   `fast-agent-resolve` for the distributed default, or customize the
   phase files listed above before choosing `hybrid-reviewer-ack` or

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -243,8 +243,8 @@ in later PR phases.
 - This dependency is on GitHub's review integration, not on every local
   agent using Copilot as its CLI.
 - Adopters who do not want that default PR policy should choose another
-  review policy profile and follow
-  the PR review profile edit-surface checklist in
+  review policy profile, apply the matching `profiles/<profile>/`
+  artifact, and follow the PR review profile edit-surface checklist in
   [IDD review policy profiles](idd-review-policy-profiles.md).
 - Expect non-default profile changes to cover review-fix, advisory-wait,
   pre-merge, merge, review-snapshot, and review-triage surfaces; the

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -243,8 +243,9 @@ in later PR phases.
 - This dependency is on GitHub's review integration, not on every local
   agent using Copilot as its CLI.
 - Adopters who do not want that default PR policy should choose another
-  review policy profile, apply the matching `profiles/<profile>/`
-  artifact, and follow the PR review profile edit-surface checklist in
+  review policy profile, apply the matching
+  `profiles/<profile>/README.md` artifact, and follow the PR review
+  profile edit-surface checklist in
   [IDD review policy profiles](idd-review-policy-profiles.md).
 - Expect non-default profile changes to cover review-fix, advisory-wait,
   pre-merge, merge, review-snapshot, and review-triage surfaces; the

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -38,12 +38,9 @@ Important: the distributed default workflow is cross-agent for
 execution, but its later PR phases still include a GitHub Copilot
 advisory review step by default. If the operator does not want that PR
 policy, choose another profile in `docs/idd-review-policy-profiles.md`
-and plan to customize the complete edit surface described there. At
-minimum, non-default profiles touch
-`.github/instructions/idd-review-fix.instructions.md`,
-`.github/instructions/idd-pre-merge.instructions.md`, and
-`.github/instructions/idd-merge.instructions.md`; some profiles require
-additional files after import.
+and apply the matching artifact from `profiles/`. The artifact records
+the complete edit surface, adopter-owned values, and verification
+evidence for the selected non-default profile.
 
 Also choose a review-thread resolution policy before treating the import
 as complete. The distributed default is `fast-agent-resolve`, where an
@@ -79,18 +76,20 @@ easy to find later.
 3. Fetch or copy the template files into the target repository.
 4. Review `docs/permissions.md` with the operator before granting agent
    credentials.
-5. Choose and record the operator's review-thread resolution policy.
-6. Choose and record the operator's merge policy before allowing
+5. Choose and record the operator's PR review policy profile. If it is
+   non-default, apply the matching profile artifact from `profiles/`.
+6. Choose and record the operator's review-thread resolution policy.
+7. Choose and record the operator's merge policy before allowing
    unattended workers to approach the merge phase. The record must live
    in repository documentation that future IDD sessions read.
-7. Confirm and record ownership timing policy values:
+8. Confirm and record ownership timing policy values:
    `claim-stale-age` (default 24 h) and
    `claim-heartbeat-interval` (default 12 h).
-8. Ask whether the operator wants the optional issue-authoring
+9. Ask whether the operator wants the optional issue-authoring
    companion skill for pre-execution issue drafting.
-9. Replace every placeholder (see table below) with the correct value.
-10. Add IDD references to the repository's agent entry files.
-11. Verify the result with the checklist at the bottom.
+10. Replace every placeholder (see table below) with the correct value.
+11. Add IDD references to the repository's agent entry files.
+12. Verify the result with the checklist at the bottom.
 
 ---
 
@@ -145,8 +144,8 @@ entire lifetime of the roadmap.
 
 ## Step 2 — Fetch or copy template files
 
-You need the following core execution files in the target repository.
-Use whichever method applies to your situation.
+You need the following core execution and profile artifact files in the
+target repository. Use whichever method applies to your situation.
 
 The issue-authoring skill is available as an optional companion artifact
 from `skills/issue-authoring/` in the source repository. That path is
@@ -158,11 +157,11 @@ pre-execution issue drafting or roadmap decomposition support.
 
 Before importing, confirm whether the operator wants to keep the default
 Copilot advisory review policy described above. If not, choose the
-closest profile in `docs/idd-review-policy-profiles.md` and note which
-phase files and profile-specific surfaces must be customized after the
-files are copied in. Use the PR review profile edit-surface checklist in
-that document before marking onboarding complete; the selected profile
-is not complete until the repository records the decision, updates the
+closest profile in `docs/idd-review-policy-profiles.md`, then open the
+matching artifact in `profiles/<profile>/README.md` after the files are
+copied in. Use the artifact and the PR review profile edit-surface
+checklist before marking onboarding complete; the selected profile is
+not complete until the repository records the decision, updates every
 matching phase behavior, and captures verification evidence.
 
 Confirm the review-thread resolution policy as well. Keep
@@ -218,6 +217,10 @@ docs/concepts.md
 docs/customization.md
 docs/policy-constants.md
 docs/reference.md
+profiles/README.md
+profiles/human-required/README.md
+profiles/no-advisory/README.md
+profiles/external-bot/README.md
 ```
 
 <!-- /audit:generated -->
@@ -278,8 +281,13 @@ for FILE in \
   "docs/concepts.md" \
   "docs/customization.md" \
   "docs/policy-constants.md" \
-  "docs/reference.md"
+  "docs/reference.md" \
+  "profiles/README.md" \
+  "profiles/human-required/README.md" \
+  "profiles/no-advisory/README.md" \
+  "profiles/external-bot/README.md"
 do
+  mkdir -p "$(dirname "${DEST}/${FILE}")"
   gh api -H "Accept: application/vnd.github.raw+json" \
     "repos/kurone-kito/idd-skill/contents/idd-template/${FILE}" \
     > "${DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
@@ -346,8 +354,13 @@ for FILE in \
   "docs/concepts.md" \
   "docs/customization.md" \
   "docs/policy-constants.md" \
-  "docs/reference.md"
+  "docs/reference.md" \
+  "profiles/README.md" \
+  "profiles/human-required/README.md" \
+  "profiles/no-advisory/README.md" \
+  "profiles/external-bot/README.md"
 do
+  mkdir -p "$(dirname "${DEST}/${FILE}")"
   curl -fsSL "${BASE}/${FILE}" -o "${DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
 ```
@@ -560,9 +573,14 @@ After completing the steps above, confirm each item:
       `docs/idd-helper-scripts.md`,
       `docs/idd-comment-minimization.md`, and `docs/permissions.md`
       are present.
+- [ ] `profiles/README.md` and the non-default profile artifacts under
+      `profiles/` are present.
 - [ ] The operator's selected PR review policy profile is recorded, and
       the matching edit-surface checklist in
       `docs/idd-review-policy-profiles.md` is complete.
+- [ ] If the selected PR review policy profile is non-default, the
+      matching `profiles/<profile>/README.md` artifact was applied and
+      its verification evidence is recorded.
 - [ ] The operator's selected review-thread resolution policy is
       recorded, and any non-default profile has matching phase-file
       customizations.

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -13,10 +13,12 @@ multi-agent GitHub automation.
    import to the first IDD loop.
 5. Read `docs/customization.md` before changing review, merge, CI, or
    discovery policy.
-6. Choose and record a merge policy in repository documentation while
+6. Choose a PR review policy profile. If it is non-default, apply the
+   matching profile artifact from `profiles/`.
+7. Choose and record a merge policy in repository documentation while
    reviewing `docs/permissions.md` before granting credentials to
    unattended or merge-capable agents.
-7. Optional: install the issue-authoring companion skill if the project
+8. Optional: install the issue-authoring companion skill if the project
    wants pre-execution issue drafting. The canonical source bundle in
    this repository lives at `skills/issue-authoring/`; install copies
    into the agent-specific skill directory your runtime reads.
@@ -49,12 +51,10 @@ issues through the normal IDD loop.
 The distributed template is cross-agent for execution, but its later PR
 phases include a GitHub Copilot advisory review step by default. If an
 adopter does not want that PR policy, they should choose a profile in
-`docs/idd-review-policy-profiles.md` and apply the complete edit surface
-described there. At minimum, non-default profiles touch
-`.github/instructions/idd-review-fix.instructions.md`,
-`.github/instructions/idd-pre-merge.instructions.md`, and
-`.github/instructions/idd-merge.instructions.md` after import; some
-profiles require additional files.
+`docs/idd-review-policy-profiles.md` and apply the matching artifact
+from `profiles/`. The artifact records the complete edit surface,
+adopter-owned values, and verification evidence for the selected
+non-default profile.
 
 ## Merge credential policy note
 
@@ -105,6 +105,11 @@ docs/
   idd-helper-scripts.md              ← optional helper-script evaluation and policy
   idd-comment-minimization.md        ← post-merge comment cleanup policy and experiment
   permissions.md                     ← permission profiles and threat model
+profiles/
+  README.md                          ← profile artifact index
+  human-required/README.md           ← required human review artifact
+  no-advisory/README.md              ← no advisory reviewer artifact
+  external-bot/README.md             ← external advisory bot artifact
 ONBOARDING.md                        ← AI agent import guide (start here)
 README.md                            ← this file
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -39,6 +39,12 @@ authority:
 - `external-bot` when a non-Copilot reviewer has a stable actor identity
   and a current-head completion signal.
 
+When importing the template, keep the `profiles/` directory with the
+copied docs. For any non-default PR review profile, use the matching
+`profiles/<profile>/README.md` artifact as the reusable patch surface.
+The artifact records adopter-owned values, the files to edit, and the
+verification evidence to capture after applying the profile.
+
 Changing the profile is a workflow change. Update the phase files named
 by the profile in the same pull request as the local policy note. Use
 the PR review profile edit-surface checklist in

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -34,8 +34,9 @@ project-specific command values, and updates agent entry files such as
 
 Before the first full loop, decide whether the default Copilot advisory
 review policy applies. If it does not, choose another profile from
-`docs/idd-review-policy-profiles.md` and apply the listed instruction
-file changes before agents reach PR review and merge phases.
+`docs/idd-review-policy-profiles.md`, apply the matching
+`profiles/<profile>/README.md` artifact, and capture its verification
+evidence before agents reach PR review and merge phases.
 
 Keep this decision explicit. Review policy changes are workflow changes,
 not just documentation preferences.

--- a/idd-template/docs/idd-review-policy-profiles.md
+++ b/idd-template/docs/idd-review-policy-profiles.md
@@ -35,6 +35,19 @@ The advisory wait windows, request cap, and CI wait defaults are named in
 [IDD policy constants](policy-constants.md), so adopters can record those
 values separately from the review profile choice.
 
+## Profile Artifacts
+
+The exported template includes profile artifacts under `profiles/`.
+When working in this source repository, maintain those artifacts under
+`idd-template/profiles/`. Each non-default artifact is a documented
+patch surface that records adopter-owned values, files to edit, and
+verification evidence for the selected profile.
+
+Use the artifact when choosing `human-required`, `no-advisory`, or
+`external-bot` instead of reconstructing the edit surface from memory.
+The checklist below remains the policy contract; the artifact packages
+that checklist into a reusable onboarding unit.
+
 ## Human-Required Profile
 
 Use `human-required` when a person, CODEOWNER, or required reviewer is
@@ -262,6 +275,8 @@ the target repository's local documentation or onboarding notes.
   and branch protection as sufficient gates.
 - Choose `external-bot` only after proving the bot's reviewer identity,
   current-head coverage signal, and wait/timeout behavior.
+- For any non-default PR review profile, apply the matching artifact
+  from `profiles/` and record its verification evidence.
 - Record the review-thread resolution profile separately. Keep
   `fast-agent-resolve` for the distributed default, or customize the
   phase files listed above before choosing `hybrid-reviewer-ack` or

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -232,8 +232,9 @@ phases.
 - This dependency is on GitHub's review integration, not on every local
   agent using Copilot as its CLI.
 - Adopters who do not want that default PR policy should choose another
-  review policy profile, apply the matching `profiles/<profile>/`
-  artifact, and follow the PR review profile edit-surface checklist in
+  review policy profile, apply the matching
+  `profiles/<profile>/README.md` artifact, and follow the PR review
+  profile edit-surface checklist in
   [IDD review policy profiles](idd-review-policy-profiles.md).
 - Expect non-default profile changes to cover review-fix, advisory-wait,
   pre-merge, merge, review-snapshot, and review-triage surfaces; the

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -232,8 +232,8 @@ phases.
 - This dependency is on GitHub's review integration, not on every local
   agent using Copilot as its CLI.
 - Adopters who do not want that default PR policy should choose another
-  review policy profile and follow
-  the PR review profile edit-surface checklist in
+  review policy profile, apply the matching `profiles/<profile>/`
+  artifact, and follow the PR review profile edit-surface checklist in
   [IDD review policy profiles](idd-review-policy-profiles.md).
 - Expect non-default profile changes to cover review-fix, advisory-wait,
   pre-merge, merge, review-snapshot, and review-triage surfaces; the

--- a/idd-template/profiles/README.md
+++ b/idd-template/profiles/README.md
@@ -1,0 +1,51 @@
+# IDD Review Policy Profile Artifacts
+
+This directory packages the supported non-default PR review policy
+profiles as adopter-facing artifacts. Each profile README is a
+documented patch surface: it names the files to edit, the local values
+to fill in, and the verification evidence to capture before onboarding
+is complete.
+
+Use these artifacts only when the target repository does not keep the
+distributed `copilot-advisory` profile. Copy them with the rest of the
+template, choose exactly one non-default profile, and apply the chosen
+profile as one unit.
+
+## Available Artifacts
+
+| Profile          | Use when                                                             | Artifact                                   |
+| ---------------- | -------------------------------------------------------------------- | ------------------------------------------ |
+| `human-required` | A maintainer, CODEOWNER, or required reviewer must approve every PR. | [human-required](human-required/README.md) |
+| `no-advisory`    | The repository intentionally has no IDD-managed advisory reviewer.   | [no-advisory](no-advisory/README.md)       |
+| `external-bot`   | A named non-Copilot bot supplies the advisory review signal.         | [external-bot](external-bot/README.md)     |
+
+## How to Apply an Artifact
+
+1. Import the default template files first.
+2. Open the selected profile README.
+3. Fill in every adopter-owned value listed by the profile.
+4. Edit every file in the profile's patch surface during the same
+   change.
+5. Capture the verification evidence named by the profile.
+6. Record the completion note in repository documentation that future
+   IDD sessions read.
+
+Do not combine profiles unless the repository first documents a new
+local policy. Mixed profile behavior is harder for later agents to
+verify and should be treated as a separate workflow customization.
+
+## Artifact Contract
+
+Every profile artifact must record:
+
+- The local values the adopter owns.
+- The complete file list affected by the profile.
+- The intended edit for each file.
+- The evidence required to prove the selected policy is active.
+- A completion note format that can be copied into local repository
+  documentation.
+
+When maintaining this source repository, keep these artifacts aligned
+with `docs/idd-review-policy-profiles.md`,
+`idd-template/docs/idd-review-policy-profiles.md`, and
+`idd-template/ONBOARDING.md`.

--- a/idd-template/profiles/external-bot/README.md
+++ b/idd-template/profiles/external-bot/README.md
@@ -1,0 +1,63 @@
+# External-Bot Review Policy Artifact
+
+Use this artifact when a named non-Copilot bot supplies the advisory
+review signal. Do not complete this profile with a generic bot name or
+an unstated completion signal; the adopter must fill in the bot actor
+and the current-head completion proof before the profile is active.
+
+## Adopter-Owned Values
+
+Record these values before editing phase behavior:
+
+- Bot actor: `<external-bot-login>`
+- Bot request mechanism: `<external-bot-request-command-or-event>`
+- Current-head coverage signal:
+  `<external-bot-current-head-signal>`
+- Completion or skipped signal:
+  `<external-bot-completion-signal>`
+- Timeout and unavailable-state policy:
+- PATH A comment rules:
+- PATH B advisory comment rules:
+- Review-thread resolution profile:
+- Merge policy:
+- Verification PR or dry-run reference:
+
+## Patch Surface
+
+| File                                                       | Required local edit                                                                                                                             |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | Replace Copilot-specific fetch, request, pending, recovery, and wait logic with the external bot's actor and current-head completion signals.   |
+| `.github/instructions/idd-review-fix.instructions.md`      | Request the external bot after review-fix pushes, or document the outside system that requests it.                                              |
+| `.github/instructions/idd-pre-merge.instructions.md`       | Replace Copilot advisory checks with the external bot gate for the current PR head.                                                             |
+| `.github/instructions/idd-merge.instructions.md`           | Repeat the external bot freshness gate immediately before merge.                                                                                |
+| `.github/instructions/idd-review-snapshot.instructions.md` | Fetch the external bot activity and expose enough metadata to prove whether it covered the current PR head.                                     |
+| `.github/instructions/idd-review-triage.instructions.md`   | Define which bot comments are PATH A, which are PATH B, and how blocked or unavailable bot states are surfaced.                                 |
+| `docs/idd-review-policy-profiles.md`                       | Record the selected `external-bot` profile, the bot actor, and the completion signal without hiding adopter-owned values in phase instructions. |
+| `docs/customization.md` or another local policy document   | Record the request mechanism, timeout policy, unavailable-state recovery path, and verification evidence.                                       |
+
+## Verification Evidence
+
+Capture all of these before marking onboarding complete:
+
+- A PR-state example showing the configured bot reviewed the current
+  head.
+- Evidence that stale, missing, pending, skipped, or unavailable bot
+  states block or hold according to the recorded policy.
+- Confirmation that PATH A and PATH B bot comment rules are written in
+  review triage guidance.
+- The final local diff showing every file in the patch surface was
+  reviewed.
+
+## Completion Note
+
+```markdown
+PR review policy profile: external-bot
+Bot actor:
+Current-head coverage signal:
+Completion or skipped signal:
+Timeout and unavailable-state policy:
+PATH A comment rules:
+PATH B advisory comment rules:
+Verification evidence:
+Profile artifact applied: profiles/external-bot/README.md
+```

--- a/idd-template/profiles/human-required/README.md
+++ b/idd-template/profiles/human-required/README.md
@@ -1,0 +1,53 @@
+# Human-Required Review Policy Artifact
+
+Use this artifact when a maintainer, CODEOWNER, or required reviewer is
+the authoritative review gate for every PR. Apply the complete surface
+below as one workflow change; documentation alone does not make this
+profile active.
+
+## Adopter-Owned Values
+
+Record these values before editing phase behavior:
+
+- Required reviewer source:
+- Branch protection rule:
+- CODEOWNERS path or reviewer team:
+- Review-thread resolution profile:
+- Merge policy:
+- Verification PR or dry-run reference:
+
+## Patch Surface
+
+| File                                                       | Required local edit                                                                                                                                      |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.github/instructions/idd-review-fix.instructions.md`      | Remove the E14 Copilot re-review request and advisory wait. Replace it with a human-review handoff only if the repository wants that handoff documented. |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | Mark the Copilot advisory wait helper unused by this profile, or remove local references to it from the customized phase flow.                           |
+| `.github/instructions/idd-pre-merge.instructions.md`       | Make required human approval, branch protection, unresolved conversations, CI, freshness, and claim evidence the F2 gate.                                |
+| `.github/instructions/idd-merge.instructions.md`           | Remove final Copilot advisory rechecks while keeping CI, claim, freshness, required review, and unresolved-thread checks.                                |
+| `.github/instructions/idd-review-snapshot.instructions.md` | Keep human comments in the review universe and remove assumptions that Copilot advisory PATH B items must appear.                                        |
+| `.github/instructions/idd-review-triage.instructions.md`   | Keep human review comments as decision-relevant feedback and remove Copilot-specific advisory requirements.                                              |
+| `docs/idd-review-policy-profiles.md`                       | Record the selected `human-required` profile and link to the local verification evidence.                                                                |
+| `docs/customization.md` or another local policy document   | Record the reviewer authority, branch protection rule, and review-thread resolution profile.                                                             |
+
+## Verification Evidence
+
+Capture all of these before marking onboarding complete:
+
+- A PR-state example or branch protection dry run showing that a PR
+  without required human approval cannot merge.
+- Evidence that the review-fix and pre-merge phases no longer request
+  or wait for Copilot advisory review.
+- Confirmation that unresolved conversations and CI remain merge gates.
+- The final local diff showing every file in the patch surface was
+  reviewed.
+
+## Completion Note
+
+```markdown
+PR review policy profile: human-required
+Required reviewer source:
+Branch protection rule:
+Review-thread resolution profile:
+Verification evidence:
+Profile artifact applied: profiles/human-required/README.md
+```

--- a/idd-template/profiles/no-advisory/README.md
+++ b/idd-template/profiles/no-advisory/README.md
@@ -1,0 +1,55 @@
+# No-Advisory Review Policy Artifact
+
+Use this artifact only when the repository intentionally relies on CI,
+branch protection, unresolved-conversation checks, and any human review
+rules configured outside IDD. Apply the complete surface below as one
+workflow change so later agents do not wait for a reviewer that the
+repository no longer uses.
+
+## Adopter-Owned Values
+
+Record these values before editing phase behavior:
+
+- Reason no IDD-managed advisory reviewer is used:
+- Branch protection rule:
+- Human review rule outside IDD, if any:
+- Review-thread resolution profile:
+- Merge policy:
+- Verification PR or dry-run reference:
+
+## Patch Surface
+
+| File                                                       | Required local edit                                                                                                            |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `.github/instructions/idd-review-fix.instructions.md`      | Remove the E14 advisory request and wait path.                                                                                 |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | Mark the advisory wait helper unused by this profile, or remove local references to it from the customized phase flow.         |
+| `.github/instructions/idd-pre-merge.instructions.md`       | Gate on CI, branch protection, unresolved conversations, freshness, and claim evidence without requiring an advisory reviewer. |
+| `.github/instructions/idd-merge.instructions.md`           | Remove final advisory rechecks while keeping CI, claim, freshness, branch protection, and unresolved-thread checks.            |
+| `.github/instructions/idd-review-snapshot.instructions.md` | Keep human comments in scope and remove advisory-only PATH B requirements.                                                     |
+| `.github/instructions/idd-review-triage.instructions.md`   | Keep human review comments in the review universe and remove advisory-only disposition requirements.                           |
+| `docs/idd-review-policy-profiles.md`                       | Record the selected `no-advisory` profile and link to the local verification evidence.                                         |
+| `docs/customization.md` or another local policy document   | Record why no IDD-managed advisory reviewer is used and which outside gates still protect merges.                              |
+
+## Verification Evidence
+
+Capture all of these before marking onboarding complete:
+
+- Evidence that review-fix, pre-merge, and merge phases no longer
+  request or wait for an advisory reviewer.
+- A PR-state example showing CI and branch protection still gate
+  merges.
+- Confirmation that unresolved conversations remain visible to review
+  snapshot and pre-merge checks.
+- The final local diff showing every file in the patch surface was
+  reviewed.
+
+## Completion Note
+
+```markdown
+PR review policy profile: no-advisory
+Reason:
+Branch protection rule:
+Review-thread resolution profile:
+Verification evidence:
+Profile artifact applied: profiles/no-advisory/README.md
+```


### PR DESCRIPTION
## Summary

- Add reusable `idd-template/profiles/` artifacts for `human-required`, `no-advisory`, and `external-bot` PR review profiles.
- Include profile artifacts in the exported template file list and fetch loops.
- Update onboarding and synchronized docs so adopters choose the artifact, apply the whole patch surface, and record verification evidence.

Closes #195

## Follow-up

- None.

## Validation

- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`
- `node scripts/audit-docs.mjs --check`

## Notes

The first artifact format is documented patch surfaces rather than executable patches. That keeps the template reusable for adopter repositories whose imported instruction text may already have local policy edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced onboarding and getting-started guides with steps to select and apply PR review policy profiles and record verification evidence.
  * Added comprehensive profile artifacts documentation (human-required, no-advisory, external-bot) describing usage, patch surface, verification, and completion notes.
  * Clarified customization guidance to preserve profile artifacts when importing the template.
  * Expanded artifact manifest to include profile documentation in sync generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/204)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->