### PR TITLE
docs(resume): route human-gated forced handoff recovery

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -66,6 +66,9 @@ comment. An inheritable claim comment is either:
 - the latest trusted `claimed-by` comment that was later released by a
   matching trusted `unclaimed-by` comment (the last voluntarily released
   branch), or
+- trusted forced-handoff evidence already verified by Resume Step 1,
+  but only when its branch and linked PR fields match the live GitHub
+  state, or
 - the latest trusted legacy `claimed-by` comment when performing a
   legacy migration (see the migration-only decision input above)
 
@@ -89,7 +92,8 @@ name:
 6. If the result is empty, use `task`.
 
 No remote branch with that name may exist, unless it matches the
-`branch` field in an inheritable claim comment as defined in (c) above.
+`branch` field in an inheritable claim comment or trusted
+forced-handoff evidence as defined in (c) above.
 
 Before posting a claim, also perform a **scoped issue-wide branch pattern
 check** to detect concurrent sessions working on the same issue with
@@ -117,9 +121,9 @@ catches parallel-session concurrency before a new claim comment is posted.
    - **If no local worktree or remote branch matches `issue/<number>-*`**:
      Proceed to claim posting (the safe, single-session path).
 
-   - **If a match is found and corresponds to an inheritable claim** (i.e.,
-     its `branch` field matches one of the branches in an inheritable claim
-     comment as defined in (c) above):
+   - **If a match is found and corresponds to an inheritable claim or
+     trusted forced-handoff evidence** (i.e., its `branch` field matches
+     one of the branches allowed in (c) above):
      Proceed to claim posting. The branch is expected.
 
    - **If a match is found, does NOT correspond to an inheritable claim,
@@ -149,10 +153,12 @@ claim.
 
 Determine `{branch-name}`:
 
-- **Re-claim / takeover**: use the exact branch name from the
-  inheritable claim comment (the `branch` field of the active stale
-  claim, the last-released trusted `claimed-by`, or the trusted legacy
-  claim being migrated). Do not compute a new name.
+- **Re-claim / takeover / forced-handoff recovery**: use the exact
+  branch name from the inheritable claim comment or trusted
+  forced-handoff evidence (the `branch` field of the active stale claim, the
+  last-released trusted `claimed-by`, the forced-handoff evidence
+  approved in Resume Step 1, or the trusted legacy claim being
+  migrated). Do not compute a new name.
 - **Fresh claim**: compute a new name using the IDD naming convention:
   `issue/<number>-<slug>` where `<slug>` follows the deterministic title
   normalization algorithm from pre-check (d).
@@ -161,6 +167,11 @@ Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
 
 - **Takeover of an active claim** (stale claim recovery) → the current
   active claim's `{claim-id}`
+- **Forced-handoff recovery** → `none` once the human-gated handoff has
+  already released or otherwise cleared the displaced claim in GitHub
+  state; if the displaced non-stale claim is still active, stop and wait
+  for the handoff mechanism instead of inventing a local superseding
+  claim
 - **Migration from a legacy claim** → `none`
 - **Fresh claim** or claim after a released / unclaimed state → `none`
 
@@ -213,6 +224,11 @@ unless the operator has explicitly switched to normal discovery.
 Once verified, record this `{claim-id}` as your current claim token for
 the rest of the workflow.
 
+When the new claim came from forced-handoff recovery, cite the trusted
+forced-handoff evidence in the issue digest or resume report's
+`Authoritative by` field. Do not invent ad hoc `claimed-by` fields and
+do not reuse the displaced `{claim-id}`.
+
 After claim verification, upsert the issue live status digest when there
 is exactly one marked digest or none. Use the verified `claimed-by`
 comment as the authority: set `Phase` to `A5 claimed`, `Claim` to the
@@ -263,6 +279,9 @@ and use heartbeats; do not post a fresh takeover claim. If the session
 cannot prove ownership of the active `{claim-id}`, the active claim is
 treated as owned by another live session until it is released or stale,
 even when `{agent-id}` matches.
+If a successor posts a fresh claim after forced handoff, later
+heartbeats from the displaced old `{claim-id}` are ignored as stale
+events; they do not reclaim ownership or refresh the stale clock.
 
 ## Legacy claim migration
 

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -129,7 +129,9 @@ push, rebase, reply, resolve, reviewer request, merge), re-read the
 issue and parse the active claim using the rules in
 `idd-claim.instructions.md`. The active claim must still use your
 current `{claim-id}`. If it does not, the claim was lost. Stop, do not
-post further operational comments, and report the handoff or race.
+post further operational comments, and report the handoff or race. If
+loss came from handoff, the displaced session must not push,
+comment, resolve reviews, request reviewers, or merge.
 
 A1.5 roadmap completion audit side effects use the roadmap issue itself
 as the claim target (see `idd-roadmap-audit.instructions.md`). Even

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -15,6 +15,12 @@ for the canonical values, not as a behavior override.
 Before any F-phase mutating action, apply the shared claim revalidation
 gate. The active claim must still use your current `{claim-id}`.
 
