### PR TITLE
ci(deps): enable npm dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,16 @@ updates:
     package-ecosystem: github-actions
     schedule:
       interval: monthly
+  - directory: /
+    groups:
+      npm-minor:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+    package-ecosystem: npm
+    schedule:
+      interval: monthly


### PR DESCRIPTION
## Summary
- add a monthly npm Dependabot entry for the repository root
- group npm minor and patch updates under `npm-minor`
- keep the existing GitHub Actions Dependabot policy unchanged

## Context
This is a selective import from `kurone-kito/pnpm-project-template`, not a broader workflow reset.

## Follow-up issues
- none

Closes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated dependency management configuration for improved package update handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/348)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->