### PR TITLE
docs: make onboarding merge policy opt-out

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -123,9 +123,9 @@ the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
-future IDD sessions read, not only in local onboarding notes. When no
-policy is recorded, the distributed default is `fully_autonomous_merge`.
-Unknown recorded policy values must stop until the policy is corrected.
+future IDD sessions read, not only in local onboarding notes. Missing
+policy defaults to `fully_autonomous_merge`; unknown recorded policy
+values must stop with a maintainer hold until the policy is corrected.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the
 human maintainer. For `separate_merge_agent`, keep the worker stop gate

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,8 @@ evidence before agents reach PR review and merge phases.
 Keep this decision explicit. Review policy changes are workflow changes,
 not just documentation preferences.
 
+### Merge policy
+
 Before unattended runs begin, choose and record a merge policy with
 `fully_autonomous_merge` preselected as the distributed default, and ask
 whether the operator wants an explicit opt-out to `human_merge` or

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,11 +43,12 @@ not just documentation preferences.
 
 Before unattended runs begin, choose and record merge policy with
 `fully_autonomous_merge` preselected as the distributed default, and ask
-whether the operator wants to opt out to `human_merge` or
-`separate_merge_agent`. Keep the selected policy in repository
-documentation that future IDD sessions read. Missing policy defaults to
-`fully_autonomous_merge`; unknown recorded policy values must stop with
-a maintainer hold until corrected.
+whether the operator wants an explicit opt-out to `human_merge` or
+prefers `separate_merge_agent` as a non-default split-authority profile.
+Keep the selected policy in repository documentation that future IDD
+sessions read. Missing policy defaults to `fully_autonomous_merge`;
+unknown recorded policy values must stop with a maintainer hold until
+corrected.
 
 ## 3. Prepare Issues
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,7 +41,7 @@ evidence before agents reach PR review and merge phases.
 Keep this decision explicit. Review policy changes are workflow changes,
 not just documentation preferences.
 
-Before unattended runs begin, choose and record merge policy with
+Before unattended runs begin, choose and record a merge policy with
 `fully_autonomous_merge` preselected as the distributed default, and ask
 whether the operator wants an explicit opt-out to `human_merge` or
 prefers `separate_merge_agent` as a non-default split-authority profile.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,14 @@ evidence before agents reach PR review and merge phases.
 Keep this decision explicit. Review policy changes are workflow changes,
 not just documentation preferences.
 
+Before unattended runs begin, choose and record merge policy with
+`fully_autonomous_merge` preselected as the distributed default, and ask
+whether the operator wants to opt out to `human_merge` or
+`separate_merge_agent`. Keep the selected policy in repository
+documentation that future IDD sessions read. Missing policy defaults to
+`fully_autonomous_merge`; unknown recorded policy values must stop with
+a maintainer hold until corrected.
+
 ## 3. Prepare Issues
 
 IDD works from GitHub Issues. At least one issue should be ready before

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -42,8 +42,10 @@ granting unattended agent credentials:
 
 The distributed default is `fully_autonomous_merge` when merge policy is
 missing from repository docs. Public or OSS repositories that do not
-want unattended merges should explicitly opt out to `human_merge` (or
-`separate_merge_agent`) before granting worker credentials. If a
+want unattended merges should explicitly opt out to `human_merge` before
+granting worker credentials. `separate_merge_agent` remains a distinct
+non-default split-authority profile for repositories that want a
+dedicated merge-capable session. If a
 recorded merge policy value is unknown, the merge phase must stop with a
 maintainer hold until the policy is corrected.
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -45,9 +45,9 @@ missing from repository docs. Public or OSS repositories that do not
 want unattended merges should explicitly opt out to `human_merge` before
 granting worker credentials. `separate_merge_agent` remains a distinct
 non-default split-authority profile for repositories that want a
-dedicated merge-capable session. If a
-recorded merge policy value is unknown, the merge phase must stop with a
-maintainer hold until the policy is corrected.
+dedicated merge-capable session. If a recorded merge policy value is
+unknown, the merge phase must stop with a maintainer hold until the
+policy is corrected.
 
 ## Phase Permissions
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -61,8 +61,13 @@ trusted agent session merge authority to continue through merge execution
 in F3. Ask whether the operator wants an explicit opt-out to
 `human_merge` before unattended runs begin, or prefers
 `separate_merge_agent` as a non-default split-authority handoff profile.
