### PR TITLE
feat(policy): parameterize advisory wait windows

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -44,6 +44,11 @@ Required helper fields:
 - `f3Outcome`
 - `earliestSameHeadAt`
 - `requestMarkerCount`
+- `requestCap`
+- `pendingWindowMinutes`
+- `settledWindowMinutes`
+- `pollIntervalMinutes`
+- `capExhaustedRoute`
 - `trustedMarkerSummary`
 
 Allowed `outcome` / `f3Outcome` values:
@@ -57,16 +62,31 @@ Allowed `outcome` / `f3Outcome` values:
 `HOLD` remains a protocol-level routing state for AW4/AW5 fail-closed
 stops. It is caller-derived and not emitted by helper enums.
 
+Resolve the effective advisory policy from helper output when available;
+otherwise read `.github/idd/config.json` `advisoryWait.*`, falling back
+to the distributed defaults named in `docs/policy-constants.md`:
+
+- `REQUEST_CAP`
+- `PENDING_WINDOW_MINUTES`
+- `SETTLED_WINDOW_MINUTES`
+- `POLL_INTERVAL_MINUTES`
+- `CAP_EXHAUSTED_ROUTE`
+
+`CAP_EXHAUSTED_ROUTE` must remain fail-closed. Supported values are:
+
+- `phase-specific` (default): E14 skips to E15; F2 and F3 hold.
+- `hold`: E14, F2, and F3 all hold on `CAP_EXHAUSTED`.
+
 ### Caller mapping
 
-| Outcome           | E14                                | F2                               | F3                                    |
-| ----------------- | ---------------------------------- | -------------------------------- | ------------------------------------- |
-| `SATISFIED`       | proceed to E15                     | continue to CI check             | proceed with merge                    |
-| `REQUEST_NEEDED`  | request Copilot + marker + poll    | return to E14                    | return to E14                         |
-| `RECOVERY_NEEDED` | post recovery marker + poll        | post recovery marker + poll      | post recovery marker and return to F2 |
-| `CAP_EXHAUSTED`   | skip advisory wait; proceed to E15 | post cap-exhausted hold and stop | post cap-exhausted hold and stop      |
-| `WAIT`            | continue polling                   | poll then restart F2 from top    | do not merge; return to F2            |
-| `HOLD`            | post hold and stop                 | post hold and stop               | post hold and stop                    |
+| Outcome           | E14                             | F2                               | F3                                    |
+| ----------------- | ------------------------------- | -------------------------------- | ------------------------------------- |
+| `SATISFIED`       | proceed to E15                  | continue to CI check             | proceed with merge                    |
+| `REQUEST_NEEDED`  | request Copilot + marker + poll | return to E14                    | return to E14                         |
+| `RECOVERY_NEEDED` | post recovery marker + poll     | post recovery marker + poll      | post recovery marker and return to F2 |
+| `CAP_EXHAUSTED`   | use `CAP_EXHAUSTED_ROUTE`       | post cap-exhausted hold and stop | post cap-exhausted hold and stop      |
+| `WAIT`            | continue polling                | poll then restart F2 from top    | do not merge; return to F2            |
+| `HOLD`            | post hold and stop              | post hold and stop               | post hold and stop                    |
 
 ### F3-specific interpretation
 
@@ -224,18 +244,18 @@ Rules:
 
 Evaluate top-to-bottom; first match wins.
 
-| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof / cap                   | Elapsed   | Outcome           |
-| --------------------- | ----------------- | ------------------- | ---------------------------------- | --------- | ----------------- |
-| `== PR_HEAD_SHA`      | any               | any                 | any                                | any       | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true` | —         | `RECOVERY_NEEDED` |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap < 30       | —         | `REQUEST_NEEDED`  |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap >= 30      | —         | `CAP_EXHAUSTED`   |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                | >= 30 min | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                | < 30 min  | `WAIT`            |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                | >= 10 min | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                | < 10 min  | `WAIT`            |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap >= 30                  | —         | `CAP_EXHAUSTED`   |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap < 30                   | —         | `REQUEST_NEEDED`  |
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof / cap                         | Elapsed                         | Outcome           |
+| --------------------- | ----------------- | ------------------- | ---------------------------------------- | ------------------------------- | ----------------- |
+| `== PR_HEAD_SHA`      | any               | any                 | any                                      | any                             | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true`       | —                               | `RECOVERY_NEEDED` |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap < `REQUEST_CAP`  | —                               | `REQUEST_NEEDED`  |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap >= `REQUEST_CAP` | —                               | `CAP_EXHAUSTED`   |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                      | >= `PENDING_WINDOW_MINUTES` min | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                      | < `PENDING_WINDOW_MINUTES` min  | `WAIT`            |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                      | >= `SETTLED_WINDOW_MINUTES` min | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                      | < `SETTLED_WINDOW_MINUTES` min  | `WAIT`            |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap >= `REQUEST_CAP`             | —                               | `CAP_EXHAUSTED`   |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap < `REQUEST_CAP`              | —                               | `REQUEST_NEEDED`  |
 
 ### AW3-R — Recovery marker
 
@@ -270,7 +290,7 @@ Rules:
 
 #### Cap exhausted
 
-> The 30-per-PR Copilot re-review cap is exhausted. A maintainer must
+> The configured per-PR Copilot re-review cap is exhausted. A maintainer must
 > manually request and evaluate a Copilot review before merge.
 
 ### AW5 — Missing-marker recovery during polling

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -244,18 +244,18 @@ Rules:
 
 Evaluate top-to-bottom; first match wins.
 
-| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof / cap                         | Elapsed                         | Outcome           |
-| --------------------- | ----------------- | ------------------- | ---------------------------------------- | ------------------------------- | ----------------- |
-| `== PR_HEAD_SHA`      | any               | any                 | any                                      | any                             | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true`       | —                               | `RECOVERY_NEEDED` |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap < `REQUEST_CAP`  | —                               | `REQUEST_NEEDED`  |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap >= `REQUEST_CAP` | —                               | `CAP_EXHAUSTED`   |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                      | >= `PENDING_WINDOW_MINUTES` min | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                      | < `PENDING_WINDOW_MINUTES` min  | `WAIT`            |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                      | >= `SETTLED_WINDOW_MINUTES` min | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                      | < `SETTLED_WINDOW_MINUTES` min  | `WAIT`            |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap >= `REQUEST_CAP`             | —                               | `CAP_EXHAUSTED`   |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap < `REQUEST_CAP`              | —                               | `REQUEST_NEEDED`  |
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof / cap                                    | Elapsed                         | Outcome           |
+| --------------------- | ----------------- | ------------------- | --------------------------------------------------- | ------------------------------- | ----------------- |
+| `== PR_HEAD_SHA`      | any               | any                 | any                                                 | any                             | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true`                  | —                               | `RECOVERY_NEEDED` |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; `REQUEST_MARKER_COUNT` < `REQUEST_CAP`  | —                               | `REQUEST_NEEDED`  |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; `REQUEST_MARKER_COUNT` >= `REQUEST_CAP` | —                               | `CAP_EXHAUSTED`   |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                                 | >= `PENDING_WINDOW_MINUTES` min | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                                 | < `PENDING_WINDOW_MINUTES` min  | `WAIT`            |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                                 | >= `SETTLED_WINDOW_MINUTES` min | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                                 | < `SETTLED_WINDOW_MINUTES` min  | `WAIT`            |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | `REQUEST_MARKER_COUNT` >= `REQUEST_CAP`             | —                               | `CAP_EXHAUSTED`   |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | `REQUEST_MARKER_COUNT` < `REQUEST_CAP`              | —                               | `REQUEST_NEEDED`  |
 
 ### AW3-R — Recovery marker
 

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -146,15 +146,17 @@ must align with every F2 condition below.
        **AW4** and stop.
      - **REQUEST_NEEDED** → return to E14 to request Copilot review and
        post a fresh marker. Do not post a new request in F2.
-     - **WAIT** (`COPILOT_PENDING` is `"true"`, elapsed < 30 min) →
-       wait for the remainder of the applicable window (poll every 2
-       min), refreshing `EARLIEST_SAME_HEAD_AT` per **AW2** at each
-       iteration and applying **AW5** if the marker disappears. Then
-       **go back to the first condition in F2** (the 'Review currency'
-       check) to re-evaluate all conditions.
-     - **WAIT** (`COPILOT_PENDING` is `"false"`, elapsed < 10 min) →
-       wait for the remainder of the 10-minute window (same polling
-       rules). Then **go back to the first condition in F2**.
+     - **WAIT** (`COPILOT_PENDING` is `"true"`, elapsed <
+       `PENDING_WINDOW_MINUTES` min) → wait for the remainder of the
+       applicable window (poll every `POLL_INTERVAL_MINUTES` min),
+       refreshing `EARLIEST_SAME_HEAD_AT` per **AW2** at each iteration
+       and applying **AW5** if the marker disappears. Then **go back to
+       the first condition in F2** (the 'Review currency' check) to
+       re-evaluate all conditions.
+     - **WAIT** (`COPILOT_PENDING` is `"false"`, elapsed <
+       `SETTLED_WINDOW_MINUTES` min) → wait for the remainder of the
+       settled window (same polling rules). Then **go back to the first
+       condition in F2**.
 
   GitHub removes a reviewer from `requested_reviewers` when they submit
   a review OR when the request is manually cancelled — either counts as

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -105,8 +105,10 @@ gh pr edit {pr-number} --add-reviewer {reviewer-login}
 
 **Copilot**: after every push, regardless of any reviewer's state,
 request a Copilot re-review if Copilot has not yet reviewed the current
-HEAD SHA. Subject to a **workflow cap of 30 Copilot re-review requests
-per PR** (this is a process limit, not a GitHub-enforced constraint).
+HEAD SHA. Subject to the configured Copilot re-review request cap
+(`REQUEST_CAP` from helper output or `.github/idd/config.json`
+`advisoryWait.requestCap`; default 30). This is a process limit, not a
+GitHub-enforced constraint.
 
 1. Fetch `PR_HEAD_SHA`:
 
@@ -123,14 +125,17 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
    - **RECOVERY_NEEDED** (`COPILOT_PENDING` is `"true"`, no same-head
      marker): post the recovery marker from **AW3-R**. Do not request
      another Copilot review.
-   - **CAP_EXHAUSTED** (`REQUEST_MARKER_COUNT` ≥ 30, no same-head
-     marker) →
-     skip the advisory wait entirely; proceed directly to E15.
+   - **CAP_EXHAUSTED** (`REQUEST_MARKER_COUNT` ≥ `REQUEST_CAP`, no
+     same-head marker) →
+     if `CAP_EXHAUSTED_ROUTE` is `hold`, post the hold comment from
+     **AW4** and stop. Otherwise (`phase-specific`, the default), skip
+     the advisory wait entirely and proceed directly to E15.
    - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, or
      `COPILOT_PENDING` is `"true"` but current-head coverage is not
