### PR TITLE
docs(idd): expand shared ci helper instructions

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -7,16 +7,73 @@ The shared CI wait thresholds and retry defaults are listed in
 [IDD policy constants](../../docs/policy-constants.md). Use that inventory
 to find the current named values; this helper still owns the behavior.
 
-## Algorithm
+## Inputs
 
-1. Identify the full set of required checks for the current PR head SHA
-   by reading the branch protection / ruleset via GH CLI or GH MCP.
-2. Poll `gh pr checks` (or equivalent) at a reasonable interval.
+Before polling, collect:
+
+1. PR number and current PR head SHA.
+2. The required-check set for the target base branch.
+3. Current check/run statuses for the same head SHA.
+
+Use GitHub server timestamps and states only.
+
+## Required-check discovery
+
+Determine required checks from branch protection or rulesets before
+interpreting `gh pr checks` output.
+
+1. Prefer rulesets:
+
+   ```sh
+   gh api repos/{owner}/{repo}/rulesets --paginate
+   ```
+
+   Extract required status checks from rulesets that apply to the PR base
+   branch.
+
+2. If rulesets do not provide required checks, fall back to branch
+   protection:
+
+   ```sh
+   gh api repos/{owner}/{repo}/branches/{base-branch}/protection
+   ```
+
+3. If neither source yields a required-check set, stop and post a hold
+   comment (missing merge-gate policy evidence).
+
+When caller phases already provide a trusted required-check set, reuse
+that set instead of re-deriving it.
+
+## Polling algorithm
+
+1. Fetch current checks for the PR:
+
+   ```sh
+   gh pr checks {pr-number} --json name,state,completedAt,link
+   ```
+
+2. Normalize check states:
+   - treat `skipped`, `neutral`, and `not_applicable` as pass-equivalent
+   - keep `queued` and `in_progress` as running
+   - keep `failure`, `cancelled`, and `timed_out` as non-pass
+3. Evaluate only checks that are in the required-check set.
+4. Repeat at a reasonable interval until a terminal route in the table
+   below is reached.
+
+Do not rely on `gh pr checks` command exit code as the gate decision.
+The decision must be based on normalized required-check states.
+
+## Rerun mechanics
+
+When this helper says rerun once, rerun the exact failed or stalled run:
+
+- rerun whole run: `gh run rerun <run-id>`
+- rerun failed jobs only: `gh run rerun --failed <run-id>`
+
+If GH CLI cannot resolve a run ID, use Actions REST endpoints directly
+for the same run before posting a hold.
 
 ## Interpretation
-
-Treat `skipped`, `neutral`, and `not_applicable` as equivalent to
-`success`.
 
 | State                                           | Action                                                                                                                                                                             |
 | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -22,23 +22,34 @@ Use GitHub server timestamps and states only.
 Determine required checks from branch protection or rulesets before
 interpreting `gh pr checks` output.
 
-1. Prefer rulesets:
+1. Fetch ruleset summaries:
 
    ```sh
    gh api repos/{owner}/{repo}/rulesets --paginate
    ```
 
-   Extract required status checks from rulesets that apply to the PR base
-   branch.
-
-2. If rulesets do not provide required checks, fall back to branch
-   protection:
+2. Fetch each ruleset detail:
 
    ```sh
-   gh api repos/{owner}/{repo}/branches/{base-branch}/protection
+   gh api repos/{owner}/{repo}/rulesets/{ruleset-id}
    ```
 
-3. If neither source yields a required-check set, stop and post a hold
+   Use detail payload rules only from enforcing rulesets that apply to
+   the PR base branch.
+
+3. Fetch branch protection checks for the base branch too (do not treat
+   this as mutually exclusive with rulesets). URL-encode branch names
+   before calling this endpoint:
+
+   ```sh
+   gh api repos/{owner}/{repo}/branches/{url-encoded-base-branch}/protection
+   ```
+
+4. Build the required-check set as the union of enforcing-ruleset checks
+   and branch-protection checks. Keep expected check source metadata
+   (GitHub App/integration) when configured.
+
+5. If neither source yields a required-check set, stop and post a hold
    comment (missing merge-gate policy evidence).
 
 When caller phases already provide a trusted required-check set, reuse
@@ -49,14 +60,17 @@ that set instead of re-deriving it.
 1. Fetch current checks for the PR:
 
    ```sh
-   gh pr checks {pr-number} --json name,state,completedAt,link
+   gh pr checks {pr-number} --json name,state,bucket,completedAt,link
    ```
 
 2. Normalize check states:
    - treat `skipped`, `neutral`, and `not_applicable` as pass-equivalent
-   - keep `queued` and `in_progress` as running
+   - treat `pending`, `requested`, `waiting`, `queued`, and
+     `in_progress` as running
    - keep `failure`, `cancelled`, and `timed_out` as non-pass
