### PR TITLE
feat(merge): gate f2/f3 on completed e7 disposition evidence

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -63,6 +63,13 @@ gate. The active claim must still use your current `{claim-id}`.
    `F3_UNRESOLVED_ACTIONABLE_COUNT > 0`, stop and return to E1. Do not
    execute `gh pr merge` in this pass.
 
+   If the carried F2 evidence includes helper-side
+   `dispositionEvidence`, require
+   `dispositionEvidence.route == "proceed"` and
+   `dispositionEvidence.blockingCount == 0` before merge. If either
+   check fails, stop and return to E1/E4 with the reported missing
+   thread/comment disposition items.
+
    Execute the merge immediately after this final fetch **and the claim
    re-validation and advisory state revalidation below**, with no other
    actions in between. Re-validate claim: re-read the issue and confirm

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -74,6 +74,10 @@ minimum, capture:
    state satisfies the advisory gate for merge.
 6. CI evidence: required-check generation state and pass/fail status for
    all required checks on the current PR HEAD.
+7. E7 disposition evidence: whether each actionable PATH A item and
+   advisory PATH B item has a fresh `**Accepted**`/`**Rejected**`
+   disposition marker, plus the exact missing-thread and
+   missing-regular-comment blocker items when incomplete.
 
 Do not treat "one bot says clean" as sufficient evidence. The checklist
 must cover the full activity universe (human reviewers plus advisory bot
@@ -211,6 +215,12 @@ must align with every F2 condition below.
   E1's regular-comment filter for non-advisory discussion. Copilot and
   CI advisory bot comments are handled earlier in the PATH B triage flow
   (E4-E7) and are excluded from this gate.
+- **E7 disposition evidence complete**: If helper evidence includes a
+  `dispositionEvidence` section, require
+  `dispositionEvidence.route == "proceed"` and
+  `dispositionEvidence.blockingCount == 0`. If either check fails, route
+  to E1/E4 with the missing-thread or missing-comment evidence reported
+  from that section.
 
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the PR live status digest after the blocking evidence is recorded and

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -176,7 +176,8 @@ default `instructions-only` profile keep using the written shell /
   [`pre-merge-readiness.schema.json`][pre-merge-readiness-schema]
 - Stable sections consumed by the instructions: `reviewCurrency`,
   `threads`, `unrepliedComments`, `reviewerStates`,
-  `advisoryWait`, `ci`, and `claim`
+  `advisoryWait`, `ci`, `claim`, and optional
+  `dispositionEvidence`
 
 ## Friction Inventory
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -63,6 +63,13 @@ gate. The active claim must still use your current `{claim-id}`.
    `F3_UNRESOLVED_ACTIONABLE_COUNT > 0`, stop and return to E1. Do not
    execute `gh pr merge` in this pass.
 
+   If the carried F2 evidence includes helper-side
+   `dispositionEvidence`, require
+   `dispositionEvidence.route == "proceed"` and
+   `dispositionEvidence.blockingCount == 0` before merge. If either
+   check fails, stop and return to E1/E4 with the reported missing
+   thread/comment disposition items.
+
    Execute the merge immediately after this final fetch **and the claim
    re-validation and advisory state revalidation below**, with no other
    actions in between. Re-validate claim: re-read the issue and confirm

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -74,6 +74,10 @@ minimum, capture:
    state satisfies the advisory gate for merge.
 6. CI evidence: required-check generation state and pass/fail status for
    all required checks on the current PR HEAD.
+7. E7 disposition evidence: whether each actionable PATH A item and
+   advisory PATH B item has a fresh `**Accepted**`/`**Rejected**`
+   disposition marker, plus the exact missing-thread and
+   missing-regular-comment blocker items when incomplete.
 
 Do not treat "one bot says clean" as sufficient evidence. The checklist
 must cover the full activity universe (human reviewers plus advisory bot
@@ -211,6 +215,12 @@ must align with every F2 condition below.
   E1's regular-comment filter for non-advisory discussion. Copilot and
   CI advisory bot comments are handled earlier in the PATH B triage flow
   (E4-E7) and are excluded from this gate.
+- **E7 disposition evidence complete**: If helper evidence includes a
+  `dispositionEvidence` section, require
+  `dispositionEvidence.route == "proceed"` and
+  `dispositionEvidence.blockingCount == 0`. If either check fails, route
+  to E1/E4 with the missing-thread or missing-comment evidence reported
+  from that section.
 
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the PR live status digest after the blocking evidence is recorded and

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -176,7 +176,8 @@ default `instructions-only` profile keep using the written shell /
   [`pre-merge-readiness.schema.json`][pre-merge-readiness-schema]
 - Stable sections consumed by the instructions: `reviewCurrency`,
   `threads`, `unrepliedComments`, `reviewerStates`,
-  `advisoryWait`, `ci`, and `claim`
+  `advisoryWait`, `ci`, `claim`, and optional
+  `dispositionEvidence`
 
 ## Friction Inventory
 

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -434,6 +434,70 @@
           "enum": ["match", "missing-active-claim", "claim-id-mismatch", "agent-id-mismatch"]
         }
       }
