### PR TITLE
feat(idd): add live status digest helper

### DIFF
--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -209,6 +209,10 @@ and authoritative state collection. If multiple marked digests exist,
 preserve them, report the duplicate URLs, and do not choose one as
 authoritative during an unattended run. See
 `docs/idd-comment-minimization.md` for the full digest contract.
+When available, the optional helper
+`node scripts/live-status-digest.mjs` may perform the same discovery,
+dry-run, duplicate refusal, and claim-checked upsert; its output remains
+convenience context, not workflow authority.
 
 Treat every digest create or edit as a GitHub side effect: re-validate
 the active claim first, write fields from the authoritative state just

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -101,8 +101,8 @@ Cleanup is intentionally conservative. It should make active issues and
 PRs easier to read without deleting the evidence needed to understand
 what happened.
 
-See [comment minimization](idd-comment-minimization.md) for the cleanup
-policy and helper notes.
+See [comment minimization](idd-comment-minimization.md) for the live
+status digest contract, cleanup policy, and helper notes.
 
 ## Where to Read Next
 

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -58,6 +58,62 @@ authoritative during an unattended run; preserve the audit history,
 report the duplicate URLs, and use trusted markers and GitHub state for
 all workflow decisions until a repair path selects one current digest.
 
+## Live Status Digest Helper
+
+When the repository-local helper is available, use dry-run first:
+
+```sh
+node scripts/live-status-digest.mjs --issue <issue-number> --dry-run \
+  --phase "<phase>" \
+  --claim "<agent-id> / <claim-id>" \
+  --branch "<branch-name>" \
+  --open-blockers "<blocker-summary>" \
+  --next-action "<next-action>" \
+  --authoritative-by "<trusted-evidence>"
+```
+
+Use `--pr <pr-number>` for pull request digests. If `--last-checked`
+is omitted, the helper writes the current UTC time. The helper emits
+stable JSON by default; add `--format table` for terminal inspection or
+`--include-body` when reviewing the rendered Markdown.
+
+Apply mode is explicit and claim-checked:
+
+```sh
+node scripts/live-status-digest.mjs --issue <issue-number> --apply \
+  --claim-issue <issue-number> --claim-id <claim-id> \
+  --phase "<phase>" \
+  --claim "<agent-id> / <claim-id>" \
+  --branch "<branch-name>" \
+  --open-blockers "<blocker-summary>" \
+  --next-action "<next-action>" \
+  --authoritative-by "<trusted-evidence>"
+```
+
+During ordinary IDD execution, pass the active issue and claim id so the
+helper re-reads the claim before mutating. Maintainer-led repairs outside
+an active claim may use `--skip-claim-check`, but routine agents should
+not. The helper creates a digest when none exists, updates the single
+current digest when one exists, and reports `noop` when the current
+digest already matches the requested fields.
+
+If multiple marked digests exist, the helper exits non-zero and reports
+their URLs plus a repair path. It does not choose between duplicates,
+delete comments, minimize comments, or edit immutable operational
+markers.
+
+The JSON report includes these fields:
+
+| Field        | Purpose                                                      |
+| ------------ | ------------------------------------------------------------ |
+| `mode`       | `dry-run` or `apply`                                         |
+| `action`     | `create`, `update`, `noop`, or `duplicate`                   |
+| `canApply`   | Whether apply mode may mutate without duplicate repair       |
+| `commentId`  | Current or newly written digest comment ID, when known       |
+| `url`        | Direct link to the digest comment, when known                |
+| `duplicates` | Duplicate marked digest comments that block unattended edits |
+| `repairPath` | Human repair guidance for duplicate marked digests           |
+
 ## Timing
 
 Run minimization only after one of these is true:

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -6,10 +6,12 @@ directly instead of re-evaluating the same suggestion from scratch.
 
 ## Decision
 
-In this source repository, adopt two optional helpers:
+In this source repository, adopt three optional helpers:
 
 - `scripts/review-activity-snapshot.mjs` for read-only E/F review
   activity and CI snapshot metrics
+- `scripts/live-status-digest.mjs` for issue or PR live status digest
+  discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
 
 The canonical workflow remains the portable shell / `gh` / `jq`
@@ -30,8 +32,18 @@ The adopted helper boundaries are intentionally narrow:
 - it does not replace the E/F gate decision tables; it only reduces
   command-copy variance when collecting canonical snapshot fields
 
-- dry-run is the default and prints stable JSON unless `--format table`
-  is requested
+- `live-status-digest.mjs` defaults to dry-run, supports issue and PR
+  targets, and mutates only with explicit `--apply`
+- apply mode re-validates an active claim unless a maintainer explicitly
+  uses `--skip-claim-check`
+- it creates or updates only the single current digest comment and
+  refuses duplicate marked digests with repair URLs instead of choosing
+  one, deleting, or minimizing audit history
+- digest text remains non-authoritative UI state; phase decisions still
+  come from trusted markers and GitHub state
+
+- `audit-pr-cleanup.mjs` defaults to dry-run and prints stable JSON
+  unless `--format table` is requested
 - apply mode is explicit and can re-validate an active claim before
   every minimization mutation
 - known review-bot regular comments are considered only after merge and
@@ -48,6 +60,7 @@ The repeated query patterns most likely to benefit from helpers are:
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Claim-state parsing             | HTML marker parsing is stateful and easy to simplify incorrectly.                                                       | A script would become another parser that must stay exactly aligned with the instruction rules.               |
 | Review activity snapshots       | E1/F2/F3 need the same activity universe and marker exclusions.                                                         | Any mismatch between script output and written gates could make merge freshness checks unsound.               |
