### PR TITLE
fix(cleanup): recompute summary after apply mutations

### DIFF
--- a/scripts/audit-pr-cleanup-summary.mjs
+++ b/scripts/audit-pr-cleanup-summary.mjs
@@ -1,0 +1,37 @@
+export function computeReportSummary(report) {
+  const alreadyMinimized = report.skipped.filter((skip) => skip.isMinimized).length;
+  const viewerCanMinimize = report.candidates.length
+    + report.skipped.filter((skip) => skip.viewerCanMinimize).length;
+  const viewerCannotMinimize = report.skipped.filter((skip) => !skip.viewerCanMinimize).length;
+
+  report.summary = {
+    candidate: report.candidates.length,
+    skipped: report.skipped.length,
+    applied: report.applied.length,
+    failed: report.failed.length,
+    "already-minimized": alreadyMinimized,
+    "viewer-can-minimize": viewerCanMinimize,
+    "viewer-cannot-minimize": viewerCannotMinimize,
+  };
+
+  if (report.mode === "dry-run") {
+    report.status = report.candidates.length === 0 ? "clean" : "needs-apply";
+    return;
+  }
+
+  if (report.mode === "apply") {
+    if (report.failed.length > 0) {
+      report.status = "failed";
+      return;
+    }
+    if (report.applied.length > 0 && report.candidates.length === report.applied.length) {
+      report.status = "applied";
+      return;
+    }
+    if (report.applied.length > 0) {
+      report.status = "incomplete";
+      return;
+    }
+    report.status = report.candidates.length === 0 ? "clean" : "incomplete";
+  }
+}

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { computeReportSummary } from "./audit-pr-cleanup-summary.mjs";
 import {
   classifyRegularBotComment,
   hasFreshDisposition,
@@ -113,12 +114,14 @@ if (args.apply) {
     }
   }
 
+  computeReportSummary(report);
   if (report.failed.length > 0) {
     writeReport(report, args.format);
     process.exit(1);
   }
 }
 
+computeReportSummary(report);
 writeReport(report, args.format);
 
 async function buildReport(owner, repo, prNumber, options = {}) {
@@ -157,9 +160,6 @@ async function buildReport(owner, repo, prNumber, options = {}) {
   for (const review of reviews) {
     evaluateReviewParent(review, pr, threadIndex, latestGatingReviews, report);
   }
-
-  // Calculate summary and status
-  computeReportSummary(report);
 
   return report;
 }
@@ -433,57 +433,6 @@ function addSkipped(report, subject, reason) {
     skipReason: reason,
   });
 }
-
-function computeReportSummary(report) {
-  // Count already-minimized and viewer-can-minimize from skipped reasons
-  let alreadyMinimized = 0;
-  let viewerCannotMinimize = 0;
-
-  for (const skip of report.skipped) {
-    if (skip.skipReason === "already minimized") {
-      alreadyMinimized += 1;
-    } else if (skip.skipReason === "viewer cannot minimize this comment") {
-      viewerCannotMinimize += 1;
-    }
-  }
-
-  // From candidates, we know viewerCanMinimize is true
-  const viewerCanMinimize = report.candidates.length;
-
-  report.summary = {
-    candidate: report.candidates.length,
-    skipped: report.skipped.length,
-    applied: report.applied.length,
-    failed: report.failed.length,
-    "already-minimized": alreadyMinimized,
-    "viewer-can-minimize": viewerCanMinimize,
-  };
-
-  // Determine status
-  if (report.mode === "dry-run") {
-    if (report.candidates.length === 0) {
-      report.status = "clean";
-    } else {
-      report.status = "needs-apply";
-    }
-  } else if (report.mode === "apply") {
-    if (report.failed.length > 0) {
-      report.status = "failed";
-    } else if (
-      report.applied.length > 0 &&
-      report.candidates.length === report.applied.length
-    ) {
-      report.status = "applied";
-    } else if (report.applied.length > 0) {
-      report.status = "incomplete";
-    } else if (report.candidates.length === 0) {
-      report.status = "clean";
-    } else {
-      report.status = "incomplete";
-    }
-  }
-}
-
 
 function fetchPullRequest(owner, repo, number, options = {}) {
   const query = `query($owner:String!,$repo:String!,$number:Int!){

--- a/tests/audit-pr-cleanup-summary.test.mjs
+++ b/tests/audit-pr-cleanup-summary.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { computeReportSummary } from "../scripts/audit-pr-cleanup-summary.mjs";
+
+function createReport(overrides = {}) {
+  return {
+    mode: "dry-run",
+    candidates: [],
+    skipped: [],
+    applied: [],
+    failed: [],
+    summary: null,
+    status: null,
+    ...overrides,
+  };
+}
+
+test("computeReportSummary counts viewer eligibility from evaluated subjects", () => {
+  const report = createReport({
+    candidates: [{ subjectId: "candidate-1" }, { subjectId: "candidate-2" }],
+    skipped: [
+      { subjectId: "skip-1", isMinimized: true, viewerCanMinimize: true },
+      { subjectId: "skip-2", isMinimized: false, viewerCanMinimize: false },
+    ],
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.summary.candidate, 2);
+  assert.equal(report.summary.skipped, 2);
+  assert.equal(report.summary["already-minimized"], 1);
+  assert.equal(report.summary["viewer-can-minimize"], 3);
+  assert.equal(report.summary["viewer-cannot-minimize"], 1);
+  assert.equal(report.status, "needs-apply");
+});
+
+test("computeReportSummary reflects apply results after mutations", () => {
+  const report = createReport({
+    mode: "apply",
+    candidates: [{ subjectId: "candidate-1" }],
+    skipped: [{ subjectId: "skip-1", isMinimized: false, viewerCanMinimize: true }],
+    applied: [],
+    failed: [],
+  });
+
+  computeReportSummary(report);
+  assert.equal(report.status, "incomplete");
+  assert.equal(report.summary.applied, 0);
+
+  report.applied.push({ subjectId: "candidate-1" });
+  computeReportSummary(report);
+
+  assert.equal(report.status, "applied");
+  assert.equal(report.summary.applied, 1);
+  assert.equal(report.summary.failed, 0);
+  assert.equal(report.summary.skipped, 1);
+});


### PR DESCRIPTION
## Summary
- move cleanup report summary/status calculation into a dedicated helper
- recompute summary after apply-mode mutations so `applied/failed/skipped/status` reflect final state
- count `viewer-can-minimize` from evaluated subjects (candidates + eligible skipped rows) and add explicit `viewer-cannot-minimize`
- add regression tests for viewer eligibility counting and post-mutation apply summaries

## Verification
- `node --test tests/audit-pr-cleanup-summary.test.mjs`
- `pnpm run test`
- `pnpm run lint`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

Closes #412
Refs #411


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized report summary and status computation logic into a dedicated, reusable module to improve code organization and maintainability.

* **Tests**
  * Added comprehensive test coverage for report summary computation, including validation of status transitions and minimization eligibility counters across different operational modes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/418)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->