### PR TITLE
docs(examples): add minimal idd run artifact set

### DIFF
--- a/examples/minimal-run/README.md
+++ b/examples/minimal-run/README.md
@@ -1,0 +1,16 @@
+# Minimal IDD Run Sample
+
+This directory shows one compact end-to-end IDD run in human-readable
+artifacts. Each file is a realistic example, not a strict schema.
+
+| File                    | Purpose                                         |
+| ----------------------- | ----------------------------------------------- |
+| `issue.md`              | Initial issue statement and acceptance criteria |
+| `claim-comment.md`      | `claimed-by` marker comment body                |
+| `heartbeat.md`          | Claim heartbeat refresh comment body            |
+| `pr-body.md`            | Pull request body used in D3                    |
+| `review-snapshot.md`    | E1 snapshot summary and watermark marker        |
+| `path-a-response.md`    | E13 reply for accepted actionable feedback      |
+| `path-b-response.md`    | E6 triage response for advisory feedback        |
+| `pre-merge-snapshot.md` | F2 evidence snapshot summary                    |
+| `cleanup-comment.md`    | F4 post-merge cleanup summary                   |

--- a/examples/minimal-run/claim-comment.md
+++ b/examples/minimal-run/claim-comment.md
@@ -1,0 +1,23 @@
+# A5 — Claim comment
+
+Posted to the issue after a successful A5 claim verification.
+The IDD agent posts this as a GitHub issue comment.
+
+---
+
+<!-- markdownlint-disable-next-line MD013 -->
+<!-- claimed-by: copilot-cli-abc12345 claim-20260510T090000Z-55521 supersedes: none 2026-05-10T09:00:00Z branch: issue/123-add-onboarding-doctor -->
+
+_copilot-cli-abc12345: issue claim — IDD automation marker. Do not edit._
+
+---
+
+## Field reference
+
+| Field        | Value in this sample              | Meaning                                                           |
+| ------------ | --------------------------------- | ----------------------------------------------------------------- |
+| `agent-id`   | `copilot-cli-abc12345`            | Tool/session identifier                                           |
+| `claim-id`   | `claim-20260510T090000Z-55521`    | Opaque ownership token for this claim lineage                     |
+| `supersedes` | `none`                            | Fresh claim; no prior stale claim being taken over                |
+| `timestamp`  | `2026-05-10T09:00:00Z`            | Human-readable context only; GitHub `created_at` is authoritative |
+| `branch`     | `issue/123-add-onboarding-doctor` | Branch the agent will create and push to                          |

--- a/examples/minimal-run/cleanup-comment.md
+++ b/examples/minimal-run/cleanup-comment.md
@@ -1,0 +1,15 @@
+# F4/F5 - Post-merge cleanup comments
+
+After merge, post cleanup context and release the issue claim.
+
+```md
+Merged in #456 (`11223344556677889900aabbccddeeff00112233`).
+Local cleanup complete: worktree removed, branch pruned, main refreshed.
+Returning to Discover for the next issue.
+```
+
+```md
+<!-- unclaimed-by: copilot-cli-abc12345 claim-20260510T090000Z-55521 2026-05-10T12:00:00Z -->
+
+_copilot-cli-abc12345: issue claim released - IDD automation marker. Do not edit._
+```

--- a/examples/minimal-run/heartbeat.md
+++ b/examples/minimal-run/heartbeat.md
@@ -1,0 +1,19 @@
+# B/C hold or long phase - heartbeat comment
+
+Posted when the agent keeps the claim during a long hold or long-running
+phase. The claim ID and branch stay exactly the same as the active claim.
+
+---
+
+<!-- markdownlint-disable-next-line MD013 -->
+<!-- claimed-by: copilot-cli-abc12345 claim-20260510T090000Z-55521 supersedes: none 2026-05-10T21:00:00Z branch: issue/123-add-onboarding-doctor -->
+
+_copilot-cli-abc12345: issue claim - IDD automation marker. Do not edit._
+
+---
+
+## Notes
+
+- This is a heartbeat, not a takeover, so `supersedes` remains `none`.
+- The branch field must match the original claim branch exactly.
+- The stale clock uses GitHub comment `created_at`, not the embedded time.

--- a/examples/minimal-run/issue.md
+++ b/examples/minimal-run/issue.md
@@ -1,0 +1,16 @@
+# Issue #123 — Add sample onboarding doctor check
+
+## Background
+
+New adopters can import IDD, but they need a quick way to confirm that
+required files and policy markers are present before the first loop.
+
+## Goal
+
+Add a portable onboarding doctor command and basic documentation.
+
+## Acceptance Criteria
+
+1. A doctor command exists and can run from repository root.
+1. The command reports missing core IDD files and unresolved placeholders.
+1. README contains a short usage snippet.