+| Live status digest edits        | Each phase repeats marker discovery, create/update/no-op handling, duplicate refusal, and claim revalidation.           | A mutating helper could make digest text look authoritative unless docs keep it as UI-only state.             |
 | Advisory-wait marker parsing    | AW1/AW2 combine review API state, requested reviewers, marker comments, and elapsed-time rules.                         | A helper could hide important decision-table semantics that agents must still understand during holds.        |
 | Final pre-merge freshness check | The merge path repeats review, comment, thread, CI, claim, and advisory checks immediately before F3.                   | A mutating helper would be risky; even a read-only helper needs strict output contracts.                      |
 | Post-merge cleanup candidates   | F4 cleanup requires repeat GraphQL checks for marker comments, review parents, permissions, and resolved child threads. | Adopted narrowly as `scripts/audit-pr-cleanup.mjs`; dry-run first, apply only after F3, and never gate merge. |
@@ -68,9 +81,9 @@ rule must be maintained twice: once in the instructions that agents read,
 and once in code that agents run.
 
 For now, the safer balance is to keep pre-merge instructions canonical
-while allowing one read-only E/F snapshot helper and one post-merge
-cleanup helper. Merge safety still depends on the written checks, not on
-helper output alone.
+while allowing one read-only E/F snapshot helper, one live digest upsert
+helper, and one post-merge cleanup helper. Merge safety still depends on
+the written checks, not on helper output alone.
 
 ## Future Adoption Criteria
 
@@ -89,6 +102,6 @@ the following:
 - They are introduced only after the corresponding instruction protocol
   has stabilized enough that drift risk is lower than command-copy risk.
 
-Good future candidates would be read-only snapshot commands for review
-activity, advisory-wait state, or claim-state inspection. They should
-not replace the written decision tables.
+Good future candidates would be read-only snapshot commands for
+advisory-wait state or claim-state inspection. They should not replace
+the written decision tables.

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -273,10 +273,12 @@ reviewer because that is part of this repository's current PR policy.
 
 ## Optional helper scripts
 
-This source repository currently ships two optional helper scripts:
+This source repository currently ships three optional helper scripts:
 
 - `scripts/review-activity-snapshot.mjs` (read-only E/F activity and CI
   snapshot metrics)
+- `scripts/live-status-digest.mjs` (issue or PR live status digest
+  dry-run and claim-checked upsert)
 - `scripts/audit-pr-cleanup.mjs` (post-merge cleanup audit and optional
   apply mode)
 
@@ -289,7 +291,7 @@ current inventory of high-friction query patterns, the adopted helper
 scope in this source repository, and the criteria for future helper
 changes.
 
-See [IDD comment minimization](idd-comment-minimization.md) for the
-post-merge cleanup helper, GraphQL fallback command shape, and merged-PR
-experiment for hiding completed feedback and stale operational markers
-without deleting the audit trail.
+See [IDD comment minimization](idd-comment-minimization.md) for the live
+status digest helper, post-merge cleanup helper, GraphQL fallback command
+shape, and merged-PR experiment for hiding completed feedback and stale
+operational markers without deleting the audit trail.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,8 +56,8 @@ also serve as the source for a future GitHub Pages site.
   current workflow stays portable shell / `gh` / `jq` instructions
   instead of requiring helper scripts.
 - [IDD comment minimization](idd-comment-minimization.md) defines the
-  safe post-merge cleanup policy for stale operational markers and
-  completed feedback.
+  live status digest helper contract and safe post-merge cleanup policy
+  for stale operational markers and completed feedback.
 
 ### Native Companions
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -36,7 +36,7 @@ or [Core concepts](concepts.md) before using this reference.
 | Distributed policy defaults            | [IDD policy constants](policy-constants.md)                 |
 | Credential boundaries and threat model | [Permissions](permissions.md)                               |
 | Safe adopter customization surfaces    | [Customization](customization.md)                           |
-| Post-merge comment cleanup             | [IDD comment minimization](idd-comment-minimization.md)     |
+| Live digest and comment cleanup        | [IDD comment minimization](idd-comment-minimization.md)     |
 | Helper-script adoption policy          | [IDD helper script evaluation](idd-helper-scripts.md)       |
 
 ## Maintainer Note

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -209,6 +209,10 @@ and authoritative state collection. If multiple marked digests exist,
 preserve them, report the duplicate URLs, and do not choose one as
 authoritative during an unattended run. See
 `docs/idd-comment-minimization.md` for the full digest contract.
+When available, the optional helper
+`node scripts/live-status-digest.mjs` may perform the same discovery,
+dry-run, duplicate refusal, and claim-checked upsert; its output remains
+convenience context, not workflow authority.
 
 Treat every digest create or edit as a GitHub side effect: re-validate
 the active claim first, write fields from the authoritative state just

--- a/idd-template/docs/concepts.md
+++ b/idd-template/docs/concepts.md
@@ -101,8 +101,8 @@ Cleanup is intentionally conservative. It should make active issues and
 PRs easier to read without deleting the evidence needed to understand
 what happened.
 
-See [comment minimization](idd-comment-minimization.md) for the cleanup
-policy and helper notes.
+See [comment minimization](idd-comment-minimization.md) for the live
+status digest contract, cleanup policy, and helper notes.
 
 ## Where to Read Next
 

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -58,6 +58,62 @@ authoritative during an unattended run; preserve the audit history,
 report the duplicate URLs, and use trusted markers and GitHub state for
 all workflow decisions until a repair path selects one current digest.
 
