### PR TITLE
feat(idd): enforce issue-author approval gate across explicit target and discovery

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -3,7 +3,7 @@
 Read this file after `idd-suitability.instructions.md` (A4.5) passes for
 the selected issue — whether selected via A4 or verified through an
 explicit issue target (A0-T) — or after a successful re-claim decision
-in the resume phase. It covers the four pre-checks, claim execution, and
+in the resume phase. It covers the five pre-checks, claim execution, and
 claim verification.
 
 ## Pre-checks (all five must pass)
@@ -18,8 +18,9 @@ issue-author approval rule immediately before claim.
 
 - If `.github/idd/config.json` exists and is valid and
   `skipIssueAuthorApprovalGate` is `true`, skip this check.
-- Otherwise, use `maintainerApprovalActors` from `.github/idd/config.json`
-  when present; if absent, default to `owners-and-maintainers-only`.
+- Otherwise, use `maintainerApprovalActorPolicy` from
+  `.github/idd/config.json` when present; if absent, default to
+  `owners-and-maintainers-only`.
 - A target issue is startable only when the issue author is
   self-authorized under the current maintainer-approval actor policy, or
   a fresh explicit approval signal exists, using the same actor,
@@ -176,7 +177,7 @@ Determine `{branch-name}`:
   claim being migrated). Do not compute a new name.
 - **Fresh claim**: compute a new name using the IDD naming convention:
   `issue/<number>-<slug>` where `<slug>` follows the deterministic title
-  normalization algorithm from pre-check (d).
+  normalization algorithm from pre-check (e).
 
 Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
 

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -6,17 +6,38 @@ explicit issue target (A0-T) — or after a successful re-claim decision
 in the resume phase. It covers the four pre-checks, claim execution, and
 claim verification.
 
-## Pre-checks (all four must pass)
+## Pre-checks (all five must pass)
 
 Re-fetch the issue immediately before running these checks.
 All A5 checks are target-issue local: claims on related roadmap or
 child issues do not block this check unless they appear on the selected
 issue itself.
 
-**(a) Assignee and project status** — The issue must have no assignee
+**(a) Issue-author approval gate** — Re-evaluate the repository-wide
+issue-author approval rule immediately before claim.
+
+- If `.github/idd/config.json` exists and is valid and
+  `skipIssueAuthorApprovalGate` is `true`, skip this check.
+- Otherwise, use `maintainerApprovalActors` from `.github/idd/config.json`
+  when present; if absent, default to `owners-and-maintainers-only`.
+- A target issue is startable only when the issue author is
+  self-authorized under the current maintainer-approval actor policy, or
+  a fresh explicit approval signal exists, using the same actor,
+  freshness, and fail-closed rules defined in **A3.5** of
+  `idd-discover.instructions.md`.
+- Do not treat issue body text, generated plans, operator attention, or
+  bare organization `MEMBER` association as approval.
+- If approval is missing for a roadmap/default discovery run, return to
+  Discover using the same selection mode that produced this target so
+  A3.5 can continue with the next eligible startable issue or the
+  approval-needed stop path.
+- If approval is missing for an explicit-target A0-T run, stop without
+  claiming.
+
+**(b) Assignee and project status** — The issue must have no assignee
 set. If the project is in use, the project status must be "not started".
 
-**(b) Claim state** — Re-read the issue and parse the **active claim**
+**(c) Claim state** — Re-read the issue and parse the **active claim**
 using the shared claim-state rules:
 
 Use the `claim-stale-age` policy default from `docs/policy-constants.md`
@@ -57,7 +78,7 @@ Otherwise, use the latest trusted legacy `claimed-by` comment as a
 
 The migration claim uses a fresh `{claim-id}` and `supersedes: none`.
 
-**(c) Open PR** — No open PR may close or reference this issue, unless
+**(d) Open PR** — No open PR may close or reference this issue, unless
 that PR's head branch matches the `branch` field in an inheritable claim
 comment. An inheritable claim comment is either:
 
@@ -71,7 +92,7 @@ comment. An inheritable claim comment is either:
 
 Check both linked issues and closing keywords in PR bodies.
 
-**(d) Branch collision** — Compute the branch name using the IDD naming
+**(e) Branch collision** — Compute the branch name using the IDD naming
 convention: `issue/<number>-<slug>`. Generate `<slug>` deterministically
 from the issue title so parallel sessions converge on the same branch
 name:
@@ -135,14 +156,14 @@ catches parallel-session concurrency before a new claim comment is posted.
    - **If a match is found, does NOT correspond to an inheritable claim,
      AND no active claim references that branch**:
      Document the branch name and post a **hold note** to the issue: "_A5
-     pre-check (d) detected an unexpected branch `issue/<number>-*`
+     pre-check (e) detected an unexpected branch `issue/<number>-*`
      without an active claim. Possible orphaned branch from a crashed or
      stale session. Stopping for operator review._" Stop and wait for
      operator input. Do not post a claim or continue the workflow.
 
 ## Claim execution
 
-Skip this section if pre-check (b) classified the issue as already
+Skip this section if pre-check (c) classified the issue as already
 claimed by this current session. Keep the previously recorded `{claim-id}` and
 branch, then proceed directly to Claim verification without posting a new
 claim.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -107,7 +107,7 @@ body satisfies **all** of the following:
   issue is open (apply the same fail-safe as A3: if a reference cannot
   be resolved, treat as blocked).
 
-Apply the configured policy before passing A0-O candidates to A4:
+Apply the configured policy before passing A0-O candidates to A3.5:
 
 - `none` (the default): apply no extra orphan-first approval gate.
 - `maintainer-approved`: keep only candidates that have at least one

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -40,6 +40,25 @@ that issue only:
      the matching roadmap work is closed or otherwise complete;
    - no external human coordination is required to start.
 3. Run the normal A4 viability gate against the target only.
