### PR TITLE
test: add claim lifecycle golden scenarios

### DIFF
--- a/fixtures/claim-lifecycle/same-second-tie-break.json
+++ b/fixtures/claim-lifecycle/same-second-tie-break.json
@@ -2,14 +2,14 @@
   "name": "same-second competing claims use lexicographically earlier claim id",
   "events": [
     {
-      "createdAt": "2026-05-11T07:08:33.900Z",
+      "createdAt": "2026-05-11T07:08:33.100Z",
       "author": {
         "login": "agent-b"
       },
       "body": "<!-- claimed-by: agent-b claim-zzzzzzzz supersedes: none 2026-05-11T07:08:31Z branch: issue/269-discover-suitability-split -->\n\n_agent-b: issue claim - IDD automation marker. Do not edit._\n"
     },
     {
-      "createdAt": "2026-05-11T07:08:33.100Z",
+      "createdAt": "2026-05-11T07:08:33.900Z",
       "author": {
         "login": "agent-a"
       },
@@ -21,6 +21,6 @@
     "claimId": "claim-aaaaaaaa",
     "supersedes": "none",
     "branch": "issue/269-discover-suitability-split",
-    "createdAt": "2026-05-11T07:08:33.100Z"
+    "createdAt": "2026-05-11T07:08:33.900Z"
   }
 }

--- a/fixtures/claim-lifecycle/same-second-tie-break.json
+++ b/fixtures/claim-lifecycle/same-second-tie-break.json
@@ -1,0 +1,26 @@
+{
+  "name": "same-second competing claims use lexicographically earlier claim id",
+  "events": [
+    {
+      "createdAt": "2026-05-11T07:08:33.900Z",
+      "author": {
+        "login": "agent-b"
+      },
+      "body": "<!-- claimed-by: agent-b claim-zzzzzzzz supersedes: none 2026-05-11T07:08:31Z branch: issue/269-discover-suitability-split -->\n\n_agent-b: issue claim - IDD automation marker. Do not edit._\n"
+    },
+    {
+      "createdAt": "2026-05-11T07:08:33.100Z",
+      "author": {
+        "login": "agent-a"
+      },
+      "body": "<!-- claimed-by: agent-a claim-aaaaaaaa supersedes: none 2026-05-11T07:08:31Z branch: issue/269-discover-suitability-split -->\n\n_agent-a: issue claim - IDD automation marker. Do not edit._\n"
+    }
+  ],
+  "expectedActiveClaim": {
+    "agentId": "agent-a",
+    "claimId": "claim-aaaaaaaa",
+    "supersedes": "none",
+    "branch": "issue/269-discover-suitability-split",
+    "createdAt": "2026-05-11T07:08:33.100Z"
+  }
+}

--- a/fixtures/claim-lifecycle/stale-takeover.json
+++ b/fixtures/claim-lifecycle/stale-takeover.json
@@ -1,0 +1,33 @@
+{
+  "name": "stale takeover ignores stale owner release",
+  "events": [
+    {
+      "createdAt": "2026-05-09T10:00:00Z",
+      "author": {
+        "login": "codex-cli"
+      },
+      "body": "<!-- claimed-by: codex-cli 11111111111111111111111111111111 supersedes: none 2026-05-09T10:00:00Z branch: issue/118-protocol-test-fixtures -->\n\n_codex-cli: issue claim - IDD automation marker. Do not edit._\n"
+    },
+    {
+      "createdAt": "2026-05-10T11:00:00Z",
+      "author": {
+        "login": "copilot-cli"
+      },
+      "body": "<!-- claimed-by: copilot-cli 22222222222222222222222222222222 supersedes: 11111111111111111111111111111111 2026-05-10T11:00:00Z branch: issue/118-protocol-test-fixtures -->\n\n_copilot-cli: issue claim - IDD automation marker. Do not edit._\n"
+    },
+    {
+      "createdAt": "2026-05-10T11:05:00Z",
+      "author": {
+        "login": "codex-cli"
+      },
+      "body": "<!-- unclaimed-by: codex-cli 11111111111111111111111111111111 2026-05-10T11:05:00Z -->\n\n_codex-cli: issue claim released - IDD automation marker. Do not edit._\n"
+    }
+  ],
+  "expectedActiveClaim": {
+    "agentId": "copilot-cli",
+    "claimId": "22222222222222222222222222222222",
+    "supersedes": "11111111111111111111111111111111",
+    "branch": "issue/118-protocol-test-fixtures",
+    "createdAt": "2026-05-10T11:00:00Z"
+  }
+}

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -3,8 +3,8 @@
 import { execFileSync } from "node:child_process";
 
 import {
-  applyClaimEvent,
   planLiveStatusDigestUpsert,
+  resolveActiveClaim,
 } from "./protocol-helpers.mjs";
 
 const TRUSTED_MARKER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
