### PR TITLE
docs(onboarding): extract agent-entry and verification reference

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -85,6 +85,7 @@
         "idd-template/docs/customization.md",
         "idd-template/docs/policy-constants.md",
         "idd-template/docs/reference.md",
+        "idd-template/docs/onboarding/agent-entry-and-verification.md",
         "idd-template/docs/onboarding/placeholders.md",
         "idd-template/docs/onboarding/policy-decisions.md",
         "idd-template/profiles/README.md",

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -571,8 +571,8 @@ workflow references and the same opt-out rule.
 If `.github/copilot-instructions.md` already exists, add a parallel IDD
 workflow section there as well. Keep the
 `excludeAgent: "code-review"` behavior in
-`idd-overview.instructions.md`; repository-wide Copilot guidance may
-still apply to reviews.
+`.github/instructions/idd-overview.instructions.md`; repository-wide
+Copilot guidance may still apply to reviews.
 
 ---
 
@@ -588,9 +588,9 @@ After completing the steps above, confirm each item:
       listed in Step 2 is present in the imported repository.
 - [ ] The selected PR review profile is recorded, and any non-default
       profile artifact and phase-file edits are complete.
-- [ ] The selected review-thread resolution and critique-loop policies
-      are recorded, and any non-default phase-file customizations are
-      complete.
+- [ ] The selected review-thread resolution policy and critique-loop
+      profile are recorded, and any non-default phase-file
+      customizations are complete.
 - [ ] The selected merge policy, credential scope, claim timing values,
       and helper runtime profile are explicitly recorded.
 - [ ] If the operator opted into issue authoring, the companion skill
@@ -598,8 +598,9 @@ After completing the steps above, confirm each item:
 - [ ] No `{{...}}` placeholders remain, the `Project commands` table is
       correct, and any `orphan-first` scope choice has a valid policy
       value.
-- [ ] `idd-overview.instructions.md` keeps `applyTo: "**"` and
-      `excludeAgent: "code-review"` in its frontmatter.
+- [ ] `.github/instructions/idd-overview.instructions.md` keeps
+      `applyTo: "**"` and `excludeAgent: "code-review"` in its
+      frontmatter.
 - [ ] `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` exist and reference
       `docs/idd-workflow.md`, unless the operator explicitly opted out
       of creating them.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -277,6 +277,7 @@ docs/concepts.md
 docs/customization.md
 docs/policy-constants.md
 docs/reference.md
+docs/onboarding/agent-entry-and-verification.md
 docs/onboarding/placeholders.md
 docs/onboarding/policy-decisions.md
 profiles/README.md
@@ -349,6 +350,7 @@ for FILE in \
   "docs/customization.md" \
   "docs/policy-constants.md" \
   "docs/reference.md" \
+  "docs/onboarding/agent-entry-and-verification.md" \
   "docs/onboarding/placeholders.md" \
   "docs/onboarding/policy-decisions.md" \
   "profiles/README.md" \
@@ -429,6 +431,7 @@ for FILE in \
   "docs/customization.md" \
   "docs/policy-constants.md" \
   "docs/reference.md" \
+  "docs/onboarding/agent-entry-and-verification.md" \
   "docs/onboarding/placeholders.md" \
   "docs/onboarding/policy-decisions.md" \
   "profiles/README.md" \
@@ -535,10 +538,12 @@ manually-routed non-Copilot agent named in `docs/idd-workflow.md`:
 - Only skip creating a missing root agent entry file when the operator
   explicitly opts out of adding new files.
 
-### CLAUDE.md
+Use
+[Onboarding Reference — Agent Entry and Verification](docs/onboarding/agent-entry-and-verification.md)
+for the per-file examples, create-from-scratch stubs, and expanded
+verification guidance for this step.
 
-If `CLAUDE.md` already exists, add the following section (adapt wording
-to fit the existing document style):
+The minimal IDD workflow section should tell agents to:
 
 ```markdown
 ## IDD Workflow
@@ -552,164 +557,56 @@ Before starting IDD work, open
 phase file manually when the current step changes.
 ```
 
-If `CLAUDE.md` does not exist, create a minimal file such as:
+- point to `docs/idd-workflow.md` as the cross-agent entry path
+- open `.github/instructions/idd-overview.instructions.md` before
+  starting IDD work
+- manually open the routed phase file when the current step changes
 
