### PR TITLE
docs(skill): align issue-authoring buckets with A4.5 gate outcomes

### DIFF
--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -158,6 +158,39 @@ Recommended routing rules:
 - if the work does not belong in this repository, route to
   `out-of-scope`
 
+## Alignment with A4.5 Suitability Gate
+
+The IDD discover phase uses an A4.5 pre-claim suitability gate that
+evaluates whether an already-published issue is suitable for autonomous
+execution. This gate applies the same readiness buckets as the issue
+authoring skill, **and adds new outcomes** for defects discovered at
+discover time.
+
+### Mapping authoring buckets to A4.5 outcomes
+
+| Authoring Bucket     | A4.5 Gate Checks | Pass/Fail              | A4.5 Outcome       |
+| -------------------- | ---------------- | ---------------------- | ------------------ |
+| **ready**            | All 7 checks     | All pass               | **(pass)** → claim |
+| **deferred**         | (not published)  | N/A during drafting    | Not yet evaluated  |
+| **needs-decision**   | Check 5 or 7     | Fail on decision block | `needs-decision`   |
+| **blocked-by-human** | Check 6          | Fail on autonomy block | `blocked-by-human` |
+| **out-of-scope**     | Check 1          | Fail on scope check    | `out-of-scope`     |
+
+### New A4.5 outcomes not in authoring buckets
+
+The A4.5 gate may discover new issues that should have been caught
+during drafting:
+
+| A4.5 Outcome  | A4.5 Check | Meaning                               | Drafting Prevention                     |
+| ------------- | ---------- | ------------------------------------- | --------------------------------------- |
+| **unclear**   | Check 2    | Issue body is malformed or incoherent | Run coherence validation before publish |
+| **invalid**   | Check 3    | Untrusted input or safety concern     | Screen for markers and code injection   |
+| **duplicate** | Check 4    | Duplicate of existing work            | Run reuse-first check before publish    |
+
+**Prevention during drafting**: Before publishing an issue, validate that
+it will not fail A4.5 for coherence, safety, or uniqueness. If it would,
+resolve the issue during drafting instead of publishing it.
+
 ## Reuse-first issue policy
 
 Before creating any new issue, the skill should check whether the work

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -194,12 +194,16 @@ authoring skill should catch these issues before publishing:
 
 Pre-publish validation checklist:
 
-1. **Coherence**: Issue body is well-formed, title+description are clear, intent is parseable
-2. **Safety**: No code injection, marker injection, or untrusted input in issue body
-3. **Uniqueness**: Reuse-first check passed; no duplicate or superseded work
+1. **Coherence**: Issue body is well-formed, title+description are
+   clear, intent is parseable
+2. **Safety**: No code injection, marker injection, or untrusted input
+   in issue body
+3. **Uniqueness**: Reuse-first check passed; no duplicate or superseded
+   work
 
-If any check is uncertain, route the issue to `needs-decision` or `blocked-by-human`
-during drafting instead of publishing a marginally-ready issue.
+If any check is uncertain, route the issue to `needs-decision` or
+`blocked-by-human` during drafting instead of publishing a
+marginally-ready issue.
 
 ## Publication boundary
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -183,14 +183,15 @@ When an issue is published and reaches the IDD discover phase, the A4.5
 pre-claim gate will evaluate it against seven suitability checks. The
 authoring skill should catch these issues before publishing:
 
