### PR TITLE
feat(schema): restrict policy config keys

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -396,6 +396,11 @@ Trusted marker actors remain a separate control. Approval labels or
 approval comments decide whether work may start; trusted marker actors
 decide who may post operational state markers.
 
+The policy config schema keeps top-level keys strict. Unknown
+top-level keys fail validation unless they use the `x-` prefix. Use
+`x-*` keys for repository-local extensions and keep official policy keys
+exact so typoed settings fail loudly.
+
 ## Suitability Outcomes and Label Mapping
 
 Use this mapping when A4.5 rejects a candidate. The goal is to preserve

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -396,6 +396,11 @@ Trusted marker actors remain a separate control. Approval labels or
 approval comments decide whether work may start; trusted marker actors
 decide who may post operational state markers.
 
+The policy config schema keeps top-level keys strict. Unknown
+top-level keys fail validation unless they use the `x-` prefix. Use
+`x-*` keys for repository-local extensions and keep official policy keys
+exact so typoed settings fail loudly.
+
 ## Suitability Outcomes and Label Mapping
 
 Use this mapping when A4.5 rejects a candidate. The goal is to preserve

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -15,6 +15,10 @@
     "commands"
   ],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "minLength": 1
+    },
     "iddVersion": {
       "type": "string",
       "pattern": "^\\d+\\.\\d+\\.\\d+$"
@@ -143,5 +147,8 @@
       }
     }
   },
-  "additionalProperties": true
+  "patternProperties": {
+    "^x-": {}
+  },
+  "additionalProperties": false
 }

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -155,24 +155,30 @@ export function validate(data, schema, path = "$") {
         errors.push(...validate(data[prop], propSchema, `${path}.${prop}`));
       }
     }
