### PR TITLE
docs(policy): define canonical source map for mirrored assets

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -573,17 +573,17 @@ template copies.
    - Instruction files → `.github/instructions/idd-*.md`
 
 2. If the repository distributes IDD as a template (source of a reusable IDD
-   distribution), run the synchronization script to keep copies in sync:
+   distribution), run the documentation audit check:
 
    ```sh
-   node scripts/audit-docs.mjs
+   node scripts/audit-docs.mjs --check
    ```
 
-   This ensures `idd-template/` copies remain current and placeholder substitutions
-   are correct.
+   This verifies canonical/template pairs and placeholder substitutions stay
+   consistent.
 
-3. Do **not** manually edit files in `idd-template/`. They will be overwritten on
-   the next sync run.
+3. Do **not** edit files in `idd-template/` first. Update canonical sources
+   before mirroring equivalent template changes in the same commit.
 
 **When working with template imports** (external repositories importing IDD):
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -506,6 +506,94 @@ changing merge gates, changing discovery scope, or altering validation
 commands. Keep live instruction files and the exported template in sync
 when the repository is the source of a reusable IDD distribution.
 
+## Canonical Asset Map
+
+IDD distributes documentation, instruction files, and policy guidance in
+multiple locations. This section identifies which copies are canonical
+(authored directly) and which are generated or synchronized from other
+sources.
+
+### Canonical Sources (Authored Directly)
+
+**Documentation**:
+
+- `docs/customization.md` → canonical source for IDD customization guidance
+- `docs/idd-workflow.md` → canonical source for workflow description
+- `docs/policy-constants.md` → canonical source for distributed timing and
+  gate defaults
+
+**Instruction Files**:
+
+- `.github/instructions/idd-*.md` → canonical source for IDD phase files and
+  shared definitions
+
+### Generated/Synchronized Assets
+
+**Template Distribution**:
+
+- `idd-template/docs/*.md` → synchronized copies of canonical docs/
+- `idd-template/.github/instructions/*.md` → synchronized copies with
+  placeholder substitution
+
+**Synchronization Mechanics**:
+
+- `audit-docs.mjs` enforces synchronization rules defined in
+  `sync-manifest.json`
+- Template copies use placeholders like `{{REPO_NAME}}` to support
+  repository-specific values during import
+- The `sync-manifest.json` defines source→target mappings and sync modes
+  (exact copy vs placeholder substitution)
+
+**Why This Structure**:
+
+- Canonical sources remain authoritative and avoid drift
+- Template copies can be independently imported and customized
+- Synchronization is automated and verifiable via CI
+- Contributors have one source of truth for each piece of guidance
+
+### Scope Note
+
+This map documents which files are canonical sources and which are synchronized
+copies. Downstream tasks (referenced by issue #481 and #482 in roadmap #483) will
+implement:
+
+- CI checks to detect and prevent canonical-source drift
+- Contributor tooling to guide edits toward canonical sources
+- Integration with the contribution workflow
+
+## Where to Edit
+
+**Always edit canonical sources** in `docs/` and `.github/instructions/`, not the
+template copies.
+
+**When editing canonical sources**:
+
+1. Update the file in its canonical location:
+   - Policy guidance → `docs/customization.md`, `docs/policy-constants.md`, etc.
+   - Instruction files → `.github/instructions/idd-*.md`
+
+2. If the repository distributes IDD as a template (source of a reusable IDD
+   distribution), run the synchronization script to keep copies in sync:
+
+   ```sh
+   node scripts/audit-docs.mjs
+   ```
+
+   This ensures `idd-template/` copies remain current and placeholder substitutions
+   are correct.
+
+3. Do **not** manually edit files in `idd-template/`. They will be overwritten on
+   the next sync run.
+
+**When working with template imports** (external repositories importing IDD):
+
+- When the repository **imports** IDD from a template:
+  - The imported files start as copies of the template
+  - Apply local customization to `.github/idd/config.json` or to
+    canonical sources only
+  - Never manually edit idd-template/ files — they represent the source
+    template and may be re-imported
+
 ## Repository-local IDD policy
 
 The trusted marker actors definition is abstract to support diverse

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -573,17 +573,17 @@ template copies.
    - Instruction files → `.github/instructions/idd-*.md`
 
 2. If the repository distributes IDD as a template (source of a reusable IDD
-   distribution), run the synchronization script to keep copies in sync:
+   distribution), run the documentation audit check:
 
    ```sh
-   node scripts/audit-docs.mjs
+   node scripts/audit-docs.mjs --check
    ```
 
-   This ensures `idd-template/` copies remain current and placeholder substitutions
-   are correct.
+   This verifies canonical/template pairs and placeholder substitutions stay
+   consistent.
 