-| Check                   | Authoring Bucket     | How to Prevent                                                                  |
-| ----------------------- | -------------------- | ------------------------------------------------------------------------------- |
-| Coherence (Check 2)     | `ready` or escalated | Validate issue body against schema before publish                               |
-| Safety/trust (Check 3)  | `ready` or escalated | Screen issue body for code injection and untrusted markers                      |
-| Duplicates (Check 4)    | `ready` or escalated | Run reuse-first checks before creating a new issue                              |
-| Actionability (Check 5) | `ready` or escalated | Ensure the issue describes concrete work; escalate if blocked by human decision |
-| Autonomy (Check 6)      | `ready` or escalated | Ensure agent can complete without external coordination                         |
-| Verifiability (Check 7) | `ready` or escalated | Ensure success is verifiable; escalate if it requires subjective approval       |
+| Check                    | Authoring Bucket     | How to Prevent                                                                  |
+| ------------------------ | -------------------- | ------------------------------------------------------------------------------- |
+| Repository Fit (Check 1) | `out-of-scope`       | Ensure issue is scoped to this repository; escalate if it crosses boundaries    |
+| Coherence (Check 2)      | `ready` or escalated | Validate issue body against schema before publish                               |
+| Safety/trust (Check 3)   | `ready` or escalated | Screen issue body for code injection and untrusted markers                      |
+| Duplicates (Check 4)     | `ready` or escalated | Run reuse-first checks before creating a new issue                              |
+| Actionability (Check 5)  | `ready` or escalated | Ensure the issue describes concrete work; escalate if blocked by human decision |
+| Autonomy (Check 6)       | `ready` or escalated | Ensure agent can complete without external coordination                         |
+| Verifiability (Check 7)  | `ready` or escalated | Ensure success is verifiable; escalate if it requires subjective approval       |
 
 Pre-publish validation checklist:
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -177,6 +177,30 @@ Validation expectations:
 - the issue is referenced from its parent roadmap task list
 - it can be claimed independently without owning the whole roadmap
 
+## A4.5 Suitability Gate Alignment
+
+When an issue is published and reaches the IDD discover phase, the A4.5
+pre-claim gate will evaluate it against seven suitability checks. The
+authoring skill should catch these issues before publishing:
+
+| Check                   | Authoring Bucket     | How to Prevent                                                                  |
+| ----------------------- | -------------------- | ------------------------------------------------------------------------------- |
+| Coherence (Check 2)     | `ready` or escalated | Validate issue body against schema before publish                               |
+| Safety/trust (Check 3)  | `ready` or escalated | Screen issue body for code injection and untrusted markers                      |
+| Duplicates (Check 4)    | `ready` or escalated | Run reuse-first checks before creating a new issue                              |
+| Actionability (Check 5) | `ready` or escalated | Ensure the issue describes concrete work; escalate if blocked by human decision |
+| Autonomy (Check 6)      | `ready` or escalated | Ensure agent can complete without external coordination                         |
+| Verifiability (Check 7) | `ready` or escalated | Ensure success is verifiable; escalate if it requires subjective approval       |
+
+Pre-publish validation checklist:
+
+1. **Coherence**: Issue body is well-formed, title+description are clear, intent is parseable
+2. **Safety**: No code injection, marker injection, or untrusted input in issue body
+3. **Uniqueness**: Reuse-first check passed; no duplicate or superseded work
+
+If any check is uncertain, route the issue to `needs-decision` or `blocked-by-human`
+during drafting instead of publishing a marginally-ready issue.
+
 ## Publication boundary
 
 Drafting issues does not authorize publishing them or starting the IDD

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -66,6 +66,37 @@ Resolve `<marker-prefix>` from the target repository's onboarding or IDD
 docs before publishing the draft. Use `idd-skill` only when the target
 repository actually configured that prefix.
 
