### PR TITLE
feat(idd): enforce mandatory F4 cleanup apply with explicit fallback paths

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -213,20 +213,18 @@ gate. The active claim must still use your current `{claim-id}`.
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-     After apply, post one evidence comment to the PR with the apply
-     `status`, `applied`, `failed`, and `skipped` counts, the reason
-     for any skipped or failed items, and the `viewer-cannot-minimize`
-     count whenever it is non-zero — regardless of whether apply
-     succeeded, partially succeeded, or failed. See
-     `docs/idd-comment-minimization.md` for the evidence comment
-     and cleanup-failure comment formats.
+     After apply, post a comment to the PR recording the outcome. See
+     `docs/idd-comment-minimization.md` for the exact format:
 
-     If the apply `status` is `applied`: proceed to step 3.
+     If the apply `status` is `applied`: post the evidence comment
+     format (with `status`, `applied`, `failed`, `skipped`, and
+     `viewer-cannot-minimize` counts). Proceed to step 3.
 
-     If the apply `status` is `failed` or `incomplete`: use the
-     cleanup-failure comment format instead of the evidence comment
-     format. This is explicit evidence, not a merge gate — the merge
-     already succeeded. Proceed to step 3.
+     If the apply `status` is `failed` or `incomplete`: post the
+     cleanup-failure comment format instead. Include the
+     `viewer-cannot-minimize` count when it is non-zero. This is
+     explicit evidence, not a merge gate — the merge already succeeded.
+     Proceed to step 3.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates were

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -155,12 +155,11 @@ gate. The active claim must still use your current `{claim-id}`.
    re-validating the claim. Do not minimize the digest as an
    operational marker unless a future cleanup policy explicitly supports
    digest retirement.
-2. Run best-effort merged-PR comment cleanup when credentials permit.
-   This cleanup is never a merge gate and must not run before F3
-   succeeds. If cleanup fails, record the failure only if it is useful
-   for a later audit, then continue with local cleanup.
-   Re-validate the active claim before each GitHub minimization
-   mutation.
+2. Run merged-PR comment cleanup. This step must not run before F3
+   succeeds. Re-validate the active claim before each GitHub
+   minimization mutation.
+
+   Apply the following cleanup policy rules when evaluating candidates:
 
    - Feedback or review parent comments may be minimized as `RESOLVED`
      only after every actionable child review comment/thread under that
@@ -186,32 +185,64 @@ gate. The active claim must still use your current `{claim-id}`.
      decisions, active holds, failed-CI context still needed by
      maintainers, non-operational human discussion, or any content that
      still participates in active F2/F3 gates.
-   - In the idd-skill source repository, `scripts/audit-pr-cleanup.mjs`
-     is available; run it first in dry-run mode so eligible and skipped
-     candidates are visible. In adopter repositories, skip to the
-     GitHub GraphQL step below unless the helper scripts were explicitly
-     installed.
 
-     ```sh
-     node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
-     ```
+   **Mandatory apply decision tree** — follow this sequence; no path
+   may exit without a recorded reason when cleanup candidates exist:
 
