### PR TITLE
docs: wire live status digest phases

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -118,4 +118,14 @@ to Discover using the same selection mode that produced this target
 the A3-ready path).
 
 Once verified, record this `{claim-id}` as your current claim token for
-the rest of the workflow, then continue to `idd-work.instructions.md`.
+the rest of the workflow.
+
+After claim verification, upsert the issue live status digest when there
+is exactly one marked digest or none. Use the verified `claimed-by`
+comment as the authority: set `Phase` to `A5 claimed`, `Claim` to the
+current `{agent-id}` / `{claim-id}`, `Branch` to the verified branch,
+`Open blockers` to `none`, and `Next action` to `B1 create branch and
+worktree`. If multiple marked digests exist, report their URLs and
+continue from the verified claim without editing a digest.
+
+Then continue to `idd-work.instructions.md`.

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -111,6 +111,12 @@ gate. The active claim must still use your current `{claim-id}`.
    ```
 
    Do not use squash merge or rebase merge.
+   After the merge succeeds and claim ownership is re-validated, upsert
+   the PR live status digest with `Phase: F3 merged`,
+   `Open blockers: none`, `Next action: F4 cleanup then F5 discover`,
+   and `Authoritative by` pointing to the merge commit and matched head
+   SHA. This post-merge digest update is not a merge gate and must not
+   happen before the successful merge command.
 5. If merge fails:
    - Base branch updated or conflict → return to
      `idd-pre-merge.instructions.md` F1
@@ -131,9 +137,19 @@ gate. The active claim must still use your current `{claim-id}`.
      `**Awaiting maintainer decision**` reply → post a hold comment and
      stop.
 
+   When a merge failure routes to F1, D4, E1, F2, or a hold, update the
+   digest after recording the failure evidence. Set `Phase` to
+   `F3 blocked`, summarize the GitHub merge error or unresolved thread
+   class in `Open blockers`, and set `Next action` to the routed phase
+   or maintainer action.
+
 ## F4 — Cleanup
 
-1. Run best-effort merged-PR comment cleanup when credentials permit.
+1. Confirm the post-merge digest update above exists or repair it after
+   re-validating the claim. Do not minimize the digest as an
+   operational marker unless a future cleanup policy explicitly supports
+   digest retirement.
+2. Run best-effort merged-PR comment cleanup when credentials permit.
    This cleanup is never a merge gate and must not run before F3
    succeeds. If cleanup fails, record the failure only if it is useful
    for a later audit, then continue with local cleanup.
@@ -187,10 +203,10 @@ gate. The active claim must still use your current `{claim-id}`.
 
    See `docs/idd-comment-minimization.md` for the helper report shape,
    fallback GraphQL commands, and experiment notes.
-2. Delete the local worktree and local branch.
-3. Update the local `main` branch.
-4. If GitHub auto-delete is disabled: delete the remote branch too.
-   (Worktrunk may be used for steps 2–4.)
+3. Delete the local worktree and local branch.
+4. Update the local `main` branch.
+5. If GitHub auto-delete is disabled: delete the remote branch too.
+   (Worktrunk may be used for steps 3–5.)
 
 ## F5 — Loop
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -137,11 +137,18 @@ gate. The active claim must still use your current `{claim-id}`.
      `**Awaiting maintainer decision**` reply → post a hold comment and
      stop.
 
-   When a merge failure routes to F1, D4, E1, F2, or a hold, update the
+   When a merge failure routes to F1, D4, E1, or a hold, update the
    digest after recording the failure evidence. Set `Phase` to
    `F3 blocked`, summarize the GitHub merge error or unresolved thread
    class in `Open blockers`, and set `Next action` to the routed phase
    or maintainer action.
+
+   If the merge failure path resolves or acknowledges awaiting-reviewer
+   threads and restarts F2, do not update the digest before restarting
+   F2. That PR activity would invalidate the F2 restart and force an E1
+   snapshot even though E1 intentionally has no actionable
+   awaiting-reviewer item. Let the restarted F2 pass record blockers if
+   it finds one.
 
 ## F4 — Cleanup
 

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -221,23 +221,23 @@ that authoritative re-read.
 On pull requests, a digest edit is still PR activity unless a future
 repository helper explicitly classifies it otherwise. Therefore do not
 edit a PR digest between a valid E1 review watermark and an intended F3
-merge pass. Edit it only before returning to E1, when posting a hold or
-stopping, or after F3 has merged. This keeps digest text from satisfying
-or perturbing review-currency, advisory, CI, or merge gates.
+merge pass. Edit it only when the flow leaves merge intent (for example,
+returning to E1, routing from F3 to F1/D4/F2 as blocked, or posting a
+hold/stop), or after F3 has merged. This keeps digest text from
+satisfying or perturbing review-currency, advisory, CI, or merge gates.
 
 ## Abort
 
 On abort, re-validate ownership first. If the active claim still uses
-your current `{claim-id}`, post an `unclaimed-by` comment with that same
-`{claim-id}`. If the active claim no longer uses your `{claim-id}`, do
-not post a release comment because another session already took over.
-Open PR and remote branch left by a stale or unclaimed state are
-inheritable by the next agent (see `idd-resume.instructions.md`).
-When releasing a claim you still own, update the digest before posting
+your current `{claim-id}`, update the digest before posting
 `unclaimed-by` so it shows `Phase: aborted/released`, the planned
 release in `Next action`, and the verified claim plus abort reason in
-`Authoritative by`. If the claim was already lost, leave the digest
-untouched.
+`Authoritative by`; then post an `unclaimed-by` comment with that same
+`{claim-id}`. If the active claim no longer uses your `{claim-id}`, do
+not update the digest and do not post a release comment because another
+session already took over. Open PR and remote branch left by a stale or
+unclaimed state are inheritable by the next agent (see
+`idd-resume.instructions.md`).
 
 ## Hold / suspend
 

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -222,9 +222,11 @@ On pull requests, a digest edit is still PR activity unless a future
 repository helper explicitly classifies it otherwise. Therefore do not
 edit a PR digest between a valid E1 review watermark and an intended F3
 merge pass. Edit it only when the flow leaves merge intent (for example,
-returning to E1, routing from F3 to F1/D4/F2 as blocked, or posting a
-hold/stop), or after F3 has merged. This keeps digest text from
-satisfying or perturbing review-currency, advisory, CI, or merge gates.
+returning to E1, routing from F3 to F1/D4 as blocked, or posting a
+hold/stop), or after F3 has merged. The F3 awaiting-reviewer restart-F2
+path intentionally skips digest edits so that F2 can restart without
+self-invalidating review currency. This keeps digest text from satisfying
+or perturbing review-currency, advisory, CI, or merge gates.
 
 ## Abort
 

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -210,6 +210,21 @@ preserve them, report the duplicate URLs, and do not choose one as
 authoritative during an unattended run. See
 `docs/idd-comment-minimization.md` for the full digest contract.
 
+Treat every digest create or edit as a GitHub side effect: re-validate
+the active claim first, write fields from the authoritative state just
+collected by the current phase, and set `Authoritative by` to the
+specific claim, review, CI, advisory, PR, or issue evidence used. If the
+claim was lost, do not repair or update the digest. Every digest update
+refreshes `Last checked` to the server-observed or current UTC time of
+that authoritative re-read.
+
+On pull requests, a digest edit is still PR activity unless a future
+repository helper explicitly classifies it otherwise. Therefore do not
+edit a PR digest between a valid E1 review watermark and an intended F3
+merge pass. Edit it only before returning to E1, when posting a hold or
+stopping, or after F3 has merged. This keeps digest text from satisfying
+or perturbing review-currency, advisory, CI, or merge gates.
+
 ## Abort
 
 On abort, re-validate ownership first. If the active claim still uses
@@ -218,12 +233,21 @@ your current `{claim-id}`, post an `unclaimed-by` comment with that same
 not post a release comment because another session already took over.
 Open PR and remote branch left by a stale or unclaimed state are
 inheritable by the next agent (see `idd-resume.instructions.md`).
+When releasing a claim you still own, update the digest before posting
+`unclaimed-by` so it shows `Phase: aborted/released`, the planned
+release in `Next action`, and the verified claim plus abort reason in
+`Authoritative by`. If the claim was already lost, leave the digest
+untouched.
 
 ## Hold / suspend
 
 Keep the claim. Post the hold reason and resume condition to the PR or
 issue comment. After re-validating ownership, re-post the claim comment
 with the same `{claim-id}` every 12 h as heartbeat.
+After posting the hold reason, upsert the digest with the hold phase, the
+blocking condition in `Open blockers`, and the resume condition in
+`Next action`. Long holds still need claim heartbeats; the digest does
+not reset the claim stale clock.
 
 ## Roadmap markers
 

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -38,6 +38,9 @@ If `mergeable` is `CONFLICTING` or `mergeStateStatus` is `BEHIND` or
 4. Push (use `--force-with-lease` if you rebased).
 5. If the HEAD changed (new commits were added): return to
    `idd-review-snapshot.instructions.md` (E1) to re-evaluate reviews.
+   Before returning, update the PR live status digest with
+   `Phase: F1 rebased`, the new HEAD in `Authoritative by`, and
+   `Next action: E1 review snapshot`.
 
 ## F2 — Pre-merge condition check
 
@@ -194,6 +197,16 @@ must align with every F2 condition below.
   E1's regular-comment filter for non-advisory discussion. Copilot and
   CI advisory bot comments are handled earlier in the PATH B triage flow
   (E4-E7) and are excluded from this gate.
+
+When any F2 condition routes to a hold/stop or back to E1/E14, update
+the PR live status digest after the blocking evidence is recorded and
+before stopping or returning. Set `Phase` to the failing F2 check,
+`Open blockers` to the concrete unmet condition, `Next action` to the
+required reviewer, CI, advisory, maintainer, or agent action, and
+`Authoritative by` to the F2 evidence fetched in this pass. If every F2
+condition is satisfied, do **not** edit the digest before F3; carry the
+F2 snapshot forward unchanged so the final F3 freshness check can use
+the same activity universe.
 
 Note: `required_approvals` is fetched at runtime from the ruleset. The
 practical blockers are `CHANGES_REQUESTED` states and missing CODEOWNER

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -117,6 +117,13 @@ claim state, PR state, CI state, and review activity when doing so is
 safe under the claim revalidation gate. If multiple marked digests
 exist, preserve them, report their URLs, and continue routing from
 trusted markers and GitHub state rather than digest text.
+For a successful stale takeover or legacy migration, the digest belongs
+to the new verified `{claim-id}` only after that claim is active; include
+the superseded or migrated claim marker in `Authoritative by` and do not
+reuse prior-claim review-watermark or review-baseline comments. For
+non-owned, non-stale claims, do not edit the digest; stalled-session
+handling records evidence in session logs only unless the claim becomes
+yours.
 
 ## Step 2 — Locate or restore branch and worktree
 
@@ -140,6 +147,14 @@ configured).
 | No             | No             | Worktree dirty                        | Resume from B3                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | No             | No             | Worktree clean, unpushed              | Resume from D1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | No             | No             | Worktree clean, no unpushed           | Resume from B2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+
+After Step 2 chooses a route, refresh the digest only when the route
+materially changes what a human should expect next. Examples:
+`Phase: resume -> B3` for dirty worktree recovery, `Phase: resume -> D1`
+for unpushed clean commits, or `Phase: resume -> F1` when CI and review
+state are already clear. The `Authoritative by` field should cite the
+claim marker, PR/branch evidence, CI status, and review snapshot used for
+the routing decision.
 
 ## Step 3 — Determine PR and CI/review state
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -14,8 +14,8 @@ The advisory-review timing defaults used by E14 are named in
 you need the values, but keep the phase logic here unchanged.
 
 Apply the shared claim revalidation gate before E9, before the E12 push,
-and before each E13/E14 GitHub side effect (reply, resolve, reviewer
-request, or hold comment).
+and before each E13/E14/E15 GitHub side effect (reply, resolve,
+reviewer request, hold comment, or digest update).
 
 ## E9 — Fix accepted issues
 
@@ -237,8 +237,8 @@ proceeding to F — do not skip triage.
   cancels or times out again, post a hold comment and stop (do not
   loop). On success after the rerun, **return to E1**.
 
-When E15 stops on a CI hold, update the digest with `Phase: E15 hold`,
-the failing or missing checks in `Open blockers`, and the maintainer or
-rerun expectation in `Next action`. On CI success, do not edit the
-digest before returning to E1; let the next E1/F pass refresh review
-currency first.
+When E15 stops on a CI hold, re-validate the claim and then update the
+digest with `Phase: E15 hold`, the failing or missing checks in
+`Open blockers`, and the maintainer or rerun expectation in
+`Next action`. On CI success, do not edit the digest before returning to
+E1; let the next E1/F pass refresh review currency first.

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -84,6 +84,15 @@ unambiguous:
   the next E1 pass.
 - **Regular comments**: reply only; do not resolve.
 
+After E13 replies and resolutions are complete, upsert the PR live
+status digest before E14 if the next route is still review-fix or CI
+wait. Set `Phase` to `E13 feedback replied`, `Open blockers` to any
+remaining reviewer, advisory, or CI wait, `Next action` to E14 or E15,
+and `Authoritative by` to the accepted feedback replies, resolved
+threads, current HEAD, and verified claim. Because E15 returns to E1
+after CI, this digest edit is safe activity; do not use it to bypass the
+next E1 snapshot.
+
 ## E14 — Re-review request
 
 **Human reviewers**: for each reviewer whose latest state is
@@ -147,6 +156,12 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
 
 Copilot and CI advisory bot comments are advisory; unanswered ones do
 not block merge.
+
+Whenever E14 posts a Copilot request marker, recovery marker, or hold
+comment, update the digest after that side effect with the current
+advisory state. Use the marker or hold comment as `Authoritative by`,
+set `Open blockers` to the advisory wait or hold reason, and set
+`Next action` to polling, E15, or maintainer action.
 
 **Active polling loop** (applies when `COPILOT_PENDING` is `"true"`, or
 immediately after posting a marker in the **REQUEST_NEEDED** or
@@ -221,3 +236,9 @@ proceeding to F — do not skip triage.
 - **On cancelled / timed_out / infra**: re-push or rerun CI once; if it
   cancels or times out again, post a hold comment and stop (do not
   loop). On success after the rerun, **return to E1**.
+
+When E15 stops on a CI hold, update the digest with `Phase: E15 hold`,
+the failing or missing checks in `Open blockers`, and the maintainer or
+rerun expectation in `Next action`. On CI success, do not edit the
+digest before returning to E1; let the next E1/F pass refresh review
+currency first.

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -108,10 +108,12 @@ restart or takeover; if no trusted same-claim watermark exists, rerun E1
 from scratch.
 
 Do not create or edit the PR live status digest after posting this
-watermark unless the next route is to E1, to an F3 blocked reroute
-(F1/D4/F2), to a hold/stop, or to post-merge cleanup. A digest edit
-after the watermark is new PR activity for review-currency purposes and
-would require a fresh E1 snapshot before F2 can pass.
+watermark unless the next route is to E1, to an F3 blocked reroute that
+leaves the F2 restart path (F1/D4), to a hold/stop, or to post-merge
+cleanup. The F3 awaiting-reviewer restart-F2 path skips digest edits so
+that F2 can restart without self-invalidating review currency. A digest
+edit after the watermark is new PR activity for review-currency purposes
+and would require a fresh E1 snapshot before F2 can pass.
 
 **Step 3 — Filter into List A.** From the snapshot, select and combine
 into **List A**. Record the source URL for each item.

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -107,6 +107,12 @@ Legacy watermarks without `{claim-id}` are not resumable across a
 restart or takeover; if no trusted same-claim watermark exists, rerun E1
 from scratch.
 
+Do not create or edit the PR live status digest after posting this
+watermark unless the next route is to E1, to a hold/stop, or to
+post-merge cleanup. A digest edit after the watermark is new PR activity
+for review-currency purposes and would require a fresh E1 snapshot
+before F2 can pass.
+
 **Step 3 — Filter into List A.** From the snapshot, select and combine
 into **List A**. Record the source URL for each item.
 

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -108,10 +108,10 @@ restart or takeover; if no trusted same-claim watermark exists, rerun E1
 from scratch.
 
 Do not create or edit the PR live status digest after posting this
-watermark unless the next route is to E1, to a hold/stop, or to
-post-merge cleanup. A digest edit after the watermark is new PR activity
-for review-currency purposes and would require a fresh E1 snapshot
-before F2 can pass.
+watermark unless the next route is to E1, to an F3 blocked reroute
+(F1/D4/F2), to a hold/stop, or to post-merge cleanup. A digest edit
+after the watermark is new PR activity for review-currency purposes and
+would require a fresh E1 snapshot before F2 can pass.
 
 **Step 3 — Filter into List A.** From the snapshot, select and combine
 into **List A**. Record the source URL for each item.

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -201,6 +201,17 @@ required by its path:
 If any check fails, do not continue. Return to E4-E6 as needed until the
 missing evidence is recorded.
 
+After E7 succeeds, update the PR live status digest only when doing so
+will not invalidate a merge-bound E1 snapshot. Safe update points are:
+when triage posts a hold and stops, when Accepted PATH A items remain
+and the next route is E9, or when the update is followed by a fresh E1
+snapshot before F2. Set `Phase` to `E triage`, summarize remaining
+Accepted PATH A work or `none` in `Open blockers`, set `Next action` to
+E9 or F2 as appropriate, and cite the disposition replies plus the
+trusted review-watermark in `Authoritative by`. If List A is empty and
+the next step is F2, defer the digest update unless you intentionally
+return to E1 afterward.
+
 ## E8 — Accepted PATH A count check
 
 If the Accepted PATH A count is zero → proceed to

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -88,12 +88,23 @@ Draft an implementation plan and post it as an issue comment. Then run a
 critique pass to review the plan for correctness and concreteness (see
 `idd-overview.instructions.md` for per-agent implementation). Post the
 refined final plan as a follow-up or update to the same issue comment.
+After the final plan comment is posted and claim ownership is
+re-validated, update the issue live status digest: `Phase` is `B2
+planned`, `Open blockers` is `none` unless the plan found a blocker,
+`Next action` is `B3 implement`, and `Authoritative by` points to the
+plan comment and verified claim.
 
 ## B3 — Implement
 
 Implement the plan. Before each commit, run **fix-validate**.
 
 Keep commits atomic — one logical change per commit.
+
+If B3 or C must stop for a hold, use the shared Hold / suspend rules in
+`idd-overview.instructions.md` and update the issue digest with the
+blocking condition before stopping. Do not use the digest as the only
+record of unfinished work; material decisions still need issue comments
+or commits.
 
 ---
 
@@ -115,6 +126,11 @@ satisfied, whether adequate test coverage exists, and whether any other
 problems exist. See `idd-overview.instructions.md` for per-agent
 implementation. The distributed defaults for the C-phase skip and loop
 guards are listed in `docs/policy-constants.md`.
+
+After each critique loop decision, update the issue digest only if the
+next action changes materially: for example, `C accepted fixes` before
+C5, `C clean` before moving to PR submission, or a hold state when
+guardrails stop the loop.
 
 ### C2 — Check for issues
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -144,6 +144,19 @@ history and reported for repair; unattended agents must continue from
 the authoritative markers and GitHub state rather than picking a digest
 arbitrarily.
 
+Phase files now define digest update points rather than leaving them to
+agent judgment. Issue digests are refreshed after claim verification,
+planning, meaningful C-loop decisions, hold, abort, and resume route
+selection. PR digests are refreshed for review-fix progress, advisory
+wait or CI holds, pre-merge blockers, merge failures, and post-merge
+cleanup.
+
+Agents deliberately avoid editing a PR digest between a valid E1 review
+watermark and a successful F3 merge path. A digest edit can be PR
+activity, so successful F2 passes carry their activity snapshot forward
+without touching the digest; blocker and hold paths may update the
+digest because they stop or return to E1 anyway.
+
 ### Roadmap-claim contention playbook
 
 Use this playbook when multiple sessions are active:

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -155,7 +155,10 @@ Agents deliberately avoid editing a PR digest between a valid E1 review
 watermark and a successful F3 merge path. A digest edit can be PR
 activity, so successful F2 passes carry their activity snapshot forward
 without touching the digest; blocked reroutes and hold paths may update
-the digest because they stop or leave merge intent anyway.
+the digest because they stop or leave merge intent anyway. The F3
+awaiting-reviewer restart-F2 path is the exception: it skips digest
+updates so the restarted F2 pass does not self-invalidate review
+currency.
 
 ### Roadmap-claim contention playbook
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -154,8 +154,8 @@ cleanup.
 Agents deliberately avoid editing a PR digest between a valid E1 review
 watermark and a successful F3 merge path. A digest edit can be PR
 activity, so successful F2 passes carry their activity snapshot forward
-without touching the digest; blocker and hold paths may update the
-digest because they stop or return to E1 anyway.
+without touching the digest; blocked reroutes and hold paths may update
+the digest because they stop or leave merge intent anyway.
 
 ### Roadmap-claim contention playbook
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -118,4 +118,14 @@ to Discover using the same selection mode that produced this target
 the A3-ready path).
 
 Once verified, record this `{claim-id}` as your current claim token for
-the rest of the workflow, then continue to `idd-work.instructions.md`.
+the rest of the workflow.
+
+After claim verification, upsert the issue live status digest when there
+is exactly one marked digest or none. Use the verified `claimed-by`
+comment as the authority: set `Phase` to `A5 claimed`, `Claim` to the
+current `{agent-id}` / `{claim-id}`, `Branch` to the verified branch,
+`Open blockers` to `none`, and `Next action` to `B1 create branch and
+worktree`. If multiple marked digests exist, report their URLs and
+continue from the verified claim without editing a digest.
+
+Then continue to `idd-work.instructions.md`.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -111,6 +111,12 @@ gate. The active claim must still use your current `{claim-id}`.
    ```
 
    Do not use squash merge or rebase merge.