+    },
+    "dispositionEvidence": {
+      "type": "object",
+      "required": [
+        "route",
+        "reason",
+        "blockingCount",
+        "missingRegularCommentCount",
+        "missingThreadCount",
+        "missingRegularComments",
+        "missingThreads"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "type": "string",
+          "enum": ["proceed", "return-to-e1"]
+        },
+        "reason": {
+          "type": "string",
+          "enum": ["complete", "missing-disposition-evidence"]
+        },
+        "blockingCount": { "type": "integer", "minimum": 0 },
+        "missingRegularCommentCount": { "type": "integer", "minimum": 0 },
+        "missingThreadCount": { "type": "integer", "minimum": 0 },
+        "missingRegularComments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "authorLogin", "createdAt", "bodyPreview"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "authorLogin": { "type": "string", "minLength": 1 },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+              },
+              "bodyPreview": { "type": "string" }
+            }
+          }
+        },
+        "missingThreads": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "isResolved", "reason"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "isResolved": { "type": "boolean" },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "incomplete-thread-comments",
+                  "missing-fresh-disposition",
+                  "unresolved-without-fresh-disposition"
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -144,6 +144,7 @@ const summary = buildPreMergeReadinessSummary(
     prAuthorLogin,
     expectedClaimId: args.expectedClaimId,
     expectedAgentId: args.expectedAgentId,
+    includeDispositionEvidence: true,
     requestCap: 30,
     pendingWindowMinutes: 30,
     settledWindowMinutes: 10,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -762,19 +762,32 @@ function inferReviewerReopenedAt(thread) {
   return "";
 }
 
-export function hasFreshDisposition(thread) {
+export function hasFreshDisposition(thread, options = {}) {
+  const dispositionAuthorPredicate =
+    typeof options.isDispositionAuthor === "function"
+      ? options.isDispositionAuthor
+      : (login) => !isKnownReviewBot(login);
   const comments = thread.comments?.nodes ?? [];
   const latestFeedbackAt = maxIsoTimestamp(
     comments
-    .filter((comment) => !isIddDispositionComment(comment))
-    .map((comment) => comment.createdAt),
+      .filter((comment) => {
+        const authorLogin = String(comment.author?.login ?? "").trim().toLowerCase();
+        return !(isDispositionComment(comment) && dispositionAuthorPredicate(authorLogin));
+      })
+      .map((comment) => effectiveThreadCommentActivityAt(comment))
+      .filter(isValidIsoTimestamp),
   );
 
   return comments.some((comment) => {
-    if (!isIddDispositionComment(comment)) {
+    const authorLogin = String(comment.author?.login ?? "").trim().toLowerCase();
+    if (!(isDispositionComment(comment) && dispositionAuthorPredicate(authorLogin))) {
       return false;
     }
-    return !latestFeedbackAt || compareIsoTimestamps(comment.createdAt, latestFeedbackAt) > 0;
+    const dispositionActivityAt = effectiveThreadCommentActivityAt(comment);
+    if (!isValidIsoTimestamp(dispositionActivityAt)) {
+      return false;
+    }
+    return !latestFeedbackAt || compareIsoTimestamps(dispositionActivityAt, latestFeedbackAt) > 0;
   });
 }
 
@@ -1271,6 +1284,120 @@ export function summarizeRegularCommentsForGate(comments, options = {}) {
   };
 }
 
+export function summarizeDispositionEvidenceForGate(
+  { comments = [], threads = [] },
+  options = {},
+) {
+  const iddAgentLogins = new Set(normalizeTrustedMarkerLogins(options.iddAgentLogins ?? []));
+  const advisoryBotLogins = new Set(normalizeTrustedMarkerLogins(options.advisoryBotLogins ?? []));
+  const trustedMarkerLogins = new Set(normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []));
+  const prAuthorLogin = String(options.prAuthorLogin ?? "").trim().toLowerCase();
+
+  const normalizedComments = comments
+    .map((comment, inputIndex) => ({
+      id: String(comment.id ?? ""),
+      authorLogin: String(comment.author?.login ?? comment.user?.login ?? "").trim().toLowerCase(),
+      body: String(comment.body ?? ""),
+      createdAt: String(comment.createdAt ?? comment.created_at ?? ""),
+      updatedAt: String(comment.updatedAt ?? comment.updated_at ?? ""),
+      inputIndex,
+    }))
+    .filter((comment) => isValidIsoTimestamp(comment.createdAt))
+    .map((comment) => ({
+      ...comment,
+      activityAt: effectiveRegularCommentActivityAt(comment),
+    }))
+    .sort((left, right) => {
+      const leftTime = Date.parse(left.activityAt);
+      const rightTime = Date.parse(right.activityAt);
+      if (leftTime !== rightTime) {
+        return leftTime - rightTime;
+      }
+      return left.inputIndex - right.inputIndex;
+    })
+    .map((comment, sortedIndex) => ({ ...comment, sortedIndex }));
+
+  const classificationComments = normalizedComments.map((comment) => ({
+    author: { login: comment.authorLogin },
+    body: comment.body,
+    createdAt: comment.createdAt,
+  }));
+
+  const missingRegularComments = normalizedComments
+    .filter((comment) => !isOperationalOrDigestCommentForGate(comment.body, comment.authorLogin, trustedMarkerLogins))
+    .filter((comment) => !iddAgentLogins.has(comment.authorLogin))
+    .filter((comment) => {
+      if (!isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins)) {
+        return true;
+      }
+      return classifyRegularBotComment(
+        {
+          author: { login: comment.authorLogin },
+          body: comment.body,
+          createdAt: comment.createdAt,
+        },
+        classificationComments,
+        threads,
+      ) === null;
+    })
+    .filter((comment) => {
+      return !normalizedComments.some((reply) => {
+        return iddAgentLogins.has(reply.authorLogin)
+          && isDispositionComment({ body: reply.body })
+          && compareIsoTimestamps(reply.activityAt, comment.activityAt) > 0;
+      });
+    })
+    .map((comment) => ({
+      id: comment.id || `comment-${comment.sortedIndex + 1}`,
+      authorLogin: comment.authorLogin || "unknown",
+      createdAt: comment.createdAt,
+      bodyPreview: buildBodyPreview(comment.body),
+    }));
+
+  const missingThreads = (threads ?? [])
+    .map((thread, index) => {
+      const commentsInThread = thread.comments?.nodes ?? [];
+      const hasExternalFeedback = commentsInThread.some((comment) => {
+        const authorLogin = String(comment.author?.login ?? "").trim().toLowerCase();
+        return authorLogin && !iddAgentLogins.has(authorLogin) && authorLogin !== prAuthorLogin;
+      });
+      if (!hasExternalFeedback) {
+        return null;
+      }
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        return {
+          id: String(thread.id ?? "") || `thread-${index + 1}`,
+          isResolved: Boolean(thread.isResolved),
+          reason: "incomplete-thread-comments",
+        };
+      }
+      if (hasFreshDisposition(thread, {
+        isDispositionAuthor: (login) => iddAgentLogins.has(String(login ?? "").trim().toLowerCase()),
+      })) {
+        return null;
+      }
+      return {
+        id: String(thread.id ?? "") || `thread-${index + 1}`,
+        isResolved: Boolean(thread.isResolved),
+        reason: thread.isResolved
+          ? "missing-fresh-disposition"
+          : "unresolved-without-fresh-disposition",
+      };
+    })
+    .filter(Boolean);
+
+  const blockingCount = missingRegularComments.length + missingThreads.length;
+  return {
+    route: blockingCount > 0 ? "return-to-e1" : "proceed",
+    reason: blockingCount > 0 ? "missing-disposition-evidence" : "complete",
+    blockingCount,
+    missingRegularCommentCount: missingRegularComments.length,
+    missingThreadCount: missingThreads.length,
+    missingRegularComments,
+    missingThreads,
+  };
+}
+
 export function summarizeBranchReviewRequirements(branchRules = [], branchProtection = {}) {
   const requiredCheckNames = new Set();
   const requiredReviewerLogins = new Set();
@@ -1751,7 +1878,19 @@ export function buildPreMergeReadinessSummary(
     expectedAgentId: options.expectedAgentId,
   });
 
