### PR TITLE
fix(idd): make A5 claim verification race-safe

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -116,18 +116,19 @@ consistency settle. Then re-read the full issue comment stream and parse
 the active claim in chronological order using the shared claim-state
 rules. Apply all race-safe checks below:
 
-1. Build the same-second contender set from trusted `claimed-by` markers
-   that share your claim event's `created_at` second and have different
-   `{claim-id}` values.
+1. Build the same-second contender set from your own trusted
+   `claimed-by` marker plus every trusted `claimed-by` marker in that
+   exact `created_at` second.
 2. If that set has two or more contenders, the winner is the
    lexicographically earlier `{claim-id}` (case-sensitive ASCII compare).
    This race-safe tie-break extends the shared parsing rules for this
    verification step.
 3. Verify that the active claim now uses **your** `{claim-id}` after the
    same-second tie-break is applied.
-4. Verify no trusted competing `claimed-by` with a different
-   `{claim-id}` appears in a strictly later `created_at` second than
-   your claim event.
+4. Verify no later trusted competing `claimed-by` with a different
+   `{claim-id}` would be accepted as the active claim by the shared
+   claim-state rules (for example, a valid stale takeover) in a strictly
+   later `created_at` second than your claim event.
 
 If any check fails, treat the claim as contested. Return to Discover
 using the same selection mode that produced this target and pick the

--- a/.github/instructions/idd-resume-stall.instructions.md
+++ b/.github/instructions/idd-resume-stall.instructions.md
@@ -79,8 +79,9 @@ Immediately before posting takeover:
    (`idd-claim.instructions.md`) for the upcoming takeover post-and-
    verify sequence: wait 5–10 seconds after posting, re-parse
    chronologically, apply same-second lexicographic `{claim-id}`
-   tie-break, and reject later trusted competing `claimed-by` markers
-   with different `{claim-id}` values.
+   tie-break, and reject only later trusted competing `claimed-by`
+   markers with different `{claim-id}` values that the shared
+   claim-state rules would accept.
 
 If any check fails, stop and restart from Resume discovery/routing.
 Do not post takeover with stale evidence.

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -103,8 +103,9 @@ must follow A5 race-safe verification from
 `idd-claim.instructions.md`: wait 5–10 seconds after posting
 `claimed-by`, re-read and parse the full claim stream chronologically,
 apply the same-second lexicographic `{claim-id}` tie-breaker, and fail
-verification if a later trusted competing `claimed-by` with a different
-`{claim-id}` appears.
+verification only when a later trusted competing `claimed-by` with a
+different `{claim-id}` would be accepted by the shared claim-state
+rules.
 
 A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -116,18 +116,19 @@ consistency settle. Then re-read the full issue comment stream and parse
 the active claim in chronological order using the shared claim-state
 rules. Apply all race-safe checks below:
 
-1. Build the same-second contender set from trusted `claimed-by` markers
-   that share your claim event's `created_at` second and have different
-   `{claim-id}` values.
+1. Build the same-second contender set from your own trusted
+   `claimed-by` marker plus every trusted `claimed-by` marker in that
+   exact `created_at` second.
 2. If that set has two or more contenders, the winner is the
    lexicographically earlier `{claim-id}` (case-sensitive ASCII compare).
    This race-safe tie-break extends the shared parsing rules for this
    verification step.
 3. Verify that the active claim now uses **your** `{claim-id}` after the
    same-second tie-break is applied.
-4. Verify no trusted competing `claimed-by` with a different
-   `{claim-id}` appears in a strictly later `created_at` second than
-   your claim event.
+4. Verify no later trusted competing `claimed-by` with a different
+   `{claim-id}` would be accepted as the active claim by the shared
+   claim-state rules (for example, a valid stale takeover) in a strictly
+   later `created_at` second than your claim event.
 
 If any check fails, treat the claim as contested. Return to Discover
 using the same selection mode that produced this target and pick the

--- a/idd-template/.github/instructions/idd-resume-stall.instructions.md
+++ b/idd-template/.github/instructions/idd-resume-stall.instructions.md
@@ -79,8 +79,9 @@ Immediately before posting takeover:
    (`idd-claim.instructions.md`) for the upcoming takeover post-and-
    verify sequence: wait 5–10 seconds after posting, re-parse
    chronologically, apply same-second lexicographic `{claim-id}`
-   tie-break, and reject later trusted competing `claimed-by` markers
-   with different `{claim-id}` values.
+   tie-break, and reject only later trusted competing `claimed-by`
+   markers with different `{claim-id}` values that the shared
+   claim-state rules would accept.
 
 If any check fails, stop and restart from Resume discovery/routing.
 Do not post takeover with stale evidence.

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -103,8 +103,9 @@ must follow A5 race-safe verification from
 `idd-claim.instructions.md`: wait 5–10 seconds after posting
 `claimed-by`, re-read and parse the full claim stream chronologically,
 apply the same-second lexicographic `{claim-id}` tie-breaker, and fail
-verification if a later trusted competing `claimed-by` with a different
-`{claim-id}` appears.
+verification only when a later trusted competing `claimed-by` with a
+different `{claim-id}` would be accepted by the shared claim-state
+rules.
 
 A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the


### PR DESCRIPTION
Supersedes #240 due head linkage drift.\n\nCloses #231