### PR TITLE
docs(readme): add persona-first start navigation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,6 +15,18 @@ IDD Skill は、リポジトリへ移植できる Issue-Driven Development
 選択したマージポリシーに従ってマージと後片づけまで進めます。ループ全体は、
 リポジトリ内の Markdown で書かれた指示ファイルとして管理されます。
 
+## 最初の入口（ペルソナ別ナビゲーション）
+
+初見の場合は、目的に合う入口から始めてください:
+
+| 目的                                     | まず読む場所                                                                                                                                       |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 概念を先に理解したい                     | [`docs/concepts.md`](docs/concepts.md)                                                                                                             |
+| 自分のリポジトリに IDD を導入したい      | [`idd-template/ONBOARDING.md`](idd-template/ONBOARDING.md)                                                                                         |
+| このリポジトリでエージェントを動かしたい | [`AGENTS.md`](AGENTS.md)、[`CLAUDE.md`](CLAUDE.md)、[`GEMINI.md`](GEMINI.md)、[`.github/copilot-instructions.md`](.github/copilot-instructions.md) |
+| ポリシーを調整したい                     | [`docs/customization.md`](docs/customization.md)                                                                                                   |
+| AI 向けに issue を整備したい             | [`skills/issue-authoring/SKILL.md`](skills/issue-authoring/SKILL.md)                                                                               |
+
 ## IDD が選ばれる理由
 
 AI コーディングエージェントは強力です。ただ、チームの開発フローに入れると、
@@ -166,22 +178,6 @@ commitlint により Conventional Commits を検証します。
 
 `idd-template/` 配下の正規ソースファイルを編集したときは、`pnpm run docs:sync`
 を実行して、すべてのミラーアーティファクトに変更を伝播してください。
-
-### 5 分で読む導線
-
-IDD を評価または導入するときは、focused docs を次の順に読んでください:
-
-1. [Getting started](docs/getting-started.md) — テンプレートを取り込み、
-   最初のループを実行する。
-2. [Core concepts](docs/concepts.md) — claim、review、merge、cleanup の
-   語彙を把握する。
-3. [Customization](docs/customization.md) — ワークフロー全体を fork せずに
-   policy surface を選ぶ。
-4. [Permissions and threat model](docs/permissions.md) — agent profile ごとに
-   渡す認証情報を決める。
-5. [リファレンスマニュアル](docs/index.md) と
-   [detailed reference](docs/reference.md) — landing page から phase file、
-   policy、maintenance note へ進む。
 
 ## IDD が自動化すること
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ branch, open a PR, handle review feedback, wait for CI, merge, and clean
 up according to the repository's selected merge policy. The whole loop
 lives in your repo as Markdown instruction files.
 
+## Start here (persona navigation)
+
+If this is your first visit, choose the path that matches your goal:
+
+| Goal                            | Start here                                                                                                                                             |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Understand the concept first    | [`docs/concepts.md`](docs/concepts.md)                                                                                                                 |
+| Adopt IDD in my repository      | [`idd-template/ONBOARDING.md`](idd-template/ONBOARDING.md)                                                                                             |
+| Run an agent on this repository | [`AGENTS.md`](AGENTS.md), [`CLAUDE.md`](CLAUDE.md), [`GEMINI.md`](GEMINI.md), and [`.github/copilot-instructions.md`](.github/copilot-instructions.md) |
+| Customize policy                | [`docs/customization.md`](docs/customization.md)                                                                                                       |
+| Author AI-ready issues          | [`skills/issue-authoring/SKILL.md`](skills/issue-authoring/SKILL.md)                                                                                   |
+
 ## Why Teams Use IDD
 
 AI coding agents are powerful, but team workflows get messy fast:
@@ -173,23 +185,6 @@ hook enforces Conventional Commits through commitlint.
 
 When you edit canonical source files in `idd-template/`, run
 `pnpm run docs:sync` to propagate the changes to all mirrored artifacts.
-
-### 5-Minute Reading Path
-
-Use the focused docs in this order when you are evaluating or adopting
-IDD:
-
-1. [Getting started](docs/getting-started.md) — import the template and
-   run the first loop.
-2. [Core concepts](docs/concepts.md) — learn the claim, review, merge,
-   and cleanup vocabulary.
-3. [Customization](docs/customization.md) — choose policy surfaces
-   without forking the whole workflow.
-4. [Permissions and threat model](docs/permissions.md) — decide which
-   credentials each agent profile should receive.
-5. [Reference manual](docs/index.md) and
-   [detailed reference](docs/reference.md) — jump from the landing page
-   into phase files, policies, and maintenance notes.
 
 ## What IDD Automates
 


### PR DESCRIPTION
## Summary
- add a persona-based "Start here" navigation section near the top of README and README.ja
- include the five entry-point links requested in issue #518
- remove the older 5-Minute Reading Path section to avoid duplicated onboarding guidance

Part of #522
Closes #518