### PR TITLE
perf(cspell): enable local cache settings

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -1,4 +1,9 @@
 allowCompoundWords: true
+cache:
+  cacheFormat: universal
+  cacheLocation: node_modules/.cache/cspell/.cspell.cache
+  cacheStrategy: metadata
+  useCache: true
 dictionaries:
   - cpp
   - en_US


### PR DESCRIPTION
## Summary
- enable cspell cache usage explicitly
- store the cache under node_modules/.cache/cspell
- preserve the existing in-repo dictionaries and ignore paths

## Context
This is a selective cache-path adoption from kurone-kito/pnpm-project-template, not a switch to the shared config model.

## Follow-up issues
- none

Closes #346
