### PR TITLE
docs(template): add node.js/npx 3-level fallback to command guidance

### DIFF
--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -293,10 +293,10 @@ next step that requires no uncommitted changes.
 recreated worktrees must not require manual cleanup and should not leave
 unexpected tracked changes.
 
-**Tool availability**: the commands above are required when the listed
-tools are present. For Node.js: prefer project scripts; use bare
-`npx <tool>` if none exist; use `true` if Node.js is absent. For
-other tools, replace with `true` when absent.
+**Tool availability**: run commands only when tools exist. For Node.js:
+prefer project scripts; use `npx <tool>` only when `npx` is available
+and no relevant script exists; else use `true`. For other tools, use
+`true` when absent.
 
 ## Phase routing table
 

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -294,9 +294,9 @@ recreated worktrees must not require manual cleanup and should not leave
 unexpected tracked changes.
 
 **Tool availability**: the commands above are required when the listed
-tools are present. In repositories without Node.js or a specific tool,
-replace that command with `true` — the same no-op convention used by
-**install-deps** in this project.
+tools are present. For Node.js: prefer project scripts; use bare
+`npx <tool>` if none exist; use `true` if Node.js is absent. For
+other tools, replace with `true` when absent.
 
 ## Phase routing table
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -172,13 +172,13 @@ the `Project commands` table in
 The following policy matrix defines the tooling requirements and
 fallback order for repositories adopting IDD:
 
-| Context                                  | Requirement         | Fallback order                                                                       |
-| ---------------------------------------- | ------------------- | ------------------------------------------------------------------------------------ |
-| `git`, `gh`, `jq`, `curl`                | **Required**        | No fallback; IDD cannot run without these                                            |
-| `install-deps` command                   | Project-dependent   | Use project's native package manager; `true` as no-op when no install step is needed |
-| Validate commands (`fix-validate`, etc.) | Project-dependent   | Use project tooling; `true` as no-op                                                 |
-| Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` if Node.js is present; 3. `true` no-op |
-| pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                              |
+| Context                                  | Requirement         | Fallback order                                                                                           |
+| ---------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- |
+| `git`, `gh`, `jq`, `curl`                | **Required**        | No fallback; IDD cannot run without these                                                                |
+| `install-deps` command                   | Project-dependent   | Use project's native package manager; `true` as no-op when no install step is needed                     |
+| Validate commands (`fix-validate`, etc.) | Project-dependent   | Use project tooling; `true` as no-op                                                                     |
+| Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` when available; 3. `true` when unavailable or not relevant |
+| pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                                                  |
 
 Decision points:
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -187,9 +187,9 @@ Decision points:
 - **Out of scope for IDD**: package manager choice, build tooling,
   language runtime. Adopt whatever the target project already uses.
 - **Fallback order for npx-using templates**: (1) use an existing
-  Node.js project's script runner; (2) use bare `npx <tool>` if
-  Node.js is available; (3) replace with `true` if the tool is absent
-  and its check is not relevant to the project.
+  Node.js project's script runner; (2) use bare `npx <tool>` when
+  `npx` is available; (3) replace with `true` when `npx` is unavailable
+  or the check is not relevant to the project.
 
 ## Reusable pnpm boundary guard workflow
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -308,9 +308,10 @@ unexpected tracked changes.
 tools are present. For Node.js tooling, apply the three-level fallback
 in order: (1) run the relevant project package-manager script if one
 exists (e.g., `npm run <script>`, `pnpm run <script>`); (2) use bare
