### PR TITLE
docs: add Phase 1 helpers to idd-helper-scripts.md adopted list

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -8,6 +8,29 @@ directly instead of re-evaluating the same suggestion from scratch.
 
 In the idd-skill source repository, the following optional helpers were adopted:
 
+**Discover & Claim Phase Helpers (Phase 1):**
+
+- `scripts/discover-orphan-filter.mjs` for A0-O orphan issue detection and
+  filtering (referenced in
+  [kurone-kito/idd-skill#390](https://github.com/kurone-kito/idd-skill/issues/390))
+- `scripts/discover-readiness-check.mjs` for A3 readiness criterion
+  evaluation (referenced in
+  [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391))
+- `scripts/suitability-triage.mjs` for A4.5 seven-check suitability
+  evaluation (referenced in
+  [kurone-kito/idd-skill#392](https://github.com/kurone-kito/idd-skill/issues/392))
+- `scripts/claim-approval-gate.mjs` for A5(a) issue-author approval
+  verification (referenced in
+  [kurone-kito/idd-skill#393](https://github.com/kurone-kito/idd-skill/issues/393))
+- `scripts/resume-claim-routing.mjs` for Resume Step 1 claim-state
+  evaluation and takeover routing (referenced in
+  [kurone-kito/idd-skill#394](https://github.com/kurone-kito/idd-skill/issues/394))
+- `scripts/resume-route-selection.mjs` for Resume Step 3 PR/CI/review
+  state routing (referenced in
+  [kurone-kito/idd-skill#395](https://github.com/kurone-kito/idd-skill/issues/395))
+
+**Review & Merge Phase Helpers:**
+
 - `scripts/review-activity-snapshot.mjs` for read-only E/F review
   activity and CI snapshot metrics
 - `scripts/advisory-wait-state.mjs` for read-only advisory-wait evidence

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -8,6 +8,29 @@ directly instead of re-evaluating the same suggestion from scratch.
 
 In the idd-skill source repository, the following optional helpers were adopted:
 
+**Discover & Claim Phase Helpers (Phase 1):**
+
+- `scripts/discover-orphan-filter.mjs` for A0-O orphan issue detection and
+  filtering (referenced in
+  [kurone-kito/idd-skill#390](https://github.com/kurone-kito/idd-skill/issues/390))
+- `scripts/discover-readiness-check.mjs` for A3 readiness criterion
+  evaluation (referenced in
+  [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391))
+- `scripts/suitability-triage.mjs` for A4.5 seven-check suitability
+  evaluation (referenced in
+  [kurone-kito/idd-skill#392](https://github.com/kurone-kito/idd-skill/issues/392))
+- `scripts/claim-approval-gate.mjs` for A5(a) issue-author approval
+  verification (referenced in
+  [kurone-kito/idd-skill#393](https://github.com/kurone-kito/idd-skill/issues/393))
+- `scripts/resume-claim-routing.mjs` for Resume Step 1 claim-state
+  evaluation and takeover routing (referenced in
+  [kurone-kito/idd-skill#394](https://github.com/kurone-kito/idd-skill/issues/394))
+- `scripts/resume-route-selection.mjs` for Resume Step 3 PR/CI/review
+  state routing (referenced in
+  [kurone-kito/idd-skill#395](https://github.com/kurone-kito/idd-skill/issues/395))
+
+**Review & Merge Phase Helpers:**
+
 - `scripts/review-activity-snapshot.mjs` for read-only E/F review
   activity and CI snapshot metrics
 - `scripts/advisory-wait-state.mjs` for read-only advisory-wait evidence


### PR DESCRIPTION
## Overview

This PR adds documentation for the six Phase 1 (Discover & Claim) helper utilities to the adopted helpers list in `docs/idd-helper-scripts.md`.

## Changes

- **discover-orphan-filter.mjs**: A0-O orphan issue detection and filtering
- **discover-readiness-check.mjs**: A3 readiness criterion evaluation
- **suitability-triage.mjs**: A4.5 seven-check suitability evaluation
- **claim-approval-gate.mjs**: A5(a) issue-author approval verification
- **resume-claim-routing.mjs**: Resume Step 1 claim-state evaluation and routing
- **resume-route-selection.mjs**: Resume Step 3 PR/CI/review state routing

Each helper includes a phase integration reference and a GitHub issue link for traceability.

Both `docs/idd-helper-scripts.md` and `idd-template/docs/idd-helper-scripts.md` are updated to maintain template sync.

## Verification

- All lint checks pass ✓
- No breaking changes
- Documentation is complete and accurate

Closes #450
Related: #389, #438, #391, #392, #393, #394, #395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation Updates

* **Documentation**
  * Updated documentation to specify the helper scripts adopted for the Discover & Claim phase, covering orphan detection, readiness assessment, suitability evaluation, approval verification, and claim-state routing.
  * Reorganized documentation with distinct sections for Discover & Claim and Review & Merge phase helper scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/454)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->