### PR TITLE
fix(idd): add issue-scoped branch/worktree pattern check to A5 for fast concurrent-session detection

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -76,6 +76,53 @@ hyphenated words describing the issue (e.g. `issue/<number>-<slug>`). No
 remote branch with that name may exist, unless it matches the `branch`
 field in an inheritable claim comment as defined in (c) above.
 
+Before posting a claim, also perform a **scoped issue-wide branch pattern
+check** to detect concurrent sessions working on the same issue with
+different slug variants. This is the fast-path collision detection that
+catches parallel-session concurrency before a new claim comment is posted.
+
+1. **Local worktree scan**: Check whether any local worktree matches the
+   pattern `issue/<number>-*`:
+   ```sh
+   git worktree list | grep "issue/<number>-"
+   ```
+
+2. **Remote branch scan** (scoped Refs API, not repo-wide):
+   Query the Refs API with the issue-number prefix only, to stay within
+   the scope invariant defined in idd-overview.instructions.md:
+   ```sh
+   gh api "repos/{owner}/{repo}/git/matching-refs/heads/issue/<number>-" \
+     --jq '.[].ref'
+   ```
+
+3. **Collision action tree**:
+
+   - **If no local worktree or remote branch matches `issue/<number>-*`**:
+     Proceed to claim posting (the safe, single-session path).
+
+   - **If a match is found and corresponds to an inheritable claim** (i.e.,
+     its `branch` field matches one of the branches in an inheritable claim
+     comment as defined in (c) above):
+     Proceed to claim posting. The branch is expected.
+
+   - **If a match is found, does NOT correspond to an inheritable claim,
+     AND an active non-stale claim on this issue references that branch**:
+     Treat as **claimed by a concurrent session** running in parallel. Do
+     not post a new claim. Instead, **return to Discover** using the same
+     selection mode that produced this target (orphan-first: continue the
+     A0-O capable path; roadmap mode: continue the A3-ready path), and
+     select the **next eligible issue**. This is the scale-out path that
+     allows multiple sessions to work on different issues when one issue
+     has concurrent claims.
+
+   - **If a match is found, does NOT correspond to an inheritable claim,
+     AND no active claim references that branch**:
+     Document the branch name and post a **hold note** to the issue: "_A5
+     pre-check (d) detected an unexpected branch `issue/<number>-*`
+     without an active claim. Possible orphaned branch from a crashed or
+     stale session. Stopping for operator review._" Stop and wait for
+     operator input. Do not post a claim or continue the workflow.
+
 ## Claim execution
 
 Skip this section if pre-check (b) classified the issue as already

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -26,6 +26,14 @@ Record the selected values for `claim-stale-age` and
 `claim-heartbeat-interval` in repository onboarding notes before running
 unattended sessions.
 
+## Concurrent Session Defaults
+
+| Policy default                     | Distributed value                                                                                              | Owning surface                                                                                                                    | Onboarding expectation                                                                                                                              |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Branch pattern scope invariant     | Scoped Refs API query per issue (`/git/matching-refs/heads/issue/<number>-`), not repo-wide branch list        | [Claim](../.github/instructions/idd-claim.instructions.md), [A5 pre-check (d)](../.github/instructions/idd-claim.instructions.md) | Keep to maintain scope invariant; avoid repo-wide queries which violate A3-only restriction and harm multi-session scale-out.                       |
+| Branch pattern collision detection | Check both local worktrees (`git worktree list`) and scoped remote refs before posting a new claim             | [Claim](../.github/instructions/idd-claim.instructions.md), [A5 pre-check (d)](../.github/instructions/idd-claim.instructions.md) | Keep to catch parallel-session concurrency on the same issue; issue concurrent sessions will return to Discover and select the next eligible issue. |
+| Unexpected branch hold policy      | Post a hold note and wait for operator review when a branch matches `issue/<number>-*` but has no active claim | [Claim](../.github/instructions/idd-claim.instructions.md), [A5 pre-check (d)](../.github/instructions/idd-claim.instructions.md) | Keep as a safety gate to prevent orphaned-branch corruption; do not automate orphaned-branch cleanup without explicit operator verification.        |
+
 ## Advisory Review Defaults
 
 The distributed PR policy is `copilot-advisory`. These values apply to

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -76,6 +76,53 @@ hyphenated words describing the issue (e.g. `issue/<number>-<slug>`). No
 remote branch with that name may exist, unless it matches the `branch`
 field in an inheritable claim comment as defined in (c) above.
 