-`human_merge` and `separate_merge_agent` always stop before merge by
-design, even if recorded. Record the selected policy in repository
+For public/OSS repositories, or whenever human validation is required
+before merge, recommend an explicit opt-out to `human_merge` before
+granting unattended credentials. Normal worker sessions stop before
+merge under `human_merge` and `separate_merge_agent`; only the trusted
+merge-capable session configured for `separate_merge_agent` continues
+past the default F3 gate after the required customization. Record the
+selected policy in repository
 documentation that future IDD sessions read. Missing policy defaults to
 `fully_autonomous_merge`; unknown recorded policy values must stop with
 a maintainer hold until corrected.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -58,11 +58,14 @@ Also choose a merge policy before the first unattended run:
 `human_merge`, `separate_merge_agent`, or `fully_autonomous_merge`.
 The distributed default is `fully_autonomous_merge`, which gives one
 trusted agent session merge authority to continue through merge execution
-in F3. `human_merge` and `separate_merge_agent` always stop before the
-merge phase by design, even if recorded. Public repositories or those
-requiring human validation should explicitly opt out to `human_merge`.
-Record the selected policy in repository documentation that future IDD
-sessions read.
+in F3. Ask whether the operator wants an explicit opt-out to
+`human_merge` before unattended runs begin, or prefers
+`separate_merge_agent` as a non-default split-authority handoff profile.
+`human_merge` and `separate_merge_agent` always stop before merge by
+design, even if recorded. Record the selected policy in repository
+documentation that future IDD sessions read. Missing policy defaults to
+`fully_autonomous_merge`; unknown recorded policy values must stop with
+a maintainer hold until corrected.
 
 If you keep the distributed advisory/CI defaults, record that choice
 alongside the merge policy and point operators to
@@ -301,15 +304,20 @@ merge phase files listed in `docs/idd-review-policy-profiles.md`.
 
 Also confirm the operator's merge policy:
 `human_merge`, `separate_merge_agent`, or `fully_autonomous_merge`.
-Record the selected policy in repository documentation, such as a local
-policy section in the imported docs or agent entry files. The distributed
-default is `fully_autonomous_merge`. For `human_merge` (explicit opt-out
-from default) or `separate_merge_agent`, do not grant merge-capable
-credentials to normal worker sessions. Keep the default F3 stop gate for
-worker sessions, and record the human maintainer or separate
-merge-capable actor plus the resume condition. Customize the local F3
-gate only when a repository needs that separate merge-capable actor to
-continue through merge execution under repository-specific guidance.
+Preselect `fully_autonomous_merge` as the distributed default and ask
+whether the operator wants an explicit opt-out to `human_merge` before
+unattended runs begin, or prefers `separate_merge_agent` as a
+non-default split-authority profile. Record the selected policy in
+repository documentation, such as a local policy section in the imported
+docs or agent entry files. For `human_merge` and
+`separate_merge_agent`, do not grant merge-capable credentials to
+normal worker sessions. Keep the default F3 stop gate for worker
+sessions, and record the human maintainer or separate merge-capable
+actor plus the resume condition. Missing policy defaults to
+`fully_autonomous_merge`; unknown recorded policy values must stop with
+a maintainer hold until corrected. Customize the local F3 gate only when
+the repository needs that separate merge-capable actor to continue
+through merge execution under repository-specific guidance.
 
 Confirm claim timing policy defaults from `docs/policy-constants.md` as
 well: `claim-stale-age` (default `24 h`) and

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -123,9 +123,9 @@ the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
-future IDD sessions read, not only in local onboarding notes. When no
-policy is recorded, the distributed default is `fully_autonomous_merge`.
-Unknown recorded policy values must stop until the policy is corrected.
+future IDD sessions read, not only in local onboarding notes. Missing
+policy defaults to `fully_autonomous_merge`; unknown recorded policy
+values must stop with a maintainer hold until the policy is corrected.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the
 human maintainer. For `separate_merge_agent`, keep the worker stop gate

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -41,6 +41,8 @@ evidence before agents reach PR review and merge phases.
 Keep this decision explicit. Review policy changes are workflow changes,
 not just documentation preferences.
 