+   After the merge succeeds and claim ownership is re-validated, upsert
+   the PR live status digest with `Phase: F3 merged`,
+   `Open blockers: none`, `Next action: F4 cleanup then F5 discover`,
+   and `Authoritative by` pointing to the merge commit and matched head
+   SHA. This post-merge digest update is not a merge gate and must not
+   happen before the successful merge command.
 5. If merge fails:
    - Base branch updated or conflict → return to
      `idd-pre-merge.instructions.md` F1
@@ -131,9 +137,19 @@ gate. The active claim must still use your current `{claim-id}`.
      `**Awaiting maintainer decision**` reply → post a hold comment and
      stop.
 
+   When a merge failure routes to F1, D4, E1, F2, or a hold, update the
+   digest after recording the failure evidence. Set `Phase` to
+   `F3 blocked`, summarize the GitHub merge error or unresolved thread
+   class in `Open blockers`, and set `Next action` to the routed phase
+   or maintainer action.
+
 ## F4 — Cleanup
 
-1. Run best-effort merged-PR comment cleanup when credentials permit.
+1. Confirm the post-merge digest update above exists or repair it after
+   re-validating the claim. Do not minimize the digest as an
+   operational marker unless a future cleanup policy explicitly supports
+   digest retirement.
+2. Run best-effort merged-PR comment cleanup when credentials permit.
    This cleanup is never a merge gate and must not run before F3
    succeeds. If cleanup fails, record the failure only if it is useful
    for a later audit, then continue with local cleanup.