-3. Evaluate only checks that are in the required-check set.
+3. Evaluate only checks in the required-check set, and match expected
+   check source when the required definition includes an app/integration
+   constraint.
 4. Repeat at a reasonable interval until a terminal route in the table
    below is reached.
 
@@ -70,15 +84,20 @@ When this helper says rerun once, rerun the exact failed or stalled run:
 - rerun whole run: `gh run rerun <run-id>`
 - rerun failed jobs only: `gh run rerun --failed <run-id>`
 
+Extract `<run-id>` from the failing check `link` field (for example:
+`https://github.com/{owner}/{repo}/actions/runs/<run-id>/job/<job-id>`),
+or query the Actions API for runs filtered to the current PR head SHA and
+check name.
+
 If GH CLI cannot resolve a run ID, use Actions REST endpoints directly
 for the same run before posting a hold.
 
 ## Interpretation
 
-| State                                           | Action                                                                                                                                                                             |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| All required checks generated and all `success` | → **on-success** (caller-defined)                                                                                                                                                  |
-| Any required check `failure`                    | Inspect the log. If infra/flaky: rerun once. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step.                                  |
-| Any `cancelled` or `timed_out`                  | Investigate cause. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. If infra-caused: re-push or rerun CI, then resume polling. |
-| Any `queued` or `in_progress`                   | Continue waiting. After 30 min of no completion: rerun CI once. If still not complete: post a hold comment and stop.                                                               |
-| Required checks not generated after 10 min      | Treat as `queued`/`in_progress`. If the corresponding workflow run does not exist at all: post a hold comment and escalate to a maintainer, then stop.                             |
+| State (required checks only, normalized)                            | Action                                                                                                                                                                             |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| All required checks are generated and pass-equivalent               | → **on-success** (caller-defined)                                                                                                                                                  |
+| Any required check is non-pass `failure`                            | Inspect the log. If infra/flaky: rerun once. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step.                                  |
+| Any required check is non-pass `cancelled` or `timed_out`           | Investigate cause. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. If infra-caused: re-push or rerun CI, then resume polling. |
+| Any required check is running (`pending`/`requested`/`waiting`/...) | Continue waiting. After 30 min of no completion: rerun CI once. If still not complete: post a hold comment and stop.                                                               |
+| Required checks are not generated after 10 min                      | Treat as running. If the corresponding workflow run does not exist at all: post a hold comment and escalate to a maintainer, then stop.                                            |

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -83,6 +83,7 @@ catches parallel-session concurrency before a new claim comment is posted.
 
 1. **Local worktree scan**: Check whether any local worktree matches the
    pattern `issue/<number>-*`:
+
    ```sh
    git worktree list | grep "issue/<number>-"
    ```
@@ -90,6 +91,7 @@ catches parallel-session concurrency before a new claim comment is posted.
 2. **Remote branch scan** (scoped Refs API, not repo-wide):
    Query the Refs API with the issue-number prefix only, to stay within
    the scope invariant defined in idd-overview.instructions.md:
