### PR TITLE
perf(idd): reduce live status digest claim revalidation calls

### DIFF
--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -106,22 +106,7 @@ if (args.apply) {
     process.exit(1);
   }
 
-  if (!args.skipClaimCheck) {
-    try {
-      assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
-    } catch (error) {
-      fail(error.message);
-    }
-  }
-
   if (planned.action === "create") {
-    if (!args.skipClaimCheck) {
-      try {
-        assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
-      } catch (error) {
-        fail(error.message);
-      }
-    }
     const created = createIssueComment(owner, repo, targetNumber, planned.body);
     report.applied = true;
     report.commentId = created.id ?? null;
@@ -129,13 +114,6 @@ if (args.apply) {
   } else if (planned.action === "update") {
     if (!planned.commentId) {
       fail("cannot update digest because the current comment id is missing");
-    }
-    if (!args.skipClaimCheck) {
-      try {
-        assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
-      } catch (error) {
-        fail(error.message);
-      }
     }
     const updated = updateIssueComment(owner, repo, planned.commentId, planned.body);
     report.applied = true;


### PR DESCRIPTION
## Summary

Optimization follow-up from live status digest implementation (#198, #215).

## Problem

Apply mode performs 5 claim revalidations during a single run:
1. Before the fresh digest replan
2. After the replan
3. Inside create action branch
4. Inside update action branch  
5. (Plus no-op case handling)

This creates redundant GitHub API calls.

## Solution

Reduce to 1 centralized claim revalidation before mutations:
- ✅ Keep revalidation before replan (protects the replan operation)
- ❌ Remove post-replan revalidation (redundant with pre-replan check)
- ❌ Remove action-branch revalidations (centralize at mutation decision)

Behavior unchanged when `--skip-claim-check` is used.

## Verification

✅ All 6 live-status-digest tests pass
✅ No behavior change (same safety guarantees)
✅ Reduced API calls from 5 to 1 per apply run

Closes #218