### PR TITLE
refactor(instructions): make resume-stall helper-first for quiet-window evidence

### DIFF
--- a/.github/instructions/idd-resume-stall.instructions.md
+++ b/.github/instructions/idd-resume-stall.instructions.md
@@ -54,11 +54,39 @@ remote branch tip movement, no running CI activity (`queued` or
 `in_progress` checks/runs), and no new review/comment/CI completion
 activity.
 
+When helper runtime is enabled, use
+`idd-stalled-session-quiet-check` as the canonical read-only evidence
+collector for this step. Pass the active PR number and, when known, the
+latest valid trusted `claimed-by` `created_at` from the active non-owned
+claim:
+
+```bash
+idd-stalled-session-quiet-check \
+  --pr <pr-number> \
+  --claim-created-at <latest-valid-claimed-by-created_at>
+```
+
+Use `node scripts/stalled-session-quiet-check.mjs ...` as the vendored
+equivalent when the packaged binary is unavailable. Consume the helper's
+stable fields `quiet_window_met`, `quiet_window_ms`, `window_start`,
+`now`, `latest_activity`, `latest_activity_type`, `reason`, and
+`evidence` (`activity_count_in_window`, `blocking_activities`,
+`has_heartbeat_in_window`, `has_ci_running`,
+`has_pr_head_movement`, `has_branch_tip_movement`).
+
+The helper gathers evidence only. It never decides trusted-marker
+validity, stale-age, advisory state, forced-handoff routing, or takeover
+eligibility by itself. If helper runtime is unavailable, the command
+fails, or the output is missing or contradictory, fall back to the
+written quiet-window procedure in this file and the collected live
+signals above. That written procedure remains authoritative.
+
 - Quiet window not met or evidence is contradictory/incomplete:
   **hold and stop**. Do not claim, push, or mutate review state.
 - Quiet window met: continue to S3.
 
-Quiet-window evidence does not permit takeover by itself.
+Quiet-window evidence does not permit takeover by itself and never
+waives the stale-threshold gate in S3.
 
 ### S3 — Stale-threshold gate (ownership transfer gate)
 
@@ -79,8 +107,10 @@ Immediately before posting takeover:
 2. Confirm the active claim still uses the same non-owned `{claim-id}`
    observed in S1-S3.
 3. Confirm it is still stale at this moment.
-4. Re-check quiet-window evidence against the latest externally visible
-   activity. If new progress appeared after S2, stop and restart.
+4. Re-run `idd-stalled-session-quiet-check` (or repeat the written
+   manual procedure when helper runtime is unavailable) against the
+   latest externally visible activity. If new progress appeared after
+   S2, stop and restart.
 5. Re-check closed/merged guards. If the issue is now closed or the PR
    is now merged, stop and return to `idd-resume.instructions.md` Step 1
    cleanup behavior.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -437,9 +437,12 @@ default `instructions-only` profile keep using the written shell /
 
 ### S2 quiet-window evidence
 
-- Command: `node scripts/stalled-session-quiet-check.mjs --pr <pr-number>`
-  with optional `--now <ISO8601>`, `--quiet-window-ms <ms>`,
-  and `--claim-created-at <ISO8601>`
+- When helper runtime is enabled, Resume/S2 should call the
+  profile-selected `idd-stalled-session-quiet-check --pr <pr-number>`
+  command first. `node scripts/stalled-session-quiet-check.mjs --pr
+  <pr-number>` is the vendored equivalent.
+- Optional parameters: `--now <ISO8601>`, `--quiet-window-ms <ms>`,
+  `--claim-created-at <ISO8601>`, and `--policy <path>`
 - Stable fields consumed by the instructions: `quiet_window_met`,
   `quiet_window_ms`, `window_start`, `now`, `latest_activity`,
   `latest_activity_type`, `reason`, and `evidence`
@@ -449,6 +452,10 @@ default `instructions-only` profile keep using the written shell /
 - `ci-running` activities always break the quiet window regardless
   of their timestamp; all other types are checked against
   `window_start = now - quiet_window_ms`
+- Before takeover, re-run the helper against live GitHub state and pair
+  it with the written Resume/S2-S4 checks for the same active claim,
+  stale-threshold gating, closed/merged guards, and A5 race-safe claim
+  verification. `quiet_window_met = true` alone is never sufficient.
 
 ### Review-disposition verification
 

--- a/docs/stalled-session-quiet-check.md
+++ b/docs/stalled-session-quiet-check.md
@@ -1,222 +1,191 @@
 # Stalled Session Quiet-Check Helper
 
-Detects quiet windows (no activity for a configurable period, default 30
-minutes) for the Resume/S2 stalled-session recovery specification.
+Detects quiet windows for the Resume/S2 stalled-session recovery path.
 
 ## Purpose
 
-This helper supports the Resume phase S2 (Quiet-Window Check) by detecting
-whether a stalled session has truly been inactive. The quiet window must be
-met before the S3 stale-threshold gate permits takeover of a non-owned claim.
+When helper runtime is enabled, `idd-stalled-session-quiet-check` is the
+canonical read-only evidence collector for Resume/S2 quiet-window checks.
+It helps gather externally observable activity for an open PR without
+changing claim state, review state, or CI state.
+
+The helper does not replace the written policy. Resume/S2-S4 still owns
+trusted-marker validation, stale-threshold gating, forced-handoff
+routing, advisory constraints, and A5 race-safe takeover checks.
 
 ## Specification Reference
 
-See `idd-resume-stall.instructions.md` for the full stalled-session recovery
-context and the decision rules that consume this helper's output.
+- `/.github/instructions/idd-resume-stall.instructions.md`
+- [`docs/idd-helper-scripts.md`](idd-helper-scripts.md)
+- [`schemas/stalled-session-quiet-check.schema.json`](../schemas/stalled-session-quiet-check.schema.json)
 
 ## Usage
 
 ### CLI
 
+Preferred helper-runtime command:
+
 ```bash
-node scripts/stalled-session-quiet-check.mjs \
-  --issue <number> \
+idd-stalled-session-quiet-check \
   --pr <number> \
-  --branch <name> \
   [--owner <owner>] \
   [--repo <repo>] \
-  [--window-minutes <minutes>] \
+  [--token <token>] \
   [--now <ISO8601>] \
-  [--previous-branch-tip-sha <sha>]
+  [--quiet-window-ms <ms>] \
+  [--claim-created-at <ISO8601>] \
+  [--policy <path>]
 ```
 
-#### Required Parameters
+Vendored equivalent:
 
-- `--issue <number>`: Issue number (for fetching claim comments)
-- `--pr <number>`: PR number (for fetching timeline and review state)
-- `--branch <name>`: Remote branch name (for fetching branch tip SHA)
+```bash
+node scripts/stalled-session-quiet-check.mjs \
+  --pr <number> \
+  [--owner <owner>] \
+  [--repo <repo>] \
+  [--token <token>] \
+  [--now <ISO8601>] \
+  [--quiet-window-ms <ms>] \
+  [--claim-created-at <ISO8601>] \
+  [--policy <path>]
+```
 
-#### Optional Parameters
+#### Required parameter
 
-- `--owner <owner>`: Repository owner; defaults to current repository
-- `--repo <repo>`: Repository name; defaults to current repository
-- `--window-minutes <minutes>`: Quiet window duration in minutes;
-  default: 30
+- `--pr <number>`: Pull request number used to gather activity evidence
+
+#### Optional parameters
+
+- `--owner <owner>`: Repository owner; defaults to the current repository
+- `--repo <repo>`: Repository name; defaults to the current repository
+- `--token <token>`: GitHub token override for `gh` API calls
 - `--now <ISO8601>`: Reference timestamp; defaults to current UTC time
-  (in format `YYYY-MM-DDTHH:MM:SSZ`)
-- `--previous-branch-tip-sha <sha>`: Previous branch tip SHA for movement
-  detection
+- `--quiet-window-ms <ms>`: Quiet-window duration in milliseconds;
+  defaults to the policy value or `1800000`
+- `--claim-created-at <ISO8601>`: Latest valid trusted `claimed-by`
+  `created_at` for the active non-owned claim; enables heartbeat
+  evidence in Resume/S2
+- `--policy <path>`: Alternate policy file used to resolve the default
+  quiet window
 - `--help`: Show help text
 
-### Node.js (Programmatic)
+`--claim-created-at` should come from the trusted active-claim parse that
+Resume already performs. If helper runtime is unavailable or the helper
+output is unusable, the written manual procedure in
+`idd-resume-stall.instructions.md` remains authoritative.
 
-```javascript
-import { execFileSync } from "node:child_process";
+## Stable output fields consumed by Resume/S2
 
-const result = JSON.parse(
-  execFileSync("node", [
-    "scripts/stalled-session-quiet-check.mjs",
-    "--issue", "123",
-    "--pr", "456",
-    "--branch", "issue/123-feature",
-    "--owner", "my-org",
-    "--repo", "my-repo",
-    "--window-minutes", "30",
-  ], { encoding: "utf8" })
-);
+Resume/S2 treats these fields as the stable contract:
 
-if (result.isQuiet) {
-  console.log("Quiet window confirmed; proceed with S3 check");
-} else {
-  console.log("Activity detected within window; abort takeover");
-  console.log("Details:", result.evidence.details);
-}
-```
+- `quiet_window_met`
+- `quiet_window_ms`
+- `window_start`
+- `now`
+- `latest_activity`
+- `latest_activity_type`
+- `reason`
+- `evidence.activity_count_in_window`
+- `evidence.blocking_activities`
+- `evidence.has_heartbeat_in_window`
+- `evidence.has_ci_running`
+- `evidence.has_pr_head_movement`
+- `evidence.has_branch_tip_movement`
 
-## Return Value Schema
+The CLI also includes `repository`, `pr`, and `policy` envelopes for
+operator context. Those fields are useful for logging and diagnostics but
+are not the gating fields Resume/S2 relies on.
+
+## Output schema
+
+The CLI returns JSON shaped like:
 
 ```json
 {
-  "isQuiet": boolean,
+  "repository": {
+    "owner": "kurone-kito",
+    "repo": "idd-skill"
+  },
+  "pr": {
+    "number": 526,
+    "title": "refactor(instructions): make resume-stall helper-first",
+    "head_sha": "9bf7bd353fe09a0514fcf3e36b3a323cb6c936fe",
+    "html_url": "https://github.com/kurone-kito/idd-skill/pull/526"
+  },
+  "policy": {
+    "quiet_window_ms": 1800000,
+    "claim_created_at": "2026-05-13T17:40:00Z"
+  },
+  "quiet_window_met": false,
+  "quiet_window_ms": 1800000,
+  "window_start": "2026-05-13T17:30:00Z",
+  "now": "2026-05-13T18:00:00Z",
+  "latest_activity": "2026-05-13T17:58:02Z",
+  "latest_activity_type": "ci-completed",
+  "reason": "activity-in-window: comment, ci-completed",
   "evidence": {
-    "windowMinutes": number,
-    "windowStartUtc": "ISO8601 timestamp",
-    "windowEndUtc": "ISO8601 timestamp",
-    "latestActivityUtc": "ISO8601 timestamp or null",
-    "reason": "string explanation",
-    "details": ["array of activity findings"],
-    "checkSummary": {
-      "heartbeatCheck": "PASSED" | "FAILED",
-      "prHeadMovementCheck": "PASSED" | "FAILED",
-      "branchTipMovementCheck": "PASSED" | "FAILED",
-      "runningCiCheck": "PASSED" | "FAILED",
-      "reviewActivityCheck": "PASSED" | "FAILED",
-      "commentActivityCheck": "PASSED" | "FAILED",
-      "ciCompletionCheck": "PASSED" | "FAILED"
-    }
+    "activity_count_in_window": 2,
+    "blocking_activities": [
+      {
+        "type": "comment",
+        "timestamp": "2026-05-13T17:52:41Z"
+      },
+      {
+        "type": "ci-completed",
+        "timestamp": "2026-05-13T17:58:02Z"
+      }
+    ],
+    "has_heartbeat_in_window": false,
+    "has_ci_running": false,
+    "has_pr_head_movement": false,
+    "has_branch_tip_movement": false
   }
 }
 ```
 
-### `isQuiet`
+`latest_activity_type` is descriptive evidence, not a standalone policy
+decision. Resume/S2 still interprets the full response together with the
+written instructions.
 
-Boolean flag indicating whether the quiet window is satisfied (all checks
-passed).
+## Live rechecks required before takeover
 
-### `evidence`
+Quiet-window evidence is only one gate in stalled-session recovery.
+Before takeover, Resume/S4 must still:
 
-Detailed evidence collected during the check:
+1. Re-parse the active claim from trusted markers and confirm it is the
+   same non-owned `{claim-id}` observed earlier.
+2. Re-run this helper against live GitHub state, or repeat the written
+   manual procedure when helper runtime is unavailable.
+3. Re-check the stale-threshold gate. `quiet_window_met = true` never
+   waives stale-age by itself.
+4. Re-check closed/merged guards and stop if the issue or PR closed in
+   the meantime.
+5. Use A5 race-safe claim verification after posting takeover.
 
-- **`windowMinutes`**: The quiet window duration used for the check
-- **`windowStartUtc`**: The earliest timestamp within the quiet window
-  (reference time minus window duration)
-- **`windowEndUtc`**: The reference timestamp (end of the window)
-- **`latestActivityUtc`**: The most recent activity timestamp across all
-  sources, or `null` if no activity was found
-- **`reason`**: Human-readable summary of the outcome
-- **`details`**: Array of specific findings (heartbeat, PR movement, etc.)
-- **`checkSummary`**: Per-check status showing which specific activity
-  types were detected
+If helper output is missing, contradictory, or no longer quiet, stop and
+restart Resume routing instead of taking over.
 
-## Quiet Window Checks
+## Return code
 
-The helper validates all five sources required by Resume/S2:
+Successful evaluations always exit with code `0`, including cases where
+`quiet_window_met` is `false`. Use the JSON output to decide whether the
+quiet window is satisfied.
 
-1. **Heartbeat Check**: Looks for trusted `<!-- claimed-by: ... -->`
-   markers within the window
-   - Detects ongoing claim activity that would indicate an active session
-
-2. **PR Head Movement Check**: Detects new commits in the PR timeline
-   within the window
-   - Indicates work is being pushed to the branch
-
-3. **Branch Tip Movement Check**: Compares current branch tip SHA against
-   previous snapshot
-   - Requires `--previous-branch-tip-sha` parameter
-   - Detects force-push or new commits on the remote branch
-
-4. **Running CI Check**: Detects `queued` or `in_progress` CI checks
-   - Indicates active workflow execution
-
-5. **Review Activity Check**: Detects new review submissions within the
-   window
-   - Includes formal code reviews and automated advisory reviews
-
-6. **Comment Activity Check**: Detects new comments (excluding claim
-   markers)
-   - Includes issue and PR comments from humans and bots
-
-7. **CI Completion Check**: Detects recently completed CI runs
-   - Indicates workflow activity that occurred within the window
-
-## Integration with Resume/S2
-
-In `idd-resume-stall.instructions.md`, use this helper to decide whether to
-proceed with takeover:
-
-```bash
-RESULT=$(node scripts/stalled-session-quiet-check.mjs \
-  --issue "$ISSUE_NUMBER" \
-  --pr "$PR_NUMBER" \
-  --branch "$BRANCH_NAME" \
-  --window-minutes 30)
-
-IS_QUIET=$(echo "$RESULT" | jq '.isQuiet')
-
-if [ "$IS_QUIET" = "true" ]; then
-  echo "Quiet window confirmed; continue to S3 check"
-else
-  echo "Activity detected; hold and stop"
-  echo "$RESULT" | jq '.evidence.details[]'
-fi
-```
-
-## Return Code
-
-Always exits with code 0 on success (regardless of `isQuiet` value). Use the
-JSON output to determine the result.
-
-## Error Handling
+## Error handling
 
 The helper throws an error if:
 
-- Required parameters are missing (--issue, --pr, or --branch)
+- `--pr` is missing or invalid
 - GitHub API calls fail
-- Invalid parameter values are provided
+- The helper cannot parse a provided argument value
 
-## Timestamp Handling
+## Timestamp handling
 
-- Uses GitHub server-provided timestamps (from API responses)
-- Never uses local wall-clock time
-- Assumes all timestamps are in UTC
-- ISO8601 format with `Z` suffix (e.g., `2024-05-13T12:00:00Z`)
-
-## Example Output
-
-```json
-{
-  "isQuiet": false,
-  "evidence": {
-    "windowMinutes": 30,
-    "windowStartUtc": "2024-05-13T11:30:00Z",
-    "windowEndUtc": "2024-05-13T12:00:00Z",
-    "latestActivityUtc": "2024-05-13T11:45:00Z",
-    "reason": "Activity detected within 30-minute window",
-    "details": [
-      "Comment activity detected: 1 comment(s) within window"
-    ],
-    "checkSummary": {
-      "heartbeatCheck": "PASSED",
-      "prHeadMovementCheck": "PASSED",
-      "branchTipMovementCheck": "PASSED",
-      "runningCiCheck": "PASSED",
-      "reviewActivityCheck": "PASSED",
-      "commentActivityCheck": "FAILED",
-      "ciCompletionCheck": "PASSED"
-    }
-  }
-}
-```
+- Uses GitHub server timestamps from API responses
+- Normalizes timestamps to ISO8601 UTC with a `Z` suffix
+- Treats `ci-running` as blocking even if its timestamp would otherwise
+  fall outside the window
 
 ## Dependencies
 

--- a/idd-template/.github/instructions/idd-resume-stall.instructions.md
+++ b/idd-template/.github/instructions/idd-resume-stall.instructions.md
@@ -54,11 +54,39 @@ remote branch tip movement, no running CI activity (`queued` or
 `in_progress` checks/runs), and no new review/comment/CI completion
 activity.
 
