### PR TITLE
docs(authoring): make decomposition dependency-minimal and parallel-safe

### DIFF
--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -290,9 +290,32 @@ sub-issue when:
 
 - do not create a roadmap only because a description is long
 - do not keep multiple unrelated atomic changes in one sub-issue
+- do not create an artificial serial chain when sibling tasks could be
+  reviewed and verified independently
+- do not split one natural, cohesive change into artificial sibling
+  issues only to widen parallel execution
 - do not use hidden dependency markers to group active sub-tasks under
   an open roadmap
 - do not hide low-confidence work by omitting it from the output
+
+## Dependency minimization
+
+Encode a dependency edge only when it reflects a true correctness,
+availability, or ordering constraint.
+
+- keep independent sibling tasks as roadmap task-list entries, with
+  short sequencing or parallelization notes when that helps reviewers or
+  later agents
+- use visible or sequential dependency markers only when the issue
+  cannot start safely until the dependency resolves
+- do not create an artificial serial chain when sibling tasks could be
+  reviewed and verified independently
+- do not split one natural, cohesive change into artificial sibling
+  issues only to widen parallel execution
+
+When an issue keeps a dependency edge, justify each dependency edge in
+the surrounding issue body and confirm that the split still preserves
+natural cohesion.
 
 ## Dependency encoding rules
 
@@ -409,6 +432,7 @@ Validation expectations:
   as narrative text
 - dependency notes distinguish between active grouping and true
   sequential blocking
+- each dependency edge is justified and preserves natural cohesion
 - the roadmap can survive multi-session handoffs without relying on
   private session memory
 
@@ -436,7 +460,8 @@ Validation expectations:
 
 - the issue is referenced from its parent roadmap task list
 - acceptance criteria are locally verifiable
-- any dependency marker is resolvable and intentionally chosen
+- any dependency marker is resolvable, intentionally chosen, and
+  justified
 - the issue can be claimed independently without absorbing sibling work
 
 ## Validation checklist for drafted output
@@ -449,6 +474,7 @@ Before reporting or publishing issue drafts, the skill should verify:
   stable bucket instead of being dropped
 - each roadmap has one roadmap marker and uses task-list links for child
   issues
+- each dependency edge is justified and preserves natural cohesion
 - each `Blocked by #NNN` reference resolves to the intended issue
 - each `idd-skill-blocked-by` marker points to a real roadmap and is
   used only for true sequential dependencies

--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -44,7 +44,7 @@ needs-decision, blocked-by-human, and out-of-scope.
    dependency markers. Use the prefix documented by the target
    repository's onboarding or IDD docs, and ask the user instead of
    guessing when the prefix is not discoverable.
-5. Keep dependencies machine-readable:
+5. Keep dependencies machine-readable and minimal:
    - roadmap identity via
      `<!-- <marker-prefix>-roadmap-id: ... -->`
    - active child issues via roadmap task-list links
@@ -53,6 +53,9 @@ needs-decision, blocked-by-human, and out-of-scope.
      `<!-- <marker-prefix>-blocked-by: ... -->` only when a separate
      roadmap
      must close first
+   - keep independent sibling work in roadmap task lists unless a true
+     correctness, availability, or ordering constraint requires a
+     dependency edge
 6. Stop at the approval boundary. Drafting issues does not authorize
    publishing them or starting the IDD execution loop unless the user
    explicitly asked for that.
@@ -76,6 +79,8 @@ needs-decision, blocked-by-human, and out-of-scope.
 - Preserve low-readiness work in stable buckets instead of dropping it.
 - Keep acceptance criteria explicitly verifiable.
 - Link every active child issue from its roadmap body.
+- Justify each dependency edge and keep independent sibling work as
+  roadmap task-list entries.
 - Record reuse or extension decisions when the skill does not create a
   new issue.
 - Avoid widening drafting output beyond the user request without saying

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -158,6 +158,25 @@ Choose the smallest safe output shape:
 - **Stable non-ready buckets**: some work is deferred, blocked by a
   human, waiting on a decision, or outside the repository scope.
 