@@ -187,10 +203,10 @@ gate. The active claim must still use your current `{claim-id}`.
 
    See `docs/idd-comment-minimization.md` for the helper report shape,
    fallback GraphQL commands, and experiment notes.
-2. Delete the local worktree and local branch.
-3. Update the local `main` branch.
-4. If GitHub auto-delete is disabled: delete the remote branch too.
-   (Worktrunk may be used for steps 2–4.)
+3. Delete the local worktree and local branch.
+4. Update the local `main` branch.
+5. If GitHub auto-delete is disabled: delete the remote branch too.
+   (Worktrunk may be used for steps 3–5.)
 
 ## F5 — Loop
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -137,11 +137,18 @@ gate. The active claim must still use your current `{claim-id}`.
      `**Awaiting maintainer decision**` reply → post a hold comment and
      stop.
 
-   When a merge failure routes to F1, D4, E1, F2, or a hold, update the
+   When a merge failure routes to F1, D4, E1, or a hold, update the
    digest after recording the failure evidence. Set `Phase` to
    `F3 blocked`, summarize the GitHub merge error or unresolved thread
    class in `Open blockers`, and set `Next action` to the routed phase
    or maintainer action.
+
+   If the merge failure path resolves or acknowledges awaiting-reviewer
+   threads and restarts F2, do not update the digest before restarting
+   F2. That PR activity would invalidate the F2 restart and force an E1
+   snapshot even though E1 intentionally has no actionable
+   awaiting-reviewer item. Let the restarted F2 pass record blockers if
+   it finds one.
 
 ## F4 — Cleanup
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -221,23 +221,23 @@ that authoritative re-read.
 On pull requests, a digest edit is still PR activity unless a future
 repository helper explicitly classifies it otherwise. Therefore do not
 edit a PR digest between a valid E1 review watermark and an intended F3
