### PR TITLE
docs: switch distributed merge policy default

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -19,16 +19,10 @@ gate. The active claim must still use your current `{claim-id}`.
    the claim was lost — report this and stop.
 2. Read the repository's recorded merge policy from repository
    documentation that future IDD sessions read. If no policy is
-   recorded, treat it as `fully_autonomous_merge` (distributed
-   default). If the recorded value is not one of
-   `fully_autonomous_merge`, `human_merge`, or
-   `separate_merge_agent`, treat it as an unknown merge policy:
-   stop, post a hold comment, and request maintainer decision.
-   Do not execute the final freshness fetch, `gh pr merge`, or F4
-   cleanup when the policy is unknown.
+   recorded, treat it as `fully_autonomous_merge`.
 
-   If the recorded policy is `human_merge` or
-   `separate_merge_agent`, stop before the final freshness fetch and
+   If the recorded policy is anything other than
+   `fully_autonomous_merge`, stop before the final freshness fetch and
    before `gh pr merge`. After the claim revalidation above, report or
    post a concise handoff summary with the PR number, branch, current
    HEAD from F2, the F2 readiness evidence, and the actor expected to
@@ -38,10 +32,9 @@ gate. The active claim must still use your current `{claim-id}`.
    maintainer direction. Do not run the F3 merge command or F4 cleanup
    in the same worker session.
 
