### PR TITLE
test: cover helper runtime profiles and fallback paths

### DIFF
--- a/tests/fixtures/helper-runtime-config/absent.json
+++ b/tests/fixtures/helper-runtime-config/absent.json
@@ -1,0 +1,18 @@
+{
+  "iddVersion": "0.1.0",
+  "mergePolicy": "fully_autonomous_merge",
+  "reviewPolicy": "copilot-advisory",
+  "threadResolutionPolicy": "fast-agent-resolve",
+  "claimTiming": {
+    "staleAge": "PT24H",
+    "heartbeatInterval": "PT12H"
+  },
+  "commands": {
+    "install-deps": "true",
+    "fix-validate": "node --test tests/*.mjs",
+    "pre-push-validate": "node --test tests/*.mjs",
+    "post-fix-validate": "node --test tests/*.mjs"
+  },
+  "issueScope": "roadmap",
+  "orphanFirstPolicy": "none"
+}

--- a/tests/fixtures/helper-runtime-config/instructions-only.json
+++ b/tests/fixtures/helper-runtime-config/instructions-only.json
@@ -1,0 +1,21 @@
+{
+  "iddVersion": "0.1.0",
+  "mergePolicy": "fully_autonomous_merge",
+  "reviewPolicy": "copilot-advisory",
+  "threadResolutionPolicy": "fast-agent-resolve",
+  "claimTiming": {
+    "staleAge": "PT24H",
+    "heartbeatInterval": "PT12H"
+  },
+  "commands": {
+    "install-deps": "true",
+    "fix-validate": "node --test tests/*.mjs",
+    "pre-push-validate": "node --test tests/*.mjs",
+    "post-fix-validate": "node --test tests/*.mjs"
+  },
+  "helperRuntime": {
+    "profile": "instructions-only"
+  },
+  "issueScope": "roadmap",
+  "orphanFirstPolicy": "none"
+}

--- a/tests/fixtures/helper-runtime-config/invalid-extra-key.json
+++ b/tests/fixtures/helper-runtime-config/invalid-extra-key.json
@@ -1,0 +1,22 @@
+{
+  "iddVersion": "0.1.0",
+  "mergePolicy": "fully_autonomous_merge",
+  "reviewPolicy": "copilot-advisory",
+  "threadResolutionPolicy": "fast-agent-resolve",
+  "claimTiming": {
+    "staleAge": "PT24H",
+    "heartbeatInterval": "PT12H"
+  },
+  "commands": {
+    "install-deps": "true",
+    "fix-validate": "node --test tests/*.mjs",
+    "pre-push-validate": "node --test tests/*.mjs",
+    "post-fix-validate": "node --test tests/*.mjs"
+  },
+  "helperRuntime": {
+    "profile": "package-manager",
+    "manager": "pnpm"
+  },
+  "issueScope": "roadmap",
+  "orphanFirstPolicy": "none"
+}

--- a/tests/fixtures/helper-runtime-config/invalid-profile.json
+++ b/tests/fixtures/helper-runtime-config/invalid-profile.json
@@ -1,0 +1,21 @@
+{
+  "iddVersion": "0.1.0",
+  "mergePolicy": "fully_autonomous_merge",
+  "reviewPolicy": "copilot-advisory",
+  "threadResolutionPolicy": "fast-agent-resolve",
+  "claimTiming": {
+    "staleAge": "PT24H",
+    "heartbeatInterval": "PT12H"
+  },
+  "commands": {
+    "install-deps": "true",
+    "fix-validate": "node --test tests/*.mjs",
+    "pre-push-validate": "node --test tests/*.mjs",
+    "post-fix-validate": "node --test tests/*.mjs"
+  },
+  "helperRuntime": {
+    "profile": "bun"
+  },
+  "issueScope": "roadmap",
+  "orphanFirstPolicy": "none"
+}

--- a/tests/fixtures/helper-runtime-config/package-manager.json
+++ b/tests/fixtures/helper-runtime-config/package-manager.json
@@ -1,0 +1,21 @@
+{
+  "iddVersion": "0.1.0",
+  "mergePolicy": "fully_autonomous_merge",
+  "reviewPolicy": "copilot-advisory",
+  "threadResolutionPolicy": "fast-agent-resolve",
+  "claimTiming": {
+    "staleAge": "PT24H",
+    "heartbeatInterval": "PT12H"
+  },
+  "commands": {
+    "install-deps": "true",
+    "fix-validate": "node --test tests/*.mjs",
+    "pre-push-validate": "node --test tests/*.mjs",
+    "post-fix-validate": "node --test tests/*.mjs"
+  },
+  "helperRuntime": {
+    "profile": "package-manager"
+  },
+  "issueScope": "roadmap",
+  "orphanFirstPolicy": "none"
+}

