### PR TITLE
fix(idd): add heartbeat branch invariant to prevent silent claim inconsistencies

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -109,6 +109,16 @@ of the body, followed by the visible note:
 _{agent-id}: issue claim — IDD automation marker. Do not edit._
 ```
 
+### Heartbeat posting
+
+When posting a heartbeat (i.e., when the issue is already claimed by this current
+session and you are extending the active claim's stale clock), copy the
+`{branch}` field **verbatim** from the original `claimed-by` comment. Do not
+recompute or derive a new branch name. The heartbeat's `{claim-id}` and
+`{agent-id}` must match the original claim exactly. The branch field must also
+match exactly to satisfy the heartbeat branch invariant (rule 3.5 in
+`idd-overview.instructions.md`).
+
 ## Claim verification
 
 After posting `claimed-by`, wait 5–10 seconds to let GitHub eventual

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -95,7 +95,7 @@ chronologically and apply these rules:
 3. A `claimed-by` whose `{agent-id}` AND `{claim-id}` both match the
    current active claim is a candidate **heartbeat**. Before recognizing
    it as a heartbeat, apply rule 3.5.
-3.5. **Heartbeat branch invariant**: A heartbeat candidate is recognized
+   3.5. **Heartbeat branch invariant**: A heartbeat candidate is recognized
    only when the `{branch}` field exactly matches the `{branch}` field of
    the currently active claim. If `{branch}` differs, treat the comment as
    **anomalous** — do not refresh the stale clock. The comment does not

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -93,8 +93,16 @@ chronologically and apply these rules:
 2. Ignore any `claimed-by` or `unclaimed-by` marker whose GitHub comment
    author is not a trusted marker actor.
 3. A `claimed-by` whose `{agent-id}` AND `{claim-id}` both match the
-   current active claim is a **heartbeat**. Refresh the active claim's
-   GitHub `created_at`.
+   current active claim is a candidate **heartbeat**. Before recognizing
+   it as a heartbeat, apply rule 3.5.
+3.5. **Heartbeat branch invariant**: A heartbeat candidate is recognized
+   only when the `{branch}` field exactly matches the `{branch}` field of
+   the currently active claim. If `{branch}` differs, treat the comment as
+   **anomalous** — do not refresh the stale clock. The comment does not
+   update any claim state. When an anomalous heartbeat affects a routing
+   decision (e.g., in resume or worktree selection), surface it as a
+   warning. The **detecting session** continues with its own verified claim
+   unchanged; no corrective comment is required.
 4. A `claimed-by` with a **new** `{claim-id}` becomes the active claim
    only if either:
    - there is no active claim AND its `supersedes:` value is `none`, or

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -140,6 +140,14 @@ When any row below requires creating a worktree, follow the B1
 **install-deps** (depends on whether WorkTrunk's pre-start hook is
 configured).
 
+**Important**: The `{branch}` field in the table below refers to the branch
+name from the current active claim (or inheritable claim in recovery scenarios).
+This branch value must be used verbatim when creating or restoring worktrees.
+The heartbeat branch invariant (rule 3.5 in `idd-overview.instructions.md`)
+requires that heartbeat comments preserve the original branch field exactly. If
+you encounter anomalous heartbeats with a different branch field, ignore that
+branch value and use the currently active claim's branch instead.
+
 | PR exists?     | Remote branch? | Local state                           | Action                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | -------------- | -------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Yes (1 match)  | —              | worktree missing                      | Run `git fetch origin`. If a local branch named `{branch}` exists, check for unpushed commits: `git log origin/{branch}..{branch} --oneline`. If any commits appear, create the worktree from the existing local branch; if reviews exist on the PR → resume from E11; if no reviews → route to D1. If no local commits, reset: `git branch -f {branch} origin/{branch}`, then create worktree. If no local branch named `{branch}` exists, create it from remote: `git branch {branch} origin/{branch}`, then create worktree. |

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -109,6 +109,16 @@ of the body, followed by the visible note:
 _{agent-id}: issue claim — IDD automation marker. Do not edit._
 ```
 
