### PR TITLE
test(issue-authoring): cover specificity guidance sync

### DIFF
--- a/tests/issue-authoring-specificity.test.mjs
+++ b/tests/issue-authoring-specificity.test.mjs
@@ -47,24 +47,15 @@ function readText(relativePath) {
 
 function extractSpecificitySection(text, fileLabel) {
   const startMarker = "## Specificity target";
-  const endMarkers = [
-    "\n## Stable readiness buckets",
-    "\n## Reuse-first issue policy",
-  ];
+  const nextSectionMarker = "\n## ";
 
   const start = text.indexOf(startMarker);
   assert.notEqual(start, -1, `${fileLabel} is missing section marker: ${startMarker}`);
 
-  const end = endMarkers
-    .map((marker) => text.indexOf(marker, start))
-    .filter((index) => index !== -1)
-    .sort((left, right) => left - right)[0];
-
-  assert.notEqual(
-    end,
-    undefined,
-    `${fileLabel} is missing an end marker for the specificity section; expected one of: ${endMarkers.join(", ")}`,
-  );
+  // If the section is last in the file, compare through EOF instead of
+  // coupling the test to a specific following heading.
+  const nextSectionStart = text.indexOf(nextSectionMarker, start + startMarker.length);
+  const end = nextSectionStart === -1 ? text.length : nextSectionStart;
 
   return text.slice(start, end).trim();
 }

--- a/tests/issue-authoring-specificity.test.mjs
+++ b/tests/issue-authoring-specificity.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+test("specificity guidance stays synced between canonical and bundled contract", () => {
+  const canonical = readText("docs/issue-authoring-skill.md");
+  const bundled = readText("skills/issue-authoring/references/contract.md");
+
+  assert.equal(
+    extractSpecificitySection(canonical),
+    extractSpecificitySection(bundled),
+    "canonical and bundled issue-authoring specificity guidance must stay in sync",
+  );
+});
+
+test("specificity guidance keeps the three band labels and tier phrases", () => {
+  for (const file of [
+    "docs/issue-authoring-skill.md",
+    "skills/issue-authoring/references/contract.md",
+  ]) {
+    const section = extractSpecificitySection(readText(file));
+
+    for (const needle of [
+      "## Specificity target",
+      "### Three specificity bands",
+      "**Under-specified**",
+      "**Target**",
+      "**Over-specified**",
+      "frontier cloud model class",
+      "middle-tier cloud model class",
+      "lightweight local or compact cloud model class",
+      "\"ready and stable for a middle-tier model,\" not \"maximally detailed.\"",
+    ]) {
+      assert.ok(
+        section.includes(needle),
+        `${file} must keep specificity guidance phrase: ${needle}`,
+      );
+    }
+  }
+});
+
+function readText(relativePath) {
+  return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
+}
+
+function extractSpecificitySection(text) {
+  const startMarker = "## Specificity target";
+  const endMarkers = [
+    "\n## Stable readiness buckets",
+    "\n## Reuse-first issue policy",
+  ];
+
+  const start = text.indexOf(startMarker);
+  assert.notEqual(start, -1, `Missing section marker: ${startMarker}`);
+
+  const end = endMarkers
+    .map((marker) => text.indexOf(marker, start))
+    .filter((index) => index !== -1)
+    .sort((left, right) => left - right)[0];
+
+  assert.notEqual(end, undefined, "Missing end marker for specificity section");
+
+  return text.slice(start, end).trim();
+}

--- a/tests/issue-authoring-specificity.test.mjs
+++ b/tests/issue-authoring-specificity.test.mjs
@@ -11,7 +11,7 @@ test("specificity guidance stays synced between canonical and bundled contract",
   assert.equal(
     extractSpecificitySection(canonical, canonicalFile),
     extractSpecificitySection(bundled, bundledFile),
-    "canonical and bundled issue-authoring specificity guidance must stay in sync",
+    `canonical and bundled issue-authoring specificity guidance must stay in sync (${canonicalFile} vs ${bundledFile})`,
   );
 });
 

--- a/tests/issue-authoring-specificity.test.mjs
+++ b/tests/issue-authoring-specificity.test.mjs
@@ -3,12 +3,14 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 test("specificity guidance stays synced between canonical and bundled contract", () => {
-  const canonical = readText("docs/issue-authoring-skill.md");
-  const bundled = readText("skills/issue-authoring/references/contract.md");
+  const canonicalFile = "docs/issue-authoring-skill.md";
+  const bundledFile = "skills/issue-authoring/references/contract.md";
+  const canonical = readText(canonicalFile);
+  const bundled = readText(bundledFile);
 
   assert.equal(
-    extractSpecificitySection(canonical),
-    extractSpecificitySection(bundled),
+    extractSpecificitySection(canonical, canonicalFile),
+    extractSpecificitySection(bundled, bundledFile),
     "canonical and bundled issue-authoring specificity guidance must stay in sync",
   );
 });
@@ -18,7 +20,7 @@ test("specificity guidance keeps the three band labels and tier phrases", () => 
     "docs/issue-authoring-skill.md",
     "skills/issue-authoring/references/contract.md",
   ]) {
-    const section = extractSpecificitySection(readText(file));
+    const section = extractSpecificitySection(readText(file), file);
 
     for (const needle of [
       "## Specificity target",
@@ -43,7 +45,7 @@ function readText(relativePath) {
   return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
 }
 
-function extractSpecificitySection(text) {
+function extractSpecificitySection(text, fileLabel) {
   const startMarker = "## Specificity target";
   const endMarkers = [
     "\n## Stable readiness buckets",
@@ -51,14 +53,18 @@ function extractSpecificitySection(text) {
   ];
 
   const start = text.indexOf(startMarker);
-  assert.notEqual(start, -1, `Missing section marker: ${startMarker}`);
+  assert.notEqual(start, -1, `${fileLabel} is missing section marker: ${startMarker}`);
 
   const end = endMarkers
     .map((marker) => text.indexOf(marker, start))
     .filter((index) => index !== -1)
     .sort((left, right) => left - right)[0];
 
-  assert.notEqual(end, undefined, "Missing end marker for specificity section");
+  assert.notEqual(
+    end,
+    undefined,
+    `${fileLabel} is missing an end marker for the specificity section; expected one of: ${endMarkers.join(", ")}`,
+  );
 
   return text.slice(start, end).trim();
 }


### PR DESCRIPTION
## Summary

- add a focused regression test for the issue-authoring specificity-target section
- verify the canonical and bundled specificity sections stay synchronized
- verify the three band labels and their key capability-tier phrases remain present through the existing `node --test tests/*.mjs` path

## Rationale

Issue #300 added the specificity-target contract, but existing validation did not fail when one side drifted or when a key judgment phrase disappeared. This PR adds minimal coverage through the repository's existing test entrypoint without expanding the docs-audit scope.

Closes #302


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite to verify "specificity guidance" documentation sections remain synchronized across multiple locations and contain all required components including subheadings, band labels, and guidance text.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/318)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->