### PR TITLE
docs(idd): rename list a to reviewitems snapshot

### DIFF
--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -314,7 +314,7 @@ file that matches your current situation.
 | PR open, CI running, reviews exist            | `idd-review-snapshot.instructions.md` (E1–E3)                         |
 | PR open, CI passed, no reviews yet            | `idd-review-snapshot.instructions.md` (E3 empty-list → merge)         |
 | PR open, CI passed, reviews pending           | `idd-review-snapshot.instructions.md`                                 |
-| Snapshot done, List A non-empty               | `idd-review-triage.instructions.md` (E4–E8)                           |
+| Snapshot done, ReviewItems_snapshot non-empty | `idd-review-triage.instructions.md` (E4–E8)                           |
 | Review feedback accepted, pushing fixes       | `idd-review-fix.instructions.md`                                      |
 | Ready for pre-merge gate check                | `idd-pre-merge.instructions.md`                                       |
 | All pre-merge conditions satisfied            | `idd-merge-handoff.instructions.md` (F2.5)                            |

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -1,7 +1,8 @@
 # IDD — Pre-Merge Conditions Phase (F1–F2)
 
-Read this file after List A is empty (E3 or E8), or when returning to
-merge gate checks after a fix cycle. It covers final conflict resolution
+Read this file after ReviewItems_snapshot is empty (E3 or E8), or when
+returning to merge gate checks after a fix cycle. It covers final conflict
+resolution
 (F1) and the full pre-merge condition checklist (F2).
 
 This phase includes a repository-specific GitHub Copilot advisory review
@@ -159,7 +160,7 @@ must align with every F2 condition below.
   re-evaluate F2)
 - **Required reviews**: Required approvals count is satisfied and all
   CODEOWNER approvals are obtained. If approvals are absent but there
-  are no open actionable review items (List A is empty), do **not**
+  are no open actionable review items (ReviewItems_snapshot is empty), do **not**
   route to E1 — instead, request CODEOWNER/required reviewers directly
   (if not already requested), post a hold comment, and stop. Return to
   E1 only when there are actual review threads or comments to address (→

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -19,7 +19,7 @@ reviewer request, hold comment, or digest update).
 
 ## E9 — Fix accepted issues
 
-Fix all Accepted PATH A items from List A. Run **fix-validate**.
+Fix all Accepted PATH A items from ReviewItems_snapshot. Run **fix-validate**.
 
 Commit fixes atomically — one logical change per commit.
 

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -2,17 +2,17 @@
 
 Read this file after CI passes on a newly pushed PR, or after returning
 from a fix cycle. It covers fetching review items (E1), running the
-critique pass (E2), and checking whether List A is empty (E3).
+critique pass (E2), and checking whether ReviewItems_snapshot is empty (E3).
 
 Before posting any E-phase operational comment or GitHub reply, apply
 the shared claim revalidation gate. The active claim must still use your
 current `{claim-id}`.
 
-**If List A is empty after E3**: proceed to `idd-pre-merge.instructions.md`.
-**If List A is non-empty after E3**: proceed to
+**If ReviewItems_snapshot is empty after E3**: proceed to `idd-pre-merge.instructions.md`.
+**If ReviewItems_snapshot is non-empty after E3**: proceed to
 `idd-review-triage.instructions.md` (E4).
 
-## E1 — Fetch review items into List A
+## E1 — Fetch review items into ReviewItems_snapshot
 
 **Step 1 — Snapshot the activity universe.** First, read the current PR
 HEAD SHA from the GitHub API and store it as `{head-SHA}`. Do not
@@ -40,8 +40,8 @@ prefixes and whose GitHub author is a trusted marker actor per
 - `<!-- advisory-wait:`
 
 Do not exclude marker-shaped comments from untrusted authors. Keep them
-in the snapshot/List A and report them as suspicious context when they
-affect a decision.
+in the snapshot/ReviewItems_snapshot and report them as suspicious
+context when they affect a decision.
 
 In the idd-skill source repository, you may optionally use the read-only helper
 `node scripts/review-activity-snapshot.mjs --pr {pr-number}` to compute