+## Live Status Digest Helper
+
+When the repository-local helper is available, use dry-run first:
+
+```sh
+node scripts/live-status-digest.mjs --issue <issue-number> --dry-run \
+  --phase "<phase>" \
+  --claim "<agent-id> / <claim-id>" \
+  --branch "<branch-name>" \
+  --open-blockers "<blocker-summary>" \
+  --next-action "<next-action>" \
+  --authoritative-by "<trusted-evidence>"
+```
+
+Use `--pr <pr-number>` for pull request digests. If `--last-checked`
+is omitted, the helper writes the current UTC time. The helper emits
+stable JSON by default; add `--format table` for terminal inspection or
+`--include-body` when reviewing the rendered Markdown.
+
+Apply mode is explicit and claim-checked:
+
+```sh
+node scripts/live-status-digest.mjs --issue <issue-number> --apply \
+  --claim-issue <issue-number> --claim-id <claim-id> \
+  --phase "<phase>" \
+  --claim "<agent-id> / <claim-id>" \
+  --branch "<branch-name>" \
+  --open-blockers "<blocker-summary>" \
+  --next-action "<next-action>" \
+  --authoritative-by "<trusted-evidence>"
+```
+
+During ordinary IDD execution, pass the active issue and claim id so the
+helper re-reads the claim before mutating. Maintainer-led repairs outside
+an active claim may use `--skip-claim-check`, but routine agents should
+not. The helper creates a digest when none exists, updates the single
+current digest when one exists, and reports `noop` when the current
+digest already matches the requested fields.
+
+If multiple marked digests exist, the helper exits non-zero and reports
+their URLs plus a repair path. It does not choose between duplicates,
+delete comments, minimize comments, or edit immutable operational
+markers.
+
+The JSON report includes these fields:
+
+| Field        | Purpose                                                      |
+| ------------ | ------------------------------------------------------------ |
+| `mode`       | `dry-run` or `apply`                                         |
+| `action`     | `create`, `update`, `noop`, or `duplicate`                   |
+| `canApply`   | Whether apply mode may mutate without duplicate repair       |
+| `commentId`  | Current or newly written digest comment ID, when known       |
+| `url`        | Direct link to the digest comment, when known                |
+| `duplicates` | Duplicate marked digest comments that block unattended edits |
+| `repairPath` | Human repair guidance for duplicate marked digests           |
+
 ## Timing
 
 Run minimization only after one of these is true:

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -6,10 +6,12 @@ directly instead of re-evaluating the same suggestion from scratch.
 
 ## Decision
 
-In this source repository, adopt two optional helpers:
+In this source repository, adopt three optional helpers:
 
 - `scripts/review-activity-snapshot.mjs` for read-only E/F review
   activity and CI snapshot metrics
+- `scripts/live-status-digest.mjs` for issue or PR live status digest
+  discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
 
 The canonical workflow remains the portable shell / `gh` / `jq`
@@ -30,8 +32,18 @@ The adopted helper boundaries are intentionally narrow:
 - it does not replace the E/F gate decision tables; it only reduces
   command-copy variance when collecting canonical snapshot fields
 
-- dry-run is the default and prints stable JSON unless `--format table`
-  is requested
+- `live-status-digest.mjs` defaults to dry-run, supports issue and PR
+  targets, and mutates only with explicit `--apply`
+- apply mode re-validates an active claim unless a maintainer explicitly
+  uses `--skip-claim-check`
+- it creates or updates only the single current digest comment and
+  refuses duplicate marked digests with repair URLs instead of choosing
+  one, deleting, or minimizing audit history
+- digest text remains non-authoritative UI state; phase decisions still
+  come from trusted markers and GitHub state
+
+- `audit-pr-cleanup.mjs` defaults to dry-run and prints stable JSON
+  unless `--format table` is requested
 - apply mode is explicit and can re-validate an active claim before
   every minimization mutation
 - known review-bot regular comments are considered only after merge and
@@ -48,6 +60,7 @@ The repeated query patterns most likely to benefit from helpers are:
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Claim-state parsing             | HTML marker parsing is stateful and easy to simplify incorrectly.                                                       | A script would become another parser that must stay exactly aligned with the instruction rules.               |
 | Review activity snapshots       | E1/F2/F3 need the same activity universe and marker exclusions.                                                         | Any mismatch between script output and written gates could make merge freshness checks unsound.               |
+| Live status digest edits        | Each phase repeats marker discovery, create/update/no-op handling, duplicate refusal, and claim revalidation.           | A mutating helper could make digest text look authoritative unless docs keep it as UI-only state.             |
 | Advisory-wait marker parsing    | AW1/AW2 combine review API state, requested reviewers, marker comments, and elapsed-time rules.                         | A helper could hide important decision-table semantics that agents must still understand during holds.        |
 | Final pre-merge freshness check | The merge path repeats review, comment, thread, CI, claim, and advisory checks immediately before F3.                   | A mutating helper would be risky; even a read-only helper needs strict output contracts.                      |
 | Post-merge cleanup candidates   | F4 cleanup requires repeat GraphQL checks for marker comments, review parents, permissions, and resolved child threads. | Adopted narrowly as `scripts/audit-pr-cleanup.mjs`; dry-run first, apply only after F3, and never gate merge. |
@@ -68,9 +81,9 @@ rule must be maintained twice: once in the instructions that agents read,
 and once in code that agents run.
 
 For now, the safer balance is to keep pre-merge instructions canonical
-while allowing one read-only E/F snapshot helper and one post-merge
-cleanup helper. Merge safety still depends on the written checks, not on
-helper output alone.
+while allowing one read-only E/F snapshot helper, one live digest upsert
+helper, and one post-merge cleanup helper. Merge safety still depends on
+the written checks, not on helper output alone.
 
 ## Future Adoption Criteria
 
@@ -89,6 +102,6 @@ the following:
 - They are introduced only after the corresponding instruction protocol
   has stabilized enough that drift risk is lower than command-copy risk.
 