-`npx <tool>` if Node.js is present but no relevant project script
-exists; (3) replace with `true` (no-op) if Node.js is absent. For other
-tools, replace the command with `true` when the tool is absent. Set
+`npx <tool>` if Node.js and `npx` are available but no relevant project
+script exists; (3) replace with `true` (no-op) if Node.js or `npx` is
+absent. For other tools, replace the command with `true` when the tool
+is absent. Set
 `{{INSTALL_DEPS_COMMAND}}` to `true` if the project has no install step.
 See [Tooling boundary](../../docs/customization.md#tooling-boundary) for
 the full policy matrix.

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -305,10 +305,14 @@ recreated worktrees must not require manual cleanup and should not leave
 unexpected tracked changes.
 
 **Tool availability**: the commands above are required when the listed
-tools are present. In repositories without a specific tool, replace
-that command with `true` — the same no-op convention used by
-**install-deps**. Set `{{INSTALL_DEPS_COMMAND}}` to `true` if the
-project has no install step.
+tools are present. For Node.js tooling, apply the three-level fallback
+in order: (1) run the project script if one exists (`npm run <script>`);
+(2) use bare `npx <tool>` if Node.js is present but no project script
+exists; (3) replace with `true` (no-op) if Node.js is absent. For other
+tools, replace the command with `true` when the tool is absent. Set
+`{{INSTALL_DEPS_COMMAND}}` to `true` if the project has no install step.
+See [Tooling boundary](docs/customization.md#tooling-boundary) for the
+full policy matrix.
 
 ## Phase routing table
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -306,9 +306,10 @@ unexpected tracked changes.
 
 **Tool availability**: the commands above are required when the listed
 tools are present. For Node.js tooling, apply the three-level fallback
-in order: (1) run the project script if one exists (`npm run <script>`);
-(2) use bare `npx <tool>` if Node.js is present but no project script
-exists; (3) replace with `true` (no-op) if Node.js is absent. For other
+in order: (1) run the project's package-manager script if one exists
+(e.g., `npm run <script>`, `pnpm run <script>`); (2) use bare
+`npx <tool>` if Node.js is present but no project script exists;
+(3) replace with `true` (no-op) if Node.js is absent. For other
 tools, replace the command with `true` when the tool is absent. Set
 `{{INSTALL_DEPS_COMMAND}}` to `true` if the project has no install step.
 See [Tooling boundary](docs/customization.md#tooling-boundary) for the

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -99,7 +99,7 @@ marker being authored by a trusted actor, and the GitHub server
 
 For repository-local configuration (trusted-marker-logins,
 maintainer-approval-actors, collaborator-authored-markers, and example
-policy blocks), see `docs/customization.md`.
+policy blocks), see `../../docs/customization.md`.
 
 ## Claim-state parsing
 
@@ -306,14 +306,14 @@ unexpected tracked changes.
 
 **Tool availability**: the commands above are required when the listed
 tools are present. For Node.js tooling, apply the three-level fallback
-in order: (1) run the project's package-manager script if one exists
-(e.g., `npm run <script>`, `pnpm run <script>`); (2) use bare
-`npx <tool>` if Node.js is present but no project script exists;
-(3) replace with `true` (no-op) if Node.js is absent. For other
+in order: (1) run the relevant project package-manager script if one
+exists (e.g., `npm run <script>`, `pnpm run <script>`); (2) use bare
+`npx <tool>` if Node.js is present but no relevant project script
+exists; (3) replace with `true` (no-op) if Node.js is absent. For other
 tools, replace the command with `true` when the tool is absent. Set
 `{{INSTALL_DEPS_COMMAND}}` to `true` if the project has no install step.
-See [Tooling boundary](docs/customization.md#tooling-boundary) for the
-full policy matrix.
+See [Tooling boundary](../../docs/customization.md#tooling-boundary) for
+the full policy matrix.
 
 ## Phase routing table
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -135,7 +135,8 @@ values. The operator can confirm these proposed values or correct them.
   auto-fix + validate sequence inferred from tooling present in the
   repository (e.g., `dprint fmt` + linter, `black` + `isort`, `cargo fmt`,
   `go fmt`, `prettier --write`). Common patterns:
-  - Node.js (project scripts present): `npm run lint:fix && npm run lint`
+  - Node.js (relevant project script exists):
+    `<package-manager> run lint:fix && <package-manager> run lint`
   - Node.js (no project scripts, Node.js present):
     `npx <linter> --fix && npx <linter>`
   - No Node.js: `true` (no-op)
@@ -145,8 +146,8 @@ values. The operator can confirm these proposed values or correct them.
   - If no standard auto-fix tooling, propose `true` as fallback.
 - **Pre-push-validate commands** (`{{PRE_PUSH_VALIDATE_COMMANDS}}`):
   Propose a lint + build + test sequence (no mutations). Common patterns:
-  - Node.js (project scripts present):
-    `npm run lint && npm run build && npm run test`
+  - Node.js (relevant project script exists):
+    `<pm> run lint && <pm> run build && <pm> run test`
   - Node.js (no project scripts, Node.js present):
     `npx <linter> && npx <builder> && npx <test-runner>`
   - No Node.js: `true` (no-op)

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -148,7 +148,7 @@ values. The operator can confirm these proposed values or correct them.
   - Node.js (project scripts present):
     `npm run lint && npm run build && npm run test`
   - Node.js (no project scripts, Node.js present):
-    `npx <linter> && npx <test-runner>`
+    `npx <linter> && npx <builder> && npx <test-runner>`
   - No Node.js: `true` (no-op)
   - Python: `pylint . && python -m pytest`
   - Go: `go vet ./... && go test ./...`

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -137,9 +137,9 @@ values. The operator can confirm these proposed values or correct them.
   `go fmt`, `prettier --write`). Common patterns:
   - Node.js (relevant project script exists):
     `<pm> run lint:fix && <pm> run lint`
-  - Node.js (no project scripts, Node.js present):
+  - Node.js (no relevant project script, `npx` available):
     `npx <linter> --fix && npx <linter>`
-  - No Node.js: `true` (no-op)
+  - No Node.js and no other relevant tooling: `true` (no-op)
   - Python: `black . && isort .` or equivalent
   - Go: `go fmt ./...`
   - Rust: `cargo fmt`

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -135,14 +135,21 @@ values. The operator can confirm these proposed values or correct them.
   auto-fix + validate sequence inferred from tooling present in the
   repository (e.g., `dprint fmt` + linter, `black` + `isort`, `cargo fmt`,
   `go fmt`, `prettier --write`). Common patterns:
-  - Node.js: `npm run lint:fix && npm run lint`
+  - Node.js (project scripts present): `npm run lint:fix && npm run lint`
+  - Node.js (no project scripts, Node.js present):
+    `npx <linter> --fix && npx <linter>`
+  - No Node.js: `true` (no-op)
   - Python: `black . && isort .` or equivalent
   - Go: `go fmt ./...`
   - Rust: `cargo fmt`
   - If no standard auto-fix tooling, propose `true` as fallback.
 - **Pre-push-validate commands** (`{{PRE_PUSH_VALIDATE_COMMANDS}}`):
   Propose a lint + build + test sequence (no mutations). Common patterns:
-  - Node.js: `npm run lint && npm run build && npm run test`
+  - Node.js (project scripts present):
+    `npm run lint && npm run build && npm run test`
+  - Node.js (no project scripts, Node.js present):
+    `npx <linter> && npx <test-runner>`
+  - No Node.js: `true` (no-op)
   - Python: `pylint . && python -m pytest`
   - Go: `go vet ./... && go test ./...`
   - Rust: `cargo check && cargo test`

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -148,9 +148,9 @@ values. The operator can confirm these proposed values or correct them.
   Propose a lint + build + test sequence (no mutations). Common patterns:
   - Node.js (relevant project script exists):
     `<pm> run lint && <pm> run build && <pm> run test`
-  - Node.js (no project scripts, Node.js present):
+  - Node.js (no relevant project script, `npx` available):
     `npx <linter> && npx <builder> && npx <test-runner>`
-  - No Node.js: `true` (no-op)
+  - No Node.js and no other relevant tooling: `true` (no-op)
   - Python: `pylint . && python -m pytest`
   - Go: `go vet ./... && go test ./...`
   - Rust: `cargo check && cargo test`

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -136,7 +136,7 @@ values. The operator can confirm these proposed values or correct them.
   repository (e.g., `dprint fmt` + linter, `black` + `isort`, `cargo fmt`,
   `go fmt`, `prettier --write`). Common patterns:
   - Node.js (relevant project script exists):
-    `<package-manager> run lint:fix && <package-manager> run lint`
+    `<pm> run lint:fix && <pm> run lint`
   - Node.js (no project scripts, Node.js present):
     `npx <linter> --fix && npx <linter>`
   - No Node.js: `true` (no-op)

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -172,13 +172,13 @@ the `Project commands` table in
 The following policy matrix defines the tooling requirements and
 fallback order for repositories adopting IDD:
 
-| Context                                  | Requirement         | Fallback order                                                                       |
-| ---------------------------------------- | ------------------- | ------------------------------------------------------------------------------------ |
-| `git`, `gh`, `jq`, `curl`                | **Required**        | No fallback; IDD cannot run without these                                            |
-| `install-deps` command                   | Project-dependent   | Use project's native package manager; `true` as no-op when no install step is needed |
-| Validate commands (`fix-validate`, etc.) | Project-dependent   | Use project tooling; `true` as no-op                                                 |
-| Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` if Node.js is present; 3. `true` no-op |
-| pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                              |
+| Context                                  | Requirement         | Fallback order                                                                                           |
+| ---------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- |
+| `git`, `gh`, `jq`, `curl`                | **Required**        | No fallback; IDD cannot run without these                                                                |
+| `install-deps` command                   | Project-dependent   | Use project's native package manager; `true` as no-op when no install step is needed                     |
+| Validate commands (`fix-validate`, etc.) | Project-dependent   | Use project tooling; `true` as no-op                                                                     |
+| Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` when available; 3. `true` when unavailable or not relevant |
+| pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                                                  |
 
 Decision points:
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -187,9 +187,9 @@ Decision points:
 - **Out of scope for IDD**: package manager choice, build tooling,
   language runtime. Adopt whatever the target project already uses.
 - **Fallback order for npx-using templates**: (1) use an existing
-  Node.js project's script runner; (2) use bare `npx <tool>` if
-  Node.js is available; (3) replace with `true` if the tool is absent
-  and its check is not relevant to the project.
+  Node.js project's script runner; (2) use bare `npx <tool>` when
+  `npx` is available; (3) replace with `true` when `npx` is unavailable
+  or the check is not relevant to the project.
 
 ## Reusable pnpm boundary guard workflow
 


### PR DESCRIPTION
## Summary

Adds a three-level execution fallback for Node.js tooling to the IDD command guidance, so adopter repositories without Node.js can participate gracefully without the workflow hard-failing.

### Changes

- **`.github/instructions/idd-overview.instructions.md`** (live): Updated "Tool availability" paragraph to describe the 3-level hierarchy concisely, within the 20,000-byte hard limit.
- **`idd-template/.github/instructions/idd-overview.instructions.md`**: Updated "Tool availability" paragraph with full 3-level fallback prose using package-manager-neutral language (covers npm, pnpm, yarn) and a cross-reference to the policy matrix in `docs/customization.md`.
- **`idd-template/ONBOARDING.md`**: Updated command derivation patterns in Step 1A to show the 3-tier structure for both fix-validate and pre-push-validate patterns, including the missing `npx <builder>` step in the no-project-scripts path.

### Fallback order (for Node.js commands)

1. Run the project's package-manager script if one exists (e.g., `npm run <script>`, `pnpm run <script>`)
2. Use bare `npx <tool>` if Node.js is present but no project script exists
3. Replace with `true` (no-op) if Node.js is absent

This is consistent with the existing policy matrix in `idd-template/docs/customization.md#tooling-boundary`.

Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified command-availability rules with a Node.js-specific fallback order: prefer project scripts, then npx, then a no-op when tooling is absent; non-Node tools fall back to a no-op.
  * Expanded onboarding guidance to cover multiple ecosystems (Node.js variants, Python, Go, Rust) instead of Node-only examples.
  * Updated template documentation links and formatting for clearer repository guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/292)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->