+After a forced handoff on an open PR, the successor must rebuild review
+state through E1/E2 under its own `{claim-id}` before merge-bound
+routing continues. A live status digest or prior-claim operational
+marker is UI or audit context only; it cannot satisfy review currency,
+claim ownership, advisory wait, or CI gates.
+
 When all F2 conditions are satisfied, proceed to
 `idd-merge-handoff.instructions.md`.
 
@@ -86,6 +92,11 @@ must align with every F2 condition below.
   watermarks without `{claim-id}` must not be reused across a restart or
   takeover, and same-claim watermarks from untrusted authors must be
   ignored and reported as suspicious context when they affect routing.
+  Forced-handoff successors must treat prior-claim watermarks the same
+  way even when the branch and HEAD are unchanged. Do not delete, hide,
+  minimize, or otherwise unmark open-PR operational markers during this
+  recovery; if no trusted same-claim watermark exists for the successor
+  claim, return to E1 and rebuild review state there.
   To collect this evidence, either use the documented merge-gate helper
   reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)

--- a/.github/instructions/idd-resume-stall.instructions.md
+++ b/.github/instructions/idd-resume-stall.instructions.md
@@ -5,6 +5,10 @@ rate-limited session and needs a dedicated, safety-first decision path.
 This path relies only on externally observable state. It never depends
 on the prior session posting a graceful shutdown.
 
+This file applies only to unattended stale-takeover evidence for a
+non-owned claim. Human-gated forced handoff is a separate recovery path
+and is routed from `idd-resume.instructions.md` before this file runs.
+
 Read `idd-overview.instructions.md` and
 `idd-resume.instructions.md` first.
 
@@ -34,6 +38,11 @@ Use GitHub server timestamps only.
 - If no active claim exists, or the active claim already uses your
   current `{claim-id}`, this is not a stalled-session takeover case.
   Return to `idd-resume.instructions.md`.
+- If trusted forced-handoff evidence exists and matches the active claim
+  or inheritable released branch / PR state, this is not a
+  stalled-session takeover case. Return to
+  `idd-resume.instructions.md` Step 1 and use the forced-handoff route
+  instead. Do not apply the quiet-window or stale-threshold gates here.
 - If the active claim belongs to another `{claim-id}`, continue.
 
 ### S2 — Quiet-window check (stall evidence, not ownership transfer)

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -7,15 +7,30 @@ definitions (claim format, stale threshold, abort, hold).
 Resume stale checks use the `claim-stale-age` policy default from
 `docs/policy-constants.md` (distributed default: `24 h`).
 
-## Step 0 — Route stalled-session recovery
+## Step 0 — Route forced handoff and stalled-session recovery
 
-Before Step 1, decide whether this is a stalled-session case:
+Before Step 1, decide whether this run should route through the
+forced-handoff path, the stalled-session path, or neither:
 
 - If the issue is already closed, or the corresponding PR is already
   merged, skip stalled-session routing and continue to Step 1 cleanup
   behavior.
-- If a non-owned active claim exists, run
+- If the repository records `forced-handoff: human-gated`, first check
+  whether trusted forced-handoff evidence exists for this issue or its
+  linked PR under the contract recorded in `docs/customization.md`.
+  Record the approving human, displaced `{claim-id}`, `{branch}`,
+  linked PR (if any), and the evidence comment URL.
+- If trusted forced-handoff evidence exists and matches the current
+  active claim or inheritable released branch / PR state, skip
+  stalled-session routing and continue to Step 1's forced-handoff path.
+  Quiet-window and stale-threshold checks do not apply once this
+  human-gated recovery route is verified.
+- Only when no usable forced-handoff evidence exists and a non-owned
+  active claim remains, run
   `idd-resume-stall.instructions.md` first.
+- Autopilot and unattended agents must never invent, request, or
+  broaden forced handoff on their own. They may only consume already
+  recorded human-gated evidence.
 - Use only externally observable evidence (trusted claim heartbeat
   timestamps, PR head movement, remote branch tip movement, review/
   comment activity, and CI timestamps).
@@ -35,28 +50,37 @@ Before routing, collect all of the following:
    unclaimed. Also record the latest released branch, if any. The
    shared rules ignore marker-shaped comments from untrusted authors;
    record their URLs as suspicious context when they affect routing.
-2. **Open PR and current head** — check for an open PR that
+2. **Forced-handoff evidence** — when the repository records
+   `forced-handoff: human-gated`, collect the trusted human approval
+   note that satisfies the contract in `docs/customization.md`. Record
+   the approving human, old claim ID, branch, linked PR if any, and
+   evidence URL. When an open PR exists, require the issue-plus-PR
+   approval text that names that PR; an issue-only approval is
+   insufficient for PR-scoped recovery. If any field required by the
+   current approval-note format is missing or contradictory, treat the
+   evidence as unusable and do not route forced handoff.
+3. **Open PR and current head** — check for an open PR that
    closes/references this issue. Record the current PR HEAD SHA.