+Before posting a claim, also perform a **scoped issue-wide branch pattern
+check** to detect concurrent sessions working on the same issue with
+different slug variants. This is the fast-path collision detection that
+catches parallel-session concurrency before a new claim comment is posted.
+
+1. **Local worktree scan**: Check whether any local worktree matches the
+   pattern `issue/<number>-*`:
+   ```sh
+   git worktree list | grep "issue/<number>-"
+   ```
+
+2. **Remote branch scan** (scoped Refs API, not repo-wide):
+   Query the Refs API with the issue-number prefix only, to stay within
+   the scope invariant defined in idd-overview.instructions.md:
+   ```sh
+   gh api "repos/{owner}/{repo}/git/matching-refs/heads/issue/<number>-" \
+     --jq '.[].ref'
+   ```
+
+3. **Collision action tree**:
+
+   - **If no local worktree or remote branch matches `issue/<number>-*`**:
+     Proceed to claim posting (the safe, single-session path).
+
+   - **If a match is found and corresponds to an inheritable claim** (i.e.,
+     its `branch` field matches one of the branches in an inheritable claim
+     comment as defined in (c) above):
+     Proceed to claim posting. The branch is expected.
+
+   - **If a match is found, does NOT correspond to an inheritable claim,
+     AND an active non-stale claim on this issue references that branch**:
+     Treat as **claimed by a concurrent session** running in parallel. Do
+     not post a new claim. Instead, **return to Discover** using the same
+     selection mode that produced this target (orphan-first: continue the
+     A0-O capable path; roadmap mode: continue the A3-ready path), and
+     select the **next eligible issue**. This is the scale-out path that
+     allows multiple sessions to work on different issues when one issue
+     has concurrent claims.
+
+   - **If a match is found, does NOT correspond to an inheritable claim,
+     AND no active claim references that branch**:
+     Document the branch name and post a **hold note** to the issue: "_A5
+     pre-check (d) detected an unexpected branch `issue/<number>-*`
+     without an active claim. Possible orphaned branch from a crashed or
+     stale session. Stopping for operator review._" Stop and wait for
+     operator input. Do not post a claim or continue the workflow.
+
 ## Claim execution
 
 Skip this section if pre-check (b) classified the issue as already

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -26,6 +26,14 @@ Record the selected values for `claim-stale-age` and
 `claim-heartbeat-interval` in repository onboarding notes before running
 unattended sessions.
 
+## Concurrent Session Defaults
+
+| Policy default                     | Distributed value                                                                                              | Owning surface                                                                                                                    | Onboarding expectation                                                                                                                              |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Branch pattern scope invariant     | Scoped Refs API query per issue (`/git/matching-refs/heads/issue/<number>-`), not repo-wide branch list        | [Claim](../.github/instructions/idd-claim.instructions.md), [A5 pre-check (d)](../.github/instructions/idd-claim.instructions.md) | Keep to maintain scope invariant; avoid repo-wide queries which violate A3-only restriction and harm multi-session scale-out.                       |
+| Branch pattern collision detection | Check both local worktrees (`git worktree list`) and scoped remote refs before posting a new claim             | [Claim](../.github/instructions/idd-claim.instructions.md), [A5 pre-check (d)](../.github/instructions/idd-claim.instructions.md) | Keep to catch parallel-session concurrency on the same issue; issue concurrent sessions will return to Discover and select the next eligible issue. |
+| Unexpected branch hold policy      | Post a hold note and wait for operator review when a branch matches `issue/<number>-*` but has no active claim | [Claim](../.github/instructions/idd-claim.instructions.md), [A5 pre-check (d)](../.github/instructions/idd-claim.instructions.md) | Keep as a safety gate to prevent orphaned-branch corruption; do not automate orphaned-branch cleanup without explicit operator verification.        |
+
 ## Advisory Review Defaults
 
 The distributed PR policy is `copilot-advisory`. These values apply to