--- a/examples/minimal-run/path-a-response.md
+++ b/examples/minimal-run/path-a-response.md
@@ -1,0 +1,11 @@
+# E13 - PATH A reviewer feedback response
+
+Use this when accepted actionable feedback is fixed.
+
+```md
+**Accepted** - fixed in e1f2a3b, c4d5e6f: tightened marker parsing so
+uppercase prefixes are detected consistently, and added regression tests
+for mixed-case markers.
+```
+
+For review threads, post this reply and then resolve the thread.

--- a/examples/minimal-run/path-b-response.md
+++ b/examples/minimal-run/path-b-response.md
@@ -1,0 +1,16 @@
+# E6 - PATH B advisory response
+
+Use this for advisory bot comments (Copilot/CI/CodeRabbit advisory items).
+
+```md
+**Accepted** - advisory confirms current implementation already includes
+the required branch-protection check and no further code change is needed.
+```
+
+```md
+**Rejected** - advisory suggestion conflicts with repository policy; no
+action is required for this PR.
+```
+
+For advisory review threads, resolve the thread immediately after posting
+the marker response.

--- a/examples/minimal-run/pr-body.md
+++ b/examples/minimal-run/pr-body.md
@@ -1,0 +1,21 @@
+# D3 - Pull request body
+
+```md
+## Summary
+
+- add a minimal onboarding doctor command
+- add fixture-backed tests for placeholder and marker checks
+- document doctor usage in the English and Japanese README
+
+## Why this change
+
+New adopters need a quick way to verify that imported IDD files are
+present and consistent before running the first loop.
+
+## Follow-up
+
+- consider adding an onboarding section to docs/getting-started.md
+- consider exposing doctor output as JSON in CI examples
+
+Closes #123
+```

--- a/examples/minimal-run/pre-merge-snapshot.md
+++ b/examples/minimal-run/pre-merge-snapshot.md
@@ -1,0 +1,23 @@
+# F2 - Pre-merge evidence snapshot
+
+This is a human-readable summary of the final F2 gate evidence collected
+before handing off to merge execution.
+
+```md
+F2 snapshot
+
+- head SHA: aabbccddeeff0011223344556677889900aabbcc
+- max activity updatedAt: 2026-05-10T11:08:42Z
+- total activity item count: 17
+- latest CI pass completedAt: 2026-05-10T11:05:13Z
+
+Gate checklist
+
+- review currency: pass
+- advisory wait: SATISFIED
+- required checks: pass
+- required approvals and CODEOWNER: pass
+- CHANGES_REQUESTED: none
+- unresolved actionable threads: 0
+- unreplied regular comments: 0
+```

--- a/examples/minimal-run/review-snapshot.md
+++ b/examples/minimal-run/review-snapshot.md
@@ -1,0 +1,17 @@
+# E1/E2 - Review snapshot markers
+
+Post E1 review watermark after collecting review activity and CI status.
+
+```md
+<!-- review-watermark: copilot-cli-abc12345 claim-20260510T090000Z-55521 aabbccddeeff0011223344556677889900aabbcc 2026-05-10T11:08:42Z 17 2026-05-10T11:05:13Z -->
+
+_copilot-cli-abc12345: review triage snapshot - IDD automation marker. Do not edit._
+```
+
+Post E2 critique baseline after the critique pass.
+
+```md
+<!-- review-baseline: copilot-cli-abc12345 claim-20260510T090000Z-55521 aabbccddeeff0011223344556677889900aabbcc -->
+
+_copilot-cli-abc12345: critique baseline - IDD automation marker. Do not edit._
+```


### PR DESCRIPTION
## Summary
- add examples/minimal-run/ with a compact end-to-end IDD sample run
- include sample comment bodies for claim, heartbeat, review snapshot, PATH A and PATH B replies, pre-merge evidence, and cleanup
- keep examples aligned with current marker formats used by the IDD workflow

## Why
Issue #254 asks for a beginner-friendly sample that shows what comments and artifacts are posted during a real IDD run.

## Follow-up
- optionally add links from workflow docs if maintainers want this folder in the main reading path

Closes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example templates and markdown files to the minimal-run directory, including GitHub issue and pull request templates, claim/cleanup comment markers, heartbeat templates for long-running operations, reviewer feedback responses, and pre-merge/review snapshots.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/260)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->