### PR TITLE
feat(build): add helper runtime bundle manifest

### DIFF
--- a/bin/idd-advisory-wait-state.mjs
+++ b/bin/idd-advisory-wait-state.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/advisory-wait-state.mjs");

--- a/bin/idd-audit-pr-cleanup.mjs
+++ b/bin/idd-audit-pr-cleanup.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/audit-pr-cleanup.mjs");

--- a/bin/idd-doctor.mjs
+++ b/bin/idd-doctor.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/idd-doctor.mjs");

--- a/bin/idd-helper-bundle-manifest.mjs
+++ b/bin/idd-helper-bundle-manifest.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/helper-runtime-manifest.mjs");

--- a/bin/idd-live-status-digest.mjs
+++ b/bin/idd-live-status-digest.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/live-status-digest.mjs");

--- a/bin/idd-pre-merge-readiness.mjs
+++ b/bin/idd-pre-merge-readiness.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/pre-merge-readiness.mjs");

--- a/bin/idd-review-activity-snapshot.mjs
+++ b/bin/idd-review-activity-snapshot.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/review-activity-snapshot.mjs");

--- a/bin/run-helper.mjs
+++ b/bin/run-helper.mjs
@@ -8,18 +8,11 @@ export function runHelper(relativeScriptPath) {
   const binDirectory = dirname(fileURLToPath(import.meta.url));
   const scriptPath = resolve(binDirectory, relativeScriptPath);
   const result = spawnSync(process.execPath, [scriptPath, ...process.argv.slice(2)], {
-    encoding: "utf8",
+    stdio: "inherit",
   });
 
   if (result.error) {
     throw result.error;
-  }
-
-  if (result.stdout) {
-    process.stdout.write(result.stdout);
-  }
-  if (result.stderr) {
-    process.stderr.write(result.stderr);
   }
 
   process.exit(result.status ?? 1);

--- a/bin/run-helper.mjs
+++ b/bin/run-helper.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function runHelper(relativeScriptPath) {
+  const binDirectory = dirname(fileURLToPath(import.meta.url));
+  const scriptPath = resolve(binDirectory, relativeScriptPath);
+  const result = spawnSync(process.execPath, [scriptPath, ...process.argv.slice(2)], {
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  process.exit(result.status ?? 1);
+}

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -54,16 +54,26 @@ npx --yes --package github:kurone-kito/idd-skill \
 ```
 
 The manifest auto-detects npm, pnpm, or yarn from the target repository
-when possible. If detection is ambiguous, pass `--package-manager
-<npm|pnpm|yarn>` explicitly. The output shows which dependency entries,
-`package.json` scripts, vendored files, or one-shot commands belong to
-the selected profile.
+when possible. If detection is ambiguous, pass this flag explicitly:
+
+```text
+--package-manager <npm|pnpm|yarn>
+```
+
+The output shows which dependency entries, `package.json` scripts,
+vendored files, or one-shot commands belong to the selected profile.
 
 To switch profiles later, rerun the same command with
-`--from-profile <current-profile>` and the new `--profile
-<target-profile>`. Use the returned add/remove lists to update the
-repository intentionally instead of leaving stale vendored files or
-helper dependency wiring behind.
+these flags:
+
+```text
+--from-profile <current-profile>
+--profile <target-profile>
+```
+
+Use the returned add/remove lists to update the repository
+intentionally instead of leaving stale vendored files or helper
+dependency wiring behind.
 
 ## Review Policy
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -49,7 +49,7 @@ from the target repository root to get the concrete import surface for
 the chosen profile:
 
 ```sh
-npx --yes --package github:kurone-kito/idd-skill \
+npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main \
   idd-helper-bundle-manifest --profile package-manager
 ```
 
@@ -62,6 +62,8 @@ when possible. If detection is ambiguous, pass this flag explicitly:
 
 The output shows which dependency entries, `package.json` scripts,
 vendored files, or one-shot commands belong to the selected profile.
+Pass `--package-spec <pinned-spec>` when you want the manifest to emit a
+reviewed tarball or mirror URL instead of the default archive URL.
 
 To switch profiles later, rerun the same command with
 these flags:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -44,6 +44,27 @@ This choice is separate from the project command placeholders. A
 repository without Node.js can still import and run IDD with the written
 instructions alone.
 
+When a repository does opt into helper support, run the manifest helper
+from the target repository root to get the concrete import surface for
+the chosen profile:
+
+```sh
+npx --yes --package github:kurone-kito/idd-skill \
+  idd-helper-bundle-manifest --profile package-manager
+```
+
+The manifest auto-detects npm, pnpm, or yarn from the target repository
+when possible. If detection is ambiguous, pass `--package-manager
+<npm|pnpm|yarn>` explicitly. The output shows which dependency entries,
+`package.json` scripts, vendored files, or one-shot commands belong to
+the selected profile.
+
+To switch profiles later, rerun the same command with
+`--from-profile <current-profile>` and the new `--profile
+<target-profile>`. Use the returned add/remove lists to update the
+repository intentionally instead of leaving stale vendored files or
+helper dependency wiring behind.
+
 ## Review Policy
 
 Start with [IDD review policy profiles](idd-review-policy-profiles.md).

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -66,6 +66,34 @@ turning every adopter into a Node.js-first repository. The written
 decision tables remain the canonical protocol regardless of which helper
 profile is selected.
 
+## Profile Wiring Surface
+
+Use `idd-helper-bundle-manifest` as the canonical import helper for these
+profiles. It is published from this source repository as both
+`scripts/helper-runtime-manifest.mjs` and the package bin
+`idd-helper-bundle-manifest`, so adopters can inspect one machine-readable
+manifest instead of hand-maintaining helper file lists.
+
+- `package-manager`: run the manifest from the target repository root and
+  let it detect npm, pnpm, or yarn (or pass `--package-manager` if
+  detection is ambiguous). The output includes the package-manager
+  install command, the `@kurone-kito/idd-skill` helper dependency, and a
+  `package.json` scripts block that calls stable `idd-*` bins without
+  assuming pnpm.
+- `vendored-node`: use the manifest's `managedFiles` list to copy the
+  helper bundle into matching paths in the target repository, then run
+  the emitted local `node scripts/...` commands.
+- `ephemeral-npx`: use the manifest's one-shot
+  `npx --yes --package github:kurone-kito/idd-skill idd-*` commands
+  without copying helper files into the repository.
+- `instructions-only`: keep helper dependencies, helper files, and helper
+  wrapper scripts out of the target repository entirely.
+
+To switch profiles later, rerun the manifest with both
+`--profile <target-profile>` and `--from-profile <current-profile>`. The
+switch section reports the files, dependency entries, and `package.json`
+scripts to add or remove for that transition.
+
 The adopted helper boundaries are intentionally narrow:
 
 - `review-activity-snapshot.mjs` is read-only, emits machine-readable

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -83,9 +83,11 @@ manifest instead of hand-maintaining helper file lists.
 - `vendored-node`: use the manifest's `managedFiles` list to copy the
   helper bundle into matching paths in the target repository, then run
   the emitted local `node scripts/...` commands.
-- `ephemeral-npx`: use the manifest's one-shot
-  `npx --yes --package github:kurone-kito/idd-skill idd-*` commands
-  without copying helper files into the repository.
+- `ephemeral-npx`: use the manifest's one-shot `npx --yes --package
+  <helper-package-spec> idd-*` commands without copying helper files
+  into the repository. The default helper package spec is an HTTPS
+  archive URL, and `--package-spec` lets adopters pin a reviewed tarball
+  or mirror URL explicitly.
 - `instructions-only`: keep helper dependencies, helper files, and helper
   wrapper scripts out of the target repository entirely.
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -768,9 +768,8 @@ Notes:
   notes and JSON as a configuration bug and update both in the same change.
 - Keep command strings JSON-escaped. Do not paste raw shell directly if
   it contains quotes or backslashes.
-- Helper runtime selection is currently recorded in the human-readable
-  policy section. Do not add a `helperRuntime` JSON field unless the
-  schema is extended first.
+- When helper support is enabled, keep `helperRuntime.profile` in sync
+  with the human-readable helper runtime section above.
 - Extend the schema only when the repository records extra policy
   decisions (for example: critique-loop profile, merge handoff actor,
   external advisory bot, or maintainer approval actors).

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -711,6 +711,16 @@ This repository uses the following IDD policies:
   `instructions-only`.
 - Existing pnpm/npm/yarn repositories should reuse their package-manager
   dependencies instead of ad hoc `npx`.
+- Run `npx --yes --package github:kurone-kito/idd-skill
+  idd-helper-bundle-manifest --profile <selected-profile>` from the
+  target repository root to print the exact dependency, script, vendored
+  file, or one-shot command surface for that choice.
+- If the repository chooses `package-manager` and auto-detection does not
+  resolve npm, pnpm, or yarn, pass `--package-manager <npm|pnpm|yarn>`
+  explicitly to the manifest helper.
+- When switching profiles later, rerun the same helper with
+  `--from-profile <current-profile>` so the add/remove surface is
+  explicit and auditable.
 - Repositories without Node.js stay supported through
   `instructions-only`.
 
@@ -731,8 +741,8 @@ override the command table values in `idd-overview.instructions.md`. It is
 included in the core file list and copied as part of Step 2. The file is
 optional; IDD operates from the Markdown instruction files when the JSON is
 absent or invalid. When you do use it, keep the human-readable policy
-section in sync with this JSON file, except for helper runtime which stays
-human-readable only until the schema is extended.
+section in sync with this JSON file, including the selected
+`helperRuntime.profile` when helper support is enabled.
 
 After copying, the file contains placeholders. Fill them in along with the
 rest of the placeholder-replacement pass in Step 4. Also replace the

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -715,12 +715,15 @@ This repository uses the following IDD policies:
   dependency, script, vendored file, or one-shot command surface for
   the selected profile:
 
-      npx --yes --package github:kurone-kito/idd-skill \
+      npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main \
         idd-helper-bundle-manifest --profile <selected-profile>
 
 - If the repository chooses `package-manager` and auto-detection does not
   resolve npm, pnpm, or yarn, pass `--package-manager <npm|pnpm|yarn>`
   explicitly to the manifest helper.
+- Pass `--package-spec <pinned-spec>` when the repository wants the
+  emitted package-manager or `ephemeral-npx` commands to use a reviewed
+  tarball or internal mirror URL instead of the default archive URL.
 - When switching profiles later, rerun the same helper with
   `--from-profile <current-profile>` so the add/remove surface is
   explicit and auditable.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -711,9 +711,13 @@ This repository uses the following IDD policies:
   `instructions-only`.
 - Existing pnpm/npm/yarn repositories should reuse their package-manager
   dependencies instead of ad hoc `npx`.
-- Run `npx --yes --package github:kurone-kito/idd-skill idd-helper-bundle-manifest --profile <selected-profile>` from the
-  target repository root to print the exact dependency, script, vendored
-  file, or one-shot command surface for that choice.
+- Run this command from the target repository root to print the exact
+  dependency, script, vendored file, or one-shot command surface for
+  the selected profile:
+
+      npx --yes --package github:kurone-kito/idd-skill \
+        idd-helper-bundle-manifest --profile <selected-profile>
+
 - If the repository chooses `package-manager` and auto-detection does not
   resolve npm, pnpm, or yarn, pass `--package-manager <npm|pnpm|yarn>`
   explicitly to the manifest helper.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -711,8 +711,7 @@ This repository uses the following IDD policies:
   `instructions-only`.
 - Existing pnpm/npm/yarn repositories should reuse their package-manager
   dependencies instead of ad hoc `npx`.
-- Run `npx --yes --package github:kurone-kito/idd-skill
-  idd-helper-bundle-manifest --profile <selected-profile>` from the
+- Run `npx --yes --package github:kurone-kito/idd-skill idd-helper-bundle-manifest --profile <selected-profile>` from the
   target repository root to print the exact dependency, script, vendored
   file, or one-shot command surface for that choice.
 - If the repository chooses `package-manager` and auto-detection does not

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -54,16 +54,26 @@ npx --yes --package github:kurone-kito/idd-skill \
 ```
 
 The manifest auto-detects npm, pnpm, or yarn from the target repository
-when possible. If detection is ambiguous, pass `--package-manager
-<npm|pnpm|yarn>` explicitly. The output shows which dependency entries,
-`package.json` scripts, vendored files, or one-shot commands belong to
-the selected profile.
+when possible. If detection is ambiguous, pass this flag explicitly:
+
+```text
+--package-manager <npm|pnpm|yarn>
+```
+
+The output shows which dependency entries, `package.json` scripts,
+vendored files, or one-shot commands belong to the selected profile.
 
 To switch profiles later, rerun the same command with
-`--from-profile <current-profile>` and the new `--profile
-<target-profile>`. Use the returned add/remove lists to update the
-repository intentionally instead of leaving stale vendored files or
-helper dependency wiring behind.
+these flags:
+
+```text
+--from-profile <current-profile>
+--profile <target-profile>
+```
+
+Use the returned add/remove lists to update the repository
+intentionally instead of leaving stale vendored files or helper
+dependency wiring behind.
 
 ## Review Policy
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -49,7 +49,7 @@ from the target repository root to get the concrete import surface for
 the chosen profile:
 
 ```sh
-npx --yes --package github:kurone-kito/idd-skill \
+npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main \
   idd-helper-bundle-manifest --profile package-manager
 ```
 
@@ -62,6 +62,8 @@ when possible. If detection is ambiguous, pass this flag explicitly:
 
 The output shows which dependency entries, `package.json` scripts,
 vendored files, or one-shot commands belong to the selected profile.
+Pass `--package-spec <pinned-spec>` when you want the manifest to emit a
+reviewed tarball or mirror URL instead of the default archive URL.
 
 To switch profiles later, rerun the same command with
 these flags:

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -44,6 +44,27 @@ This choice is separate from the project command placeholders. A
 repository without Node.js can still import and run IDD with the written
 instructions alone.
 
+When a repository does opt into helper support, run the manifest helper
+from the target repository root to get the concrete import surface for
+the chosen profile:
+
+```sh
+npx --yes --package github:kurone-kito/idd-skill \
+  idd-helper-bundle-manifest --profile package-manager
+```
+
+The manifest auto-detects npm, pnpm, or yarn from the target repository
+when possible. If detection is ambiguous, pass `--package-manager
+<npm|pnpm|yarn>` explicitly. The output shows which dependency entries,
+`package.json` scripts, vendored files, or one-shot commands belong to
+the selected profile.
+
+To switch profiles later, rerun the same command with
+`--from-profile <current-profile>` and the new `--profile
+<target-profile>`. Use the returned add/remove lists to update the
+repository intentionally instead of leaving stale vendored files or
+helper dependency wiring behind.
+
 ## Review Policy
 
 Start with [IDD review policy profiles](idd-review-policy-profiles.md).

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -66,6 +66,34 @@ turning every adopter into a Node.js-first repository. The written
 decision tables remain the canonical protocol regardless of which helper
 profile is selected.
 
+## Profile Wiring Surface
+
+Use `idd-helper-bundle-manifest` as the canonical import helper for these
+profiles. It is published from this source repository as both
+`scripts/helper-runtime-manifest.mjs` and the package bin
+`idd-helper-bundle-manifest`, so adopters can inspect one machine-readable
+manifest instead of hand-maintaining helper file lists.
+
+- `package-manager`: run the manifest from the target repository root and
+  let it detect npm, pnpm, or yarn (or pass `--package-manager` if
+  detection is ambiguous). The output includes the package-manager
+  install command, the `@kurone-kito/idd-skill` helper dependency, and a
+  `package.json` scripts block that calls stable `idd-*` bins without
+  assuming pnpm.
+- `vendored-node`: use the manifest's `managedFiles` list to copy the
+  helper bundle into matching paths in the target repository, then run
+  the emitted local `node scripts/...` commands.
+- `ephemeral-npx`: use the manifest's one-shot
+  `npx --yes --package github:kurone-kito/idd-skill idd-*` commands
+  without copying helper files into the repository.
+- `instructions-only`: keep helper dependencies, helper files, and helper
+  wrapper scripts out of the target repository entirely.
+
+To switch profiles later, rerun the manifest with both
+`--profile <target-profile>` and `--from-profile <current-profile>`. The
+switch section reports the files, dependency entries, and `package.json`
+scripts to add or remove for that transition.
+
 The adopted helper boundaries are intentionally narrow:
 
 - `review-activity-snapshot.mjs` is read-only, emits machine-readable

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -83,9 +83,11 @@ manifest instead of hand-maintaining helper file lists.
 - `vendored-node`: use the manifest's `managedFiles` list to copy the
   helper bundle into matching paths in the target repository, then run
   the emitted local `node scripts/...` commands.
-- `ephemeral-npx`: use the manifest's one-shot
-  `npx --yes --package github:kurone-kito/idd-skill idd-*` commands
-  without copying helper files into the repository.
+- `ephemeral-npx`: use the manifest's one-shot `npx --yes --package
+  <helper-package-spec> idd-*` commands without copying helper files
+  into the repository. The default helper package spec is an HTTPS
+  archive URL, and `--package-spec` lets adopters pin a reviewed tarball
+  or mirror URL explicitly.
 - `instructions-only`: keep helper dependencies, helper files, and helper
   wrapper scripts out of the target repository entirely.
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,15 @@
   "license": "MIT",
   "repository": "github:kurone-kito/idd-skill",
   "type": "module",
+  "bin": {
+    "idd-advisory-wait-state": "./bin/idd-advisory-wait-state.mjs",
+    "idd-audit-pr-cleanup": "./bin/idd-audit-pr-cleanup.mjs",
+    "idd-doctor": "./bin/idd-doctor.mjs",
+    "idd-helper-bundle-manifest": "./bin/idd-helper-bundle-manifest.mjs",
+    "idd-live-status-digest": "./bin/idd-live-status-digest.mjs",
+    "idd-pre-merge-readiness": "./bin/idd-pre-merge-readiness.mjs",
+    "idd-review-activity-snapshot": "./bin/idd-review-activity-snapshot.mjs"
+  },
   "scripts": {
     "prepare": "husky",
     "lint": "pnpm run lint:minimum",

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -236,12 +236,22 @@ export function resolveSourcePackageMetadata(packageRoot = resolve(dirname(fileU
     }
     return {
       name: PACKAGE_NAME,
-      repository: String(packageJson.repository ?? SOURCE_REPOSITORY),
+      repository: normalizeRepository(packageJson.repository),
       nodeEngines: String(packageJson.engines?.node ?? NODE_ENGINES),
     };
   } catch {
     return fallback;
   }
+}
+
+function normalizeRepository(repository) {
+  if (typeof repository === "string" && repository) {
+    return repository;
+  }
+  if (repository && typeof repository === "object" && typeof repository.url === "string" && repository.url) {
+    return repository.url;
+  }
+  return SOURCE_REPOSITORY;
 }
 
 function buildProfileCatalog({ packageMetadata, managedFiles, packageManager }) {

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -71,21 +71,23 @@ const HELPER_COMMANDS = [
   },
 ];
 
-const args = parseArgs(process.argv.slice(2));
+if (isMainModule(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2));
 
-if (args.help) {
-  printHelp();
-  process.exit(0);
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const manifest = buildHelperRuntimeManifest({
+    profile: args.profile,
+    fromProfile: args.fromProfile,
+    packageManager: args.packageManager,
+    targetRoot: args.targetRoot,
+  });
+
+  process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
 }
-
-const manifest = buildHelperRuntimeManifest({
-  profile: args.profile,
-  fromProfile: args.fromProfile,
-  packageManager: args.packageManager,
-  targetRoot: args.targetRoot,
-});
-
-process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
 
 export function buildHelperRuntimeManifest({
   profile = "",
@@ -97,8 +99,9 @@ export function buildHelperRuntimeManifest({
   const packageJson = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
   const normalizedProfile = normalizeProfile(profile);
   const normalizedFromProfile = normalizeOptionalProfile(fromProfile);
+  const normalizedTargetRoot = targetRoot || process.cwd();
   const normalizedPackageManager = normalizePackageManager(
-    packageManager || detectPackageManager(targetRoot),
+    packageManager || detectPackageManager(normalizedTargetRoot),
     normalizedProfile,
   );
   const managedFiles = collectVendoredFiles(packageRoot);
@@ -355,28 +358,34 @@ function parseArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     const value = argv[index + 1];
+    const requireValue = () => {
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
 
     if (token === "--help" || token === "-h") {
       parsed.help = true;
       continue;
     }
     if (token === "--profile") {
-      parsed.profile = value ?? "";
+      parsed.profile = requireValue();
       index += 1;
       continue;
     }
     if (token === "--from-profile") {
-      parsed.fromProfile = value ?? "";
+      parsed.fromProfile = requireValue();
       index += 1;
       continue;
     }
     if (token === "--package-manager") {
-      parsed.packageManager = value ?? "";
+      parsed.packageManager = requireValue();
       index += 1;
       continue;
     }
     if (token === "--target-root") {
-      parsed.targetRoot = value ?? "";
+      parsed.targetRoot = requireValue();
       index += 1;
       continue;
     }
@@ -455,4 +464,8 @@ function resolveRelativeImport(fromFile, specifier) {
 
 function relativePath(root, target) {
   return relative(root, target).replaceAll("\\", "/");
+}
+
+function isMainModule(moduleUrl) {
+  return process.argv[1] === fileURLToPath(moduleUrl);
 }

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_MANAGERS = ["npm", "pnpm", "yarn"];
+const PROFILE_NAMES = ["package-manager", "vendored-node", "ephemeral-npx", "instructions-only"];
+const PACKAGE_SPEC = "github:kurone-kito/idd-skill";
+const PACKAGE_SPEC_PIN_HINT = "Pin the helper package to a tag or commit SHA when importing into another repository.";
+const SCRIPT_FILE_EXTENSIONS = [".mjs", ".js", ".json"];
+
+const HELPER_COMMANDS = [
+  {
+    id: "doctor",
+    scriptName: "idd:doctor",
+    binName: "idd-doctor",
+    entryPath: "scripts/idd-doctor.mjs",
+    vendoredCommand: "node scripts/idd-doctor.mjs",
+    description: "Run IDD onboarding drift checks against the local repository.",
+  },
+  {
+    id: "helper-bundle-manifest",
+    scriptName: "idd:helper-bundle-manifest",
+    binName: "idd-helper-bundle-manifest",
+    entryPath: "scripts/helper-runtime-manifest.mjs",
+    vendoredCommand: "node scripts/helper-runtime-manifest.mjs",
+    description: "Print the canonical helper bundle import plan for each runtime profile.",
+  },
+  {
+    id: "review-activity-snapshot",
+    scriptName: "idd:review-activity-snapshot",
+    binName: "idd-review-activity-snapshot",
+    entryPath: "scripts/review-activity-snapshot.mjs",
+    vendoredCommand: "node scripts/review-activity-snapshot.mjs",
+    description: "Collect read-only review activity and CI snapshot evidence.",
+  },
+  {
+    id: "advisory-wait-state",
+    scriptName: "idd:advisory-wait-state",
+    binName: "idd-advisory-wait-state",
+    entryPath: "scripts/advisory-wait-state.mjs",
+    vendoredCommand: "node scripts/advisory-wait-state.mjs",
+    description: "Collect advisory-wait state without mutating PR review state.",
+    contractPaths: ["schemas/advisory-wait-state.schema.json"],
+  },
+  {
+    id: "pre-merge-readiness",
+    scriptName: "idd:pre-merge-readiness",
+    binName: "idd-pre-merge-readiness",
+    entryPath: "scripts/pre-merge-readiness.mjs",
+    vendoredCommand: "node scripts/pre-merge-readiness.mjs",
+    description: "Collect read-only F2/F3 merge-gate evidence.",
+    contractPaths: ["schemas/pre-merge-readiness.schema.json"],
+  },
+  {
+    id: "live-status-digest",
+    scriptName: "idd:live-status-digest",
+    binName: "idd-live-status-digest",
+    entryPath: "scripts/live-status-digest.mjs",
+    vendoredCommand: "node scripts/live-status-digest.mjs",
+    description: "Render or apply the optional live status digest.",
+  },
+  {
+    id: "audit-pr-cleanup",
+    scriptName: "idd:audit-pr-cleanup",
+    binName: "idd-audit-pr-cleanup",
+    entryPath: "scripts/audit-pr-cleanup.mjs",
+    vendoredCommand: "node scripts/audit-pr-cleanup.mjs",
+    description: "Audit or apply post-merge comment cleanup.",
+  },
+];
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const manifest = buildHelperRuntimeManifest({
+  profile: args.profile,
+  fromProfile: args.fromProfile,
+  packageManager: args.packageManager,
+  targetRoot: args.targetRoot,
+});
+
+process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+
+export function buildHelperRuntimeManifest({
+  profile = "",
+  fromProfile = "",
+  packageManager = "",
+  targetRoot = process.cwd(),
+} = {}) {
+  const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const packageJson = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
+  const normalizedProfile = normalizeProfile(profile);
+  const normalizedFromProfile = normalizeOptionalProfile(fromProfile);
+  const normalizedPackageManager = normalizePackageManager(
+    packageManager || detectPackageManager(targetRoot),
+    normalizedProfile,
+  );
+  const managedFiles = collectVendoredFiles(packageRoot);
+  const commandCatalog = buildCommandCatalog();
+  const profileCatalog = buildProfileCatalog({
+    packageJson,
+    managedFiles,
+    packageManager: normalizedPackageManager,
+  });
+
+  const selectedProfiles = normalizedProfile
+    ? { [normalizedProfile]: profileCatalog[normalizedProfile] }
+    : profileCatalog;
+
+  return {
+    version: 1,
+    sourceRepository: packageJson.repository,
+    packageName: packageJson.name,
+    packageSpec: PACKAGE_SPEC,
+    packageSpecPinHint: PACKAGE_SPEC_PIN_HINT,
+    nodeEngines: packageJson.engines?.node ?? "",
+    packageManager: normalizedPackageManager,
+    availableProfiles: [...PROFILE_NAMES],
+    commandCatalog,
+    profiles: selectedProfiles,
+    switching: normalizedProfile && normalizedFromProfile
+      ? buildSwitchPlan({
+        fromProfile: normalizedFromProfile,
+        toProfile: normalizedProfile,
+        profileCatalog,
+      })
+      : null,
+  };
+}
+
+export function collectVendoredFiles(packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")) {
+  const queue = HELPER_COMMANDS
+    .map((command) => command.entryPath)
+    .map((entryPath) => resolve(packageRoot, entryPath));
+  const visited = new Set();
+  const managedFiles = new Set();
+
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    managedFiles.add(relativePath(packageRoot, current));
+
+    const source = readFileSync(current, "utf8");
+    for (const specifier of findRelativeImports(source)) {
+      const dependency = resolveRelativeImport(current, specifier);
+      if (!dependency) {
+        continue;
+      }
+      queue.push(dependency);
+    }
+  }
+
+  for (const command of HELPER_COMMANDS) {
+    for (const contractPath of command.contractPaths ?? []) {
+      managedFiles.add(relativePath(packageRoot, resolve(packageRoot, contractPath)));
+    }
+  }
+
+  return [...managedFiles].sort().map((targetPath) => ({
+    sourcePath: targetPath,
+    targetPath,
+  }));
+}
+
+export function detectPackageManager(root = process.cwd()) {
+  const packageJsonPath = resolve(root, "package.json");
+  if (existsSync(packageJsonPath)) {
+    try {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+      const declared = String(packageJson.packageManager ?? "");
+      for (const manager of PACKAGE_MANAGERS) {
+        if (declared.startsWith(`${manager}@`)) {
+          return manager;
+        }
+      }
+    } catch {
+      // Ignore parse errors here and fall back to lockfile detection.
+    }
+  }
+
+  if (existsSync(resolve(root, "pnpm-lock.yaml"))) {
+    return "pnpm";
+  }
+  if (existsSync(resolve(root, "package-lock.json"))) {
+    return "npm";
+  }
+  if (existsSync(resolve(root, "yarn.lock"))) {
+    return "yarn";
+  }
+
+  return "";
+}
+
+function buildCommandCatalog() {
+  return HELPER_COMMANDS.map((command) => ({
+    id: command.id,
+    scriptName: command.scriptName,
+    binName: command.binName,
+    entryPath: command.entryPath,
+    vendoredCommand: command.vendoredCommand,
+    description: command.description,
+    contractPaths: command.contractPaths ?? [],
+  }));
+}
+
+function buildProfileCatalog({ packageJson, managedFiles, packageManager }) {
+  const packageManagerScripts = Object.fromEntries(
+    HELPER_COMMANDS.map((command) => [command.scriptName, command.binName]),
+  );
+  const vendoredCommands = Object.fromEntries(
+    HELPER_COMMANDS.map((command) => [command.scriptName, command.vendoredCommand]),
+  );
+  const ephemeralCommands = Object.fromEntries(
+    HELPER_COMMANDS.map((command) => [
+      command.scriptName,
+      `npx --yes --package ${PACKAGE_SPEC} ${command.binName}`,
+    ]),
+  );
+
+  return {
+    "package-manager": {
+      profile: "package-manager",
+      description: "Install the helper bundle through the repository's existing package manager and invoke helper bins through package.json scripts.",
+      packageManager,
+      installCommand: packageManager ? buildPackageManagerInstallCommand(packageManager) : "",
+      managedDependencies: {
+        devDependencies: {
+          [packageJson.name]: PACKAGE_SPEC,
+        },
+      },
+      managedPackageJsonScripts: packageManagerScripts,
+      managedFiles: [],
+      commands: packageManagerScripts,
+      notes: [
+        "Use the repository's existing package manager instead of assuming pnpm.",
+        PACKAGE_SPEC_PIN_HINT,
+      ],
+    },
+    "vendored-node": {
+      profile: "vendored-node",
+      description: "Copy the helper bundle into the target repository and invoke helpers through local node scripts.",
+      packageManager: "",
+      installCommand: "",
+      managedDependencies: {
+        devDependencies: {},
+      },
+      managedPackageJsonScripts: {},
+      managedFiles,
+      commands: vendoredCommands,
+      notes: [
+        "Copy the listed files into matching paths in the target repository.",
+        "The managed file list is derived from the helper entrypoint import graph to avoid hand-maintained drift.",
+      ],
+    },
+    "ephemeral-npx": {
+      profile: "ephemeral-npx",
+      description: "Resolve helper commands one-shot through npx without copying files into the repository.",
+      packageManager: "",
+      installCommand: "",
+      managedDependencies: {
+        devDependencies: {},
+      },
+      managedPackageJsonScripts: {},
+      managedFiles: [],
+      commands: ephemeralCommands,
+      notes: [
+        "This profile requires Node.js and npm with npx available at execution time.",
+        PACKAGE_SPEC_PIN_HINT,
+      ],
+    },
+    "instructions-only": {
+      profile: "instructions-only",
+      description: "Keep the portable Markdown workflow only and omit helper dependencies entirely.",
+      packageManager: "",
+      installCommand: "",
+      managedDependencies: {
+        devDependencies: {},
+      },
+      managedPackageJsonScripts: {},
+      managedFiles: [],
+      commands: {},
+      notes: [
+        "No helper files, helper package dependencies, or helper wrapper scripts are required.",
+      ],
+    },
+  };
+}
+
+function buildSwitchPlan({ fromProfile, toProfile, profileCatalog }) {
+  const from = profileCatalog[fromProfile];
+  const to = profileCatalog[toProfile];
+  return {
+    fromProfile,
+    toProfile,
+    removeFiles: subtractPaths(from.managedFiles, to.managedFiles),
+    addFiles: subtractPaths(to.managedFiles, from.managedFiles),
+    removePackageJsonScripts: Object.keys(from.managedPackageJsonScripts)
+      .filter((name) => !(name in to.managedPackageJsonScripts))
+      .sort(),
+    addPackageJsonScripts: Object.fromEntries(
+      Object.entries(to.managedPackageJsonScripts)
+        .filter(([name, command]) => from.managedPackageJsonScripts[name] !== command)
+        .sort(([left], [right]) => left.localeCompare(right)),
+    ),
+    removeDevDependencies: Object.keys(from.managedDependencies.devDependencies)
+      .filter((name) => !(name in to.managedDependencies.devDependencies))
+      .sort(),
+    addDevDependencies: Object.fromEntries(
+      Object.entries(to.managedDependencies.devDependencies)
+        .filter(([name, spec]) => from.managedDependencies.devDependencies[name] !== spec)
+        .sort(([left], [right]) => left.localeCompare(right)),
+    ),
+  };
+}
+
+function subtractPaths(leftFiles, rightFiles) {
+  const right = new Set(rightFiles.map((file) => file.targetPath));
+  return leftFiles
+    .filter((file) => !right.has(file.targetPath))
+    .map((file) => file.targetPath)
+    .sort();
+}
+
+function buildPackageManagerInstallCommand(packageManager) {
+  if (packageManager === "npm") {
+    return `npm install --save-dev ${PACKAGE_SPEC}`;
+  }
+  if (packageManager === "pnpm") {
+    return `pnpm add -D ${PACKAGE_SPEC}`;
+  }
+  if (packageManager === "yarn") {
+    return `yarn add --dev ${PACKAGE_SPEC}`;
+  }
+  throw new Error(`unsupported package manager: ${packageManager}`);
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    help: false,
+    profile: "",
+    fromProfile: "",
+    packageManager: "",
+    targetRoot: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+
+    if (token === "--help" || token === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (token === "--profile") {
+      parsed.profile = value ?? "";
+      index += 1;
+      continue;
+    }
+    if (token === "--from-profile") {
+      parsed.fromProfile = value ?? "";
+      index += 1;
+      continue;
+    }
+    if (token === "--package-manager") {
+      parsed.packageManager = value ?? "";
+      index += 1;
+      continue;
+    }
+    if (token === "--target-root") {
+      parsed.targetRoot = value ?? "";
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`unknown argument: ${token}`);
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  process.stdout.write(`usage: node scripts/helper-runtime-manifest.mjs [options]
+
+Options:
+  --profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
+  --from-profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
+  --package-manager <npm|pnpm|yarn>
+  --target-root <path>
+  --help
+`);
+}
+
+function normalizeProfile(profile) {
+  if (!profile) {
+    return "";
+  }
+  if (!PROFILE_NAMES.includes(profile)) {
+    throw new Error(`unsupported profile: ${profile}`);
+  }
+  return profile;
+}
+
+function normalizeOptionalProfile(profile) {
+  if (!profile) {
+    return "";
+  }
+  return normalizeProfile(profile);
+}
+
+function normalizePackageManager(packageManager, profile) {
+  if (!packageManager) {
+    if (profile === "package-manager") {
+      throw new Error("package-manager profile requires --package-manager <npm|pnpm|yarn> or a detectable package manager in --target-root");
+    }
+    return "";
+  }
+  if (!PACKAGE_MANAGERS.includes(packageManager)) {
+    throw new Error(`unsupported package manager: ${packageManager}`);
+  }
+  return packageManager;
+}
+
+function findRelativeImports(source) {
+  const specifiers = new Set();
+  const patterns = [
+    /\b(?:import|export)\s+(?:[^"'`]+\s+from\s+)?["'](\.[^"']+)["']/g,
+    /\bimport\s*\(\s*["'](\.[^"']+)["']\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      specifiers.add(match[1]);
+    }
+  }
+  return [...specifiers];
+}
+
+function resolveRelativeImport(fromFile, specifier) {
+  const directory = dirname(fromFile);
+  const basePath = resolve(directory, specifier);
+  const candidates = existsSync(basePath)
+    ? [basePath]
+    : SCRIPT_FILE_EXTENSIONS.map((extension) => `${basePath}${extension}`);
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? "";
+}
+
+function relativePath(root, target) {
+  return relative(root, target).replaceAll("\\", "/");
+}

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -193,14 +193,13 @@ export function detectPackageManager(root = process.cwd()) {
     }
   }
 