+4. If `.github/idd/config.json` exists and is valid and
+   `skipIssueAuthorApprovalGate` is `true`, skip the issue-author
+   approval gate and keep the target selected.
+5. Otherwise, apply the same issue-author approval evaluation used in
+   **A3.5**:
+   - use `maintainerApprovalActors` from `.github/idd/config.json` when
+     present; if absent, default to `owners-and-maintainers-only`;
+   - treat the issue author as self-authorized only when that author is
+     permitted by the current maintainer-approval actor policy;
+   - treat bare organization `MEMBER` association, issue body text,
+     generated plans, or operator attention as **not** authorizing the
+     issue;
+   - if approval state or permission resolution is unavailable or
+     ambiguous, fail closed and treat approval as missing unless the
+     repository explicitly opted out.
+     If the target lacks required approval, report that the issue-author
+     approval gate blocked claim and stop before A5. Do not fall back to
+     another issue unless the operator explicitly asks for normal
+     discovery in the same run.
 
 If any targeted readiness or viability check fails, report the exact
 failed criterion and stop without claiming. Do not fall back to another
@@ -94,31 +113,39 @@ Apply the configured policy before passing A0-O candidates to A4:
   current maintainer approval signal:
   - the `idd:ready` label, only when repository policy reserves that
     label to maintainer approval actors;
-  - an issue author who is a repository owner or collaborator with
-    Write, Maintain, or Admin permission, verified with the collaborator
-    permission API; do not treat organization `MEMBER` association alone
-    as approval;
+  - an issue author who is a repository owner or collaborator permitted
+    by the current maintainer-approval actor policy, verified with the
+    collaborator permission API; do not treat organization `MEMBER`
+    association alone as approval;
   - a visible comment from a maintainer approval actor whose trimmed
     body is exactly `IDD ready` or contains `IDD ready` as a standalone
     line. The approval comment must be newer than the latest issue
-    title/body edit and any generated-plan update; if freshness cannot
-    be determined, require a fresh approval comment or a reserved label.
+    title/body edit and any generated-plan update, or any equivalent
+    draft-stability signal the repository uses locally. If freshness
+    cannot be determined, require a fresh approval comment or a reserved
+    label.
 - `public-disabled`: for private or internal repositories, behave the
   same as `none`.
 
-A maintainer approval actor is a human repository owner or collaborator
-with Write, Maintain, or Admin permission. Do not reuse the trusted
-marker actor set for this approval gate, and do not count automation or
-the current agent unless repository policy explicitly grants that actor
-maintainer approval authority.
+A maintainer approval actor is a human repository actor allowed by the
+current `maintainerApprovalActors` policy:
+
+- `owners-and-maintainers-only` (default): repository owners and
+  collaborators with Maintain or Admin permission. Write-only
+  collaborators do not count.
+- `all-write-permission-actors`: repository owners and collaborators
+  with Write, Maintain, or Admin permission.
+
+Do not reuse the trusted marker actor set for this approval gate, and do
+not count automation or the current agent unless repository policy
+explicitly grants that actor maintainer approval authority.
 
 If at least one orphan issue remains after the configured policy is
-applied: pass the remaining set directly to **A4** (viability gate).
-Skip A1–A3 entirely.
+applied: pass the remaining set directly to **A3.5**. Skip A1–A3.
 
 If no orphan issues remain after the configured policy is applied: fall
 back to the roadmap path. Proceed to **A1** and continue with the normal
-A1 → A1.5 → A2 → A3 → A4 sequence.
+A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: when
@@ -288,13 +315,59 @@ scope:
      this run only. Prior or standing instructions do not count as
      opt-in.
 
+## A3.5 — Apply issue-author approval gate
+
+Before passing any candidate set to A4 — whether it came from A0-O or
+from A3 — evaluate the repository-wide issue-author approval gate.
+
+- If `.github/idd/config.json` exists and is valid and
+  `skipIssueAuthorApprovalGate` is `true`, the gate is disabled. Keep
+  every ready candidate in the normal startable set.
+- Otherwise the gate is enabled. Use `maintainerApprovalActors` from
+  `.github/idd/config.json` when present; if absent, default to
+  `owners-and-maintainers-only`.
+
+When the gate is enabled, a candidate is **startable** only when at
+least one of the following is true:
+
+- the issue author is self-authorized under the current
+  maintainer-approval actor policy;
+- the issue has the reserved `idd:ready` label, when repository policy
+  reserves that label to maintainer approval actors;
+- the issue has a visible approval comment from a maintainer approval
+  actor whose trimmed body is exactly `IDD ready` or contains
+  `IDD ready` as a standalone line, and that approval is newer than the
+  latest issue title/body edit and any generated-plan update, or any
+  equivalent draft-stability signal the repository uses locally. If
+  freshness cannot be determined, require a fresh approval comment or a
+  reserved label.
+
+Fail closed when approval state or permission resolution is unavailable
+or ambiguous unless the repository explicitly opted out via
+`skipIssueAuthorApprovalGate`.
+
+Candidates that fail the gate are **not** ready-to-start. Keep them in
+an **approval-needed fallback bucket** ordered by ascending issue number.
+Continue to A4 with only the startable candidates. Preserve any earlier
+A0-O filtering from `orphan-first-policy`; this gate never widens
+previously excluded orphan candidates back into scope.
+
+If no startable candidates remain but the approval-needed fallback
+bucket is non-empty:
+
+- **Unattended mode**: report that only approval-needed fallback issues
+  remain and stop without claiming. Do not auto-claim from the fallback
+  bucket.
+- **Attended mode**: ask the operator whether to obtain approval or to
+  opt out explicitly in `.github/idd/config.json`. Do not treat operator
+  attention alone as approval.
+
 ## A4 — Gate, then pick
 
 ### Step 1 — Viability gate
 
-For each candidate from A0-O or A3, evaluate **all three** criteria.
-Fail any one →
-discard the issue.
+For each **startable** candidate from A3.5, evaluate **all three**
+criteria. Fail any one → discard the issue.
 
 | Criterion                 | Pass                                                                                                                | Fail examples                                                                                    |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
@@ -302,9 +375,15 @@ discard the issue.
 | **Clear verification**    | Outcome verified by lint / test / CI — including adding or updating targeted automated tests as part of the work    | Success depends on UX or product judgment                                                        |
 | **Autonomous completion** | No external coordination, human decision, unavailable system, or product judgment required to **complete** the work | Requires operator to provide credentials; requires a product decision before the work can finish |
 