+When helper runtime is enabled, use
+`idd-stalled-session-quiet-check` as the canonical read-only evidence
+collector for this step. Pass the active PR number and, when known, the
+latest valid trusted `claimed-by` `created_at` from the active non-owned
+claim:
+
+```bash
+idd-stalled-session-quiet-check \
+  --pr <pr-number> \
+  --claim-created-at <latest-valid-claimed-by-created_at>
+```
+
+Use `node scripts/stalled-session-quiet-check.mjs ...` as the vendored
+equivalent when the packaged binary is unavailable. Consume the helper's
+stable fields `quiet_window_met`, `quiet_window_ms`, `window_start`,
+`now`, `latest_activity`, `latest_activity_type`, `reason`, and
+`evidence` (`activity_count_in_window`, `blocking_activities`,
+`has_heartbeat_in_window`, `has_ci_running`,
+`has_pr_head_movement`, `has_branch_tip_movement`).
+
+The helper gathers evidence only. It never decides trusted-marker
+validity, stale-age, advisory state, forced-handoff routing, or takeover
+eligibility by itself. If helper runtime is unavailable, the command
+fails, or the output is missing or contradictory, fall back to the
+written quiet-window procedure in this file and the collected live
+signals above. That written procedure remains authoritative.
+
 - Quiet window not met or evidence is contradictory/incomplete:
   **hold and stop**. Do not claim, push, or mutate review state.
 - Quiet window met: continue to S3.
 
-Quiet-window evidence does not permit takeover by itself.
+Quiet-window evidence does not permit takeover by itself and never
+waives the stale-threshold gate in S3.
 
 ### S3 — Stale-threshold gate (ownership transfer gate)
 
@@ -79,8 +107,10 @@ Immediately before posting takeover:
 2. Confirm the active claim still uses the same non-owned `{claim-id}`
    observed in S1-S3.
 3. Confirm it is still stale at this moment.
-4. Re-check quiet-window evidence against the latest externally visible
-   activity. If new progress appeared after S2, stop and restart.
+4. Re-run `idd-stalled-session-quiet-check` (or repeat the written
+   manual procedure when helper runtime is unavailable) against the
+   latest externally visible activity. If new progress appeared after
+   S2, stop and restart.
 5. Re-check closed/merged guards. If the issue is now closed or the PR
    is now merged, stop and return to `idd-resume.instructions.md` Step 1
    cleanup behavior.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -437,9 +437,12 @@ default `instructions-only` profile keep using the written shell /
 
 ### S2 quiet-window evidence
 
-- Command: `node scripts/stalled-session-quiet-check.mjs --pr <pr-number>`
-  with optional `--now <ISO8601>`, `--quiet-window-ms <ms>`,
-  and `--claim-created-at <ISO8601>`
+- When helper runtime is enabled, Resume/S2 should call the
+  profile-selected `idd-stalled-session-quiet-check --pr <pr-number>`
+  command first. `node scripts/stalled-session-quiet-check.mjs --pr
+  <pr-number>` is the vendored equivalent.
+- Optional parameters: `--now <ISO8601>`, `--quiet-window-ms <ms>`,
+  `--claim-created-at <ISO8601>`, and `--policy <path>`
 - Stable fields consumed by the instructions: `quiet_window_met`,
   `quiet_window_ms`, `window_start`, `now`, `latest_activity`,
   `latest_activity_type`, `reason`, and `evidence`
@@ -449,6 +452,10 @@ default `instructions-only` profile keep using the written shell /
 - `ci-running` activities always break the quiet window regardless
   of their timestamp; all other types are checked against
   `window_start = now - quiet_window_ms`
+- Before takeover, re-run the helper against live GitHub state and pair
+  it with the written Resume/S2-S4 checks for the same active claim,
+  stale-threshold gating, closed/merged guards, and A5 race-safe claim
+  verification. `quiet_window_met = true` alone is never sufficient.
 
 ### Review-disposition verification
 

--- a/schemas/stalled-session-quiet-check.schema.json
+++ b/schemas/stalled-session-quiet-check.schema.json
@@ -2,133 +2,188 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://kurone-kito.github.io/idd-skill/schemas/stalled-session-quiet-check.schema.json",
   "title": "Stalled Session Quiet Check",
