### PR TITLE
test: tighten approval gate coverage

### DIFF
--- a/tests/issue-author-approval-gate.test.mjs
+++ b/tests/issue-author-approval-gate.test.mjs
@@ -21,7 +21,11 @@ test("discover instructions define approval-needed fallback routing", () => {
   assert.match(live, /maintainerApprovalActorPolicy/);
   assert.match(live, /owners-and-maintainers-only/);
   assert.match(live, /all-write-permission-actors/);
+  assert.match(live, /visible approval comment/i);
+  assert.match(live, /IDD ready/);
+  assert.match(live, /bare organization `MEMBER` association/i);
   assert.match(live, /stop before A5/i);
+  assert.match(live, /do not auto-claim from the fallback[\s\S]*bucket/i);
 });
 
 test("discover approval gate section stays synced with the template mirror", () => {
@@ -51,6 +55,8 @@ test("claim approval pre-check stays synced with the template mirror", () => {
     "**(b) Assignee and project status**",
   );
 
+  assert.match(live, /stop without[\s\S]*claiming/i);
+  assert.match(live, /bare organization `MEMBER` association/i);
   assert.equal(template, live);
 });
 


### PR DESCRIPTION
Tighten regression coverage around the issue-author approval gate so the discover/claim instructions stay aligned with the current fallback wording and the `MEMBER` non-approval behavior.

Closes #361


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for approval gate and claim pre-check validation scenarios, including fallback-routing requirements and auto-claiming restrictions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/382)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->