### PR TITLE
ci(docs): clarify mirror drift remediation guidance

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -559,7 +559,8 @@ copies.
 - CI already enforces canonical-source drift detection through
   `node scripts/audit-docs.mjs --check` in the lint workflow.
 - When drift is detected, follow the remediation shown by the audit output
-  (`pnpm run docs:sync` when available), then re-run the check.
+  (the `docs:sync` script via your package manager when available), then
+  re-run the check.
 - Contributor tooling should guide edits toward canonical sources instead of
   editing mirrors first.
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -554,12 +554,14 @@ sources.
 ### Scope Note
 
 This map documents which files are canonical sources and which are synchronized
-copies. Downstream tasks (referenced by issue #481 and #482 in roadmap #483) will
-implement:
+copies.
 
-- CI checks to detect and prevent canonical-source drift
-- Contributor tooling to guide edits toward canonical sources
-- Integration with the contribution workflow
+- CI already enforces canonical-source drift detection through
+  `node scripts/audit-docs.mjs --check` in the lint workflow.
+- When drift is detected, follow the remediation shown by the audit output
+  (`pnpm run docs:sync` when available), then re-run the check.
+- Contributor tooling should guide edits toward canonical sources instead of
+  editing mirrors first.
 
 ## Where to Edit
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -559,7 +559,8 @@ copies.
 - CI already enforces canonical-source drift detection through
   `node scripts/audit-docs.mjs --check` in the lint workflow.
 - When drift is detected, follow the remediation shown by the audit output
-  (`pnpm run docs:sync` when available), then re-run the check.
+  (the `docs:sync` script via your package manager when available), then
+  re-run the check.
 - Contributor tooling should guide edits toward canonical sources instead of
   editing mirrors first.
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -554,12 +554,14 @@ sources.
 ### Scope Note
 
 This map documents which files are canonical sources and which are synchronized
-copies. Downstream tasks (referenced by issue #481 and #482 in roadmap #483) will
-implement:
+copies.
 
-- CI checks to detect and prevent canonical-source drift
-- Contributor tooling to guide edits toward canonical sources
-- Integration with the contribution workflow
+- CI already enforces canonical-source drift detection through
+  `node scripts/audit-docs.mjs --check` in the lint workflow.
+- When drift is detected, follow the remediation shown by the audit output
+  (`pnpm run docs:sync` when available), then re-run the check.
+- Contributor tooling should guide edits toward canonical sources instead of
+  editing mirrors first.
 
 ## Where to Edit
 

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -36,6 +36,14 @@ if (errors.length > 0) {
   for (const error of errors) {
     console.error(`- ${error}`);
   }
+  const remediation = buildRemediation(errors);
+  if (remediation.length > 0) {
+    console.error("");
+    console.error("remediation:");
+    for (const line of remediation) {
+      console.error(`- ${line}`);
+    }
+  }
   process.exit(1);
 }
 
@@ -330,6 +338,46 @@ function checkConfigInstructionDrift() {
 
     notices.push(`${pair.configPath} matches ${pair.overviewPath} command and scope defaults`);
   }
+}
+
+function buildRemediation(currentErrors) {
+  if (!containsMirrorDrift(currentErrors)) {
+    return [];
+  }
+  const syncCommand = detectSyncCommand();
+  const lines = [];
+  if (syncCommand) {
+    lines.push(`run \`${syncCommand}\` to refresh mirrored files from canonical sources`);
+  } else {
+    lines.push("refresh mirrored files from canonical sources listed in audit/sync-manifest.json");
+  }
+  lines.push("re-run `node scripts/audit-docs.mjs --check`");
+  return lines;
+}
+
+function containsMirrorDrift(currentErrors) {
+  return currentErrors.some((error) =>
+    /generated block .* is stale|shell file list .* is stale| and .* differ in (exact|concreted) mode/.test(
+      error,
+    ),
+  );
+}
+
+function detectSyncCommand() {
+  if (repoFiles.includes("package.json")) {
+    try {
+      const packageJson = JSON.parse(readText("package.json"));
+      if (typeof packageJson.scripts?.["docs:sync"] === "string") {
+        return "pnpm run docs:sync";
+      }
+    } catch {
+      // Keep fallback discovery if package.json is not parseable.
+    }
+  }
+  if (repoFiles.includes("scripts/sync-docs.mjs")) {
+    return "node scripts/sync-docs.mjs --apply";
+  }
+  return "";
 }
 
 function checkInstructionSizeBudgets(config) {

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -368,7 +368,7 @@ function detectSyncCommand() {
     try {
       const packageJson = JSON.parse(readText("package.json"));
       if (typeof packageJson.scripts?.["docs:sync"] === "string") {
-        return "pnpm run docs:sync";
+        return docsSyncCommandByPackageManager(packageJson.packageManager);
       }
     } catch {
       // Keep fallback discovery if package.json is not parseable.
@@ -378,6 +378,22 @@ function detectSyncCommand() {
     return "node scripts/sync-docs.mjs --apply";
   }
   return "";
+}
+
+function docsSyncCommandByPackageManager(packageManager) {
+  const name = typeof packageManager === "string" ? packageManager.split("@")[0] : "";
+  switch (name) {
+    case "pnpm":
+      return "pnpm run docs:sync";
+    case "npm":
+      return "npm run docs:sync";
+    case "yarn":
+      return "yarn docs:sync";
+    case "bun":
+      return "bun run docs:sync";
+    default:
+      return "npm run docs:sync";
+  }
 }
 
 function checkInstructionSizeBudgets(config) {

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -368,7 +368,10 @@ function detectSyncCommand() {
     try {
       const packageJson = JSON.parse(readText("package.json"));
       if (typeof packageJson.scripts?.["docs:sync"] === "string") {
-        return docsSyncCommandByPackageManager(packageJson.packageManager);
+        const command = docsSyncCommandByPackageManager(packageJson.packageManager);
+        if (command) {
+          return command;
+        }
       }
     } catch {
       // Keep fallback discovery if package.json is not parseable.

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -349,7 +349,7 @@ function buildRemediation(currentErrors) {
   if (syncCommand) {
     lines.push(`run \`${syncCommand}\` to refresh mirrored files from canonical sources`);
   } else {
-    lines.push("refresh mirrored files from canonical sources listed in audit/sync-manifest.json");
+    lines.push("align canonical files and their mirrored counterparts for the reported drift paths");
   }
   lines.push("re-run `node scripts/audit-docs.mjs --check`");
   return lines;
@@ -357,7 +357,7 @@ function buildRemediation(currentErrors) {
 
 function containsMirrorDrift(currentErrors) {
   return currentErrors.some((error) =>
-    /generated block .* is stale|shell file list .* is stale| and .* differ in (exact|concreted) mode|heading structure differs between/.test(
+    /generated block .* is stale|shell file list .* is stale| and .* differ in (exact|concreted) mode|heading structure differs between|target is missing|target has unexpected|is missing a syncPairs entry|manifest paths omit|manifest path does not exist or match globs/.test(
       error,
     ),
   );

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -392,7 +392,7 @@ function docsSyncCommandByPackageManager(packageManager) {
     case "bun":
       return "bun run docs:sync";
     default:
-      return "npm run docs:sync";
+      return "";
   }
 }
 

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -357,7 +357,7 @@ function buildRemediation(currentErrors) {
 
 function containsMirrorDrift(currentErrors) {
   return currentErrors.some((error) =>
-    /generated block .* is stale|shell file list .* is stale| and .* differ in (exact|concreted) mode/.test(
+    /generated block .* is stale|shell file list .* is stale| and .* differ in (exact|concreted) mode|heading structure differs between/.test(
       error,
     ),
   );


### PR DESCRIPTION
## Summary
- add remediation guidance in `scripts/audit-docs.mjs` when mirror drift failures are detected
- auto-detect a sync command when available (prefer `pnpm run docs:sync`, fallback to `node scripts/sync-docs.mjs --apply`) and always instruct rerun of audit check
- update customization guidance in both `docs/customization.md` and `idd-template/docs/customization.md` to document that CI drift checks are active

## Why
Issue #482 requires CI drift failures to be actionable. The audit already enforced drift, but failure output did not clearly direct contributors to the sync/remediation path.

## Follow-up
- none

Closes #482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the "Canonical Asset Map" with concise, actionable bullets: how CI detects drift, how to remediate when drift is found, and to re-run the check; guidance emphasizes editing canonical sources before mirrors.

* **New Features**
  * Audit tooling now prints an actionable remediation plan when mirror drift is detected, suggests an appropriate refresh command, and prompts re-running the check.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/491)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->