### PR TITLE
docs(onboarding): require issue-author gate confirmation

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -167,9 +167,13 @@ require explicit operator confirmation:
 5. credential scope for worker and merge-capable sessions
 6. claim-timing defaults (`claim-stale-age` and
    `claim-heartbeat-interval`)
-7. issue-authoring companion status (`installed` or `not installed`)
-8. helper runtime profile (`instructions-only` by default, or an
-   explicitly requested helper profile)
+7. issue-author approval gate (`enabled-by-default` by default, or
+   explicit config opt-out via `skipIssueAuthorApprovalGate: true`)
+8. maintainer approval actor policy (`owners-and-maintainers-only` by
+   default, or `all-write-permission-actors`)
+9. issue-authoring companion status (`installed` or `not installed`)
+10. helper runtime profile (`instructions-only` by default, or an
+    explicitly requested helper profile)
 
 Use
 [Onboarding Reference — Policy Decisions](docs/onboarding/policy-decisions.md)
@@ -219,6 +223,7 @@ pre-execution issue drafting or roadmap decomposition support.
 Before importing files, re-check the policy choices confirmed in Step 1B:
 merge policy, PR review profile, review-thread resolution policy,
 critique-loop profile, credential scope, claim-timing defaults,
+issue-author approval gate, maintainer approval actor policy,
 issue-authoring companion status, and helper runtime profile.
 
 Use
@@ -576,7 +581,8 @@ After completing the steps above, confirm each item:
       profile are recorded, and any non-default phase-file
       customizations are complete.
 - [ ] The selected merge policy, credential scope, claim timing values,
-      and helper runtime profile are explicitly recorded.
+      issue-author approval gate decision, maintainer approval actor
+      policy, and helper runtime profile are explicitly recorded.
 - [ ] If the operator opted into issue authoring, the companion skill
       files are present.
 - [ ] No `{{...}}` placeholders remain, the `Project commands` table is

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -90,6 +90,9 @@ execution begins.
 Choose whether the repository keeps the distributed secure-by-default
 issue-author approval gate or records a current config opt-out:
 
+Onboarding should ask this question explicitly before unattended
+execution is allowed to start.
+
 - `enabled-by-default` (distributed default): unattended work requires a
   self-authorizing issue author or a fresh explicit maintainer approval
   signal before claim

--- a/tests/non-node-fallback.test.mjs
+++ b/tests/non-node-fallback.test.mjs
@@ -169,7 +169,12 @@ test("onboarding keeps claim timing in the explicit confirmation path", () => {
   );
   assert.match(
     onboarding,
-    /critique-loop profile, credential scope, claim-timing defaults,\s+issue-authoring companion status, and helper runtime profile\./,
+    /issue-author approval gate \(`enabled-by-default` by default, or\s+explicit config opt-out via `skipIssueAuthorApprovalGate: true`\)/,
+    "ONBOARDING Step 1B must explicitly confirm keep-default vs opt-out for the issue-author gate",
+  );
+  assert.match(
+    onboarding,
+    /critique-loop profile, credential scope, claim-timing defaults,\s+issue-author approval gate, maintainer approval actor policy,\s+issue-authoring companion status, and helper runtime profile\./,
     "ONBOARDING Step 2 re-check must stay aligned with the Step 1B confirmation list",
   );
   assert.match(


### PR DESCRIPTION
## Summary
- add an explicit Step 1B onboarding decision for keeping the distributed issue-author approval gate vs opting out with skipIssueAuthorApprovalGate
- align the Step 2 re-check list and Step 6 verification checklist with that policy decision
- make the policy-decisions reference explicitly state that onboarding must ask this question
- update onboarding tests to enforce the new confirmation list wording

Closes #386
Refs #364

## Follow-ups
- none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded onboarding guide to explicitly document issue-author approval gate and maintainer approval actor policy decisions in confirmation steps.
  * Added explicit requirement that issue-author approval gate confirmation be obtained before unattended execution begins.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/388)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->