+
    ```sh
    gh api "repos/{owner}/{repo}/git/matching-refs/heads/issue/<number>-" \
      --jq '.[].ref'

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -66,6 +66,7 @@
         "idd-template/.github/instructions/idd-review-triage.instructions.md",
         "idd-template/.github/instructions/idd-review-fix.instructions.md",
         "idd-template/.github/instructions/idd-pre-merge.instructions.md",
+        "idd-template/.github/instructions/idd-merge-handoff.instructions.md",
         "idd-template/.github/instructions/idd-merge.instructions.md",
         "idd-template/.github/instructions/idd-resume.instructions.md",
         "idd-template/.github/instructions/idd-resume-stall.instructions.md",
@@ -154,6 +155,12 @@
       "id": "idd-merge-instructions",
       "source": "idd-template/.github/instructions/idd-merge.instructions.md",
       "target": ".github/instructions/idd-merge.instructions.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-merge-handoff-instructions",
+      "source": "idd-template/.github/instructions/idd-merge-handoff.instructions.md",
+      "target": ".github/instructions/idd-merge-handoff.instructions.md",
       "mode": "exact"
     },
     {

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -7,16 +7,73 @@ The shared CI wait thresholds and retry defaults are listed in
 [IDD policy constants](../../docs/policy-constants.md). Use that inventory
 to find the current named values; this helper still owns the behavior.
 
-## Algorithm
+## Inputs
 
-1. Identify the full set of required checks for the current PR head SHA
-   by reading the branch protection / ruleset via GH CLI or GH MCP.
-2. Poll `gh pr checks` (or equivalent) at a reasonable interval.
+Before polling, collect:
+
+1. PR number and current PR head SHA.
+2. The required-check set for the target base branch.
+3. Current check/run statuses for the same head SHA.
+
+Use GitHub server timestamps and states only.
+
+## Required-check discovery
+
+Determine required checks from branch protection or rulesets before
+interpreting `gh pr checks` output.
+
+1. Prefer rulesets:
+
+   ```sh
+   gh api repos/{owner}/{repo}/rulesets --paginate
+   ```
+
+   Extract required status checks from rulesets that apply to the PR base
+   branch.
+
+2. If rulesets do not provide required checks, fall back to branch
+   protection:
+
+   ```sh
+   gh api repos/{owner}/{repo}/branches/{base-branch}/protection
+   ```
+
+3. If neither source yields a required-check set, stop and post a hold
+   comment (missing merge-gate policy evidence).
+
+When caller phases already provide a trusted required-check set, reuse
+that set instead of re-deriving it.
+
+## Polling algorithm
+
+1. Fetch current checks for the PR:
+
+   ```sh
+   gh pr checks {pr-number} --json name,state,completedAt,link
+   ```
+
+2. Normalize check states:
+   - treat `skipped`, `neutral`, and `not_applicable` as pass-equivalent
+   - keep `queued` and `in_progress` as running
+   - keep `failure`, `cancelled`, and `timed_out` as non-pass
+3. Evaluate only checks that are in the required-check set.
+4. Repeat at a reasonable interval until a terminal route in the table
+   below is reached.
+
+Do not rely on `gh pr checks` command exit code as the gate decision.
+The decision must be based on normalized required-check states.
+
+## Rerun mechanics
+
+When this helper says rerun once, rerun the exact failed or stalled run:
+
+- rerun whole run: `gh run rerun <run-id>`
+- rerun failed jobs only: `gh run rerun --failed <run-id>`
+
+If GH CLI cannot resolve a run ID, use Actions REST endpoints directly
+for the same run before posting a hold.
 
 ## Interpretation
-
-Treat `skipped`, `neutral`, and `not_applicable` as equivalent to
-`success`.
 
 | State                                           | Action                                                                                                                                                                             |
 | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -22,23 +22,34 @@ Use GitHub server timestamps and states only.
 Determine required checks from branch protection or rulesets before
 interpreting `gh pr checks` output.
 
-1. Prefer rulesets:
+1. Fetch ruleset summaries:
 
    ```sh
    gh api repos/{owner}/{repo}/rulesets --paginate
    ```
 
-   Extract required status checks from rulesets that apply to the PR base
-   branch.
-
-2. If rulesets do not provide required checks, fall back to branch
-   protection:
+2. Fetch each ruleset detail:
 
    ```sh
-   gh api repos/{owner}/{repo}/branches/{base-branch}/protection
+   gh api repos/{owner}/{repo}/rulesets/{ruleset-id}
    ```
 
-3. If neither source yields a required-check set, stop and post a hold
+   Use detail payload rules only from enforcing rulesets that apply to
+   the PR base branch.
+
+3. Fetch branch protection checks for the base branch too (do not treat
+   this as mutually exclusive with rulesets). URL-encode branch names
+   before calling this endpoint:
+
+   ```sh
+   gh api repos/{owner}/{repo}/branches/{url-encoded-base-branch}/protection
+   ```
+
+4. Build the required-check set as the union of enforcing-ruleset checks
+   and branch-protection checks. Keep expected check source metadata
+   (GitHub App/integration) when configured.
+
+5. If neither source yields a required-check set, stop and post a hold
    comment (missing merge-gate policy evidence).
 
 When caller phases already provide a trusted required-check set, reuse
@@ -49,14 +60,17 @@ that set instead of re-deriving it.
 1. Fetch current checks for the PR:
 
    ```sh
-   gh pr checks {pr-number} --json name,state,completedAt,link
+   gh pr checks {pr-number} --json name,state,bucket,completedAt,link
    ```
 
 2. Normalize check states:
    - treat `skipped`, `neutral`, and `not_applicable` as pass-equivalent
-   - keep `queued` and `in_progress` as running
+   - treat `pending`, `requested`, `waiting`, `queued`, and
+     `in_progress` as running
    - keep `failure`, `cancelled`, and `timed_out` as non-pass
-3. Evaluate only checks that are in the required-check set.
+3. Evaluate only checks in the required-check set, and match expected
+   check source when the required definition includes an app/integration
+   constraint.
 4. Repeat at a reasonable interval until a terminal route in the table
    below is reached.
 
@@ -70,15 +84,20 @@ When this helper says rerun once, rerun the exact failed or stalled run:
 - rerun whole run: `gh run rerun <run-id>`
 - rerun failed jobs only: `gh run rerun --failed <run-id>`
 
+Extract `<run-id>` from the failing check `link` field (for example:
+`https://github.com/{owner}/{repo}/actions/runs/<run-id>/job/<job-id>`),
+or query the Actions API for runs filtered to the current PR head SHA and
+check name.
+
 If GH CLI cannot resolve a run ID, use Actions REST endpoints directly
 for the same run before posting a hold.
 
 ## Interpretation
 