@@ -61,8 +61,9 @@ CI pass exists yet for this HEAD.
 **Step 2 — Record the watermark.** Using the `{head-SHA}` stored at the
 start of Step 1, compute `{max-activity-updatedAt}` as the highest
 `updatedAt` server timestamp across the **entire snapshot** (not just
-the items that will appear in List A). Write `none` if the snapshot is
-empty. Compute `{total-item-count}` as the total number of items in the
+the items that will appear in ReviewItems_snapshot). Write `none` if
+the snapshot is empty. Compute `{total-item-count}` as the total number
+of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
 PR comment with this format:
 
@@ -120,13 +121,13 @@ that F2 can restart without self-invalidating review currency. A digest
 edit after the watermark is new PR activity for review-currency purposes
 and would require a fresh E1 snapshot before F2 can pass.
 
-**Step 3 — Filter into List A.** From the snapshot, select and combine
-into **List A**. Record the source URL for each item.
+**Step 3 — Filter into ReviewItems_snapshot.** From the snapshot, select and combine
+into **ReviewItems_snapshot**. Record the source URL for each item.
 
 **Review threads** (`isResolved=false`) — exclude threads where the
 latest substantive reply is from any IDD agent or the PR author, and no
 reviewer has replied since (awaiting-reviewer state). A thread is
-**not** awaiting-reviewer (and therefore remains in List A as an active
+**not** awaiting-reviewer (and therefore remains in ReviewItems_snapshot as an active
 item) if any of the following is true:
 
 - The reviewer reopened (unresolved) the thread after the latest
@@ -148,7 +149,7 @@ Copilot and CI advisory bot comments; they follow PATH B in E4-E7.
 ## E2 — Critique pass
 
 Run a critique pass on the branch's changes and add any newly found
-issues to List A. See `idd-overview.instructions.md` for per-agent
+issues to ReviewItems_snapshot. See `idd-overview.instructions.md` for per-agent
 implementation.
 
 **Incremental review**: on the second and later passes **within the same
@@ -160,7 +161,7 @@ GitHub author is a trusted marker actor). Reset to full-branch diff
 after a rebase, multi-fix batch, when the baseline SHA is not an
 ancestor of the current HEAD, when no trusted same-claim baseline
 exists, or whenever the active `{claim-id}` changed due to restart or
-takeover, including forced handoff. List A is session-local; do not
+takeover, including forced handoff. ReviewItems_snapshot is session-local; do not
 inherit a previous claim's
 critique findings unless they were persisted as reviewer-visible
 comments.
@@ -183,6 +184,6 @@ comment token; use the HTTP `POST` path for reliability).
 
 ## E3 — Empty list check
 
-If List A is empty → proceed to `idd-pre-merge.instructions.md`.
+If ReviewItems_snapshot is empty → proceed to `idd-pre-merge.instructions.md`.
 
 Otherwise → proceed to `idd-review-triage.instructions.md` (E4).

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -1,7 +1,7 @@
 # IDD — Review Triage Phase (E4–E8)
 
 Read this file after `idd-review-snapshot.instructions.md` (E3) finds
-List A is non-empty. It covers classifying items, scoring, recording
+ReviewItems_snapshot is non-empty. It covers classifying items, scoring, recording
 dispositions, and counting accepted items.
 
 Before posting any E-phase operational comment or GitHub reply, apply
@@ -11,9 +11,9 @@ current `{claim-id}`.
 **Skip condition E8**: if the Accepted PATH A count after verification
 is zero, proceed to `idd-pre-merge.instructions.md`.
 
-## E4 — Classify and score List A
+## E4 — Classify and score ReviewItems_snapshot
 
-For each item in List A, first classify it:
+For each item in ReviewItems_snapshot, first classify it:
 
 - **PATH A — actionable feedback**: human reviewer threads and regular
   comments, `CHANGES_REQUESTED` review bodies, and critique-pass
@@ -92,7 +92,7 @@ For each Rejected PATH A item whose source is reviewer feedback:
   which point: if they agree with rejection, close the AMD by replying
   to confirm and remove the hold comment; if they override, Accept the
   feedback and implement it).
-- **When an `Awaiting maintainer decision` thread re-appears in List A**
+- **When an `Awaiting maintainer decision` thread re-appears in ReviewItems_snapshot**
   (because the maintainer has not yet responded in the thread): first
   check the full activity universe (PR review list, review threads, and
   regular PR comments) for any response from any CODEOWNER, required
@@ -184,7 +184,7 @@ PATH B — Advisory items:
 
 ## E7 — Verify recorded dispositions
 
-Before leaving triage, verify that every List A item has the evidence
+Before leaving triage, verify that every ReviewItems_snapshot item has the evidence
 required by its path:
 
 - Every PATH A item has a recorded classification and an Accept or
@@ -208,8 +208,9 @@ and the next route is E9, or when the update is followed by a fresh E1
 snapshot before F2. Set `Phase` to `E triage`, summarize remaining
 Accepted PATH A work or `none` in `Open blockers`, set `Next action` to
 E9 or F2 as appropriate, and cite the disposition replies plus the
-trusted review-watermark in `Authoritative by`. If List A is empty and
-the next step is F2, defer the digest update unless you intentionally
+trusted review-watermark in `Authoritative by`. If
+ReviewItems_snapshot is empty and the next step is F2, defer the digest
+update unless you intentionally
 return to E1 afterward.
 
 ## E8 — Accepted PATH A count check
@@ -221,8 +222,8 @@ Otherwise continue to `idd-review-fix.instructions.md`.
 
 ## Review item classes
 
-During E-phase review triage, classify each List A item into one of two
-paths before deciding what to do with it:
+During E-phase review triage, classify each ReviewItems_snapshot item
+into one of two paths before deciding what to do with it:
 
 - **PATH A — actionable feedback**: human reviewer comments,
   `CHANGES_REQUESTED` review bodies, and critique-pass findings that

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -33,26 +33,42 @@ you are reading this guide first, start at step 1.
 
 ## IDD file map
 
