### PR TITLE
docs(template): abstract template command placeholders

### DIFF
--- a/idd-template/.github/idd/config.json
+++ b/idd-template/.github/idd/config.json
@@ -11,10 +11,10 @@
   },
   "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTOR}}"],
   "commands": {
-    "install-deps": "true",
-    "fix-validate": "npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
-    "pre-push-validate": "npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress",
-    "post-fix-validate": "npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress"
+    "install-deps": "{{INSTALL_DEPS_COMMAND}}",
+    "fix-validate": "{{FIX_VALIDATE_COMMANDS}}",
+    "pre-push-validate": "{{PRE_PUSH_VALIDATE_COMMANDS}}",
+    "post-fix-validate": "{{POST_FIX_VALIDATE_COMMANDS}}"
   },
   "helperRuntime": {
     "profile": "package-manager"

--- a/idd-template/.github/instructions/idd-overview.instructions.md
+++ b/idd-template/.github/instructions/idd-overview.instructions.md
@@ -36,14 +36,14 @@ the recorded machine-readable policy. Absent values keep the gate
 enabled and default approval actors to
 `owners-and-maintainers-only`.
 
-| Name                    | Commands                                                                                                                                     |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| **fix-validate**        | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
-| **pre-push-validate**   | `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                        |
-| **post-fix-validate**   | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
-| **install-deps**        | `true`                                                                                                                                       |
-| **issue-scope**         | `roadmap`                                                                                                                                    |
-| **orphan-first-policy** | `none`                                                                                                                                       |
+| Name                    | Commands                         |
+| ----------------------- | -------------------------------- |
+| **fix-validate**        | `{{FIX_VALIDATE_COMMANDS}}`      |
+| **pre-push-validate**   | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |
+| **post-fix-validate**   | `{{POST_FIX_VALIDATE_COMMANDS}}` |
+| **install-deps**        | `{{INSTALL_DEPS_COMMAND}}`       |
+| **issue-scope**         | `roadmap`                        |
+| **orphan-first-policy** | `none`                           |
 
 Non-shell rows such as **issue-scope** and **orphan-first-policy** are
 workflow settings. Read them literally, not as commands.

--- a/tests/non-node-fallback.test.mjs
+++ b/tests/non-node-fallback.test.mjs
@@ -59,6 +59,26 @@ test("onboarding links extracted placeholder guidance and keeps fallback wording
     /{{TRUSTED_MARKER_ACTORS}}/,
     "template config must not keep the legacy trusted marker actors placeholder",
   );
+  assert.match(
+    configText,
+    /"install-deps": "{{INSTALL_DEPS_COMMAND}}"/,
+    "template config must keep install-deps as a placeholder token",
+  );
+  assert.match(
+    configText,
+    /"fix-validate": "{{FIX_VALIDATE_COMMANDS}}"/,
+    "template config must keep fix-validate as a placeholder token",
+  );
+  assert.match(
+    configText,
+    /"pre-push-validate": "{{PRE_PUSH_VALIDATE_COMMANDS}}"/,
+    "template config must keep pre-push-validate as a placeholder token",
+  );
+  assert.match(
+    configText,
+    /"post-fix-validate": "{{POST_FIX_VALIDATE_COMMANDS}}"/,
+    "template config must keep post-fix-validate as a placeholder token",
+  );
 
   const text = readText("idd-template/docs/onboarding/placeholders.md");
   assert.match(
@@ -338,6 +358,26 @@ test("overview instructions document the npx-availability gate", () => {
   assert.ok(
     template.includes("`npx <tool>` if Node.js and `npx` are available"),
     "template overview must keep the npx-availability gate for Node.js fallback",
+  );
+  assert.match(
+    template,
+    /\| \*\*fix-validate\*\* +\| `{{FIX_VALIDATE_COMMANDS}}` +\|/,
+    "template overview must keep fix-validate as a placeholder row",
+  );
+  assert.match(
+    template,
+    /\| \*\*pre-push-validate\*\* +\| `{{PRE_PUSH_VALIDATE_COMMANDS}}` +\|/,
+    "template overview must keep pre-push-validate as a placeholder row",
+  );
+  assert.match(
+    template,
+    /\| \*\*post-fix-validate\*\* +\| `{{POST_FIX_VALIDATE_COMMANDS}}` +\|/,
+    "template overview must keep post-fix-validate as a placeholder row",
+  );
+  assert.match(
+    template,
+    /\| \*\*install-deps\*\* +\| `{{INSTALL_DEPS_COMMAND}}` +\|/,
+    "template overview must keep install-deps as a placeholder row",
   );
 });
 


### PR DESCRIPTION
# Summary

Replace the idd-skill-specific command strings in the distributed template config and template overview command table with the existing onboarding placeholder tokens. This keeps the live source-repo config untouched while making the distributed template fail closed until adopters fill in their own toolchain commands.

## Linked issue

Closes #517

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The distributed template already asks operators to replace `{{FIX_VALIDATE_COMMANDS}}`, `{{PRE_PUSH_VALIDATE_COMMANDS}}`, `{{POST_FIX_VALIDATE_COMMANDS}}`, and `{{INSTALL_DEPS_COMMAND}}`, but `idd-template/.github/idd/config.json` and the template overview table still shipped concrete idd-skill markdown-lint commands. This change aligns those shipped files with the documented placeholder workflow.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [ ] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

`pnpm lint` still fails in this worktree only because the package script invokes bare `cspell`, which is not on PATH here (`command not found: cspell`) after `audit-docs`, `dprint`, and the full test suite all pass. Equivalent spell-checking succeeded with `npx cspell lint idd-template/.github/instructions/idd-overview.instructions.md idd-template/.github/idd/config.json tests/non-node-fallback.test.mjs --no-progress`.

`node scripts/idd-doctor.mjs` was not part of this acceptance path and still reports the known repository-baseline issues unrelated to #517 (`docs/customization.md: {{REPO_NAME}}` and marker-prefix drift between discover and overview instructions).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed