### PR TITLE
docs(idd): make review snapshot and merge gates helper-first

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -33,15 +33,16 @@ gate. The active claim must still use your current `{claim-id}`.
    (all review threads, review bodies, and regular PR comments,
    excluding trusted agent operational marker comments only). Compare
    against the F2 snapshot carried forward from
-   `idd-pre-merge.instructions.md`. In the idd-skill source repository,
-   or in adopters that explicitly
-   installed the same helpers, the documented merge-gate helper
-   reference in
+   `idd-pre-merge.instructions.md`. When helper runtime is enabled,
+   prefer the documented merge-gate helper reference in
    [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
-   may collect the documented snapshot tuple and broader
-   `pre-merge-readiness` JSON report. Both helpers are evidence
-   collectors only; the written gate rules remain canonical. Return to
-   E1 if **any** of the following is true:
+   to collect the documented snapshot tuple and broader
+   `pre-merge-readiness` JSON report. Both helpers remain read-only
+   evidence collectors only: if helper execution fails, output is
+   invalid JSON, required sections are missing, or live GitHub state
+   disagrees with helper output, discard helper output and run the live
+   fetch in this step directly. The written gate rules remain canonical.
+   Return to E1 if **any** of the following is true:
 
    - The current PR HEAD SHA differs from `{f2-head-SHA}`.
    - `{f2-max-activity-updatedAt}` is `none` and the final fetch is

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -102,14 +102,19 @@ must align with every F2 condition below.
   minimize, or otherwise unmark open-PR operational markers during this
   recovery; if no trusted same-claim watermark exists for the successor
   claim, return to E1 and rebuild review state there.
-  To collect this evidence, either use the documented merge-gate helper
-  reference in
+  When helper runtime is enabled, prefer the documented merge-gate
+  helper reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
-  (in the idd-skill source repository or adopters that explicitly
-  installed the same helpers) or fetch the activity universe snapshot
-  (same scope as E1 Step 1) and the current CI state for the HEAD SHA
-  directly. The instruction rules remain canonical. Return to E1 if
-  **any** of the
+  to collect this evidence. Consume helper evidence from
+  `reviewCurrency` (including `comparisonRoute`), `threads`,
+  `unrepliedComments`, `reviewerStates`, `advisoryWait`, `ci`, `claim`,
+  and optional `dispositionEvidence`.
+  Helpers remain read-only evidence collectors: if helper execution
+  fails, output is invalid JSON, required sections are missing, or live
+  GitHub state disagrees with helper output, discard helper output and
+  fetch the activity universe snapshot (same scope as E1 Step 1) plus
+  current CI state for the HEAD SHA directly. The instruction rules
+  remain canonical. Return to E1 if **any** of the
   following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new
     push occurred after E1's snapshot, even if the watermark comment was

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -43,14 +43,16 @@ Do not exclude marker-shaped comments from untrusted authors. Keep them
 in the snapshot/ReviewItems_snapshot and report them as suspicious
 context when they affect a decision.
 
-In the idd-skill source repository, you may optionally use the read-only helper
-`node scripts/review-activity-snapshot.mjs --pr {pr-number}` to compute
+When helper runtime is enabled, prefer the read-only helper
+`node scripts/review-activity-snapshot.mjs --pr {pr-number}` to collect
 `{head-SHA}`, `{max-activity-updatedAt}`, `{total-item-count}`, and CI
 completion timestamps. Pass trusted marker actors with
-`--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`. The
-helper is convenience only; this instruction remains canonical and any
-mismatch must be resolved in favor of this specification. In adopter
-repositories, use the portable gh/jq/API procedure instead.
+`--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`.
+Helpers remain evidence collectors only: if helper execution fails,
+returns invalid JSON, omits required fields, or conflicts with live
+GitHub state in this phase, discard helper output and run the portable
+gh/jq/API procedure below. The written instruction rules remain the
+authoritative decision path.
 
 Additionally, fetch the **current CI state** for `{head-SHA}`:
 `gh pr checks {pr-number} --json name,state,completedAt`. Record the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -399,6 +399,9 @@ default `instructions-only` profile keep using the written shell /
 
 ### Merge-gate evidence
 
+- When helper runtime is enabled, these commands are the preferred
+  evidence collection path for E1/F2/F3 review-currency and merge-gate
+  checks.
 - Snapshot command: `node scripts/review-activity-snapshot.mjs`
   with `--pr <pr-number>` and
   `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
@@ -417,8 +420,13 @@ default `instructions-only` profile keep using the written shell /
 - Stable sections consumed by the instructions: `reviewCurrency`,
   `threads`, `unrepliedComments`, `reviewerStates`,
   `advisoryWait` (including the effective advisory policy fields), `ci`,
-  `claim`, and optional
-  `dispositionEvidence`
+  `claim`, and optional `dispositionEvidence`
+- `reviewCurrency.comparisonRoute` remains advisory evidence only. Agents
+  must still apply written instruction checks against live GitHub state.
+- Fail closed: if helper execution fails, output is invalid JSON,
+  required fields/sections are missing, or helper evidence conflicts with
+  live GitHub state, discard helper output and use the portable manual
+  fetch path.
 
 ### E7 disposition verification
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -338,7 +338,10 @@ This source repository currently ships the following optional helper scripts:
 
 Shell / `gh` / `jq` snippets in
 `.github/instructions/*.instructions.md` remain the canonical portable
-path for adopters, and the helper scripts are convenience layers only.
+path for repositories that stay on `instructions-only`. When helper
+runtime is enabled, these shipped helpers are the preferred evidence
+collection path, while live GitHub checks and written gate rules remain
+authoritative.
 
 See [IDD helper script evaluation](idd-helper-scripts.md) for the
 current inventory of high-friction query patterns, the adopted helper

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -33,15 +33,16 @@ gate. The active claim must still use your current `{claim-id}`.
    (all review threads, review bodies, and regular PR comments,
    excluding trusted agent operational marker comments only). Compare
    against the F2 snapshot carried forward from
-   `idd-pre-merge.instructions.md`. In the idd-skill source repository,
-   or in adopters that explicitly
-   installed the same helpers, the documented merge-gate helper
-   reference in
+   `idd-pre-merge.instructions.md`. When helper runtime is enabled,
+   prefer the documented merge-gate helper reference in
    [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
-   may collect the documented snapshot tuple and broader
-   `pre-merge-readiness` JSON report. Both helpers are evidence
-   collectors only; the written gate rules remain canonical. Return to
-   E1 if **any** of the following is true:
+   to collect the documented snapshot tuple and broader
+   `pre-merge-readiness` JSON report. Both helpers remain read-only
+   evidence collectors only: if helper execution fails, output is
+   invalid JSON, required sections are missing, or live GitHub state
+   disagrees with helper output, discard helper output and run the live
+   fetch in this step directly. The written gate rules remain canonical.
+   Return to E1 if **any** of the following is true:
 
    - The current PR HEAD SHA differs from `{f2-head-SHA}`.
    - `{f2-max-activity-updatedAt}` is `none` and the final fetch is

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -102,14 +102,19 @@ must align with every F2 condition below.
   minimize, or otherwise unmark open-PR operational markers during this
   recovery; if no trusted same-claim watermark exists for the successor
   claim, return to E1 and rebuild review state there.
-  To collect this evidence, either use the documented merge-gate helper
-  reference in
+  When helper runtime is enabled, prefer the documented merge-gate
+  helper reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
-  (in the idd-skill source repository or adopters that explicitly
-  installed the same helpers) or fetch the activity universe snapshot
-  (same scope as E1 Step 1) and the current CI state for the HEAD SHA
-  directly. The instruction rules remain canonical. Return to E1 if
-  **any** of the
+  to collect this evidence. Consume helper evidence from
+  `reviewCurrency` (including `comparisonRoute`), `threads`,
+  `unrepliedComments`, `reviewerStates`, `advisoryWait`, `ci`, `claim`,
+  and optional `dispositionEvidence`.
+  Helpers remain read-only evidence collectors: if helper execution
+  fails, output is invalid JSON, required sections are missing, or live
+  GitHub state disagrees with helper output, discard helper output and
+  fetch the activity universe snapshot (same scope as E1 Step 1) plus
+  current CI state for the HEAD SHA directly. The instruction rules
+  remain canonical. Return to E1 if **any** of the
   following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new
     push occurred after E1's snapshot, even if the watermark comment was

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -43,14 +43,16 @@ Do not exclude marker-shaped comments from untrusted authors. Keep them
 in the snapshot/ReviewItems_snapshot and report them as suspicious
 context when they affect a decision.
 
-In the idd-skill source repository, you may optionally use the read-only helper
-`node scripts/review-activity-snapshot.mjs --pr {pr-number}` to compute
+When helper runtime is enabled, prefer the read-only helper
+`node scripts/review-activity-snapshot.mjs --pr {pr-number}` to collect
 `{head-SHA}`, `{max-activity-updatedAt}`, `{total-item-count}`, and CI
 completion timestamps. Pass trusted marker actors with
-`--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`. The
-helper is convenience only; this instruction remains canonical and any
-mismatch must be resolved in favor of this specification. In adopter
-repositories, use the portable gh/jq/API procedure instead.
+`--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`.
+Helpers remain evidence collectors only: if helper execution fails,
+returns invalid JSON, omits required fields, or conflicts with live
+GitHub state in this phase, discard helper output and run the portable
+gh/jq/API procedure below. The written instruction rules remain the
+authoritative decision path.
 
 Additionally, fetch the **current CI state** for `{head-SHA}`:
 `gh pr checks {pr-number} --json name,state,completedAt`. Record the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -399,6 +399,9 @@ default `instructions-only` profile keep using the written shell /
 
 ### Merge-gate evidence
 
+- When helper runtime is enabled, these commands are the preferred
+  evidence collection path for E1/F2/F3 review-currency and merge-gate
+  checks.
 - Snapshot command: `node scripts/review-activity-snapshot.mjs`
   with `--pr <pr-number>` and
   `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
@@ -417,8 +420,13 @@ default `instructions-only` profile keep using the written shell /
 - Stable sections consumed by the instructions: `reviewCurrency`,
   `threads`, `unrepliedComments`, `reviewerStates`,
   `advisoryWait` (including the effective advisory policy fields), `ci`,
-  `claim`, and optional
-  `dispositionEvidence`
+  `claim`, and optional `dispositionEvidence`
+- `reviewCurrency.comparisonRoute` remains advisory evidence only. Agents
+  must still apply written instruction checks against live GitHub state.
+- Fail closed: if helper execution fails, output is invalid JSON,
+  required fields/sections are missing, or helper evidence conflicts with
+  live GitHub state, discard helper output and use the portable manual
+  fetch path.
 
 ### E7 disposition verification
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -328,8 +328,10 @@ following optional helper scripts:
 
 Shell / `gh` / `jq` snippets in
 `.github/instructions/*.instructions.md` remain the canonical portable
-path for adopters, and helper scripts remain optional convenience
-layers.
+path for repositories that stay on `instructions-only`. When helper
+runtime is enabled, these shipped helpers are the preferred evidence
+collection path, while live GitHub checks and written gate rules remain
+authoritative.
 
 See [IDD helper script evaluation](idd-helper-scripts.md) for the
 current inventory of high-friction query patterns, the adopted helper


### PR DESCRIPTION
## Summary
- make E1/F2/F3 instruction wording helper-first for shipped read-only merge-gate helpers
- define explicit fail-closed behavior for invalid or conflicting helper evidence
- keep portable instructions-only manual path and sync source/template docs

Closes #509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated merge-gate instructions to support optional helper runtime for evidence collection in E1, F2, and F3 steps.
  * When enabled, helper scripts become the preferred method for gathering review-currency and merge-gate evidence.
  * Added fail-closed safeguards: if helper execution fails or conflicts with live GitHub state, the system falls back to manual fetch procedures.
  * Written gate rules remain authoritative; instruction procedures are canonical.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/528)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->