-     proven; request cap < 30): request Copilot review and immediately
-     post a plain-text marker. If `COPILOT_PENDING` is `"true"` in this
-     branch, first remove the stale/unproven pending reviewer request:
+     proven; request cap < `REQUEST_CAP`): request Copilot review and
+     immediately post a plain-text marker. If `COPILOT_PENDING` is
+     `"true"` in this branch, first remove the stale/unproven pending
+     reviewer request:
 
      ```sh
      gh pr edit {pr-number} --remove-reviewer "@copilot"
@@ -183,7 +188,7 @@ the `createdAt` of the latest
 a trusted marker actor. If no trusted same-claim watermark exists, stop
 and return to E1 to create one.
 
-Poll every 2 minutes:
+Poll every `POLL_INTERVAL_MINUTES` minutes:
 
 1. Re-fetch `PR_HEAD_SHA`:
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -165,6 +165,20 @@ for parameterized follow-up work: `stallRecovery`, `forcedHandoff`,
 `critiqueLoop`, `reviewEscalation`, `approvalSignals`, and
 `issueAuthoring`. Leaving these keys unset keeps distributed behavior.
 
+For advisory review timing, repositories may now customize
+`advisoryWait.requestCap`, `advisoryWait.pendingWindow`,
+`advisoryWait.settledWindow`, and `advisoryWait.pollInterval` in
+`.github/idd/config.json`. Keep those keys aligned with the helper
+contracts and any instruction text that references the effective wait
+values. The three duration keys accept positive whole-minute ISO 8601
+durations only; zero-length values and second-based values are invalid.
+
+`advisoryWait.capExhaustedRoute` is intentionally fail-closed. The
+default `phase-specific` behavior keeps the current E14 skip / F2-F3
+hold split, while `hold` is a stricter override that also stops E14 on
+cap exhaustion. Do not introduce an override that weakens the F2/F3
+merge hold.
+
 ## Phase ID Compatibility Contract
 
 Treat phase IDs as a compatibility surface, not as presentation text.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -258,7 +258,9 @@ default `instructions-only` profile keep using the written shell /
 - Stable fields consumed by the instructions: `prHeadSha`,
   `lastCopilotCommit`, `copilotPending`,
   `copilotPendingCoversHead`, `outcome`, `f3Outcome`,
-  `earliestSameHeadAt`, `requestMarkerCount`, and
+  `earliestSameHeadAt`, `requestMarkerCount`, `requestCap`,
+  `pendingWindowMinutes`, `settledWindowMinutes`,
+  `pollIntervalMinutes`, `capExhaustedRoute`, and
   `trustedMarkerSummary`
 
 ### Merge-gate evidence
@@ -280,7 +282,8 @@ default `instructions-only` profile keep using the written shell /
   [`pre-merge-readiness.schema.json`][pre-merge-readiness-schema]
 - Stable sections consumed by the instructions: `reviewCurrency`,
   `threads`, `unrepliedComments`, `reviewerStates`,
-  `advisoryWait`, `ci`, `claim`, and optional
+  `advisoryWait` (including the effective advisory policy fields), `ci`,
+  `claim`, and optional
   `dispositionEvidence`
 
 ### E7 disposition verification

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -141,7 +141,8 @@ The current policy schema and helper runtime now support
 `.github/idd/config.json` `advisoryWait.requestCap`,
 `advisoryWait.pendingWindow`, `advisoryWait.settledWindow`,
 `advisoryWait.pollInterval`, and `advisoryWait.capExhaustedRoute`.
-Omitted keys keep the distributed defaults below.
+Omitted keys keep the distributed defaults below. The three duration
+keys accept positive whole-minute ISO 8601 durations only.
 
 | Policy default                          | Distributed value                                                           | Owning surface                                                                                                                                                                                                       | Onboarding expectation                                                                       |
 | --------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -137,6 +137,12 @@ The distributed PR policy is `copilot-advisory`. These values apply to
 that profile and remain policy defaults until the relevant instruction
 files are edited.
 
+The current policy schema and helper runtime now support
+`.github/idd/config.json` `advisoryWait.requestCap`,
+`advisoryWait.pendingWindow`, `advisoryWait.settledWindow`,
+`advisoryWait.pollInterval`, and `advisoryWait.capExhaustedRoute`.
+Omitted keys keep the distributed defaults below.
+
 | Policy default                          | Distributed value                                                           | Owning surface                                                                                                                                                                                                       | Onboarding expectation                                                                       |
 | --------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | Copilot re-review request cap           | 30 requests per PR                                                          | [Review fix](../.github/instructions/idd-review-fix.instructions.md), [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)                                                                     | Confirm that the repository accepts this process cap before using the default advisory flow. |

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -167,6 +167,11 @@
       "earliestSameHeadAt": "",
       "sameHeadMarkerCount": 0,
       "requestMarkerCount": 0,
+      "requestCap": 30,
+      "pendingWindowMinutes": 30,
+      "settledWindowMinutes": 10,
+      "pollIntervalMinutes": 2,
+      "capExhaustedRoute": "phase-specific",
       "elapsedMinutes": 0
     },
     "ci": {

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -167,6 +167,11 @@
       "earliestSameHeadAt": "",
       "sameHeadMarkerCount": 0,
       "requestMarkerCount": 0,
+      "requestCap": 30,
+      "pendingWindowMinutes": 30,
+      "settledWindowMinutes": 10,
+      "pollIntervalMinutes": 2,
+      "capExhaustedRoute": "phase-specific",
       "elapsedMinutes": 0
     },
     "ci": {

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -191,6 +191,11 @@
       "earliestSameHeadAt": "",
       "sameHeadMarkerCount": 0,
       "requestMarkerCount": 0,
+      "requestCap": 30,
+      "pendingWindowMinutes": 30,
+      "settledWindowMinutes": 10,
+      "pollIntervalMinutes": 2,
+      "capExhaustedRoute": "phase-specific",
       "elapsedMinutes": 0
     },
     "ci": {

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -191,6 +191,11 @@
       "earliestSameHeadAt": "",
       "sameHeadMarkerCount": 0,
       "requestMarkerCount": 0,
+      "requestCap": 30,
+      "pendingWindowMinutes": 30,
+      "settledWindowMinutes": 10,
+      "pollIntervalMinutes": 2,
+      "capExhaustedRoute": "phase-specific",
       "elapsedMinutes": 0
     },
     "ci": {

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -191,6 +191,11 @@
       "earliestSameHeadAt": "",
       "sameHeadMarkerCount": 0,
       "requestMarkerCount": 0,
+      "requestCap": 30,
+      "pendingWindowMinutes": 30,
+      "settledWindowMinutes": 10,
+      "pollIntervalMinutes": 2,
+      "capExhaustedRoute": "phase-specific",
       "elapsedMinutes": 0
     },
     "ci": {

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -181,6 +181,11 @@
       "earliestSameHeadAt": "",
       "sameHeadMarkerCount": 0,
       "requestMarkerCount": 0,
+      "requestCap": 30,
+      "pendingWindowMinutes": 30,
+      "settledWindowMinutes": 10,
+      "pollIntervalMinutes": 2,
+      "capExhaustedRoute": "phase-specific",
       "elapsedMinutes": 0
     },
     "ci": {

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -191,6 +191,11 @@
       "earliestSameHeadAt": "",
       "sameHeadMarkerCount": 0,
       "requestMarkerCount": 0,
+      "requestCap": 30,
+      "pendingWindowMinutes": 30,
+      "settledWindowMinutes": 10,
+      "pollIntervalMinutes": 2,
+      "capExhaustedRoute": "phase-specific",
       "elapsedMinutes": 0
     },
     "ci": {

--- a/fixtures/schemas/advisory-wait-state.valid.json
+++ b/fixtures/schemas/advisory-wait-state.valid.json
@@ -10,6 +10,8 @@
   "requestCap": 30,
   "pendingWindowMinutes": 30,
   "settledWindowMinutes": 10,
+  "pollIntervalMinutes": 2,
+  "capExhaustedRoute": "phase-specific",
   "elapsedMinutes": 0,
   "sameHeadMarkerPresent": false,
   "earliestSameHeadAt": "",

--- a/fixtures/schemas/policy.valid.json
+++ b/fixtures/schemas/policy.valid.json
@@ -30,7 +30,7 @@
     "pendingWindow": "PT30M",
     "settledWindow": "PT10M",
     "pollInterval": "PT2M",
-    "capExhaustedRoute": "phase-default"
+    "capExhaustedRoute": "phase-specific"
   },
   "ciWait": {
     "runningTimeout": "PT30M",

--- a/fixtures/schemas/pre-merge-readiness.invalid.json
+++ b/fixtures/schemas/pre-merge-readiness.invalid.json
@@ -83,6 +83,11 @@
     "earliestSameHeadAt": "",
     "sameHeadMarkerCount": 0,
     "requestMarkerCount": 0,
+    "requestCap": 30,
+    "pendingWindowMinutes": 30,
+    "settledWindowMinutes": 10,
+    "pollIntervalMinutes": 2,
+    "capExhaustedRoute": "phase-specific",
     "elapsedMinutes": 0
   },
   "ci": {

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -92,6 +92,11 @@
     "earliestSameHeadAt": "",
     "sameHeadMarkerCount": 0,
     "requestMarkerCount": 0,
+    "requestCap": 30,
+    "pendingWindowMinutes": 30,
+    "settledWindowMinutes": 10,
+    "pollIntervalMinutes": 2,
+    "capExhaustedRoute": "phase-specific",
     "elapsedMinutes": 0
   },
   "ci": {

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -44,6 +44,11 @@ Required helper fields:
 - `f3Outcome`
 - `earliestSameHeadAt`
 - `requestMarkerCount`
+- `requestCap`
+- `pendingWindowMinutes`
+- `settledWindowMinutes`
+- `pollIntervalMinutes`
+- `capExhaustedRoute`
 - `trustedMarkerSummary`
 
 Allowed `outcome` / `f3Outcome` values:
@@ -57,16 +62,31 @@ Allowed `outcome` / `f3Outcome` values:
 `HOLD` remains a protocol-level routing state for AW4/AW5 fail-closed
 stops. It is caller-derived and not emitted by helper enums.
 
+Resolve the effective advisory policy from helper output when available;
+otherwise read `.github/idd/config.json` `advisoryWait.*`, falling back
+to the distributed defaults named in `docs/policy-constants.md`:
+
+- `REQUEST_CAP`
+- `PENDING_WINDOW_MINUTES`
+- `SETTLED_WINDOW_MINUTES`
+- `POLL_INTERVAL_MINUTES`
+- `CAP_EXHAUSTED_ROUTE`
+
+`CAP_EXHAUSTED_ROUTE` must remain fail-closed. Supported values are:
+
+- `phase-specific` (default): E14 skips to E15; F2 and F3 hold.
+- `hold`: E14, F2, and F3 all hold on `CAP_EXHAUSTED`.
+
 ### Caller mapping
 
-| Outcome           | E14                                | F2                               | F3                                    |
-| ----------------- | ---------------------------------- | -------------------------------- | ------------------------------------- |
-| `SATISFIED`       | proceed to E15                     | continue to CI check             | proceed with merge                    |
-| `REQUEST_NEEDED`  | request Copilot + marker + poll    | return to E14                    | return to E14                         |
-| `RECOVERY_NEEDED` | post recovery marker + poll        | post recovery marker + poll      | post recovery marker and return to F2 |
-| `CAP_EXHAUSTED`   | skip advisory wait; proceed to E15 | post cap-exhausted hold and stop | post cap-exhausted hold and stop      |
-| `WAIT`            | continue polling                   | poll then restart F2 from top    | do not merge; return to F2            |
-| `HOLD`            | post hold and stop                 | post hold and stop               | post hold and stop                    |
+| Outcome           | E14                             | F2                               | F3                                    |
+| ----------------- | ------------------------------- | -------------------------------- | ------------------------------------- |
+| `SATISFIED`       | proceed to E15                  | continue to CI check             | proceed with merge                    |
+| `REQUEST_NEEDED`  | request Copilot + marker + poll | return to E14                    | return to E14                         |
+| `RECOVERY_NEEDED` | post recovery marker + poll     | post recovery marker + poll      | post recovery marker and return to F2 |
+| `CAP_EXHAUSTED`   | use `CAP_EXHAUSTED_ROUTE`       | post cap-exhausted hold and stop | post cap-exhausted hold and stop      |
+| `WAIT`            | continue polling                | poll then restart F2 from top    | do not merge; return to F2            |
+| `HOLD`            | post hold and stop              | post hold and stop               | post hold and stop                    |
 
 ### F3-specific interpretation
 
@@ -224,18 +244,18 @@ Rules:
 
 Evaluate top-to-bottom; first match wins.
 
-| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof / cap                   | Elapsed   | Outcome           |
-| --------------------- | ----------------- | ------------------- | ---------------------------------- | --------- | ----------------- |
-| `== PR_HEAD_SHA`      | any               | any                 | any                                | any       | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true` | —         | `RECOVERY_NEEDED` |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap < 30       | —         | `REQUEST_NEEDED`  |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap >= 30      | —         | `CAP_EXHAUSTED`   |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                | >= 30 min | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                | < 30 min  | `WAIT`            |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                | >= 10 min | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                | < 10 min  | `WAIT`            |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap >= 30                  | —         | `CAP_EXHAUSTED`   |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap < 30                   | —         | `REQUEST_NEEDED`  |
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof / cap                         | Elapsed                         | Outcome           |
+| --------------------- | ----------------- | ------------------- | ---------------------------------------- | ------------------------------- | ----------------- |
+| `== PR_HEAD_SHA`      | any               | any                 | any                                      | any                             | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true`       | —                               | `RECOVERY_NEEDED` |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap < `REQUEST_CAP`  | —                               | `REQUEST_NEEDED`  |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap >= `REQUEST_CAP` | —                               | `CAP_EXHAUSTED`   |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                      | >= `PENDING_WINDOW_MINUTES` min | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                      | < `PENDING_WINDOW_MINUTES` min  | `WAIT`            |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                      | >= `SETTLED_WINDOW_MINUTES` min | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                      | < `SETTLED_WINDOW_MINUTES` min  | `WAIT`            |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap >= `REQUEST_CAP`             | —                               | `CAP_EXHAUSTED`   |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap < `REQUEST_CAP`              | —                               | `REQUEST_NEEDED`  |
 
 ### AW3-R — Recovery marker
 
@@ -270,7 +290,7 @@ Rules:
 
 #### Cap exhausted
 
-> The 30-per-PR Copilot re-review cap is exhausted. A maintainer must
+> The configured per-PR Copilot re-review cap is exhausted. A maintainer must
 > manually request and evaluate a Copilot review before merge.
 
 ### AW5 — Missing-marker recovery during polling

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -244,18 +244,18 @@ Rules:
 
 Evaluate top-to-bottom; first match wins.
 
-| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof / cap                         | Elapsed                         | Outcome           |
-| --------------------- | ----------------- | ------------------- | ---------------------------------------- | ------------------------------- | ----------------- |
-| `== PR_HEAD_SHA`      | any               | any                 | any                                      | any                             | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true`       | —                               | `RECOVERY_NEEDED` |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap < `REQUEST_CAP`  | —                               | `REQUEST_NEEDED`  |
-| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; request cap >= `REQUEST_CAP` | —                               | `CAP_EXHAUSTED`   |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                      | >= `PENDING_WINDOW_MINUTES` min | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                      | < `PENDING_WINDOW_MINUTES` min  | `WAIT`            |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                      | >= `SETTLED_WINDOW_MINUTES` min | `SATISFIED`       |
-| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                      | < `SETTLED_WINDOW_MINUTES` min  | `WAIT`            |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap >= `REQUEST_CAP`             | —                               | `CAP_EXHAUSTED`   |
-| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | request cap < `REQUEST_CAP`              | —                               | `REQUEST_NEEDED`  |
+| `LAST_COPILOT_COMMIT` | `COPILOT_PENDING` | Marker state        | Head proof / cap                                    | Elapsed                         | Outcome           |
+| --------------------- | ----------------- | ------------------- | --------------------------------------------------- | ------------------------------- | ----------------- |
+| `== PR_HEAD_SHA`      | any               | any                 | any                                                 | any                             | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | `COPILOT_PENDING_COVERS_HEAD=true`                  | —                               | `RECOVERY_NEEDED` |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; `REQUEST_MARKER_COUNT` < `REQUEST_CAP`  | —                               | `REQUEST_NEEDED`  |
+| `!= PR_HEAD_SHA`      | `"true"`          | no same-head marker | not proven; `REQUEST_MARKER_COUNT` >= `REQUEST_CAP` | —                               | `CAP_EXHAUSTED`   |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                                 | >= `PENDING_WINDOW_MINUTES` min | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"true"`          | marker exists       | any                                                 | < `PENDING_WINDOW_MINUTES` min  | `WAIT`            |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                                 | >= `SETTLED_WINDOW_MINUTES` min | `SATISFIED`       |
+| `!= PR_HEAD_SHA`      | `"false"`         | marker exists       | any                                                 | < `SETTLED_WINDOW_MINUTES` min  | `WAIT`            |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | `REQUEST_MARKER_COUNT` >= `REQUEST_CAP`             | —                               | `CAP_EXHAUSTED`   |
+| `!= PR_HEAD_SHA`      | `"false"`         | no same-head marker | `REQUEST_MARKER_COUNT` < `REQUEST_CAP`              | —                               | `REQUEST_NEEDED`  |
 
 ### AW3-R — Recovery marker
 

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -146,15 +146,17 @@ must align with every F2 condition below.
        **AW4** and stop.
      - **REQUEST_NEEDED** → return to E14 to request Copilot review and
        post a fresh marker. Do not post a new request in F2.
-     - **WAIT** (`COPILOT_PENDING` is `"true"`, elapsed < 30 min) →
-       wait for the remainder of the applicable window (poll every 2
-       min), refreshing `EARLIEST_SAME_HEAD_AT` per **AW2** at each
-       iteration and applying **AW5** if the marker disappears. Then
-       **go back to the first condition in F2** (the 'Review currency'
-       check) to re-evaluate all conditions.
-     - **WAIT** (`COPILOT_PENDING` is `"false"`, elapsed < 10 min) →
-       wait for the remainder of the 10-minute window (same polling
-       rules). Then **go back to the first condition in F2**.
+     - **WAIT** (`COPILOT_PENDING` is `"true"`, elapsed <
+       `PENDING_WINDOW_MINUTES` min) → wait for the remainder of the
+       applicable window (poll every `POLL_INTERVAL_MINUTES` min),
+       refreshing `EARLIEST_SAME_HEAD_AT` per **AW2** at each iteration
+       and applying **AW5** if the marker disappears. Then **go back to
+       the first condition in F2** (the 'Review currency' check) to
+       re-evaluate all conditions.
+     - **WAIT** (`COPILOT_PENDING` is `"false"`, elapsed <
+       `SETTLED_WINDOW_MINUTES` min) → wait for the remainder of the
+       settled window (same polling rules). Then **go back to the first
+       condition in F2**.
 
   GitHub removes a reviewer from `requested_reviewers` when they submit
   a review OR when the request is manually cancelled — either counts as

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -105,8 +105,10 @@ gh pr edit {pr-number} --add-reviewer {reviewer-login}
 
 **Copilot**: after every push, regardless of any reviewer's state,
 request a Copilot re-review if Copilot has not yet reviewed the current
-HEAD SHA. Subject to a **workflow cap of 30 Copilot re-review requests
-per PR** (this is a process limit, not a GitHub-enforced constraint).
+HEAD SHA. Subject to the configured Copilot re-review request cap
+(`REQUEST_CAP` from helper output or `.github/idd/config.json`
+`advisoryWait.requestCap`; default 30). This is a process limit, not a
+GitHub-enforced constraint.
 
 1. Fetch `PR_HEAD_SHA`:
 
@@ -123,14 +125,17 @@ per PR** (this is a process limit, not a GitHub-enforced constraint).
    - **RECOVERY_NEEDED** (`COPILOT_PENDING` is `"true"`, no same-head
      marker): post the recovery marker from **AW3-R**. Do not request
      another Copilot review.
-   - **CAP_EXHAUSTED** (`REQUEST_MARKER_COUNT` ≥ 30, no same-head
-     marker) →
-     skip the advisory wait entirely; proceed directly to E15.
+   - **CAP_EXHAUSTED** (`REQUEST_MARKER_COUNT` ≥ `REQUEST_CAP`, no
+     same-head marker) →
+     if `CAP_EXHAUSTED_ROUTE` is `hold`, post the hold comment from
+     **AW4** and stop. Otherwise (`phase-specific`, the default), skip
+     the advisory wait entirely and proceed directly to E15.
    - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, or
      `COPILOT_PENDING` is `"true"` but current-head coverage is not
-     proven; request cap < 30): request Copilot review and immediately
-     post a plain-text marker. If `COPILOT_PENDING` is `"true"` in this
-     branch, first remove the stale/unproven pending reviewer request:
+     proven; request cap < `REQUEST_CAP`): request Copilot review and
+     immediately post a plain-text marker. If `COPILOT_PENDING` is
+     `"true"` in this branch, first remove the stale/unproven pending
+     reviewer request:
 
      ```sh
      gh pr edit {pr-number} --remove-reviewer "@copilot"
@@ -183,7 +188,7 @@ the `createdAt` of the latest
 a trusted marker actor. If no trusted same-claim watermark exists, stop
 and return to E1 to create one.
 
-Poll every 2 minutes:
+Poll every `POLL_INTERVAL_MINUTES` minutes:
 
 1. Re-fetch `PR_HEAD_SHA`:
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -165,6 +165,20 @@ for parameterized follow-up work: `stallRecovery`, `forcedHandoff`,
 `critiqueLoop`, `reviewEscalation`, `approvalSignals`, and
 `issueAuthoring`. Leaving these keys unset keeps distributed behavior.
 
+For advisory review timing, repositories may now customize
+`advisoryWait.requestCap`, `advisoryWait.pendingWindow`,
+`advisoryWait.settledWindow`, and `advisoryWait.pollInterval` in
+`.github/idd/config.json`. Keep those keys aligned with the helper
+contracts and any instruction text that references the effective wait
+values. The three duration keys accept positive whole-minute ISO 8601
+durations only; zero-length values and second-based values are invalid.
+
+`advisoryWait.capExhaustedRoute` is intentionally fail-closed. The
+default `phase-specific` behavior keeps the current E14 skip / F2-F3
+hold split, while `hold` is a stricter override that also stops E14 on
+cap exhaustion. Do not introduce an override that weakens the F2/F3
+merge hold.
+
 ## Phase ID Compatibility Contract
 
 Treat phase IDs as a compatibility surface, not as presentation text.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -258,7 +258,9 @@ default `instructions-only` profile keep using the written shell /
 - Stable fields consumed by the instructions: `prHeadSha`,
   `lastCopilotCommit`, `copilotPending`,
   `copilotPendingCoversHead`, `outcome`, `f3Outcome`,
