### PR TITLE
chore(gitignore): add safe pnpm ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,8 @@ node_modules/
 .pnpm-store/
 .pnpm-config/
 .pnpm-debug.log*
+*.tgz
+pnpm-lock.yaml.*
 
 ### AI Agents ###
 # Claude Code local config


### PR DESCRIPTION
## Summary
- ignore package tarballs generated by `npm pack` or `pnpm pack`
- ignore temporary `pnpm-lock.yaml.*` backup files
- keep the `.gitignore` import intentionally narrower than the full template Node section

## Context
This is a selective import from the template's Node and pnpm `.gitignore`
entries. The repository does not currently generate broader TypeScript, Yarn,
coverage, or generic build-output artifacts, so those template patterns were
left out on purpose.

## Follow-ups
- none

Closes #347