--- a/tests/helper-runtime-profiles.test.mjs
+++ b/tests/helper-runtime-profiles.test.mjs
@@ -1,0 +1,183 @@
+import { execFileSync } from "node:child_process";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { buildHelperRuntimeManifest } from "../scripts/helper-runtime-manifest.mjs";
+import { runDoctor } from "../scripts/idd-doctor.mjs";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const FIXTURE_ROOT = new URL("./fixtures/helper-runtime-config/", import.meta.url);
+const REQUIRED_INSTRUCTION_FILES = [
+  ".github/instructions/idd-overview.instructions.md",
+  ".github/instructions/idd-discover.instructions.md",
+  ".github/instructions/idd-suitability.instructions.md",
+  ".github/instructions/idd-claim.instructions.md",
+  ".github/instructions/idd-work.instructions.md",
+  ".github/instructions/idd-pr-submit.instructions.md",
+  ".github/instructions/idd-ci.instructions.md",
+  ".github/instructions/idd-review-snapshot.instructions.md",
+  ".github/instructions/idd-review-triage.instructions.md",
+  ".github/instructions/idd-review-fix.instructions.md",
+  ".github/instructions/idd-pre-merge.instructions.md",
+  ".github/instructions/idd-merge-handoff.instructions.md",
+  ".github/instructions/idd-merge.instructions.md",
+  ".github/instructions/idd-resume.instructions.md",
+  ".github/instructions/idd-resume-stall.instructions.md",
+  ".github/instructions/idd-advisory-wait.instructions.md",
+];
+const REQUIRED_DOC_FILES = [
+  "docs/getting-started.md",
+  "docs/concepts.md",
+  "docs/customization.md",
+  "docs/reference.md",
+  "docs/idd-workflow.md",
+  "docs/idd-review-policy-profiles.md",
+  "docs/idd-helper-scripts.md",
+  "docs/idd-comment-minimization.md",
+  "docs/permissions.md",
+  "docs/policy-constants.md",
+];
+const PROFILE_FIXTURE_FILES = [
+  "profiles/README.md",
+  "profiles/human-required/README.md",
+  "profiles/no-advisory/README.md",
+  "profiles/external-bot/README.md",
+];
+const OVERVIEW_TEXT = `# IDD overview
+
+<!-- helper-runtime-fixture-roadmap-id: value -->
+<!-- helper-runtime-fixture-blocked-by: value -->
+
+| Name | Commands |
+| ---- | -------- |
+| **fix-validate** | \`node --test tests/*.mjs\` |
+| **pre-push-validate** | \`node --test tests/*.mjs\` |
+| **post-fix-validate** | \`node --test tests/*.mjs\` |
+| **install-deps** | \`true\` |
+| **issue-scope** | \`roadmap\` |
+| **orphan-first-policy** | \`none\` |
+`;
+const DISCOVER_TEXT = `# IDD discover
+
+<!-- helper-runtime-fixture-roadmap-id: value -->
+<!-- helper-runtime-fixture-blocked-by: value -->
+`;
+
+test("idd-doctor accepts missing helperRuntime as instructions-only fallback fixture", () => {
+  const root = createDoctorFixtureRepo("absent.json");
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.deepEqual(report.errors, []);
+  assert.ok(
+    report.passes.includes(".github/idd/config.json leaves helperRuntime unset (instructions-only fallback)"),
+  );
+});
+
+test("instructions-only fixture emits no helper commands or dependencies", () => {
+  const root = createDoctorFixtureRepo("instructions-only.json");
+  const manifest = buildHelperRuntimeManifest({
+    profile: "instructions-only",
+    targetRoot: root,
+  });
+  const profile = manifest.profiles["instructions-only"];
+
+  assert.deepEqual(profile.managedDependencies, {
+    devDependencies: {},
+  });
+  assert.deepEqual(profile.managedPackageJsonScripts, {});
+  assert.deepEqual(profile.commands, {});
+  assert.deepEqual(profile.managedFiles, []);
+});
+
+test("package-manager fixture can run idd-doctor through the helper bin", () => {
+  const root = createDoctorFixtureRepo("package-manager.json", {
+    packageJson: {
+      name: "fixture-package-manager",
+      packageManager: "npm@10.9.0",
+    },
+  });
+  const manifest = buildHelperRuntimeManifest({
+    profile: "package-manager",
+    targetRoot: root,
+  });
+  const report = JSON.parse(
+    execFileSync(
+      process.execPath,
+      [join(REPO_ROOT, "bin/idd-doctor.mjs"), "--json", "--repo-root", root],
+      { encoding: "utf8" },
+    ),
+  );
+
+  assert.equal(manifest.packageManager, "npm");
+  assert.ok(
+    manifest.profiles["package-manager"].commands["idd:doctor"],
+    "package-manager profile should emit a doctor command",
+  );
+  assert.deepEqual(report.errors, []);
+  assert.ok(
+    report.passes.includes('.github/idd/config.json declares helper runtime profile "package-manager"'),
+  );
+});
+
+test("idd-doctor fixture rejects unsupported helperRuntime profiles", () => {
+  const root = createDoctorFixtureRepo("invalid-profile.json");
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.ok(
+    report.errors.includes('.github/idd/config.json: unsupported helperRuntime.profile "bun"'),
+  );
+});
+
+test("idd-doctor fixture rejects unsupported helperRuntime keys", () => {
+  const root = createDoctorFixtureRepo("invalid-extra-key.json");
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.ok(
+    report.errors.includes(".github/idd/config.json: unsupported helperRuntime keys: manager"),
+  );
+});
+
+function createDoctorFixtureRepo(configFixtureName, { packageJson = null } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "idd-helper-runtime-profile-"));
+  const configText = readFileSync(new URL(configFixtureName, FIXTURE_ROOT), "utf8");
+
+  for (const file of REQUIRED_INSTRUCTION_FILES) {
+    const contents = file.endsWith("idd-overview.instructions.md")
+      ? OVERVIEW_TEXT
+      : file.endsWith("idd-discover.instructions.md")
+        ? DISCOVER_TEXT
+        : `# ${file}\n`;
+    writeFixtureFile(root, file, contents);
+  }
+  for (const file of REQUIRED_DOC_FILES) {
+    writeFixtureFile(root, file, `# ${file}\n`);
+  }
+  for (const file of PROFILE_FIXTURE_FILES) {
+    writeFixtureFile(root, file, `# ${file}\n`);
+  }
+
+  writeFixtureFile(
+    root,
+    ".github/copilot-instructions.md",
+    "This fixture uses fully_autonomous_merge and copilot advisory.\n",
+  );
+  writeFixtureFile(root, ".github/idd/config.json", configText);
+  writeFixtureFile(root, "AGENTS.md", "See docs/idd-workflow.md.\n");
+  writeFixtureFile(root, "CLAUDE.md", "See docs/idd-workflow.md.\n");
+  writeFixtureFile(root, "GEMINI.md", "See docs/idd-workflow.md.\n");
+  if (packageJson) {
+    writeFixtureFile(root, "package.json", `${JSON.stringify(packageJson, null, 2)}\n`);
+  }
+
+  return root;
+}
+
+function writeFixtureFile(root, relativePath, contents) {
+  const absolutePath = join(root, relativePath);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, contents);
+}