-  "description": "Evidence snapshot for quiet-window detection (Resume/S2 stalled-session recovery)",
+  "description": "CLI contract for quiet-window evidence collection (Resume/S2 stalled-session recovery)",
   "type": "object",
   "required": [
-    "isQuiet",
+    "repository",
+    "pr",
+    "policy",
+    "quiet_window_met",
+    "quiet_window_ms",
+    "window_start",
+    "now",
+    "latest_activity",
+    "latest_activity_type",
+    "reason",
     "evidence"
   ],
   "properties": {
-    "isQuiet": {
-      "type": "boolean",
-      "description": "Whether the quiet window is satisfied (all activity checks passed)"
-    },
-    "evidence": {
+    "repository": {
       "type": "object",
       "required": [
-        "windowMinutes",
-        "windowStartUtc",
-        "windowEndUtc",
-        "latestActivityUtc",
-        "reason",
-        "details",
-        "checkSummary"
+        "owner",
+        "repo"
       ],
       "properties": {
-        "windowMinutes": {
-          "type": "number",
+        "owner": {
+          "type": "string",
+          "description": "Repository owner used for helper collection"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name used for helper collection"
+        }
+      },
+      "additionalProperties": false
+    },
+    "pr": {
+      "type": "object",
+      "required": [
+        "number",
+        "title",
+        "head_sha",
+        "html_url"
+      ],
+      "properties": {
+        "number": {
+          "type": "integer",
           "minimum": 1,
-          "description": "The quiet window duration in minutes"
+          "description": "Pull request number evaluated by the helper"
         },
-        "windowStartUtc": {
+        "title": {
           "type": "string",
-          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
-          "description": "The earliest timestamp within the quiet window"
+          "description": "Current PR title"
         },
-        "windowEndUtc": {
+        "head_sha": {
           "type": "string",
-          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
-          "description": "The reference timestamp (end of the window)"
+          "description": "Current PR head SHA"
         },
-        "latestActivityUtc": {
+        "html_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical PR URL"
+        }
+      },
+      "additionalProperties": false
+    },
+    "policy": {
+      "type": "object",
+      "required": [
+        "quiet_window_ms",
+        "claim_created_at"
+      ],
+      "properties": {
+        "quiet_window_ms": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Quiet-window duration used for this evaluation"
+        },
+        "claim_created_at": {
           "type": [
             "string",
             "null"
           ],
           "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)?$",
-          "description": "The most recent activity timestamp across all sources, or null if no activity was found"
+          "description": "Trusted active-claim heartbeat timestamp passed to the helper, or null"
+        }
+      },
+      "additionalProperties": false
+    },
+    "quiet_window_met": {
+      "type": "boolean",
+      "description": "Whether the quiet window is satisfied"
+    },
+    "quiet_window_ms": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Quiet-window duration used for the evaluation"
+    },
+    "window_start": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "description": "Inclusive lower bound for timestamped activity checks"
+    },
+    "now": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "description": "Reference timestamp used for the evaluation"
+    },
+    "latest_activity": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)?$",
+      "description": "Most recent blocking activity timestamp, or null when none were observed"
+    },
+    "latest_activity_type": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Activity type for latest_activity, or null when none were observed"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Stable summary of the quiet-window outcome"
+    },
+    "evidence": {
+      "type": "object",
+      "required": [
+        "activity_count_in_window",
+        "blocking_activities",
+        "has_heartbeat_in_window",
+        "has_ci_running",
+        "has_pr_head_movement",
+        "has_branch_tip_movement"
+      ],
+      "properties": {
+        "activity_count_in_window": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of blocking activities that broke the quiet window"
         },
-        "reason": {
-          "type": "string",
-          "description": "Human-readable summary of the outcome"
-        },
-        "details": {
+        "blocking_activities": {
           "type": "array",
+          "description": "Blocking activity records considered by the helper",
           "items": {
-            "type": "string"
-          },
-          "description": "Array of specific findings (heartbeat, PR movement, etc.)"
+            "type": "object",
+            "required": [
+              "type",
+              "timestamp"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Observed activity type"
+              },
+              "timestamp": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)?$",
+                "description": "Activity timestamp, or null for timestamp-less ci-running inputs"
+              }
+            },
+            "additionalProperties": false
+          }
         },
-        "checkSummary": {
-          "type": "object",
-          "required": [
-            "heartbeatCheck",
-            "prHeadMovementCheck",
-            "branchTipMovementCheck",
-            "runningCiCheck",
-            "reviewActivityCheck",
-            "commentActivityCheck",
-            "ciCompletionCheck"
-          ],
-          "properties": {
-            "heartbeatCheck": {
-              "type": "string",
-              "enum": [
-                "PASSED",
-                "FAILED"
-              ],
-              "description": "Status of heartbeat (claimed-by markers) check"
-            },
-            "prHeadMovementCheck": {
-              "type": "string",
-              "enum": [
-                "PASSED",
-                "FAILED"
-              ],
-              "description": "Status of PR head SHA movement check"
-            },
-            "branchTipMovementCheck": {
-              "type": "string",
-              "enum": [
-                "PASSED",
-                "FAILED"
-              ],
-              "description": "Status of remote branch tip SHA change check"
-            },
-            "runningCiCheck": {
-              "type": "string",
-              "enum": [
-                "PASSED",
-                "FAILED"
-              ],
-              "description": "Status of running CI (queued/in_progress) check"
-            },
-            "reviewActivityCheck": {
-              "type": "string",
-              "enum": [
-                "PASSED",
-                "FAILED"
-              ],
-              "description": "Status of review submission activity check"
-            },
-            "commentActivityCheck": {
-              "type": "string",
-              "enum": [
-                "PASSED",
-                "FAILED"
-              ],
-              "description": "Status of comment activity check (excluding operational markers)"
-            },
-            "ciCompletionCheck": {
-              "type": "string",
-              "enum": [
-                "PASSED",
-                "FAILED"
-              ],
-              "description": "Status of CI completion (success/failure) check"
-            }
-          },
-          "additionalProperties": false
+        "has_heartbeat_in_window": {
+          "type": "boolean",
+          "description": "Whether a trusted active-claim heartbeat was observed in the quiet window"
+        },
+        "has_ci_running": {
+          "type": "boolean",
+          "description": "Whether running or queued CI was observed"
+        },
+        "has_pr_head_movement": {
+          "type": "boolean",
+          "description": "Whether PR head movement was observed in the quiet window"
+        },
+        "has_branch_tip_movement": {
+          "type": "boolean",
+          "description": "Whether branch-tip movement was observed in the quiet window"
         }
       },
       "additionalProperties": false

--- a/tests/stalled-session-quiet-check.test.mjs
+++ b/tests/stalled-session-quiet-check.test.mjs
@@ -1,412 +1,120 @@
 #!/usr/bin/env node
 
