### PR TITLE
docs: define helper runtime profile policy

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -24,6 +24,41 @@ Adopters can copy the helper separately when they want the same
 repository-local convenience, otherwise the documented GraphQL fallback
 remains the portable path.
 
+Absent helper runtime configuration means `instructions-only`. Repositories
+that do not opt into helper support should still be able to copy the
+Markdown instructions, run the portable shell / `gh` / `jq` procedures,
+and complete the workflow without a Node.js dependency.
+
+## Helper Runtime Profiles
+
+When a repository imports the IDD template, helper support should be
+selected from one of these profiles:
+
+| Profile             | Intended use                                                                                                      | Dependency model                                                               | Portability expectation                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `package-manager`   | The adopter already uses pnpm, npm, or yarn for the repository.                                                   | Reuse the repository's existing package manager and pre-resolved dependencies. | Preferred when a package manager project already exists; do not fall back to ad hoc `npx` in this mode. |
+| `vendored-node`     | The adopter has Node.js available but does not want helper execution to depend on registry resolution at runtime. | Copy a local helper bundle into the repository during import.                  | Keeps helper execution repository-local while remaining optional.                                       |
+| `ephemeral-npx`     | The adopter has Node.js available but does not vend helper files into the repository.                             | Resolve helper execution through one-shot `npx` commands.                      | Acceptable convenience path when the repository can tolerate runtime resolution.                        |
+| `instructions-only` | The adopter does not want or cannot use helper scripts.                                                           | No helper runtime. Agents follow the Markdown instructions directly.           | First-class supported fallback; no helper config is required.                                           |
+
+## Import-Time Selection Order
+
+Helper runtime choice is an import-time policy decision. Use this order
+unless a repository has an explicit maintainer override:
+
+1. If the repository already has a supported package manager project,
+   select `package-manager`.
+2. Otherwise, if Node.js is available and the import flow is allowed to
+   copy helper files, select `vendored-node`.
+3. Otherwise, if Node.js is available and the repository accepts
+   one-shot runtime resolution, select `ephemeral-npx`.
+4. Otherwise, use `instructions-only`.
+
+This selection order exists to keep helper support optional without
+turning every adopter into a Node.js-first repository. The written
+decision tables remain the canonical protocol regardless of which helper
+profile is selected.
+
 The adopted helper boundaries are intentionally narrow:
 
 - `review-activity-snapshot.mjs` is read-only, emits machine-readable
@@ -84,6 +119,17 @@ For now, the safer balance is to keep pre-merge instructions canonical
 while allowing one read-only E/F snapshot helper, one live digest upsert
 helper, and one post-merge cleanup helper. Merge safety still depends on
 the written checks, not on helper output alone.
+
+## Non-goals
+
+This helper policy does **not** imply the following:
+
+- Node.js becomes mandatory for repositories that only copy the Markdown
+  instructions
+- helper output becomes authoritative over the written decision tables
+- new helper work may perform mutating review or merge actions by default
+- the project is committed to publishing a separate npm package before
+  the local and templated helper profiles are proven
 
 ## Future Adoption Criteria
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -34,25 +34,28 @@ and complete the workflow without a Node.js dependency.
 When a repository imports the IDD template, helper support should be
 selected from one of these profiles:
 
-| Profile             | Intended use                                                                                                      | Dependency model                                                               | Portability expectation                                                                                 |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `package-manager`   | The adopter already uses pnpm, npm, or yarn for the repository.                                                   | Reuse the repository's existing package manager and pre-resolved dependencies. | Preferred when a package manager project already exists; do not fall back to ad hoc `npx` in this mode. |
-| `vendored-node`     | The adopter has Node.js available but does not want helper execution to depend on registry resolution at runtime. | Copy a local helper bundle into the repository during import.                  | Keeps helper execution repository-local while remaining optional.                                       |
-| `ephemeral-npx`     | The adopter has Node.js available but does not vend helper files into the repository.                             | Resolve helper execution through one-shot `npx` commands.                      | Acceptable convenience path when the repository can tolerate runtime resolution.                        |
-| `instructions-only` | The adopter does not want or cannot use helper scripts.                                                           | No helper runtime. Agents follow the Markdown instructions directly.           | First-class supported fallback; no helper config is required.                                           |
+| Profile             | Intended use                                                                                                                | Dependency model                                                               | Portability expectation                                                                                                                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `package-manager`   | The adopter already uses pnpm, npm, or yarn for the repository.                                                             | Reuse the repository's existing package manager and pre-resolved dependencies. | Preferred when a package manager project already exists; do not fall back to ad hoc `npx` in this mode.                                 |
+| `vendored-node`     | The adopter has Node.js available but does not want helper execution to depend on registry resolution at runtime.           | Copy a local helper bundle into the repository during import.                  | Keeps helper execution repository-local while remaining optional.                                                                       |
+| `ephemeral-npx`     | The adopter has Node.js available, does not vend helper files, and can resolve a runnable helper command at execution time. | Resolve helper execution through one-shot `npx` commands.                      | Reserved for cases where a published or otherwise resolvable helper command already exists; otherwise fall back to `instructions-only`. |
+| `instructions-only` | The adopter does not want or cannot use helper scripts.                                                                     | No helper runtime. Agents follow the Markdown instructions directly.           | First-class supported fallback; no helper config is required.                                                                           |
 
 ## Import-Time Selection Order
 