-3. **Issue/PR activity recency** — snapshot issue comments, review
+4. **Issue/PR activity recency** — snapshot issue comments, review
    threads, review bodies, and regular PR comments, then record the
    latest `updatedAt` across that universe. When an open PR exists,
    include PR `createdAt`/`updatedAt` as additional recency signals.
-4. **PR HEAD movement evidence** — define a baseline before comparison:
+5. **PR HEAD movement evidence** — define a baseline before comparison:
    use the latest trusted same-claim `review-watermark`/`review-baseline`
    marker SHA when available; otherwise use the current PR HEAD SHA
-   captured in step 2 as the baseline. Then confirm whether commits were
+   captured in step 3 as the baseline. Then confirm whether commits were
    added after that baseline from PR timeline/activity.
-5. **CI transition state** — record current CI states for the PR HEAD,
+6. **CI transition state** — record current CI states for the PR HEAD,
    the latest completed CI transition `completedAt` (any terminal
    outcome), and the latest successful CI pass `completedAt` (or `none`).
-6. **Local worktrees** — run `git worktree list`.
-7. **Local branch** — check whether the branch named in the claim
+7. **Local worktrees** — run `git worktree list`.
+8. **Local branch** — check whether the branch named in the claim
    comment exists locally.
-8. **Dirty/clean** — run `git status` in the worktree (if it exists).
-9. **Unpushed commits** — run `git log @{u}..HEAD` in the worktree. If
-   no upstream is configured, treat all local commits as unpushed.
-10. **Current local HEAD SHA** — run `git rev-parse HEAD`.
-11. **Live status digest state** — record whether the issue or PR has
+9. **Dirty/clean** — run `git status` in the worktree (if it exists).
+10. **Unpushed commits** — run `git log @{u}..HEAD` in the worktree. If
+    no upstream is configured, treat all local commits as unpushed.
+11. **Current local HEAD SHA** — run `git rev-parse HEAD`.
+12. **Live status digest state** — record whether the issue or PR has
     zero, one, or multiple comments whose first line is
     `<!-- idd-live-status: current -->`. Do not use digest text to route
     resume; it is repairable UI state only.
@@ -65,6 +89,36 @@ Before routing, collect all of the following:
 
 - If the issue is **closed** or the corresponding PR is **merged**:
   clean up any remaining local worktree and branch, then stop.
+
+Before ordinary claim-state branching, check for trusted forced-handoff
+evidence under a repository policy of `forced-handoff: human-gated`:
+
+- If the evidence names a `{claim-id}` that this current session had
+  already verified before this routing step, this is the displaced old
+  session. Recording the old claim ID as evidence does not count as
+  ownership. Stop immediately. Do not push, comment, reply, resolve
+  threads, request reviewers, or merge until a maintainer reassigns
+  ownership.
+- If the active claim already uses a `{claim-id}` that this current
+  session had previously verified, and the forced-handoff evidence cites
+  a different displaced claim ID, ignore that historical evidence and
+  continue with the normal already-owned branch below.
+- If no usable forced-handoff evidence exists, continue with the normal
+  legacy and claim-state flow below.
+- If the evidence cites a `{claim-id}`, branch, or linked PR that does
+  not match the live active claim or inheritable released branch / PR
+  state, stop and report the mismatch. Do not claim, push, or mutate
+  review state.
+- Otherwise, treat the issue as **forced-handoff recovery**. Re-claim
+  only after the human-gated handoff mechanism has already updated the
+  GitHub claim stream to a released or successor-ready state. If the
+  displaced non-stale claim still remains active, stop and wait instead
+  of inventing a local superseding claim. Once GitHub state reflects the
+  handoff outcome, re-claim via `idd-claim.instructions.md` with a fresh
+  `{claim-id}` and the branch named in the forced-handoff evidence, then
+  continue to Step 2 after A5 verification. The successor must cite the
+  forced-handoff evidence in its resume report or digest
+  `Authoritative by`; it must not silently inherit the old `{claim-id}`.
 
 If the issue has no trusted new-format `claimed-by` comments but has legacy
 claim comments from trusted marker actors, treat the latest trusted
@@ -98,7 +152,8 @@ Otherwise, determine claim state from the parsed active claim:
   `{claim-id}` whose `supersedes:` value is the current active claim's
   `{claim-id}`, then continue to Step 2.
 
-When Step 1 performs a re-claim or stale takeover, claim verification
+When Step 1 performs a re-claim, forced-handoff recovery, or stale
+takeover, claim verification
 must follow A5 race-safe verification from
 `idd-claim.instructions.md`: wait 5–10 seconds after posting
 `claimed-by`, re-read and parse the full claim stream chronologically,
@@ -108,7 +163,10 @@ verification if a later trusted competing `claimed-by` with a different
 
 A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the
