### PR TITLE
docs(issue-authoring): define specificity target range

### DIFF
--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -119,6 +119,31 @@ These three axes align directly with the IDD viability gate in
 `idd-discover.instructions.md`. A task is not draft-ready for execution
 until all three pass.
 
+### Specificity target range
+
+Each execution-ready issue should land in a target specificity range:
+
+- **Under-specified**: the issue is so abstract that a high-range
+  reasoning model would need to infer hidden implementation direction,
+  missing dependencies, or the verification shape. Tighten the issue by
+  naming the affected surface, intended outcome, and acceptance
+  criteria, or split it into smaller tasks.
+- **Target range**: a mid-range cloud model (for example, Claude Haiku
+  4.5 or GPT-5.4 mini class) can keep a stable implementation direction
+  from the issue alone, while still choosing the exact files, helpers,
+  and edit order during execution.
+- **Over-specified**: the issue reads like a fixed implementation script
+  that a lightweight model could follow step by step. Prefer outcome,
+  constraints, and verification over prescribing exact edit sequences
+  unless a narrow migration or compatibility hazard truly requires them.
+
+Model classes here are practical heuristics, not hard execution gates.
+The goal is to calibrate drafting effort, not to require a specific
+runtime. If extra detail is needed only because limited scope, clear
+verification, or autonomous completion is still failing, fix that issue
+by splitting, clarifying, or re-bucketing the work instead of turning
+one issue into an oversized procedure.
+
 ### Supporting drafting axes
 
 - **Dependency clarity**: dependencies are explicit, resolvable, and

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -82,6 +82,27 @@ candidate task into one stable bucket:
   system
 - **out-of-scope**: does not belong in the repository or skill scope
 
+## Specificity target range
+
+Draft ready issues into a practical middle range:
+
+- **Under-specified**: a high-range reasoning model would have to infer
+  hidden implementation direction, missing dependencies, or verification
+  details. Add the affected surface, intended outcome, or explicit
+  acceptance criteria, or split the work.
+- **Target range**: a mid-range cloud model (for example, Claude Haiku
+  4.5 or GPT-5.4 mini class) can hold a stable implementation direction
+  from the issue alone without the issue becoming a step-by-step script.
+- **Over-specified**: the issue prescribes an exact edit order that a
+  lightweight model could follow mechanically. Prefer outcome,
+  constraints, and verification unless a narrow compatibility hazard
+  truly requires fixed steps.
+
+Treat model classes as heuristics for drafting quality, not execution
+requirements. If more detail is needed only because limited scope, clear
+verification, or autonomous completion is still failing, split or
+re-bucket the work instead of turning one issue into a procedure.
+
 ## Reuse-first issue policy
 
 Before creating any new issue, check whether the work already has a


### PR DESCRIPTION
## Summary
- define the issue-authoring specificity target range in the canonical contract
- mirror the same heuristic-only guidance into the bundled contract reference
- keep the new wording aligned with limited scope, clear verification, and autonomous completion

Closes #302


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on specificity target ranges for issue authoring, defining three tiers: under-specified, target range, and over-specified.
  * Clarified how to draft issues at the appropriate abstraction level.
  * Provided recommendations to split or clarify issues rather than expanding them into oversized procedures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/314)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->