### PR TITLE
fix(onboarding): narrow trusted marker actor placeholder

### DIFF
--- a/idd-template/.github/idd/config.json
+++ b/idd-template/.github/idd/config.json
@@ -9,7 +9,7 @@
     "staleAge": "PT24H",
     "heartbeatInterval": "PT12H"
   },
-  "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTORS}}"],
+  "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTOR}}"],
   "commands": {
     "install-deps": "true",
     "fix-validate": "npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
@@ -22,4 +22,3 @@
   "issueScope": "roadmap",
   "orphanFirstPolicy": "none"
 }
-

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -137,7 +137,7 @@ before starting Step 1A.
 
 Inspect the target repository and propose candidate values for all seven placeholders:
 `{{REPO_NAME}}`, `{{PROJECT_MARKER_PREFIX}}`,
-`{{TRUSTED_MARKER_ACTORS}}`, `{{FIX_VALIDATE_COMMANDS}}`,
+`{{TRUSTED_MARKER_ACTOR}}`, `{{FIX_VALIDATE_COMMANDS}}`,
 `{{PRE_PUSH_VALIDATE_COMMANDS}}`, `{{POST_FIX_VALIDATE_COMMANDS}}`,
 and `{{INSTALL_DEPS_COMMAND}}`.
 
@@ -189,7 +189,7 @@ placeholders:
 
 - `{{REPO_NAME}}`
 - `{{PROJECT_MARKER_PREFIX}}`
-- `{{TRUSTED_MARKER_ACTORS}}`
+- `{{TRUSTED_MARKER_ACTOR}}`
 - `{{FIX_VALIDATE_COMMANDS}}`
 - `{{PRE_PUSH_VALIDATE_COMMANDS}}`
 - `{{POST_FIX_VALIDATE_COMMANDS}}`
@@ -512,7 +512,7 @@ that mention IDD workflow.
 
 In the copied files, perform a global replacement for:
 `{{REPO_NAME}}`, `{{PROJECT_MARKER_PREFIX}}`,
-`{{TRUSTED_MARKER_ACTORS}}`, `{{FIX_VALIDATE_COMMANDS}}`,
+`{{TRUSTED_MARKER_ACTOR}}`, `{{FIX_VALIDATE_COMMANDS}}`,
 `{{PRE_PUSH_VALIDATE_COMMANDS}}`, `{{POST_FIX_VALIDATE_COMMANDS}}`,
 and `{{INSTALL_DEPS_COMMAND}}`.
 

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -82,7 +82,7 @@ strings). This JSON is optional and does not replace
 | -------------------------------- | ----------------------------------------------- |
 | `{{REPO_NAME}}`                  | Repository short name                           |
 | `{{PROJECT_MARKER_PREFIX}}`      | Marker prefix matching `^[a-z][a-z0-9-]{1,31}$` |
-| `{{TRUSTED_MARKER_ACTORS}}`      | JSON-escaped marker-author logins               |
+| `{{TRUSTED_MARKER_ACTOR}}`       | Single JSON-escaped trusted marker login        |
 | `{{FIX_VALIDATE_COMMANDS}}`      | Lint-fix + lint commands                        |
 | `{{PRE_PUSH_VALIDATE_COMMANDS}}` | Lint + build + test (no auto-fix)               |
 | `{{POST_FIX_VALIDATE_COMMANDS}}` | Lint-fix + lint + build + test                  |

--- a/idd-template/docs/onboarding/placeholders.md
+++ b/idd-template/docs/onboarding/placeholders.md
@@ -30,11 +30,11 @@ short hyphenated marker prefix. The final value must match:
 
 That means 2-32 characters, lowercase, starting with a letter.
 
-### `{{TRUSTED_MARKER_ACTORS}}`
+### `{{TRUSTED_MARKER_ACTOR}}`
 
 List the GitHub logins allowed to post trusted IDD markers in
