### PR TITLE
docs(onboarding): add trusted marker actors placeholder

### DIFF
--- a/idd-template/.github/idd/config.json
+++ b/idd-template/.github/idd/config.json
@@ -9,7 +9,7 @@
     "staleAge": "PT24H",
     "heartbeatInterval": "PT12H"
   },
-  "trustedMarkerActors": ["<trusted-login>"],
+  "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTORS}}"],
   "commands": {
     "install-deps": "{{INSTALL_DEPS_COMMAND}}",
     "fix-validate": "{{FIX_VALIDATE_COMMANDS}}",

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -147,10 +147,11 @@ before starting Step 1A.
 ## Step 1A — Auto-derive candidate values
 
 Before asking the operator to enter values, inspect the target
-repository and propose candidate values for all six placeholders:
+repository and propose candidate values for all seven placeholders:
 `{{REPO_NAME}}`, `{{PROJECT_MARKER_PREFIX}}`,
-`{{FIX_VALIDATE_COMMANDS}}`, `{{PRE_PUSH_VALIDATE_COMMANDS}}`,
-`{{POST_FIX_VALIDATE_COMMANDS}}`, and `{{INSTALL_DEPS_COMMAND}}`.
+`{{TRUSTED_MARKER_ACTORS}}`, `{{FIX_VALIDATE_COMMANDS}}`,
+`{{PRE_PUSH_VALIDATE_COMMANDS}}`, `{{POST_FIX_VALIDATE_COMMANDS}}`,
+and `{{INSTALL_DEPS_COMMAND}}`.
 
 Use the detailed derivation rules in
 [Onboarding Reference — Placeholder Values](docs/onboarding/placeholders.md),
@@ -163,6 +164,7 @@ including the tooling-boundary fallback order and marker-prefix notes.
 >
 > - Repository name: `{proposed-repo-name}`
 > - Marker prefix: `{proposed-prefix}`
+> - Trusted marker actors: `{proposed-trusted-marker-actors}`
 > - Install command: `{proposed-install}`
 > - Fix-validate: `{proposed-fix-validate}`
 > - Pre-push-validate: `{proposed-pre-push}`
@@ -204,11 +206,12 @@ policy-recording template.
 
 ## Step 1C — Collect placeholder values
 
-Use the operator-confirmed values from Step 1A for these six
+Use the operator-confirmed values from Step 1A for these seven
 placeholders:
 
 - `{{REPO_NAME}}`
 - `{{PROJECT_MARKER_PREFIX}}`
+- `{{TRUSTED_MARKER_ACTORS}}`
 - `{{FIX_VALIDATE_COMMANDS}}`
 - `{{PRE_PUSH_VALIDATE_COMMANDS}}`
 - `{{POST_FIX_VALIDATE_COMMANDS}}`
@@ -515,8 +518,9 @@ that mention IDD workflow.
 
 In the copied files, perform a global replacement for:
 `{{REPO_NAME}}`, `{{PROJECT_MARKER_PREFIX}}`,
-`{{FIX_VALIDATE_COMMANDS}}`, `{{PRE_PUSH_VALIDATE_COMMANDS}}`,
-`{{POST_FIX_VALIDATE_COMMANDS}}`, and `{{INSTALL_DEPS_COMMAND}}`.
+`{{TRUSTED_MARKER_ACTORS}}`, `{{FIX_VALIDATE_COMMANDS}}`,
+`{{PRE_PUSH_VALIDATE_COMMANDS}}`, `{{POST_FIX_VALIDATE_COMMANDS}}`,
+and `{{INSTALL_DEPS_COMMAND}}`.
 
 Use
 [Onboarding Reference — Placeholder Values](docs/onboarding/placeholders.md)

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -82,6 +82,7 @@ strings). This JSON is optional and does not replace
 | -------------------------------- | ----------------------------------------------- |
 | `{{REPO_NAME}}`                  | Repository short name                           |
 | `{{PROJECT_MARKER_PREFIX}}`      | Marker prefix matching `^[a-z][a-z0-9-]{1,31}$` |