-| File                                                       | Role                                                                                |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping              |
-| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue, route roadmap audits, audit suitability, and start work |
-| `.github/instructions/idd-roadmap-audit.instructions.md`   | A1.5: audit roadmap completion and run roadmap-side coordination before A2          |
-| `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                                         |
-| `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                               |
-| `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                                |
-| `.github/instructions/idd-ci.instructions.md`              | Shared CI polling helper used by later phases                                       |
-| `.github/instructions/idd-advisory-wait.instructions.md`   | Shared Copilot advisory-wait protocol (E14, F2, F3)                                 |
-| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if List A is empty              |
-| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, record dispositions                                   |
-| `.github/instructions/idd-review-fix.instructions.md`      | Fix accepted review items and push follow-up commits                                |
-| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions                        |
-| `.github/instructions/idd-merge-handoff.instructions.md`   | F2.5: resolve merge-policy handoff vs autonomous merge routing                      |
-| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover                       |
-| `.github/instructions/idd-resume.instructions.md`          | Route resume into crash, stalled, stale-takeover, or clean continuation             |
-| `.github/instructions/idd-resume-stall.instructions.md`    | Handle stalled-session recovery with a dedicated safety gate                        |
-| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                                |
-| `docs/idd-comment-minimization.md`                         | Live status digest contract and post-merge comment minimization policy              |
+| File                                                       | Role                                                                                 |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping               |
+| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue, route roadmap audits, audit suitability, and start work  |
+| `.github/instructions/idd-roadmap-audit.instructions.md`   | A1.5: audit roadmap completion and run roadmap-side coordination before A2           |
+| `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                                          |
+| `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                                |
+| `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                                 |
+| `.github/instructions/idd-ci.instructions.md`              | Shared CI polling helper used by later phases                                        |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | Shared Copilot advisory-wait protocol (E14, F2, F3)                                  |
+| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if ReviewItems_snapshot is empty |
+| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, record dispositions                                    |
+| `.github/instructions/idd-review-fix.instructions.md`      | Fix accepted review items and push follow-up commits                                 |
+| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions                         |
+| `.github/instructions/idd-merge-handoff.instructions.md`   | F2.5: resolve merge-policy handoff vs autonomous merge routing                       |
+| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover                        |
+| `.github/instructions/idd-resume.instructions.md`          | Route resume into crash, stalled, stale-takeover, or clean continuation              |
+| `.github/instructions/idd-resume-stall.instructions.md`    | Handle stalled-session recovery with a dedicated safety gate                         |
+| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                                 |
+| `docs/idd-comment-minimization.md`                         | Live status digest contract and post-merge comment minimization policy               |
+
+## ReviewItems_snapshot lifecycle
+
+`ReviewItems_snapshot` is the immutable collection created from E1's
+activity-universe fetch.
+
+| Phase | Operation                                                                                                   | State     |
+| ----- | ----------------------------------------------------------------------------------------------------------- | --------- |
+| E1    | Fetch threads/reviews/comments, exclude trusted operational markers, and freeze the current item universe   | created   |
+| E2    | Run critique pass and append newly found findings to the same snapshot scope                                | extended  |
+| E3    | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
+| E4-E8 | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
+| E9    | Fix Accepted PATH A items that were selected from the snapshot                                              | actioned  |
+
+The name intentionally emphasizes snapshot semantics: E1-E3 builds and
+gates on a time-locked view, while E4-E8 triages that view.
 
 ## Artifact taxonomy and ownership
 

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -331,7 +331,7 @@ file that matches your current situation.
 | PR open, CI running, reviews exist            | `idd-review-snapshot.instructions.md` (E1–E3)                         |
 | PR open, CI passed, no reviews yet            | `idd-review-snapshot.instructions.md` (E3 empty-list → merge)         |
 | PR open, CI passed, reviews pending           | `idd-review-snapshot.instructions.md`                                 |
-| Snapshot done, List A non-empty               | `idd-review-triage.instructions.md` (E4–E8)                           |
+| Snapshot done, ReviewItems_snapshot non-empty | `idd-review-triage.instructions.md` (E4–E8)                           |
 | Review feedback accepted, pushing fixes       | `idd-review-fix.instructions.md`                                      |
 | Ready for pre-merge gate check                | `idd-pre-merge.instructions.md`                                       |
 | All pre-merge conditions satisfied            | `idd-merge-handoff.instructions.md` (F2.5)                            |

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -1,7 +1,8 @@
 # IDD — Pre-Merge Conditions Phase (F1–F2)
 
-Read this file after List A is empty (E3 or E8), or when returning to
-merge gate checks after a fix cycle. It covers final conflict resolution
+Read this file after ReviewItems_snapshot is empty (E3 or E8), or when
+returning to merge gate checks after a fix cycle. It covers final conflict
+resolution
 (F1) and the full pre-merge condition checklist (F2).
 
 This phase includes a repository-specific GitHub Copilot advisory review
@@ -159,7 +160,7 @@ must align with every F2 condition below.
   re-evaluate F2)
 - **Required reviews**: Required approvals count is satisfied and all
   CODEOWNER approvals are obtained. If approvals are absent but there
-  are no open actionable review items (List A is empty), do **not**
+  are no open actionable review items (ReviewItems_snapshot is empty), do **not**
   route to E1 — instead, request CODEOWNER/required reviewers directly
   (if not already requested), post a hold comment, and stop. Return to
   E1 only when there are actual review threads or comments to address (→

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -19,7 +19,7 @@ reviewer request, hold comment, or digest update).
 
 ## E9 — Fix accepted issues
 
-Fix all Accepted PATH A items from List A. Run **fix-validate**.
+Fix all Accepted PATH A items from ReviewItems_snapshot. Run **fix-validate**.
 
 Commit fixes atomically — one logical change per commit.
 

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -2,17 +2,17 @@
 
 Read this file after CI passes on a newly pushed PR, or after returning
 from a fix cycle. It covers fetching review items (E1), running the