-`.github/idd/config.json`. Because the placeholder sits inside a quoted
-JSON array entry, replace the quoted placeholder with a single
+`.github/idd/config.json`. This placeholder is intentionally singular:
+it fills one quoted JSON array entry, so replace it with a single
 JSON-escaped login string first. Examples:
 
 - one trusted marker actor → `trusted-user-a`
@@ -113,15 +113,15 @@ For the full fallback order and policy matrix, see
 After Step 1A and Step 1C, you should have final values for these seven
 placeholders:
 
-| Placeholder                      | Meaning                                                | Example                             |
-| -------------------------------- | ------------------------------------------------------ | ----------------------------------- |
-| `{{REPO_NAME}}`                  | Repository short name used in worktree examples        | `my-app`                            |
-| `{{PROJECT_MARKER_PREFIX}}`      | Hidden issue-body marker prefix                        | `my-app`                            |
-| `{{TRUSTED_MARKER_ACTORS}}`      | JSON-escaped logins allowed to post trusted markers    | `"trusted-user-a", "trusted-bot-a"` |
-| `{{FIX_VALIDATE_COMMANDS}}`      | Auto-fix plus validate command row                     | `npm run lint:fix && npm run lint`  |
-| `{{PRE_PUSH_VALIDATE_COMMANDS}}` | Non-mutating verify command row                        | `npm run lint && npm run test`      |
-| `{{POST_FIX_VALIDATE_COMMANDS}}` | Post-fix validate command row                          | `npm run lint:fix && npm test`      |
-| `{{INSTALL_DEPS_COMMAND}}`       | Dependency install command, or `true` when unnecessary | `npm install`                       |
+| Placeholder                      | Meaning                                                   | Example                            |
+| -------------------------------- | --------------------------------------------------------- | ---------------------------------- |
+| `{{REPO_NAME}}`                  | Repository short name used in worktree examples           | `my-app`                           |
+| `{{PROJECT_MARKER_PREFIX}}`      | Hidden issue-body marker prefix                           | `my-app`                           |
+| `{{TRUSTED_MARKER_ACTOR}}`       | Single JSON-escaped login allowed to post trusted markers | `trusted-user-a`                   |
+| `{{FIX_VALIDATE_COMMANDS}}`      | Auto-fix plus validate command row                        | `npm run lint:fix && npm run lint` |
+| `{{PRE_PUSH_VALIDATE_COMMANDS}}` | Non-mutating verify command row                           | `npm run lint && npm run test`     |
+| `{{POST_FIX_VALIDATE_COMMANDS}}` | Post-fix validate command row                             | `npm run lint:fix && npm test`     |
+| `{{INSTALL_DEPS_COMMAND}}`       | Dependency install command, or `true` when unnecessary    | `npm install`                      |
 
 ### No-op substitution
 

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -276,7 +276,7 @@ Keep these rules in mind:
   approval model that the distributed runtime already enforces
 - use `skipIssueAuthorApprovalGate: true` when the repository
   intentionally opts out; omitted or `false` keeps the gate enabled
-- replace `{{TRUSTED_MARKER_ACTORS}}` in `trustedMarkerActors` with a
+- replace `{{TRUSTED_MARKER_ACTOR}}` in `trustedMarkerActors` with a
   single JSON-escaped GitHub login string first, then add any extra
   quoted array entries manually for additional trusted marker actors
 - keep command strings JSON-escaped instead of pasting fragile raw shell

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -16,7 +16,7 @@ test("placeholder scenarios detect clean and dirty post-onboarding fixtures", ()
 
   assert.deepEqual(clean, []);
   assert.deepEqual(dirty, [
-    ".github/idd/config.json: {{PROJECT_MARKER_PREFIX}}, {{TRUSTED_MARKER_ACTORS}}",
+    ".github/idd/config.json: {{PROJECT_MARKER_PREFIX}}, {{TRUSTED_MARKER_ACTOR}}",
     "README.md: {{REPO_NAME}}",
   ]);
 });

