### PR TITLE
docs(onboarding): clarify command placeholder contracts

### DIFF
--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -342,6 +342,10 @@ If **fix-validate** or **post-fix-validate** produces file changes
 (auto-fixes), stage and commit those changes before any push, rebase, or
 next step that requires no uncommitted changes.
 
+`install-deps` must be idempotent. Re-running it in fresh, reused, or
+recreated worktrees must not require manual cleanup and should not leave
+unexpected tracked changes.
+
 **Tool availability**: the commands above are required when the listed
 tools are present. In repositories without Node.js or a specific tool,
 replace that command with `true` — the same no-op convention used by

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -82,6 +82,9 @@ are installed:
 - **Manual `git worktree add` or WorkTrunk without a hook**: `cd` into
   the newly created worktree, then run **install-deps**.
 
+`install-deps` must remain safe to rerun during retries, takeovers, and
+recreated worktrees without manual cleanup.
+
 ## B2 — Create and refine plan
 
 Draft an implementation plan and post it as an issue comment. Then run a

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -150,13 +150,20 @@ contract agents follow. During onboarding, replace the template
 placeholders with the target repository's commands:
 
 - `fix-validate`: auto-fix and verify before each commit.
-- `pre-push-validate`: verify before pushing, without auto-fix.
+- `pre-push-validate`: verify before pushing, without auto-fix, and keep
+  it non-mutating for tracked files.
 - `post-fix-validate`: auto-fix and fully verify after review fixes.
-- `install-deps`: prepare dependencies in a fresh worktree.
+- `install-deps`: prepare dependencies in a fresh worktree. Keep this
+  command idempotent so retries, takeovers, and recreated worktrees can
+  rerun it safely without manual cleanup.
 
 Use `true` only when a command is intentionally a no-op for the target
 repository. If validation is expensive, prefer an explicit lightweight
 command over leaving the surface ambiguous.
+
+When WorkTrunk uses a pre-start install hook, that hook may satisfy
+`install-deps` automatically. The underlying command contract is the
+same: repeated runs must stay safe and predictable.
 
 ## Issue Scope
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -343,6 +343,10 @@ If **fix-validate** or **post-fix-validate** produces file changes
 (auto-fixes), stage and commit those changes before any push, rebase, or
 next step that requires no uncommitted changes.
 
+`install-deps` must be idempotent. Re-running it in fresh, reused, or
+recreated worktrees must not require manual cleanup and should not leave
+unexpected tracked changes.
+
 **Tool availability**: the commands above are required when the listed
 tools are present. In repositories without a specific tool, replace
 that command with `true` — the same no-op convention used by

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -82,6 +82,9 @@ are installed:
 - **Manual `git worktree add` or WorkTrunk without a hook**: `cd` into
   the newly created worktree, then run **install-deps**.
 
+`install-deps` must remain safe to rerun during retries, takeovers, and
+recreated worktrees without manual cleanup.
+
 ## B2 — Create and refine plan
 
 Draft an implementation plan and post it as an issue comment. Then run a

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -103,10 +103,10 @@ request missing values.
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | `{{REPO_NAME}}`                  | The repository's short name. Used in worktree path examples.                                                                                                                                                   | `my-app`                                                            |
 | `{{PROJECT_MARKER_PREFIX}}`      | A short, URL-safe prefix unique to this project. Used in HTML comment markers embedded in issue bodies to track roadmap and blocked-by state. The same prefix must be used consistently throughout all issues. | `my-app`                                                            |
-| `{{FIX_VALIDATE_COMMANDS}}`      | Commands that auto-fix linting and verify the result. Run before every commit.                                                                                                                                 | `npm run lint:fix && npm run lint`                                  |
-| `{{PRE_PUSH_VALIDATE_COMMANDS}}` | Commands that verify correctness before a push (no auto-fix — code must already be clean). Typically includes build and test.                                                                                  | `npm run lint && npm run build && npm run test`                     |
-| `{{POST_FIX_VALIDATE_COMMANDS}}` | Commands that auto-fix and fully verify after review fixes. Usually a superset of the other two.                                                                                                               | `npm run lint:fix && npm run lint && npm run build && npm run test` |
-| `{{INSTALL_DEPS_COMMAND}}`       | Command to install dependencies in a fresh worktree.                                                                                                                                                           | `npm install`                                                       |
+| `{{FIX_VALIDATE_COMMANDS}}`      | Commands that may auto-fix linting/formatting and verify the result. Run before every commit. If files change, stage and commit those changes before continuing.                                               | `npm run lint:fix && npm run lint`                                  |
+| `{{PRE_PUSH_VALIDATE_COMMANDS}}` | Commands that verify correctness before a push and do not mutate tracked files. Typically includes lint, build, and test.                                                                                      | `npm run lint && npm run build && npm run test`                     |
+| `{{POST_FIX_VALIDATE_COMMANDS}}` | Commands that may auto-fix and fully verify after review fixes. Usually a superset of the other two. If files change, stage and commit those changes before push/rebase.                                       | `npm run lint:fix && npm run lint && npm run build && npm run test` |
+| `{{INSTALL_DEPS_COMMAND}}`       | Command to install dependencies in a fresh worktree. It must be idempotent and safe to rerun in fresh, reused, or recreated worktrees without manual cleanup.                                                  | `npm install`                                                       |
 
 > **No-op substitution**: any command that is not applicable to your
 > project can be set to `true`. For example, a repository without a
@@ -114,6 +114,9 @@ request missing values.
 > The same applies to validation commands in projects that do not use
 > the listed tools — set the relevant placeholder to `true` to skip
 > that step without breaking the workflow.
+>
+> `{{INSTALL_DEPS_COMMAND}}` must be safe to run repeatedly across
+> retries, takeovers, and recreated worktrees.
 
 ### Notes on `{{PROJECT_MARKER_PREFIX}}`
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -150,13 +150,20 @@ contract agents follow. During onboarding, replace the template
 placeholders with the target repository's commands:
 
 - `fix-validate`: auto-fix and verify before each commit.
-- `pre-push-validate`: verify before pushing, without auto-fix.
+- `pre-push-validate`: verify before pushing, without auto-fix, and keep
+  it non-mutating for tracked files.
 - `post-fix-validate`: auto-fix and fully verify after review fixes.
-- `install-deps`: prepare dependencies in a fresh worktree.
+- `install-deps`: prepare dependencies in a fresh worktree. Keep this
+  command idempotent so retries, takeovers, and recreated worktrees can
+  rerun it safely without manual cleanup.
 
 Use `true` only when a command is intentionally a no-op for the target
 repository. If validation is expensive, prefer an explicit lightweight
 command over leaving the surface ambiguous.
+
+When WorkTrunk uses a pre-start install hook, that hook may satisfy
+`install-deps` automatically. The underlying command contract is the
+same: repeated runs must stay safe and predictable.
 
 ## Issue Scope
 


### PR DESCRIPTION
## Summary
- clarify command placeholder contracts in onboarding and customization docs
- document that fix-validate and post-fix-validate may mutate files and require committing generated changes
- document that pre-push-validate must remain non-mutating and install-deps must be idempotent across retries/takeovers/recreated worktrees
- mirror instruction updates to template instruction files to keep source/template sync

## Why
Issue #191 requests explicit operational semantics for project command placeholders so onboarding and phase behavior stay predictable across retries and claim takeovers.

Closes #191