-```markdown
-# Guidelines for AI Agents
+Apply this section to `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`,
+adapting the surrounding wording to each tool while preserving the same
+workflow references and the same opt-out rule.
 
-## Immediate rules
-
-- Match the conversational language to the user's language.
-- Write comments and documentation in English unless there is a clear
-  project-specific reason otherwise.
-- If uncertainty, hidden risk, or missing context blocks a safe change,
-  stop and ask a concise question before proceeding.
-
-## IDD Workflow
-
-This project uses Issue-Driven Development (IDD) with parallel AI
-agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
-cross-agent entry path and phase routing.
-
-Before starting IDD work, open
-`.github/instructions/idd-overview.instructions.md`. Open the routed
-phase file manually when the current step changes.
-```
-
-### .github/copilot-instructions.md (if present)
-
-Add a parallel section so GitHub Copilot execution surfaces also receive
-the IDD context. The content can mirror the CLAUDE.md addition above.
-The template keeps the heavier `idd-overview.instructions.md` out of
-Copilot code review with `excludeAgent: "code-review"`; repository-wide
-`.github/copilot-instructions.md` guidance may still apply to reviews.
-
-### AGENTS.md (for Codex CLI)
-
-If `AGENTS.md` already exists, add a short IDD workflow section that
-points to `docs/idd-workflow.md` and tells Codex CLI agents to manually
-open `.github/instructions/idd-overview.instructions.md` and the
-relevant phase file before starting IDD work.
-
-If `AGENTS.md` does not exist, create a minimal file such as:
-
-```markdown
-# Guidelines for AI Agents
-
-## Immediate rules
-
-- Match the conversational language to the user's language.
-- Write comments and documentation in English unless there is a clear
-  project-specific reason otherwise.
-- If uncertainty, hidden risk, or missing context blocks a safe change,
-  stop and ask a concise question before proceeding.
-
-## IDD Workflow
-
-This project uses Issue-Driven Development (IDD) with parallel AI
-agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
-cross-agent entry path and phase routing.
-
-Before starting IDD work, open
-`.github/instructions/idd-overview.instructions.md`. Open the routed
-phase file manually when the current step changes.
-```
-
-### GEMINI.md
-
-If `GEMINI.md` already exists, apply the same IDD guidance as
-`AGENTS.md`, adapted to Gemini CLI's wording and still pointing to
-`docs/idd-workflow.md`.
-
-If `GEMINI.md` does not exist, create a minimal file such as:
-
-```markdown
-# Guidelines for AI Agents
-
-## Immediate rules
-
-- Match the conversational language to the user's language.
-- Write comments and documentation in English unless there is a clear
-  project-specific reason otherwise.
-- If uncertainty, hidden risk, or missing context blocks a safe change,
-  stop and ask a concise question before proceeding.
-
-## IDD Workflow
-
-This project uses Issue-Driven Development (IDD) with parallel AI
-agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
-cross-agent entry path and phase routing.
-
-Before starting IDD work, open
-`.github/instructions/idd-overview.instructions.md`. Open the routed
-phase file manually when the current step changes.
-```
+If `.github/copilot-instructions.md` already exists, add a parallel IDD
+workflow section there as well. Keep the
+`excludeAgent: "code-review"` behavior in
+`idd-overview.instructions.md`; repository-wide Copilot guidance may
+still apply to reviews.
 
 ---
 
 ## Step 6 — Verification checklist
 
+Use
+[Onboarding Reference — Agent Entry and Verification](docs/onboarding/agent-entry-and-verification.md)
+for the expanded verification details and evidence expectations.
+
 After completing the steps above, confirm each item:
 