-Good future candidates would be read-only snapshot commands for review
-activity, advisory-wait state, or claim-state inspection. They should
-not replace the written decision tables.
+Good future candidates would be read-only snapshot commands for
+advisory-wait state or claim-state inspection. They should not replace
+the written decision tables.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -262,11 +262,13 @@ reviewer because that is part of this repository's current PR policy.
 
 ## Optional helper scripts
 
-The source repository that ships this template currently includes two
+The source repository that ships this template currently includes three
 optional helper scripts:
 
 - `scripts/review-activity-snapshot.mjs` (read-only E/F activity and CI
   snapshot metrics)
+- `scripts/live-status-digest.mjs` (issue or PR live status digest
+  dry-run and claim-checked upsert)
 - `scripts/audit-pr-cleanup.mjs` (post-merge cleanup audit and optional
   apply mode)
 
@@ -280,7 +282,7 @@ current inventory of high-friction query patterns, the adopted helper
 scope in the source repository, and the criteria for future helper
 changes.
 
-See [IDD comment minimization](idd-comment-minimization.md) for the
-post-merge cleanup helper, GraphQL fallback command shape, and merged-PR
-experiment for hiding completed feedback and stale operational markers
-without deleting the audit trail.
+See [IDD comment minimization](idd-comment-minimization.md) for the live
+status digest helper, post-merge cleanup helper, GraphQL fallback command
+shape, and merged-PR experiment for hiding completed feedback and stale
+operational markers without deleting the audit trail.

--- a/idd-template/docs/reference.md
+++ b/idd-template/docs/reference.md
@@ -36,7 +36,7 @@ or [Core concepts](concepts.md) before using this reference.
 | Distributed policy defaults            | [IDD policy constants](policy-constants.md)                 |
 | Credential boundaries and threat model | [Permissions](permissions.md)                               |
 | Safe adopter customization surfaces    | [Customization](customization.md)                           |
