### PR TITLE
chore(vscode): import safe watcher and nesting settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,16 +5,28 @@
     "*.md": "${capture}.*.md",
     ".gitattributes": ".gitignore, .gitmessage",
     ".markdownlint.*": ".markdownlint-cli2.*",
-    "AGENTS.md": "CLAUDE.md, GEMINI.md"
+    "AGENTS.md": "CLAUDE.md, GEMINI.md",
+    "package.json": "pnpm-lock.yaml, pnpm-workspace.yaml"
   },
   "files.associations": {
     ".gitmessage": "git-commit",
     ".imgbotconfig": "json",
     "LICENSE": "plaintext"
   },
+  "files.watcherExclude": {
+    "**/*.tgz": true,
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/.husky/_/**": true,
+    "**/node_modules/**": true,
+    "**/pnpm-lock.yaml.*": true
+  },
   "git.branchProtection": ["main"],
   "material-icon-theme.files.associations": {
     ".imgbotconfig": "robots"
+  },
+  "search.exclude": {
+    "**/node_modules/**": true
   },
   "yaml.schemas": {
     "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/packages/cspell-types/cspell.schema.json": ".cspell.config.yml",


### PR DESCRIPTION
## Summary
- add safe `files.watcherExclude` entries to reduce local VS Code noise
- add `search.exclude` for `node_modules`
- nest `pnpm-lock.yaml` and `pnpm-workspace.yaml` under `package.json`

## Context
This selectively imports the low-risk VS Code ergonomics from the template
without adopting Biome defaults, readonly node_modules settings, or future-only
nesting patterns that do not fit this repository today.

## Follow-ups
- none

Closes #345


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration settings for improved local workspace management.

---

**Note:** This release contains only internal developer configuration updates with no impact on end-user functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/349)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->