+## Handling duplicates and non-ready outcomes
+
+Before publishing an issue, apply a reuse-first decision tree:
+
+1. Is an existing open issue a better fit? If yes, extend it instead of
+   creating a new one. Add a comment linking to the new schema request.
+2. Is the work already complete in a closed issue or merged PR? If yes,
+   create a reference or learning note instead of reopening it.
+3. Is a parent roadmap already managing this work? If yes, add it to the
+   task list instead of filing independently.
+4. Does the issue have any of these properties? If yes, escalate to
+   `needs-decision` or `blocked-by-human` during drafting:
+   - Unclear intent or malformed body (→ fix during drafting or mark unclear)
+   - Requires maintainer or product decision (→ mark needs-decision)
+   - Blocked by external work or human coordination (→ mark
+     blocked-by-human)
+   - Depends on unavailable resources or credentials (→ mark blocked-by-human)
+5. Otherwise, publish as `ready`.
+
+### A4.5 prevention checklist
+
+The A4.5 suitability gate will later evaluate published issues. Prevent
+common failures by validating before publish:
+
+- **Coherence**: Issue body is well-formed; title and description are
+  clear; intent is parseable
+- **Safety**: No code injection, marker injection, or untrusted input in
+  issue body
+- **Uniqueness**: Reuse-first check passed; the work is not a duplicate
+  or superseded
+
 ## Publication boundary
 
 If the user asked for drafts only, stop after reporting the issue set,

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -78,7 +78,7 @@ Before publishing an issue, apply a reuse-first decision tree:
    task list instead of filing independently.
 4. Does the issue have any of these properties? If yes, escalate to
    `needs-decision` or `blocked-by-human` during drafting:
-   - Unclear intent or malformed body (→ fix during drafting or mark unclear)
+   - Unclear intent or malformed body (→ fix during drafting or mark needs-decision)
    - Requires maintainer or product decision (→ mark needs-decision)
    - Blocked by external work or human coordination (→ mark
      blocked-by-human)

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -2,7 +2,68 @@
 
 This bundle handles pre-approval issue drafting only.
 
-Use it to:
+## Handoff sequence
+
+The issue-authoring bundle fits into a three-phase handoff:
+
+### Phase 1: Drafting (this bundle)
+
+- Skill drafts issues in the target repository
+- Issues move through readiness buckets: `deferred` → `ready` or
+  → escalation bucket (`needs-decision`, `blocked-by-human`, `out-of-scope`)
+- User approves the issue set before any publication
+
+### Phase 2: Publishing (user-authorized handoff)
+
+- User explicitly asks for publication
+- Bundled skill creates or updates issues in the target repository
+- User verifies the published issues look correct
+- Published issues remain on hold until user explicitly requests IDD execution
+
+### Phase 3: Execution (separate IDD loop)
+
+- User explicitly asks to start the IDD execution loop
+- Target repository's `.github/instructions/idd-discover.instructions.md` takes over
+- IDD discover phase runs A0-T/A0-O/A1-A4.5 gates
+- Suitable issues are claimed, worked, and merged
+
+**Approval boundaries**:
+
+- **After drafting** (Phase 1 → Phase 2): User must explicitly approve the
+  issue set
+- **After publishing** (Phase 2 → Phase 3): User must explicitly request IDD
+  execution
+- **No implicit progression**: Each handoff requires explicit user request.
+  The bundle must not auto-transition to publishing or execution.
+
+## A4.5 Gate Timing
+
+The IDD discover phase evaluates published issues through the A4.5
+pre-claim suitability gate. This gate runs after an issue is published
+but before it is claimed for work.
+
+**Why A4.5 exists**: Issues drafted with incomplete information or from
+assumptions that did not hold when published may fail A4.5 checks
+(incoherent, unsafe, duplicate, etc.). A4.5 catches these before they
+waste agent time during work.
+
+**Prevention during drafting**: This bundle is where coherence, safety,
+and uniqueness should be validated **before** publishing. The three
+A4.5 prevention checks (coherence, safety, uniqueness) correspond to
+bucket escalation triggers during drafting:
+
+- If an issue might be incoherent → escalate to `needs-decision` during
+  drafting
+- If an issue might contain untrusted input → escalate to `blocked-by-human`
+  or fix during drafting
+- If an issue might be a duplicate → run reuse-first checks during
+  drafting before publishing
+
+When these prevent-during-drafting checks are applied correctly, published
+issues will pass A4.5; if they do not, A4.5 will catch them at discover
+time and report the specific failure (unclear, invalid, duplicate).
+
+## Use this bundle to:
 
 - prepare IDD-ready orphan issues when the target repository supports
   `issue-scope: orphan-first`, including any required