-  if (existsSync(resolve(root, "pnpm-lock.yaml"))) {
-    return "pnpm";
-  }
-  if (existsSync(resolve(root, "package-lock.json"))) {
-    return "npm";
-  }
-  if (existsSync(resolve(root, "yarn.lock"))) {
-    return "yarn";
+  const lockfileMatches = [
+    ["pnpm-lock.yaml", "pnpm"],
+    ["package-lock.json", "npm"],
+    ["yarn.lock", "yarn"],
+  ].filter(([filename]) => existsSync(resolve(root, filename)));
+  if (lockfileMatches.length === 1) {
+    return lockfileMatches[0][1];
   }
 
   return "";

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -7,9 +7,9 @@ import { fileURLToPath } from "node:url";
 const PACKAGE_MANAGERS = ["npm", "pnpm", "yarn"];
 const PROFILE_NAMES = ["package-manager", "vendored-node", "ephemeral-npx", "instructions-only"];
 const PACKAGE_NAME = "@kurone-kito/idd-skill";
-const PACKAGE_SPEC = "github:kurone-kito/idd-skill";
+const DEFAULT_PACKAGE_SPEC = "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main";
 const SOURCE_REPOSITORY = "github:kurone-kito/idd-skill";
-const PACKAGE_SPEC_PIN_HINT = "Pin the helper package to a tag or commit SHA when importing into another repository.";
+const PACKAGE_SPEC_PIN_HINT = "Pass --package-spec with a pinned tarball URL or reviewed commit archive when you need reproducible helper imports.";
 const NODE_ENGINES = "^22.22.2 || >=24";
 const SCRIPT_FILE_EXTENSIONS = [".mjs", ".js", ".json"];
 
@@ -86,6 +86,7 @@ if (isMainModule(import.meta.url)) {
     profile: args.profile,
     fromProfile: args.fromProfile,
     packageManager: args.packageManager,
+    packageSpec: args.packageSpec,
     targetRoot: args.targetRoot,
   });
 
