### PR TITLE
docs(idd): wire E7 verification through helper runtime

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -69,7 +69,9 @@ gate. The active claim must still use your current `{claim-id}`.
    `dispositionEvidence.route == "proceed"` and
    `dispositionEvidence.blockingCount == 0` before merge. If either
    check fails, stop and return to E1/E4 with the reported missing
-   thread/comment disposition items.
+   thread/comment disposition items. Use only the carried
+   `pre-merge-readiness` `dispositionEvidence` shape here; E7 verifier
+   fields (`passed`, `items[]`) are not merge-gate substitutes.
 
    Execute the merge immediately after this final fetch **and the claim
    re-validation and advisory state revalidation below**, with no other

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -228,7 +228,9 @@ must align with every F2 condition below.
   `dispositionEvidence.route == "proceed"` and
   `dispositionEvidence.blockingCount == 0`. If either check fails, route
   to E1/E4 with the missing-thread or missing-comment evidence reported
-  from that section.
+  from that section. This gate consumes the `pre-merge-readiness`
+  `dispositionEvidence` shape only; do not substitute E7 verifier fields
+  (`passed`, `items[]`) here.
 
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the PR live status digest after the blocking evidence is recorded and

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -186,6 +186,21 @@ PATH B — Advisory items:
 
 ## E7 — Verify recorded dispositions
 
+When helper runtime is enabled, prefer the read-only verifier command:
+
+```sh
+idd-review-disposition-verify --items '<json>'
+```
+
+In the source repository, `node scripts/review-disposition-verify.mjs`
+is equivalent evidence collection. E7 consumes helper fields `passed`,
+`items[].passed`, `items[].checks`, and `items[].issues`.
+This helper never posts replies or resolves threads: all E6 mutations
+remain manual and authoritative. If helper execution fails, output is
+invalid JSON, required fields are missing, or helper output conflicts
+with observed review state, discard helper output and apply the written
+E7 checks below directly.
+
 Before leaving triage, verify that every ReviewItems_snapshot item has the evidence
 required by its path:
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -430,7 +430,9 @@ default `instructions-only` profile keep using the written shell /
 
 ### E7 disposition verification
 
-- Command:
+- Preferred command when helper runtime is enabled:
+  `idd-review-disposition-verify --items '<json>'`
+- Source repository equivalent:
   `node scripts/review-disposition-verify.mjs --items '<json>'`
 - Input: JSON array of ReviewItems_snapshot items, each with `id`,
   `path` (`"A"` or `"B"`), `type`, `decision`, `markerReply`, and
@@ -461,6 +463,11 @@ default `instructions-only` profile keep using the written shell /
 
 - Stable fields consumed at E7: `passed`, `items[].passed`,
   `items[].checks`, and `items[].issues`
+- Read-only boundary: the helper never posts replies, resolves threads,
+  or performs any E6 mutation.
+- Fail closed: if execution fails, output is invalid JSON, required
+  fields are missing, or output conflicts with observed triage evidence,
+  discard helper output and apply written E7 checks directly.
 
 ### S2 quiet-window evidence
 
@@ -476,37 +483,6 @@ default `instructions-only` profile keep using the written shell /
 - `ci-running` activities always break the quiet window regardless
   of their timestamp; all other types are checked against
   `window_start = now - quiet_window_ms`
-
-### Review-disposition verification
-
-- Command: `node scripts/review-disposition-verify.mjs` or
-  `echo '<JSON array of review items>' | idd-review-disposition-verify`
-- Input format: JSON array of review items with schema:
-
-  ```json
-  [
-    {
-      "id": "unique-item-id",
-      "type": "REVIEW_THREAD|REVIEW_BODY|COMMENT",
-      "body": "comment body text",
-      "author": { "login": "github-username" },
-      "isThread": true,
-      "isResolved": false
-    }
-  ]
-  ```
-
-- Output format: Verification result with `isValid`, `missingMarkers`,
-  `errors`, and `summary` fields
-- Supported disposition markers: `**Accepted** —`, `**Rejected** —`,
-  `**Awaiting maintainer decision** —`
-- Classification rules:
-  - **PATH A (actionable feedback)**: Human reviewer threads, review
-    bodies, and comments (requires disposition marker)
-  - **PATH B (advisory feedback)**: Bot reviewer comments (should have
-    explicit marker)
-- Reference: E7 review-triage logic in
-  `.github/instructions/idd-review-triage.instructions.md`
 
 ## Friction Inventory
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -331,6 +331,8 @@ This source repository currently ships the following optional helper scripts:
   and AW outcome reporting)
 - `scripts/pre-merge-readiness.mjs` (read-only F2/F3 readiness evidence
   collection)