-     To apply the safe candidates during this claimed IDD run, pass the
-     active issue and claim token so the helper re-validates the claim
-     before each minimization mutation:
+   In the idd-skill source repository, run the helper in dry-run mode
+   first. In adopter repositories, skip to the GraphQL fallback below
+   unless the helper scripts were explicitly installed.
+
+   ```sh
+   node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
+   ```
+
+   Evaluate the dry-run `status` field:
+
+   - **`clean`**: no candidates detected. Proceed to step 3.
+
+   - **`needs-apply`**: eligible candidates exist and the viewer can
+     minimize them. Apply is mandatory. Re-validate the active claim,
+     then run:
 
      ```sh
      node scripts/audit-pr-cleanup.mjs --pr <pr-number> --apply \
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-   - Otherwise, use GitHub GraphQL `minimizeComment`
-     with node IDs. Check `viewerCanMinimize` and `isMinimized` before
-     minimizing; skip already-minimized comments and comments the viewer
-     cannot minimize. Re-validate the active claim before each mutation.
+     After apply, post a cleanup evidence comment to the PR with the
+     apply `status`, `applied`, `failed`, and `skipped` counts, and
+     the reason for any skipped or failed items. If
+     `viewer-cannot-minimize > 0` alongside applied candidates, include
+     the permission-blocked count in the evidence comment. See
+     `docs/idd-comment-minimization.md` for the evidence comment
+     format.
 
-   See `docs/idd-comment-minimization.md` for the helper report shape,
-   fallback GraphQL commands, and experiment notes.
+     If the apply `status` is `applied`: proceed to step 3.
+
+     If the apply `status` is `failed` or `incomplete`: post a
+     cleanup-failure comment to the PR identifying the failed or
+     unapplied candidates and the reason. This is explicit evidence,
+     not a merge gate — the merge already succeeded. Proceed to step 3.
+
+   - **`permission-blocked`**: skipped items exist with
+     `viewerCanMinimize: false` and no apply-eligible candidates were
+     found. Post a cleanup-permission-blocked comment to the PR listing
+     the blocked candidates and the count. Do not silently skip.
+     Proceed to step 3.
+
+   For the GraphQL fallback (when the helper is unavailable): check
+   `viewerCanMinimize` and `isMinimized` before minimizing; skip
+   already-minimized comments and comments the viewer cannot minimize.
+   Re-validate the active claim before each mutation. After GraphQL
+   cleanup, post an evidence comment summarizing the outcome (status,
+   applied count, skipped count with reasons). If the viewer cannot
+   minimize any detected candidates, post a
+   cleanup-permission-blocked comment instead of exiting silently.
+
+   See `docs/idd-comment-minimization.md` for the evidence comment
+   format, cleanup-failure comment format, permission-blocked comment
+   format, and fallback GraphQL commands.
 3. Delete the local worktree and local branch.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -213,22 +213,20 @@ gate. The active claim must still use your current `{claim-id}`.
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-     After apply, post a cleanup evidence comment to the PR with the
-     apply `status`, `applied`, `failed`, and `skipped` counts, and
-     the reason for any skipped or failed items. If
-     `viewer-cannot-minimize > 0` appears alongside applied candidates,
-     include the permission-blocked count in the evidence comment. See
+     After apply, post one evidence comment to the PR with the apply
+     `status`, `applied`, `failed`, and `skipped` counts, the reason
+     for any skipped or failed items, and the `viewer-cannot-minimize`
+     count whenever it is non-zero — regardless of whether apply
+     succeeded, partially succeeded, or failed. See
      `docs/idd-comment-minimization.md` for the evidence comment
-     format.
+     and cleanup-failure comment formats.
 
      If the apply `status` is `applied`: proceed to step 3.
 
-     If the apply `status` is `failed` or `incomplete`: post a
-     cleanup-failure comment to the PR identifying the failed or
-     unapplied candidates and the reason; if `viewer-cannot-minimize > 0`
-     is also non-zero, include the blocked count in the same comment.
-     This is explicit evidence, not a merge gate — the merge already
-     succeeded. Proceed to step 3.
+     If the apply `status` is `failed` or `incomplete`: use the
+     cleanup-failure comment format instead of the evidence comment
+     format. This is explicit evidence, not a merge gate — the merge
+     already succeeded. Proceed to step 3.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates were

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -197,9 +197,12 @@ gate. The active claim must still use your current `{claim-id}`.
    node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
    ```
 
-   Evaluate the dry-run `status` field:
+   Evaluate the dry-run `status` field (this is a dry-run status; apply
+   mode emits different values and is never invoked unless dry-run
+   shows `needs-apply`):
 
-   - **`clean`**: no candidates detected. Proceed to step 3.
+   - **`clean`**: no candidates and no permission-blocked items.
+     Proceed to step 3.
 
    - **`needs-apply`**: eligible candidates exist and the viewer can
      minimize them. Apply is mandatory. Re-validate the active claim,
@@ -213,8 +216,8 @@ gate. The active claim must still use your current `{claim-id}`.
      After apply, post a cleanup evidence comment to the PR with the
      apply `status`, `applied`, `failed`, and `skipped` counts, and
      the reason for any skipped or failed items. If
-     `viewer-cannot-minimize > 0` alongside applied candidates, include
-     the permission-blocked count in the evidence comment. See
+     `viewer-cannot-minimize > 0` appears alongside applied candidates,
+     include the permission-blocked count in the evidence comment. See
      `docs/idd-comment-minimization.md` for the evidence comment
      format.
 
@@ -222,14 +225,15 @@ gate. The active claim must still use your current `{claim-id}`.
 
      If the apply `status` is `failed` or `incomplete`: post a
      cleanup-failure comment to the PR identifying the failed or
-     unapplied candidates and the reason. This is explicit evidence,
-     not a merge gate — the merge already succeeded. Proceed to step 3.
+     unapplied candidates and the reason; if `viewer-cannot-minimize > 0`
+     is also non-zero, include the blocked count in the same comment.
+     This is explicit evidence, not a merge gate — the merge already
+     succeeded. Proceed to step 3.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates were
      found. Post a cleanup-permission-blocked comment to the PR listing
-     the blocked candidates and the count. Do not silently skip.
-     Proceed to step 3.
+     the blocked candidates and the count, then proceed to step 3.
 
    For the GraphQL fallback (when the helper is unavailable): check
    `viewerCanMinimize` and `isMinimized` before minimizing; skip

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -307,12 +307,13 @@ cleanup candidates are detected.
 After the dry-run, evaluate the `status` field and follow the
 corresponding path:
 