+### Heartbeat posting
+
+When posting a heartbeat (i.e., when the issue is already claimed by this current
+session and you are extending the active claim's stale clock), copy the
+`{branch}` field **verbatim** from the original `claimed-by` comment. Do not
+recompute or derive a new branch name. The heartbeat's `{claim-id}` and
+`{agent-id}` must match the original claim exactly. The branch field must also
+match exactly to satisfy the heartbeat branch invariant (rule 3.5 in
+`idd-overview.instructions.md`).
+
 ## Claim verification
 
 After posting `claimed-by`, wait 5–10 seconds to let GitHub eventual

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -95,7 +95,7 @@ chronologically and apply these rules:
 3. A `claimed-by` whose `{agent-id}` AND `{claim-id}` both match the
    current active claim is a candidate **heartbeat**. Before recognizing
    it as a heartbeat, apply rule 3.5.
-3.5. **Heartbeat branch invariant**: A heartbeat candidate is recognized
+   3.5. **Heartbeat branch invariant**: A heartbeat candidate is recognized
    only when the `{branch}` field exactly matches the `{branch}` field of
    the currently active claim. If `{branch}` differs, treat the comment as
    **anomalous** — do not refresh the stale clock. The comment does not

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -93,8 +93,16 @@ chronologically and apply these rules:
 2. Ignore any `claimed-by` or `unclaimed-by` marker whose GitHub comment
    author is not a trusted marker actor.
 3. A `claimed-by` whose `{agent-id}` AND `{claim-id}` both match the
-   current active claim is a **heartbeat**. Refresh the active claim's
-   GitHub `created_at`.
+   current active claim is a candidate **heartbeat**. Before recognizing
+   it as a heartbeat, apply rule 3.5.
+3.5. **Heartbeat branch invariant**: A heartbeat candidate is recognized
+   only when the `{branch}` field exactly matches the `{branch}` field of
+   the currently active claim. If `{branch}` differs, treat the comment as
+   **anomalous** — do not refresh the stale clock. The comment does not
+   update any claim state. When an anomalous heartbeat affects a routing
+   decision (e.g., in resume or worktree selection), surface it as a
+   warning. The **detecting session** continues with its own verified claim
+   unchanged; no corrective comment is required.
 4. A `claimed-by` with a **new** `{claim-id}` becomes the active claim
    only if either:
    - there is no active claim AND its `supersedes:` value is `none`, or

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -140,6 +140,14 @@ When any row below requires creating a worktree, follow the B1
 **install-deps** (depends on whether WorkTrunk's pre-start hook is
 configured).
 
+**Important**: The `{branch}` field in the table below refers to the branch
+name from the current active claim (or inheritable claim in recovery scenarios).
+This branch value must be used verbatim when creating or restoring worktrees.
+The heartbeat branch invariant (rule 3.5 in `idd-overview.instructions.md`)
+requires that heartbeat comments preserve the original branch field exactly. If
+you encounter anomalous heartbeats with a different branch field, ignore that
+branch value and use the currently active claim's branch instead.
+
 | PR exists?     | Remote branch? | Local state                           | Action                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | -------------- | -------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Yes (1 match)  | —              | worktree missing                      | Run `git fetch origin`. If a local branch named `{branch}` exists, check for unpushed commits: `git log origin/{branch}..{branch} --oneline`. If any commits appear, create the worktree from the existing local branch; if reviews exist on the PR → resume from E11; if no reviews → route to D1. If no local commits, reset: `git branch -f {branch} origin/{branch}`, then create worktree. If no local branch named `{branch}` exists, create it from remote: `git branch {branch} origin/{branch}`, then create worktree. |


### PR DESCRIPTION
## Problem
During the issue #220 multi-session incident (2026-05-10), a heartbeat comment was posted with a **different branch name** than the original claim. This silent inconsistency could mislead resume logic.

**Original claim**: `branch: issue/220-clarify-template-source-repo-wording`
**Heartbeat**: `branch: issue/220-fix-template-source-repo` (different)

The claim-state parsing rules validate `{agent-id}` and `{claim-id}` for heartbeat identification but did not validate the `branch` field.

## Solution
This PR implements the heartbeat branch invariant (rule 3.5 in claim-state parsing rules):

### 1. **Heartbeat Branch Invariant** (`idd-overview.instructions.md`)
- A heartbeat is recognized only when the `{branch}` field exactly matches the currently active claim
- If branch differs, treat the comment as **anomalous**
- Do not refresh the stale clock for anomalous heartbeats
- No corrective comment required; detecting session continues with verified claim unchanged

### 2. **Heartbeat Posting Guidance** (`idd-claim.instructions.md`)
- When posting heartbeats, copy the `{branch}` field **verbatim** from the original claim
- Do not recompute or derive a new branch name
- Ensures exact match with heartbeat branch invariant validation

### 3. **Resume Phase Step 2 Reference** (`idd-resume.instructions.md`)
- Reference the heartbeat branch invariant when selecting branch for worktree creation
- Guidance: Use only the currently active claim's verified branch value
- If anomalous heartbeat encountered, ignore its branch value

### 4. **Template Sync**
- All changes mirrored to `idd-template/.github/instructions/` for consistency

## Acceptance Criteria
✅ Claim-state parsing rules include heartbeat branch invariant with anomalous-heartbeat continuation path
✅ A5 heartbeat posting instructions require copying branch field verbatim
✅ Resume phase Step 2 references invariant for worktree creation
✅ Template equivalents updated in sync

## Impact
- Prevents silent inconsistencies in multi-session scenarios
- Protects against mismatched branch names in context-summarized sessions
- Strengthens claim-state parsing robustness

## Related Issues
- Closes #232
- References #220 (multi-session incident investigation)
- Part of roadmap #237 (A5 claim race-safety)