### PR TITLE
docs(onboarding): add template distribution reference

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -87,6 +87,7 @@
         "idd-template/docs/reference.md",
         "idd-template/docs/onboarding/placeholders.md",
         "idd-template/docs/onboarding/policy-decisions.md",
+        "idd-template/docs/onboarding/template-distribution.md",
         "idd-template/profiles/README.md",
         "idd-template/profiles/human-required/README.md",
         "idd-template/profiles/no-advisory/README.md",

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -225,6 +225,9 @@ notes, and `blocked-by` guidance, see
 
 You need the following core execution and profile artifact files in the
 target repository. Use whichever method applies to your situation.
+For detailed maintenance guidance about this generated file list and the
+remote-fetch examples, see
+[Template distribution reference](docs/onboarding/template-distribution.md).
 
 The issue-authoring skill is available as an optional companion artifact
 from `skills/issue-authoring/` in the idd-skill source repository. That path is
@@ -279,6 +282,7 @@ docs/policy-constants.md
 docs/reference.md
 docs/onboarding/placeholders.md
 docs/onboarding/policy-decisions.md
+docs/onboarding/template-distribution.md
 profiles/README.md
 profiles/human-required/README.md
 profiles/no-advisory/README.md
@@ -351,6 +355,7 @@ for FILE in \
   "docs/reference.md" \
   "docs/onboarding/placeholders.md" \
   "docs/onboarding/policy-decisions.md" \
+  "docs/onboarding/template-distribution.md" \
   "profiles/README.md" \
   "profiles/human-required/README.md" \
   "profiles/no-advisory/README.md" \
@@ -431,6 +436,7 @@ for FILE in \
   "docs/reference.md" \
   "docs/onboarding/placeholders.md" \
   "docs/onboarding/policy-decisions.md" \
+  "docs/onboarding/template-distribution.md" \
   "profiles/README.md" \
   "profiles/human-required/README.md" \
   "profiles/no-advisory/README.md" \

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -225,9 +225,9 @@ notes, and `blocked-by` guidance, see
 
 You need the following core execution and profile artifact files in the
 target repository. Use whichever method applies to your situation.
-For detailed maintenance guidance about this generated file list and the
+For `idd-skill` maintainers working on this generated file list and the
 remote-fetch examples, see
-[Template distribution reference](docs/onboarding/template-distribution.md).
+[Template distribution maintainer reference](docs/onboarding/template-distribution.md).
 
 The issue-authoring skill is available as an optional companion artifact
 from `skills/issue-authoring/` in the idd-skill source repository. That path is

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -118,6 +118,8 @@ docs/
   idd-helper-scripts.md              ← optional helper-script evaluation and policy
   idd-comment-minimization.md        ← post-merge comment cleanup policy and experiment
   permissions.md                     ← permission profiles and threat model
+  onboarding/
+    template-distribution.md         ← generated file-list and fetch-surface maintenance
 profiles/
   README.md                          ← profile artifact index
   human-required/README.md           ← required human review artifact

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -6,6 +6,11 @@ operator-facing import path; this page explains how the file list and
 fetch examples stay correct when the template gains, removes, or moves
 files.
 