@@ -185,23 +185,15 @@ function assertActiveClaim(owner, repo, issueNumber, agentId, claimId) {
 }
 
 function readActiveClaim(owner, repo, issueNumber) {
-  const comments = fetchIssueComments(owner, repo, issueNumber).sort((left, right) => {
-    return new Date(left.created_at) - new Date(right.created_at);
+  const comments = fetchIssueComments(owner, repo, issueNumber).map((comment) => {
+    return {
+      body: comment.body,
+      createdAt: comment.created_at,
+      author: { login: comment.author?.login ?? "" },
+    };
   });
 
-  let active = null;
-  for (const comment of comments) {
-    active = applyClaimEvent(
-      active,
-      {
-        body: comment.body,
-        createdAt: comment.created_at,
-        author: { login: comment.author?.login ?? "" },
-      },
-      (login) => isTrustedMarkerAuthor(owner, repo, login),
-    );
-  }
-  return active;
+  return resolveActiveClaim(comments, (login) => isTrustedMarkerAuthor(owner, repo, login));
 }
 
 function isTrustedMarkerAuthor(owner, repo, login) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -476,6 +476,47 @@ export function isStaleAt(activeCreatedAt, nextCreatedAt) {
   return new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >= staleMs;
 }
 
+function compareClaimIds(left, right) {
+  if (left === right) {
+    return 0;
+  }
+  return left < right ? -1 : 1;
+}
+
+function createdAtToSecond(createdAt) {
+  return Math.floor(new Date(createdAt ?? "").getTime() / 1000);
+}
+
+export function resolveActiveClaim(events, isTrustedAuthor = () => true) {
+  const orderedEvents = [...events].sort((left, right) => {
+    const leftTime = new Date(left.createdAt ?? "").getTime();
+    const rightTime = new Date(right.createdAt ?? "").getTime();
+    const leftSecond = createdAtToSecond(left.createdAt);
+    const rightSecond = createdAtToSecond(right.createdAt);
+    if (leftSecond !== rightSecond) {
+      return leftSecond - rightSecond;
+    }
+
+    const leftClaim = parseClaimComment(left.body ?? "", left.createdAt ?? "");
+    const rightClaim = parseClaimComment(right.body ?? "", right.createdAt ?? "");
+    if (leftClaim && rightClaim && leftClaim.claimId !== rightClaim.claimId) {
+      return compareClaimIds(leftClaim.claimId, rightClaim.claimId);
+    }
+
+    if (leftTime !== rightTime) {
+      return leftTime - rightTime;
+    }
+
+    return 0;
+  });
+
+  let active = null;
+  for (const event of orderedEvents) {
+    active = applyClaimEvent(active, event, isTrustedAuthor);
+  }
+  return active;
+}
+
 export function applyClaimEvent(activeClaim, event, isTrustedAuthor = () => true) {
   if (!isTrustedAuthor(event.author?.login ?? "")) {
     return activeClaim;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -483,32 +483,59 @@ function compareClaimIds(left, right) {
   return left < right ? -1 : 1;
 }
 
+function createdAtToTime(createdAt) {
+  const time = new Date(createdAt ?? "").getTime();
+  return Number.isFinite(time) ? time : null;
+}
+
 function createdAtToSecond(createdAt) {
-  return Math.floor(new Date(createdAt ?? "").getTime() / 1000);
+  const time = createdAtToTime(createdAt);
+  if (time === null) {
+    return null;
+  }
+  return Math.floor(time / 1000);
 }
 
 export function resolveActiveClaim(events, isTrustedAuthor = () => true) {
-  const orderedEvents = [...events].sort((left, right) => {
-    const leftTime = new Date(left.createdAt ?? "").getTime();
-    const rightTime = new Date(right.createdAt ?? "").getTime();
-    const leftSecond = createdAtToSecond(left.createdAt);
-    const rightSecond = createdAtToSecond(right.createdAt);
-    if (leftSecond !== rightSecond) {
-      return leftSecond - rightSecond;
-    }
+  const orderedEvents = events
+    .map((event, index) => {
+      const claim = parseClaimComment(event.body ?? "", event.createdAt ?? "");
+      return {
+        event,
+        index,
+        claimId: claim?.claimId ?? null,
+        time: createdAtToTime(event.createdAt),
+        second: createdAtToSecond(event.createdAt),
+      };
+    })
+    .sort((left, right) => {
+      if (left.second !== null && right.second !== null && left.second !== right.second) {
+        return left.second - right.second;
+      }
+      if (left.second !== null && right.second === null) {
+        return -1;
+      }
+      if (left.second === null && right.second !== null) {
+        return 1;
+      }
 
-    const leftClaim = parseClaimComment(left.body ?? "", left.createdAt ?? "");
-    const rightClaim = parseClaimComment(right.body ?? "", right.createdAt ?? "");
-    if (leftClaim && rightClaim && leftClaim.claimId !== rightClaim.claimId) {
-      return compareClaimIds(leftClaim.claimId, rightClaim.claimId);
-    }
+      if (
+        left.second !== null &&
+        right.second !== null &&
+        left.claimId &&
+        right.claimId &&
+        left.claimId !== right.claimId
+      ) {
+        return compareClaimIds(left.claimId, right.claimId);
+      }
 
-    if (leftTime !== rightTime) {
-      return leftTime - rightTime;
-    }
+      if (left.time !== null && right.time !== null && left.time !== right.time) {
+        return left.time - right.time;
+      }
 
-    return 0;
-  });
+      return left.index - right.index;
+    })
+    .map(({ event }) => event);
 
   let active = null;
   for (const event of orderedEvents) {

--- a/tests/claim-lifecycle.test.mjs
+++ b/tests/claim-lifecycle.test.mjs
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveActiveClaim } from "../scripts/protocol-helpers.mjs";
+
+const fixtures = {
+  staleTakeover: readJson("fixtures/claim-lifecycle/stale-takeover.json"),
+  sameSecondTieBreak: readJson("fixtures/claim-lifecycle/same-second-tie-break.json"),
+};
+
+test("golden scenario: stale takeover keeps the newer active claim", () => {
+  const active = resolveActiveClaim(fixtures.staleTakeover.events);
+  assert.deepEqual(active, fixtures.staleTakeover.expectedActiveClaim);
+});
+
+test("golden scenario: same-second competing claims use deterministic tie-break", () => {
+  const active = resolveActiveClaim(fixtures.sameSecondTieBreak.events);
+  assert.deepEqual(active, fixtures.sameSecondTieBreak.expectedActiveClaim);
+});
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8"));
+}


### PR DESCRIPTION
## Summary
- add fixture-backed claim lifecycle golden tests for stale takeover and same-second claim races
- centralize live status claim reconstruction on the shared resolver
- harden resolver ordering by precomputing sort keys once and falling back to stable event order when timestamps are unavailable

Closes #279

## Notes
- same-second competing claims resolve by lexicographically earlier claim-id within the same GitHub `created_at` second
- no follow-up issues identified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added golden tests validating claim lifecycle: same-second competing claims and stale-owner releases to ensure expected active claim outcomes.

* **Bug Fixes**
  * Deterministic claim resolution: ties within the same second are resolved predictably (lexicographic claim ID), and stale releases no longer override newer active claims.
* **Reliability**
  * Status digest now uses the deterministic resolver so reported active claims are consistent.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/287)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->