-If **no issue** survives the gate: report the full list of discarded
-issues with the criterion or criteria each failed, then **stop** — do
-not post `unclaimed-by` because no claim was made. This is not an abort.
+If **no issue** survives the gate:
+
+- if the approval-needed fallback bucket from A3.5 is non-empty, report
+  that only approval-needed issues remain and stop without claim in
+  unattended mode. In attended mode, ask the operator whether to obtain
+  approval or opt out explicitly;
+- otherwise report the full list of discarded issues with the criterion
+  or criteria each failed, then **stop** — do not post `unclaimed-by`
+  because no claim was made. This is not an abort.
 
 ### Step 1.5 — Active-claim pre-scan
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -56,7 +56,7 @@ that issue only:
    - if approval state or permission resolution is unavailable or
      ambiguous, fail closed and treat approval as missing unless the
      repository explicitly opted out.
-     If the target lacks required approval, report that the issue-author
+   - if the target lacks required approval, report that the issue-author
      approval gate blocked claim and stop before A5. Do not fall back to
      another issue unless the operator explicitly asks for normal
      discovery in the same run.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -45,8 +45,9 @@ that issue only:
    approval gate and keep the target selected.
 5. Otherwise, apply the same issue-author approval evaluation used in
    **A3.5**:
-   - use `maintainerApprovalActors` from `.github/idd/config.json` when
-     present; if absent, default to `owners-and-maintainers-only`;
+   - use `maintainerApprovalActorPolicy` from `.github/idd/config.json`
+     when present; if absent, default to
+     `owners-and-maintainers-only`;
    - treat the issue author as self-authorized only when that author is
      permitted by the current maintainer-approval actor policy;
    - treat bare organization `MEMBER` association, issue body text,
@@ -128,7 +129,7 @@ Apply the configured policy before passing A0-O candidates to A4:
   same as `none`.
 
 A maintainer approval actor is a human repository actor allowed by the
-current `maintainerApprovalActors` policy:
+current `maintainerApprovalActorPolicy`:
 
 - `owners-and-maintainers-only` (default): repository owners and
   collaborators with Maintain or Admin permission. Write-only
@@ -323,7 +324,7 @@ from A3 — evaluate the repository-wide issue-author approval gate.
 - If `.github/idd/config.json` exists and is valid and
   `skipIssueAuthorApprovalGate` is `true`, the gate is disabled. Keep
   every ready candidate in the normal startable set.
-- Otherwise the gate is enabled. Use `maintainerApprovalActors` from
+- Otherwise the gate is enabled. Use `maintainerApprovalActorPolicy` from
   `.github/idd/config.json` when present; if absent, default to
   `owners-and-maintainers-only`.
 

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -263,9 +263,11 @@ different project.**
 If `.github/idd/config.json` exists and is valid per the canonical schema at
 <https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json>, its `commands`
 object provides the authoritative command values and overrides the table
-values below. Its policy fields (`mergePolicy`, `reviewPolicy`, etc.) are
-the machine-readable equivalent of the repository's recorded policy
-decisions.
+values below. Its policy fields, including
+`skipIssueAuthorApprovalGate` and `maintainerApprovalActors`, are the
+machine-readable equivalent of recorded policy decisions. Absent values
+keep the gate enabled and default approval actors to
+`owners-and-maintainers-only`.
 
 | Name                    | Commands                                                                                                                                     |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -260,13 +260,13 @@ When a phase refers to a named command set, run the corresponding
 commands. **Adapt this section when applying this workflow to a
 different project.**
 
-If `.github/idd/config.json` exists and is valid per the canonical schema at
+If `.github/idd/config.json` exists and validates against the canonical
+schema at
 <https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json>, its `commands`
-object provides the authoritative command values and overrides the table
-values below. Its policy fields, including
-`skipIssueAuthorApprovalGate` and `maintainerApprovalActorPolicy`, are
-the machine-readable equivalent of recorded policy decisions. Absent
-values keep the gate enabled and default approval actors to
+object overrides the table below. Policy fields such as
+`skipIssueAuthorApprovalGate` and `maintainerApprovalActorPolicy` are
+the recorded machine-readable policy. Absent values keep the gate
+enabled and default approval actors to
 `owners-and-maintainers-only`.
 
 | Name                    | Commands                                                                                                                                     |
@@ -278,17 +278,15 @@ values keep the gate enabled and default approval actors to
 | **issue-scope**         | `roadmap`                                                                                                                                    |
 | **orphan-first-policy** | `none`                                                                                                                                       |
 
-Rows whose values are not shell syntax, such as **issue-scope** and
-**orphan-first-policy**, are workflow settings. Read them literally
-instead of executing them.
+Non-shell rows such as **issue-scope** and **orphan-first-policy** are
+workflow settings. Read them literally, not as commands.
 
-`pre-push-validate` intentionally omits auto-fix — all code should
-already pass lint at the push step. If lint fails, run **fix-validate**
-first, commit, then re-run **pre-push-validate**.
+`pre-push-validate` omits auto-fix. If lint fails, run
+**fix-validate**, commit, then re-run **pre-push-validate**.
 
-If **fix-validate** or **post-fix-validate** produces file changes
-(auto-fixes), stage and commit those changes before any push, rebase, or
-next step that requires no uncommitted changes.
+If **fix-validate** or **post-fix-validate** changes files, stage and
+commit them before any push, rebase, or step that requires a clean
+tree.
 
 `install-deps` must be idempotent. Re-running it in fresh, reused, or
 recreated worktrees must not require manual cleanup and should not leave

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -264,9 +264,9 @@ If `.github/idd/config.json` exists and is valid per the canonical schema at
 <https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json>, its `commands`
 object provides the authoritative command values and overrides the table
 values below. Its policy fields, including
-`skipIssueAuthorApprovalGate` and `maintainerApprovalActors`, are the
-machine-readable equivalent of recorded policy decisions. Absent values
-keep the gate enabled and default approval actors to
+`skipIssueAuthorApprovalGate` and `maintainerApprovalActorPolicy`, are
+the machine-readable equivalent of recorded policy decisions. Absent
+values keep the gate enabled and default approval actors to
 `owners-and-maintainers-only`.
 
 | Name                    | Commands                                                                                                                                     |

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -13,6 +13,11 @@ This gate evaluates whether an issue is **suitable for autonomous
 execution** independent of the current run's context. Where A4 asks "can
 we do this NOW?", A4.5 asks "SHOULD we do this at all?"
 