-Helper runtime choice is an import-time policy decision. Use this order
-unless a repository has an explicit maintainer override:
+Helper runtime choice is an import-time policy decision. Apply this order
+only after a maintainer or import flow has explicitly opted into helper
+support. If helper support was not requested, keep `instructions-only`.
 
-1. If the repository already has a supported package manager project,
-   select `package-manager`.
-2. Otherwise, if Node.js is available and the import flow is allowed to
+1. If helper support has not been requested, use `instructions-only`.
+2. Otherwise, if the repository already has a supported package manager
+   project, select `package-manager`.
+3. Otherwise, if Node.js is available and the import flow is allowed to
    copy helper files, select `vendored-node`.
-3. Otherwise, if Node.js is available and the repository accepts
-   one-shot runtime resolution, select `ephemeral-npx`.
-4. Otherwise, use `instructions-only`.
+4. Otherwise, if Node.js is available and a published or otherwise
+   resolvable helper command exists for one-shot execution, select
+   `ephemeral-npx`.
+5. Otherwise, use `instructions-only`.
 
 This selection order exists to keep helper support optional without
 turning every adopter into a Node.js-first repository. The written

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -130,7 +130,8 @@ This helper policy does **not** imply the following:
 - Node.js becomes mandatory for repositories that only copy the Markdown
   instructions
 - helper output becomes authoritative over the written decision tables
-- new helper work may perform mutating review or merge actions by default
+- helpers perform mutating review or merge actions by default; mutation
+  must remain explicit in the written instructions
 - the project is committed to publishing a separate npm package before
   the local and templated helper profiles are proven
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -24,6 +24,41 @@ Adopters can copy the helper separately when they want the same
 repository-local convenience, otherwise the documented GraphQL fallback
 remains the portable path.
 
+Absent helper runtime configuration means `instructions-only`. Repositories
+that do not opt into helper support should still be able to copy the
+Markdown instructions, run the portable shell / `gh` / `jq` procedures,
+and complete the workflow without a Node.js dependency.
+
+## Helper Runtime Profiles
+
+When a repository imports the IDD template, helper support should be
+selected from one of these profiles:
+
+| Profile             | Intended use                                                                                                      | Dependency model                                                               | Portability expectation                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `package-manager`   | The adopter already uses pnpm, npm, or yarn for the repository.                                                   | Reuse the repository's existing package manager and pre-resolved dependencies. | Preferred when a package manager project already exists; do not fall back to ad hoc `npx` in this mode. |
+| `vendored-node`     | The adopter has Node.js available but does not want helper execution to depend on registry resolution at runtime. | Copy a local helper bundle into the repository during import.                  | Keeps helper execution repository-local while remaining optional.                                       |
+| `ephemeral-npx`     | The adopter has Node.js available but does not vend helper files into the repository.                             | Resolve helper execution through one-shot `npx` commands.                      | Acceptable convenience path when the repository can tolerate runtime resolution.                        |
+| `instructions-only` | The adopter does not want or cannot use helper scripts.                                                           | No helper runtime. Agents follow the Markdown instructions directly.           | First-class supported fallback; no helper config is required.                                           |
+
+## Import-Time Selection Order
+
+Helper runtime choice is an import-time policy decision. Use this order
+unless a repository has an explicit maintainer override:
+
+1. If the repository already has a supported package manager project,
+   select `package-manager`.
+2. Otherwise, if Node.js is available and the import flow is allowed to
+   copy helper files, select `vendored-node`.
+3. Otherwise, if Node.js is available and the repository accepts
+   one-shot runtime resolution, select `ephemeral-npx`.
+4. Otherwise, use `instructions-only`.
+
+This selection order exists to keep helper support optional without
+turning every adopter into a Node.js-first repository. The written
+decision tables remain the canonical protocol regardless of which helper
+profile is selected.
+
 The adopted helper boundaries are intentionally narrow:
 
 - `review-activity-snapshot.mjs` is read-only, emits machine-readable
@@ -84,6 +119,17 @@ For now, the safer balance is to keep pre-merge instructions canonical
 while allowing one read-only E/F snapshot helper, one live digest upsert
 helper, and one post-merge cleanup helper. Merge safety still depends on
 the written checks, not on helper output alone.