+## Dependency minimization
+
+Encode a dependency edge only when it reflects a true correctness,
+availability, or ordering constraint.
+
+- keep independent sibling tasks as roadmap task-list entries, with
+  short sequencing or parallelization notes when that helps reviewers or
+  later agents
+- use visible or sequential dependency markers only when the issue
+  cannot start safely until the dependency resolves
+- do not create an artificial serial chain when sibling tasks could be
+  reviewed and verified independently
+- do not split one natural, cohesive change into artificial sibling
+  issues only to widen parallel execution
+
+When an issue keeps a dependency edge, justify each dependency edge in
+the surrounding issue body and confirm that the split still preserves
+natural cohesion.
+
 ## Required dependency encoding
 
 - Roadmap identity via `<!-- <marker-prefix>-roadmap-id: ... -->`
@@ -199,6 +218,7 @@ Validation expectations:
 - every active child issue is referenced from the roadmap body
 - the roadmap explains why multiple issues exist
 - sequencing and blocking are explicit
+- each dependency edge is justified and preserves natural cohesion
 
 ### Child issue under a roadmap
 
@@ -211,7 +231,10 @@ Validation expectations:
 Validation expectations:
 
 - the issue is referenced from its parent roadmap task list
-- it can be claimed independently without owning the whole roadmap
+- acceptance criteria are locally verifiable
+- any dependency marker is resolvable, intentionally chosen, and
+  justified
+- the issue can be claimed independently without absorbing sibling work
 
 ## A4.5 Suitability Gate Alignment
 

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -97,6 +97,52 @@ Child issue:
 Keep ready child issues in the roadmap task list rather than grouping
 them with hidden dependency markers.
 
+## Dependency minimization examples
+
+### Natural parallel decomposition
+
+Roadmap `## Tracks` excerpt:
+
+```md
+- [ ] #401 — update the issue-authoring contract
+- [ ] #402 — add draft-pattern examples
+
+_Parallel note: #401 and #402 can proceed independently once the roadmap
+exists because neither task depends on the other's output._
+```
+
+This is the preferred shape for sibling tasks that can be reviewed and
+verified independently. The roadmap keeps both tasks visible in its task
+list, and the short note explains the safe parallelism without adding a
+fake `Blocked by` edge.
+
+### Artificial decomposition
+
+Bad serial chain:
+
+```md
+#401 — update the issue-authoring contract
+#402 — add draft-pattern examples
+
+Blocked by #401
+```
+
+This is over-serialized when `#402` can be reviewed and verified without
+waiting for `#401`. Do not create a serial chain just to make the order
+feel tidy.
+
+Bad split for parallelism:
+
+```md
+#410 — add one checklist bullet
+#411 — add one example paragraph
+#412 — add one anti-pattern sentence
+```
+
+This is an artificial split when the three edits form one natural,
+cohesive authoring change. Do not break a single reviewable task into
+multiple sibling issues only to widen parallel execution.
+
 Resolve `<marker-prefix>` from the target repository's onboarding or IDD
 docs before publishing the draft. Use `idd-skill` only when the target
 repository actually configured that prefix.

--- a/tests/issue-authoring-specificity.test.mjs
+++ b/tests/issue-authoring-specificity.test.mjs
@@ -9,8 +9,8 @@ test("specificity guidance stays synced between canonical and bundled contract",
   const bundled = readText(bundledFile);
 
   assert.equal(
-    extractSpecificitySection(canonical, canonicalFile),
-    extractSpecificitySection(bundled, bundledFile),
+    extractTopLevelSection(canonical, canonicalFile, "## Specificity target"),
+    extractTopLevelSection(bundled, bundledFile, "## Specificity target"),
     `canonical and bundled issue-authoring specificity guidance must stay in sync (${canonicalFile} vs ${bundledFile})`,
   );
 });
