### PR TITLE
test(idd): harden phase-id alias regression coverage

### DIFF
--- a/tests/idd-workflow-phase-map-sync.test.mjs
+++ b/tests/idd-workflow-phase-map-sync.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const CANONICAL_DOC = "docs/idd-workflow.md";
+const TEMPLATE_DOC = "idd-template/docs/idd-workflow.md";
+
+test("IDD file map phase guidance stays synced between docs and template", () => {
+  const canonicalText = readText(CANONICAL_DOC);
+  const templateText = readText(TEMPLATE_DOC);
+
+  assert.equal(
+    extractTopLevelSection(canonicalText, CANONICAL_DOC, "## IDD file map"),
+    extractTopLevelSection(templateText, TEMPLATE_DOC, "## IDD file map"),
+  );
+});
+
+test("IDD file map keeps canonical phase-ID anchors", () => {
+  for (const file of [CANONICAL_DOC, TEMPLATE_DOC]) {
+    const section = extractTopLevelSection(readText(file), file, "## IDD file map");
+    for (const anchor of [
+      "A0-T–A4.5",
+      "B1-B3 + C1-C6",
+      "F2.5",
+      "Resume Step 0-3",
+      "Resume S1-S5",
+    ]) {
+      assert.ok(section.includes(anchor), `${file} must keep file-map anchor: ${anchor}`);
+    }
+  }
+});
+
+function readText(relativePath) {
+  return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
+}
+
+function extractTopLevelSection(text, fileLabel, startMarker) {
+  const nextSectionMarker = "\n## ";
+  const start = text.indexOf(startMarker);
+  assert.notEqual(start, -1, `${fileLabel} is missing section marker: ${startMarker}`);
+  const nextSectionStart = text.indexOf(nextSectionMarker, start + startMarker.length);
+  const end = nextSectionStart === -1 ? text.length : nextSectionStart;
+  return text.slice(start, end).trim();
+}

--- a/tests/phase-id-resolver.test.mjs
+++ b/tests/phase-id-resolver.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
@@ -29,9 +30,31 @@ test("resolves dotted and hyphen aliases to canonical IDs", () => {
   assert.equal(resolvePhaseId("A4-5").canonicalPhaseId, "A4_5");
 });
 
+test("resolves documented legacy aliases to canonical IDs", () => {
+  const aliases = {
+    A0_O: ["A0-O", "A0O"],
+    A0_T: ["A0-T", "A0T"],
+    A1_5: ["A1.5", "A1-5", "A15"],
+    A3_5: ["A3.5", "A3-5", "A35"],
+    A4_5: ["A4.5", "A4-5", "A45"],
+    F2_5: ["F2.5", "F2-5", "F25"],
+  };
+
+  for (const [canonical, variants] of Object.entries(aliases)) {
+    for (const variant of variants) {
+      const result = resolvePhaseId(variant);
+      assert.equal(result.canonicalPhaseId, canonical, `${variant} -> ${canonical}`);
+      assert.equal(result.matchedBy, "legacy-alias");
+    }
+  }
+});
+
 test("normalization is deterministic across repeated separators", () => {
   assert.equal(normalizePhaseIdToken("  a4...5  "), "A4_5");
   assert.equal(normalizePhaseIdToken("A4---5"), "A4_5");
+  assert.equal(normalizePhaseIdToken("A4/5"), "A4_5");
+  assert.equal(normalizePhaseIdToken("A4 : 5"), "A4_5");
+  assert.equal(normalizePhaseIdToken("A4\\5"), "A4_5");
 });
 
 test("throws explicit unknown phase diagnostics for unsupported IDs", () => {
@@ -46,6 +69,15 @@ test("throws explicit invalid diagnostics for malformed IDs", () => {
     () => resolvePhaseId("A4$5"),
     (error) => error && error.code === "invalid_phase_id",
   );
+});
+
+test("throws explicit invalid diagnostics for unsupported alias punctuation", () => {
+  for (const alias of ["A4(5)", "A4,5", "A4#5"]) {
+    assert.throws(
+      () => resolvePhaseId(alias),
+      (error) => error && error.code === "invalid_phase_id",
+    );
+  }
 });
 
 test("detects ambiguous alias configuration", () => {
@@ -71,3 +103,29 @@ test("CLI prints canonical machine-facing output", () => {
   assert.equal(parsed.canonicalPhaseId, "A4_5");
   assert.equal(parsed.matchedBy, "legacy-alias");
 });
+
+test("phase-graph edges remain valid under normalized phase IDs", () => {
+  const graph = readJson("schemas/phase-graph.json");
+  const normalizedNodeIds = graph.nodes.map((node) => normalizePhaseIdToken(node.id));
+  const normalizedNodeSet = new Set(normalizedNodeIds);
+
+  assert.equal(
+    normalizedNodeSet.size,
+    normalizedNodeIds.length,
+    "phase-graph IDs must stay unique after normalization",
+  );
+
+  for (const node of graph.nodes) {
+    for (const edge of node.next) {
+      const normalizedEdge = normalizePhaseIdToken(edge);
+      assert.ok(
+        normalizedNodeSet.has(normalizedEdge),
+        `normalized edge ${edge} -> ${normalizedEdge} is not defined in graph nodes`,
+      );
+    }
+  }
+});
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(join(REPO_ROOT, relativePath), "utf8"));
+}


### PR DESCRIPTION
## Summary
- extend phase-id resolver tests to cover every documented legacy alias and unsupported alias punctuation failures
- add deterministic normalization cases for separator variants (`/`, `:`, `\`)
- add a phase-graph normalization integrity regression test to prove no routing-edge breakage
- add docs/template sync tests for the IDD file-map phase-ID anchors

## Verification
- [x] `pnpm run lint:minimum`
- [x] `pnpm run test`

Closes #402

## Follow-ups
- none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for documentation consistency and phase identifier resolution validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/425)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->