+- `scripts/review-disposition-verify.mjs` (read-only E7 disposition
+  verification evidence)
 - `scripts/live-status-digest.mjs` (issue or PR live status digest
   dry-run and claim-checked upsert)
 - `scripts/audit-pr-cleanup.mjs` (post-merge cleanup audit and optional

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -69,7 +69,9 @@ gate. The active claim must still use your current `{claim-id}`.
    `dispositionEvidence.route == "proceed"` and
    `dispositionEvidence.blockingCount == 0` before merge. If either
    check fails, stop and return to E1/E4 with the reported missing
-   thread/comment disposition items.
+   thread/comment disposition items. Use only the carried
+   `pre-merge-readiness` `dispositionEvidence` shape here; E7 verifier
+   fields (`passed`, `items[]`) are not merge-gate substitutes.
 
    Execute the merge immediately after this final fetch **and the claim
    re-validation and advisory state revalidation below**, with no other

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -228,7 +228,9 @@ must align with every F2 condition below.
   `dispositionEvidence.route == "proceed"` and
   `dispositionEvidence.blockingCount == 0`. If either check fails, route
   to E1/E4 with the missing-thread or missing-comment evidence reported
-  from that section.
+  from that section. This gate consumes the `pre-merge-readiness`
+  `dispositionEvidence` shape only; do not substitute E7 verifier fields
+  (`passed`, `items[]`) here.
 
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the PR live status digest after the blocking evidence is recorded and

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -186,6 +186,21 @@ PATH B — Advisory items:
 
 ## E7 — Verify recorded dispositions
 
+When helper runtime is enabled, prefer the read-only verifier command:
+
+```sh
+idd-review-disposition-verify --items '<json>'
+```
+
+In the source repository, `node scripts/review-disposition-verify.mjs`
+is equivalent evidence collection. E7 consumes helper fields `passed`,
+`items[].passed`, `items[].checks`, and `items[].issues`.
+This helper never posts replies or resolves threads: all E6 mutations
+remain manual and authoritative. If helper execution fails, output is
+invalid JSON, required fields are missing, or helper output conflicts
+with observed review state, discard helper output and apply the written
+E7 checks below directly.
+
 Before leaving triage, verify that every ReviewItems_snapshot item has the evidence
 required by its path:
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -430,7 +430,9 @@ default `instructions-only` profile keep using the written shell /
 
 ### E7 disposition verification
 
-- Command:
+- Preferred command when helper runtime is enabled:
+  `idd-review-disposition-verify --items '<json>'`
+- Source repository equivalent:
   `node scripts/review-disposition-verify.mjs --items '<json>'`
 - Input: JSON array of ReviewItems_snapshot items, each with `id`,
   `path` (`"A"` or `"B"`), `type`, `decision`, `markerReply`, and
@@ -461,6 +463,11 @@ default `instructions-only` profile keep using the written shell /
 
 - Stable fields consumed at E7: `passed`, `items[].passed`,
   `items[].checks`, and `items[].issues`
+- Read-only boundary: the helper never posts replies, resolves threads,
+  or performs any E6 mutation.
+- Fail closed: if execution fails, output is invalid JSON, required
+  fields are missing, or output conflicts with observed triage evidence,
+  discard helper output and apply written E7 checks directly.
 
 ### S2 quiet-window evidence
 
@@ -476,37 +483,6 @@ default `instructions-only` profile keep using the written shell /
 - `ci-running` activities always break the quiet window regardless
   of their timestamp; all other types are checked against
   `window_start = now - quiet_window_ms`
-
-### Review-disposition verification
-
-- Command: `node scripts/review-disposition-verify.mjs` or
-  `echo '<JSON array of review items>' | idd-review-disposition-verify`
-- Input format: JSON array of review items with schema:
-
-  ```json
-  [
-    {
-      "id": "unique-item-id",
-      "type": "REVIEW_THREAD|REVIEW_BODY|COMMENT",
-      "body": "comment body text",
-      "author": { "login": "github-username" },
-      "isThread": true,
-      "isResolved": false
-    }
-  ]
-  ```
-
-- Output format: Verification result with `isValid`, `missingMarkers`,
-  `errors`, and `summary` fields
-- Supported disposition markers: `**Accepted** —`, `**Rejected** —`,
-  `**Awaiting maintainer decision** —`
-- Classification rules:
-  - **PATH A (actionable feedback)**: Human reviewer threads, review
-    bodies, and comments (requires disposition marker)
-  - **PATH B (advisory feedback)**: Bot reviewer comments (should have
-    explicit marker)
-- Reference: E7 review-triage logic in
-  `.github/instructions/idd-review-triage.instructions.md`
 
 ## Friction Inventory
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -321,6 +321,8 @@ following optional helper scripts:
   and AW outcome reporting)
 - `scripts/pre-merge-readiness.mjs` (read-only F2/F3 readiness evidence
   collection)
+- `scripts/review-disposition-verify.mjs` (read-only E7 disposition
+  verification evidence)
 - `scripts/live-status-digest.mjs` (issue or PR live status digest
   dry-run and claim-checked upsert)
 - `scripts/audit-pr-cleanup.mjs` (post-merge cleanup audit and optional


### PR DESCRIPTION
## Summary
- make E7 verification helper-first via idd-review-disposition-verify when helper runtime is enabled
- keep E6 reply/resolve mutations manual and authoritative
- align F2/F3 disposition-evidence wording with pre-merge-readiness shape and sync source/template docs

Closes #510