### PR TITLE
test: add review gate golden routes

### DIFF
--- a/fixtures/review-gate/changes-requested-routes.json
+++ b/fixtures/review-gate/changes-requested-routes.json
@@ -1,0 +1,64 @@
+[
+  {
+    "name": "hold before 24h escalation window",
+    "input": {
+      "reviewState": "CHANGES_REQUESTED",
+      "rejectionCommentCreatedAt": "2026-05-11T00:00:00Z",
+      "now": "2026-05-11T12:00:00Z"
+    },
+    "expected": {
+      "route": "hold-before-escalation",
+      "reason": "still within the first 24 hours after the rejection reply"
+    }
+  },
+  {
+    "name": "escalate after 24h without reviewer response",
+    "input": {
+      "reviewState": "CHANGES_REQUESTED",
+      "rejectionCommentCreatedAt": "2026-05-10T00:00:00Z",
+      "now": "2026-05-11T01:00:00Z"
+    },
+    "expected": {
+      "route": "escalate-maintainer",
+      "reason": "the changes-requested review is still blocking after 24 hours with no reviewer response"
+    }
+  },
+  {
+    "name": "maintainer agreement still blocks until state clears",
+    "input": {
+      "reviewState": "CHANGES_REQUESTED",
+      "rejectionCommentCreatedAt": "2026-05-10T00:00:00Z",
+      "now": "2026-05-11T12:00:00Z",
+      "maintainerDisposition": "agreed-state-unchanged"
+    },
+    "expected": {
+      "route": "hold-await-state-clear",
+      "reason": "maintainer agreement does not clear the original changes-requested state"
+    }
+  },
+  {
+    "name": "reviewer disagreement returns to E1",
+    "input": {
+      "reviewState": "CHANGES_REQUESTED",
+      "rejectionCommentCreatedAt": "2026-05-10T00:00:00Z",
+      "now": "2026-05-11T12:00:00Z",
+      "reviewerDisposition": "disagreed"
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "reviewer disagreed with the rejection and the feedback must return to triage"
+    }
+  },
+  {
+    "name": "label and release after 48h without escalation response",
+    "input": {
+      "reviewState": "CHANGES_REQUESTED",
+      "rejectionCommentCreatedAt": "2026-05-09T00:00:00Z",
+      "now": "2026-05-11T01:00:00Z"
+    },
+    "expected": {
+      "route": "label-and-release",
+      "reason": "the changes-requested review is still blocking after 48 hours with no escalation response"
+    }
+  }
+]

--- a/fixtures/review-gate/changes-requested-routes.json
+++ b/fixtures/review-gate/changes-requested-routes.json
@@ -36,7 +36,7 @@
     }
   },
   {
-    "name": "reviewer agreement with cleared state proceeds",
+    "name": "reviewer agreement still waits for state to clear",
     "input": {
       "reviewState": "CHANGES_REQUESTED",
       "rejectionCommentCreatedAt": "2026-05-10T00:00:00Z",
@@ -44,8 +44,8 @@
       "reviewerDisposition": "agreed-state-cleared"
     },
     "expected": {
-      "route": "proceed",
-      "reason": "reviewer agreed with the rejection and cleared the changes-requested state"
+      "route": "hold-await-state-clear",
+      "reason": "reviewer agreement alone does not clear a changes-requested state"
     }
   },
   {
@@ -88,10 +88,36 @@
     }
   },
   {
-    "name": "label and release after 48h without escalation response",
+    "name": "48h age still escalates if no escalation evidence exists",
     "input": {
       "reviewState": "CHANGES_REQUESTED",
       "rejectionCommentCreatedAt": "2026-05-09T00:00:00Z",
+      "now": "2026-05-11T01:00:00Z"
+    },
+    "expected": {
+      "route": "escalate-maintainer",
+      "reason": "the changes-requested review still needs maintainer escalation evidence before release"
+    }
+  },
+  {
+    "name": "hold after escalation until a full day has passed",
+    "input": {
+      "reviewState": "CHANGES_REQUESTED",
+      "rejectionCommentCreatedAt": "2026-05-09T00:00:00Z",
+      "escalationCommentCreatedAt": "2026-05-10T18:00:00Z",
+      "now": "2026-05-11T01:00:00Z"
+    },
+    "expected": {
+      "route": "hold-after-escalation",
+      "reason": "still within 24 hours of the maintainer escalation comment"
+    }
+  },
+  {
+    "name": "label and release after 48h with no escalation response",
+    "input": {
+      "reviewState": "CHANGES_REQUESTED",
+      "rejectionCommentCreatedAt": "2026-05-09T00:00:00Z",
+      "escalationCommentCreatedAt": "2026-05-10T00:30:00Z",
       "now": "2026-05-11T01:00:00Z"
     },
     "expected": {

--- a/fixtures/review-gate/changes-requested-routes.json
+++ b/fixtures/review-gate/changes-requested-routes.json
@@ -1,5 +1,17 @@
 [
   {
+    "name": "already cleared state proceeds immediately",
+    "input": {
+      "reviewState": "APPROVED",
+      "rejectionCommentCreatedAt": "2026-05-10T00:00:00Z",
+      "now": "2026-05-11T12:00:00Z"
+    },
+    "expected": {
+      "route": "proceed",
+      "reason": "changes-requested state already cleared"
+    }
+  },
+  {
     "name": "hold before 24h escalation window",
     "input": {
       "reviewState": "CHANGES_REQUESTED",
@@ -21,6 +33,32 @@
     "expected": {
       "route": "escalate-maintainer",
       "reason": "the changes-requested review is still blocking after 24 hours with no reviewer response"
+    }
+  },
+  {
+    "name": "reviewer agreement with cleared state proceeds",
+    "input": {
+      "reviewState": "CHANGES_REQUESTED",
+      "rejectionCommentCreatedAt": "2026-05-10T00:00:00Z",
+      "now": "2026-05-11T12:00:00Z",
+      "reviewerDisposition": "agreed-state-cleared"
+    },
+    "expected": {
+      "route": "proceed",
+      "reason": "reviewer agreed with the rejection and cleared the changes-requested state"
+    }
+  },
+  {
+    "name": "reviewer agreement without state change still blocks",
+    "input": {
+      "reviewState": "CHANGES_REQUESTED",
+      "rejectionCommentCreatedAt": "2026-05-10T00:00:00Z",
+      "now": "2026-05-11T12:00:00Z",
+      "reviewerDisposition": "agreed-state-unchanged"
+    },
+    "expected": {
+      "route": "hold-await-state-clear",
+      "reason": "reviewer agreement alone does not clear a changes-requested state"
     }
   },
   {

--- a/fixtures/review-gate/snapshot-diff-routes.json
+++ b/fixtures/review-gate/snapshot-diff-routes.json
@@ -1,0 +1,116 @@
+[
+  {
+    "name": "proceed when snapshot still matches live state",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "expected": {
+      "route": "proceed",
+      "reason": "snapshot-current"
+    }
+  },
+  {
+    "name": "return to E1 on newer activity",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:01Z",
+      "totalItemCount": 5,
+      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "newer-activity"
+    }
+  },
+  {
+    "name": "return to E1 when head SHA changes",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "def456",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "head-changed"
+    }
+  },
+  {
+    "name": "return to E1 on same-timestamp item count growth",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 6,
+      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "same-timestamp-count-growth"
+    }
+  },
+  {
+    "name": "return to E1 on CI pass drift",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestCiCompletedAt": "2026-05-11T08:06:00Z"
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "ci-pass-drift"
+    }
+  },
+  {
+    "name": "return to E1 when empty snapshot becomes non-empty",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "none",
+      "totalItemCount": 0,
+      "latestCiCompletedAt": "none"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 1,
+      "latestCiCompletedAt": "none"
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "snapshot-was-empty-now-nonempty"
+    }
+  }
+]

