### PR TITLE
docs(onboarding): add optional machine-readable idd config

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -614,6 +614,40 @@ Make this policy section discoverable and point to it from any entry files
 (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`)
 that mention IDD workflow.
 
+### Optional: add a machine-readable policy file
+
+For repositories that want stable automation input beyond Markdown,
+create `.github/idd/config.json` as a machine-readable mirror of the
+decisions above. Keep the human-readable policy section and this JSON in
+sync.
+
+Suggested shape:
+
+```json
+{
+  "iddVersion": "0.1.0",
+  "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
+  "mergePolicy": "fully_autonomous_merge",
+  "reviewPolicy": "copilot-advisory",
+  "threadResolutionPolicy": "fast-agent-resolve",
+  "trustedMarkerActors": ["<maintainer-or-bot-login>"],
+  "commands": {
+    "install": "{{INSTALL_DEPS_COMMAND}}",
+    "fixValidate": "{{FIX_VALIDATE_COMMANDS}}",
+    "prePushValidate": "{{PRE_PUSH_VALIDATE_COMMANDS}}",
+    "postFixValidate": "{{POST_FIX_VALIDATE_COMMANDS}}"
+  }
+}
+```
+
+Notes:
+
+- This file is optional by default and does not replace instruction files.
+- IDD behavior still comes from `.github/instructions/*.instructions.md`
+  unless the adopter explicitly builds tooling that consumes this config.
+- If the repository uses this file, treat drift between Markdown policy
+  notes and JSON as a configuration bug and update both in the same change.
+
 ---
 
 ## Step 4 — Replace placeholders
@@ -816,6 +850,8 @@ After completing the steps above, confirm each item:
       `{{PROJECT_MARKER_PREFIX}}-blocked-by` marker names in
       `idd-discover.instructions.md` and `idd-overview.instructions.md`
       match the prefix chosen for this project.
+- [ ] If `.github/idd/config.json` is used, it matches the recorded
+      merge/review/thread policies, marker prefix, and command values.
 
 Once all items are checked, the IDD workflow is ready for use. Point the
 operator to `docs/idd-workflow.md` as the starting guide.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -631,8 +631,8 @@ Suggested shape:
   "reviewPolicy": "<operator-review-policy>",
   "threadResolutionPolicy": "<operator-thread-resolution-policy>",
   "claimTiming": {
-    "staleAge": "<operator-claim-stale-age>",
-    "heartbeatInterval": "<operator-claim-heartbeat-interval>"
+    "staleAge": "PT24H",
+    "heartbeatInterval": "PT12H"
   },
   "trustedMarkerActors": ["<trusted-login-1>", "<trusted-login-2>"],
   "commands": {
@@ -651,8 +651,13 @@ Notes:
   unless the adopter explicitly builds tooling that consumes this config.
 - If the repository uses this file, treat drift between Markdown policy
   notes and JSON as a configuration bug and update both in the same change.
+- If this file is created before Step 4, include it in the same
+  placeholder-replacement pass as the copied template files.
 - Keep command strings JSON-escaped. Do not paste raw shell directly if
   it contains quotes or backslashes.
+- Extend the schema only when the repository records extra policy
+  decisions (for example: critique-loop profile, merge handoff actor,
+  external advisory bot, `issue-scope`, or maintainer approval actors).
 
 ---
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -851,7 +851,8 @@ After completing the steps above, confirm each item:
       `idd-discover.instructions.md` and `idd-overview.instructions.md`
       match the prefix chosen for this project.
 - [ ] If `.github/idd/config.json` is used, it matches the recorded
-      merge/review/thread policies, marker prefix, and command values.
+      `iddVersion`, marker prefix, merge/review/thread policies,
+      `trustedMarkerActors`, and command values.
 
 Once all items are checked, the IDD workflow is ready for use. Point the
 operator to `docs/idd-workflow.md` as the starting guide.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -627,15 +627,19 @@ Suggested shape:
 {
   "iddVersion": "0.1.0",
   "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
-  "mergePolicy": "fully_autonomous_merge",
-  "reviewPolicy": "copilot-advisory",
-  "threadResolutionPolicy": "fast-agent-resolve",
-  "trustedMarkerActors": ["<maintainer-or-bot-login>"],
+  "mergePolicy": "<operator-merge-policy>",
+  "reviewPolicy": "<operator-review-policy>",
+  "threadResolutionPolicy": "<operator-thread-resolution-policy>",
+  "claimTiming": {
+    "staleAge": "<operator-claim-stale-age>",
+    "heartbeatInterval": "<operator-claim-heartbeat-interval>"
+  },
+  "trustedMarkerActors": ["<trusted-login-1>", "<trusted-login-2>"],
   "commands": {
-    "install": "{{INSTALL_DEPS_COMMAND}}",
-    "fixValidate": "{{FIX_VALIDATE_COMMANDS}}",
-    "prePushValidate": "{{PRE_PUSH_VALIDATE_COMMANDS}}",
-    "postFixValidate": "{{POST_FIX_VALIDATE_COMMANDS}}"
+    "install": "<json-escaped install-deps command>",
+    "fixValidate": "<json-escaped fix-validate command>",
+    "prePushValidate": "<json-escaped pre-push-validate command>",
+    "postFixValidate": "<json-escaped post-fix-validate command>"
   }
 }
 ```
@@ -647,6 +651,8 @@ Notes:
   unless the adopter explicitly builds tooling that consumes this config.
 - If the repository uses this file, treat drift between Markdown policy
   notes and JSON as a configuration bug and update both in the same change.
+- Keep command strings JSON-escaped. Do not paste raw shell directly if
+  it contains quotes or backslashes.
 
 ---
 
@@ -852,7 +858,7 @@ After completing the steps above, confirm each item:
       match the prefix chosen for this project.
 - [ ] If `.github/idd/config.json` is used, it matches the recorded
       `iddVersion`, marker prefix, merge/review/thread policies,
-      `trustedMarkerActors`, and command values.
+      claim timing values, `trustedMarkerActors`, and command values.
 
 Once all items are checked, the IDD workflow is ready for use. Point the
 operator to `docs/idd-workflow.md` as the starting guide.

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -67,6 +67,14 @@ distributed default is `fully_autonomous_merge`; choose `human_merge` or
 `separate_merge_agent` as explicit opt-out profiles when normal worker
 sessions must hand off before F3.
 
+## Optional machine-readable config
+
+Adopters that want a stable config input for local tooling can add
+`.github/idd/config.json` and mirror their recorded policy decisions
+(merge policy, review policy, thread resolution policy, marker prefix,
+and command strings). This JSON is optional and does not replace
+`.github/instructions/*.instructions.md` as the execution authority.
+
 ## Placeholders
 
 | Placeholder                      | Description                                     |

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -71,8 +71,9 @@ sessions must hand off before F3.
 
 Adopters that want a stable config input for local tooling can add
 `.github/idd/config.json` and mirror their recorded policy decisions
-(merge policy, review policy, thread resolution policy, marker prefix,
-and command strings). This JSON is optional and does not replace
+(`iddVersion`, marker prefix, merge/review/thread policies,
+`trustedMarkerActors`, and command strings). This JSON is optional and
+does not replace
 `.github/instructions/*.instructions.md` as the execution authority.
 
 ## Placeholders

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -72,8 +72,8 @@ sessions must hand off before F3.
 Adopters that want a stable config input for local tooling can add
 `.github/idd/config.json` and mirror their recorded policy decisions
 (`iddVersion`, marker prefix, merge/review/thread policies,
-`trustedMarkerActors`, and command strings). This JSON is optional and
-does not replace
+claim timing values, `trustedMarkerActors`, and JSON-escaped command
+strings). This JSON is optional and does not replace
 `.github/instructions/*.instructions.md` as the execution authority.
 
 ## Placeholders


### PR DESCRIPTION
## Summary\n- add optional \.github/idd/config.json guidance in ONBOARDING\n- provide a concrete JSON schema example that mirrors policy decisions\n- add README note describing machine-readable config intent and authority boundary\n\nCloses #250\n\n## Follow-up\n- none\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for an optional machine-readable config to the IDD template so teams can record stable policy decisions (version, marker prefix, merge/review/thread policies, trusted actors, and command strings) for local tooling.
  * Extended onboarding verification to require that the machine-readable config, if used, matches the human-readable policy entries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/252)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->