-critique pass (E2), and checking whether List A is empty (E3).
+critique pass (E2), and checking whether ReviewItems_snapshot is empty (E3).
 
 Before posting any E-phase operational comment or GitHub reply, apply
 the shared claim revalidation gate. The active claim must still use your
 current `{claim-id}`.
 
-**If List A is empty after E3**: proceed to `idd-pre-merge.instructions.md`.
-**If List A is non-empty after E3**: proceed to
+**If ReviewItems_snapshot is empty after E3**: proceed to `idd-pre-merge.instructions.md`.
+**If ReviewItems_snapshot is non-empty after E3**: proceed to
 `idd-review-triage.instructions.md` (E4).
 
-## E1 — Fetch review items into List A
+## E1 — Fetch review items into ReviewItems_snapshot
 
 **Step 1 — Snapshot the activity universe.** First, read the current PR
 HEAD SHA from the GitHub API and store it as `{head-SHA}`. Do not
@@ -40,8 +40,8 @@ prefixes and whose GitHub author is a trusted marker actor per
 - `<!-- advisory-wait:`
 
 Do not exclude marker-shaped comments from untrusted authors. Keep them
-in the snapshot/List A and report them as suspicious context when they
-affect a decision.
+in the snapshot/ReviewItems_snapshot and report them as suspicious
+context when they affect a decision.
 
 In the idd-skill source repository, you may optionally use the read-only helper
 `node scripts/review-activity-snapshot.mjs --pr {pr-number}` to compute
@@ -61,8 +61,9 @@ CI pass exists yet for this HEAD.
 **Step 2 — Record the watermark.** Using the `{head-SHA}` stored at the
 start of Step 1, compute `{max-activity-updatedAt}` as the highest
 `updatedAt` server timestamp across the **entire snapshot** (not just
-the items that will appear in List A). Write `none` if the snapshot is
-empty. Compute `{total-item-count}` as the total number of items in the
+the items that will appear in ReviewItems_snapshot). Write `none` if
+the snapshot is empty. Compute `{total-item-count}` as the total number
+of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
 PR comment with this format:
 
@@ -120,13 +121,13 @@ that F2 can restart without self-invalidating review currency. A digest
 edit after the watermark is new PR activity for review-currency purposes
 and would require a fresh E1 snapshot before F2 can pass.
 
-**Step 3 — Filter into List A.** From the snapshot, select and combine
-into **List A**. Record the source URL for each item.
+**Step 3 — Filter into ReviewItems_snapshot.** From the snapshot, select and combine
+into **ReviewItems_snapshot**. Record the source URL for each item.
 
 **Review threads** (`isResolved=false`) — exclude threads where the
 latest substantive reply is from any IDD agent or the PR author, and no
 reviewer has replied since (awaiting-reviewer state). A thread is
-**not** awaiting-reviewer (and therefore remains in List A as an active
+**not** awaiting-reviewer (and therefore remains in ReviewItems_snapshot as an active
 item) if any of the following is true:
 
 - The reviewer reopened (unresolved) the thread after the latest
@@ -148,7 +149,7 @@ Copilot and CI advisory bot comments; they follow PATH B in E4-E7.
 ## E2 — Critique pass
 
 Run a critique pass on the branch's changes and add any newly found
-issues to List A. See `idd-overview.instructions.md` for per-agent
+issues to ReviewItems_snapshot. See `idd-overview.instructions.md` for per-agent
 implementation.
 
 **Incremental review**: on the second and later passes **within the same
@@ -160,7 +161,7 @@ GitHub author is a trusted marker actor). Reset to full-branch diff
 after a rebase, multi-fix batch, when the baseline SHA is not an
 ancestor of the current HEAD, when no trusted same-claim baseline
 exists, or whenever the active `{claim-id}` changed due to restart or
-takeover, including forced handoff. List A is session-local; do not
+takeover, including forced handoff. ReviewItems_snapshot is session-local; do not
 inherit a previous claim's
 critique findings unless they were persisted as reviewer-visible
 comments.
