### PR TITLE
docs(idd): add pre-claim issue suitability triage gate (A4.5)

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -303,6 +303,11 @@ touch issues outside the roadmap traversal graph:
   `idd-skill-blocked-by` dependency markers (see A3
   below). The result is used solely to determine blocked status and is
   not added to the A2 candidate set.
+- **A4.5 only**: a narrow duplicate/reuse search for the candidate
+  selected in A4 Step 2 (title match, body-content, or fuzzy match to
+  detect known open or closed issues that supersede or duplicate it).
+  The result is used solely to determine duplicate status for the
+  selected candidate and is not added to any candidate set.
 
 **Prohibited in all other contexts** — the following must not be used in
 any phase except as listed above, or when A3 step 4 explicit opt-in
@@ -512,16 +517,20 @@ Can success be verified independently by the agent?
 ### Failure Outcomes
 
 When an issue fails any suitability check, classify it into one of six
-stable outcomes:
+stable outcomes. Then remove the failing candidate from the A4 survivor
+set and return to A4 Step 2 to try the next-lowest-numbered candidate.
+Report each failure before continuing. Stop when the survivor set is
+empty (no suitable issue found this run) or when an `invalid` outcome
+occurs (trust/safety concerns require human review before continuing):
 
-| Outcome            | Meaning                        | Next Steps      |
-| ------------------ | ------------------------------ | --------------- |
-| `unclear`          | Issue needs clarification      | Report and stop |
-| `needs-decision`   | Requires maintainer decision   | Report and stop |
-| `blocked-by-human` | Requires human coordination    | Report and stop |
-| `duplicate`        | Duplicate or superseded work   | Report and stop |
-| `out-of-scope`     | Outside repository scope       | Report and stop |
-| `invalid`          | Trust/safety concern or defect | Report and stop |
+| Outcome            | Meaning                        | Next Steps                     |
+| ------------------ | ------------------------------ | ------------------------------ |
+| `unclear`          | Issue needs clarification      | Report, try next candidate     |
+| `needs-decision`   | Requires maintainer decision   | Report, try next candidate     |
+| `blocked-by-human` | Requires human coordination    | Report, try next candidate     |
+| `duplicate`        | Duplicate or superseded work   | Report, try next candidate     |
+| `out-of-scope`     | Outside repository scope       | Report, try next candidate     |
+| `invalid`          | Trust/safety concern or defect | Report and stop (do not retry) |
 
 ### Mutation Policy
 
@@ -577,28 +586,30 @@ implementation work:
 ### Decision Flow
 
 ```text
-Issue picked in A4 Step 2
+Candidates = A4 survivor set (sorted by ascending issue number)
+Loop: Pick lowest-numbered candidate from Candidates
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
-    → FAIL → Classify as out-of-scope → Report and STOP (no claim)
+    → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop
   → Run Check 2 (Coherence)
     → PASS → Run Check 3
-    → FAIL → Classify as unclear → Report and STOP
+    → FAIL → Classify as unclear → Report, remove from Candidates, loop
   → Run Check 3 (Trust/Safety)
     → PASS → Run Check 4
-    → FAIL → Classify as invalid → Report and STOP
+    → FAIL → Classify as invalid → Report and STOP (do not retry)
   → Run Check 4 (Duplicates)
     → PASS → Run Check 5
-    → FAIL → Classify as duplicate → Report and STOP
+    → FAIL → Classify as duplicate → Report, remove from Candidates, loop
   → Run Check 5 (Actionability)
     → PASS → Run Check 6
-    → FAIL → Classify as needs-decision → Report and STOP
+    → FAIL → Classify as needs-decision → Report, remove from Candidates, loop
   → Run Check 6 (Autonomy)
     → PASS → Run Check 7
-    → FAIL → Classify as blocked-by-human → Report and STOP
+    → FAIL → Classify as blocked-by-human → Report, remove from Candidates, loop
   → Run Check 7 (Verifiability)
     → PASS → Proceed to A5 (claim)
-    → FAIL → Classify as needs-decision → Report and STOP (no claim)
+    → FAIL → Classify as needs-decision → Report, remove from Candidates, loop
+Candidates empty → STOP (no suitable issue found this run)
 ```
 
 ### Edge Cases

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -1,12 +1,13 @@
-# IDD — Discover Phase (A0-T–A4)
+# IDD — Discover Phase (A0-T–A4.5)
 
 Read this file when starting a new task. It covers finding and selecting
 the next issue to work on, including an operator-provided exact issue