-    const patternSchemas = Object.entries(schema.patternProperties ?? {});
+    const declaredProperties = schema.properties ?? {};
+    const compiledPatternSchemas = [];
+    for (const [pattern, patternSchema] of Object.entries(schema.patternProperties ?? {})) {
+      try {
+        compiledPatternSchemas.push([new RegExp(pattern), patternSchema]);
+      } catch {
+        errors.push(`${path}: invalid patternProperties regex "${pattern}"`);
+      }
+    }
     const additionalPropertiesSchema = (
       typeof schema.additionalProperties === "object" && schema.additionalProperties !== null
     )
       ? schema.additionalProperties
       : null;
     for (const key of Object.keys(data)) {
-      if ((schema.properties ?? {})[key] !== undefined) {
-        continue;
-      }
+      const isDeclaredProperty = Object.hasOwn(declaredProperties, key);
       let matchedPattern = false;
-      for (const [pattern, patternSchema] of patternSchemas) {
-        if (new RegExp(pattern).test(key)) {
+      for (const [patternRegex, patternSchema] of compiledPatternSchemas) {
+        if (patternRegex.test(key)) {
           matchedPattern = true;
           errors.push(...validate(data[key], patternSchema, `${path}.${key}`));
         }
       }
-      if (matchedPattern) {
+      if (isDeclaredProperty || matchedPattern) {
         continue;
       }
       if (schema.additionalProperties === false) {

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -5,7 +5,7 @@
  * fixture instances against their schemas.
  *
  * Supported enforcement keywords:
- *   type, required, properties, additionalProperties,
+ *   type, required, properties, patternProperties, additionalProperties,
  *   minLength, minimum, pattern, format (date-time only),
  *   minItems, items, enum
  *
@@ -27,6 +27,7 @@ const ENFORCED_KEYWORDS = new Set([
   "type",
   "required",
   "properties",
+  "patternProperties",
   "additionalProperties",
   "minLength",
   "minimum",
@@ -61,6 +62,9 @@ export function checkSchemaKeywords(schema, path = "$") {
   }
   for (const [prop, propSchema] of Object.entries(schema.properties ?? {})) {
     errors.push(...checkSchemaKeywords(propSchema, `${path}.properties.${prop}`));
+  }
+  for (const [pattern, propSchema] of Object.entries(schema.patternProperties ?? {})) {
+    errors.push(...checkSchemaKeywords(propSchema, `${path}.patternProperties.${pattern}`));
   }
   if (schema.items && typeof schema.items === "object") {
     errors.push(...checkSchemaKeywords(schema.items, `${path}.items`));
@@ -151,12 +155,32 @@ export function validate(data, schema, path = "$") {
         errors.push(...validate(data[prop], propSchema, `${path}.${prop}`));
       }
     }
-    if (schema.additionalProperties === false) {
-      const allowed = new Set(Object.keys(schema.properties ?? {}));
-      for (const key of Object.keys(data)) {
-        if (!allowed.has(key)) {
-          errors.push(`${path}: additional property "${key}" not allowed`);
+    const patternSchemas = Object.entries(schema.patternProperties ?? {});
+    const additionalPropertiesSchema = (
+      typeof schema.additionalProperties === "object" && schema.additionalProperties !== null
+    )
+      ? schema.additionalProperties
+      : null;
+    for (const key of Object.keys(data)) {
+      if ((schema.properties ?? {})[key] !== undefined) {
+        continue;
+      }
+      let matchedPattern = false;
+      for (const [pattern, patternSchema] of patternSchemas) {
+        if (new RegExp(pattern).test(key)) {
+          matchedPattern = true;
+          errors.push(...validate(data[key], patternSchema, `${path}.${key}`));
         }
+      }
+      if (matchedPattern) {
+        continue;
+      }
+      if (schema.additionalProperties === false) {
+        errors.push(`${path}: additional property "${key}" not allowed`);
+        continue;
+      }
+      if (additionalPropertiesSchema !== null) {
+        errors.push(...validate(data[key], additionalPropertiesSchema, `${path}.${key}`));
       }
     }
   }

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -251,6 +251,47 @@ test("policy schema rejects unknown non x-* top-level keys", () => {
   );
 });
 
+test("validate reports invalid patternProperties regex without throwing", () => {
+  const schema = {
+    type: "object",
+    patternProperties: {
+      "[invalid": {
+        type: "string",
+      },
+    },
+    additionalProperties: false,
+  };
+  const errors = validate({ sample: "value" }, schema);
+  assert.ok(
+    errors.some((error) => error.includes('invalid patternProperties regex "[invalid"')),
+    errors.join("\n"),
+  );
+});
+
+test("validate applies patternProperties even for declared properties", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "string",
+      },
+    },
+    patternProperties: {
+      "^foo$": {
+        minLength: 3,
+      },
+    },
+    additionalProperties: false,
+  };
+  const failing = validate({ foo: "ab" }, schema);
+  assert.ok(
+    failing.some((error) => error.includes("$.foo: length 2 < minLength 3")),
+    failing.join("\n"),
+  );
+  const passing = validate({ foo: "abc" }, schema);
+  assert.deepEqual(passing, []);
+});
+
 test("policy invalid fixture fails validation", () => {
   const { ok } = validateFixture(
     "schemas/policy.schema.json",

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -225,6 +225,32 @@ test("policy schema rejects non-boolean issue-author approval opt-out", () => {
   );
 });
 
+test("policy schema accepts x-* extension keys", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(
+    JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")),
+  );
+  instance["x-local-note"] = "opt-in";
+  instance["x-local-flags"] = {
+    dryRun: true,
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema rejects unknown non x-* top-level keys", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(
+    JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")),
+  );
+  instance.localNote = "opt-in";
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) => error.includes('additional property "localNote"')),
+    errors.join("\n"),
+  );
+});
+
 test("policy invalid fixture fails validation", () => {
   const { ok } = validateFixture(
     "schemas/policy.schema.json",


### PR DESCRIPTION
## Summary
- make `schemas/policy.schema.json` strict at top level while allowing `x-*` extension keys via `patternProperties`
- extend `scripts/validate-schemas.mjs` to enforce `patternProperties` during schema keyword checks and runtime validation
- add schema validation tests for accepted `x-*` keys and rejected unknown non-`x-*` top-level keys
- document the `x-*` extension rule in `docs/customization.md` and mirror it in `idd-template/docs/customization.md`

Closes #371