### PR TITLE
ci(policy): add runtime bundle token/size budget checks

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -144,6 +144,30 @@
     "alwaysLoadedLimitBytes": 20000,
     "phaseLimitBytes": 30000
   },
+  "bundleBudgets": [
+    {
+      "id": "bundle-discovery",
+      "description": "Discovery path: idd-overview-core + idd-overview-appendix + idd-discover + idd-suitability + idd-claim",
+      "files": [
+        ".github/instructions/idd-overview-core.instructions.md",
+        ".github/instructions/idd-overview-appendix.instructions.md",
+        ".github/instructions/idd-discover.instructions.md",
+        ".github/instructions/idd-suitability.instructions.md",
+        ".github/instructions/idd-claim.instructions.md"
+      ],
+      "limitBytes": 75000
+    },
+    {
+      "id": "bundle-resume",
+      "description": "Resume path: idd-overview-core + idd-overview-appendix + idd-resume",
+      "files": [
+        ".github/instructions/idd-overview-core.instructions.md",
+        ".github/instructions/idd-overview-appendix.instructions.md",
+        ".github/instructions/idd-resume.instructions.md"
+      ],
+      "limitBytes": 46000
+    }
+  ],
   "syncPairs": [
     {
       "id": "idd-advisory-wait-instructions",

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -167,6 +167,28 @@ files are edited.
 | E10 repeated accepted finding guard     | Hold after 3 consecutive passes without meaningful progress                        | [Review fix](../.github/instructions/idd-review-fix.instructions.md)       | Keep unless maintainers want a different stop condition for non-converging fixes.                                            |
 | Rejected `CHANGES_REQUESTED` escalation | Escalate after 24 h; after 48 h consider `status:needs-decision` and claim release | [Review triage](../.github/instructions/idd-review-triage.instructions.md) | Keep unless the repository has an explicit reviewer escalation service-level expectation.                                    |
 
+## Runtime Instruction Size and Bundle Budgets
+
+CI enforces two layers of instruction file size limits via `audit/sync-manifest.json`.
+
+### Per-file limits
+
+| Limit type    | Value        | Applies to                                                                 |
+| ------------- | ------------ | -------------------------------------------------------------------------- |
+| Always-loaded | 20,000 bytes | Files with `applyTo: "**"` in `.github/instructions/idd-*.instructions.md` |
+| Phase         | 30,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                |
+
+### Bundle limits
+
+| Bundle ID          | Files included                                                                                   | Limit        |
+| ------------------ | ------------------------------------------------------------------------------------------------ | ------------ |
+| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 75,000 bytes |
+| `bundle-resume`    | `idd-overview-core` + `idd-overview-appendix` + `idd-resume`                                     | 46,000 bytes |
+
+Bundle checks run unconditionally (not filtered by changed files) and
+measure the combined byte length of all listed files. Adjust limits in
+`audit/sync-manifest.json` when deliberate growth is accepted.
+
 ## Changing A Default
 
 For now, this page records the defaults; it does not centralize them.

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -167,6 +167,28 @@ files are edited.
 | E10 repeated accepted finding guard     | Hold after 3 consecutive passes without meaningful progress                        | [Review fix](../.github/instructions/idd-review-fix.instructions.md)       | Keep unless maintainers want a different stop condition for non-converging fixes.                                            |
 | Rejected `CHANGES_REQUESTED` escalation | Escalate after 24 h; after 48 h consider `status:needs-decision` and claim release | [Review triage](../.github/instructions/idd-review-triage.instructions.md) | Keep unless the repository has an explicit reviewer escalation service-level expectation.                                    |
 
+## Runtime Instruction Size and Bundle Budgets
+
+CI enforces two layers of instruction file size limits via `audit/sync-manifest.json`.
+
+### Per-file limits
+
+| Limit type    | Value        | Applies to                                                                 |
+| ------------- | ------------ | -------------------------------------------------------------------------- |
+| Always-loaded | 20,000 bytes | Files with `applyTo: "**"` in `.github/instructions/idd-*.instructions.md` |
+| Phase         | 30,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                |
+
+### Bundle limits
+
+| Bundle ID          | Files included                                                                                   | Limit        |
+| ------------------ | ------------------------------------------------------------------------------------------------ | ------------ |
+| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 75,000 bytes |
+| `bundle-resume`    | `idd-overview-core` + `idd-overview-appendix` + `idd-resume`                                     | 46,000 bytes |
+
+Bundle checks run unconditionally (not filtered by changed files) and
+measure the combined byte length of all listed files. Adjust limits in
+`audit/sync-manifest.json` when deliberate growth is accepted.
+
 ## Changing A Default
 
 For now, this page records the defaults; it does not centralize them.

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -27,6 +27,7 @@ checkGeneratedBlocks(manifest.generatedBlocks ?? []);
 checkShellFileLists(manifest.shellFileLists ?? [], manifest.generatedBlocks ?? []);
 checkSyncPairs(manifest.syncPairs ?? []);
 checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? null);
+checkBundleBudgets(manifest.bundleBudgets ?? []);
 checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
 checkConfigInstructionDrift();
 
@@ -356,6 +357,23 @@ function checkInstructionSizeBudgets(config) {
         `${id}: ${file} is ${bytes} bytes (limit ${limit}; ${
           alwaysLoaded ? "always-loaded" : "phase"
         })`,
+      );
+    }
+  }
+}
+
+function checkBundleBudgets(budgets) {
+  for (const budget of budgets) {
+    const id = budget.id ?? "bundle-budget";
+    const files = budget.files ?? [];
+    let totalBytes = 0;
+    for (const file of files) {
+      const text = readText(file);
+      totalBytes += Buffer.byteLength(text, "utf8");
+    }
+    if (totalBytes > budget.limitBytes) {
+      errors.push(
+        `${id}: bundle total is ${totalBytes} bytes (limit ${budget.limitBytes}); files: ${files.join(", ")}`,
       );
     }
   }

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -366,14 +366,19 @@ function checkBundleBudgets(budgets) {
   for (const budget of budgets) {
     const id = budget.id ?? "bundle-budget";
     const files = budget.files ?? [];
+    const limitBytes = Number(budget.limitBytes);
+    if (!Number.isFinite(limitBytes) || limitBytes < 0) {
+      errors.push(`${id}: limitBytes must be a non-negative number`);
+      continue;
+    }
     let totalBytes = 0;
     for (const file of files) {
       const text = readText(file);
       totalBytes += Buffer.byteLength(text, "utf8");
     }
-    if (totalBytes > budget.limitBytes) {
+    if (totalBytes > limitBytes) {
       errors.push(
-        `${id}: bundle total is ${totalBytes} bytes (limit ${budget.limitBytes}); files: ${files.join(", ")}`,
+        `${id}: bundle total is ${totalBytes} bytes (limit ${limitBytes}); files: ${files.join(", ")}`,
       );
     }
   }


### PR DESCRIPTION
## Summary

- Add `checkBundleBudgets()` to `scripts/audit-docs.mjs` and wire it
  into the `audit-docs.mjs --check` CI step.
- Add `bundleBudgets` config to `audit/sync-manifest.json` with two
  entries: a discovery-path bundle (75,000 bytes) and a resume-path
  bundle (46,000 bytes).
- Document per-file and bundle limits in a new section of
  `docs/policy-constants.md` and the mirrored
  `idd-template/docs/policy-constants.md`.

Existing per-file limits (`alwaysLoadedLimitBytes`, `phaseLimitBytes`)
are unchanged.

## Bundle limits defined

| Bundle | Files | Limit |
| --- | --- | --- |
| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 75,000 bytes |
| `bundle-resume` | `idd-overview-core` + `idd-overview-appendix` + `idd-resume` | 46,000 bytes |

Current measured sizes: 72,451 bytes (discovery) and 43,981 bytes
(resume). Limits are intentionally tight to enforce the context-
lightweighting goal from roadmap #465.

Closes #464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on CI-enforced instruction file size limits and bundle byte-size budgets.

* **Chores**
  * Configured bundle size budgets (`bundle-discovery`: 75KB, `bundle-resume`: 46KB) with automated CI validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/486)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->