### PR TITLE
docs(issue-authoring): define specificity target

### DIFF
--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -140,15 +140,14 @@ infer and step-by-step runbooks that cost too much to author.
 
 ### Three specificity bands
 
-| Band                | Practical signal                                                                                                                                  | Drafting response                                                                    |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **Under-specified** | Stable execution likely depends on a frontier cloud model class such as a Claude Opus/Sonnet-class model or a flagship GPT-class                  | Add missing constraints, split scope, or make acceptance criteria more explicit      |
-| **Target**          | A middle-tier cloud model class such as a Claude Haiku-class model or a comparable mid-tier coding model can implement the issue without drifting | Treat this as the preferred drafting target when the execution axes already pass     |
-| **Over-specified**  | Even a lightweight local or compact cloud model class could follow the issue mechanically because it has become a runbook                         | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
+| Band                | Practical signal                                                                                                          | Drafting response                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Under-specified** | Stable execution likely depends on a frontier cloud model class                                                           | Add missing constraints, split scope, or make acceptance criteria more explicit      |
+| **Target**          | A middle-tier cloud model class can implement the issue without drifting                                                  | Treat this as the preferred drafting target when the execution axes already pass     |
+| **Over-specified**  | Even a lightweight local or compact cloud model class could follow the issue mechanically because it has become a runbook | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
 
-The named models above are examples only. They are shorthand for
-relative capability bands, not a fixed compatibility matrix or runtime
-requirement.
+The capability tiers above are practical heuristics, not a fixed
+compatibility matrix or runtime requirement.
 
 ### How the specificity target interacts with readiness
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -130,6 +130,43 @@ until all three pass.
 These supporting axes determine whether a ready task becomes an orphan
 issue, a roadmap plus sub-issues, or a non-ready bucket.
 
+## Specificity target
+
+Issue drafting should aim for a level of specificity where a
+middle-tier cloud model can implement the task without drifting. This
+is a practical drafting heuristic, not a hard model requirement. The
+goal is to avoid both hidden assumptions that only a top-tier model can
+infer and step-by-step runbooks that cost too much to author.
+
+### Three specificity bands
+
+| Band                | Practical signal                                                                                                                | Drafting response                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Under-specified** | Stable execution likely depends on a high-end model class such as Claude Sonnet 4.6 or GPT-5.4                                  | Add missing constraints, split scope, or make acceptance criteria more explicit      |
+| **Target**          | A middle-tier cloud model class such as Claude Haiku 4.5 or GPT-5.4 mini can implement the issue without drifting               | Treat this as the preferred drafting target when the execution axes already pass     |
+| **Over-specified**  | Even a lightweight model class such as Gemma4 or GPT-5 mini could follow the issue mechanically because it has become a runbook | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
+
+The named models above are examples only. They are shorthand for
+relative capability bands, not a fixed compatibility matrix or runtime
+requirement.
+
+### How the specificity target interacts with readiness
+
+This heuristic does not replace the IDD execution axes:
+
+- **Limited scope** still decides whether the work fits one issue or
+  needs a roadmap.
+- **Clear verification** still decides whether success is objectively
+  checkable.
+- **Autonomous completion** still decides whether the task can finish
+  without outside coordination.
+
+An issue can be specific yet still fail A4 or A4.5 because it is too
+broad, not verifiable, or blocked on a human decision. Conversely, an
+issue that passes those gates can still be under-specified if it leaves
+too much implementation shape implicit. The drafting target is therefore
+"ready and stable for a middle-tier model," not "maximally detailed."
+
 ## Stable readiness buckets
 
 Low-confidence or low-readiness work must not be silently deleted. The

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -140,11 +140,11 @@ infer and step-by-step runbooks that cost too much to author.
 
 ### Three specificity bands
 
-| Band                | Practical signal                                                                                                                | Drafting response                                                                    |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **Under-specified** | Stable execution likely depends on a high-end model class such as Claude Sonnet 4.6 or GPT-5.4                                  | Add missing constraints, split scope, or make acceptance criteria more explicit      |
-| **Target**          | A middle-tier cloud model class such as Claude Haiku 4.5 or GPT-5.4 mini can implement the issue without drifting               | Treat this as the preferred drafting target when the execution axes already pass     |
-| **Over-specified**  | Even a lightweight model class such as Gemma4 or GPT-5 mini could follow the issue mechanically because it has become a runbook | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
+| Band                | Practical signal                                                                                                                                  | Drafting response                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Under-specified** | Stable execution likely depends on a frontier cloud model class such as a Claude Opus/Sonnet-class model or a flagship GPT-class                  | Add missing constraints, split scope, or make acceptance criteria more explicit      |
+| **Target**          | A middle-tier cloud model class such as a Claude Haiku-class model or a comparable mid-tier coding model can implement the issue without drifting | Treat this as the preferred drafting target when the execution axes already pass     |
+| **Over-specified**  | Even a lightweight local or compact cloud model class could follow the issue mechanically because it has become a runbook                         | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
 
 The named models above are examples only. They are shorthand for
 relative capability bands, not a fixed compatibility matrix or runtime

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -92,15 +92,14 @@ infer and step-by-step runbooks that cost too much to author.
 
 ### Three specificity bands
 
