### PR TITLE
docs(policy): opt into human-gated forced handoff locally

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -526,7 +526,7 @@ This repository uses the following IDD configuration:
 - **issue-author-approval-gate**: `enabled-by-default`
 - **issue-author-approval-opt-out**: `skipIssueAuthorApprovalGate: true` only when the repository intentionally skips the gate
 - **collaborator-authored-markers**: `false`
-- **forced-handoff**: `disabled`
+- **forced-handoff**: `human-gated`
 - **forced-handoff-authority**: `owners-and-maintainers-only`
 ```
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -526,7 +526,7 @@ This repository uses the following IDD configuration:
 - **issue-author-approval-gate**: `enabled-by-default`
 - **issue-author-approval-opt-out**: `skipIssueAuthorApprovalGate: true` only when the repository intentionally skips the gate
 - **collaborator-authored-markers**: `false`
-- **forced-handoff**: `human-gated`
+- **forced-handoff**: `disabled`
 - **forced-handoff-authority**: `owners-and-maintainers-only`
 ```
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -526,7 +526,7 @@ This repository uses the following IDD configuration:
 - **issue-author-approval-gate**: `enabled-by-default`
 - **issue-author-approval-opt-out**: `skipIssueAuthorApprovalGate: true` only when the repository intentionally skips the gate
 - **collaborator-authored-markers**: `false`
-- **forced-handoff**: `disabled`
+- **forced-handoff**: `human-gated`
 - **forced-handoff-authority**: `owners-and-maintainers-only`
 ```
 


### PR DESCRIPTION
## Summary
- mark this repository's local policy block as human-gated forced handoff
- keep the maintainer authority rule unchanged
- preserve the disabled default for adopters in the surrounding policy guidance

Closes #443



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated policy configuration examples across documentation to demonstrate the `human-gated` approach for forced handoff settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/444)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->