@@ -96,6 +97,7 @@ export function buildHelperRuntimeManifest({
   profile = "",
   fromProfile = "",
   packageManager = "",
+  packageSpec = "",
   targetRoot = process.cwd(),
 } = {}) {
   const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -103,6 +105,7 @@ export function buildHelperRuntimeManifest({
   const normalizedProfile = normalizeProfile(profile);
   const normalizedFromProfile = normalizeOptionalProfile(fromProfile);
   const normalizedTargetRoot = targetRoot || process.cwd();
+  const normalizedPackageSpec = normalizePackageSpec(packageSpec);
   const normalizedPackageManager = normalizePackageManager(
     packageManager || detectPackageManager(normalizedTargetRoot),
     normalizedProfile,
@@ -113,6 +116,7 @@ export function buildHelperRuntimeManifest({
     packageMetadata,
     managedFiles,
     packageManager: normalizedPackageManager,
+    packageSpec: normalizedPackageSpec,
   });
 
   const selectedProfiles = normalizedProfile
@@ -123,7 +127,7 @@ export function buildHelperRuntimeManifest({
     version: 1,
     sourceRepository: packageMetadata.repository,
     packageName: packageMetadata.name,
-    packageSpec: PACKAGE_SPEC,
+    packageSpec: normalizedPackageSpec,
     packageSpecPinHint: PACKAGE_SPEC_PIN_HINT,
     nodeEngines: packageMetadata.nodeEngines,
     packageManager: normalizedPackageManager,
@@ -253,7 +257,7 @@ function normalizeRepository(repository) {
   return SOURCE_REPOSITORY;
 }
 
-function buildProfileCatalog({ packageMetadata, managedFiles, packageManager }) {
+function buildProfileCatalog({ packageMetadata, managedFiles, packageManager, packageSpec }) {
   const packageManagerScripts = Object.fromEntries(
     HELPER_COMMANDS.map((command) => [command.scriptName, command.binName]),
   );
@@ -263,7 +267,7 @@ function buildProfileCatalog({ packageMetadata, managedFiles, packageManager }) 
   const ephemeralCommands = Object.fromEntries(
     HELPER_COMMANDS.map((command) => [
       command.scriptName,
-      `npx --yes --package ${PACKAGE_SPEC} ${command.binName}`,
+      `npx --yes --package ${packageSpec} ${command.binName}`,
     ]),
   );
 
@@ -272,10 +276,10 @@ function buildProfileCatalog({ packageMetadata, managedFiles, packageManager }) 
       profile: "package-manager",
       description: "Install the helper bundle through the repository's existing package manager and invoke helper bins through package.json scripts.",
       packageManager,
-      installCommand: packageManager ? buildPackageManagerInstallCommand(packageManager) : "",
+      installCommand: packageManager ? buildPackageManagerInstallCommand(packageManager, packageSpec) : "",
       managedDependencies: {
         devDependencies: {
-          [packageMetadata.name]: PACKAGE_SPEC,
+          [packageMetadata.name]: packageSpec,
         },
       },
       managedPackageJsonScripts: packageManagerScripts,
@@ -371,15 +375,15 @@ function subtractPaths(leftFiles, rightFiles) {
     .sort();
 }
 
-function buildPackageManagerInstallCommand(packageManager) {
+function buildPackageManagerInstallCommand(packageManager, packageSpec) {
   if (packageManager === "npm") {
-    return `npm install --save-dev ${PACKAGE_SPEC}`;
+    return `npm install --save-dev ${packageSpec}`;
   }
   if (packageManager === "pnpm") {
-    return `pnpm add -D ${PACKAGE_SPEC}`;
+    return `pnpm add -D ${packageSpec}`;
   }
   if (packageManager === "yarn") {
-    return `yarn add --dev ${PACKAGE_SPEC}`;
+    return `yarn add --dev ${packageSpec}`;
   }
   throw new Error(`unsupported package manager: ${packageManager}`);
 }
@@ -390,6 +394,7 @@ function parseArgs(argv) {
     profile: "",
     fromProfile: "",
     packageManager: "",
+    packageSpec: "",
     targetRoot: "",
   };
 
@@ -422,6 +427,11 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (token === "--package-spec") {
+      parsed.packageSpec = requireValue();
+      index += 1;
+      continue;
+    }
     if (token === "--target-root") {
       parsed.targetRoot = requireValue();
       index += 1;
@@ -441,9 +451,14 @@ Options:
   --profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
   --from-profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
   --package-manager <npm|pnpm|yarn>
+  --package-spec <npm-spec-or-tarball-url>
   --target-root <path>
   --help
 `);
+}
+
+function normalizePackageSpec(packageSpec) {
+  return packageSpec || DEFAULT_PACKAGE_SPEC;
 }
 
 function normalizeProfile(profile) {

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -496,5 +496,8 @@ function relativePath(root, target) {
 }
 
 function isMainModule(moduleUrl) {
-  return process.argv[1] === fileURLToPath(moduleUrl);
+  if (!process.argv[1]) {
+    return false;
+  }
+  return fileURLToPath(moduleUrl) === resolve(process.argv[1]);
 }

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -6,8 +6,11 @@ import { fileURLToPath } from "node:url";
 
 const PACKAGE_MANAGERS = ["npm", "pnpm", "yarn"];
 const PROFILE_NAMES = ["package-manager", "vendored-node", "ephemeral-npx", "instructions-only"];
+const PACKAGE_NAME = "@kurone-kito/idd-skill";
 const PACKAGE_SPEC = "github:kurone-kito/idd-skill";
+const SOURCE_REPOSITORY = "github:kurone-kito/idd-skill";
 const PACKAGE_SPEC_PIN_HINT = "Pin the helper package to a tag or commit SHA when importing into another repository.";
+const NODE_ENGINES = "^22.22.2 || >=24";
 const SCRIPT_FILE_EXTENSIONS = [".mjs", ".js", ".json"];
 
 const HELPER_COMMANDS = [
@@ -96,7 +99,7 @@ export function buildHelperRuntimeManifest({
   targetRoot = process.cwd(),
 } = {}) {
   const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const packageJson = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
+  const packageMetadata = resolveSourcePackageMetadata(packageRoot);
   const normalizedProfile = normalizeProfile(profile);
   const normalizedFromProfile = normalizeOptionalProfile(fromProfile);
   const normalizedTargetRoot = targetRoot || process.cwd();
@@ -107,7 +110,7 @@ export function buildHelperRuntimeManifest({
   const managedFiles = collectVendoredFiles(packageRoot);
   const commandCatalog = buildCommandCatalog();
   const profileCatalog = buildProfileCatalog({
-    packageJson,
+    packageMetadata,
     managedFiles,
     packageManager: normalizedPackageManager,
   });
@@ -118,11 +121,11 @@ export function buildHelperRuntimeManifest({
 
   return {
     version: 1,
-    sourceRepository: packageJson.repository,
-    packageName: packageJson.name,
+    sourceRepository: packageMetadata.repository,
+    packageName: packageMetadata.name,
     packageSpec: PACKAGE_SPEC,
     packageSpecPinHint: PACKAGE_SPEC_PIN_HINT,
-    nodeEngines: packageJson.engines?.node ?? "",
+    nodeEngines: packageMetadata.nodeEngines,
     packageManager: normalizedPackageManager,
     availableProfiles: [...PROFILE_NAMES],
     commandCatalog,
@@ -215,7 +218,33 @@ function buildCommandCatalog() {
   }));
 }
 
-function buildProfileCatalog({ packageJson, managedFiles, packageManager }) {
+export function resolveSourcePackageMetadata(packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")) {
+  const fallback = {
+    name: PACKAGE_NAME,
+    repository: SOURCE_REPOSITORY,
+    nodeEngines: NODE_ENGINES,
+  };
+  const packageJsonPath = resolve(packageRoot, "package.json");
+  if (!existsSync(packageJsonPath)) {
+    return fallback;
+  }
+
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    if (packageJson.name !== PACKAGE_NAME) {
+      return fallback;
+    }
+    return {
+      name: PACKAGE_NAME,
+      repository: String(packageJson.repository ?? SOURCE_REPOSITORY),
+      nodeEngines: String(packageJson.engines?.node ?? NODE_ENGINES),
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function buildProfileCatalog({ packageMetadata, managedFiles, packageManager }) {
   const packageManagerScripts = Object.fromEntries(
     HELPER_COMMANDS.map((command) => [command.scriptName, command.binName]),
   );
@@ -237,7 +266,7 @@ function buildProfileCatalog({ packageJson, managedFiles, packageManager }) {
       installCommand: packageManager ? buildPackageManagerInstallCommand(packageManager) : "",
       managedDependencies: {
         devDependencies: {
-          [packageJson.name]: PACKAGE_SPEC,
+          [packageMetadata.name]: PACKAGE_SPEC,
         },
       },
       managedPackageJsonScripts: packageManagerScripts,

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -106,6 +106,26 @@ test("source package metadata falls back when vendored into another repository",
   });
 });
 
+test("source package metadata accepts repository objects with url", () => {
+  const sourceRoot = mkdtempSync(join(tmpdir(), "idd-helper-runtime-source-root-"));
+  writeFileSync(join(sourceRoot, "package.json"), JSON.stringify({
+    name: "@kurone-kito/idd-skill",
+    repository: {
+      type: "git",
+      url: "https://github.com/kurone-kito/idd-skill.git",
+    },
+    engines: {
+      node: "^22.22.2 || >=24",
+    },
+  }));
+
+  assert.deepEqual(resolveSourcePackageMetadata(sourceRoot), {
+    name: "@kurone-kito/idd-skill",
+    repository: "https://github.com/kurone-kito/idd-skill.git",
+    nodeEngines: "^22.22.2 || >=24",
+  });
+});
+
 test("empty targetRoot falls back to the current working directory", () => {
   const emptyTarget = buildHelperRuntimeManifest({
     profile: "package-manager",

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -87,6 +87,11 @@ test("detectPackageManager respects package metadata and lockfiles", () => {
   const lockfileRoot = mkdtempSync(join(tmpdir(), "idd-helper-runtime-lockfile-"));
   writeFileSync(join(lockfileRoot, "yarn.lock"), "# lockfile");
   assert.equal(detectPackageManager(lockfileRoot), "yarn");
+
+  const ambiguousRoot = mkdtempSync(join(tmpdir(), "idd-helper-runtime-ambiguous-lockfile-"));
+  writeFileSync(join(ambiguousRoot, "package-lock.json"), "{}");
+  writeFileSync(join(ambiguousRoot, "yarn.lock"), "# lockfile");
+  assert.equal(detectPackageManager(ambiguousRoot), "");
 });
 
 test("source package metadata falls back when vendored into another repository", () => {

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -83,6 +83,20 @@ test("detectPackageManager respects package metadata and lockfiles", () => {
   assert.equal(detectPackageManager(lockfileRoot), "yarn");
 });
 
+test("empty targetRoot falls back to the current working directory", () => {
+  const emptyTarget = buildHelperRuntimeManifest({
+    profile: "package-manager",
+    packageManager: "pnpm",
+    targetRoot: "",
+  });
+  const defaultTarget = buildHelperRuntimeManifest({
+    profile: "package-manager",
+    packageManager: "pnpm",
+  });
+
+  assert.deepEqual(emptyTarget, defaultTarget);
+});
+
 test("switching away from vendored-node enumerates removal paths", () => {
   const manifest = buildHelperRuntimeManifest({
     profile: "instructions-only",
@@ -107,4 +121,15 @@ test("helper bundle manifest bin wrapper produces JSON output", () => {
 
   const launcher = readFileSync(join(REPO_ROOT, "bin/idd-helper-bundle-manifest.mjs"), "utf8");
   assert.ok(launcher.startsWith("#!/usr/bin/env node"));
+});
+
+test("manifest CLI rejects flags that are missing required values", () => {
+  assert.throws(
+    () => execFileSync(
+      process.execPath,
+      [join(REPO_ROOT, "scripts/helper-runtime-manifest.mjs"), "--profile"],
+      { encoding: "utf8", stdio: "pipe" },
+    ),
+    /missing value for argument: --profile/,
+  );
 });

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -10,6 +10,7 @@ import {
   buildHelperRuntimeManifest,
   collectVendoredFiles,
   detectPackageManager,
+  resolveSourcePackageMetadata,
 } from "../scripts/helper-runtime-manifest.mjs";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -31,6 +32,11 @@ test("package-manager profile emits manager-specific install commands without ha
 
     assert.equal(profile.packageManager, packageManager);
     assert.equal(profile.installCommand, expectedInstall[packageManager]);
+    assert.deepEqual(profile.managedDependencies, {
+      devDependencies: {
+        "@kurone-kito/idd-skill": "github:kurone-kito/idd-skill",
+      },
+    });
     if (packageManager !== "pnpm") {
       assert.doesNotMatch(profile.installCommand, /\bpnpm\b/);
     }
@@ -81,6 +87,23 @@ test("detectPackageManager respects package metadata and lockfiles", () => {
   const lockfileRoot = mkdtempSync(join(tmpdir(), "idd-helper-runtime-lockfile-"));
   writeFileSync(join(lockfileRoot, "yarn.lock"), "# lockfile");
   assert.equal(detectPackageManager(lockfileRoot), "yarn");
+});
+
+test("source package metadata falls back when vendored into another repository", () => {
+  const foreignRoot = mkdtempSync(join(tmpdir(), "idd-helper-runtime-foreign-root-"));
+  writeFileSync(join(foreignRoot, "package.json"), JSON.stringify({ name: "target-app" }));
+  assert.deepEqual(resolveSourcePackageMetadata(foreignRoot), {
+    name: "@kurone-kito/idd-skill",
+    repository: "github:kurone-kito/idd-skill",
+    nodeEngines: "^22.22.2 || >=24",
+  });
+
+  const missingRoot = mkdtempSync(join(tmpdir(), "idd-helper-runtime-missing-root-"));
+  assert.deepEqual(resolveSourcePackageMetadata(missingRoot), {
+    name: "@kurone-kito/idd-skill",
+    repository: "github:kurone-kito/idd-skill",
+    nodeEngines: "^22.22.2 || >=24",
+  });
 });
 
 test("empty targetRoot falls back to the current working directory", () => {

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import {
+  buildHelperRuntimeManifest,
+  collectVendoredFiles,
+  detectPackageManager,
+} from "../scripts/helper-runtime-manifest.mjs";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+test("package-manager profile emits manager-specific install commands without hard-coded pnpm", () => {
+  const expectedInstall = {
+    npm: "npm install --save-dev github:kurone-kito/idd-skill",
+    pnpm: "pnpm add -D github:kurone-kito/idd-skill",
+    yarn: "yarn add --dev github:kurone-kito/idd-skill",
+  };
+
+  for (const packageManager of ["npm", "pnpm", "yarn"]) {
+    const manifest = buildHelperRuntimeManifest({
+      profile: "package-manager",
+      packageManager,
+      targetRoot: REPO_ROOT,
+    });
+    const profile = manifest.profiles["package-manager"];
+
+    assert.equal(profile.packageManager, packageManager);
+    assert.equal(profile.installCommand, expectedInstall[packageManager]);
+    if (packageManager !== "pnpm") {
+      assert.doesNotMatch(profile.installCommand, /\bpnpm\b/);
+    }
+    for (const command of Object.values(profile.managedPackageJsonScripts)) {
+      assert.doesNotMatch(command, /\bpnpm\b/);
+    }
+  }
+});
+
+test("instructions-only profile omits helper files, scripts, and dependencies", () => {
+  const manifest = buildHelperRuntimeManifest({
+    profile: "instructions-only",
+    targetRoot: REPO_ROOT,
+  });
+  const profile = manifest.profiles["instructions-only"];
+
+  assert.deepEqual(profile.managedFiles, []);
+  assert.deepEqual(profile.managedPackageJsonScripts, {});
+  assert.deepEqual(profile.managedDependencies, {
+    devDependencies: {},
+  });
+  assert.deepEqual(profile.commands, {});
+});
+
+test("vendored-node managed files match the canonical helper import closure", () => {
+  const manifest = buildHelperRuntimeManifest({
+    profile: "vendored-node",
+    targetRoot: REPO_ROOT,
+  });
+  const managedFiles = manifest.profiles["vendored-node"].managedFiles.map((file) => file.targetPath);
+  const expectedFiles = collectVendoredFiles(REPO_ROOT).map((file) => file.targetPath);
+
+  assert.deepEqual(managedFiles, expectedFiles);
+  assert.ok(managedFiles.includes("scripts/protocol-helpers.mjs"));
+  assert.ok(managedFiles.includes("scripts/idd-doctor.mjs"));
+  assert.ok(managedFiles.includes("schemas/pre-merge-readiness.schema.json"));
+  assert.ok(managedFiles.includes("schemas/advisory-wait-state.schema.json"));
+  for (const relativePath of managedFiles) {
+    assert.equal(existsSync(join(REPO_ROOT, relativePath)), true, relativePath);
+  }
+});
+
+test("detectPackageManager respects package metadata and lockfiles", () => {
+  const packageJsonRoot = mkdtempSync(join(tmpdir(), "idd-helper-runtime-package-json-"));
+  writeFileSync(join(packageJsonRoot, "package.json"), JSON.stringify({ packageManager: "npm@10.9.0" }));
+  assert.equal(detectPackageManager(packageJsonRoot), "npm");
+
+  const lockfileRoot = mkdtempSync(join(tmpdir(), "idd-helper-runtime-lockfile-"));
+  writeFileSync(join(lockfileRoot, "yarn.lock"), "# lockfile");
+  assert.equal(detectPackageManager(lockfileRoot), "yarn");
+});
+
+test("switching away from vendored-node enumerates removal paths", () => {
+  const manifest = buildHelperRuntimeManifest({
+    profile: "instructions-only",
+    fromProfile: "vendored-node",
+    targetRoot: REPO_ROOT,
+  });
+
+  assert.ok(manifest.switching.removeFiles.length > 0);
+  assert.deepEqual(manifest.switching.removePackageJsonScripts, []);
+});
+
+test("helper bundle manifest bin wrapper produces JSON output", () => {
+  const output = execFileSync(
+    process.execPath,
+    [join(REPO_ROOT, "bin/idd-helper-bundle-manifest.mjs"), "--profile", "instructions-only"],
+    { encoding: "utf8" },
+  );
+  const parsed = JSON.parse(output);
+
+  assert.equal(parsed.packageSpec, "github:kurone-kito/idd-skill");
+  assert.ok(parsed.profiles["instructions-only"]);
+
+  const launcher = readFileSync(join(REPO_ROOT, "bin/idd-helper-bundle-manifest.mjs"), "utf8");
+  assert.ok(launcher.startsWith("#!/usr/bin/env node"));
+});

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -14,12 +14,13 @@ import {
 } from "../scripts/helper-runtime-manifest.mjs";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DEFAULT_PACKAGE_SPEC = "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main";
 
 test("package-manager profile emits manager-specific install commands without hard-coded pnpm", () => {
   const expectedInstall = {
-    npm: "npm install --save-dev github:kurone-kito/idd-skill",
-    pnpm: "pnpm add -D github:kurone-kito/idd-skill",
-    yarn: "yarn add --dev github:kurone-kito/idd-skill",
+    npm: `npm install --save-dev ${DEFAULT_PACKAGE_SPEC}`,
+    pnpm: `pnpm add -D ${DEFAULT_PACKAGE_SPEC}`,
+    yarn: `yarn add --dev ${DEFAULT_PACKAGE_SPEC}`,
   };
 
   for (const packageManager of ["npm", "pnpm", "yarn"]) {
@@ -32,11 +33,11 @@ test("package-manager profile emits manager-specific install commands without ha
 
     assert.equal(profile.packageManager, packageManager);
     assert.equal(profile.installCommand, expectedInstall[packageManager]);
-    assert.deepEqual(profile.managedDependencies, {
-      devDependencies: {
-        "@kurone-kito/idd-skill": "github:kurone-kito/idd-skill",
-      },
-    });
+      assert.deepEqual(profile.managedDependencies, {
+        devDependencies: {
+        "@kurone-kito/idd-skill": DEFAULT_PACKAGE_SPEC,
+        },
+      });
     if (packageManager !== "pnpm") {
       assert.doesNotMatch(profile.installCommand, /\bpnpm\b/);
     }
@@ -164,11 +165,25 @@ test("helper bundle manifest bin wrapper produces JSON output", () => {
   );
   const parsed = JSON.parse(output);
 
-  assert.equal(parsed.packageSpec, "github:kurone-kito/idd-skill");
+  assert.equal(parsed.packageSpec, DEFAULT_PACKAGE_SPEC);
   assert.ok(parsed.profiles["instructions-only"]);
 
   const launcher = readFileSync(join(REPO_ROOT, "bin/idd-helper-bundle-manifest.mjs"), "utf8");
   assert.ok(launcher.startsWith("#!/usr/bin/env node"));
+});
+
+test("manifest accepts an explicit package spec override", () => {
+  const packageSpec = "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0123456789abcdef0123456789abcdef01234567";
+  const manifest = buildHelperRuntimeManifest({
+    profile: "ephemeral-npx",
+    packageSpec,
+  });
+
+  assert.equal(manifest.packageSpec, packageSpec);
+  assert.equal(
+    manifest.profiles["ephemeral-npx"].commands["idd:helper-bundle-manifest"],
+    `npx --yes --package ${packageSpec} idd-helper-bundle-manifest`,
+  );
 });
 
 test("manifest CLI rejects flags that are missing required values", () => {


### PR DESCRIPTION
## Summary
- add a canonical `idd-helper-bundle-manifest` CLI plus stable `idd-*` package bins for the optional helper bundle
- derive vendored-node helper file lists from the live helper import graph instead of hand-maintained docs
- document package-manager, vendored-node, ephemeral-npx, and instructions-only wiring plus profile switching, and add focused manifest tests

## Validation
- pnpm run lint
- pnpm run test

Closes #310

## Follow-up
- #311 will expand the broader helper runtime profile and fallback matrix coverage on top of this import surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds multiple executable CLI commands and a shared CLI helper to invoke them.
  * Adds a manifest generator that emits profile-driven helper runtime manifests, detects package managers, supports packageSpec overrides, computes managed-file lists, and produces deterministic profile-switch plans.

* **Documentation**
  * New and expanded guides on helper runtime profiles, manifest usage, onboarding, package-manager options, profile wiring, and switching procedures.

* **Tests**
  * Expanded test suite validating manifest output, profile behaviors, package-manager detection, vendored-file collection, CLI parsing, and switching diffs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/340)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->