-stale active claim you are taking over, or in the latest released claim.
+stale active claim you are taking over, in the latest released claim, or
+in trusted forced-handoff evidence whose branch and linked PR fields
+still match the live GitHub state. Forced-handoff recovery never waives
+the normal A5 branch-collision and open-PR safety checks.
 
 If the active or inherited branch field starts with `roadmap-audit/`,
 the claim is an A1.5 roadmap-audit coordination claim, not a work branch.
@@ -133,6 +191,10 @@ reuse prior-claim review-watermark or review-baseline comments. For
 non-owned, non-stale claims, do not edit the digest; stalled-session
 handling records evidence in session logs only unless the claim becomes
 yours.
+During forced handoff on an open PR, do not delete, hide, minimize, or
+otherwise unmark prior-claim operational markers just to clear state;
+they remain audit context while the successor rebuilds fresh markers
+under its own `{claim-id}`.
 
 ## Step 2 — Locate or restore branch and worktree
 
@@ -177,6 +239,14 @@ the routing decision.
 
 Read the PR's current CI and review status:
 
+After a forced handoff on an open PR, rebuild review state from current
+GitHub state. Prior-claim `review-watermark` and `review-baseline`
+comments are not reusable, even when the branch and HEAD are unchanged.
+If the linked PR is open and review state matters, route to E1 before
+any merge-bound F check. Live status digests remain UI-only handoff
+context and do not satisfy review currency, claim ownership, advisory
+wait, or CI gates.
+
 | Condition                                                                          | Action                                                         |
 | ---------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | Required CI checks not yet generated, no reviews yet                               | Wait for generation, then apply D4 logic                       |
@@ -187,3 +257,8 @@ Read the PR's current CI and review status:
 | CI `failure` / `cancelled` / `timed_out`, reviews exist                            | Apply E15 CI failure/cancelled branch                          |
 | CI `success`, unresolved threads / unreplied comments / active `CHANGES_REQUESTED` | Resume from E1                                                 |
 | CI `success`, none of the above                                                    | Resume from F1                                                 |
+
+For forced-handoff recovery on an open PR, treat the final
+`CI success, none of the above` row as `Resume from E1` until the
+successor has posted its own same-claim review watermark and baseline
+for the current `{claim-id}`.

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -107,6 +107,10 @@ watermark comments from any other claim or from untrusted authors.
 Legacy watermarks without `{claim-id}` are not resumable across a
 restart or takeover; if no trusted same-claim watermark exists, rerun E1
 from scratch.
+After forced handoff, all prior-claim watermarks are foreign restore
+markers. Do not delete, hide, minimize, or otherwise unmark them on an
+open PR to "clear" state; ignore them and rerun E1 under the successor
+claim instead.
 
 Do not create or edit the PR live status digest after posting this
 watermark unless the next route is to E1, to an F3 blocked reroute that
@@ -156,7 +160,8 @@ GitHub author is a trusted marker actor). Reset to full-branch diff
 after a rebase, multi-fix batch, when the baseline SHA is not an
 ancestor of the current HEAD, when no trusted same-claim baseline
 exists, or whenever the active `{claim-id}` changed due to restart or
-takeover. List A is session-local; do not inherit a previous claim's
+takeover, including forced handoff. List A is session-local; do not
+inherit a previous claim's
 critique findings unless they were persisted as reviewer-visible
 comments.
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -66,6 +66,9 @@ comment. An inheritable claim comment is either:
 - the latest trusted `claimed-by` comment that was later released by a
   matching trusted `unclaimed-by` comment (the last voluntarily released
   branch), or
+- trusted forced-handoff evidence already verified by Resume Step 1,
+  but only when its branch and linked PR fields match the live GitHub
+  state, or
 - the latest trusted legacy `claimed-by` comment when performing a
   legacy migration (see the migration-only decision input above)
 
@@ -89,7 +92,8 @@ name:
 6. If the result is empty, use `task`.
 
 No remote branch with that name may exist, unless it matches the
-`branch` field in an inheritable claim comment as defined in (c) above.
+`branch` field in an inheritable claim comment or trusted
+forced-handoff evidence as defined in (c) above.
 
 Before posting a claim, also perform a **scoped issue-wide branch pattern
 check** to detect concurrent sessions working on the same issue with
@@ -117,9 +121,9 @@ catches parallel-session concurrency before a new claim comment is posted.
    - **If no local worktree or remote branch matches `issue/<number>-*`**:
      Proceed to claim posting (the safe, single-session path).
 
-   - **If a match is found and corresponds to an inheritable claim** (i.e.,
-     its `branch` field matches one of the branches in an inheritable claim
-     comment as defined in (c) above):
+   - **If a match is found and corresponds to an inheritable claim or
+     trusted forced-handoff evidence** (i.e., its `branch` field matches
+     one of the branches allowed in (c) above):
      Proceed to claim posting. The branch is expected.
 
    - **If a match is found, does NOT correspond to an inheritable claim,
@@ -149,10 +153,12 @@ claim.
 
 Determine `{branch-name}`:
 