-| Post-merge comment cleanup             | [IDD comment minimization](idd-comment-minimization.md)     |
+| Live digest and comment cleanup        | [IDD comment minimization](idd-comment-minimization.md)     |
 | Helper-script adoption policy          | [IDD helper script evaluation](idd-helper-scripts.md)       |
 
 ## Maintainer Note

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -1,0 +1,526 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+import {
+  applyClaimEvent,
+  planLiveStatusDigestUpsert,
+} from "./protocol-helpers.mjs";
+
+const TRUSTED_MARKER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+const trustedMarkerAuthorCache = new Map();
+let cachedConfiguredTrustedMarkerAuthors = null;
+let cachedCurrentViewerLogin = null;
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+  printUsage();
+  process.exit(0);
+}
+
+if (args.issue && args.pr) {
+  fail("choose only one of --issue or --pr");
+}
+if (!args.issue && !args.pr) {
+  fail("missing required --issue <number> or --pr <number>");
+}
+if (args.apply && args.dryRun) {
+  fail("choose only one of --dry-run or --apply");
+}
+if (!args.apply) {
+  args.dryRun = true;
+}
+if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
+  fail("--skip-claim-check cannot be combined with --claim-issue or --claim-id");
+}
+if (args.apply && !args.skipClaimCheck && (!args.claimIssue || !args.claimId)) {
+  fail("--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check");
+}
+
+const repository = args.repo ?? detectRepository();
+const [owner, repo] = parseRepository(repository);
+const targetType = args.issue ? "issue" : "pr";
+const targetNumber = parsePositiveInteger(args.issue ?? args.pr, `--${targetType}`);
+
+if (args.claimIssue) {
+  args.claimIssue = String(parsePositiveInteger(args.claimIssue, "--claim-issue"));
+}
+
+const fields = {
+  phase: args.phase,
+  claim: args.claim,
+  branch: args.branch,
+  lastChecked: args.lastChecked ?? currentIsoTimestamp(),
+  openBlockers: args.openBlockers,
+  nextAction: args.nextAction,
+  authoritativeBy: args.authoritativeBy,
+};
+
+const comments = fetchIssueComments(owner, repo, targetNumber);
+let planned;
+try {
+  planned = planLiveStatusDigestUpsert(comments, fields);
+} catch (error) {
+  fail(error.message);
+}
+const report = {
+  repository: `${owner}/${repo}`,
+  target: {
+    type: targetType,
+    number: targetNumber,
+  },
+  mode: args.apply ? "apply" : "dry-run",
+  action: planned.action,
+  canApply: planned.canApply,
+  commentId: planned.commentId ?? null,
+  url: planned.url ?? null,
+  duplicates: planned.duplicates ?? [],
+  repairPath: planned.repairPath ?? null,
+  applied: false,
+  body: args.includeBody ? planned.body : undefined,
+};
+
+if (planned.action === "duplicate") {
+  writeReport(report, args.format);
+  process.exit(1);
+}
+
+if (args.apply) {
+  if (!args.skipClaimCheck) {
+    try {
+      assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+    } catch (error) {
+      fail(error.message);
+    }
+  }
+
+  try {
+    planned = planLiveStatusDigestUpsert(fetchIssueComments(owner, repo, targetNumber), fields);
+  } catch (error) {
+    fail(error.message);
+  }
+  updateReportFromPlan(report, planned);
+  if (planned.action === "duplicate") {
+    writeReport(report, args.format);
+    process.exit(1);
+  }
+
+  if (!args.skipClaimCheck) {
+    try {
+      assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+    } catch (error) {
+      fail(error.message);
+    }
+  }
+
+  if (planned.action === "create") {
+    if (!args.skipClaimCheck) {
+      try {
+        assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+      } catch (error) {
+        fail(error.message);
+      }
+    }
+    const created = createIssueComment(owner, repo, targetNumber, planned.body);
+    report.applied = true;
+    report.commentId = created.id ?? null;
+    report.url = created.html_url ?? created.url ?? null;
+  } else if (planned.action === "update") {
+    if (!planned.commentId) {
+      fail("cannot update digest because the current comment id is missing");
+    }
+    if (!args.skipClaimCheck) {
+      try {
+        assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+      } catch (error) {
+        fail(error.message);
+      }
+    }
+    const updated = updateIssueComment(owner, repo, planned.commentId, planned.body);
+    report.applied = true;
+    report.commentId = updated.id ?? planned.commentId;
+    report.url = updated.html_url ?? updated.url ?? planned.url ?? null;
+  }
+}
+
+writeReport(report, args.format);
+
+function updateReportFromPlan(report, planned) {
+  report.action = planned.action;
+  report.canApply = planned.canApply;
+  report.commentId = planned.commentId ?? null;
+  report.url = planned.url ?? null;
+  report.duplicates = planned.duplicates ?? [];
+  report.repairPath = planned.repairPath ?? null;
+  if (args.includeBody) {
+    report.body = planned.body;
+  }
+}
+
+function fetchIssueComments(owner, repo, number) {
+  const result = ghJson([
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/${owner}/${repo}/issues/${number}/comments`,
+  ]);
+  return result.flat().map((comment) => ({
+    id: comment.id,
+    url: comment.url,
+    html_url: comment.html_url,
+    body: comment.body ?? "",
+    created_at: comment.created_at ?? "",
+    updated_at: comment.updated_at ?? comment.created_at ?? "",
+    author: { login: comment.user?.login ?? "" },
+  }));
+}
+
+function createIssueComment(owner, repo, number, body) {
+  return ghJson([
+    "api",
+    `repos/${owner}/${repo}/issues/${number}/comments`,
+    "-X",
+    "POST",
+    "-f",
+    `body=${body}`,
+  ]);
+}
+
+function updateIssueComment(owner, repo, commentId, body) {
+  return ghJson([
+    "api",
+    `repos/${owner}/${repo}/issues/comments/${commentId}`,
+    "-X",
+    "PATCH",
+    "-f",
+    `body=${body}`,
+  ]);
+}
+
+function assertActiveClaim(owner, repo, issueNumber, agentId, claimId) {
+  const active = readActiveClaim(owner, repo, issueNumber);
+  if (!active || active.claimId !== claimId || (agentId && active.agentId !== agentId)) {
+    const activeLabel = active ? `${active.agentId} ${active.claimId}` : "none";
+    throw new Error(`claim check failed for #${issueNumber}: active claim is ${activeLabel}`);
+  }
+}
+
+function readActiveClaim(owner, repo, issueNumber) {
+  const comments = fetchIssueComments(owner, repo, issueNumber).sort((left, right) => {
+    return new Date(left.created_at) - new Date(right.created_at);
+  });
+
+  let active = null;
+  for (const comment of comments) {
+    active = applyClaimEvent(
+      active,
+      {
+        body: comment.body,
+        createdAt: comment.created_at,
+        author: { login: comment.author?.login ?? "" },
+      },
+      (login) => isTrustedMarkerAuthor(owner, repo, login),
+    );
+  }
+  return active;
+}
+
+function isTrustedMarkerAuthor(owner, repo, login) {
+  if (!login) {
+    return false;
+  }
+
+  const normalized = login.toLowerCase();
+  if (normalized === currentViewerLogin()) {
+    return true;
+  }
+  if (configuredTrustedMarkerAuthors().has(normalized)) {
+    return true;
+  }
+
+  if (!trustCollaboratorMarkers()) {
+    return false;
+  }
+
+  const cacheKey = `${owner}/${repo}:${normalized}`;
+  if (trustedMarkerAuthorCache.has(cacheKey)) {
+    return trustedMarkerAuthorCache.get(cacheKey);
+  }
+
+  let trusted = false;
+  try {
+    const permission = execFileSync(
+      "gh",
+      [
+        "api",
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        "--jq",
+        ".permission",
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim().toLowerCase();
+    trusted = TRUSTED_MARKER_PERMISSIONS.has(permission);
+  } catch {
+    trusted = false;
+  }
+
+  trustedMarkerAuthorCache.set(cacheKey, trusted);
+  return trusted;
+}
+
+function currentViewerLogin() {
+  if (cachedCurrentViewerLogin !== null) {
+    return cachedCurrentViewerLogin;
+  }
+
+  try {
+    cachedCurrentViewerLogin = execFileSync(
+      "gh",
+      ["api", "user", "--jq", ".login"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim().toLowerCase();
+  } catch {
+    cachedCurrentViewerLogin = "";
+  }
+  return cachedCurrentViewerLogin;
+}
+
+function configuredTrustedMarkerAuthors() {
+  if (cachedConfiguredTrustedMarkerAuthors) {
+    return cachedConfiguredTrustedMarkerAuthors;
+  }
+
+  cachedConfiguredTrustedMarkerAuthors = new Set(
+    (process.env.IDD_TRUSTED_MARKER_ACTORS ?? "")
+      .split(",")
+      .map((login) => login.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  return cachedConfiguredTrustedMarkerAuthors;
+}
+
+function trustCollaboratorMarkers() {
+  return /^(1|true|yes)$/i.test(process.env.IDD_TRUST_COLLABORATOR_MARKERS ?? "");
+}
+
+function detectRepository() {
+  if (process.env.GITHUB_REPOSITORY) {
+    return process.env.GITHUB_REPOSITORY;
+  }
+  return execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function parseRepository(value) {
+  const parts = value.split("/");
+  if (
+    parts.length !== 2
+    || parts.some((part) => part.length === 0 || /\s/.test(part))
+  ) {
+    fail(`invalid repository ${value}; expected owner/name`);
+  }
+  return parts;
+}
+
+function ghJson(commandArgs) {
+  try {
+    return JSON.parse(execFileSync("gh", commandArgs, { encoding: "utf8" }));
+  } catch (error) {
+    const stdout = String(error.stdout ?? "").trim();
+    const stderr = String(error.stderr ?? "").trim();
+    const response = parseJsonOrNull(stdout);
+    if (response?.message || response?.errors) {
+      fail(`gh ${commandArgs.join(" ")} failed: ${JSON.stringify(response)}`);
+    }
+    if (response) {
+      return response;
+    }
+    fail(`gh ${commandArgs.join(" ")} failed: ${stderr || error.message}`);
+  }
+}
+
+function parseJsonOrNull(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function writeReport(report, format) {
+  if (format === "json") {
+    console.log(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+
+  console.log(`mode\taction\tcanApply\tapplied\tcommentId\turl`);
+  console.log([
+    report.mode,
+    report.action,
+    report.canApply,
+    report.applied,
+    report.commentId ?? "",
+    report.url ?? "",
+  ].join("\t"));
+  if (report.duplicates.length > 0) {
+    console.log("duplicates:");
+    console.log("id\tcreatedAt\tupdatedAt\turl");
+    for (const duplicate of report.duplicates) {
+      console.log([
+        duplicate.id ?? "",
+        duplicate.createdAt ?? "",
+        duplicate.updatedAt ?? "",
+        duplicate.url ?? "",
+      ].join("\t"));
+    }
+  }
+  if (report.repairPath) {
+    console.log(`repairPath:\t${report.repairPath}`);
+  }
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    format: "json",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--issue":
+        parsed.issue = readValue(argv, ++index, arg);
+        break;
+      case "--pr":
+        parsed.pr = readValue(argv, ++index, arg);
+        break;
+      case "--repo":
+        parsed.repo = readValue(argv, ++index, arg);
+        break;
+      case "--dry-run":
+        parsed.dryRun = true;
+        break;
+      case "--apply":
+        parsed.apply = true;
+        break;
+      case "--phase":
+        parsed.phase = readValue(argv, ++index, arg);
+        break;
+      case "--claim":
+        parsed.claim = readValue(argv, ++index, arg);
+        break;
+      case "--branch":
+        parsed.branch = readValue(argv, ++index, arg);
+        break;
+      case "--last-checked":
+        parsed.lastChecked = readValue(argv, ++index, arg);
+        break;
+      case "--open-blockers":
+        parsed.openBlockers = readValue(argv, ++index, arg);
+        break;
+      case "--next-action":
+        parsed.nextAction = readValue(argv, ++index, arg);
+        break;
+      case "--authoritative-by":
+        parsed.authoritativeBy = readValue(argv, ++index, arg);
+        break;
+      case "--claim-issue":
+        parsed.claimIssue = readValue(argv, ++index, arg);
+        break;
+      case "--claim-id":
+        parsed.claimId = readValue(argv, ++index, arg);
+        break;
+      case "--agent-id":
+        parsed.agentId = readValue(argv, ++index, arg);
+        break;
+      case "--skip-claim-check":
+        parsed.skipClaimCheck = true;
+        break;
+      case "--include-body":
+        parsed.includeBody = true;
+        break;
+      case "--format":
+        parsed.format = readValue(argv, ++index, arg);
+        if (!["json", "table"].includes(parsed.format)) {
+          fail("--format must be json or table");
+        }
+        break;
+      default:
+        fail(`unknown argument ${arg}`);
+    }
+  }
+
+  for (const flag of [
+    ["phase", "--phase"],
+    ["claim", "--claim"],
+    ["branch", "--branch"],
+    ["openBlockers", "--open-blockers"],
+    ["nextAction", "--next-action"],
+    ["authoritativeBy", "--authoritative-by"],
+  ]) {
+    if (!parsed[flag[0]]) {
+      if (!parsed.help) {
+        fail(`${flag[1]} is required`);
+      }
+    }
+  }
+
+  return parsed;
+}
+
+function readValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    fail(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value, flag) {
+  if (!/^[1-9]\d*$/.test(value)) {
+    fail(`${flag} must be a positive integer`);
+  }
+  return Number.parseInt(value, 10);
+}
+
+function currentIsoTimestamp() {
+  return new Date().toISOString().replace(".000Z", "Z");
+}
+
+function printUsage() {
+  console.log(`usage: node scripts/live-status-digest.mjs (--issue <number> | --pr <number>) [options]
+
+Options:
+  --dry-run                         compute the create/update/noop action (default)
+  --apply                           create or update the single current digest
+  --phase <text>                    digest Phase field
+  --claim <text>                    digest Claim field
+  --branch <text>                   digest Branch field
+  --last-checked <timestamp>        digest Last checked field (default: current UTC)
+  --open-blockers <text>            digest Open blockers field
+  --next-action <text>              digest Next action field
+  --authoritative-by <text>         digest Authoritative by field
+  --claim-issue <number>            issue whose active claim protects apply mode
+  --claim-id <id>                   active claim id required for apply mode
+  --agent-id <id>                   optionally require this claim agent id
+  --skip-claim-check                explicit maintainer override for apply mode
+  --repo <owner/name>               repository override
+  --format <json|table>             output format (default: json)
+  --include-body                    include the rendered body in JSON reports
+  --help                            show this help
+
+Environment:
+  IDD_TRUSTED_MARKER_ACTORS         comma-separated trusted bot/app logins
+  IDD_TRUST_COLLABORATOR_MARKERS    set true to trust Write/Maintain/Admin collaborators
+`);
+}
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(2);
+}

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1,4 +1,7 @@
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
+const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
+
+export const LIVE_STATUS_DIGEST_MARKER = "<!-- idd-live-status: current -->";
 
 const OPERATIONAL_MARKERS = [
   {
@@ -56,7 +59,8 @@ const UNSAFE_TEXT_RULES = [
 export function parseClaimComment(body, createdAt) {
   const match = body.trimEnd().match(
     new RegExp(
-      `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->$`,
+      `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+      "i",
     ),
   );
   if (!match || !isValidIsoTimestamp(match[4])) {
@@ -74,7 +78,8 @@ export function parseClaimComment(body, createdAt) {
 export function parseReleaseComment(body) {
   const match = body.trimEnd().match(
     new RegExp(
-      `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->$`,
+      `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+      "i",
     ),
   );
   if (!match || !isValidIsoTimestamp(match[3])) {
@@ -96,6 +101,82 @@ export function operationalMarkerPrefixByStart(body) {
   return OPERATIONAL_MARKERS
     .map((marker) => marker.label)
     .find((prefix) => normalized.startsWith(prefix)) ?? null;
+}
+
+export function findLiveStatusDigestComments(comments) {
+  return comments.filter((comment) => {
+    return firstLine(comment.body ?? "") === LIVE_STATUS_DIGEST_MARKER;
+  });
+}
+
+export function renderLiveStatusDigest(fields) {
+  const normalized = normalizeLiveStatusDigestFields(fields);
+  return `${LIVE_STATUS_DIGEST_MARKER}
+
+| Field | Value |
+| --- | --- |
+| Phase | ${escapeMarkdownTableCell(normalized.phase)} |
+| Claim | ${escapeMarkdownTableCell(normalized.claim)} |
+| Branch | ${escapeMarkdownTableCell(normalized.branch)} |
+| Last checked | ${escapeMarkdownTableCell(normalized.lastChecked)} |
+| Open blockers | ${escapeMarkdownTableCell(normalized.openBlockers)} |
+| Next action | ${escapeMarkdownTableCell(normalized.nextAction)} |
+| Authoritative by | ${escapeMarkdownTableCell(normalized.authoritativeBy)} |
+`;
+}
+
+export function planLiveStatusDigestUpsert(comments, fields) {
+  const matches = findLiveStatusDigestComments(comments);
+  const nextBody = renderLiveStatusDigest(fields);
+
+  if (matches.length > 1) {
+    return {
+      action: "duplicate",
+      canApply: false,
+      body: null,
+      duplicates: matches.map((comment) => ({
+        id: comment.id ?? null,
+        url: comment.html_url ?? comment.url ?? null,
+        createdAt: comment.created_at ?? comment.createdAt ?? null,
+        updatedAt: comment.updated_at ?? comment.updatedAt ?? null,
+      })),
+      repairPath: [
+        "Multiple current live status digest comments were found.",
+        "Do not delete or minimize any audit history during unattended execution.",
+        "Use trusted markers and GitHub state for workflow decisions until a maintainer selects one current digest and converts stale duplicate markers to non-current digest text.",
+      ].join(" "),
+    };
+  }
+
+  if (matches.length === 0) {
+    return {
+      action: "create",
+      canApply: true,
+      body: nextBody,
+      duplicates: [],
+    };
+  }
+
+  const [current] = matches;
+  if (sameDigestBody(current.body ?? "", nextBody)) {
+    return {
+      action: "noop",
+      canApply: true,
+      body: nextBody,
+      commentId: current.id ?? null,
+      url: current.html_url ?? current.url ?? null,
+      duplicates: [],
+    };
+  }
+
+  return {
+    action: "update",
+    canApply: true,
+    body: nextBody,
+    commentId: current.id ?? null,
+    url: current.html_url ?? current.url ?? null,
+    duplicates: [],
+  };
 }
 
 export function unsafeTextReason(body) {
@@ -349,6 +430,47 @@ export function buildActivitySnapshotSummary(
   };
 }
 
+function normalizeLiveStatusDigestFields(fields) {
+  const normalized = {
+    phase: normalizeDigestField(fields.phase, "Phase"),
+    claim: normalizeDigestField(fields.claim, "Claim"),
+    branch: normalizeDigestField(fields.branch, "Branch"),
+    lastChecked: normalizeDigestField(fields.lastChecked, "Last checked"),
+    openBlockers: normalizeDigestField(fields.openBlockers, "Open blockers"),
+    nextAction: normalizeDigestField(fields.nextAction, "Next action"),
+    authoritativeBy: normalizeDigestField(fields.authoritativeBy, "Authoritative by"),
+  };
+
+  if (!isValidIsoTimestamp(normalized.lastChecked)) {
+    throw new Error("Last checked must be an ISO 8601 UTC timestamp");
+  }
+
+  return normalized;
+}
+
+function normalizeDigestField(value, label) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`${label} is required`);
+  }
+  return normalized;
+}
+
+function escapeMarkdownTableCell(value) {
+  return String(value)
+    .replaceAll("\\", "\\\\")
+    .replaceAll("|", "\\|")
+    .replace(/\r?\n/g, "<br>");
+}
+
+function firstLine(value) {
+  return String(value).replace(/^\uFEFF/, "").split(/\r?\n/, 1)[0].trimEnd();
+}
+
+function sameDigestBody(currentBody, nextBody) {
+  return currentBody.trimEnd() === nextBody.trimEnd();
+}
+
 export function isStaleAt(activeCreatedAt, nextCreatedAt) {
   const staleMs = 24 * 60 * 60 * 1000;
   return new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >= staleMs;
@@ -534,5 +656,7 @@ function hasUnresolvedKnownBotThreads(threads) {
 
 function isValidIsoTimestamp(value) {
   const time = Date.parse(value);
-  return Number.isFinite(time) && new Date(time).toISOString().replace(".000Z", "Z") === value;
+  if (!Number.isFinite(time)) return false;
+  const normalize = (ts) => ts.replace(".000Z", "Z");
+  return normalize(new Date(time).toISOString()) === normalize(value);
 }

--- a/tests/live-status-digest.test.mjs
+++ b/tests/live-status-digest.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  LIVE_STATUS_DIGEST_MARKER,
+  findLiveStatusDigestComments,
+  planLiveStatusDigestUpsert,
+  renderLiveStatusDigest,
+} from "../scripts/protocol-helpers.mjs";
+
+const fields = {
+  phase: "B2 planned",
+  claim: "codex-cli / claim-1",
+  branch: "issue/198-live-status-digest-helper",
+  lastChecked: "2026-05-10T16:20:00Z",
+  openBlockers: "none",
+  nextAction: "B3 implement",
+  authoritativeBy: "verified claim claim-1",
+};
+
+test("discovers only current live status digest comments", () => {
+  const comments = [
+    {
+      id: 1,
+      body: `${LIVE_STATUS_DIGEST_MARKER}\n\n| Field | Value |`,
+    },
+    {
+      id: 2,
+      body: ` ${LIVE_STATUS_DIGEST_MARKER}\n\nnot first-column marker`,
+    },
+    {
+      id: 3,
+      body: "<!-- claimed-by: codex-cli claim-1 supersedes: none 2026-05-10T16:00:00Z branch: issue/example -->",
+    },
+  ];
+
+  assert.deepEqual(findLiveStatusDigestComments(comments).map((comment) => comment.id), [1]);
+});
+
+test("plans creation when no digest exists", () => {
+  const plan = planLiveStatusDigestUpsert([], fields);
+
+  assert.equal(plan.action, "create");
+  assert.equal(plan.canApply, true);
+  assert.equal(plan.body, renderLiveStatusDigest(fields));
+});
+
+test("plans update for the single current digest", () => {
+  const plan = planLiveStatusDigestUpsert(
+    [
+      {
+        id: 101,
+        html_url: "https://github.example/comment/101",
+        body: renderLiveStatusDigest({ ...fields, phase: "A5 claimed" }),
+      },
+    ],
+    fields,
+  );
+
+  assert.equal(plan.action, "update");
+  assert.equal(plan.commentId, 101);
+  assert.equal(plan.url, "https://github.example/comment/101");
+});
+
+test("refuses duplicate current digests and reports repair context", () => {
+  const plan = planLiveStatusDigestUpsert(
+    [
+      {
+        id: 101,
+        html_url: "https://github.example/comment/101",
+        body: renderLiveStatusDigest({ ...fields, phase: "A5 claimed" }),
+      },
+      {
+        id: 102,
+        html_url: "https://github.example/comment/102",
+        body: renderLiveStatusDigest({ ...fields, phase: "B2 planned" }),
+      },
+    ],
+    fields,
+  );
+
+  assert.equal(plan.action, "duplicate");
+  assert.equal(plan.canApply, false);
+  assert.equal(plan.body, null);
+  assert.deepEqual(plan.duplicates.map((comment) => comment.url), [
+    "https://github.example/comment/101",
+    "https://github.example/comment/102",
+  ]);
+  assert.match(plan.repairPath, /Do not delete or minimize/);
+});
+
+test("plans no-op when the current digest is already up to date", () => {
+  const body = renderLiveStatusDigest(fields);
+  const plan = planLiveStatusDigestUpsert(
+    [
+      {
+        id: 101,
+        html_url: "https://github.example/comment/101",
+        body,
+      },
+    ],
+    fields,
+  );
+
+  assert.equal(plan.action, "noop");
+  assert.equal(plan.commentId, 101);
+  assert.equal(plan.body, body);
+});
+
+test("does not modify operational marker comments during digest operations", () => {
+  const operationalMarkerComment = {
+    id: 200,
+    body: "<!-- claimed-by: codex-cli claim-1 supersedes: none 2026-05-10T16:00:00Z branch: example -->",
+  };
+  const digestComment = {
+    id: 201,
+    body: LIVE_STATUS_DIGEST_MARKER + "\n\n| Field | Value |",
+  };
+
+  const plan = planLiveStatusDigestUpsert(
+    [operationalMarkerComment, digestComment],
+    fields,
+  );
+
+  assert.equal(plan.action, "update");
+  assert.equal(plan.commentId, 201);
+  assert.notEqual(plan.commentId, 200);
+});


### PR DESCRIPTION
## Summary

- Add `scripts/live-status-digest.mjs` for issue/PR digest dry-run, duplicate detection, and claim-checked apply mode.
- Add reusable digest rendering/upsert decision helpers with Node test coverage for discovery, creation, update, duplicate refusal, no-op, and operational marker preservation.
- Document the helper in source and exported-template docs while keeping digest text non-authoritative workflow UI state.

Closes #198

## Follow-up Issues

None recommended.

## Background

The helper intentionally mutates only the single current digest comment and refuses multiple marked digests with repair URLs. It does not edit immutable operational markers, delete comments, minimize comments, or make workflow decisions from digest text.

## Validation

- `node scripts/audit-docs.mjs --check`
- `npx dprint check "**/*.md"`
- `node --test tests/*.mjs`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`
- `git diff --check HEAD`
