### PR TITLE
docs: dogfood fully autonomous merge policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,18 @@ through a pull request.
   unreasonably large commit, keep the fix commit separate or
   re-split the history so each commit remains reviewable.
 
+## Local merge policy
+
+This source repository records `fully_autonomous_merge` as its local IDD
+dogfooding policy. The setting applies only to `kurone-kito/idd-skill`
+and does not change the exported template default for adopter
+repositories.
+
+An IDD session may continue through F3 merge execution only after the
+normal claim, freshness, CI, advisory, review, and unresolved-thread
+gates pass. Repositories without a recorded `fully_autonomous_merge`
+policy still stop at the F3 handoff gate.
+
 ## Commit rules
 
 This project follows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,18 @@ disabled). Feature branches are always rebased onto `main`, never
 merged. See the full rules in
 [.github/copilot-instructions.md](.github/copilot-instructions.md#branch-strategy).
 
+## Local merge policy
+
+This source repository records `fully_autonomous_merge` as its local IDD
+dogfooding policy. The setting applies only to `kurone-kito/idd-skill`
+and does not change the exported template default for adopter
+repositories.
+
+An IDD session may continue through F3 merge execution only after the
+normal claim, freshness, CI, advisory, review, and unresolved-thread
+gates pass. Repositories without a recorded `fully_autonomous_merge`
+policy still stop at the F3 handoff gate.
+
 ## IDD Workflow
 
 Open `.github/instructions/idd-overview.instructions.md` and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,18 @@ disabled). Feature branches are always rebased onto `main`, never
 merged. See the full rules in
 [.github/copilot-instructions.md](.github/copilot-instructions.md#branch-strategy).
 
+## Local merge policy
+
+This source repository records `fully_autonomous_merge` as its local IDD
+dogfooding policy. The setting applies only to `kurone-kito/idd-skill`
+and does not change the exported template default for adopter
+repositories.
+
+An IDD session may continue through F3 merge execution only after the
+normal claim, freshness, CI, advisory, review, and unresolved-thread
+gates pass. Repositories without a recorded `fully_autonomous_merge`
+policy still stop at the F3 handoff gate.
+
 ## IDD Workflow
 
 This project uses Issue-Driven Development (IDD) with parallel AI

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -51,6 +51,18 @@ disabled). Feature branches are always rebased onto `main`, never
 merged. See the full rules in
 [.github/copilot-instructions.md](.github/copilot-instructions.md#branch-strategy).
 
+## Local merge policy
+
+This source repository records `fully_autonomous_merge` as its local IDD
+dogfooding policy. The setting applies only to `kurone-kito/idd-skill`
+and does not change the exported template default for adopter
+repositories.
+
+An IDD session may continue through F3 merge execution only after the
+normal claim, freshness, CI, advisory, review, and unresolved-thread
+gates pass. Repositories without a recorded `fully_autonomous_merge`
+policy still stop at the F3 handoff gate.
+
 ## IDD Workflow
 
 Open `.github/instructions/idd-overview.instructions.md` and the


### PR DESCRIPTION
## Summary

- Record `fully_autonomous_merge` as the local IDD merge policy for this source repository in agent entrypoint docs.
- Scope the note to `kurone-kito/idd-skill` so the exported template default remains unchanged for adopter repositories.
- Preserve the F3 safety model by naming the claim, freshness, CI, advisory, review, and unresolved-thread gates as still required.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `node scripts/audit-docs.mjs --check`
- `node --test tests/*.test.mjs`

## Follow-up Issues

None.

Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation across multiple guides to clarify the repository's merge policy and conditions for automated merge execution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/205)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->