--- a/fixtures/review-gate/snapshot-diff-routes.json
+++ b/fixtures/review-gate/snapshot-diff-routes.json
@@ -131,5 +131,24 @@
       "route": "proceed",
       "reason": "snapshot-current"
     }
+  },
+  {
+    "name": "proceed when equivalent ISO forms only differ by milliseconds",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00.000Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00.000Z"
+    },
+    "expected": {
+      "route": "proceed",
+      "reason": "snapshot-current"
+    }
   }
 ]

--- a/fixtures/review-gate/snapshot-diff-routes.json
+++ b/fixtures/review-gate/snapshot-diff-routes.json
@@ -114,7 +114,7 @@
     }
   },
   {
-    "name": "proceed when live max activity is missing",
+    "name": "return to E1 when live max activity evidence is missing",
     "snapshot": {
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",

--- a/fixtures/review-gate/snapshot-diff-routes.json
+++ b/fixtures/review-gate/snapshot-diff-routes.json
@@ -128,8 +128,27 @@
       "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
     },
     "expected": {
-      "route": "proceed",
-      "reason": "snapshot-current"
+      "route": "return-to-e1",
+      "reason": "missing-live-activity-evidence"
+    }
+  },
+  {
+    "name": "return to E1 when CI evidence is invalid",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "invalid"
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "missing-ci-evidence"
     }
   },
   {
@@ -149,6 +168,25 @@
     "expected": {
       "route": "proceed",
       "reason": "snapshot-current"
+    }
+  },
+  {
+    "name": "return to E1 when live activity is newer within the same second",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00.100Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "newer-activity"
     }
   }
 ]

--- a/fixtures/review-gate/snapshot-diff-routes.json
+++ b/fixtures/review-gate/snapshot-diff-routes.json
@@ -5,13 +5,13 @@
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
       "totalItemCount": 5,
-      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
     },
     "live": {
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
       "totalItemCount": 5,
-      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
     },
     "expected": {
       "route": "proceed",
@@ -24,13 +24,13 @@
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
       "totalItemCount": 5,
-      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
     },
     "live": {
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:01Z",
       "totalItemCount": 5,
-      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
     },
     "expected": {
       "route": "return-to-e1",
@@ -43,13 +43,13 @@
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
       "totalItemCount": 5,
-      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
     },
     "live": {
       "headSha": "def456",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
       "totalItemCount": 5,
-      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
     },
     "expected": {
       "route": "return-to-e1",
@@ -62,13 +62,13 @@
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
       "totalItemCount": 5,
-      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
     },
     "live": {
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
       "totalItemCount": 6,
-      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
     },
     "expected": {
       "route": "return-to-e1",
@@ -81,13 +81,13 @@
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
       "totalItemCount": 5,
-      "latestCiCompletedAt": "2026-05-11T08:05:00Z"
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
     },
     "live": {
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
       "totalItemCount": 5,
-      "latestCiCompletedAt": "2026-05-11T08:06:00Z"
+      "latestPassingCiCompletedAt": "2026-05-11T08:06:00Z"
     },
     "expected": {
       "route": "return-to-e1",
@@ -100,17 +100,36 @@
       "headSha": "abc123",
       "maxActivityUpdatedAt": "none",
       "totalItemCount": 0,
-      "latestCiCompletedAt": "none"
+      "latestPassingCiCompletedAt": "none"
     },
     "live": {
       "headSha": "abc123",
       "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
       "totalItemCount": 1,
-      "latestCiCompletedAt": "none"
+      "latestPassingCiCompletedAt": "none"
     },
     "expected": {
       "route": "return-to-e1",
       "reason": "snapshot-was-empty-now-nonempty"
+    }
+  },
+  {
+    "name": "proceed when live max activity is missing",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "none",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "expected": {
+      "route": "proceed",
+      "reason": "snapshot-current"
     }
   }
 ]

--- a/fixtures/review-gate/thread-gate-routes.json
+++ b/fixtures/review-gate/thread-gate-routes.json
@@ -118,7 +118,7 @@
       {
         "id": "THREAD-reopened",
         "isResolved": false,
-        "updatedAt": "2026-05-11T08:06:00Z",
+        "reviewerReopenedAt": "2026-05-11T08:06:00Z",
         "comments": {
           "nodes": [
             {
@@ -148,6 +148,48 @@
       "classifications": [
         {
           "id": "THREAD-reopened",
+          "classification": "actionable-blocking"
+        }
+      ]
+    }
+  },
+  {
+    "name": "edited IDD reply does not hide a later reopen",
+    "threads": [
+      {
+        "id": "THREAD-reopen-after-reply",
+        "isResolved": false,
+        "reviewerReopenedAt": "2026-05-11T08:06:00Z",
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "reviewer" },
+              "body": "Please adjust this branch.",
+              "createdAt": "2026-05-11T08:00:00Z"
+            },
+            {
+              "author": { "login": "idd-bot" },
+              "body": "**Accepted** — fixed in abc123: adjusted the branch wording.",
+              "createdAt": "2026-05-11T08:05:00Z",
+              "updatedAt": "2026-05-11T08:07:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 1,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-reopen-after-reply",
           "classification": "actionable-blocking"
         }
       ]
@@ -230,6 +272,41 @@
         {
           "id": "THREAD-non-agent-amd",
           "classification": "actionable-blocking"
+        }
+      ]
+    }
+  },
+  {
+    "name": "quoted AMD marker after other text stays actionable",
+    "threads": [
+      {
+        "id": "THREAD-quoted-amd",
+        "isResolved": false,
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "idd-bot" },
+              "body": "Follow-up note: `**Awaiting maintainer decision**` is only quoted here.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 0,
+      "awaitingReviewerCount": 1,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-quoted-amd",
+          "classification": "awaiting-reviewer"
         }
       ]
     }