-target. After selecting or verifying a target, read
-`idd-claim.instructions.md` to claim it.
+target, pre-claim suitability filtering, and claim handoff. After
+selecting a suitable candidate, read `idd-claim.instructions.md` to
+claim it.
 
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
-**Early stop condition**: A0-T or A4 (no claim made — see below).
+**Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).
 
 ## A0-T — Explicit issue target shortcut
 
@@ -44,7 +45,9 @@ failed criterion and stop without claiming. Do not fall back to another
 issue unless the operator explicitly asks for normal discovery in the
 same run.
 
-If all checks pass, the target is selected. Continue directly to
+If all checks pass, the target is selected. Continue to
+`idd-discover.instructions.md` **A4.5** for suitability triage. A4.5
+follows the same standards as roadmap paths. If A4.5 passes, proceed to
 `idd-claim.instructions.md` A5. A5 claim-state, open-PR, takeover,
 branch-collision, and claim-verification rules remain unchanged.
 
@@ -409,4 +412,193 @@ not post `unclaimed-by` because no claim was made. This is not an abort.
 Among the surviving viable issues, pick the one with the **lowest issue
 number**.
 
-After picking, continue to `idd-claim.instructions.md`.
+After picking, proceed to **A4.5**.
+
+## A4.5 — Pre-Claim Issue-Suitability Triage
+
+**Position**: After A4 (viability), before A5 (claim)\
+**Scope**: Applies to explicit-target, roadmap, and orphan-first candidates\
+**Purpose**: Filter incoherent, unsafe, duplicated, or out-of-scope issues
+
+This gate evaluates whether an issue is **suitable for autonomous
+execution** independent of the current run's context. Where A4 asks "can
+we do this NOW?", A4.5 asks "SHOULD we do this at all?"
+
+### Seven Suitability Checks
+
+For the candidate picked in A4 Step 2, evaluate the following checks in
+order. Stop and fail on the first check that is not satisfied.
+
+#### Check 1: Repository Fit
+
+Does the issue describe work scoped to this repository?
+
+- **Pass**: Work is entirely within this repository's scope; no external
+  system coordination needed
+- **Fail**: Issue crosses repository boundaries, requires external system
+  access, or is out-of-scope for this repository
+- **Outcome on fail**: `out-of-scope`
+
+#### Check 2: Issue Coherence
+
+Is the issue body coherent and well-structured?
+
+- **Pass**: Title and description are clear; body structure is
+  interpretable; intent can be restated safely
+- **Fail**: Body is malformed, contradictory, incomplete, or intent is
+  impossible to parse reliably
+- **Outcome on fail**: `unclear`
+
+#### Check 3: Trust/Safety
+
+Can the agent safely interpret and execute this issue without undue
+trust or safety risk?
+
+- **Pass**: Issue body and comments contain only trusted input; no code
+  injection risk in markers; no safety concern apparent
+- **Fail**: Untrusted input risk (e.g., embedded code in markers without
+  escaping), ambiguous safety concern, or requires human judgment on
+  safety
+- **Outcome on fail**: `invalid`
+
+#### Check 4: Duplicate or Superseded Work
+
+Is this work a duplicate of an existing open issue, closed issue, or
+merged PR?
+
+- **Pass**: No duplicate or superseded work detected; this issue
+  represents novel work
+- **Fail**: Issue duplicates an existing open or closed issue, is
+  superseded by newer work, or the work was already completed
+- **Outcome on fail**: `duplicate`
+
+#### Check 5: Actionability
+
+Does the issue describe concrete, actionable work?
+
+- **Pass**: Issue specifies clear acceptance criteria, actionable steps,
+  or verifiable outcomes
+- **Fail**: Issue is too vague, aspirational, blocked by human decision,
+  or lacks concrete direction
+- **Outcome on fail**: `needs-decision`
+
+#### Check 6: Autonomy (Suitability Perspective)
+
+Can the agent complete this work without external coordination beyond
+those already checked in A4?
+
+- **Note**: A4 already checks "no external coordination required"; A4.5
+  re-confirms in context of suitability
+- **Pass**: No additional coordination, approvals, or stakeholder
+  sign-offs required beyond what A4 evaluated
+- **Fail**: Issue requires maintainer approval before work can proceed,
+  stakeholder coordination, or external availability gate
+- **Outcome on fail**: `blocked-by-human`
+
+#### Check 7: Verifiability (Suitability Perspective)
+
+Can success be verified independently by the agent?
+
+- **Note**: A4 checks "clear verification"; A4.5 re-confirms the issue
+  does not require subjective approval
+- **Pass**: Success is verifiable through automated tests, CI, lint, or
+  concrete objective criteria
+- **Fail**: Success depends on maintainer opinion, UX judgment call, or
+  external stakeholder sign-off
+- **Outcome on fail**: `needs-decision`
+
+### Failure Outcomes
+
+When an issue fails any suitability check, classify it into one of six
+stable outcomes:
+
+| Outcome            | Meaning                        | Next Steps      |
+| ------------------ | ------------------------------ | --------------- |
+| `unclear`          | Issue needs clarification      | Report and stop |
+| `needs-decision`   | Requires maintainer decision   | Report and stop |
+| `blocked-by-human` | Requires human coordination    | Report and stop |
+| `duplicate`        | Duplicate or superseded work   | Report and stop |
+| `out-of-scope`     | Outside repository scope       | Report and stop |
+| `invalid`          | Trust/safety concern or defect | Report and stop |
+
+### Mutation Policy
+
+**A4.5 is a triage gate, not an execution claim.** The gate determines
+readiness but does NOT automatically apply labels or post claims.
+
+**Read-only approach** (recommended):
+
+- Agent evaluates all seven checks
+- If any check fails, agent reports the failure outcome and stops
+- NO implementation claim comment is posted
+- NO branch or worktree is created
+- NO labels are applied
+- A5 is never reached
+
+**Optional labeled approach** (if policy permits):
+
+- Agent MAY optionally apply a transient `triage:{outcome}` label to
+  document the rejection reason
+- Label must NOT masquerade as an implementation claim
+- Label is intended as a diagnostic aid for humans reviewing rejected
+  candidates
+- Labeled approach still stops at A4.5; A5 is never reached
+
+### Coordination Rule
+
+A4.5 rejections must clearly indicate they are **triage decisions**, not
+implementation work:
+
+- Do NOT post claim comments or claim markers
+- Do NOT create branches or worktrees
+- Do NOT post operational markers (review-watermark, review-baseline,
+  etc.)
+- If posting a label, use a `triage:` prefix to distinguish from
+  implementation state
+- Any diagnostic comments MUST state clearly: "A4.5 suitability gate
+  rejection" to distinguish from claim or work-in-progress
+
+### Decision Flow
+
+```text
+Issue picked in A4 Step 2
+  → Run Check 1 (Repository Fit)
+    → PASS → Run Check 2
+    → FAIL → Classify as out-of-scope → Report and STOP (no claim)
+  → Run Check 2 (Coherence)
+    → PASS → Run Check 3
+    → FAIL → Classify as unclear → Report and STOP
+  → Run Check 3 (Trust/Safety)
+    → PASS → Run Check 4
+    → FAIL → Classify as invalid → Report and STOP
+  → Run Check 4 (Duplicates)
+    → PASS → Run Check 5
+    → FAIL → Classify as duplicate → Report and STOP
+  → Run Check 5 (Actionability)
+    → PASS → Run Check 6
+    → FAIL → Classify as needs-decision → Report and STOP
+  → Run Check 6 (Autonomy)
+    → PASS → Run Check 7
+    → FAIL → Classify as blocked-by-human → Report and STOP
+  → Run Check 7 (Verifiability)
+    → PASS → Proceed to A5 (claim)
+    → FAIL → Classify as needs-decision → Report and STOP (no claim)
+```
+
+### Edge Cases
+
+**Malformed markers or body**: If the issue body contains unparseable
+structured data (e.g., corrupted marker), treat it as **Check 2
+(Coherence) failure** → `unclear`. Report the parsing error so a human
+can correct the issue.
+
+**Timeout on duplicate detection**: If duplicate detection (Check 4)
+times out or becomes expensive, fall back to exact title match only. If
+exact match is not found, PASS the check and continue.
+
+**Agent-specific limitations**: All seven checks should be agent-agnostic
+(work for Copilot, Claude, Codex, Gemini). If an agent cannot reliably
+perform a check, document that limitation and treat as a PASS so work is
+not blocked by agent capability limits.
+
+After A4.5, proceed to `idd-claim.instructions.md`.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -463,13 +463,15 @@ trust or safety risk?
 
 #### Check 4: Duplicate or Superseded Work
 
