### PR TITLE
docs(policy): define canonical phase-id compatibility contract

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -159,6 +159,35 @@ changes `claim-stale-age` (24 h default) and
 `claim-heartbeat-interval` (12 h default) before enabling unattended
 workers.
 
+## Phase ID Compatibility Contract
+
+Treat phase IDs as a compatibility surface, not as presentation text.
+Use one canonical ID per phase for machine-facing behavior
+(instructions, helpers, tests, routing), and treat display labels or
+ordering as a separate human-facing concern.
+
+When phase numbering needs cleanup, keep behavior compatibility first:
+
+- keep canonical IDs stable while introducing display-only ordering
+- accept legacy aliases on input during migration
+- emit canonical IDs in new machine-written outputs
+
+Example:
+
+- canonical ID: `A4_5`
+- accepted legacy aliases (input only): `A4.5`, `A4-5`
+- preferred display label: `A4.5`
+
+Alias removal is a semver-governed change. Do not remove supported
+aliases in patch or minor releases. Removal requires:
+
+1. A major-version boundary with explicit migration guidance.
+2. A documented compatibility window where aliases are still accepted.
+3. A deprecation announcement in docs before enforcement switches.
+
+This issue defines the policy contract only. Broad phase renumbering or
+global identifier rewrites must land in follow-up implementation issues.
+
 ## Merge Policy and Credentials
 
 IDD can describe an end-to-end loop, but that does not mean every worker

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -70,6 +70,18 @@ Record the selected values for `claim-stale-age` and
 `claim-heartbeat-interval` in repository onboarding notes before running
 unattended sessions.
 
+## Phase ID Compatibility Defaults
+
+The phase-ID compatibility contract separates machine-facing canonical
+IDs from human-facing display labels. Keep this contract stable before
+semver introduction so helper/runtime changes can migrate safely.
+
+| Policy key                      | Policy default                                               | Distributed value                                                                                                                                                               | Owning surface                                                                                                                                             | Onboarding expectation                                                                                  |
+| ------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `phase-id-canonical`            | Canonical phase ID stability                                 | One canonical ID per phase is treated as machine-facing API. Display numbering or labels are separate presentation fields.                                                      | [Customizing IDD](customization.md#phase-id-compatibility-contract), [IDD workflow](idd-workflow.md), helper/runtime docs and tests touching phase routing | Keep canonical IDs stable unless a major migration is intentionally planned and documented.             |
+| `phase-id-legacy-aliases`       | Input aliases allowed during migration                       | Legacy aliases may be accepted on input, but new machine-generated output should emit canonical IDs.                                                                            | [Customizing IDD](customization.md#phase-id-compatibility-contract), helper/runtime parsers, migration tests                                               | Record accepted aliases and output normalization behavior before introducing implementation changes.    |
+| `phase-id-alias-removal-policy` | Alias removal deferred to semver-major with migration notice | Alias removal is not a patch/minor change. Removal requires major-version timing, a documented compatibility window, and explicit deprecation notice before enforcement change. | [Customizing IDD](customization.md#phase-id-compatibility-contract), release policy docs, semver migration plans                                           | Do not remove aliases opportunistically; schedule removal only with explicit semver migration criteria. |
+
 ## Issue-Author Approval Defaults
 
 The repository-wide issue-author approval gate is part of the current

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -159,6 +159,35 @@ changes `claim-stale-age` (24 h default) and
 `claim-heartbeat-interval` (12 h default) before enabling unattended
 workers.
 
+## Phase ID Compatibility Contract
+
+Treat phase IDs as a compatibility surface, not as presentation text.
+Use one canonical ID per phase for machine-facing behavior
+(instructions, helpers, tests, routing), and treat display labels or
+ordering as a separate human-facing concern.
+
+When phase numbering needs cleanup, keep behavior compatibility first:
+
+- keep canonical IDs stable while introducing display-only ordering
+- accept legacy aliases on input during migration
+- emit canonical IDs in new machine-written outputs
+
+Example:
+
+- canonical ID: `A4_5`
+- accepted legacy aliases (input only): `A4.5`, `A4-5`
+- preferred display label: `A4.5`
+
+Alias removal is a semver-governed change. Do not remove supported
+aliases in patch or minor releases. Removal requires:
+
+1. A major-version boundary with explicit migration guidance.
+2. A documented compatibility window where aliases are still accepted.
+3. A deprecation announcement in docs before enforcement switches.
+
+This issue defines the policy contract only. Broad phase renumbering or
+global identifier rewrites must land in follow-up implementation issues.
+
 ## Merge Policy and Credentials
 
 IDD can describe an end-to-end loop, but that does not mean every worker

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -70,6 +70,18 @@ Record the selected values for `claim-stale-age` and
 `claim-heartbeat-interval` in repository onboarding notes before running
 unattended sessions.
 
+## Phase ID Compatibility Defaults
+
+The phase-ID compatibility contract separates machine-facing canonical
+IDs from human-facing display labels. Keep this contract stable before
+semver introduction so helper/runtime changes can migrate safely.
+
+| Policy key                      | Policy default                                               | Distributed value                                                                                                                                                               | Owning surface                                                                                                                                             | Onboarding expectation                                                                                  |
+| ------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `phase-id-canonical`            | Canonical phase ID stability                                 | One canonical ID per phase is treated as machine-facing API. Display numbering or labels are separate presentation fields.                                                      | [Customizing IDD](customization.md#phase-id-compatibility-contract), [IDD workflow](idd-workflow.md), helper/runtime docs and tests touching phase routing | Keep canonical IDs stable unless a major migration is intentionally planned and documented.             |
+| `phase-id-legacy-aliases`       | Input aliases allowed during migration                       | Legacy aliases may be accepted on input, but new machine-generated output should emit canonical IDs.                                                                            | [Customizing IDD](customization.md#phase-id-compatibility-contract), helper/runtime parsers, migration tests                                               | Record accepted aliases and output normalization behavior before introducing implementation changes.    |
+| `phase-id-alias-removal-policy` | Alias removal deferred to semver-major with migration notice | Alias removal is not a patch/minor change. Removal requires major-version timing, a documented compatibility window, and explicit deprecation notice before enforcement change. | [Customizing IDD](customization.md#phase-id-compatibility-contract), release policy docs, semver migration plans                                           | Do not remove aliases opportunistically; schedule removal only with explicit semver migration criteria. |
+
 ## Issue-Author Approval Defaults
 
 The repository-wide issue-author approval gate is part of the current


### PR DESCRIPTION
## Summary
- define a compatibility contract that separates canonical phase IDs from display numbering/labels
- document legacy alias input handling with canonical output normalization examples
- add semver-major deprecation criteria for alias removal
- sync the contract across live and template customization/policy docs

Closes #399