+| `{{TRUSTED_MARKER_ACTORS}}`      | JSON-escaped marker-author logins               |
 | `{{FIX_VALIDATE_COMMANDS}}`      | Lint-fix + lint commands                        |
 | `{{PRE_PUSH_VALIDATE_COMMANDS}}` | Lint + build + test (no auto-fix)               |
 | `{{POST_FIX_VALIDATE_COMMANDS}}` | Lint-fix + lint + build + test                  |

--- a/idd-template/docs/onboarding/placeholders.md
+++ b/idd-template/docs/onboarding/placeholders.md
@@ -33,11 +33,16 @@ That means 2-32 characters, lowercase, starting with a letter.
 ### `{{TRUSTED_MARKER_ACTORS}}`
 
 List the GitHub logins allowed to post trusted IDD markers in
-`.github/idd/config.json`. Because the placeholder sits inside a JSON
-array, the replacement value should be one or more JSON-escaped string
-entries separated by commas. Examples:
+`.github/idd/config.json`. Because the placeholder sits inside a quoted
+JSON array entry, replace the quoted placeholder with a single
+JSON-escaped login string first. Examples:
 
-- one trusted marker actor → `"trusted-user-a"`
+- one trusted marker actor → `trusted-user-a`
+
+If the target repository needs more than one trusted marker actor, add
+the extra quoted array entries manually after the first replacement, for
+example:
+
 - multiple trusted marker actors → `"trusted-user-a", "trusted-bot-a"`
 
 Derive the candidate list from the people or bots allowed to post

--- a/idd-template/docs/onboarding/placeholders.md
+++ b/idd-template/docs/onboarding/placeholders.md
@@ -30,6 +30,21 @@ short hyphenated marker prefix. The final value must match:
 
 That means 2-32 characters, lowercase, starting with a letter.
 
+### `{{TRUSTED_MARKER_ACTORS}}`
+
+List the GitHub logins allowed to post trusted IDD markers in
+`.github/idd/config.json`. Because the placeholder sits inside a JSON
+array, the replacement value should be one or more JSON-escaped string
+entries separated by commas. Examples:
+
+- one trusted marker actor → `"trusted-user-a"`
+- multiple trusted marker actors → `"trusted-user-a", "trusted-bot-a"`
+
+Derive the candidate list from the people or bots allowed to post
+trusted claim, release, watermark, baseline, and advisory markers for
+the target repository. Keep the value aligned with any helper
+invocations that pass `--trusted-marker-logins`.
+
 ### `{{INSTALL_DEPS_COMMAND}}`
 
 Look for the target repository's dependency tooling and propose the
@@ -90,22 +105,23 @@ For the full fallback order and policy matrix, see
 
 ## Final placeholder meanings
 
-After Step 1A and Step 1C, you should have final values for these six
+After Step 1A and Step 1C, you should have final values for these seven
 placeholders:
 
-| Placeholder                      | Meaning                                                | Example                            |
-| -------------------------------- | ------------------------------------------------------ | ---------------------------------- |
-| `{{REPO_NAME}}`                  | Repository short name used in worktree examples        | `my-app`                           |
-| `{{PROJECT_MARKER_PREFIX}}`      | Hidden issue-body marker prefix                        | `my-app`                           |
-| `{{FIX_VALIDATE_COMMANDS}}`      | Auto-fix plus validate command row                     | `npm run lint:fix && npm run lint` |
-| `{{PRE_PUSH_VALIDATE_COMMANDS}}` | Non-mutating verify command row                        | `npm run lint && npm run test`     |
-| `{{POST_FIX_VALIDATE_COMMANDS}}` | Post-fix validate command row                          | `npm run lint:fix && npm test`     |
-| `{{INSTALL_DEPS_COMMAND}}`       | Dependency install command, or `true` when unnecessary | `npm install`                      |
+| Placeholder                      | Meaning                                                | Example                             |
+| -------------------------------- | ------------------------------------------------------ | ----------------------------------- |
+| `{{REPO_NAME}}`                  | Repository short name used in worktree examples        | `my-app`                            |
+| `{{PROJECT_MARKER_PREFIX}}`      | Hidden issue-body marker prefix                        | `my-app`                            |
+| `{{TRUSTED_MARKER_ACTORS}}`      | JSON-escaped logins allowed to post trusted markers    | `"trusted-user-a", "trusted-bot-a"` |
+| `{{FIX_VALIDATE_COMMANDS}}`      | Auto-fix plus validate command row                     | `npm run lint:fix && npm run lint`  |
+| `{{PRE_PUSH_VALIDATE_COMMANDS}}` | Non-mutating verify command row                        | `npm run lint && npm run test`      |
+| `{{POST_FIX_VALIDATE_COMMANDS}}` | Post-fix validate command row                          | `npm run lint:fix && npm test`      |
+| `{{INSTALL_DEPS_COMMAND}}`       | Dependency install command, or `true` when unnecessary | `npm install`                       |
 
 ### No-op substitution
 
