### PR TITLE
fix: align merge policy guidance across documentation surfaces

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -123,9 +123,8 @@ the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
-future IDD sessions read, not only in local onboarding notes. Only an
-explicitly recorded `fully_autonomous_merge` enables autonomous merge;
-missing or unknown policy values must stop with a maintainer hold.
+future IDD sessions read, not only in local onboarding notes. When no
+policy is recorded, the distributed default is `fully_autonomous_merge`.
 Unknown recorded policy values must stop until the policy is corrected.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -123,9 +123,8 @@ the current PR state once CI, review, freshness, and claim evidence are
 ready for the merge-capable actor.
 
 Record the selected merge policy in repository documentation that
-future IDD sessions read, not only in local onboarding notes. Only an
-explicitly recorded `fully_autonomous_merge` enables autonomous merge;
-missing or unknown policy values must stop with a maintainer hold.
+future IDD sessions read, not only in local onboarding notes. When no
+policy is recorded, the distributed default is `fully_autonomous_merge`.
 Unknown recorded policy values must stop until the policy is corrected.
 
 For `human_merge`, keep the default F3 stop gate and hand off to the


### PR DESCRIPTION
## Summary

Fixes cross-surface documentation inconsistency in merge policy defaults discovered during PR #210 audit.

## Rationale

The authoritative merge policy guidance in `.github/instructions/idd-merge.instructions.md` F3 step 2 states:
- When no policy is recorded, the distributed default is `fully_autonomous_merge`

However, `docs/customization.md` and `idd-template/docs/customization.md` incorrectly stated:
- Only explicitly recorded `fully_autonomous_merge` enables autonomous merge
- Missing policies must stop with a maintainer hold

This created conflicting guidance across surfaces.

## Changes

- Updated `docs/customization.md` lines 125-128 to reflect distributed default behavior
- Updated `idd-template/docs/customization.md` (template sync)
- Clarified that missing policy defaults to `fully_autonomous_merge`

## Verification

✅ Pre-push validation: dprint, markdownlint, cspell all pass
✅ Template sync: changes applied to both source and template

Closes #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how merge policy settings are interpreted across future sessions, with guidance that the selected policy must be recorded in repository documentation.
  * Updated default merge behavior: when no policy is recorded, the distributed default setting applies automatically.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/217)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->