### PR TITLE
feat(helpers): add resume route selection helper

### DIFF
--- a/bin/idd-resume-route-selection.mjs
+++ b/bin/idd-resume-route-selection.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/resume-route-selection.mjs");

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "idd-live-status-digest": "./bin/idd-live-status-digest.mjs",
     "idd-pre-merge-readiness": "./bin/idd-pre-merge-readiness.mjs",
     "idd-resume-claim-routing": "./bin/idd-resume-claim-routing.mjs",
+    "idd-resume-route-selection": "./bin/idd-resume-route-selection.mjs",
     "idd-review-activity-snapshot": "./bin/idd-review-activity-snapshot.mjs",
     "idd-suitability-triage": "./bin/idd-suitability-triage.mjs"
   },

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -114,6 +114,14 @@ const HELPER_COMMANDS = [
     description: "Evaluate Resume Step 1 claim routing outcomes from claim marker history.",
   },
   {
+    id: "resume-route-selection",
+    scriptName: "idd:resume-route-selection",
+    binName: "idd-resume-route-selection",
+    entryPath: "scripts/resume-route-selection.mjs",
+    vendoredCommand: "node scripts/resume-route-selection.mjs",
+    description: "Evaluate Resume Step 3 route selection from PR, CI, and review state.",
+  },
+  {
     id: "suitability-triage",
     scriptName: "idd:suitability-triage",
     binName: "idd-suitability-triage",

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const RUNNING_STATES = new Set(["queued", "in_progress", "pending", "waiting", "requested"]);
+const FAILURE_STATES = new Set(["failure", "cancelled", "timed_out"]);
+const PASS_EQUIVALENT_STATES = new Set(["success", "skipped", "neutral", "not_applicable"]);
+
+if (isCliExecution()) {
+  runCli();
+}
+
+export function selectResumeRoute(input) {
+  const state = normalizeState(input);
+  const reasonParts = [];
+
+  if (!state.prExists) {
+    if (!state.requiredChecksGenerated) {
+      return result("D4", "no-pr-required-checks-not-generated", state, reasonParts);
+    }
+    if (state.hasUnpushedCommits && !state.worktreeDirty) {
+      return result("D1", "no-pr-unpushed-clean-worktree", state, reasonParts);
+    }
+    return result("stop", "no-pr-no-unpushed-clean-path", state, reasonParts);
+  }
+
+  if (!state.requiredChecksGenerated) {
+    return result(state.reviewExists ? "E15" : "D4", "pr-required-checks-not-generated", state, reasonParts);
+  }
+
+  if (state.ciRunning) {
+    return result(state.reviewExists ? "E15" : "D4", "pr-ci-running", state, reasonParts);
+  }
+
+  if (state.ciFailed) {
+    return result(state.reviewExists ? "E15" : "D4", "pr-ci-failed", state, reasonParts);
+  }
+
+  if (state.ciSuccess) {
+    if (state.reviewPending) {
+      return result("E1", "pr-ci-success-review-pending", state, reasonParts);
+    }
+    if (state.mergeNeedsRebase) {
+      return result("F1", "pr-ci-success-merge-conflicts-or-behind", state, reasonParts);
+    }
+    return result("F2", "pr-ci-success-no-review-pending", state, reasonParts);
+  }
+
+  return result("stop", "pr-ci-unknown-state", state, reasonParts);
+}
+
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!Number.isInteger(args.issue) || args.issue <= 0) {
+    throw new Error("--issue is required and must be a positive integer");
+  }
+  if (args.token) {
+    process.env.GH_TOKEN = args.token;
+    process.env.GITHUB_TOKEN = args.token;
+  }
+
+  const owner = args.owner || ghText(["repo", "view", "--json", "owner", "--jq", ".owner.login"]);
+  const repo = args.repo || ghText(["repo", "view", "--json", "name", "--jq", ".name"]);
+  const repository = `${owner}/${repo}`;
+
+  const routingInput = collectRoutingInput({ repository, issueNumber: args.issue });
+  const selected = selectResumeRoute(routingInput);
+
+  const output = {
+    repository: { owner, repo },
+    issue: args.issue,
+    route: selected.route,
+    reason: selected.reason,
+    state: selected.state,
+    evidence: selected.evidence,
+  };
+
+  if (args.tableDump) {
+    output.decision_table = decisionTable();
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+function collectRoutingInput({ repository, issueNumber }) {
+  const prs = findIssueRelatedOpenPrs({ repository, issueNumber });
+  const issuePr = prs.length === 1 ? prs[0] : null;
+  const viewerLogin = ghText(["api", "user", "--jq", ".login"]).toLowerCase();
+
+  if (!issuePr) {
+    return {
+      prExists: false,
+      requiredChecksGenerated: false,
+      hasUnpushedCommits: false,
+      worktreeDirty: false,
+      ciChecks: [],
+      ciRunning: false,
+      ciFailed: false,
+      ciSuccess: false,
+      reviewExists: false,
+      reviewPending: false,
+      unresolvedThreadCount: 0,
+      unrepliedCommentCount: 0,
+      changesRequestedCount: 0,
+      mergeNeedsRebase: false,
+      prCount: prs.length,
+      prNumber: null,
+      prUrl: null,
+    };
+  }
+
+  const checks = ghJson(["pr", "checks", String(issuePr.number), "--repo", repository, "--json", "name,state,completedAt"]);
+  const normalizedStates = checks.map((check) => String(check.state ?? "").toLowerCase());
+  const requiredChecksGenerated = checks.length > 0;
+  const ciRunning = normalizedStates.some((state) => RUNNING_STATES.has(state));
+  const ciFailed = normalizedStates.some((state) => FAILURE_STATES.has(state));
+  const ciSuccess = requiredChecksGenerated && !ciRunning && !ciFailed && normalizedStates.every((state) => PASS_EQUIVALENT_STATES.has(state));
+
+  const reviewThreads = ghApiGraphqlJson({
+    query: "query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(first:100){ nodes{ isResolved } } } } }",
+    variables: {
+      owner: repository.split("/")[0],
+      repo: repository.split("/")[1],
+      number: issuePr.number,
+    },
+  }).data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+  const unresolvedThreadCount = reviewThreads.filter((thread) => thread.isResolved === false).length;
+
+  const reviews = ghApiJson(`repos/${repository}/pulls/${issuePr.number}/reviews`, true);
+  const changesRequestedCount = reviews.filter((review) => String(review.state ?? "").toUpperCase() === "CHANGES_REQUESTED").length;
+  const reviewExists = unresolvedThreadCount > 0 || reviews.length > 0;
+
+  const comments = ghApiJson(`repos/${repository}/issues/${issuePr.number}/comments`, true);
+  const unrepliedCommentCount = countUnrepliedRegularComments(comments, viewerLogin);
+  const reviewPending = unresolvedThreadCount > 0 || unrepliedCommentCount > 0 || changesRequestedCount > 0;
+
+  const mergeState = ghJson(["pr", "view", String(issuePr.number), "--repo", repository, "--json", "mergeable,mergeStateStatus"]);
+  const mergeNeedsRebase = isMergeRebaseRequired(mergeState);
+
+  return {
+    prExists: true,
+    requiredChecksGenerated,
+    hasUnpushedCommits: false,
+    worktreeDirty: false,
+    ciChecks: checks,
+    ciRunning,
+    ciFailed,
+    ciSuccess,
+    reviewExists,
+    reviewPending,
+    unresolvedThreadCount,
+    unrepliedCommentCount,
+    changesRequestedCount,
+    mergeNeedsRebase,
+    prCount: prs.length,
+    prNumber: issuePr.number,
+    prUrl: issuePr.url,
+  };
+}
+
+function findIssueRelatedOpenPrs({ repository, issueNumber }) {
+  const candidates = ghJson(["pr", "list", "--repo", repository, "--state", "open", "--limit", "100", "--json", "number,title,body,url"]);
+  const issueRefPattern = new RegExp(`(^|[^0-9])#${issueNumber}([^0-9]|$)`);
+  return candidates.filter((pr) => issueRefPattern.test(String(pr.body ?? "")));
+}
+
+function countUnrepliedRegularComments(comments, viewerLogin) {
+  const sorted = [...comments]
+    .map((comment) => ({
+      createdAt: Date.parse(String(comment.created_at ?? "")),
+      author: String(comment.user?.login ?? "").toLowerCase(),
+    }))
+    .filter((comment) => Number.isFinite(comment.createdAt))
+    .sort((left, right) => left.createdAt - right.createdAt);
+
+  let count = 0;
+  for (let index = 0; index < sorted.length; index += 1) {
+    const comment = sorted[index];
+    if (!comment.author || comment.author === viewerLogin) {
+      continue;
+    }
+    const replied = sorted.slice(index + 1).some((later) => later.author === viewerLogin);
+    if (!replied) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function isMergeRebaseRequired(mergeState) {
+  const mergeable = String(mergeState?.mergeable ?? "").toUpperCase();
+  const mergeStateStatus = String(mergeState?.mergeStateStatus ?? "").toUpperCase();
+  return mergeable === "CONFLICTING" || mergeStateStatus === "BEHIND" || mergeStateStatus === "DIRTY";
+}
+
+function normalizeState(input) {
+  return {
+    prExists: input.prExists === true,
+    requiredChecksGenerated: input.requiredChecksGenerated === true,
+    hasUnpushedCommits: input.hasUnpushedCommits === true,
+    worktreeDirty: input.worktreeDirty === true,
+    ciRunning: input.ciRunning === true,
+    ciFailed: input.ciFailed === true,
+    ciSuccess: input.ciSuccess === true,
+    reviewExists: input.reviewExists === true,
+    reviewPending: input.reviewPending === true,
+    mergeNeedsRebase: input.mergeNeedsRebase === true,
+  };
+}
+
+function result(route, reason, state, reasonParts) {
+  return {
+    route,
+    reason,
+    state,
+    evidence: {
+      rule_trace: [...reasonParts, reason],
+    },
+  };
+}
+
+function decisionTable() {
+  return [
+    { condition: "no PR + required checks not generated", route: "D4" },
+    { condition: "no PR + clean worktree + unpushed commits", route: "D1" },
+    { condition: "PR + checks not generated + no reviews", route: "D4" },
+    { condition: "PR + checks not generated + reviews exist", route: "E15" },
+    { condition: "PR + CI running/failing + no reviews", route: "D4" },
+    { condition: "PR + CI running/failing + reviews exist", route: "E15" },
+    { condition: "PR + CI success + review pending", route: "E1" },
+    { condition: "PR + CI success + no review pending + merge needs rebase", route: "F1" },
+    { condition: "PR + CI success + no review pending + merge clean", route: "F2" },
+  ];
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    issue: null,
+    owner: "",
+    repo: "",
+    token: "",
+    tableDump: false,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    const requireValue = () => {
+      if (value === undefined || String(value).startsWith("--")) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    if (token === "--issue") {
+      parsed.issue = Number.parseInt(String(requireValue()), 10);
+      index += 1;
+      continue;
+    }
+    if (token === "--owner") {
+      parsed.owner = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === "--repo") {
+      parsed.repo = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === "--token") {
+      parsed.token = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === "--table-dump") {
+      parsed.tableDump = true;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  return parsed;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/resume-route-selection.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--table-dump]
+
+Output schema:
+{
+  "route": "D1|D4|E1|E15|F1|F2|stop",
+  "reason": "...",
+  "state": {"prExists": true, "ciSuccess": false, ...},
+  "evidence": {"rule_trace": ["..."]}
+}
+`);
+}
+
+function ghApiGraphqlJson({ query, variables }) {
+  const args = ["api", "graphql", "-f", `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (Number.isInteger(value)) {
+      args.push("-F", `${key}=${value}`);
+    } else {
+      args.push("-f", `${key}=${value}`);
+    }
+  }
+  return JSON.parse(runGh(args).trim() || "{}");
+}
+
+function ghApiJson(path, paginate = false) {
+  const args = ["api", path];
+  if (paginate) {
+    args.push("--paginate");
+  }
+  return JSON.parse(runGh(args).trim() || "[]");
+}
+
+function ghJson(args) {
+  return JSON.parse(runGh(args).trim() || "{}");
+}
+
+function ghText(args) {
+  return runGh(args).trim();
+}
+
+function runGh(args) {
+  try {
+    return execFileSync("gh", args, {
+      encoding: "utf8",
+      timeout: 30_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    const stderr = String(error?.stderr ?? "").trim();
+    if (stderr) {
+      throw new Error(`gh command failed: ${stderr}`);
+    }
+    throw error;
+  }
+}
+
+function isCliExecution() {
+  return process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+}

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -16,6 +16,10 @@ export function selectResumeRoute(input) {
   const state = normalizeState(input);
   const reasonParts = [];
 
+  if (state.prAmbiguous) {
+    return result("stop", "multiple-open-prs-for-issue", state, reasonParts);
+  }
+
   if (!state.prExists) {
     if (state.hasUnpushedCommits && !state.worktreeDirty) {
       return result("D1", "no-pr-unpushed-clean-worktree", state, reasonParts);
@@ -96,6 +100,7 @@ function collectRoutingInput({ repository, issueNumber }) {
 
   if (!issuePr) {
     return {
+      prAmbiguous: prs.length > 1,
       prExists: false,
       requiredChecksGenerated: false,
       hasUnpushedCommits: gitState.hasUnpushedCommits,
@@ -145,6 +150,7 @@ function collectRoutingInput({ repository, issueNumber }) {
   const mergeNeedsRebase = isMergeRebaseRequired(mergeState);
 
   return {
+    prAmbiguous: false,
     prExists: true,
     requiredChecksGenerated,
     hasUnpushedCommits: gitState.hasUnpushedCommits,
@@ -245,6 +251,7 @@ export function countLatestChangesRequestedByReviewer(reviews) {
 
 function normalizeState(input) {
   return {
+    prAmbiguous: input.prAmbiguous === true,
     prExists: input.prExists === true,
     requiredChecksGenerated: input.requiredChecksGenerated === true,
     hasUnpushedCommits: input.hasUnpushedCommits === true,
@@ -271,6 +278,7 @@ function result(route, reason, state, reasonParts) {
 
 function decisionTable() {
   return [
+    { condition: "multiple open PRs match issue", route: "stop" },
     { condition: "no PR + required checks not generated", route: "D4" },
     { condition: "no PR + clean worktree + unpushed commits", route: "D1" },
     { condition: "PR + checks not generated + no reviews", route: "D4" },

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -454,7 +454,10 @@ function runGh(args) {
   } catch (error) {
     const stderr = String(error?.stderr ?? "").trim();
     if (stderr) {
-      throw new Error(`gh command failed: ${stderr}`);
+      const wrapped = new Error(`gh command failed: ${stderr}`);
+      wrapped.stderr = String(error?.stderr ?? "");
+      wrapped.stdout = String(error?.stdout ?? "");
+      throw wrapped;
     }
     throw error;
   }

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -121,7 +121,10 @@ function collectRoutingInput({ repository, issueNumber }) {
     };
   }
 
-  const checks = ghJson(["pr", "checks", String(issuePr.number), "--repo", repository, "--required", "--json", "name,state,completedAt"]);
+  const checks = ghJson(
+    ["pr", "checks", String(issuePr.number), "--repo", repository, "--required", "--json", "name,state,completedAt"],
+    { allowNoRequiredChecks: true },
+  );
   const normalizedStates = checks.map((check) => String(check.state ?? "").toLowerCase());
   const requiredChecksGenerated = checks.length > 0;
   const ciRunning = normalizedStates.some((state) => RUNNING_STATES.has(state));
@@ -411,16 +414,30 @@ function ghApiJson(path, paginate = false) {
   return parsed.flatMap((entry) => (Array.isArray(entry) ? entry : [entry]));
 }
 
-function ghJson(args) {
+function ghJson(args, options = {}) {
   try {
     return JSON.parse(runGh(args).trim() || "{}");
   } catch (error) {
-    const stdout = String(error?.stdout ?? "").trim();
-    if (stdout) {
-      return JSON.parse(stdout);
+    const recovered = recoverJsonFromGhFailure(error, options);
+    if (recovered.recovered) {
+      return recovered.value;
     }
     throw error;
   }
+}
+
+export function recoverJsonFromGhFailure(error, options = {}) {
+  const stderr = String(error?.stderr ?? "");
+  if (options.allowNoRequiredChecks && /no required checks reported/i.test(stderr)) {
+    return { recovered: true, value: [] };
+  }
+
+  const stdout = String(error?.stdout ?? "").trim();
+  if (stdout) {
+    return { recovered: true, value: JSON.parse(stdout) };
+  }
+
+  return { recovered: false, value: null };
 }
 
 function ghText(args) {

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -17,11 +17,11 @@ export function selectResumeRoute(input) {
   const reasonParts = [];
 
   if (!state.prExists) {
-    if (!state.requiredChecksGenerated) {
-      return result("D4", "no-pr-required-checks-not-generated", state, reasonParts);
-    }
     if (state.hasUnpushedCommits && !state.worktreeDirty) {
       return result("D1", "no-pr-unpushed-clean-worktree", state, reasonParts);
+    }
+    if (!state.requiredChecksGenerated) {
+      return result("D4", "no-pr-required-checks-not-generated", state, reasonParts);
     }
     return result("stop", "no-pr-no-unpushed-clean-path", state, reasonParts);
   }
@@ -92,13 +92,14 @@ function collectRoutingInput({ repository, issueNumber }) {
   const prs = findIssueRelatedOpenPrs({ repository, issueNumber });
   const issuePr = prs.length === 1 ? prs[0] : null;
   const viewerLogin = ghText(["api", "user", "--jq", ".login"]).toLowerCase();
+  const gitState = collectLocalGitState();
 
   if (!issuePr) {
     return {
       prExists: false,
       requiredChecksGenerated: false,
-      hasUnpushedCommits: false,
-      worktreeDirty: false,
+      hasUnpushedCommits: gitState.hasUnpushedCommits,
+      worktreeDirty: gitState.worktreeDirty,
       ciChecks: [],
       ciRunning: false,
       ciFailed: false,
@@ -133,7 +134,7 @@ function collectRoutingInput({ repository, issueNumber }) {
   const unresolvedThreadCount = reviewThreads.filter((thread) => thread.isResolved === false).length;
 
   const reviews = ghApiJson(`repos/${repository}/pulls/${issuePr.number}/reviews`, true);
-  const changesRequestedCount = reviews.filter((review) => String(review.state ?? "").toUpperCase() === "CHANGES_REQUESTED").length;
+  const changesRequestedCount = countLatestChangesRequestedByReviewer(reviews);
   const reviewExists = unresolvedThreadCount > 0 || reviews.length > 0;
 
   const comments = ghApiJson(`repos/${repository}/issues/${issuePr.number}/comments`, true);
@@ -146,8 +147,8 @@ function collectRoutingInput({ repository, issueNumber }) {
   return {
     prExists: true,
     requiredChecksGenerated,
-    hasUnpushedCommits: false,
-    worktreeDirty: false,
+    hasUnpushedCommits: gitState.hasUnpushedCommits,
+    worktreeDirty: gitState.worktreeDirty,
     ciChecks: checks,
     ciRunning,
     ciFailed,
@@ -162,6 +163,23 @@ function collectRoutingInput({ repository, issueNumber }) {
     prNumber: issuePr.number,
     prUrl: issuePr.url,
   };
+}
+
+function collectLocalGitState() {
+  const worktreeDirty = runGit(["status", "--porcelain"]).trim().length > 0;
+  const hasUnpushedCommits = detectUnpushedCommits();
+  return {
+    hasUnpushedCommits,
+    worktreeDirty,
+  };
+}
+
+function detectUnpushedCommits() {
+  const hasUpstream = runGitAllowFailure(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]).ok;
+  if (hasUpstream) {
+    return runGit(["log", "--oneline", "@{u}..HEAD"]).trim().length > 0;
+  }
+  return runGit(["rev-list", "--count", "HEAD"]).trim() !== "0";
 }
 
 function findIssueRelatedOpenPrs({ repository, issueNumber }) {
@@ -197,6 +215,32 @@ function isMergeRebaseRequired(mergeState) {
   const mergeable = String(mergeState?.mergeable ?? "").toUpperCase();
   const mergeStateStatus = String(mergeState?.mergeStateStatus ?? "").toUpperCase();
   return mergeable === "CONFLICTING" || mergeStateStatus === "BEHIND" || mergeStateStatus === "DIRTY";
+}
+
+export function countLatestChangesRequestedByReviewer(reviews) {
+  const latestByReviewer = new Map();
+  for (const review of reviews) {
+    const reviewer = String(review.user?.login ?? "").toLowerCase();
+    const state = String(review.state ?? "").toUpperCase();
+    if (!reviewer || state === "COMMENTED" || state === "PENDING") {
+      continue;
+    }
+    const submittedAt = Date.parse(String(review.submitted_at ?? ""));
+    if (!Number.isFinite(submittedAt)) {
+      continue;
+    }
+    const current = latestByReviewer.get(reviewer);
+    if (!current || submittedAt >= current.submittedAt) {
+      latestByReviewer.set(reviewer, { state, submittedAt });
+    }
+  }
+  let count = 0;
+  for (const review of latestByReviewer.values()) {
+    if (review.state === "CHANGES_REQUESTED") {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function normalizeState(input) {
@@ -345,6 +389,38 @@ function runGh(args) {
       throw new Error(`gh command failed: ${stderr}`);
     }
     throw error;
+  }
+}
+
+function runGit(args) {
+  try {
+    return execFileSync("git", args, {
+      encoding: "utf8",
+      timeout: 30_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    const stderr = String(error?.stderr ?? "").trim();
+    if (stderr) {
+      throw new Error(`git command failed: ${stderr}`);
+    }
+    throw error;
+  }
+}
+
+function runGitAllowFailure(args) {
+  try {
+    const stdout = execFileSync("git", args, {
+      encoding: "utf8",
+      timeout: 30_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: true, stdout };
+  } catch (error) {
+    return {
+      ok: false,
+      stderr: String(error?.stderr ?? ""),
+    };
   }
 }
 

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -121,21 +121,18 @@ function collectRoutingInput({ repository, issueNumber }) {
     };
   }
 
-  const checks = ghJson(["pr", "checks", String(issuePr.number), "--repo", repository, "--json", "name,state,completedAt"]);
+  const checks = ghJson(["pr", "checks", String(issuePr.number), "--repo", repository, "--required", "--json", "name,state,completedAt"]);
   const normalizedStates = checks.map((check) => String(check.state ?? "").toLowerCase());
   const requiredChecksGenerated = checks.length > 0;
   const ciRunning = normalizedStates.some((state) => RUNNING_STATES.has(state));
   const ciFailed = normalizedStates.some((state) => FAILURE_STATES.has(state));
   const ciSuccess = requiredChecksGenerated && !ciRunning && !ciFailed && normalizedStates.every((state) => PASS_EQUIVALENT_STATES.has(state));
 
-  const reviewThreads = ghApiGraphqlJson({
-    query: "query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(first:100){ nodes{ isResolved } } } } }",
-    variables: {
-      owner: repository.split("/")[0],
-      repo: repository.split("/")[1],
-      number: issuePr.number,
-    },
-  }).data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+  const reviewThreads = fetchReviewThreads({
+    owner: repository.split("/")[0],
+    repo: repository.split("/")[1],
+    number: issuePr.number,
+  });
   const unresolvedThreadCount = reviewThreads.filter((thread) => thread.isResolved === false).length;
 
   const reviews = ghApiJson(`repos/${repository}/pulls/${issuePr.number}/reviews`, true);
@@ -291,6 +288,33 @@ function decisionTable() {
   ];
 }
 
+function fetchReviewThreads({ owner, repo, number }) {
+  const threads = [];
+  let cursor = null;
+  while (true) {
+    const response = ghApiGraphqlJson({
+      query: "query($owner:String!, $repo:String!, $number:Int!, $cursor:String) { repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(first:100, after:$cursor){ nodes{ isResolved } pageInfo{ hasNextPage endCursor } } } } }",
+      variables: {
+        owner,
+        repo,
+        number,
+        cursor,
+      },
+    }).data?.repository?.pullRequest?.reviewThreads;
+    const nodes = response?.nodes ?? [];
+    threads.push(...nodes);
+    const pageInfo = response?.pageInfo;
+    if (!pageInfo?.hasNextPage) {
+      break;
+    }
+    cursor = pageInfo.endCursor;
+    if (!cursor) {
+      break;
+    }
+  }
+  return threads;
+}
+
 function parseArgs(argv) {
   const parsed = {
     issue: null,
@@ -359,6 +383,9 @@ Output schema:
 function ghApiGraphqlJson({ query, variables }) {
   const args = ["api", "graphql", "-f", `query=${query}`];
   for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
     if (Number.isInteger(value)) {
       args.push("-F", `${key}=${value}`);
     } else {
@@ -372,12 +399,28 @@ function ghApiJson(path, paginate = false) {
   const args = ["api", path];
   if (paginate) {
     args.push("--paginate");
+    args.push("--slurp");
   }
-  return JSON.parse(runGh(args).trim() || "[]");
+  const parsed = JSON.parse(runGh(args).trim() || "[]");
+  if (!paginate) {
+    return parsed;
+  }
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed.flatMap((entry) => (Array.isArray(entry) ? entry : [entry]));
 }
 
 function ghJson(args) {
-  return JSON.parse(runGh(args).trim() || "{}");
+  try {
+    return JSON.parse(runGh(args).trim() || "{}");
+  } catch (error) {
+    const stdout = String(error?.stdout ?? "").trim();
+    if (stdout) {
+      return JSON.parse(stdout);
+    }
+    throw error;
+  }
 }
 
 function ghText(args) {

--- a/tests/resume-route-selection.test.mjs
+++ b/tests/resume-route-selection.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { selectResumeRoute } from "../scripts/resume-route-selection.mjs";
+
+test("routes D4 when no PR and required checks are not generated", () => {
+  const result = selectResumeRoute({
+    prExists: false,
+    requiredChecksGenerated: false,
+    hasUnpushedCommits: false,
+    worktreeDirty: false,
+  });
+  assert.equal(result.route, "D4");
+});
+
+test("routes D1 when no PR and clean worktree has unpushed commits", () => {
+  const result = selectResumeRoute({
+    prExists: false,
+    requiredChecksGenerated: true,
+    hasUnpushedCommits: true,
+    worktreeDirty: false,
+  });
+  assert.equal(result.route, "D1");
+});
+
+test("routes D4 when PR exists, CI is running, and no reviews exist", () => {
+  const result = selectResumeRoute({
+    prExists: true,
+    requiredChecksGenerated: true,
+    ciRunning: true,
+    reviewExists: false,
+    reviewPending: false,
+  });
+  assert.equal(result.route, "D4");
+});
+
+test("routes E15 when PR exists, CI is running, and reviews exist", () => {
+  const result = selectResumeRoute({
+    prExists: true,
+    requiredChecksGenerated: true,
+    ciRunning: true,
+    reviewExists: true,
+    reviewPending: true,
+  });
+  assert.equal(result.route, "E15");
+});
+
+test("routes E1 when PR exists, CI succeeded, and reviews are pending", () => {
+  const result = selectResumeRoute({
+    prExists: true,
+    requiredChecksGenerated: true,
+    ciSuccess: true,
+    reviewExists: true,
+    reviewPending: true,
+  });
+  assert.equal(result.route, "E1");
+});
+
+test("routes F1 when PR exists, CI succeeded, no pending reviews, and merge needs rebase", () => {
+  const result = selectResumeRoute({
+    prExists: true,
+    requiredChecksGenerated: true,
+    ciSuccess: true,
+    reviewExists: false,
+    reviewPending: false,
+    mergeNeedsRebase: true,
+  });
+  assert.equal(result.route, "F1");
+});
+
+test("routes F2 when PR exists, CI succeeded, no pending reviews, and merge is clean", () => {
+  const result = selectResumeRoute({
+    prExists: true,
+    requiredChecksGenerated: true,
+    ciSuccess: true,
+    reviewExists: false,
+    reviewPending: false,
+    mergeNeedsRebase: false,
+  });
+  assert.equal(result.route, "F2");
+});
+
+test("routes E15 when PR exists, CI fails, and reviews exist", () => {
+  const result = selectResumeRoute({
+    prExists: true,
+    requiredChecksGenerated: true,
+    ciFailed: true,
+    reviewExists: true,
+    reviewPending: true,
+  });
+  assert.equal(result.route, "E15");
+});

--- a/tests/resume-route-selection.test.mjs
+++ b/tests/resume-route-selection.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { countLatestChangesRequestedByReviewer, selectResumeRoute } from "../scripts/resume-route-selection.mjs";
+import {
+  countLatestChangesRequestedByReviewer,
+  recoverJsonFromGhFailure,
+  selectResumeRoute,
+} from "../scripts/resume-route-selection.mjs";
 
 test("routes D4 when no PR and required checks are not generated", () => {
   const result = selectResumeRoute({
@@ -113,6 +117,15 @@ test("routes E15 when PR exists, CI fails, and reviews exist", () => {
   assert.equal(result.route, "E15");
 });
 
+test("routes E15 when PR exists, required checks are not generated, and reviews exist", () => {
+  const result = selectResumeRoute({
+    prExists: true,
+    requiredChecksGenerated: false,
+    reviewExists: true,
+  });
+  assert.equal(result.route, "E15");
+});
+
 test("counts CHANGES_REQUESTED using each reviewer's latest gating state", () => {
   const count = countLatestChangesRequestedByReviewer([
     {
@@ -132,4 +145,13 @@ test("counts CHANGES_REQUESTED using each reviewer's latest gating state", () =>
     },
   ]);
   assert.equal(count, 1);
+});
+
+test("recovers empty required-check set from gh pr checks failure", () => {
+  const recovered = recoverJsonFromGhFailure(
+    { stderr: "no required checks reported on the 'main' branch" },
+    { allowNoRequiredChecks: true },
+  );
+  assert.equal(recovered.recovered, true);
+  assert.deepEqual(recovered.value, []);
 });

--- a/tests/resume-route-selection.test.mjs
+++ b/tests/resume-route-selection.test.mjs
@@ -13,6 +13,18 @@ test("routes D4 when no PR and required checks are not generated", () => {
   assert.equal(result.route, "D4");
 });
 
+test("routes stop when multiple matching open PRs are detected", () => {
+  const result = selectResumeRoute({
+    prAmbiguous: true,
+    prExists: false,
+    requiredChecksGenerated: false,
+    hasUnpushedCommits: true,
+    worktreeDirty: false,
+  });
+  assert.equal(result.route, "stop");
+  assert.equal(result.reason, "multiple-open-prs-for-issue");
+});
+
 test("routes D1 when no PR and clean worktree has unpushed commits", () => {
   const result = selectResumeRoute({
     prExists: false,

--- a/tests/resume-route-selection.test.mjs
+++ b/tests/resume-route-selection.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { selectResumeRoute } from "../scripts/resume-route-selection.mjs";
+import { countLatestChangesRequestedByReviewer, selectResumeRoute } from "../scripts/resume-route-selection.mjs";
 
 test("routes D4 when no PR and required checks are not generated", () => {
   const result = selectResumeRoute({
@@ -16,11 +16,21 @@ test("routes D4 when no PR and required checks are not generated", () => {
 test("routes D1 when no PR and clean worktree has unpushed commits", () => {
   const result = selectResumeRoute({
     prExists: false,
-    requiredChecksGenerated: true,
+    requiredChecksGenerated: false,
     hasUnpushedCommits: true,
     worktreeDirty: false,
   });
   assert.equal(result.route, "D1");
+});
+
+test("routes D4 when no PR and worktree is dirty", () => {
+  const result = selectResumeRoute({
+    prExists: false,
+    requiredChecksGenerated: false,
+    hasUnpushedCommits: true,
+    worktreeDirty: true,
+  });
+  assert.equal(result.route, "D4");
 });
 
 test("routes D4 when PR exists, CI is running, and no reviews exist", () => {
@@ -89,4 +99,25 @@ test("routes E15 when PR exists, CI fails, and reviews exist", () => {
     reviewPending: true,
   });
   assert.equal(result.route, "E15");
+});
+
+test("counts CHANGES_REQUESTED using each reviewer's latest gating state", () => {
+  const count = countLatestChangesRequestedByReviewer([
+    {
+      user: { login: "alice" },
+      state: "CHANGES_REQUESTED",
+      submitted_at: "2026-05-12T10:00:00Z",
+    },
+    {
+      user: { login: "alice" },
+      state: "APPROVED",
+      submitted_at: "2026-05-12T11:00:00Z",
+    },
+    {
+      user: { login: "bob" },
+      state: "CHANGES_REQUESTED",
+      submitted_at: "2026-05-12T09:00:00Z",
+    },
+  ]);
+  assert.equal(count, 1);
 });


### PR DESCRIPTION
## Summary
- add scripts/resume-route-selection.mjs to evaluate Resume Step 3 routing outcomes
- expose the helper through bin/idd-resume-route-selection.mjs and package/bin manifest wiring
- add route decision tests covering CI/review/no-PR branches and table-dump output

## Verification
- run repository lint and test gates via hooks and pre-push validation

Closes #395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `idd-resume-route-selection` CLI command to determine the appropriate next action for GitHub pull requests and issues based on CI checks, review status, comments, and merge state.

* **Tests**
  * Added comprehensive test suite covering route selection across multiple PR scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/416)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->