-Any command row that does not apply to the target project may be set to
-`true`. For example:
+Only the command placeholders may be set to `true` when a step does not
+apply to the target project. For example:
 
 - no dependency install step →
   `{{INSTALL_DEPS_COMMAND}} = true`
@@ -143,5 +159,5 @@ task list as `- [ ] #NNN` entries.
 ## Replacement pass
 
 After copying the template files into the target repository, replace the
-six placeholders above globally. Then verify that no `{{...}}` strings
+seven placeholders above globally. Then verify that no `{{...}}` strings
 remain in the copied files.

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -209,8 +209,9 @@ Keep these rules in mind:
   aligned in the same change
 - treat non-command policy fields as synchronized metadata, not as a
   substitute for updating the instruction files that own phase behavior
-- replace `<trusted-login>` in `trustedMarkerActors` with the GitHub
-  login of each person or bot allowed to post trusted IDD markers
+- replace `{{TRUSTED_MARKER_ACTORS}}` in `trustedMarkerActors` with one
+  or more JSON-escaped GitHub login strings for each person or bot
+  allowed to post trusted IDD markers
 - keep command strings JSON-escaped instead of pasting fragile raw shell
 - keep `helperRuntime.profile` aligned with the human-readable helper
   runtime section when helper support is enabled

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -209,9 +209,9 @@ Keep these rules in mind:
   aligned in the same change
 - treat non-command policy fields as synchronized metadata, not as a
   substitute for updating the instruction files that own phase behavior
-- replace `{{TRUSTED_MARKER_ACTORS}}` in `trustedMarkerActors` with one
-  or more JSON-escaped GitHub login strings for each person or bot
-  allowed to post trusted IDD markers
+- replace `{{TRUSTED_MARKER_ACTORS}}` in `trustedMarkerActors` with a
+  single JSON-escaped GitHub login string first, then add any extra
+  quoted array entries manually for additional trusted marker actors
 - keep command strings JSON-escaped instead of pasting fragile raw shell
 - keep `helperRuntime.profile` aligned with the human-readable helper
   runtime section when helper support is enabled

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -16,7 +16,7 @@ test("placeholder scenarios detect clean and dirty post-onboarding fixtures", ()
 
   assert.deepEqual(clean, []);
   assert.deepEqual(dirty, [
-    ".github/idd/config.json: {{PROJECT_MARKER_PREFIX}}",
+    ".github/idd/config.json: {{PROJECT_MARKER_PREFIX}}, {{TRUSTED_MARKER_ACTORS}}",
     "README.md: {{REPO_NAME}}",
   ]);
 });

--- a/tests/fixtures/consistency/placeholders/clean/.github/idd/config.json
+++ b/tests/fixtures/consistency/placeholders/clean/.github/idd/config.json
@@ -1,4 +1,5 @@
 {
   "markerPrefix": "example-skill",
+  "trustedMarkerActors": ["trusted-user-a", "trusted-bot-a"],
   "issueScope": "roadmap"
 }

--- a/tests/fixtures/consistency/placeholders/dirty/.github/idd/config.json
+++ b/tests/fixtures/consistency/placeholders/dirty/.github/idd/config.json
@@ -1,4 +1,5 @@
 {
   "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
+  "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTORS}}"],
   "issueScope": "roadmap"
 }