-- [ ] Every `idd-*.instructions.md` file listed in the generated core
-      file list is present in `.github/instructions/`.
-- [ ] `docs/getting-started.md`, `docs/concepts.md`,
-      `docs/customization.md`, `docs/reference.md`,
-      `docs/idd-workflow.md`,
-      `docs/idd-review-policy-profiles.md`,
-      `docs/idd-helper-scripts.md`,
-      `docs/idd-comment-minimization.md`, and `docs/permissions.md`
-      are present.
-- [ ] `profiles/README.md` and the non-default profile artifacts under
-      `profiles/` are present.
-- [ ] The operator's selected PR review policy profile is recorded, and
-      the matching edit-surface checklist in
-      `docs/idd-review-policy-profiles.md` is complete.
-- [ ] If the selected PR review policy profile is non-default, the
-      matching `profiles/<profile>/README.md` artifact was applied and
-      its verification evidence is recorded.
-- [ ] The operator's selected review-thread resolution policy is
-      recorded, and any non-default profile has matching phase-file
-      customizations.
-- [ ] The operator's selected critique-loop policy is recorded, and any
-      non-default profile has matching phase-file customizations.
-- [ ] The operator's selected merge policy is recorded in repository
-      documentation, the F3 handoff behavior matches that policy, and
-      worker credentials match that boundary.
-- [ ] Ownership timing policy values `claim-stale-age` and
-      `claim-heartbeat-interval` are explicitly recorded for the target
-      repository.
-- [ ] The selected helper runtime profile is recorded, including whether
-      the repository stays on `instructions-only` or opted into
-      `package-manager`, `vendored-node`, or `ephemeral-npx`.
-- [ ] If the operator opted into issue authoring,
-      `skills/issue-authoring/SKILL.md`,
-      `skills/issue-authoring/agents/openai.yaml`, and the
-      `skills/issue-authoring/references/` files are present.
-- [ ] No `{{...}}` placeholders remain in any copied file.
-- [ ] `idd-overview.instructions.md` has `applyTo: "**"` and
+- [ ] Every core execution file, supporting doc, and profile artifact
+      listed in Step 2 is present in the imported repository.
+- [ ] The selected PR review profile is recorded, and any non-default
+      profile artifact and phase-file edits are complete.
+- [ ] The selected review-thread resolution and critique-loop policies
+      are recorded, and any non-default phase-file customizations are
+      complete.
+- [ ] The selected merge policy, credential scope, claim timing values,
+      and helper runtime profile are explicitly recorded.
+- [ ] If the operator opted into issue authoring, the companion skill
+      files are present.
+- [ ] No `{{...}}` placeholders remain, the `Project commands` table is
+      correct, and any `orphan-first` scope choice has a valid policy
+      value.
+- [ ] `idd-overview.instructions.md` keeps `applyTo: "**"` and
       `excludeAgent: "code-review"` in its frontmatter.
-- [ ] `CLAUDE.md` exists and references `docs/idd-workflow.md`, unless
-      the operator explicitly opted out of creating it.
-- [ ] `AGENTS.md` exists and references `docs/idd-workflow.md`, unless
-      the operator explicitly opted out of creating it.
-- [ ] `GEMINI.md` exists and references `docs/idd-workflow.md`, unless
-      the operator explicitly opted out of creating it.
+- [ ] `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` exist and reference
+      `docs/idd-workflow.md`, unless the operator explicitly opted out
+      of creating them.
 - [ ] If `.github/copilot-instructions.md` existed before onboarding,
       it now includes the IDD workflow reference as well.
-- [ ] The `Project commands` table in `idd-overview.instructions.md`
-      contains the correct commands for this project.
-- [ ] If the project chooses `issue-scope: orphan-first`, the
-      `orphan-first-policy` value is recorded as `none`,
-      `maintainer-approved`, or `public-disabled`. Public repositories
-      use either `maintainer-approved` or `public-disabled`, not `none`.
 - [ ] The `{{PROJECT_MARKER_PREFIX}}-roadmap-id` and
-      `{{PROJECT_MARKER_PREFIX}}-blocked-by` marker names in
-      `idd-discover.instructions.md` and `idd-overview.instructions.md`
-      match the prefix chosen for this project.
-- [ ] If `.github/idd/config.json` is used, it matches the recorded
-      `iddVersion`, marker prefix, merge/review/thread policies,
-      claim timing values, `trustedMarkerActors`, and command values.
+      `{{PROJECT_MARKER_PREFIX}}-blocked-by` marker names match the
+      selected prefix, and `.github/idd/config.json` stays aligned when
+      the repository uses it.
 
 Once all items are checked, the IDD workflow is ready for use. Point the
 operator to `docs/idd-workflow.md` as the starting guide.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -186,11 +186,13 @@ require explicit operator confirmation:
    non-default profile)
 3. review-thread resolution policy (`fast-agent-resolve` by default, or
    a stricter profile)