-| Dry-run `status`     | Action                                                  |
-| -------------------- | ------------------------------------------------------- |
-| `clean`              | Nothing to do. Proceed to local cleanup (F4 step 3).    |
-| `needs-apply`        | Run apply (mandatory). Post a cleanup evidence comment. |
-| `permission-blocked` | Post a cleanup-permission-blocked comment. Do not exit  |
-|                      | silently. Proceed to local cleanup (F4 step 3).         |
+| Dry-run `status`     | Action                                                        |
+| -------------------- | ------------------------------------------------------------- |
+| `clean`              | No candidates and no permission-blocked items. Proceed to F4  |
+|                      | step 3.                                                       |
+| `needs-apply`        | Run apply (mandatory). Post a cleanup evidence comment.       |
+| `permission-blocked` | Post a cleanup-permission-blocked comment, then proceed to F4 |
+|                      | step 3.                                                       |
 
 After apply, if `status` is `failed` or `incomplete`, post a
 cleanup-failure comment. A cleanup failure after a successful F3 merge
@@ -320,9 +321,14 @@ does not re-block the merge; it is an explicit record only.
 
 ### Cleanup evidence comment
 
-Post this comment to the PR after a successful or partial apply:
+Post this comment to the PR after a successful or partial apply. The
+HTML comment token on the first line acts as a stable machine-readable
+marker so a resuming agent can detect whether the evidence was already
+posted:
 
 ```markdown
+<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} permission-blocked:{N} -->
+
 **F4 Cleanup Evidence**
 
 | Field              | Value                                  |
@@ -337,9 +343,14 @@ Post this comment to the PR after a successful or partial apply:
 
 ### Cleanup-failure comment
 
-Post this comment when apply `status` is `failed` or `incomplete`:
+Post this comment when apply `status` is `failed` or `incomplete`. If
+`viewer-cannot-minimize > 0` is also non-zero, include the blocked count
+in the same comment rather than posting a separate permission-blocked
+comment:
 
 ```markdown
+<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} permission-blocked:{N} -->
+
 **F4 Cleanup Failure**
 
 Cleanup candidates were detected but not all could be applied.
@@ -347,6 +358,7 @@ Cleanup candidates were detected but not all could be applied.
 - Status: failed / incomplete
 - Failed: N candidates (reason: ...)
 - Unapplied: N candidates
+- Permission-blocked: N candidates (if any)
 
 This does not re-block the merge. A maintainer may run cleanup
 manually: `node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check`
@@ -354,9 +366,14 @@ manually: `node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check
 
 ### Cleanup-permission-blocked comment
 
-Post this comment when dry-run `status` is `permission-blocked`:
+Post this comment when dry-run `status` is `permission-blocked` (no
+apply-eligible candidates exist, only viewer-cannot-minimize items).
+This status is only emitted in dry-run mode; it is never emitted during
+apply (apply failures use `failed` or `incomplete` instead):
 
 ```markdown
+<!-- idd-cleanup-evidence: permission-blocked applied:0 failed:0 skipped:N permission-blocked:{N} -->
+
 **F4 Cleanup Permission Blocked**
 
 Cleanup candidates were detected but the current viewer cannot minimize

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -327,7 +327,7 @@ marker so a resuming agent can detect whether the evidence was already
 posted:
 
 ```markdown
-<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} permission-blocked:{N} -->
+<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->
 
 **F4 Cleanup Evidence**
 
@@ -349,7 +349,7 @@ in the same comment rather than posting a separate permission-blocked
 comment:
 
 ```markdown
-<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} permission-blocked:{N} -->
+<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->
 
 **F4 Cleanup Failure**
 