@@ -20,7 +20,11 @@ test("specificity guidance keeps the three band labels and tier phrases", () => 
     "docs/issue-authoring-skill.md",
     "skills/issue-authoring/references/contract.md",
   ]) {
-    const section = extractSpecificitySection(readText(file), file);
+    const section = extractTopLevelSection(
+      readText(file),
+      file,
+      "## Specificity target",
+    );
 
     for (const needle of [
       "## Specificity target",
@@ -41,12 +45,92 @@ test("specificity guidance keeps the three band labels and tier phrases", () => 
   }
 });
 
+test("dependency minimization guidance stays synced between canonical and bundled contract", () => {
+  const canonicalFile = "docs/issue-authoring-skill.md";
+  const bundledFile = "skills/issue-authoring/references/contract.md";
+  const canonical = readText(canonicalFile);
+  const bundled = readText(bundledFile);
+
+  assert.equal(
+    extractTopLevelSection(
+      canonical,
+      canonicalFile,
+      "## Dependency minimization",
+    ),
+    extractTopLevelSection(
+      bundled,
+      bundledFile,
+      "## Dependency minimization",
+    ),
+    `canonical and bundled dependency minimization guidance must stay in sync (${canonicalFile} vs ${bundledFile})`,
+  );
+});
+
+test("dependency minimization guidance keeps the edge-justification rules", () => {
+  for (const file of [
+    "docs/issue-authoring-skill.md",
+    "skills/issue-authoring/references/contract.md",
+  ]) {
+    const section = extractTopLevelSection(
+      readText(file),
+      file,
+      "## Dependency minimization",
+    );
+    const normalizedSection = normalizeWhitespace(section);
+
+    for (const needle of [
+      "true correctness, availability, or ordering constraint",
+      "roadmap task-list entries",
+      "artificial serial chain",
+      "artificial sibling issues only to widen parallel execution",
+      "justify each dependency edge",
+      "natural cohesion",
+    ]) {
+      assert.ok(
+        normalizedSection.includes(normalizeWhitespace(needle)),
+        `${file} must keep dependency-minimization phrase: ${needle}`,
+      );
+    }
+  }
+});
+
+test("draft patterns keep the dependency minimization examples", () => {
+  const file = "skills/issue-authoring/references/draft-patterns.md";
+  const text = readText(file);
+
+  for (const needle of [
+    "## Dependency minimization examples",
+    "### Natural parallel decomposition",
+    "### Artificial decomposition",
+    "Bad serial chain:",
+    "Bad split for parallelism:",
+  ]) {
+    assert.ok(text.includes(needle), `${file} must keep example anchor: ${needle}`);
+  }
+});
+
+test("child issue validation keeps verification and dependency-marker guidance", () => {
+  for (const file of [
+    "docs/issue-authoring-skill.md",
+    "skills/issue-authoring/references/contract.md",
+  ]) {
+    const text = readText(file);
+
+    for (const needle of [
+      "acceptance criteria are locally verifiable",
+      "any dependency marker is resolvable, intentionally chosen, and",
+      "the issue can be claimed independently without absorbing sibling work",
+    ]) {
+      assert.ok(text.includes(needle), `${file} must keep child validation phrase: ${needle}`);
+    }
+  }
+});
+
 function readText(relativePath) {
   return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
 }
 
-function extractSpecificitySection(text, fileLabel) {
-  const startMarker = "## Specificity target";
+function extractTopLevelSection(text, fileLabel, startMarker) {
   const nextSectionMarker = "\n## ";
 
   const start = text.indexOf(startMarker);
@@ -58,4 +142,8 @@ function extractSpecificitySection(text, fileLabel) {
   const end = nextSectionStart === -1 ? text.length : nextSectionStart;
 
   return text.slice(start, end).trim();
+}
+
+function normalizeWhitespace(text) {
+  return text.replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
## Summary

- add explicit dependency-minimization guidance to the issue-authoring contract
- show natural parallel roadmap siblings versus artificial decomposition examples
- extend issue-authoring tests to keep canonical and bundled guidance aligned

Closes #331


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced issue-authoring guidelines with expanded dependency minimization rules to prevent artificial task serialization
  * Clarified that dependency edges must be explicitly justified and preserve natural cohesion
  * Added new examples and patterns demonstrating proper vs. improper task decomposition
  * Strengthened validation requirements for roadmap issues and sub-issue dependencies

* **Tests**
  * Extended validation tests to ensure documentation consistency across guidance materials

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/339)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->