-4. credential scope for worker and merge-capable sessions
-5. claim-timing defaults (`claim-stale-age` and
+4. critique-loop profile (distributed defaults, or a documented
+   repository override)
+5. credential scope for worker and merge-capable sessions
+6. claim-timing defaults (`claim-stale-age` and
    `claim-heartbeat-interval`)
-6. issue-authoring companion status (`installed` or `not installed`)
-7. helper runtime profile (`instructions-only` by default, or an
+7. issue-authoring companion status (`installed` or `not installed`)
+8. helper runtime profile (`instructions-only` by default, or an
    explicitly requested helper profile)
 
 Use
@@ -236,8 +238,8 @@ pre-execution issue drafting or roadmap decomposition support.
 
 Before importing files, re-check the policy choices confirmed in Step 1B:
 merge policy, PR review profile, review-thread resolution policy,
-credential scope, claim-timing defaults, issue-authoring companion
-status, and helper runtime profile.
+critique-loop profile, credential scope, claim-timing defaults,
+issue-authoring companion status, and helper runtime profile.
 
 Use
 [Onboarding Reference — Policy Decisions](docs/onboarding/policy-decisions.md)

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -1,0 +1,217 @@
+# Onboarding Reference — Agent Entry and Verification
+
+Use this reference alongside `idd-template/ONBOARDING.md` when you need
+the detailed agent-entry examples and expanded verification guidance
+that the thin onboarding entry point now links to.
+
+This page is the detailed companion for:
+
+- Step 5 — update agent entry files
+- Step 6 — verification checklist
+
+## Agent entry files
+
+By default, leave the target repository with root entry files for every
+manually-routed non-Copilot agent named in `docs/idd-workflow.md`:
+`CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`.
+
+Keep these rules explicit:
+
+- If the file already exists, append or adapt an IDD workflow section
+  without replacing unrelated repository guidance.
+- If the file is missing, create a minimal stub.
+- Only skip creating a missing root agent entry file when the operator
+  explicitly opts out of adding new files.
+
+### Shared IDD workflow stub
+
+All three root entry files should point agents to the same workflow
+entry path:
+
+```markdown
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
+cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+`.github/instructions/idd-overview.instructions.md`. Open the routed
+phase file manually when the current step changes.
+```
+
+### CLAUDE.md
+
+If `CLAUDE.md` already exists, add the shared IDD workflow section
+above and adapt the surrounding wording to the existing document style.
+
+If `CLAUDE.md` does not exist, create a minimal file such as:
+
+```markdown
+# Guidelines for AI Agents
+
+## Immediate rules
+
+- Match the conversational language to the user's language.
+- Write comments and documentation in English unless there is a clear
+  project-specific reason otherwise.
+- If uncertainty, hidden risk, or missing context blocks a safe change,
+  stop and ask a concise question before proceeding.
+
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
+cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+`.github/instructions/idd-overview.instructions.md`. Open the routed
+phase file manually when the current step changes.
+```
+
+### AGENTS.md (for Codex CLI)
+
+If `AGENTS.md` already exists, add the shared IDD workflow section and
+keep the wording explicit that Codex CLI agents should manually open
+`.github/instructions/idd-overview.instructions.md` and the routed
+phase file before starting IDD work.
+
+If `AGENTS.md` does not exist, create a minimal file such as:
+
+```markdown
+# Guidelines for AI Agents
+
+## Immediate rules
+
+- Match the conversational language to the user's language.
+- Write comments and documentation in English unless there is a clear
+  project-specific reason otherwise.
+- If uncertainty, hidden risk, or missing context blocks a safe change,
+  stop and ask a concise question before proceeding.
+
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
+cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+`.github/instructions/idd-overview.instructions.md`. Open the routed
+phase file manually when the current step changes.
+```
+
+### GEMINI.md
+
+If `GEMINI.md` already exists, apply the same IDD workflow section as
+`AGENTS.md`, adapted to Gemini CLI's wording and still pointing to
+`docs/idd-workflow.md`.
+
+If `GEMINI.md` does not exist, create a minimal file such as:
+
+```markdown
+# Guidelines for AI Agents
+
+## Immediate rules
+
+- Match the conversational language to the user's language.
+- Write comments and documentation in English unless there is a clear
+  project-specific reason otherwise.
+- If uncertainty, hidden risk, or missing context blocks a safe change,
+  stop and ask a concise question before proceeding.
+
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
+cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+`.github/instructions/idd-overview.instructions.md`. Open the routed
+phase file manually when the current step changes.
+```
+
+### .github/copilot-instructions.md (if present)
+
+If `.github/copilot-instructions.md` already exists, add a parallel IDD
+workflow section there as well so GitHub Copilot execution surfaces
+receive the same entry path. Keep the
+`excludeAgent: "code-review"` behavior in
+`.github/instructions/idd-overview.instructions.md`; repository-wide
+Copilot guidance may still apply during review.
+
+## Verification details
+
+Use the Step 6 checklist in `idd-template/ONBOARDING.md` as the final
+go/no-go gate. When you need the concrete evidence behind those shorter
+checks, confirm the detailed items below.
+
+### Imported files and profile artifacts
+
+- [ ] Every `idd-*.instructions.md` file listed in the generated core
+      file list is present in `.github/instructions/`.
+- [ ] `docs/getting-started.md`, `docs/concepts.md`,
+      `docs/customization.md`, `docs/reference.md`,
+      `docs/idd-workflow.md`,
+      `docs/idd-review-policy-profiles.md`,
+      `docs/idd-helper-scripts.md`,
+      `docs/idd-comment-minimization.md`, and `docs/permissions.md`
+      are present.
+- [ ] `profiles/README.md` and the non-default profile artifacts under
+      `profiles/` are present.
+
+### Recorded policies and selected companions
+
+- [ ] The operator's selected PR review policy profile is recorded, and
+      the matching edit-surface checklist in
+      `docs/idd-review-policy-profiles.md` is complete.
+- [ ] If the selected PR review policy profile is non-default, the
+      matching `profiles/<profile>/README.md` artifact was applied and
+      its verification evidence is recorded.
+- [ ] The operator's selected review-thread resolution policy is
+      recorded, and any non-default profile has matching phase-file
+      customizations.
+- [ ] The operator's selected critique-loop policy is recorded, and any
+      non-default profile has matching phase-file customizations.
+- [ ] The operator's selected merge policy is recorded in repository
+      documentation, the F3 handoff behavior matches that policy, and
+      worker credentials match that boundary.
+- [ ] Ownership timing policy values `claim-stale-age` and
+      `claim-heartbeat-interval` are explicitly recorded for the target
+      repository.
+- [ ] The selected helper runtime profile is recorded, including whether
+      the repository stays on `instructions-only` or opted into
+      `package-manager`, `vendored-node`, or `ephemeral-npx`.
+- [ ] If the operator opted into issue authoring,
+      `skills/issue-authoring/SKILL.md`,
+      `skills/issue-authoring/agents/openai.yaml`, and the
+      `skills/issue-authoring/references/` files are present.
+
+### Placeholder, marker, and config alignment
+
+- [ ] No `{{...}}` placeholders remain in any copied file.
+- [ ] `idd-overview.instructions.md` has `applyTo: "**"` and
+      `excludeAgent: "code-review"` in its frontmatter.
+- [ ] The `Project commands` table in `idd-overview.instructions.md`
+      contains the correct commands for this project.
+- [ ] If the project chooses `issue-scope: orphan-first`, the
+      `orphan-first-policy` value is recorded as `none`,
+      `maintainer-approved`, or `public-disabled`. Public repositories
+      use either `maintainer-approved` or `public-disabled`, not `none`.
+- [ ] The `{{PROJECT_MARKER_PREFIX}}-roadmap-id` and
+      `{{PROJECT_MARKER_PREFIX}}-blocked-by` marker names in
+      `idd-discover.instructions.md` and `idd-overview.instructions.md`
+      match the prefix chosen for this project.
+- [ ] If `.github/idd/config.json` is used, it matches the recorded
+      `iddVersion`, marker prefix, merge/review/thread policies,
+      claim timing values, `trustedMarkerActors`, and command values.
+
+### Agent entry files
+
+- [ ] `CLAUDE.md` exists and references `docs/idd-workflow.md`, unless
+      the operator explicitly opted out of creating it.
+- [ ] `AGENTS.md` exists and references `docs/idd-workflow.md`, unless
+      the operator explicitly opted out of creating it.
+- [ ] `GEMINI.md` exists and references `docs/idd-workflow.md`, unless
+      the operator explicitly opted out of creating it.
+- [ ] If `.github/copilot-instructions.md` existed before onboarding,
+      it now includes the IDD workflow reference as well.

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -192,7 +192,8 @@ checks, confirm the detailed items below.
 - [ ] `.github/instructions/idd-overview.instructions.md` has
       `applyTo: "**"` and `excludeAgent: "code-review"` in its
       frontmatter.
-- [ ] The `Project commands` table in `idd-overview.instructions.md`
+- [ ] The `Project commands` table in
+      `.github/instructions/idd-overview.instructions.md`
       contains the correct commands for this project.
 - [ ] If the project chooses `issue-scope: orphan-first`, the
       `orphan-first-policy` value is recorded as `none`,
@@ -200,7 +201,8 @@ checks, confirm the detailed items below.
       use either `maintainer-approved` or `public-disabled`, not `none`.
 - [ ] The `{{PROJECT_MARKER_PREFIX}}-roadmap-id` and
       `{{PROJECT_MARKER_PREFIX}}-blocked-by` marker names in
-      `idd-discover.instructions.md` and `idd-overview.instructions.md`
+      `.github/instructions/idd-discover.instructions.md` and
+      `.github/instructions/idd-overview.instructions.md`
       match the prefix chosen for this project.
 - [ ] If `.github/idd/config.json` is used, it matches the recorded
       `iddVersion`, marker prefix, merge/review/thread policies,

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -170,7 +170,7 @@ checks, confirm the detailed items below.
 - [ ] The operator's selected review-thread resolution policy is
       recorded, and any non-default profile has matching phase-file
       customizations.
-- [ ] The operator's selected critique-loop policy is recorded, and any
+- [ ] The operator's selected critique-loop profile is recorded, and any
       non-default profile has matching phase-file customizations.
 - [ ] The operator's selected merge policy is recorded in repository
       documentation, the F3 handoff behavior matches that policy, and
@@ -189,8 +189,9 @@ checks, confirm the detailed items below.
 ### Placeholder, marker, and config alignment
 
 - [ ] No `{{...}}` placeholders remain in any copied file.
-- [ ] `idd-overview.instructions.md` has `applyTo: "**"` and
-      `excludeAgent: "code-review"` in its frontmatter.
+- [ ] `.github/instructions/idd-overview.instructions.md` has
+      `applyTo: "**"` and `excludeAgent: "code-review"` in its
+      frontmatter.
 - [ ] The `Project commands` table in `idd-overview.instructions.md`
       contains the correct commands for this project.
 - [ ] If the project chooses `issue-scope: orphan-first`, the

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -164,7 +164,7 @@ This repository uses the following IDD policies:
 
 **Policy**: `{fast-agent-resolve | hybrid-reviewer-ack | strict-reviewer-resolve}`
 
-### Critique-Loop Policy
+### Critique-Loop Profile
 
 **Profile**: `{distributed defaults | repository override}`
 

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -77,6 +77,14 @@ If the repository chooses a non-default profile, update the review
 snapshot, triage, review-fix, pre-merge, and merge phase files named in
 `docs/idd-review-policy-profiles.md`.
 
+### Critique-loop profile
+
+Confirm whether the repository keeps the distributed critique-loop
+defaults from `docs/policy-constants.md` or documents a local override.
+At minimum, record whether the repository uses the shipped guardrails or
+intentionally customizes the critique-loop behavior before unattended
+execution begins.
+
 ### Issue-authoring companion
 
 Confirm whether the operator wants the optional issue-authoring skill:
@@ -155,6 +163,10 @@ This repository uses the following IDD policies:
 ### Review-Thread Resolution Policy
 
 **Policy**: `{fast-agent-resolve | hybrid-reviewer-ack | strict-reviewer-resolve}`
+
+### Critique-Loop Policy
+
+**Profile**: `{distributed defaults | repository override}`
 
 ### Claim Timing
 

--- a/tests/non-node-fallback.test.mjs
+++ b/tests/non-node-fallback.test.mjs
@@ -96,6 +96,11 @@ test("onboarding links extracted policy guidance including credential scope", ()
     /### Credential Scope/,
     "policy reference template must include a credential-scope section",
   );
+  assert.match(
+    policyText,
+    /### Critique-Loop Profile/,
+    "policy reference template must keep critique-loop terminology aligned",
+  );
 });
 
 test("onboarding keeps claim timing in the explicit confirmation path", () => {
@@ -114,6 +119,16 @@ test("onboarding keeps claim timing in the explicit confirmation path", () => {
     onboarding,
     /critique-loop profile, credential scope, claim-timing defaults,\s+issue-authoring companion status, and helper runtime profile\./,
     "ONBOARDING Step 2 re-check must stay aligned with the Step 1B confirmation list",
+  );
+  assert.match(
+    onboarding,
+    /review-thread resolution policy and critique-loop\s+profile are recorded/,
+    "ONBOARDING Step 6 must keep critique-loop terminology aligned with Step 1B",
+  );
+  assert.match(
+    onboarding,
+    /`\.github\/instructions\/idd-overview\.instructions\.md` keeps/,
+    "ONBOARDING Step 6 must use the full idd-overview path in the checklist",
   );
 });
 
@@ -198,6 +213,16 @@ test("onboarding links extracted agent-entry and verification guidance", () => {
     reference,
     /## Verification details/,
     "agent-entry reference must include the expanded verification guidance",
+  );
+  assert.match(
+    reference,
+    /selected critique-loop profile is recorded/,
+    "agent-entry reference must keep critique-loop terminology aligned",
+  );
+  assert.match(
+    reference,
+    /`\.github\/instructions\/idd-overview\.instructions\.md` has/,
+    "agent-entry reference must use the full idd-overview path in the checklist",
   );
 });
 

