### PR TITLE
fix(idd): make A5 claim verification race-safe

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -116,13 +116,18 @@ consistency settle. Then re-read the full issue comment stream and parse
 the active claim in chronological order using the shared claim-state
 rules. Apply all race-safe checks below:
 
-1. Verify that the active claim now uses **your** `{claim-id}`.
-2. If two or more trusted, valid `claimed-by` contenders share the same
-   `created_at` second, the winner is the lexicographically earlier
-   `{claim-id}` (case-sensitive ASCII compare). This race-safe
-   tie-break extends the shared parsing rules for this verification step.
-3. Verify no later trusted `claimed-by` with a different `{claim-id}`
-   appears after your claim event.
+1. Build the same-second contender set from trusted `claimed-by` markers
+   that share your claim event's `created_at` second and have different
+   `{claim-id}` values.
+2. If that set has two or more contenders, the winner is the
+   lexicographically earlier `{claim-id}` (case-sensitive ASCII compare).
+   This race-safe tie-break extends the shared parsing rules for this
+   verification step.
+3. Verify that the active claim now uses **your** `{claim-id}` after the
+   same-second tie-break is applied.
+4. Verify no trusted competing `claimed-by` with a different
+   `{claim-id}` appears in a strictly later `created_at` second than
+   your claim event.
 
 If any check fails, treat the claim as contested. Return to Discover
 using the same selection mode that produced this target and pick the

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -111,11 +111,24 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 
 ## Claim verification
 
-Re-read the issue immediately and parse the active claim. Verify that
-the active claim now uses **your** `{claim-id}`. If it does not, return
-to Discover using the same selection mode that produced this target
-(orphan-first: continue the A0-O capable path; roadmap mode: continue
-the A3-ready path).
+After posting `claimed-by`, wait 5–10 seconds to let GitHub eventual
+consistency settle. Then re-read the full issue comment stream and parse
+the active claim in chronological order using the shared claim-state
+rules. Apply all race-safe checks below:
+
+1. Verify that the active claim now uses **your** `{claim-id}`.
+2. If two or more trusted, valid `claimed-by` contenders share the same
+   `created_at` second, the winner is the lexicographically earlier
+   `{claim-id}` (case-sensitive ASCII compare).
+3. Verify no trusted, valid `claimed-by` with a different `{claim-id}`
+   appears later than your claim event.
+
+If any check fails, treat the claim as contested. Return to Discover
+using the same selection mode that produced this target and pick the
+next eligible issue (orphan-first: continue the A0-O capable path;
+roadmap mode: continue the A3-ready path). Do not retry the same issue.
+For explicit-target A0-T runs, report the contested claim and stop
+unless the operator has explicitly switched to normal discovery.
 
 Once verified, record this `{claim-id}` as your current claim token for
 the rest of the workflow.

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -119,9 +119,10 @@ rules. Apply all race-safe checks below:
 1. Verify that the active claim now uses **your** `{claim-id}`.
 2. If two or more trusted, valid `claimed-by` contenders share the same
    `created_at` second, the winner is the lexicographically earlier
-   `{claim-id}` (case-sensitive ASCII compare).
-3. Verify no trusted, valid `claimed-by` with a different `{claim-id}`
-   appears later than your claim event.
+   `{claim-id}` (case-sensitive ASCII compare). This race-safe
+   tie-break extends the shared parsing rules for this verification step.
+3. Verify no later trusted `claimed-by` with a different `{claim-id}`
+   appears after your claim event.
 
 If any check fails, treat the claim as contested. Return to Discover
 using the same selection mode that produced this target and pick the

--- a/.github/instructions/idd-resume-stall.instructions.md
+++ b/.github/instructions/idd-resume-stall.instructions.md
@@ -79,7 +79,8 @@ Immediately before posting takeover:
    (`idd-claim.instructions.md`) for the upcoming takeover post-and-
    verify sequence: wait 5–10 seconds after posting, re-parse
    chronologically, apply same-second lexicographic `{claim-id}`
-   tie-break, and reject later trusted valid competing claims.
+   tie-break, and reject later trusted competing `claimed-by` markers
+   with different `{claim-id}` values.
 
 If any check fails, stop and restart from Resume discovery/routing.
 Do not post takeover with stale evidence.

--- a/.github/instructions/idd-resume-stall.instructions.md
+++ b/.github/instructions/idd-resume-stall.instructions.md
@@ -75,6 +75,11 @@ Immediately before posting takeover:
 5. Re-check closed/merged guards. If the issue is now closed or the PR
    is now merged, stop and return to `idd-resume.instructions.md` Step 1
    cleanup behavior.
