### PR TITLE
docs: slim helper-backed IDD phase instructions

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -20,17 +20,13 @@ steps and for defining their own routing on each outcome.
 
 ## Optional evidence helper
 
-When helper support is available, agents may collect the AW state with:
-
-```sh
-node scripts/advisory-wait-state.mjs --pr {pr-number}
-```
-
-The helper is read-only and emits AW evidence plus the computed AW
-outcome as JSON. It does **not** request reviewers, post markers, post
-holds, or replace the canonical shell / `gh` / `jq` fallbacks below. If
-the helper is unavailable, or if its output disagrees with the written
-protocol, follow the written AW1-AW5 steps in this file.
+When helper support is available in the idd-skill source repository, or
+in an adopter that explicitly installed the same helper, agents may use
+the documented advisory-wait helper reference in
+[`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs).
+That reference defines the stable `advisory-wait-state` JSON contract.
+The helper is read-only; if it is unavailable or disagrees with the
+written protocol, follow AW1-AW5 below.
 
 ## AW1 — Fetch Copilot review state
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -33,16 +33,15 @@ gate. The active claim must still use your current `{claim-id}`.
    (all review threads, review bodies, and regular PR comments,
    excluding trusted agent operational marker comments only). Compare
    against the F2 snapshot carried forward from
-   `idd-pre-merge.instructions.md`. Return to E1 if **any** of the
-   following is true:
-
-   In the idd-skill source repository, or in adopters that explicitly
+   `idd-pre-merge.instructions.md`. In the idd-skill source repository,
+   or in adopters that explicitly
    installed the same helpers, the documented merge-gate helper
    reference in
    [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
    may collect the documented snapshot tuple and broader
    `pre-merge-readiness` JSON report. Both helpers are evidence
-   collectors only; the written gate rules remain canonical.
+   collectors only; the written gate rules remain canonical. Return to
+   E1 if **any** of the following is true:
 
    - The current PR HEAD SHA differs from `{f2-head-SHA}`.
    - `{f2-max-activity-updatedAt}` is `none` and the final fetch is

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -36,25 +36,13 @@ gate. The active claim must still use your current `{claim-id}`.
    `idd-pre-merge.instructions.md`. Return to E1 if **any** of the
    following is true:
 
-   In the idd-skill source repository, you may optionally use the
-   read-only helper:
-
-   ```sh
-   node scripts/review-activity-snapshot.mjs --pr {pr-number} \
-     --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"
-   ```
-
-   You may also optionally use:
-
-   ```sh
-   node scripts/pre-merge-readiness.mjs --pr {pr-number} \
-     --claim-issue {issue-number} --expected-claim-id {claim-id} \
-     --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"
-   ```
-
-   to collect the broader F2/F3 evidence set immediately before the
-   merge attempt. Both helpers are evidence collectors only; the written
-   gate rules remain canonical.
+   In the idd-skill source repository, or in adopters that explicitly
+   installed the same helpers, the documented merge-gate helper
+   reference in
+   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
+   may collect the documented snapshot tuple and broader
+   `pre-merge-readiness` JSON report. Both helpers are evidence
+   collectors only; the written gate rules remain canonical.
 
    - The current PR HEAD SHA differs from `{f2-head-SHA}`.
    - `{f2-max-activity-updatedAt}` is `none` and the final fetch is

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -88,25 +88,12 @@ must align with every F2 condition below.
   ignored and reported as suspicious context when they affect routing.
   Then fetch the activity universe snapshot (same scope as E1 Step 1)
   and the current CI state for the HEAD SHA. In the idd-skill source
-  repository, you may optionally use the read-only helper:
-
-  ```sh
-  node scripts/review-activity-snapshot.mjs --pr {pr-number} \
-    --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"
-  ```
-
-  You may also optionally use:
-
-  ```sh
-  node scripts/pre-merge-readiness.mjs --pr {pr-number} \
-    --claim-issue {issue-number} --expected-claim-id {claim-id} \
-    --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"
-  ```
-
-  to collect the wider F2 evidence set (review currency, unresolved
-  threads, unreplied comments, reviewer states, advisory state, CI, and
-  claim validation) in one read-only JSON report; the instruction rules
-  remain canonical. Return to E1 if **any** of the
+  repository, or in adopters that explicitly installed the same
+  helpers, the documented merge-gate helper reference in
+  [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
+  may collect the documented snapshot tuple and broader
+  `pre-merge-readiness` JSON report. The instruction rules remain
+  canonical. Return to E1 if **any** of the
   following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new
     push occurred after E1's snapshot, even if the watermark comment was

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -86,14 +86,15 @@ must align with every F2 condition below.
   watermarks without `{claim-id}` must not be reused across a restart or
   takeover, and same-claim watermarks from untrusted authors must be
   ignored and reported as suspicious context when they affect routing.
-  Then fetch the activity universe snapshot (same scope as E1 Step 1)
-  and the current CI state for the HEAD SHA. In the idd-skill source
+  In the idd-skill source
   repository, or in adopters that explicitly installed the same
   helpers, the documented merge-gate helper reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
   may collect the documented snapshot tuple and broader
   `pre-merge-readiness` JSON report. The instruction rules remain
-  canonical. Return to E1 if **any** of the
+  canonical. Then fetch the activity universe snapshot (same scope as
+  E1 Step 1) and the current CI state for the HEAD SHA. Return to E1 if
+  **any** of the
   following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new
     push occurred after E1's snapshot, even if the watermark comment was

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -86,14 +86,13 @@ must align with every F2 condition below.
   watermarks without `{claim-id}` must not be reused across a restart or
   takeover, and same-claim watermarks from untrusted authors must be
   ignored and reported as suspicious context when they affect routing.
-  In the idd-skill source
-  repository, or in adopters that explicitly installed the same
-  helpers, the documented merge-gate helper reference in
+  To collect this evidence, either use the documented merge-gate helper
+  reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
-  may collect the documented snapshot tuple and broader
-  `pre-merge-readiness` JSON report. The instruction rules remain
-  canonical. Fetch the activity universe snapshot (same scope as E1
-  Step 1) and the current CI state for the HEAD SHA. Return to E1 if
+  (in the idd-skill source repository or adopters that explicitly
+  installed the same helpers) or fetch the activity universe snapshot
+  (same scope as E1 Step 1) and the current CI state for the HEAD SHA
+  directly. The instruction rules remain canonical. Return to E1 if
   **any** of the
   following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -92,8 +92,8 @@ must align with every F2 condition below.
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
   may collect the documented snapshot tuple and broader
   `pre-merge-readiness` JSON report. The instruction rules remain
-  canonical. Then fetch the activity universe snapshot (same scope as
-  E1 Step 1) and the current CI state for the HEAD SHA. Return to E1 if
+  canonical. Fetch the activity universe snapshot (same scope as E1
+  Step 1) and the current CI state for the HEAD SHA. Return to E1 if
   **any** of the
   following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -138,6 +138,46 @@ The adopted helper boundaries are intentionally narrow:
 - direct GraphQL fallback commands remain documented in
   `docs/idd-comment-minimization.md`
 
+## Stable Helper Evidence Outputs
+
+The references in this section apply only when a repository explicitly
+installs the matching helper scripts. Repositories that stay on the
+default `instructions-only` profile keep using the written shell /
+`gh` / `jq` procedures in the phase instructions and do not need a
+`scripts/` directory.
+
+### Advisory-wait evidence
+
+- Command: `node scripts/advisory-wait-state.mjs --pr <pr-number>`
+- Stable contract:
+  [`advisory-wait-state.schema.json`][advisory-wait-state-schema]
+- Stable fields consumed by the instructions: `prHeadSha`,
+  `lastCopilotCommit`, `copilotPending`,
+  `copilotPendingCoversHead`, `outcome`, `f3Outcome`,
+  `earliestSameHeadAt`, `requestMarkerCount`, and
+  `trustedMarkerSummary`
+
+### Merge-gate evidence
+
+- Snapshot command: `node scripts/review-activity-snapshot.mjs`
+  with `--pr <pr-number>` and
+  `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
+- Stable E1/F2/F3 snapshot tuple: `headSha`,
+  `maxActivityUpdatedAt`, `totalItemCount`,
+  `latestPassingCiCompletedAt`, and `counts`
+- Additional CI completion field: `latestCiCompletedAt` reports the
+  latest terminal run of any state; watermark and merge-gate checks use
+  `latestPassingCiCompletedAt`
+- Readiness command: `node scripts/pre-merge-readiness.mjs`
+  with `--pr <pr-number>`, `--claim-issue <issue-number>`,
+  `--expected-claim-id <claim-id>`, and
+  `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
+- Stable contract:
+  [`pre-merge-readiness.schema.json`][pre-merge-readiness-schema]
+- Stable sections consumed by the instructions: `reviewCurrency`,
+  `threads`, `unrepliedComments`, `reviewerStates`,
+  `advisoryWait`, `ci`, and `claim`
+
 ## Friction Inventory
 
 The workflow areas most likely to benefit from optional helpers are:
@@ -242,3 +282,6 @@ the following:
 Good future candidates remain read-only evidence collectors for
 pre-merge readiness or later claim-state inspection. They should not
 replace the written decision tables.
+
+[advisory-wait-state-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-wait-state.schema.json
+[pre-merge-readiness-schema]: https://kurone-kito.github.io/idd-skill/schemas/pre-merge-readiness.schema.json

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -20,17 +20,13 @@ steps and for defining their own routing on each outcome.
 
 ## Optional evidence helper
 
-When helper support is available, agents may collect the AW state with:
-
-```sh
-node scripts/advisory-wait-state.mjs --pr {pr-number}
-```
-
-The helper is read-only and emits AW evidence plus the computed AW
-outcome as JSON. It does **not** request reviewers, post markers, post
-holds, or replace the canonical shell / `gh` / `jq` fallbacks below. If
-the helper is unavailable, or if its output disagrees with the written
-protocol, follow the written AW1-AW5 steps in this file.
+When helper support is available in the idd-skill source repository, or
+in an adopter that explicitly installed the same helper, agents may use
+the documented advisory-wait helper reference in
+[`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs).
+That reference defines the stable `advisory-wait-state` JSON contract.
+The helper is read-only; if it is unavailable or disagrees with the
+written protocol, follow AW1-AW5 below.
 
 ## AW1 — Fetch Copilot review state
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -33,16 +33,15 @@ gate. The active claim must still use your current `{claim-id}`.
    (all review threads, review bodies, and regular PR comments,
    excluding trusted agent operational marker comments only). Compare
    against the F2 snapshot carried forward from