-merge pass. Edit it only before returning to E1, when posting a hold or
-stopping, or after F3 has merged. This keeps digest text from satisfying
-or perturbing review-currency, advisory, CI, or merge gates.
+merge pass. Edit it only when the flow leaves merge intent (for example,
+returning to E1, routing from F3 to F1/D4/F2 as blocked, or posting a
+hold/stop), or after F3 has merged. This keeps digest text from
+satisfying or perturbing review-currency, advisory, CI, or merge gates.
 
 ## Abort
 
 On abort, re-validate ownership first. If the active claim still uses
-your current `{claim-id}`, post an `unclaimed-by` comment with that same
-`{claim-id}`. If the active claim no longer uses your `{claim-id}`, do
-not post a release comment because another session already took over.
-Open PR and remote branch left by a stale or unclaimed state are
-inheritable by the next agent (see `idd-resume.instructions.md`).
-When releasing a claim you still own, update the digest before posting
+your current `{claim-id}`, update the digest before posting
 `unclaimed-by` so it shows `Phase: aborted/released`, the planned
 release in `Next action`, and the verified claim plus abort reason in
-`Authoritative by`. If the claim was already lost, leave the digest
-untouched.
+`Authoritative by`; then post an `unclaimed-by` comment with that same
+`{claim-id}`. If the active claim no longer uses your `{claim-id}`, do
+not update the digest and do not post a release comment because another
+session already took over. Open PR and remote branch left by a stale or
+unclaimed state are inheritable by the next agent (see
+`idd-resume.instructions.md`).
 
 ## Hold / suspend
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -222,9 +222,11 @@ On pull requests, a digest edit is still PR activity unless a future
 repository helper explicitly classifies it otherwise. Therefore do not
 edit a PR digest between a valid E1 review watermark and an intended F3
 merge pass. Edit it only when the flow leaves merge intent (for example,
-returning to E1, routing from F3 to F1/D4/F2 as blocked, or posting a
-hold/stop), or after F3 has merged. This keeps digest text from
-satisfying or perturbing review-currency, advisory, CI, or merge gates.
+returning to E1, routing from F3 to F1/D4 as blocked, or posting a
+hold/stop), or after F3 has merged. The F3 awaiting-reviewer restart-F2
+path intentionally skips digest edits so that F2 can restart without
+self-invalidating review currency. This keeps digest text from satisfying
+or perturbing review-currency, advisory, CI, or merge gates.
 
 ## Abort
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -210,6 +210,21 @@ preserve them, report the duplicate URLs, and do not choose one as
 authoritative during an unattended run. See
 `docs/idd-comment-minimization.md` for the full digest contract.
 