--- a/tests/fixtures/consistency/placeholders/dirty/.github/idd/config.json
+++ b/tests/fixtures/consistency/placeholders/dirty/.github/idd/config.json
@@ -1,5 +1,5 @@
 {
   "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
-  "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTORS}}"],
+  "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTOR}}"],
   "issueScope": "roadmap"
 }

--- a/tests/non-node-fallback.test.mjs
+++ b/tests/non-node-fallback.test.mjs
@@ -35,26 +35,36 @@ test("onboarding links extracted placeholder guidance and keeps fallback wording
   );
   assert.match(
     onboarding,
-    /all seven placeholders:[\s\S]*`{{TRUSTED_MARKER_ACTORS}}`/,
-    "ONBOARDING must include the trusted marker actors placeholder in Step 1A",
+    /all seven placeholders:[\s\S]*`{{TRUSTED_MARKER_ACTOR}}`/,
+    "ONBOARDING must include the trusted marker actor placeholder in Step 1A",
   );
   assert.match(
     onboarding,
-    /perform a global replacement for:[\s\S]*`{{TRUSTED_MARKER_ACTORS}}`/,
-    "ONBOARDING Step 4 must replace the trusted marker actors placeholder",
+    /perform a global replacement for:[\s\S]*`{{TRUSTED_MARKER_ACTOR}}`/,
+    "ONBOARDING Step 4 must replace the trusted marker actor placeholder",
+  );
+  assert.doesNotMatch(
+    onboarding,
+    /{{TRUSTED_MARKER_ACTORS}}/,
+    "ONBOARDING must not refer to the legacy trusted marker actors placeholder",
   );
   const configText = readText("idd-template/.github/idd/config.json");
   assert.match(
     configText,
-    /"trustedMarkerActors": \["{{TRUSTED_MARKER_ACTORS}}"\]/,
+    /"trustedMarkerActors": \["{{TRUSTED_MARKER_ACTOR}}"\]/,
     "template config must keep trustedMarkerActors as a real placeholder token",
+  );
+  assert.doesNotMatch(
+    configText,
+    /{{TRUSTED_MARKER_ACTORS}}/,
+    "template config must not keep the legacy trusted marker actors placeholder",
   );
 
   const text = readText("idd-template/docs/onboarding/placeholders.md");
   assert.match(
     text,
-    /### `{{TRUSTED_MARKER_ACTORS}}`/,
-    "placeholder reference must document the trusted marker actors placeholder",
+    /### `{{TRUSTED_MARKER_ACTOR}}`/,
+    "placeholder reference must document the trusted marker actor placeholder",
   );
   assert.match(
     text,
@@ -74,8 +84,8 @@ test("onboarding links extracted placeholder guidance and keeps fallback wording
   const readme = readText("idd-template/README.md");
   assert.match(
     readme,
-    /\| `{{TRUSTED_MARKER_ACTORS}}` +\| JSON-escaped marker-author logins/,
-    "template README must list the trusted marker actors placeholder",
+    /\| `{{TRUSTED_MARKER_ACTOR}}` +\| Single JSON-escaped trusted marker login/,
+    "template README must list the trusted marker actor placeholder",
   );
   const fixValidateSection = extractSection(
     text,


### PR DESCRIPTION
## Summary
- rename the trusted-marker placeholder to a singular token that matches one `trustedMarkerActors` array entry
- update onboarding and reference docs so multi-actor setups are still documented as an explicit follow-up edit
- tighten placeholder-focused tests and dirty fixtures to reject mixed old/new token states

Closes #479

## Follow-up issues
- none

## Rationale
The template JSON shape expects one trusted marker login per array entry, but the old plural placeholder name made a comma-separated replacement look valid. This keeps runtime semantics unchanged while making the default onboarding replacement step clearer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated placeholder naming across onboarding guides, configuration documentation, and reference materials for consistency.

* **Configuration**
  * Updated trusted marker placeholder references in configuration files.

* **Tests**
  * Updated test assertions to validate placeholder naming across configuration and documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/494)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->