### PR TITLE
docs(idd): clarify trusted marker actor configuration (issue #221)

### DIFF
--- a/.github/instructions/idd-merge-handoff.instructions.md
+++ b/.github/instructions/idd-merge-handoff.instructions.md
@@ -1,0 +1,43 @@
+# IDD — Merge Policy Handoff Phase (F2.5)
+
+Read this file after `idd-pre-merge.instructions.md` (F2) satisfies all
+pre-merge conditions. It decides whether the current session can proceed
+to merge execution or must stop and hand off.
+
+Before any mutating action in this phase, apply the shared claim
+revalidation gate. The active claim must still use your current
+`{claim-id}`.
+
+## F2.5 — Resolve merge policy route
+
+1. Confirm the claim is still yours: the **active claim** must still use
+   your current `{claim-id}`. If the active claim is missing, released,
+   or held by a different `{claim-id}` (even under the same agent ID),
+   the claim was lost — report this and stop.
+2. Read the repository's recorded merge policy from repository
+   documentation that future IDD sessions read. If no policy is
+   recorded, treat it as `fully_autonomous_merge` (distributed default).
+3. If the recorded value is not one of `fully_autonomous_merge`,
+   `human_merge`, or `separate_merge_agent`, treat it as an unknown merge
+   policy: stop, post a hold comment, and request maintainer decision.
+4. If the recorded policy is `human_merge` or `separate_merge_agent`,
+   stop before the final freshness fetch and before `gh pr merge`. After
+   claim revalidation, report or post a concise handoff summary that
+   includes:
+   - PR number and branch
+   - current HEAD from F2 (`{f2-head-SHA}`)
+   - the F2 readiness evidence
+   - unresolved-thread count, advisory state, and CI state
+   - active `{claim-id}`
+   - merge command candidate:
+
+   ```sh
+   gh pr merge {pr-number} --merge --match-head-commit "{f2-head-SHA}"
+   ```
+
+   For `human_merge`, hand off to the human maintainer. For
+   `separate_merge_agent`, hand off to the configured merge-capable
+   session; if that actor or resume condition is not recorded, hold for
+   maintainer direction.
+5. Only when the policy is `fully_autonomous_merge` may the same session
+   continue to `idd-merge.instructions.md`.

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -124,6 +124,7 @@ is enabled.
 
 **maintainer-approval-actors**: Policy for who counts as a maintainer when
 approving pre-merge reviews. Possible values:
+
 - `owners-and-maintainers-only`: Only GitHub organization owners and repository
   maintainers (Maintain, Admin roles) satisfy maintainer approval requirements.
   Repository collaborators with Write permission do not count.
@@ -146,27 +147,31 @@ understanding the security implications.
 ### Example configurations
 
 **Small team, high trust**:
-```
+
+```yaml
 - trusted-marker-logins: `kurone-kito`, `chatgpt-codex-connector[bot]`
 - maintainer-approval-actors: `owners-and-maintainers-only`
 - collaborator-authored-markers: false
 ```
 
 **OSS with external contributors**:
-```
+
+```yaml
 - trusted-marker-logins: `github-actions[bot]`, `copilot-automation-bot`
 - maintainer-approval-actors: `owners-and-maintainers-only`
 - collaborator-authored-markers: false
 ```
 
 **Team with trusted collaborators**:
-```
+
+```yaml
 - trusted-marker-logins: `team-automation`, `renovate[bot]`
 - maintainer-approval-actors: `all-write-permission-actors`
 - collaborator-authored-markers: true
 ```
 
 For further details, see:
+
 - [Claim-state parsing](#claim-state-parsing) for how `trusted-marker-logins`
   and `collaborator-authored-markers` affect claim validation.
 - `docs/policy-constants.md` for distributed policy defaults.

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -95,6 +95,82 @@ comes from the current session having recorded the claim token, the
 marker being authored by a trusted actor, and the GitHub server
 `created_at` timestamp satisfying the phase rules.
 
+## Repository-local IDD policy
+
+The trusted marker actors definition is abstract to support diverse repository
+models. Each repository using IDD should explicitly document its local
+configuration so that AI agents and maintainers can reason about which actors
+can authorize state transitions.
+
+Document repository-local settings in a dedicated policy block like this example:
+
+```md
+### IDD repository policy
+
+This repository uses the following IDD configuration:
+
+- **trusted-marker-logins**: `kurone-kito`, `renovate[bot]`, `github-actions[bot]`
+- **maintainer-approval-actors**: `owners-and-maintainers-only`
+- **collaborator-authored-markers**: `false`
+```
+
+**trusted-marker-logins**: Comma-separated GitHub user or bot logins that are
+trusted to post operational markers (`claimed-by`, `unclaimed-by`,
+`review-watermark`, `review-baseline`, `advisory-wait`) for IDD state transitions.
+Typically includes the primary agent or automation actor, plus any pinned
+dependency bots (e.g., `renovate[bot]` or `dependabot[bot]`) if configured for
+the workflow. Always include repository maintainers if `collaborator-authored-markers`
+is enabled.
+
+**maintainer-approval-actors**: Policy for who counts as a maintainer when
+approving pre-merge reviews. Possible values:
+- `owners-and-maintainers-only`: Only GitHub organization owners and repository
+  maintainers (Maintain, Admin roles) satisfy maintainer approval requirements.
+  Repository collaborators with Write permission do not count.
+- `all-write-permission-actors`: Any actor with Write, Maintain, or Admin
+  permission on the repository can provide maintainer approval.
+
+For public or OSS repositories, prefer `owners-and-maintainers-only` unless
+the repository explicitly trusts all collaborators for approval authority.
+
+**collaborator-authored-markers**: Boolean (true/false). Determines whether to
+trust operational markers authored by repository collaborators (Write, Maintain,
+or Admin permission) when parsing claim state and running state transitions.
+
+For public or large-team repositories, `false` is safer: only configured trusted
+bots and explicit actor logins can post operational markers. Set to `true` only
+if your repository explicitly approves all collaborators for IDD marker authority.
+This setting directly affects claim parsing rules and should not be changed without
+understanding the security implications.
+
+### Example configurations
+
+**Small team, high trust**:
+```
+- trusted-marker-logins: `kurone-kito`, `chatgpt-codex-connector[bot]`
+- maintainer-approval-actors: `owners-and-maintainers-only`
+- collaborator-authored-markers: false
+```
+
+**OSS with external contributors**:
+```
+- trusted-marker-logins: `github-actions[bot]`, `copilot-automation-bot`
+- maintainer-approval-actors: `owners-and-maintainers-only`
+- collaborator-authored-markers: false
+```
+
+**Team with trusted collaborators**:
+```
+- trusted-marker-logins: `team-automation`, `renovate[bot]`
+- maintainer-approval-actors: `all-write-permission-actors`
+- collaborator-authored-markers: true
+```
+
+For further details, see:
+- [Claim-state parsing](#claim-state-parsing) for how `trusted-marker-logins`
+  and `collaborator-authored-markers` affect claim validation.
+- `docs/policy-constants.md` for distributed policy defaults.
+
 ## Claim-state parsing
 
 To determine the current active claim, read issue comments

--- a/idd-template/.github/instructions/idd-merge-handoff.instructions.md
+++ b/idd-template/.github/instructions/idd-merge-handoff.instructions.md
@@ -1,0 +1,43 @@
+# IDD — Merge Policy Handoff Phase (F2.5)
+
+Read this file after `idd-pre-merge.instructions.md` (F2) satisfies all
+pre-merge conditions. It decides whether the current session can proceed
+to merge execution or must stop and hand off.
+
+Before any mutating action in this phase, apply the shared claim
+revalidation gate. The active claim must still use your current
+`{claim-id}`.
+
+## F2.5 — Resolve merge policy route
+
+1. Confirm the claim is still yours: the **active claim** must still use
+   your current `{claim-id}`. If the active claim is missing, released,
+   or held by a different `{claim-id}` (even under the same agent ID),
+   the claim was lost — report this and stop.
+2. Read the repository's recorded merge policy from repository
+   documentation that future IDD sessions read. If no policy is
+   recorded, treat it as `fully_autonomous_merge` (distributed default).
+3. If the recorded value is not one of `fully_autonomous_merge`,
+   `human_merge`, or `separate_merge_agent`, treat it as an unknown merge
+   policy: stop, post a hold comment, and request maintainer decision.
+4. If the recorded policy is `human_merge` or `separate_merge_agent`,
+   stop before the final freshness fetch and before `gh pr merge`. After
+   claim revalidation, report or post a concise handoff summary that
+   includes:
+   - PR number and branch
+   - current HEAD from F2 (`{f2-head-SHA}`)
+   - the F2 readiness evidence
+   - unresolved-thread count, advisory state, and CI state
+   - active `{claim-id}`
+   - merge command candidate:
+
+   ```sh
+   gh pr merge {pr-number} --merge --match-head-commit "{f2-head-SHA}"
+   ```
+
+   For `human_merge`, hand off to the human maintainer. For
+   `separate_merge_agent`, hand off to the configured merge-capable
+   session; if that actor or resume condition is not recorded, hold for
+   maintainer direction.
+5. Only when the policy is `fully_autonomous_merge` may the same session
+   continue to `idd-merge.instructions.md`.

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -124,6 +124,7 @@ is enabled.
 
 **maintainer-approval-actors**: Policy for who counts as a maintainer when
 approving pre-merge reviews. Possible values:
+
 - `owners-and-maintainers-only`: Only GitHub organization owners and repository
   maintainers (Maintain, Admin roles) satisfy maintainer approval requirements.
   Repository collaborators with Write permission do not count.
@@ -146,27 +147,31 @@ understanding the security implications.
 ### Example configurations
 
 **Small team, high trust**:
-```
+
+```yaml
 - trusted-marker-logins: `kurone-kito`, `chatgpt-codex-connector[bot]`
 - maintainer-approval-actors: `owners-and-maintainers-only`
 - collaborator-authored-markers: false
 ```
 
 **OSS with external contributors**:
-```
+
+```yaml
 - trusted-marker-logins: `github-actions[bot]`, `copilot-automation-bot`
 - maintainer-approval-actors: `owners-and-maintainers-only`
 - collaborator-authored-markers: false
 ```
 
 **Team with trusted collaborators**:
-```
+
+```yaml
 - trusted-marker-logins: `team-automation`, `renovate[bot]`
 - maintainer-approval-actors: `all-write-permission-actors`
 - collaborator-authored-markers: true
 ```
 
 For further details, see:
+
 - [Claim-state parsing](#claim-state-parsing) for how `trusted-marker-logins`
   and `collaborator-authored-markers` affect claim validation.
 - `docs/policy-constants.md` for distributed policy defaults.

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -95,6 +95,82 @@ comes from the current session having recorded the claim token, the
 marker being authored by a trusted actor, and the GitHub server
 `created_at` timestamp satisfying the phase rules.
 
+## Repository-local IDD policy
+
+The trusted marker actors definition is abstract to support diverse repository
+models. Each repository using IDD should explicitly document its local
+configuration so that AI agents and maintainers can reason about which actors
+can authorize state transitions.
+
+Document repository-local settings in a dedicated policy block like this example:
+
+```md
+### IDD repository policy
+
+This repository uses the following IDD configuration:
+
+- **trusted-marker-logins**: `kurone-kito`, `renovate[bot]`, `github-actions[bot]`
+- **maintainer-approval-actors**: `owners-and-maintainers-only`
+- **collaborator-authored-markers**: `false`
+```
+
+**trusted-marker-logins**: Comma-separated GitHub user or bot logins that are
+trusted to post operational markers (`claimed-by`, `unclaimed-by`,
+`review-watermark`, `review-baseline`, `advisory-wait`) for IDD state transitions.
+Typically includes the primary agent or automation actor, plus any pinned
+dependency bots (e.g., `renovate[bot]` or `dependabot[bot]`) if configured for
+the workflow. Always include repository maintainers if `collaborator-authored-markers`
+is enabled.
+
+**maintainer-approval-actors**: Policy for who counts as a maintainer when
+approving pre-merge reviews. Possible values:
+- `owners-and-maintainers-only`: Only GitHub organization owners and repository
+  maintainers (Maintain, Admin roles) satisfy maintainer approval requirements.
+  Repository collaborators with Write permission do not count.
+- `all-write-permission-actors`: Any actor with Write, Maintain, or Admin
+  permission on the repository can provide maintainer approval.
+
+For public or OSS repositories, prefer `owners-and-maintainers-only` unless
+the repository explicitly trusts all collaborators for approval authority.
+
+**collaborator-authored-markers**: Boolean (true/false). Determines whether to
+trust operational markers authored by repository collaborators (Write, Maintain,
+or Admin permission) when parsing claim state and running state transitions.
+
+For public or large-team repositories, `false` is safer: only configured trusted
+bots and explicit actor logins can post operational markers. Set to `true` only
+if your repository explicitly approves all collaborators for IDD marker authority.
+This setting directly affects claim parsing rules and should not be changed without
+understanding the security implications.
+
+### Example configurations
+
+**Small team, high trust**:
+```
+- trusted-marker-logins: `kurone-kito`, `chatgpt-codex-connector[bot]`
+- maintainer-approval-actors: `owners-and-maintainers-only`
+- collaborator-authored-markers: false
+```
+
+**OSS with external contributors**:
+```
+- trusted-marker-logins: `github-actions[bot]`, `copilot-automation-bot`
+- maintainer-approval-actors: `owners-and-maintainers-only`
+- collaborator-authored-markers: false
+```
+
+**Team with trusted collaborators**:
+```
+- trusted-marker-logins: `team-automation`, `renovate[bot]`
+- maintainer-approval-actors: `all-write-permission-actors`
+- collaborator-authored-markers: true
+```
+
+For further details, see:
+- [Claim-state parsing](#claim-state-parsing) for how `trusted-marker-logins`
+  and `collaborator-authored-markers` affect claim validation.
+- `docs/policy-constants.md` for distributed policy defaults.
+
 ## Claim-state parsing
 
 To determine the current active claim, read issue comments


### PR DESCRIPTION
## Issue
Resolves #221

## Problem
The concept of 'trusted marker actor' is well-designed, but the configuration of 'who are the trusted marker actors' in a repository was documented abstractly. This made it harder for AI agents to reason about state transitions, especially important for public repositories deciding whether to trust collaborator-authored markers.

## Solution
Added comprehensive documentation for repository-local IDD policy configuration with:

### Changes
- **idd-overview.instructions.md**: New 'Repository-local IDD policy' section documenting:
  - `trusted-marker-logins`: list of trusted actor logins for operational markers
  - `maintainer-approval-actors`: policy for who counts as maintainer for approvals
  - `collaborator-authored-markers`: whether to trust markers from collaborators

- **idd-template/.github/instructions/idd-overview.instructions.md**: Mirrored all changes

### Documentation includes
- Clear policy format with example configuration blocks
- Three representative configurations:
  - Small team with high trust
  - OSS with external contributors
  - Team with trusted collaborators
- Guidance for public repositories (recommend `owners-and-maintainers-only`)
- Security implications for each configuration option
- Cross-references to claim-state parsing and policy constants

### Example policy block
```md
### IDD repository policy

This repository uses the following IDD configuration:

- **trusted-marker-logins**: `kurone-kito`, `renovate[bot]`, `github-actions[bot]`
- **maintainer-approval-actors**: `owners-and-maintainers-only`
- **collaborator-authored-markers**: `false`
```

## Type
- [x] Documentation
- [ ] Enhancement
- [ ] Bug fix
- [ ] Breaking change

## Testing
Documentation change - no code behavior modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated IDD policy instructions with new Repository-local IDD policy section, defining three configuration keys for managing trusted marker actors and approval rules.
  * Added configuration examples and references to related claim-state parsing and policy documentation for implementers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/246)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->