@@ -372,7 +372,7 @@ This status is only emitted in dry-run mode; it is never emitted during
 apply (apply failures use `failed` or `incomplete` instead):
 
 ```markdown
-<!-- idd-cleanup-evidence: permission-blocked applied:0 failed:0 skipped:N permission-blocked:{N} -->
+<!-- idd-cleanup-evidence: permission-blocked applied:0 failed:0 skipped:N viewer-cannot-minimize:{N} -->
 
 **F4 Cleanup Permission Blocked**
 

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -296,6 +296,78 @@ The helper applies only safe candidates and reports applied, skipped,
 and failed rows. A helper failure is still cleanup-only context; it does
 not retroactively block a merge that already passed F3.
 
+## Mandatory F4 Cleanup Contract
+
+F4 cleanup apply is mandatory when candidates exist and the viewer can
+minimize them. No path may exit F4 without a recorded reason when
+cleanup candidates are detected.
+
+### Decision tree
+
+After the dry-run, evaluate the `status` field and follow the
+corresponding path:
+
+| Dry-run `status`     | Action                                                  |
+| -------------------- | ------------------------------------------------------- |
+| `clean`              | Nothing to do. Proceed to local cleanup (F4 step 3).    |
+| `needs-apply`        | Run apply (mandatory). Post a cleanup evidence comment. |
+| `permission-blocked` | Post a cleanup-permission-blocked comment. Do not exit  |
+|                      | silently. Proceed to local cleanup (F4 step 3).         |
+
+After apply, if `status` is `failed` or `incomplete`, post a
+cleanup-failure comment. A cleanup failure after a successful F3 merge
+does not re-block the merge; it is an explicit record only.
+
+### Cleanup evidence comment
+
+Post this comment to the PR after a successful or partial apply:
+
+```markdown
+**F4 Cleanup Evidence**
+
+| Field              | Value                                  |
+| ------------------ | -------------------------------------- |
+| Status             | applied / failed / incomplete          |
+| Applied            | N                                      |
+| Failed             | N                                      |
+| Skipped            | N                                      |
+| Permission-blocked | N                                      |
+| Notes              | reason for any failed or skipped items |
+```
+
+### Cleanup-failure comment
+
+Post this comment when apply `status` is `failed` or `incomplete`:
+
+```markdown
+**F4 Cleanup Failure**
+
+Cleanup candidates were detected but not all could be applied.
+
+- Status: failed / incomplete
+- Failed: N candidates (reason: ...)
+- Unapplied: N candidates
+
+This does not re-block the merge. A maintainer may run cleanup
+manually: `node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check`
+```
+
+### Cleanup-permission-blocked comment
+
+Post this comment when dry-run `status` is `permission-blocked`:
+
+```markdown
+**F4 Cleanup Permission Blocked**
+
+Cleanup candidates were detected but the current viewer cannot minimize
+them (`viewerCanMinimize: false`).
+
+- Permission-blocked: N candidates
+
+This does not re-block the merge. A maintainer with minimize permission
+may run cleanup manually: `node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check`
+```
+
 ## Fallback GraphQL
 
 If the helper is unavailable, use the direct GraphQL capability checks

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -189,9 +189,9 @@ gate. The active claim must still use your current `{claim-id}`.
    **Mandatory apply decision tree** — follow this sequence; no path
    may exit without a recorded reason when cleanup candidates exist:
 
-   In the `{{REPO_NAME}}` source repository, run the helper in dry-run
-   mode first. In adopter repositories, skip to the GraphQL fallback
-   below unless the helper scripts were explicitly installed.
+   In the idd-skill source repository, run the helper in dry-run mode
+   first. In adopter repositories, skip to the GraphQL fallback below
+   unless the helper scripts were explicitly installed.
 
    ```sh
    node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -155,12 +155,11 @@ gate. The active claim must still use your current `{claim-id}`.
    re-validating the claim. Do not minimize the digest as an
    operational marker unless a future cleanup policy explicitly supports
    digest retirement.
-2. Run best-effort merged-PR comment cleanup when credentials permit.
-   This cleanup is never a merge gate and must not run before F3
-   succeeds. If cleanup fails, record the failure only if it is useful
-   for a later audit, then continue with local cleanup.
-   Re-validate the active claim before each GitHub minimization
-   mutation.
+2. Run merged-PR comment cleanup. This step must not run before F3
+   succeeds. Re-validate the active claim before each GitHub
+   minimization mutation.
+
+   Apply the following cleanup policy rules when evaluating candidates:
 
    - Feedback or review parent comments may be minimized as `RESOLVED`
      only after every actionable child review comment/thread under that
@@ -186,32 +185,64 @@ gate. The active claim must still use your current `{claim-id}`.
      decisions, active holds, failed-CI context still needed by
      maintainers, non-operational human discussion, or any content that
      still participates in active F2/F3 gates.
-   - In the idd-skill source repository, `scripts/audit-pr-cleanup.mjs`
-     is available; run it first in dry-run mode so eligible and skipped
-     candidates are visible. In adopter repositories, skip to the
-     GitHub GraphQL step below unless the helper scripts were explicitly
-     installed.
 
-     ```sh
-     node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
-     ```
+   **Mandatory apply decision tree** — follow this sequence; no path
+   may exit without a recorded reason when cleanup candidates exist:
 