@@ -183,6 +184,6 @@ comment token; use the HTTP `POST` path for reliability).
 
 ## E3 — Empty list check
 
-If List A is empty → proceed to `idd-pre-merge.instructions.md`.
+If ReviewItems_snapshot is empty → proceed to `idd-pre-merge.instructions.md`.
 
 Otherwise → proceed to `idd-review-triage.instructions.md` (E4).

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -1,7 +1,7 @@
 # IDD — Review Triage Phase (E4–E8)
 
 Read this file after `idd-review-snapshot.instructions.md` (E3) finds
-List A is non-empty. It covers classifying items, scoring, recording
+ReviewItems_snapshot is non-empty. It covers classifying items, scoring, recording
 dispositions, and counting accepted items.
 
 Before posting any E-phase operational comment or GitHub reply, apply
@@ -11,9 +11,9 @@ current `{claim-id}`.
 **Skip condition E8**: if the Accepted PATH A count after verification
 is zero, proceed to `idd-pre-merge.instructions.md`.
 
-## E4 — Classify and score List A
+## E4 — Classify and score ReviewItems_snapshot
 
-For each item in List A, first classify it:
+For each item in ReviewItems_snapshot, first classify it:
 
 - **PATH A — actionable feedback**: human reviewer threads and regular
   comments, `CHANGES_REQUESTED` review bodies, and critique-pass
@@ -92,7 +92,7 @@ For each Rejected PATH A item whose source is reviewer feedback:
   which point: if they agree with rejection, close the AMD by replying
   to confirm and remove the hold comment; if they override, Accept the
   feedback and implement it).
-- **When an `Awaiting maintainer decision` thread re-appears in List A**
+- **When an `Awaiting maintainer decision` thread re-appears in ReviewItems_snapshot**
   (because the maintainer has not yet responded in the thread): first
   check the full activity universe (PR review list, review threads, and
   regular PR comments) for any response from any CODEOWNER, required
@@ -184,7 +184,7 @@ PATH B — Advisory items:
 
 ## E7 — Verify recorded dispositions
 
-Before leaving triage, verify that every List A item has the evidence
+Before leaving triage, verify that every ReviewItems_snapshot item has the evidence
 required by its path:
 
 - Every PATH A item has a recorded classification and an Accept or
@@ -208,8 +208,9 @@ and the next route is E9, or when the update is followed by a fresh E1
 snapshot before F2. Set `Phase` to `E triage`, summarize remaining
 Accepted PATH A work or `none` in `Open blockers`, set `Next action` to
 E9 or F2 as appropriate, and cite the disposition replies plus the
-trusted review-watermark in `Authoritative by`. If List A is empty and
-the next step is F2, defer the digest update unless you intentionally
+trusted review-watermark in `Authoritative by`. If
+ReviewItems_snapshot is empty and the next step is F2, defer the digest
+update unless you intentionally
 return to E1 afterward.
 
 ## E8 — Accepted PATH A count check
@@ -221,8 +222,8 @@ Otherwise continue to `idd-review-fix.instructions.md`.
 
 ## Review item classes
 
-During E-phase review triage, classify each List A item into one of two
-paths before deciding what to do with it:
+During E-phase review triage, classify each ReviewItems_snapshot item
+into one of two paths before deciding what to do with it:
 
 - **PATH A — actionable feedback**: human reviewer comments,
   `CHANGES_REQUESTED` review bodies, and critique-pass findings that

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -39,26 +39,42 @@ entry file should be an explicit operator choice, not the default.
 
 ## IDD file map
 