-   `idd-pre-merge.instructions.md`. Return to E1 if **any** of the
-   following is true:
-
-   In the idd-skill source repository, or in adopters that explicitly
+   `idd-pre-merge.instructions.md`. In the idd-skill source repository,
+   or in adopters that explicitly
    installed the same helpers, the documented merge-gate helper
    reference in
    [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
    may collect the documented snapshot tuple and broader
    `pre-merge-readiness` JSON report. Both helpers are evidence
-   collectors only; the written gate rules remain canonical.
+   collectors only; the written gate rules remain canonical. Return to
+   E1 if **any** of the following is true:
 
    - The current PR HEAD SHA differs from `{f2-head-SHA}`.
    - `{f2-max-activity-updatedAt}` is `none` and the final fetch is

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -36,25 +36,13 @@ gate. The active claim must still use your current `{claim-id}`.
    `idd-pre-merge.instructions.md`. Return to E1 if **any** of the
    following is true:
 
-   In the idd-skill source repository, you may optionally use the
-   read-only helper:
-
-   ```sh
-   node scripts/review-activity-snapshot.mjs --pr {pr-number} \
-     --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"
-   ```
-
-   You may also optionally use:
-
-   ```sh
-   node scripts/pre-merge-readiness.mjs --pr {pr-number} \
-     --claim-issue {issue-number} --expected-claim-id {claim-id} \
-     --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"
-   ```
-
-   to collect the broader F2/F3 evidence set immediately before the
-   merge attempt. Both helpers are evidence collectors only; the written
-   gate rules remain canonical.
+   In the idd-skill source repository, or in adopters that explicitly
+   installed the same helpers, the documented merge-gate helper
+   reference in
+   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
+   may collect the documented snapshot tuple and broader
+   `pre-merge-readiness` JSON report. Both helpers are evidence
+   collectors only; the written gate rules remain canonical.
 
    - The current PR HEAD SHA differs from `{f2-head-SHA}`.
    - `{f2-max-activity-updatedAt}` is `none` and the final fetch is

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -88,25 +88,12 @@ must align with every F2 condition below.
   ignored and reported as suspicious context when they affect routing.
   Then fetch the activity universe snapshot (same scope as E1 Step 1)
   and the current CI state for the HEAD SHA. In the idd-skill source
-  repository, you may optionally use the read-only helper:
-
-  ```sh
-  node scripts/review-activity-snapshot.mjs --pr {pr-number} \
-    --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"
-  ```
-
-  You may also optionally use:
-
-  ```sh
-  node scripts/pre-merge-readiness.mjs --pr {pr-number} \
-    --claim-issue {issue-number} --expected-claim-id {claim-id} \
-    --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"
-  ```
-
-  to collect the wider F2 evidence set (review currency, unresolved
-  threads, unreplied comments, reviewer states, advisory state, CI, and
-  claim validation) in one read-only JSON report; the instruction rules
-  remain canonical. Return to E1 if **any** of the
+  repository, or in adopters that explicitly installed the same
+  helpers, the documented merge-gate helper reference in
+  [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
+  may collect the documented snapshot tuple and broader
+  `pre-merge-readiness` JSON report. The instruction rules remain
+  canonical. Return to E1 if **any** of the
   following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new
     push occurred after E1's snapshot, even if the watermark comment was

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -86,14 +86,15 @@ must align with every F2 condition below.
   watermarks without `{claim-id}` must not be reused across a restart or
   takeover, and same-claim watermarks from untrusted authors must be
   ignored and reported as suspicious context when they affect routing.
-  Then fetch the activity universe snapshot (same scope as E1 Step 1)
-  and the current CI state for the HEAD SHA. In the idd-skill source
+  In the idd-skill source
   repository, or in adopters that explicitly installed the same
   helpers, the documented merge-gate helper reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
   may collect the documented snapshot tuple and broader
   `pre-merge-readiness` JSON report. The instruction rules remain
-  canonical. Return to E1 if **any** of the
+  canonical. Then fetch the activity universe snapshot (same scope as
+  E1 Step 1) and the current CI state for the HEAD SHA. Return to E1 if
+  **any** of the
   following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new
     push occurred after E1's snapshot, even if the watermark comment was

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -86,14 +86,13 @@ must align with every F2 condition below.
   watermarks without `{claim-id}` must not be reused across a restart or
   takeover, and same-claim watermarks from untrusted authors must be
   ignored and reported as suspicious context when they affect routing.
-  In the idd-skill source
-  repository, or in adopters that explicitly installed the same
-  helpers, the documented merge-gate helper reference in
+  To collect this evidence, either use the documented merge-gate helper
+  reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
-  may collect the documented snapshot tuple and broader
-  `pre-merge-readiness` JSON report. The instruction rules remain
-  canonical. Fetch the activity universe snapshot (same scope as E1
-  Step 1) and the current CI state for the HEAD SHA. Return to E1 if
+  (in the idd-skill source repository or adopters that explicitly
+  installed the same helpers) or fetch the activity universe snapshot
+  (same scope as E1 Step 1) and the current CI state for the HEAD SHA
+  directly. The instruction rules remain canonical. Return to E1 if
   **any** of the
   following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -92,8 +92,8 @@ must align with every F2 condition below.
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
   may collect the documented snapshot tuple and broader
   `pre-merge-readiness` JSON report. The instruction rules remain
-  canonical. Then fetch the activity universe snapshot (same scope as
-  E1 Step 1) and the current CI state for the HEAD SHA. Return to E1 if
+  canonical. Fetch the activity universe snapshot (same scope as E1
+  Step 1) and the current CI state for the HEAD SHA. Return to E1 if
   **any** of the
   following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -138,6 +138,46 @@ The adopted helper boundaries are intentionally narrow:
 - direct GraphQL fallback commands remain documented in
   `docs/idd-comment-minimization.md`
 
+## Stable Helper Evidence Outputs
+
+The references in this section apply only when a repository explicitly
+installs the matching helper scripts. Repositories that stay on the
+default `instructions-only` profile keep using the written shell /
+`gh` / `jq` procedures in the phase instructions and do not need a
+`scripts/` directory.
+
+### Advisory-wait evidence
+
+- Command: `node scripts/advisory-wait-state.mjs --pr <pr-number>`
+- Stable contract:
+  [`advisory-wait-state.schema.json`][advisory-wait-state-schema]
+- Stable fields consumed by the instructions: `prHeadSha`,
+  `lastCopilotCommit`, `copilotPending`,
+  `copilotPendingCoversHead`, `outcome`, `f3Outcome`,
+  `earliestSameHeadAt`, `requestMarkerCount`, and
+  `trustedMarkerSummary`
+
+### Merge-gate evidence
+
+- Snapshot command: `node scripts/review-activity-snapshot.mjs`
+  with `--pr <pr-number>` and
+  `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
+- Stable E1/F2/F3 snapshot tuple: `headSha`,
+  `maxActivityUpdatedAt`, `totalItemCount`,
+  `latestPassingCiCompletedAt`, and `counts`
+- Additional CI completion field: `latestCiCompletedAt` reports the
+  latest terminal run of any state; watermark and merge-gate checks use
+  `latestPassingCiCompletedAt`
+- Readiness command: `node scripts/pre-merge-readiness.mjs`
+  with `--pr <pr-number>`, `--claim-issue <issue-number>`,
+  `--expected-claim-id <claim-id>`, and
+  `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
+- Stable contract:
+  [`pre-merge-readiness.schema.json`][pre-merge-readiness-schema]
+- Stable sections consumed by the instructions: `reviewCurrency`,
+  `threads`, `unrepliedComments`, `reviewerStates`,
+  `advisoryWait`, `ci`, and `claim`
+
 ## Friction Inventory
 
 The workflow areas most likely to benefit from optional helpers are:
@@ -242,3 +282,6 @@ the following:
 Good future candidates remain read-only evidence collectors for
 pre-merge readiness or later claim-state inspection. They should not
 replace the written decision tables.
+
+[advisory-wait-state-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-wait-state.schema.json
+[pre-merge-readiness-schema]: https://kurone-kito.github.io/idd-skill/schemas/pre-merge-readiness.schema.json


### PR DESCRIPTION
## Summary
- add a shared helper-evidence reference section to the live/template helper docs with schema links and field mappings
- replace duplicated helper command blocks in advisory-wait, pre-merge, and merge instructions with references to that shared contract
- keep the instructions-only fallback canonical in the phase instructions

## Byte counts
| file | before | after | delta |
| --- | ---: | ---: | ---: |
| `.github/instructions/idd-advisory-wait.instructions.md` | 14119 | 14112 | -7 |
| `.github/instructions/idd-pre-merge.instructions.md` | 12769 | 12450 | -319 |
| `.github/instructions/idd-merge.instructions.md` | 11487 | 11266 | -221 |
| `idd-template/.github/instructions/idd-advisory-wait.instructions.md` | 14119 | 14112 | -7 |
| `idd-template/.github/instructions/idd-pre-merge.instructions.md` | 12769 | 12450 | -319 |
| `idd-template/.github/instructions/idd-merge.instructions.md` | 11487 | 11266 | -221 |

Closes #312


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated guidance for optional evidence helper scripts into a single reference.
  * Added a stable helper evidence outputs section documenting JSON contracts and named fields for advisory-wait and pre-merge/merge-gate evidence.
  * Removed explicit command examples for running helpers; guidance now points to the consolidated reference.
  * Clarified helpers are read-only and written protocol rules remain canonical when helpers are unavailable or disagree.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/358)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->