### PR TITLE
docs(readme): add operational evidence section

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -98,7 +98,7 @@ IDD は Markdown ネイティブですが、依存関係なしではありませ
 
 ## 実運用の実績
 
-2026-05-13 時点で、このリポジトリでは IDD を multi-agent / multi-session で
+2026-05-12 時点で、このリポジトリでは IDD を multi-agent / multi-session で
 dogfooding しており、x4-6 ほどの並列実行が入ることがあります。このワークフローは
 private な業務リポジトリで原型を運用したうえで本リポジトリへ逆輸入され、その後も
 約 2 週間、Copilot CLI を x8-10 同時に回す形で使われました。失敗ゼロではありま

--- a/README.ja.md
+++ b/README.ja.md
@@ -96,6 +96,14 @@ IDD は Markdown ネイティブですが、依存関係なしではありませ
 の外に置き、明示的な opt-in により選択します。merge policy は
 [Customizing IDD](docs/customization.md) で 1 つ選んで記録します。
 
+## 実運用の実績
+
+2026-05-13 時点で、このリポジトリでは IDD を multi-agent / multi-session で
+dogfooding しており、x4-6 ほどの並列実行が入ることがあります。このワークフローは
+private な業務リポジトリで原型を運用したうえで本リポジトリへ逆輸入され、その後も
+約 2 週間、Copilot CLI を x8-10 同時に回す形で使われました。失敗ゼロではありま
+せんが、実運用で出た境界条件を拾いながら継続的に磨いています。
+
 ## ローカル pnpm ツール基盤（このリポジトリのコントリビューター専用）
 
 このリポジトリには project-local の pnpm 基盤と Husky hook を追加し、

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ the worker session by explicit opt-in. Choose and record one profile in
 
 ## Operational Evidence
 
-As of 2026-05-13, this repository has been dogfooding IDD through
+As of 2026-05-12, this repository has been dogfooding IDD through
 multi-agent, multi-session runs, including bursts of roughly x4-6
 parallel sessions. The workflow also originated in a private work
 repository and was later backported here, where it was exercised for

--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ The distributed default allows worker sessions to continue through merge
 the worker session by explicit opt-in. Choose and record one profile in
 [Customizing IDD](docs/customization.md).
 
+## Operational Evidence
+
+As of 2026-05-13, this repository has been dogfooding IDD through
+multi-agent, multi-session runs, including bursts of roughly x4-6
+parallel sessions. The workflow also originated in a private work
+repository and was later backported here, where it was exercised for
+about two weeks with roughly x8-10 concurrent Copilot CLI sessions.
+That is not zero-failure; it is a workflow that keeps getting tightened
+as edge cases appear.
+
 ## Local pnpm tooling baseline (contributors to this repository only)
 
 This repository uses a project-local pnpm baseline and Husky hooks so


### PR DESCRIPTION
Add a bounded operational evidence section to README.md and README.ja.md so adopters can see real-world usage without overclaiming or exposing confidential details.

Closes #397
Refs #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Operational Evidence section to README documenting multi-agent and multi-session usage history, including parallel execution capacity details and ongoing performance improvements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/408)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->