### PR TITLE
ci(boundary): add reusable pnpm boundary defense

### DIFF
--- a/.github/workflows/pnpm-boundary.yml
+++ b/.github/workflows/pnpm-boundary.yml
@@ -1,0 +1,62 @@
+name: Pnpm boundary guard
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+      - "!main"
+  workflow_call:
+    inputs:
+      runner:
+        default: ubuntu-slim
+        required: false
+        type: string
+      node-version:
+        default: 24.x
+        required: false
+        type: string
+      install-command:
+        default: pnpm install --frozen-lockfile --prefer-offline
+        required: false
+        type: string
+      lint-command:
+        default: pnpm run lint:minimum
+        required: false
+        type: string
+      boundary-command:
+        default: node scripts/check-pnpm-boundary.mjs
+        required: false
+        type: string
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  pnpm-boundary:
+    # Imported from kurone-kito/pnpm-project-template push workflow shape
+    # and adapted as a reusable workflow with repository-specific guards.
+    runs-on: ${{ inputs.runner || 'ubuntu-slim' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          check-latest: true
+          cache: pnpm
+          node-version: ${{ inputs.node-version || '24.x' }}
+      - name: Install dependencies
+        env:
+          HUSKY: 0
+        run: ${{ inputs.install-command || 'pnpm install --frozen-lockfile --prefer-offline' }}
+      - name: Run lint minimum
+        run: ${{ inputs.lint-command || 'pnpm run lint:minimum' }}
+      - name: Check distributable pnpm boundary
+        run: ${{ inputs.boundary-command || 'node scripts/check-pnpm-boundary.mjs' }}

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -191,6 +191,41 @@ Decision points:
   Node.js is available; (3) replace with `true` if the tool is absent
   and its check is not relevant to the project.
 
+## Reusable pnpm boundary guard workflow
+
+This repository exposes `.github/workflows/pnpm-boundary.yml` as both:
+
+- a normal CI workflow (`push` and `pull_request`)
+- a reusable workflow (`workflow_call`) for downstream repositories
+
+The job shape is imported from
+`kurone-kito/pnpm-project-template/.github/workflows/push.yml` and then
+adapted for IDD boundary checks.
+
+Reusable inputs:
+
+| Input              | Default                                           | Purpose                                                  |
+| ------------------ | ------------------------------------------------- | -------------------------------------------------------- |
+| `runner`           | `ubuntu-slim`                                     | Runner label for the boundary job                        |
+| `node-version`     | `24.x`                                            | Node.js version used by `setup-node`                     |
+| `install-command`  | `pnpm install --frozen-lockfile --prefer-offline` | Dependency install step                                  |
+| `lint-command`     | `pnpm run lint:minimum`                           | Project lint/test command                                |
+| `boundary-command` | `node scripts/check-pnpm-boundary.mjs`            | Check that distributable command rows do not leak `pnpm` |
+
+Example downstream usage:
+
+```yaml
+jobs:
+  pnpm-boundary:
+    uses: owner/repo/.github/workflows/pnpm-boundary.yml@main
+    with:
+      node-version: "24.x"
+      boundary-command: node scripts/check-pnpm-boundary.mjs
+```
+
+If a downstream repository is non-Node.js, either skip this workflow or
+override commands with project-appropriate checks.
+
 ## Issue Scope
 
 The default `issue-scope` is `roadmap`, which keeps discovery inside the

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -191,6 +191,42 @@ Decision points:
   Node.js is available; (3) replace with `true` if the tool is absent
   and its check is not relevant to the project.
 
+## Reusable pnpm boundary guard workflow
+
+The source repository publishes `.github/workflows/pnpm-boundary.yml` as
+both:
+
+- a normal CI workflow (`push` and `pull_request`)
+- a reusable workflow (`workflow_call`) for downstream repositories
+
+The job shape is imported from
+`kurone-kito/pnpm-project-template/.github/workflows/push.yml` and then
+adapted for IDD boundary checks.
+
+Reusable inputs:
+
+| Input              | Default                                           | Purpose                                                  |
+| ------------------ | ------------------------------------------------- | -------------------------------------------------------- |
+| `runner`           | `ubuntu-slim`                                     | Runner label for the boundary job                        |
+| `node-version`     | `24.x`                                            | Node.js version used by `setup-node`                     |
+| `install-command`  | `pnpm install --frozen-lockfile --prefer-offline` | Dependency install step                                  |
+| `lint-command`     | `pnpm run lint:minimum`                           | Project lint/test command                                |
+| `boundary-command` | `node scripts/check-pnpm-boundary.mjs`            | Check that distributable command rows do not leak `pnpm` |
+
+Example downstream usage:
+
+```yaml
+jobs:
+  pnpm-boundary:
+    uses: owner/repo/.github/workflows/pnpm-boundary.yml@main
+    with:
+      node-version: "24.x"
+      boundary-command: node scripts/check-pnpm-boundary.mjs
+```
+
+If a downstream repository is non-Node.js, either skip this workflow or
+override commands with project-appropriate checks.
+
 ## Issue Scope
 
 The default `issue-scope` is `roadmap`, which keeps discovery inside the

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -193,8 +193,7 @@ Decision points:
 
 ## Reusable pnpm boundary guard workflow
 
-The source repository publishes `.github/workflows/pnpm-boundary.yml` as
-both:
+This repository exposes `.github/workflows/pnpm-boundary.yml` as both:
 
 - a normal CI workflow (`push` and `pull_request`)
 - a reusable workflow (`workflow_call`) for downstream repositories

--- a/scripts/check-pnpm-boundary.mjs
+++ b/scripts/check-pnpm-boundary.mjs
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseProjectCommandRows } from "./idd-doctor.mjs";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const TEMPLATE_OVERVIEW_PATH =
+  "idd-template/.github/instructions/idd-overview.instructions.md";
+const COMMAND_ROWS = [
+  "fix-validate",
+  "pre-push-validate",
+  "post-fix-validate",
+  "install-deps",
+];
+const FORBIDDEN_TOKEN = /\bpnpm\b/i;
+
+/**
+ * Find pnpm leaks in template Project commands rows.
+ * @param {string} overviewText
+ * @returns {string[]}
+ */
+export function findPnpmCommandLeaks(overviewText) {
+  const rows = parseProjectCommandRows(overviewText);
+  return COMMAND_ROWS.flatMap((name) => {
+    const command = rows.get(name) ?? "";
+    if (!command || !FORBIDDEN_TOKEN.test(command)) return [];
+    return [`${name}: contains forbidden token "pnpm" (${command})`];
+  });
+}
+
+/**
+ * Check distributable template boundary in the current repository.
+ * @param {string} [root]
+ * @returns {{ ok: boolean, errors: string[] }}
+ */
+export function checkPnpmBoundary(root = ROOT) {
+  const text = readFileSync(join(root, TEMPLATE_OVERVIEW_PATH), "utf8");
+  const errors = findPnpmCommandLeaks(text);
+  return { ok: errors.length === 0, errors };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const result = checkPnpmBoundary();
+  if (!result.ok) {
+    console.error("pnpm boundary check failed:");
+    for (const error of result.errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+  console.log("pnpm boundary check passed.");
+}

--- a/tests/pnpm-boundary.test.mjs
+++ b/tests/pnpm-boundary.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { findPnpmCommandLeaks } from "../scripts/check-pnpm-boundary.mjs";
+
+test("passes when template command rows avoid pnpm", () => {
+  const overview = `
+| Name | Commands |
+| ---- | -------- |
+| **fix-validate** | \`npx dprint fmt "**/*.md"\` |
+| **pre-push-validate** | \`npx markdownlint-cli2 "**/*.md"\` |
+| **post-fix-validate** | \`node --test tests/*.mjs\` |
+| **install-deps** | \`true\` |
+`;
+
+  assert.deepEqual(findPnpmCommandLeaks(overview), []);
+});
+
+test("fails when any command row leaks pnpm", () => {
+  const overview = `
+| Name | Commands |
+| ---- | -------- |
+| **fix-validate** | \`pnpm run lint\` |
+| **pre-push-validate** | \`npx markdownlint-cli2 "**/*.md"\` |
+| **post-fix-validate** | \`node --test tests/*.mjs\` |
+| **install-deps** | \`pnpm install --frozen-lockfile\` |
+`;
+
+  assert.deepEqual(findPnpmCommandLeaks(overview), [
+    'fix-validate: contains forbidden token "pnpm" (pnpm run lint)',
+    'install-deps: contains forbidden token "pnpm" (pnpm install --frozen-lockfile)',
+  ]);
+});


### PR DESCRIPTION
## Summary
- add .github/workflows/pnpm-boundary.yml as a reusable workflow_call CI guard based on the pnpm-project-template push workflow shape
- add scripts/check-pnpm-boundary.mjs to fail when pnpm leaks into distributable Project command rows
- add tests/pnpm-boundary.test.mjs and document reusable extension inputs in docs/customization.md and idd-template/docs/customization.md

## Why
Issue #265 requires a final CI defense line that keeps dogfooding pnpm usage from leaking into the distributable template.

## Extension points
The reusable workflow exposes runner, node-version, install-command, lint-command, and boundary-command inputs for downstream reuse.

Closes #265
Refs #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable CI workflow to check package manager boundary rules and run a boundary-check job.

* **Documentation**
  * Added guide and examples documenting the reusable workflow and how to customize inputs for downstream repos.

* **Tests**
  * Added unit tests validating detection of disallowed package-manager usage in template command listings.

* **Tooling**
  * Added a boundary-check script to detect forbidden package-manager tokens in project templates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/283)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->