### PR TITLE
fix(readiness): classify inaccessible issues as unresolvable

### DIFF
--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -2,6 +2,9 @@
 
 import { execFileSync } from "node:child_process";
 
+const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({ __iddLookupStatus: "inaccessible" });
+const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
+
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
   if (args.issueNumbers.length === 0) {
@@ -45,17 +48,18 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
 
   for (const issueNumber of normalizeIssueNumbers(issueNumbers)) {
     const issue = await getIssue(issueNumber, issueCache, loadIssue);
-    if (!issue) {
+    if (!issue || isInaccessibleIssue(issue)) {
+      const issueReason = isInaccessibleIssue(issue) ? "issue_inaccessible" : "issue_not_found";
       unresolvable.push({
         issueNumber,
         kind: "issue",
         reference: `#${issueNumber}`,
-        reason: "issue_not_found",
+        reason: issueReason,
       });
       filteredOut.push({
         number: issueNumber,
         title: "",
-        reasons: ["issue_not_found"],
+        reasons: [issueReason],
       });
       continue;
     }
@@ -79,13 +83,16 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
 
     for (const dependencyNumber of extractDependencyIssueNumbers(issue.body)) {
       const dependencyIssue = await getIssue(dependencyNumber, issueCache, loadIssue);
-      if (!dependencyIssue) {
+      if (!dependencyIssue || isInaccessibleIssue(dependencyIssue)) {
+        const dependencyReason = isInaccessibleIssue(dependencyIssue)
+          ? "issue_inaccessible"
+          : "issue_not_found";
         reasons.add("unresolvable_dependency_issue");
         unresolvable.push({
           issueNumber: issue.number,
           kind: "dependency",
           reference: `#${dependencyNumber}`,
-          reason: "issue_not_found",
+          reason: dependencyReason,
         });
         continue;
       }
@@ -96,13 +103,14 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
 
     for (const blockedNumber of extractBlockedByIssueNumbers(issue.body)) {
       const blockedIssue = await getIssue(blockedNumber, issueCache, loadIssue);
-      if (!blockedIssue) {
+      if (!blockedIssue || isInaccessibleIssue(blockedIssue)) {
+        const blockedReason = isInaccessibleIssue(blockedIssue) ? "issue_inaccessible" : "issue_not_found";
         reasons.add("unresolvable_blocked_by_issue");
         unresolvable.push({
           issueNumber: issue.number,
           kind: "blocked_by_issue",
           reference: `#${blockedNumber}`,
-          reason: "issue_not_found",
+          reason: blockedReason,
         });
         continue;
       }
@@ -300,7 +308,9 @@ async function getIssue(issueNumber, cache, loadIssue) {
     return cache.get(issueNumber);
   }
   const rawIssue = await loadIssue(issueNumber);
-  const issue = rawIssue ? normalizeIssue(rawIssue) : null;
+  const issue = isInaccessibleIssue(rawIssue)
+    ? INACCESSIBLE_ISSUE_SENTINEL
+    : (rawIssue ? normalizeIssue(rawIssue) : null);
   cache.set(issueNumber, issue);
   return issue;
 }
@@ -354,11 +364,18 @@ function buildIssueLoader(owner, repo) {
       "--jq",
       ".",
     ];
-    const result = runGh(args, { allowStatuses: [404] }).trim();
-    if (!result || result === "null") {
-      return null;
+    try {
+      const result = runGh(args, { allowStatuses: [404] }).trim();
+      if (!result || result === "null") {
+        return null;
+      }
+      return JSON.parse(result);
+    } catch (error) {
+      if (isInaccessibleIssueLookupError(error)) {
+        return INACCESSIBLE_ISSUE_SENTINEL;
+      }
+      throw error;
     }
-    return JSON.parse(result);
   };
 }
 
@@ -394,8 +411,27 @@ function runGh(args, options = {}) {
     }
     const stderr = String(error.stderr ?? "").trim();
     const prefix = `gh ${args.join(" ")}`;
-    throw new Error(stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`);
+    const wrapped = new Error(stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`);
+    wrapped.status = status;
+    wrapped.stderr = stderr;
+    throw wrapped;
   }
+}
+
+function isInaccessibleIssue(value) {
+  return value?.__iddLookupStatus === "inaccessible";
+}
+
+function isInaccessibleIssueLookupError(error) {
+  if (!error) {
+    return false;
+  }
+  const status = typeof error.status === "number" ? error.status : null;
+  if (status !== null && INACCESSIBLE_HTTP_STATUSES.has(status)) {
+    return true;
+  }
+  const stderr = String(error.stderr ?? error.message ?? "");
+  return /resource not accessible|forbidden|requires authentication|visibility/i.test(stderr);
 }
 
 function isMainModule(metaUrl) {

--- a/tests/discover-readiness-check.test.mjs
+++ b/tests/discover-readiness-check.test.mjs
@@ -117,3 +117,59 @@ test("returns empty unresolvable list when include-unresolvable is disabled", as
   assert.deepEqual(summary.unresolvable, []);
   assert.equal(summary.summary.unresolvableCount, 1);
 });
+
+test("treats inaccessible dependencies as unresolvable entries", async () => {
+  const issues = new Map([
+    [601, { number: 601, title: "candidate", state: "OPEN", body: "Depends on #602", labels: [] }],
+    [602, { __iddLookupStatus: "inaccessible" }],
+  ]);
+  const summary = await evaluateDiscoverReadiness([601], {
+    includeUnresolvable: true,
+    loadIssue: async (number) => issues.get(number) ?? null,
+    findRoadmapsByMarker: async () => [],
+  });
+
+  assert.equal(summary.ready.length, 0);
+  assert.match(summary.filteredOut[0].reasons.join(","), /unresolvable_dependency_issue/);
+  assert.deepEqual(summary.unresolvable, [
+    {
+      issueNumber: 601,
+      kind: "dependency",
+      reference: "#602",
+      reason: "issue_inaccessible",
+    },
+  ]);
+});
+
+test("treats inaccessible target issue as unresolvable", async () => {
+  const summary = await evaluateDiscoverReadiness([701], {
+    includeUnresolvable: true,
+    loadIssue: async () => ({ __iddLookupStatus: "inaccessible" }),
+    findRoadmapsByMarker: async () => [],
+  });
+
+  assert.equal(summary.ready.length, 0);
+  assert.deepEqual(summary.filteredOut, [{
+    number: 701,
+    title: "",
+    reasons: ["issue_inaccessible"],
+  }]);
+  assert.deepEqual(summary.unresolvable, [{
+    issueNumber: 701,
+    kind: "issue",
+    reference: "#701",
+    reason: "issue_inaccessible",
+  }]);
+});
+
+test("bubbles non-recoverable loader failures", async () => {
+  await assert.rejects(
+    evaluateDiscoverReadiness([801], {
+      loadIssue: async () => {
+        throw new Error("network timeout");
+      },
+      findRoadmapsByMarker: async () => [],
+    }),
+    /network timeout/,
+  );
+});


### PR DESCRIPTION
## Summary
- add inaccessible-issue sentinel handling for `discover-readiness-check`
- treat inaccessible target/dependency/blocked-by issue lookups as unresolvable evidence (`issue_inaccessible`) instead of hard failure
- preserve hard-fail behavior for non-recoverable loader errors
- add regression tests for inaccessible target/dependency paths and non-recoverable error bubbling

## Verification
- `node --test tests/discover-readiness-check.test.mjs`
- `pnpm run test`
- `pnpm run lint`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

Closes #413
Refs #411


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness check to distinguish between missing issues and issues that are present but inaccessible.
  * Enhanced handling of inaccessible dependencies and blocked-by relationships.
  * Better error categorization with specific reason codes for inaccessible items.

* **Tests**
  * Added comprehensive test coverage for inaccessible issue detection scenarios and error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/419)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->