-     To apply the safe candidates during this claimed IDD run, pass the
-     active issue and claim token so the helper re-validates the claim
-     before each minimization mutation:
+   In the `{{REPO_NAME}}` source repository, run the helper in dry-run
+   mode first. In adopter repositories, skip to the GraphQL fallback
+   below unless the helper scripts were explicitly installed.
+
+   ```sh
+   node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
+   ```
+
+   Evaluate the dry-run `status` field:
+
+   - **`clean`**: no candidates detected. Proceed to step 3.
+
+   - **`needs-apply`**: eligible candidates exist and the viewer can
+     minimize them. Apply is mandatory. Re-validate the active claim,
+     then run:
 
      ```sh
      node scripts/audit-pr-cleanup.mjs --pr <pr-number> --apply \
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-   - Otherwise, use GitHub GraphQL `minimizeComment`
-     with node IDs. Check `viewerCanMinimize` and `isMinimized` before
-     minimizing; skip already-minimized comments and comments the viewer
-     cannot minimize. Re-validate the active claim before each mutation.
+     After apply, post a cleanup evidence comment to the PR with the
+     apply `status`, `applied`, `failed`, and `skipped` counts, and
+     the reason for any skipped or failed items. If
+     `viewer-cannot-minimize > 0` alongside applied candidates, include
+     the permission-blocked count in the evidence comment. See
+     `docs/idd-comment-minimization.md` for the evidence comment
+     format.
 
-   See `docs/idd-comment-minimization.md` for the helper report shape,
-   fallback GraphQL commands, and experiment notes.
+     If the apply `status` is `applied`: proceed to step 3.
+
+     If the apply `status` is `failed` or `incomplete`: post a
+     cleanup-failure comment to the PR identifying the failed or
+     unapplied candidates and the reason. This is explicit evidence,
+     not a merge gate — the merge already succeeded. Proceed to step 3.
+
+   - **`permission-blocked`**: skipped items exist with
+     `viewerCanMinimize: false` and no apply-eligible candidates were
+     found. Post a cleanup-permission-blocked comment to the PR listing
+     the blocked candidates and the count. Do not silently skip.
+     Proceed to step 3.
+
+   For the GraphQL fallback (when the helper is unavailable): check
+   `viewerCanMinimize` and `isMinimized` before minimizing; skip
+   already-minimized comments and comments the viewer cannot minimize.
+   Re-validate the active claim before each mutation. After GraphQL
+   cleanup, post an evidence comment summarizing the outcome (status,
+   applied count, skipped count with reasons). If the viewer cannot
+   minimize any detected candidates, post a
+   cleanup-permission-blocked comment instead of exiting silently.
+
+   See `docs/idd-comment-minimization.md` for the evidence comment
+   format, cleanup-failure comment format, permission-blocked comment
+   format, and fallback GraphQL commands.
 3. Delete the local worktree and local branch.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -213,20 +213,18 @@ gate. The active claim must still use your current `{claim-id}`.
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-     After apply, post one evidence comment to the PR with the apply
-     `status`, `applied`, `failed`, and `skipped` counts, the reason
-     for any skipped or failed items, and the `viewer-cannot-minimize`
-     count whenever it is non-zero — regardless of whether apply
-     succeeded, partially succeeded, or failed. See
-     `docs/idd-comment-minimization.md` for the evidence comment
-     and cleanup-failure comment formats.
+     After apply, post a comment to the PR recording the outcome. See
+     `docs/idd-comment-minimization.md` for the exact format:
 
-     If the apply `status` is `applied`: proceed to step 3.
+     If the apply `status` is `applied`: post the evidence comment
+     format (with `status`, `applied`, `failed`, `skipped`, and
+     `viewer-cannot-minimize` counts). Proceed to step 3.
 
-     If the apply `status` is `failed` or `incomplete`: use the
-     cleanup-failure comment format instead of the evidence comment
-     format. This is explicit evidence, not a merge gate — the merge
-     already succeeded. Proceed to step 3.
+     If the apply `status` is `failed` or `incomplete`: post the
+     cleanup-failure comment format instead. Include the
+     `viewer-cannot-minimize` count when it is non-zero. This is
+     explicit evidence, not a merge gate — the merge already succeeded.
+     Proceed to step 3.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates were

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -213,22 +213,20 @@ gate. The active claim must still use your current `{claim-id}`.
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-     After apply, post a cleanup evidence comment to the PR with the
-     apply `status`, `applied`, `failed`, and `skipped` counts, and
-     the reason for any skipped or failed items. If
-     `viewer-cannot-minimize > 0` appears alongside applied candidates,
-     include the permission-blocked count in the evidence comment. See
+     After apply, post one evidence comment to the PR with the apply
+     `status`, `applied`, `failed`, and `skipped` counts, the reason
+     for any skipped or failed items, and the `viewer-cannot-minimize`
+     count whenever it is non-zero — regardless of whether apply
+     succeeded, partially succeeded, or failed. See
      `docs/idd-comment-minimization.md` for the evidence comment
-     format.
+     and cleanup-failure comment formats.
 
      If the apply `status` is `applied`: proceed to step 3.
 
-     If the apply `status` is `failed` or `incomplete`: post a
-     cleanup-failure comment to the PR identifying the failed or
-     unapplied candidates and the reason; if `viewer-cannot-minimize > 0`
-     is also non-zero, include the blocked count in the same comment.
-     This is explicit evidence, not a merge gate — the merge already
-     succeeded. Proceed to step 3.
+     If the apply `status` is `failed` or `incomplete`: use the
+     cleanup-failure comment format instead of the evidence comment
+     format. This is explicit evidence, not a merge gate — the merge
+     already succeeded. Proceed to step 3.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates were

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -197,9 +197,12 @@ gate. The active claim must still use your current `{claim-id}`.
    node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
    ```
 
-   Evaluate the dry-run `status` field:
+   Evaluate the dry-run `status` field (this is a dry-run status; apply
+   mode emits different values and is never invoked unless dry-run
+   shows `needs-apply`):
 