### PR DESCRIPTION
# Fix(idd): Add issue-scoped branch/worktree pattern check to A5 pre-check (d)

## Summary

Strengthen A5 pre-check (d) "Branch collision" with fast-path concurrent-session detection. This fix addresses the race condition discovered in issue #220 where three parallel sessions computed three different branch names for the same issue, all of which passed the current A5 pre-check because none matched each other exactly.

## The Problem

When multiple sessions independently compute slightly different slugs for the same issue (e.g., `issue/220-clarify-template-source-repo-wording`, `issue/220-fix-template-source-repo`, `issue/220-fix-source-repo-wording`), the current A5 check only looks for the exact computed branch name. Since each session computes a different slug, each check passes independently — missing the actual concurrency.

## The Solution

Before posting a claim, also check for **any branch matching `issue/<number>-*`** using the scoped Refs API:

1. **Local worktree scan**: `git worktree list | grep "issue/<number>-"`
2. **Remote branch scan** (scoped, not repo-wide): `gh api "repos/{owner}/{repo}/git/matching-refs/heads/issue/<number>-"`

### Collision action tree:

- **No match** → proceed (single-session path)
- **Match with inheritable claim** → proceed (expected branch)
- **Match without inheritable claim + active non-stale claim** → return to Discover, pick next issue (scale-out path allows parallelism across issues)
- **Match without active claim** → post hold note, wait for operator review (orphaned-branch safety gate)

## Changes

### Files modified

1. **`.github/instructions/idd-claim.instructions.md`**
   - Enhance A5 pre-check (d) with scoped branch pattern checks
   - Document the collision action tree with three outcomes
   - Clarify scope invariant: uses `matching-refs/heads/issue/<number>-`, not repo-wide queries

2. **`idd-template/.github/instructions/idd-claim.instructions.md`**
   - Sync the same changes to the template for downstream repositories

3. **`docs/policy-constants.md`**
   - Add "Concurrent Session Defaults" policy section
   - Document the scoped Refs API scope-invariant default
   - Record the collision detection and orphaned-branch hold defaults

## Policy Invariants

- **Scope invariant**: Uses scoped Refs API (`/git/matching-refs/heads/issue/<number>-`), not repo-wide branch queries, to maintain the A3-only restriction on repo-wide queries.
- **Scale-out path**: When concurrent sessions detect each other, they return to Discover and select different issues (no blocking, no retry).
- **Orphaned-branch safety**: Unexpected branches without active claims trigger a hold for operator review, preventing silent branch corruption.

## Verification

- [ ] A5 pre-check (d) correctly identifies concurrent-session branches via scoped pattern matching
- [ ] Scope invariant maintained: no repo-wide queries in A5
- [ ] Action tree routes concurrent sessions to scale-out (Discover → next issue)
- [ ] Orphaned branches are held for operator review
- [ ] Template sync complete
- [ ] Policy documentation added to `policy-constants.md`

## Refs

- Closes #233
- Related: #220 (incident), #231 (claim verification), #232 (heartbeat invariant)
- Roadmap: #237 (A5 claim race-safety)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated branching guidelines with scoped issue-wide branch pattern checks to detect and manage concurrent sessions working on the same issue.
  * Added new "Concurrent Session Defaults" section documenting policy defaults for branch-pattern scoping and collision detection behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/243)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->