+### Merge policy
+
 Before unattended runs begin, choose and record a merge policy with
 `fully_autonomous_merge` preselected as the distributed default, and ask
 whether the operator wants an explicit opt-out to `human_merge` or

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -43,11 +43,12 @@ not just documentation preferences.
 
 Before unattended runs begin, choose and record merge policy with
 `fully_autonomous_merge` preselected as the distributed default, and ask
-whether the operator wants to opt out to `human_merge` or
-`separate_merge_agent`. Keep the selected policy in repository
-documentation that future IDD sessions read. Missing policy defaults to
-`fully_autonomous_merge`; unknown recorded policy values must stop with
-a maintainer hold until corrected.
+whether the operator wants an explicit opt-out to `human_merge` or
+prefers `separate_merge_agent` as a non-default split-authority profile.
+Keep the selected policy in repository documentation that future IDD
+sessions read. Missing policy defaults to `fully_autonomous_merge`;
+unknown recorded policy values must stop with a maintainer hold until
+corrected.
 
 ## 3. Prepare Issues
 

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -41,7 +41,7 @@ evidence before agents reach PR review and merge phases.
 Keep this decision explicit. Review policy changes are workflow changes,
 not just documentation preferences.
 
-Before unattended runs begin, choose and record merge policy with
+Before unattended runs begin, choose and record a merge policy with
 `fully_autonomous_merge` preselected as the distributed default, and ask
 whether the operator wants an explicit opt-out to `human_merge` or
 prefers `separate_merge_agent` as a non-default split-authority profile.

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -41,6 +41,14 @@ evidence before agents reach PR review and merge phases.
 Keep this decision explicit. Review policy changes are workflow changes,
 not just documentation preferences.
 
+Before unattended runs begin, choose and record merge policy with
+`fully_autonomous_merge` preselected as the distributed default, and ask
+whether the operator wants to opt out to `human_merge` or
+`separate_merge_agent`. Keep the selected policy in repository
+documentation that future IDD sessions read. Missing policy defaults to
+`fully_autonomous_merge`; unknown recorded policy values must stop with
+a maintainer hold until corrected.
+
 ## 3. Prepare Issues
 
 IDD works from GitHub Issues. At least one issue should be ready before

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -42,8 +42,10 @@ granting unattended agent credentials:
 
 The distributed default is `fully_autonomous_merge` when merge policy is
 missing from repository docs. Public or OSS repositories that do not
-want unattended merges should explicitly opt out to `human_merge` (or
-`separate_merge_agent`) before granting worker credentials. If a
+want unattended merges should explicitly opt out to `human_merge` before
+granting worker credentials. `separate_merge_agent` remains a distinct
+non-default split-authority profile for repositories that want a
+dedicated merge-capable session. If a
 recorded merge policy value is unknown, the merge phase must stop with a
 maintainer hold until the policy is corrected.
 

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -45,9 +45,9 @@ missing from repository docs. Public or OSS repositories that do not
 want unattended merges should explicitly opt out to `human_merge` before
 granting worker credentials. `separate_merge_agent` remains a distinct
 non-default split-authority profile for repositories that want a
-dedicated merge-capable session. If a
-recorded merge policy value is unknown, the merge phase must stop with a
-maintainer hold until the policy is corrected.
+dedicated merge-capable session. If a recorded merge policy value is
+unknown, the merge phase must stop with a maintainer hold until the
+policy is corrected.
 
 ## Phase Permissions
 


### PR DESCRIPTION
## Summary

- updates idd-template/ONBOARDING.md so onboarding preselects fully_autonomous_merge and explicitly asks whether to opt out to human_merge
- keeps separate_merge_agent guidance as a non-default split-authority handoff profile
- aligns docs/getting-started.md + template and docs/customization.md + template with the same default/opt-out wording
- keeps merge-policy safety semantics explicit: missing policy defaults to fully autonomous, unknown recorded values hold for maintainer correction

Closes #209

## Follow-up

- none

## Background / rationale

This PR is scoped to onboarding-facing wording and keeps the broader onboarding streamlining work in #192 separate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a required merge policy selection/recording step to onboarding and getting-started guides.
  * Clarified that missing merge policy defaults to "fully_autonomous_merge".
  * Explained opt-out options: "human_merge" or "separate_merge_agent".
  * Stated that unknown recorded policy values halt automated progress and require a maintainer hold.
  * Updated customization and permissions docs with defaults and error-handling guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/213)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->