-   - **`clean`**: no candidates detected. Proceed to step 3.
+   - **`clean`**: no candidates and no permission-blocked items.
+     Proceed to step 3.
 
    - **`needs-apply`**: eligible candidates exist and the viewer can
      minimize them. Apply is mandatory. Re-validate the active claim,
@@ -213,8 +216,8 @@ gate. The active claim must still use your current `{claim-id}`.
      After apply, post a cleanup evidence comment to the PR with the
      apply `status`, `applied`, `failed`, and `skipped` counts, and
      the reason for any skipped or failed items. If
-     `viewer-cannot-minimize > 0` alongside applied candidates, include
-     the permission-blocked count in the evidence comment. See
+     `viewer-cannot-minimize > 0` appears alongside applied candidates,
+     include the permission-blocked count in the evidence comment. See
      `docs/idd-comment-minimization.md` for the evidence comment
      format.
 
@@ -222,14 +225,15 @@ gate. The active claim must still use your current `{claim-id}`.
 
      If the apply `status` is `failed` or `incomplete`: post a
      cleanup-failure comment to the PR identifying the failed or
-     unapplied candidates and the reason. This is explicit evidence,
-     not a merge gate — the merge already succeeded. Proceed to step 3.
+     unapplied candidates and the reason; if `viewer-cannot-minimize > 0`
+     is also non-zero, include the blocked count in the same comment.
+     This is explicit evidence, not a merge gate — the merge already
+     succeeded. Proceed to step 3.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates were
      found. Post a cleanup-permission-blocked comment to the PR listing
-     the blocked candidates and the count. Do not silently skip.
-     Proceed to step 3.
+     the blocked candidates and the count, then proceed to step 3.
 
    For the GraphQL fallback (when the helper is unavailable): check
    `viewerCanMinimize` and `isMinimized` before minimizing; skip

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -327,7 +327,7 @@ marker so a resuming agent can detect whether the evidence was already
 posted:
 
 ```markdown
-<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} permission-blocked:{N} -->
+<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->
 
 **F4 Cleanup Evidence**
 
@@ -349,7 +349,7 @@ in the same comment rather than posting a separate permission-blocked
 comment:
 
 ```markdown
-<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} permission-blocked:{N} -->
+<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->
 
 **F4 Cleanup Failure**
 