-- **Re-claim / takeover**: use the exact branch name from the
-  inheritable claim comment (the `branch` field of the active stale
-  claim, the last-released trusted `claimed-by`, or the trusted legacy
-  claim being migrated). Do not compute a new name.
+- **Re-claim / takeover / forced-handoff recovery**: use the exact
+  branch name from the inheritable claim comment or trusted
+  forced-handoff evidence (the `branch` field of the active stale claim, the
+  last-released trusted `claimed-by`, the forced-handoff evidence
+  approved in Resume Step 1, or the trusted legacy claim being
+  migrated). Do not compute a new name.
 - **Fresh claim**: compute a new name using the IDD naming convention:
   `issue/<number>-<slug>` where `<slug>` follows the deterministic title
   normalization algorithm from pre-check (d).
@@ -161,6 +167,11 @@ Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
 
 - **Takeover of an active claim** (stale claim recovery) → the current
   active claim's `{claim-id}`
+- **Forced-handoff recovery** → `none` once the human-gated handoff has
+  already released or otherwise cleared the displaced claim in GitHub
+  state; if the displaced non-stale claim is still active, stop and wait
+  for the handoff mechanism instead of inventing a local superseding
+  claim
 - **Migration from a legacy claim** → `none`
 - **Fresh claim** or claim after a released / unclaimed state → `none`
 
@@ -213,6 +224,11 @@ unless the operator has explicitly switched to normal discovery.
 Once verified, record this `{claim-id}` as your current claim token for
 the rest of the workflow.
 
+When the new claim came from forced-handoff recovery, cite the trusted
+forced-handoff evidence in the issue digest or resume report's
+`Authoritative by` field. Do not invent ad hoc `claimed-by` fields and
+do not reuse the displaced `{claim-id}`.
+
 After claim verification, upsert the issue live status digest when there
 is exactly one marked digest or none. Use the verified `claimed-by`
 comment as the authority: set `Phase` to `A5 claimed`, `Claim` to the
@@ -263,6 +279,9 @@ and use heartbeats; do not post a fresh takeover claim. If the session
 cannot prove ownership of the active `{claim-id}`, the active claim is
 treated as owned by another live session until it is released or stale,
 even when `{agent-id}` matches.
+If a successor posts a fresh claim after forced handoff, later
+heartbeats from the displaced old `{claim-id}` are ignored as stale
+events; they do not reclaim ownership or refresh the stale clock.
 
 ## Legacy claim migration
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -139,7 +139,9 @@ push, rebase, reply, resolve, reviewer request, merge), re-read the
 issue and parse the active claim using the rules in
 `idd-claim.instructions.md`. The active claim must still use your
 current `{claim-id}`. If it does not, the claim was lost. Stop, do not
-post further operational comments, and report the handoff or race.
+post further operational comments, and report the handoff or race. If
+loss came from handoff, the displaced session must not push,
+comment, resolve reviews, request reviewers, or merge.
 
 A1.5 roadmap completion audit side effects use the roadmap issue itself
 as the claim target (see `idd-roadmap-audit.instructions.md`). Even

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -15,6 +15,12 @@ for the canonical values, not as a behavior override.
 Before any F-phase mutating action, apply the shared claim revalidation
 gate. The active claim must still use your current `{claim-id}`.
 
+After a forced handoff on an open PR, the successor must rebuild review
+state through E1/E2 under its own `{claim-id}` before merge-bound
+routing continues. A live status digest or prior-claim operational
+marker is UI or audit context only; it cannot satisfy review currency,
+claim ownership, advisory wait, or CI gates.
+
 When all F2 conditions are satisfied, proceed to
 `idd-merge-handoff.instructions.md`.
 
@@ -86,6 +92,11 @@ must align with every F2 condition below.
   watermarks without `{claim-id}` must not be reused across a restart or
   takeover, and same-claim watermarks from untrusted authors must be
   ignored and reported as suspicious context when they affect routing.
+  Forced-handoff successors must treat prior-claim watermarks the same
+  way even when the branch and HEAD are unchanged. Do not delete, hide,
+  minimize, or otherwise unmark open-PR operational markers during this
+  recovery; if no trusted same-claim watermark exists for the successor
+  claim, return to E1 and rebuild review state there.
   To collect this evidence, either use the documented merge-gate helper
   reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)

--- a/idd-template/.github/instructions/idd-resume-stall.instructions.md
+++ b/idd-template/.github/instructions/idd-resume-stall.instructions.md
@@ -5,6 +5,10 @@ rate-limited session and needs a dedicated, safety-first decision path.
 This path relies only on externally observable state. It never depends
 on the prior session posting a graceful shutdown.
 
+This file applies only to unattended stale-takeover evidence for a
+non-owned claim. Human-gated forced handoff is a separate recovery path
+and is routed from `idd-resume.instructions.md` before this file runs.
+
 Read `idd-overview.instructions.md` and
 `idd-resume.instructions.md` first.
 