--- a/tests/helper-runtime-profiles.test.mjs
+++ b/tests/helper-runtime-profiles.test.mjs
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -67,8 +67,9 @@ const DISCOVER_TEXT = `# IDD discover
 <!-- helper-runtime-fixture-blocked-by: value -->
 `;
 
-test("idd-doctor accepts missing helperRuntime as instructions-only fallback fixture", () => {
+test("idd-doctor accepts missing helperRuntime as instructions-only fallback fixture", (t) => {
   const root = createDoctorFixtureRepo("absent.json");
+  t.after(() => rmSync(root, { recursive: true, force: true }));
   const report = runDoctor({ root, requireGithub: false });
 
   assert.deepEqual(report.errors, []);
@@ -77,8 +78,9 @@ test("idd-doctor accepts missing helperRuntime as instructions-only fallback fix
   );
 });
 
-test("instructions-only fixture emits no helper commands or dependencies", () => {
+test("instructions-only fixture emits no helper commands or dependencies", (t) => {
   const root = createDoctorFixtureRepo("instructions-only.json");
+  t.after(() => rmSync(root, { recursive: true, force: true }));
   const manifest = buildHelperRuntimeManifest({
     profile: "instructions-only",
     targetRoot: root,
@@ -93,13 +95,14 @@ test("instructions-only fixture emits no helper commands or dependencies", () =>
   assert.deepEqual(profile.managedFiles, []);
 });
 
-test("package-manager fixture can run idd-doctor through the helper bin", () => {
+test("package-manager fixture can run idd-doctor through the helper bin", (t) => {
   const root = createDoctorFixtureRepo("package-manager.json", {
     packageJson: {
       name: "fixture-package-manager",
       packageManager: "npm@10.9.0",
     },
   });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
   const manifest = buildHelperRuntimeManifest({
     profile: "package-manager",
     targetRoot: root,
@@ -123,8 +126,9 @@ test("package-manager fixture can run idd-doctor through the helper bin", () => 
   );
 });
 
-test("idd-doctor fixture rejects unsupported helperRuntime profiles", () => {
+test("idd-doctor fixture rejects unsupported helperRuntime profiles", (t) => {
   const root = createDoctorFixtureRepo("invalid-profile.json");
+  t.after(() => rmSync(root, { recursive: true, force: true }));
   const report = runDoctor({ root, requireGithub: false });
 
   assert.ok(
@@ -132,8 +136,9 @@ test("idd-doctor fixture rejects unsupported helperRuntime profiles", () => {
   );
 });
 
-test("idd-doctor fixture rejects unsupported helperRuntime keys", () => {
+test("idd-doctor fixture rejects unsupported helperRuntime keys", (t) => {
   const root = createDoctorFixtureRepo("invalid-extra-key.json");
+  t.after(() => rmSync(root, { recursive: true, force: true }));
   const report = runDoctor({ root, requireGithub: false });
 
   assert.ok(

--- a/tests/pnpm-boundary.test.mjs
+++ b/tests/pnpm-boundary.test.mjs
@@ -58,6 +58,6 @@ test("helper runtime docs avoid pnpm-only command assumptions", () => {
 
   for (const file of files) {
     const text = readFileSync(join(REPO_ROOT, file), "utf8");
-    assert.doesNotMatch(text, /\bpnpm\s+(add|install|exec|dlx|run)\b/i, file);
+    assert.doesNotMatch(text, /`[^`\n]*\bpnpm\s+\S+[^`\n]*`/i, file);
   }
 });

--- a/tests/pnpm-boundary.test.mjs
+++ b/tests/pnpm-boundary.test.mjs
@@ -1,7 +1,12 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { findPnpmCommandLeaks } from "../scripts/check-pnpm-boundary.mjs";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
 test("passes when template command rows avoid pnpm", () => {
   const overview = `
@@ -30,4 +35,29 @@ test("fails when any command row leaks pnpm", () => {
     'fix-validate: contains forbidden token "pnpm" (pnpm run lint)',
     'install-deps: contains forbidden token "pnpm" (pnpm install --frozen-lockfile)',
   ]);
+});
+
+test("passes when command rows use npm, yarn, or npx examples", () => {
+  const overview = `
+| Name | Commands |
+| ---- | -------- |
+| **fix-validate** | \`npm run lint\` |
+| **pre-push-validate** | \`yarn test\` |
+| **post-fix-validate** | \`npx markdownlint-cli2 "**/*.md"\` |
+| **install-deps** | \`npm install\` |
+`;
+
+  assert.deepEqual(findPnpmCommandLeaks(overview), []);
+});
+
+test("helper runtime docs avoid pnpm-only command assumptions", () => {
+  const files = [
+    "docs/idd-helper-scripts.md",
+    "idd-template/docs/idd-helper-scripts.md",
+  ];
+
+  for (const file of files) {
+    const text = readFileSync(join(REPO_ROOT, file), "utf8");
+    assert.doesNotMatch(text, /\bpnpm\s+(add|install|exec|dlx|run)\b/i, file);
+  }
 });


### PR DESCRIPTION
## Summary
- add fixture-backed helper runtime profile coverage for idd-doctor and the helper manifest
- verify instructions-only fallback, explicit instructions-only behavior, and a package-manager fixture run
- extend pnpm-boundary tests so npm/yarn/npx examples stay allowed and generic helper docs stay pnpm-neutral

Closes #311

Recommended follow-up issues: none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added fixtures and test cases to validate helper runtime configuration profiles and error handling.
  * Expanded tests to verify manifest/command behavior for instructions-only and package-manager profiles.
  * Added boundary tests ensuring documentation and examples do not leak unsupported package manager commands.

**Note:** These are internal testing improvements with no direct end-user impact.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/356)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->