+Treat every digest create or edit as a GitHub side effect: re-validate
+the active claim first, write fields from the authoritative state just
+collected by the current phase, and set `Authoritative by` to the
+specific claim, review, CI, advisory, PR, or issue evidence used. If the
+claim was lost, do not repair or update the digest. Every digest update
+refreshes `Last checked` to the server-observed or current UTC time of
+that authoritative re-read.
+
+On pull requests, a digest edit is still PR activity unless a future
+repository helper explicitly classifies it otherwise. Therefore do not
+edit a PR digest between a valid E1 review watermark and an intended F3
+merge pass. Edit it only before returning to E1, when posting a hold or
+stopping, or after F3 has merged. This keeps digest text from satisfying
+or perturbing review-currency, advisory, CI, or merge gates.
+
 ## Abort
 
 On abort, re-validate ownership first. If the active claim still uses
@@ -218,12 +233,21 @@ your current `{claim-id}`, post an `unclaimed-by` comment with that same
 not post a release comment because another session already took over.
 Open PR and remote branch left by a stale or unclaimed state are
 inheritable by the next agent (see `idd-resume.instructions.md`).
+When releasing a claim you still own, update the digest before posting
+`unclaimed-by` so it shows `Phase: aborted/released`, the planned
+release in `Next action`, and the verified claim plus abort reason in
+`Authoritative by`. If the claim was already lost, leave the digest
+untouched.
 
 ## Hold / suspend
 
 Keep the claim. Post the hold reason and resume condition to the PR or
 issue comment. After re-validating ownership, re-post the claim comment
 with the same `{claim-id}` every 12 h as heartbeat.