-   Only a recorded `fully_autonomous_merge` policy lets the same agent
-   session continue through the remaining F3 gates. This policy gate
-   does not relax claim, freshness, unresolved-thread, advisory, CI, or
-   review requirements.
+   Only a recorded non-`fully_autonomous_merge` policy stops the merge.
+   This policy gate does not relax claim, freshness, unresolved-thread,
+   advisory, CI, or review requirements.
 3. Immediately before executing the merge command, do one final live
    fetch using the **exact same activity-universe scope as E1 Step 1**
    (all review threads, review bodies, and regular PR comments,

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -19,10 +19,16 @@ gate. The active claim must still use your current `{claim-id}`.
    the claim was lost — report this and stop.
 2. Read the repository's recorded merge policy from repository
    documentation that future IDD sessions read. If no policy is
-   recorded, treat it as `human_merge`.
+   recorded, treat it as `fully_autonomous_merge` (distributed
+   default). If the recorded value is not one of
+   `fully_autonomous_merge`, `human_merge`, or
+   `separate_merge_agent`, treat it as an unknown merge policy:
+   stop, post a hold comment, and request maintainer decision.
+   Do not execute the final freshness fetch, `gh pr merge`, or F4
+   cleanup when the policy is unknown.
 
-   If the recorded policy is anything other than
-   `fully_autonomous_merge`, stop before the final freshness fetch and
+   If the recorded policy is `human_merge` or
+   `separate_merge_agent`, stop before the final freshness fetch and
    before `gh pr merge`. After the claim revalidation above, report or
    post a concise handoff summary with the PR number, branch, current
    HEAD from F2, the F2 readiness evidence, and the actor expected to

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -18,22 +18,31 @@ gate. The active claim must still use your current `{claim-id}`.
    or held by a different `{claim-id}` (even under the same agent ID),
    the claim was lost — report this and stop.
 2. Read the repository's recorded merge policy from repository
-   documentation that future IDD sessions read. If the recorded policy is
-   not `fully_autonomous_merge`, stop before the final freshness fetch and
-   before `gh pr merge`. This includes missing/unknown policies — unless
-   explicitly recorded as `fully_autonomous_merge`, apply the handoff or
-   hold path. After the claim revalidation above, report or post a concise
-   handoff summary with the PR number, branch, current HEAD from F2, the
-   F2 readiness evidence, and the actor expected to merge. For
-   `human_merge`, hand off to the human maintainer. For
+   documentation that future IDD sessions read. If no policy is
+   recorded, treat it as `fully_autonomous_merge` (distributed
+   default). If the recorded value is not one of
+   `fully_autonomous_merge`, `human_merge`, or
+   `separate_merge_agent`, treat it as an unknown merge policy:
+   stop, post a hold comment, and request maintainer decision.
+   Do not execute the final freshness fetch, `gh pr merge`, or F4
+   cleanup when the policy is unknown.
+
+   If the recorded policy is `human_merge` or
+   `separate_merge_agent`, stop before the final freshness fetch and
+   before `gh pr merge`. After the claim revalidation above, report or
+   post a concise handoff summary with the PR number, branch, current
+   HEAD from F2, the F2 readiness evidence, and the actor expected to
+   merge. For `human_merge`, hand off to the human maintainer. For
    `separate_merge_agent`, hand off to the configured merge-capable
    session; if that actor or resume condition is not recorded, hold for
    maintainer direction. Do not run the F3 merge command or F4 cleanup
    in the same worker session.
 
-   Only an explicitly recorded `fully_autonomous_merge` policy enables
-   the merge. This policy gate does not relax claim, freshness,
-   unresolved-thread, advisory, CI, or review requirements.
+   Only the `fully_autonomous_merge` policy path lets the same agent
+   session continue through the remaining F3 gates (recorded explicitly
+   or defaulted when policy is missing). This policy gate does not
+   relax claim, freshness, unresolved-thread, advisory, CI, or review
+   requirements.
 3. Immediately before executing the merge command, do one final live
    fetch using the **exact same activity-universe scope as E1 Step 1**
    (all review threads, review bodies, and regular PR comments,

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -18,23 +18,22 @@ gate. The active claim must still use your current `{claim-id}`.
    or held by a different `{claim-id}` (even under the same agent ID),
    the claim was lost — report this and stop.
 2. Read the repository's recorded merge policy from repository
-   documentation that future IDD sessions read. If no policy is
-   recorded, treat it as `fully_autonomous_merge`.
-
-   If the recorded policy is anything other than
-   `fully_autonomous_merge`, stop before the final freshness fetch and
-   before `gh pr merge`. After the claim revalidation above, report or
-   post a concise handoff summary with the PR number, branch, current
-   HEAD from F2, the F2 readiness evidence, and the actor expected to
-   merge. For `human_merge`, hand off to the human maintainer. For
+   documentation that future IDD sessions read. If the recorded policy is
+   not `fully_autonomous_merge`, stop before the final freshness fetch and
+   before `gh pr merge`. This includes missing/unknown policies — unless
+   explicitly recorded as `fully_autonomous_merge`, apply the handoff or
+   hold path. After the claim revalidation above, report or post a concise
+   handoff summary with the PR number, branch, current HEAD from F2, the
+   F2 readiness evidence, and the actor expected to merge. For
+   `human_merge`, hand off to the human maintainer. For
    `separate_merge_agent`, hand off to the configured merge-capable
    session; if that actor or resume condition is not recorded, hold for
    maintainer direction. Do not run the F3 merge command or F4 cleanup
    in the same worker session.
 
-   Only a recorded non-`fully_autonomous_merge` policy stops the merge.
-   This policy gate does not relax claim, freshness, unresolved-thread,
-   advisory, CI, or review requirements.
+   Only an explicitly recorded `fully_autonomous_merge` policy enables
+   the merge. This policy gate does not relax claim, freshness,
+   unresolved-thread, advisory, CI, or review requirements.
 3. Immediately before executing the merge command, do one final live
    fetch using the **exact same activity-universe scope as E1 Step 1**
    (all review threads, review bodies, and regular PR comments,

--- a/README.ja.md
+++ b/README.ja.md
@@ -76,9 +76,10 @@ IDD は Markdown ネイティブですが、依存関係なしではありませ
 必要なコマンドの詳細はワークフロードキュメントを参照してください。無人または
 マージ可能なエージェントへ認証情報を渡す前に、
 [Permissions and threat model](docs/permissions.md) も確認してください。
-配布時の merge policy 既定は `fully_autonomous_merge` です。worker
-credential をマージ手前で止めたい場合は、`human_merge` または
-`separate_merge_agent` へ明示的に opt-out してください。merge policy は
+分散デフォルトでは、worker session がマージを通して続行する
+(`fully_autonomous_merge`) ことを許可します。
+`human_merge` と `separate_merge_agent` では、マージ権限を worker session
+の外に置き、明示的な opt-in により選択します。merge policy は
 [Customizing IDD](docs/customization.md) で 1 つ選んで記録します。
 
 ### 5 分で読む導線

--- a/README.ja.md
+++ b/README.ja.md
@@ -76,11 +76,10 @@ IDD は Markdown ネイティブですが、依存関係なしではありませ
 必要なコマンドの詳細はワークフロードキュメントを参照してください。無人または
 マージ可能なエージェントへ認証情報を渡す前に、
 [Permissions and threat model](docs/permissions.md) も確認してください。
-リポジトリが `fully_autonomous_merge` へ明示 opt-in しない限り、通常の
-worker credential はマージ手前で止める前提にしてください。
-`human_merge` と `separate_merge_agent` では、マージ権限を worker session
-の外に置きます。merge policy は [Customizing IDD](docs/customization.md) で
-1 つ選んで記録します。
+配布時の merge policy 既定は `fully_autonomous_merge` です。worker
+credential をマージ手前で止めたい場合は、`human_merge` または
+`separate_merge_agent` へ明示的に opt-out してください。merge policy は
+[Customizing IDD](docs/customization.md) で 1 つ選んで記録します。
 
 ### 5 分で読む導線
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ To run the full loop, an agent needs:
 See the workflow docs for the detailed command contract. Review
 [Permissions and threat model](docs/permissions.md) before granting
 credentials to unattended or merge-capable agents.
-Treat normal worker credentials as stopping before merge unless the
-repository explicitly opts into `fully_autonomous_merge`.
-`human_merge` and `separate_merge_agent` keep merge authority outside
-the worker session. Choose and record one profile in
+The distributed merge default is `fully_autonomous_merge`; repositories
+that want workers to stop before merge should explicitly opt out to
+`human_merge` or `separate_merge_agent`.
+Choose and record one profile in
 [Customizing IDD](docs/customization.md).
 
 ### 5-Minute Reading Path

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ To run the full loop, an agent needs:
 See the workflow docs for the detailed command contract. Review
 [Permissions and threat model](docs/permissions.md) before granting
 credentials to unattended or merge-capable agents.
-The distributed merge default is `fully_autonomous_merge`; repositories
-that want workers to stop before merge should explicitly opt out to
-`human_merge` or `separate_merge_agent`.
-Choose and record one profile in
+The distributed default allows worker sessions to continue through merge
+(`fully_autonomous_merge`).
+`human_merge` and `separate_merge_agent` keep merge authority outside
+the worker session by explicit opt-in. Choose and record one profile in
 [Customizing IDD](docs/customization.md).
 
 ### 5-Minute Reading Path

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -10,17 +10,17 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface               | Default                                                                                      | Where to customize                                                                                                                                                                                                                           |
-| --------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Review policy         | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                                                                               |
-| Advisory reviewer     | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                                                                    |
-| Review threads        | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles.                                       |
-| Policy constants      | Distributed timing, wait, and loop defaults                                                  | Review [IDD policy constants](policy-constants.md) before changing claim ownership timing, advisory waits, CI waits, or critique-loop guardrails. Record the selected critique-loop profile in onboarding notes before unattended operation. |
-| Merge policy          | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and keep or customize the F3 handoff gate for non-autonomous profiles.                                                                 |
-| Stall recovery safety | 30-minute quiet-window evidence plus 24-hour stale-threshold ownership gate                  | Keep `idd-resume-stall.instructions.md` aligned with `idd-overview` claim rules, and customize both files together if local policy changes quiet-window or takeover timing.                                                                  |
-| CI commands           | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                                                                   |
-| Issue scope           | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.                                                  |
-| Orphan-first approval | No extra gate beyond orphan readiness checks                                                 | Keep `orphan-first-policy` as `none`, or opt in to `maintainer-approved` or `public-disabled` when public or community-submitted issues need an explicit maintainer approval layer before A0-O can select them.                              |
+| Surface               | Default                                                                                                    | Where to customize                                                                                                                                                                                                                           |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy         | GitHub Copilot advisory review                                                                             | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                                                                               |
+| Advisory reviewer     | Copilot wait and recovery gates                                                                            | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                                                                    |
+| Review threads        | Agents may resolve handled review threads under the fast default                                           | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles.                                       |
+| Policy constants      | Distributed timing, wait, and loop defaults                                                                | Review [IDD policy constants](policy-constants.md) before changing claim ownership timing, advisory waits, CI waits, or critique-loop guardrails. Record the selected critique-loop profile in onboarding notes before unattended operation. |
+| Merge policy          | Merge gates after CI, review, freshness, and claim checks; distributed default is `fully_autonomous_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and keep or customize the F3 handoff gate for non-autonomous profiles.                                                                 |
+| Stall recovery safety | 30-minute quiet-window evidence plus 24-hour stale-threshold ownership gate                                | Keep `idd-resume-stall.instructions.md` aligned with `idd-overview` claim rules, and customize both files together if local policy changes quiet-window or takeover timing.                                                                  |
+| CI commands           | Project-specific command rows in the overview file                                                         | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                                                                   |
+| Issue scope           | Roadmap-first discovery                                                                                    | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.                                                  |
+| Orphan-first approval | No extra gate beyond orphan readiness checks                                                               | Keep `orphan-first-policy` as `none`, or opt in to `maintainer-approved` or `public-disabled` when public or community-submitted issues need an explicit maintainer approval layer before A0-O can select them.                              |
 
 ## Review Policy
 
@@ -109,15 +109,15 @@ credential should be able to merge. Use
 [Permissions and threat model](permissions.md) to record exactly one
 merge policy profile:
 
-- `human_merge`: the safe default for public or OSS repositories. The
-  worker stops before merge and a maintainer runs the final merge after
-  reviewing the PR state.
+- `fully_autonomous_merge`: the distributed default. One agent session
+  can complete the final merge too, but only after the repository
+  accepts the credential risk and grants the right credentials.
+- `human_merge`: a conservative opt-out profile for public or OSS
+  repositories. The worker stops before merge and a maintainer runs the
+  final merge after reviewing the PR state.
 - `separate_merge_agent`: a worker handles claim, implementation, PR,
   and review fixes; a trusted merge-capable session runs only the final
   merge phase.
-- `fully_autonomous_merge`: one agent session can complete the final
-  merge too. Use this only as an explicit opt-in after the repository
-  accepts the credential risk.
 
 For `human_merge` and `separate_merge_agent`, keep merge-capable
 credentials out of normal worker sessions. The worker should hand off
@@ -126,9 +126,9 @@ ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
 future IDD sessions read, not only in local onboarding notes. The
-distributed merge phase treats a missing or unknown policy as
-`human_merge` and stops in F3 unless the recorded policy is exactly
-`fully_autonomous_merge`.
+distributed merge phase treats a missing policy as
+`fully_autonomous_merge` and stops with a maintainer hold when the
+recorded value is unknown.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the
 human maintainer. For `separate_merge_agent`, keep the worker stop gate

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -124,9 +124,8 @@ ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
 future IDD sessions read, not only in local onboarding notes. Missing
-or unknown policy is treated as `fully_autonomous_merge`; only an
-explicitly recorded `human_merge` or `separate_merge_agent` policy
-stops in F3.
+policy is treated as `fully_autonomous_merge`; unknown recorded policy
+values must stop with a maintainer hold until the policy is corrected.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the
 human maintainer. For `separate_merge_agent`, keep the worker stop gate

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -109,15 +109,13 @@ credential should be able to merge. Use
 [Permissions and threat model](permissions.md) to record exactly one
 merge policy profile:
 
-- `fully_autonomous_merge`: the distributed default. One agent session
-  can complete the final merge too, but only after the repository
-  accepts the credential risk and grants the right credentials.
-- `human_merge`: a conservative opt-out profile for public or OSS
-  repositories. The worker stops before merge and a maintainer runs the
-  final merge after reviewing the PR state.
+- `human_merge`: explicitly opt-out. Use this for public or OSS
+  repositories where a human maintainer must perform merge and cleanup.
 - `separate_merge_agent`: a worker handles claim, implementation, PR,
   and review fixes; a trusted merge-capable session runs only the final
   merge phase.
+- `fully_autonomous_merge`: the distributed default. One agent session
+  can complete merge. Standard for production repositories.
 
 For `human_merge` and `separate_merge_agent`, keep merge-capable
 credentials out of normal worker sessions. The worker should hand off
@@ -125,10 +123,10 @@ the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
-future IDD sessions read, not only in local onboarding notes. The
-distributed merge phase treats a missing policy as
-`fully_autonomous_merge` and stops with a maintainer hold when the
-recorded value is unknown.
+future IDD sessions read, not only in local onboarding notes. Missing
+or unknown policy is treated as `fully_autonomous_merge`; only an
+explicitly recorded `human_merge` or `separate_merge_agent` policy
+stops in F3.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the
 human maintainer. For `separate_merge_agent`, keep the worker stop gate

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -123,9 +123,10 @@ the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
-future IDD sessions read, not only in local onboarding notes. Missing
-policy is treated as `fully_autonomous_merge`; unknown recorded policy
-values must stop with a maintainer hold until the policy is corrected.
+future IDD sessions read, not only in local onboarding notes. Only an
+explicitly recorded `fully_autonomous_merge` enables autonomous merge;
+missing or unknown policy values must stop with a maintainer hold.
+Unknown recorded policy values must stop until the policy is corrected.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the
 human maintainer. For `separate_merge_agent`, keep the worker stop gate

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -34,11 +34,11 @@ production.
 Choose and record one merge policy in repository documentation before
 granting unattended agent credentials:
 
-| Merge policy             | Who may merge                                                            | Worker credential boundary                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | This conservative opt-out profile keeps worker sessions at the F3 handoff gate for human review.                     |
-| `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions stop at the default F3 gate; repository guidance names the merge-capable actor and resume condition. |
-| `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined only by explicit repository opt-in.                                  |
+| Merge policy             | Who may merge                                                            | Worker credential boundary                                                                                                   |
+| ------------------------ | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | This conservative opt-out profile keeps worker sessions at the F3 handoff gate for human review.                             |
+| `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions stop at the default F3 gate; repository guidance names the merge-capable actor and resume condition.         |
+| `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined when the repository keeps this distributed default or records it explicitly. |
 
 The distributed default is `fully_autonomous_merge` when merge policy is
 missing from repository docs. Public or OSS repositories that do not

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -36,16 +36,16 @@ granting unattended agent credentials:
 
 | Merge policy             | Who may merge                                                            | Worker credential boundary                                                                                           |
 | ------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | The default F3 gate stops worker sessions before merge and reports the PR state for human review.                    |
+| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | This conservative opt-out profile keeps worker sessions at the F3 handoff gate for human review.                     |
 | `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions stop at the default F3 gate; repository guidance names the merge-capable actor and resume condition. |
 | `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined only by explicit repository opt-in.                                  |
 
-Use `human_merge` as the safe default for public or OSS repositories.
-Treat `fully_autonomous_merge` as an explicit credential decision, never
-as an automatic consequence of installing IDD. The merge phase treats a
-missing or unknown merge policy as `human_merge`, and only a recorded
-`fully_autonomous_merge` policy lets the same agent session continue
-through F3 merge execution.
+The distributed default is `fully_autonomous_merge` when merge policy is
+missing from repository docs. Public or OSS repositories that do not
+want unattended merges should explicitly opt out to `human_merge` (or
+`separate_merge_agent`) before granting worker credentials. If a
+recorded merge policy value is unknown, the merge phase must stop with a
+maintainer hold until the policy is corrected.
 
 ## Phase Permissions
 

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -26,14 +26,6 @@ Record the selected values for `claim-stale-age` and
 `claim-heartbeat-interval` in repository onboarding notes before running
 unattended sessions.
 
-## Merge Policy Defaults
-
-| Policy default                      | Distributed value                                                                 | Owning surface                                                                                | Onboarding expectation                                                                     |
-| ----------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| Merge policy when missing           | `fully_autonomous_merge`                                                          | [Merge](../.github/instructions/idd-merge.instructions.md)                                    | Keep unless the repository explicitly opts out to `human_merge` or `separate_merge_agent`. |
-| Unknown merge policy handling       | Hold and require maintainer decision before F3 freshness fetch, merge, or cleanup | [Merge](../.github/instructions/idd-merge.instructions.md)                                    | Treat as a safety gate; unknown values must not silently route to another policy.          |
-| Non-autonomous merge-policy handoff | `human_merge` and `separate_merge_agent` stop before merge and hand off           | [Merge](../.github/instructions/idd-merge.instructions.md), [Customization](customization.md) | Keep unless the repository intentionally customizes F3 handoff behavior.                   |
-
 ## Advisory Review Defaults
 
 The distributed PR policy is `copilot-advisory`. These values apply to
@@ -61,6 +53,14 @@ files are edited.
 | Review-fix CI infra recovery           | Rerun once; hold if the infra-flaky or pre-existing failure persists          | [Review fix](../.github/instructions/idd-review-fix.instructions.md), [CI polling](../.github/instructions/idd-ci.instructions.md) | Keep unless E15 should use a different review-fix failure escalation path.                  |
 | Required check generation wait         | 10 min                                                                        | [CI polling](../.github/instructions/idd-ci.instructions.md)                                                                       | Keep unless branch protection or workflow dispatch latency is known to need another window. |
 | Missing workflow after generation wait | Hold and escalate to a maintainer                                             | [CI polling](../.github/instructions/idd-ci.instructions.md)                                                                       | Treat as a safety default; replacing it should be an explicit workflow change.              |
+
+## Merge Policy Defaults
+
+| Policy default               | Distributed value                                                           | Owning surface                                                                                                               | Onboarding expectation                                                                                                                              |
+| ---------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Merge policy when unrecorded | `fully_autonomous_merge` (distributed default for production repositories)  | [Merge](../.github/instructions/idd-merge.instructions.md), [Customization](customization.md), [Permissions](permissions.md) | Keep for production repositories; opt out to `human_merge` for public/OSS repositories, or customize to `separate_merge_agent` for split authority. |
+| Merge method                 | Merge commits (squash and rebase merge are disabled in repository settings) | [Merge](../.github/instructions/idd-merge.instructions.md), [GitHub Flow rules](./../.github/copilot-instructions.md)        | Keep unless the repository has a different merge strategy; customize only with branch protection changes.                                           |
+| Post-merge comment cleanup   | Minimize operational markers and resolved feedback after merge succeeds     | [Merge](../.github/instructions/idd-merge.instructions.md), audit scripts, and helper tooling                                | Keep as best-effort; safe cleanup candidates are enumerated in [comment minimization](idd-comment-minimization.md).                                 |
 
 ## Critique And Review Loop Defaults
 

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -26,6 +26,14 @@ Record the selected values for `claim-stale-age` and
 `claim-heartbeat-interval` in repository onboarding notes before running
 unattended sessions.
 
+## Merge Policy Defaults
+
+| Policy default                      | Distributed value                                                                 | Owning surface                                                                                | Onboarding expectation                                                                     |
+| ----------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Merge policy when missing           | `fully_autonomous_merge`                                                          | [Merge](../.github/instructions/idd-merge.instructions.md)                                    | Keep unless the repository explicitly opts out to `human_merge` or `separate_merge_agent`. |
+| Unknown merge policy handling       | Hold and require maintainer decision before F3 freshness fetch, merge, or cleanup | [Merge](../.github/instructions/idd-merge.instructions.md)                                    | Treat as a safety gate; unknown values must not silently route to another policy.          |
+| Non-autonomous merge-policy handoff | `human_merge` and `separate_merge_agent` stop before merge and hand off           | [Merge](../.github/instructions/idd-merge.instructions.md), [Customization](customization.md) | Keep unless the repository intentionally customizes F3 handoff behavior.                   |
+
 ## Advisory Review Defaults
 
 The distributed PR policy is `copilot-advisory`. These values apply to

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -19,16 +19,10 @@ gate. The active claim must still use your current `{claim-id}`.
    the claim was lost — report this and stop.
 2. Read the repository's recorded merge policy from repository
    documentation that future IDD sessions read. If no policy is
-   recorded, treat it as `fully_autonomous_merge` (distributed
-   default). If the recorded value is not one of
-   `fully_autonomous_merge`, `human_merge`, or
-   `separate_merge_agent`, treat it as an unknown merge policy:
-   stop, post a hold comment, and request maintainer decision.
-   Do not execute the final freshness fetch, `gh pr merge`, or F4
-   cleanup when the policy is unknown.
+   recorded, treat it as `fully_autonomous_merge`.
 
-   If the recorded policy is `human_merge` or
-   `separate_merge_agent`, stop before the final freshness fetch and
+   If the recorded policy is anything other than
+   `fully_autonomous_merge`, stop before the final freshness fetch and
    before `gh pr merge`. After the claim revalidation above, report or
    post a concise handoff summary with the PR number, branch, current
    HEAD from F2, the F2 readiness evidence, and the actor expected to
@@ -38,10 +32,9 @@ gate. The active claim must still use your current `{claim-id}`.
    maintainer direction. Do not run the F3 merge command or F4 cleanup
    in the same worker session.
 
-   Only a recorded `fully_autonomous_merge` policy lets the same agent
-   session continue through the remaining F3 gates. This policy gate
-   does not relax claim, freshness, unresolved-thread, advisory, CI, or
-   review requirements.
+   Only a recorded non-`fully_autonomous_merge` policy stops the merge.
+   This policy gate does not relax claim, freshness, unresolved-thread,
+   advisory, CI, or review requirements.
 3. Immediately before executing the merge command, do one final live
    fetch using the **exact same activity-universe scope as E1 Step 1**
    (all review threads, review bodies, and regular PR comments,

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -19,10 +19,16 @@ gate. The active claim must still use your current `{claim-id}`.
    the claim was lost — report this and stop.
 2. Read the repository's recorded merge policy from repository
    documentation that future IDD sessions read. If no policy is
-   recorded, treat it as `human_merge`.
+   recorded, treat it as `fully_autonomous_merge` (distributed
+   default). If the recorded value is not one of
+   `fully_autonomous_merge`, `human_merge`, or
+   `separate_merge_agent`, treat it as an unknown merge policy:
+   stop, post a hold comment, and request maintainer decision.
+   Do not execute the final freshness fetch, `gh pr merge`, or F4
+   cleanup when the policy is unknown.
 
-   If the recorded policy is anything other than
-   `fully_autonomous_merge`, stop before the final freshness fetch and
+   If the recorded policy is `human_merge` or
+   `separate_merge_agent`, stop before the final freshness fetch and
    before `gh pr merge`. After the claim revalidation above, report or
    post a concise handoff summary with the PR number, branch, current
    HEAD from F2, the F2 readiness evidence, and the actor expected to

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -18,22 +18,31 @@ gate. The active claim must still use your current `{claim-id}`.
    or held by a different `{claim-id}` (even under the same agent ID),
    the claim was lost — report this and stop.
 2. Read the repository's recorded merge policy from repository
-   documentation that future IDD sessions read. If the recorded policy is
-   not `fully_autonomous_merge`, stop before the final freshness fetch and
-   before `gh pr merge`. This includes missing/unknown policies — unless
-   explicitly recorded as `fully_autonomous_merge`, apply the handoff or
-   hold path. After the claim revalidation above, report or post a concise
-   handoff summary with the PR number, branch, current HEAD from F2, the
-   F2 readiness evidence, and the actor expected to merge. For
-   `human_merge`, hand off to the human maintainer. For
+   documentation that future IDD sessions read. If no policy is
+   recorded, treat it as `fully_autonomous_merge` (distributed
+   default). If the recorded value is not one of
+   `fully_autonomous_merge`, `human_merge`, or
+   `separate_merge_agent`, treat it as an unknown merge policy:
+   stop, post a hold comment, and request maintainer decision.
+   Do not execute the final freshness fetch, `gh pr merge`, or F4
+   cleanup when the policy is unknown.
+
+   If the recorded policy is `human_merge` or
+   `separate_merge_agent`, stop before the final freshness fetch and
+   before `gh pr merge`. After the claim revalidation above, report or
+   post a concise handoff summary with the PR number, branch, current
+   HEAD from F2, the F2 readiness evidence, and the actor expected to
+   merge. For `human_merge`, hand off to the human maintainer. For
    `separate_merge_agent`, hand off to the configured merge-capable
    session; if that actor or resume condition is not recorded, hold for
    maintainer direction. Do not run the F3 merge command or F4 cleanup
    in the same worker session.
 
-   Only an explicitly recorded `fully_autonomous_merge` policy enables
-   the merge. This policy gate does not relax claim, freshness,
-   unresolved-thread, advisory, CI, or review requirements.
+   Only the `fully_autonomous_merge` policy path lets the same agent
+   session continue through the remaining F3 gates (recorded explicitly
+   or defaulted when policy is missing). This policy gate does not
+   relax claim, freshness, unresolved-thread, advisory, CI, or review
+   requirements.
 3. Immediately before executing the merge command, do one final live
    fetch using the **exact same activity-universe scope as E1 Step 1**
    (all review threads, review bodies, and regular PR comments,

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -18,23 +18,22 @@ gate. The active claim must still use your current `{claim-id}`.
    or held by a different `{claim-id}` (even under the same agent ID),
    the claim was lost — report this and stop.
 2. Read the repository's recorded merge policy from repository
-   documentation that future IDD sessions read. If no policy is
-   recorded, treat it as `fully_autonomous_merge`.
-
-   If the recorded policy is anything other than
-   `fully_autonomous_merge`, stop before the final freshness fetch and
-   before `gh pr merge`. After the claim revalidation above, report or
-   post a concise handoff summary with the PR number, branch, current
-   HEAD from F2, the F2 readiness evidence, and the actor expected to
-   merge. For `human_merge`, hand off to the human maintainer. For
+   documentation that future IDD sessions read. If the recorded policy is
+   not `fully_autonomous_merge`, stop before the final freshness fetch and
+   before `gh pr merge`. This includes missing/unknown policies — unless
+   explicitly recorded as `fully_autonomous_merge`, apply the handoff or
+   hold path. After the claim revalidation above, report or post a concise
+   handoff summary with the PR number, branch, current HEAD from F2, the
+   F2 readiness evidence, and the actor expected to merge. For
+   `human_merge`, hand off to the human maintainer. For
    `separate_merge_agent`, hand off to the configured merge-capable
    session; if that actor or resume condition is not recorded, hold for
    maintainer direction. Do not run the F3 merge command or F4 cleanup
    in the same worker session.
 
-   Only a recorded non-`fully_autonomous_merge` policy stops the merge.
-   This policy gate does not relax claim, freshness, unresolved-thread,
-   advisory, CI, or review requirements.
+   Only an explicitly recorded `fully_autonomous_merge` policy enables
+   the merge. This policy gate does not relax claim, freshness,
+   unresolved-thread, advisory, CI, or review requirements.
 3. Immediately before executing the merge command, do one final live
    fetch using the **exact same activity-universe scope as E1 Step 1**
    (all review threads, review bodies, and regular PR comments,

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -62,9 +62,10 @@ IDD can run an end-to-end loop, but normal worker credentials should not
 imply merge authority. Before granting unattended credentials, choose
 `human_merge`, `separate_merge_agent`, or `fully_autonomous_merge` in
 `docs/customization.md` and `docs/permissions.md`, and record the choice
-in repository documentation that future IDD sessions read. Treat
-`fully_autonomous_merge` as the explicit opt-in; `human_merge` and
-`separate_merge_agent` require a handoff before F3.
+in repository documentation that future IDD sessions read. The
+distributed default is `fully_autonomous_merge`; choose `human_merge` or
+`separate_merge_agent` as explicit opt-out profiles when normal worker
+sessions must hand off before F3.
 
 ## Placeholders
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -10,17 +10,17 @@ behavior change too.
 
 ## Customization Surfaces
 
-| Surface               | Default                                                                                      | Where to customize                                                                                                                                                                                                                           |
-| --------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Review policy         | GitHub Copilot advisory review                                                               | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                                                                               |
-| Advisory reviewer     | Copilot wait and recovery gates                                                              | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                                                                    |
-| Review threads        | Agents may resolve handled review threads under the fast default                             | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles.                                       |
-| Policy constants      | Distributed timing, wait, and loop defaults                                                  | Review [IDD policy constants](policy-constants.md) before changing claim ownership timing, advisory waits, CI waits, or critique-loop guardrails. Record the selected critique-loop profile in onboarding notes before unattended operation. |
-| Merge policy          | Merge gates after CI, review, freshness, and claim checks; safe OSS default is `human_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and keep or customize the F3 handoff gate for non-autonomous profiles.                                                                 |
-| Stall recovery safety | 30-minute quiet-window evidence plus 24-hour stale-threshold ownership gate                  | Keep `idd-resume-stall.instructions.md` aligned with `idd-overview` claim rules, and customize both files together if local policy changes quiet-window or takeover timing.                                                                  |
-| CI commands           | Project-specific command rows in the overview file                                           | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                                                                   |
-| Issue scope           | Roadmap-first discovery                                                                      | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.                                                  |
-| Orphan-first approval | No extra gate beyond orphan readiness checks                                                 | Keep `orphan-first-policy` as `none`, or opt in to `maintainer-approved` or `public-disabled` when public or community-submitted issues need an explicit maintainer approval layer before A0-O can select them.                              |
+| Surface               | Default                                                                                                    | Where to customize                                                                                                                                                                                                                           |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Review policy         | GitHub Copilot advisory review                                                                             | Choose a profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the listed phase files for any non-default profile.                                                                                               |
+| Advisory reviewer     | Copilot wait and recovery gates                                                                            | For `human-required`, `no-advisory`, or `external-bot`, update the review-fix, pre-merge, merge, advisory-wait, snapshot, and triage files named by the selected profile.                                                                    |
+| Review threads        | Agents may resolve handled review threads under the fast default                                           | Choose a thread-resolution profile in [IDD review policy profiles](idd-review-policy-profiles.md), then edit the snapshot, triage, review-fix, pre-merge, and merge phase files for stricter profiles.                                       |
+| Policy constants      | Distributed timing, wait, and loop defaults                                                                | Review [IDD policy constants](policy-constants.md) before changing claim ownership timing, advisory waits, CI waits, or critique-loop guardrails. Record the selected critique-loop profile in onboarding notes before unattended operation. |
+| Merge policy          | Merge gates after CI, review, freshness, and claim checks; distributed default is `fully_autonomous_merge` | Review [Permissions and threat model](permissions.md), record the selected policy in repository docs, and keep or customize the F3 handoff gate for non-autonomous profiles.                                                                 |
+| Stall recovery safety | 30-minute quiet-window evidence plus 24-hour stale-threshold ownership gate                                | Keep `idd-resume-stall.instructions.md` aligned with `idd-overview` claim rules, and customize both files together if local policy changes quiet-window or takeover timing.                                                                  |
+| CI commands           | Project-specific command rows in the overview file                                                         | Set `fix-validate`, `pre-push-validate`, `post-fix-validate`, and `install-deps` in `.github/instructions/idd-overview.instructions.md` during onboarding.                                                                                   |
+| Issue scope           | Roadmap-first discovery                                                                                    | Keep `issue-scope` as `roadmap` for roadmap-scoped work, or deliberately choose `orphan-first` when the repository wants unblocked orphan issues to be considered before roadmap traversal.                                                  |
+| Orphan-first approval | No extra gate beyond orphan readiness checks                                                               | Keep `orphan-first-policy` as `none`, or opt in to `maintainer-approved` or `public-disabled` when public or community-submitted issues need an explicit maintainer approval layer before A0-O can select them.                              |
 
 ## Review Policy
 
@@ -109,15 +109,15 @@ credential should be able to merge. Use
 [Permissions and threat model](permissions.md) to record exactly one
 merge policy profile:
 
-- `human_merge`: the safe default for public or OSS repositories. The
-  worker stops before merge and a maintainer runs the final merge after
-  reviewing the PR state.
+- `fully_autonomous_merge`: the distributed default. One agent session
+  can complete the final merge too, but only after the repository
+  accepts the credential risk and grants the right credentials.
+- `human_merge`: a conservative opt-out profile for public or OSS
+  repositories. The worker stops before merge and a maintainer runs the
+  final merge after reviewing the PR state.
 - `separate_merge_agent`: a worker handles claim, implementation, PR,
   and review fixes; a trusted merge-capable session runs only the final
   merge phase.
-- `fully_autonomous_merge`: one agent session can complete the final
-  merge too. Use this only as an explicit opt-in after the repository
-  accepts the credential risk.
 
 For `human_merge` and `separate_merge_agent`, keep merge-capable
 credentials out of normal worker sessions. The worker should hand off
@@ -126,9 +126,9 @@ ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
 future IDD sessions read, not only in local onboarding notes. The
-distributed merge phase treats a missing or unknown policy as
-`human_merge` and stops in F3 unless the recorded policy is exactly
-`fully_autonomous_merge`.
+distributed merge phase treats a missing policy as
+`fully_autonomous_merge` and stops with a maintainer hold when the
+recorded value is unknown.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the
 human maintainer. For `separate_merge_agent`, keep the worker stop gate

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -124,9 +124,8 @@ ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
 future IDD sessions read, not only in local onboarding notes. Missing
-or unknown policy is treated as `fully_autonomous_merge`; only an
-explicitly recorded `human_merge` or `separate_merge_agent` policy
-stops in F3.
+policy is treated as `fully_autonomous_merge`; unknown recorded policy
+values must stop with a maintainer hold until the policy is corrected.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the
 human maintainer. For `separate_merge_agent`, keep the worker stop gate

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -109,15 +109,13 @@ credential should be able to merge. Use
 [Permissions and threat model](permissions.md) to record exactly one
 merge policy profile:
 
-- `fully_autonomous_merge`: the distributed default. One agent session
-  can complete the final merge too, but only after the repository
-  accepts the credential risk and grants the right credentials.
-- `human_merge`: a conservative opt-out profile for public or OSS
-  repositories. The worker stops before merge and a maintainer runs the
-  final merge after reviewing the PR state.
+- `human_merge`: explicitly opt-out. Use this for public or OSS
+  repositories where a human maintainer must perform merge and cleanup.
 - `separate_merge_agent`: a worker handles claim, implementation, PR,
   and review fixes; a trusted merge-capable session runs only the final
   merge phase.
+- `fully_autonomous_merge`: the distributed default. One agent session
+  can complete merge. Standard for production repositories.
 
 For `human_merge` and `separate_merge_agent`, keep merge-capable
 credentials out of normal worker sessions. The worker should hand off
@@ -125,10 +123,10 @@ the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
-future IDD sessions read, not only in local onboarding notes. The
-distributed merge phase treats a missing policy as
-`fully_autonomous_merge` and stops with a maintainer hold when the
-recorded value is unknown.
+future IDD sessions read, not only in local onboarding notes. Missing
+or unknown policy is treated as `fully_autonomous_merge`; only an
+explicitly recorded `human_merge` or `separate_merge_agent` policy
+stops in F3.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the
 human maintainer. For `separate_merge_agent`, keep the worker stop gate

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -123,9 +123,10 @@ the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
-future IDD sessions read, not only in local onboarding notes. Missing
-policy is treated as `fully_autonomous_merge`; unknown recorded policy
-values must stop with a maintainer hold until the policy is corrected.
+future IDD sessions read, not only in local onboarding notes. Only an
+explicitly recorded `fully_autonomous_merge` enables autonomous merge;
+missing or unknown policy values must stop with a maintainer hold.
+Unknown recorded policy values must stop until the policy is corrected.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the
 human maintainer. For `separate_merge_agent`, keep the worker stop gate

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -34,11 +34,11 @@ production.
 Choose and record one merge policy in repository documentation before
 granting unattended agent credentials:
 
-| Merge policy             | Who may merge                                                            | Worker credential boundary                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | This conservative opt-out profile keeps worker sessions at the F3 handoff gate for human review.                     |
-| `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions stop at the default F3 gate; repository guidance names the merge-capable actor and resume condition. |
-| `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined only by explicit repository opt-in.                                  |
+| Merge policy             | Who may merge                                                            | Worker credential boundary                                                                                                   |
+| ------------------------ | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | This conservative opt-out profile keeps worker sessions at the F3 handoff gate for human review.                             |
+| `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions stop at the default F3 gate; repository guidance names the merge-capable actor and resume condition.         |
+| `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined when the repository keeps this distributed default or records it explicitly. |
 
 The distributed default is `fully_autonomous_merge` when merge policy is
 missing from repository docs. Public or OSS repositories that do not

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -36,16 +36,16 @@ granting unattended agent credentials:
 
 | Merge policy             | Who may merge                                                            | Worker credential boundary                                                                                           |
 | ------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | The default F3 gate stops worker sessions before merge and reports the PR state for human review.                    |
+| `human_merge`            | A human maintainer performs the final merge and any post-merge cleanup.  | This conservative opt-out profile keeps worker sessions at the F3 handoff gate for human review.                     |
 | `separate_merge_agent`   | A trusted merge-capable session performs only the final merge phase.     | Worker sessions stop at the default F3 gate; repository guidance names the merge-capable actor and resume condition. |
 | `fully_autonomous_merge` | One trusted agent session may complete the merge and cleanup phases too. | Worker and merge-capable authority are combined only by explicit repository opt-in.                                  |
 
-Use `human_merge` as the safe default for public or OSS repositories.
-Treat `fully_autonomous_merge` as an explicit credential decision, never
-as an automatic consequence of installing IDD. The merge phase treats a
-missing or unknown merge policy as `human_merge`, and only a recorded
-`fully_autonomous_merge` policy lets the same agent session continue
-through F3 merge execution.
+The distributed default is `fully_autonomous_merge` when merge policy is
+missing from repository docs. Public or OSS repositories that do not
+want unattended merges should explicitly opt out to `human_merge` (or
+`separate_merge_agent`) before granting worker credentials. If a
+recorded merge policy value is unknown, the merge phase must stop with a
+maintainer hold until the policy is corrected.
 
 ## Phase Permissions
 

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -26,14 +26,6 @@ Record the selected values for `claim-stale-age` and
 `claim-heartbeat-interval` in repository onboarding notes before running
 unattended sessions.
 
-## Merge Policy Defaults
-
-| Policy default                      | Distributed value                                                                 | Owning surface                                                                                | Onboarding expectation                                                                     |
-| ----------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| Merge policy when missing           | `fully_autonomous_merge`                                                          | [Merge](../.github/instructions/idd-merge.instructions.md)                                    | Keep unless the repository explicitly opts out to `human_merge` or `separate_merge_agent`. |
-| Unknown merge policy handling       | Hold and require maintainer decision before F3 freshness fetch, merge, or cleanup | [Merge](../.github/instructions/idd-merge.instructions.md)                                    | Treat as a safety gate; unknown values must not silently route to another policy.          |
-| Non-autonomous merge-policy handoff | `human_merge` and `separate_merge_agent` stop before merge and hand off           | [Merge](../.github/instructions/idd-merge.instructions.md), [Customization](customization.md) | Keep unless the repository intentionally customizes F3 handoff behavior.                   |
-
 ## Advisory Review Defaults
 
 The distributed PR policy is `copilot-advisory`. These values apply to
@@ -61,6 +53,14 @@ files are edited.
 | Review-fix CI infra recovery           | Rerun once; hold if the infra-flaky or pre-existing failure persists          | [Review fix](../.github/instructions/idd-review-fix.instructions.md), [CI polling](../.github/instructions/idd-ci.instructions.md) | Keep unless E15 should use a different review-fix failure escalation path.                  |
 | Required check generation wait         | 10 min                                                                        | [CI polling](../.github/instructions/idd-ci.instructions.md)                                                                       | Keep unless branch protection or workflow dispatch latency is known to need another window. |
 | Missing workflow after generation wait | Hold and escalate to a maintainer                                             | [CI polling](../.github/instructions/idd-ci.instructions.md)                                                                       | Treat as a safety default; replacing it should be an explicit workflow change.              |
+
+## Merge Policy Defaults
+
+| Policy default               | Distributed value                                                           | Owning surface                                                                                                               | Onboarding expectation                                                                                                                              |
+| ---------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Merge policy when unrecorded | `fully_autonomous_merge` (distributed default for production repositories)  | [Merge](../.github/instructions/idd-merge.instructions.md), [Customization](customization.md), [Permissions](permissions.md) | Keep for production repositories; opt out to `human_merge` for public/OSS repositories, or customize to `separate_merge_agent` for split authority. |
+| Merge method                 | Merge commits (squash and rebase merge are disabled in repository settings) | [Merge](../.github/instructions/idd-merge.instructions.md), [GitHub Flow rules](./../.github/copilot-instructions.md)        | Keep unless the repository has a different merge strategy; customize only with branch protection changes.                                           |
+| Post-merge comment cleanup   | Minimize operational markers and resolved feedback after merge succeeds     | [Merge](../.github/instructions/idd-merge.instructions.md), audit scripts, and helper tooling                                | Keep as best-effort; safe cleanup candidates are enumerated in [comment minimization](idd-comment-minimization.md).                                 |
 
 ## Critique And Review Loop Defaults
 

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -26,6 +26,14 @@ Record the selected values for `claim-stale-age` and
 `claim-heartbeat-interval` in repository onboarding notes before running
 unattended sessions.
 
+## Merge Policy Defaults
+
+| Policy default                      | Distributed value                                                                 | Owning surface                                                                                | Onboarding expectation                                                                     |
+| ----------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Merge policy when missing           | `fully_autonomous_merge`                                                          | [Merge](../.github/instructions/idd-merge.instructions.md)                                    | Keep unless the repository explicitly opts out to `human_merge` or `separate_merge_agent`. |
+| Unknown merge policy handling       | Hold and require maintainer decision before F3 freshness fetch, merge, or cleanup | [Merge](../.github/instructions/idd-merge.instructions.md)                                    | Treat as a safety gate; unknown values must not silently route to another policy.          |
+| Non-autonomous merge-policy handoff | `human_merge` and `separate_merge_agent` stop before merge and hand off           | [Merge](../.github/instructions/idd-merge.instructions.md), [Customization](customization.md) | Keep unless the repository intentionally customizes F3 handoff behavior.                   |
+
 ## Advisory Review Defaults
 
 The distributed PR policy is `copilot-advisory`. These values apply to


### PR DESCRIPTION
## Summary\n\n- switches the distributed merge-policy default to `fully_autonomous_merge` across merge instructions, customization/permissions docs, policy constants, and README surfaces\n- keeps `human_merge` and `separate_merge_agent` as explicit handoff profiles instead of default behavior\n- clarifies F3 behavior for missing vs unknown merge-policy values (missing defaults to fully autonomous; unknown values hold for maintainer decision)\n\nCloses #208\n\n## Follow-up\n\n- #209 updates onboarding wording to keep the opt-out flow explicit during initial setup\n\n## Background / rationale\n\nThis change focuses on policy semantics and consistency for the distributed default. It intentionally leaves onboarding-flow phrasing to #209 so this PR stays scoped to merge-policy behavior and reference surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated merge policy defaults across README and documentation files to reflect new behavior
  * Clarified that repositories must explicitly opt out to enable conservative merge behavior before granting worker credentials
  * Added "Merge Policy Defaults" section documenting default behavior and handling of unknown or missing merge policies
  * Updated merge-phase flow to require maintainer review when merge policy cannot be determined

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/210)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->