-import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 
-// Mock detection logic for testing
-function detectQuietWindow(state, options) {
-  const {
-    issueComments,
-    prHeadSha,
-    prTimeline,
-    reviewThreads,
-    branchTipSha,
-    prChecks,
-  } = state;
-  const { now, windowMs } = options;
-
-  const quietWindowStart = new Date(now.getTime() - windowMs);
-  const details = [];
-  let isQuiet = true;
-
-  // 1. Check for trusted heartbeat within window
-  const recentHeartbeat = issueComments.find((comment) => {
-    const claimedByMatch = comment.body?.match(
-      /<!-- claimed-by: \S+ (\S+) .*?(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)/,
-    );
-    if (!claimedByMatch) {
-      return false;
-    }
-    const heartbeatTime = new Date(claimedByMatch[2]);
-    return heartbeatTime >= quietWindowStart;
-  });
-
-  if (recentHeartbeat) {
-    isQuiet = false;
-    details.push(
-      `Recent heartbeat found at ${recentHeartbeat.created_at}: claim activity within window`,
-    );
-  }
-
-  // 2. Check for PR head SHA changes (PR head movement)
-  const prHeadChanges = prTimeline.filter(
-    (event) =>
-      event.event === "committed" &&
-      event.sha &&
-      new Date(event.created_at ?? event.timestamp ?? "") >= quietWindowStart,
-  );
-
-  if (prHeadChanges.length > 0) {
-    isQuiet = false;
-    details.push(
-      `PR head movement detected: ${prHeadChanges.length} commit(s) within window`,
-    );
-  }
-
-  // 3. Check for branch tip SHA changes (remote branch tip movement)
-  if (state.previousBranchTipSha && branchTipSha !== state.previousBranchTipSha) {
-    isQuiet = false;
-    details.push(
-      `Branch tip changed from ${state.previousBranchTipSha.slice(0, 7)} to ${branchTipSha.slice(0, 7)}`,
-    );
-  }
-
-  // 4. Check for running CI activity (queued/in_progress checks)
-  const runningChecks = prChecks.filter((check) => {
-    const status = check.status ?? "";
-    return status === "queued" || status === "in_progress";
-  });
-
-  if (runningChecks.length > 0) {
-    isQuiet = false;
-    details.push(
-      `Active CI runs detected: ${runningChecks.length} check(s) in progress`,
-    );
-  }
-
-  // 5. Check for new review/comment/CI completion activity
-  const recentReviewActivity = reviewThreads.filter((review) => {
-    const reviewTime = new Date(review.submitted_at ?? "");
-    return reviewTime >= quietWindowStart;
-  });
-
-  if (recentReviewActivity.length > 0) {
-    isQuiet = false;
-    details.push(
-      `Review activity detected: ${recentReviewActivity.length} review(s) within window`,
-    );
-  }
-
-  const recentComments = issueComments.filter((comment) => {
-    const commentTime = new Date(comment.created_at ?? "");
-    return (
-      commentTime >= quietWindowStart &&
-      !comment.body?.startsWith("<!-- claimed-by:") &&
-      !comment.body?.startsWith("<!-- unclaimed-by:")
-    );
-  });
-
-  if (recentComments.length > 0) {
-    isQuiet = false;
-    details.push(`Comment activity detected: ${recentComments.length} comment(s) within window`);
-  }
-
-  const recentChecksCompleted = prChecks.filter((check) => {
-    const completedTime = check.completed_at ? new Date(check.completed_at) : null;
-    return completedTime && completedTime >= quietWindowStart;
-  });
-
-  if (recentChecksCompleted.length > 0) {
-    isQuiet = false;
-    details.push(`CI completion detected: ${recentChecksCompleted.length} check(s) completed`);
-  }
-
-  return {
-    isQuiet,
-    evidence: {
-      reason: isQuiet
-        ? "No activity detected within quiet window"
-        : "Activity detected within quiet window",
-      details,
-      checkSummary: {
-        heartbeatCheck: recentHeartbeat ? "FAILED" : "PASSED",
-        prHeadMovementCheck: prHeadChanges.length === 0 ? "PASSED" : "FAILED",
-        branchTipMovementCheck:
-          !state.previousBranchTipSha || branchTipSha === state.previousBranchTipSha
-            ? "PASSED"
-            : "FAILED",
-        runningCiCheck: runningChecks.length === 0 ? "PASSED" : "FAILED",
-        reviewActivityCheck: recentReviewActivity.length === 0 ? "PASSED" : "FAILED",
-        commentActivityCheck: recentComments.length === 0 ? "PASSED" : "FAILED",
-        ciCompletionCheck: recentChecksCompleted.length === 0 ? "PASSED" : "FAILED",
-      },
-    },
-  };
-}
+import { evaluateQuietWindow } from "../scripts/stalled-session-quiet-check.mjs";
 
 describe("stalled-session-quiet-check", () => {
-  const now = new Date("2024-05-13T12:00:00Z");
-  const windowMs = 30 * 60 * 1000; // 30 minutes
+  const now = "2026-05-13T12:00:00Z";
 
-  it("Case 1: No activity in window → isQuiet=true", () => {
-    const state = {
-      issueComments: [],
-      prHeadSha: "abc123",
-      prTimeline: [],
-      reviewThreads: [],
-      branchTipSha: "abc123",
-      prChecks: [],
-      previousBranchTipSha: "abc123",
-    };
+  it("returns a quiet result when no blocking activity is present", () => {
+    const result = evaluateQuietWindow({ now, activities: [] });
 
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    assert.strictEqual(result.isQuiet, true);
-    assert.strictEqual(result.evidence.checkSummary.heartbeatCheck, "PASSED");
-    assert.strictEqual(result.evidence.checkSummary.prHeadMovementCheck, "PASSED");
-    assert.strictEqual(result.evidence.checkSummary.runningCiCheck, "PASSED");
+    assert.deepStrictEqual(result, {
+      quiet_window_met: true,
+      quiet_window_ms: 30 * 60 * 1000,
+      window_start: "2026-05-13T11:30:00Z",
+      now,
+      latest_activity: null,
+      latest_activity_type: null,
+      reason: "no-activity-in-window",
+      evidence: {
+        activity_count_in_window: 0,
+        blocking_activities: [],
+        has_heartbeat_in_window: false,
+        has_ci_running: false,
+        has_pr_head_movement: false,
+        has_branch_tip_movement: false,
+      },
+    });
   });
 
-  it("Case 2: Recent heartbeat within window → isQuiet=false", () => {
-    const recentTime = "2024-05-13T11:50:00Z"; // 10 minutes before now
-    const state = {
-      issueComments: [
-        {
-          body: `<!-- claimed-by: copilot abc123 supersedes: none ${recentTime} branch: issue/123 -->`,
-          created_at: recentTime,
-        },
-      ],
-      prHeadSha: "abc123",
-      prTimeline: [],
-      reviewThreads: [],
-      branchTipSha: "abc123",
-      prChecks: [],
-      previousBranchTipSha: "abc123",
-    };
+  it("treats boundary timestamps as within the quiet window", () => {
+    const result = evaluateQuietWindow({
+      now,
+      quietWindowMs: 30 * 60 * 1000,
+      activities: [{ type: "comment", timestamp: "2026-05-13T11:30:00Z" }],
+    });
 
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    assert.strictEqual(result.isQuiet, false);
-    assert.strictEqual(result.evidence.checkSummary.heartbeatCheck, "FAILED");
-    assert(result.evidence.details.some((d) => d.includes("heartbeat")));
+    assert.strictEqual(result.quiet_window_met, false);
+    assert.strictEqual(result.latest_activity, "2026-05-13T11:30:00Z");
+    assert.strictEqual(result.latest_activity_type, "comment");
+    assert.strictEqual(result.reason, "activity-in-window: comment");
+    assert.deepStrictEqual(result.evidence.blocking_activities, [
+      { type: "comment", timestamp: "2026-05-13T11:30:00Z" },
+    ]);
   });
 
-  it("Case 3: PR head SHA changed → isQuiet=false", () => {
-    const recentTime = "2024-05-13T11:50:00Z";
-    const state = {
-      issueComments: [],
-      prHeadSha: "abc123",
-      prTimeline: [
-        {
-          event: "committed",
-          sha: "def456",
-          created_at: recentTime,
-        },
+  it("reports heartbeat and branch movement through the stable evidence flags", () => {
+    const result = evaluateQuietWindow({
+      now,
+      activities: [
+        { type: "heartbeat", timestamp: "2026-05-13T11:40:00Z" },
+        { type: "branch-tip-movement", timestamp: "2026-05-13T11:50:00Z" },
       ],
-      reviewThreads: [],
-      branchTipSha: "abc123",
-      prChecks: [],
-      previousBranchTipSha: "abc123",
-    };
+    });
 
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    assert.strictEqual(result.isQuiet, false);
-    assert.strictEqual(result.evidence.checkSummary.prHeadMovementCheck, "FAILED");
-    assert(result.evidence.details.some((d) => d.includes("PR head movement")));
+    assert.strictEqual(result.quiet_window_met, false);
+    assert.strictEqual(result.latest_activity, "2026-05-13T11:50:00Z");
+    assert.strictEqual(result.latest_activity_type, "branch-tip-movement");
+    assert.strictEqual(result.reason, "activity-in-window: heartbeat, branch-tip-movement");
+    assert.strictEqual(result.evidence.activity_count_in_window, 2);
+    assert.strictEqual(result.evidence.has_heartbeat_in_window, true);
+    assert.strictEqual(result.evidence.has_branch_tip_movement, true);
+    assert.strictEqual(result.evidence.has_pr_head_movement, false);
   });
 
-  it("Case 4: Branch tip changed → isQuiet=false", () => {
-    const state = {
-      issueComments: [],
-      prHeadSha: "abc123",
-      prTimeline: [],
-      reviewThreads: [],
-      branchTipSha: "def456",
-      prChecks: [],
-      previousBranchTipSha: "abc123",
-    };
+  it("always treats ci-running as blocking even without a timestamp", () => {
+    const result = evaluateQuietWindow({
+      now,
+      activities: [
+        { type: "comment", timestamp: "2026-05-13T10:00:00Z" },
+        { type: "ci-running" },
+      ],
+    });
 
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    assert.strictEqual(result.isQuiet, false);
-    assert.strictEqual(result.evidence.checkSummary.branchTipMovementCheck, "FAILED");
-    assert(result.evidence.details.some((d) => d.includes("Branch tip changed")));
+    assert.strictEqual(result.quiet_window_met, false);
+    assert.strictEqual(result.latest_activity, null);
+    assert.strictEqual(result.latest_activity_type, "ci-running");
+    assert.strictEqual(result.reason, "activity-in-window: ci-running");
+    assert.strictEqual(result.evidence.activity_count_in_window, 1);
+    assert.strictEqual(result.evidence.has_ci_running, true);
+    assert.deepStrictEqual(result.evidence.blocking_activities, [
+      { type: "ci-running", timestamp: null },
+    ]);
   });
 
-  it("Case 5: Running CI checks → isQuiet=false", () => {
-    const state = {
-      issueComments: [],
-      prHeadSha: "abc123",
-      prTimeline: [],
-      reviewThreads: [],
-      branchTipSha: "abc123",
-      prChecks: [
-        {
-          status: "in_progress",
-          name: "test-suite",
-        },
-      ],
-      previousBranchTipSha: "abc123",
-    };
+  it("falls back to the default quiet window when an invalid value is provided", () => {
+    const result = evaluateQuietWindow({
+      now,
+      quietWindowMs: -1,
+      activities: [{ type: "review", timestamp: "2026-05-13T11:45:00Z" }],
+    });
 
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    assert.strictEqual(result.isQuiet, false);
-    assert.strictEqual(result.evidence.checkSummary.runningCiCheck, "FAILED");
-    assert(result.evidence.details.some((d) => d.includes("Active CI runs")));
+    assert.strictEqual(result.quiet_window_ms, 30 * 60 * 1000);
+    assert.strictEqual(result.quiet_window_met, false);
+    assert.strictEqual(result.latest_activity_type, "review");
   });
 
-  it("Case 6: Recent comment activity → isQuiet=false", () => {
-    const recentTime = "2024-05-13T11:50:00Z";
-    const state = {
-      issueComments: [
-        {
-          body: "This is a regular comment",
-          created_at: recentTime,
-        },
+  it("ignores non-ci activities that do not carry a valid timestamp", () => {
+    const result = evaluateQuietWindow({
+      now,
+      activities: [
+        { type: "comment", timestamp: "not-an-iso-timestamp" },
+        { type: "review" },
       ],
-      prHeadSha: "abc123",
-      prTimeline: [],
-      reviewThreads: [],
-      branchTipSha: "abc123",
-      prChecks: [],
-      previousBranchTipSha: "abc123",
-    };
+    });
 
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    assert.strictEqual(result.isQuiet, false);
-    assert.strictEqual(result.evidence.checkSummary.commentActivityCheck, "FAILED");
-    assert(result.evidence.details.some((d) => d.includes("Comment activity")));
+    assert.strictEqual(result.quiet_window_met, true);
+    assert.strictEqual(result.evidence.activity_count_in_window, 0);
+    assert.deepStrictEqual(result.evidence.blocking_activities, []);
   });
 
-  it("Case 7: Multiple activity types → isQuiet=false", () => {
-    const recentTime = "2024-05-13T11:50:00Z";
-    const state = {
-      issueComments: [
-        {
-          body: "This is a comment",
-          created_at: recentTime,
-        },
-      ],
-      prHeadSha: "abc123",
-      prTimeline: [
-        {
-          event: "committed",
-          sha: "def456",
-          created_at: recentTime,
-        },
-      ],
-      reviewThreads: [
-        {
-          submitted_at: recentTime,
-        },
-      ],
-      branchTipSha: "abc123",
-      prChecks: [
-        {
-          status: "queued",
-          name: "test",
-        },
-      ],
-      previousBranchTipSha: "abc123",
-    };
-
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    assert.strictEqual(result.isQuiet, false);
-    assert(result.evidence.details.length >= 4, `Expected at least 4 details, got ${result.evidence.details.length}`);
-  });
-
-  it("Case 8: Edge case - activity at exact window boundary → isQuiet=false", () => {
-    const boundaryTime = "2024-05-13T11:30:00Z"; // Exactly 30 min before now
-    const state = {
-      issueComments: [
-        {
-          body: "Comment at boundary",
-          created_at: boundaryTime,
-        },
-      ],
-      prHeadSha: "abc123",
-      prTimeline: [],
-      reviewThreads: [],
-      branchTipSha: "abc123",
-      prChecks: [],
-      previousBranchTipSha: "abc123",
-    };
-
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    // Activity at exact boundary is considered within window (>= check)
-    assert.strictEqual(result.isQuiet, false);
-    assert(result.evidence.details.some((d) => d.includes("Comment activity")));
-  });
-
-  it("Case 9: Old heartbeat outside window → isQuiet=true", () => {
-    const oldTime = "2024-05-13T11:20:00Z"; // 40 min before now
-    const state = {
-      issueComments: [
-        {
-          body: `<!-- claimed-by: copilot xyz ${oldTime} branch: issue/123 -->`,
-          created_at: oldTime,
-        },
-      ],
-      prHeadSha: "abc123",
-      prTimeline: [],
-      reviewThreads: [],
-      branchTipSha: "abc123",
-      prChecks: [],
-      previousBranchTipSha: "abc123",
-    };
-
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    assert.strictEqual(result.isQuiet, true);
-    assert.strictEqual(result.evidence.checkSummary.heartbeatCheck, "PASSED");
-  });
-
-  it("Case 10: Filtered comments (heartbeat/unclaim markers) don't count", () => {
-    const recentTime = "2024-05-13T11:50:00Z";
-    const state = {
-      issueComments: [
-        {
-          body: `<!-- claimed-by: copilot xyz ${recentTime} branch: issue/123 -->`,
-          created_at: recentTime,
-        },
-        {
-          body: `<!-- unclaimed-by: copilot xyz ${recentTime} -->`,
-          created_at: recentTime,
-        },
-      ],
-      prHeadSha: "abc123",
-      prTimeline: [],
-      reviewThreads: [],
-      branchTipSha: "abc123",
-      prChecks: [],
-      previousBranchTipSha: "abc123",
-    };
-
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    assert.strictEqual(result.isQuiet, false);
-    // First heartbeat marks it as not quiet
-    assert.strictEqual(result.evidence.checkSummary.heartbeatCheck, "FAILED");
-    // But unclaim marker should be filtered from comment activity
-    assert.strictEqual(result.evidence.checkSummary.commentActivityCheck, "PASSED");
-  });
-
-  it("Case 11: CI completion detection", () => {
-    const recentTime = "2024-05-13T11:50:00Z";
-    const state = {
-      issueComments: [],
-      prHeadSha: "abc123",
-      prTimeline: [],
-      reviewThreads: [],
-      branchTipSha: "abc123",
-      prChecks: [
-        {
-          status: "success",
-          completed_at: recentTime,
-        },
-      ],
-      previousBranchTipSha: "abc123",
-    };
-
-    const result = detectQuietWindow(state, { now, windowMs });
-
-    assert.strictEqual(result.isQuiet, false);
-    assert.strictEqual(result.evidence.checkSummary.ciCompletionCheck, "FAILED");
-    assert(result.evidence.details.some((d) => d.includes("CI completion")));
+  it("throws when now is not a valid ISO8601 timestamp", () => {
+    assert.throws(
+      () => evaluateQuietWindow({ now: "invalid-timestamp", activities: [] }),
+      /input\.now must be a valid ISO8601 timestamp/u,
+    );
   });
 });


### PR DESCRIPTION
# Summary

Make Resume/S2 helper-first for quiet-window evidence while keeping the written stall/takeover policy authoritative. This aligns the instruction flow, helper docs, schema contract, and regression tests with the shipped `idd-stalled-session-quiet-check` behavior.

## Linked issue

Closes #508

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The helper inventory already documented the stable `idd-stalled-session-quiet-check` contract, but `idd-resume-stall.instructions.md`, `docs/stalled-session-quiet-check.md`, the schema, and the quiet-check tests still described an older manual/legacy shape. This change removes that drift without changing the stale-threshold policy.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [ ] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

`pnpm lint` still fails in this worktree only because the package script invokes bare `cspell`, which is not on PATH here (`command not found: cspell`) after `audit-docs`, `dprint`, and the full test suite all pass. Equivalent spell-checking succeeded with `npx cspell lint "**" --no-progress`.

`node scripts/idd-doctor.mjs` still reports pre-existing repository-baseline issues unrelated to #508: `docs/customization.md: {{REPO_NAME}}` and marker-prefix drift between discover and overview instructions.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed