### PR TITLE
feat(policy): add first-class schema/runtime key foundation

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -159,6 +159,12 @@ changes `claim-stale-age` (24 h default) and
 `claim-heartbeat-interval` (12 h default) before enabling unattended
 workers.
 
+Policy foundation namespaces are available in `.github/idd/config.json`
+for parameterized follow-up work: `stallRecovery`, `forcedHandoff`,
+`markerTrust`, `advisoryWait`, `ciWait`, `discover`, `claim`,
+`critiqueLoop`, `reviewEscalation`, `approvalSignals`, and
+`issueAuthoring`. Leaving these keys unset keeps distributed behavior.
+
 ## Phase ID Compatibility Contract
 
 Treat phase IDs as a compatibility surface, not as presentation text.

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -58,6 +58,18 @@ commands table where helper tooling supports it. For behavior encoded
 only in phase instructions, the instruction file governs until the
 instruction is updated too.
 
+## Policy Key Foundation Namespaces
+
+The policy schema now includes first-class foundation namespaces used by
+follow-up parameterization work. When omitted, runtime normalization
+falls back to distributed defaults so existing behavior remains
+unchanged.
+
+`stallRecovery`, `forcedHandoff`, `markerTrust`, `advisoryWait`,
+`ciWait`, `discover`, `claim`, `critiqueLoop`, `reviewEscalation`,
+`approvalSignals`, and `issueAuthoring` are now valid top-level policy
+objects in `.github/idd/config.json`.
+
 ## Ownership Defaults
 
 | Policy key                 | Policy default            | Distributed value                                                                                                                             | Owning surface                                                                                                                                                                                                                                                                                                                                                                                                         | Onboarding expectation                                                                    |

--- a/fixtures/schemas/policy.invalid.json
+++ b/fixtures/schemas/policy.invalid.json
@@ -14,5 +14,8 @@
     "fix-validate": "npx dprint fmt",
     "pre-push-validate": "npx dprint check",
     "post-fix-validate": "npx dprint fmt && npx markdownlint-cli2"
+  },
+  "advisoryWait": {
+    "requestCap": 0
   }
 }

--- a/fixtures/schemas/policy.valid.json
+++ b/fixtures/schemas/policy.valid.json
@@ -14,5 +14,48 @@
     "fix-validate": "npx dprint fmt",
     "pre-push-validate": "npx dprint check",
     "post-fix-validate": "npx dprint fmt && npx markdownlint-cli2"
+  },
+  "stallRecovery": {
+    "quietWindow": "PT30M"
+  },
+  "forcedHandoff": {
+    "mode": "disabled",
+    "authorityPolicy": "owners-and-maintainers-only"
+  },
+  "markerTrust": {
+    "allowCollaboratorMarkers": false
+  },
+  "advisoryWait": {
+    "requestCap": 30,
+    "pendingWindow": "PT30M",
+    "settledWindow": "PT10M",
+    "pollInterval": "PT2M",
+    "capExhaustedRoute": "phase-default"
+  },
+  "ciWait": {
+    "runningTimeout": "PT30M",
+    "generationTimeout": "PT10M",
+    "rerunPolicy": "rerun-once"
+  },
+  "discover": {
+    "activeClaimPreScanBatchSize": 10
+  },
+  "claim": {
+    "verifySettleDelay": "PT5S"
+  },
+  "critiqueLoop": {
+    "cPhaseLowSeveritySkipAfter": 3,
+    "e10NoProgressHoldAfter": 3
+  },
+  "reviewEscalation": {
+    "changesRequestedFirstEscalation": "PT24H",
+    "changesRequestedSecondEscalation": "PT48H"
+  },
+  "approvalSignals": {
+    "readyLabelName": "idd:ready",
+    "labelFreshnessMode": "presence-only"
+  },
+  "issueAuthoring": {
+    "maxClarificationRounds": 3
   }
 }

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -159,6 +159,12 @@ changes `claim-stale-age` (24 h default) and
 `claim-heartbeat-interval` (12 h default) before enabling unattended
 workers.
 
+Policy foundation namespaces are available in `.github/idd/config.json`
+for parameterized follow-up work: `stallRecovery`, `forcedHandoff`,
+`markerTrust`, `advisoryWait`, `ciWait`, `discover`, `claim`,
+`critiqueLoop`, `reviewEscalation`, `approvalSignals`, and
+`issueAuthoring`. Leaving these keys unset keeps distributed behavior.
+
 ## Phase ID Compatibility Contract
 
 Treat phase IDs as a compatibility surface, not as presentation text.

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -58,6 +58,18 @@ commands table where helper tooling supports it. For behavior encoded
 only in phase instructions, the instruction file governs until the
 instruction is updated too.
 
+## Policy Key Foundation Namespaces
+
+The policy schema now includes first-class foundation namespaces used by
+follow-up parameterization work. When omitted, runtime normalization
+falls back to distributed defaults so existing behavior remains
+unchanged.
+
+`stallRecovery`, `forcedHandoff`, `markerTrust`, `advisoryWait`,
+`ciWait`, `discover`, `claim`, `critiqueLoop`, `reviewEscalation`,
+`approvalSignals`, and `issueAuthoring` are now valid top-level policy
+objects in `.github/idd/config.json`.
+
 ## Ownership Defaults
 
 | Policy key                 | Policy default            | Distributed value                                                                                                                             | Owning surface                                                                                                                                                                                                                                                                                                                                                                                                         | Onboarding expectation                                                                    |

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -170,12 +170,158 @@
         }
       }
     },