--- a/tests/non-node-fallback.test.mjs
+++ b/tests/non-node-fallback.test.mjs
@@ -83,6 +83,11 @@ test("onboarding links extracted policy guidance including credential scope", ()
   );
   assert.match(
     policyText,
+    /### Critique-loop profile/,
+    "policy reference must keep critique-loop guidance outside ONBOARDING",
+  );
+  assert.match(
+    policyText,
     /Review `docs\/permissions\.md` with the operator/,
     "policy reference must point credential decisions at docs/permissions.md",
   );
@@ -97,12 +102,17 @@ test("onboarding keeps claim timing in the explicit confirmation path", () => {
   const onboarding = readText("idd-template/ONBOARDING.md");
   assert.match(
     onboarding,
+    /critique-loop profile \(distributed defaults, or a documented\s+repository override\)/,
+    "ONBOARDING Step 1B must explicitly confirm the critique-loop profile",
+  );
+  assert.match(
+    onboarding,
     /claim-timing defaults \(`claim-stale-age` and\s+`claim-heartbeat-interval`\)/,
     "ONBOARDING Step 1B must explicitly confirm claim-timing defaults",
   );
   assert.match(
     onboarding,
-    /credential scope, claim-timing defaults, issue-authoring companion\s+status, and helper runtime profile\./,
+    /critique-loop profile, credential scope, claim-timing defaults,\s+issue-authoring companion status, and helper runtime profile\./,
     "ONBOARDING Step 2 re-check must stay aligned with the Step 1B confirmation list",
   );
 });