--- a/fixtures/review-gate/thread-gate-routes.json
+++ b/fixtures/review-gate/thread-gate-routes.json
@@ -277,7 +277,7 @@
     }
   },
   {
-    "name": "quoted AMD marker after other text stays actionable",
+    "name": "quoted AMD marker after other text stays awaiting-reviewer",
     "threads": [
       {
         "id": "THREAD-quoted-amd",

--- a/fixtures/review-gate/thread-gate-routes.json
+++ b/fixtures/review-gate/thread-gate-routes.json
@@ -35,6 +35,7 @@
       {
         "id": "THREAD-awaiting",
         "isResolved": false,
+        "updatedAt": "2026-05-11T08:05:00Z",
         "comments": {
           "nodes": [
             {
@@ -70,12 +71,54 @@
     }
   },
   {
+    "name": "reopen before the latest IDD reply stays awaiting-reviewer",
+    "threads": [
+      {
+        "id": "THREAD-reopen-before-reply",
+        "isResolved": false,
+        "reviewerReopenedAt": "2026-05-11T08:03:00Z",
+        "updatedAt": "2026-05-11T08:05:00Z",
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "reviewer" },
+              "body": "Please adjust this branch.",
+              "createdAt": "2026-05-11T08:00:00Z"
+            },
+            {
+              "author": { "login": "idd-bot" },
+              "body": "**Accepted** — fixed in abc123: adjusted the branch wording.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 0,
+      "awaitingReviewerCount": 1,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-reopen-before-reply",
+          "classification": "awaiting-reviewer"
+        }
+      ]
+    }
+  },
+  {
     "name": "reviewer reopen without text makes the thread actionable again",
     "threads": [
       {
         "id": "THREAD-reopened",
         "isResolved": false,
-        "reviewerReopenedAt": "2026-05-11T08:06:00Z",
+        "updatedAt": "2026-05-11T08:06:00Z",
         "comments": {
           "nodes": [
             {
@@ -156,16 +199,53 @@
     }
   },
   {
+    "name": "non-agent AMD marker text stays actionable",
+    "threads": [
+      {
+        "id": "THREAD-non-agent-amd",
+        "isResolved": false,
+        "updatedAt": "2026-05-11T08:05:00Z",
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "reviewer" },
+              "body": "**Awaiting maintainer decision** — I think this still needs work.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 1,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-non-agent-amd",
+          "classification": "actionable-blocking"
+        }
+      ]
+    }
+  },
+  {
     "name": "AMD thread remains blocking",
     "threads": [
       {
         "id": "THREAD-amd",
         "isResolved": false,
+        "updatedAt": "2026-05-11T08:05:00Z",
         "comments": {
           "nodes": [
             {
               "author": { "login": "idd-bot" },
-              "body": "**Awaiting maintainer decision** — rejecting this review item needs maintainer confirmation.",
+              "body": "**awaiting maintainer decision** — rejecting this review item needs maintainer confirmation.",
               "createdAt": "2026-05-11T08:05:00Z"
             }
           ]
@@ -186,6 +266,43 @@
         {
           "id": "THREAD-amd",
           "classification": "amd-blocking"
+        }
+      ]
+    }
+  },
+  {
+    "name": "truncated unresolved thread blocks until fully fetched",
+    "threads": [
+      {
+        "id": "THREAD-truncated",
+        "isResolved": false,
+        "updatedAt": "2026-05-11T08:05:00Z",
+        "comments": {
+          "pageInfo": { "hasNextPage": true },
+          "nodes": [
+            {
+              "author": { "login": "idd-bot" },
+              "body": "**Accepted** — fixed in abc123: adjusted the branch wording.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 1,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-truncated",
+          "classification": "actionable-blocking"
         }
       ]
     }
@@ -218,7 +335,7 @@
       "requiresConversationResolution": true
     },
     "expected": {
-      "actionableCount": 0,
+      "actionableCount": 1,
       "awaitingReviewerCount": 0,
       "amdBlockingCount": 0,
       "conversationResolveAgentCount": 1,
@@ -259,7 +376,7 @@
       "requiresConversationResolution": true
     },
     "expected": {
-      "actionableCount": 0,
+      "actionableCount": 1,
       "awaitingReviewerCount": 0,
       "amdBlockingCount": 0,
       "conversationResolveAgentCount": 0,

--- a/fixtures/review-gate/thread-gate-routes.json
+++ b/fixtures/review-gate/thread-gate-routes.json
@@ -348,6 +348,46 @@
     }
   },
   {
+    "name": "maintainer reply after AMD returns the thread to actionable triage",
+    "threads": [
+      {
+        "id": "THREAD-amd-maintainer-replied",
+        "isResolved": false,
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "idd-bot" },
+              "body": "**Awaiting maintainer decision** — rejecting this review item needs maintainer confirmation.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            },
+            {
+              "author": { "login": "maintainer" },
+              "body": "I disagree; please take the requested change.",
+              "createdAt": "2026-05-11T08:06:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 1,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-amd-maintainer-replied",
+          "classification": "actionable-blocking"
+        }
+      ]
+    }
+  },
+  {
     "name": "truncated unresolved thread blocks until fully fetched",
     "threads": [
       {

--- a/fixtures/review-gate/thread-gate-routes.json
+++ b/fixtures/review-gate/thread-gate-routes.json
@@ -1,0 +1,245 @@
+[
+  {
+    "name": "awaiting-reviewer thread is excluded from blocking count",
+    "threads": [
+      {
+        "id": "THREAD-awaiting",
+        "isResolved": false,
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "reviewer" },
+              "body": "Please adjust this branch.",
+              "createdAt": "2026-05-11T08:00:00Z"
+            },
+            {
+              "author": { "login": "idd-bot" },
+              "body": "**Accepted** — fixed in abc123: adjusted the branch wording.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 0,
+      "awaitingReviewerCount": 1,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-awaiting",
+          "classification": "awaiting-reviewer"
+        }
+      ]
+    }
+  },
+  {
+    "name": "reviewer reopen without text makes the thread actionable again",
+    "threads": [
+      {
+        "id": "THREAD-reopened",
+        "isResolved": false,
+        "reviewerReopenedAt": "2026-05-11T08:06:00Z",
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "reviewer" },
+              "body": "Please adjust this branch.",
+              "createdAt": "2026-05-11T08:00:00Z"
+            },
+            {
+              "author": { "login": "idd-bot" },
+              "body": "**Accepted** — fixed in abc123: adjusted the branch wording.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 1,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-reopened",
+          "classification": "actionable-blocking"
+        }
+      ]
+    }
+  },
+  {
+    "name": "reviewer comment after an IDD reply is actionable again",
+    "threads": [
+      {
+        "id": "THREAD-reviewer-latest",
+        "isResolved": false,
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "reviewer" },
+              "body": "Please adjust this branch.",
+              "createdAt": "2026-05-11T08:00:00Z"
+            },
+            {
+              "author": { "login": "idd-bot" },
+              "body": "**Accepted** — fixed in abc123: adjusted the branch wording.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            },
+            {
+              "author": { "login": "reviewer" },
+              "body": "Not quite right yet.",
+              "createdAt": "2026-05-11T08:06:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 1,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-reviewer-latest",
+          "classification": "actionable-blocking"
+        }
+      ]
+    }
+  },
+  {
+    "name": "AMD thread remains blocking",
+    "threads": [
+      {
+        "id": "THREAD-amd",
+        "isResolved": false,
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "idd-bot" },
+              "body": "**Awaiting maintainer decision** — rejecting this review item needs maintainer confirmation.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 1,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 1,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-amd",
+          "classification": "amd-blocking"
+        }
+      ]
+    }
+  },
+  {
+    "name": "conversation resolution required lets an IDD agent resolve directly",
+    "threads": [
+      {
+        "id": "THREAD-conv-agent",
+        "isResolved": false,
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "reviewer" },
+              "body": "Please adjust this branch.",
+              "createdAt": "2026-05-11T08:00:00Z"
+            },
+            {
+              "author": { "login": "idd-bot" },
+              "body": "**Accepted** — fixed in abc123: adjusted the branch wording.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author",
+      "requiresConversationResolution": true
+    },
+    "expected": {
+      "actionableCount": 0,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 1,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-conv-agent",
+          "classification": "conversation-resolve-agent"
+        }
+      ]
+    }
+  },
+  {
+    "name": "conversation resolution required asks for author acknowledgement",
+    "threads": [
+      {
+        "id": "THREAD-conv-author",
+        "isResolved": false,
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "reviewer" },
+              "body": "Please adjust this branch.",
+              "createdAt": "2026-05-11T08:00:00Z"
+            },
+            {
+              "author": { "login": "author" },
+              "body": "Applied in the latest push.",
+              "createdAt": "2026-05-11T08:05:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author",
+      "requiresConversationResolution": true
+    },
+    "expected": {
+      "actionableCount": 0,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 1,
+      "classifications": [
+        {
+          "id": "THREAD-conv-author",
+          "classification": "conversation-resolve-author"
+        }
+      ]
+    }
+  }
+]