-3. Do **not** manually edit files in `idd-template/`. They will be overwritten on
-   the next sync run.
+3. Do **not** edit files in `idd-template/` first. Update canonical sources
+   before mirroring equivalent template changes in the same commit.
 
 **When working with template imports** (external repositories importing IDD):
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -506,6 +506,94 @@ changing merge gates, changing discovery scope, or altering validation
 commands. Keep live instruction files and the exported template in sync
 when the repository is the source of a reusable IDD distribution.
 
+## Canonical Asset Map
+
+IDD distributes documentation, instruction files, and policy guidance in
+multiple locations. This section identifies which copies are canonical
+(authored directly) and which are generated or synchronized from other
+sources.
+
+### Canonical Sources (Authored Directly)
+
+**Documentation**:
+
+- `docs/customization.md` → canonical source for IDD customization guidance
+- `docs/idd-workflow.md` → canonical source for workflow description
+- `docs/policy-constants.md` → canonical source for distributed timing and
+  gate defaults
+
+**Instruction Files**:
+
+- `.github/instructions/idd-*.md` → canonical source for IDD phase files and
+  shared definitions
+
+### Generated/Synchronized Assets
+
+**Template Distribution**:
+
+- `idd-template/docs/*.md` → synchronized copies of canonical docs/
+- `idd-template/.github/instructions/*.md` → synchronized copies with
+  placeholder substitution
+
+**Synchronization Mechanics**:
+
+- `audit-docs.mjs` enforces synchronization rules defined in
+  `sync-manifest.json`
+- Template copies use placeholders like `{{REPO_NAME}}` to support
+  repository-specific values during import
+- The `sync-manifest.json` defines source→target mappings and sync modes
+  (exact copy vs placeholder substitution)
+
+**Why This Structure**:
+
+- Canonical sources remain authoritative and avoid drift
+- Template copies can be independently imported and customized
+- Synchronization is automated and verifiable via CI
+- Contributors have one source of truth for each piece of guidance
+
+### Scope Note
+
+This map documents which files are canonical sources and which are synchronized
+copies. Downstream tasks (referenced by issue #481 and #482 in roadmap #483) will
+implement:
+
+- CI checks to detect and prevent canonical-source drift
+- Contributor tooling to guide edits toward canonical sources
+- Integration with the contribution workflow
+
+## Where to Edit
+
+**Always edit canonical sources** in `docs/` and `.github/instructions/`, not the
+template copies.
+
+**When editing canonical sources**:
+
+1. Update the file in its canonical location:
+   - Policy guidance → `docs/customization.md`, `docs/policy-constants.md`, etc.
+   - Instruction files → `.github/instructions/idd-*.md`
+
+2. If the repository distributes IDD as a template (source of a reusable IDD
+   distribution), run the synchronization script to keep copies in sync:
+
+   ```sh
+   node scripts/audit-docs.mjs
+   ```
+
+   This ensures `idd-template/` copies remain current and placeholder substitutions
+   are correct.
+
+3. Do **not** manually edit files in `idd-template/`. They will be overwritten on
+   the next sync run.
+
+**When working with template imports** (external repositories importing IDD):
+
+- When the repository **imports** IDD from a template:
+  - The imported files start as copies of the template
+  - Apply local customization to `.github/idd/config.json` or to
+    canonical sources only
+  - Never manually edit idd-template/ files — they represent the source
+    template and may be re-imported
+
 ## Repository-local IDD policy
 
 The trusted marker actors definition is abstract to support diverse


### PR DESCRIPTION
## Summary

Define canonical source map for mirrored assets in IDD distribution.

Adds guidance to docs/customization.md and idd-template/docs/customization.md:
- **Canonical Asset Map**: identifies which docs/, instructions, and policy files are canonical sources vs synchronized copies from idd-template/
- **Where to Edit**: explains that contributors should edit canonical sources only, never manually edit template copies; documents sync mechanics
- **Scope Note**: clarifies this foundation task documents structure only; downstream tasks (#481, #482) will implement CI drift checks and contributor tooling

All existing guidance preserved with no semantic loss.

## Foundation Task

This is Track A of roadmap #483 (single-source rollout for mirrored docs/instructions). Downstream tasks:
- Issue #481: CI checks to detect and prevent canonical-source drift
- Issue #482: Contributor workflow integration for guided edits

Closes #480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Canonical Asset Map" explaining which docs/instructions are canonical vs generated template copies, how synchronization and placeholder substitution work, and planned drift-detection/edit guidance.
  * Added "Where to Edit" guidance: edit canonical sources only, run the provided audit/sync check after canonical edits when distributing templates, and avoid editing generated template copies directly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/485)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->