@@ -34,6 +38,11 @@ Use GitHub server timestamps only.
 - If no active claim exists, or the active claim already uses your
   current `{claim-id}`, this is not a stalled-session takeover case.
   Return to `idd-resume.instructions.md`.
+- If trusted forced-handoff evidence exists and matches the active claim
+  or inheritable released branch / PR state, this is not a
+  stalled-session takeover case. Return to
+  `idd-resume.instructions.md` Step 1 and use the forced-handoff route
+  instead. Do not apply the quiet-window or stale-threshold gates here.
 - If the active claim belongs to another `{claim-id}`, continue.
 
 ### S2 — Quiet-window check (stall evidence, not ownership transfer)

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -7,15 +7,30 @@ definitions (claim format, stale threshold, abort, hold).
 Resume stale checks use the `claim-stale-age` policy default from
 `docs/policy-constants.md` (distributed default: `24 h`).
 
-## Step 0 — Route stalled-session recovery
+## Step 0 — Route forced handoff and stalled-session recovery
 
-Before Step 1, decide whether this is a stalled-session case:
+Before Step 1, decide whether this run should route through the
+forced-handoff path, the stalled-session path, or neither:
 
 - If the issue is already closed, or the corresponding PR is already
   merged, skip stalled-session routing and continue to Step 1 cleanup
   behavior.
-- If a non-owned active claim exists, run
+- If the repository records `forced-handoff: human-gated`, first check
+  whether trusted forced-handoff evidence exists for this issue or its
+  linked PR under the contract recorded in `docs/customization.md`.
+  Record the approving human, displaced `{claim-id}`, `{branch}`,
+  linked PR (if any), and the evidence comment URL.
+- If trusted forced-handoff evidence exists and matches the current
+  active claim or inheritable released branch / PR state, skip
+  stalled-session routing and continue to Step 1's forced-handoff path.
+  Quiet-window and stale-threshold checks do not apply once this
+  human-gated recovery route is verified.
+- Only when no usable forced-handoff evidence exists and a non-owned
+  active claim remains, run
   `idd-resume-stall.instructions.md` first.
+- Autopilot and unattended agents must never invent, request, or
+  broaden forced handoff on their own. They may only consume already
+  recorded human-gated evidence.
 - Use only externally observable evidence (trusted claim heartbeat
   timestamps, PR head movement, remote branch tip movement, review/
   comment activity, and CI timestamps).
@@ -35,28 +50,37 @@ Before routing, collect all of the following:
    unclaimed. Also record the latest released branch, if any. The
    shared rules ignore marker-shaped comments from untrusted authors;
    record their URLs as suspicious context when they affect routing.
-2. **Open PR and current head** — check for an open PR that
+2. **Forced-handoff evidence** — when the repository records
+   `forced-handoff: human-gated`, collect the trusted human approval
+   note that satisfies the contract in `docs/customization.md`. Record
+   the approving human, old claim ID, branch, linked PR if any, and
+   evidence URL. When an open PR exists, require the issue-plus-PR
+   approval text that names that PR; an issue-only approval is
+   insufficient for PR-scoped recovery. If any field required by the
+   current approval-note format is missing or contradictory, treat the
+   evidence as unusable and do not route forced handoff.
+3. **Open PR and current head** — check for an open PR that
    closes/references this issue. Record the current PR HEAD SHA.
-3. **Issue/PR activity recency** — snapshot issue comments, review
+4. **Issue/PR activity recency** — snapshot issue comments, review
    threads, review bodies, and regular PR comments, then record the
    latest `updatedAt` across that universe. When an open PR exists,
    include PR `createdAt`/`updatedAt` as additional recency signals.
-4. **PR HEAD movement evidence** — define a baseline before comparison:
+5. **PR HEAD movement evidence** — define a baseline before comparison:
    use the latest trusted same-claim `review-watermark`/`review-baseline`
    marker SHA when available; otherwise use the current PR HEAD SHA
-   captured in step 2 as the baseline. Then confirm whether commits were
+   captured in step 3 as the baseline. Then confirm whether commits were
    added after that baseline from PR timeline/activity.
-5. **CI transition state** — record current CI states for the PR HEAD,
+6. **CI transition state** — record current CI states for the PR HEAD,
    the latest completed CI transition `completedAt` (any terminal
    outcome), and the latest successful CI pass `completedAt` (or `none`).
-6. **Local worktrees** — run `git worktree list`.
-7. **Local branch** — check whether the branch named in the claim
+7. **Local worktrees** — run `git worktree list`.
+8. **Local branch** — check whether the branch named in the claim
    comment exists locally.
-8. **Dirty/clean** — run `git status` in the worktree (if it exists).
-9. **Unpushed commits** — run `git log @{u}..HEAD` in the worktree. If
-   no upstream is configured, treat all local commits as unpushed.
-10. **Current local HEAD SHA** — run `git rev-parse HEAD`.
-11. **Live status digest state** — record whether the issue or PR has
+9. **Dirty/clean** — run `git status` in the worktree (if it exists).
+10. **Unpushed commits** — run `git log @{u}..HEAD` in the worktree. If
+    no upstream is configured, treat all local commits as unpushed.
+11. **Current local HEAD SHA** — run `git rev-parse HEAD`.
+12. **Live status digest state** — record whether the issue or PR has
     zero, one, or multiple comments whose first line is
     `<!-- idd-live-status: current -->`. Do not use digest text to route
     resume; it is repairable UI state only.
