### PR TITLE
docs: make resume routing helper-first and fail-closed

### DIFF
--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -50,6 +50,27 @@ If stalled-session routing returns hold/inconclusive, stop.
 
 ## Step 1 — Identify claim state
 
+When helper runtime is enabled, you may collect Step 1 evidence with:
+
+```sh
+node scripts/resume-claim-routing.mjs --issue {issue-number}
+```
+
+Use helper output as evidence mapped to this table, not as an
+authoritative replacement:
+
+- `state: already_owned` + `action: keep` → continue with the same
+  `{claim-id}` route.
+- `state: unclaimed` + `action: re_claim` → no-active-claim route.
+- `state: stale` + `action: takeover` → stale-claim takeover route.
+- `state: non_inheritable` + `action: stop` → active non-stale claim
+  stop route.
+- `state: disputed` + `action: stop` → contested-claim stop route.
+
+If helper runtime is absent, helper output is invalid, or helper evidence
+disagrees with live GitHub state, use the written table below and treat
+it as authoritative.
+
 Evaluate in order; take the first matching row.
 
 | Claim state                                                                                     | Route                                                                                                                         |
@@ -111,6 +132,23 @@ a human should expect next (e.g., `Phase: resume → B3`, `Phase: resume → D1`
 and review evidence used for the routing decision.
 
 ## Step 3 — Determine PR and CI/review state
+
+When helper runtime is enabled, you may collect Step 3 routing evidence
+with:
+
+```sh
+node scripts/resume-route-selection.mjs --issue {issue-number}
+```
+
+Map helper `route` to the Step 3 table outcomes:
+
+- `D1`, `D4`, `E1`, `E15`, `F1`, `F2` → matching row outcome.
+- `stop` → stop and report the helper reason; do not mutate state.
+
+Before any mutation after helper-assisted routing, still re-check live
+claim ownership, current PR HEAD, and current CI/review state in this
+phase's authoritative tables. If helper runtime is absent or helper
+output is invalid, use the written table below directly.
 
 | CI state                              | Reviews                                                              | Action                                             |
 | ------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------- |

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -348,6 +348,25 @@ default `instructions-only` profile keep using the written shell /
   and linked-issue exceptions do not yet have a supported helper
   contract
 
+### Resume claim and route evidence
+
+- Claim routing command:
+  `node scripts/resume-claim-routing.mjs --issue <issue-number>`
+- Stable fields consumed by resume instructions: `state`, `action`,
+  `reason`, `active_claim`, `claim_id_checked`, `stale_age_ms`, `now`,
+  `warnings`, and `evidence`
+- Stable enums:
+  - `state`:
+    `unclaimed|already_owned|stale|non_inheritable|disputed`
+  - `action`: `re_claim|takeover|keep|stop`
+
+- Step 3 route command:
+  `node scripts/resume-route-selection.mjs --issue <issue-number>`
+- Stable fields consumed by resume instructions: `route`, `reason`,
+  `state`, and `evidence`
+- Stable enum:
+  - `route`: `D1|D4|E1|E15|F1|F2|stop`
+
 ### Advisory-wait evidence
 
 - Command: `node scripts/advisory-wait-state.mjs --pr <pr-number>`

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -321,6 +321,10 @@ reviewer because that is part of this repository's current PR policy.
 
 This source repository currently ships the following optional helper scripts:
 
+- `scripts/resume-claim-routing.mjs` (read-only Resume Step 1 claim
+  routing evidence)
+- `scripts/resume-route-selection.mjs` (read-only Resume Step 3 route
+  selection evidence)
 - `scripts/review-activity-snapshot.mjs` (read-only E/F activity and CI
   snapshot metrics)
 - `scripts/advisory-wait-state.mjs` (read-only advisory-wait evidence

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -50,6 +50,27 @@ If stalled-session routing returns hold/inconclusive, stop.
 
 ## Step 1 — Identify claim state
 
+When helper runtime is enabled, you may collect Step 1 evidence with:
+
+```sh
+node scripts/resume-claim-routing.mjs --issue {issue-number}
+```
+
+Use helper output as evidence mapped to this table, not as an
+authoritative replacement:
+
+- `state: already_owned` + `action: keep` → continue with the same
+  `{claim-id}` route.
+- `state: unclaimed` + `action: re_claim` → no-active-claim route.
+- `state: stale` + `action: takeover` → stale-claim takeover route.
+- `state: non_inheritable` + `action: stop` → active non-stale claim
+  stop route.
+- `state: disputed` + `action: stop` → contested-claim stop route.
+
+If helper runtime is absent, helper output is invalid, or helper evidence
+disagrees with live GitHub state, use the written table below and treat
+it as authoritative.
+
 Evaluate in order; take the first matching row.
 
 | Claim state                                                                                     | Route                                                                                                                         |
@@ -111,6 +132,23 @@ a human should expect next (e.g., `Phase: resume → B3`, `Phase: resume → D1`
 and review evidence used for the routing decision.
 
 ## Step 3 — Determine PR and CI/review state
+
+When helper runtime is enabled, you may collect Step 3 routing evidence
+with:
+
+```sh
+node scripts/resume-route-selection.mjs --issue {issue-number}
+```
+
+Map helper `route` to the Step 3 table outcomes:
+
+- `D1`, `D4`, `E1`, `E15`, `F1`, `F2` → matching row outcome.
+- `stop` → stop and report the helper reason; do not mutate state.
+
+Before any mutation after helper-assisted routing, still re-check live
+claim ownership, current PR HEAD, and current CI/review state in this
+phase's authoritative tables. If helper runtime is absent or helper
+output is invalid, use the written table below directly.
 
 | CI state                              | Reviews                                                              | Action                                             |
 | ------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------- |

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -348,6 +348,25 @@ default `instructions-only` profile keep using the written shell /
   and linked-issue exceptions do not yet have a supported helper
   contract
 
+### Resume claim and route evidence
+
+- Claim routing command:
+  `node scripts/resume-claim-routing.mjs --issue <issue-number>`
+- Stable fields consumed by resume instructions: `state`, `action`,
+  `reason`, `active_claim`, `claim_id_checked`, `stale_age_ms`, `now`,
+  `warnings`, and `evidence`
+- Stable enums:
+  - `state`:
+    `unclaimed|already_owned|stale|non_inheritable|disputed`
+  - `action`: `re_claim|takeover|keep|stop`
+
+- Step 3 route command:
+  `node scripts/resume-route-selection.mjs --issue <issue-number>`
+- Stable fields consumed by resume instructions: `route`, `reason`,
+  `state`, and `evidence`
+- Stable enum:
+  - `route`: `D1|D4|E1|E15|F1|F2|stop`
+
 ### Advisory-wait evidence
 
 - Command: `node scripts/advisory-wait-state.mjs --pr <pr-number>`

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -311,6 +311,10 @@ reviewer because that is part of this repository's current PR policy.
 The idd-skill source repository that ships this template currently includes the
 following optional helper scripts:
 
+- `scripts/resume-claim-routing.mjs` (read-only Resume Step 1 claim
+  routing evidence)
+- `scripts/resume-route-selection.mjs` (read-only Resume Step 3 route
+  selection evidence)
 - `scripts/review-activity-snapshot.mjs` (read-only E/F activity and CI
   snapshot metrics)
 - `scripts/advisory-wait-state.mjs` (read-only advisory-wait evidence


### PR DESCRIPTION
## Summary
- make Resume Step 1 and Step 3 helper-first in IDD instructions while preserving table authority
- document stable output fields/enums for resume claim-routing and route-selection helpers
- add resume helpers to workflow optional helper inventory

Closes #507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional helper runtime now available for the Resume workflow to collect claim-state and route-selection evidence.

* **Documentation**
  * Resume instructions updated to describe helper runtime usage, evidence mapping, and explicit fallback to authoritative live state when helper output is absent or disagrees.
  * Helpers documented with response fields and enum values; guidance added that a helper "stop" halts reporting without mutating state and that live claim ownership, PR HEAD, and CI/review must be rechecked before any mutation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/527)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->