+    "forced-handoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["disabled", "human-gated"]
+        },
+        "authorityPolicy": {
+          "type": "string",
+          "enum": ["owners-and-maintainers-only", "all-write-permission-actors"]
+        }
+      }
+    },
+    "forcedHandoffMode": {
+      "type": "string",
+      "enum": ["disabled", "human-gated"]
+    },
+    "forced-handoff-mode": {
+      "type": "string",
+      "enum": ["disabled", "human-gated"]
+    },
+    "forcedHandoffAuthority": {
+      "type": "string",
+      "enum": ["owners-and-maintainers-only", "all-write-permission-actors"]
+    },
+    "forced-handoff-authority": {
+      "type": "string",
+      "enum": ["owners-and-maintainers-only", "all-write-permission-actors"]
+    },
     "markerTrust": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "allowCollaboratorMarkers": {
           "type": "boolean"
+        }
+      }
+    },
+    "advisoryWait": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requestCap": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "pendingWindow": {
+          "type": "string",
+          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+        },
+        "settledWindow": {
+          "type": "string",
+          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+        },
+        "pollInterval": {
+          "type": "string",
+          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+        },
+        "capExhaustedRoute": {
+          "type": "string",
+          "enum": ["phase-default", "strict-hold"]
+        }
+      }
+    },
+    "ciWait": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "runningTimeout": {
+          "type": "string",
+          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+        },
+        "generationTimeout": {
+          "type": "string",
+          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+        },
+        "rerunPolicy": {
+          "type": "string",
+          "enum": ["rerun-once"]
+        }
+      }
+    },
+    "discover": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "activeClaimPreScanBatchSize": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "verifySettleDelay": {
+          "type": "string",
+          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+        }
+      }
+    },
+    "critiqueLoop": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cPhaseLowSeveritySkipAfter": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "e10NoProgressHoldAfter": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "reviewEscalation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "changesRequestedFirstEscalation": {
+          "type": "string",
+          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+        },
+        "changesRequestedSecondEscalation": {
+          "type": "string",
+          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+        }
+      }
+    },
+    "approvalSignals": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readyLabelName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "labelFreshnessMode": {
+          "type": "string",
+          "enum": ["presence-only", "event-freshness"]
+        }
+      }
+    },
+    "issueAuthoring": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "maxClarificationRounds": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     }

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -157,7 +157,6 @@
       }
     },
     "forcedHandoff": {
-      "type": "object",
       "additionalProperties": false,
       "properties": {
         "mode": {
@@ -171,7 +170,6 @@
       }
     },
     "forced-handoff": {
-      "type": "object",
       "additionalProperties": false,
       "properties": {
         "mode": {

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -157,6 +157,7 @@
       }
     },
     "forcedHandoff": {
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "mode": {
@@ -170,6 +171,7 @@
       }
     },
     "forced-handoff": {
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "mode": {
@@ -206,6 +208,12 @@
           "type": "boolean"
         }
       }
+    },
+    "markerTrustAllowCollaboratorMarkers": {
+      "type": "boolean"
+    },
+    "allowCollaboratorMarkers": {
+      "type": "boolean"
     },
     "advisoryWait": {
       "type": "object",

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -3,6 +3,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { computeReportSummary } from "./audit-pr-cleanup-summary.mjs";
+import { normalizePolicyConfig } from "./policy-helpers.mjs";
 import {
   classifyRegularBotComment,
   hasFreshDisposition,
@@ -17,19 +18,13 @@ import {
 } from "./protocol-helpers.mjs";
 
 const TRUSTED_MARKER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
-const FORCED_HANDOFF_AUTHORITY_POLICIES = new Set([
-  "owners-and-maintainers-only",
-  "all-write-permission-actors",
-]);
-const FORCED_HANDOFF_AUTHORITY_POLICY_DEFAULT = "owners-and-maintainers-only";
-const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
-const FORCED_HANDOFF_MODE_DEFAULT = "disabled";
 const trustedMarkerAuthorCache = new Map();
 const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerAuthors = null;
 let cachedCurrentViewerLogin = null;
 let cachedForcedHandoffAuthorityPolicy = null;
 let cachedForcedHandoffMode = null;
+let cachedNormalizedPolicy = null;
 
 const args = parseArgs(process.argv.slice(2));
 
@@ -704,22 +699,7 @@ function forcedHandoffAuthorityPolicy() {
   if (cachedForcedHandoffAuthorityPolicy !== null) {
     return cachedForcedHandoffAuthorityPolicy;
   }
-  try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const policy = String(
-      config?.forcedHandoff?.authorityPolicy ??
-        config?.forcedHandoffAuthority ??
-        config?.["forced-handoff-authority"] ??
-        "",
-    ).trim();
-    if (FORCED_HANDOFF_AUTHORITY_POLICIES.has(policy)) {
-      cachedForcedHandoffAuthorityPolicy = policy;
-      return cachedForcedHandoffAuthorityPolicy;
-    }
-  } catch {
-    // Default policy remains owners-and-maintainers-only.
-  }
-  cachedForcedHandoffAuthorityPolicy = FORCED_HANDOFF_AUTHORITY_POLICY_DEFAULT;
+  cachedForcedHandoffAuthorityPolicy = readNormalizedPolicy().forcedHandoff.authorityPolicy;
   return cachedForcedHandoffAuthorityPolicy;
 }
 
@@ -727,20 +707,23 @@ function readForcedHandoffMode() {
   if (cachedForcedHandoffMode !== null) {
     return cachedForcedHandoffMode;
   }
-  try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const mode = String(
-      config?.forcedHandoff?.mode ?? config?.forcedHandoff ?? config?.["forced-handoff"] ?? "",
-    ).trim();
-    if (FORCED_HANDOFF_MODES.has(mode)) {
-      cachedForcedHandoffMode = mode;
-      return cachedForcedHandoffMode;
-    }
-  } catch {
-    // Default mode remains disabled.
-  }
-  cachedForcedHandoffMode = FORCED_HANDOFF_MODE_DEFAULT;
+  cachedForcedHandoffMode = readNormalizedPolicy().forcedHandoff.mode;
   return cachedForcedHandoffMode;
+}
+
+function readNormalizedPolicy() {
+  if (cachedNormalizedPolicy !== null) {
+    return cachedNormalizedPolicy;
+  }
+  try {
+    cachedNormalizedPolicy = normalizePolicyConfig(
+      JSON.parse(readFileSync(".github/idd/config.json", "utf8")),
+    );
+    return cachedNormalizedPolicy;
+  } catch {
+    cachedNormalizedPolicy = normalizePolicyConfig({});
+    return cachedNormalizedPolicy;
+  }
 }
 
 function isAuthorizedForcedHandoffActor(owner, repo, login, policy = forcedHandoffAuthorityPolicy()) {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -3,7 +3,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { computeReportSummary } from "./audit-pr-cleanup-summary.mjs";
-import { normalizePolicyConfig } from "./policy-helpers.mjs";
+import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
 import {
   classifyRegularBotComment,
   hasFreshDisposition,
@@ -814,10 +814,10 @@ function configuredTrustedMarkerAuthors() {
 
 function trustCollaboratorMarkers() {
   try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    if (typeof config?.markerTrust?.allowCollaboratorMarkers === "boolean") {
-      return config.markerTrust.allowCollaboratorMarkers;
-    }
+    return resolveCollaboratorMarkerTrust(
+      JSON.parse(readFileSync(".github/idd/config.json", "utf8")),
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+    );
   } catch {
     // Fall through to env-var fallback.
   }

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -1,6 +1,6 @@
 import { parseProjectCommandRows } from "./policy-helpers.mjs";
 
-export { inspectHelperRuntimeConfig, normalizePolicyConfig } from "./policy-helpers.mjs";
+export { inspectHelperRuntimeConfig, normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
 
 const COMMAND_KEYS = [
   "install-deps",

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -1,6 +1,6 @@
 import { parseProjectCommandRows } from "./policy-helpers.mjs";
 
-export { inspectHelperRuntimeConfig } from "./policy-helpers.mjs";
+export { inspectHelperRuntimeConfig, normalizePolicyConfig } from "./policy-helpers.mjs";
 
 const COMMAND_KEYS = [
   "install-deps",

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 import { renderForcedHandoffComment, summarizeClaimValidation } from "./protocol-helpers.mjs";
-import { normalizePolicyConfig } from "./policy-helpers.mjs";
+import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
 
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
@@ -313,10 +313,10 @@ function safeGhText(args) {
 
 function readCollaboratorTrustEnabled() {
   try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    if (typeof config?.markerTrust?.allowCollaboratorMarkers === "boolean") {
-      return config.markerTrust.allowCollaboratorMarkers;
-    }
+    return resolveCollaboratorMarkerTrust(
+      JSON.parse(readFileSync(".github/idd/config.json", "utf8")),
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+    );
   } catch {
     // Fall through to env-var fallback.
   }

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -5,14 +5,7 @@ import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 import { renderForcedHandoffComment, summarizeClaimValidation } from "./protocol-helpers.mjs";
-
-const APPROVAL_ACTOR_POLICIES = new Set([
-  "owners-and-maintainers-only",
-  "all-write-permission-actors",
-]);
-const APPROVAL_ACTOR_POLICY_DEFAULT = "owners-and-maintainers-only";
-const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
-const FORCED_HANDOFF_MODE_DEFAULT = "disabled";
+import { normalizePolicyConfig } from "./policy-helpers.mjs";
 
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
@@ -331,36 +324,24 @@ function readCollaboratorTrustEnabled() {
 }
 
 function readForcedHandoffAuthorityPolicy() {
-  try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const policy = String(
-      config?.forcedHandoff?.authorityPolicy ??
-        config?.forcedHandoffAuthority ??
-        config?.["forced-handoff-authority"] ??
-        "",
-    ).trim();
-    if (APPROVAL_ACTOR_POLICIES.has(policy)) {
-      return policy;
-    }
-  } catch {
-    // Default policy remains owners-and-maintainers-only.
-  }
-  return APPROVAL_ACTOR_POLICY_DEFAULT;
+  return readNormalizedPolicy().forcedHandoff.authorityPolicy;
 }
 
 function readForcedHandoffMode() {
   try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const mode = String(
-      config?.forcedHandoff?.mode ?? config?.forcedHandoff ?? config?.["forced-handoff"] ?? "",
-    ).trim();
-    if (FORCED_HANDOFF_MODES.has(mode)) {
-      return mode;
-    }
+    return readNormalizedPolicy().forcedHandoff.mode;
   } catch {
     // Default mode remains disabled.
+    return "disabled";
   }
-  return FORCED_HANDOFF_MODE_DEFAULT;
+}
+
+function readNormalizedPolicy() {
+  try {
+    return normalizePolicyConfig(JSON.parse(readFileSync(".github/idd/config.json", "utf8")));
+  } catch {
+    return normalizePolicyConfig({});
+  }
 }
 
 function collaboratorPermission(owner, repo, login, cache) {

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -8,21 +8,16 @@ import {
   planLiveStatusDigestUpsert,
   summarizeClaimValidation,
 } from "./protocol-helpers.mjs";
+import { normalizePolicyConfig } from "./policy-helpers.mjs";
 
 const TRUSTED_MARKER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
-const FORCED_HANDOFF_AUTHORITY_POLICIES = new Set([
-  "owners-and-maintainers-only",
-  "all-write-permission-actors",
-]);
-const FORCED_HANDOFF_AUTHORITY_POLICY_DEFAULT = "owners-and-maintainers-only";
-const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
-const FORCED_HANDOFF_MODE_DEFAULT = "disabled";
 const trustedMarkerAuthorCache = new Map();
 const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerAuthors = null;
 let cachedCurrentViewerLogin = null;
 let cachedForcedHandoffAuthorityPolicy = null;
 let cachedForcedHandoffMode = null;
+let cachedNormalizedPolicy = null;
 
 const args = parseArgs(process.argv.slice(2));
 
@@ -267,41 +262,30 @@ function forcedHandoffAuthorityPolicy() {
 }
 
 function readForcedHandoffAuthorityPolicy() {
-  try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const policy = String(
-      config?.forcedHandoff?.authorityPolicy ??
-        config?.forcedHandoffAuthority ??
-        config?.["forced-handoff-authority"] ??
-        "",
-    ).trim();
-    if (FORCED_HANDOFF_AUTHORITY_POLICIES.has(policy)) {
-      return policy;
-    }
-  } catch {
-    // Default policy remains owners-and-maintainers-only.
-  }
-  return FORCED_HANDOFF_AUTHORITY_POLICY_DEFAULT;
+  return readNormalizedPolicy().forcedHandoff.authorityPolicy;
 }
 
 function readForcedHandoffMode() {
   if (cachedForcedHandoffMode !== null) {
     return cachedForcedHandoffMode;
   }
-  try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const mode = String(
-      config?.forcedHandoff?.mode ?? config?.forcedHandoff ?? config?.["forced-handoff"] ?? "",
-    ).trim();
-    if (FORCED_HANDOFF_MODES.has(mode)) {
-      cachedForcedHandoffMode = mode;
-      return cachedForcedHandoffMode;
-    }
-  } catch {
-    // Default mode remains disabled.
-  }
-  cachedForcedHandoffMode = FORCED_HANDOFF_MODE_DEFAULT;
+  cachedForcedHandoffMode = readNormalizedPolicy().forcedHandoff.mode;
   return cachedForcedHandoffMode;
+}
+
+function readNormalizedPolicy() {
+  if (cachedNormalizedPolicy !== null) {
+    return cachedNormalizedPolicy;
+  }
+  try {
+    cachedNormalizedPolicy = normalizePolicyConfig(
+      JSON.parse(readFileSync(".github/idd/config.json", "utf8")),
+    );
+    return cachedNormalizedPolicy;
+  } catch {
+    cachedNormalizedPolicy = normalizePolicyConfig({});
+    return cachedNormalizedPolicy;
+  }
 }
 
 function isTrustedMarkerAuthor(owner, repo, login) {

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -8,7 +8,7 @@ import {
   planLiveStatusDigestUpsert,
   summarizeClaimValidation,
 } from "./protocol-helpers.mjs";
-import { normalizePolicyConfig } from "./policy-helpers.mjs";
+import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
 
 const TRUSTED_MARKER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 const trustedMarkerAuthorCache = new Map();
@@ -375,10 +375,10 @@ function configuredTrustedMarkerAuthors() {
 
 function trustCollaboratorMarkers() {
   try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    if (typeof config?.markerTrust?.allowCollaboratorMarkers === "boolean") {
-      return config.markerTrust.allowCollaboratorMarkers;
-    }
+    return resolveCollaboratorMarkerTrust(
+      JSON.parse(readFileSync(".github/idd/config.json", "utf8")),
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+    );
   } catch {
     // Fall through to env-var fallback.
   }

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -129,8 +129,6 @@ export function normalizePolicyConfig(config) {
     config?.["forced-handoff"]?.mode,
     config?.forcedHandoffMode,
     config?.["forced-handoff-mode"],
-    typeof config?.forcedHandoff === "string" ? config.forcedHandoff : "",
-    typeof config?.["forced-handoff"] === "string" ? config["forced-handoff"] : "",
   );
   const markerTrustAlias = firstBoolean(
     config?.markerTrust?.allowCollaboratorMarkers,

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -245,6 +245,13 @@ export function normalizePolicyConfig(config) {
   };
 }
 
+export function resolveCollaboratorMarkerTrust(config, envValue = "") {
+  if (hasConfiguredCollaboratorMarkerTrust(config)) {
+    return normalizePolicyConfig(config).markerTrust.allowCollaboratorMarkers;
+  }
+  return isTruthy(envValue);
+}
+
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
@@ -296,6 +303,16 @@ function parsePositiveInteger(value, fallback) {
 
 function parseNonEmptyString(value, fallback) {
   return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function hasConfiguredCollaboratorMarkerTrust(config) {
+  return typeof config?.markerTrust?.allowCollaboratorMarkers === "boolean"
+    || typeof config?.markerTrustAllowCollaboratorMarkers === "boolean"
+    || typeof config?.allowCollaboratorMarkers === "boolean";
+}
+
+function isTruthy(value) {
+  return /^(1|true|yes)$/i.test(String(value ?? "").trim());
 }
 
 function hasOwn(value, key) {

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -118,13 +118,15 @@ export function normalizePolicyConfig(config) {
     return clone(POLICY_DEFAULTS);
   }
 
-  const forcedHandoffAuthorityAlias = firstString(
+  const forcedHandoffAuthorityAlias = firstAcceptedString(
+    APPROVAL_ACTOR_POLICIES,
     config?.forcedHandoff?.authorityPolicy,
     config?.["forced-handoff"]?.authorityPolicy,
     config?.forcedHandoffAuthority,
     config?.["forced-handoff-authority"],
   );
-  const forcedHandoffModeAlias = firstString(
+  const forcedHandoffModeAlias = firstAcceptedString(
+    FORCED_HANDOFF_MODES,
     config?.forcedHandoff?.mode,
     config?.["forced-handoff"]?.mode,
     config?.forcedHandoffMode,
@@ -250,6 +252,15 @@ function clone(value) {
 function firstString(...values) {
   for (const value of values) {
     if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return "";
+}
+
+function firstAcceptedString(accepted, ...values) {
+  for (const value of values) {
+    if (typeof value === "string" && accepted.has(value)) {
       return value;
     }
   }

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -5,6 +5,64 @@ const HELPER_RUNTIME_PROFILES = new Set([
   "instructions-only",
 ]);
 const HELPER_RUNTIME_KEYS = new Set(["profile"]);
+const ISSUE_SCOPES = new Set(["roadmap", "orphan-first"]);
+const ORPHAN_FIRST_POLICIES = new Set(["none", "maintainer-approved", "public-disabled"]);
+const APPROVAL_ACTOR_POLICIES = new Set(["owners-and-maintainers-only", "all-write-permission-actors"]);
+const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
+const ADVISORY_CAP_ROUTES = new Set(["phase-default", "strict-hold"]);
+const CI_RERUN_POLICIES = new Set(["rerun-once"]);
+const LABEL_FRESHNESS_MODES = new Set(["presence-only", "event-freshness"]);
+const ISO_DURATION_RE = /^P(?=\d|T\d)(?:\d+D)?(?:T(?=\d)(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$/;
+
+export const POLICY_DEFAULTS = Object.freeze({
+  issueScope: "roadmap",
+  orphanFirstPolicy: "none",
+  skipIssueAuthorApprovalGate: false,
+  maintainerApprovalActorPolicy: "owners-and-maintainers-only",
+  stallRecovery: Object.freeze({
+    quietWindow: "PT30M",
+  }),
+  forcedHandoff: Object.freeze({
+    mode: "disabled",
+    authorityPolicy: "owners-and-maintainers-only",
+  }),
+  markerTrust: Object.freeze({
+    allowCollaboratorMarkers: false,
+  }),
+  advisoryWait: Object.freeze({
+    requestCap: 30,
+    pendingWindow: "PT30M",
+    settledWindow: "PT10M",
+    pollInterval: "PT2M",
+    capExhaustedRoute: "phase-default",
+  }),
+  ciWait: Object.freeze({
+    runningTimeout: "PT30M",
+    generationTimeout: "PT10M",
+    rerunPolicy: "rerun-once",
+  }),
+  discover: Object.freeze({
+    activeClaimPreScanBatchSize: 10,
+  }),
+  claim: Object.freeze({
+    verifySettleDelay: "PT5S",
+  }),
+  critiqueLoop: Object.freeze({
+    cPhaseLowSeveritySkipAfter: 3,
+    e10NoProgressHoldAfter: 3,
+  }),
+  reviewEscalation: Object.freeze({
+    changesRequestedFirstEscalation: "PT24H",
+    changesRequestedSecondEscalation: "PT48H",
+  }),
+  approvalSignals: Object.freeze({
+    readyLabelName: "idd:ready",
+    labelFreshnessMode: "presence-only",
+  }),
+  issueAuthoring: Object.freeze({
+    maxClarificationRounds: 3,
+  }),
+});
 
 export function parseProjectCommandRows(text) {
   const commands = new Map();
@@ -53,6 +111,182 @@ export function inspectHelperRuntimeConfig(config) {
   }
 
   return { status: "ok", profile };
+}
+
+export function normalizePolicyConfig(config) {
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return clone(POLICY_DEFAULTS);
+  }
+
+  const forcedHandoffAuthorityAlias = firstString(
+    config?.forcedHandoff?.authorityPolicy,
+    config?.["forced-handoff"]?.authorityPolicy,
+    config?.forcedHandoffAuthority,
+    config?.["forced-handoff-authority"],
+  );
+  const forcedHandoffModeAlias = firstString(
+    config?.forcedHandoff?.mode,
+    config?.["forced-handoff"]?.mode,
+    config?.forcedHandoffMode,
+    config?.["forced-handoff-mode"],
+    typeof config?.forcedHandoff === "string" ? config.forcedHandoff : "",
+    typeof config?.["forced-handoff"] === "string" ? config["forced-handoff"] : "",
+  );
+  const markerTrustAlias = firstBoolean(
+    config?.markerTrust?.allowCollaboratorMarkers,
+    config?.markerTrustAllowCollaboratorMarkers,
+    config?.allowCollaboratorMarkers,
+  );
+
+  return {
+    issueScope: parseEnum(config?.issueScope, ISSUE_SCOPES, POLICY_DEFAULTS.issueScope),
+    orphanFirstPolicy: parseEnum(
+      config?.orphanFirstPolicy,
+      ORPHAN_FIRST_POLICIES,
+      POLICY_DEFAULTS.orphanFirstPolicy,
+    ),
+    skipIssueAuthorApprovalGate: config?.skipIssueAuthorApprovalGate === true,
+    maintainerApprovalActorPolicy: parseEnum(
+      config?.maintainerApprovalActorPolicy,
+      APPROVAL_ACTOR_POLICIES,
+      POLICY_DEFAULTS.maintainerApprovalActorPolicy,
+    ),
+    stallRecovery: {
+      quietWindow: parseDuration(config?.stallRecovery?.quietWindow, POLICY_DEFAULTS.stallRecovery.quietWindow),
+    },
+    forcedHandoff: {
+      mode: parseEnum(forcedHandoffModeAlias, FORCED_HANDOFF_MODES, POLICY_DEFAULTS.forcedHandoff.mode),
+      authorityPolicy: parseEnum(
+        forcedHandoffAuthorityAlias,
+        APPROVAL_ACTOR_POLICIES,
+        POLICY_DEFAULTS.forcedHandoff.authorityPolicy,
+      ),
+    },
+    markerTrust: {
+      allowCollaboratorMarkers: markerTrustAlias ?? POLICY_DEFAULTS.markerTrust.allowCollaboratorMarkers,
+    },
+    advisoryWait: {
+      requestCap: parsePositiveInteger(config?.advisoryWait?.requestCap, POLICY_DEFAULTS.advisoryWait.requestCap),
+      pendingWindow: parseDuration(
+        config?.advisoryWait?.pendingWindow,
+        POLICY_DEFAULTS.advisoryWait.pendingWindow,
+      ),
+      settledWindow: parseDuration(
+        config?.advisoryWait?.settledWindow,
+        POLICY_DEFAULTS.advisoryWait.settledWindow,
+      ),
+      pollInterval: parseDuration(
+        config?.advisoryWait?.pollInterval,
+        POLICY_DEFAULTS.advisoryWait.pollInterval,
+      ),
+      capExhaustedRoute: parseEnum(
+        config?.advisoryWait?.capExhaustedRoute,
+        ADVISORY_CAP_ROUTES,
+        POLICY_DEFAULTS.advisoryWait.capExhaustedRoute,
+      ),
+    },
+    ciWait: {
+      runningTimeout: parseDuration(config?.ciWait?.runningTimeout, POLICY_DEFAULTS.ciWait.runningTimeout),
+      generationTimeout: parseDuration(
+        config?.ciWait?.generationTimeout,
+        POLICY_DEFAULTS.ciWait.generationTimeout,
+      ),
+      rerunPolicy: parseEnum(config?.ciWait?.rerunPolicy, CI_RERUN_POLICIES, POLICY_DEFAULTS.ciWait.rerunPolicy),
+    },
+    discover: {
+      activeClaimPreScanBatchSize: parsePositiveInteger(
+        config?.discover?.activeClaimPreScanBatchSize,
+        POLICY_DEFAULTS.discover.activeClaimPreScanBatchSize,
+      ),
+    },
+    claim: {
+      verifySettleDelay: parseDuration(
+        config?.claim?.verifySettleDelay,
+        POLICY_DEFAULTS.claim.verifySettleDelay,
+      ),
+    },
+    critiqueLoop: {
+      cPhaseLowSeveritySkipAfter: parsePositiveInteger(
+        config?.critiqueLoop?.cPhaseLowSeveritySkipAfter,
+        POLICY_DEFAULTS.critiqueLoop.cPhaseLowSeveritySkipAfter,
+      ),
+      e10NoProgressHoldAfter: parsePositiveInteger(
+        config?.critiqueLoop?.e10NoProgressHoldAfter,
+        POLICY_DEFAULTS.critiqueLoop.e10NoProgressHoldAfter,
+      ),
+    },
+    reviewEscalation: {
+      changesRequestedFirstEscalation: parseDuration(
+        config?.reviewEscalation?.changesRequestedFirstEscalation,
+        POLICY_DEFAULTS.reviewEscalation.changesRequestedFirstEscalation,
+      ),
+      changesRequestedSecondEscalation: parseDuration(
+        config?.reviewEscalation?.changesRequestedSecondEscalation,
+        POLICY_DEFAULTS.reviewEscalation.changesRequestedSecondEscalation,
+      ),
+    },
+    approvalSignals: {
+      readyLabelName: parseNonEmptyString(
+        config?.approvalSignals?.readyLabelName,
+        POLICY_DEFAULTS.approvalSignals.readyLabelName,
+      ),
+      labelFreshnessMode: parseEnum(
+        config?.approvalSignals?.labelFreshnessMode,
+        LABEL_FRESHNESS_MODES,
+        POLICY_DEFAULTS.approvalSignals.labelFreshnessMode,
+      ),
+    },
+    issueAuthoring: {
+      maxClarificationRounds: parsePositiveInteger(
+        config?.issueAuthoring?.maxClarificationRounds,
+        POLICY_DEFAULTS.issueAuthoring.maxClarificationRounds,
+      ),
+    },
+  };
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return "";
+}
+
+function firstBoolean(...values) {
+  for (const value of values) {
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  return null;
+}
+
+function parseEnum(value, accepted, fallback) {
+  if (typeof value === "string" && accepted.has(value)) {
+    return value;
+  }
+  return fallback;
+}
+
+function parseDuration(value, fallback) {
+  if (typeof value === "string" && ISO_DURATION_RE.test(value)) {
+    return value;
+  }
+  return fallback;
+}
+
+function parsePositiveInteger(value, fallback) {
+  return Number.isInteger(value) && value >= 1 ? value : fallback;
+}
+
+function parseNonEmptyString(value, fallback) {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
 }
 
 function hasOwn(value, key) {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -10,7 +10,7 @@ import {
   operationalMarkerPrefix,
   selectCodeownersText,
 } from "./protocol-helpers.mjs";
-import { normalizePolicyConfig } from "./policy-helpers.mjs";
+import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
 
 const APPROVAL_ACTOR_POLICY = new Set([
   "owners-and-maintainers-only",
@@ -510,10 +510,10 @@ function isTruthy(value) {
 
 function readCollaboratorTrustEnabled() {
   try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    if (typeof config?.markerTrust?.allowCollaboratorMarkers === "boolean") {
-      return config.markerTrust.allowCollaboratorMarkers;
-    }
+    return resolveCollaboratorMarkerTrust(
+      JSON.parse(readFileSync(".github/idd/config.json", "utf8")),
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+    );
   } catch {
     // Fall through to env-var fallback.
   }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -10,14 +10,13 @@ import {
   operationalMarkerPrefix,
   selectCodeownersText,
 } from "./protocol-helpers.mjs";
+import { normalizePolicyConfig } from "./policy-helpers.mjs";
 
 const APPROVAL_ACTOR_POLICY = new Set([
   "owners-and-maintainers-only",
   "all-write-permission-actors",
 ]);
 const APPROVAL_ACTOR_POLICY_DEFAULT = "owners-and-maintainers-only";
-const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
-const FORCED_HANDOFF_MODE_DEFAULT = "disabled";
 
 const args = parseArgs(process.argv.slice(2));
 if (!args.prNumber) {
@@ -522,36 +521,20 @@ function readCollaboratorTrustEnabled() {
 }
 
 function readForcedHandoffAuthorityPolicy() {
-  try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const policy = String(
-      config?.forcedHandoff?.authorityPolicy ??
-        config?.forcedHandoffAuthority ??
-        config?.["forced-handoff-authority"] ??
-        "",
-    ).trim();
-    if (APPROVAL_ACTOR_POLICY.has(policy)) {
-      return policy;
-    }
-  } catch {
-    // Default policy remains owners-and-maintainers-only.
-  }
-  return APPROVAL_ACTOR_POLICY_DEFAULT;
+  const policy = readNormalizedPolicy().forcedHandoff.authorityPolicy;
+  return APPROVAL_ACTOR_POLICY.has(policy) ? policy : APPROVAL_ACTOR_POLICY_DEFAULT;
 }
 
 function readForcedHandoffMode() {
+  return readNormalizedPolicy().forcedHandoff.mode;
+}
+
+function readNormalizedPolicy() {
   try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const mode = String(
-      config?.forcedHandoff?.mode ?? config?.forcedHandoff ?? config?.["forced-handoff"] ?? "",
-    ).trim();
-    if (FORCED_HANDOFF_MODES.has(mode)) {
-      return mode;
-    }
+    return normalizePolicyConfig(JSON.parse(readFileSync(".github/idd/config.json", "utf8")));
   } catch {
-    // Default mode remains disabled.
+    return normalizePolicyConfig({});
   }
-  return FORCED_HANDOFF_MODE_DEFAULT;
 }
 
 function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -4,7 +4,11 @@ import { fileURLToPath } from "node:url";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { collectPolicyConfigDrift, inspectHelperRuntimeConfig } from "../scripts/consistency-helpers.mjs";
+import {
+  collectPolicyConfigDrift,
+  inspectHelperRuntimeConfig,
+  normalizePolicyConfig,
+} from "../scripts/consistency-helpers.mjs";
 import { findPlaceholders } from "../scripts/idd-doctor.mjs";
 
 const FIXTURE_ROOT = new URL("./fixtures/", import.meta.url);
@@ -100,6 +104,163 @@ test("helper runtime inspection accepts absent and supported profiles, rejects u
   }), {
     status: "invalid",
     reason: "unsupported helperRuntime keys: manager",
+  });
+});
+
+test("policy normalization provides default-safe values and supports aliases", () => {
+  assert.deepEqual(normalizePolicyConfig(null), {
+    issueScope: "roadmap",
+    orphanFirstPolicy: "none",
+    skipIssueAuthorApprovalGate: false,
+    maintainerApprovalActorPolicy: "owners-and-maintainers-only",
+    stallRecovery: {
+      quietWindow: "PT30M",
+    },
+    forcedHandoff: {
+      mode: "disabled",
+      authorityPolicy: "owners-and-maintainers-only",
+    },
+    markerTrust: {
+      allowCollaboratorMarkers: false,
+    },
+    advisoryWait: {
+      requestCap: 30,
+      pendingWindow: "PT30M",
+      settledWindow: "PT10M",
+      pollInterval: "PT2M",
+      capExhaustedRoute: "phase-default",
+    },
+    ciWait: {
+      runningTimeout: "PT30M",
+      generationTimeout: "PT10M",
+      rerunPolicy: "rerun-once",
+    },
+    discover: {
+      activeClaimPreScanBatchSize: 10,
+    },
+    claim: {
+      verifySettleDelay: "PT5S",
+    },
+    critiqueLoop: {
+      cPhaseLowSeveritySkipAfter: 3,
+      e10NoProgressHoldAfter: 3,
+    },
+    reviewEscalation: {
+      changesRequestedFirstEscalation: "PT24H",
+      changesRequestedSecondEscalation: "PT48H",
+    },
+    approvalSignals: {
+      readyLabelName: "idd:ready",
+      labelFreshnessMode: "presence-only",
+    },
+    issueAuthoring: {
+      maxClarificationRounds: 3,
+    },
+  });
+
+  assert.deepEqual(normalizePolicyConfig({
+    issueScope: "orphan-first",
+    orphanFirstPolicy: "maintainer-approved",
+    skipIssueAuthorApprovalGate: true,
+    maintainerApprovalActorPolicy: "all-write-permission-actors",
+    stallRecovery: {
+      quietWindow: "PT45M",
+    },
+    forcedHandoff: "human-gated",
+    "forced-handoff-authority": "all-write-permission-actors",
+    markerTrustAllowCollaboratorMarkers: true,
+    advisoryWait: {
+      requestCap: 5,
+      pendingWindow: "PT40M",
+      settledWindow: "PT11M",
+      pollInterval: "PT3M",
+      capExhaustedRoute: "strict-hold",
+    },
+    ciWait: {
+      runningTimeout: "PT35M",
+      generationTimeout: "PT15M",
+      rerunPolicy: "rerun-once",
+    },
+    discover: {
+      activeClaimPreScanBatchSize: 11,
+    },
+    claim: {
+      verifySettleDelay: "PT7S",
+    },
+    critiqueLoop: {
+      cPhaseLowSeveritySkipAfter: 4,
+      e10NoProgressHoldAfter: 2,
+    },
+    reviewEscalation: {
+      changesRequestedFirstEscalation: "PT18H",
+      changesRequestedSecondEscalation: "PT36H",
+    },
+    approvalSignals: {
+      readyLabelName: "custom:ready",
+      labelFreshnessMode: "event-freshness",
+    },
+    issueAuthoring: {
+      maxClarificationRounds: 4,
+    },
+  }), {
+    issueScope: "orphan-first",
+    orphanFirstPolicy: "maintainer-approved",
+    skipIssueAuthorApprovalGate: true,
+    maintainerApprovalActorPolicy: "all-write-permission-actors",
+    stallRecovery: {
+      quietWindow: "PT45M",
+    },
+    forcedHandoff: {
+      mode: "human-gated",
+      authorityPolicy: "all-write-permission-actors",
+    },
+    markerTrust: {
+      allowCollaboratorMarkers: true,
+    },
+    advisoryWait: {
+      requestCap: 5,
+      pendingWindow: "PT40M",
+      settledWindow: "PT11M",
+      pollInterval: "PT3M",
+      capExhaustedRoute: "strict-hold",
+    },
+    ciWait: {
+      runningTimeout: "PT35M",
+      generationTimeout: "PT15M",
+      rerunPolicy: "rerun-once",
+    },
+    discover: {
+      activeClaimPreScanBatchSize: 11,
+    },
+    claim: {
+      verifySettleDelay: "PT7S",
+    },
+    critiqueLoop: {
+      cPhaseLowSeveritySkipAfter: 4,
+      e10NoProgressHoldAfter: 2,
+    },
+    reviewEscalation: {
+      changesRequestedFirstEscalation: "PT18H",
+      changesRequestedSecondEscalation: "PT36H",
+    },
+    approvalSignals: {
+      readyLabelName: "custom:ready",
+      labelFreshnessMode: "event-freshness",
+    },
+    issueAuthoring: {
+      maxClarificationRounds: 4,
+    },
+  });
+
+  assert.deepEqual(normalizePolicyConfig({
+    forcedHandoff: {
+      mode: "human-gated",
+      authorityPolicy: "owners-and-maintainers-only",
+    },
+    "forced-handoff-authority": "all-write-permission-actors",
+  }).forcedHandoff, {
+    mode: "human-gated",
+    authorityPolicy: "owners-and-maintainers-only",
   });
 });
 

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -8,6 +8,7 @@ import {
   collectPolicyConfigDrift,
   inspectHelperRuntimeConfig,
   normalizePolicyConfig,
+  resolveCollaboratorMarkerTrust,
 } from "../scripts/consistency-helpers.mjs";
 import { findPlaceholders } from "../scripts/idd-doctor.mjs";
 
@@ -274,6 +275,21 @@ test("policy normalization provides default-safe values and supports aliases", (
     mode: "human-gated",
     authorityPolicy: "all-write-permission-actors",
   });
+});
+
+test("collaborator trust resolution honors aliases and env fallback", () => {
+  assert.equal(resolveCollaboratorMarkerTrust({}, "true"), true);
+  assert.equal(resolveCollaboratorMarkerTrust({
+    markerTrustAllowCollaboratorMarkers: true,
+  }, ""), true);
+  assert.equal(resolveCollaboratorMarkerTrust({
+    allowCollaboratorMarkers: false,
+  }, "true"), false);
+  assert.equal(resolveCollaboratorMarkerTrust({
+    markerTrust: {
+      allowCollaboratorMarkers: "invalid",
+    },
+  }, "true"), true);
 });
 
 test("A4.5 outcome fixtures match the documented check-to-outcome mapping", () => {

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -166,7 +166,7 @@ test("policy normalization provides default-safe values and supports aliases", (
     stallRecovery: {
       quietWindow: "PT45M",
     },
-    forcedHandoff: "human-gated",
+    forcedHandoffMode: "human-gated",
     "forced-handoff-authority": "all-write-permission-actors",
     markerTrustAllowCollaboratorMarkers: true,
     advisoryWait: {

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -262,6 +262,18 @@ test("policy normalization provides default-safe values and supports aliases", (
     mode: "human-gated",
     authorityPolicy: "owners-and-maintainers-only",
   });
+
+  assert.deepEqual(normalizePolicyConfig({
+    forcedHandoff: {
+      mode: "human-gated-invalid",
+      authorityPolicy: "owners-and-maintainers-invalid",
+    },
+    forcedHandoffMode: "human-gated",
+    "forced-handoff-authority": "all-write-permission-actors",
+  }).forcedHandoff, {
+    mode: "human-gated",
+    authorityPolicy: "all-write-permission-actors",
+  });
 });
 
 test("A4.5 outcome fixtures match the documented check-to-outcome mapping", () => {

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -360,6 +360,24 @@ test(".github/idd/config.json validates against policy schema", () => {
   assert.ok(ok, errors.join("\n"));
 });
 
+test("policy schema accepts foundation policy namespaces", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = loadJson("fixtures/schemas/policy.valid.json");
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema rejects non-positive advisory wait request cap", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = loadJson("fixtures/schemas/policy.valid.json");
+  instance.advisoryWait.requestCap = 0;
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) => error.includes("$.advisoryWait.requestCap")),
+    errors.join("\n"),
+  );
+});
+
 test("policy schema accepts explicit instructions-only helperRuntime", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = loadJson("fixtures/schemas/policy.valid.json");

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -367,6 +367,15 @@ test("policy schema accepts foundation policy namespaces", () => {
   assert.deepEqual(errors, []);
 });
 
+test("policy schema accepts legacy scalar forced-handoff aliases", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = loadJson("fixtures/schemas/policy.valid.json");
+  instance.forcedHandoff = "human-gated";
+  instance["forced-handoff"] = "disabled";
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
 test("policy schema rejects non-positive advisory wait request cap", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = loadJson("fixtures/schemas/policy.valid.json");

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -367,11 +367,27 @@ test("policy schema accepts foundation policy namespaces", () => {
   assert.deepEqual(errors, []);
 });
 
-test("policy schema accepts legacy scalar forced-handoff aliases", () => {
+test("policy schema rejects scalar values at forced-handoff object keys", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = loadJson("fixtures/schemas/policy.valid.json");
   instance.forcedHandoff = "human-gated";
   instance["forced-handoff"] = "disabled";
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) => error.includes("$.forcedHandoff: expected type \"object\"")),
+    errors.join("\n"),
+  );
+  assert.ok(
+    errors.some((error) => error.includes("$.forced-handoff: expected type \"object\"")),
+    errors.join("\n"),
+  );
+});
+
+test("policy schema accepts marker trust boolean aliases", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = loadJson("fixtures/schemas/policy.valid.json");
+  instance.markerTrustAllowCollaboratorMarkers = true;
+  instance.allowCollaboratorMarkers = false;
   const errors = validate(instance, schema);
   assert.deepEqual(errors, []);
 });


### PR DESCRIPTION
## Summary
- extend policy.schema.json with foundation namespaces for parameterized policy tracks
- add normalizePolicyConfig defaults/alias handling in scripts/policy-helpers.mjs
- switch forced-handoff policy reads in runtime scripts to the normalized config reader
- expand schema and consistency tests plus fixtures for namespace coverage and precedence behavior
- document the new foundation namespaces in docs/* and mirrored idd-template/docs/*

## Follow-up issues
- #468
- #469
- #470
- #471
- #472
- #473

## Rationale
This lands the shared schema/runtime foundation first so follow-up parameterization issues can add behavior-specific wiring without duplicating key parsing, default logic, or compatibility handling.

Closes #467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for new policy foundation namespaces for finer policy configuration (stall recovery, forced handoff, marker trust, advisory wait, CI wait, discovery, claim verification, critique loop, review escalation, approval signals, issue authoring).
  * Policy config normalization and collaborator-trust resolution added for reliable parsing and env-var fallback.

* **Documentation**
  * Docs updated to describe the new namespaces and fallback/default behavior.

* **Schema**
  * Policy schema extended to accept the new optional sections and aliases.

* **Tests**
  * Added unit and schema tests covering normalization, aliases, and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/489)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->