### PR TITLE
feat(protocol): add auditable forced handoff markers

### DIFF
--- a/bin/idd-forced-handoff-marker.mjs
+++ b/bin/idd-forced-handoff-marker.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/forced-handoff-marker.mjs");

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -520,18 +520,18 @@ marker followed by the visible consent note above. The JSON payload uses
 the field names below exactly, and maintainer-facing helpers should
 generate the full body so humans do not hand-write fragile claim IDs.
 
-| Field           | Requirement | Meaning                                                            |
-| --------------- | ----------- | ------------------------------------------------------------------ |
-| `old-agent-id`  | Required    | The agent ID that held the superseded claim                        |
-| `old-claim-id`  | Required    | The exact active claim being taken over                            |
-| `new-agent-id`  | Required    | The agent or session identifier that receives ownership            |
-| `new-claim-id`  | Required    | The new claim token that becomes authoritative after the handoff   |
-| `branch`        | Required    | The inherited work branch                                          |
-| `linked-pr`     | Conditional | The PR number or URL when PR context is part of the handoff        |
-| `forced-by`     | Required    | The approving human actor                                          |
-| `reason`        | Required    | Why the prior session is considered unavailable                    |
-| `timestamp`     | Required    | The GitHub server timestamp of the approval                        |
-| `context-scope` | Required    | Whether the handoff covers `issue-only` or `issue-plus-pr` context |
+| Field           | Requirement | Meaning                                                                       |
+| --------------- | ----------- | ----------------------------------------------------------------------------- |
+| `old-agent-id`  | Required    | The agent ID that held the superseded claim                                   |
+| `old-claim-id`  | Required    | The exact active claim being taken over                                       |
+| `new-agent-id`  | Required    | The agent or session identifier that receives ownership                       |
+| `new-claim-id`  | Required    | The new claim token that becomes authoritative after the handoff              |
+| `branch`        | Required    | The inherited work branch                                                     |
+| `linked-pr`     | Conditional | The decimal PR number or `http(s)` URL when PR context is part of the handoff |
+| `forced-by`     | Required    | The approving human actor                                                     |
+| `reason`        | Required    | Why the prior session is considered unavailable                               |
+| `timestamp`     | Required    | The GitHub server timestamp of the approval                                   |
+| `context-scope` | Required    | Whether the handoff covers `issue-only` or `issue-plus-pr` context            |
 
 The future marker must stay distinct from normal `claimed-by` and
 `unclaimed-by` events so older parsers do not mistake it for a standard

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -515,8 +515,10 @@ push, comment, resolve review state, or merge until a maintainer
 reassigns ownership.
 ```
 
-Future protocol work may use a dedicated marker or marker pair, but the
-contract must record at least these fields:
+The implemented protocol uses a dedicated `<!-- forced-handoff: {json} -->`
+marker followed by the visible consent note above. The JSON payload uses
+the field names below exactly, and maintainer-facing helpers should
+generate the full body so humans do not hand-write fragile claim IDs.
 
 | Field           | Requirement | Meaning                                                            |
 | --------------- | ----------- | ------------------------------------------------------------------ |

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -509,7 +509,7 @@ For `issue-plus-pr` context:
 ```text
 Forced handoff approved by {human-actor}. I verified that the current
 owning session or agent is unavailable. This transfers ownership away
-from claim `{old-claim-id}` on branch `{branch}` for PR #{pr-number}.
+from claim `{old-claim-id}` on branch `{branch}` for PR {pr-reference}.
 If the prior session resumes, it must stop immediately and must not
 push, comment, resolve review state, or merge until a maintainer
 reassigns ownership.
@@ -530,7 +530,7 @@ generate the full body so humans do not hand-write fragile claim IDs.
 | `linked-pr`     | Conditional | The decimal PR number or `http(s)` URL when PR context is part of the handoff |
 | `forced-by`     | Required    | The approving human actor                                                     |
 | `reason`        | Required    | Why the prior session is considered unavailable                               |
-| `timestamp`     | Required    | The GitHub server timestamp of the approval                                   |
+| `timestamp`     | Required    | Operator-recorded UTC timestamp captured in the marker payload                |
 | `context-scope` | Required    | Whether the handoff covers `issue-only` or `issue-plus-pr` context            |
 
 The forced-handoff marker must stay distinct from normal `claimed-by` and

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -533,7 +533,7 @@ generate the full body so humans do not hand-write fragile claim IDs.
 | `timestamp`     | Required    | The GitHub server timestamp of the approval                                   |
 | `context-scope` | Required    | Whether the handoff covers `issue-only` or `issue-plus-pr` context            |
 
-The future marker must stay distinct from normal `claimed-by` and
+The forced-handoff marker must stay distinct from normal `claimed-by` and
 `unclaimed-by` events so older parsers do not mistake it for a standard
 release or claim.
 

--- a/fixtures/schemas/forced-handoff-marker.invalid.json
+++ b/fixtures/schemas/forced-handoff-marker.invalid.json
@@ -1,0 +1,11 @@
+{
+  "oldAgentId": "github-copilot-cli-old",
+  "oldClaimId": "claim-20260512T090000Z-337-old",
+  "newAgentId": "github-copilot-cli-new",
+  "branch": "issue/337-feat-protocol-add-auditable-forced",
+  "forcedBy": "kurone-kito",
+  "reason": "",
+  "timestamp": "2026-05-12 11:00:00",
+  "contextScope": "issue-plus-pr",
+  "createdAt": "2026-05-12T11:00:05Z"
+}

--- a/fixtures/schemas/forced-handoff-marker.valid.json
+++ b/fixtures/schemas/forced-handoff-marker.valid.json
@@ -1,0 +1,13 @@
+{
+  "oldAgentId": "github-copilot-cli-old",
+  "oldClaimId": "claim-20260512T090000Z-337-old",
+  "newAgentId": "github-copilot-cli-new",
+  "newClaimId": "claim-20260512T110000Z-337-new",
+  "branch": "issue/337-feat-protocol-add-auditable-forced",
+  "linkedPr": "341",
+  "forcedBy": "kurone-kito",
+  "reason": "session-unavailable-after-operator-check",
+  "timestamp": "2026-05-12T11:00:00Z",
+  "contextScope": "issue-plus-pr",
+  "createdAt": "2026-05-12T11:00:05Z"
+}

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -520,18 +520,18 @@ marker followed by the visible consent note above. The JSON payload uses
 the field names below exactly, and maintainer-facing helpers should
 generate the full body so humans do not hand-write fragile claim IDs.
 
-| Field           | Requirement | Meaning                                                            |
-| --------------- | ----------- | ------------------------------------------------------------------ |
-| `old-agent-id`  | Required    | The agent ID that held the superseded claim                        |
-| `old-claim-id`  | Required    | The exact active claim being taken over                            |
-| `new-agent-id`  | Required    | The agent or session identifier that receives ownership            |
-| `new-claim-id`  | Required    | The new claim token that becomes authoritative after the handoff   |
-| `branch`        | Required    | The inherited work branch                                          |
-| `linked-pr`     | Conditional | The PR number or URL when PR context is part of the handoff        |
-| `forced-by`     | Required    | The approving human actor                                          |
-| `reason`        | Required    | Why the prior session is considered unavailable                    |
-| `timestamp`     | Required    | The GitHub server timestamp of the approval                        |
-| `context-scope` | Required    | Whether the handoff covers `issue-only` or `issue-plus-pr` context |
+| Field           | Requirement | Meaning                                                                       |
+| --------------- | ----------- | ----------------------------------------------------------------------------- |
+| `old-agent-id`  | Required    | The agent ID that held the superseded claim                                   |
+| `old-claim-id`  | Required    | The exact active claim being taken over                                       |
+| `new-agent-id`  | Required    | The agent or session identifier that receives ownership                       |
+| `new-claim-id`  | Required    | The new claim token that becomes authoritative after the handoff              |
+| `branch`        | Required    | The inherited work branch                                                     |
+| `linked-pr`     | Conditional | The decimal PR number or `http(s)` URL when PR context is part of the handoff |
+| `forced-by`     | Required    | The approving human actor                                                     |
+| `reason`        | Required    | Why the prior session is considered unavailable                               |
+| `timestamp`     | Required    | The GitHub server timestamp of the approval                                   |
+| `context-scope` | Required    | Whether the handoff covers `issue-only` or `issue-plus-pr` context            |
 
 The future marker must stay distinct from normal `claimed-by` and
 `unclaimed-by` events so older parsers do not mistake it for a standard

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -515,8 +515,10 @@ push, comment, resolve review state, or merge until a maintainer
 reassigns ownership.
 ```
 
-Future protocol work may use a dedicated marker or marker pair, but the
-contract must record at least these fields:
+The implemented protocol uses a dedicated `<!-- forced-handoff: {json} -->`
+marker followed by the visible consent note above. The JSON payload uses
+the field names below exactly, and maintainer-facing helpers should
+generate the full body so humans do not hand-write fragile claim IDs.
 
 | Field           | Requirement | Meaning                                                            |
 | --------------- | ----------- | ------------------------------------------------------------------ |

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -509,7 +509,7 @@ For `issue-plus-pr` context:
 ```text
 Forced handoff approved by {human-actor}. I verified that the current
 owning session or agent is unavailable. This transfers ownership away
-from claim `{old-claim-id}` on branch `{branch}` for PR #{pr-number}.
+from claim `{old-claim-id}` on branch `{branch}` for PR {pr-reference}.
 If the prior session resumes, it must stop immediately and must not
 push, comment, resolve review state, or merge until a maintainer
 reassigns ownership.
@@ -530,7 +530,7 @@ generate the full body so humans do not hand-write fragile claim IDs.
 | `linked-pr`     | Conditional | The decimal PR number or `http(s)` URL when PR context is part of the handoff |
 | `forced-by`     | Required    | The approving human actor                                                     |
 | `reason`        | Required    | Why the prior session is considered unavailable                               |
-| `timestamp`     | Required    | The GitHub server timestamp of the approval                                   |
+| `timestamp`     | Required    | Operator-recorded UTC timestamp captured in the marker payload                |
 | `context-scope` | Required    | Whether the handoff covers `issue-only` or `issue-plus-pr` context            |
 
 The forced-handoff marker must stay distinct from normal `claimed-by` and

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -533,7 +533,7 @@ generate the full body so humans do not hand-write fragile claim IDs.
 | `timestamp`     | Required    | The GitHub server timestamp of the approval                                   |
 | `context-scope` | Required    | Whether the handoff covers `issue-only` or `issue-plus-pr` context            |
 
-The future marker must stay distinct from normal `claimed-by` and
+The forced-handoff marker must stay distinct from normal `claimed-by` and
 `unclaimed-by` events so older parsers do not mistake it for a standard
 release or claim.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "idd-advisory-wait-state": "./bin/idd-advisory-wait-state.mjs",
     "idd-audit-pr-cleanup": "./bin/idd-audit-pr-cleanup.mjs",
     "idd-doctor": "./bin/idd-doctor.mjs",
+    "idd-forced-handoff-marker": "./bin/idd-forced-handoff-marker.mjs",
     "idd-helper-bundle-manifest": "./bin/idd-helper-bundle-manifest.mjs",
     "idd-live-status-digest": "./bin/idd-live-status-digest.mjs",
     "idd-pre-merge-readiness": "./bin/idd-pre-merge-readiness.mjs",

--- a/schemas/forced-handoff-marker.schema.json
+++ b/schemas/forced-handoff-marker.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/forced-handoff-marker.schema.json",
+  "title": "IDD Forced Handoff Marker Payload",
+  "description": "Structured forced-handoff marker payload parsed from forced-handoff comments.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "oldAgentId",
+    "oldClaimId",
+    "newAgentId",
+    "newClaimId",
+    "branch",
+    "forcedBy",
+    "reason",
+    "timestamp",
+    "contextScope"
+  ],
+  "properties": {
+    "oldAgentId": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^\\S+$"
+    },
+    "oldClaimId": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^\\S+$"
+    },
+    "newAgentId": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^\\S+$"
+    },
+    "newClaimId": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^\\S+$"
+    },
+    "branch": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\s>]+$"
+    },
+    "linkedPr": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^\\S+$"
+    },
+    "forcedBy": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^\\S+$"
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+    },
+    "contextScope": {
+      "type": "string",
+      "enum": [
+        "issue-only",
+        "issue-plus-pr"
+      ]
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+    }
+  }
+}

--- a/schemas/forced-handoff-marker.schema.json
+++ b/schemas/forced-handoff-marker.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://kurone-kito.github.io/idd-skill/schemas/forced-handoff-marker.schema.json",
-  "title": "IDD Forced Handoff Marker Payload",
-  "description": "Structured forced-handoff marker payload parsed from forced-handoff comments.",
+  "title": "IDD Forced Handoff Parsed Payload",
+  "description": "Normalized camelCase payload returned by parseForcedHandoffComment; raw on-wire marker JSON may use hyphen-case aliases that the parser resolves before schema validation.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -45,7 +45,7 @@
     "linkedPr": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^\\S+$"
+      "pattern": "^(?:[1-9]\\d*|https?://[^\\s<>\"]+)$"
     },
     "forcedBy": {
       "type": "string",

--- a/schemas/forced-handoff-marker.schema.json
+++ b/schemas/forced-handoff-marker.schema.json
@@ -54,7 +54,8 @@
     },
     "reason": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "^(?!.*(?:-->)).+$"
     },
     "timestamp": {
       "type": "string",

--- a/schemas/forced-handoff-marker.schema.json
+++ b/schemas/forced-handoff-marker.schema.json
@@ -20,27 +20,27 @@
     "oldAgentId": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^\\S+$"
+      "pattern": "^(?!.*(?:<!--|-->))\\S+$"
     },
     "oldClaimId": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^\\S+$"
+      "pattern": "^(?!.*(?:<!--|-->))\\S+$"
     },
     "newAgentId": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^\\S+$"
+      "pattern": "^(?!.*(?:<!--|-->))\\S+$"
     },
     "newClaimId": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^\\S+$"
+      "pattern": "^(?!.*(?:<!--|-->))\\S+$"
     },
     "branch": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[^\\s>]+$"