-| State                                           | Action                                                                                                                                                                             |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| All required checks generated and all `success` | → **on-success** (caller-defined)                                                                                                                                                  |
-| Any required check `failure`                    | Inspect the log. If infra/flaky: rerun once. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step.                                  |
-| Any `cancelled` or `timed_out`                  | Investigate cause. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. If infra-caused: re-push or rerun CI, then resume polling. |
-| Any `queued` or `in_progress`                   | Continue waiting. After 30 min of no completion: rerun CI once. If still not complete: post a hold comment and stop.                                                               |
-| Required checks not generated after 10 min      | Treat as `queued`/`in_progress`. If the corresponding workflow run does not exist at all: post a hold comment and escalate to a maintainer, then stop.                             |
+| State (required checks only, normalized)                            | Action                                                                                                                                                                             |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| All required checks are generated and pass-equivalent               | → **on-success** (caller-defined)                                                                                                                                                  |
+| Any required check is non-pass `failure`                            | Inspect the log. If infra/flaky: rerun once. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step.                                  |
+| Any required check is non-pass `cancelled` or `timed_out`           | Investigate cause. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. If infra-caused: re-push or rerun CI, then resume polling. |
+| Any required check is running (`pending`/`requested`/`waiting`/...) | Continue waiting. After 30 min of no completion: rerun CI once. If still not complete: post a hold comment and stop.                                                               |
+| Required checks are not generated after 10 min                      | Treat as running. If the corresponding workflow run does not exist at all: post a hold comment and escalate to a maintainer, then stop.                                            |

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -83,6 +83,7 @@ catches parallel-session concurrency before a new claim comment is posted.
 
 1. **Local worktree scan**: Check whether any local worktree matches the
    pattern `issue/<number>-*`:
+
    ```sh
    git worktree list | grep "issue/<number>-"
    ```
@@ -90,6 +91,7 @@ catches parallel-session concurrency before a new claim comment is posted.
 2. **Remote branch scan** (scoped Refs API, not repo-wide):
    Query the Refs API with the issue-number prefix only, to stay within
    the scope invariant defined in idd-overview.instructions.md:
+
    ```sh
    gh api "repos/{owner}/{repo}/git/matching-refs/heads/issue/<number>-" \
      --jq '.[].ref'

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -345,6 +345,7 @@ repository keeps these defaults before unattended runs.
 .github/instructions/idd-review-triage.instructions.md
 .github/instructions/idd-review-fix.instructions.md
 .github/instructions/idd-pre-merge.instructions.md
+.github/instructions/idd-merge-handoff.instructions.md
 .github/instructions/idd-merge.instructions.md
 .github/instructions/idd-resume.instructions.md
 .github/instructions/idd-resume-stall.instructions.md
@@ -410,6 +411,7 @@ for FILE in \
   ".github/instructions/idd-review-triage.instructions.md" \
   ".github/instructions/idd-review-fix.instructions.md" \
   ".github/instructions/idd-pre-merge.instructions.md" \
+  ".github/instructions/idd-merge-handoff.instructions.md" \
   ".github/instructions/idd-merge.instructions.md" \
   ".github/instructions/idd-resume.instructions.md" \
   ".github/instructions/idd-resume-stall.instructions.md" \
@@ -483,6 +485,7 @@ for FILE in \
   ".github/instructions/idd-review-triage.instructions.md" \
   ".github/instructions/idd-review-fix.instructions.md" \
   ".github/instructions/idd-pre-merge.instructions.md" \
+  ".github/instructions/idd-merge-handoff.instructions.md" \
   ".github/instructions/idd-merge.instructions.md" \
   ".github/instructions/idd-resume.instructions.md" \
   ".github/instructions/idd-resume-stall.instructions.md" \


### PR DESCRIPTION
Closes #225

## Summary

Expand the shared CI helper instructions so agents can execute CI polling
with concrete, reproducible steps instead of phase-local guesswork.

## Changes

- Add explicit CI helper inputs (PR/head/required checks/current states).
- Add required-check discovery flow (rulesets first, then branch protection).
- Add polling-state normalization and explicit warning to not rely on
  `gh pr checks` exit code.
- Add rerun mechanics (`gh run rerun` / `gh run rerun --failed`).
- Keep interpretation routing table and behavior intact.
- Mirror all updates in `idd-template/.github/instructions/idd-ci.instructions.md`.

## Follow-up

- none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced CI polling documentation with detailed procedures for required-check discovery, state normalization, and rerun mechanics.
  * Updated onboarding guide to include references to new instruction materials.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/248)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->