--- a/tests/non-node-fallback.test.mjs
+++ b/tests/non-node-fallback.test.mjs
@@ -58,6 +58,16 @@ test("onboarding links extracted placeholder guidance and keeps fallback wording
   );
   assert.match(
     text,
+    /single[\s\S]*login string first/,
+    "placeholder reference must explain the single-login replacement step",
+  );
+  assert.match(
+    text,
+    /extra[\s\S]*quoted array entries manually/,
+    "placeholder reference must explain how to add more trusted marker actors",
+  );
+  assert.match(
+    text,
     /Only the command placeholders may be set to `true`/,
     "placeholder reference must keep the trusted marker actors placeholder out of the `true` fallback",
   );
@@ -135,8 +145,13 @@ test("onboarding links extracted policy guidance including credential scope", ()
   );
   assert.match(
     policyText,
-    /replace `{{TRUSTED_MARKER_ACTORS}}` in `trustedMarkerActors`/,
-    "policy reference must document the trusted marker actors placeholder token",
+    /single[\s\S]*GitHub login string first/,
+    "policy reference must document the first trusted marker actor replacement step",
+  );
+  assert.match(
+    policyText,
+    /extra[\s\S]*quoted array entries manually/,
+    "policy reference must document how to add more trusted marker actors",
   );
 });
 

--- a/tests/non-node-fallback.test.mjs
+++ b/tests/non-node-fallback.test.mjs
@@ -33,8 +33,40 @@ test("onboarding links extracted placeholder guidance and keeps fallback wording
     onboarding.includes("docs/onboarding/placeholders.md"),
     "ONBOARDING must link to the extracted placeholder reference",
   );
+  assert.match(
+    onboarding,
+    /all seven placeholders:[\s\S]*`{{TRUSTED_MARKER_ACTORS}}`/,
+    "ONBOARDING must include the trusted marker actors placeholder in Step 1A",
+  );
+  assert.match(
+    onboarding,
+    /perform a global replacement for:[\s\S]*`{{TRUSTED_MARKER_ACTORS}}`/,
+    "ONBOARDING Step 4 must replace the trusted marker actors placeholder",
+  );
+  const configText = readText("idd-template/.github/idd/config.json");
+  assert.match(
+    configText,
+    /"trustedMarkerActors": \["{{TRUSTED_MARKER_ACTORS}}"\]/,
+    "template config must keep trustedMarkerActors as a real placeholder token",
+  );
 
   const text = readText("idd-template/docs/onboarding/placeholders.md");
+  assert.match(
+    text,
+    /### `{{TRUSTED_MARKER_ACTORS}}`/,
+    "placeholder reference must document the trusted marker actors placeholder",
+  );
+  assert.match(
+    text,
+    /Only the command placeholders may be set to `true`/,
+    "placeholder reference must keep the trusted marker actors placeholder out of the `true` fallback",
+  );
+  const readme = readText("idd-template/README.md");
+  assert.match(
+    readme,
+    /\| `{{TRUSTED_MARKER_ACTORS}}` +\| JSON-escaped marker-author logins/,
+    "template README must list the trusted marker actors placeholder",
+  );
   const fixValidateSection = extractSection(
     text,
     "### `{{FIX_VALIDATE_COMMANDS}}`",
@@ -100,6 +132,11 @@ test("onboarding links extracted policy guidance including credential scope", ()
     policyText,
     /### Critique-Loop Profile/,
     "policy reference template must keep critique-loop terminology aligned",
+  );
+  assert.match(
+    policyText,
+    /replace `{{TRUSTED_MARKER_ACTORS}}` in `trustedMarkerActors`/,
+    "policy reference must document the trusted marker actors placeholder token",
   );
 });
 


### PR DESCRIPTION
Add a real placeholder token for `trustedMarkerActors` and update the onboarding docs and regression tests so the template config, placeholder guidance, and consistency fixtures stay aligned.

Closes #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable trusted marker actors via a new template placeholder ({{TRUSTED_MARKER_ACTORS}}) for policy configuration.

* **Documentation**
  * Updated onboarding and reference docs to include guidance, examples, and replacement steps for the trusted marker actors placeholder.

* **Tests**
  * Expanded tests and fixtures to validate consistent handling, documentation, and onboarding coverage for the trusted marker actors placeholder.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/379)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->