### PR TITLE
docs: add model selection note for compaction risk in ONBOARDING

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -77,6 +77,15 @@ alongside the merge policy and point operators to
 [IDD policy constants](docs/policy-constants.md) so the named values are
 easy to find later.
 
+Also consider the AI model used for the IDD execution session. Large and
+premium reasoning models are more likely to trigger frequent context
+compaction when the full instruction file set is loaded, which can
+interrupt unattended IDD loops. For day-to-day execution, standard models
+(for example, models in the Sonnet class) handle the instruction overhead
+more efficiently and are the recommended choice. Reserve large or premium
+reasoning models for tasks that genuinely benefit from their extended
+reasoning depth, not for routine IDD loop execution.
+
 ## Your task
 
 1. Read this entire document first.


### PR DESCRIPTION
## Summary

Add a 4-sentence note to `idd-template/ONBOARDING.md`'s "What you are setting up" section explaining that large and premium reasoning models are more likely to trigger frequent context compaction with a large instruction file set, and that standard models (e.g., Sonnet class) are recommended for day-to-day IDD loop execution.

The note uses model-class terminology ("large/premium reasoning models" vs. "standard models") to avoid tying the guidance to specific model names.

Closes #271

## Background

Adopters using Claude Opus 4.7 (and similar large/premium reasoning models) via GitHub Copilot reported frequent context compaction during IDD loops. The instruction file set is large, which amplifies the problem. This note helps adopters choose an appropriate model before their first unattended run.

## Verification

- `node scripts/audit-docs.mjs --check` passes ✓
- `npx dprint check "**/*.md"` passes ✓
- `npx markdownlint-cli2 "**/*.md"` passes ✓
- `npx cspell lint "**" --no-progress` passes ✓
- `node --test tests/*.mjs` (68 tests) passes ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added best-practice guidance for selecting AI models in IDD execution sessions, with recommendations for standard models in routine scenarios and premium reasoning models for complex tasks requiring deeper analysis.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/285)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->