### PR TITLE
ci(audit): enforce instruction size budget guard

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -128,6 +128,13 @@
       "stripPrefix": "skills/issue-authoring/"
     }
   ],
+  "instructionSizeBudgets": {
+    "id": "instruction-size-budgets",
+    "glob": ".github/instructions/idd-*.instructions.md",
+    "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
+    "alwaysLoadedLimitBytes": 20000,
+    "phaseLimitBytes": 30000
+  },
   "syncPairs": [
     {
       "id": "idd-advisory-wait-instructions",

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -24,6 +24,7 @@ checkFileSets(manifest.fileSets ?? [], manifest.syncPairs ?? []);
 checkGeneratedBlocks(manifest.generatedBlocks ?? []);
 checkShellFileLists(manifest.shellFileLists ?? [], manifest.generatedBlocks ?? []);
 checkSyncPairs(manifest.syncPairs ?? []);
+checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? null);
 checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
 
 if (errors.length > 0) {
@@ -274,6 +275,36 @@ function checkForbiddenPatterns(patterns) {
       if (regex.test(stripGeneratedBlocks(text))) {
         errors.push(`${pattern.id}: ${file}: ${pattern.message}`);
       }
+    }
+  }
+}
+
+function checkInstructionSizeBudgets(config) {
+  if (!config) {
+    return;
+  }
+
+  const id = config.id ?? "instruction-size-budgets";
+  const files = globFiles(config.glob ?? ".github/instructions/idd-*.instructions.md");
+  const alwaysLoadedPattern = config.alwaysLoadedPattern ?? 'applyTo:\\s*"\\*\\*"';
+  const alwaysLoadedRegex = new RegExp(alwaysLoadedPattern, "m");
+  const alwaysLoadedLimitBytes = config.alwaysLoadedLimitBytes ?? 20_000;
+  const phaseLimitBytes = config.phaseLimitBytes ?? 30_000;
+  const candidates = changedFiles === null
+    ? files
+    : files.filter((file) => changedFiles.has(file));
+
+  for (const file of candidates) {
+    const text = readText(file);
+    const bytes = Buffer.byteLength(text, "utf8");
+    const alwaysLoaded = alwaysLoadedRegex.test(text);
+    const limit = alwaysLoaded ? alwaysLoadedLimitBytes : phaseLimitBytes;
+    if (bytes > limit) {
+      errors.push(
+        `${id}: ${file} is ${bytes} bytes (limit ${limit}; ${
+          alwaysLoaded ? "always-loaded" : "phase"
+        })`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary
- add instruction size budget checks to scripts/audit-docs.mjs
- configure budgets in audit/sync-manifest.json (always-loaded: 20000 bytes, phase: 30000 bytes)
- report file name, current byte size, and budget limit when a changed instruction file exceeds its budget

## Why
Issue #270 requires CI enforcement for instruction-size regressions, especially for always-loaded files.

## Scope note
The guard evaluates instruction files changed in the current diff so existing historical oversize files do not block unrelated PRs.

Closes #270
Refs #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added instruction documentation size budget auditing with configurable byte limits. Automated validation now enforces file size constraints during documentation audits, with separate limits for different document categories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/284)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->