-| File                                                       | Role                                                                                |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping              |
-| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue, route roadmap audits, audit suitability, and start work |
-| `.github/instructions/idd-roadmap-audit.instructions.md`   | A1.5: audit roadmap completion and run roadmap-side coordination before A2          |
-| `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                                         |
-| `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                               |
-| `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                                |
-| `.github/instructions/idd-ci.instructions.md`              | Shared CI polling helper used by later phases                                       |
-| `.github/instructions/idd-advisory-wait.instructions.md`   | Shared Copilot advisory-wait protocol (E14, F2, F3)                                 |
-| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if List A is empty              |
-| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, record dispositions                                   |
-| `.github/instructions/idd-review-fix.instructions.md`      | Fix accepted review items and push follow-up commits                                |
-| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions                        |
-| `.github/instructions/idd-merge-handoff.instructions.md`   | F2.5: resolve merge-policy handoff vs autonomous merge routing                      |
-| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover                       |
-| `.github/instructions/idd-resume.instructions.md`          | Route resume into crash, stalled, stale-takeover, or clean continuation             |
-| `.github/instructions/idd-resume-stall.instructions.md`    | Handle stalled-session recovery with a dedicated safety gate                        |
-| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                                |
-| `docs/idd-comment-minimization.md`                         | Live status digest contract and post-merge comment minimization policy              |
+| File                                                       | Role                                                                                 |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping               |
+| `.github/instructions/idd-discover.instructions.md`        | Find the next viable issue, route roadmap audits, audit suitability, and start work  |
+| `.github/instructions/idd-roadmap-audit.instructions.md`   | A1.5: audit roadmap completion and run roadmap-side coordination before A2           |
+| `.github/instructions/idd-claim.instructions.md`           | Run claim pre-checks and claim verification                                          |
+| `.github/instructions/idd-work.instructions.md`            | Create the worktree, plan, implement, and self-review                                |
+| `.github/instructions/idd-pr-submit.instructions.md`       | Rebase, validate, push, open the PR, and wait for CI                                 |
+| `.github/instructions/idd-ci.instructions.md`              | Shared CI polling helper used by later phases                                        |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | Shared Copilot advisory-wait protocol (E14, F2, F3)                                  |
+| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if ReviewItems_snapshot is empty |
+| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, record dispositions                                    |
+| `.github/instructions/idd-review-fix.instructions.md`      | Fix accepted review items and push follow-up commits                                 |
+| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions                         |
+| `.github/instructions/idd-merge-handoff.instructions.md`   | F2.5: resolve merge-policy handoff vs autonomous merge routing                       |
+| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover                        |
+| `.github/instructions/idd-resume.instructions.md`          | Route resume into crash, stalled, stale-takeover, or clean continuation              |
+| `.github/instructions/idd-resume-stall.instructions.md`    | Handle stalled-session recovery with a dedicated safety gate                         |
+| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                                 |
+| `docs/idd-comment-minimization.md`                         | Live status digest contract and post-merge comment minimization policy               |
+
+## ReviewItems_snapshot lifecycle
+
+`ReviewItems_snapshot` is the immutable collection created from E1's
+activity-universe fetch.
+
+| Phase | Operation                                                                                                   | State     |
+| ----- | ----------------------------------------------------------------------------------------------------------- | --------- |
+| E1    | Fetch threads/reviews/comments, exclude trusted operational markers, and freeze the current item universe   | created   |
+| E2    | Run critique pass and append newly found findings to the same snapshot scope                                | extended  |
+| E3    | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
+| E4-E8 | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
+| E9    | Fix Accepted PATH A items that were selected from the snapshot                                              | actioned  |
+
+The name intentionally emphasizes snapshot semantics: E1-E3 builds and
+gates on a time-locked view, while E4-E8 triages that view.
 
 ## Artifact taxonomy and ownership
 


### PR DESCRIPTION
Rename E-phase `List A` references to `ReviewItems_snapshot` across the live instruction set and template mirror, and add lifecycle rationale sections in both `docs/idd-workflow.md` files.

This keeps terminology aligned with immutable E1 snapshot semantics and preserves phase routing language consistently in E1–E9 surfaces.

Closes #383


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow instruction files to clarify review item snapshot terminology and handling across all review phases.

* **Refactor**
  * Standardized review item tracking terminology throughout the workflow documentation to improve clarity and consistency in how review items are managed during the review and triage process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/387)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->