@@ -65,6 +89,36 @@ Before routing, collect all of the following:
 
 - If the issue is **closed** or the corresponding PR is **merged**:
   clean up any remaining local worktree and branch, then stop.
+
+Before ordinary claim-state branching, check for trusted forced-handoff
+evidence under a repository policy of `forced-handoff: human-gated`:
+
+- If the evidence names a `{claim-id}` that this current session had
+  already verified before this routing step, this is the displaced old
+  session. Recording the old claim ID as evidence does not count as
+  ownership. Stop immediately. Do not push, comment, reply, resolve
+  threads, request reviewers, or merge until a maintainer reassigns
+  ownership.
+- If the active claim already uses a `{claim-id}` that this current
+  session had previously verified, and the forced-handoff evidence cites
+  a different displaced claim ID, ignore that historical evidence and
+  continue with the normal already-owned branch below.
+- If no usable forced-handoff evidence exists, continue with the normal
+  legacy and claim-state flow below.
+- If the evidence cites a `{claim-id}`, branch, or linked PR that does
+  not match the live active claim or inheritable released branch / PR
+  state, stop and report the mismatch. Do not claim, push, or mutate
+  review state.
+- Otherwise, treat the issue as **forced-handoff recovery**. Re-claim
+  only after the human-gated handoff mechanism has already updated the
+  GitHub claim stream to a released or successor-ready state. If the
+  displaced non-stale claim still remains active, stop and wait instead
+  of inventing a local superseding claim. Once GitHub state reflects the
+  handoff outcome, re-claim via `idd-claim.instructions.md` with a fresh
+  `{claim-id}` and the branch named in the forced-handoff evidence, then
+  continue to Step 2 after A5 verification. The successor must cite the
+  forced-handoff evidence in its resume report or digest
+  `Authoritative by`; it must not silently inherit the old `{claim-id}`.
 
 If the issue has no trusted new-format `claimed-by` comments but has legacy
 claim comments from trusted marker actors, treat the latest trusted
@@ -98,7 +152,8 @@ Otherwise, determine claim state from the parsed active claim:
   `{claim-id}` whose `supersedes:` value is the current active claim's
   `{claim-id}`, then continue to Step 2.
 
-When Step 1 performs a re-claim or stale takeover, claim verification
+When Step 1 performs a re-claim, forced-handoff recovery, or stale
+takeover, claim verification
 must follow A5 race-safe verification from
 `idd-claim.instructions.md`: wait 5–10 seconds after posting
 `claimed-by`, re-read and parse the full claim stream chronologically,
@@ -108,7 +163,10 @@ verification if a later trusted competing `claimed-by` with a different
 
 A branch left by a stale or released claim is inheritable. An open PR or
 remote branch may be reused when it matches the branch recorded in the
-stale active claim you are taking over, or in the latest released claim.
+stale active claim you are taking over, in the latest released claim, or
+in trusted forced-handoff evidence whose branch and linked PR fields
+still match the live GitHub state. Forced-handoff recovery never waives
+the normal A5 branch-collision and open-PR safety checks.
 
 If the active or inherited branch field starts with `roadmap-audit/`,
 the claim is an A1.5 roadmap-audit coordination claim, not a work branch.
@@ -133,6 +191,10 @@ reuse prior-claim review-watermark or review-baseline comments. For
 non-owned, non-stale claims, do not edit the digest; stalled-session
 handling records evidence in session logs only unless the claim becomes
 yours.
+During forced handoff on an open PR, do not delete, hide, minimize, or
+otherwise unmark prior-claim operational markers just to clear state;
+they remain audit context while the successor rebuilds fresh markers
+under its own `{claim-id}`.
 
 ## Step 2 — Locate or restore branch and worktree
 
@@ -177,6 +239,14 @@ the routing decision.
 
 Read the PR's current CI and review status:
 
+After a forced handoff on an open PR, rebuild review state from current
+GitHub state. Prior-claim `review-watermark` and `review-baseline`
+comments are not reusable, even when the branch and HEAD are unchanged.
+If the linked PR is open and review state matters, route to E1 before
+any merge-bound F check. Live status digests remain UI-only handoff
+context and do not satisfy review currency, claim ownership, advisory
+wait, or CI gates.
+
 | Condition                                                                          | Action                                                         |
 | ---------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | Required CI checks not yet generated, no reviews yet                               | Wait for generation, then apply D4 logic                       |
@@ -187,3 +257,8 @@ Read the PR's current CI and review status:
 | CI `failure` / `cancelled` / `timed_out`, reviews exist                            | Apply E15 CI failure/cancelled branch                          |
 | CI `success`, unresolved threads / unreplied comments / active `CHANGES_REQUESTED` | Resume from E1                                                 |
 | CI `success`, none of the above                                                    | Resume from F1                                                 |
