### PR TITLE
test(consistency): add golden coverage for config drift and A4.5

### DIFF
--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -295,7 +295,13 @@ function checkConfigInstructionDrift() {
   ];
 
   for (const pair of pairs) {
-    if (!repoFiles.includes(pair.configPath) || !repoFiles.includes(pair.overviewPath)) {
+    const hasConfig = repoFiles.includes(pair.configPath);
+    const hasOverview = repoFiles.includes(pair.overviewPath);
+    if (!hasConfig && !hasOverview) {
+      continue;
+    }
+    if (!hasConfig || !hasOverview) {
+      errors.push(`missing config/overview pair: expected both ${pair.configPath} and ${pair.overviewPath}`);
       continue;
     }
 

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -283,31 +283,46 @@ function checkForbiddenPatterns(patterns) {
 }
 
 function checkConfigInstructionDrift() {
-  const configPath = ".github/idd/config.json";
-  const overviewPath = ".github/instructions/idd-overview.instructions.md";
+  const pairs = [
+    {
+      configPath: ".github/idd/config.json",
+      overviewPath: ".github/instructions/idd-overview.instructions.md",
+    },
+    {
+      configPath: "idd-template/.github/idd/config.json",
+      overviewPath: "idd-template/.github/instructions/idd-overview.instructions.md",
+    },
+  ];
 
-  if (!repoFiles.includes(configPath) || !repoFiles.includes(overviewPath)) {
-    return;
+  for (const pair of pairs) {
+    if (!repoFiles.includes(pair.configPath) || !repoFiles.includes(pair.overviewPath)) {
+      continue;
+    }
+
+    let config;
+    try {
+      config = JSON.parse(readText(pair.configPath));
+    } catch {
+      errors.push(`${pair.configPath} is not valid JSON`);
+      continue;
+    }
+
+    const drifts = collectPolicyConfigDrift(config, readText(pair.overviewPath));
+    if (drifts.length > 0) {
+      const summary = drifts
+        .map((drift) => {
+          if (drift.reason) {
+            return `${drift.path} ${drift.reason}`;
+          }
+          return `${drift.path} expected ${JSON.stringify(drift.expected)} got ${JSON.stringify(drift.actual)}`;
+        })
+        .join("; ");
+      errors.push(`${pair.configPath} drifts from ${pair.overviewPath}: ${summary}`);
+      continue;
+    }
+
+    notices.push(`${pair.configPath} matches ${pair.overviewPath} command and scope defaults`);
   }
-
-  let config;
-  try {
-    config = JSON.parse(readText(configPath));
-  } catch {
-    errors.push(`${configPath} is not valid JSON`);
-    return;
-  }
-
-  const drifts = collectPolicyConfigDrift(config, readText(overviewPath));
-  if (drifts.length > 0) {
-    const summary = drifts
-      .map((drift) => `${drift.path} expected ${JSON.stringify(drift.expected)} got ${JSON.stringify(drift.actual)}`)
-      .join("; ");
-    errors.push(`${configPath} drifts from ${overviewPath}: ${summary}`);
-    return;
-  }
-
-  notices.push(`${configPath} matches ${overviewPath} command and scope defaults`);
 }
 
 function checkInstructionSizeBudgets(config) {

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -4,6 +4,8 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { collectPolicyConfigDrift } from "./consistency-helpers.mjs";
+
 const root = process.cwd();
 const manifestPath = "audit/sync-manifest.json";
 const args = new Set(process.argv.slice(2));
@@ -26,6 +28,7 @@ checkShellFileLists(manifest.shellFileLists ?? [], manifest.generatedBlocks ?? [
 checkSyncPairs(manifest.syncPairs ?? []);
 checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? null);
 checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
+checkConfigInstructionDrift();
 
 if (errors.length > 0) {
   console.error("documentation audit failed:");
@@ -277,6 +280,34 @@ function checkForbiddenPatterns(patterns) {
       }
     }
   }
+}
+
+function checkConfigInstructionDrift() {
+  const configPath = ".github/idd/config.json";
+  const overviewPath = ".github/instructions/idd-overview.instructions.md";
+
+  if (!repoFiles.includes(configPath) || !repoFiles.includes(overviewPath)) {
+    return;
+  }
+
+  let config;
+  try {
+    config = JSON.parse(readText(configPath));
+  } catch {
+    errors.push(`${configPath} is not valid JSON`);
+    return;
+  }
+
+  const drifts = collectPolicyConfigDrift(config, readText(overviewPath));
+  if (drifts.length > 0) {
+    const summary = drifts
+      .map((drift) => `${drift.path} expected ${JSON.stringify(drift.expected)} got ${JSON.stringify(drift.actual)}`)
+      .join("; ");
+    errors.push(`${configPath} drifts from ${overviewPath}: ${summary}`);
+    return;
+  }
+
+  notices.push(`${configPath} matches ${overviewPath} command and scope defaults`);
 }
 
 function checkInstructionSizeBudgets(config) {

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -19,6 +19,12 @@ export function collectPolicyConfigDrift(config, overviewText) {
   for (const key of COMMAND_KEYS) {
     const expected = commandRows.get(key);
     if (expected === undefined) {
+      drifts.push({
+        path: `commands.${key}`,
+        expected: null,
+        actual: config?.commands?.[key] ?? null,
+        reason: `missing instruction row ${key}`,
+      });
       continue;
     }
     const actual = config?.commands?.[key];
@@ -34,9 +40,15 @@ export function collectPolicyConfigDrift(config, overviewText) {
   for (const [field, row] of POLICY_FIELD_ROWS) {
     const expected = commandRows.get(row);
     if (expected === undefined) {
+      drifts.push({
+        path: field,
+        expected: null,
+        actual: hasOwn(config, field) ? config[field] : null,
+        reason: `missing instruction row ${row}`,
+      });
       continue;
     }
-    const actual = config?.[field];
+    const actual = hasOwn(config, field) ? config[field] : expected;
     if (actual !== expected) {
       drifts.push({
         path: field,
@@ -47,4 +59,8 @@ export function collectPolicyConfigDrift(config, overviewText) {
   }
 
   return drifts;
+}
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value ?? {}, key);
 }

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -1,0 +1,50 @@
+import { parseProjectCommandRows } from "./idd-doctor.mjs";
+
+const COMMAND_KEYS = [
+  "install-deps",
+  "fix-validate",
+  "pre-push-validate",
+  "post-fix-validate",
+];
+
+const POLICY_FIELD_ROWS = new Map([
+  ["issueScope", "issue-scope"],
+  ["orphanFirstPolicy", "orphan-first-policy"],
+]);
+
+export function collectPolicyConfigDrift(config, overviewText) {
+  const drifts = [];
+  const commandRows = parseProjectCommandRows(overviewText);
+
+  for (const key of COMMAND_KEYS) {
+    const expected = commandRows.get(key);
+    if (expected === undefined) {
+      continue;
+    }
+    const actual = config?.commands?.[key];
+    if (actual !== expected) {
+      drifts.push({
+        path: `commands.${key}`,
+        expected,
+        actual: actual ?? null,
+      });
+    }
+  }
+
+  for (const [field, row] of POLICY_FIELD_ROWS) {
+    const expected = commandRows.get(row);
+    if (expected === undefined) {
+      continue;
+    }
+    const actual = config?.[field];
+    if (actual !== expected) {
+      drifts.push({
+        path: field,
+        expected,
+        actual: actual ?? null,
+      });
+    }
+  }
+
+  return drifts;
+}

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -23,6 +23,7 @@ test("placeholder scenarios detect clean and dirty post-onboarding fixtures", ()
 
 test("config drift scenarios detect mismatches between config and overview defaults", () => {
   const overview = readText("consistency/config/overview.txt");
+  const missingRowOverview = readText("consistency/config/overview-missing-policy-row.txt");
   const aligned = readJson("consistency/config/aligned-config.json");
   const drifted = readJson("consistency/config/drifted-config.json");
 
@@ -37,6 +38,14 @@ test("config drift scenarios detect mismatches between config and overview defau
       path: "issueScope",
       expected: "roadmap",
       actual: "orphan-first",
+    },
+  ]);
+  assert.deepEqual(collectPolicyConfigDrift(aligned, missingRowOverview), [
+    {
+      path: "orphanFirstPolicy",
+      expected: null,
+      actual: null,
+      reason: "missing instruction row orphan-first-policy",
     },
   ]);
 });

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -77,7 +77,8 @@ function collectPlaceholderHits(url) {
     if (placeholders.length === 0) {
       return;
     }
-    hits.push(`${relative(root, fullPath)}: ${placeholders.join(", ")}`);
+    const relativePath = relative(root, fullPath).replaceAll("\\", "/");
+    hits.push(`${relativePath}: ${placeholders.join(", ")}`);
   });
 
   return hits.sort();

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -1,0 +1,116 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { collectPolicyConfigDrift } from "../scripts/consistency-helpers.mjs";
+import { findPlaceholders } from "../scripts/idd-doctor.mjs";
+
+const FIXTURE_ROOT = new URL("./fixtures/", import.meta.url);
+const SUITABILITY_PATH = new URL("../.github/instructions/idd-suitability.instructions.md", import.meta.url);
+
+test("placeholder scenarios detect clean and dirty post-onboarding fixtures", () => {
+  const clean = collectPlaceholderHits(new URL("./fixtures/consistency/placeholders/clean", import.meta.url));
+  const dirty = collectPlaceholderHits(new URL("./fixtures/consistency/placeholders/dirty", import.meta.url));
+
+  assert.deepEqual(clean, []);
+  assert.deepEqual(dirty, [
+    ".github/idd/config.json: {{PROJECT_MARKER_PREFIX}}",
+    "README.md: {{REPO_NAME}}",
+  ]);
+});
+
+test("config drift scenarios detect mismatches between config and overview defaults", () => {
+  const overview = readText("consistency/config/overview.txt");
+  const aligned = readJson("consistency/config/aligned-config.json");
+  const drifted = readJson("consistency/config/drifted-config.json");
+
+  assert.deepEqual(collectPolicyConfigDrift(aligned, overview), []);
+  assert.deepEqual(collectPolicyConfigDrift(drifted, overview), [
+    {
+      path: "commands.fix-validate",
+      expected: "npm run fix",
+      actual: "npm run fix && npm test",
+    },
+    {
+      path: "issueScope",
+      expected: "roadmap",
+      actual: "orphan-first",
+    },
+  ]);
+});
+
+test("A4.5 outcome fixtures match the documented check-to-outcome mapping", () => {
+  const text = readFileSync(SUITABILITY_PATH, "utf8");
+  const checks = extractCheckOutcomes(text);
+  const outcomes = extractOutcomeTable(text);
+  const cases = readJson("consistency/a45-outcomes.json");
+
+  for (const fixture of cases) {
+    assert.equal(checks.get(fixture.failedCheck), fixture.expectedOutcome, fixture.id);
+    assert.ok(outcomes.has(fixture.expectedOutcome), fixture.expectedOutcome);
+  }
+
+  assert.deepEqual(
+    [...new Set(cases.map((fixture) => fixture.expectedOutcome))].sort(),
+    ["blocked-by-human", "duplicate", "invalid", "needs-decision", "out-of-scope", "unclear"],
+  );
+  assert.match(outcomes.get("invalid"), /do not retry/i);
+});
+
+function collectPlaceholderHits(url) {
+  const root = fileURLToPath(url);
+  const hits = [];
+
+  walk(root, (fullPath) => {
+    const placeholders = [...new Set(findPlaceholders(readFileSync(fullPath, "utf8")))];
+    if (placeholders.length === 0) {
+      return;
+    }
+    hits.push(`${relative(root, fullPath)}: ${placeholders.join(", ")}`);
+  });
+
+  return hits.sort();
+}
+
+function walk(directory, visit) {
+  for (const entry of readdirSync(directory)) {
+    const fullPath = join(directory, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      walk(fullPath, visit);
+      continue;
+    }
+    visit(fullPath);
+  }
+}
+
+function extractCheckOutcomes(text) {
+  const entries = [...text.matchAll(
+    /^### Check \d+: ([^\n]+)\n[\s\S]*?^- \*\*Outcome on fail\*\*: `([^`]+)`$/gm,
+  )];
+  return new Map(entries.map(([, heading, outcome]) => [heading.trim(), outcome]));
+}
+
+function extractOutcomeTable(text) {
+  const sectionMatch = text.match(/## Failure Outcomes[\s\S]*?\n\| Outcome[\s\S]*?\n((?:\|[^\n]+\n)+)/);
+  const rows = (sectionMatch?.[1] ?? "")
+    .split(/\r?\n/)
+    .filter((row) => row.startsWith("| `"));
+  return new Map(rows.map((row) => {
+    const cells = row
+      .split("|")
+      .slice(1, -1)
+      .map((cell) => cell.trim());
+    return [cells[0].replaceAll("`", ""), cells[2]];
+  }));
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readText(relativePath));
+}
+
+function readText(relativePath) {
+  return readFileSync(new URL(relativePath, FIXTURE_ROOT), "utf8");
+}

--- a/tests/fixtures/consistency/a45-outcomes.json
+++ b/tests/fixtures/consistency/a45-outcomes.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "repository-fit",
+    "failedCheck": "Repository Fit",
+    "expectedOutcome": "out-of-scope"
+  },
+  {
+    "id": "issue-coherence",
+    "failedCheck": "Issue Coherence",
+    "expectedOutcome": "unclear"
+  },
+  {
+    "id": "trust-safety",
+    "failedCheck": "Trust/Safety",
+    "expectedOutcome": "invalid"
+  },
+  {
+    "id": "duplicate-or-superseded",
+    "failedCheck": "Duplicate or Superseded Work",
+    "expectedOutcome": "duplicate"
+  },
+  {
+    "id": "actionability",
+    "failedCheck": "Actionability",
+    "expectedOutcome": "needs-decision"
+  },
+  {
+    "id": "autonomy",
+    "failedCheck": "Autonomy (Suitability Perspective)",
+    "expectedOutcome": "blocked-by-human"
+  },
+  {
+    "id": "verifiability",
+    "failedCheck": "Verifiability (Suitability Perspective)",
+    "expectedOutcome": "needs-decision"
+  }
+]

--- a/tests/fixtures/consistency/config/aligned-config.json
+++ b/tests/fixtures/consistency/config/aligned-config.json
@@ -1,0 +1,10 @@
+{
+  "commands": {
+    "install-deps": "npm ci",
+    "fix-validate": "npm run fix",
+    "pre-push-validate": "npm run lint && npm test",
+    "post-fix-validate": "npm run check"
+  },
+  "issueScope": "roadmap",
+  "orphanFirstPolicy": "none"
+}

--- a/tests/fixtures/consistency/config/aligned-config.json
+++ b/tests/fixtures/consistency/config/aligned-config.json
@@ -4,7 +4,5 @@
     "fix-validate": "npm run fix",
     "pre-push-validate": "npm run lint && npm test",
     "post-fix-validate": "npm run check"
-  },
-  "issueScope": "roadmap",
-  "orphanFirstPolicy": "none"
+  }
 }

--- a/tests/fixtures/consistency/config/drifted-config.json
+++ b/tests/fixtures/consistency/config/drifted-config.json
@@ -1,0 +1,10 @@
+{
+  "commands": {
+    "install-deps": "npm ci",
+    "fix-validate": "npm run fix && npm test",
+    "pre-push-validate": "npm run lint && npm test",
+    "post-fix-validate": "npm run check"
+  },
+  "issueScope": "orphan-first",
+  "orphanFirstPolicy": "none"
+}

--- a/tests/fixtures/consistency/config/overview-missing-policy-row.txt
+++ b/tests/fixtures/consistency/config/overview-missing-policy-row.txt
@@ -1,0 +1,7 @@
+| Name                  | Commands                   |
+| --------------------- | -------------------------- |
+| **install-deps**      | `npm ci`                   |
+| **fix-validate**      | `npm run fix`              |
+| **pre-push-validate** | `npm run lint && npm test` |
+| **post-fix-validate** | `npm run check`            |
+| **issue-scope**       | `roadmap`                  |

--- a/tests/fixtures/consistency/config/overview.txt
+++ b/tests/fixtures/consistency/config/overview.txt
@@ -1,0 +1,8 @@
+| Name                    | Commands                   |
+| ----------------------- | -------------------------- |
+| **install-deps**        | `npm ci`                   |
+| **fix-validate**        | `npm run fix`              |
+| **pre-push-validate**   | `npm run lint && npm test` |
+| **post-fix-validate**   | `npm run check`            |
+| **issue-scope**         | `roadmap`                  |
+| **orphan-first-policy** | `none`                     |

--- a/tests/fixtures/consistency/placeholders/clean/.github/idd/config.json
+++ b/tests/fixtures/consistency/placeholders/clean/.github/idd/config.json
@@ -1,0 +1,4 @@
+{
+  "markerPrefix": "example-skill",
+  "issueScope": "roadmap"
+}

--- a/tests/fixtures/consistency/placeholders/clean/README.md
+++ b/tests/fixtures/consistency/placeholders/clean/README.md
@@ -1,0 +1,4 @@
+# Example repository
+
+IDD is installed and all onboarding placeholders have already been
+replaced with concrete values.

--- a/tests/fixtures/consistency/placeholders/dirty/.github/idd/config.json
+++ b/tests/fixtures/consistency/placeholders/dirty/.github/idd/config.json
@@ -1,0 +1,4 @@
+{
+  "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
+  "issueScope": "roadmap"
+}

--- a/tests/fixtures/consistency/placeholders/dirty/README.md
+++ b/tests/fixtures/consistency/placeholders/dirty/README.md
@@ -1,0 +1,4 @@
+# {{REPO_NAME}}
+
+This fixture simulates an onboarding output that still contains one
+unresolved placeholder.


### PR DESCRIPTION
## Summary

Adds fixture-backed consistency coverage for the three gaps tracked by #281.

- adds `tests/consistency.test.mjs` plus placeholder/config/A4.5 fixtures
- wires `.github/idd/config.json` vs `idd-overview.instructions.md` drift detection into `scripts/audit-docs.mjs`
- verifies A4.5 outcome mappings against the live suitability document instead of a duplicated classifier

This keeps placeholder scanning test-local, but moves config drift checking into the live audit path so real repo drift fails validation instead of only fixture tests.

Closes #281


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration drift validation to the audit process, which checks that `.github/idd/config.json` files align with their corresponding instruction documentation.

* **Tests**
  * Added comprehensive test suite covering repository consistency checks, including configuration validation, placeholder detection, and outcomes verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/294)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->