+      "pattern": "^(?!.*(?:<!--|-->))[^\\s>]+$"
     },
     "linkedPr": {
       "type": "string",
@@ -50,7 +50,7 @@
     "forcedBy": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^\\S+$"
+      "pattern": "^(?!.*(?:<!--|-->))\\S+$"
     },
     "reason": {
       "type": "string",

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import {
   classifyRegularBotComment,
   hasFreshDisposition,
@@ -8,17 +9,26 @@ import {
   indexThreadsByReview,
   isDispositionComment,
   isKnownReviewBot,
+  normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
+  summarizeClaimValidation,
   unsafeTextReason,
 } from "./protocol-helpers.mjs";
 
-const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
 const TRUSTED_MARKER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+const FORCED_HANDOFF_AUTHORITY_POLICIES = new Set([
+  "owners-and-maintainers-only",
+  "all-write-permission-actors",
+]);
+const FORCED_HANDOFF_AUTHORITY_POLICY_DEFAULT = "owners-and-maintainers-only";
+const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
+const FORCED_HANDOFF_MODE_DEFAULT = "disabled";
 const trustedMarkerAuthorCache = new Map();
+const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerAuthors = null;
 let cachedCurrentViewerLogin = null;
-
-const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
+let cachedForcedHandoffAuthorityPolicy = null;
+let cachedForcedHandoffMode = null;
 
 const args = parseArgs(process.argv.slice(2));
 
@@ -696,101 +706,83 @@ function readActiveClaim(owner, repo, issueNumber) {
     ),
   );
 
-  const comments = [...(result.comments ?? [])].sort((left, right) => {
-    return new Date(left.createdAt) - new Date(right.createdAt);
+  const comments = (result.comments ?? []).map((comment) => ({
+    body: comment.body ?? "",
+    createdAt: comment.createdAt ?? "",
+    author: { login: comment.author?.login ?? "" },
+  }));
+
+  const summary = summarizeClaimValidation(comments, {
+    trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
+    forcedHandoffEnabled: readForcedHandoffMode() === "human-gated",
+    isAuthorizedForcedHandoff: (forcedBy) => {
+      return isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy(),
+      );
+    },
   });
 
-  let active = null;
-  const retiredClaimIds = new Set();
-
-  for (const comment of comments) {
-    const author = comment.author?.login ?? "";
-
-    const claim = parseClaim(comment.body, comment.createdAt, author);
-    if (claim) {
-      if (!isTrustedMarkerAuthor(owner, repo, author)) {
-        continue;
-      }
-      if (retiredClaimIds.has(claim.claimId)) {
-        continue;
-      }
-
-      if (active && claim.agentId === active.agentId && claim.claimId === active.claimId) {
-        active.createdAt = claim.createdAt;
-        continue;
-      }
-
-      if (active && claim.claimId === active.claimId) {
-        continue;
-      }
-
-      if (!active && claim.supersedes === "none") {
-        active = claim;
-        continue;
-      }
-
-      if (
-        active
-        && claim.supersedes === active.claimId
-        && isStaleAt(active.createdAt, claim.createdAt)
-      ) {
-        retiredClaimIds.add(active.claimId);
-        active = claim;
-      }
-      continue;
-    }
-
-    const release = parseRelease(comment.body, author);
-    if (
-      release
-      && isTrustedMarkerAuthor(owner, repo, author)
-      && active
-      && release.agentId === active.agentId
-      && release.claimId === active.claimId
-    ) {
-      retiredClaimIds.add(active.claimId);
-      active = null;
-    }
-  }
-
-  return active;
+  return summary.activeClaimPresent ? summary.activeClaim : null;
 }
 
-function parseClaim(body, createdAt, author) {
-  const match = body.trimEnd().match(
-    new RegExp(
-      `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
-      "i",
-    ),
+function resolveTrustedMarkerLogins(owner, repo, comments) {
+  return normalizeTrustedMarkerLogins(
+    comments
+      .map((comment) => comment.author?.login ?? "")
+      .filter(Boolean)
+      .filter((login) => isTrustedMarkerAuthor(owner, repo, login)),
   );
-  if (!match || !isValidIsoTimestamp(match[4])) {
-    return null;
-  }
-  return {
-    agentId: match[1],
-    claimId: match[2],
-    supersedes: match[3],
-    branch: match[5],
-    createdAt,
-    author,
-  };
 }
 
-function parseRelease(body, author) {
-  const match = body.trimEnd().match(
-    new RegExp(
-      `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
-      "i",
-    ),
-  );
-  if (!match || !isValidIsoTimestamp(match[3])) {
-    return null;
+function forcedHandoffAuthorityPolicy() {
+  if (cachedForcedHandoffAuthorityPolicy !== null) {
+    return cachedForcedHandoffAuthorityPolicy;
   }
-  return {
-    agentId: match[1],
-    claimId: match[2],
-    author,
-  };
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const policy = String(config?.forcedHandoffAuthority ?? config?.["forced-handoff-authority"] ?? "").trim();
+    if (FORCED_HANDOFF_AUTHORITY_POLICIES.has(policy)) {
+      cachedForcedHandoffAuthorityPolicy = policy;
+      return cachedForcedHandoffAuthorityPolicy;
+    }
+  } catch {
+    // Default policy remains owners-and-maintainers-only.
+  }
+  cachedForcedHandoffAuthorityPolicy = FORCED_HANDOFF_AUTHORITY_POLICY_DEFAULT;
+  return cachedForcedHandoffAuthorityPolicy;
+}
+
+function readForcedHandoffMode() {
+  if (cachedForcedHandoffMode !== null) {
+    return cachedForcedHandoffMode;
+  }
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const mode = String(config?.forcedHandoff ?? config?.["forced-handoff"] ?? "").trim();
+    if (FORCED_HANDOFF_MODES.has(mode)) {
+      cachedForcedHandoffMode = mode;
+      return cachedForcedHandoffMode;
+    }
+  } catch {
+    // Default mode remains disabled.
+  }
+  cachedForcedHandoffMode = FORCED_HANDOFF_MODE_DEFAULT;
+  return cachedForcedHandoffMode;
+}
+
+function isAuthorizedForcedHandoffActor(owner, repo, login, policy = forcedHandoffAuthorityPolicy()) {
+  const normalized = String(login ?? "").trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const permission = collaboratorPermission(owner, repo, normalized);
+  if (policy === "all-write-permission-actors") {
+    return permission === "admin" || permission === "maintain" || permission === "write";
+  }
+  return permission === "admin" || permission === "maintain";
 }
 
 function isTrustedMarkerAuthor(owner, repo, login) {
@@ -871,14 +863,30 @@ function trustCollaboratorMarkers() {
   return /^(1|true|yes)$/i.test(process.env.IDD_TRUST_COLLABORATOR_MARKERS ?? "");
 }
 
-function isValidIsoTimestamp(value) {
-  const time = Date.parse(value);
-  return Number.isFinite(time) && new Date(time).toISOString().replace(".000Z", "Z") === value;
-}
+function collaboratorPermission(owner, repo, login) {
+  const cacheKey = `${owner}/${repo}:${login}`;
+  if (collaboratorPermissionCache.has(cacheKey)) {
+    return collaboratorPermissionCache.get(cacheKey);
+  }
 
-function isStaleAt(activeCreatedAt, nextCreatedAt) {
-  const staleMs = 24 * 60 * 60 * 1000;
-  return new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >= staleMs;
+  let permission = "";
+  try {
+    permission = execFileSync(
+      "gh",
+      [
+        "api",
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        "--jq",
+        ".permission",
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim().toLowerCase();
+  } catch {
+    permission = "";
+  }
+
+  collaboratorPermissionCache.set(cacheKey, permission);
+  return permission;
 }
 
 function ghGraphql(query, variables, options = {}) {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -61,6 +61,7 @@ const repository = args.repo ?? detectRepository();
 const [owner, repo] = parseRepository(repository);
 
 const prNumber = parsePositiveInteger(args.pr, "--pr");
+const claimContext = { expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, prNumber) };
 
 if (args.claimIssue) {
   args.claimIssue = String(parsePositiveInteger(args.claimIssue, "--claim-issue"));
@@ -73,7 +74,7 @@ if (args.apply) {
   for (const candidate of report.candidates) {
     if (!args.skipClaimCheck) {
       try {
-        assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+        assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId, claimContext);
       } catch (error) {
         report.failed.push({
           ...candidate,
@@ -89,7 +90,7 @@ if (args.apply) {
       }
       if (!args.skipClaimCheck) {
         try {
-          assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+          assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId, claimContext);
         } catch (error) {
           report.failed.push({
             ...freshCandidate,
@@ -681,15 +682,15 @@ async function revalidateCandidate(owner, repo, prNumber, candidate, report) {
   return null;
 }
 
-function assertActiveClaim(owner, repo, issueNumber, agentId, claimId) {
-  const active = readActiveClaim(owner, repo, issueNumber);
+function assertActiveClaim(owner, repo, issueNumber, agentId, claimId, options = {}) {
+  const active = readActiveClaim(owner, repo, issueNumber, options);
   if (!active || active.claimId !== claimId || (agentId && active.agentId !== agentId)) {
     const activeLabel = active ? `${active.agentId} ${active.claimId}` : "none";
     throw new Error(`claim check failed for #${issueNumber}: active claim is ${activeLabel}`);
   }
 }
 
-function readActiveClaim(owner, repo, issueNumber) {
+function readActiveClaim(owner, repo, issueNumber, options = {}) {
   const result = JSON.parse(
     execFileSync(
       "gh",
@@ -715,6 +716,7 @@ function readActiveClaim(owner, repo, issueNumber) {
   const summary = summarizeClaimValidation(comments, {
     trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
     forcedHandoffEnabled: readForcedHandoffMode() === "human-gated",
+    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
     isAuthorizedForcedHandoff: (forcedBy) => {
       return isAuthorizedForcedHandoffActor(
         owner,
@@ -726,6 +728,18 @@ function readActiveClaim(owner, repo, issueNumber) {
   });
 
   return summary.activeClaimPresent ? summary.activeClaim : null;
+}
+
+function buildExpectedLinkedPrReferences(owner, repo, prNumber) {
+  const normalized = String(prNumber ?? "").trim();
+  if (!normalized) {
+    return [];
+  }
+  return [
+    normalized,
+    `#${normalized}`,
+    `https://github.com/${owner}/${repo}/pull/${normalized}`,
+  ];
 }
 
 function resolveTrustedMarkerLogins(owner, repo, comments) {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -167,6 +167,11 @@ function evaluateOperationalComment(comment, pr, report, owner, repo) {
     return true;
   }
 
+  if (prefix === "<!-- forced-handoff:") {
+    addSkipped(report, subject, "forced-handoff markers remain audit evidence");
+    return true;
+  }
+
   if (!pr.merged) {
     addSkipped(report, subject, "PR is not merged");
     return true;

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -173,7 +173,7 @@ function buildTrustedMarkerLogins(owner, repo, viewerLogin, cliLogins, issueComm
     }
     const permission = permissionCache.get(login) ?? safeGhText([
       "api",
-      `repos/${owner}/${repo}/collaborators/${login}/permission`,
+      `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
       "--jq",
       ".permission",
     ]).toLowerCase();

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -1,98 +1,101 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 import { renderForcedHandoffComment, resolveActiveClaim } from "./protocol-helpers.mjs";
 
-const args = parseArgs(process.argv.slice(2));
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
 
-if (args.help) {
-  printUsage();
-  process.exit(0);
-}
-
-if (!args.issueNumber) {
-  throw new Error("missing required --issue <number> argument");
-}
-if (!args.newAgentId) {
-  throw new Error("missing required --new-agent-id <id> argument");
-}
-if (!args.newClaimId) {
-  throw new Error("missing required --new-claim-id <id> argument");
-}
-if (!args.forcedBy) {
-  throw new Error("missing required --forced-by <actor> argument");
-}
-if (!args.reason) {
-  throw new Error("missing required --reason <text> argument");
-}
-
-const repo = args.repo ?? ghText(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
-const [owner, name] = repo.split("/", 2);
-const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true).flat();
-const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
-const trustedMarkerLogins = buildTrustedMarkerLogins(owner, name, viewerLogin, args.trustedMarkerLogins, issueComments);
-const activeClaim = resolveActiveClaim(
-  issueComments.map(normalizeIssueComment),
-  (login) => trustedMarkerLogins.has(String(login ?? "").trim().toLowerCase()),
-);
-
-if (!activeClaim) {
-  throw new Error(`issue #${args.issueNumber} has no active trusted claim`);
-}
-
-let linkedPr = "";
-if (args.prNumber) {
-  const pr = ghJson([
-    "pr",
-    "view",
-    String(args.prNumber),
-    "-R",
-    repo,
-    "--json",
-    "headRefName,url",
-    "--jq",
-    ".",
-  ]);
-  const headRefName = String(pr.headRefName ?? "");
-  if (headRefName !== activeClaim.branch) {
-    throw new Error(
-      `PR #${args.prNumber} head branch ${headRefName} does not match active claim branch ${activeClaim.branch}`,
-    );
+  if (args.help) {
+    printUsage();
+    return;
   }
-  linkedPr = String(args.prNumber);
-}
 
-const payload = {
-  oldAgentId: activeClaim.agentId,
-  oldClaimId: activeClaim.claimId,
-  newAgentId: args.newAgentId,
-  newClaimId: args.newClaimId,
-  branch: activeClaim.branch,
-  ...(linkedPr ? { linkedPr } : {}),
-  forcedBy: args.forcedBy,
-  reason: args.reason,
-  timestamp: args.timestamp ?? currentIsoTimestamp(),
-  contextScope: linkedPr ? "issue-plus-pr" : "issue-only",
-};
+  if (!args.issueNumber) {
+    throw new Error("missing required --issue <number> argument");
+  }
+  if (!args.newAgentId) {
+    throw new Error("missing required --new-agent-id <id> argument");
+  }
+  if (!args.newClaimId) {
+    throw new Error("missing required --new-claim-id <id> argument");
+  }
+  if (!args.forcedBy) {
+    throw new Error("missing required --forced-by <actor> argument");
+  }
+  if (!args.reason) {
+    throw new Error("missing required --reason <text> argument");
+  }
 
-const commentBody = renderForcedHandoffComment(payload);
-if (args.format === "json") {
-  console.log(
-    JSON.stringify(
-      {
-        repository: repo,
-        issueNumber: args.issueNumber,
-        activeClaim,
-        payload,
-        commentBody,
-      },
-      null,
-      2,
-    ),
+  const repo = args.repo ?? ghText(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
+  const [owner, name] = repo.split("/", 2);
+  const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true).flat();
+  const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
+  const trustedMarkerLogins = buildTrustedMarkerLogins(owner, name, viewerLogin, args.trustedMarkerLogins, issueComments);
+  const activeClaim = resolveActiveClaim(
+    issueComments.map(normalizeIssueComment),
+    (login) => trustedMarkerLogins.has(String(login ?? "").trim().toLowerCase()),
   );
-} else {
-  console.log(commentBody);
+
+  if (!activeClaim) {
+    throw new Error(`issue #${args.issueNumber} has no active trusted claim`);
+  }
+
+  let linkedPr = "";
+  if (args.prNumber) {
+    const pr = ghJson([
+      "pr",
+      "view",
+      String(args.prNumber),
+      "-R",
+      repo,
+      "--json",
+      "headRefName,url",
+      "--jq",
+      ".",
+    ]);
+    const headRefName = String(pr.headRefName ?? "");
+    if (headRefName !== activeClaim.branch) {
+      throw new Error(
+        `PR #${args.prNumber} head branch ${headRefName} does not match active claim branch ${activeClaim.branch}`,
+      );
+    }
+    linkedPr = String(args.prNumber);
+  }
+
+  const payload = {
+    oldAgentId: activeClaim.agentId,
+    oldClaimId: activeClaim.claimId,
+    newAgentId: args.newAgentId,
+    newClaimId: args.newClaimId,
+    branch: activeClaim.branch,
+    ...(linkedPr ? { linkedPr } : {}),
+    forcedBy: args.forcedBy,
+    reason: args.reason,
+    timestamp: args.timestamp ?? currentIsoTimestamp(),
+    contextScope: linkedPr ? "issue-plus-pr" : "issue-only",
+  };
+
+  const commentBody = renderForcedHandoffComment(payload);
+  if (args.format === "json") {
+    console.log(
+      JSON.stringify(
+        {
+          repository: repo,
+          issueNumber: args.issueNumber,
+          activeClaim,
+          payload,
+          commentBody,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(commentBody);
+  }
 }
 
 function parseArgs(argv) {
@@ -233,8 +236,8 @@ function safeGhText(args) {
   }
 }
 
-function currentIsoTimestamp() {
-  return new Date().toISOString().replace(".000Z", "Z");
+export function currentIsoTimestamp() {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
 function printUsage() {
@@ -256,4 +259,8 @@ Environment:
   IDD_TRUSTED_MARKER_ACTORS        comma-separated trusted bot/app logins
   IDD_TRUST_COLLABORATOR_MARKERS   set true to trust Write/Maintain/Admin collaborators
 `);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
 }

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -4,13 +4,15 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-import { renderForcedHandoffComment, resolveActiveClaim } from "./protocol-helpers.mjs";
+import { renderForcedHandoffComment, summarizeClaimValidation } from "./protocol-helpers.mjs";
 
 const APPROVAL_ACTOR_POLICIES = new Set([
   "owners-and-maintainers-only",
   "all-write-permission-actors",
 ]);
 const APPROVAL_ACTOR_POLICY_DEFAULT = "owners-and-maintainers-only";
+const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
+const FORCED_HANDOFF_MODE_DEFAULT = "disabled";
 
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
@@ -38,12 +40,18 @@ export function main(argv = process.argv.slice(2)) {
 
   const repoRef = args.repo ?? ghText(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
   const { owner, name } = parseOwnerRepo(repoRef);
+  if (readForcedHandoffMode() !== "human-gated") {
+    throw new Error("forced-handoff mode is not human-gated; marker generation is disabled");
+  }
   const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true).flat();
   const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
   const trustedMarkerLogins = buildTrustedMarkerLogins(owner, name, viewerLogin, args.trustedMarkerLogins, issueComments);
   const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
   const permissionCache = new Map();
   const activeClaim = resolveHelperActiveClaim(issueComments, trustedMarkerLogins, {
+    expectedLinkedPrs: args.prNumber
+      ? [String(args.prNumber), `https://github.com/${owner}/${name}/pull/${args.prNumber}`]
+      : [],
     isAuthorizedForcedHandoff:
       (forcedBy) => isAuthorizedForcedHandoffActor(
         owner,
@@ -56,6 +64,20 @@ export function main(argv = process.argv.slice(2)) {
 
   if (!activeClaim) {
     throw new Error(`issue #${args.issueNumber} has no active trusted claim`);
+  }
+
+  if (
+    !isAuthorizedForcedHandoffActor(
+      owner,
+      name,
+      args.forcedBy,
+      forcedHandoffAuthorityPolicy,
+      permissionCache,
+    )
+  ) {
+    throw new Error(
+      `--forced-by actor ${args.forcedBy} is not authorized under ${forcedHandoffAuthorityPolicy}`,
+    );
   }
 
   let linkedPr = "";
@@ -124,17 +146,20 @@ export function resolveHelperActiveClaim(issueComments, trustedMarkerLogins, opt
       .map((login) => String(login ?? "").trim().toLowerCase())
       .filter(Boolean),
   );
-  return resolveActiveClaim(
+  const summary = summarizeClaimValidation(
     issueComments.map(normalizeIssueComment),
     {
-      isTrustedAuthor: (login) => trustedLogins.has(String(login ?? "").trim().toLowerCase()),
-      isForcedHandoffEnabled: () => true,
+      trustedMarkerLogins: [...trustedLogins],
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: options.expectedLinkedPrs ?? [],
       isAuthorizedForcedHandoff:
         typeof options.isAuthorizedForcedHandoff === "function"
           ? options.isAuthorizedForcedHandoff
           : () => false,
     },
   );
+
+  return summary.activeClaimPresent ? summary.activeClaim : null;
 }
 
 function parseArgs(argv) {
@@ -304,6 +329,19 @@ function readForcedHandoffAuthorityPolicy() {
     // Default policy remains owners-and-maintainers-only.
   }
   return APPROVAL_ACTOR_POLICY_DEFAULT;
+}
+
+function readForcedHandoffMode() {
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const mode = String(config?.forcedHandoff ?? config?.["forced-handoff"] ?? "").trim();
+    if (FORCED_HANDOFF_MODES.has(mode)) {
+      return mode;
+    }
+  } catch {
+    // Default mode remains disabled.
+  }
+  return FORCED_HANDOFF_MODE_DEFAULT;
 }
 
 function collaboratorPermission(owner, repo, login, cache) {

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -6,11 +6,11 @@ import { pathToFileURL } from "node:url";
 
 import { renderForcedHandoffComment, resolveActiveClaim } from "./protocol-helpers.mjs";
 
-const MAINTAINER_APPROVAL_POLICIES = new Set([
+const APPROVAL_ACTOR_POLICIES = new Set([
   "owners-and-maintainers-only",
   "all-write-permission-actors",
 ]);
-const MAINTAINER_APPROVAL_POLICY_DEFAULT = "owners-and-maintainers-only";
+const APPROVAL_ACTOR_POLICY_DEFAULT = "owners-and-maintainers-only";
 
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
@@ -41,7 +41,7 @@ export function main(argv = process.argv.slice(2)) {
   const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true).flat();
   const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
   const trustedMarkerLogins = buildTrustedMarkerLogins(owner, name, viewerLogin, args.trustedMarkerLogins, issueComments);
-  const maintainerApprovalActorPolicy = readMaintainerApprovalActorPolicy();
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
   const permissionCache = new Map();
   const activeClaim = resolveHelperActiveClaim(issueComments, trustedMarkerLogins, {
     isAuthorizedForcedHandoff:
@@ -49,7 +49,7 @@ export function main(argv = process.argv.slice(2)) {
         owner,
         name,
         forcedBy,
-        maintainerApprovalActorPolicy,
+        forcedHandoffAuthorityPolicy,
         permissionCache,
       ),
   });
@@ -293,17 +293,17 @@ function safeGhText(args) {
   }
 }
 
-function readMaintainerApprovalActorPolicy() {
+function readForcedHandoffAuthorityPolicy() {
   try {
     const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const policy = String(config?.maintainerApprovalActorPolicy ?? "").trim();
-    if (MAINTAINER_APPROVAL_POLICIES.has(policy)) {
+    const policy = String(config?.forcedHandoffAuthority ?? config?.["forced-handoff-authority"] ?? "").trim();
+    if (APPROVAL_ACTOR_POLICIES.has(policy)) {
       return policy;
     }
   } catch {
     // Default policy remains owners-and-maintainers-only.
   }
-  return MAINTAINER_APPROVAL_POLICY_DEFAULT;
+  return APPROVAL_ACTOR_POLICY_DEFAULT;
 }
 
 function collaboratorPermission(owner, repo, login, cache) {

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -29,15 +29,12 @@ export function main(argv = process.argv.slice(2)) {
     throw new Error("missing required --reason <text> argument");
   }
 
-  const repo = args.repo ?? ghText(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
-  const [owner, name] = repo.split("/", 2);
+  const repoRef = args.repo ?? ghText(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
+  const { owner, name } = parseOwnerRepo(repoRef);
   const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true).flat();
   const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
   const trustedMarkerLogins = buildTrustedMarkerLogins(owner, name, viewerLogin, args.trustedMarkerLogins, issueComments);
-  const activeClaim = resolveActiveClaim(
-    issueComments.map(normalizeIssueComment),
-    (login) => trustedMarkerLogins.has(String(login ?? "").trim().toLowerCase()),
-  );
+  const activeClaim = resolveHelperActiveClaim(issueComments, trustedMarkerLogins);
 
   if (!activeClaim) {
     throw new Error(`issue #${args.issueNumber} has no active trusted claim`);
@@ -48,12 +45,12 @@ export function main(argv = process.argv.slice(2)) {
     const pr = ghJson([
       "pr",
       "view",
-      String(args.prNumber),
-      "-R",
-      repo,
-      "--json",
-      "headRefName,url",
-      "--jq",
+        String(args.prNumber),
+        "-R",
+        `${owner}/${name}`,
+        "--json",
+        "headRefName,url",
+        "--jq",
       ".",
     ]);
     const headRefName = String(pr.headRefName ?? "");
@@ -82,8 +79,8 @@ export function main(argv = process.argv.slice(2)) {
   if (args.format === "json") {
     console.log(
       JSON.stringify(
-        {
-          repository: repo,
+          {
+          repository: `${owner}/${name}`,
           issueNumber: args.issueNumber,
           activeClaim,
           payload,
@@ -96,6 +93,27 @@ export function main(argv = process.argv.slice(2)) {
   } else {
     console.log(commentBody);
   }
+}
+
+export function resolveHelperActiveClaim(issueComments, trustedMarkerLogins) {
+  const trustedSources = Array.isArray(trustedMarkerLogins)
+    ? trustedMarkerLogins
+    : trustedMarkerLogins instanceof Set
+      ? [...trustedMarkerLogins]
+      : splitCsv(trustedMarkerLogins);
+  const trustedLogins = new Set(
+    trustedSources
+      .map((login) => String(login ?? "").trim().toLowerCase())
+      .filter(Boolean),
+  );
+  return resolveActiveClaim(
+    issueComments.map(normalizeIssueComment),
+    {
+      isTrustedAuthor: (login) => trustedLogins.has(String(login ?? "").trim().toLowerCase()),
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => trustedLogins.has(String(forcedBy ?? "").trim().toLowerCase()),
+    },
+  );
 }
 
 function parseArgs(argv) {
@@ -220,6 +238,18 @@ export function parsePositiveInteger(value, flag) {
     throw new Error(`invalid ${flag} value: ${value}`);
   }
   return Number(raw);
+}
+
+function parseOwnerRepo(value) {
+  const repo = String(value ?? "").trim();
+  const match = repo.match(/^([^/\s]+)\/([^/\s]+)$/);
+  if (!match) {
+    throw new Error(`invalid --repo value: ${value} (expected owner/name)`);
+  }
+  return {
+    owner: match[1],
+    name: match[2],
+  };
 }
 
 function ghJson(args, slurp = false) {

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -107,10 +107,10 @@ function parseArgs(argv) {
     const token = argv[index];
     switch (token) {
       case "--issue":
-        parsed.issueNumber = parsePositiveInteger(argv[++index], "--issue");
+        parsed.issueNumber = parsePositiveInteger(readValue(argv, ++index, token), token);
         break;
       case "--pr":
-        parsed.prNumber = parsePositiveInteger(argv[++index], "--pr");
+        parsed.prNumber = parsePositiveInteger(readValue(argv, ++index, token), token);
         break;
       case "--new-agent-id":
         parsed.newAgentId = readValue(argv, ++index, token);

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 import { renderForcedHandoffComment, resolveActiveClaim } from "./protocol-helpers.mjs";
+
+const MAINTAINER_APPROVAL_POLICIES = new Set([
+  "owners-and-maintainers-only",
+  "all-write-permission-actors",
+]);
+const MAINTAINER_APPROVAL_POLICY_DEFAULT = "owners-and-maintainers-only";
 
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
@@ -34,7 +41,18 @@ export function main(argv = process.argv.slice(2)) {
   const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true).flat();
   const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
   const trustedMarkerLogins = buildTrustedMarkerLogins(owner, name, viewerLogin, args.trustedMarkerLogins, issueComments);
-  const activeClaim = resolveHelperActiveClaim(issueComments, trustedMarkerLogins);
+  const maintainerApprovalActorPolicy = readMaintainerApprovalActorPolicy();
+  const permissionCache = new Map();
+  const activeClaim = resolveHelperActiveClaim(issueComments, trustedMarkerLogins, {
+    isAuthorizedForcedHandoff:
+      (forcedBy) => isAuthorizedForcedHandoffActor(
+        owner,
+        name,
+        forcedBy,
+        maintainerApprovalActorPolicy,
+        permissionCache,
+      ),
+  });
 
   if (!activeClaim) {
     throw new Error(`issue #${args.issueNumber} has no active trusted claim`);
@@ -95,7 +113,7 @@ export function main(argv = process.argv.slice(2)) {
   }
 }
 
-export function resolveHelperActiveClaim(issueComments, trustedMarkerLogins) {
+export function resolveHelperActiveClaim(issueComments, trustedMarkerLogins, options = {}) {
   const trustedSources = Array.isArray(trustedMarkerLogins)
     ? trustedMarkerLogins
     : trustedMarkerLogins instanceof Set
@@ -111,7 +129,10 @@ export function resolveHelperActiveClaim(issueComments, trustedMarkerLogins) {
     {
       isTrustedAuthor: (login) => trustedLogins.has(String(login ?? "").trim().toLowerCase()),
       isForcedHandoffEnabled: () => true,
-      isAuthorizedForcedHandoff: (forcedBy) => trustedLogins.has(String(forcedBy ?? "").trim().toLowerCase()),
+      isAuthorizedForcedHandoff:
+        typeof options.isAuthorizedForcedHandoff === "function"
+          ? options.isAuthorizedForcedHandoff
+          : () => false,
     },
   );
 }
@@ -270,6 +291,45 @@ function safeGhText(args) {
   } catch {
     return "";
   }
+}
+
+function readMaintainerApprovalActorPolicy() {
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const policy = String(config?.maintainerApprovalActorPolicy ?? "").trim();
+    if (MAINTAINER_APPROVAL_POLICIES.has(policy)) {
+      return policy;
+    }
+  } catch {
+    // Default policy remains owners-and-maintainers-only.
+  }
+  return MAINTAINER_APPROVAL_POLICY_DEFAULT;
+}
+
+function collaboratorPermission(owner, repo, login, cache) {
+  if (cache.has(login)) {
+    return cache.get(login);
+  }
+  const permission = safeGhText([
+    "api",
+    `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+    "--jq",
+    ".permission",
+  ]).toLowerCase();
+  cache.set(login, permission);
+  return permission;
+}
+
+function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
+  const normalized = String(login ?? "").trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const permission = collaboratorPermission(owner, repo, normalized, cache);
+  if (policy === "all-write-permission-actors") {
+    return permission === "admin" || permission === "maintain" || permission === "write";
+  }
+  return permission === "admin" || permission === "maintain";
 }
 
 export function currentIsoTimestamp() {

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+import { renderForcedHandoffComment, resolveActiveClaim } from "./protocol-helpers.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+  printUsage();
+  process.exit(0);
+}
+
+if (!args.issueNumber) {
+  throw new Error("missing required --issue <number> argument");
+}
+if (!args.newAgentId) {
+  throw new Error("missing required --new-agent-id <id> argument");
+}
+if (!args.newClaimId) {
+  throw new Error("missing required --new-claim-id <id> argument");
+}
+if (!args.forcedBy) {
+  throw new Error("missing required --forced-by <actor> argument");
+}
+if (!args.reason) {
+  throw new Error("missing required --reason <text> argument");
+}
+
+const repo = args.repo ?? ghText(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
+const [owner, name] = repo.split("/", 2);
+const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true).flat();
+const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
+const trustedMarkerLogins = buildTrustedMarkerLogins(owner, name, viewerLogin, args.trustedMarkerLogins, issueComments);
+const activeClaim = resolveActiveClaim(
+  issueComments.map(normalizeIssueComment),
+  (login) => trustedMarkerLogins.has(String(login ?? "").trim().toLowerCase()),
+);
+
+if (!activeClaim) {
+  throw new Error(`issue #${args.issueNumber} has no active trusted claim`);
+}
+
+let linkedPr = "";
+if (args.prNumber) {
+  const pr = ghJson([
+    "pr",
+    "view",
+    String(args.prNumber),
+    "-R",
+    repo,
+    "--json",
+    "headRefName,url",
+    "--jq",
+    ".",
+  ]);
+  const headRefName = String(pr.headRefName ?? "");
+  if (headRefName !== activeClaim.branch) {
+    throw new Error(
+      `PR #${args.prNumber} head branch ${headRefName} does not match active claim branch ${activeClaim.branch}`,
+    );
+  }
+  linkedPr = String(args.prNumber);
+}
+
+const payload = {
+  oldAgentId: activeClaim.agentId,
+  oldClaimId: activeClaim.claimId,
+  newAgentId: args.newAgentId,
+  newClaimId: args.newClaimId,
+  branch: activeClaim.branch,
+  ...(linkedPr ? { linkedPr } : {}),
+  forcedBy: args.forcedBy,
+  reason: args.reason,
+  timestamp: args.timestamp ?? currentIsoTimestamp(),
+  contextScope: linkedPr ? "issue-plus-pr" : "issue-only",
+};
+
+const commentBody = renderForcedHandoffComment(payload);
+if (args.format === "json") {
+  console.log(
+    JSON.stringify(
+      {
+        repository: repo,
+        issueNumber: args.issueNumber,
+        activeClaim,
+        payload,
+        commentBody,
+      },
+      null,
+      2,
+    ),
+  );
+} else {
+  console.log(commentBody);
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    format: "text",
+    trustedMarkerLogins: "",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    switch (token) {
+      case "--issue":
+        parsed.issueNumber = parsePositiveInteger(argv[++index], "--issue");
+        break;
+      case "--pr":
+        parsed.prNumber = parsePositiveInteger(argv[++index], "--pr");
+        break;
+      case "--new-agent-id":
+        parsed.newAgentId = readValue(argv, ++index, token);
+        break;
+      case "--new-claim-id":
+        parsed.newClaimId = readValue(argv, ++index, token);
+        break;
+      case "--forced-by":
+        parsed.forcedBy = readValue(argv, ++index, token);
+        break;
+      case "--reason":
+        parsed.reason = readValue(argv, ++index, token);
+        break;
+      case "--timestamp":
+        parsed.timestamp = readValue(argv, ++index, token);
+        break;
+      case "--trusted-marker-logins":
+        parsed.trustedMarkerLogins = readValue(argv, ++index, token);
+        break;
+      case "--repo":
+        parsed.repo = readValue(argv, ++index, token);
+        break;
+      case "--format":
+        parsed.format = readValue(argv, ++index, token);
+        if (parsed.format !== "text" && parsed.format !== "json") {
+          throw new Error(`unsupported --format value: ${parsed.format}`);
+        }
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  return parsed;
+}
+
+function buildTrustedMarkerLogins(owner, repo, viewerLogin, cliLogins, issueComments) {
+  const configured = [
+    viewerLogin,
+    ...splitCsv(cliLogins),
+    ...splitCsv(process.env.IDD_TRUSTED_MARKER_ACTORS),
+  ];
+  if (!isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS)) {
+    return new Set(configured.filter(Boolean).map((login) => login.toLowerCase()));
+  }
+
+  const trusted = new Set(configured.filter(Boolean).map((login) => login.toLowerCase()));
+  for (const comment of issueComments) {
+    const login = String(comment.user?.login ?? "").toLowerCase();
+    if (!login) {
+      continue;
+    }
+    const permission = safeGhText([
+      "api",
+      `repos/${owner}/${repo}/collaborators/${login}/permission`,
+      "--jq",
+      ".permission",
+    ]).toLowerCase();
+    if (permission === "admin" || permission === "maintain" || permission === "write") {
+      trusted.add(login);
+    }
+  }
+  return trusted;
+}
+
+function normalizeIssueComment(comment) {
+  return {
+    body: comment.body ?? "",
+    createdAt: comment.created_at ?? "",
+    author: {
+      login: comment.user?.login ?? "",
+    },
+  };
+}
+
+function splitCsv(value) {
+  return String(value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function isTruthy(value) {
+  return /^(1|true|yes)$/i.test(String(value ?? "").trim());
+}
+
+function readValue(argv, index, name) {
+  const value = argv[index];
+  if (value === undefined) {
+    throw new Error(`missing value for ${name}`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value, flag) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`invalid ${flag} value: ${value}`);
+  }
+  return parsed;
+}
+
+function ghJson(args, slurp = false) {
+  const finalArgs = [...args];
+  if (slurp) {
+    finalArgs.splice(1, 0, "--slurp");
+  }
+  return JSON.parse(execFileSync("gh", finalArgs, { encoding: "utf8" }));
+}
+
+function ghText(args) {
+  return execFileSync("gh", args, { encoding: "utf8" }).trim();
+}
+
+function safeGhText(args) {
+  try {
+    return ghText(args);
+  } catch {
+    return "";
+  }
+}
+
+function currentIsoTimestamp() {
+  return new Date().toISOString().replace(".000Z", "Z");
+}
+
+function printUsage() {
+  console.log(`usage: node scripts/forced-handoff-marker.mjs --issue <number> [options]
+
+Options:
+  --pr <number>                    optional PR number for issue-plus-pr context
+  --new-agent-id <id>              successor session agent id
+  --new-claim-id <id>              successor claim id
+  --forced-by <actor>              approving human actor recorded in the marker
+  --reason <text>                  why the prior session is considered unavailable
+  --timestamp <ISO8601>            override the marker payload timestamp (default: current UTC)
+  --trusted-marker-logins <csv>    additional trusted marker authors for claim reconstruction
+  --repo <owner/name>              repository override
+  --format <text|json>             output format (default: text)
+  --help                           show this help
+
+Environment:
+  IDD_TRUSTED_MARKER_ACTORS        comma-separated trusted bot/app logins
+  IDD_TRUST_COLLABORATOR_MARKERS   set true to trust Write/Maintain/Admin collaborators
+`);
+}

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -161,17 +161,23 @@ function buildTrustedMarkerLogins(owner, repo, viewerLogin, cliLogins, issueComm
   }
 
   const trusted = new Set(configured.filter(Boolean).map((login) => login.toLowerCase()));
-  for (const comment of issueComments) {
-    const login = String(comment.user?.login ?? "").toLowerCase();
-    if (!login) {
+  const permissionCache = new Map();
+  const uniqueLogins = new Set(
+    issueComments
+      .map((comment) => String(comment.user?.login ?? "").toLowerCase())
+      .filter(Boolean),
+  );
+  for (const login of uniqueLogins) {
+    if (trusted.has(login)) {
       continue;
     }
-    const permission = safeGhText([
+    const permission = permissionCache.get(login) ?? safeGhText([
       "api",
       `repos/${owner}/${repo}/collaborators/${login}/permission`,
       "--jq",
       ".permission",
     ]).toLowerCase();
+    permissionCache.set(login, permission);
     if (permission === "admin" || permission === "maintain" || permission === "write") {
       trusted.add(login);
     }
@@ -208,12 +214,12 @@ function readValue(argv, index, name) {
   return value;
 }
 
-function parsePositiveInteger(value, flag) {
-  const parsed = Number.parseInt(String(value ?? ""), 10);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
+export function parsePositiveInteger(value, flag) {
+  const raw = String(value ?? "").trim();
+  if (!/^[1-9]\d*$/.test(raw)) {
     throw new Error(`invalid ${flag} value: ${value}`);
   }
-  return parsed;
+  return Number(raw);
 }
 
 function ghJson(args, slurp = false) {

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -23,6 +23,15 @@ const HELPER_COMMANDS = [
     description: "Run IDD onboarding drift checks against the local repository.",
   },
   {
+    id: "forced-handoff-marker",
+    scriptName: "idd:forced-handoff-marker",
+    binName: "idd-forced-handoff-marker",
+    entryPath: "scripts/forced-handoff-marker.mjs",
+    vendoredCommand: "node scripts/forced-handoff-marker.mjs",
+    description: "Render a maintainer-approved forced-handoff marker body for an active claim.",
+    contractPaths: ["schemas/forced-handoff-marker.schema.json"],
+  },
+  {
     id: "helper-bundle-manifest",
     scriptName: "idd:helper-bundle-manifest",
     binName: "idd-helper-bundle-manifest",

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -4,21 +4,25 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 import {
+  normalizeTrustedMarkerLogins,
   planLiveStatusDigestUpsert,
-  resolveActiveClaim,
+  summarizeClaimValidation,
 } from "./protocol-helpers.mjs";
 
 const TRUSTED_MARKER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
-const MAINTAINER_APPROVAL_POLICIES = new Set([
+const FORCED_HANDOFF_AUTHORITY_POLICIES = new Set([
   "owners-and-maintainers-only",
   "all-write-permission-actors",
 ]);
-const MAINTAINER_APPROVAL_POLICY_DEFAULT = "owners-and-maintainers-only";
+const FORCED_HANDOFF_AUTHORITY_POLICY_DEFAULT = "owners-and-maintainers-only";
+const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
+const FORCED_HANDOFF_MODE_DEFAULT = "disabled";
 const trustedMarkerAuthorCache = new Map();
 const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerAuthors = null;
 let cachedCurrentViewerLogin = null;
-let cachedMaintainerApprovalPolicy = null;
+let cachedForcedHandoffAuthorityPolicy = null;
+let cachedForcedHandoffMode = null;
 
 const args = parseArgs(process.argv.slice(2));
 
@@ -50,6 +54,9 @@ const repository = args.repo ?? detectRepository();
 const [owner, repo] = parseRepository(repository);
 const targetType = args.issue ? "issue" : "pr";
 const targetNumber = parsePositiveInteger(args.issue ?? args.pr, `--${targetType}`);
+const claimContext = targetType === "pr"
+  ? { expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, targetNumber) }
+  : {};
 
 if (args.claimIssue) {
   args.claimIssue = String(parsePositiveInteger(args.claimIssue, "--claim-issue"));
@@ -97,7 +104,7 @@ if (planned.action === "duplicate") {
 if (args.apply) {
   if (!args.skipClaimCheck) {
     try {
-      assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId);
+      assertActiveClaim(owner, repo, args.claimIssue, args.agentId, args.claimId, claimContext);
     } catch (error) {
       fail(error.message);
     }
@@ -184,15 +191,15 @@ function updateIssueComment(owner, repo, commentId, body) {
   ]);
 }
 
-function assertActiveClaim(owner, repo, issueNumber, agentId, claimId) {
-  const active = readActiveClaim(owner, repo, issueNumber);
+function assertActiveClaim(owner, repo, issueNumber, agentId, claimId, options = {}) {
+  const active = readActiveClaim(owner, repo, issueNumber, options);
   if (!active || active.claimId !== claimId || (agentId && active.agentId !== agentId)) {
     const activeLabel = active ? `${active.agentId} ${active.claimId}` : "none";
     throw new Error(`claim check failed for #${issueNumber}: active claim is ${activeLabel}`);
   }
 }
 
-function readActiveClaim(owner, repo, issueNumber) {
+function readActiveClaim(owner, repo, issueNumber, options = {}) {
   const comments = fetchIssueComments(owner, repo, issueNumber).map((comment) => {
     return {
       body: comment.body,
@@ -201,47 +208,93 @@ function readActiveClaim(owner, repo, issueNumber) {
     };
   });
 
-  return resolveActiveClaim(
-    comments,
-    {
-      isTrustedAuthor: (login) => isTrustedMarkerAuthor(owner, repo, login),
-      isForcedHandoffEnabled: () => true,
-      isAuthorizedForcedHandoff: (forcedBy) => isAuthorizedForcedHandoffActor(owner, repo, forcedBy),
+  const summary = summarizeClaimValidation(comments, {
+    trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
+    forcedHandoffEnabled: readForcedHandoffMode() === "human-gated",
+    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    isAuthorizedForcedHandoff: (forcedBy) => {
+      return isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy(),
+      );
     },
+  });
+
+  return summary.activeClaimPresent ? summary.activeClaim : null;
+}
+
+function resolveTrustedMarkerLogins(owner, repo, comments) {
+  return normalizeTrustedMarkerLogins(
+    comments
+      .map((comment) => comment.author?.login ?? "")
+      .filter(Boolean)
+      .filter((login) => isTrustedMarkerAuthor(owner, repo, login)),
   );
 }
 
-function isAuthorizedForcedHandoffActor(owner, repo, login) {
+function buildExpectedLinkedPrReferences(owner, repo, prNumber) {
+  const normalized = String(prNumber ?? "").trim();
+  if (!normalized) {
+    return [];
+  }
+  return [
+    normalized,
+    `#${normalized}`,
+    `https://github.com/${owner}/${repo}/pull/${normalized}`,
+  ];
+}
+
+function isAuthorizedForcedHandoffActor(owner, repo, login, policy = forcedHandoffAuthorityPolicy()) {
   const normalized = String(login ?? "").trim().toLowerCase();
   if (!normalized) {
     return false;
   }
   const permission = collaboratorPermission(owner, repo, normalized);
-  if (maintainerApprovalActorPolicy() === "all-write-permission-actors") {
+  if (policy === "all-write-permission-actors") {
     return permission === "admin" || permission === "maintain" || permission === "write";
   }
   return permission === "admin" || permission === "maintain";
 }
 
-function maintainerApprovalActorPolicy() {
-  if (cachedMaintainerApprovalPolicy !== null) {
-    return cachedMaintainerApprovalPolicy;
+function forcedHandoffAuthorityPolicy() {
+  if (cachedForcedHandoffAuthorityPolicy !== null) {
+    return cachedForcedHandoffAuthorityPolicy;
   }
-  cachedMaintainerApprovalPolicy = readMaintainerApprovalActorPolicy();
-  return cachedMaintainerApprovalPolicy;
+  cachedForcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  return cachedForcedHandoffAuthorityPolicy;
 }
 
-function readMaintainerApprovalActorPolicy() {
+function readForcedHandoffAuthorityPolicy() {
   try {
     const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const policy = String(config?.maintainerApprovalActorPolicy ?? "").trim();
-    if (MAINTAINER_APPROVAL_POLICIES.has(policy)) {
+    const policy = String(config?.forcedHandoffAuthority ?? config?.["forced-handoff-authority"] ?? "").trim();
+    if (FORCED_HANDOFF_AUTHORITY_POLICIES.has(policy)) {
       return policy;
     }
   } catch {
     // Default policy remains owners-and-maintainers-only.
   }
-  return MAINTAINER_APPROVAL_POLICY_DEFAULT;
+  return FORCED_HANDOFF_AUTHORITY_POLICY_DEFAULT;
+}
+
+function readForcedHandoffMode() {
+  if (cachedForcedHandoffMode !== null) {
+    return cachedForcedHandoffMode;
+  }
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const mode = String(config?.forcedHandoff ?? config?.["forced-handoff"] ?? "").trim();
+    if (FORCED_HANDOFF_MODES.has(mode)) {
+      cachedForcedHandoffMode = mode;
+      return cachedForcedHandoffMode;
+    }
+  } catch {
+    // Default mode remains disabled.
+  }
+  cachedForcedHandoffMode = FORCED_HANDOFF_MODE_DEFAULT;
+  return cachedForcedHandoffMode;
 }
 
 function isTrustedMarkerAuthor(owner, repo, login) {

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 import {
   planLiveStatusDigestUpsert,
@@ -8,9 +9,16 @@ import {
 } from "./protocol-helpers.mjs";
 
 const TRUSTED_MARKER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+const MAINTAINER_APPROVAL_POLICIES = new Set([
+  "owners-and-maintainers-only",
+  "all-write-permission-actors",
+]);
+const MAINTAINER_APPROVAL_POLICY_DEFAULT = "owners-and-maintainers-only";
 const trustedMarkerAuthorCache = new Map();
+const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerAuthors = null;
 let cachedCurrentViewerLogin = null;
+let cachedMaintainerApprovalPolicy = null;
 
 const args = parseArgs(process.argv.slice(2));
 
@@ -198,9 +206,42 @@ function readActiveClaim(owner, repo, issueNumber) {
     {
       isTrustedAuthor: (login) => isTrustedMarkerAuthor(owner, repo, login),
       isForcedHandoffEnabled: () => true,
-      isAuthorizedForcedHandoff: (forcedBy) => isTrustedMarkerAuthor(owner, repo, forcedBy),
+      isAuthorizedForcedHandoff: (forcedBy) => isAuthorizedForcedHandoffActor(owner, repo, forcedBy),
     },
   );
+}
+
+function isAuthorizedForcedHandoffActor(owner, repo, login) {
+  const normalized = String(login ?? "").trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const permission = collaboratorPermission(owner, repo, normalized);
+  if (maintainerApprovalActorPolicy() === "all-write-permission-actors") {
+    return permission === "admin" || permission === "maintain" || permission === "write";
+  }
+  return permission === "admin" || permission === "maintain";
+}
+
+function maintainerApprovalActorPolicy() {
+  if (cachedMaintainerApprovalPolicy !== null) {
+    return cachedMaintainerApprovalPolicy;
+  }
+  cachedMaintainerApprovalPolicy = readMaintainerApprovalActorPolicy();
+  return cachedMaintainerApprovalPolicy;
+}
+
+function readMaintainerApprovalActorPolicy() {
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const policy = String(config?.maintainerApprovalActorPolicy ?? "").trim();
+    if (MAINTAINER_APPROVAL_POLICIES.has(policy)) {
+      return policy;
+    }
+  } catch {
+    // Default policy remains owners-and-maintainers-only.
+  }
+  return MAINTAINER_APPROVAL_POLICY_DEFAULT;
 }
 
 function isTrustedMarkerAuthor(owner, repo, login) {
@@ -225,22 +266,7 @@ function isTrustedMarkerAuthor(owner, repo, login) {
     return trustedMarkerAuthorCache.get(cacheKey);
   }
 
-  let trusted = false;
-  try {
-    const permission = execFileSync(
-      "gh",
-      [
-        "api",
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        "--jq",
-        ".permission",
-      ],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-    ).trim().toLowerCase();
-    trusted = TRUSTED_MARKER_PERMISSIONS.has(permission);
-  } catch {
-    trusted = false;
-  }
+  const trusted = TRUSTED_MARKER_PERMISSIONS.has(collaboratorPermission(owner, repo, normalized));
 
   trustedMarkerAuthorCache.set(cacheKey, trusted);
   return trusted;
@@ -261,6 +287,32 @@ function currentViewerLogin() {
     cachedCurrentViewerLogin = "";
   }
   return cachedCurrentViewerLogin;
+}
+
+function collaboratorPermission(owner, repo, login) {
+  const cacheKey = `${owner}/${repo}:${login}`;
+  if (collaboratorPermissionCache.has(cacheKey)) {
+    return collaboratorPermissionCache.get(cacheKey);
+  }
+
+  let permission = "";
+  try {
+    permission = execFileSync(
+      "gh",
+      [
+        "api",
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        "--jq",
+        ".permission",
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim().toLowerCase();
+  } catch {
+    permission = "";
+  }
+
+  collaboratorPermissionCache.set(cacheKey, permission);
+  return permission;
 }
 
 function configuredTrustedMarkerAuthors() {

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -193,7 +193,14 @@ function readActiveClaim(owner, repo, issueNumber) {
     };
   });
 
-  return resolveActiveClaim(comments, (login) => isTrustedMarkerAuthor(owner, repo, login));
+  return resolveActiveClaim(
+    comments,
+    {
+      isTrustedAuthor: (login) => isTrustedMarkerAuthor(owner, repo, login),
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => isTrustedMarkerAuthor(owner, repo, forcedBy),
+    },
+  );
 }
 
 function isTrustedMarkerAuthor(owner, repo, login) {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 import {
   buildPreMergeReadinessSummary,
@@ -9,6 +10,12 @@ import {
   operationalMarkerPrefix,
   selectCodeownersText,
 } from "./protocol-helpers.mjs";
+
+const MAINTAINER_APPROVAL_POLICY = new Set([
+  "owners-and-maintainers-only",
+  "all-write-permission-actors",
+]);
+const MAINTAINER_APPROVAL_POLICY_DEFAULT = "owners-and-maintainers-only";
 
 const args = parseArgs(process.argv.slice(2));
 if (!args.prNumber) {
@@ -106,6 +113,8 @@ const iddAgentLogins = deriveIddAgentLogins({
   trustedMarkerLogins,
   operationalComments: [...comments, ...claimComments],
 });
+const maintainerApprovalActorPolicy = readMaintainerApprovalActorPolicy();
+const forcedHandoffPermissionCache = new Map();
 
 const summary = buildPreMergeReadinessSummary(
   {
@@ -134,6 +143,14 @@ const summary = buildPreMergeReadinessSummary(
     requestCap: 30,
     pendingWindowMinutes: 30,
     settledWindowMinutes: 10,
+    isAuthorizedForcedHandoff:
+      (forcedBy) => isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        maintainerApprovalActorPolicy,
+        forcedHandoffPermissionCache,
+      ),
     viewerLogin,
     configuredTrustedActors,
     collaboratorTrustEnabled,
@@ -483,4 +500,40 @@ function splitCsv(value) {
 
 function isTruthy(value) {
   return /^(1|true|yes)$/i.test(String(value ?? "").trim());
+}
+
+function readMaintainerApprovalActorPolicy() {
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const policy = String(config?.maintainerApprovalActorPolicy ?? "").trim();
+    if (MAINTAINER_APPROVAL_POLICY.has(policy)) {
+      return policy;
+    }
+  } catch {
+    // Default policy remains owners-and-maintainers-only.
+  }
+  return MAINTAINER_APPROVAL_POLICY_DEFAULT;
+}
+
+function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
+  const normalized = String(login ?? "").trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (cache.has(normalized)) {
+    return cache.get(normalized);
+  }
+
+  const permission = safeGhText([
+    "api",
+    `repos/${owner}/${repo}/collaborators/${encodeURIComponent(normalized)}/permission`,
+    "--jq",
+    ".permission",
+  ]).toLowerCase();
+  const isAuthorized = policy === "all-write-permission-actors"
+    ? permission === "admin" || permission === "maintain" || permission === "write"
+    : permission === "admin" || permission === "maintain";
+
+  cache.set(normalized, isAuthorized);
+  return isAuthorized;
 }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -11,11 +11,13 @@ import {
   selectCodeownersText,
 } from "./protocol-helpers.mjs";
 
-const MAINTAINER_APPROVAL_POLICY = new Set([
+const APPROVAL_ACTOR_POLICY = new Set([
   "owners-and-maintainers-only",
   "all-write-permission-actors",
 ]);
-const MAINTAINER_APPROVAL_POLICY_DEFAULT = "owners-and-maintainers-only";
+const APPROVAL_ACTOR_POLICY_DEFAULT = "owners-and-maintainers-only";
+const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
+const FORCED_HANDOFF_MODE_DEFAULT = "disabled";
 
 const args = parseArgs(process.argv.slice(2));
 if (!args.prNumber) {
@@ -42,12 +44,13 @@ const pr = ghJson([
   "-R",
   repoRef,
   "--json",
-  "headRefOid,baseRefName,author,reviewDecision",
+  "headRefOid,baseRefName,url,author,reviewDecision",
   "--jq",
   ".",
 ]);
 const prHeadSha = String(pr.headRefOid ?? "");
 const baseRefName = String(pr.baseRefName ?? "");
+const prUrl = String(pr.url ?? "");
 const prAuthorLogin = String(pr.author?.login ?? "").toLowerCase();
 const reviewDecision = String(pr.reviewDecision ?? "");
 const encodedBaseRefName = encodeURIComponent(baseRefName);
@@ -113,7 +116,8 @@ const iddAgentLogins = deriveIddAgentLogins({
   trustedMarkerLogins,
   operationalComments: [...comments, ...claimComments],
 });
-const maintainerApprovalActorPolicy = readMaintainerApprovalActorPolicy();
+const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+const forcedHandoffEnabled = readForcedHandoffMode() === "human-gated";
 const forcedHandoffPermissionCache = new Map();
 
 const summary = buildPreMergeReadinessSummary(
@@ -143,12 +147,14 @@ const summary = buildPreMergeReadinessSummary(
     requestCap: 30,
     pendingWindowMinutes: 30,
     settledWindowMinutes: 10,
+    forcedHandoffEnabled,
+    expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
     isAuthorizedForcedHandoff:
       (forcedBy) => isAuthorizedForcedHandoffActor(
         owner,
         repo,
         forcedBy,
-        maintainerApprovalActorPolicy,
+        forcedHandoffAuthorityPolicy,
         forcedHandoffPermissionCache,
       ),
     viewerLogin,
@@ -502,17 +508,30 @@ function isTruthy(value) {
   return /^(1|true|yes)$/i.test(String(value ?? "").trim());
 }
 
-function readMaintainerApprovalActorPolicy() {
+function readForcedHandoffAuthorityPolicy() {
   try {
     const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const policy = String(config?.maintainerApprovalActorPolicy ?? "").trim();
-    if (MAINTAINER_APPROVAL_POLICY.has(policy)) {
+    const policy = String(config?.forcedHandoffAuthority ?? config?.["forced-handoff-authority"] ?? "").trim();
+    if (APPROVAL_ACTOR_POLICY.has(policy)) {
       return policy;
     }
   } catch {
     // Default policy remains owners-and-maintainers-only.
   }
-  return MAINTAINER_APPROVAL_POLICY_DEFAULT;
+  return APPROVAL_ACTOR_POLICY_DEFAULT;
+}
+
+function readForcedHandoffMode() {
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const mode = String(config?.forcedHandoff ?? config?.["forced-handoff"] ?? "").trim();
+    if (FORCED_HANDOFF_MODES.has(mode)) {
+      return mode;
+    }
+  } catch {
+    // Default mode remains disabled.
+  }
+  return FORCED_HANDOFF_MODE_DEFAULT;
 }
 
 function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -36,7 +36,7 @@ const OPERATIONAL_MARKERS = [
   },
   {
     label: "<!-- forced-handoff:",
-    pattern: /^<!--\s*forced-handoff:\s*\{[\s\S]*\}\s*-->[\s\S]*$/i,
+    pattern: /^\s*<!--\s*forced-handoff:\s*\{[\s\S]*\}\s*-->[\s\S]*$/i,
     startPattern: /^<!--\s*forced-handoff:/i,
   },
 ];
@@ -112,7 +112,7 @@ export function parseReleaseComment(body) {
 }
 
 export function parseForcedHandoffComment(body, createdAt) {
-  const trimmed = body.trimEnd();
+  const trimmed = body.trimStart().trimEnd();
   const markerMatch = trimmed.match(/^<!--\s*forced-handoff:\s*/i);
   if (!markerMatch) {
     return null;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -37,6 +37,7 @@ const OPERATIONAL_MARKERS = [
   {
     label: "<!-- forced-handoff:",
     pattern: /^<!--\s*forced-handoff:\s*\{[\s\S]*\}\s*-->[\s\S]*$/i,
+    startPattern: /^<!--\s*forced-handoff:/i,
   },
 ];
 
@@ -62,8 +63,8 @@ const UNSAFE_TEXT_RULES = [
   },
 ];
 const AMD_MARKER_PATTERN = /^\*\*Awaiting maintainer decision\*\*/i;
-const FORCED_HANDOFF_MARKER_PREFIX = "<!-- forced-handoff:";
 const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(["issue-only", "issue-plus-pr"]);
+const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/i;
 
 export function parseClaimComment(body, createdAt) {
   const match = body.trimEnd().match(
@@ -291,8 +292,8 @@ export function operationalMarkerPrefix(body) {
 export function operationalMarkerPrefixByStart(body) {
   const normalized = body.trimStart();
   return OPERATIONAL_MARKERS
-    .map((marker) => marker.label)
-    .find((prefix) => normalized.startsWith(prefix)) ?? null;
+    .find((marker) => marker.startPattern?.test(normalized) ?? normalized.startsWith(marker.label))
+    ?.label ?? null;
 }
 
 export function findLiveStatusDigestComments(comments) {
@@ -1993,17 +1994,11 @@ function normalizeContextScope(value) {
 }
 
 function normalizeLinkedPr(value) {
-  if (value === undefined || value === null) {
+  const token = normalizeNonWhitespaceToken(value);
+  if (!token || !FORCED_HANDOFF_LINKED_PR_PATTERN.test(token)) {
     return "";
   }
-  if (typeof value !== "string") {
-    return "";
-  }
-  const trimmed = value.trim();
-  if (!trimmed || /\s/.test(trimmed) || trimmed.includes("-->")) {
-    return "";
-  }
-  return trimmed;
+  return token;
 }
 
 export function classifyResumeRoutingCase(input, options = {}) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -102,7 +102,8 @@ export function parseReleaseComment(body) {
 
 export function parseForcedHandoffComment(body, createdAt) {
   const trimmed = body.trimEnd();
-  if (!trimmed.startsWith(FORCED_HANDOFF_MARKER_PREFIX)) {
+  const markerMatch = trimmed.match(/^<!--\s*forced-handoff:\s*/i);
+  if (!markerMatch) {
     return null;
   }
 
@@ -116,7 +117,7 @@ export function parseForcedHandoffComment(body, createdAt) {
     return null;
   }
 
-  const payloadText = trimmed.slice(FORCED_HANDOFF_MARKER_PREFIX.length, markerEnd).trim();
+  const payloadText = trimmed.slice(markerMatch[0].length, markerEnd).trim();
   let payload;
   try {
     payload = JSON.parse(payloadText);
@@ -129,6 +130,18 @@ export function parseForcedHandoffComment(body, createdAt) {
 
 export function normalizeForcedHandoffPayload(payload, options = {}) {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+
+  if (
+    hasConflictingPayloadAliases(payload, "oldAgentId", "old-agent-id")
+    || hasConflictingPayloadAliases(payload, "oldClaimId", "old-claim-id")
+    || hasConflictingPayloadAliases(payload, "newAgentId", "new-agent-id")
+    || hasConflictingPayloadAliases(payload, "newClaimId", "new-claim-id")
+    || hasConflictingPayloadAliases(payload, "forcedBy", "forced-by")
+    || hasConflictingPayloadAliases(payload, "linkedPr", "linked-pr")
+    || hasConflictingPayloadAliases(payload, "contextScope", "context-scope")
+  ) {
     return null;
   }
 
@@ -1871,7 +1884,7 @@ export function applyClaimEvent(activeClaim, event, options = {}) {
       claimId: forcedHandoff.newClaimId,
       supersedes: forcedHandoff.oldClaimId,
       branch: forcedHandoff.branch,
-      createdAt: event.createdAt ?? activeClaim.createdAt,
+      createdAt: forcedHandoff.createdAt ?? activeClaim.createdAt,
     };
   }
 
@@ -1920,6 +1933,17 @@ function pickPayloadValue(payload, ...keys) {
     }
   }
   return undefined;
+}
+
+function hasConflictingPayloadAliases(payload, firstKey, secondKey) {
+  if (
+    !Object.prototype.hasOwnProperty.call(payload, firstKey)
+    || !Object.prototype.hasOwnProperty.call(payload, secondKey)
+  ) {
+    return false;
+  }
+
+  return String(payload[firstKey] ?? "").trim() !== String(payload[secondKey] ?? "").trim();
 }
 
 function normalizeBranchToken(value) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -139,10 +139,10 @@ export function normalizeForcedHandoffPayload(payload, options = {}) {
   const branch = normalizeBranchToken(pickPayloadValue(payload, "branch"));
   const forcedBy = normalizeNonWhitespaceToken(pickPayloadValue(payload, "forcedBy", "forced-by"));
   const reason = normalizeForcedHandoffReason(pickPayloadValue(payload, "reason"));
-  const timestamp = normalizeIsoTimestamp(pickPayloadValue(payload, "timestamp"));
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(pickPayloadValue(payload, "timestamp"));
   const contextScope = normalizeContextScope(pickPayloadValue(payload, "contextScope", "context-scope"));
   const linkedPr = normalizeLinkedPr(pickPayloadValue(payload, "linkedPr", "linked-pr"));
-  const createdAt = normalizeIsoTimestamp(options.createdAt);
+  const createdAt = normalizeSecondPrecisionIsoTimestamp(options.createdAt);
 
   if (
     !oldAgentId
@@ -1907,7 +1907,7 @@ function normalizeNonWhitespaceToken(value) {
     return "";
   }
   const trimmed = value.trim();
-  if (!trimmed || /\s/.test(trimmed)) {
+  if (!trimmed || /\s/.test(trimmed) || trimmed.includes("<!--") || trimmed.includes("-->")) {
     return "";
   }
   return trimmed;
@@ -1950,6 +1950,14 @@ function normalizeIsoTimestamp(value) {
     return "";
   }
   return trimmed;
+}
+
+function normalizeSecondPrecisionIsoTimestamp(value) {
+  const timestamp = normalizeIsoTimestamp(value);
+  if (!timestamp || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(timestamp)) {
+    return "";
+  }
+  return timestamp;
 }
 
 function normalizeContextScope(value) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1191,6 +1191,7 @@ export function resolveLatestReviewWatermark(comments, options = {}) {
 export function summarizeRegularCommentsForGate(comments, options = {}) {
   const iddAgentLogins = new Set(normalizeTrustedMarkerLogins(options.iddAgentLogins ?? []));
   const advisoryBotLogins = new Set(normalizeTrustedMarkerLogins(options.advisoryBotLogins ?? []));
+  const trustedMarkerLogins = new Set(normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []));
   const threads = Array.isArray(options.threads) ? options.threads : [];
 
   const normalized = comments
@@ -1218,7 +1219,10 @@ export function summarizeRegularCommentsForGate(comments, options = {}) {
     .map((comment, sortedIndex) => ({ ...comment, sortedIndex }));
 
   const lastIddReplyAt = normalized.reduce((latestTimestamp, comment) => {
-    if (isOperationalOrDigestComment(comment.body) || !iddAgentLogins.has(comment.authorLogin)) {
+    if (
+      isOperationalOrDigestCommentForGate(comment.body, comment.authorLogin, trustedMarkerLogins)
+      || !iddAgentLogins.has(comment.authorLogin)
+    ) {
       return latestTimestamp;
     }
     if (!latestTimestamp || compareIsoTimestamps(comment.createdAt, latestTimestamp) > 0) {
@@ -1234,7 +1238,7 @@ export function summarizeRegularCommentsForGate(comments, options = {}) {
   }));
 
   const items = normalized
-    .filter((comment) => !isOperationalOrDigestComment(comment.body))
+    .filter((comment) => !isOperationalOrDigestCommentForGate(comment.body, comment.authorLogin, trustedMarkerLogins))
     .filter((comment) => !iddAgentLogins.has(comment.authorLogin))
     .filter((comment) => !lastIddReplyAt || compareIsoTimestamps(lastIddReplyAt, comment.activityAt) <= 0)
     .filter((comment) => {
@@ -1558,7 +1562,12 @@ export function summarizeReviewerStates(
 export function summarizeClaimValidation(claimEvents = [], options = {}) {
   const trustedMarkerLogins = new Set(normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []));
   const authorizedForcedHandoffLogins = new Set(
-    normalizeTrustedMarkerLogins(options.authorizedForcedHandoffLogins ?? options.trustedMarkerLogins ?? []),
+    normalizeTrustedMarkerLogins(options.authorizedForcedHandoffLogins ?? []),
+  );
+  const expectedLinkedPrReferences = new Set(
+    (options.expectedLinkedPrs ?? [])
+      .map((value) => normalizeLinkedPrReference(value))
+      .filter(Boolean),
   );
   const expectedClaimId = String(options.expectedClaimId ?? "").trim();
   const expectedAgentId = String(options.expectedAgentId ?? "").trim();
@@ -1567,7 +1576,21 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
     {
       isTrustedAuthor:
         (login) => trustedMarkerLogins.size === 0 || trustedMarkerLogins.has(String(login ?? "").trim().toLowerCase()),
-      isForcedHandoffEnabled: () => true,
+      isForcedHandoffEnabled:
+        typeof options.isForcedHandoffEnabled === "function"
+          ? options.isForcedHandoffEnabled
+          : (forcedHandoff) => {
+            if (options.forcedHandoffEnabled !== true) {
+              return false;
+            }
+            if (expectedLinkedPrReferences.size === 0) {
+              return true;
+            }
+            if (forcedHandoff.contextScope !== "issue-plus-pr") {
+              return false;
+            }
+            return expectedLinkedPrReferences.has(normalizeLinkedPrReference(forcedHandoff.linkedPr));
+          },
       isAuthorizedForcedHandoff:
         typeof options.isAuthorizedForcedHandoff === "function"
           ? options.isAuthorizedForcedHandoff
@@ -1675,6 +1698,7 @@ export function buildPreMergeReadinessSummary(
   const unrepliedComments = summarizeRegularCommentsForGate(comments, {
     iddAgentLogins,
     advisoryBotLogins,
+    trustedMarkerLogins,
     threads,
   });
   const reviewerStates = summarizeReviewerStates(reviews, {
@@ -1711,8 +1735,11 @@ export function buildPreMergeReadinessSummary(
   );
   const claim = summarizeClaimValidation(claimEvents, {
     trustedMarkerLogins,
+    forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
     authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
     isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
+    isForcedHandoffEnabled: options.isForcedHandoffEnabled,
     expectedClaimId: options.expectedClaimId,
     expectedAgentId: options.expectedAgentId,
   });
@@ -2012,6 +2039,17 @@ function normalizeForcedHandoffReason(value) {
     return "";
   }
   return trimmed;
+}
+
+function normalizeLinkedPrReference(value) {
+  const token = String(value ?? "").trim();
+  if (!token) {
+    return "";
+  }
+  if (/^#?[1-9]\d*$/.test(token)) {
+    return token.replace(/^#/, "");
+  }
+  return token.toLowerCase();
 }
 
 function normalizeIsoTimestamp(value) {
@@ -2412,6 +2450,14 @@ function isGateAdvisoryBotLogin(login, advisoryBotLogins) {
 
 function isOperationalOrDigestComment(body) {
   return operationalMarkerPrefix(body) !== null || firstLine(body) === LIVE_STATUS_DIGEST_MARKER;
+}
+
+function isOperationalOrDigestCommentForGate(body, authorLogin, trustedMarkerLogins) {
+  const marker = operationalMarkerPrefix(body);
+  if (marker === "<!-- forced-handoff:" && trustedMarkerLogins.size > 0) {
+    return trustedMarkerLogins.has(String(authorLogin ?? "").trim().toLowerCase());
+  }
+  return marker !== null || firstLine(body) === LIVE_STATUS_DIGEST_MARKER;
 }
 
 function isValidForcedHandoffOperationalMarker(body) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -124,7 +124,10 @@ export function parseForcedHandoffComment(body, createdAt) {
   }
 
   const visibleNote = trimmed.slice(markerEnd + 3);
-  const visibleText = visibleNote.replace(/<!--[\s\S]*?-->/g, " ").trim();
+  const visibleText = visibleNote
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<!--[\s\S]*$/g, " ")
+    .trim();
   if (!visibleText) {
     return null;
   }
@@ -1571,11 +1574,15 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
   );
   const expectedClaimId = String(options.expectedClaimId ?? "").trim();
   const expectedAgentId = String(options.expectedAgentId ?? "").trim();
+  const trustedAuthorPredicate =
+    typeof options.isTrustedAuthor === "function"
+      ? options.isTrustedAuthor
+      : (login) => trustedMarkerLogins.has(String(login ?? "").trim().toLowerCase());
+
   const activeClaim = resolveActiveClaim(
     claimEvents,
     {
-      isTrustedAuthor:
-        (login) => trustedMarkerLogins.size === 0 || trustedMarkerLogins.has(String(login ?? "").trim().toLowerCase()),
+      isTrustedAuthor: trustedAuthorPredicate,
       isForcedHandoffEnabled:
         typeof options.isForcedHandoffEnabled === "function"
           ? options.isForcedHandoffEnabled

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2008,7 +2008,7 @@ function normalizeForcedHandoffReason(value) {
     return "";
   }
   const trimmed = value.trim();
-  if (!trimmed || trimmed.includes("-->")) {
+  if (!trimmed || /[\r\n]/.test(trimmed) || trimmed.includes("-->")) {
     return "";
   }
   return trimmed;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -113,8 +113,9 @@ export function parseForcedHandoffComment(body, createdAt) {
     return null;
   }
 
-  const visibleNote = trimmed.slice(markerEnd + 3).trim();
-  if (!visibleNote) {
+  const visibleNote = trimmed.slice(markerEnd + 3);
+  const visibleText = visibleNote.replace(/<!--[\s\S]*?-->/g, " ").trim();
+  if (!visibleText) {
     return null;
   }
 

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1557,6 +1557,9 @@ export function summarizeReviewerStates(
 
 export function summarizeClaimValidation(claimEvents = [], options = {}) {
   const trustedMarkerLogins = new Set(normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []));
+  const authorizedForcedHandoffLogins = new Set(
+    normalizeTrustedMarkerLogins(options.authorizedForcedHandoffLogins ?? options.trustedMarkerLogins ?? []),
+  );
   const expectedClaimId = String(options.expectedClaimId ?? "").trim();
   const expectedAgentId = String(options.expectedAgentId ?? "").trim();
   const activeClaim = resolveActiveClaim(
@@ -1566,7 +1569,14 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
         (login) => trustedMarkerLogins.size === 0 || trustedMarkerLogins.has(String(login ?? "").trim().toLowerCase()),
       isForcedHandoffEnabled: () => true,
       isAuthorizedForcedHandoff:
-        (forcedBy) => trustedMarkerLogins.size === 0 || trustedMarkerLogins.has(String(forcedBy ?? "").trim().toLowerCase()),
+        typeof options.isAuthorizedForcedHandoff === "function"
+          ? options.isAuthorizedForcedHandoff
+          : (forcedBy) => {
+            if (authorizedForcedHandoffLogins.size === 0) {
+              return false;
+            }
+            return authorizedForcedHandoffLogins.has(String(forcedBy ?? "").trim().toLowerCase());
+          },
     },
   );
 
@@ -1701,6 +1711,8 @@ export function buildPreMergeReadinessSummary(
   );
   const claim = summarizeClaimValidation(claimEvents, {
     trustedMarkerLogins,
+    authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
+    isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
     expectedClaimId: options.expectedClaimId,
     expectedAgentId: options.expectedAgentId,
   });

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -41,6 +41,16 @@ const OPERATIONAL_MARKERS = [
   },
 ];
 
+const IDD_AGENT_DERIVED_MARKERS = new Set([
+  "<!-- claimed-by:",
+  "<!-- unclaimed-by:",
+  "<!-- review-watermark:",
+  "<!-- review-baseline:",
+  "advisory-wait:",
+  "advisory-wait-recovery:",
+  "<!-- advisory-wait:",
+]);
+
 const REVIEW_BOT_LOGINS = new Set([
   "coderabbitai",
   "coderabbitai[bot]",
@@ -288,14 +298,27 @@ export function parseReviewWatermarkComment(body, createdAt) {
 
 export function operationalMarkerPrefix(body) {
   const normalized = body.trimEnd();
-  return OPERATIONAL_MARKERS.find((marker) => marker.pattern.test(normalized))?.label ?? null;
+  const marker = OPERATIONAL_MARKERS.find((candidate) => candidate.pattern.test(normalized));
+  if (!marker) {
+    return null;
+  }
+  if (marker.label === "<!-- forced-handoff:" && !isValidForcedHandoffOperationalMarker(normalized)) {
+    return null;
+  }
+  return marker.label;
 }
 
 export function operationalMarkerPrefixByStart(body) {
   const normalized = body.trimStart();
-  return OPERATIONAL_MARKERS
-    .find((marker) => marker.startPattern?.test(normalized) ?? normalized.startsWith(marker.label))
-    ?.label ?? null;
+  const marker = OPERATIONAL_MARKERS
+    .find((candidate) => candidate.startPattern?.test(normalized) ?? normalized.startsWith(candidate.label));
+  if (!marker) {
+    return null;
+  }
+  if (marker.label === "<!-- forced-handoff:" && !isValidForcedHandoffOperationalMarker(normalized)) {
+    return null;
+  }
+  return marker.label;
 }
 
 export function findLiveStatusDigestComments(comments) {
@@ -872,7 +895,12 @@ export function deriveIddAgentLogins({
   for (const comment of operationalComments ?? []) {
     const authorLogin = String(comment?.author?.login ?? comment?.user?.login ?? "").trim().toLowerCase();
     const body = String(comment?.body ?? "");
-    if (!trustedLogins.has(authorLogin) || !isOperationalOrDigestComment(body)) {
+    const markerPrefix = operationalMarkerPrefix(body);
+    if (
+      !trustedLogins.has(authorLogin)
+      || !markerPrefix
+      || !IDD_AGENT_DERIVED_MARKERS.has(markerPrefix)
+    ) {
       continue;
     }
     derivedLogins.push(authorLogin);
@@ -2366,6 +2394,10 @@ function isGateAdvisoryBotLogin(login, advisoryBotLogins) {
 
 function isOperationalOrDigestComment(body) {
   return operationalMarkerPrefix(body) !== null || firstLine(body) === LIVE_STATUS_DIGEST_MARKER;
+}
+
+function isValidForcedHandoffOperationalMarker(body) {
+  return parseForcedHandoffComment(body, "") !== null;
 }
 
 function buildBodyPreview(body) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2454,7 +2454,7 @@ function isOperationalOrDigestComment(body) {
 
 function isOperationalOrDigestCommentForGate(body, authorLogin, trustedMarkerLogins) {
   const marker = operationalMarkerPrefix(body);
-  if (marker === "<!-- forced-handoff:" && trustedMarkerLogins.size > 0) {
+  if (marker === "<!-- forced-handoff:") {
     return trustedMarkerLogins.has(String(authorLogin ?? "").trim().toLowerCase());
   }
   return marker !== null || firstLine(body) === LIVE_STATUS_DIGEST_MARKER;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -206,10 +206,11 @@ export function renderForcedHandoffConsentNote(payload) {
   }
 
   if (normalized.contextScope === "issue-plus-pr") {
+    const prReference = /^\d+$/.test(normalized.linkedPr) ? `#${normalized.linkedPr}` : normalized.linkedPr;
     return [
       `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
       "owning session or agent is unavailable. This transfers ownership away",
-      `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\` for PR #${normalized.linkedPr}.`,
+      `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\` for PR ${prReference}.`,
       "If the prior session resumes, it must stop immediately and must not",
       "push, comment, resolve review state, or merge until a maintainer",
       "reassigns ownership.",

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2056,6 +2056,23 @@ function normalizeLinkedPrReference(value) {
   if (/^#?[1-9]\d*$/.test(token)) {
     return token.replace(/^#/, "");
   }
+  try {
+    const parsed = new URL(token);
+    const protocol = parsed.protocol.toLowerCase();
+    const hostname = parsed.hostname.toLowerCase();
+    if (protocol !== "http:" && protocol !== "https:") {
+      return token.toLowerCase();
+    }
+    if (hostname !== "github.com" && hostname !== "www.github.com") {
+      return token.toLowerCase();
+    }
+    const pathMatch = parsed.pathname.match(/^\/[^/]+\/[^/]+\/pull\/([1-9]\d*)\/?$/i);
+    if (pathMatch) {
+      return pathMatch[1];
+    }
+  } catch {
+    // Not a URL-form linked-pr reference.
+  }
   return token.toLowerCase();
 }
 

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -34,6 +34,10 @@ const OPERATIONAL_MARKERS = [
     label: "<!-- advisory-wait:",
     pattern: /^<!--\s*advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\S+\s*-->\s*$/,
   },
+  {
+    label: "<!-- forced-handoff:",
+    pattern: /^<!--\s*forced-handoff:\s*\{[\s\S]*\}\s*-->[\s\S]*$/i,
+  },
 ];
 
 const REVIEW_BOT_LOGINS = new Set([
@@ -58,6 +62,8 @@ const UNSAFE_TEXT_RULES = [
   },
 ];
 const AMD_MARKER_PATTERN = /^\*\*Awaiting maintainer decision\*\*/i;
+const FORCED_HANDOFF_MARKER_PREFIX = "<!-- forced-handoff:";
+const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(["issue-only", "issue-plus-pr"]);
 
 export function parseClaimComment(body, createdAt) {
   const match = body.trimEnd().match(
@@ -92,6 +98,140 @@ export function parseReleaseComment(body) {
     agentId: match[1],
     claimId: match[2],
   };
+}
+
+export function parseForcedHandoffComment(body, createdAt) {
+  const trimmed = body.trimEnd();
+  if (!trimmed.startsWith(FORCED_HANDOFF_MARKER_PREFIX)) {
+    return null;
+  }
+
+  const markerEnd = trimmed.indexOf("-->");
+  if (markerEnd < 0) {
+    return null;
+  }
+
+  const visibleNote = trimmed.slice(markerEnd + 3).trim();
+  if (!visibleNote) {
+    return null;
+  }
+
+  const payloadText = trimmed.slice(FORCED_HANDOFF_MARKER_PREFIX.length, markerEnd).trim();
+  let payload;
+  try {
+    payload = JSON.parse(payloadText);
+  } catch {
+    return null;
+  }
+
+  return normalizeForcedHandoffPayload(payload, { createdAt });
+}
+
+export function normalizeForcedHandoffPayload(payload, options = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+
+  const oldAgentId = normalizeNonWhitespaceToken(pickPayloadValue(payload, "oldAgentId", "old-agent-id"));
+  const oldClaimId = normalizeNonWhitespaceToken(pickPayloadValue(payload, "oldClaimId", "old-claim-id"));
+  const newAgentId = normalizeNonWhitespaceToken(pickPayloadValue(payload, "newAgentId", "new-agent-id"));
+  const newClaimId = normalizeNonWhitespaceToken(pickPayloadValue(payload, "newClaimId", "new-claim-id"));
+  const branch = normalizeBranchToken(pickPayloadValue(payload, "branch"));
+  const forcedBy = normalizeNonWhitespaceToken(pickPayloadValue(payload, "forcedBy", "forced-by"));
+  const reason = normalizeForcedHandoffReason(pickPayloadValue(payload, "reason"));
+  const timestamp = normalizeIsoTimestamp(pickPayloadValue(payload, "timestamp"));
+  const contextScope = normalizeContextScope(pickPayloadValue(payload, "contextScope", "context-scope"));
+  const linkedPr = normalizeLinkedPr(pickPayloadValue(payload, "linkedPr", "linked-pr"));
+  const createdAt = normalizeIsoTimestamp(options.createdAt);
+
+  if (
+    !oldAgentId
+    || !oldClaimId
+    || !newAgentId
+    || !newClaimId
+    || !branch
+    || !forcedBy
+    || !reason
+    || !timestamp
+    || !contextScope
+  ) {
+    return null;
+  }
+
+  if (oldClaimId === newClaimId) {
+    return null;
+  }
+
+  if (contextScope === "issue-plus-pr" && !linkedPr) {
+    return null;
+  }
+
+  if (contextScope === "issue-only" && linkedPr) {
+    return null;
+  }
+
+  return {
+    oldAgentId,
+    oldClaimId,
+    newAgentId,
+    newClaimId,
+    branch,
+    ...(linkedPr ? { linkedPr } : {}),
+    forcedBy,
+    reason,
+    timestamp,
+    contextScope,
+    ...(createdAt ? { createdAt } : {}),
+  };
+}
+
+export function renderForcedHandoffConsentNote(payload) {
+  const normalized = normalizeForcedHandoffPayload(payload);
+  if (!normalized) {
+    throw new Error("invalid forced handoff payload");
+  }
+
+  if (normalized.contextScope === "issue-plus-pr") {
+    return [
+      `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
+      "owning session or agent is unavailable. This transfers ownership away",
+      `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\` for PR #${normalized.linkedPr}.`,
+      "If the prior session resumes, it must stop immediately and must not",
+      "push, comment, resolve review state, or merge until a maintainer",
+      "reassigns ownership.",
+    ].join("\n");
+  }
+
+  return [
+    `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
+    "owning session or agent is unavailable. This transfers ownership away",
+    `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\`.`,
+    "If the prior session resumes, it must stop immediately and must not",
+    "push, comment, resolve review state, or merge until a maintainer",
+    "reassigns ownership.",
+  ].join("\n");
+}
+
+export function renderForcedHandoffComment(payload) {
+  const normalized = normalizeForcedHandoffPayload(payload);
+  if (!normalized) {
+    throw new Error("invalid forced handoff payload");
+  }
+
+  const markerPayload = {
+    "old-agent-id": normalized.oldAgentId,
+    "old-claim-id": normalized.oldClaimId,
+    "new-agent-id": normalized.newAgentId,
+    "new-claim-id": normalized.newClaimId,
+    branch: normalized.branch,
+    ...(normalized.linkedPr ? { "linked-pr": normalized.linkedPr } : {}),
+    "forced-by": normalized.forcedBy,
+    reason: normalized.reason,
+    timestamp: normalized.timestamp,
+    "context-scope": normalized.contextScope,
+  };
+
+  return `<!-- forced-handoff: ${JSON.stringify(markerPayload)} -->\n\n${renderForcedHandoffConsentNote(normalized)}`;
 }
 
 export function parseReviewWatermarkComment(body, createdAt) {
@@ -1636,6 +1776,7 @@ function createdAtToSecond(createdAt) {
 }
 
 export function resolveActiveClaim(events, isTrustedAuthor = () => true) {
+  const options = normalizeClaimResolutionOptions(isTrustedAuthor);
   const orderedEvents = events
     .map((event, index) => {
       const claim = parseClaimComment(event.body ?? "", event.createdAt ?? "");
@@ -1678,13 +1819,15 @@ export function resolveActiveClaim(events, isTrustedAuthor = () => true) {
 
   let active = null;
   for (const event of orderedEvents) {
-    active = applyClaimEvent(active, event, isTrustedAuthor);
+    active = applyClaimEvent(active, event, options);
   }
   return active;
 }
 
-export function applyClaimEvent(activeClaim, event, isTrustedAuthor = () => true) {
-  if (!isTrustedAuthor(event.author?.login ?? "")) {
+export function applyClaimEvent(activeClaim, event, options = {}) {
+  const normalizedOptions = normalizeClaimResolutionOptions(options);
+  const authorLogin = event.author?.login ?? "";
+  if (!normalizedOptions.isTrustedAuthor(authorLogin)) {
     return activeClaim;
   }
 
@@ -1713,7 +1856,122 @@ export function applyClaimEvent(activeClaim, event, isTrustedAuthor = () => true
     return null;
   }
 
+  const forcedHandoff = parseForcedHandoffComment(event.body ?? "", event.createdAt ?? "");
+  if (
+    forcedHandoff
+    && activeClaim
+    && normalizedOptions.isForcedHandoffEnabled(forcedHandoff, event)
+    && normalizedOptions.isAuthorizedForcedHandoff(forcedHandoff.forcedBy, forcedHandoff, event)
+    && forcedHandoff.oldAgentId === activeClaim.agentId
+    && forcedHandoff.oldClaimId === activeClaim.claimId
+    && forcedHandoff.branch === activeClaim.branch
+  ) {
+    return {
+      agentId: forcedHandoff.newAgentId,
+      claimId: forcedHandoff.newClaimId,
+      supersedes: forcedHandoff.oldClaimId,
+      branch: forcedHandoff.branch,
+      createdAt: event.createdAt ?? activeClaim.createdAt,
+    };
+  }
+
   return activeClaim;
+}
+
+function normalizeClaimResolutionOptions(optionsOrPredicate) {
+  if (typeof optionsOrPredicate === "function") {
+    return {
+      isTrustedAuthor: optionsOrPredicate,
+      isForcedHandoffEnabled: () => false,
+      isAuthorizedForcedHandoff: () => false,
+    };
+  }
+
+  const options = optionsOrPredicate ?? {};
+  return {
+    isTrustedAuthor:
+      typeof options.isTrustedAuthor === "function" ? options.isTrustedAuthor : () => true,
+    isForcedHandoffEnabled:
+      typeof options.isForcedHandoffEnabled === "function"
+        ? options.isForcedHandoffEnabled
+        : () => false,
+    isAuthorizedForcedHandoff:
+      typeof options.isAuthorizedForcedHandoff === "function"
+        ? options.isAuthorizedForcedHandoff
+        : () => false,
+  };
+}
+
+function normalizeNonWhitespaceToken(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed || /\s/.test(trimmed)) {
+    return "";
+  }
+  return trimmed;
+}
+
+function pickPayloadValue(payload, ...keys) {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(payload, key)) {
+      return payload[key];
+    }
+  }
+  return undefined;
+}
+
+function normalizeBranchToken(value) {
+  const token = normalizeNonWhitespaceToken(value);
+  if (!token || token.includes(">")) {
+    return "";
+  }
+  return token;
+}
+
+function normalizeForcedHandoffReason(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.includes("-->")) {
+    return "";
+  }
+  return trimmed;
+}
+
+function normalizeIsoTimestamp(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed || !isValidIsoTimestamp(trimmed)) {
+    return "";
+  }
+  return trimmed;
+}
+
+function normalizeContextScope(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  return FORCED_HANDOFF_CONTEXT_SCOPES.has(trimmed) ? trimmed : "";
+}
+
+function normalizeLinkedPr(value) {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed || /\s/.test(trimmed) || trimmed.includes("-->")) {
+    return "";
+  }
+  return trimmed;
 }
 
 export function classifyResumeRoutingCase(input, options = {}) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -64,7 +64,7 @@ const UNSAFE_TEXT_RULES = [
 ];
 const AMD_MARKER_PATTERN = /^\*\*Awaiting maintainer decision\*\*/i;
 const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(["issue-only", "issue-plus-pr"]);
-const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/i;
+const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/;
 
 export function parseClaimComment(body, createdAt) {
   const match = body.trimEnd().match(

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1561,7 +1561,13 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
   const expectedAgentId = String(options.expectedAgentId ?? "").trim();
   const activeClaim = resolveActiveClaim(
     claimEvents,
-    (login) => trustedMarkerLogins.size === 0 || trustedMarkerLogins.has(String(login ?? "").trim().toLowerCase()),
+    {
+      isTrustedAuthor:
+        (login) => trustedMarkerLogins.size === 0 || trustedMarkerLogins.has(String(login ?? "").trim().toLowerCase()),
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff:
+        (forcedBy) => trustedMarkerLogins.size === 0 || trustedMarkerLogins.has(String(forcedBy ?? "").trim().toLowerCase()),
+    },
   );
 
   let reason = "match";

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -243,6 +243,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const cases = [
     ["schemas/claim-marker.schema.json", "fixtures/schemas/claim-marker.valid.json", true],
     ["schemas/claim-marker.schema.json", "fixtures/schemas/claim-marker.invalid.json", false],
+    ["schemas/forced-handoff-marker.schema.json", "fixtures/schemas/forced-handoff-marker.valid.json", true],
+    ["schemas/forced-handoff-marker.schema.json", "fixtures/schemas/forced-handoff-marker.invalid.json", false],
     ["schemas/live-status-digest.schema.json", "fixtures/schemas/live-status-digest.valid.json", true],
     ["schemas/live-status-digest.schema.json", "fixtures/schemas/live-status-digest.invalid.json", false],
     ["schemas/advisory-wait-state.schema.json", "fixtures/schemas/advisory-wait-state.valid.json", true],

--- a/tests/cleanup-boundaries.test.mjs
+++ b/tests/cleanup-boundaries.test.mjs
@@ -20,6 +20,9 @@ function classifyComment(comment, disposition, isOperationalMarker, threads = []
     threads.length > 0 && threads.every((t) => t.isResolved === true);
 
   // Operational markers (review-watermark, review-baseline, advisory-wait) on merged PRs
+  if (isOperationalMarker === "<!-- forced-handoff:") {
+    return null;
+  }
   if (isOperationalMarker) {
     return { classifier: "OUTDATED" };
   }
@@ -116,6 +119,25 @@ describe("Cleanup candidate boundaries", () => {
     );
 
     assert.strictEqual(result?.classifier, "OUTDATED");
+  });
+
+  test("unsafe: forced-handoff audit markers stay out of cleanup candidates", () => {
+    const marker = {
+      id: 350,
+      body:
+        "<!-- forced-handoff: {\"old-agent-id\":\"a\",\"old-claim-id\":\"c1\",\"new-agent-id\":\"b\",\"new-claim-id\":\"c2\",\"branch\":\"issue/1-task\",\"forced-by\":\"kurone-kito\",\"reason\":\"approved\",\"timestamp\":\"2026-05-10T10:00:00Z\",\"context-scope\":\"issue-only\"} -->",
+      user: { login: "kurone-kito" },
+      created_at: "2026-05-10T10:00:00Z",
+    };
+
+    const result = classifyComment(
+      marker.body,
+      null,
+      "<!-- forced-handoff:",
+      []
+    );
+
+    assert.strictEqual(result, null);
   });
 
   test("safe: CodeRabbit completed summary with IDD disposition marker", () => {

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { currentIsoTimestamp, parsePositiveInteger } from "../scripts/forced-handoff-marker.mjs";
+import { currentIsoTimestamp, main, parsePositiveInteger } from "../scripts/forced-handoff-marker.mjs";
 import {
   applyClaimEvent,
   normalizeForcedHandoffPayload,
@@ -90,6 +90,11 @@ test("forced handoff helper timestamps stay on whole seconds", () => {
 test("forced handoff helper rejects malformed positive integers", () => {
   assert.equal(parsePositiveInteger("123", "--issue"), 123);
   assert.throws(() => parsePositiveInteger("123abc", "--issue"), /invalid --issue value: 123abc/);
+});
+
+test("forced handoff helper reports missing numeric flag values clearly", () => {
+  assert.throws(() => main(["--issue"]), /missing value for --issue/);
+  assert.throws(() => main(["--issue", "337", "--pr"]), /missing value for --pr/);
 });
 
 test("forced handoff markers are ignored by default when the feature is not enabled", () => {

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -5,6 +5,7 @@ import { currentIsoTimestamp, parsePositiveInteger } from "../scripts/forced-han
 import {
   applyClaimEvent,
   normalizeForcedHandoffPayload,
+  operationalMarkerPrefixByStart,
   parseForcedHandoffComment,
   renderForcedHandoffComment,
 } from "../scripts/protocol-helpers.mjs";
@@ -56,6 +57,13 @@ test("forced handoff parsing accepts flexible marker spacing and casing", () => 
     ...payload,
     createdAt: "2026-05-12T11:00:05Z",
   });
+});
+
+test("forced handoff start-prefix detection matches flexible marker spelling", () => {
+  assert.equal(
+    operationalMarkerPrefixByStart("  <!--   FORCED-HANDOFF: {\"old-agent-id\":\"a\"} -->"),
+    "<!-- forced-handoff:",
+  );
 });
 
 test("forced handoff normalization omits createdAt when comment metadata is unavailable", () => {
@@ -218,6 +226,32 @@ test("forced handoff rejects marker-breaking token values", () => {
     }),
     /invalid forced handoff payload/,
   );
+});
+
+test("forced handoff rejects invalid linked PR tokens", () => {
+  for (const linkedPr of ["0", "-1", "1.5", "not-a-pr", "ftp://example.test/pr/341", "<!--hidden"]) {
+    assert.throws(
+      () => renderForcedHandoffComment({
+        ...payload,
+        linkedPr,
+      }),
+      /invalid forced handoff payload/,
+      linkedPr,
+    );
+  }
+});
+
+test("forced handoff accepts PR URLs in linked PR scope", () => {
+  const body = renderForcedHandoffComment({
+    ...payload,
+    linkedPr: "https://github.com/kurone-kito/idd-skill/pull/359",
+  });
+
+  assert.deepEqual(parseForcedHandoffComment(body, "2026-05-12T11:00:05Z"), {
+    ...payload,
+    linkedPr: "https://github.com/kurone-kito/idd-skill/pull/359",
+    createdAt: "2026-05-12T11:00:05Z",
+  });
 });
 
 test("forced handoff rejects conflicting alias keys", () => {

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { currentIsoTimestamp } from "../scripts/forced-handoff-marker.mjs";
+import { currentIsoTimestamp, parsePositiveInteger } from "../scripts/forced-handoff-marker.mjs";
 import {
   applyClaimEvent,
   normalizeForcedHandoffPayload,
@@ -48,6 +48,11 @@ test("forced handoff normalization omits createdAt when comment metadata is unav
 
 test("forced handoff helper timestamps stay on whole seconds", () => {
   assert.match(currentIsoTimestamp(), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+});
+
+test("forced handoff helper rejects malformed positive integers", () => {
+  assert.equal(parsePositiveInteger("123", "--issue"), 123);
+  assert.throws(() => parsePositiveInteger("123abc", "--issue"), /invalid --issue value: 123abc/);
 });
 
 test("forced handoff markers are ignored by default when the feature is not enabled", () => {
@@ -128,4 +133,46 @@ test("forced handoff requires an exact old-claim match before transferring owner
   );
 
   assert.deepEqual(next, activeClaim);
+});
+
+test("forced handoff requires an exact old-agent match before transferring ownership", () => {
+  const body = renderForcedHandoffComment({
+    ...payload,
+    oldAgentId: "github-copilot-cli-other",
+  });
+  const next = applyClaimEvent(
+    activeClaim,
+    {
+      author: { login: "trusted-relay[bot]" },
+      body,
+      createdAt: "2026-05-12T11:00:05Z",
+    },
+    {
+      isTrustedAuthor: (login) => login === "trusted-relay[bot]",
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    },
+  );
+
+  assert.deepEqual(next, activeClaim);
+});
+
+test("forced handoff rejects fractional-second timestamps", () => {
+  assert.throws(
+    () => renderForcedHandoffComment({
+      ...payload,
+      timestamp: "2026-05-12T11:00:00.123Z",
+    }),
+    /invalid forced handoff payload/,
+  );
+});
+
+test("forced handoff rejects marker-breaking token values", () => {
+  assert.throws(
+    () => renderForcedHandoffComment({
+      ...payload,
+      forcedBy: "kurone-kito-->",
+    }),
+    /invalid forced handoff payload/,
+  );
 });

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -40,6 +40,24 @@ test("forced handoff marker render/parse round-trips through the normalized payl
   });
 });
 
+test("forced handoff parsing accepts flexible marker spacing and casing", () => {
+  const body = [
+    "<!--   FORCED-HANDOFF: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"linked-pr\":\"341\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-plus-pr\"} -->",
+    "",
+    "Forced handoff approved by kurone-kito. I verified that the current",
+    "owning session or agent is unavailable. This transfers ownership away",
+    "from claim `claim-20260512T090000Z-337-old` on branch `issue/337-feat-protocol-add-auditable-forced` for PR #341.",
+    "If the prior session resumes, it must stop immediately and must not",
+    "push, comment, resolve review state, or merge until a maintainer",
+    "reassigns ownership.",
+  ].join("\n");
+
+  assert.deepEqual(parseForcedHandoffComment(body, "2026-05-12T11:00:05Z"), {
+    ...payload,
+    createdAt: "2026-05-12T11:00:05Z",
+  });
+});
+
 test("forced handoff normalization omits createdAt when comment metadata is unavailable", () => {
   const normalized = normalizeForcedHandoffPayload(payload);
 
@@ -88,6 +106,31 @@ test("forced handoff transfers the active claim when trusted, enabled, and autho
     supersedes: "claim-20260512T090000Z-337-old",
     branch: "issue/337-feat-protocol-add-auditable-forced",
     createdAt: "2026-05-12T11:00:05Z",
+  });
+});
+
+test("forced handoff falls back to the active claim timestamp when event metadata is missing", () => {
+  const body = renderForcedHandoffComment(payload);
+  const next = applyClaimEvent(
+    activeClaim,
+    {
+      author: { login: "trusted-relay[bot]" },
+      body,
+      createdAt: "",
+    },
+    {
+      isTrustedAuthor: (login) => login === "trusted-relay[bot]",
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    },
+  );
+
+  assert.deepEqual(next, {
+    agentId: "github-copilot-cli-new",
+    claimId: "claim-20260512T110000Z-337-new",
+    supersedes: "claim-20260512T090000Z-337-old",
+    branch: "issue/337-feat-protocol-add-auditable-forced",
+    createdAt: "2026-05-12T09:00:00Z",
   });
 });
 
@@ -175,4 +218,19 @@ test("forced handoff rejects marker-breaking token values", () => {
     }),
     /invalid forced handoff payload/,
   );
+});
+
+test("forced handoff rejects conflicting alias keys", () => {
+  const body = [
+    "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"oldAgentId\":\"github-copilot-cli-other\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"linked-pr\":\"341\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-plus-pr\"} -->",
+    "",
+    "Forced handoff approved by kurone-kito. I verified that the current",
+    "owning session or agent is unavailable. This transfers ownership away",
+    "from claim `claim-20260512T090000Z-337-old` on branch `issue/337-feat-protocol-add-auditable-forced` for PR #341.",
+    "If the prior session resumes, it must stop immediately and must not",
+    "push, comment, resolve review state, or merge until a maintainer",
+    "reassigns ownership.",
+  ].join("\n");
+
+  assert.equal(parseForcedHandoffComment(body, "2026-05-12T11:00:05Z"), null);
 });

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -10,6 +10,7 @@ import {
 import {
   applyClaimEvent,
   normalizeForcedHandoffPayload,
+  operationalMarkerPrefix,
   operationalMarkerPrefixByStart,
   parseForcedHandoffComment,
   renderForcedHandoffConsentNote,
@@ -63,6 +64,26 @@ test("forced handoff parsing accepts flexible marker spacing and casing", () => 
     ...payload,
     createdAt: "2026-05-12T11:00:05Z",
   });
+});
+
+test("forced handoff parsing accepts leading whitespace before marker", () => {
+  const body = [
+    "   ",
+    "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"linked-pr\":\"341\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-plus-pr\"} -->",
+    "",
+    "Forced handoff approved by kurone-kito. I verified that the current",
+    "owning session or agent is unavailable. This transfers ownership away",
+    "from claim `claim-20260512T090000Z-337-old` on branch `issue/337-feat-protocol-add-auditable-forced` for PR #341.",
+    "If the prior session resumes, it must stop immediately and must not",
+    "push, comment, resolve review state, or merge until a maintainer",
+    "reassigns ownership.",
+  ].join("\n");
+
+  assert.deepEqual(parseForcedHandoffComment(body, "2026-05-12T11:00:05Z"), {
+    ...payload,
+    createdAt: "2026-05-12T11:00:05Z",
+  });
+  assert.equal(operationalMarkerPrefix(body), "<!-- forced-handoff:");
 });
 
 test("forced handoff rejects markers without visible consent text", () => {

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -259,7 +259,15 @@ test("forced handoff rejects marker-breaking token values", () => {
 });
 
 test("forced handoff rejects invalid linked PR tokens", () => {
-  for (const linkedPr of ["0", "-1", "1.5", "not-a-pr", "ftp://example.test/pr/341", "<!--hidden"]) {
+  for (const linkedPr of [
+    "0",
+    "-1",
+    "1.5",
+    "not-a-pr",
+    "ftp://example.test/pr/341",
+    "HTTP://github.com/kurone-kito/idd-skill/pull/359",
+    "<!--hidden",
+  ]) {
     assert.throws(
       () => renderForcedHandoffComment({
         ...payload,

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -164,6 +164,25 @@ test("forced handoff is rejected when the approving actor is unauthorized", () =
   assert.deepEqual(next, activeClaim);
 });
 
+test("forced handoff is rejected when the marker author is untrusted", () => {
+  const body = renderForcedHandoffComment(payload);
+  const next = applyClaimEvent(
+    activeClaim,
+    {
+      author: { login: "untrusted-user" },
+      body,
+      createdAt: "2026-05-12T11:00:05Z",
+    },
+    {
+      isTrustedAuthor: (login) => login === "trusted-relay[bot]",
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    },
+  );
+
+  assert.deepEqual(next, activeClaim);
+});
+
 test("forced handoff requires an exact old-claim match before transferring ownership", () => {
   const body = renderForcedHandoffComment({
     ...payload,
@@ -242,16 +261,21 @@ test("forced handoff rejects invalid linked PR tokens", () => {
 });
 
 test("forced handoff accepts PR URLs in linked PR scope", () => {
-  const body = renderForcedHandoffComment({
-    ...payload,
-    linkedPr: "https://github.com/kurone-kito/idd-skill/pull/359",
-  });
+  for (const linkedPr of [
+    "https://github.com/kurone-kito/idd-skill/pull/359",
+    "http://github.com/kurone-kito/idd-skill/pull/359",
+  ]) {
+    const body = renderForcedHandoffComment({
+      ...payload,
+      linkedPr,
+    });
 
-  assert.deepEqual(parseForcedHandoffComment(body, "2026-05-12T11:00:05Z"), {
-    ...payload,
-    linkedPr: "https://github.com/kurone-kito/idd-skill/pull/359",
-    createdAt: "2026-05-12T11:00:05Z",
-  });
+    assert.deepEqual(parseForcedHandoffComment(body, "2026-05-12T11:00:05Z"), {
+      ...payload,
+      linkedPr,
+      createdAt: "2026-05-12T11:00:05Z",
+    });
+  }
 });
 
 test("forced handoff rejects conflicting alias keys", () => {

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -60,6 +60,16 @@ test("forced handoff parsing accepts flexible marker spacing and casing", () => 
   });
 });
 
+test("forced handoff rejects markers without visible consent text", () => {
+  const body = [
+    "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-only\"} -->",
+    "",
+    "<!-- hidden only -->",
+  ].join("\n");
+
+  assert.equal(parseForcedHandoffComment(body, "2026-05-12T11:00:05Z"), null);
+});
+
 test("forced handoff start-prefix detection matches flexible marker spelling", () => {
   assert.equal(
     operationalMarkerPrefixByStart("  <!--   FORCED-HANDOFF: {\"old-agent-id\":\"a\"} -->"),

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -96,6 +96,16 @@ test("forced handoff rejects markers without visible consent text", () => {
   assert.equal(parseForcedHandoffComment(body, "2026-05-12T11:00:05Z"), null);
 });
 
+test("forced handoff rejects notes hidden by unterminated html comment openers", () => {
+  const body = [
+    "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-only\"} -->",
+    "",
+    "<!-- hidden",
+  ].join("\n");
+
+  assert.equal(parseForcedHandoffComment(body, "2026-05-12T11:00:05Z"), null);
+});
+
 test("forced handoff start-prefix detection matches flexible marker spelling", () => {
   assert.equal(
     operationalMarkerPrefixByStart(`  ${renderForcedHandoffComment(payload)}`),

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { currentIsoTimestamp } from "../scripts/forced-handoff-marker.mjs";
 import {
   applyClaimEvent,
   normalizeForcedHandoffPayload,
@@ -43,6 +44,10 @@ test("forced handoff normalization omits createdAt when comment metadata is unav
   const normalized = normalizeForcedHandoffPayload(payload);
 
   assert.deepEqual(normalized, payload);
+});
+
+test("forced handoff helper timestamps stay on whole seconds", () => {
+  assert.match(currentIsoTimestamp(), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
 });
 
 test("forced handoff markers are ignored by default when the feature is not enabled", () => {

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { currentIsoTimestamp, main, parsePositiveInteger } from "../scripts/forced-handoff-marker.mjs";
+import {
+  currentIsoTimestamp,
+  main,
+  parsePositiveInteger,
+  resolveHelperActiveClaim,
+} from "../scripts/forced-handoff-marker.mjs";
 import {
   applyClaimEvent,
   normalizeForcedHandoffPayload,
@@ -72,8 +77,12 @@ test("forced handoff rejects markers without visible consent text", () => {
 
 test("forced handoff start-prefix detection matches flexible marker spelling", () => {
   assert.equal(
-    operationalMarkerPrefixByStart("  <!--   FORCED-HANDOFF: {\"old-agent-id\":\"a\"} -->"),
+    operationalMarkerPrefixByStart(`  ${renderForcedHandoffComment(payload)}`),
     "<!-- forced-handoff:",
+  );
+  assert.equal(
+    operationalMarkerPrefixByStart("  <!--   FORCED-HANDOFF: {\"old-agent-id\":\"a\"} -->"),
+    null,
   );
 });
 
@@ -95,6 +104,77 @@ test("forced handoff helper rejects malformed positive integers", () => {
 test("forced handoff helper reports missing numeric flag values clearly", () => {
   assert.throws(() => main(["--issue"]), /missing value for --issue/);
   assert.throws(() => main(["--issue", "337", "--pr"]), /missing value for --pr/);
+});
+
+test("forced handoff helper validates --repo format before API calls", () => {
+  assert.throws(
+    () => main([
+      "--issue",
+      "337",
+      "--new-agent-id",
+      "github-copilot-cli-new",
+      "--new-claim-id",
+      "claim-20260512T110000Z-337-new",
+      "--forced-by",
+      "kurone-kito",
+      "--reason",
+      "operator-approved-recovery",
+      "--repo",
+      "invalid-repo-format",
+    ]),
+    /invalid --repo value: invalid-repo-format \(expected owner\/name\)/,
+  );
+});
+
+test("forced handoff helper replays prior handoffs when resolving the active claim", () => {
+  const trustedLogins = ["github-copilot-cli-old", "github-copilot-cli-mid", "github-copilot-cli-new", "kurone-kito"];
+  const claimBody = [
+    "<!-- claimed-by: github-copilot-cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat-protocol-add-auditable-forced -->",
+    "",
+    "_github-copilot-cli-old: issue claim - IDD automation marker. Do not edit._",
+  ].join("\n");
+  const firstHandoff = renderForcedHandoffComment({
+    ...payload,
+    newAgentId: "github-copilot-cli-mid",
+    newClaimId: "claim-20260512T110000Z-337-mid",
+  });
+  const secondHandoff = renderForcedHandoffComment({
+    ...payload,
+    oldAgentId: "github-copilot-cli-mid",
+    oldClaimId: "claim-20260512T110000Z-337-mid",
+    newAgentId: "github-copilot-cli-new",
+    newClaimId: "claim-20260512T120000Z-337-next",
+    timestamp: "2026-05-12T12:00:00Z",
+  });
+
+  const active = resolveHelperActiveClaim(
+    [
+      {
+        body: claimBody,
+        created_at: "2026-05-12T09:00:00Z",
+        user: { login: "github-copilot-cli-old" },
+      },
+      {
+        body: firstHandoff,
+        created_at: "2026-05-12T11:00:05Z",
+        user: { login: "github-copilot-cli-mid" },
+      },
+      {
+        body: secondHandoff,
+        created_at: "2026-05-12T12:00:05Z",
+        user: { login: "github-copilot-cli-new" },
+      },
+    ],
+    trustedLogins,
+  );
+
+  assert.deepEqual(active, {
+    agentId: "github-copilot-cli-new",
+    claimId: "claim-20260512T120000Z-337-next",
+    supersedes: "claim-20260512T110000Z-337-mid",
+    branch: "issue/337-feat-protocol-add-auditable-forced",
+    createdAt: "2026-05-12T12:00:05Z",
+  });
 });
 
 test("forced handoff markers are ignored by default when the feature is not enabled", () => {

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -187,6 +187,9 @@ test("forced handoff helper replays prior handoffs when resolving the active cla
       },
     ],
     trustedLogins,
+    {
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    },
   );
 
   assert.deepEqual(active, {
@@ -362,6 +365,21 @@ test("forced handoff rejects marker-breaking token values", () => {
     }),
     /invalid forced handoff payload/,
   );
+});
+
+test("forced handoff rejects multiline reason values", () => {
+  const body = [
+    "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"linked-pr\":\"341\",\"forced-by\":\"kurone-kito\",\"reason\":\"line1\\nline2\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-plus-pr\"} -->",
+    "",
+    "Forced handoff approved by kurone-kito. I verified that the current",
+    "owning session or agent is unavailable. This transfers ownership away",
+    "from claim `claim-20260512T090000Z-337-old` on branch `issue/337-feat-protocol-add-auditable-forced` for PR #341.",
+    "If the prior session resumes, it must stop immediately and must not",
+    "push, comment, resolve review state, or merge until a maintainer",
+    "reassigns ownership.",
+  ].join("\n");
+
+  assert.equal(parseForcedHandoffComment(body, "2026-05-12T11:00:05Z"), null);
 });
 
 test("forced handoff rejects invalid linked PR tokens", () => {

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { test } from "node:test";
 
 import {
@@ -209,6 +212,79 @@ test("forced handoff helper replays prior handoffs when resolving the active cla
     branch: "issue/337-feat-protocol-add-auditable-forced",
     createdAt: "2026-05-12T12:00:05Z",
   });
+});
+
+test("forced handoff helper keeps PR-scoped active claim when issue-only handoff exists", () => {
+  const trustedLogins = ["github-copilot-cli-old", "github-copilot-cli-mid", "github-copilot-cli-new", "kurone-kito"];
+  const claimBody = [
+    "<!-- claimed-by: github-copilot-cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat-protocol-add-auditable-forced -->",
+    "",
+    "_github-copilot-cli-old: issue claim - IDD automation marker. Do not edit._",
+  ].join("\n");
+  const issueOnlyHandoff = renderForcedHandoffComment({
+    oldAgentId: "github-copilot-cli-old",
+    oldClaimId: "claim-20260512T090000Z-337-old",
+    newAgentId: "github-copilot-cli-mid",
+    newClaimId: "claim-20260512T110000Z-337-mid",
+    branch: "issue/337-feat-protocol-add-auditable-forced",
+    forcedBy: "kurone-kito",
+    reason: "operator-approved-recovery",
+    timestamp: "2026-05-12T11:00:00Z",
+    contextScope: "issue-only",
+  });
+
+  const active = resolveHelperActiveClaim(
+    [
+      {
+        body: claimBody,
+        created_at: "2026-05-12T09:00:00Z",
+        user: { login: "github-copilot-cli-old" },
+      },
+      {
+        body: issueOnlyHandoff,
+        created_at: "2026-05-12T11:00:05Z",
+        user: { login: "github-copilot-cli-mid" },
+      },
+    ],
+    trustedLogins,
+    {
+      expectedLinkedPrs: ["359", "https://github.com/kurone-kito/idd-skill/pull/359"],
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    },
+  );
+
+  assert.equal(active?.claimId, "claim-20260512T090000Z-337-old");
+  assert.equal(active?.agentId, "github-copilot-cli-old");
+});
+
+test("forced handoff helper refuses output when forced-handoff mode is disabled", () => {
+  const originalCwd = process.cwd();
+  const sandbox = mkdtempSync(join(tmpdir(), "idd-forced-handoff-marker-"));
+  mkdirSync(join(sandbox, ".github", "idd"), { recursive: true });
+  writeFileSync(join(sandbox, ".github", "idd", "config.json"), JSON.stringify({ forcedHandoff: "disabled" }));
+
+  process.chdir(sandbox);
+  try {
+    assert.throws(
+      () => main([
+        "--issue",
+        "337",
+        "--new-agent-id",
+        "github-copilot-cli-new",
+        "--new-claim-id",
+        "claim-20260512T110000Z-337-new",
+        "--forced-by",
+        "kurone-kito",
+        "--reason",
+        "operator-approved-recovery",
+        "--repo",
+        "kurone-kito/idd-skill",
+      ]),
+      /forced-handoff mode is not human-gated; marker generation is disabled/,
+    );
+  } finally {
+    process.chdir(originalCwd);
+  }
 });
 
 test("forced handoff markers are ignored by default when the feature is not enabled", () => {

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -7,6 +7,7 @@ import {
   normalizeForcedHandoffPayload,
   operationalMarkerPrefixByStart,
   parseForcedHandoffComment,
+  renderForcedHandoffConsentNote,
   renderForcedHandoffComment,
 } from "../scripts/protocol-helpers.mjs";
 
@@ -276,6 +277,16 @@ test("forced handoff accepts PR URLs in linked PR scope", () => {
       createdAt: "2026-05-12T11:00:05Z",
     });
   }
+});
+
+test("forced handoff consent note keeps URL PR references unprefixed", () => {
+  assert.match(
+    renderForcedHandoffConsentNote({
+      ...payload,
+      linkedPr: "https://github.com/kurone-kito/idd-skill/pull/359",
+    }),
+    /for PR https:\/\/github\.com\/kurone-kito\/idd-skill\/pull\/359\./,
+  );
 });
 
 test("forced handoff rejects conflicting alias keys", () => {

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  applyClaimEvent,
+  normalizeForcedHandoffPayload,
+  parseForcedHandoffComment,
+  renderForcedHandoffComment,
+} from "../scripts/protocol-helpers.mjs";
+
+const activeClaim = {
+  agentId: "github-copilot-cli-old",
+  claimId: "claim-20260512T090000Z-337-old",
+  supersedes: "none",
+  branch: "issue/337-feat-protocol-add-auditable-forced",
+  createdAt: "2026-05-12T09:00:00Z",
+};
+
+const payload = {
+  oldAgentId: activeClaim.agentId,
+  oldClaimId: activeClaim.claimId,
+  newAgentId: "github-copilot-cli-new",
+  newClaimId: "claim-20260512T110000Z-337-new",
+  branch: activeClaim.branch,
+  linkedPr: "341",
+  forcedBy: "kurone-kito",
+  reason: "operator-approved-recovery",
+  timestamp: "2026-05-12T11:00:00Z",
+  contextScope: "issue-plus-pr",
+};
+
+test("forced handoff marker render/parse round-trips through the normalized payload", () => {
+  const body = renderForcedHandoffComment(payload);
+  const parsed = parseForcedHandoffComment(body, "2026-05-12T11:00:05Z");
+
+  assert.deepEqual(parsed, {
+    ...payload,
+    createdAt: "2026-05-12T11:00:05Z",
+  });
+});
+
+test("forced handoff normalization omits createdAt when comment metadata is unavailable", () => {
+  const normalized = normalizeForcedHandoffPayload(payload);
+
+  assert.deepEqual(normalized, payload);
+});
+
+test("forced handoff markers are ignored by default when the feature is not enabled", () => {
+  const body = renderForcedHandoffComment(payload);
+  const next = applyClaimEvent(activeClaim, {
+    author: { login: "kurone-kito" },
+    body,
+    createdAt: "2026-05-12T11:00:05Z",
+  });
+
+  assert.deepEqual(next, activeClaim);
+});
+
+test("forced handoff transfers the active claim when trusted, enabled, and authorized", () => {
+  const body = renderForcedHandoffComment(payload);
+  const next = applyClaimEvent(
+    activeClaim,
+    {
+      author: { login: "trusted-relay[bot]" },
+      body,
+      createdAt: "2026-05-12T11:00:05Z",
+    },
+    {
+      isTrustedAuthor: (login) => login === "trusted-relay[bot]",
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    },
+  );
+
+  assert.deepEqual(next, {
+    agentId: "github-copilot-cli-new",
+    claimId: "claim-20260512T110000Z-337-new",
+    supersedes: "claim-20260512T090000Z-337-old",
+    branch: "issue/337-feat-protocol-add-auditable-forced",
+    createdAt: "2026-05-12T11:00:05Z",
+  });
+});
+
+test("forced handoff is rejected when the approving actor is unauthorized", () => {
+  const body = renderForcedHandoffComment({
+    ...payload,
+    forcedBy: "unauthorized-user",
+  });
+  const next = applyClaimEvent(
+    activeClaim,
+    {
+      author: { login: "trusted-relay[bot]" },
+      body,
+      createdAt: "2026-05-12T11:00:05Z",
+    },
+    {
+      isTrustedAuthor: (login) => login === "trusted-relay[bot]",
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    },
+  );
+
+  assert.deepEqual(next, activeClaim);
+});
+
+test("forced handoff requires an exact old-claim match before transferring ownership", () => {
+  const body = renderForcedHandoffComment({
+    ...payload,
+    oldClaimId: "claim-20260512T090000Z-337-other",
+  });
+  const next = applyClaimEvent(
+    activeClaim,
+    {
+      author: { login: "trusted-relay[bot]" },
+      body,
+      createdAt: "2026-05-12T11:00:05Z",
+    },
+    {
+      isTrustedAuthor: (login) => login === "trusted-relay[bot]",
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    },
+  );
+
+  assert.deepEqual(next, activeClaim);
+});

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -71,8 +71,10 @@ test("vendored-node managed files match the canonical helper import closure", ()
   const expectedFiles = collectVendoredFiles(REPO_ROOT).map((file) => file.targetPath);
 
   assert.deepEqual(managedFiles, expectedFiles);
+  assert.ok(managedFiles.includes("scripts/forced-handoff-marker.mjs"));
   assert.ok(managedFiles.includes("scripts/protocol-helpers.mjs"));
   assert.ok(managedFiles.includes("scripts/idd-doctor.mjs"));
+  assert.ok(managedFiles.includes("schemas/forced-handoff-marker.schema.json"));
   assert.ok(managedFiles.includes("schemas/pre-merge-readiness.schema.json"));
   assert.ok(managedFiles.includes("schemas/advisory-wait-state.schema.json"));
   for (const relativePath of managedFiles) {
@@ -170,6 +172,28 @@ test("helper bundle manifest bin wrapper produces JSON output", () => {
 
   const launcher = readFileSync(join(REPO_ROOT, "bin/idd-helper-bundle-manifest.mjs"), "utf8");
   assert.ok(launcher.startsWith("#!/usr/bin/env node"));
+});
+
+test("helper bundle manifest publishes the forced handoff helper command", () => {
+  const packageManagerManifest = buildHelperRuntimeManifest({
+    profile: "package-manager",
+    packageManager: "pnpm",
+    targetRoot: REPO_ROOT,
+  });
+  const vendoredManifest = buildHelperRuntimeManifest({
+    profile: "vendored-node",
+    targetRoot: REPO_ROOT,
+  });
+
+  assert.equal(
+    packageManagerManifest.profiles["package-manager"].commands["idd:forced-handoff-marker"],
+    "idd-forced-handoff-marker",
+  );
+  assert.equal(
+    vendoredManifest.profiles["vendored-node"].commands["idd:forced-handoff-marker"],
+    "node scripts/forced-handoff-marker.mjs",
+  );
+  assert.equal(existsSync(join(REPO_ROOT, "bin/idd-forced-handoff-marker.mjs")), true);
 });
 
 test("manifest accepts an explicit package spec override", () => {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -828,6 +828,43 @@ test("summarizeClaimValidation accepts issue-plus-pr handoff with matching linke
   assert.equal(summary.activeClaim.agentId, "github-copilot-cli-new");
 });
 
+test("summarizeClaimValidation rejects issue-only handoff for PR-scoped checks", () => {
+  const claimEvents = [
+    {
+      body: [
+        "<!-- claimed-by: github-copilot-cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat-protocol-add-auditable-forced -->",
+        "",
+        "_github-copilot-cli-old: issue claim - IDD automation marker. Do not edit._",
+      ].join("\n"),
+      createdAt: "2026-05-12T09:00:00Z",
+      author: { login: "github-copilot-cli-old" },
+    },
+    {
+      body: [
+        "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-only\"} -->",
+        "",
+        "Forced handoff approved by kurone-kito.",
+      ].join("\n"),
+      createdAt: "2026-05-12T11:00:05Z",
+      author: { login: "kurone-kito" },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ["github-copilot-cli-old", "github-copilot-cli-new", "kurone-kito"],
+    forcedHandoffEnabled: true,
+    isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    expectedLinkedPrs: ["359", "#359", "https://github.com/kurone-kito/idd-skill/pull/359"],
+    expectedClaimId: "claim-20260512T090000Z-337-old",
+    expectedAgentId: "github-copilot-cli-old",
+  });
+
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, "match");
+  assert.equal(summary.activeClaim.claimId, "claim-20260512T090000Z-337-old");
+  assert.equal(summary.activeClaim.agentId, "github-copilot-cli-old");
+});
+
 test("advisory wait summary keeps F2 and F3 outcomes distinct when Copilot is no longer pending", () => {
   const summary = buildAdvisoryWaitSummary(
     {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -12,6 +12,7 @@ import {
   resolveCodeownersForFiles,
   selectCodeownersText,
   summarizeAdvisoryWaitMarkers,
+  summarizeClaimValidation,
   summarizeRegularCommentsForGate,
   summarizeRequiredChecks,
   summarizeReviewerStates,
@@ -595,6 +596,45 @@ test("deriveIddAgentLogins excludes trusted forced-handoff marker authors", () =
     }),
     ["current-agent"],
   );
+});
+
+test("summarizeClaimValidation follows trusted forced-handoff transitions", () => {
+  const claimEvents = [
+    {
+      body: [
+        "<!-- claimed-by: github-copilot-cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat-protocol-add-auditable-forced -->",
+        "",
+        "_github-copilot-cli-old: issue claim - IDD automation marker. Do not edit._",
+      ].join("\n"),
+      createdAt: "2026-05-12T09:00:00Z",
+      author: { login: "github-copilot-cli-old" },
+    },
+    {
+      body: [
+        "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-only\"} -->",
+        "",
+        "Forced handoff approved by kurone-kito. I verified that the current",
+        "owning session or agent is unavailable. This transfers ownership away",
+        "from claim `claim-20260512T090000Z-337-old` on branch `issue/337-feat-protocol-add-auditable-forced`.",
+        "If the prior session resumes, it must stop immediately and must not",
+        "push, comment, resolve review state, or merge until a maintainer",
+        "reassigns ownership.",
+      ].join("\n"),
+      createdAt: "2026-05-12T11:00:05Z",
+      author: { login: "kurone-kito" },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ["github-copilot-cli-old", "github-copilot-cli-new", "kurone-kito"],
+    expectedClaimId: "claim-20260512T110000Z-337-new",
+    expectedAgentId: "github-copilot-cli-new",
+  });
+
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, "match");
+  assert.equal(summary.activeClaim.claimId, "claim-20260512T110000Z-337-new");
+  assert.equal(summary.activeClaim.agentId, "github-copilot-cli-new");
 });
 
 test("advisory wait summary keeps F2 and F3 outcomes distinct when Copilot is no longer pending", () => {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -776,6 +776,30 @@ test("summarizeClaimValidation ignores forced handoff when policy is disabled", 
   assert.equal(summary.activeClaim.claimId, "claim-20260512T090000Z-337-old");
 });
 
+test("summarizeClaimValidation does not trust all authors when trusted marker set is empty", () => {
+  const claimEvents = [
+    {
+      body: [
+        "<!-- claimed-by: github-copilot-cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat-protocol-add-auditable-forced -->",
+        "",
+        "_github-copilot-cli-old: issue claim - IDD automation marker. Do not edit._",
+      ].join("\n"),
+      createdAt: "2026-05-12T09:00:00Z",
+      author: { login: "github-copilot-cli-old" },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: [],
+    expectedClaimId: "claim-20260512T090000Z-337-old",
+    expectedAgentId: "github-copilot-cli-old",
+  });
+
+  assert.equal(summary.activeClaimPresent, false);
+  assert.equal(summary.claimLost, true);
+  assert.equal(summary.reason, "missing-active-claim");
+});
+
 test("summarizeClaimValidation requires linked-pr match for issue-plus-pr handoff", () => {
   const claimEvents = [
     {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -550,6 +550,47 @@ test("regular comment gate skips resolved CodeRabbit summary comments", () => {
   assert.equal(summary.count, 0);
 });
 
+test("regular comment gate keeps untrusted forced-handoff marker-shaped comments", () => {
+  const summary = summarizeRegularCommentsForGate(
+    [
+      {
+        id: 1,
+        createdAt: "2026-05-12T00:00:00Z",
+        body: "<!-- forced-handoff: {} -->\n\nPlease verify this marker by a maintainer.",
+        author: { login: "external-user" },
+      },
+    ],
+    {
+      trustedMarkerLogins: ["idd-bot"],
+    },
+  );
+
+  assert.equal(summary.count, 1);
+  assert.deepEqual(summary.items.map((item) => item.id), ["1"]);
+});
+
+test("regular comment gate ignores trusted forced-handoff operational markers", () => {
+  const summary = summarizeRegularCommentsForGate(
+    [
+      {
+        id: 1,
+        createdAt: "2026-05-12T00:00:00Z",
+        body: [
+          "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"forced-by\":\"maintainer\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-only\"} -->",
+          "",
+          "Forced handoff approved by maintainer.",
+        ].join("\n"),
+        author: { login: "maintainer" },
+      },
+    ],
+    {
+      trustedMarkerLogins: ["maintainer"],
+    },
+  );
+
+  assert.equal(summary.count, 0);
+});
+
 test("deriveIddAgentLogins keeps prior trusted operational actors but not generic maintainer comments", () => {
   assert.deepEqual(
     deriveIddAgentLogins({
@@ -627,6 +668,8 @@ test("summarizeClaimValidation follows trusted forced-handoff transitions", () =
 
   const summary = summarizeClaimValidation(claimEvents, {
     trustedMarkerLogins: ["github-copilot-cli-old", "github-copilot-cli-new", "kurone-kito"],
+    forcedHandoffEnabled: true,
+    isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
     expectedClaimId: "claim-20260512T110000Z-337-new",
     expectedAgentId: "github-copilot-cli-new",
   });
@@ -666,6 +709,7 @@ test("summarizeClaimValidation rejects forced handoff from unauthorized approver
 
   const summary = summarizeClaimValidation(claimEvents, {
     trustedMarkerLogins: ["github-copilot-cli-old", "trusted-relay[bot]"],
+    forcedHandoffEnabled: true,
     isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
     expectedClaimId: "claim-20260512T090000Z-337-old",
     expectedAgentId: "github-copilot-cli-old",
@@ -675,6 +719,113 @@ test("summarizeClaimValidation rejects forced handoff from unauthorized approver
   assert.equal(summary.reason, "match");
   assert.equal(summary.activeClaim.claimId, "claim-20260512T090000Z-337-old");
   assert.equal(summary.activeClaim.agentId, "github-copilot-cli-old");
+});
+
+test("summarizeClaimValidation ignores forced handoff when policy is disabled", () => {
+  const claimEvents = [
+    {
+      body: [
+        "<!-- claimed-by: github-copilot-cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat-protocol-add-auditable-forced -->",
+        "",
+        "_github-copilot-cli-old: issue claim - IDD automation marker. Do not edit._",
+      ].join("\n"),
+      createdAt: "2026-05-12T09:00:00Z",
+      author: { login: "github-copilot-cli-old" },
+    },
+    {
+      body: [
+        "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-only\"} -->",
+        "",
+        "Forced handoff approved by kurone-kito.",
+      ].join("\n"),
+      createdAt: "2026-05-12T11:00:05Z",
+      author: { login: "kurone-kito" },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ["github-copilot-cli-old", "kurone-kito"],
+    forcedHandoffEnabled: false,
+    expectedClaimId: "claim-20260512T090000Z-337-old",
+    expectedAgentId: "github-copilot-cli-old",
+  });
+
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, "match");
+  assert.equal(summary.activeClaim.claimId, "claim-20260512T090000Z-337-old");
+});
+
+test("summarizeClaimValidation requires linked-pr match for issue-plus-pr handoff", () => {
+  const claimEvents = [
+    {
+      body: [
+        "<!-- claimed-by: github-copilot-cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat-protocol-add-auditable-forced -->",
+        "",
+        "_github-copilot-cli-old: issue claim - IDD automation marker. Do not edit._",
+      ].join("\n"),
+      createdAt: "2026-05-12T09:00:00Z",
+      author: { login: "github-copilot-cli-old" },
+    },
+    {
+      body: [
+        "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"linked-pr\":\"359\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-plus-pr\"} -->",
+        "",
+        "Forced handoff approved by kurone-kito.",
+      ].join("\n"),
+      createdAt: "2026-05-12T11:00:05Z",
+      author: { login: "kurone-kito" },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ["github-copilot-cli-old", "github-copilot-cli-new", "kurone-kito"],
+    forcedHandoffEnabled: true,
+    expectedLinkedPrs: ["#1000", "https://github.com/octo/repo/pull/1000"],
+    expectedClaimId: "claim-20260512T090000Z-337-old",
+    expectedAgentId: "github-copilot-cli-old",
+  });
+
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, "match");
+  assert.equal(summary.activeClaim.claimId, "claim-20260512T090000Z-337-old");
+  assert.equal(summary.activeClaim.agentId, "github-copilot-cli-old");
+});
+
+test("summarizeClaimValidation accepts issue-plus-pr handoff with matching linked-pr", () => {
+  const claimEvents = [
+    {
+      body: [
+        "<!-- claimed-by: github-copilot-cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat-protocol-add-auditable-forced -->",
+        "",
+        "_github-copilot-cli-old: issue claim - IDD automation marker. Do not edit._",
+      ].join("\n"),
+      createdAt: "2026-05-12T09:00:00Z",
+      author: { login: "github-copilot-cli-old" },
+    },
+    {
+      body: [
+        "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"linked-pr\":\"359\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-plus-pr\"} -->",
+        "",
+        "Forced handoff approved by kurone-kito.",
+      ].join("\n"),
+      createdAt: "2026-05-12T11:00:05Z",
+      author: { login: "kurone-kito" },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ["github-copilot-cli-old", "github-copilot-cli-new", "kurone-kito"],
+    forcedHandoffEnabled: true,
+    isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    expectedLinkedPrs: ["#359", "https://github.com/kurone-kito/idd-skill/pull/359"],
+    expectedClaimId: "claim-20260512T110000Z-337-new",
+    expectedAgentId: "github-copilot-cli-new",
+  });
+
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, "match");
+  assert.equal(summary.activeClaim.claimId, "claim-20260512T110000Z-337-new");
+  assert.equal(summary.activeClaim.agentId, "github-copilot-cli-new");
 });
 
 test("advisory wait summary keeps F2 and F3 outcomes distinct when Copilot is no longer pending", () => {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -637,6 +637,46 @@ test("summarizeClaimValidation follows trusted forced-handoff transitions", () =
   assert.equal(summary.activeClaim.agentId, "github-copilot-cli-new");
 });
 
+test("summarizeClaimValidation rejects forced handoff from unauthorized approver", () => {
+  const claimEvents = [
+    {
+      body: [
+        "<!-- claimed-by: github-copilot-cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat-protocol-add-auditable-forced -->",
+        "",
+        "_github-copilot-cli-old: issue claim - IDD automation marker. Do not edit._",
+      ].join("\n"),
+      createdAt: "2026-05-12T09:00:00Z",
+      author: { login: "github-copilot-cli-old" },
+    },
+    {
+      body: [
+        "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"forced-by\":\"trusted-relay[bot]\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-only\"} -->",
+        "",
+        "Forced handoff approved by trusted-relay[bot]. I verified that the current",
+        "owning session or agent is unavailable. This transfers ownership away",
+        "from claim `claim-20260512T090000Z-337-old` on branch `issue/337-feat-protocol-add-auditable-forced`.",
+        "If the prior session resumes, it must stop immediately and must not",
+        "push, comment, resolve review state, or merge until a maintainer",
+        "reassigns ownership.",
+      ].join("\n"),
+      createdAt: "2026-05-12T11:00:05Z",
+      author: { login: "trusted-relay[bot]" },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ["github-copilot-cli-old", "trusted-relay[bot]"],
+    isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    expectedClaimId: "claim-20260512T090000Z-337-old",
+    expectedAgentId: "github-copilot-cli-old",
+  });
+
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, "match");
+  assert.equal(summary.activeClaim.claimId, "claim-20260512T090000Z-337-old");
+  assert.equal(summary.activeClaim.agentId, "github-copilot-cli-old");
+});
+
 test("advisory wait summary keeps F2 and F3 outcomes distinct when Copilot is no longer pending", () => {
   const summary = buildAdvisoryWaitSummary(
     {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -570,6 +570,33 @@ test("deriveIddAgentLogins keeps prior trusted operational actors but not generi
   );
 });
 
+test("deriveIddAgentLogins excludes trusted forced-handoff marker authors", () => {
+  const forcedHandoffBody = [
+    "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"forced-by\":\"maintainer\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-only\"} -->",
+    "",
+    "Forced handoff approved by maintainer. I verified that the current",
+    "owning session or agent is unavailable. This transfers ownership away",
+    "from claim `claim-20260512T090000Z-337-old` on branch `issue/337-feat-protocol-add-auditable-forced`.",
+    "If the prior session resumes, it must stop immediately and must not",
+    "push, comment, resolve review state, or merge until a maintainer",
+    "reassigns ownership.",
+  ].join("\n");
+
+  assert.deepEqual(
+    deriveIddAgentLogins({
+      viewerLogin: "current-agent",
+      trustedMarkerLogins: ["current-agent", "maintainer"],
+      operationalComments: [
+        {
+          author: { login: "maintainer" },
+          body: forcedHandoffBody,
+        },
+      ],
+    }),
+    ["current-agent"],
+  );
+});
+
 test("advisory wait summary keeps F2 and F3 outcomes distinct when Copilot is no longer pending", () => {
   const summary = buildAdvisoryWaitSummary(
     {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -873,6 +873,43 @@ test("summarizeClaimValidation accepts issue-plus-pr handoff with matching linke
   assert.equal(summary.activeClaim.agentId, "github-copilot-cli-new");
 });
 
+test("summarizeClaimValidation normalizes linked-pr URL variants for matching", () => {
+  const claimEvents = [
+    {
+      body: [
+        "<!-- claimed-by: github-copilot-cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat-protocol-add-auditable-forced -->",
+        "",
+        "_github-copilot-cli-old: issue claim - IDD automation marker. Do not edit._",
+      ].join("\n"),
+      createdAt: "2026-05-12T09:00:00Z",
+      author: { login: "github-copilot-cli-old" },
+    },
+    {
+      body: [
+        "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"linked-pr\":\"http://github.com/kurone-kito/idd-skill/pull/359/\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-plus-pr\"} -->",
+        "",
+        "Forced handoff approved by kurone-kito.",
+      ].join("\n"),
+      createdAt: "2026-05-12T11:00:05Z",
+      author: { login: "kurone-kito" },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ["github-copilot-cli-old", "github-copilot-cli-new", "kurone-kito"],
+    forcedHandoffEnabled: true,
+    isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "kurone-kito",
+    expectedLinkedPrs: ["#359", "https://github.com/kurone-kito/idd-skill/pull/359"],
+    expectedClaimId: "claim-20260512T110000Z-337-new",
+    expectedAgentId: "github-copilot-cli-new",
+  });
+
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, "match");
+  assert.equal(summary.activeClaim.claimId, "claim-20260512T110000Z-337-new");
+  assert.equal(summary.activeClaim.agentId, "github-copilot-cli-new");
+});
+
 test("summarizeClaimValidation rejects issue-only handoff for PR-scoped checks", () => {
   const claimEvents = [
     {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -591,6 +591,27 @@ test("regular comment gate ignores trusted forced-handoff operational markers", 
   assert.equal(summary.count, 0);
 });
 
+test("regular comment gate keeps forced-handoff markers visible without explicit trust", () => {
+  const summary = summarizeRegularCommentsForGate(
+    [
+      {
+        id: 1,
+        createdAt: "2026-05-12T00:00:00Z",
+        body: [
+          "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"forced-by\":\"maintainer\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-only\"} -->",
+          "",
+          "Forced handoff approved by maintainer.",
+        ].join("\n"),
+        author: { login: "maintainer" },
+      },
+    ],
+    {},
+  );
+
+  assert.equal(summary.count, 1);
+  assert.deepEqual(summary.items.map((item) => item.id), ["1"]);
+});
+
 test("deriveIddAgentLogins keeps prior trusted operational actors but not generic maintainer comments", () => {
   assert.deepEqual(
     deriveIddAgentLogins({

--- a/tests/review-snapshot.test.mjs
+++ b/tests/review-snapshot.test.mjs
@@ -145,6 +145,29 @@ test("builds activity snapshot metrics with trusted marker filtering", () => {
   assert.equal(summary.latestPassingCiCompletedAt, "2026-05-10T10:25:00Z");
 });
 
+test("malformed forced-handoff comments remain visible activity", () => {
+  const summary = buildActivitySnapshotSummary(
+    {
+      comments: [
+        {
+          author: { login: "idd-bot" },
+          body: "<!-- forced-handoff: {} -->\n\nPlease fix this handoff marker.",
+          createdAt: "2026-05-10T10:40:00Z",
+          updatedAt: "2026-05-10T10:40:00Z",
+        },
+      ],
+      reviews: [],
+      threads: [],
+      checks: [],
+    },
+    { trustedMarkerLogins: ["idd-bot"] },
+  );
+
+  assert.equal(summary.counts.comments, 1);
+  assert.equal(summary.totalItemCount, 1);
+  assert.equal(summary.maxActivityUpdatedAt, "2026-05-10T10:40:00Z");
+});
+
 function readJson(relativePath) {
   return JSON.parse(readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8"));
 }

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -9,7 +9,7 @@ import {
   validateFixture,
   validatePhaseGraph,
 } from "../scripts/validate-schemas.mjs";
-import { parseClaimComment } from "../scripts/protocol-helpers.mjs";
+import { parseClaimComment, parseForcedHandoffComment } from "../scripts/protocol-helpers.mjs";
 
 // ---------------------------------------------------------------------------
 // Schema keyword hygiene — no unsupported keywords allowed
@@ -17,6 +17,11 @@ import { parseClaimComment } from "../scripts/protocol-helpers.mjs";
 
 test("claim-marker schema uses only allowed keywords", () => {
   const schema = loadJson("schemas/claim-marker.schema.json");
+  assert.deepEqual(checkSchemaKeywords(schema), []);
+});
+
+test("forced-handoff-marker schema uses only allowed keywords", () => {
+  const schema = loadJson("schemas/forced-handoff-marker.schema.json");
   assert.deepEqual(checkSchemaKeywords(schema), []);
 });
 
@@ -83,6 +88,24 @@ test("claim-marker invalid fixture fails validation", () => {
   const { ok } = validateFixture(
     "schemas/claim-marker.schema.json",
     "fixtures/schemas/claim-marker.invalid.json",
+    false,
+  );
+  assert.ok(ok, "Expected invalid fixture to fail schema validation");
+});
+
+test("forced-handoff-marker valid fixture passes validation", () => {
+  const { ok, errors } = validateFixture(
+    "schemas/forced-handoff-marker.schema.json",
+    "fixtures/schemas/forced-handoff-marker.valid.json",
+    true,
+  );
+  assert.ok(ok, errors.join("\n"));
+});
+
+test("forced-handoff-marker invalid fixture fails validation", () => {
+  const { ok } = validateFixture(
+    "schemas/forced-handoff-marker.schema.json",
+    "fixtures/schemas/forced-handoff-marker.invalid.json",
     false,
   );
   assert.ok(ok, "Expected invalid fixture to fail schema validation");
@@ -373,6 +396,25 @@ test("protocol-helpers parseClaimComment output matches claim-marker schema", ()
   assert.ok(parsed !== null, "parseClaimComment returned null");
 
   const schema = loadJson("schemas/claim-marker.schema.json");
+  const errors = validate(parsed, schema);
+  assert.deepEqual(errors, [], `Schema/runtime drift detected:\n${errors.join("\n")}`);
+});
+
+test("protocol-helpers parseForcedHandoffComment output matches forced-handoff schema", () => {
+  const body = [
+    "<!-- forced-handoff: {\"old-agent-id\":\"github-copilot-cli-old\",\"old-claim-id\":\"claim-20260512T090000Z-337-old\",\"new-agent-id\":\"github-copilot-cli-new\",\"new-claim-id\":\"claim-20260512T110000Z-337-new\",\"branch\":\"issue/337-feat-protocol-add-auditable-forced\",\"linked-pr\":\"341\",\"forced-by\":\"kurone-kito\",\"reason\":\"operator-approved-recovery\",\"timestamp\":\"2026-05-12T11:00:00Z\",\"context-scope\":\"issue-plus-pr\"} -->",
+    "",
+    "Forced handoff approved by kurone-kito. I verified that the current",
+    "owning session or agent is unavailable. This transfers ownership away",
+    "from claim `claim-20260512T090000Z-337-old` on branch `issue/337-feat-protocol-add-auditable-forced` for PR #341.",
+    "If the prior session resumes, it must stop immediately and must not",
+    "push, comment, resolve review state, or merge until a maintainer",
+    "reassigns ownership.",
+  ].join("\n");
+  const parsed = parseForcedHandoffComment(body, "2026-05-12T11:00:05Z");
+  assert.ok(parsed !== null, "parseForcedHandoffComment returned null");
+
+  const schema = loadJson("schemas/forced-handoff-marker.schema.json");
   const errors = validate(parsed, schema);
   assert.deepEqual(errors, [], `Schema/runtime drift detected:\n${errors.join("\n")}`);
 });

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -430,6 +430,7 @@ test("forced-handoff schema rejects marker-breaking token values", () => {
     ["newClaimId", "new-->"],
     ["branch", "issue/337-<!--bad"],
     ["forcedBy", "owner-->"],
+    ["reason", "operator-->note"],
   ]) {
     const instance = { ...base, [field]: value };
     const errors = validate(instance, schema);

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -419,6 +419,24 @@ test("protocol-helpers parseForcedHandoffComment output matches forced-handoff s
   assert.deepEqual(errors, [], `Schema/runtime drift detected:\n${errors.join("\n")}`);
 });
 
+test("forced-handoff schema rejects marker-breaking token values", () => {
+  const schema = loadJson("schemas/forced-handoff-marker.schema.json");
+  const base = loadJson("fixtures/schemas/forced-handoff-marker.valid.json");
+
+  for (const [field, value] of [
+    ["oldAgentId", "agent-->"],
+    ["oldClaimId", "claim<!--x"],
+    ["newAgentId", "new<!--x"],
+    ["newClaimId", "new-->"],
+    ["branch", "issue/337-<!--bad"],
+    ["forcedBy", "owner-->"],
+  ]) {
+    const instance = { ...base, [field]: value };
+    const errors = validate(instance, schema);
+    assert.ok(errors.length > 0, `Expected ${field}=${value} to fail schema validation`);
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Claim ID pattern — accepts opaque tokens including hyphens
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add forced-handoff marker parsing and rendering to the shared protocol helpers
- add a dry-run maintainer helper plus schema fixtures and tests for the normalized payload
- document the shipped marker format in the customization docs and template mirror

## Validation
- pnpm run lint:minimum

Recommended follow-up issues: none.

Closes #337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added forced-handoff marker support for transferring claim ownership, plus a CLI to create and emit markers and runtime helpers to parse/validate them.

* **Documentation**
  * Updated forced-handoff protocol docs with exact required payload fields and usage contract.

* **Tests**
  * Added end-to-end and schema validation tests covering parsing, rendering, validation, and transfer behavior (valid/invalid fixtures included).

* **Chores**
  * Registered new CLI/binary and updated helper manifest; audit/cleanup now treat forced-handoff markers as preserved evidence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/359)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->