### PR TITLE
feat(force-handoff): add an interactive operator facade

### DIFF
--- a/bin/idd-force-handoff.mjs
+++ b/bin/idd-force-handoff.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/force-handoff.mjs");

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "idd-discover-orphan-filter": "./bin/idd-discover-orphan-filter.mjs",
     "idd-discover-viability-gate": "./bin/idd-discover-viability-gate.mjs",
     "idd-doctor": "./bin/idd-doctor.mjs",
+    "idd-force-handoff": "./bin/idd-force-handoff.mjs",
     "idd-forced-handoff-marker": "./bin/idd-forced-handoff-marker.mjs",
     "idd-helper-bundle-manifest": "./bin/idd-helper-bundle-manifest.mjs",
     "idd-live-status-digest": "./bin/idd-live-status-digest.mjs",

--- a/scripts/force-handoff.mjs
+++ b/scripts/force-handoff.mjs
@@ -28,10 +28,17 @@ export async function runHandoff(options = {}) {
     fetchIssueComments,
     fetchLinkedPrs,
     postComment,
+    mode,
   } = options;
 
   if (!isTTY) {
     throw new Error(NON_TTY_ERROR);
+  }
+
+  if ((mode ?? readForcedHandoffMode()) !== "human-gated") {
+    throw new Error(
+      "forced-handoff mode is not human-gated; idd-force-handoff is only available when forcedHandoff.mode is 'human-gated'",
+    );
   }
 
   const ask = promptFn ?? makeReadlinePrompt();