+
+## Non-goals
+
+This helper policy does **not** imply the following:
+
+- Node.js becomes mandatory for repositories that only copy the Markdown
+  instructions
+- helper output becomes authoritative over the written decision tables
+- new helper work may perform mutating review or merge actions by default
+- the project is committed to publishing a separate npm package before
+  the local and templated helper profiles are proven
 
 ## Future Adoption Criteria
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -34,25 +34,28 @@ and complete the workflow without a Node.js dependency.
 When a repository imports the IDD template, helper support should be
 selected from one of these profiles:
 
-| Profile             | Intended use                                                                                                      | Dependency model                                                               | Portability expectation                                                                                 |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `package-manager`   | The adopter already uses pnpm, npm, or yarn for the repository.                                                   | Reuse the repository's existing package manager and pre-resolved dependencies. | Preferred when a package manager project already exists; do not fall back to ad hoc `npx` in this mode. |
-| `vendored-node`     | The adopter has Node.js available but does not want helper execution to depend on registry resolution at runtime. | Copy a local helper bundle into the repository during import.                  | Keeps helper execution repository-local while remaining optional.                                       |
-| `ephemeral-npx`     | The adopter has Node.js available but does not vend helper files into the repository.                             | Resolve helper execution through one-shot `npx` commands.                      | Acceptable convenience path when the repository can tolerate runtime resolution.                        |
-| `instructions-only` | The adopter does not want or cannot use helper scripts.                                                           | No helper runtime. Agents follow the Markdown instructions directly.           | First-class supported fallback; no helper config is required.                                           |
+| Profile             | Intended use                                                                                                                | Dependency model                                                               | Portability expectation                                                                                                                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `package-manager`   | The adopter already uses pnpm, npm, or yarn for the repository.                                                             | Reuse the repository's existing package manager and pre-resolved dependencies. | Preferred when a package manager project already exists; do not fall back to ad hoc `npx` in this mode.                                 |
+| `vendored-node`     | The adopter has Node.js available but does not want helper execution to depend on registry resolution at runtime.           | Copy a local helper bundle into the repository during import.                  | Keeps helper execution repository-local while remaining optional.                                                                       |
+| `ephemeral-npx`     | The adopter has Node.js available, does not vend helper files, and can resolve a runnable helper command at execution time. | Resolve helper execution through one-shot `npx` commands.                      | Reserved for cases where a published or otherwise resolvable helper command already exists; otherwise fall back to `instructions-only`. |
+| `instructions-only` | The adopter does not want or cannot use helper scripts.                                                                     | No helper runtime. Agents follow the Markdown instructions directly.           | First-class supported fallback; no helper config is required.                                                                           |
 
 ## Import-Time Selection Order
 
-Helper runtime choice is an import-time policy decision. Use this order
-unless a repository has an explicit maintainer override:
+Helper runtime choice is an import-time policy decision. Apply this order
+only after a maintainer or import flow has explicitly opted into helper
+support. If helper support was not requested, keep `instructions-only`.
 
-1. If the repository already has a supported package manager project,
-   select `package-manager`.
-2. Otherwise, if Node.js is available and the import flow is allowed to
+1. If helper support has not been requested, use `instructions-only`.
+2. Otherwise, if the repository already has a supported package manager
+   project, select `package-manager`.
+3. Otherwise, if Node.js is available and the import flow is allowed to
    copy helper files, select `vendored-node`.
-3. Otherwise, if Node.js is available and the repository accepts
-   one-shot runtime resolution, select `ephemeral-npx`.
-4. Otherwise, use `instructions-only`.
+4. Otherwise, if Node.js is available and a published or otherwise
+   resolvable helper command exists for one-shot execution, select
+   `ephemeral-npx`.
+5. Otherwise, use `instructions-only`.
 
 This selection order exists to keep helper support optional without
 turning every adopter into a Node.js-first repository. The written

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -130,7 +130,8 @@ This helper policy does **not** imply the following:
 - Node.js becomes mandatory for repositories that only copy the Markdown
   instructions
 - helper output becomes authoritative over the written decision tables
-- new helper work may perform mutating review or merge actions by default
+- helpers perform mutating review or merge actions by default; mutation
+  must remain explicit in the written instructions
 - the project is committed to publishing a separate npm package before
   the local and templated helper profiles are proven
 


### PR DESCRIPTION
## Summary
- define the helper runtime profile taxonomy in the helper policy docs
- document the import-time selection order and the `instructions-only` default
- record non-goals so follow-up schema and packaging issues keep their own scope

Closes #304

## Follow-up issues
- #305
- #306
- #307

## Background
This change codifies the optional helper policy before schema, onboarding, and packaging follow-ups build on top of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Expanded helper-script runtime behavior with four runtime profiles (package-manager, vendored-node, ephemeral-npx, instructions-only fallback).
* Added explicit import-time runtime selection order for adopters and fallback behavior when helpers aren’t opted in.
* Clarified non-goals: Node.js not mandatory, helper output not authoritative, helpers don’t default to mutating actions, and npm publishing isn’t required before local/templated validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/316)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->