+This is primarily a maintainer reference for the `idd-skill` source
+repository. Adopters who receive it with the copied template can treat it
+as background unless they intentionally customize their local template
+distribution lists.
+
 ## Distribution surfaces
 
 The template has three distribution surfaces:

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -1,4 +1,4 @@
-# Template Distribution Reference
+# Template Distribution Maintainer Reference
 
 Use this page when maintaining the file distribution surface for
 `idd-template/ONBOARDING.md`. The onboarding entry point remains the

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -1,0 +1,88 @@
+# Template Distribution Reference
+
+Use this page when maintaining the file distribution surface for
+`idd-template/ONBOARDING.md`. The onboarding entry point remains the
+operator-facing import path; this page explains how the file list and
+fetch examples stay correct when the template gains, removes, or moves
+files.
+
+## Distribution surfaces
+
+The template has three distribution surfaces:
+
+1. **Core template files** copied from `idd-template/` into the adopter
+   repository. These include `.github/idd/`, `.github/instructions/`,
+   `docs/`, and `profiles/`.
+2. **Optional issue-authoring companion files** copied from
+   `skills/issue-authoring/` only when the operator explicitly opts into
+   pre-execution issue drafting.
+3. **Local-copy installs** where an agent copies the full
+   `idd-template/` directory from a cloned `idd-skill` checkout instead
+   of fetching individual files.
+
+`idd-template/ONBOARDING.md` keeps the executable import snippets for
+the first two surfaces so a raw-URL onboarding run can still complete
+without opening this reference first.
+
+## Generated file lists
+
+The authoritative generated lists are configured in
+`audit/sync-manifest.json`:
+
+- `generatedBlocks[].id == "idd-template-core-files"` owns the core
+  template file list.
+- `generatedBlocks[].id == "issue-authoring-companion-files"` owns the
+  optional issue-authoring companion list.
+- `shellFileLists` ties each generated list to the `gh api` and `curl`
+  loops in `idd-template/ONBOARDING.md`.
+
+When adding a core template file, update both `sourceGlobs` and `paths`
+for `idd-template-core-files` when the new path is not already covered.
+The docs audit compares those entries with the repository files and
+fails if the generated block or shell loops are stale.
+
+When adding an optional issue-authoring companion file, update the
+`issue-authoring-companion-files` block instead. Do not put optional
+companion files in the core template list unless the execution loop
+requires every adopter to receive them.
+
+## Remote fetch examples
+
+The `gh api` and `curl` loops in `idd-template/ONBOARDING.md` intentionally
+list every file instead of fetching directories. This keeps raw-content
+imports deterministic and makes missing files visible during onboarding.
+
+For a new core file, ensure that both loops include the path after the
+generated list is updated. The audit checks the shell lists against the
+same generated block, so a path that appears in one loop but not the
+other is treated as stale documentation.
+
+For nested documentation such as `docs/onboarding/*.md`, the existing
+loop body creates parent directories with `mkdir -p "$(dirname
+"${DEST}/${FILE}")"`. No extra top-level `mkdir -p` entry is required
+for each nested docs directory.
+
+## Local-copy installs
+
+The local-copy path is intentionally broader than the remote-fetch path:
+copy the contents of `idd-template/` while preserving relative paths.
+That means new core files under `idd-template/` are automatically covered
+by local-copy installs after they are committed.
+
+Keep the local-copy prose in `idd-template/ONBOARDING.md` short. Use this
+reference for maintenance details and the generated remote-fetch snippets
+for exact file coverage.
+
+## Maintenance checklist
+
+Before merging a distribution-surface change, verify:
+
+- `audit/sync-manifest.json` includes every required new core file.
+- the generated core file block in `idd-template/ONBOARDING.md` includes
+  the new path.
+- the `gh api` and `curl` loops in `idd-template/ONBOARDING.md` include
+  the same path.
+- optional issue-authoring files remain in the optional companion list.
+- `idd-template/README.md` mentions the new reference page when it is
+  part of the exported template documentation set.
+- `node scripts/audit-docs.mjs --check` passes.


### PR DESCRIPTION
## Summary

- Add `docs/onboarding/template-distribution.md` as the onboarding reference for generated file coverage and template distribution commands.
- Include the new reference in the template file manifest, onboarding fetch lists, and template README file map.

## Validation

- `pnpm run lint`
- `pnpm run test`

Closes #373


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new onboarding page describing template distribution surfaces, fetch/copy behaviors, and a maintenance checklist.
  * Updated the onboarding guide and README to reference the new distribution guidance and maintenance steps.

* **Chores**
  * Updated the manifest/configuration to include the new onboarding documentation in generated file lists.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/377)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->