@@ -194,12 +201,69 @@ function ghJson(args, slurp = false) {
 }
 
 function buildTrustedMarkerLogins(owner, repo, viewerLogin, issueComments) {
+  const configuredActors = readTrustedMarkerActorsFromConfig();
   const configured = [
     viewerLogin,
+    ...configuredActors,
     ...splitCsv(process.env.IDD_TRUSTED_MARKER_ACTORS),
   ];
   const trusted = new Set(configured.filter(Boolean).map((l) => l.toLowerCase()));
+
+  if (!readCollaboratorTrustEnabled()) {
+    return trusted;
+  }
+
+  const permissionCache = new Map();
+  const uniqueLogins = new Set(
+    issueComments
+      .map((comment) => String(comment.user?.login ?? comment.author?.login ?? "").toLowerCase())
+      .filter(Boolean),
+  );
+  for (const login of uniqueLogins) {
+    if (trusted.has(login)) {
+      continue;
+    }
+    const permission = permissionCache.get(login) ?? safeGhText([
+      "api",
+      `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+      "--jq",
+      ".permission",
+    ]).toLowerCase();
+    permissionCache.set(login, permission);
+    if (permission === "admin" || permission === "maintain" || permission === "write") {
+      trusted.add(login);
+    }
+  }
   return trusted;
+}
+
+function readTrustedMarkerActorsFromConfig() {
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const actors = config?.trustedMarkerActors;
+    if (Array.isArray(actors)) {
+      return actors.map(String).filter(Boolean);
+    }
+  } catch {
+    // config absent or unreadable
+  }
+  return [];
+}
+
+function readCollaboratorTrustEnabled() {
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    if (typeof config?.markerTrust?.allowCollaboratorMarkers === "boolean") {
+      return config.markerTrust.allowCollaboratorMarkers;
+    }
+  } catch {
+    // Fall through to env-var fallback.
+  }
+  return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
+}
+
+function isTruthy(value) {
+  return /^(1|true|yes)$/i.test(String(value ?? "").trim());
 }
 
 function splitCsv(value) {

--- a/scripts/force-handoff.mjs
+++ b/scripts/force-handoff.mjs
@@ -275,7 +275,11 @@ function readForcedHandoffMode() {
   try {
     const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
     const mode = String(
-      config?.forcedHandoff?.mode ?? config?.forcedHandoff ?? config?.["forced-handoff"] ?? "",
+      config?.forcedHandoff?.mode ??
+        config?.["forced-handoff"]?.mode ??
+        config?.forcedHandoffMode ??
+        config?.["forced-handoff-mode"] ??
+        "",
     ).trim();
     if (FORCED_HANDOFF_MODES.has(mode)) {
       return mode;

--- a/scripts/force-handoff.mjs
+++ b/scripts/force-handoff.mjs
@@ -255,8 +255,11 @@ function readTrustedMarkerActorsFromConfig() {
 function readCollaboratorTrustEnabled() {
   try {
     const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    if (typeof config?.markerTrust?.allowCollaboratorMarkers === "boolean") {
-      return config.markerTrust.allowCollaboratorMarkers;
+    const nested = config?.markerTrust?.allowCollaboratorMarkers;
+    const topLevel = config?.markerTrustAllowCollaboratorMarkers ?? config?.allowCollaboratorMarkers;
+    const value = nested ?? topLevel;
+    if (typeof value === "boolean") {
+      return value;
     }
   } catch {
     // Fall through to env-var fallback.
@@ -292,6 +295,7 @@ function readForcedHandoffAuthorityPolicy() {
     const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
     const policy = String(
       config?.forcedHandoff?.authorityPolicy ??
+        config?.["forced-handoff"]?.authorityPolicy ??
         config?.forcedHandoffAuthority ??
         config?.["forced-handoff-authority"] ??
         "",

--- a/scripts/force-handoff.mjs
+++ b/scripts/force-handoff.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+import { pathToFileURL } from "node:url";
+
+import { planHandoff } from "./forced-handoff-marker.mjs";
+
+const APPROVAL_ACTOR_POLICIES = new Set([
+  "owners-and-maintainers-only",
+  "all-write-permission-actors",
+]);
+const APPROVAL_ACTOR_POLICY_DEFAULT = "owners-and-maintainers-only";
+
+export const NON_TTY_ERROR =
+  "operator interaction is required; run idd-force-handoff in an interactive TTY";
+
+export async function runHandoff(options = {}) {
+  const {
+    isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    prompt: promptFn,
+    repo,
+    forcedBy: givenForcedBy,
+    reason = "operator-approved-recovery",
+    trustedMarkerLogins: givenTrustedLogins,
+    isAuthorizedForcedHandoff: givenAuthPredicate,
+    fetchIssueComments,
+    fetchLinkedPrs,
+    postComment,
+  } = options;
+
+  if (!isTTY) {
+    throw new Error(NON_TTY_ERROR);
+  }
+
+  const ask = promptFn ?? makeReadlinePrompt();
+
+  const rawIssue = await ask("Issue number: ");
+  const issueNumber = parsePositiveInteger(rawIssue, "--issue");
+
+  const repoRef = repo ?? ghText(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
+  const { owner, name } = parseOwnerRepo(repoRef);
+
+  const forcedBy = givenForcedBy ?? safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
+  if (!forcedBy) {
+    throw new Error("could not determine current GitHub user; ensure gh is authenticated");
+  }
+
+  const issueComments = fetchIssueComments
+    ? await fetchIssueComments(issueNumber)
+    : ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${issueNumber}/comments`], true).flat();
+
+  const trustedMarkerLogins = givenTrustedLogins
+    ?? buildTrustedMarkerLogins(owner, name, forcedBy, issueComments);
+
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const permissionCache = new Map();
+  const isAuthorizedForcedHandoff = givenAuthPredicate
+    ?? ((actor) => isAuthorizedForcedHandoffActor(owner, name, actor, forcedHandoffAuthorityPolicy, permissionCache));
+
+  const resolveOpts = { trustedMarkerLogins, isAuthorizedForcedHandoff, forcedBy, reason };
+
+  const firstPass = planHandoff(issueComments, [], resolveOpts);
+
+  const linkedPrs = fetchLinkedPrs
+    ? await fetchLinkedPrs(firstPass.branch)
+    : ghJson([
+        "pr", "list",
+        "--repo", `${owner}/${name}`,
+        "--head", firstPass.branch,
+        "--state", "open",
+        "--json", "number,headRefName",
+      ]);
+
+  let plan = planHandoff(issueComments, linkedPrs, resolveOpts);
+
+  let resolvedPrNumber;
+  if (plan.contextScope === "issue-plus-pr") {
+    const prList = plan.prReferences.join(", ");
+    const rawPr = await ask(`Open PR on branch (${prList}). Enter PR number: `);
+    const prNumber = parsePositiveInteger(rawPr, "--pr");
+    plan = planHandoff(issueComments, linkedPrs, { ...resolveOpts, prNumber });
+    resolvedPrNumber = prNumber;
+  }
+
+  if (!plan.markerBody) {
+    throw new Error(
+      "cannot generate forced-handoff marker: check that forced-handoff mode is human-gated and the actor is authorized",
+    );
+  }
+
+  const { newAgentId, newClaimId } = plan.successorIds;
+  const lines = [
+    "",
+    `Forced-handoff plan for issue #${issueNumber}:`,
+    `  Context:   ${plan.contextScope}`,
+    `  Branch:    ${plan.branch}`,
+    `  Old claim: ${plan.activeClaim.agentId} / ${plan.activeClaim.claimId}`,
+    `  Successor: ${newAgentId} / ${newClaimId}`,
+    ...(resolvedPrNumber ? [`  PR:        #${resolvedPrNumber}`] : []),
+    "",
+    "Marker preview:",
+    plan.markerBody,
+    "",
+  ];
+  process.stdout.write(lines.join("\n") + "\n");
+
+  const confirm = await ask("Confirm forced handoff? [y/N] ");
+  ask.close?.();
+  if (confirm.trim().toLowerCase() !== "y") {
+    process.stdout.write("Aborted. No changes made.\n");
+    return { posted: false };
+  }
+
+  const result = postComment
+    ? await postComment(issueNumber, plan.markerBody)
+    : ghJson([
+        "api",
+        `repos/${owner}/${name}/issues/${issueNumber}/comments`,
+        "--method", "POST",
+        "-f", `body=${plan.markerBody}`,
+      ]);
+
+  const commentUrl = String(result.html_url ?? result.url ?? "");
+  process.stdout.write([
+    "",
+    `Forced handoff posted: ${commentUrl}`,
+    `  Successor agent-id:  ${newAgentId}`,
+    `  Successor claim-id:  ${newClaimId}`,
+    "",
+  ].join("\n"));
+
+  return {
+    posted: true,
+    commentUrl,
+    successorIds: { newAgentId, newClaimId },
+    contextScope: plan.contextScope,
+  };
+}
+
+export function main() {
+  runHandoff().catch((err) => {
+    process.stderr.write(`Error: ${err.message}\n`);
+    process.exit(1);
+  });
+}
+
+function makeReadlinePrompt() {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const ask = (question) =>
+    new Promise((resolve) => rl.question(question, (answer) => {
+      resolve(answer);
+    }));
+  ask.close = () => rl.close();
+  return ask;
+}
+
+function parsePositiveInteger(value, flag) {
+  const raw = String(value ?? "").trim();
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`invalid ${flag} value: ${raw}`);
+  }
+  return Number(raw);
+}
+
+function parseOwnerRepo(value) {
+  const repo = String(value ?? "").trim();
+  const match = repo.match(/^([^/\s]+)\/([^/\s]+)$/);
+  if (!match) {
+    throw new Error(`invalid repo value: ${value} (expected owner/name)`);
+  }
+  return { owner: match[1], name: match[2] };
+}
+
+function ghText(args) {
+  return execFileSync("gh", args, { encoding: "utf8" }).trim();
+}
+
+function safeGhText(args) {
+  try {
+    return ghText(args);
+  } catch {
+    return "";
+  }
+}
+
+function ghJson(args, slurp = false) {
+  const finalArgs = [...args];
+  if (slurp) {
+    finalArgs.splice(1, 0, "--slurp");
+  }
+  return JSON.parse(execFileSync("gh", finalArgs, { encoding: "utf8" }));
+}
+
+function buildTrustedMarkerLogins(owner, repo, viewerLogin, issueComments) {
+  const configured = [
+    viewerLogin,
+    ...splitCsv(process.env.IDD_TRUSTED_MARKER_ACTORS),
+  ];
+  const trusted = new Set(configured.filter(Boolean).map((l) => l.toLowerCase()));
+  return trusted;
+}
+
+function splitCsv(value) {
+  return String(value ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+function readForcedHandoffAuthorityPolicy() {
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const policy = String(
+      config?.forcedHandoff?.authorityPolicy ??
+        config?.forcedHandoffAuthority ??
+        config?.["forced-handoff-authority"] ??
+        "",
+    ).trim();
+    if (APPROVAL_ACTOR_POLICIES.has(policy)) {
+      return policy;
+    }
+  } catch {
+    // default
+  }
+  return APPROVAL_ACTOR_POLICY_DEFAULT;
+}
+
+function collaboratorPermission(owner, repo, login, cache) {
+  if (cache.has(login)) {
+    return cache.get(login);
+  }
+  const permission = safeGhText([
+    "api",
+    `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+    "--jq",
+    ".permission",
+  ]).toLowerCase();
+  cache.set(login, permission);
+  return permission;
+}
+
+function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
+  const normalized = String(login ?? "").trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const permission = collaboratorPermission(owner, repo, normalized, cache);
+  if (policy === "all-write-permission-actors") {
+    return permission === "admin" || permission === "maintain" || permission === "write";
+  }
+  return permission === "admin" || permission === "maintain";
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/force-handoff.mjs
+++ b/scripts/force-handoff.mjs
@@ -12,6 +12,8 @@ const APPROVAL_ACTOR_POLICIES = new Set([
   "all-write-permission-actors",
 ]);
 const APPROVAL_ACTOR_POLICY_DEFAULT = "owners-and-maintainers-only";
+const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
+const FORCED_HANDOFF_MODE_DEFAULT = "disabled";
 
 export const NON_TTY_ERROR =
   "operator interaction is required; run idd-force-handoff in an interactive TTY";
@@ -264,6 +266,21 @@ function readCollaboratorTrustEnabled() {
 
 function isTruthy(value) {
   return /^(1|true|yes)$/i.test(String(value ?? "").trim());
+}
+
+function readForcedHandoffMode() {
+  try {
+    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+    const mode = String(
+      config?.forcedHandoff?.mode ?? config?.forcedHandoff ?? config?.["forced-handoff"] ?? "",
+    ).trim();
+    if (FORCED_HANDOFF_MODES.has(mode)) {
+      return mode;
+    }
+  } catch {
+    // Default mode remains disabled.
+  }
+  return FORCED_HANDOFF_MODE_DEFAULT;
 }
 
 function splitCsv(value) {

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -26,6 +26,14 @@ const HELPER_COMMANDS = [
     description: "Run IDD onboarding drift checks against the local repository.",
   },
   {
+    id: "force-handoff",
+    scriptName: "idd:force-handoff",
+    binName: "idd-force-handoff",
+    entryPath: "scripts/force-handoff.mjs",
+    vendoredCommand: "node scripts/force-handoff.mjs",
+    description: "Interactive TTY-only operator facade for forced handoff: issue → optional PR → y/N confirmation.",
+  },
+  {
     id: "forced-handoff-marker",
     scriptName: "idd:forced-handoff-marker",
     binName: "idd-forced-handoff-marker",

--- a/tests/force-handoff.test.mjs
+++ b/tests/force-handoff.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { runHandoff, NON_TTY_ERROR } from "../scripts/force-handoff.mjs";
+
+const CLAIM_BODY = [
+  "<!-- claimed-by: github-copilot-cli-old claim-497-test supersedes: none 2026-05-13T10:00:00Z branch: issue/497-feat-force-handoff-add-interactive -->",
+  "",
+  "_github-copilot-cli-old: issue claim — IDD automation marker. Do not edit._",
+].join("\n");
+
+const ISSUE_COMMENTS = [
+  {
+    body: CLAIM_BODY,
+    created_at: "2026-05-13T10:00:00Z",
+    user: { login: "kurone-kito" },
+  },
+];
+
+const TRUSTED_LOGINS = ["kurone-kito", "github-copilot-cli-old"];
+
+function makeCommonOpts(overrides = {}) {
+  return {
+    isTTY: true,
+    repo: "kurone-kito/idd-skill",
+    forcedBy: "kurone-kito",
+    trustedMarkerLogins: TRUSTED_LOGINS,
+    isAuthorizedForcedHandoff: (actor) => actor === "kurone-kito",
+    fetchIssueComments: async () => ISSUE_COMMENTS,
+    fetchLinkedPrs: async () => [],
+    postComment: async (_issueNum, body) => ({ html_url: "https://github.com/kurone-kito/idd-skill/issues/497#issuecomment-test", body }),
+    ...overrides,
+  };
+}
+
+test("runHandoff throws when not running in a TTY", async () => {
+  await assert.rejects(
+    () => runHandoff({ isTTY: false }),
+    (err) => {
+      assert.ok(err.message.includes("interactive TTY"), `unexpected message: ${err.message}`);
+      return true;
+    },
+  );
+});
+
+test("runHandoff completes issue-only flow without PR prompt", async () => {
+  const responses = ["497", "y"];
+  let callIndex = 0;
+  const postedBodies = [];
+
+  const result = await runHandoff(makeCommonOpts({
+    prompt: async () => responses[callIndex++],
+    postComment: async (_issueNum, body) => {
+      postedBodies.push(body);
+      return { html_url: "https://github.com/kurone-kito/idd-skill/issues/497#issuecomment-1" };
+    },
+  }));
+
+  assert.equal(result.posted, true, "should post the comment");
+  assert.equal(result.contextScope, "issue-only");
+  assert.ok(result.commentUrl.includes("issuecomment"), "should return comment URL");
+  assert.ok(postedBodies.length === 1, "should post exactly one comment");
+  assert.ok(postedBodies[0].includes("issue-only"), "marker body should contain context scope");
+  assert.ok(postedBodies[0].includes("kurone-kito"), "marker body should contain forcedBy");
+  assert.equal(callIndex, 2, "should ask for issue number and confirmation only");
+});
+
+test("runHandoff completes issue-plus-pr flow with PR prompt", async () => {
+  const responses = ["497", "501", "y"];
+  let callIndex = 0;
+  const postedBodies = [];
+
+  const linkedPrs = [
+    { number: 501, headRefName: "issue/497-feat-force-handoff-add-interactive" },
+  ];
+
+  const result = await runHandoff(makeCommonOpts({
+    fetchLinkedPrs: async () => linkedPrs,
+    prompt: async () => responses[callIndex++],
+    postComment: async (_issueNum, body) => {
+      postedBodies.push(body);
+      return { html_url: "https://github.com/kurone-kito/idd-skill/issues/497#issuecomment-2" };
+    },
+  }));
+
+  assert.equal(result.posted, true, "should post the comment");
+  assert.equal(result.contextScope, "issue-plus-pr");
+  assert.ok(postedBodies[0].includes("issue-plus-pr"), "marker body should contain issue-plus-pr scope");
+  assert.ok(postedBodies[0].includes('"linked-pr":"501"'), "marker body should include linked PR");
+  assert.equal(callIndex, 3, "should ask for issue number, PR number, and confirmation");
+});
+
+test("runHandoff returns posted: false when operator declines confirmation", async () => {
+  const responses = ["497", "N"];
+  let callIndex = 0;
+  let postCalled = false;
+
+  const result = await runHandoff(makeCommonOpts({
+    prompt: async () => responses[callIndex++],
+    postComment: async () => {
+      postCalled = true;
+      return { html_url: "https://example.com" };
+    },
+  }));
+
+  assert.equal(result.posted, false, "should not post when operator declines");
+  assert.equal(postCalled, false, "postComment should not be called on refusal");
+});
+
+test("runHandoff reports posted: true and returns successorIds and commentUrl", async () => {
+  const responses = ["497", "y"];
+  let callIndex = 0;
+
+  const result = await runHandoff(makeCommonOpts({
+    prompt: async () => responses[callIndex++],
+  }));
+
+  assert.equal(result.posted, true);
+  assert.ok(result.commentUrl, "should return a comment URL");
+  assert.ok(result.successorIds?.newAgentId, "should return successor newAgentId");
+  assert.ok(result.successorIds?.newClaimId, "should return successor newClaimId");
+  assert.match(result.successorIds.newClaimId, /^claim-[0-9a-f]{16}$/, "claim ID should match expected format");
+});

--- a/tests/force-handoff.test.mjs
+++ b/tests/force-handoff.test.mjs
@@ -22,6 +22,7 @@ const TRUSTED_LOGINS = ["kurone-kito", "github-copilot-cli-old"];
 function makeCommonOpts(overrides = {}) {
   return {
     isTTY: true,
+    mode: "human-gated",
     repo: "kurone-kito/idd-skill",
     forcedBy: "kurone-kito",
     trustedMarkerLogins: TRUSTED_LOGINS,


### PR DESCRIPTION
## Summary

Add `scripts/force-handoff.mjs` — a TTY-gated interactive command that drives the three-step operator forced-handoff workflow:

1. **Issue number** — required before any GitHub state is read
2. **Optional PR number** — prompted only when `planHandoff()` detects an open PR on the claim branch (`issue-plus-pr` context); skipped entirely for `issue-only` context
3. **`y/N` confirmation** — defaults to `N`; any non-affirmative answer leaves GitHub state unchanged

After confirmed execution, the canonical forced-handoff comment is posted and the exact successor `agent-id` / `claim-id` values plus the comment URL are printed.

Non-interactive or non-TTY execution exits non-zero with actionable guidance.

## Test coverage (`tests/force-handoff.test.mjs`)

All tests use fully injected mocks — no network calls:

- Non-interactive refusal (`isTTY: false` → throws)
- Issue-only flow (no linked PR → skips PR prompt → posts)
- Issue-plus-pr flow (linked PR → prompts PR number → posts with `linked-pr`)
- Confirmation refusal (`N` → `posted: false`, no comment posted)
- Successful posting (returns `{ posted: true, commentUrl, successorIds }`)

## Related

- Depends on `planHandoff()` / `generateSuccessorIds()` from #496 (merged)
- Documentation PR: #498

Closes #497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive TTY-only command to perform a manual forced handoff workflow, including prompts, confirmation, and posting a handoff marker with resulting links/IDs.

* **Tests**
  * Added comprehensive tests covering TTY enforcement, issue-only and issue+PR flows, confirmation handling, and successful posting/results.

* **Chores**
  * Registered the new command in package configuration and command catalog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/514)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->