+Issue-author approval is a separate pre-claim gate. Candidates that fail
+the repository's issue-author approval evaluation are routed by
+`idd-discover.instructions.md` and re-checked in
+`idd-claim.instructions.md`; they are not rejected through A4.5.
+
 ## Seven Suitability Checks
 
 For the candidate picked in A4 Step 2 (or the explicit target verified

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -3,7 +3,7 @@
 Read this file after `idd-suitability.instructions.md` (A4.5) passes for
 the selected issue — whether selected via A4 or verified through an
 explicit issue target (A0-T) — or after a successful re-claim decision
-in the resume phase. It covers the four pre-checks, claim execution, and
+in the resume phase. It covers the five pre-checks, claim execution, and
 claim verification.
 
 ## Pre-checks (all five must pass)
@@ -18,8 +18,9 @@ issue-author approval rule immediately before claim.
 
 - If `.github/idd/config.json` exists and is valid and
   `skipIssueAuthorApprovalGate` is `true`, skip this check.
-- Otherwise, use `maintainerApprovalActors` from `.github/idd/config.json`
-  when present; if absent, default to `owners-and-maintainers-only`.
+- Otherwise, use `maintainerApprovalActorPolicy` from
+  `.github/idd/config.json` when present; if absent, default to
+  `owners-and-maintainers-only`.
 - A target issue is startable only when the issue author is
   self-authorized under the current maintainer-approval actor policy, or
   a fresh explicit approval signal exists, using the same actor,
@@ -176,7 +177,7 @@ Determine `{branch-name}`:
   claim being migrated). Do not compute a new name.
 - **Fresh claim**: compute a new name using the IDD naming convention:
   `issue/<number>-<slug>` where `<slug>` follows the deterministic title
-  normalization algorithm from pre-check (d).
+  normalization algorithm from pre-check (e).
 
 Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -6,17 +6,38 @@ explicit issue target (A0-T) — or after a successful re-claim decision
 in the resume phase. It covers the four pre-checks, claim execution, and
 claim verification.
 
-## Pre-checks (all four must pass)
+## Pre-checks (all five must pass)
 
 Re-fetch the issue immediately before running these checks.
 All A5 checks are target-issue local: claims on related roadmap or
 child issues do not block this check unless they appear on the selected
 issue itself.
 
-**(a) Assignee and project status** — The issue must have no assignee
+**(a) Issue-author approval gate** — Re-evaluate the repository-wide
+issue-author approval rule immediately before claim.
+
+- If `.github/idd/config.json` exists and is valid and
+  `skipIssueAuthorApprovalGate` is `true`, skip this check.
+- Otherwise, use `maintainerApprovalActors` from `.github/idd/config.json`
+  when present; if absent, default to `owners-and-maintainers-only`.
+- A target issue is startable only when the issue author is
+  self-authorized under the current maintainer-approval actor policy, or
+  a fresh explicit approval signal exists, using the same actor,
+  freshness, and fail-closed rules defined in **A3.5** of
+  `idd-discover.instructions.md`.
+- Do not treat issue body text, generated plans, operator attention, or
+  bare organization `MEMBER` association as approval.
+- If approval is missing for a roadmap/default discovery run, return to
+  Discover using the same selection mode that produced this target so
+  A3.5 can continue with the next eligible startable issue or the
+  approval-needed stop path.
+- If approval is missing for an explicit-target A0-T run, stop without
+  claiming.
+
+**(b) Assignee and project status** — The issue must have no assignee
 set. If the project is in use, the project status must be "not started".
 
-**(b) Claim state** — Re-read the issue and parse the **active claim**
+**(c) Claim state** — Re-read the issue and parse the **active claim**
 using the shared claim-state rules:
 
 Use the `claim-stale-age` policy default from `docs/policy-constants.md`
@@ -57,7 +78,7 @@ Otherwise, use the latest trusted legacy `claimed-by` comment as a
 
 The migration claim uses a fresh `{claim-id}` and `supersedes: none`.
 
-**(c) Open PR** — No open PR may close or reference this issue, unless
+**(d) Open PR** — No open PR may close or reference this issue, unless
 that PR's head branch matches the `branch` field in an inheritable claim
 comment. An inheritable claim comment is either:
 
@@ -71,7 +92,7 @@ comment. An inheritable claim comment is either:
 
 Check both linked issues and closing keywords in PR bodies.
 
-**(d) Branch collision** — Compute the branch name using the IDD naming
+**(e) Branch collision** — Compute the branch name using the IDD naming
 convention: `issue/<number>-<slug>`. Generate `<slug>` deterministically
 from the issue title so parallel sessions converge on the same branch
 name:
@@ -135,14 +156,14 @@ catches parallel-session concurrency before a new claim comment is posted.
    - **If a match is found, does NOT correspond to an inheritable claim,
      AND no active claim references that branch**:
      Document the branch name and post a **hold note** to the issue: "_A5
-     pre-check (d) detected an unexpected branch `issue/<number>-*`
+     pre-check (e) detected an unexpected branch `issue/<number>-*`
      without an active claim. Possible orphaned branch from a crashed or
      stale session. Stopping for operator review._" Stop and wait for
      operator input. Do not post a claim or continue the workflow.
 
 ## Claim execution
 
-Skip this section if pre-check (b) classified the issue as already
+Skip this section if pre-check (c) classified the issue as already
 claimed by this current session. Keep the previously recorded `{claim-id}` and
 branch, then proceed directly to Claim verification without posting a new
 claim.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -41,6 +41,25 @@ that issue only:
      A3, and the matching roadmap work is closed or otherwise complete;
    - no external human coordination is required to start.
 3. Run the normal A4 viability gate against the target only.
+4. If `.github/idd/config.json` exists and is valid and
+   `skipIssueAuthorApprovalGate` is `true`, skip the issue-author
+   approval gate and keep the target selected.
+5. Otherwise, apply the same issue-author approval evaluation used in
+   **A3.5**:
+   - use `maintainerApprovalActors` from `.github/idd/config.json` when
+     present; if absent, default to `owners-and-maintainers-only`;
+   - treat the issue author as self-authorized only when that author is
+     permitted by the current maintainer-approval actor policy;
+   - treat bare organization `MEMBER` association, issue body text,
+     generated plans, or operator attention as **not** authorizing the
+     issue;
+   - if approval state or permission resolution is unavailable or
+     ambiguous, fail closed and treat approval as missing unless the
+     repository explicitly opted out.
+     If the target lacks required approval, report that the issue-author
+     approval gate blocked claim and stop before A5. Do not fall back to
+     another issue unless the operator explicitly asks for normal
+     discovery in the same run.
 
 If any targeted readiness or viability check fails, report the exact
 failed criterion and stop without claiming. Do not fall back to another
