### PR TITLE
docs(readme): add footprint and adoption sizing guidance

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -96,6 +96,47 @@ IDD は Markdown ネイティブですが、依存関係なしではありませ
 の外に置き、明示的な opt-in により選択します。merge policy は
 [Customizing IDD](docs/customization.md) で 1 つ選んで記録します。
 
+## フットプリントと導入規模の目安
+
+IDD は instruction の増加を、手作業のファイル数カウントではなく、
+メンテされる予算値と監査メタデータで機械的に上限管理します。
+
+| 予算タイプ                            | 維持される値 |
+| ------------------------------------- | ------------ |
+| 常時ロード instruction ファイル       | 20,000 bytes |
+| フェーズ instruction ファイル         | 30,000 bytes |
+| Discovery bundle (`bundle-discovery`) | 75,000 bytes |
+| Resume bundle (`bundle-resume`)       | 46,000 bytes |
+
+正規の値と所有箇所は
+[Policy constants: Runtime Instruction Size and Bundle Budgets](docs/policy-constants.md#runtime-instruction-size-and-bundle-budgets)
+を参照してください。
+
+source repository の最新フットプリント証跡を確認するには:
+
+```sh
+node scripts/audit-docs.mjs --check
+jq '.instructionSizeBudgets, .bundleBudgets' audit/sync-manifest.json
+```
+
+`audit-docs` は現在の instruction ファイルが維持予算内かを検証し、
+`sync-manifest.json` はその予算契約を保持します。
+
+導入先では、実運用時のループ負荷は helper runtime の選択で変わります:
+
+- E/F フェーズの文脈負荷を下げたい場合は helper runtime 対応を優先
+  します（helper は証跡収集のみで、マージや mutation の判断は引き続き
+  instruction のゲートに従います）。
+- Node.js / helper tooling を使わない方針なら `instructions-only` を選び、
+  shell/`gh`/`jq` の手動経路を維持します。
+- どちらの場合も、ローカル policy 追加、ローカル docs、追加 instruction
+  により実効フットプリントは source repository より小さくも大きくもなりえます。
+
+プロファイル選定時は
+[ONBOARDING Step 1B policy decisions](idd-template/ONBOARDING.md#step-1b--confirm-policy-decisions)
+と [helper runtime の選択順](docs/idd-helper-scripts.md#import-time-selection-order)
+を併せて確認してください。
+
 ## 実運用の実績
 
 2026-05-12 時点で、このリポジトリでは IDD を multi-agent / multi-session で

--- a/README.md
+++ b/README.md
@@ -99,6 +99,48 @@ The distributed default allows worker sessions to continue through merge
 the worker session by explicit opt-in. Choose and record one profile in
 [Customizing IDD](docs/customization.md).
 
+## Footprint and sizing guidance
+
+IDD keeps instruction growth mechanically bounded. The maintained budget
+values are tracked in policy docs and enforced by audit metadata rather
+than hand-counted file totals:
+
+| Budget type                           | Maintained value |
+| ------------------------------------- | ---------------- |
+| Always-loaded instruction file        | 20,000 bytes     |
+| Phase instruction file                | 30,000 bytes     |
+| Discovery bundle (`bundle-discovery`) | 75,000 bytes     |
+| Resume bundle (`bundle-resume`)       | 46,000 bytes     |
+
+See [Policy constants: Runtime Instruction Size and Bundle
+Budgets](docs/policy-constants.md#runtime-instruction-size-and-bundle-budgets)
+for the canonical table and ownership details.
+
+To inspect current source-repo footprint evidence:
+
+```sh
+node scripts/audit-docs.mjs --check
+jq '.instructionSizeBudgets, .bundleBudgets' audit/sync-manifest.json
+```
+
+`audit-docs` verifies that the current instruction files still fit the
+maintained limits, and `sync-manifest.json` carries the budget contract.
+
+For adopters, practical loop pressure depends on helper runtime choices:
+
+- Prefer helper runtime support when you want lower day-to-day context
+  pressure in E/F phases (helper commands collect evidence, while merge
+  and mutation decisions still follow written gates).
+- Keep `instructions-only` when your repository avoids Node.js/helper
+  tooling or your team prefers a fully manual shell/`gh`/`jq` path.
+- Expect variance either way: local policy additions, local docs, and
+  extra repository instructions can make your practical footprint smaller
+  or larger than this source repository.
+
+Use [ONBOARDING Step 1B policy decisions](idd-template/ONBOARDING.md#step-1b--confirm-policy-decisions)
+and [helper runtime selection order](docs/idd-helper-scripts.md#import-time-selection-order)
+to pick a profile deliberately.
+
 ## Operational Evidence
 
 As of 2026-05-12, this repository has been dogfooding IDD through


### PR DESCRIPTION
## Summary
- add matching README and README.ja sections for footprint and adoption sizing guidance
- distinguish maintained instruction/bundle budgets from live source-repo measurements
- document helper-runtime vs instructions-only practical loop-pressure tradeoffs with links to onboarding and helper docs

Closes #512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added sizing and deployment footprint guidance including runtime budget values, helper runtime vs instructions-only profile recommendations, policy tracking guidance, and commands to monitor current bundle metrics (available in English and Japanese).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/531)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->