+
+For forced-handoff recovery on an open PR, treat the final
+`CI success, none of the above` row as `Resume from E1` until the
+successor has posted its own same-claim review watermark and baseline
+for the current `{claim-id}`.

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -107,6 +107,10 @@ watermark comments from any other claim or from untrusted authors.
 Legacy watermarks without `{claim-id}` are not resumable across a
 restart or takeover; if no trusted same-claim watermark exists, rerun E1
 from scratch.
+After forced handoff, all prior-claim watermarks are foreign restore
+markers. Do not delete, hide, minimize, or otherwise unmark them on an
+open PR to "clear" state; ignore them and rerun E1 under the successor
+claim instead.
 
 Do not create or edit the PR live status digest after posting this
 watermark unless the next route is to E1, to an F3 blocked reroute that
@@ -156,7 +160,8 @@ GitHub author is a trusted marker actor). Reset to full-branch diff
 after a rebase, multi-fix batch, when the baseline SHA is not an
 ancestor of the current HEAD, when no trusted same-claim baseline
 exists, or whenever the active `{claim-id}` changed due to restart or
-takeover. List A is session-local; do not inherit a previous claim's
+takeover, including forced handoff. List A is session-local; do not
+inherit a previous claim's
 critique findings unless they were persisted as reviewer-visible
 comments.
 

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1722,6 +1722,13 @@ export function classifyResumeRoutingCase(input, options = {}) {
   const pendingCiStates = new Set(options.pendingCiStates ?? ["queued", "in_progress", "waiting", "pending"]);
   const terminalSafeCiStates = new Set(options.terminalSafeCiStates ?? ["success", "none"]);
 
+  if (input.displacedByForcedHandoff) {
+    return {
+      route: "claim-lost-stop",
+      reason: "session was displaced by trusted forced-handoff evidence",
+    };
+  }
+
   if (!input.hasActiveClaim) {
     return {
       route: "unclaimed-reclaim-required",
@@ -1739,6 +1746,13 @@ export function classifyResumeRoutingCase(input, options = {}) {
     return {
       route: "ordinary-continuation",
       reason: "owned claim with clean local state",
+    };
+  }
+
+  if (input.hasUsableForcedHandoffEvidence) {
+    return {
+      route: "forced-handoff-recovery",
+      reason: "trusted forced-handoff evidence takes precedence over stalled-session takeover",
     };
   }
 

--- a/tests/fixtures/resume-recovery/nonowned-forced-handoff-displaced.json
+++ b/tests/fixtures/resume-recovery/nonowned-forced-handoff-displaced.json
@@ -1,0 +1,18 @@
+{
+  "name": "displaced old session stops immediately after forced handoff",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": false,
+    "claimAgeHours": 1,
+    "latestActivityAgeMinutes": 3,
+    "ciState": "success",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false,
+    "displacedByForcedHandoff": true
+  },
+  "expected": {
+    "route": "claim-lost-stop",
+    "reasonContains": "displaced"
+  }
+}

--- a/tests/fixtures/resume-recovery/nonowned-forced-handoff-successor.json
+++ b/tests/fixtures/resume-recovery/nonowned-forced-handoff-successor.json
@@ -1,0 +1,18 @@
+{
+  "name": "non-owned claim with trusted forced handoff routes to successor recovery",
+  "input": {
+    "hasActiveClaim": true,
+    "claimOwnedBySession": false,
+    "claimAgeHours": 2,
+    "latestActivityAgeMinutes": 4,
+    "ciState": "in_progress",
+    "worktreeDirty": false,
+    "hasUnpushedCommits": false,
+    "rebaseInProgress": false,
+    "hasUsableForcedHandoffEvidence": true
+  },
+  "expected": {
+    "route": "forced-handoff-recovery",
+    "reasonContains": "forced-handoff evidence"
+  }
+}


### PR DESCRIPTION
## Summary
- add an explicit forced-handoff recovery path across resume, stall, claim, review snapshot, and pre-merge guidance
- require fresh successor claim ids, branch/PR reuse only when evidence matches, and explicit stop behavior for the displaced old session
- mirror the instruction changes into idd-template and add resume-recovery fixtures for the successor and displaced-session routes

## Notes
- old open-PR operational markers remain audit context during forced handoff; the successor rebuilds review state under a new claim instead of reusing prior review-watermark/review-baseline markers
- this stays scoped to the human-gated policy from #336 and does not weaken unattended stale takeover

Closes #338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for forced handoffs: verified handoff evidence may be used to recover claims and reuse matching branch names; requires citation in resume/digest reports; tightens branch-collision and open-PR safety checks; mandates rebuilding review state under the successor claim; treats later heartbeats from displaced claims as stale.

* **Tests**
  * Added fixtures covering forced-handoff recovery and displaced-claim stop scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/360)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->