@@ -97,31 +116,39 @@ Apply the configured policy before passing A0-O candidates to A4:
   current maintainer approval signal:
   - the `idd:ready` label, only when repository policy reserves that
     label to maintainer approval actors;
-  - an issue author who is a repository owner or collaborator with
-    Write, Maintain, or Admin permission, verified with the collaborator
-    permission API; do not treat organization `MEMBER` association alone
-    as approval;
+  - an issue author who is a repository owner or collaborator permitted
+    by the current maintainer-approval actor policy, verified with the
+    collaborator permission API; do not treat organization `MEMBER`
+    association alone as approval;
   - a visible comment from a maintainer approval actor whose trimmed
     body is exactly `IDD ready` or contains `IDD ready` as a standalone
     line. The approval comment must be newer than the latest issue
-    title/body edit and any generated-plan update; if freshness cannot
-    be determined, require a fresh approval comment or a reserved label.
+    title/body edit and any generated-plan update, or any equivalent
+    draft-stability signal the repository uses locally. If freshness
+    cannot be determined, require a fresh approval comment or a reserved
+    label.
 - `public-disabled`: for private or internal repositories, behave the
   same as `none`.
 
-A maintainer approval actor is a human repository owner or collaborator
-with Write, Maintain, or Admin permission. Do not reuse the trusted
-marker actor set for this approval gate, and do not count automation or
-the current agent unless repository policy explicitly grants that actor
-maintainer approval authority.
+A maintainer approval actor is a human repository actor allowed by the
+current `maintainerApprovalActors` policy:
+
+- `owners-and-maintainers-only` (default): repository owners and
+  collaborators with Maintain or Admin permission. Write-only
+  collaborators do not count.
+- `all-write-permission-actors`: repository owners and collaborators
+  with Write, Maintain, or Admin permission.
+
+Do not reuse the trusted marker actor set for this approval gate, and do
+not count automation or the current agent unless repository policy
+explicitly grants that actor maintainer approval authority.
 
 If at least one orphan issue remains after the configured policy is
-applied: pass the remaining set directly to **A4** (viability gate).
-Skip A1–A3 entirely.
+applied: pass the remaining set directly to **A3.5**. Skip A1–A3.
 
 If no orphan issues remain after the configured policy is applied: fall
 back to the roadmap path. Proceed to **A1** and continue with the normal
-A1 → A1.5 → A2 → A3 → A4 sequence.
+A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: when
@@ -295,13 +322,59 @@ scope:
      this run only. Prior or standing instructions do not count as
      opt-in.
 
+## A3.5 — Apply issue-author approval gate
+
+Before passing any candidate set to A4 — whether it came from A0-O or
+from A3 — evaluate the repository-wide issue-author approval gate.
+
+- If `.github/idd/config.json` exists and is valid and
+  `skipIssueAuthorApprovalGate` is `true`, the gate is disabled. Keep
+  every ready candidate in the normal startable set.
+- Otherwise the gate is enabled. Use `maintainerApprovalActors` from
+  `.github/idd/config.json` when present; if absent, default to
+  `owners-and-maintainers-only`.
+
+When the gate is enabled, a candidate is **startable** only when at
+least one of the following is true:
+
+- the issue author is self-authorized under the current
+  maintainer-approval actor policy;
+- the issue has the reserved `idd:ready` label, when repository policy
+  reserves that label to maintainer approval actors;
+- the issue has a visible approval comment from a maintainer approval
+  actor whose trimmed body is exactly `IDD ready` or contains
+  `IDD ready` as a standalone line, and that approval is newer than the
+  latest issue title/body edit and any generated-plan update, or any
+  equivalent draft-stability signal the repository uses locally. If
+  freshness cannot be determined, require a fresh approval comment or a
+  reserved label.
+
+Fail closed when approval state or permission resolution is unavailable
+or ambiguous unless the repository explicitly opted out via
+`skipIssueAuthorApprovalGate`.
+
+Candidates that fail the gate are **not** ready-to-start. Keep them in
+an **approval-needed fallback bucket** ordered by ascending issue number.
+Continue to A4 with only the startable candidates. Preserve any earlier
+A0-O filtering from `orphan-first-policy`; this gate never widens
+previously excluded orphan candidates back into scope.
+
+If no startable candidates remain but the approval-needed fallback
+bucket is non-empty:
+
+- **Unattended mode**: report that only approval-needed fallback issues
+  remain and stop without claiming. Do not auto-claim from the fallback
+  bucket.
+- **Attended mode**: ask the operator whether to obtain approval or to
+  opt out explicitly in `.github/idd/config.json`. Do not treat operator
+  attention alone as approval.
+
 ## A4 — Gate, then pick
 
 ### Step 1 — Viability gate
 
-For each candidate from A0-O or A3, evaluate **all three** criteria.
-Fail any one →
-discard the issue.
+For each **startable** candidate from A3.5, evaluate **all three**
+criteria. Fail any one → discard the issue.
 
 | Criterion                 | Pass                                                                                                                | Fail examples                                                                                    |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
@@ -309,9 +382,15 @@ discard the issue.
 | **Clear verification**    | Outcome verified by lint / test / CI — including adding or updating targeted automated tests as part of the work    | Success depends on UX or product judgment                                                        |
 | **Autonomous completion** | No external coordination, human decision, unavailable system, or product judgment required to **complete** the work | Requires operator to provide credentials; requires a product decision before the work can finish |
 
-If **no issue** survives the gate: report the full list of discarded
-issues with the criterion or criteria each failed, then **stop** — do
-not post `unclaimed-by` because no claim was made. This is not an abort.
+If **no issue** survives the gate:
+
+- if the approval-needed fallback bucket from A3.5 is non-empty, report
+  that only approval-needed issues remain and stop without claim in
+  unattended mode. In attended mode, ask the operator whether to obtain
+  approval or opt out explicitly;
+- otherwise report the full list of discarded issues with the criterion
+  or criteria each failed, then **stop** — do not post `unclaimed-by`
+  because no claim was made. This is not an abort.
 
 ### Step 1.5 — Active-claim pre-scan
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -110,7 +110,7 @@ body satisfies **all** of the following:
   issue is open (apply the same fail-safe as A3: if a reference cannot
   be resolved, treat as blocked).
 