-Is this work a duplicate of an existing open issue, closed issue, or
-merged PR?
+Is this work a duplicate of an existing open issue, closed issue,
+merged PR, or draft PR? Is it superseded by paused work marked with
+`status:blocked-by-human` or `status:needs-decision`?
 
 - **Pass**: No duplicate or superseded work detected; this issue
   represents novel work
 - **Fail**: Issue duplicates an existing open or closed issue, is
-  superseded by newer work, or the work was already completed
+  superseded by newer work, or the work was already completed or is in
+  progress (including draft PRs)
 - **Outcome on fail**: `duplicate`
 
 #### Check 5: Actionability
@@ -543,6 +545,20 @@ readiness but does NOT automatically apply labels or post claims.
 - Label is intended as a diagnostic aid for humans reviewing rejected
   candidates
 - Labeled approach still stops at A4.5; A5 is never reached
+
+**Permitted and prohibited mutations**:
+
+- **Permitted**: Agents may post a single diagnostic comment explaining
+  the A4.5 rejection outcome, prefixed with **"A4.5 suitability gate
+  rejection"** to distinguish from claim or work-in-progress markers.
+- **Prohibited**: Agents must NOT post implementation claim comments,
+  create branches or worktrees, close issues unilaterally, or modify
+  roadmap structures or relationships. Do NOT apply other labels except
+  the optional `triage:{outcome}` label in the labeled approach above.
+- **Linking**: Issues may be linked as related context (e.g., "Related
+  to #NNN which addresses similar work") in diagnostic comments, but
+  must NOT be treated as duplicates without explicit human confirmation
+  first.
 
 ### Coordination Rule
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -36,7 +36,7 @@ you are reading this guide first, start at step 1.
 | File                                                       | Role                                                                    |
 | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping  |
-| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue and audit completed roadmaps                 |
+| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue, audit suitability, and start work           |
 | `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                             |
 | `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                   |
 | `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                    |
@@ -97,8 +97,9 @@ files that own each value.
 
 When an operator gives exactly one issue target, Discover can verify that
 target directly before Claim. The shortcut avoids broad roadmap
-enumeration, but it still applies targeted readiness checks and the A4
-viability gate before the normal A5 claim safety checks.
+enumeration, but it still applies targeted readiness checks, the A4
+viability gate, and the A4.5 suitability gate before the normal A5 claim
+safety checks.
 
 ## Roadmap completion audits
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -308,6 +308,11 @@ touch issues outside the roadmap traversal graph:
   `{{PROJECT_MARKER_PREFIX}}-blocked-by` dependency markers (see A3
   below). The result is used solely to determine blocked status and is
   not added to the A2 candidate set.
+- **A4.5 only**: a narrow duplicate/reuse search for the candidate
+  selected in A4 Step 2 (title match, body-content, or fuzzy match to
+  detect known open or closed issues that supersede or duplicate it).
+  The result is used solely to determine duplicate status for the
+  selected candidate and is not added to any candidate set.
 
 **Prohibited in all other contexts** — the following must not be used in
 any phase except as listed above, or when A3 step 4 explicit opt-in
@@ -518,16 +523,20 @@ Can success be verified independently by the agent?
 ### Failure Outcomes
 
 When an issue fails any suitability check, classify it into one of six
-stable outcomes:
+stable outcomes. Then remove the failing candidate from the A4 survivor
+set and return to A4 Step 2 to try the next-lowest-numbered candidate.
+Report each failure before continuing. Stop when the survivor set is
+empty (no suitable issue found this run) or when an `invalid` outcome
+occurs (trust/safety concerns require human review before continuing):
 
-| Outcome            | Meaning                        | Next Steps      |
-| ------------------ | ------------------------------ | --------------- |
-| `unclear`          | Issue needs clarification      | Report and stop |
-| `needs-decision`   | Requires maintainer decision   | Report and stop |
-| `blocked-by-human` | Requires human coordination    | Report and stop |
-| `duplicate`        | Duplicate or superseded work   | Report and stop |
-| `out-of-scope`     | Outside repository scope       | Report and stop |
-| `invalid`          | Trust/safety concern or defect | Report and stop |
+| Outcome            | Meaning                        | Next Steps                     |
+| ------------------ | ------------------------------ | ------------------------------ |
+| `unclear`          | Issue needs clarification      | Report, try next candidate     |
+| `needs-decision`   | Requires maintainer decision   | Report, try next candidate     |
+| `blocked-by-human` | Requires human coordination    | Report, try next candidate     |
+| `duplicate`        | Duplicate or superseded work   | Report, try next candidate     |
+| `out-of-scope`     | Outside repository scope       | Report, try next candidate     |
+| `invalid`          | Trust/safety concern or defect | Report and stop (do not retry) |
 
 ### Mutation Policy
 
@@ -583,28 +592,30 @@ implementation work:
 ### Decision Flow
 
 ```text
-Issue picked in A4 Step 2
+Candidates = A4 survivor set (sorted by ascending issue number)
+Loop: Pick lowest-numbered candidate from Candidates
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
-    → FAIL → Classify as out-of-scope → Report and STOP (no claim)
+    → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop
   → Run Check 2 (Coherence)
     → PASS → Run Check 3
-    → FAIL → Classify as unclear → Report and STOP
+    → FAIL → Classify as unclear → Report, remove from Candidates, loop
   → Run Check 3 (Trust/Safety)
     → PASS → Run Check 4
-    → FAIL → Classify as invalid → Report and STOP
+    → FAIL → Classify as invalid → Report and STOP (do not retry)
   → Run Check 4 (Duplicates)
     → PASS → Run Check 5
-    → FAIL → Classify as duplicate → Report and STOP
+    → FAIL → Classify as duplicate → Report, remove from Candidates, loop
   → Run Check 5 (Actionability)
     → PASS → Run Check 6
-    → FAIL → Classify as needs-decision → Report and STOP
+    → FAIL → Classify as needs-decision → Report, remove from Candidates, loop
   → Run Check 6 (Autonomy)
     → PASS → Run Check 7
-    → FAIL → Classify as blocked-by-human → Report and STOP
+    → FAIL → Classify as blocked-by-human → Report, remove from Candidates, loop
   → Run Check 7 (Verifiability)
     → PASS → Proceed to A5 (claim)
-    → FAIL → Classify as needs-decision → Report and STOP (no claim)
+    → FAIL → Classify as needs-decision → Report, remove from Candidates, loop
+Candidates empty → STOP (no suitable issue found this run)
 ```
 
 ### Edge Cases
@@ -622,3 +633,5 @@ exact match is not found, PASS the check and continue.
 (work for Copilot, Claude, Codex, Gemini). If an agent cannot reliably
 perform a check, document that limitation and treat as a PASS so work is
 not blocked by agent capability limits.
+
+After A4.5, proceed to `idd-claim.instructions.md`.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -1,4 +1,4 @@
-# IDD — Discover Phase (A0-T–A4)
+# IDD — Discover Phase (A0-T–A4.5)
 
 Read this file when starting a new task. It covers finding and selecting
 the next issue to work on, including an operator-provided exact issue
@@ -6,7 +6,7 @@ target. After selecting or verifying a target, read
 `idd-claim.instructions.md` to claim it.
 
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
-**Early stop condition**: A0-T or A4 (no claim made — see below).
+**Early stop condition**: A0-T, A4.5, or A4 (no claim made — see below).
 
 ## A0-T — Explicit issue target shortcut
 
@@ -45,7 +45,9 @@ failed criterion and stop without claiming. Do not fall back to another
 issue unless the operator explicitly asks for normal discovery in the
 same run.
 
-If all checks pass, the target is selected. Continue directly to
+If all checks pass, the target is selected. Continue to
+`idd-discover.instructions.md` **A4.5** for suitability triage. A4.5
+follows the same standards as roadmap paths. If A4.5 passes, proceed to
 `idd-claim.instructions.md` A5. A5 claim-state, open-PR, takeover,
 branch-collision, and claim-verification rules remain unchanged.
 
@@ -416,4 +418,191 @@ not post `unclaimed-by` because no claim was made. This is not an abort.
 Among the surviving viable issues, pick the one with the **lowest issue
 number**.
 
-After picking, continue to `idd-claim.instructions.md`.
+After picking, continue to **A4.5**.
+
+## A4.5 — Pre-Claim Issue-Suitability Triage
+
+**Position**: After A4 (viability), before A5 (claim)\
+**Scope**: Applies to explicit-target, roadmap, and orphan-first candidates\
+**Purpose**: Filter incoherent, unsafe, duplicated, or out-of-scope issues
+
+This gate evaluates whether an issue is **suitable for autonomous
+execution** independent of the current run's context. Where A4 asks "can
+we do this NOW?", A4.5 asks "SHOULD we do this at all?"
+
+### Seven Suitability Checks
+
+For the candidate picked in A4 Step 2, evaluate the following checks in
+order. Stop and fail on the first check that is not satisfied.
+
+#### Check 1: Repository Fit
+
+Does the issue describe work scoped to this repository?
+
+- **Pass**: Work is entirely within this repository's scope; no external
+  system coordination needed
+- **Fail**: Issue crosses repository boundaries, requires external system
+  access, or is out-of-scope for this repository
+- **Outcome on fail**: `out-of-scope`
+
+#### Check 2: Issue Coherence
+
+Is the issue body coherent and well-structured?
+
+- **Pass**: Title and description are clear; body structure is
+  interpretable; intent can be restated safely
+- **Fail**: Body is malformed, contradictory, incomplete, or intent is
+  impossible to parse reliably
+- **Outcome on fail**: `unclear`
+
+#### Check 3: Trust/Safety
+
+Can the agent safely interpret and execute this issue without undue
+trust or safety risk?
+
+- **Pass**: Issue body and comments contain only trusted input; no code
+  injection risk in markers; no safety concern apparent
+- **Fail**: Untrusted input risk (e.g., embedded code in markers without
+  escaping), ambiguous safety concern, or requires human judgment on
+  safety
+- **Outcome on fail**: `invalid`
+
+#### Check 4: Duplicate or Superseded Work
+
+Is this work a duplicate of an existing open issue, closed issue, or
+merged PR?
+
+- **Pass**: No duplicate or superseded work detected; this issue
+  represents novel work
+- **Fail**: Issue duplicates an existing open or closed issue, is
+  superseded by newer work, or the work was already completed
+- **Outcome on fail**: `duplicate`
+
+#### Check 5: Actionability
+
+Does the issue describe concrete, actionable work?
+
+- **Pass**: Issue specifies clear acceptance criteria, actionable steps,
+  or verifiable outcomes
+- **Fail**: Issue is too vague, aspirational, blocked by human decision,
+  or lacks concrete direction
+- **Outcome on fail**: `needs-decision`
+
+#### Check 6: Autonomy (Suitability Perspective)
+
+Can the agent complete this work without external coordination beyond
+those already checked in A4?
+
+- **Note**: A4 already checks "no external coordination required"; A4.5
+  re-confirms in context of suitability
+- **Pass**: No additional coordination, approvals, or stakeholder
+  sign-offs required beyond what A4 evaluated
+- **Fail**: Issue requires maintainer approval before work can proceed,
+  stakeholder coordination, or external availability gate
+- **Outcome on fail**: `blocked-by-human`
+
+#### Check 7: Verifiability (Suitability Perspective)
+
+Can success be verified independently by the agent?
+
+- **Note**: A4 checks "clear verification"; A4.5 re-confirms the issue
+  does not require subjective approval
+- **Pass**: Success is verifiable through automated tests, CI, lint, or
+  concrete objective criteria
+- **Fail**: Success depends on maintainer opinion, UX judgment call, or
+  external stakeholder sign-off
+- **Outcome on fail**: `needs-decision`
+
+### Failure Outcomes
+
+When an issue fails any suitability check, classify it into one of six
+stable outcomes:
+
+| Outcome            | Meaning                        | Next Steps      |
+| ------------------ | ------------------------------ | --------------- |
+| `unclear`          | Issue needs clarification      | Report and stop |
+| `needs-decision`   | Requires maintainer decision   | Report and stop |
+| `blocked-by-human` | Requires human coordination    | Report and stop |
+| `duplicate`        | Duplicate or superseded work   | Report and stop |
+| `out-of-scope`     | Outside repository scope       | Report and stop |
+| `invalid`          | Trust/safety concern or defect | Report and stop |
+
+### Mutation Policy
+
+**A4.5 is a triage gate, not an execution claim.** The gate determines
+readiness but does NOT automatically apply labels or post claims.
+
+**Read-only approach** (recommended):
+
+- Agent evaluates all seven checks
+- If any check fails, agent reports the failure outcome and stops
+- NO implementation claim comment is posted
+- NO branch or worktree is created
+- NO labels are applied
+- A5 is never reached
+
+**Optional labeled approach** (if policy permits):
+
+- Agent MAY optionally apply a transient `triage:{outcome}` label to
+  document the rejection reason
+- Label must NOT masquerade as an implementation claim
+- Label is intended as a diagnostic aid for humans reviewing rejected
+  candidates
+- Labeled approach still stops at A4.5; A5 is never reached
+
+### Coordination Rule
+
+A4.5 rejections must clearly indicate they are **triage decisions**, not
+implementation work:
+
+- Do NOT post claim comments or claim markers
+- Do NOT create branches or worktrees
+- Do NOT post operational markers (review-watermark, review-baseline,
+  etc.)
+- If posting a label, use a `triage:` prefix to distinguish from
+  implementation state
+- Any diagnostic comments MUST state clearly: "A4.5 suitability gate
+  rejection" to distinguish from claim or work-in-progress
+
+### Decision Flow
+
+```text
+Issue picked in A4 Step 2
+  → Run Check 1 (Repository Fit)
+    → PASS → Run Check 2
+    → FAIL → Classify as out-of-scope → Report and STOP (no claim)
+  → Run Check 2 (Coherence)
+    → PASS → Run Check 3
+    → FAIL → Classify as unclear → Report and STOP
+  → Run Check 3 (Trust/Safety)
+    → PASS → Run Check 4
+    → FAIL → Classify as invalid → Report and STOP
+  → Run Check 4 (Duplicates)
+    → PASS → Run Check 5
+    → FAIL → Classify as duplicate → Report and STOP
+  → Run Check 5 (Actionability)
+    → PASS → Run Check 6
+    → FAIL → Classify as needs-decision → Report and STOP
+  → Run Check 6 (Autonomy)
+    → PASS → Run Check 7
+    → FAIL → Classify as blocked-by-human → Report and STOP
+  → Run Check 7 (Verifiability)
+    → PASS → Proceed to A5 (claim)
+    → FAIL → Classify as needs-decision → Report and STOP (no claim)
+```
+
+### Edge Cases
+
+**Malformed markers or body**: If the issue body contains unparseable
+structured data (e.g., corrupted marker), treat it as **Check 2
+(Coherence) failure** → `unclear`. Report the parsing error so a human
+can correct the issue.
+
+**Timeout on duplicate detection**: If duplicate detection (Check 4)
+times out or becomes expensive, fall back to exact title match only. If
+exact match is not found, PASS the check and continue.
+
+**Agent-specific limitations**: All seven checks should be agent-agnostic
+(work for Copilot, Claude, Codex, Gemini). If an agent cannot reliably
+perform a check, document that limitation and treat as a PASS so work is
+not blocked by agent capability limits.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -6,7 +6,7 @@ target. After selecting or verifying a target, read
 `idd-claim.instructions.md` to claim it.
 
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
-**Early stop condition**: A0-T, A4.5, or A4 (no claim made — see below).
+**Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).
 
 ## A0-T — Explicit issue target shortcut
 
@@ -469,13 +469,15 @@ trust or safety risk?
 
 #### Check 4: Duplicate or Superseded Work
 
-Is this work a duplicate of an existing open issue, closed issue, or
-merged PR?
+Is this work a duplicate of an existing open issue, closed issue,
+merged PR, or draft PR? Is it superseded by paused work marked with
+`status:blocked-by-human` or `status:needs-decision`?
 
 - **Pass**: No duplicate or superseded work detected; this issue
   represents novel work
 - **Fail**: Issue duplicates an existing open or closed issue, is
-  superseded by newer work, or the work was already completed
+  superseded by newer work, or the work was already completed or is in
+  progress (including draft PRs)
 - **Outcome on fail**: `duplicate`
 
 #### Check 5: Actionability
@@ -549,6 +551,20 @@ readiness but does NOT automatically apply labels or post claims.
 - Label is intended as a diagnostic aid for humans reviewing rejected
   candidates
 - Labeled approach still stops at A4.5; A5 is never reached
+
+**Permitted and prohibited mutations**:
+
+- **Permitted**: Agents may post a single diagnostic comment explaining
+  the A4.5 rejection outcome, prefixed with **"A4.5 suitability gate
+  rejection"** to distinguish from claim or work-in-progress markers.
+- **Prohibited**: Agents must NOT post implementation claim comments,
+  create branches or worktrees, close issues unilaterally, or modify
+  roadmap structures or relationships. Do NOT apply other labels except
+  the optional `triage:{outcome}` label in the labeled approach above.
+- **Linking**: Issues may be linked as related context (e.g., "Related
+  to #NNN which addresses similar work") in diagnostic comments, but
+  must NOT be treated as duplicates without explicit human confirmation
+  first.
 
 ### Coordination Rule
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -42,7 +42,7 @@ entry file should be an explicit operator choice, not the default.
 | File                                                       | Role                                                                    |
 | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping  |
-| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue and audit completed roadmaps                 |
+| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue, audit suitability, and start work           |
 | `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                             |
 | `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                   |
 | `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                    |
@@ -90,8 +90,9 @@ files that own each value.
 
 When an operator gives exactly one issue target, Discover can verify that
 target directly before Claim. The shortcut avoids broad roadmap
-enumeration, but it still applies targeted readiness checks and the A4
-viability gate before the normal A5 claim safety checks.
+enumeration, but it still applies targeted readiness checks, the A4
+viability gate, and the A4.5 suitability gate before the normal A5 claim
+safety checks.
 
 ## Roadmap completion audits
 


### PR DESCRIPTION
Closes #228

## Summary
Added A4.5 pre-claim issue-suitability triage gate with seven structured checks and six stable failure outcomes. Gate is positioned after A4 (viability) and before A5 (claim), applying to all discovery paths (explicit-target, roadmap, orphan-first).

## Acceptance Criteria (Issue #228)
- [x] Define pre-claim gate for explicit-target, roadmap, orphan paths
- [x] Seven checks: repo fit, coherence, trust/safety, duplicates, actionability, autonomy, verifiability
- [x] Passing candidates continue without changing A3/A4/A5
- [x] Failing candidates mapped to stable outcomes
- [x] Define mutation policy (read-only or optional labeled)
- [x] Coordination rules (no masquerading)
- [x] Source and template synchronized
- [x] Docs validation passes (markdownlint, cspell)

## Changes
- .github/instructions/idd-discover.instructions.md: new A4.5 section
- idd-template/.github/instructions/idd-discover.instructions.md: mirrored
- docs/idd-workflow.md and template equiv: updated references

## Validation
✅ markdownlint, dprint, cspell all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced A4.5 pre-claim suitability triage as a validation checkpoint between issue selection and claiming
  * Added seven ordered suitability checks: repository fit, coherence, trust/safety, duplication/supersession, actionability, autonomy, verifiability
  * Defined standardized outcomes (e.g., unclear, needs-decision, blocked-by-human, duplicate, out-of-scope, invalid) and a read-only mutation policy (optional diagnostic label)
  * Updated workflow and single-issue-target flows to include A4.5 and adjusted early-stop behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/235)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/235)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->