--- a/tests/non-node-fallback.test.mjs
+++ b/tests/non-node-fallback.test.mjs
@@ -224,6 +224,11 @@ test("onboarding links extracted agent-entry and verification guidance", () => {
     /`\.github\/instructions\/idd-overview\.instructions\.md` has/,
     "agent-entry reference must use the full idd-overview path in the checklist",
   );
+  assert.match(
+    reference,
+    /`\.github\/instructions\/idd-discover\.instructions\.md` and\s+`\.github\/instructions\/idd-overview\.instructions\.md`/,
+    "agent-entry reference must use the full instruction paths in the marker checklist",
+  );
 });
 
 test("policy reference keeps helper specs pinned and config scope accurate", () => {

--- a/tests/non-node-fallback.test.mjs
+++ b/tests/non-node-fallback.test.mjs
@@ -117,6 +117,7 @@ test("onboarding generated import surface includes extracted reference docs", ()
   );
 
   for (const file of [
+    "docs/onboarding/agent-entry-and-verification.md",
     "docs/onboarding/placeholders.md",
     "docs/onboarding/policy-decisions.md",
   ]) {
@@ -131,6 +132,7 @@ test("onboarding generated import surface includes extracted reference docs", ()
   );
   assert.ok(coreBlock, "sync manifest must define the idd-template core file block");
   for (const file of [
+    "idd-template/docs/onboarding/agent-entry-and-verification.md",
     "idd-template/docs/onboarding/placeholders.md",
     "idd-template/docs/onboarding/policy-decisions.md",
   ]) {
@@ -142,6 +144,50 @@ test("onboarding generated import surface includes extracted reference docs", ()
   assert.ok(
     coreBlock.sourceGlobs.includes("idd-template/docs/onboarding/*.md"),
     "sync manifest must include the onboarding docs glob in the generated file inputs",
+  );
+});
+
+test("onboarding links extracted agent-entry and verification guidance", () => {
+  const onboarding = readText("idd-template/ONBOARDING.md");
+  assert.ok(
+    onboarding.includes("docs/onboarding/agent-entry-and-verification.md"),
+    "ONBOARDING must link to the extracted agent-entry and verification reference",
+  );
+  assert.match(
+    onboarding,
+    /`CLAUDE\.md`, `AGENTS\.md`, and `GEMINI\.md`/,
+    "ONBOARDING must keep the root agent entry file list inline",
+  );
+  assert.match(
+    onboarding,
+    /explicitly opts out of adding new files/,
+    "ONBOARDING must keep the operator opt-out rule inline for agent entry files",
+  );
+  assert.ok(
+    onboarding.includes("If `.github/copilot-instructions.md` existed before onboarding,"),
+    "ONBOARDING must keep the Copilot entry-file reminder inline",
+  );
+
+  const reference = readText("idd-template/docs/onboarding/agent-entry-and-verification.md");
+  assert.match(
+    reference,
+    /### CLAUDE\.md/,
+    "agent-entry reference must keep the CLAUDE.md example outside ONBOARDING",
+  );
+  assert.match(
+    reference,
+    /### AGENTS\.md \(for Codex CLI\)/,
+    "agent-entry reference must keep the AGENTS.md example outside ONBOARDING",
+  );
+  assert.match(
+    reference,
+    /### GEMINI\.md/,
+    "agent-entry reference must keep the GEMINI.md example outside ONBOARDING",
+  );
+  assert.match(
+    reference,
+    /## Verification details/,
+    "agent-entry reference must include the expanded verification guidance",
   );
 });
 


### PR DESCRIPTION
## Summary
- extract the detailed agent-entry examples and expanded verification guidance into a dedicated onboarding reference doc
- keep `idd-template/ONBOARDING.md` self-contained with the inline entry-file list, opt-out rule, shared IDD workflow stub, Copilot reminder, and a shorter actionable checklist
- include the new onboarding reference in the generated import surface and cover the new links in tests

## Section mapping
| Original section | Destination |
| --- | --- |
| Step 5 per-file `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` examples and stubs | `idd-template/docs/onboarding/agent-entry-and-verification.md` |
| Step 6 expanded verification details | `idd-template/docs/onboarding/agent-entry-and-verification.md` |
| Step 5 inline minimum workflow stub and opt-out rules | `idd-template/ONBOARDING.md` |
| Step 6 final actionable checklist | `idd-template/ONBOARDING.md` |

## Validation
- `pnpm run lint`
- `pnpm run test`

## Follow-ups
- #375 can slim the final onboarding entrypoint after #373 and #374 land.

Closes #374
Refs #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new agent-entry-and-verification reference and updated onboarding with a condensed verification checklist, a minimal agent-entry workflow, and guidance for optionally surfacing the entry path in Copilot instructions.
  * Surfaced “Critique-loop profile” as an explicit policy decision and recording field.

* **Tests**
  * Updated onboarding tests to assert the critique-loop profile and verify links to the new onboarding reference.

* **Chores**
  * Updated sync manifest to include the new onboarding reference.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/378)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->