-Apply the configured policy before passing A0-O candidates to A4:
+Apply the configured policy before passing A0-O candidates to A3.5:
 
 - `none` (the default): apply no extra orphan-first approval gate.
 - `maintainer-approved`: keep only candidates that have at least one

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -57,7 +57,7 @@ that issue only:
    - if approval state or permission resolution is unavailable or
      ambiguous, fail closed and treat approval as missing unless the
      repository explicitly opted out.
-     If the target lacks required approval, report that the issue-author
+   - if the target lacks required approval, report that the issue-author
      approval gate blocked claim and stop before A5. Do not fall back to
      another issue unless the operator explicitly asks for normal
      discovery in the same run.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -46,8 +46,9 @@ that issue only:
    approval gate and keep the target selected.
 5. Otherwise, apply the same issue-author approval evaluation used in
    **A3.5**:
-   - use `maintainerApprovalActors` from `.github/idd/config.json` when
-     present; if absent, default to `owners-and-maintainers-only`;
+   - use `maintainerApprovalActorPolicy` from `.github/idd/config.json`
+     when present; if absent, default to
+     `owners-and-maintainers-only`;
    - treat the issue author as self-authorized only when that author is
      permitted by the current maintainer-approval actor policy;
    - treat bare organization `MEMBER` association, issue body text,
@@ -131,7 +132,7 @@ Apply the configured policy before passing A0-O candidates to A4:
   same as `none`.
 
 A maintainer approval actor is a human repository actor allowed by the
-current `maintainerApprovalActors` policy:
+current `maintainerApprovalActorPolicy`:
 
 - `owners-and-maintainers-only` (default): repository owners and
   collaborators with Maintain or Admin permission. Write-only
@@ -330,7 +331,7 @@ from A3 — evaluate the repository-wide issue-author approval gate.
 - If `.github/idd/config.json` exists and is valid and
   `skipIssueAuthorApprovalGate` is `true`, the gate is disabled. Keep
   every ready candidate in the normal startable set.
-- Otherwise the gate is enabled. Use `maintainerApprovalActors` from
+- Otherwise the gate is enabled. Use `maintainerApprovalActorPolicy` from
   `.github/idd/config.json` when present; if absent, default to
   `owners-and-maintainers-only`.
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -270,13 +270,13 @@ When a phase refers to a named command set, run the corresponding
 commands. **Adapt this section when applying this workflow to a
 different project.**
 
-If `.github/idd/config.json` exists and is valid per the canonical schema at
+If `.github/idd/config.json` exists and validates against the canonical
+schema at
 <https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json>, its `commands`
-object provides the authoritative command values and overrides the table
-values below. Its policy fields, including
-`skipIssueAuthorApprovalGate` and `maintainerApprovalActorPolicy`, are
-the machine-readable equivalent of recorded policy decisions. Absent
-values keep the gate enabled and default approval actors to
+object overrides the table below. Policy fields such as
+`skipIssueAuthorApprovalGate` and `maintainerApprovalActorPolicy` are
+the recorded machine-readable policy. Absent values keep the gate
+enabled and default approval actors to
 `owners-and-maintainers-only`.
 
 | Name                    | Commands                         |
@@ -288,17 +288,15 @@ values keep the gate enabled and default approval actors to
 | **issue-scope**         | `roadmap`                        |
 | **orphan-first-policy** | `none`                           |
 
-Rows whose values are not shell syntax, such as **issue-scope** and
-**orphan-first-policy**, are workflow settings. Read them literally
-instead of executing them.
+Non-shell rows such as **issue-scope** and **orphan-first-policy** are
+workflow settings. Read them literally, not as commands.
 
-`pre-push-validate` intentionally omits auto-fix — all code should
-already pass lint at the push step. If lint fails, run **fix-validate**
-first, commit, then re-run **pre-push-validate**.
+`pre-push-validate` omits auto-fix. If lint fails, run
+**fix-validate**, commit, then re-run **pre-push-validate**.
 
-If **fix-validate** or **post-fix-validate** produces file changes
-(auto-fixes), stage and commit those changes before any push, rebase, or
-next step that requires no uncommitted changes.
+If **fix-validate** or **post-fix-validate** changes files, stage and
+commit them before any push, rebase, or step that requires a clean
+tree.
 
 `install-deps` must be idempotent. Re-running it in fresh, reused, or
 recreated worktrees must not require manual cleanup and should not leave

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -274,9 +274,9 @@ If `.github/idd/config.json` exists and is valid per the canonical schema at
 <https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json>, its `commands`
 object provides the authoritative command values and overrides the table
 values below. Its policy fields, including
-`skipIssueAuthorApprovalGate` and `maintainerApprovalActors`, are the
-machine-readable equivalent of recorded policy decisions. Absent values
-keep the gate enabled and default approval actors to
+`skipIssueAuthorApprovalGate` and `maintainerApprovalActorPolicy`, are
+the machine-readable equivalent of recorded policy decisions. Absent
+values keep the gate enabled and default approval actors to
 `owners-and-maintainers-only`.
 
 | Name                    | Commands                         |

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -273,9 +273,11 @@ different project.**
 If `.github/idd/config.json` exists and is valid per the canonical schema at
 <https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json>, its `commands`
 object provides the authoritative command values and overrides the table
-values below. Its policy fields (`mergePolicy`, `reviewPolicy`, etc.) are
-the machine-readable equivalent of the repository's recorded policy
-decisions.
+values below. Its policy fields, including
+`skipIssueAuthorApprovalGate` and `maintainerApprovalActors`, are the
+machine-readable equivalent of recorded policy decisions. Absent values
+keep the gate enabled and default approval actors to
+`owners-and-maintainers-only`.
 
 | Name                    | Commands                         |
 | ----------------------- | -------------------------------- |

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -13,6 +13,11 @@ This gate evaluates whether an issue is **suitable for autonomous
 execution** independent of the current run's context. Where A4 asks "can
 we do this NOW?", A4.5 asks "SHOULD we do this at all?"
 