+After posting the hold reason, upsert the digest with the hold phase, the
+blocking condition in `Open blockers`, and the resume condition in
+`Next action`. Long holds still need claim heartbeats; the digest does
+not reset the claim stale clock.
 
 ## Roadmap markers
 

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -38,6 +38,9 @@ If `mergeable` is `CONFLICTING` or `mergeStateStatus` is `BEHIND` or
 4. Push (use `--force-with-lease` if you rebased).
 5. If the HEAD changed (new commits were added): return to
    `idd-review-snapshot.instructions.md` (E1) to re-evaluate reviews.
+   Before returning, update the PR live status digest with
+   `Phase: F1 rebased`, the new HEAD in `Authoritative by`, and
+   `Next action: E1 review snapshot`.
 
 ## F2 — Pre-merge condition check
 
@@ -194,6 +197,16 @@ must align with every F2 condition below.
   E1's regular-comment filter for non-advisory discussion. Copilot and
   CI advisory bot comments are handled earlier in the PATH B triage flow
   (E4-E7) and are excluded from this gate.
+
+When any F2 condition routes to a hold/stop or back to E1/E14, update
+the PR live status digest after the blocking evidence is recorded and
+before stopping or returning. Set `Phase` to the failing F2 check,
+`Open blockers` to the concrete unmet condition, `Next action` to the
+required reviewer, CI, advisory, maintainer, or agent action, and
+`Authoritative by` to the F2 evidence fetched in this pass. If every F2
+condition is satisfied, do **not** edit the digest before F3; carry the
+F2 snapshot forward unchanged so the final F3 freshness check can use
+the same activity universe.
 
 Note: `required_approvals` is fetched at runtime from the ruleset. The
 practical blockers are `CHANGES_REQUESTED` states and missing CODEOWNER

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -117,6 +117,13 @@ claim state, PR state, CI state, and review activity when doing so is
 safe under the claim revalidation gate. If multiple marked digests
 exist, preserve them, report their URLs, and continue routing from
 trusted markers and GitHub state rather than digest text.
+For a successful stale takeover or legacy migration, the digest belongs
+to the new verified `{claim-id}` only after that claim is active; include
+the superseded or migrated claim marker in `Authoritative by` and do not
+reuse prior-claim review-watermark or review-baseline comments. For
+non-owned, non-stale claims, do not edit the digest; stalled-session
+handling records evidence in session logs only unless the claim becomes
+yours.
 
 ## Step 2 — Locate or restore branch and worktree
 
@@ -140,6 +147,14 @@ configured).
 | No             | No             | Worktree dirty                        | Resume from B3                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | No             | No             | Worktree clean, unpushed              | Resume from D1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | No             | No             | Worktree clean, no unpushed           | Resume from B2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+
+After Step 2 chooses a route, refresh the digest only when the route
+materially changes what a human should expect next. Examples:
+`Phase: resume -> B3` for dirty worktree recovery, `Phase: resume -> D1`
+for unpushed clean commits, or `Phase: resume -> F1` when CI and review
+state are already clear. The `Authoritative by` field should cite the
+claim marker, PR/branch evidence, CI status, and review snapshot used for
+the routing decision.
 
 ## Step 3 — Determine PR and CI/review state
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -14,8 +14,8 @@ The advisory-review timing defaults used by E14 are named in
 you need the values, but keep the phase logic here unchanged.
 
 Apply the shared claim revalidation gate before E9, before the E12 push,
-and before each E13/E14 GitHub side effect (reply, resolve, reviewer
-request, or hold comment).
+and before each E13/E14/E15 GitHub side effect (reply, resolve,
+reviewer request, hold comment, or digest update).
 
 ## E9 — Fix accepted issues
 