-| Band                | Practical signal                                                                                                                                  | Drafting response                                                                    |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **Under-specified** | Stable execution likely depends on a frontier cloud model class such as a Claude Opus/Sonnet-class model or a flagship GPT-class                  | Add missing constraints, split scope, or make acceptance criteria more explicit      |
-| **Target**          | A middle-tier cloud model class such as a Claude Haiku-class model or a comparable mid-tier coding model can implement the issue without drifting | Treat this as the preferred drafting target when the execution axes already pass     |
-| **Over-specified**  | Even a lightweight local or compact cloud model class could follow the issue mechanically because it has become a runbook                         | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
+| Band                | Practical signal                                                                                                          | Drafting response                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Under-specified** | Stable execution likely depends on a frontier cloud model class                                                           | Add missing constraints, split scope, or make acceptance criteria more explicit      |
+| **Target**          | A middle-tier cloud model class can implement the issue without drifting                                                  | Treat this as the preferred drafting target when the execution axes already pass     |
+| **Over-specified**  | Even a lightweight local or compact cloud model class could follow the issue mechanically because it has become a runbook | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
 
-The named models above are examples only. They are shorthand for
-relative capability bands, not a fixed compatibility matrix or runtime
-requirement.
+The capability tiers above are practical heuristics, not a fixed
+compatibility matrix or runtime requirement.
 
 ### How the specificity target interacts with readiness
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -82,6 +82,43 @@ candidate task into one stable bucket:
   system
 - **out-of-scope**: does not belong in the repository or skill scope
 
+## Specificity target
+
+Issue drafting should aim for a level of specificity where a
+middle-tier cloud model can implement the task without drifting. This
+is a practical drafting heuristic, not a hard model requirement. The
+goal is to avoid both hidden assumptions that only a top-tier model can
+infer and step-by-step runbooks that cost too much to author.
+
+### Three specificity bands
+
+| Band                | Practical signal                                                                                                                | Drafting response                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Under-specified** | Stable execution likely depends on a high-end model class such as Claude Sonnet 4.6 or GPT-5.4                                  | Add missing constraints, split scope, or make acceptance criteria more explicit      |
+| **Target**          | A middle-tier cloud model class such as Claude Haiku 4.5 or GPT-5.4 mini can implement the issue without drifting               | Treat this as the preferred drafting target when the execution axes already pass     |
+| **Over-specified**  | Even a lightweight model class such as Gemma4 or GPT-5 mini could follow the issue mechanically because it has become a runbook | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
+
+The named models above are examples only. They are shorthand for
+relative capability bands, not a fixed compatibility matrix or runtime
+requirement.
+
+### How the specificity target interacts with readiness
+
+This heuristic does not replace the IDD execution axes:
+
+- **Limited scope** still decides whether the work fits one issue or
+  needs a roadmap.
+- **Clear verification** still decides whether success is objectively
+  checkable.
+- **Autonomous completion** still decides whether the task can finish
+  without outside coordination.
+
+An issue can be specific yet still fail A4 or A4.5 because it is too
+broad, not verifiable, or blocked on a human decision. Conversely, an
+issue that passes those gates can still be under-specified if it leaves
+too much implementation shape implicit. The drafting target is therefore
+"ready and stable for a middle-tier model," not "maximally detailed."
+
 ## Reuse-first issue policy
 
 Before creating any new issue, check whether the work already has a

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -92,11 +92,11 @@ infer and step-by-step runbooks that cost too much to author.
 
 ### Three specificity bands
 
-| Band                | Practical signal                                                                                                                | Drafting response                                                                    |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **Under-specified** | Stable execution likely depends on a high-end model class such as Claude Sonnet 4.6 or GPT-5.4                                  | Add missing constraints, split scope, or make acceptance criteria more explicit      |
-| **Target**          | A middle-tier cloud model class such as Claude Haiku 4.5 or GPT-5.4 mini can implement the issue without drifting               | Treat this as the preferred drafting target when the execution axes already pass     |
-| **Over-specified**  | Even a lightweight model class such as Gemma4 or GPT-5 mini could follow the issue mechanically because it has become a runbook | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
+| Band                | Practical signal                                                                                                                                  | Drafting response                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Under-specified** | Stable execution likely depends on a frontier cloud model class such as a Claude Opus/Sonnet-class model or a flagship GPT-class                  | Add missing constraints, split scope, or make acceptance criteria more explicit      |
+| **Target**          | A middle-tier cloud model class such as a Claude Haiku-class model or a comparable mid-tier coding model can implement the issue without drifting | Treat this as the preferred drafting target when the execution axes already pass     |
+| **Over-specified**  | Even a lightweight local or compact cloud model class could follow the issue mechanically because it has become a runbook                         | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
 
 The named models above are examples only. They are shorthand for
 relative capability bands, not a fixed compatibility matrix or runtime


### PR DESCRIPTION
## Summary

- add a specificity-target section to the canonical issue-authoring contract
- define under-specified / target / over-specified drafting bands using model classes as heuristics
- mirror the same guidance into the bundled contract reference and keep it aligned with A4/A4.5 readiness rules

## Rationale

The issue-authoring contract already defined atomic scope, clear verification, and autonomous completion, but it did not say how concrete a drafted issue should be for stable autonomous implementation. This change adds a practical target that aims for middle-tier cloud model stability without turning issues into step-by-step runbooks.

Closes #300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced issue-authoring guidance with a new "Specificity target" framework: three bands (under-specified, target, over-specified) and drafting heuristics for each.
  * Clarified how the specificity target complements existing execution-readiness axes (limited scope, clear verification, autonomous completion) without replacing them.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/313)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->