--- a/fixtures/review-gate/thread-gate-routes.json
+++ b/fixtures/review-gate/thread-gate-routes.json
@@ -388,6 +388,42 @@
     }
   },
   {
+    "name": "reviewer reopen after AMD returns the thread to actionable triage",
+    "threads": [
+      {
+        "id": "THREAD-amd-reopened",
+        "isResolved": false,
+        "reviewerReopenedAt": "2026-05-11T08:06:00.100Z",
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "idd-bot" },
+              "body": "**Awaiting maintainer decision** — rejecting this review item needs maintainer confirmation.",
+              "createdAt": "2026-05-11T08:06:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 1,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "THREAD-amd-reopened",
+          "classification": "actionable-blocking"
+        }
+      ]
+    }
+  },
+  {
     "name": "truncated unresolved thread blocks until fully fetched",
     "threads": [
       {

--- a/fixtures/review-gate/thread-gate-routes.json
+++ b/fixtures/review-gate/thread-gate-routes.json
@@ -1,5 +1,35 @@
 [
   {
+    "name": "resolved thread is ignored by gate counts",
+    "threads": [
+      {
+        "id": "THREAD-resolved",
+        "isResolved": true,
+        "comments": {
+          "nodes": [
+            {
+              "author": { "login": "reviewer" },
+              "body": "Please adjust this branch.",
+              "createdAt": "2026-05-11T08:00:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "options": {
+      "iddAgentLogins": ["idd-bot"],
+      "prAuthorLogin": "author"
+    },
+    "expected": {
+      "actionableCount": 0,
+      "awaitingReviewerCount": 0,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": []
+    }
+  },
+  {
     "name": "awaiting-reviewer thread is excluded from blocking count",
     "threads": [
       {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -410,13 +410,24 @@ export function classifyReviewThreadForGate(thread, options = {}) {
   const prAuthorLogin = String(options.prAuthorLogin ?? "").toLowerCase();
   const latestIsIddAgent = iddAgentLogins.has(latestAuthor);
   const latestIsPrAuthor = Boolean(prAuthorLogin) && latestAuthor === prAuthorLogin;
-  const hasAmd = comments.some((comment) => {
+  let latestAmdIndex = -1;
+  for (let index = 0; index < comments.length; index += 1) {
+    const comment = comments[index];
     const authorLogin = String(comment.author?.login ?? "").toLowerCase();
-    return iddAgentLogins.has(authorLogin)
-      && AMD_MARKER_PATTERN.test(String(comment.body ?? "").trimStart());
-  });
+    if (
+      iddAgentLogins.has(authorLogin)
+      && AMD_MARKER_PATTERN.test(String(comment.body ?? "").trimStart())
+    ) {
+      latestAmdIndex = index;
+    }
+  }
+  const amdAwaitsMaintainer = latestAmdIndex >= 0
+    && !comments.slice(latestAmdIndex + 1).some((comment) => {
+      const authorLogin = String(comment.author?.login ?? "").toLowerCase();
+      return !iddAgentLogins.has(authorLogin) && authorLogin !== prAuthorLogin;
+    });
 
-  if (hasAmd) {
+  if (amdAwaitsMaintainer) {
     return { classification: "amd-blocking" };
   }
 

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -55,6 +55,7 @@ const UNSAFE_TEXT_RULES = [
     reason: "contains failed-CI context",
   },
 ];
+const AMD_MARKER_PATTERN = /^\*\*Awaiting maintainer decision\*\*/i;
 
 export function parseClaimComment(body, createdAt) {
   const match = body.trimEnd().match(
@@ -362,25 +363,25 @@ export function diffReviewSnapshot(snapshot, live) {
     return { route: "return-to-e1", reason: "head-changed" };
   }
 
-  const snapshotMax = String(snapshot.maxActivityUpdatedAt ?? "none");
-  const liveMax = String(live.maxActivityUpdatedAt ?? "none");
+  const snapshotMax = normalizeComparableTimestamp(snapshot.maxActivityUpdatedAt);
+  const liveMax = normalizeComparableTimestamp(live.maxActivityUpdatedAt);
   const snapshotCount = Number(snapshot.totalItemCount ?? 0);
   const liveCount = Number(live.totalItemCount ?? 0);
   if (snapshotMax === "none" && liveCount > 0) {
     return { route: "return-to-e1", reason: "snapshot-was-empty-now-nonempty" };
   }
-  if (snapshotMax !== "none" && liveMax !== "none" && liveMax > snapshotMax) {
+  if (snapshotMax && liveMax && snapshotMax !== "none" && liveMax !== "none" && liveMax > snapshotMax) {
     return { route: "return-to-e1", reason: "newer-activity" };
   }
   if (liveCount > snapshotCount) {
     return { route: "return-to-e1", reason: "same-timestamp-count-growth" };
   }
 
-  const snapshotCi = String(
-    snapshot.latestPassingCiCompletedAt ?? snapshot.latestCiCompletedAt ?? "none",
+  const snapshotCi = normalizeComparableTimestamp(
+    snapshot.latestPassingCiCompletedAt ?? snapshot.latestCiCompletedAt,
   );
-  const liveCi = String(
-    live.latestPassingCiCompletedAt ?? live.latestCiCompletedAt ?? "none",
+  const liveCi = normalizeComparableTimestamp(
+    live.latestPassingCiCompletedAt ?? live.latestCiCompletedAt,
   );
   if (snapshotCi !== liveCi) {
     return { route: "return-to-e1", reason: "ci-pass-drift" };
@@ -399,7 +400,7 @@ export function classifyReviewThreadForGate(thread, options = {}) {
 
   const comments = thread.comments?.nodes ?? [];
   const latestComment = comments.at(-1) ?? null;
-  const latestCommentAt = String(latestComment?.updatedAt ?? latestComment?.createdAt ?? "");
+  const latestCommentAt = String(latestComment?.createdAt ?? "");
   const latestAuthor = String(latestComment?.author?.login ?? "").toLowerCase();
   const iddAgentLogins = new Set(
     (options.iddAgentLogins ?? [])
@@ -412,7 +413,7 @@ export function classifyReviewThreadForGate(thread, options = {}) {
   const hasAmd = comments.some((comment) => {
     const authorLogin = String(comment.author?.login ?? "").toLowerCase();
     return iddAgentLogins.has(authorLogin)
-      && UNSAFE_TEXT_RULES[0].pattern.test(String(comment.body ?? "").trimStart());
+      && AMD_MARKER_PATTERN.test(String(comment.body ?? "").trimStart());
   });
 
   if (hasAmd) {
@@ -423,7 +424,7 @@ export function classifyReviewThreadForGate(thread, options = {}) {
     return { classification: "actionable-blocking" };
   }
 
-  const reviewerReopenedAt = inferReviewerReopenedAt(thread, latestCommentAt);
+  const reviewerReopenedAt = inferReviewerReopenedAt(thread);
   if (!latestCommentAt && reviewerReopenedAt) {
     return { classification: "actionable-blocking" };
   }
@@ -489,21 +490,12 @@ export function summarizeReviewThreadsForGate(threads, options = {}) {
   return summary;
 }
 
-function inferReviewerReopenedAt(thread, latestCommentAt) {
+function inferReviewerReopenedAt(thread) {
   const explicit = String(thread.reviewerReopenedAt ?? "");
   if (isValidIsoTimestamp(explicit)) {
     return explicit;
   }
-
-  const threadUpdatedAt = String(thread.updatedAt ?? "");
-  if (!isValidIsoTimestamp(threadUpdatedAt)) {
-    return "";
-  }
-  if (!latestCommentAt || !isValidIsoTimestamp(latestCommentAt)) {
-    return threadUpdatedAt;
-  }
-
-  return threadUpdatedAt > latestCommentAt ? threadUpdatedAt : "";
+  return "";
 }
 
 export function hasFreshDisposition(thread) {
@@ -936,4 +928,15 @@ function isValidIsoTimestamp(value) {
   if (!Number.isFinite(time)) return false;
   const normalize = (ts) => ts.replace(".000Z", "Z");
   return normalize(new Date(time).toISOString()) === normalize(value);
+}
+
+function normalizeComparableTimestamp(value) {
+  const normalized = String(value ?? "none");
+  if (normalized === "none") {
+    return "none";
+  }
+  if (!isValidIsoTimestamp(normalized)) {
+    return "";
+  }
+  return new Date(Date.parse(normalized)).toISOString().replace(".000Z", "Z");
 }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -369,15 +369,19 @@ export function diffReviewSnapshot(snapshot, live) {
   if (snapshotMax === "none" && liveCount > 0) {
     return { route: "return-to-e1", reason: "snapshot-was-empty-now-nonempty" };
   }
-  if (snapshotMax !== "none" && liveMax > snapshotMax) {
+  if (snapshotMax !== "none" && liveMax !== "none" && liveMax > snapshotMax) {
     return { route: "return-to-e1", reason: "newer-activity" };
   }
   if (liveCount > snapshotCount) {
     return { route: "return-to-e1", reason: "same-timestamp-count-growth" };
   }
 
-  const snapshotCi = String(snapshot.latestCiCompletedAt ?? "none");
-  const liveCi = String(live.latestCiCompletedAt ?? "none");
+  const snapshotCi = String(
+    snapshot.latestPassingCiCompletedAt ?? snapshot.latestCiCompletedAt ?? "none",
+  );
+  const liveCi = String(
+    live.latestPassingCiCompletedAt ?? live.latestCiCompletedAt ?? "none",
+  );
   if (snapshotCi !== liveCi) {
     return { route: "return-to-e1", reason: "ci-pass-drift" };
   }
@@ -389,9 +393,13 @@ export function classifyReviewThreadForGate(thread, options = {}) {
   if (thread.isResolved) {
     return { classification: "resolved" };
   }
+  if (thread.comments?.pageInfo?.hasNextPage) {
+    return { classification: "actionable-blocking" };
+  }
 
   const comments = thread.comments?.nodes ?? [];
   const latestComment = comments.at(-1) ?? null;
+  const latestCommentAt = String(latestComment?.updatedAt ?? latestComment?.createdAt ?? "");
   const latestAuthor = String(latestComment?.author?.login ?? "").toLowerCase();
   const iddAgentLogins = new Set(
     (options.iddAgentLogins ?? [])
@@ -402,7 +410,9 @@ export function classifyReviewThreadForGate(thread, options = {}) {
   const latestIsIddAgent = iddAgentLogins.has(latestAuthor);
   const latestIsPrAuthor = Boolean(prAuthorLogin) && latestAuthor === prAuthorLogin;
   const hasAmd = comments.some((comment) => {
-    return String(comment.body ?? "").trimStart().startsWith("**Awaiting maintainer decision**");
+    const authorLogin = String(comment.author?.login ?? "").toLowerCase();
+    return iddAgentLogins.has(authorLogin)
+      && UNSAFE_TEXT_RULES[0].pattern.test(String(comment.body ?? "").trimStart());
   });
 
   if (hasAmd) {
@@ -413,7 +423,11 @@ export function classifyReviewThreadForGate(thread, options = {}) {
     return { classification: "actionable-blocking" };
   }
 
-  if (thread.reviewerReopenedAt) {
+  const reviewerReopenedAt = inferReviewerReopenedAt(thread, latestCommentAt);
+  if (!latestCommentAt && reviewerReopenedAt) {
+    return { classification: "actionable-blocking" };
+  }
+  if (reviewerReopenedAt && reviewerReopenedAt > latestCommentAt) {
     return { classification: "actionable-blocking" };
   }
 
@@ -462,15 +476,34 @@ export function summarizeReviewThreadsForGate(threads, options = {}) {
       continue;
     }
     if (result.classification === "conversation-resolve-agent") {
+      summary.actionableCount += 1;
       summary.conversationResolveAgentCount += 1;
       continue;
     }
     if (result.classification === "conversation-resolve-author") {
+      summary.actionableCount += 1;
       summary.conversationResolveAuthorCount += 1;
     }
   }
 
   return summary;
+}
+
+function inferReviewerReopenedAt(thread, latestCommentAt) {
+  const explicit = String(thread.reviewerReopenedAt ?? "");
+  if (isValidIsoTimestamp(explicit)) {
+    return explicit;
+  }
+
+  const threadUpdatedAt = String(thread.updatedAt ?? "");
+  if (!isValidIsoTimestamp(threadUpdatedAt)) {
+    return "";
+  }
+  if (!latestCommentAt || !isValidIsoTimestamp(latestCommentAt)) {
+    return threadUpdatedAt;
+  }
+
+  return threadUpdatedAt > latestCommentAt ? threadUpdatedAt : "";
 }
 
 export function hasFreshDisposition(thread) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -313,8 +313,8 @@ export function routeRejectedChangesRequestedReview(input) {
   }
   if (reviewerDisposition === "agreed-state-cleared") {
     return {
-      route: "proceed",
-      reason: "reviewer agreed with the rejection and cleared the changes-requested state",
+      route: "hold-await-state-clear",
+      reason: "reviewer agreement alone does not clear a changes-requested state",
     };
   }
   if (reviewerDisposition === "agreed-state-unchanged") {
@@ -352,6 +352,19 @@ export function routeRejectedChangesRequestedReview(input) {
       reason: "the changes-requested review is still blocking after 24 hours with no reviewer response",
     };
   }
+  const escalationElapsedMs = Date.parse(input.now ?? "") - Date.parse(input.escalationCommentCreatedAt ?? "");
+  if (!Number.isFinite(escalationElapsedMs)) {
+    return {
+      route: "escalate-maintainer",
+      reason: "the changes-requested review still needs maintainer escalation evidence before release",
+    };
+  }
+  if (escalationElapsedMs < 24 * 60 * 60 * 1000) {
+    return {
+      route: "hold-after-escalation",
+      reason: "still within 24 hours of the maintainer escalation comment",
+    };
+  }
   return {
     route: "label-and-release",
     reason: "the changes-requested review is still blocking after 48 hours with no escalation response",
@@ -370,7 +383,14 @@ export function diffReviewSnapshot(snapshot, live) {
   if (snapshotMax === "none" && liveCount > 0) {
     return { route: "return-to-e1", reason: "snapshot-was-empty-now-nonempty" };
   }
-  if (snapshotMax && liveMax && snapshotMax !== "none" && liveMax !== "none" && liveMax > snapshotMax) {
+  if (
+    typeof snapshotMax === "number"
+    && liveCount > 0
+    && (liveMax === null || liveMax === "none")
+  ) {
+    return { route: "return-to-e1", reason: "missing-live-activity-evidence" };
+  }
+  if (typeof snapshotMax === "number" && typeof liveMax === "number" && liveMax > snapshotMax) {
     return { route: "return-to-e1", reason: "newer-activity" };
   }
   if (liveCount > snapshotCount) {
@@ -383,6 +403,9 @@ export function diffReviewSnapshot(snapshot, live) {
   const liveCi = normalizeComparableTimestamp(
     live.latestPassingCiCompletedAt ?? live.latestCiCompletedAt,
   );
+  if (snapshotCi === null || liveCi === null) {
+    return { route: "return-to-e1", reason: "missing-ci-evidence" };
+  }
   if (snapshotCi !== liveCi) {
     return { route: "return-to-e1", reason: "ci-pass-drift" };
   }
@@ -400,7 +423,7 @@ export function classifyReviewThreadForGate(thread, options = {}) {
 
   const comments = thread.comments?.nodes ?? [];
   const latestComment = comments.at(-1) ?? null;
-  const latestCommentAt = String(latestComment?.createdAt ?? "");
+  const latestCommentAt = normalizeComparableTimestamp(latestComment?.createdAt);
   const latestAuthor = String(latestComment?.author?.login ?? "").toLowerCase();
   const iddAgentLogins = new Set(
     (options.iddAgentLogins ?? [])
@@ -421,7 +444,11 @@ export function classifyReviewThreadForGate(thread, options = {}) {
       latestAmdIndex = index;
     }
   }
+  const reviewerReopenedAt = normalizeComparableTimestamp(inferReviewerReopenedAt(thread));
+  const reopenedAfterLatestComment = typeof reviewerReopenedAt === "number"
+    && (typeof latestCommentAt !== "number" || reviewerReopenedAt > latestCommentAt);
   const amdAwaitsMaintainer = latestAmdIndex >= 0
+    && !reopenedAfterLatestComment
     && !comments.slice(latestAmdIndex + 1).some((comment) => {
       const authorLogin = String(comment.author?.login ?? "").toLowerCase();
       return !iddAgentLogins.has(authorLogin) && authorLogin !== prAuthorLogin;
@@ -435,11 +462,7 @@ export function classifyReviewThreadForGate(thread, options = {}) {
     return { classification: "actionable-blocking" };
   }
 
-  const reviewerReopenedAt = inferReviewerReopenedAt(thread);
-  if (!latestCommentAt && reviewerReopenedAt) {
-    return { classification: "actionable-blocking" };
-  }
-  if (reviewerReopenedAt && reviewerReopenedAt > latestCommentAt) {
+  if (reopenedAfterLatestComment) {
     return { classification: "actionable-blocking" };
   }
 
@@ -947,7 +970,7 @@ function normalizeComparableTimestamp(value) {
     return "none";
   }
   if (!isValidIsoTimestamp(normalized)) {
-    return "";
+    return null;
   }
-  return new Date(Date.parse(normalized)).toISOString().replace(".000Z", "Z");
+  return Date.parse(normalized);
 }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -297,6 +297,182 @@ export function indexThreadsByReview(threads) {
   return index;
 }
 
+export function routeRejectedChangesRequestedReview(input) {
+  const reviewState = String(input.reviewState ?? "");
+  if (reviewState !== "CHANGES_REQUESTED") {
+    return { route: "proceed", reason: "changes-requested state already cleared" };
+  }
+
+  const reviewerDisposition = String(input.reviewerDisposition ?? "none");
+  if (reviewerDisposition === "disagreed") {
+    return {
+      route: "return-to-e1",
+      reason: "reviewer disagreed with the rejection and the feedback must return to triage",
+    };
+  }
+  if (reviewerDisposition === "agreed-state-cleared") {
+    return {
+      route: "proceed",
+      reason: "reviewer agreed with the rejection and cleared the changes-requested state",
+    };
+  }
+  if (reviewerDisposition === "agreed-state-unchanged") {
+    return {
+      route: "hold-await-state-clear",
+      reason: "reviewer agreement alone does not clear a changes-requested state",
+    };
+  }
+
+  const maintainerDisposition = String(input.maintainerDisposition ?? "none");
+  if (maintainerDisposition === "agreed-state-unchanged") {
+    return {
+      route: "hold-await-state-clear",
+      reason: "maintainer agreement does not clear the original changes-requested state",
+    };
+  }
+
+  const elapsedMs = Date.parse(input.now ?? "") - Date.parse(input.rejectionCommentCreatedAt ?? "");
+  if (!Number.isFinite(elapsedMs)) {
+    return {
+      route: "hold-for-evidence",
+      reason: "elapsed time cannot be computed for the rejected changes-requested review",
+    };
+  }
+
+  if (elapsedMs < 24 * 60 * 60 * 1000) {
+    return {
+      route: "hold-before-escalation",
+      reason: "still within the first 24 hours after the rejection reply",
+    };
+  }
+  if (elapsedMs < 48 * 60 * 60 * 1000) {
+    return {
+      route: "escalate-maintainer",
+      reason: "the changes-requested review is still blocking after 24 hours with no reviewer response",
+    };
+  }
+  return {
+    route: "label-and-release",
+    reason: "the changes-requested review is still blocking after 48 hours with no escalation response",
+  };
+}
+
+export function diffReviewSnapshot(snapshot, live) {
+  if (String(live.headSha ?? "") !== String(snapshot.headSha ?? "")) {
+    return { route: "return-to-e1", reason: "head-changed" };
+  }
+
+  const snapshotMax = String(snapshot.maxActivityUpdatedAt ?? "none");
+  const liveMax = String(live.maxActivityUpdatedAt ?? "none");
+  const snapshotCount = Number(snapshot.totalItemCount ?? 0);
+  const liveCount = Number(live.totalItemCount ?? 0);
+  if (snapshotMax === "none" && liveCount > 0) {
+    return { route: "return-to-e1", reason: "snapshot-was-empty-now-nonempty" };
+  }
+  if (snapshotMax !== "none" && liveMax > snapshotMax) {
+    return { route: "return-to-e1", reason: "newer-activity" };
+  }
+  if (liveCount > snapshotCount) {
+    return { route: "return-to-e1", reason: "same-timestamp-count-growth" };
+  }
+
+  const snapshotCi = String(snapshot.latestCiCompletedAt ?? "none");
+  const liveCi = String(live.latestCiCompletedAt ?? "none");
+  if (snapshotCi !== liveCi) {
+    return { route: "return-to-e1", reason: "ci-pass-drift" };
+  }
+
+  return { route: "proceed", reason: "snapshot-current" };
+}
+
+export function classifyReviewThreadForGate(thread, options = {}) {
+  if (thread.isResolved) {
+    return { classification: "resolved" };
+  }
+
+  const comments = thread.comments?.nodes ?? [];
+  const latestComment = comments.at(-1) ?? null;
+  const latestAuthor = String(latestComment?.author?.login ?? "").toLowerCase();
+  const iddAgentLogins = new Set(
+    (options.iddAgentLogins ?? [])
+      .map((login) => String(login ?? "").toLowerCase())
+      .filter(Boolean),
+  );
+  const prAuthorLogin = String(options.prAuthorLogin ?? "").toLowerCase();
+  const latestIsIddAgent = iddAgentLogins.has(latestAuthor);
+  const latestIsPrAuthor = Boolean(prAuthorLogin) && latestAuthor === prAuthorLogin;
+  const hasAmd = comments.some((comment) => {
+    return String(comment.body ?? "").trimStart().startsWith("**Awaiting maintainer decision**");
+  });
+
+  if (hasAmd) {
+    return { classification: "amd-blocking" };
+  }
+
+  if (!(latestIsIddAgent || latestIsPrAuthor)) {
+    return { classification: "actionable-blocking" };
+  }
+
+  if (thread.reviewerReopenedAt) {
+    return { classification: "actionable-blocking" };
+  }
+
+  if (options.requiresConversationResolution) {
+    if (latestIsIddAgent) {
+      return { classification: "conversation-resolve-agent" };
+    }
+    return { classification: "conversation-resolve-author" };
+  }
+
+  return { classification: "awaiting-reviewer" };
+}
+
+export function summarizeReviewThreadsForGate(threads, options = {}) {
+  const summary = {
+    actionableCount: 0,
+    awaitingReviewerCount: 0,
+    amdBlockingCount: 0,
+    conversationResolveAgentCount: 0,
+    conversationResolveAuthorCount: 0,
+    classifications: [],
+  };
+
+  for (const thread of threads) {
+    const result = classifyReviewThreadForGate(thread, options);
+    if (result.classification === "resolved") {
+      continue;
+    }
+
+    summary.classifications.push({
+      id: thread.id,
+      classification: result.classification,
+    });
+
+    if (result.classification === "actionable-blocking") {
+      summary.actionableCount += 1;
+      continue;
+    }
+    if (result.classification === "amd-blocking") {
+      summary.amdBlockingCount += 1;
+      summary.actionableCount += 1;
+      continue;
+    }
+    if (result.classification === "awaiting-reviewer") {
+      summary.awaitingReviewerCount += 1;
+      continue;
+    }
+    if (result.classification === "conversation-resolve-agent") {
+      summary.conversationResolveAgentCount += 1;
+      continue;
+    }
+    if (result.classification === "conversation-resolve-author") {
+      summary.conversationResolveAuthorCount += 1;
+    }
+  }
+
+  return summary;
+}
+
 export function hasFreshDisposition(thread) {
   const comments = thread.comments?.nodes ?? [];
   const latestFeedbackAt = comments

--- a/scripts/review-activity-snapshot.mjs
+++ b/scripts/review-activity-snapshot.mjs
@@ -145,7 +145,7 @@ function normalizeThread(thread) {
   return {
     id: thread.id,
     isResolved: Boolean(thread.isResolved),
-    updatedAt: thread.updatedAt ?? "",
+    updatedAt: "",
     comments: {
       pageInfo: { hasNextPage: Boolean(thread.comments?.pageInfo?.hasNextPage) },
       nodes: (thread.comments?.nodes ?? []).map((comment) => ({
@@ -174,7 +174,6 @@ function fetchReviewThreads(owner, repo, prNumber) {
                 nodes {
                   id
                   isResolved
-                  updatedAt
                   comments(first: 100) {
                     pageInfo { hasNextPage endCursor }
                     nodes {

--- a/scripts/review-activity-snapshot.mjs
+++ b/scripts/review-activity-snapshot.mjs
@@ -145,7 +145,7 @@ function normalizeThread(thread) {
   return {
     id: thread.id,
     isResolved: Boolean(thread.isResolved),
-    updatedAt: "",
+    updatedAt: thread.updatedAt ?? "",
     comments: {
       pageInfo: { hasNextPage: Boolean(thread.comments?.pageInfo?.hasNextPage) },
       nodes: (thread.comments?.nodes ?? []).map((comment) => ({
@@ -174,6 +174,7 @@ function fetchReviewThreads(owner, repo, prNumber) {
                 nodes {
                   id
                   isResolved
+                  updatedAt
                   comments(first: 100) {
                     pageInfo { hasNextPage endCursor }
                     nodes {

--- a/tests/review-gate.test.mjs
+++ b/tests/review-gate.test.mjs
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  classifyReviewThreadForGate,
+  diffReviewSnapshot,
+  routeRejectedChangesRequestedReview,
+  summarizeReviewThreadsForGate,
+} from "../scripts/protocol-helpers.mjs";
+
+const changesRequestedRoutes = readJson("fixtures/review-gate/changes-requested-routes.json");
+const snapshotDiffRoutes = readJson("fixtures/review-gate/snapshot-diff-routes.json");
+const threadGateRoutes = readJson("fixtures/review-gate/thread-gate-routes.json");
+
+test("routes rejected CHANGES_REQUESTED review-body scenarios", () => {
+  for (const fixture of changesRequestedRoutes) {
+    assert.deepEqual(
+      routeRejectedChangesRequestedReview(fixture.input),
+      fixture.expected,
+      fixture.name,
+    );
+  }
+});
+
+test("routes F2/F3 snapshot-vs-live diff scenarios", () => {
+  for (const fixture of snapshotDiffRoutes) {
+    assert.deepEqual(
+      diffReviewSnapshot(fixture.snapshot, fixture.live),
+      fixture.expected,
+      fixture.name,
+    );
+  }
+});
+
+test("classifies unresolved threads for awaiting-reviewer and conversation-resolution gates", () => {
+  for (const fixture of threadGateRoutes) {
+    assert.deepEqual(
+      summarizeReviewThreadsForGate(fixture.threads, fixture.options),
+      fixture.expected,
+      fixture.name,
+    );
+
+    assert.equal(
+      classifyReviewThreadForGate(fixture.threads[0], fixture.options).classification,
+      fixture.expected.classifications[0].classification,
+      `${fixture.name} single-thread classification`,
+    );
+  }
+});
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8"));
+}

--- a/tests/review-gate.test.mjs
+++ b/tests/review-gate.test.mjs
@@ -41,13 +41,15 @@ test("classifies unresolved threads for awaiting-reviewer and conversation-resol
       fixture.name,
     );
 
-    const expectedClassification =
-      fixture.expected.classifications[0]?.classification ?? "resolved";
-    assert.equal(
-      classifyReviewThreadForGate(fixture.threads[0], fixture.options).classification,
-      expectedClassification,
-      `${fixture.name} single-thread classification`,
-    );
+    if (fixture.threads.length === 1) {
+      const expectedClassification =
+        fixture.expected.classifications[0]?.classification ?? "resolved";
+      assert.equal(
+        classifyReviewThreadForGate(fixture.threads[0], fixture.options).classification,
+        expectedClassification,
+        `${fixture.name} single-thread classification`,
+      );
+    }
   }
 });
 

--- a/tests/review-gate.test.mjs
+++ b/tests/review-gate.test.mjs
@@ -41,9 +41,11 @@ test("classifies unresolved threads for awaiting-reviewer and conversation-resol
       fixture.name,
     );
 
+    const expectedClassification =
+      fixture.expected.classifications[0]?.classification ?? "resolved";
     assert.equal(
       classifyReviewThreadForGate(fixture.threads[0], fixture.options).classification,
-      fixture.expected.classifications[0].classification,
+      expectedClassification,
       `${fixture.name} single-thread classification`,
     );
   }


### PR DESCRIPTION
## Summary
- add pure review-gate helpers for CHANGES_REQUESTED escalation, F2/F3 snapshot drift, and unresolved-thread classification
- add fixture tables for review-body timing, snapshot diff reasons, and awaiting-reviewer / AMD / conversation-resolution branches
- cover the route decisions in `tests/review-gate.test.mjs` and keep them aligned with the existing review-snapshot fixture shape

Closes #280

## Notes
- the CHANGES_REQUESTED scenarios include the still-blocking "maintainer agreed but state unchanged" branch
- the snapshot diff fixtures cover head changes, same-timestamp count growth, and CI-pass drift
- no follow-up issues identified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive fixtures and automated tests covering review-gate routing, CHANGES_REQUESTED workflows, snapshot-vs-live comparisons, and thread classification across many edge cases.

* **Chores**
  * Improved review-gate routing, snapshot-vs-live diffing, thread classification, and aggregation logic to support the new test scenarios and more robust gating behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/289)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/289)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->