-  return {
+  const dispositionEvidence = options.includeDispositionEvidence
+    ? summarizeDispositionEvidenceForGate(
+      { comments, threads },
+      {
+        iddAgentLogins,
+        advisoryBotLogins,
+        trustedMarkerLogins,
+        prAuthorLogin,
+      },
+    )
+    : null;
+
+  const summary = {
     protocolVersion: "1",
     decisionAuthority: "instructions",
     prHeadSha,
@@ -1803,6 +1942,12 @@ export function buildPreMergeReadinessSummary(
     ci,
     claim,
   };
+
+  if (dispositionEvidence) {
+    summary.dispositionEvidence = dispositionEvidence;
+  }
+
+  return summary;
 }
 
 function normalizeLiveStatusDigestFields(fields) {
@@ -2557,6 +2702,18 @@ function threadActivityAt(thread) {
     .filter(isValidIsoTimestamp);
 
   return maxIsoTimestamp(commentTimes);
+}
+
+function effectiveThreadCommentActivityAt(comment) {
+  const updatedAt = String(comment?.updatedAt ?? "");
+  if (isValidIsoTimestamp(updatedAt)) {
+    return updatedAt;
+  }
+  const createdAt = String(comment?.createdAt ?? "");
+  if (isValidIsoTimestamp(createdAt)) {
+    return createdAt;
+  }
+  return "";
 }
 
 function hasCompletedBotThreadDispositions(threads, loginPredicate) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -763,6 +763,12 @@ function inferReviewerReopenedAt(thread) {
 }
 
 export function hasFreshDisposition(thread, options = {}) {
+  // IMPORTANT: The default disposition-author predicate rejects known bots but accepts any human.
+  // For F2/F3 merge-gate contexts (E7 disposition evidence), callers MUST pass
+  // options.isDispositionAuthor with an IDD-scoped predicate (e.g., via summarizeDispositionEvidenceForGate).
+  // Callers that require IDD-only dispositions (e.g., audit-pr-cleanup) should pass:
+  //   { isDispositionAuthor: (login) => iddAgentLogins.has(login) }
+  // This design trades stricter default behavior for backward compatibility with utility functions.
   const dispositionAuthorPredicate =
     typeof options.isDispositionAuthor === "function"
       ? options.isDispositionAuthor

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -11,6 +11,7 @@ import {
   indexLatestGatingReviewsByAuthor,
   resolveCodeownersForFiles,
   selectCodeownersText,
+  summarizeDispositionEvidenceForGate,
   summarizeAdvisoryWaitMarkers,
   summarizeClaimValidation,
   summarizeRegularCommentsForGate,
@@ -62,6 +63,18 @@ test("pre-merge readiness schema keeps UTC timestamps strict", () => {
   const invalidReviewerTime = JSON.parse(JSON.stringify(cleanSummary));
   invalidReviewerTime.reviewerStates.latestByAuthor[0].submittedAt = "2026-05-12T00:14:04+09:00";
   assert.ok(validate(invalidReviewerTime, readinessSchema).length > 0);
+});
+
+test("pre-merge readiness optionally emits disposition evidence", () => {
+  const fixture = readJson("fixtures/pre-merge-readiness/clean.json");
+  const summary = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+  });
+
+  assert.equal(summary.dispositionEvidence?.route, "proceed");
+  assert.equal(summary.dispositionEvidence?.blockingCount, 0);
+  assert.deepEqual(validate(summary, readinessSchema), []);
 });
 
 test("required check summaries block when no merge-gate policy evidence exists", () => {
@@ -610,6 +623,127 @@ test("regular comment gate keeps forced-handoff markers visible without explicit
 
   assert.equal(summary.count, 1);
   assert.deepEqual(summary.items.map((item) => item.id), ["1"]);
+});
+
+test("disposition evidence blocks when a regular comment has no disposition marker reply", () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        { id: 1, createdAt: "2026-05-12T00:00:00Z", body: "please address", author: { login: "reviewer-a" } },
+        { id: 2, createdAt: "2026-05-12T00:00:01Z", body: "Thanks, updating now.", author: { login: "idd-bot" } },
+      ],
+      threads: [],
+    },
+    { iddAgentLogins: ["idd-bot"] },
+  );
+
+  assert.equal(summary.route, "return-to-e1");
+  assert.equal(summary.blockingCount, 1);
+  assert.equal(summary.missingRegularCommentCount, 1);
+  assert.equal(summary.missingThreadCount, 0);
+});
+
+test("disposition evidence treats PATH A and PATH B as complete when both have markers", () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        { id: 1, createdAt: "2026-05-12T00:00:00Z", body: "human feedback", author: { login: "reviewer-a" } },
+        { id: 2, createdAt: "2026-05-12T00:00:01Z", body: "**Accepted** — fixed in abc123", author: { login: "idd-bot" } },
+        { id: 3, createdAt: "2026-05-12T00:00:02Z", body: "advisory note", author: { login: "chatgpt-codex-connector[bot]" } },
+        { id: 4, createdAt: "2026-05-12T00:00:03Z", body: "**Rejected** — advisory acknowledged", author: { login: "idd-bot" } },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ["idd-bot"],
+      advisoryBotLogins: ["chatgpt-codex-connector[bot]"],
+    },
+  );
+
+  assert.equal(summary.route, "proceed");
+  assert.equal(summary.blockingCount, 0);
+  assert.equal(summary.missingRegularCommentCount, 0);
+  assert.equal(summary.missingThreadCount, 0);
+});
+
+test("disposition evidence blocks unresolved threads without fresh disposition markers", () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: "thread-1",
+          isResolved: false,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              { author: { login: "reviewer-a" }, createdAt: "2026-05-12T00:00:00Z", body: "need change" },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ["idd-bot"] },
+  );
+
+  assert.equal(summary.route, "return-to-e1");
+  assert.equal(summary.blockingCount, 1);
+  assert.equal(summary.missingRegularCommentCount, 0);
+  assert.equal(summary.missingThreadCount, 1);
+  assert.equal(summary.missingThreads[0].reason, "unresolved-without-fresh-disposition");
+});
+
+test("disposition evidence rejects reviewer-authored Accepted marker in threads", () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: "thread-2",
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              { author: { login: "reviewer-a" }, createdAt: "2026-05-12T00:00:00Z", body: "please fix" },
+              { author: { login: "reviewer-a" }, createdAt: "2026-05-12T00:00:01Z", body: "**Accepted** — looks good now" },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ["idd-bot"] },
+  );
+
+  assert.equal(summary.route, "return-to-e1");
+  assert.equal(summary.missingThreadCount, 1);
+  assert.equal(summary.missingThreads[0].reason, "missing-fresh-disposition");
+});
+
+test("disposition evidence accepts edited IDD disposition comments as fresh replies", () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: "2026-05-12T00:01:00Z",
+          body: "please address this",
+          author: { login: "reviewer-a" },
+        },
+        {
+          id: 2,
+          createdAt: "2026-05-12T00:00:30Z",
+          updatedAt: "2026-05-12T00:02:00Z",
+          body: "**Accepted** — updated after latest feedback",
+          author: { login: "idd-bot" },
+        },
+      ],
+      threads: [],
+    },
+    { iddAgentLogins: ["idd-bot"] },
+  );
+
+  assert.equal(summary.route, "proceed");
+  assert.equal(summary.blockingCount, 0);
 });
 
 test("deriveIddAgentLogins keeps prior trusted operational actors but not generic maintainer comments", () => {


### PR DESCRIPTION
## Summary
- add `dispositionEvidence` computation to merge-readiness helper output to detect missing E7 Accepted/Rejected markers on review threads and regular comments
- enforce helper emission in `scripts/pre-merge-readiness.mjs` and extend schema/tests for optional structured evidence payload
- update F2/F3 instructions (and template mirrors) to consume helper-side disposition evidence when present
- document the new optional helper section in `docs/idd-helper-scripts.md` and template mirror

## Why
F2/F3 merge decisions could rely on unresolved-thread and unreplied-comment checks while still missing explicit E7 disposition markers. This change makes missing disposition evidence visible and machine-checkable before merge.

## Validation
- `node --test tests/pre-merge-readiness.test.mjs tests/review-gate.test.mjs tests/schema-validation.test.mjs`
- `npm run lint:minimum`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

Closes #433
Refs #434
Refs #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added disposition-evidence checks to pre-merge and merge gates requiring a "proceed" route and zero blockers before merging.

* **Bug Fixes**
  * Merge now halts and reports specific missing disposition items when evidence is incomplete, routing back for resolution.

* **Documentation**
  * Updated pre-merge/merge guidance and helper-docs to include optional disposition evidence fields and usage.

* **Tests**
  * Added unit and integration tests covering disposition evidence collection, routing, and blocking scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/445)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->