+6. If takeover is still eligible, use A5 race-safe claim verification
+   (`idd-claim.instructions.md`) for the upcoming takeover post-and-
+   verify sequence: wait 5–10 seconds after posting, re-parse
+   chronologically, apply same-second lexicographic `{claim-id}`
+   tie-break, and reject later trusted valid competing claims.
 
 If any check fails, stop and restart from Resume discovery/routing.
 Do not post takeover with stale evidence.
@@ -87,7 +92,8 @@ Perform takeover via `idd-claim.instructions.md` using:
 - `supersedes: <previous-active-claim-id>`
 
 Then re-read and verify the active claim now uses your fresh
-`{claim-id}`. If not, stop and return to discovery/routing.
+`{claim-id}` using the same A5 race-safe verification checks. If not,
+stop and return to discovery/routing.
 
 After successful verification, run `idd-resume.instructions.md` Step 1
 to preserve closed/merged cleanup and `roadmap-audit/*` special-case

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -103,7 +103,8 @@ must follow A5 race-safe verification from
 `idd-claim.instructions.md`: wait 5–10 seconds after posting
 `claimed-by`, re-read and parse the full claim stream chronologically,
 apply the same-second lexicographic `{claim-id}` tie-breaker, and fail
-verification if a later trusted valid competing claim appears.
+verification if a later trusted competing `claimed-by` with a different
+`{claim-id}` appears.
 
 A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -98,6 +98,13 @@ Otherwise, determine claim state from the parsed active claim:
   `{claim-id}` whose `supersedes:` value is the current active claim's
   `{claim-id}`, then continue to Step 2.
 
+When Step 1 performs a re-claim or stale takeover, claim verification
+must follow A5 race-safe verification from
+`idd-claim.instructions.md`: wait 5–10 seconds after posting
+`claimed-by`, re-read and parse the full claim stream chronologically,
+apply the same-second lexicographic `{claim-id}` tie-breaker, and fail
+verification if a later trusted valid competing claim appears.
+
 A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the
 stale active claim you are taking over, or in the latest released claim.

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -116,13 +116,18 @@ consistency settle. Then re-read the full issue comment stream and parse
 the active claim in chronological order using the shared claim-state
 rules. Apply all race-safe checks below:
 
-1. Verify that the active claim now uses **your** `{claim-id}`.
-2. If two or more trusted, valid `claimed-by` contenders share the same
-   `created_at` second, the winner is the lexicographically earlier
-   `{claim-id}` (case-sensitive ASCII compare). This race-safe
-   tie-break extends the shared parsing rules for this verification step.
-3. Verify no later trusted `claimed-by` with a different `{claim-id}`
-   appears after your claim event.
+1. Build the same-second contender set from trusted `claimed-by` markers
+   that share your claim event's `created_at` second and have different
+   `{claim-id}` values.
+2. If that set has two or more contenders, the winner is the
+   lexicographically earlier `{claim-id}` (case-sensitive ASCII compare).
+   This race-safe tie-break extends the shared parsing rules for this
+   verification step.
+3. Verify that the active claim now uses **your** `{claim-id}` after the
+   same-second tie-break is applied.
+4. Verify no trusted competing `claimed-by` with a different
+   `{claim-id}` appears in a strictly later `created_at` second than
+   your claim event.
 
 If any check fails, treat the claim as contested. Return to Discover
 using the same selection mode that produced this target and pick the

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -111,11 +111,24 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 
 ## Claim verification
 
-Re-read the issue immediately and parse the active claim. Verify that
-the active claim now uses **your** `{claim-id}`. If it does not, return
-to Discover using the same selection mode that produced this target
-(orphan-first: continue the A0-O capable path; roadmap mode: continue
-the A3-ready path).
+After posting `claimed-by`, wait 5–10 seconds to let GitHub eventual
+consistency settle. Then re-read the full issue comment stream and parse
+the active claim in chronological order using the shared claim-state
+rules. Apply all race-safe checks below:
+
+1. Verify that the active claim now uses **your** `{claim-id}`.
+2. If two or more trusted, valid `claimed-by` contenders share the same
+   `created_at` second, the winner is the lexicographically earlier
+   `{claim-id}` (case-sensitive ASCII compare).
+3. Verify no trusted, valid `claimed-by` with a different `{claim-id}`
+   appears later than your claim event.
+
+If any check fails, treat the claim as contested. Return to Discover
+using the same selection mode that produced this target and pick the
+next eligible issue (orphan-first: continue the A0-O capable path;
+roadmap mode: continue the A3-ready path). Do not retry the same issue.
+For explicit-target A0-T runs, report the contested claim and stop
+unless the operator has explicitly switched to normal discovery.
 
 Once verified, record this `{claim-id}` as your current claim token for
 the rest of the workflow.

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -119,9 +119,10 @@ rules. Apply all race-safe checks below:
 1. Verify that the active claim now uses **your** `{claim-id}`.
 2. If two or more trusted, valid `claimed-by` contenders share the same
    `created_at` second, the winner is the lexicographically earlier
