### PR TITLE
docs: make discover and suitability helper-first

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -13,6 +13,9 @@ A0-O, A3, A3.5, and A4.5. The written decision tables still own the final
 routing, and they remain authoritative when helper output is missing or
 disagrees.
 
+In particular, use `scripts/discover-viability-gate.mjs` for the A4
+viability gate before falling back to the manual criteria in this file.
+
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
 **Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -7,6 +7,12 @@ and claim. After selecting a viable candidate (A4), run suitability triage via
 `idd-suitability.instructions.md` (A4.5), then proceed to
 `idd-claim.instructions.md` to claim it.
 
+When helper support is enabled, prefer the helper scripts cataloged in
+`docs/idd-helper-scripts.md` for the read-only evidence collection used by
+A0-O, A3, A3.5, and A4.5. The written decision tables still own the final
+routing, and they remain authoritative when helper output is missing or
+disagrees.
+
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
 **Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -7,14 +7,10 @@ and claim. After selecting a viable candidate (A4), run suitability triage via
 `idd-suitability.instructions.md` (A4.5), then proceed to
 `idd-claim.instructions.md` to claim it.
 
-When helper support is enabled, prefer the helper scripts cataloged in
-`docs/idd-helper-scripts.md` for the read-only evidence collection used by
-A0-O, A3, A3.5, and A4.5. The written decision tables still own the final
-routing, and they remain authoritative when helper output is missing or
-disagrees.
-
-In particular, use `scripts/discover-viability-gate.mjs` for the A4
-viability gate before falling back to the manual criteria in this file.
+When helper support is enabled, use helper scripts from
+`docs/idd-helper-scripts.md` first for A0-O/A3/A3.5/A4/A4.5 evidence.
+Written decision tables remain authoritative when helper output is
+missing or disagrees.
 
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
 **Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -13,6 +13,11 @@ This gate evaluates whether an issue is **suitable for autonomous
 execution** independent of the current run's context. Where A4 asks "can
 we do this NOW?", A4.5 asks "SHOULD we do this at all?"
 
+When helper support is enabled, prefer the helper script catalog in
+`docs/idd-helper-scripts.md` for the read-only A4.5 evidence collection.
+The written check list and decision flow still own the outcome, and they
+remain authoritative when helper output is missing or disagrees.
+
 Issue-author approval is a separate pre-claim gate. Candidates that fail
 the repository's issue-author approval evaluation are routed by
 `idd-discover.instructions.md` and re-checked in

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -13,14 +13,10 @@ This gate evaluates whether an issue is **suitable for autonomous
 execution** independent of the current run's context. Where A4 asks "can
 we do this NOW?", A4.5 asks "SHOULD we do this at all?"
 
-When helper support is enabled, prefer the helper script catalog in
-`docs/idd-helper-scripts.md` for the read-only A4.5 evidence collection.
-The written check list and decision flow still own the outcome, and they
-remain authoritative when helper output is missing or disagrees.
-
-Use `scripts/suitability-triage.mjs` first when you need A4.5 evidence,
-then fall back to the manual seven-check triage if the helper is absent
-or disagrees.
+When helper support is enabled, use helper scripts from
+`docs/idd-helper-scripts.md` first for A4.5 evidence.
+Written checks and decision flow remain authoritative when helper output
+is missing or disagrees.
 
 Issue-author approval is a separate pre-claim gate. Candidates that fail
 the repository's issue-author approval evaluation are routed by

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -18,6 +18,10 @@ When helper support is enabled, prefer the helper script catalog in
 The written check list and decision flow still own the outcome, and they
 remain authoritative when helper output is missing or disagrees.
 
+Use `scripts/suitability-triage.mjs` first when you need A4.5 evidence,
+then fall back to the manual seven-check triage if the helper is absent
+or disagrees.
+
 Issue-author approval is a separate pre-claim gate. Candidates that fail
 the repository's issue-author approval evaluation are routed by
 `idd-discover.instructions.md` and re-checked in

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -148,6 +148,34 @@ For discover and suitability, use the adopted helpers first when helper
 support is enabled, then fall back to the portable instructions if a
 helper is unavailable or its output does not match the written rules.
 
+### Discover Viability Gate Contract
+
+`scripts/discover-viability-gate.mjs` evaluates the A4 viability gate for
+one or more issues.
+
+- **Inputs**: `--issue <number>` (repeatable) or `--issues <n1,n2,...>`,
+  with optional `--csv`, `--owner <owner>`, and `--repo <repo>`.
+- **JSON output**:
+  - `viable`: `[{ number: number, title: string }]`
+  - `discarded`: `[{ number: number, title: string,`
+    `failedCriteria: string[], criteria?: [{ id: string, name: string,`
+    `result: "pass" | "fail", evidence: string }] }]`
+  - `summary`: `{ total: number, viableCount: number,`
+    `discardedCount: number, discardedByCriterion: Record<string, number> }`
+- **Error conditions**: missing issue arguments or unknown flags throw;
+  loader or GitHub failures surface as errors; not-found or non-open
+  issues are reported in `discarded` with `failedCriteria` instead of
+  crashing.
+- **Example**:
+
+  ```json
+  {
+    "viable": [{ "number": 123, "title": "trim helper docs" }],
+    "discarded": [{ "number": 124, "title": "rewrite workflow", "failedCriteria": ["limited_scope", "autonomous_completion"] }],
+    "summary": { "total": 2, "viableCount": 1, "discardedCount": 1, "discardedByCriterion": { "limited_scope": 1, "autonomous_completion": 1 } }
+  }
+  ```
+
 The exported template remains portable without a `scripts/` directory.
 Adopters can copy the helper separately when they want the same
 repository-local convenience, otherwise the documented GraphQL fallback

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -142,6 +142,10 @@ instructions embedded in `.github/instructions/*.instructions.md`. The
 helpers are convenience layers only; written decision tables and phase
 rules remain authoritative when outputs diverge.
 
+For discover and suitability, use the adopted helpers first when helper
+support is enabled, then fall back to the portable instructions if a
+helper is unavailable or its output does not match the written rules.
+
 The exported template remains portable without a `scripts/` directory.
 Adopters can copy the helper separately when they want the same
 repository-local convenience, otherwise the documented GraphQL fallback

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -17,7 +17,9 @@ In the idd-skill source repository, the following optional helpers were adopted:
   evaluation (referenced in
   [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391))
 - `scripts/discover-viability-gate.mjs` for A4 viability gate evaluation
-  across limited scope, clear verification, and autonomous completion criteria
+  across limited scope, clear verification, and autonomous completion
+  criteria (referenced in
+  [kurone-kito/idd-skill#505](https://github.com/kurone-kito/idd-skill/issues/505))
 - `scripts/suitability-triage.mjs` for A4.5 seven-check suitability
   evaluation (referenced in
   [kurone-kito/idd-skill#392](https://github.com/kurone-kito/idd-skill/issues/392))

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -118,6 +118,12 @@ use the helper-backed evidence collectors first, but the Markdown
 instruction files remain the final authority whenever helper output is
 missing or disagrees.
 
+During onboarding, create or update `CLAUDE.md`, `AGENTS.md`, and
+`GEMINI.md` so each non-Copilot agent listed above has a stable first
+file to read. GitHub Copilot remains an update-if-present surface via
+`.github/copilot-instructions.md`. Skipping creation of a missing root
+entry file should be an explicit operator choice, not the default.
+
 When an operator gives exactly one issue target, Discover can verify that
 target directly before Claim. The shortcut avoids broad roadmap
 enumeration, but it still applies targeted readiness checks, the A4

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -113,6 +113,11 @@ with [IDD policy constants](policy-constants.md). It names the claim,
 advisory, CI, and critique-loop defaults and points to the instruction
 files that own each value.
 
+When helper support is enabled, the discover and suitability phases may
+use the helper-backed evidence collectors first, but the Markdown
+instruction files remain the final authority whenever helper output is
+missing or disagrees.
+
 When an operator gives exactly one issue target, Discover can verify that
 target directly before Claim. The shortcut avoids broad roadmap
 enumeration, but it still applies targeted readiness checks, the A4

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -31,6 +31,12 @@ you are reading this guide first, start at step 1.
 | Claude Code             | `CLAUDE.md`                       | None from `.github/instructions/` by default                                                                                                                       | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
 | Gemini CLI              | `GEMINI.md`                       | None from `.github/instructions/`                                                                                                                                  | `.github/instructions/idd-overview.instructions.md` and the routed phase file |
 
+During onboarding, create or update `CLAUDE.md`, `AGENTS.md`, and
+`GEMINI.md` so each non-Copilot agent listed above has a stable first
+file to read. GitHub Copilot remains an update-if-present surface via
+`.github/copilot-instructions.md`. Skipping creation of a missing root
+entry file should be an explicit operator choice, not the default.
+
 ## IDD file map
 
 | File                                                       | Role                                                                                 |

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -9,9 +9,9 @@ and claim. After selecting a viable candidate (A4), run suitability triage via
 
 When helper support is enabled, prefer the helper scripts cataloged in
 `docs/idd-helper-scripts.md` for the read-only evidence collection used by
-A0-O, A3, A3.5, and A4.5. The written decision tables still own the final
-routing, and they remain authoritative when helper output is missing or
-disagrees.
+A0-O, A3, A3.5, A4, and A4.5. The written decision tables still own the
+final routing, and they remain authoritative when helper output is
+missing or disagrees.
 
 In particular, use `scripts/discover-viability-gate.mjs` for the A4
 viability gate before falling back to the manual criteria in this file.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -13,6 +13,9 @@ A0-O, A3, A3.5, and A4.5. The written decision tables still own the final
 routing, and they remain authoritative when helper output is missing or
 disagrees.
 
+In particular, use `scripts/discover-viability-gate.mjs` for the A4
+viability gate before falling back to the manual criteria in this file.
+
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
 **Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -7,14 +7,10 @@ and claim. After selecting a viable candidate (A4), run suitability triage via
 `idd-suitability.instructions.md` (A4.5), then proceed to
 `idd-claim.instructions.md` to claim it.
 
-When helper support is enabled, prefer the helper scripts cataloged in
-`docs/idd-helper-scripts.md` for the read-only evidence collection used by
-A0-O, A3, A3.5, A4, and A4.5. The written decision tables still own the
-final routing, and they remain authoritative when helper output is
+When helper support is enabled, use helper scripts from
+`docs/idd-helper-scripts.md` first for A0-O/A3/A3.5/A4/A4.5 evidence.
+Written decision tables remain authoritative when helper output is
 missing or disagrees.
-
-In particular, use `scripts/discover-viability-gate.mjs` for the A4
-viability gate before falling back to the manual criteria in this file.
 
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
 **Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -7,6 +7,12 @@ and claim. After selecting a viable candidate (A4), run suitability triage via
 `idd-suitability.instructions.md` (A4.5), then proceed to
 `idd-claim.instructions.md` to claim it.
 
+When helper support is enabled, prefer the helper scripts cataloged in
+`docs/idd-helper-scripts.md` for the read-only evidence collection used by
+A0-O, A3, A3.5, and A4.5. The written decision tables still own the final
+routing, and they remain authoritative when helper output is missing or
+disagrees.
+
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
 **Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).
 

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -13,6 +13,11 @@ This gate evaluates whether an issue is **suitable for autonomous
 execution** independent of the current run's context. Where A4 asks "can
 we do this NOW?", A4.5 asks "SHOULD we do this at all?"
 
+When helper support is enabled, prefer the helper script catalog in
+`docs/idd-helper-scripts.md` for the read-only A4.5 evidence collection.
+The written check list and decision flow still own the outcome, and they
+remain authoritative when helper output is missing or disagrees.
+
 Issue-author approval is a separate pre-claim gate. Candidates that fail
 the repository's issue-author approval evaluation are routed by
 `idd-discover.instructions.md` and re-checked in

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -13,14 +13,10 @@ This gate evaluates whether an issue is **suitable for autonomous
 execution** independent of the current run's context. Where A4 asks "can
 we do this NOW?", A4.5 asks "SHOULD we do this at all?"
 
-When helper support is enabled, prefer the helper script catalog in
-`docs/idd-helper-scripts.md` for the read-only A4.5 evidence collection.
-The written check list and decision flow still own the outcome, and they
-remain authoritative when helper output is missing or disagrees.
-
-Use `scripts/suitability-triage.mjs` first when you need A4.5 evidence,
-then fall back to the manual seven-check triage if the helper is absent
-or disagrees.
+When helper support is enabled, use helper scripts from
+`docs/idd-helper-scripts.md` first for A4.5 evidence.
+Written checks and decision flow remain authoritative when helper output
+is missing or disagrees.
 
 Issue-author approval is a separate pre-claim gate. Candidates that fail
 the repository's issue-author approval evaluation are routed by

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -18,6 +18,10 @@ When helper support is enabled, prefer the helper script catalog in
 The written check list and decision flow still own the outcome, and they
 remain authoritative when helper output is missing or disagrees.
 
+Use `scripts/suitability-triage.mjs` first when you need A4.5 evidence,
+then fall back to the manual seven-check triage if the helper is absent
+or disagrees.
+
 Issue-author approval is a separate pre-claim gate. Candidates that fail
 the repository's issue-author approval evaluation are routed by
 `idd-discover.instructions.md` and re-checked in

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -148,6 +148,34 @@ For discover and suitability, use the adopted helpers first when helper
 support is enabled, then fall back to the portable instructions if a
 helper is unavailable or its output does not match the written rules.
 
+### Discover Viability Gate Contract
+
+`scripts/discover-viability-gate.mjs` evaluates the A4 viability gate for
+one or more issues.
+
+- **Inputs**: `--issue <number>` (repeatable) or `--issues <n1,n2,...>`,
+  with optional `--csv`, `--owner <owner>`, and `--repo <repo>`.
+- **JSON output**:
+  - `viable`: `[{ number: number, title: string }]`
+  - `discarded`: `[{ number: number, title: string,`
+    `failedCriteria: string[], criteria?: [{ id: string, name: string,`
+    `result: "pass" | "fail", evidence: string }] }]`
+  - `summary`: `{ total: number, viableCount: number,`
+    `discardedCount: number, discardedByCriterion: Record<string, number> }`
+- **Error conditions**: missing issue arguments or unknown flags throw;
+  loader or GitHub failures surface as errors; not-found or non-open
+  issues are reported in `discarded` with `failedCriteria` instead of
+  crashing.
+- **Example**:
+
+  ```json
+  {
+    "viable": [{ "number": 123, "title": "trim helper docs" }],
+    "discarded": [{ "number": 124, "title": "rewrite workflow", "failedCriteria": ["limited_scope", "autonomous_completion"] }],
+    "summary": { "total": 2, "viableCount": 1, "discardedCount": 1, "discardedByCriterion": { "limited_scope": 1, "autonomous_completion": 1 } }
+  }
+  ```
+
 The exported template remains portable without a `scripts/` directory.
 Adopters can copy the helper separately when they want the same
 repository-local convenience, otherwise the documented GraphQL fallback

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -142,6 +142,10 @@ instructions embedded in `.github/instructions/*.instructions.md`. The
 helpers are convenience layers only; written decision tables and phase
 rules remain authoritative when outputs diverge.
 
+For discover and suitability, use the adopted helpers first when helper
+support is enabled, then fall back to the portable instructions if a
+helper is unavailable or its output does not match the written rules.
+
 The exported template remains portable without a `scripts/` directory.
 Adopters can copy the helper separately when they want the same
 repository-local convenience, otherwise the documented GraphQL fallback

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -17,7 +17,9 @@ In the idd-skill source repository, the following optional helpers were adopted:
   evaluation (referenced in
   [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391))
 - `scripts/discover-viability-gate.mjs` for A4 viability gate evaluation
-  across limited scope, clear verification, and autonomous completion criteria
+  across limited scope, clear verification, and autonomous completion
+  criteria (referenced in
+  [kurone-kito/idd-skill#505](https://github.com/kurone-kito/idd-skill/issues/505))
 - `scripts/suitability-triage.mjs` for A4.5 seven-check suitability
   evaluation (referenced in
   [kurone-kito/idd-skill#392](https://github.com/kurone-kito/idd-skill/issues/392))

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -106,6 +106,11 @@ with [IDD policy constants](policy-constants.md). It names the claim,
 advisory, CI, and critique-loop defaults and points to the instruction
 files that own each value.
 
+When helper support is enabled, the discover and suitability phases may
+use the helper-backed evidence collectors first, but the Markdown
+instruction files remain the final authority whenever helper output is
+missing or disagrees.
+
 When an operator gives exactly one issue target, Discover can verify that
 target directly before Claim. The shortcut avoids broad roadmap
 enumeration, but it still applies targeted readiness checks, the A4

--- a/tests/helper-runtime-profiles.test.mjs
+++ b/tests/helper-runtime-profiles.test.mjs
@@ -248,6 +248,18 @@ test("idd-doctor warns when config and overview concrete commands differ", (t) =
   );
 });
 
+test("helper script docs keep the discover viability gate helper in sync", () => {
+  const live = readFileSync(new URL("../docs/idd-helper-scripts.md", import.meta.url), "utf8");
+  const template = readFileSync(
+    new URL("../idd-template/docs/idd-helper-scripts.md", import.meta.url),
+    "utf8",
+  );
+
+  assert.equal(template, live);
+  assert.match(live, /discover-viability-gate\.mjs/);
+  assert.match(live, /suitability-triage\.mjs/);
+});
+
 function createDoctorFixtureRepo(configFixtureName, { packageJson = null } = {}) {
   const configText = readFileSync(new URL(configFixtureName, FIXTURE_ROOT), "utf8");
   return createDoctorFixtureRepoFromConfig(configText, { packageJson });

--- a/tests/idd-workflow-phase-map-sync.test.mjs
+++ b/tests/idd-workflow-phase-map-sync.test.mjs
@@ -30,6 +30,17 @@ test("IDD file map keeps canonical phase-ID anchors", () => {
   }
 });
 
+test("workflow onboarding guidance stays synced between docs and template", () => {
+  const canonicalText = readText(CANONICAL_DOC);
+  const templateText = readText(TEMPLATE_DOC);
+
+  assert.match(canonicalText, /During onboarding, create or update `CLAUDE\.md`, `AGENTS\.md`, and\s+`GEMINI\.md`/);
+  assert.equal(
+    canonicalText.includes("helper-backed evidence collectors first"),
+    templateText.includes("helper-backed evidence collectors first"),
+  );
+});
+
 function readText(relativePath) {
   return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
 }

--- a/tests/idd-workflow-phase-map-sync.test.mjs
+++ b/tests/idd-workflow-phase-map-sync.test.mjs
@@ -34,7 +34,16 @@ test("workflow onboarding guidance stays synced between docs and template", () =
   const canonicalText = readText(CANONICAL_DOC);
   const templateText = readText(TEMPLATE_DOC);
 
-  assert.match(canonicalText, /During onboarding, create or update `CLAUDE\.md`, `AGENTS\.md`, and\s+`GEMINI\.md`/);
+  assert.match(
+    normalizeWhitespace(canonicalText),
+    /During onboarding, create or update `CLAUDE\.md`, `AGENTS\.md`, and `GEMINI\.md` so each non-Copilot agent listed above has a stable first file to read\. GitHub Copilot remains an update-if-present surface via `\.github\/copilot-instructions\.md`\. Skipping creation of a missing root entry file should be an explicit operator choice, not the default\./,
+    "canonical workflow doc must keep onboarding guidance",
+  );
+  assert.match(
+    normalizeWhitespace(templateText),
+    /During onboarding, create or update `CLAUDE\.md`, `AGENTS\.md`, and `GEMINI\.md` so each non-Copilot agent listed above has a stable first file to read\. GitHub Copilot remains an update-if-present surface via `\.github\/copilot-instructions\.md`\. Skipping creation of a missing root entry file should be an explicit operator choice, not the default\./,
+    "template workflow doc must keep onboarding guidance",
+  );
   assert.equal(
     canonicalText.includes("helper-backed evidence collectors first"),
     templateText.includes("helper-backed evidence collectors first"),
@@ -52,4 +61,8 @@ function extractTopLevelSection(text, fileLabel, startMarker) {
   const nextSectionStart = text.indexOf(nextSectionMarker, start + startMarker.length);
   const end = nextSectionStart === -1 ? text.length : nextSectionStart;
   return text.slice(start, end).trim();
+}
+
+function normalizeWhitespace(text) {
+  return text.replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
## Summary
- Prefer helper-backed evidence collection for discover and suitability when helper support is enabled.
- Keep the Markdown instructions authoritative when helper output is missing or disagrees.
- Mirror the guidance into the template docs.

Closes #505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Prefer helper-backed evidence collection for discover/suitability phases (A0–O, A3, A3.5, A4, A4.5); added a dedicated A4 viability-gate helper, a contract for its outputs, and explicit fallback rules. Written instruction files remain authoritative when helper output is missing or conflicts. Added onboarding guidance to ensure agent instruction entry files exist and harmonized docs/templates.
* **Tests**
  * Added tests to verify helper-script references and that workflow onboarding guidance stays synced between docs and templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/523)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->