@@ -372,7 +372,7 @@ This status is only emitted in dry-run mode; it is never emitted during
 apply (apply failures use `failed` or `incomplete` instead):
 
 ```markdown
-<!-- idd-cleanup-evidence: permission-blocked applied:0 failed:0 skipped:N permission-blocked:{N} -->
+<!-- idd-cleanup-evidence: permission-blocked applied:0 failed:0 skipped:N viewer-cannot-minimize:{N} -->
 
 **F4 Cleanup Permission Blocked**
 

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -296,6 +296,95 @@ The helper applies only safe candidates and reports applied, skipped,
 and failed rows. A helper failure is still cleanup-only context; it does
 not retroactively block a merge that already passed F3.
 
+## Mandatory F4 Cleanup Contract
+
+F4 cleanup apply is mandatory when candidates exist and the viewer can
+minimize them. No path may exit F4 without a recorded reason when
+cleanup candidates are detected.
+
+### Decision tree
+
+After the dry-run, evaluate the `status` field and follow the
+corresponding path:
+
+| Dry-run `status`     | Action                                                        |
+| -------------------- | ------------------------------------------------------------- |
+| `clean`              | No candidates and no permission-blocked items. Proceed to F4  |
+|                      | step 3.                                                       |
+| `needs-apply`        | Run apply (mandatory). Post a cleanup evidence comment.       |
+| `permission-blocked` | Post a cleanup-permission-blocked comment, then proceed to F4 |
+|                      | step 3.                                                       |
+
+After apply, if `status` is `failed` or `incomplete`, post a
+cleanup-failure comment. A cleanup failure after a successful F3 merge
+does not re-block the merge; it is an explicit record only.
+
+### Cleanup evidence comment
+
+Post this comment to the PR after a successful or partial apply. The
+HTML comment token on the first line acts as a stable machine-readable
+marker so a resuming agent can detect whether the evidence was already
+posted:
+
+```markdown
+<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} permission-blocked:{N} -->
+
+**F4 Cleanup Evidence**
+
+| Field              | Value                                  |
+| ------------------ | -------------------------------------- |
+| Status             | applied / failed / incomplete          |
+| Applied            | N                                      |
+| Failed             | N                                      |
+| Skipped            | N                                      |
+| Permission-blocked | N                                      |
+| Notes              | reason for any failed or skipped items |
+```
+
+### Cleanup-failure comment
+
+Post this comment when apply `status` is `failed` or `incomplete`. If
+`viewer-cannot-minimize > 0` is also non-zero, include the blocked count
+in the same comment rather than posting a separate permission-blocked
+comment:
+
+```markdown
+<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} permission-blocked:{N} -->
+
+**F4 Cleanup Failure**
+
+Cleanup candidates were detected but not all could be applied.
+
+- Status: failed / incomplete
+- Failed: N candidates (reason: ...)
+- Unapplied: N candidates
+- Permission-blocked: N candidates (if any)
+
+This does not re-block the merge. A maintainer may run cleanup
+manually: `node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check`
+```
+
+### Cleanup-permission-blocked comment
+
+Post this comment when dry-run `status` is `permission-blocked` (no
+apply-eligible candidates exist, only viewer-cannot-minimize items).
+This status is only emitted in dry-run mode; it is never emitted during
+apply (apply failures use `failed` or `incomplete` instead):
+
+```markdown
+<!-- idd-cleanup-evidence: permission-blocked applied:0 failed:0 skipped:N permission-blocked:{N} -->
+
+**F4 Cleanup Permission Blocked**
+
+Cleanup candidates were detected but the current viewer cannot minimize
+them (`viewerCanMinimize: false`).
+
+- Permission-blocked: N candidates
+
+This does not re-block the merge. A maintainer with minimize permission
+may run cleanup manually: `node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check`
+```
+
 ## Fallback GraphQL
 
 If the helper is unavailable, use the direct GraphQL capability checks

--- a/scripts/audit-pr-cleanup-summary.mjs
+++ b/scripts/audit-pr-cleanup-summary.mjs
@@ -2,7 +2,9 @@ export function computeReportSummary(report) {
   const alreadyMinimized = report.skipped.filter((skip) => skip.isMinimized).length;
   const viewerCanMinimize = report.candidates.length
     + report.skipped.filter((skip) => skip.viewerCanMinimize).length;
-  const viewerCannotMinimize = report.skipped.filter((skip) => !skip.viewerCanMinimize).length;
+  const viewerCannotMinimize = report.skipped.filter(
+    (skip) => !skip.isMinimized && !skip.viewerCanMinimize,
+  ).length;
 
   report.summary = {
     candidate: report.candidates.length,

--- a/scripts/audit-pr-cleanup-summary.mjs
+++ b/scripts/audit-pr-cleanup-summary.mjs
@@ -15,7 +15,13 @@ export function computeReportSummary(report) {
   };
 
   if (report.mode === "dry-run") {
-    report.status = report.candidates.length === 0 ? "clean" : "needs-apply";
+    if (report.candidates.length > 0) {
+      report.status = "needs-apply";
+    } else if (viewerCannotMinimize > 0) {
+      report.status = "permission-blocked";
+    } else {
+      report.status = "clean";
+    }
     return;
   }
 

--- a/tests/audit-pr-cleanup-summary.test.mjs
+++ b/tests/audit-pr-cleanup-summary.test.mjs
@@ -56,3 +56,67 @@ test("computeReportSummary reflects apply results after mutations", () => {
   assert.equal(report.summary.failed, 0);
   assert.equal(report.summary.skipped, 1);
 });
+
+test("computeReportSummary emits permission-blocked when all items are viewer-cannot-minimize", () => {
+  const report = createReport({
+    candidates: [],
+    skipped: [
+      { subjectId: "skip-1", isMinimized: false, viewerCanMinimize: false },
+      { subjectId: "skip-2", isMinimized: false, viewerCanMinimize: false },
+    ],
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.status, "permission-blocked");
+  assert.equal(report.summary["viewer-cannot-minimize"], 2);
+  assert.equal(report.summary.candidate, 0);
+});
+
+test("computeReportSummary emits needs-apply even when some items are viewer-cannot-minimize", () => {
+  const report = createReport({
+    candidates: [{ subjectId: "candidate-1" }],
+    skipped: [{ subjectId: "skip-1", isMinimized: false, viewerCanMinimize: false }],
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.status, "needs-apply");
+  assert.equal(report.summary["viewer-cannot-minimize"], 1);
+  assert.equal(report.summary.candidate, 1);
+});
+
+test("computeReportSummary emits failed when apply is attempted but all candidates fail", () => {
+  const report = createReport({
+    mode: "apply",
+    candidates: [{ subjectId: "candidate-1" }, { subjectId: "candidate-2" }],
+    skipped: [],
+    applied: [],
+    failed: [
+      { subjectId: "candidate-1", error: "GraphQL error" },
+      { subjectId: "candidate-2", error: "timeout" },
+    ],
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.status, "failed");
+  assert.equal(report.summary.failed, 2);
+  assert.equal(report.summary.applied, 0);
+});
+
+test("computeReportSummary emits incomplete when apply is partial", () => {
+  const report = createReport({
+    mode: "apply",
+    candidates: [{ subjectId: "candidate-1" }, { subjectId: "candidate-2" }],
+    skipped: [],
+    applied: [{ subjectId: "candidate-1" }],
+    failed: [],
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.status, "incomplete");
+  assert.equal(report.summary.applied, 1);
+  assert.equal(report.summary.failed, 0);
+});

--- a/tests/audit-pr-cleanup-summary.test.mjs
+++ b/tests/audit-pr-cleanup-summary.test.mjs
@@ -70,6 +70,20 @@ test("computeReportSummary emits clean when there are no candidates and no permi
   assert.equal(report.summary["viewer-cannot-minimize"], 0);
 });
 
+test("computeReportSummary emits clean when already-minimized items have viewerCanMinimize false", () => {
+  const report = createReport({
+    candidates: [],
+    skipped: [
+      { subjectId: "skip-1", isMinimized: true, viewerCanMinimize: false },
+    ],
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.status, "clean");
+  assert.equal(report.summary["viewer-cannot-minimize"], 0);
+});
+
 test("computeReportSummary emits permission-blocked when all items are viewer-cannot-minimize", () => {
   const report = createReport({
     candidates: [],

--- a/tests/audit-pr-cleanup-summary.test.mjs
+++ b/tests/audit-pr-cleanup-summary.test.mjs
@@ -133,3 +133,19 @@ test("computeReportSummary emits incomplete when apply is partial", () => {
   assert.equal(report.summary.applied, 1);
   assert.equal(report.summary.failed, 0);
 });
+
+test("computeReportSummary emits failed when apply has both applied and failed candidates", () => {
+  const report = createReport({
+    mode: "apply",
+    candidates: [{ subjectId: "candidate-1" }, { subjectId: "candidate-2" }],
+    skipped: [],
+    applied: [{ subjectId: "candidate-1" }],
+    failed: [{ subjectId: "candidate-2", error: "GraphQL error" }],
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.status, "failed");
+  assert.equal(report.summary.applied, 1);
+  assert.equal(report.summary.failed, 1);
+});

--- a/tests/audit-pr-cleanup-summary.test.mjs
+++ b/tests/audit-pr-cleanup-summary.test.mjs
@@ -57,6 +57,19 @@ test("computeReportSummary reflects apply results after mutations", () => {
   assert.equal(report.summary.skipped, 1);
 });
 
+test("computeReportSummary emits clean when there are no candidates and no permission-blocked items", () => {
+  const report = createReport({
+    candidates: [],
+    skipped: [{ subjectId: "skip-1", isMinimized: true, viewerCanMinimize: true }],
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.status, "clean");
+  assert.equal(report.summary.candidate, 0);
+  assert.equal(report.summary["viewer-cannot-minimize"], 0);
+});
+
 test("computeReportSummary emits permission-blocked when all items are viewer-cannot-minimize", () => {
   const report = createReport({
     candidates: [],


### PR DESCRIPTION
## Summary

Closes #430

F4 cleanup apply is now mandatory when candidates exist. The previous
"best-effort" approach silently skipped cleanup when it failed or when
the viewer lacked minimization permission, leaving merged PRs in
`needs-apply` backlog.

### Changes

**`scripts/audit-pr-cleanup-summary.mjs`**
- New `"permission-blocked"` dry-run status: emitted when no
  apply-eligible candidates exist but at least one skipped item has
  `viewerCanMinimize: false`. Allows F4 to distinguish "truly clean"
  from "items exist but viewer has no permission."

**`tests/audit-pr-cleanup-summary.test.mjs`**
- 6 new tests covering: `clean`, `permission-blocked`,
  `needs-apply` (with mixed viewer-cannot-minimize), mandatory `applied`
  path, `incomplete` (partial apply), `failed` (all-fail), and the
  mixed applied-and-failed case (pins that `failed` takes precedence).

**`.github/instructions/idd-merge.instructions.md` + template mirror**
- F4 decision tree keyed on dry-run `status`:
  - `clean` → no action
  - `needs-apply` → apply (mandatory); post one evidence comment with
    `status`, counts, `viewer-cannot-minimize` count when non-zero;
    use cleanup-failure comment format when apply is `failed`/`incomplete`
  - `permission-blocked` → post cleanup-permission-blocked comment;
    no silent exit
- GraphQL fallback path mirrors the same evidence-posting contract.

**`docs/idd-comment-minimization.md`**
- New "Mandatory F4 Cleanup Contract" section: decision-tree table,
  evidence comment format (with `<!-- idd-cleanup-evidence: ... -->`
  machine-readable token), cleanup-failure comment format, and
  cleanup-permission-blocked comment format.

### Non-goals

- Reclassifying cleanup candidates themselves (unchanged)
- Re-blocking a merge that already succeeded in F3

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Made F4 cleanup mandatory with a detailed decision tree and standardized evidence, failure, and permission-blocked comment templates; added guidance for dry-run, apply, and fallback flows.
* **Tests**
  * Added tests covering all dry-run/apply status outcomes and permission-edge cases.
* **Implementation**
  * Improved status detection to surface a permission-blocked state and enforce apply when candidates exist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/447)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->