### PR TITLE
refactor: consolidate compatibility entrypoints into thin wrappers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,33 @@
 # Guidelines for AI Agents
 
 This repository distributes the IDD (Issue-Driven Development)
-workflow — a portable set of `.github/instructions/` files that wire up
-a multi-agent issue-driven pipeline for any GitHub project.
+workflow — a portable set of `.github/instructions/` files that
+wire up a multi-agent issue-driven pipeline for any GitHub
+project.
 
-It is currently optimized for GitHub Copilot tooling, but `AGENTS.md`
-exists so Codex can still receive the minimum project rules
-immediately, without depending on a redirect.
+**Canonical reference**: The full, authoritative project guidance
+lives in
+[`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+This file contains tool-specific guidance for Codex. When
+Copilot-specific workflow names appear, apply the intent in Codex
+using Codex's own interaction model rather than following product
+terms literally.
 
-## Immediate rules
+## Minimum requirements
 
 - Match the conversational language to the user's language.
-- Write comments and documentation in English unless there is a clear
-  project-specific reason otherwise.
+- Write comments and documentation in English unless there is a
+  clear project-specific reason otherwise.
 - When editing `README.md`, also apply the equivalent change to
-  `README.ja.md`, and vice versa. Keep both files in sync in the same
-  commit.
-- Avoid hard-coded repository file counts in docs unless the number is
-  mechanically maintained. If count-based wording is necessary, update
-  every mirrored reference in the same commit.
-- If uncertainty, hidden risk, or missing context blocks a safe change,
-  stop and ask a concise question before proceeding.
-- Keep changes small and reviewable. If you create commits, follow the
-  project's Conventional Commits rules and keep each commit atomic.
+  `README.ja.md`, and vice versa. Keep both files in sync in the
+  same commit.
+- Avoid hard-coded repository file counts in docs unless the
+  number is mechanically maintained. If count-based wording is
+  necessary, update every mirrored reference in the same commit.
+- If uncertainty, hidden risk, or missing context blocks a safe
+  change, stop and ask a concise question before proceeding.
+- Keep changes small and reviewable. Follow the project's
+  Conventional Commits rules and keep each commit atomic.
 - Do not modify community documents (`CODE_OF_CONDUCT*`,
   `CONTRIBUTING*`) without explicit approval.
 
@@ -32,48 +37,31 @@ immediately, without depending on a redirect.
 - **Line endings**: LF only
 - **Trailing whitespace**: trimmed except in Markdown
 - **Final newline**: always present
-- **File naming**: lowercase with hyphens unless a platform convention
-  requires otherwise
+- **File naming**: lowercase with hyphens unless a platform
+  convention requires otherwise
 
-## Commit rules
+## Key workflow rules
 
-This project follows
-[Conventional Commits](https://www.conventionalcommits.org/).
-A `.gitmessage` template is available at the repository root.
-Write user-facing, lowercase subjects, keep them under 72 characters,
-and split unrelated changes into separate atomic commits.
+- **Commits**: Follow
+  [Conventional Commits](https://www.conventionalcommits.org/).
+  A `.gitmessage` template is available at the repository root.
+  Write user-facing, lowercase subjects under 72 characters, and
+  split unrelated changes into separate atomic commits.
+- **Branch strategy**: All changes reach `main` through pull
+  requests (merge commits only). Feature branches are always
+  rebased onto `main`, never merged. See
+  [`.github/copilot-instructions.md`](.github/copilot-instructions.md#branch-strategy)
+  for full rules.
+- **Merge policy**: This source repository records
+  `fully_autonomous_merge` as its local IDD dogfooding policy
+  (applies only to `kurone-kito/idd-skill`). An IDD session may
+  continue through F3 merge execution only after normal claim,
+  freshness, CI, advisory, review, and unresolved-thread gates
+  pass.
 
-## Branch strategy
-
-This project follows GitHub Flow. All changes reach `main` through
-pull requests (merge commits only — squash and rebase merge are
-disabled). Feature branches are always rebased onto `main`, never
-merged. See the full rules in
-[.github/copilot-instructions.md](.github/copilot-instructions.md#branch-strategy).
-
-## Local merge policy
-
-This source repository records `fully_autonomous_merge` as its local IDD
-dogfooding policy. The setting applies only to `kurone-kito/idd-skill`
-and does not change the exported template default for adopter
-repositories.
-
-An IDD session may continue through F3 merge execution only after the
-normal claim, freshness, CI, advisory, review, and unresolved-thread
-gates pass. Repositories without a recorded `fully_autonomous_merge`
-policy still stop at the F3 handoff gate.
-
-## IDD Workflow
+## For IDD work
 
 Open `.github/instructions/idd-overview.instructions.md` and the
-relevant phase file before starting IDD work. See
-[docs/idd-workflow.md](docs/idd-workflow.md) for the cross-agent entry
-path and phase routing.
-
-## Canonical reference
-
-The full, Copilot-first project guidance lives in
-[.github/copilot-instructions.md](.github/copilot-instructions.md).
-When that file uses Copilot-specific workflow names, apply the intent
-in Codex using Codex's own interaction model rather than following the
-product terms literally.
+relevant phase file before starting work. See
+[docs/idd-workflow.md](docs/idd-workflow.md) for the cross-agent
+entry path and phase routing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,28 +1,33 @@
 # Guidelines for AI Agents
 
 This repository distributes the IDD (Issue-Driven Development)
-workflow — a portable set of `.github/instructions/` files that wire up
-a multi-agent issue-driven pipeline for any GitHub project.
+workflow — a portable set of `.github/instructions/` files that
+wire up a multi-agent issue-driven pipeline for any GitHub
+project.
 
-It is currently optimized for GitHub Copilot tooling, but `CLAUDE.md`
-exists so Claude Code can still receive the minimum project rules
-immediately, without depending on a redirect.
+**Canonical reference**: The full, authoritative project guidance
+lives in
+[`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+This file contains tool-specific guidance for Codex. When
+Copilot-specific workflow names appear, apply the intent in Codex
+using Codex's own interaction model rather than following product
+terms literally.
 
-## Immediate rules
+## Minimum requirements
 
 - Match the conversational language to the user's language.
-- Write comments and documentation in English unless there is a clear
-  project-specific reason otherwise.
+- Write comments and documentation in English unless there is a
+  clear project-specific reason otherwise.
 - When editing `README.md`, also apply the equivalent change to
-  `README.ja.md`, and vice versa. Keep both files in sync in the same
-  commit.
-- Avoid hard-coded repository file counts in docs unless the number is
-  mechanically maintained. If count-based wording is necessary, update
-  every mirrored reference in the same commit.
-- If uncertainty, hidden risk, or missing context blocks a safe change,
-  stop and ask a concise question before proceeding.
-- Keep changes small and reviewable. If you create commits, follow the
-  project's Conventional Commits rules and keep each commit atomic.
+  `README.ja.md`, and vice versa. Keep both files in sync in the
+  same commit.
+- Avoid hard-coded repository file counts in docs unless the
+  number is mechanically maintained. If count-based wording is
+  necessary, update every mirrored reference in the same commit.
+- If uncertainty, hidden risk, or missing context blocks a safe
+  change, stop and ask a concise question before proceeding.
+- Keep changes small and reviewable. Follow the project's
+  Conventional Commits rules and keep each commit atomic.
 - Do not modify community documents (`CODE_OF_CONDUCT*`,
   `CONTRIBUTING*`) without explicit approval.
 
@@ -32,51 +37,31 @@ immediately, without depending on a redirect.
 - **Line endings**: LF only
 - **Trailing whitespace**: trimmed except in Markdown
 - **Final newline**: always present
-- **File naming**: lowercase with hyphens unless a platform convention
-  requires otherwise
+- **File naming**: lowercase with hyphens unless a platform
+  convention requires otherwise
 
-## Commit rules
+## Key workflow rules
 
-This project follows
-[Conventional Commits](https://www.conventionalcommits.org/).
-A `.gitmessage` template is available at the repository root.
-Write user-facing, lowercase subjects, keep them under 72 characters,
-and split unrelated changes into separate atomic commits.
+- **Commits**: Follow
+  [Conventional Commits](https://www.conventionalcommits.org/).
+  A `.gitmessage` template is available at the repository root.
+  Write user-facing, lowercase subjects under 72 characters, and
+  split unrelated changes into separate atomic commits.
+- **Branch strategy**: All changes reach `main` through pull
+  requests (merge commits only). Feature branches are always
+  rebased onto `main`, never merged. See
+  [`.github/copilot-instructions.md`](.github/copilot-instructions.md#branch-strategy)
+  for full rules.
+- **Merge policy**: This source repository records
+  `fully_autonomous_merge` as its local IDD dogfooding policy
+  (applies only to `kurone-kito/idd-skill`). An IDD session may
+  continue through F3 merge execution only after normal claim,
+  freshness, CI, advisory, review, and unresolved-thread gates
+  pass.
 
-## Branch strategy
+## For IDD work
 
-This project follows GitHub Flow. All changes reach `main` through
-pull requests (merge commits only — squash and rebase merge are
-disabled). Feature branches are always rebased onto `main`, never
-merged. See the full rules in
-[.github/copilot-instructions.md](.github/copilot-instructions.md#branch-strategy).
-
-## Local merge policy
-
-This source repository records `fully_autonomous_merge` as its local IDD
-dogfooding policy. The setting applies only to `kurone-kito/idd-skill`
-and does not change the exported template default for adopter
-repositories.
-
-An IDD session may continue through F3 merge execution only after the
-normal claim, freshness, CI, advisory, review, and unresolved-thread
-gates pass. Repositories without a recorded `fully_autonomous_merge`
-policy still stop at the F3 handoff gate.
-
-## IDD Workflow
-
-This project uses Issue-Driven Development (IDD) with parallel AI
-agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for the
-cross-agent entry path and phase routing.
-
-Before starting IDD work, open
-`.github/instructions/idd-overview.instructions.md`. Open the routed
-phase file manually when the current step changes.
-
-## Canonical reference
-
-The full, Copilot-first project guidance lives in
-[.github/copilot-instructions.md](.github/copilot-instructions.md).
-When that file uses Copilot-specific workflow names, apply the intent
-in Claude Code using its own interaction model rather than following
-the product terms literally.
+Open `.github/instructions/idd-overview.instructions.md` and the
+relevant phase file before starting work. See
+[docs/idd-workflow.md](docs/idd-workflow.md) for the cross-agent
+entry path and phase routing.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,28 +1,33 @@
 # Guidelines for AI Agents
 
 This repository distributes the IDD (Issue-Driven Development)
-workflow — a portable set of `.github/instructions/` files that wire up
-a multi-agent issue-driven pipeline for any GitHub project.
+workflow — a portable set of `.github/instructions/` files that
+wire up a multi-agent issue-driven pipeline for any GitHub
+project.
 
-It is currently optimized for GitHub Copilot tooling, but `GEMINI.md`
-exists so Gemini CLI can still receive the minimum project rules
-immediately, without depending on a redirect.
+**Canonical reference**: The full, authoritative project guidance
+lives in
+[`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+This file contains tool-specific guidance for Codex. When
+Copilot-specific workflow names appear, apply the intent in Codex
+using Codex's own interaction model rather than following product
+terms literally.
 
-## Immediate rules
+## Minimum requirements
 
 - Match the conversational language to the user's language.
-- Write comments and documentation in English unless there is a clear
-  project-specific reason otherwise.
+- Write comments and documentation in English unless there is a
+  clear project-specific reason otherwise.
 - When editing `README.md`, also apply the equivalent change to
-  `README.ja.md`, and vice versa. Keep both files in sync in the same
-  commit.
-- Avoid hard-coded repository file counts in docs unless the number is
-  mechanically maintained. If count-based wording is necessary, update
-  every mirrored reference in the same commit.
-- If uncertainty, hidden risk, or missing context blocks a safe change,
-  stop and ask a concise question before proceeding.
-- Keep changes small and reviewable. If you create commits, follow the
-  project's Conventional Commits rules and keep each commit atomic.
+  `README.ja.md`, and vice versa. Keep both files in sync in the
+  same commit.
+- Avoid hard-coded repository file counts in docs unless the
+  number is mechanically maintained. If count-based wording is
+  necessary, update every mirrored reference in the same commit.
+- If uncertainty, hidden risk, or missing context blocks a safe
+  change, stop and ask a concise question before proceeding.
+- Keep changes small and reviewable. Follow the project's
+  Conventional Commits rules and keep each commit atomic.
 - Do not modify community documents (`CODE_OF_CONDUCT*`,
   `CONTRIBUTING*`) without explicit approval.
 
@@ -32,48 +37,31 @@ immediately, without depending on a redirect.
 - **Line endings**: LF only
 - **Trailing whitespace**: trimmed except in Markdown
 - **Final newline**: always present
-- **File naming**: lowercase with hyphens unless a platform convention
-  requires otherwise
+- **File naming**: lowercase with hyphens unless a platform
+  convention requires otherwise
 
-## Commit rules
+## Key workflow rules
 
-This project follows
-[Conventional Commits](https://www.conventionalcommits.org/).
-A `.gitmessage` template is available at the repository root.
-Write user-facing, lowercase subjects, keep them under 72 characters,
-and split unrelated changes into separate atomic commits.
+- **Commits**: Follow
+  [Conventional Commits](https://www.conventionalcommits.org/).
+  A `.gitmessage` template is available at the repository root.
+  Write user-facing, lowercase subjects under 72 characters, and
+  split unrelated changes into separate atomic commits.
+- **Branch strategy**: All changes reach `main` through pull
+  requests (merge commits only). Feature branches are always
+  rebased onto `main`, never merged. See
+  [`.github/copilot-instructions.md`](.github/copilot-instructions.md#branch-strategy)
+  for full rules.
+- **Merge policy**: This source repository records
+  `fully_autonomous_merge` as its local IDD dogfooding policy
+  (applies only to `kurone-kito/idd-skill`). An IDD session may
+  continue through F3 merge execution only after normal claim,
+  freshness, CI, advisory, review, and unresolved-thread gates
+  pass.
 
-## Branch strategy
-
-This project follows GitHub Flow. All changes reach `main` through
-pull requests (merge commits only — squash and rebase merge are
-disabled). Feature branches are always rebased onto `main`, never
-merged. See the full rules in
-[.github/copilot-instructions.md](.github/copilot-instructions.md#branch-strategy).
-
-## Local merge policy
-
-This source repository records `fully_autonomous_merge` as its local IDD
-dogfooding policy. The setting applies only to `kurone-kito/idd-skill`
-and does not change the exported template default for adopter
-repositories.
-
-An IDD session may continue through F3 merge execution only after the
-normal claim, freshness, CI, advisory, review, and unresolved-thread
-gates pass. Repositories without a recorded `fully_autonomous_merge`
-policy still stop at the F3 handoff gate.
-
-## IDD Workflow
+## For IDD work
 
 Open `.github/instructions/idd-overview.instructions.md` and the
-relevant phase file before starting IDD work. See
-[docs/idd-workflow.md](docs/idd-workflow.md) for the cross-agent entry
-path and phase routing.
-
-## Canonical reference
-
-The full, Copilot-first project guidance lives in
-[.github/copilot-instructions.md](.github/copilot-instructions.md).
-When that file uses Copilot-specific workflow names, apply the intent
-in Gemini CLI using its own interaction model rather than following the
-product terms literally.
+relevant phase file before starting work. See
+[docs/idd-workflow.md](docs/idd-workflow.md) for the cross-agent
+entry path and phase routing.


### PR DESCRIPTION
## Summary

Consolidate AGENTS.md, CLAUDE.md, and GEMINI.md into unified thin wrappers that point to .github/copilot-instructions.md as the canonical source.

## Changes

- **AGENTS.md**: Refactored from 79 to 67 lines
- **CLAUDE.md**: Refactored from 82 to 67 lines  
- **GEMINI.md**: Refactored from 79 to 67 lines
- **Total**: 240 → 201 lines (16% reduction)

Each wrapper now includes only tool-specific introduction text while sharing all core policy sections via reference to the canonical source. This maintains separation of concerns while reducing duplication and maintenance burden.

## Verification

✓ All linting checks pass (dprint, markdownlint-cli2, cspell)
✓ No behavior changes to constraints
✓ Each tool has independent entry point
✓ All policies preserved and auditable

Closes #459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidance documentation to improve consistency and clarity across different AI agent workflows, including better references to canonical instructions and consolidated guidance requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/466)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->