-   `{claim-id}` (case-sensitive ASCII compare).
-3. Verify no trusted, valid `claimed-by` with a different `{claim-id}`
-   appears later than your claim event.
+   `{claim-id}` (case-sensitive ASCII compare). This race-safe
+   tie-break extends the shared parsing rules for this verification step.
+3. Verify no later trusted `claimed-by` with a different `{claim-id}`
+   appears after your claim event.
 
 If any check fails, treat the claim as contested. Return to Discover
 using the same selection mode that produced this target and pick the

--- a/idd-template/.github/instructions/idd-resume-stall.instructions.md
+++ b/idd-template/.github/instructions/idd-resume-stall.instructions.md
@@ -79,7 +79,8 @@ Immediately before posting takeover:
    (`idd-claim.instructions.md`) for the upcoming takeover post-and-
    verify sequence: wait 5–10 seconds after posting, re-parse
    chronologically, apply same-second lexicographic `{claim-id}`
-   tie-break, and reject later trusted valid competing claims.
+   tie-break, and reject later trusted competing `claimed-by` markers
+   with different `{claim-id}` values.
 
 If any check fails, stop and restart from Resume discovery/routing.
 Do not post takeover with stale evidence.

--- a/idd-template/.github/instructions/idd-resume-stall.instructions.md
+++ b/idd-template/.github/instructions/idd-resume-stall.instructions.md
@@ -75,6 +75,11 @@ Immediately before posting takeover:
 5. Re-check closed/merged guards. If the issue is now closed or the PR
    is now merged, stop and return to `idd-resume.instructions.md` Step 1
    cleanup behavior.
+6. If takeover is still eligible, use A5 race-safe claim verification
+   (`idd-claim.instructions.md`) for the upcoming takeover post-and-
+   verify sequence: wait 5–10 seconds after posting, re-parse
+   chronologically, apply same-second lexicographic `{claim-id}`
+   tie-break, and reject later trusted valid competing claims.
 
 If any check fails, stop and restart from Resume discovery/routing.
 Do not post takeover with stale evidence.
@@ -87,7 +92,8 @@ Perform takeover via `idd-claim.instructions.md` using:
 - `supersedes: <previous-active-claim-id>`
 
 Then re-read and verify the active claim now uses your fresh
-`{claim-id}`. If not, stop and return to discovery/routing.
+`{claim-id}` using the same A5 race-safe verification checks. If not,
+stop and return to discovery/routing.
 
 After successful verification, run `idd-resume.instructions.md` Step 1
 to preserve closed/merged cleanup and `roadmap-audit/*` special-case

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -103,7 +103,8 @@ must follow A5 race-safe verification from
 `idd-claim.instructions.md`: wait 5–10 seconds after posting
 `claimed-by`, re-read and parse the full claim stream chronologically,
 apply the same-second lexicographic `{claim-id}` tie-breaker, and fail
-verification if a later trusted valid competing claim appears.
+verification if a later trusted competing `claimed-by` with a different
+`{claim-id}` appears.
 
 A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -98,6 +98,13 @@ Otherwise, determine claim state from the parsed active claim:
   `{claim-id}` whose `supersedes:` value is the current active claim's
   `{claim-id}`, then continue to Step 2.
 
+When Step 1 performs a re-claim or stale takeover, claim verification
+must follow A5 race-safe verification from
+`idd-claim.instructions.md`: wait 5–10 seconds after posting
+`claimed-by`, re-read and parse the full claim stream chronologically,
+apply the same-second lexicographic `{claim-id}` tie-breaker, and fail
+verification if a later trusted valid competing claim appears.
+
 A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the
 stale active claim you are taking over, or in the latest released claim.


### PR DESCRIPTION
Closes #231

## Summary

This PR hardens A5 claim verification for concurrent-session races and
keeps resume takeover verification aligned with the same checks.

## Changes

- Add explicit 5–10 second wait-after-claim guidance before verification.
- Require full chronological claim re-parse with shared claim-state rules.
- Add deterministic same-second tie-break (lexicographically earlier claim-id wins).
- Require rejection when a later trusted valid competing claim appears.
- Route contested verification to discover-next-eligible (and explicit-target stop caveat).
- Mirror all instruction updates to `idd-template/.github/instructions/`.

## Follow-up

- none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Strengthened claim-verification instructions with race-safe checks: add a 5–10s post-claim wait, re-read and chronologically re-parse claim streams, apply same-second lexicographic tie-break for simultaneous claims, and reject later competing trusted claims with different IDs. Contested claims now return to discovery (preserving selection mode) and skip retrying the same issue; explicit-target runs report and halt unless switched to normal discovery.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/240)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->