### PR TITLE
docs: clarify pnpm is dogfooding-only and Node.js/npx is optional for adopters

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -82,7 +82,8 @@ IDD は Markdown ネイティブですが、依存関係なしではありませ
 - 認証済みの `gh` CLI または同等の GitHub MCP 連携
 - `jq`
 - `curl` などの REST クライアント
-- `npx` を使える Node.js/npm
+- `npx` を使える Node.js/npm（非 Node.js プロジェクトでは任意 — 詳細は
+  [Tooling boundary](docs/customization.md#tooling-boundary) を参照）
 - 選択した merge policy に合う repository-scoped GitHub credentials
 - ループで使う場合は、設定済みの branch protection / required review policy
 
@@ -95,10 +96,14 @@ IDD は Markdown ネイティブですが、依存関係なしではありませ
 の外に置き、明示的な opt-in により選択します。merge policy は
 [Customizing IDD](docs/customization.md) で 1 つ選んで記録します。
 
-## ローカル pnpm ツール基盤
+## ローカル pnpm ツール基盤（このリポジトリのコントリビューター専用）
 
 このリポジトリには project-local の pnpm 基盤と Husky hook を追加し、
 コミット前に最小 lint ゲートをローカルでも強制できるようにしました。
+**このセクションは、このソースリポジトリで dogfooding する場合専用です。**
+テンプレートの採用者は pnpm を必要としません — プロジェクト既存のツールを使い、
+validate コマンドを適切に設定してください。採用者向けのガイダンスは
+[Tooling boundary](docs/customization.md#tooling-boundary) を参照してください。
 
 ```sh
 corepack enable

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ To run the full loop, an agent needs:
 - An authenticated `gh` CLI or equivalent GitHub MCP integration
 - `jq`
 - A REST client such as `curl`
-- Node.js/npm with `npx`
+- Node.js/npm with `npx` (optional for non-Node.js projects — see
+  [Tooling boundary](docs/customization.md#tooling-boundary))
 - Repository-scoped GitHub credentials appropriate for the chosen merge
   policy
 - Branch protection and required review policy already configured when
@@ -98,11 +99,15 @@ The distributed default allows worker sessions to continue through merge
 the worker session by explicit opt-in. Choose and record one profile in
 [Customizing IDD](docs/customization.md).
 
-## Local pnpm tooling baseline
+## Local pnpm tooling baseline (contributors to this repository only)
 
-This repository now includes a project-local pnpm baseline and Husky
-hooks so contributors and autopilot runs can enforce the minimum lint
-gate before commit.
+This repository uses a project-local pnpm baseline and Husky hooks so
+contributors and autopilot runs can enforce the minimum lint gate before
+commit. **This section is specific to dogfooding work in this source
+repository.** Template adopters do not need pnpm — use your project's
+existing tooling and configure the validate commands accordingly. See
+[Tooling boundary](docs/customization.md#tooling-boundary) for
+adopter-facing guidance.
 
 ```sh
 corepack enable

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -166,7 +166,8 @@ same: repeated runs must stay safe and predictable.
 ## Tooling Boundary
 
 IDD workflow files are tooling-agnostic. The only tooling contract is
-the `Project commands` table in `idd-overview.instructions.md`.
+the `Project commands` table in
+`.github/instructions/idd-overview.instructions.md`.
 
 The following policy matrix defines the tooling requirements and
 fallback order for repositories adopting IDD:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -168,18 +168,8 @@ same: repeated runs must stay safe and predictable.
 IDD workflow files are tooling-agnostic. The only tooling contract is
 the `Project commands` table in `idd-overview.instructions.md`.
 
-### This source repository (dogfooding)
-
-This repository enforces pnpm strictly for local development and
-pre-commit hooks. That is a contributor concern specific to this
-repository and does not propagate to the distributed template. Do not
-treat the pnpm baseline described in this repository's `README.md` as a
-requirement for adopters.
-
-### Template adopters
-
-The following policy matrix defines the tooling boundary for adopter
-repositories:
+The following policy matrix defines the tooling requirements and
+fallback order for repositories adopting IDD:
 
 | Context                                  | Requirement         | Fallback order                                                                       |
 | ---------------------------------------- | ------------------- | ------------------------------------------------------------------------------------ |
@@ -189,7 +179,7 @@ repositories:
 | Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` if Node.js is present; 3. `true` no-op |
 | pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                              |
 
-Decision points for implementation issues:
+Decision points:
 
 - **In scope for IDD**: validate command rows and `install-deps` in the
   `Project commands` table. These are the only tooling integration points.
@@ -199,10 +189,6 @@ Decision points for implementation issues:
   Node.js project's script runner; (2) use bare `npx <tool>` if
   Node.js is available; (3) replace with `true` if the tool is absent
   and its check is not relevant to the project.
-- **CI guard (#265)**: the distributed `idd-template/` must not contain
-  commands that assume pnpm is available. A CI check scoped to
-  `idd-template/` should verify that `Project commands` placeholder
-  values do not reference `pnpm` directly.
 
 ## Issue Scope
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -163,6 +163,42 @@ When WorkTrunk uses a pre-start install hook, that hook may satisfy
 `install-deps` automatically. The underlying command contract is the
 same: repeated runs must stay safe and predictable.
 
+## Tooling Boundary
+
+IDD workflow files are tooling-agnostic. The only tooling contract is
+the `Project commands` table in `idd-overview.instructions.md`.
+
+### This source repository (dogfooding)
+
+This repository enforces pnpm strictly for local development and
+pre-commit hooks. That is a contributor concern specific to this
+repository and does not propagate to the distributed template. Do not
+treat the pnpm baseline described in this repository's `README.md` as a
+requirement for adopters.
+
+### Template adopters
+
+The following policy matrix defines the tooling boundary for adopter
+repositories:
+
+| Context                                  | Requirement         | Fallback order                                                                       |
+| ---------------------------------------- | ------------------- | ------------------------------------------------------------------------------------ |
+| `git`, `gh`, `jq`, `curl`                | **Required**        | No fallback; IDD cannot run without these                                            |
+| Validate commands (`fix-validate`, etc.) | Project-dependent   | Use project tooling; `true` as no-op                                                 |
+| Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` if Node.js is present; 3. `true` no-op |
+| pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                              |
+
+Decision points for implementation issues:
+
+- **In scope for IDD**: validate command rows and `install-deps` in the
+  `Project commands` table. These are the only tooling integration points.
+- **Out of scope for IDD**: package manager choice, build tooling,
+  language runtime. Adopt whatever the target project already uses.
+- **Fallback order for npx-using templates**: (1) use an existing
+  Node.js project's script runner; (2) use bare `npx <tool>` if
+  Node.js is available; (3) replace with `true` if the tool is absent
+  and its check is not relevant to the project.
+
 ## Issue Scope
 
 The default `issue-scope` is `roadmap`, which keeps discovery inside the

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -184,6 +184,7 @@ repositories:
 | Context                                  | Requirement         | Fallback order                                                                       |
 | ---------------------------------------- | ------------------- | ------------------------------------------------------------------------------------ |
 | `git`, `gh`, `jq`, `curl`                | **Required**        | No fallback; IDD cannot run without these                                            |
+| `install-deps` command                   | Project-dependent   | Use project's native package manager; `true` as no-op when no install step is needed |
 | Validate commands (`fix-validate`, etc.) | Project-dependent   | Use project tooling; `true` as no-op                                                 |
 | Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` if Node.js is present; 3. `true` no-op |
 | pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                              |
@@ -198,6 +199,10 @@ Decision points for implementation issues:
   Node.js project's script runner; (2) use bare `npx <tool>` if
   Node.js is available; (3) replace with `true` if the tool is absent
   and its check is not relevant to the project.
+- **CI guard (#265)**: the distributed `idd-template/` must not contain
+  commands that assume pnpm is available. A CI check scoped to
+  `idd-template/` should verify that `Project commands` placeholder
+  values do not reference `pnpm` directly.
 
 ## Issue Scope
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,10 @@ The agent that imports or runs IDD needs access to:
 - `git`
 - an authenticated `gh` CLI or equivalent GitHub integration
 - `jq`
-- Node.js/npm with `npx`
+- Node.js/npm with `npx` (optional; only required if the project's
+  validate commands use `npx`. Non-Node.js projects should set validate
+  commands to their project tooling or to `true` as a no-op — see
+  [Tooling boundary](customization.md#tooling-boundary))
 - a REST client such as `curl` for reliable operational marker posting
 
 ## 1. Import the Template

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -141,6 +141,12 @@ values. The operator can confirm these proposed values or correct them.
 - **Post-fix-validate commands** (`{{POST_FIX_VALIDATE_COMMANDS}}`):
   Usually a superset combining fix-validate and pre-push-validate.
 
+> **Tooling boundary**: IDD does not require Node.js or pnpm. Use the
+> target project's existing tooling for all command rows. Set a row to
+> `true` (no-op) when no relevant tool is present. For the full policy
+> matrix and fallback order, see
+> [Tooling boundary](docs/customization.md#tooling-boundary).
+
 **Present proposed values to the operator.** Format:
 
 > Based on the target repository's structure, I've derived these candidate

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -166,7 +166,8 @@ same: repeated runs must stay safe and predictable.
 ## Tooling Boundary
 
 IDD workflow files are tooling-agnostic. The only tooling contract is
-the `Project commands` table in `idd-overview.instructions.md`.
+the `Project commands` table in
+`.github/instructions/idd-overview.instructions.md`.
 
 The following policy matrix defines the tooling requirements and
 fallback order for repositories adopting IDD:

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -174,6 +174,7 @@ fallback order for repositories adopting IDD:
 | Context                                  | Requirement         | Fallback order                                                                       |
 | ---------------------------------------- | ------------------- | ------------------------------------------------------------------------------------ |
 | `git`, `gh`, `jq`, `curl`                | **Required**        | No fallback; IDD cannot run without these                                            |
+| `install-deps` command                   | Project-dependent   | Use project's native package manager; `true` as no-op when no install step is needed |
 | Validate commands (`fix-validate`, etc.) | Project-dependent   | Use project tooling; `true` as no-op                                                 |
 | Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` if Node.js is present; 3. `true` no-op |
 | pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                              |
@@ -188,6 +189,10 @@ Decision points:
   Node.js project's script runner; (2) use bare `npx <tool>` if
   Node.js is available; (3) replace with `true` if the tool is absent
   and its check is not relevant to the project.
+- **CI guard**: the distributed `idd-template/` must not contain
+  commands that assume pnpm is available. A CI check scoped to
+  `idd-template/` should verify that `Project commands` placeholder
+  values do not reference `pnpm` directly.
 
 ## Issue Scope
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -189,10 +189,6 @@ Decision points:
   Node.js project's script runner; (2) use bare `npx <tool>` if
   Node.js is available; (3) replace with `true` if the tool is absent
   and its check is not relevant to the project.
-- **CI guard**: the distributed `idd-template/` must not contain
-  commands that assume pnpm is available. A CI check scoped to
-  `idd-template/` should verify that `Project commands` placeholder
-  values do not reference `pnpm` directly.
 
 ## Issue Scope
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -163,6 +163,32 @@ When WorkTrunk uses a pre-start install hook, that hook may satisfy
 `install-deps` automatically. The underlying command contract is the
 same: repeated runs must stay safe and predictable.
 
+## Tooling Boundary
+
+IDD workflow files are tooling-agnostic. The only tooling contract is
+the `Project commands` table in `idd-overview.instructions.md`.
+
+The following policy matrix defines the tooling requirements and
+fallback order for repositories adopting IDD:
+
+| Context                                  | Requirement         | Fallback order                                                                       |
+| ---------------------------------------- | ------------------- | ------------------------------------------------------------------------------------ |
+| `git`, `gh`, `jq`, `curl`                | **Required**        | No fallback; IDD cannot run without these                                            |
+| Validate commands (`fix-validate`, etc.) | Project-dependent   | Use project tooling; `true` as no-op                                                 |
+| Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` if Node.js is present; 3. `true` no-op |
+| pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                              |
+
+Decision points:
+
+- **In scope for IDD**: validate command rows and `install-deps` in the
+  `Project commands` table. These are the only tooling integration points.
+- **Out of scope for IDD**: package manager choice, build tooling,
+  language runtime. Adopt whatever the target project already uses.
+- **Fallback order for npx-using templates**: (1) use an existing
+  Node.js project's script runner; (2) use bare `npx <tool>` if
+  Node.js is available; (3) replace with `true` if the tool is absent
+  and its check is not relevant to the project.
+
 ## Issue Scope
 
 The default `issue-scope` is `roadmap`, which keeps discovery inside the

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -17,7 +17,10 @@ The agent that imports or runs IDD needs access to:
 - `git`
 - an authenticated `gh` CLI or equivalent GitHub integration
 - `jq`
-- Node.js/npm with `npx`
+- Node.js/npm with `npx` (optional; only required if the project's
+  validate commands use `npx`. Non-Node.js projects should set validate
+  commands to their project tooling or to `true` as a no-op — see
+  [Tooling boundary](customization.md#tooling-boundary))
 - a REST client such as `curl` for reliable operational marker posting
 
 ## 1. Import the Template


### PR DESCRIPTION
## Summary

This PR documents the tooling boundary between this source repository (which uses pnpm strictly for local development) and the distributed IDD template (which must stay tooling-agnostic for adopters).

## Changes

- **README.md / README.ja.md**: Mark the pnpm section as "contributors to this repository only"; mark Node.js/npx as optional with a cross-reference to the tooling boundary docs.
- **docs/getting-started.md / idd-template/docs/getting-started.md**: Clarify that Node.js/npx is optional for non-Node.js adopters; add fallback guidance.
- **docs/customization.md**: Add a "Tooling Boundary" section with dogfooding and adopter subsections, a policy matrix (covering `install-deps`, validate commands, Node.js/npx, pnpm), decision points for implementation issues, and a CI guard note for #265.
- **idd-template/docs/customization.md**: Same adopter-focused section (dogfooding subsection and CI guard bullet removed).
- **idd-template/ONBOARDING.md**: Add a tooling boundary cross-reference note so the primary adopter entry point links to the policy section.

## Rationale

Dogfooding this repository requires pnpm. Distributing that requirement to all adopters raises the adoption barrier for non-Node.js projects without benefit. Documenting the boundary explicitly also gives implementation issues #264 (template optional execution path) and #265 (CI defense wall) a concrete policy reference to implement against.

Closes #263
Refs #262

### Recommended follow-up

- #264 (template: optional Node.js/npx execution path) — blocked on this policy doc
- #265 (CI: pnpm boundary defense wall in CI) — blocked on this policy doc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Node.js/npm with `npx` is optional for non-Node.js projects
  * Added a "Tooling Boundary" section explaining required vs optional tooling and explicit fallback order
  * Scoped pnpm as contributor/dogfooding-only and noted template adopters do not need pnpm
  * Updated prerequisites, onboarding, and getting-started guidance to reference the Tooling Boundary

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/267)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->