### PR TITLE
feat(cleanup): add post-merge cleanup completion summary

### DIFF
--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -128,6 +128,8 @@ async function buildReport(owner, repo, prNumber, options = {}) {
     skipped: [],
     applied: [],
     failed: [],
+    summary: null,
+    status: null,
   };
 
   for (const comment of comments) {
@@ -144,6 +146,9 @@ async function buildReport(owner, repo, prNumber, options = {}) {
   for (const review of reviews) {
     evaluateReviewParent(review, pr, threadIndex, latestGatingReviews, report);
   }
+
+  // Calculate summary and status
+  computeReportSummary(report);
 
   return report;
 }
@@ -412,6 +417,57 @@ function addSkipped(report, subject, reason) {
     skipReason: reason,
   });
 }
+
+function computeReportSummary(report) {
+  // Count already-minimized and viewer-can-minimize from skipped reasons
+  let alreadyMinimized = 0;
+  let viewerCannotMinimize = 0;
+
+  for (const skip of report.skipped) {
+    if (skip.skipReason === "already minimized") {
+      alreadyMinimized += 1;
+    } else if (skip.skipReason === "viewer cannot minimize this comment") {
+      viewerCannotMinimize += 1;
+    }
+  }
+
+  // From candidates, we know viewerCanMinimize is true
+  const viewerCanMinimize = report.candidates.length;
+
+  report.summary = {
+    candidate: report.candidates.length,
+    skipped: report.skipped.length,
+    applied: report.applied.length,
+    failed: report.failed.length,
+    "already-minimized": alreadyMinimized,
+    "viewer-can-minimize": viewerCanMinimize,
+  };
+
+  // Determine status
+  if (report.mode === "dry-run") {
+    if (report.candidates.length === 0) {
+      report.status = "clean";
+    } else {
+      report.status = "needs-apply";
+    }
+  } else if (report.mode === "apply") {
+    if (report.failed.length > 0) {
+      report.status = "failed";
+    } else if (
+      report.applied.length > 0 &&
+      report.candidates.length === report.applied.length
+    ) {
+      report.status = "applied";
+    } else if (report.applied.length > 0) {
+      report.status = "incomplete";
+    } else if (report.candidates.length === 0) {
+      report.status = "clean";
+    } else {
+      report.status = "incomplete";
+    }
+  }
+}
+
 
 function fetchPullRequest(owner, repo, number, options = {}) {
   const query = `query($owner:String!,$repo:String!,$number:Int!){
@@ -891,6 +947,14 @@ function writeReport(report, format) {
   if (format === "json") {
     console.log(`${JSON.stringify(report, null, 2)}\n`);
     return;
+  }
+
+  // Print summary header
+  if (report.summary) {
+    console.log(
+      `summary: status=${report.status}, candidates=${report.summary.candidate}, applied=${report.summary.applied}, failed=${report.summary.failed}, skipped=${report.summary.skipped}`
+    );
+    console.log("");
   }
 
   printRows("candidates", report.candidates);


### PR DESCRIPTION
## Changes

Add summary and status fields to `scripts/audit-pr-cleanup.mjs` output for both dry-run and apply modes.

### Summary Fields
- `candidate`: Number of minimizable comment candidates found
- `skipped`: Number of skipped candidates with reasons
- `applied`: Number of successfully applied minimizations
- `failed`: Number of failed minimizations
- `already-minimized`: Number of already-minimized comments
- `viewer-can-minimize`: Number of candidates viewer can minimize

### Status Values
- `clean`: No minimizable candidates found (dry-run)
- `needs-apply`: Candidates available for minimization (dry-run)
- `applied`: All candidates successfully minimized (apply)
- `incomplete`: Some candidates applied, others skipped or failed (apply)
- `failed`: Minimization failures occurred (apply)

### Output Formats
- **JSON**: New `summary` object and `status` field at top level
- **Table**: New summary line showing status and key counts for terminal logs

## Acceptance Criteria
- ✓ JSON output includes stable summary fields and status
- ✓ Table output includes compact summary suitable for terminal logs
- ✓ Apply mode performs existing safe mutations + claim re-validation
- ✓ No new helper runtime profile or import behavior introduced
- ✓ Existing tests pass (protocol helpers, audit, lint, spellcheck)

Closes #325