-  `earliestSameHeadAt`, `requestMarkerCount`, and
+  `earliestSameHeadAt`, `requestMarkerCount`, `requestCap`,
+  `pendingWindowMinutes`, `settledWindowMinutes`,
+  `pollIntervalMinutes`, `capExhaustedRoute`, and
   `trustedMarkerSummary`
 
 ### Merge-gate evidence
@@ -280,7 +282,8 @@ default `instructions-only` profile keep using the written shell /
   [`pre-merge-readiness.schema.json`][pre-merge-readiness-schema]
 - Stable sections consumed by the instructions: `reviewCurrency`,
   `threads`, `unrepliedComments`, `reviewerStates`,
-  `advisoryWait`, `ci`, `claim`, and optional
+  `advisoryWait` (including the effective advisory policy fields), `ci`,
+  `claim`, and optional
   `dispositionEvidence`
 
 ### E7 disposition verification

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -141,7 +141,8 @@ The current policy schema and helper runtime now support
 `.github/idd/config.json` `advisoryWait.requestCap`,
 `advisoryWait.pendingWindow`, `advisoryWait.settledWindow`,
 `advisoryWait.pollInterval`, and `advisoryWait.capExhaustedRoute`.
-Omitted keys keep the distributed defaults below.
+Omitted keys keep the distributed defaults below. The three duration
+keys accept positive whole-minute ISO 8601 durations only.
 
 | Policy default                          | Distributed value                                                           | Owning surface                                                                                                                                                                                                       | Onboarding expectation                                                                       |
 | --------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -137,6 +137,12 @@ The distributed PR policy is `copilot-advisory`. These values apply to
 that profile and remain policy defaults until the relevant instruction
 files are edited.
 
+The current policy schema and helper runtime now support
+`.github/idd/config.json` `advisoryWait.requestCap`,
+`advisoryWait.pendingWindow`, `advisoryWait.settledWindow`,
+`advisoryWait.pollInterval`, and `advisoryWait.capExhaustedRoute`.
+Omitted keys keep the distributed defaults below.
+
 | Policy default                          | Distributed value                                                           | Owning surface                                                                                                                                                                                                       | Onboarding expectation                                                                       |
 | --------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | Copilot re-review request cap           | 30 requests per PR                                                          | [Review fix](../.github/instructions/idd-review-fix.instructions.md), [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)                                                                     | Confirm that the repository accepts this process cap before using the default advisory flow. |

--- a/schemas/advisory-wait-state.schema.json
+++ b/schemas/advisory-wait-state.schema.json
@@ -73,13 +73,16 @@
       "minimum": 1
     },
     "pendingWindowMinutes": {
-      "type": "number"
+      "type": "number",
+      "exclusiveMinimum": 0
     },
     "settledWindowMinutes": {
-      "type": "number"
+      "type": "number",
+      "exclusiveMinimum": 0
     },
     "pollIntervalMinutes": {
-      "type": "number"
+      "type": "number",
+      "exclusiveMinimum": 0
     },
     "capExhaustedRoute": {
       "type": "string",

--- a/schemas/advisory-wait-state.schema.json
+++ b/schemas/advisory-wait-state.schema.json
@@ -16,6 +16,8 @@
     "requestCap",
     "pendingWindowMinutes",
     "settledWindowMinutes",
+    "pollIntervalMinutes",
+    "capExhaustedRoute",
     "elapsedMinutes",
     "sameHeadMarkerPresent",
     "earliestSameHeadAt",
@@ -67,13 +69,21 @@
       "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
     },
     "requestCap": {
-      "type": "number"
+      "type": "integer",
+      "minimum": 1
     },
     "pendingWindowMinutes": {
       "type": "number"
     },
     "settledWindowMinutes": {
       "type": "number"
+    },
+    "pollIntervalMinutes": {
+      "type": "number"
+    },
+    "capExhaustedRoute": {
+      "type": "string",
+      "enum": ["phase-specific", "hold"]
     },
     "elapsedMinutes": {
       "type": "number"

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -225,19 +225,19 @@
         },
         "pendingWindow": {
           "type": "string",
-          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+          "pattern": "^P(?=(?:\\d+D|T\\d+[HM]))(?=.*(?:[1-9]\\d*[DHM]))(?:\\d+D)?(?:T(?=\\d+[HM])(?:\\d+H)?(?:\\d+M)?)?$"
         },
         "settledWindow": {
           "type": "string",
-          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+          "pattern": "^P(?=(?:\\d+D|T\\d+[HM]))(?=.*(?:[1-9]\\d*[DHM]))(?:\\d+D)?(?:T(?=\\d+[HM])(?:\\d+H)?(?:\\d+M)?)?$"
         },
         "pollInterval": {
           "type": "string",
-          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
+          "pattern": "^P(?=(?:\\d+D|T\\d+[HM]))(?=.*(?:[1-9]\\d*[DHM]))(?:\\d+D)?(?:T(?=\\d+[HM])(?:\\d+H)?(?:\\d+M)?)?$"
         },
         "capExhaustedRoute": {
           "type": "string",
-          "enum": ["phase-default", "strict-hold"]
+          "enum": ["phase-specific", "hold"]
         }
       }
     },

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -350,9 +350,9 @@
         "sameHeadMarkerCount": { "type": "integer", "minimum": 0 },
         "requestMarkerCount": { "type": "integer", "minimum": 0 },
         "requestCap": { "type": "integer", "minimum": 1 },
-        "pendingWindowMinutes": { "type": "number" },
-        "settledWindowMinutes": { "type": "number" },
-        "pollIntervalMinutes": { "type": "number" },
+        "pendingWindowMinutes": { "type": "number", "exclusiveMinimum": 0 },
+        "settledWindowMinutes": { "type": "number", "exclusiveMinimum": 0 },
+        "pollIntervalMinutes": { "type": "number", "exclusiveMinimum": 0 },
         "capExhaustedRoute": {
           "type": "string",
           "enum": ["phase-specific", "hold"]

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -307,6 +307,11 @@
         "earliestSameHeadAt",
         "sameHeadMarkerCount",
         "requestMarkerCount",
+        "requestCap",
+        "pendingWindowMinutes",
+        "settledWindowMinutes",
+        "pollIntervalMinutes",
+        "capExhaustedRoute",
         "elapsedMinutes"
       ],
       "additionalProperties": false,
@@ -344,6 +349,14 @@
         },
         "sameHeadMarkerCount": { "type": "integer", "minimum": 0 },
         "requestMarkerCount": { "type": "integer", "minimum": 0 },
+        "requestCap": { "type": "integer", "minimum": 1 },
+        "pendingWindowMinutes": { "type": "number" },
+        "settledWindowMinutes": { "type": "number" },
+        "pollIntervalMinutes": { "type": "number" },
+        "capExhaustedRoute": {
+          "type": "string",
+          "enum": ["phase-specific", "hold"]
+        },
         "elapsedMinutes": { "type": "integer", "minimum": 0 }
       }
     },

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 
+import { loadJson, validate } from "./validate-schemas.mjs";
+
 export const DEFAULT_ADVISORY_REQUEST_CAP = 30;
 export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
 export const DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES = 10;
@@ -9,10 +11,15 @@ export const ADVISORY_CAP_EXHAUSTED_ROUTES = new Set([
   "phase-specific",
   "hold",
 ]);