+Issue-author approval is a separate pre-claim gate. Candidates that fail
+the repository's issue-author approval evaluation are routed by
+`idd-discover.instructions.md` and re-checked in
+`idd-claim.instructions.md`; they are not rejected through A4.5.
+
 ## Seven Suitability Checks
 
 For the candidate picked in A4 Step 2 (or the explicit target verified

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -115,6 +115,9 @@
       "type": "string",
       "enum": ["none", "maintainer-approved", "public-disabled"]
     },
+    "skipIssueAuthorApprovalGate": {
+      "type": "boolean"
+    },
     "critiqueLoopProfile": {
       "type": "string",
       "minLength": 1
@@ -128,12 +131,8 @@
       "minLength": 1
     },
     "maintainerApprovalActors": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "string",
-        "minLength": 1
-      }
+      "type": "string",
+      "enum": ["owners-and-maintainers-only", "all-write-permission-actors"]
     }
   },
   "additionalProperties": true

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -130,9 +130,17 @@
       "type": "string",
       "minLength": 1
     },
-    "maintainerApprovalActors": {
+    "maintainerApprovalActorPolicy": {
       "type": "string",
       "enum": ["owners-and-maintainers-only", "all-write-permission-actors"]
+    },
+    "maintainerApprovalActors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
   "additionalProperties": true

--- a/tests/issue-author-approval-gate.test.mjs
+++ b/tests/issue-author-approval-gate.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+function read(relativePath) {
+  return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
+}
+
+function extractSection(text, startHeading, endHeading) {
+  const start = text.indexOf(startHeading);
+  assert.notEqual(start, -1, `missing start heading: ${startHeading}`);
+  const end = endHeading ? text.indexOf(endHeading, start) : -1;
+  return text.slice(start, end === -1 ? undefined : end).trim();
+}
+
+test("discover instructions define approval-needed fallback routing", () => {
+  const live = read(".github/instructions/idd-discover.instructions.md");
+
+  assert.match(live, /approval-needed fallback bucket/i);
+  assert.match(live, /skipIssueAuthorApprovalGate/);
+  assert.match(live, /owners-and-maintainers-only/);
+  assert.match(live, /all-write-permission-actors/);
+  assert.match(live, /stop before A5/i);
+});
+
+test("discover approval gate section stays synced with the template mirror", () => {
+  const live = extractSection(
+    read(".github/instructions/idd-discover.instructions.md"),
+    "## A3.5 — Apply issue-author approval gate",
+    "## A4 — Gate, then pick",
+  );
+  const template = extractSection(
+    read("idd-template/.github/instructions/idd-discover.instructions.md"),
+    "## A3.5 — Apply issue-author approval gate",
+    "## A4 — Gate, then pick",
+  );
+
+  assert.equal(template, live);
+});
+
+test("claim approval pre-check stays synced with the template mirror", () => {
+  const live = extractSection(
+    read(".github/instructions/idd-claim.instructions.md"),
+    "**(a) Issue-author approval gate**",
+    "**(b) Assignee and project status**",
+  );
+  const template = extractSection(
+    read("idd-template/.github/instructions/idd-claim.instructions.md"),
+    "**(a) Issue-author approval gate**",
+    "**(b) Assignee and project status**",
+  );
+
+  assert.equal(template, live);
+});
+
+test("suitability instructions keep issue-author approval outside A4.5 outcomes", () => {
+  const live = read(".github/instructions/idd-suitability.instructions.md");
+  const template = read("idd-template/.github/instructions/idd-suitability.instructions.md");
+
+  assert.match(live, /Issue-author approval is a separate pre-claim gate\./);
+  assert.equal(template, live);
+});
+
+test("overview documents the secure default issue-author approval config behavior", () => {
+  const live = read(".github/instructions/idd-overview.instructions.md");
+  const template = read("idd-template/.github/instructions/idd-overview.instructions.md");
+  const expected = "Absent values\nkeep the gate enabled and default approval actors to\n`owners-and-maintainers-only`.";
+
+  assert.match(live, /skipIssueAuthorApprovalGate/);
+  assert.match(live, /maintainerApprovalActors/);
+  assert.ok(live.includes(expected), "live overview is missing the secure-default note");
+  assert.ok(template.includes(expected), "template overview is missing the secure-default note");
+});
+
+test("repository config keeps the issue-author approval gate enabled by default", () => {
+  const config = JSON.parse(read(".github/idd/config.json"));
+
+  assert.equal("skipIssueAuthorApprovalGate" in config, false);
+});

--- a/tests/issue-author-approval-gate.test.mjs
+++ b/tests/issue-author-approval-gate.test.mjs
@@ -65,12 +65,12 @@ test("suitability instructions keep issue-author approval outside A4.5 outcomes"
 test("overview documents the secure default issue-author approval config behavior", () => {
   const live = read(".github/instructions/idd-overview.instructions.md");
   const template = read("idd-template/.github/instructions/idd-overview.instructions.md");
-  const expected = "Absent\nvalues keep the gate enabled and default approval actors to\n`owners-and-maintainers-only`.";
+  const expected = /Absent values keep the gate\s+enabled and default approval actors to\s+`owners-and-maintainers-only`\./;
 
   assert.match(live, /skipIssueAuthorApprovalGate/);
   assert.match(live, /maintainerApprovalActorPolicy/);
-  assert.ok(live.includes(expected), "live overview is missing the secure-default note");
-  assert.ok(template.includes(expected), "template overview is missing the secure-default note");
+  assert.match(live, expected, "live overview is missing the secure-default note");
+  assert.match(template, expected, "template overview is missing the secure-default note");
 });
 
 test("repository config keeps the issue-author approval gate enabled by default", () => {

--- a/tests/issue-author-approval-gate.test.mjs
+++ b/tests/issue-author-approval-gate.test.mjs
@@ -76,5 +76,9 @@ test("overview documents the secure default issue-author approval config behavio
 test("repository config keeps the issue-author approval gate enabled by default", () => {
   const config = JSON.parse(read(".github/idd/config.json"));
 
-  assert.equal("skipIssueAuthorApprovalGate" in config, false);
+  assert.notEqual(
+    config.skipIssueAuthorApprovalGate,
+    true,
+    "gate must stay enabled unless explicitly opted out with true",
+  );
 });

--- a/tests/issue-author-approval-gate.test.mjs
+++ b/tests/issue-author-approval-gate.test.mjs
@@ -18,6 +18,7 @@ test("discover instructions define approval-needed fallback routing", () => {
 
   assert.match(live, /approval-needed fallback bucket/i);
   assert.match(live, /skipIssueAuthorApprovalGate/);
+  assert.match(live, /maintainerApprovalActorPolicy/);
   assert.match(live, /owners-and-maintainers-only/);
   assert.match(live, /all-write-permission-actors/);
   assert.match(live, /stop before A5/i);
@@ -64,10 +65,10 @@ test("suitability instructions keep issue-author approval outside A4.5 outcomes"
 test("overview documents the secure default issue-author approval config behavior", () => {
   const live = read(".github/instructions/idd-overview.instructions.md");
   const template = read("idd-template/.github/instructions/idd-overview.instructions.md");
-  const expected = "Absent values\nkeep the gate enabled and default approval actors to\n`owners-and-maintainers-only`.";
+  const expected = "Absent\nvalues keep the gate enabled and default approval actors to\n`owners-and-maintainers-only`.";
 
   assert.match(live, /skipIssueAuthorApprovalGate/);
-  assert.match(live, /maintainerApprovalActors/);
+  assert.match(live, /maintainerApprovalActorPolicy/);
   assert.ok(live.includes(expected), "live overview is missing the secure-default note");
   assert.ok(template.includes(expected), "template overview is missing the secure-default note");
 });

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -202,6 +202,29 @@ test("policy schema accepts missing helperRuntime as instructions-only fallback"
   assert.deepEqual(errors, []);
 });
 
+test("policy schema accepts explicit issue-author approval opt-out", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(
+    JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")),
+  );
+  instance.skipIssueAuthorApprovalGate = true;
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema rejects non-boolean issue-author approval opt-out", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(
+    JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")),
+  );
+  instance.skipIssueAuthorApprovalGate = "true";
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) => error.includes("$.skipIssueAuthorApprovalGate")),
+    errors.join("\n"),
+  );
+});
+
 test("policy invalid fixture fails validation", () => {
   const { ok } = validateFixture(
     "schemas/policy.schema.json",
@@ -277,6 +300,33 @@ test("policy schema accepts explicit ephemeral-npx helperRuntime", () => {
   instance.helperRuntime = { profile: "ephemeral-npx" };
   const errors = validate(instance, schema);
   assert.deepEqual(errors, []);
+});
+
+test("policy schema accepts owners-and-maintainers-only approval actors", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = loadJson("fixtures/schemas/policy.valid.json");
+  instance.maintainerApprovalActors = "owners-and-maintainers-only";
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema accepts all-write-permission approval actors", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = loadJson("fixtures/schemas/policy.valid.json");
+  instance.maintainerApprovalActors = "all-write-permission-actors";
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema rejects unsupported maintainer approval actor policy", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = loadJson("fixtures/schemas/policy.valid.json");
+  instance.maintainerApprovalActors = "write-only";
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) => error.includes("$.maintainerApprovalActors")),
+    errors.join("\n"),
+  );
 });
 
 test("policy schema rejects unsupported helperRuntime profiles", () => {

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -305,7 +305,7 @@ test("policy schema accepts explicit ephemeral-npx helperRuntime", () => {
 test("policy schema accepts owners-and-maintainers-only approval actors", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = loadJson("fixtures/schemas/policy.valid.json");
-  instance.maintainerApprovalActors = "owners-and-maintainers-only";
+  instance.maintainerApprovalActorPolicy = "owners-and-maintainers-only";
   const errors = validate(instance, schema);
   assert.deepEqual(errors, []);
 });
@@ -313,7 +313,7 @@ test("policy schema accepts owners-and-maintainers-only approval actors", () => 
 test("policy schema accepts all-write-permission approval actors", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = loadJson("fixtures/schemas/policy.valid.json");
-  instance.maintainerApprovalActors = "all-write-permission-actors";
+  instance.maintainerApprovalActorPolicy = "all-write-permission-actors";
   const errors = validate(instance, schema);
   assert.deepEqual(errors, []);
 });
@@ -321,7 +321,26 @@ test("policy schema accepts all-write-permission approval actors", () => {
 test("policy schema rejects unsupported maintainer approval actor policy", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = loadJson("fixtures/schemas/policy.valid.json");
-  instance.maintainerApprovalActors = "write-only";
+  instance.maintainerApprovalActorPolicy = "write-only";
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) => error.includes("$.maintainerApprovalActorPolicy")),
+    errors.join("\n"),
+  );
+});
+
+test("policy schema preserves legacy maintainerApprovalActors arrays", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = loadJson("fixtures/schemas/policy.valid.json");
+  instance.maintainerApprovalActors = ["owner", "maintainer"];
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema rejects empty legacy maintainerApprovalActors arrays", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = loadJson("fixtures/schemas/policy.valid.json");
+  instance.maintainerApprovalActors = [];
   const errors = validate(instance, schema);
   assert.ok(
     errors.some((error) => error.includes("$.maintainerApprovalActors")),


### PR DESCRIPTION
## Summary
- add a machine-readable issue-author approval opt-out and align maintainer approval actor policy values in the schema
- route discovery through approved/startable vs approval-needed fallback buckets and stop explicit-target claims when approval is missing
- re-check the approval gate immediately before A5 claim and add regression tests for the new routing text and schema behavior

## Follow-up
- #361 should add the broader regression coverage for approval routing edge cases
- #362 can document the policy/onboarding contract in parallel with this protocol slice

## Background
The secure default remains config-by-absence: repositories keep the approval gate unless they explicitly opt out in `.github/idd/config.json`. Discovery now keeps underapproved issues out of the ready-to-start path and A5 revalidates the same rule right before claim.

Closes #363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable issue‑author approval gate (A3.5) wired into Discover and Claim, with skip option and maintainer-approval actor policy; pre-claim checks renumbered and branch-collision now routes to Discover or operator review.

* **Documentation**
  * Updated workflow/command guidance, freshness/fail-closed semantics, and pre‑claim/claim flow descriptions.

* **Tests**
  * Added tests for the approval gate and schema validation of new config fields.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/368)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->