### PR TITLE
fix(orphan-filter): harden state, marker, and pagination

### DIFF
--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -71,10 +71,11 @@ export function classifyIssue(issue, options) {
   const unresolved = [];
   for (const ref of refs) {
     const state = resolveIssueState(ref, options.issueStateByNumber, options.fetchIssueStateByNumber);
-    if (state === "OPEN") {
+    const normalizedState = String(state ?? "").toUpperCase();
+    if (normalizedState === "OPEN") {
       return { orphan: false, reason: "blocked_by_open_reference", details: ref };
     }
-    if (state === "UNRESOLVABLE") {
+    if (normalizedState === "UNRESOLVABLE") {
       unresolved.push(ref);
     }
   }
@@ -175,6 +176,7 @@ function runCli() {
   const result = filterOrphanIssues(openIssues, {
     issueStateByNumber: openStateByNumber,
     fetchIssueStateByNumber: (issueNumber) => fetchIssueState(repoRef, issueNumber),
+    markerPrefix: policy.markerPrefix,
   });
 
   const output = {
@@ -284,7 +286,7 @@ function normalizeIssue(issue) {
   return {
     number: Number.parseInt(String(issue.number), 10),
     title: issue.title ?? "",
-    state: issue.state ?? "",
+    state: String(issue.state ?? "").toUpperCase(),
     labels: normalizeLabels(issue.labels),
     body: issue.body ?? "",
     url: issue.url ?? issue.html_url ?? "",
@@ -376,19 +378,20 @@ function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function fetchOpenIssues(repoRef) {
+export function fetchOpenIssues(repoRef, ghJsonFn = ghJson) {
   const issues = [];
   const pageSize = 100;
   for (let page = 1; ; page += 1) {
-    const pageItems = ghJson([
+    const rawPageItems = ghJsonFn([
       "api",
       `repos/${repoRef}/issues?state=open&per_page=${pageSize}&page=${page}`,
-    ])
+    ]);
+    const pageItems = rawPageItems
       .filter((item) => item?.pull_request === undefined)
       .map(normalizeIssue);
 
     issues.push(...pageItems);
-    if (pageItems.length < pageSize) {
+    if (rawPageItems.length < pageSize) {
       break;
     }
   }

--- a/tests/discover-orphan-filter.test.mjs
+++ b/tests/discover-orphan-filter.test.mjs
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   classifyIssue,
   extractBlockedByReferences,
+  fetchOpenIssues,
   filterOrphanIssues,
   getOrphanFirstPolicy,
 } from "../scripts/discover-orphan-filter.mjs";
@@ -149,6 +150,26 @@ test("filterOrphanIssues excludes blocked labels and open blockers", () => {
   assert.equal(result.filtered.blocked_label.length, 1);
 });
 
+test("filterOrphanIssues treats lowercase open state as open blocker", () => {
+  const issues = [
+    {
+      number: 20,
+      title: "candidate",
+      state: "OPEN",
+      labels: [],
+      body: "Blocked by #21",
+      url: "https://example.com/20",
+    },
+  ];
+
+  const result = filterOrphanIssues(issues, {
+    issueStateByNumber: new Map([[21, "open"]]),
+    fetchIssueStateByNumber: () => "UNRESOLVABLE",
+  });
+
+  assert.equal(result.filtered.blocked_by_open_reference.length, 1);
+});
+
 test("filterOrphanIssues keeps closed-blocker issues as orphan candidates", () => {
   const issues = [
     {
@@ -214,4 +235,56 @@ test("filterOrphanIssues reports unresolvable and circular references", () => {
     reason: "issue-not-found-or-inaccessible",
     reference: 99,
   });
+});
+
+test("filterOrphanIssues applies custom marker prefix across issue set filtering", () => {
+  const issues = [
+    {
+      number: 50,
+      title: "custom marker issue",
+      state: "OPEN",
+      labels: [],
+      body: "<!-- custom-roadmap-id: phase-a -->",
+      url: "https://example.com/50",
+    },
+  ];
+
+  const result = filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => "UNRESOLVABLE",
+    markerPrefix: "custom",
+  });
+
+  assert.equal(result.filtered.roadmap_marker.length, 1);
+  assert.equal(result.orphans.length, 0);
+});
+
+test("fetchOpenIssues paginates by raw API page length, not filtered issue length", () => {
+  const pages = [
+    [
+      { number: 60, title: "issue 60", state: "open", labels: [], body: "" },
+      ...Array.from({ length: 99 }, (_, index) => ({
+        number: 1000 + index,
+        title: `pr ${index}`,
+        state: "open",
+        labels: [],
+        body: "",
+        pull_request: { url: "https://example.com/pr" },
+      })),
+    ],
+    [
+      { number: 61, title: "issue 61", state: "open", labels: [], body: "" },
+    ],
+  ];
+  let callCount = 0;
+  const ghJsonMock = () => {
+    const page = pages[callCount] ?? [];
+    callCount += 1;
+    return page;
+  };
+
+  const issues = fetchOpenIssues("owner/repo", ghJsonMock);
+
+  assert.equal(callCount, 2);
+  assert.deepEqual(issues.map((issue) => issue.number), [60, 61]);
 });


### PR DESCRIPTION
Closes #414

## Summary  
- normalize blocker state comparisons (case-insensitive)
- pass policy `markerPrefix` through CLI
- paginate using raw page length to avoid truncation
- add regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed case-insensitive handling of issue and reference states to ensure consistent classification
  * Corrected pagination logic to fetch subsequent pages based on actual API results rather than filtered results

* **Tests**
  * Enhanced test coverage for state normalization and configuration-based behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/449)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->