+const POLICY_SCHEMA = loadJson("schemas/policy.schema.json");
 
 export function readAdvisoryWaitPolicy(path = ".github/idd/config.json") {
   try {
-    return resolveAdvisoryWaitPolicy(JSON.parse(readFileSync(path, "utf8")));
+    const config = JSON.parse(readFileSync(path, "utf8"));
+    if (validate(config, POLICY_SCHEMA).length > 0) {
+      return resolveAdvisoryWaitPolicy({});
+    }
+    return resolveAdvisoryWaitPolicy(config);
   } catch {
     return resolveAdvisoryWaitPolicy({});
   }
@@ -100,16 +107,15 @@ function normalizeCapExhaustedRoute(value) {
 
 function parseConfiguredDurationToMs(value) {
   if (typeof value !== "string" || value.length === 0) return null;
-  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(value);
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?)?$/.exec(value);
   if (!match) return null;
   const hasTimeDesignator = value.includes("T");
-  const hasAnyTimeUnit = match[2] !== undefined || match[3] !== undefined || match[4] !== undefined;
+  const hasAnyTimeUnit = match[2] !== undefined || match[3] !== undefined;
   if (hasTimeDesignator && !hasAnyTimeUnit) return null;
   const days = Number.parseInt(match[1] ?? "0", 10);
   const hours = Number.parseInt(match[2] ?? "0", 10);
   const minutes = Number.parseInt(match[3] ?? "0", 10);
-  const seconds = Number.parseInt(match[4] ?? "0", 10);
-  const totalMilliseconds = ((((days * 24) + hours) * 60 + minutes) * 60 + seconds) * 1000;
+  const totalMilliseconds = (((days * 24) + hours) * 60 + minutes) * 60000;
   if (totalMilliseconds <= 0 || totalMilliseconds % 60000 !== 0) {
     return null;
   }

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+
+export const DEFAULT_ADVISORY_REQUEST_CAP = 30;
+export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
+export const DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES = 10;
+export const DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES = 2;
+export const ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT = "phase-specific";
+export const ADVISORY_CAP_EXHAUSTED_ROUTES = new Set([
+  "phase-specific",
+  "hold",
+]);
+
+export function readAdvisoryWaitPolicy(path = ".github/idd/config.json") {
+  try {
+    return resolveAdvisoryWaitPolicy(JSON.parse(readFileSync(path, "utf8")));
+  } catch {
+    return resolveAdvisoryWaitPolicy({});
+  }
+}
+
+export function resolveAdvisoryWaitPolicy(config = {}) {
+  const advisoryWait = config?.advisoryWait ?? {};
+
+  return {
+    requestCap: normalizePositiveInteger(
+      advisoryWait.requestCap,
+      DEFAULT_ADVISORY_REQUEST_CAP,
+    ),
+    pendingWindowMinutes: normalizeDurationMinutes(
+      advisoryWait.pendingWindow,
+      DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES,
+    ),
+    settledWindowMinutes: normalizeDurationMinutes(
+      advisoryWait.settledWindow,
+      DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES,
+    ),
+    pollIntervalMinutes: normalizeDurationMinutes(
+      advisoryWait.pollInterval,
+      DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES,
+    ),
+    capExhaustedRoute: normalizeCapExhaustedRoute(advisoryWait.capExhaustedRoute),
+  };
+}
+
+function normalizePositiveInteger(value, fallback) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : fallback;
+}
+
+function normalizeDurationMinutes(value, fallback) {
+  const milliseconds = parseDurationToMs(value);
+  return milliseconds && milliseconds > 0 ? milliseconds / 60000 : fallback;
+}
+
+function normalizeCapExhaustedRoute(value) {
+  const route = String(value ?? "").trim();
+  return ADVISORY_CAP_EXHAUSTED_ROUTES.has(route)
+    ? route
+    : ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT;
+}
+
+function parseDurationToMs(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i.exec(text);
+  if (!match) return null;
+  const days = Number.parseInt(match[1] ?? "0", 10);
+  const hours = Number.parseInt(match[2] ?? "0", 10);
+  const minutes = Number.parseInt(match[3] ?? "0", 10);
+  const seconds = Number.parseInt(match[4] ?? "0", 10);
+  return ((((days * 24) + hours) * 60 + minutes) * 60 + seconds) * 1000;
+}

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -22,23 +22,23 @@ export function resolveAdvisoryWaitPolicy(config = {}) {
   const advisoryWait = config?.advisoryWait ?? {};
 
   return {
-    requestCap: normalizePositiveInteger(
+    requestCap: normalizeConfiguredPositiveInteger(
       advisoryWait.requestCap,
       DEFAULT_ADVISORY_REQUEST_CAP,
     ),
-    pendingWindowMinutes: normalizeDurationMinutes(
+    pendingWindowMinutes: normalizeConfiguredDurationMinutes(
       advisoryWait.pendingWindow,
       DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES,
     ),
-    settledWindowMinutes: normalizeDurationMinutes(
+    settledWindowMinutes: normalizeConfiguredDurationMinutes(
       advisoryWait.settledWindow,
       DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES,
     ),
-    pollIntervalMinutes: normalizeDurationMinutes(
+    pollIntervalMinutes: normalizeConfiguredDurationMinutes(
       advisoryWait.pollInterval,
       DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES,
     ),
-    capExhaustedRoute: normalizeCapExhaustedRoute(advisoryWait.capExhaustedRoute),
+    capExhaustedRoute: normalizeConfiguredCapExhaustedRoute(advisoryWait.capExhaustedRoute),
   };
 }
 
@@ -69,14 +69,26 @@ function normalizePositiveInteger(value, fallback) {
   return Number.isInteger(number) && number > 0 ? number : fallback;
 }
 
+function normalizeConfiguredPositiveInteger(value, fallback) {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : fallback;
+}
+
 function normalizePositiveNumber(value, fallback) {
   const number = Number(value);
   return Number.isFinite(number) && number > 0 ? number : fallback;
 }
 
-function normalizeDurationMinutes(value, fallback) {
-  const milliseconds = parseDurationToMs(value);
+function normalizeConfiguredDurationMinutes(value, fallback) {
+  const milliseconds = parseConfiguredDurationToMs(value);
   return milliseconds && milliseconds > 0 ? milliseconds / 60000 : fallback;
+}
+
+function normalizeConfiguredCapExhaustedRoute(value) {
+  return ADVISORY_CAP_EXHAUSTED_ROUTES.has(value)
+    ? value
+    : ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT;
 }
 
 function normalizeCapExhaustedRoute(value) {
@@ -86,12 +98,11 @@ function normalizeCapExhaustedRoute(value) {
     : ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT;
 }
 
-function parseDurationToMs(value) {
-  const text = String(value ?? "").trim();
-  if (!text) return null;
-  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i.exec(text);
+function parseConfiguredDurationToMs(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(value);
   if (!match) return null;
-  const hasTimeDesignator = /T/i.test(text);
+  const hasTimeDesignator = value.includes("T");
   const hasAnyTimeUnit = match[2] !== undefined || match[3] !== undefined || match[4] !== undefined;
   if (hasTimeDesignator && !hasAnyTimeUnit) return null;
   const days = Number.parseInt(match[1] ?? "0", 10);

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -42,9 +42,36 @@ export function resolveAdvisoryWaitPolicy(config = {}) {
   };
 }
 
+export function normalizeAdvisoryWaitRuntimeOptions(options = {}) {
+  return {
+    requestCap: normalizePositiveInteger(
+      options.requestCap,
+      DEFAULT_ADVISORY_REQUEST_CAP,
+    ),
+    pendingWindowMinutes: normalizePositiveNumber(
+      options.pendingWindowMinutes,
+      DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES,
+    ),
+    settledWindowMinutes: normalizePositiveNumber(
+      options.settledWindowMinutes,
+      DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES,
+    ),
+    pollIntervalMinutes: normalizePositiveNumber(
+      options.pollIntervalMinutes,
+      DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES,
+    ),
+    capExhaustedRoute: normalizeCapExhaustedRoute(options.capExhaustedRoute),
+  };
+}
+
 function normalizePositiveInteger(value, fallback) {
   const number = Number(value);
   return Number.isInteger(number) && number > 0 ? number : fallback;
+}
+
+function normalizePositiveNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
 }
 
 function normalizeDurationMinutes(value, fallback) {
@@ -64,6 +91,9 @@ function parseDurationToMs(value) {
   if (!text) return null;
   const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i.exec(text);
   if (!match) return null;
+  const hasTimeDesignator = /T/i.test(text);
+  const hasAnyTimeUnit = match[2] !== undefined || match[3] !== undefined || match[4] !== undefined;
+  if (hasTimeDesignator && !hasAnyTimeUnit) return null;
   const days = Number.parseInt(match[1] ?? "0", 10);
   const hours = Number.parseInt(match[2] ?? "0", 10);
   const minutes = Number.parseInt(match[3] ?? "0", 10);

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -109,5 +109,9 @@ function parseConfiguredDurationToMs(value) {
   const hours = Number.parseInt(match[2] ?? "0", 10);
   const minutes = Number.parseInt(match[3] ?? "0", 10);
   const seconds = Number.parseInt(match[4] ?? "0", 10);
-  return ((((days * 24) + hours) * 60 + minutes) * 60 + seconds) * 1000;
+  const totalMilliseconds = ((((days * 24) + hours) * 60 + minutes) * 60 + seconds) * 1000;
+  if (totalMilliseconds <= 0 || totalMilliseconds % 60000 !== 0) {
+    return null;
+  }
+  return totalMilliseconds;
 }

--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 
+import { readAdvisoryWaitPolicy } from "./advisory-wait-policy.mjs";
 import {
   buildAdvisoryWaitSummary,
   normalizeTrustedMarkerLogins,
@@ -56,6 +57,7 @@ const trustedMarkerLogins = normalizeTrustedMarkerLogins([
     ? resolveTrustedCollaboratorMarkerLogins(owner, repo, comments)
     : []),
 ]);
+const advisoryWaitPolicy = readAdvisoryWaitPolicy();
 
 const summary = buildAdvisoryWaitSummary(
   {
@@ -67,9 +69,11 @@ const summary = buildAdvisoryWaitSummary(
   },
   {
     now: args.now || new Date().toISOString().replace(".000Z", "Z"),
-    requestCap: 30,
-    pendingWindowMinutes: 30,
-    settledWindowMinutes: 10,
+    requestCap: advisoryWaitPolicy.requestCap,
+    pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
+    settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
+    pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
+    capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
     viewerLogin,
     configuredTrustedActors,
     collaboratorTrustEnabled,

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -12,6 +12,9 @@ const SOURCE_REPOSITORY = "github:kurone-kito/idd-skill";
 const PACKAGE_SPEC_PIN_HINT = "Pass --package-spec with a pinned tarball URL or reviewed commit archive when you need reproducible helper imports.";
 const NODE_ENGINES = "^22.22.2 || >=24";
 const SCRIPT_FILE_EXTENSIONS = [".mjs", ".js", ".json"];
+const EXTRA_RUNTIME_FILES = new Map([
+  ["scripts/advisory-wait-policy.mjs", ["schemas/policy.schema.json"]],
+]);
 
 const HELPER_COMMANDS = [
   {
@@ -256,7 +259,11 @@ export function collectVendoredFiles(packageRoot = resolve(dirname(fileURLToPath
       continue;
     }
     visited.add(current);
-    managedFiles.add(relativePath(packageRoot, current));
+    const currentPath = relativePath(packageRoot, current);
+    managedFiles.add(currentPath);
+    for (const extraFile of EXTRA_RUNTIME_FILES.get(currentPath) ?? []) {
+      managedFiles.add(relativePath(packageRoot, resolve(packageRoot, extraFile)));
+    }
 
     const source = readFileSync(current, "utf8");
     for (const specifier of findRelativeImports(source)) {

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -9,10 +9,15 @@ const ISSUE_SCOPES = new Set(["roadmap", "orphan-first"]);
 const ORPHAN_FIRST_POLICIES = new Set(["none", "maintainer-approved", "public-disabled"]);
 const APPROVAL_ACTOR_POLICIES = new Set(["owners-and-maintainers-only", "all-write-permission-actors"]);
 const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
-const ADVISORY_CAP_ROUTES = new Set(["phase-default", "strict-hold"]);
+const ADVISORY_CAP_ROUTES = new Set(["phase-specific", "hold"]);
+const LEGACY_ADVISORY_CAP_ROUTE_ALIASES = new Map([
+  ["phase-default", "phase-specific"],
+  ["strict-hold", "hold"],
+]);
 const CI_RERUN_POLICIES = new Set(["rerun-once"]);
 const LABEL_FRESHNESS_MODES = new Set(["presence-only", "event-freshness"]);
 const ISO_DURATION_RE = /^P(?=\d|T\d)(?:\d+D)?(?:T(?=\d)(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$/;
+const ADVISORY_WHOLE_MINUTE_DURATION_RE = /^P(?=(?:\d+D|T\d+[HM]))(?=.*(?:[1-9]\d*[DHM]))(?:\d+D)?(?:T(?=\d+[HM])(?:\d+H)?(?:\d+M)?)?$/;
 
 export const POLICY_DEFAULTS = Object.freeze({
   issueScope: "roadmap",
@@ -34,7 +39,7 @@ export const POLICY_DEFAULTS = Object.freeze({
     pendingWindow: "PT30M",
     settledWindow: "PT10M",
     pollInterval: "PT2M",
-    capExhaustedRoute: "phase-default",
+    capExhaustedRoute: "phase-specific",
   }),
   ciWait: Object.freeze({
     runningTimeout: "PT30M",
@@ -167,21 +172,20 @@ export function normalizePolicyConfig(config) {
     },
     advisoryWait: {
       requestCap: parsePositiveInteger(config?.advisoryWait?.requestCap, POLICY_DEFAULTS.advisoryWait.requestCap),
-      pendingWindow: parseDuration(
+      pendingWindow: parseAdvisoryWholeMinuteDuration(
         config?.advisoryWait?.pendingWindow,
         POLICY_DEFAULTS.advisoryWait.pendingWindow,
       ),
-      settledWindow: parseDuration(
+      settledWindow: parseAdvisoryWholeMinuteDuration(
         config?.advisoryWait?.settledWindow,
         POLICY_DEFAULTS.advisoryWait.settledWindow,
       ),
-      pollInterval: parseDuration(
+      pollInterval: parseAdvisoryWholeMinuteDuration(
         config?.advisoryWait?.pollInterval,
         POLICY_DEFAULTS.advisoryWait.pollInterval,
       ),
-      capExhaustedRoute: parseEnum(
+      capExhaustedRoute: parseAdvisoryCapRoute(
         config?.advisoryWait?.capExhaustedRoute,
-        ADVISORY_CAP_ROUTES,
         POLICY_DEFAULTS.advisoryWait.capExhaustedRoute,
       ),
     },
@@ -293,6 +297,23 @@ function parseEnum(value, accepted, fallback) {
 function parseDuration(value, fallback) {
   if (typeof value === "string" && ISO_DURATION_RE.test(value)) {
     return value;
+  }
+  return fallback;
+}
+
+function parseAdvisoryWholeMinuteDuration(value, fallback) {
+  if (typeof value === "string" && ADVISORY_WHOLE_MINUTE_DURATION_RE.test(value)) {
+    return value;
+  }
+  return fallback;
+}
+
+function parseAdvisoryCapRoute(value, fallback) {
+  if (typeof value === "string") {
+    if (ADVISORY_CAP_ROUTES.has(value)) {
+      return value;
+    }
+    return LEGACY_ADVISORY_CAP_ROUTE_ALIASES.get(value) ?? fallback;
   }
   return fallback;
 }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -3,6 +3,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
+import { readAdvisoryWaitPolicy } from "./advisory-wait-policy.mjs";
 import {
   buildPreMergeReadinessSummary,
   deriveIddAgentLogins,
@@ -115,6 +116,7 @@ const iddAgentLogins = deriveIddAgentLogins({
   trustedMarkerLogins,
   operationalComments: [...comments, ...claimComments],
 });
+const advisoryWaitPolicy = readAdvisoryWaitPolicy();
 const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
 const forcedHandoffEnabled = readForcedHandoffMode() === "human-gated";
 const forcedHandoffPermissionCache = new Map();
@@ -144,9 +146,11 @@ const summary = buildPreMergeReadinessSummary(
     expectedClaimId: args.expectedClaimId,
     expectedAgentId: args.expectedAgentId,
     includeDispositionEvidence: true,
-    requestCap: 30,
-    pendingWindowMinutes: 30,
-    settledWindowMinutes: 10,
+    requestCap: advisoryWaitPolicy.requestCap,
+    pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
+    settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
+    pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
+    capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
     forcedHandoffEnabled,
     expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
     isAuthorizedForcedHandoff:

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -7,6 +7,7 @@ import {
   DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES,
   DEFAULT_ADVISORY_REQUEST_CAP,
   DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES,
+  normalizeAdvisoryWaitRuntimeOptions,
 } from "./advisory-wait-policy.mjs";
 
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
@@ -992,15 +993,11 @@ export function summarizeAdvisoryWaitMarkers(comments, prHeadSha, trustedMarkerL
 }
 
 export function evaluateAdvisoryWaitOutcome(input) {
-  const requestCap = Number.isFinite(input.requestCap)
-    ? input.requestCap
-    : DEFAULT_ADVISORY_REQUEST_CAP;
-  const pendingWindowMinutes = Number.isFinite(input.pendingWindowMinutes)
-    ? input.pendingWindowMinutes
-    : DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES;
-  const settledWindowMinutes = Number.isFinite(input.settledWindowMinutes)
-    ? input.settledWindowMinutes
-    : DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES;
+  const {
+    requestCap,
+    pendingWindowMinutes,
+    settledWindowMinutes,
+  } = normalizeAdvisoryWaitRuntimeOptions(input);
 
   if (input.lastCopilotCommit === input.prHeadSha) {
     return "SATISFIED";
@@ -1056,21 +1053,13 @@ export function buildAdvisoryWaitSummary(
   const lastCopilotCommit = findLastCopilotReviewCommit(reviews);
   const copilotPending = isCopilotPending(requestedReviewers);
   const copilotPendingCoversHead = computeCopilotPendingCoversHead(timelineEvents, prHeadSha);
-  const requestCap = Number.isFinite(options.requestCap)
-    ? options.requestCap
-    : DEFAULT_ADVISORY_REQUEST_CAP;
-  const pendingWindowMinutes = Number.isFinite(options.pendingWindowMinutes)
-    ? options.pendingWindowMinutes
-    : DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES;
-  const settledWindowMinutes = Number.isFinite(options.settledWindowMinutes)
-    ? options.settledWindowMinutes
-    : DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES;
-  const pollIntervalMinutes = Number.isFinite(options.pollIntervalMinutes)
-    ? options.pollIntervalMinutes
-    : DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES;
-  const capExhaustedRoute = ADVISORY_CAP_EXHAUSTED_ROUTES.has(options.capExhaustedRoute)
-    ? options.capExhaustedRoute
-    : ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT;
+  const {
+    requestCap,
+    pendingWindowMinutes,
+    settledWindowMinutes,
+    pollIntervalMinutes,
+    capExhaustedRoute,
+  } = normalizeAdvisoryWaitRuntimeOptions(options);
 
   return {
     protocolVersion: "1",
@@ -1871,6 +1860,7 @@ export function buildPreMergeReadinessSummary(
     advisoryBotLogins,
   });
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection);
+  const advisoryWaitOptions = normalizeAdvisoryWaitRuntimeOptions(options);
   const advisoryWait = buildAdvisoryWaitSummary(
     {
       prHeadSha,
@@ -1881,21 +1871,7 @@ export function buildPreMergeReadinessSummary(
     },
     {
       now,
-      requestCap: Number.isFinite(options.requestCap)
-        ? options.requestCap
-        : DEFAULT_ADVISORY_REQUEST_CAP,
-      pendingWindowMinutes: Number.isFinite(options.pendingWindowMinutes)
-        ? options.pendingWindowMinutes
-        : DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES,
-      settledWindowMinutes: Number.isFinite(options.settledWindowMinutes)
-        ? options.settledWindowMinutes
-        : DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES,
-      pollIntervalMinutes: Number.isFinite(options.pollIntervalMinutes)
-        ? options.pollIntervalMinutes
-        : DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES,
-      capExhaustedRoute: ADVISORY_CAP_EXHAUSTED_ROUTES.has(options.capExhaustedRoute)
-        ? options.capExhaustedRoute
-        : ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT,
+      ...advisoryWaitOptions,
       viewerLogin: options.viewerLogin,
       configuredTrustedActors: options.configuredTrustedActors,
       collaboratorTrustEnabled: options.collaboratorTrustEnabled,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1,5 +1,14 @@
 import { Buffer } from "node:buffer";
 
+import {
+  ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT,
+  ADVISORY_CAP_EXHAUSTED_ROUTES,
+  DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES,
+  DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES,
+  DEFAULT_ADVISORY_REQUEST_CAP,
+  DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES,
+} from "./advisory-wait-policy.mjs";
+
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
 const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
 
@@ -983,13 +992,15 @@ export function summarizeAdvisoryWaitMarkers(comments, prHeadSha, trustedMarkerL
 }
 
 export function evaluateAdvisoryWaitOutcome(input) {
-  const requestCap = Number.isFinite(input.requestCap) ? input.requestCap : 30;
+  const requestCap = Number.isFinite(input.requestCap)
+    ? input.requestCap
+    : DEFAULT_ADVISORY_REQUEST_CAP;
   const pendingWindowMinutes = Number.isFinite(input.pendingWindowMinutes)
     ? input.pendingWindowMinutes
-    : 30;
+    : DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES;
   const settledWindowMinutes = Number.isFinite(input.settledWindowMinutes)
     ? input.settledWindowMinutes
-    : 10;
+    : DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES;
 
   if (input.lastCopilotCommit === input.prHeadSha) {
     return "SATISFIED";
@@ -1045,13 +1056,21 @@ export function buildAdvisoryWaitSummary(
   const lastCopilotCommit = findLastCopilotReviewCommit(reviews);
   const copilotPending = isCopilotPending(requestedReviewers);
   const copilotPendingCoversHead = computeCopilotPendingCoversHead(timelineEvents, prHeadSha);
-  const requestCap = Number.isFinite(options.requestCap) ? options.requestCap : 30;
+  const requestCap = Number.isFinite(options.requestCap)
+    ? options.requestCap
+    : DEFAULT_ADVISORY_REQUEST_CAP;
   const pendingWindowMinutes = Number.isFinite(options.pendingWindowMinutes)
     ? options.pendingWindowMinutes
-    : 30;
+    : DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES;
   const settledWindowMinutes = Number.isFinite(options.settledWindowMinutes)
     ? options.settledWindowMinutes
-    : 10;
+    : DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES;
+  const pollIntervalMinutes = Number.isFinite(options.pollIntervalMinutes)
+    ? options.pollIntervalMinutes
+    : DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES;
+  const capExhaustedRoute = ADVISORY_CAP_EXHAUSTED_ROUTES.has(options.capExhaustedRoute)
+    ? options.capExhaustedRoute
+    : ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT;
 
   return {
     protocolVersion: "1",
@@ -1087,6 +1106,8 @@ export function buildAdvisoryWaitSummary(
     requestCap,
     pendingWindowMinutes,
     settledWindowMinutes,
+    pollIntervalMinutes,
+    capExhaustedRoute,
     elapsedMinutes,
     sameHeadMarkerPresent: markerSummary.sameHeadMarkerPresent,
     earliestSameHeadAt: markerSummary.earliestSameHeadAt,
@@ -1860,13 +1881,21 @@ export function buildPreMergeReadinessSummary(
     },
     {
       now,
-      requestCap: Number.isFinite(options.requestCap) ? options.requestCap : 30,
+      requestCap: Number.isFinite(options.requestCap)
+        ? options.requestCap
+        : DEFAULT_ADVISORY_REQUEST_CAP,
       pendingWindowMinutes: Number.isFinite(options.pendingWindowMinutes)
         ? options.pendingWindowMinutes
-        : 30,
+        : DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES,
       settledWindowMinutes: Number.isFinite(options.settledWindowMinutes)
         ? options.settledWindowMinutes
-        : 10,
+        : DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES,
+      pollIntervalMinutes: Number.isFinite(options.pollIntervalMinutes)
+        ? options.pollIntervalMinutes
+        : DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES,
+      capExhaustedRoute: ADVISORY_CAP_EXHAUSTED_ROUTES.has(options.capExhaustedRoute)
+        ? options.capExhaustedRoute
+        : ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT,
       viewerLogin: options.viewerLogin,
       configuredTrustedActors: options.configuredTrustedActors,
       collaboratorTrustEnabled: options.collaboratorTrustEnabled,
@@ -1943,6 +1972,11 @@ export function buildPreMergeReadinessSummary(
       earliestSameHeadAt: advisoryWait.earliestSameHeadAt,
       sameHeadMarkerCount: advisoryWait.sameHeadMarkerCount,
       requestMarkerCount: advisoryWait.requestMarkerCount,
+      requestCap: advisoryWait.requestCap,
+      pendingWindowMinutes: advisoryWait.pendingWindowMinutes,
+      settledWindowMinutes: advisoryWait.settledWindowMinutes,
+      pollIntervalMinutes: advisoryWait.pollIntervalMinutes,
+      capExhaustedRoute: advisoryWait.capExhaustedRoute,
       elapsedMinutes: advisoryWait.elapsedMinutes,
     },
     ci,

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -6,7 +6,7 @@
  *
  * Supported enforcement keywords:
  *   type, required, properties, patternProperties, additionalProperties,
- *   minLength, minimum, pattern, format (date-time only),
+ *   minLength, minimum, exclusiveMinimum, pattern, format (date-time only),
  *   minItems, items, enum
  *
  * Any other keyword in a schema triggers an error, preventing false
@@ -31,6 +31,7 @@ const ENFORCED_KEYWORDS = new Set([
   "additionalProperties",
   "minLength",
   "minimum",
+  "exclusiveMinimum",
   "pattern",
   "format",
   "minItems",
@@ -131,6 +132,9 @@ export function validate(data, schema, path = "$") {
 
   if (actualType === "number" && schema.minimum !== undefined && data < schema.minimum) {
     errors.push(`${path}: ${data} < minimum ${schema.minimum}`);
+  }
+  if (actualType === "number" && schema.exclusiveMinimum !== undefined && data <= schema.exclusiveMinimum) {
+    errors.push(`${path}: ${data} <= exclusiveMinimum ${schema.exclusiveMinimum}`);
   }
 
   if (actualType === "array") {

--- a/tests/advisory-wait.test.mjs
+++ b/tests/advisory-wait.test.mjs
@@ -174,6 +174,20 @@ test("advisory wait policy resolves defaults, explicit values, and fail-safe fal
     pollIntervalMinutes: 2,
     capExhaustedRoute: "phase-specific",
   });
+
+  assert.deepEqual(resolveAdvisoryWaitPolicy({
+    advisoryWait: {
+      pendingWindow: "PT0M",
+      settledWindow: "PT30S",
+      pollInterval: "PT90S",
+    },
+  }), {
+    requestCap: 30,
+    pendingWindowMinutes: 30,
+    settledWindowMinutes: 10,
+    pollIntervalMinutes: 2,
+    capExhaustedRoute: "phase-specific",
+  });
 });
 
 test("advisory wait summary normalizes invalid direct options to defaults", () => {

--- a/tests/advisory-wait.test.mjs
+++ b/tests/advisory-wait.test.mjs
@@ -158,6 +158,22 @@ test("advisory wait policy resolves defaults, explicit values, and fail-safe fal
     pollIntervalMinutes: 2,
     capExhaustedRoute: "phase-specific",
   });
+
+  assert.deepEqual(resolveAdvisoryWaitPolicy({
+    advisoryWait: {
+      requestCap: "1",
+      pendingWindow: "pt1m",
+      settledWindow: " PT5M ",
+      pollInterval: "pt3m",
+      capExhaustedRoute: " hold ",
+    },
+  }), {
+    requestCap: 30,
+    pendingWindowMinutes: 30,
+    settledWindowMinutes: 10,
+    pollIntervalMinutes: 2,
+    capExhaustedRoute: "phase-specific",
+  });
 });
 
 test("advisory wait summary normalizes invalid direct options to defaults", () => {

--- a/tests/advisory-wait.test.mjs
+++ b/tests/advisory-wait.test.mjs
@@ -8,6 +8,7 @@ import {
   operationalMarkerPrefix,
   unsafeTextReason,
 } from "../scripts/protocol-helpers.mjs";
+import { resolveAdvisoryWaitPolicy } from "../scripts/advisory-wait-policy.mjs";
 import { loadJson, validate } from "../scripts/validate-schemas.mjs";
 
 const ciSuccess = readJson("fixtures/ci/success.json");
@@ -90,6 +91,11 @@ for (const fixtureName of [
     assert.equal(summary.sameHeadMarkerPresent, expected.sameHeadMarkerPresent);
     assert.equal(summary.sameHeadMarkerCount, expected.sameHeadMarkerCount);
     assert.equal(summary.requestMarkerCount, expected.requestMarkerCount);
+    assert.equal(summary.requestCap, input.requestCap ?? 30);
+    assert.equal(summary.pendingWindowMinutes, input.pendingWindowMinutes ?? 30);
+    assert.equal(summary.settledWindowMinutes, input.settledWindowMinutes ?? 10);
+    assert.equal(summary.pollIntervalMinutes, 2);
+    assert.equal(summary.capExhaustedRoute, "phase-specific");
     assert.equal(summary.earliestSameHeadAt, expected.earliestSameHeadAt);
     assert.equal(summary.elapsedMinutes, expected.elapsedMinutes);
     assert.equal(
@@ -111,6 +117,48 @@ for (const fixtureName of [
     assert.deepEqual(validate(summary, advisoryWaitSchema), []);
   });
 }
+
+test("advisory wait policy resolves defaults, explicit values, and fail-safe fallbacks", () => {
+  assert.deepEqual(resolveAdvisoryWaitPolicy({}), {
+    requestCap: 30,
+    pendingWindowMinutes: 30,
+    settledWindowMinutes: 10,
+    pollIntervalMinutes: 2,
+    capExhaustedRoute: "phase-specific",
+  });
+
+  assert.deepEqual(resolveAdvisoryWaitPolicy({
+    advisoryWait: {
+      requestCap: 12,
+      pendingWindow: "PT45M",
+      settledWindow: "PT15M",
+      pollInterval: "PT3M",
+      capExhaustedRoute: "hold",
+    },
+  }), {
+    requestCap: 12,
+    pendingWindowMinutes: 45,
+    settledWindowMinutes: 15,
+    pollIntervalMinutes: 3,
+    capExhaustedRoute: "hold",
+  });
+
+  assert.deepEqual(resolveAdvisoryWaitPolicy({
+    advisoryWait: {
+      requestCap: 0,
+      pendingWindow: "forty-five minutes",
+      settledWindow: "PT",
+      pollInterval: "P",
+      capExhaustedRoute: "merge-anyway",
+    },
+  }), {
+    requestCap: 30,
+    pendingWindowMinutes: 30,
+    settledWindowMinutes: 10,
+    pollIntervalMinutes: 2,
+    capExhaustedRoute: "phase-specific",
+  });
+});
 
 function readJson(relativePath) {
   return JSON.parse(readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8"));

--- a/tests/advisory-wait.test.mjs
+++ b/tests/advisory-wait.test.mjs
@@ -146,7 +146,7 @@ test("advisory wait policy resolves defaults, explicit values, and fail-safe fal
   assert.deepEqual(resolveAdvisoryWaitPolicy({
     advisoryWait: {
       requestCap: 0,
-      pendingWindow: "forty-five minutes",
+      pendingWindow: "P1DT",
       settledWindow: "PT",
       pollInterval: "P",
       capExhaustedRoute: "merge-anyway",
@@ -158,6 +158,34 @@ test("advisory wait policy resolves defaults, explicit values, and fail-safe fal
     pollIntervalMinutes: 2,
     capExhaustedRoute: "phase-specific",
   });
+});
+
+test("advisory wait summary normalizes invalid direct options to defaults", () => {
+  const fixture = readJson("fixtures/advisory-wait/request-needed.json");
+  const summary = buildAdvisoryWaitSummary({
+    prHeadSha: fixture.input.prHeadSha,
+    reviews: fixture.input.reviews,
+    requestedReviewers: fixture.input.requestedReviewers,
+    timelineEvents: fixture.input.timelineEvents,
+    comments: fixture.input.comments,
+  }, {
+    now: fixture.input.now,
+    requestCap: 0,
+    pendingWindowMinutes: -45,
+    settledWindowMinutes: 0,
+    pollIntervalMinutes: -3,
+    capExhaustedRoute: "merge-anyway",
+    trustedMarkerLogins: fixture.input.trustedMarkerLogins,
+    viewerLogin: fixture.input.viewerLogin,
+    configuredTrustedActors: fixture.input.configuredTrustedActors,
+    collaboratorTrustEnabled: fixture.input.collaboratorTrustEnabled,
+  });
+
+  assert.equal(summary.requestCap, 30);
+  assert.equal(summary.pendingWindowMinutes, 30);
+  assert.equal(summary.settledWindowMinutes, 10);
+  assert.equal(summary.pollIntervalMinutes, 2);
+  assert.equal(summary.capExhaustedRoute, "phase-specific");
 });
 
 function readJson(relativePath) {

--- a/tests/advisory-wait.test.mjs
+++ b/tests/advisory-wait.test.mjs
@@ -1,5 +1,8 @@
 import { readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 
 import {
@@ -8,7 +11,10 @@ import {
   operationalMarkerPrefix,
   unsafeTextReason,
 } from "../scripts/protocol-helpers.mjs";
-import { resolveAdvisoryWaitPolicy } from "../scripts/advisory-wait-policy.mjs";
+import {
+  readAdvisoryWaitPolicy,
+  resolveAdvisoryWaitPolicy,
+} from "../scripts/advisory-wait-policy.mjs";
 import { loadJson, validate } from "../scripts/validate-schemas.mjs";
 
 const ciSuccess = readJson("fixtures/ci/success.json");
@@ -178,10 +184,66 @@ test("advisory wait policy resolves defaults, explicit values, and fail-safe fal
   assert.deepEqual(resolveAdvisoryWaitPolicy({
     advisoryWait: {
       pendingWindow: "PT0M",
+      settledWindow: "PT60S",
+      pollInterval: "PT90S",
+    },
+  }), {
+    requestCap: 30,
+    pendingWindowMinutes: 30,
+    settledWindowMinutes: 10,
+    pollIntervalMinutes: 2,
+    capExhaustedRoute: "phase-specific",
+  });
+
+  assert.deepEqual(resolveAdvisoryWaitPolicy({
+    advisoryWait: {
+      pendingWindow: "PT30S",
       settledWindow: "PT30S",
       pollInterval: "PT90S",
     },
   }), {
+    requestCap: 30,
+    pendingWindowMinutes: 30,
+    settledWindowMinutes: 10,
+    pollIntervalMinutes: 2,
+    capExhaustedRoute: "phase-specific",
+  });
+});
+
+test("advisory wait policy only applies file overrides from schema-valid policy config", () => {
+  const root = mkdtempSync(join(tmpdir(), "idd-advisory-policy-"));
+  const validPath = join(root, "policy.valid.json");
+  const invalidPath = join(root, "policy.invalid.json");
+  const validConfig = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+
+  validConfig.advisoryWait = {
+    requestCap: 12,
+    pendingWindow: "PT45M",
+    settledWindow: "PT15M",
+    pollInterval: "PT3M",
+    capExhaustedRoute: "hold",
+  };
+
+  writeFileSync(validPath, JSON.stringify(validConfig), "utf8");
+  writeFileSync(
+    invalidPath,
+    JSON.stringify({
+      advisoryWait: {
+        pendingWindow: "PT1M",
+      },
+    }),
+    "utf8",
+  );
+
+  assert.deepEqual(readAdvisoryWaitPolicy(validPath), {
+    requestCap: 12,
+    pendingWindowMinutes: 45,
+    settledWindowMinutes: 15,
+    pollIntervalMinutes: 3,
+    capExhaustedRoute: "hold",
+  });
+
+  assert.deepEqual(readAdvisoryWaitPolicy(invalidPath), {
     requestCap: 30,
     pendingWindowMinutes: 30,
     settledWindowMinutes: 10,

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -129,7 +129,7 @@ test("policy normalization provides default-safe values and supports aliases", (
       pendingWindow: "PT30M",
       settledWindow: "PT10M",
       pollInterval: "PT2M",
-      capExhaustedRoute: "phase-default",
+      capExhaustedRoute: "phase-specific",
     },
     ciWait: {
       runningTimeout: "PT30M",
@@ -175,7 +175,7 @@ test("policy normalization provides default-safe values and supports aliases", (
       pendingWindow: "PT40M",
       settledWindow: "PT11M",
       pollInterval: "PT3M",
-      capExhaustedRoute: "strict-hold",
+      capExhaustedRoute: "hold",
     },
     ciWait: {
       runningTimeout: "PT35M",
@@ -223,7 +223,7 @@ test("policy normalization provides default-safe values and supports aliases", (
       pendingWindow: "PT40M",
       settledWindow: "PT11M",
       pollInterval: "PT3M",
-      capExhaustedRoute: "strict-hold",
+      capExhaustedRoute: "hold",
     },
     ciWait: {
       runningTimeout: "PT35M",
@@ -275,6 +275,27 @@ test("policy normalization provides default-safe values and supports aliases", (
     mode: "human-gated",
     authorityPolicy: "all-write-permission-actors",
   });
+
+  assert.deepEqual(normalizePolicyConfig({
+    advisoryWait: {
+      pendingWindow: "PT60S",
+      settledWindow: "PT0M",
+      pollInterval: "PT90S",
+      capExhaustedRoute: "phase-default",
+    },
+  }).advisoryWait, {
+    requestCap: 30,
+    pendingWindow: "PT30M",
+    settledWindow: "PT10M",
+    pollInterval: "PT2M",
+    capExhaustedRoute: "phase-specific",
+  });
+
+  assert.deepEqual(normalizePolicyConfig({
+    advisoryWait: {
+      capExhaustedRoute: "strict-hold",
+    },
+  }).advisoryWait.capExhaustedRoute, "hold");
 });
 
 test("collaborator trust resolution honors aliases and env fallback", () => {

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -77,6 +77,7 @@ test("vendored-node managed files match the canonical helper import closure", ()
   assert.ok(managedFiles.includes("schemas/forced-handoff-marker.schema.json"));
   assert.ok(managedFiles.includes("schemas/pre-merge-readiness.schema.json"));
   assert.ok(managedFiles.includes("schemas/advisory-wait-state.schema.json"));
+  assert.ok(managedFiles.includes("schemas/policy.schema.json"));
   for (const relativePath of managedFiles) {
     assert.equal(existsSync(join(REPO_ROOT, relativePath)), true, relativePath);
   }

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -77,6 +77,25 @@ test("pre-merge readiness optionally emits disposition evidence", () => {
   assert.deepEqual(validate(summary, readinessSchema), []);
 });
 
+test("pre-merge readiness exposes effective advisory policy", () => {
+  const fixture = readJson("fixtures/pre-merge-readiness/clean.json");
+  const summary = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    requestCap: 12,
+    pendingWindowMinutes: 45,
+    settledWindowMinutes: 15,
+    pollIntervalMinutes: 3,
+    capExhaustedRoute: "hold",
+  });
+
+  assert.equal(summary.advisoryWait.requestCap, 12);
+  assert.equal(summary.advisoryWait.pendingWindowMinutes, 45);
+  assert.equal(summary.advisoryWait.settledWindowMinutes, 15);
+  assert.equal(summary.advisoryWait.pollIntervalMinutes, 3);
+  assert.equal(summary.advisoryWait.capExhaustedRoute, "hold");
+  assert.deepEqual(validate(summary, readinessSchema), []);
+});
+
 test("required check summaries block when no merge-gate policy evidence exists", () => {
   assert.deepEqual(summarizeRequiredChecks([], [], {}), {
     status: "unknown",

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -828,6 +828,14 @@ test("policy schema rejects advisoryWait.requestCap below 1", () => {
   assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
 });
 
+test("policy schema rejects advisoryWait.requestCap string values", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.advisoryWait = { requestCap: "1" };
+  const errors = validate(instance, schema);
+  assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
+});
+
 test("policy schema rejects advisoryWait pending/settled/poll durations when malformed", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
@@ -840,10 +848,26 @@ test("policy schema rejects advisoryWait pending/settled/poll durations when mal
   assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
 });
 
+test("policy schema rejects advisoryWait lowercase duration values", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.advisoryWait = { pendingWindow: "pt1m" };
+  const errors = validate(instance, schema);
+  assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
+});
+
 test("policy schema rejects advisoryWait.capExhaustedRoute unknown value", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
   instance.advisoryWait = { capExhaustedRoute: "merge-anyway" };
+  const errors = validate(instance, schema);
+  assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
+});
+
+test("policy schema rejects advisoryWait.capExhaustedRoute padded values", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.advisoryWait = { capExhaustedRoute: " hold " };
   const errors = validate(instance, schema);
   assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
 });

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -801,3 +801,45 @@ test("policy schema rejects markerTrust.allowCollaboratorMarkers non-boolean", (
   const errors = validate(instance, schema);
   assert.ok(errors.some((e) => e.includes("markerTrust")), errors.join("\n"));
 });
+
+test("policy schema accepts advisoryWait request cap and duration keys", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.advisoryWait = {
+    requestCap: 12,
+    pendingWindow: "PT45M",
+    settledWindow: "PT15M",
+    pollInterval: "PT3M",
+    capExhaustedRoute: "hold",
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema rejects advisoryWait.requestCap below 1", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.advisoryWait = { requestCap: 0 };
+  const errors = validate(instance, schema);
+  assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
+});
+
+test("policy schema rejects advisoryWait pending/settled/poll durations when malformed", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.advisoryWait = {
+    pendingWindow: "forty-five minutes",
+    settledWindow: "PT",
+    pollInterval: "P",
+  };
+  const errors = validate(instance, schema);
+  assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
+});
+
+test("policy schema rejects advisoryWait.capExhaustedRoute unknown value", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.advisoryWait = { capExhaustedRoute: "merge-anyway" };
+  const errors = validate(instance, schema);
+  assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
+});

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -856,6 +856,22 @@ test("policy schema rejects advisoryWait lowercase duration values", () => {
   assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
 });
 
+test("policy schema rejects advisoryWait zero-length durations", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.advisoryWait = { pendingWindow: "PT0M" };
+  const errors = validate(instance, schema);
+  assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
+});
+
+test("policy schema rejects advisoryWait second-based durations", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.advisoryWait = { pollInterval: "PT30S" };
+  const errors = validate(instance, schema);
+  assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
+});
+
 test("policy schema rejects advisoryWait.capExhaustedRoute unknown value", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -71,6 +71,10 @@ test("checkSchemaKeywords reports unsupported keywords", () => {
   assert.ok(errors.some((e) => e.includes("anyOf")), `Expected 'anyOf' in errors: ${errors}`);
 });
 
+test("checkSchemaKeywords accepts exclusiveMinimum", () => {
+  assert.deepEqual(checkSchemaKeywords({ type: "number", exclusiveMinimum: 0 }), []);
+});
+
 // ---------------------------------------------------------------------------
 // Fixture validation — valid fixtures must pass, invalid must fail
 // ---------------------------------------------------------------------------
@@ -828,7 +832,7 @@ test("policy schema rejects advisoryWait pending/settled/poll durations when mal
   const schema = loadJson("schemas/policy.schema.json");
   const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
   instance.advisoryWait = {
-    pendingWindow: "forty-five minutes",
+    pendingWindow: "P1DT",
     settledWindow: "PT",
     pollInterval: "P",
   };
@@ -842,4 +846,30 @@ test("policy schema rejects advisoryWait.capExhaustedRoute unknown value", () =>
   instance.advisoryWait = { capExhaustedRoute: "merge-anyway" };
   const errors = validate(instance, schema);
   assert.ok(errors.some((e) => e.includes("advisoryWait")), errors.join("\n"));
+});
+
+test("validator enforces exclusiveMinimum for numbers", () => {
+  assert.ok(validate(0, { type: "number", exclusiveMinimum: 0 }).length > 0);
+  assert.ok(validate(-1, { type: "number", exclusiveMinimum: 0 }).length > 0);
+  assert.deepEqual(validate(0.5, { type: "number", exclusiveMinimum: 0 }), []);
+});
+
+test("advisory wait state schema rejects non-positive minute values", () => {
+  const schema = loadJson("schemas/advisory-wait-state.schema.json");
+  const fixture = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/advisory-wait-state.valid.json")));
+  fixture.pendingWindowMinutes = 0;
+  fixture.settledWindowMinutes = -1;
+  fixture.pollIntervalMinutes = 0;
+  const errors = validate(fixture, schema);
+  assert.ok(errors.some((e) => e.includes("exclusiveMinimum")), errors.join("\n"));
+});
+
+test("pre-merge readiness schema rejects non-positive advisory wait minute values", () => {
+  const schema = loadJson("schemas/pre-merge-readiness.schema.json");
+  const fixture = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/pre-merge-readiness.valid.json")));
+  fixture.advisoryWait.pendingWindowMinutes = 0;
+  fixture.advisoryWait.settledWindowMinutes = -1;
+  fixture.advisoryWait.pollIntervalMinutes = 0;
+  const errors = validate(fixture, schema);
+  assert.ok(errors.some((e) => e.includes("exclusiveMinimum")), errors.join("\n"));
 });


### PR DESCRIPTION
## Summary
- add a shared advisory-wait policy reader for request cap, pending/settled windows, poll interval, and cap-exhausted routing
- wire advisory wait and pre-merge helpers, schemas, fixtures, and tests to expose the effective advisory policy end to end
- update live docs, instructions, and required template mirrors so the default advisory behavior is documented as configurable

Closes #469

## Follow-up issues
- None.

## Background
- Kept this change advisory-scoped on current `main` so it can land independently of the broader policy-key work in #467 / PR #489.
- Default behavior remains unchanged when `advisoryWait.*` is omitted, and `capExhaustedRoute` stays fail-closed (`phase-specific` by default, optional stricter `hold`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advisory review timing and routing now configurable: request cap, pending/settled windows, poll interval, and cap-exhausted routing modes (`phase-specific`, `hold`).
  * Helper outputs and runtime policy resolution expose effective advisory policy used by wait logic and decision tables.

* **Documentation**
  * Added guidance on advisoryWait keys, validation rules, defaults, and fail-closed cap-exhausted semantics; updated advisory messaging to reference the configured per-PR cap.

* **Tests & Schemas**
  * Expanded tests and schemas to validate new advisoryWait fields, durations, routing options, and numeric constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->