@@ -237,8 +237,8 @@ proceeding to F — do not skip triage.
   cancels or times out again, post a hold comment and stop (do not
   loop). On success after the rerun, **return to E1**.
 
-When E15 stops on a CI hold, update the digest with `Phase: E15 hold`,
-the failing or missing checks in `Open blockers`, and the maintainer or
-rerun expectation in `Next action`. On CI success, do not edit the
-digest before returning to E1; let the next E1/F pass refresh review
-currency first.
+When E15 stops on a CI hold, re-validate the claim and then update the
+digest with `Phase: E15 hold`, the failing or missing checks in
+`Open blockers`, and the maintainer or rerun expectation in
+`Next action`. On CI success, do not edit the digest before returning to
+E1; let the next E1/F pass refresh review currency first.

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -84,6 +84,15 @@ unambiguous:
   the next E1 pass.
 - **Regular comments**: reply only; do not resolve.
 
+After E13 replies and resolutions are complete, upsert the PR live
+status digest before E14 if the next route is still review-fix or CI
+wait. Set `Phase` to `E13 feedback replied`, `Open blockers` to any
+remaining reviewer, advisory, or CI wait, `Next action` to E14 or E15,
+and `Authoritative by` to the accepted feedback replies, resolved
+threads, current HEAD, and verified claim. Because E15 returns to E1
+after CI, this digest edit is safe activity; do not use it to bypass the
+next E1 snapshot.
+
 ## E14 — Re-review request
 
 **Human reviewers**: for each reviewer whose latest state is
@@ -147,6 +156,12 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
 
 Copilot and CI advisory bot comments are advisory; unanswered ones do
 not block merge.