@@ -11,12 +72,14 @@ Use it to:
   sequencing or parallel tracks
 - surface non-ready buckets instead of guessing through blockers
 
-Do not use it to:
+## Do not use this bundle to:
 
-- start the Discover -> Claim -> Work loop implicitly
+- start the Discover → Claim → Work loop implicitly
 - treat bundled references as a replacement for repository execution
   instructions
 - publish issues unless the user explicitly asked for publishing
+
+## Handoff to execution
 
 After the user approves the issue set, wait for a separate request to
 publish the issues or start the IDD execution loop. Only then should

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -75,7 +75,7 @@ time and report the specific failure (unclear, invalid, duplicate).
 
 ## Do not use this bundle to
 
-- start the Discover → Claim → Work loop implicitly
+- start the Discover -> Claim -> Work loop implicitly
 - treat bundled references as a replacement for repository execution
   instructions
 - publish issues unless the user explicitly asked for publishing

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -23,7 +23,8 @@ The issue-authoring bundle fits into a three-phase handoff:
 ### Phase 3: Execution (separate IDD loop)
 
 - User explicitly asks to start the IDD execution loop
-- Target repository's `.github/instructions/idd-discover.instructions.md` takes over
+- Target repository's `.github/instructions/idd-discover.instructions.md`
+  takes over
 - IDD discover phase runs A0-T/A0-O/A1-A4.5 gates
 - Suitable issues are claimed, worked, and merged
 
@@ -63,7 +64,7 @@ When these prevent-during-drafting checks are applied correctly, published
 issues will pass A4.5; if they do not, A4.5 will catch them at discover
 time and report the specific failure (unclear, invalid, duplicate).
 
-## Use this bundle to:
+## Use this bundle to
 
 - prepare IDD-ready orphan issues when the target repository supports
   `issue-scope: orphan-first`, including any required
@@ -72,7 +73,7 @@ time and report the specific failure (unclear, invalid, duplicate).
   sequencing or parallel tracks
 - surface non-ready buckets instead of guessing through blockers
 
-## Do not use this bundle to:
+## Do not use this bundle to
 
 - start the Discover → Claim → Work loop implicitly
 - treat bundled references as a replacement for repository execution


### PR DESCRIPTION
Closes #229

Add A4.5 suitability gate alignment to issue-authoring documentation, clarifying how authoring readiness buckets map to discover-time gate outcomes.

## Changes

- **docs/issue-authoring-skill.md**: Added 'Alignment with A4.5 Suitability Gate' section with bucket→outcome mapping and new A4.5 outcomes (unclear, invalid, duplicate)
- **contract.md**: Added 'A4.5 Suitability Gate Alignment' section with validation guidance before publishing
- **draft-patterns.md**: Added 'Handling duplicates and non-ready outcomes' section with reuse-first checklist and A4.5 failure prevention
- **workflow-boundary.md**: Expanded with handoff sequence (Drafting → Publishing → Execution), explicit approval boundaries, and A4.5 gate timing explanation

## Acceptance Criteria
- [x] docs/issue-authoring-skill.md explains mapping to A4.5 gate outcomes
- [x] Bundled references preserve non-ready work as explicit outcomes
- [x] Reuse-first policy explicitly covers duplicates and superseded work
- [x] Draft schemas warn about unclear/invalid work before publishing
- [x] Approval boundary remains explicit (drafting ≠ execution)
- [x] SKILL.md stays brief and points to references
- [x] Validation passes (markdownlint, cspell, dprint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on issue suitability assessment with validation checklists for coherence, safety, and uniqueness
  * Documented workflow phases and handoff requirements for issue drafting, publishing, and execution
  * Introduced prevention checklists and decision trees to address duplicates and escalation pathways during issue creation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/238)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->