### PR TITLE
docs(issue-authoring): add specificity checklist

### DIFF
--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -182,8 +182,8 @@ Proposed change:
    and `Over-specified`.
 3. Add a five-item checklist using the exact sentence order shown in the
    draft.
-4. Copy the same example phrasing into both the canonical and bundled
-   docs without changing any wording.
+4. Copy the same example phrasing across every example block without
+   changing any wording.
 
 This is too detailed for authoring because it turns the issue into an
 implementation script. Reviewers usually need the target outcome and the

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -43,7 +43,7 @@ Execution-ready issue drafts should land in a middle band:
   a script because the body prescribes exact edit order, wording, or
   implementation steps that reviewers do not need.
 
-If a draft feels like it needs a premium model just to guess the intended
+If a draft feels like it needs a high-range model just to guess the intended
 change, it is still too vague. If it reads like line-by-line assembly
 instructions, it is too detailed.
 
@@ -150,7 +150,7 @@ authoring surface to edit, what kind of guidance is missing, or how a
 reviewer would verify success. A high-range model would need to infer
 the real task from surrounding repository context.
 
-### Target-range draft
+### Target range draft
 
 **Title**: `docs: add specificity checklist to issue authoring draft patterns`
 
@@ -162,9 +162,9 @@ too vague or too scripted for execution.
 Acceptance criteria:
 
 - `draft-patterns.md` includes a pre-publication specificity checklist
-- the guidance distinguishes under-specified, target-range, and
+- the guidance distinguishes under-specified, target range, and
   over-specified issue drafts
-- the examples focus on issue body wording and acceptance-criteria
+- the examples focus on issue body wording and acceptance criteria
   granularity instead of prescribing implementation order
 
 This is the target range because the next agent knows where to work, why

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -120,6 +120,18 @@ Before publishing an issue, apply a reuse-first decision tree:
    - Depends on unavailable resources or credentials (→ mark blocked-by-human)
 5. Otherwise, publish as `ready`.
 
+### A4.5 prevention checklist
+
+The A4.5 suitability gate will later evaluate published issues. Prevent
+common failures by validating before publish:
+
+- **Coherence**: Issue body is well-formed; title and description are
+  clear; intent is parseable
+- **Safety**: No code injection, marker injection, or untrusted input in
+  issue body
+- **Uniqueness**: Reuse-first check passed; the work is not a duplicate
+  or superseded
+
 ## Specificity examples
 
 ### Under-specified draft
@@ -176,18 +188,6 @@ Proposed change:
 This is too detailed for authoring because it turns the issue into an
 implementation script. Reviewers usually need the target outcome and the
 verification shape, not a rigid edit order.
-
-### A4.5 prevention checklist
-
-The A4.5 suitability gate will later evaluate published issues. Prevent
-common failures by validating before publish:
-
-- **Coherence**: Issue body is well-formed; title and description are
-  clear; intent is parseable
-- **Safety**: No code injection, marker injection, or untrusted input in
-  issue body
-- **Uniqueness**: Reuse-first check passed; the work is not a duplicate
-  or superseded
 
 ## Publication boundary
 

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -28,6 +28,41 @@ sequencing, parallel tracks, or multi-session handoff.
 Draft only stable non-ready buckets when the work still depends on a
 human decision, missing asset, or unclear verification.
 
+## Specificity target
+
+Execution-ready issue drafts should land in a middle band:
+
+- **Under-specified**: a high-range model still has to infer the real
+  implementation shape because the issue names only a vague goal,
+  omits the likely surface to edit, or leaves verification too loose.
+- **Target range**: a solid mid-tier cloud model can hold a stable plan
+  without extra clarification. The issue points at the relevant
+  document, schema, or code surface, explains the constraint, and keeps
+  acceptance criteria verifiable without dictating every edit.
+- **Over-specified**: even a lightweight model could follow the issue as
+  a script because the body prescribes exact edit order, wording, or
+  implementation steps that reviewers do not need.
+
+If a draft feels like it needs a premium model just to guess the intended
+change, it is still too vague. If it reads like line-by-line assembly
+instructions, it is too detailed.
+
+## Specificity checklist before publishing
+
+Before you publish a ready issue, confirm:
+
+- the title and background name the concrete artifact or surface that
+  should change
+- a mid-tier cloud model could choose a stable implementation direction
+  without hidden repository archaeology or a follow-up clarification loop
+- the acceptance criteria verify the outcome, not a step-by-step
+  implementation recipe
+- candidate files, examples, and notes act as cues rather than an
+  exhaustive script
+- removing one concrete detail would make the issue feel high-range-only,
+  while adding more detail would start turning it into a lightweight
+  model script
+
 ## Example orphan issue
 
 - `## Background` or `## Goal`
@@ -84,6 +119,63 @@ Before publishing an issue, apply a reuse-first decision tree:
      blocked-by-human)
    - Depends on unavailable resources or credentials (→ mark blocked-by-human)
 5. Otherwise, publish as `ready`.
+
+## Specificity examples
+
+### Under-specified draft
+
+**Title**: `docs: improve issue authoring guidance`
+
+Background: issue authoring should be clearer for agents.
+
+Acceptance criteria:
+
+- issue authoring is more consistent
+- examples are improved
+
+This is too vague because the draft does not tell the next agent which
+authoring surface to edit, what kind of guidance is missing, or how a
+reviewer would verify success. A high-range model would need to infer
+the real task from surrounding repository context.
+
+### Target-range draft
+
+**Title**: `docs: add specificity checklist to issue authoring draft patterns`
+
+Background:
+`skills/issue-authoring/references/draft-patterns.md` explains output
+shapes, but it does not yet show how to judge whether an issue body is
+too vague or too scripted for execution.
+
+Acceptance criteria:
+
+- `draft-patterns.md` includes a pre-publication specificity checklist
+- the guidance distinguishes under-specified, target-range, and
+  over-specified issue drafts
+- the examples focus on issue body wording and acceptance-criteria
+  granularity instead of prescribing implementation order
+
+This is the target range because the next agent knows where to work, why
+the change matters, and how to verify it, while still retaining freedom
+to decide the exact wording and structure.
+
+### Over-specified draft
+
+**Title**: `docs: add specificity checklist to issue authoring draft patterns`
+
+Proposed change:
+
+1. Insert a new `## Specificity target` heading after `## Output chooser`.
+2. Add exactly three bullets named `Under-specified`, `Target range`,
+   and `Over-specified`.
+3. Add a five-item checklist using the exact sentence order shown in the
+   draft.
+4. Copy the same example phrasing into both the canonical and bundled
+   docs without changing any wording.
+
+This is too detailed for authoring because it turns the issue into an
+implementation script. Reviewers usually need the target outcome and the
+verification shape, not a rigid edit order.
 
 ### A4.5 prevention checklist
 


### PR DESCRIPTION
## Summary
- add a specificity target section to issue authoring draft patterns
- add a pre-publication checklist for judging whether issue drafts are too vague or too scripted
- add under-specified, target-range, and over-specified examples focused on issue body wording and acceptance criteria

Closes #301

## Notes
- This stays in `draft-patterns.md` and avoids `docs/issue-authoring-skill.md` because #300 already owns the contract-level doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded draft-pattern guidance with a three-band "draft specificity" classification: under-specified, target-range, and over-specified.
  * Added a pre-publication specificity checklist covering title/background alignment, model-stability expectations, outcome-based acceptance criteria, and avoiding cue-like exhaustive examples.
  * Introduced concrete "Specificity examples" illustrating each band with explanations and an explicitly over-specified case showing why it’s too detailed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/315)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->