+
+Whenever E14 posts a Copilot request marker, recovery marker, or hold
+comment, update the digest after that side effect with the current
+advisory state. Use the marker or hold comment as `Authoritative by`,
+set `Open blockers` to the advisory wait or hold reason, and set
+`Next action` to polling, E15, or maintainer action.
 
 **Active polling loop** (applies when `COPILOT_PENDING` is `"true"`, or
 immediately after posting a marker in the **REQUEST_NEEDED** or
@@ -221,3 +236,9 @@ proceeding to F — do not skip triage.
 - **On cancelled / timed_out / infra**: re-push or rerun CI once; if it
   cancels or times out again, post a hold comment and stop (do not
   loop). On success after the rerun, **return to E1**.
+
+When E15 stops on a CI hold, update the digest with `Phase: E15 hold`,
+the failing or missing checks in `Open blockers`, and the maintainer or
+rerun expectation in `Next action`. On CI success, do not edit the
+digest before returning to E1; let the next E1/F pass refresh review
+currency first.

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -108,10 +108,12 @@ restart or takeover; if no trusted same-claim watermark exists, rerun E1
 from scratch.
 
 Do not create or edit the PR live status digest after posting this
-watermark unless the next route is to E1, to an F3 blocked reroute
-(F1/D4/F2), to a hold/stop, or to post-merge cleanup. A digest edit
-after the watermark is new PR activity for review-currency purposes and
-would require a fresh E1 snapshot before F2 can pass.
+watermark unless the next route is to E1, to an F3 blocked reroute that
+leaves the F2 restart path (F1/D4), to a hold/stop, or to post-merge
+cleanup. The F3 awaiting-reviewer restart-F2 path skips digest edits so
+that F2 can restart without self-invalidating review currency. A digest
+edit after the watermark is new PR activity for review-currency purposes
+and would require a fresh E1 snapshot before F2 can pass.
 
 **Step 3 — Filter into List A.** From the snapshot, select and combine
 into **List A**. Record the source URL for each item.

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -107,6 +107,12 @@ Legacy watermarks without `{claim-id}` are not resumable across a
 restart or takeover; if no trusted same-claim watermark exists, rerun E1
 from scratch.
 
+Do not create or edit the PR live status digest after posting this
+watermark unless the next route is to E1, to a hold/stop, or to
+post-merge cleanup. A digest edit after the watermark is new PR activity
+for review-currency purposes and would require a fresh E1 snapshot
+before F2 can pass.
+
 **Step 3 — Filter into List A.** From the snapshot, select and combine
 into **List A**. Record the source URL for each item.
 

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -108,10 +108,10 @@ restart or takeover; if no trusted same-claim watermark exists, rerun E1
 from scratch.
 
 Do not create or edit the PR live status digest after posting this
-watermark unless the next route is to E1, to a hold/stop, or to
-post-merge cleanup. A digest edit after the watermark is new PR activity
-for review-currency purposes and would require a fresh E1 snapshot
-before F2 can pass.
+watermark unless the next route is to E1, to an F3 blocked reroute
+(F1/D4/F2), to a hold/stop, or to post-merge cleanup. A digest edit
+after the watermark is new PR activity for review-currency purposes and
+would require a fresh E1 snapshot before F2 can pass.
 
 **Step 3 — Filter into List A.** From the snapshot, select and combine
 into **List A**. Record the source URL for each item.

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -201,6 +201,17 @@ required by its path:
 If any check fails, do not continue. Return to E4-E6 as needed until the
 missing evidence is recorded.
 
+After E7 succeeds, update the PR live status digest only when doing so
+will not invalidate a merge-bound E1 snapshot. Safe update points are:
+when triage posts a hold and stops, when Accepted PATH A items remain
+and the next route is E9, or when the update is followed by a fresh E1
+snapshot before F2. Set `Phase` to `E triage`, summarize remaining
+Accepted PATH A work or `none` in `Open blockers`, set `Next action` to
+E9 or F2 as appropriate, and cite the disposition replies plus the
+trusted review-watermark in `Authoritative by`. If List A is empty and
+the next step is F2, defer the digest update unless you intentionally
+return to E1 afterward.
+
 ## E8 — Accepted PATH A count check
 
 If the Accepted PATH A count is zero → proceed to

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -88,12 +88,23 @@ Draft an implementation plan and post it as an issue comment. Then run a
 critique pass to review the plan for correctness and concreteness (see
 `idd-overview.instructions.md` for per-agent implementation). Post the
 refined final plan as a follow-up or update to the same issue comment.
+After the final plan comment is posted and claim ownership is
+re-validated, update the issue live status digest: `Phase` is `B2
+planned`, `Open blockers` is `none` unless the plan found a blocker,
+`Next action` is `B3 implement`, and `Authoritative by` points to the
+plan comment and verified claim.
 
 ## B3 — Implement
 
 Implement the plan. Before each commit, run **fix-validate**.
 
 Keep commits atomic — one logical change per commit.
+
+If B3 or C must stop for a hold, use the shared Hold / suspend rules in
+`idd-overview.instructions.md` and update the issue digest with the
+blocking condition before stopping. Do not use the digest as the only
+record of unfinished work; material decisions still need issue comments
+or commits.
 
 ---
 
@@ -115,6 +126,11 @@ satisfied, whether adequate test coverage exists, and whether any other
 problems exist. See `idd-overview.instructions.md` for per-agent
 implementation. The distributed defaults for the C-phase skip and loop
 guards are listed in `docs/policy-constants.md`.
+
+After each critique loop decision, update the issue digest only if the
+next action changes materially: for example, `C accepted fixes` before
+C5, `C clean` before moving to PR submission, or a hold state when
+guardrails stop the loop.
 
 ### C2 — Check for issues
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -148,7 +148,10 @@ Agents deliberately avoid editing a PR digest between a valid E1 review
 watermark and a successful F3 merge path. A digest edit can be PR
 activity, so successful F2 passes carry their activity snapshot forward
 without touching the digest; blocked reroutes and hold paths may update
-the digest because they stop or leave merge intent anyway.
+the digest because they stop or leave merge intent anyway. The F3
+awaiting-reviewer restart-F2 path is the exception: it skips digest
+updates so the restarted F2 pass does not self-invalidate review
+currency.
 
 ### Roadmap-claim contention playbook
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -147,8 +147,8 @@ cleanup.
 Agents deliberately avoid editing a PR digest between a valid E1 review
 watermark and a successful F3 merge path. A digest edit can be PR
 activity, so successful F2 passes carry their activity snapshot forward
-without touching the digest; blocker and hold paths may update the
-digest because they stop or return to E1 anyway.
+without touching the digest; blocked reroutes and hold paths may update
+the digest because they stop or leave merge intent anyway.
 
 ### Roadmap-claim contention playbook
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -137,6 +137,19 @@ history and reported for repair; unattended agents must continue from
 the authoritative markers and GitHub state rather than picking a digest
 arbitrarily.
 
+Phase files now define digest update points rather than leaving them to
+agent judgment. Issue digests are refreshed after claim verification,
+planning, meaningful C-loop decisions, hold, abort, and resume route
+selection. PR digests are refreshed for review-fix progress, advisory
+wait or CI holds, pre-merge blockers, merge failures, and post-merge
+cleanup.
+
+Agents deliberately avoid editing a PR digest between a valid E1 review
+watermark and a successful F3 merge path. A digest edit can be PR
+activity, so successful F2 passes carry their activity snapshot forward
+without touching the digest; blocker and hold paths may update the
+digest because they stop or return to E1 anyway.
+
 ### Roadmap-claim contention playbook
 
 Use this playbook when multiple sessions are active:


### PR DESCRIPTION
## Summary

- Adds phase-level live status digest update points after claim, planning, review handling, advisory wait, pre-merge blockers, merge cleanup, abort/hold, and resume routing.
- Documents the E/F safety rule: do not edit a PR digest between a valid E1 watermark and an intended F3 merge pass unless the flow stops or returns to E1.
- Mirrors the instruction changes into the exported template and updates workflow docs.

Closes #197

## Follow-up

- #198 will add helper support for live status digest upserts and duplicate handling.

## Validation

- markdownlint-cli2 v0.22.1 (markdownlint v0.40.0)
Finding: **/*.md !.github/CODE_OF_CONDUCT* !fixtures/issue-comments/*.md
Linting: 71 file(s)
Summary: 0 error(s)
markdownlint-cli2 v0.22.1 (markdownlint v0.40.0)
Finding: **/*.md !.github/CODE_OF_CONDUCT* !fixtures/issue-comments/*.md
Linting: 71 file(s)
Summary: 0 error(s)
- 
- markdownlint-cli2 v0.22.1 (markdownlint v0.40.0)
Finding: **/*.md !.github/CODE_OF_CONDUCT* !fixtures/issue-comments/*.md
Linting: 71 file(s)
Summary: 0 error(s)
- 
- documentation audit passed
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded workflow docs and instructions to require deterministic "live status digest" upserts at many phase checkpoints (claim verification, planning, review snapshots, triage, pre-merge, merge success/failure, cleanup, resume/takeover, and review-fix steps).
  * Defined precise rules for populating digest fields from authoritative evidence, when digests must not be edited (merge-bound review window), and handling blockers/next-action for holds, failures, and restarts.
  * Added explicit post-merge cleanup and repair sequencing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/206)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->