### PR TITLE
feat(helpers): add review-disposition-verify.mjs for E7 marker presence meta-check

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -17,6 +17,8 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/live-status-digest.mjs` for issue or PR live status digest
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
+- `scripts/review-disposition-verify.mjs` for read-only E7 disposition
+  marker presence verification across PATH A and PATH B items
 
 The canonical workflow remains the portable shell / `gh` / `jq`
 instructions embedded in `.github/instructions/*.instructions.md`. The
@@ -138,6 +140,21 @@ The adopted helper boundaries are intentionally narrow:
 - direct GraphQL fallback commands remain documented in
   `docs/idd-comment-minimization.md`
 
+- `review-disposition-verify.mjs` is read-only, takes a JSON array of
+  ReviewItems_snapshot items, and emits per-item verification evidence
+- it checks E7 disposition requirements: decision recorded, marker
+  present and matching, and thread resolution correct per path and type
+- it never posts replies, resolves threads, or mutates any GitHub state
+- thread-resolution checks are gated on `type === "review_thread"`;
+  non-thread items must have `threadResolved: null`, not `true`/`false`
+- PATH A AMD items must have the thread unresolved; PATH A Rejected and
+  PATH B items must have review threads resolved
+- PATH A Accepted items pass without a marker (reply is handled in
+  review-fix, not triage)
+- written E7 rules in `idd-review-triage.instructions.md` remain
+  authoritative; this helper only reduces command-copy variance when
+  confirming marker presence before triage exits
+
 ## Stable Helper Evidence Outputs
 
 The references in this section apply only when a repository explicitly
@@ -178,6 +195,40 @@ default `instructions-only` profile keep using the written shell /
   `threads`, `unrepliedComments`, `reviewerStates`,
   `advisoryWait`, `ci`, and `claim`
 
+### E7 disposition verification
+
+- Command:
+  `node scripts/review-disposition-verify.mjs --items '<json>'`
+- Input: JSON array of ReviewItems_snapshot items, each with `id`,
+  `path` (`"A"` or `"B"`), `type`, `decision`, `markerReply`, and
+  `threadResolved`
+- Output schema (stable fields):
+
+  ```json
+  {
+    "passed": true,
+    "summary": "All 3 items verified.",
+    "totalCount": 3,
+    "passedCount": 3,
+    "failedCount": 0,
+    "items": [{
+      "id": "...",
+      "path": "A",
+      "checks": {
+        "decisionRecorded": true,
+        "markerPresent": true,
+        "markerMatchesDecision": true,
+        "threadResolutionCorrect": true
+      },
+      "passed": true,
+      "issues": []
+    }]
+  }
+  ```
+
+- Stable fields consumed at E7: `passed`, `items[].passed`,
+  `items[].checks`, and `items[].issues`
+
 ## Friction Inventory
 
 The workflow areas most likely to benefit from optional helpers are:
@@ -190,6 +241,7 @@ The workflow areas most likely to benefit from optional helpers are:
 | Advisory-wait state             | Adopted helper     | Read-only evidence collector       | Low           | `.github/instructions/idd-advisory-wait.instructions.md`               | Medium — helper must expose evidence without hiding the canonical decision table         | Very high — roughly 900 to 1400 bytes of repeated AW command prose      |
 | Pre-merge readiness             | Adopted helper     | Read-only evidence collector       | Low           | `.github/instructions/idd-pre-merge.instructions.md` and F3 live fetch | Medium — helper must stay evidence-only and preserve the written merge gates             | Very high — roughly 1200 to 1800 bytes of repeated merge-evidence prose |
 | Post-merge cleanup candidates   | Adopted helper     | Dry-run by default, explicit apply | High          | GraphQL minimize-comment fallback flow                                 | Medium — minimization safety still depends on exact review/marker rules                  | Medium — roughly 400 to 700 bytes of repeated GraphQL audit prose       |
+| E7 disposition verification     | Adopted helper     | Read-only evidence verifier        | Low           | E7 verification steps in `idd-review-triage.instructions.md`           | Low — verification logic is deterministic and path/type rules are stable                 | Low to medium — roughly 150 to 300 bytes of repeated E7 pre-exit checks |
 | Branch protection/ruleset reads | Deferred candidate | Read-only API adapter              | Low           | Direct ruleset / branch-protection API reads                           | Medium — repository support varies and incomplete coverage could create false confidence | Low to medium — roughly 150 to 300 bytes of repeated ruleset prose      |
 
 ### Ranked roadmap candidate list for the source roadmap

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -17,6 +17,8 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/live-status-digest.mjs` for issue or PR live status digest
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
+- `scripts/review-disposition-verify.mjs` for read-only E7 disposition
+  marker presence verification across PATH A and PATH B items
 
 The canonical workflow remains the portable shell / `gh` / `jq`
 instructions embedded in `.github/instructions/*.instructions.md`. The
@@ -138,6 +140,21 @@ The adopted helper boundaries are intentionally narrow:
 - direct GraphQL fallback commands remain documented in
   `docs/idd-comment-minimization.md`
 
+- `review-disposition-verify.mjs` is read-only, takes a JSON array of
+  ReviewItems_snapshot items, and emits per-item verification evidence
+- it checks E7 disposition requirements: decision recorded, marker
+  present and matching, and thread resolution correct per path and type
+- it never posts replies, resolves threads, or mutates any GitHub state
+- thread-resolution checks are gated on `type === "review_thread"`;
+  non-thread items must have `threadResolved: null`, not `true`/`false`
+- PATH A AMD items must have the thread unresolved; PATH A Rejected and
+  PATH B items must have review threads resolved
+- PATH A Accepted items pass without a marker (reply is handled in
+  review-fix, not triage)
+- written E7 rules in `idd-review-triage.instructions.md` remain
+  authoritative; this helper only reduces command-copy variance when
+  confirming marker presence before triage exits
+
 ## Stable Helper Evidence Outputs
 
 The references in this section apply only when a repository explicitly
@@ -178,6 +195,40 @@ default `instructions-only` profile keep using the written shell /
   `threads`, `unrepliedComments`, `reviewerStates`,
   `advisoryWait`, `ci`, and `claim`
 
+### E7 disposition verification
+
+- Command:
+  `node scripts/review-disposition-verify.mjs --items '<json>'`
+- Input: JSON array of ReviewItems_snapshot items, each with `id`,
+  `path` (`"A"` or `"B"`), `type`, `decision`, `markerReply`, and
+  `threadResolved`
+- Output schema (stable fields):
+
+  ```json
+  {
+    "passed": true,
+    "summary": "All 3 items verified.",
+    "totalCount": 3,
+    "passedCount": 3,
+    "failedCount": 0,
+    "items": [{
+      "id": "...",
+      "path": "A",
+      "checks": {
+        "decisionRecorded": true,
+        "markerPresent": true,
+        "markerMatchesDecision": true,
+        "threadResolutionCorrect": true
+      },
+      "passed": true,
+      "issues": []
+    }]
+  }
+  ```
+
+- Stable fields consumed at E7: `passed`, `items[].passed`,
+  `items[].checks`, and `items[].issues`
+
 ## Friction Inventory
 
 The workflow areas most likely to benefit from optional helpers are:
@@ -190,6 +241,7 @@ The workflow areas most likely to benefit from optional helpers are:
 | Advisory-wait state             | Adopted helper     | Read-only evidence collector       | Low           | `.github/instructions/idd-advisory-wait.instructions.md`               | Medium — helper must expose evidence without hiding the canonical decision table         | Very high — roughly 900 to 1400 bytes of repeated AW command prose      |
 | Pre-merge readiness             | Adopted helper     | Read-only evidence collector       | Low           | `.github/instructions/idd-pre-merge.instructions.md` and F3 live fetch | Medium — helper must stay evidence-only and preserve the written merge gates             | Very high — roughly 1200 to 1800 bytes of repeated merge-evidence prose |
 | Post-merge cleanup candidates   | Adopted helper     | Dry-run by default, explicit apply | High          | GraphQL minimize-comment fallback flow                                 | Medium — minimization safety still depends on exact review/marker rules                  | Medium — roughly 400 to 700 bytes of repeated GraphQL audit prose       |
+| E7 disposition verification     | Adopted helper     | Read-only evidence verifier        | Low           | E7 verification steps in `idd-review-triage.instructions.md`           | Low — verification logic is deterministic and path/type rules are stable                 | Low to medium — roughly 150 to 300 bytes of repeated E7 pre-exit checks |
 | Branch protection/ruleset reads | Deferred candidate | Read-only API adapter              | Low           | Direct ruleset / branch-protection API reads                           | Medium — repository support varies and incomplete coverage could create false confidence | Low to medium — roughly 150 to 300 bytes of repeated ruleset prose      |
 
 ### Ranked roadmap candidate list for the source roadmap

--- a/scripts/review-disposition-verify.mjs
+++ b/scripts/review-disposition-verify.mjs
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 
 const MARKER_ACCEPTED_RE = /^\*\*Accepted\*\*\s+—/;
 const MARKER_REJECTED_RE = /^\*\*Rejected\*\*\s+—/;
+const MARKER_REJECTION_CONFIRMED_RE = /^\*\*Rejection confirmed by maintainer\*\*\s+—/;
 const MARKER_AMD_RE = /^\*\*Awaiting maintainer decision\*\*\s+—/;
 
 if (isMainModule(import.meta.url)) {
@@ -20,8 +21,17 @@ if (isMainModule(import.meta.url)) {
   let rawItems;
   try {
     const parsed = JSON.parse(args.items);
-    rawItems = Array.isArray(parsed) ? parsed : (parsed.items ?? []);
-  } catch {
+    if (Array.isArray(parsed)) {
+      rawItems = parsed;
+    } else if (parsed !== null && typeof parsed === "object" && "items" in parsed) {
+      rawItems = parsed.items ?? [];
+    } else {
+      throw new Error("--items JSON object must have an 'items' key");
+    }
+  } catch (err) {
+    if (err.message.includes("--items")) {
+      throw err;
+    }
     throw new Error("--items must be a valid JSON array or object with an 'items' key");
   }
 
@@ -119,7 +129,7 @@ export function classifyMarker(text) {
   if (MARKER_ACCEPTED_RE.test(trimmed)) {
     return "accepted";
   }
-  if (MARKER_REJECTED_RE.test(trimmed)) {
+  if (MARKER_REJECTED_RE.test(trimmed) || MARKER_REJECTION_CONFIRMED_RE.test(trimmed)) {
     return "rejected";
   }
   if (MARKER_AMD_RE.test(trimmed)) {
@@ -306,7 +316,10 @@ function parseArgs(argv) {
     const token = argv[index];
     const value = argv[index + 1];
     if (token === "--items") {
-      parsed.items = value ?? "[]";
+      if (value === undefined || value.startsWith("-")) {
+        throw new Error("--items requires a JSON value");
+      }
+      parsed.items = value;
       index += 1;
       continue;
     }

--- a/scripts/review-disposition-verify.mjs
+++ b/scripts/review-disposition-verify.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 
 const MARKER_ACCEPTED_RE = /^\*\*Accepted\*\*\s+—/;
@@ -12,6 +11,10 @@ if (isMainModule(import.meta.url)) {
   if (args.help) {
     printHelp();
     process.exit(0);
+  }
+
+  if (args.items === null) {
+    throw new Error("--items is required");
   }
 
   let rawItems;
@@ -298,17 +301,13 @@ function normalizeItem(item) {
 }
 
 function parseArgs(argv) {
-  const parsed = { items: "[]", verbose: false, help: false };
+  const parsed = { items: null, help: false };
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     const value = argv[index + 1];
     if (token === "--items") {
       parsed.items = value ?? "[]";
       index += 1;
-      continue;
-    }
-    if (token === "--verbose") {
-      parsed.verbose = true;
       continue;
     }
     if (token === "--help" || token === "-h") {
@@ -322,7 +321,7 @@ function parseArgs(argv) {
 
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/review-disposition-verify.mjs --items '<json>' [--verbose] [--help]
+  node scripts/review-disposition-verify.mjs --items '<json>' [--help]
 
 Input: JSON array of items or object with an 'items' key.
 

--- a/scripts/review-disposition-verify.mjs
+++ b/scripts/review-disposition-verify.mjs
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const MARKER_ACCEPTED_RE = /^\*\*Accepted\*\*\s+—/;
+const MARKER_REJECTED_RE = /^\*\*Rejected\*\*\s+—/;
+const MARKER_AMD_RE = /^\*\*Awaiting maintainer decision\*\*\s+—/;
+
+if (isMainModule(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  let rawItems;
+  try {
+    const parsed = JSON.parse(args.items);
+    rawItems = Array.isArray(parsed) ? parsed : (parsed.items ?? []);
+  } catch {
+    throw new Error("--items must be a valid JSON array or object with an 'items' key");
+  }
+
+  const result = verifyDispositions(rawItems);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+/**
+ * Verify E7 disposition evidence for a set of ReviewItems_snapshot items.
+ *
+ * Returns:
+ * {
+ *   passed: boolean,
+ *   summary: string,
+ *   totalCount: number,
+ *   passedCount: number,
+ *   failedCount: number,
+ *   items: Array<{
+ *     id: string,
+ *     path: "A"|"B",
+ *     checks: {
+ *       decisionRecorded: boolean,
+ *       markerPresent: boolean|null,
+ *       markerMatchesDecision: boolean|null,
+ *       threadResolutionCorrect: boolean|null
+ *     },
+ *     passed: boolean,
+ *     issues: string[]
+ *   }>
+ * }
+ */
+export function verifyDispositions(items) {
+  if (!Array.isArray(items)) {
+    throw new TypeError("items must be an array");
+  }
+  if (items.length === 0) {
+    return {
+      passed: true,
+      summary: "No items to verify.",
+      totalCount: 0,
+      passedCount: 0,
+      failedCount: 0,
+      items: [],
+    };
+  }
+
+  const results = items.map((item) => {
+    const normalized = normalizeItem(item);
+    if (normalized.path === "A") {
+      return checkPathAItem(normalized);
+    }
+    if (normalized.path === "B") {
+      return checkPathBItem(normalized);
+    }
+    return {
+      id: normalized.id,
+      path: normalized.path,
+      checks: {
+        decisionRecorded: false,
+        markerPresent: null,
+        markerMatchesDecision: null,
+        threadResolutionCorrect: null,
+      },
+      passed: false,
+      issues: [`Unknown path value: ${JSON.stringify(normalized.path)}. Expected "A" or "B".`],
+    };
+  });
+
+  const passedCount = results.filter((r) => r.passed).length;
+  const failedCount = results.length - passedCount;
+  const passed = failedCount === 0;
+  const summary = passed
+    ? `All ${results.length} item${results.length === 1 ? "" : "s"} verified.`
+    : `${failedCount} of ${results.length} item${results.length === 1 ? "" : "s"} failed E7 verification.`;
+
+  return {
+    passed,
+    summary,
+    totalCount: results.length,
+    passedCount,
+    failedCount,
+    items: results,
+  };
+}
+
+/**
+ * Classify a disposition marker reply.
+ * Returns "accepted" | "rejected" | "awaiting_maintainer" | null.
+ */
+export function classifyMarker(text) {
+  if (typeof text !== "string" || text.trim() === "") {
+    return null;
+  }
+  const trimmed = text.trim();
+  if (MARKER_ACCEPTED_RE.test(trimmed)) {
+    return "accepted";
+  }
+  if (MARKER_REJECTED_RE.test(trimmed)) {
+    return "rejected";
+  }
+  if (MARKER_AMD_RE.test(trimmed)) {
+    return "awaiting_maintainer";
+  }
+  return null;
+}
+
+/**
+ * Verify a PATH A item per E7 rules.
+ *
+ * PATH A Accepted: decision must be recorded; no marker required at triage.
+ * PATH A Rejected: decision must be recorded + marker must be present + if review_thread then resolved.
+ * PATH A AMD: decision must be recorded + AMD marker must be present + if review_thread then NOT resolved.
+ */
+export function checkPathAItem(item) {
+  const normalized = normalizeItem(item);
+  const { id, type, decision, markerReply, threadResolved } = normalized;
+  const checks = {
+    decisionRecorded: false,
+    markerPresent: null,
+    markerMatchesDecision: null,
+    threadResolutionCorrect: null,
+  };
+  const issues = [];
+
+  const validDecisions = new Set(["accepted", "rejected", "awaiting_maintainer"]);
+  if (decision === null) {
+    checks.decisionRecorded = false;
+    issues.push("PATH A item has no recorded decision (null).");
+    return makeResult(id, "A", checks, issues);
+  }
+  if (!validDecisions.has(decision)) {
+    checks.decisionRecorded = false;
+    issues.push(`Unknown decision value: ${JSON.stringify(decision)}.`);
+    return makeResult(id, "A", checks, issues);
+  }
+  checks.decisionRecorded = true;
+
+  if (decision === "accepted") {
+    return makeResult(id, "A", checks, issues);
+  }
+
+  const markerType = classifyMarker(markerReply ?? "");
+
+  if (decision === "rejected") {
+    const markerPresent = markerType === "rejected";
+    checks.markerPresent = markerPresent;
+    checks.markerMatchesDecision = markerPresent;
+    if (!markerPresent) {
+      issues.push("PATH A Rejected item is missing the required `**Rejected** — {reason}` marker reply.");
+    }
+
+    if (type === "review_thread") {
+      const resolutionCorrect = threadResolved === true;
+      checks.threadResolutionCorrect = resolutionCorrect;
+      if (!resolutionCorrect) {
+        issues.push("PATH A Rejected review_thread must be resolved after posting the rejection reply.");
+      }
+    } else {
+      if (threadResolved !== null) {
+        checks.threadResolutionCorrect = false;
+        issues.push(`Non-thread item (type: ${type}) has unexpected non-null threadResolved: ${JSON.stringify(threadResolved)}.`);
+      } else {
+        checks.threadResolutionCorrect = true;
+      }
+    }
+    return makeResult(id, "A", checks, issues);
+  }
+
+  if (decision === "awaiting_maintainer") {
+    const markerPresent = markerType === "awaiting_maintainer";
+    checks.markerPresent = markerPresent;
+    checks.markerMatchesDecision = markerPresent;
+    if (!markerPresent) {
+      issues.push("PATH A AMD item is missing the required `**Awaiting maintainer decision** — {reasoning}` marker reply.");
+    }
+
+    if (type === "review_thread") {
+      const resolutionCorrect = threadResolved === false;
+      checks.threadResolutionCorrect = resolutionCorrect;
+      if (!resolutionCorrect) {
+        issues.push("PATH A AMD review_thread must NOT be resolved (leave unresolved so F2 gate blocks merge).");
+      }
+    } else {
+      if (threadResolved !== null) {
+        checks.threadResolutionCorrect = false;
+        issues.push(`Non-thread AMD item (type: ${type}) has unexpected non-null threadResolved: ${JSON.stringify(threadResolved)}.`);
+      } else {
+        checks.threadResolutionCorrect = true;
+      }
+    }
+    return makeResult(id, "A", checks, issues);
+  }
+
+  return makeResult(id, "A", checks, issues);
+}
+
+/**
+ * Verify a PATH B item per E7 rules.
+ *
+ * PATH B: decision must be accepted or rejected + marker must be present
+ *         + if review_thread then resolved; otherwise threadResolved must be null.
+ */
+export function checkPathBItem(item) {
+  const normalized = normalizeItem(item);
+  const { id, type, decision, markerReply, threadResolved } = normalized;
+  const checks = {
+    decisionRecorded: false,
+    markerPresent: null,
+    markerMatchesDecision: null,
+    threadResolutionCorrect: null,
+  };
+  const issues = [];
+
+  const validDecisions = new Set(["accepted", "rejected"]);
+  if (decision === null) {
+    checks.decisionRecorded = false;
+    issues.push("PATH B item has no recorded decision (null).");
+    return makeResult(id, "B", checks, issues);
+  }
+  if (!validDecisions.has(decision)) {
+    checks.decisionRecorded = false;
+    issues.push(`PATH B decision must be "accepted" or "rejected"; got: ${JSON.stringify(decision)}.`);
+    return makeResult(id, "B", checks, issues);
+  }
+  checks.decisionRecorded = true;
+
+  const markerType = classifyMarker(markerReply ?? "");
+  const markerPresent = markerType === "accepted" || markerType === "rejected";
+  const markerMatchesDecision = markerType === decision;
+  checks.markerPresent = markerPresent;
+  checks.markerMatchesDecision = markerMatchesDecision;
+  if (!markerPresent) {
+    issues.push("PATH B item is missing the required `**Accepted** — ...` or `**Rejected** — ...` marker reply.");
+  } else if (!markerMatchesDecision) {
+    issues.push(`PATH B marker type (${markerType}) does not match recorded decision (${decision}).`);
+  }
+
+  if (type === "review_thread") {
+    const resolutionCorrect = threadResolved === true;
+    checks.threadResolutionCorrect = resolutionCorrect;
+    if (!resolutionCorrect) {
+      issues.push("PATH B review_thread must be resolved immediately after posting the marker.");
+    }
+  } else {
+    if (threadResolved !== null) {
+      checks.threadResolutionCorrect = false;
+      issues.push(`Non-thread PATH B item (type: ${type}) has unexpected non-null threadResolved: ${JSON.stringify(threadResolved)}.`);
+    } else {
+      checks.threadResolutionCorrect = true;
+    }
+  }
+
+  return makeResult(id, "B", checks, issues);
+}
+
+function makeResult(id, path, checks, issues) {
+  return {
+    id,
+    path,
+    checks,
+    passed: issues.length === 0,
+    issues,
+  };
+}
+
+function normalizeItem(item) {
+  return {
+    id: String(item?.id ?? ""),
+    path: typeof item?.path === "string" ? item.path.toUpperCase() : item?.path,
+    type: typeof item?.type === "string" ? item.type : null,
+    decision: typeof item?.decision === "string" ? item.decision.toLowerCase() : null,
+    markerReply: typeof item?.markerReply === "string" ? item.markerReply : null,
+    threadResolved: item?.threadResolved === true ? true
+      : item?.threadResolved === false ? false
+        : null,
+  };
+}
+
+function parseArgs(argv) {
+  const parsed = { items: "[]", verbose: false, help: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === "--items") {
+      parsed.items = value ?? "[]";
+      index += 1;
+      continue;
+    }
+    if (token === "--verbose") {
+      parsed.verbose = true;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  return parsed;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/review-disposition-verify.mjs --items '<json>' [--verbose] [--help]
+
+Input: JSON array of items or object with an 'items' key.
+
+Item shape:
+{
+  "id": "string",
+  "path": "A" | "B",
+  "type": "review_thread" | "regular_comment" | "changes_requested" | "critique_finding",
+  "decision": "accepted" | "rejected" | "awaiting_maintainer" | null,
+  "markerReply": "string | null",
+  "threadResolved": true | false | null
+}
+
+Output schema:
+{
+  "passed": true,
+  "summary": "All 3 items verified.",
+  "totalCount": 3,
+  "passedCount": 3,
+  "failedCount": 0,
+  "items": [{
+    "id": "...",
+    "path": "A",
+    "checks": {
+      "decisionRecorded": true,
+      "markerPresent": true,
+      "markerMatchesDecision": true,
+      "threadResolutionCorrect": true
+    },
+    "passed": true,
+    "issues": []
+  }]
+}
+`);
+}
+
+function isMainModule(metaUrl) {
+  if (!metaUrl || !process.argv[1]) {
+    return false;
+  }
+  const scriptUrl = new URL(`file://${resolve(process.argv[1])}`);
+  return metaUrl === scriptUrl.href;
+}

--- a/scripts/review-disposition-verify.mjs
+++ b/scripts/review-disposition-verify.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { pathToFileURL } from "node:url";
 import { resolve } from "node:path";
 
 const MARKER_ACCEPTED_RE = /^\*\*Accepted\*\*\s+—/;
@@ -24,6 +25,9 @@ if (isMainModule(import.meta.url)) {
     if (Array.isArray(parsed)) {
       rawItems = parsed;
     } else if (parsed !== null && typeof parsed === "object" && "items" in parsed) {
+      if (parsed.items === null) {
+        throw new Error("--items JSON object has 'items: null'; expected an array");
+      }
       rawItems = parsed.items ?? [];
     } else {
       throw new Error("--items JSON object must have an 'items' key");
@@ -375,6 +379,5 @@ function isMainModule(metaUrl) {
   if (!metaUrl || !process.argv[1]) {
     return false;
   }
-  const scriptUrl = new URL(`file://${resolve(process.argv[1])}`);
-  return metaUrl === scriptUrl.href;
+  return metaUrl === pathToFileURL(resolve(process.argv[1])).href;
 }

--- a/tests/review-disposition-verify.test.mjs
+++ b/tests/review-disposition-verify.test.mjs
@@ -175,6 +175,19 @@ test("checkPathAItem: AMD — non-thread type, null threadResolved → pass", ()
   assert.equal(result.checks.threadResolutionCorrect, true);
 });
 
+test("checkPathAItem: AMD — non-thread type with non-null threadResolved → fail", () => {
+  const result = checkPathAItem({
+    id: "a10b",
+    path: "A",
+    type: "regular_comment",
+    decision: "awaiting_maintainer",
+    markerReply: "**Awaiting maintainer decision** — awaiting CODEOWNER response",
+    threadResolved: false,
+  });
+  assert.equal(result.passed, false);
+  assert.ok(result.issues.some((msg) => msg.includes("non-null threadResolved")));
+});
+
 test("checkPathAItem: null decision → fail", () => {
   const result = checkPathAItem({
     id: "a11",

--- a/tests/review-disposition-verify.test.mjs
+++ b/tests/review-disposition-verify.test.mjs
@@ -42,6 +42,10 @@ test("classifyMarker: null for unrecognised text", () => {
   assert.equal(classifyMarker("LGTM"), null);
 });
 
+test("classifyMarker: rejection confirmed by maintainer → rejected", () => {
+  assert.equal(classifyMarker("**Rejection confirmed by maintainer** — agreed, closing thread"), "rejected");
+});
+
 // ─── checkPathAItem ───────────────────────────────────────────────────────────
 
 test("checkPathAItem: Accepted — no reply required", () => {

--- a/tests/review-disposition-verify.test.mjs
+++ b/tests/review-disposition-verify.test.mjs
@@ -38,7 +38,7 @@ test("classifyMarker: null when no bold prefix", () => {
   assert.equal(classifyMarker("Accepted — some note"), null);
 });
 
-test("classifyMarker: null for unrecognised text", () => {
+test("classifyMarker: null for unrecognized text", () => {
   assert.equal(classifyMarker("LGTM"), null);
 });
 

--- a/tests/review-disposition-verify.test.mjs
+++ b/tests/review-disposition-verify.test.mjs
@@ -1,0 +1,396 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  checkPathAItem,
+  checkPathBItem,
+  classifyMarker,
+  verifyDispositions,
+} from "../scripts/review-disposition-verify.mjs";
+
+// ─── classifyMarker ───────────────────────────────────────────────────────────
+
+test("classifyMarker: null for empty string", () => {
+  assert.equal(classifyMarker(""), null);
+});
+
+test("classifyMarker: null for null input", () => {
+  assert.equal(classifyMarker(null), null);
+});
+
+test("classifyMarker: accepted", () => {
+  assert.equal(classifyMarker("**Accepted** — the advisory confirmed no action needed"), "accepted");
+});
+
+test("classifyMarker: rejected", () => {
+  assert.equal(classifyMarker("**Rejected** — the suggestion is out of scope"), "rejected");
+});
+
+test("classifyMarker: awaiting_maintainer", () => {
+  assert.equal(classifyMarker("**Awaiting maintainer decision** — CODEOWNER feedback on naming"), "awaiting_maintainer");
+});
+
+test("classifyMarker: null when prefix missing em-dash", () => {
+  assert.equal(classifyMarker("**Rejected** just notes the rejection"), null);
+});
+
+test("classifyMarker: null when no bold prefix", () => {
+  assert.equal(classifyMarker("Accepted — some note"), null);
+});
+
+test("classifyMarker: null for unrecognised text", () => {
+  assert.equal(classifyMarker("LGTM"), null);
+});
+
+// ─── checkPathAItem ───────────────────────────────────────────────────────────
+
+test("checkPathAItem: Accepted — no reply required", () => {
+  const result = checkPathAItem({
+    id: "a1",
+    path: "A",
+    type: "review_thread",
+    decision: "accepted",
+    markerReply: null,
+    threadResolved: null,
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.checks.decisionRecorded, true);
+  assert.deepEqual(result.issues, []);
+});
+
+test("checkPathAItem: Accepted — passes even with unexpected markerReply", () => {
+  const result = checkPathAItem({
+    id: "a2",
+    path: "A",
+    type: "review_thread",
+    decision: "accepted",
+    markerReply: "**Accepted** — confirmed",
+    threadResolved: null,
+  });
+  assert.equal(result.passed, true);
+});
+
+test("checkPathAItem: Rejected — proper reply + resolved thread → pass", () => {
+  const result = checkPathAItem({
+    id: "a3",
+    path: "A",
+    type: "review_thread",
+    decision: "rejected",
+    markerReply: "**Rejected** — out of scope for this PR",
+    threadResolved: true,
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.checks.markerPresent, true);
+  assert.equal(result.checks.threadResolutionCorrect, true);
+});
+
+test("checkPathAItem: Rejected — reply present but thread unresolved → fail", () => {
+  const result = checkPathAItem({
+    id: "a4",
+    path: "A",
+    type: "review_thread",
+    decision: "rejected",
+    markerReply: "**Rejected** — out of scope",
+    threadResolved: false,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.threadResolutionCorrect, false);
+});
+
+test("checkPathAItem: Rejected — no reply → fail", () => {
+  const result = checkPathAItem({
+    id: "a5",
+    path: "A",
+    type: "review_thread",
+    decision: "rejected",
+    markerReply: null,
+    threadResolved: true,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.markerPresent, false);
+});
+
+test("checkPathAItem: Rejected — regular_comment, null threadResolved → pass", () => {
+  const result = checkPathAItem({
+    id: "a6",
+    path: "A",
+    type: "regular_comment",
+    decision: "rejected",
+    markerReply: "**Rejected** — not applicable",
+    threadResolved: null,
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.checks.threadResolutionCorrect, true);
+});
+
+test("checkPathAItem: Rejected — regular_comment with non-null threadResolved → fail", () => {
+  const result = checkPathAItem({
+    id: "a7",
+    path: "A",
+    type: "regular_comment",
+    decision: "rejected",
+    markerReply: "**Rejected** — not applicable",
+    threadResolved: true,
+  });
+  assert.equal(result.passed, false);
+  assert.ok(result.issues.some((msg) => msg.includes("non-null threadResolved")));
+});
+
+test("checkPathAItem: AMD — proper reply + unresolved thread → pass", () => {
+  const result = checkPathAItem({
+    id: "a8",
+    path: "A",
+    type: "review_thread",
+    decision: "awaiting_maintainer",
+    markerReply: "**Awaiting maintainer decision** — CODEOWNER review required",
+    threadResolved: false,
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.checks.threadResolutionCorrect, true);
+});
+
+test("checkPathAItem: AMD — resolved thread → fail", () => {
+  const result = checkPathAItem({
+    id: "a9",
+    path: "A",
+    type: "review_thread",
+    decision: "awaiting_maintainer",
+    markerReply: "**Awaiting maintainer decision** — CODEOWNER review required",
+    threadResolved: true,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.threadResolutionCorrect, false);
+});
+
+test("checkPathAItem: AMD — non-thread type, null threadResolved → pass", () => {
+  const result = checkPathAItem({
+    id: "a10",
+    path: "A",
+    type: "regular_comment",
+    decision: "awaiting_maintainer",
+    markerReply: "**Awaiting maintainer decision** — awaiting CODEOWNER response",
+    threadResolved: null,
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.checks.threadResolutionCorrect, true);
+});
+
+test("checkPathAItem: null decision → fail", () => {
+  const result = checkPathAItem({
+    id: "a11",
+    path: "A",
+    type: "review_thread",
+    decision: null,
+    markerReply: null,
+    threadResolved: null,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.decisionRecorded, false);
+});
+
+test("checkPathAItem: unknown decision value → fail", () => {
+  const result = checkPathAItem({
+    id: "a12",
+    path: "A",
+    type: "review_thread",
+    decision: "approve",
+    markerReply: null,
+    threadResolved: null,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.decisionRecorded, false);
+});
+
+// ─── checkPathBItem ───────────────────────────────────────────────────────────
+
+test("checkPathBItem: Accepted — marker + resolved thread → pass", () => {
+  const result = checkPathBItem({
+    id: "b1",
+    path: "B",
+    type: "review_thread",
+    decision: "accepted",
+    markerReply: "**Accepted** — advisory confirmed the approach",
+    threadResolved: true,
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.checks.markerPresent, true);
+  assert.equal(result.checks.markerMatchesDecision, true);
+  assert.equal(result.checks.threadResolutionCorrect, true);
+});
+
+test("checkPathBItem: Rejected — marker + resolved thread → pass", () => {
+  const result = checkPathBItem({
+    id: "b2",
+    path: "B",
+    type: "review_thread",
+    decision: "rejected",
+    markerReply: "**Rejected** — no action required",
+    threadResolved: true,
+  });
+  assert.equal(result.passed, true);
+});
+
+test("checkPathBItem: no marker → fail", () => {
+  const result = checkPathBItem({
+    id: "b3",
+    path: "B",
+    type: "review_thread",
+    decision: "accepted",
+    markerReply: null,
+    threadResolved: true,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.markerPresent, false);
+});
+
+test("checkPathBItem: marker but unresolved thread → fail", () => {
+  const result = checkPathBItem({
+    id: "b4",
+    path: "B",
+    type: "review_thread",
+    decision: "accepted",
+    markerReply: "**Accepted** — confirmed",
+    threadResolved: false,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.threadResolutionCorrect, false);
+});
+
+test("checkPathBItem: regular_comment — marker + null threadResolved → pass", () => {
+  const result = checkPathBItem({
+    id: "b5",
+    path: "B",
+    type: "regular_comment",
+    decision: "accepted",
+    markerReply: "**Accepted** — advisory confirmed",
+    threadResolved: null,
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.checks.threadResolutionCorrect, true);
+});
+
+test("checkPathBItem: review_thread — resolved but no marker → fail", () => {
+  const result = checkPathBItem({
+    id: "b6",
+    path: "B",
+    type: "review_thread",
+    decision: "accepted",
+    markerReply: null,
+    threadResolved: true,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.markerPresent, false);
+});
+
+test("checkPathBItem: marker type mismatch (accepted decision, rejected marker) → fail", () => {
+  const result = checkPathBItem({
+    id: "b7",
+    path: "B",
+    type: "review_thread",
+    decision: "accepted",
+    markerReply: "**Rejected** — no action",
+    threadResolved: true,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.markerMatchesDecision, false);
+});
+
+test("checkPathBItem: awaiting_maintainer decision → fail (invalid for PATH B)", () => {
+  const result = checkPathBItem({
+    id: "b8",
+    path: "B",
+    type: "review_thread",
+    decision: "awaiting_maintainer",
+    markerReply: "**Awaiting maintainer decision** — ...",
+    threadResolved: false,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.decisionRecorded, false);
+});
+
+test("checkPathBItem: null decision → fail", () => {
+  const result = checkPathBItem({
+    id: "b9",
+    path: "B",
+    type: "review_thread",
+    decision: null,
+    markerReply: null,
+    threadResolved: null,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.decisionRecorded, false);
+});
+
+// ─── verifyDispositions ───────────────────────────────────────────────────────
+
+test("verifyDispositions: empty array → passed: true", () => {
+  const result = verifyDispositions([]);
+  assert.equal(result.passed, true);
+  assert.equal(result.totalCount, 0);
+  assert.equal(result.passedCount, 0);
+  assert.equal(result.failedCount, 0);
+});
+
+test("verifyDispositions: all passing items → passed: true", () => {
+  const items = [
+    {
+      id: "x1",
+      path: "A",
+      type: "review_thread",
+      decision: "accepted",
+      markerReply: null,
+      threadResolved: null,
+    },
+    {
+      id: "x2",
+      path: "B",
+      type: "review_thread",
+      decision: "accepted",
+      markerReply: "**Accepted** — confirmed",
+      threadResolved: true,
+    },
+  ];
+  const result = verifyDispositions(items);
+  assert.equal(result.passed, true);
+  assert.equal(result.passedCount, 2);
+  assert.equal(result.failedCount, 0);
+});
+
+test("verifyDispositions: mixed with one failure → passed: false", () => {
+  const items = [
+    {
+      id: "y1",
+      path: "A",
+      type: "review_thread",
+      decision: "accepted",
+      markerReply: null,
+      threadResolved: null,
+    },
+    {
+      id: "y2",
+      path: "B",
+      type: "review_thread",
+      decision: "accepted",
+      markerReply: null,
+      threadResolved: true,
+    },
+  ];
+  const result = verifyDispositions(items);
+  assert.equal(result.passed, false);
+  assert.equal(result.passedCount, 1);
+  assert.equal(result.failedCount, 1);
+});
+
+test("verifyDispositions: unknown path → fail item", () => {
+  const result = verifyDispositions([
+    { id: "z1", path: "C", type: "review_thread", decision: "accepted", markerReply: null, threadResolved: null },
+  ]);
+  assert.equal(result.passed, false);
+  const item = result.items[0];
+  assert.ok(item.issues.some((msg) => msg.includes("Unknown path value")));
+});
+
+test("verifyDispositions: throws on non-array input", () => {
+  assert.throws(() => verifyDispositions(null), TypeError);
+  assert.throws(() => verifyDispositions({ items: [] }), TypeError);
+});

--- a/tests/review-disposition-verify.test.mjs
+++ b/tests/review-disposition-verify.test.mjs
@@ -321,6 +321,19 @@ test("checkPathBItem: awaiting_maintainer decision → fail (invalid for PATH B)
   assert.equal(result.checks.decisionRecorded, false);
 });
 
+test("checkPathBItem: regular_comment with non-null threadResolved → fail", () => {
+  const result = checkPathBItem({
+    id: "b10",
+    path: "B",
+    type: "regular_comment",
+    decision: "accepted",
+    markerReply: "**Accepted** — confirmed",
+    threadResolved: true,
+  });
+  assert.equal(result.passed, false);
+  assert.ok(result.issues.some((msg) => msg.includes("non-null threadResolved")));
+});
+
 test("checkPathBItem: null decision → fail", () => {
   const result = checkPathBItem({
     id: "b9",


### PR DESCRIPTION
## Summary

- Adds `scripts/review-disposition-verify.mjs` — a read-only helper that verifies E7 disposition evidence for ReviewItems_snapshot items before triage exits
- Exports `verifyDispositions(items)`, `classifyMarker(text)`, `checkPathAItem(item)`, and `checkPathBItem(item)`
- Adds `tests/review-disposition-verify.test.mjs` — 35 tests covering all PATH A/B decision cases, edge cases, and malformed inputs
- Updates `docs/idd-helper-scripts.md` with Decision list entry, boundary description, stable output schema, and Friction Inventory row

## Key design decisions

- Thread-resolution checks are gated on `type === "review_thread"`; non-thread items must carry `threadResolved: null` (non-null is treated as a modeling error)
- PATH A AMD items on review threads must have `threadResolved: false` (E6: do not resolve so F2's unresolved-thread gate blocks merge); non-thread AMD items must have `threadResolved: null`
- PATH A Accepted items pass without a marker — E6 specifies that the reply is posted in review-fix, not triage
- `classifyMarker` requires the em-dash (`—`) after the bold prefix; a reply without the em-dash is classified as `null` (unrecognized)
- Non-null `threadResolved` on a non-thread item fails with an explicit error message (defensive input validation)

## Non-goals

- Does not post replies, resolve threads, or mutate any GitHub state
- Does not replace the written E7 verification steps in `idd-review-triage.instructions.md`; it is a convenience layer to reduce command-copy variance

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional read-only helper for E7 disposition verification to validate review markers, decisions, and thread-resolution states across review paths.

* **Documentation**
  * Updated helper scripts docs to record the new helper, its verification boundaries, expected input format, and stable output contract.

* **Tests**
  * Added comprehensive unit tests covering marker classification and path-specific disposition validations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/446)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->