### PR TITLE
feat(doctor): warn on command residue and drift

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -43,8 +43,9 @@ export function runDoctor({ root, requireGithub }) {
 
   checkRequiredFiles(files, report)
   checkPlaceholders(root, textFiles, report)
-  checkMarkerPrefixes(root, report)
-  checkProjectCommands(root, report)
+  const markerPrefix = checkMarkerPrefixes(root, report)
+  const projectCommands = checkProjectCommands(root, report)
+  checkCommandResidueAndConsistency(root, markerPrefix, projectCommands, report)
   checkPolicySignals(root, report)
   checkHelperRuntimeConfig(root, report)
   checkAgentEntryFiles(root, report)
@@ -175,7 +176,7 @@ function checkMarkerPrefixes(root, report) {
     overview = readFileSync(overviewPath, "utf8")
   } catch {
     report.warnings.push("marker-prefix checks skipped because discover/overview files are missing")
-    return
+    return null
   }
 
   const discoverPrefixes = extractMarkerPrefixes(discover)
@@ -189,32 +190,33 @@ function checkMarkerPrefixes(root, report) {
 
   if (allPrefixes.length === 0) {
     report.warnings.push("marker-prefix checks skipped because no resolved marker prefixes were found")
-    return
+    return null
   }
 
   const invalid = allPrefixes.filter((prefix) => !/^[a-z][a-z0-9-]{1,31}$/.test(prefix))
   if (invalid.length > 0) {
     report.errors.push(`invalid marker prefixes: ${invalid.join(", ")}`)
-    return
+    return null
   }
 
   if (!sameMembers(discoverPrefixes.roadmap, discoverPrefixes.blockedBy)) {
     report.errors.push("discover marker prefixes differ between roadmap-id and blocked-by")
-    return
+    return null
   }
   if (!sameMembers(overviewPrefixes.roadmap, overviewPrefixes.blockedBy)) {
     report.errors.push("overview marker prefixes differ between roadmap-id and blocked-by")
-    return
+    return null
   }
   if (
     !sameMembers(discoverPrefixes.roadmap, overviewPrefixes.roadmap) ||
     !sameMembers(discoverPrefixes.blockedBy, overviewPrefixes.blockedBy)
   ) {
     report.errors.push("marker prefixes differ between discover and overview instructions")
-    return
+    return null
   }
 
   report.passes.push(`marker prefix is valid and consistent (${allPrefixes[0]})`)
+  return allPrefixes[0]
 }
 
 function checkProjectCommands(root, report) {
@@ -224,7 +226,7 @@ function checkProjectCommands(root, report) {
     text = readFileSync(path, "utf8")
   } catch {
     report.errors.push("cannot read .github/instructions/idd-overview.instructions.md")
-    return
+    return null
   }
 
   const commands = parseProjectCommandRows(text)
@@ -232,7 +234,7 @@ function checkProjectCommands(root, report) {
   const missingRows = requiredRows.filter((row) => !commands.has(row))
   if (missingRows.length > 0) {
     report.errors.push(`project commands table is missing rows: ${missingRows.join(", ")}`)
-    return
+    return null
   }
 
   const noOps = requiredRows.filter((row) => commands.get(row) === "true")
@@ -241,6 +243,113 @@ function checkProjectCommands(root, report) {
   } else {
     report.passes.push("project commands table has non-empty command values")
   }
+  return commands
+}
+
+function checkCommandResidueAndConsistency(root, markerPrefix, projectCommands, report) {
+  if (!(projectCommands instanceof Map)) {
+    return
+  }
+
+  const policyCommands = loadPolicyCommands(root)
+  if (!(policyCommands instanceof Map)) {
+    return
+  }
+
+  const sharedKeys = unique([...policyCommands.keys()].filter((key) => projectCommands.has(key))).sort()
+  for (const key of sharedKeys) {
+    const configValue = normalizeCommandValue(policyCommands.get(key))
+    const overviewValue = normalizeCommandValue(projectCommands.get(key))
+    if (!isConcreteCommandValue(configValue) || !isConcreteCommandValue(overviewValue)) {
+      continue
+    }
+    if (configValue !== overviewValue) {
+      report.warnings.push(
+        `command mismatch between .github/idd/config.json and overview table for "${key}": config="${configValue}" overview="${overviewValue}"`,
+      )
+    }
+  }
+
+  if (typeof markerPrefix !== "string" || markerPrefix.length === 0) {
+    report.warnings.push("toolchain residue checks skipped because marker prefix could not be resolved")
+    return
+  }
+  if (markerPrefix === "idd-skill") {
+    return
+  }
+
+  const residueMessages = new Set()
+  for (const [source, commands] of [
+    [".github/idd/config.json", policyCommands],
+    ["overview project commands table", projectCommands],
+  ]) {
+    for (const [key, value] of commands.entries()) {
+      const normalized = normalizeCommandValue(value)
+      if (normalized === null) {
+        continue
+      }
+      const token = findToolchainResidueToken(normalized)
+      if (!token) {
+        continue
+      }
+      residueMessages.add(
+        `toolchain residue detected for marker prefix "${markerPrefix}": ${source} "${key}" contains "${token}"`,
+      )
+    }
+  }
+  for (const message of residueMessages) {
+    report.warnings.push(message)
+  }
+}
+
+function loadPolicyCommands(root) {
+  const configPath = join(root, ".github/idd/config.json")
+  if (!exists(configPath)) {
+    return null
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf8"))
+  } catch {
+    return null
+  }
+  const commands = parsed?.commands
+  if (!commands || typeof commands !== "object" || Array.isArray(commands)) {
+    return null
+  }
+
+  return new Map(Object.entries(commands).filter(([, value]) => typeof value === "string"))
+}
+
+function normalizeCommandValue(value) {
+  if (typeof value !== "string") {
+    return null
+  }
+  return value.trim()
+}
+
+function isConcreteCommandValue(value) {
+  if (typeof value !== "string" || value.length === 0) {
+    return false
+  }
+  if (value.toLowerCase() === "true") {
+    return false
+  }
+  return !/\{\{\s*[A-Za-z0-9_-]+\s*\}\}/.test(value)
+}
+
+function findToolchainResidueToken(value) {
+  for (const token of ["dprint", "markdownlint-cli2", "cspell"]) {
+    if (new RegExp(`\\b${escapeRegex(token)}\\b`, "i").test(value)) {
+      return token
+    }
+  }
+  return null
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
 function checkPolicySignals(root, report) {

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -252,13 +252,11 @@ function checkCommandResidueAndConsistency(root, markerPrefix, projectCommands, 
   }
 
   const policyCommands = loadPolicyCommands(root)
-  if (!(policyCommands instanceof Map)) {
-    return
-  }
+  const policyCommandMap = policyCommands instanceof Map ? policyCommands : new Map()
 
-  const sharedKeys = unique([...policyCommands.keys()].filter((key) => projectCommands.has(key))).sort()
+  const sharedKeys = unique([...policyCommandMap.keys()].filter((key) => projectCommands.has(key))).sort()
   for (const key of sharedKeys) {
-    const configValue = normalizeCommandValue(policyCommands.get(key))
+    const configValue = normalizeCommandValue(policyCommandMap.get(key))
     const overviewValue = normalizeCommandValue(projectCommands.get(key))
     if (!isConcreteCommandValue(configValue) || !isConcreteCommandValue(overviewValue)) {
       continue
@@ -280,7 +278,7 @@ function checkCommandResidueAndConsistency(root, markerPrefix, projectCommands, 
 
   const residueMessages = new Set()
   for (const [source, commands] of [
-    [".github/idd/config.json", policyCommands],
+    [".github/idd/config.json", policyCommandMap],
     ["overview project commands table", projectCommands],
   ]) {
     for (const [key, value] of commands.entries()) {

--- a/tests/helper-runtime-profiles.test.mjs
+++ b/tests/helper-runtime-profiles.test.mjs
@@ -47,25 +47,7 @@ const PROFILE_FIXTURE_FILES = [
   "profiles/no-advisory/README.md",
   "profiles/external-bot/README.md",
 ];
-const OVERVIEW_TEXT = `# IDD overview
-
-<!-- helper-runtime-fixture-roadmap-id: value -->
-<!-- helper-runtime-fixture-blocked-by: value -->
-
-| Name | Commands |
-| ---- | -------- |
-| **fix-validate** | \`node --test tests/*.mjs\` |
-| **pre-push-validate** | \`node --test tests/*.mjs\` |
-| **post-fix-validate** | \`node --test tests/*.mjs\` |
-| **install-deps** | \`true\` |
-| **issue-scope** | \`roadmap\` |
-| **orphan-first-policy** | \`none\` |
-`;
-const DISCOVER_TEXT = `# IDD discover
-
-<!-- helper-runtime-fixture-roadmap-id: value -->
-<!-- helper-runtime-fixture-blocked-by: value -->
-`;
+const DEFAULT_MARKER_PREFIX = "helper-runtime-fixture";
 
 test("idd-doctor accepts missing helperRuntime as instructions-only fallback fixture", (t) => {
   const root = createDoctorFixtureRepo("absent.json");
@@ -146,15 +128,124 @@ test("idd-doctor fixture rejects unsupported helperRuntime keys", (t) => {
   );
 });
 
+test("idd-doctor warns when adopter marker prefix keeps source-repo lint toolchain commands", (t) => {
+  const root = createDoctorFixtureRepoFromConfig({
+    commands: {
+      "fix-validate": "npx dprint check \"**/*.md\"",
+      "pre-push-validate": "npm run lint",
+      "post-fix-validate": "npm run test",
+      "install-deps": "true",
+    },
+  }, {
+    markerPrefix: "example-team",
+  });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.equal(report.errors.length, 0);
+  assert.ok(
+    report.warnings.some((warning) =>
+      warning.includes('toolchain residue detected for marker prefix "example-team"'),
+    ),
+  );
+});
+
+test("idd-doctor skips residue warnings for idd-skill marker prefix", (t) => {
+  const root = createDoctorFixtureRepoFromConfig({
+    commands: {
+      "fix-validate": "npx dprint check \"**/*.md\"",
+      "pre-push-validate": "npx markdownlint-cli2 \"**/*.md\"",
+      "post-fix-validate": "npx cspell lint \"**\" --no-progress",
+      "install-deps": "true",
+    },
+  }, {
+    markerPrefix: "idd-skill",
+  });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.equal(report.errors.length, 0);
+  assert.ok(
+    report.warnings.every((warning) => !warning.startsWith("toolchain residue detected")),
+  );
+});
+
+test("idd-doctor does not warn when config and overview concrete commands agree", (t) => {
+  const root = createDoctorFixtureRepoFromConfig({
+    commands: {
+      "fix-validate": "npm run fix",
+      "pre-push-validate": "npm run lint",
+      "post-fix-validate": "npm run test",
+      "install-deps": "true",
+    },
+  }, {
+    markerPrefix: "example-team",
+    overviewCommands: {
+      "fix-validate": "npm run fix",
+      "pre-push-validate": "npm run lint",
+      "post-fix-validate": "npm run test",
+      "install-deps": "true",
+    },
+  });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.equal(report.errors.length, 0);
+  assert.ok(
+    report.warnings.every((warning) =>
+      !warning.startsWith("command mismatch between .github/idd/config.json and overview table"),
+    ),
+  );
+});
+
+test("idd-doctor warns when config and overview concrete commands differ", (t) => {
+  const root = createDoctorFixtureRepoFromConfig({
+    commands: {
+      "fix-validate": "npm run fix && npm test",
+      "pre-push-validate": "npm run lint",
+      "post-fix-validate": "npm run test",
+      "install-deps": "true",
+    },
+  }, {
+    markerPrefix: "example-team",
+    overviewCommands: {
+      "fix-validate": "npm run fix",
+      "pre-push-validate": "npm run lint",
+      "post-fix-validate": "npm run test",
+      "install-deps": "true",
+    },
+  });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.equal(report.errors.length, 0);
+  assert.ok(
+    report.warnings.some((warning) =>
+      warning.includes('command mismatch between .github/idd/config.json and overview table for "fix-validate"'),
+    ),
+  );
+});
+
 function createDoctorFixtureRepo(configFixtureName, { packageJson = null } = {}) {
-  const root = mkdtempSync(join(tmpdir(), "idd-helper-runtime-profile-"));
   const configText = readFileSync(new URL(configFixtureName, FIXTURE_ROOT), "utf8");
+  return createDoctorFixtureRepoFromConfig(configText, { packageJson });
+}
+
+function createDoctorFixtureRepoFromConfig(config, {
+  packageJson = null,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+  overviewCommands = {},
+} = {}) {
+  const root = mkdtempSync(join(tmpdir(), "idd-helper-runtime-profile-"));
+  const configText = typeof config === "string" ? config : `${JSON.stringify(config, null, 2)}\n`;
+  const overviewText = buildOverviewText(markerPrefix, overviewCommands);
+  const discoverText = buildDiscoverText(markerPrefix);
 
   for (const file of REQUIRED_INSTRUCTION_FILES) {
     const contents = file.endsWith("idd-overview.instructions.md")
-      ? OVERVIEW_TEXT
+      ? overviewText
       : file.endsWith("idd-discover.instructions.md")
-        ? DISCOVER_TEXT
+        ? discoverText
         : `# ${file}\n`;
     writeFixtureFile(root, file, contents);
   }
@@ -179,6 +270,40 @@ function createDoctorFixtureRepo(configFixtureName, { packageJson = null } = {})
   }
 
   return root;
+}
+
+function buildOverviewText(markerPrefix, commands) {
+  const rows = {
+    "fix-validate": "node --test tests/*.mjs",
+    "pre-push-validate": "node --test tests/*.mjs",
+    "post-fix-validate": "node --test tests/*.mjs",
+    "install-deps": "true",
+    "issue-scope": "roadmap",
+    "orphan-first-policy": "none",
+    ...commands,
+  };
+  return `# IDD overview
+
+<!-- ${markerPrefix}-roadmap-id: value -->
+<!-- ${markerPrefix}-blocked-by: value -->
+
+| Name | Commands |
+| ---- | -------- |
+| **fix-validate** | \`${rows["fix-validate"]}\` |
+| **pre-push-validate** | \`${rows["pre-push-validate"]}\` |
+| **post-fix-validate** | \`${rows["post-fix-validate"]}\` |
+| **install-deps** | \`${rows["install-deps"]}\` |
+| **issue-scope** | \`${rows["issue-scope"]}\` |
+| **orphan-first-policy** | \`${rows["orphan-first-policy"]}\` |
+`;
+}
+
+function buildDiscoverText(markerPrefix) {
+  return `# IDD discover
+
+<!-- ${markerPrefix}-roadmap-id: value -->
+<!-- ${markerPrefix}-blocked-by: value -->
+`;
 }
 
 function writeFixtureFile(root, relativePath, contents) {

--- a/tests/helper-runtime-profiles.test.mjs
+++ b/tests/helper-runtime-profiles.test.mjs
@@ -150,6 +150,28 @@ test("idd-doctor warns when adopter marker prefix keeps source-repo lint toolcha
   );
 });
 
+test("idd-doctor still checks overview residue when policy config is missing", (t) => {
+  const root = createDoctorFixtureRepoFromConfig(null, {
+    markerPrefix: "example-team",
+    overviewCommands: {
+      "fix-validate": "npx dprint check \"**/*.md\"",
+      "pre-push-validate": "npm run lint",
+      "post-fix-validate": "npm run test",
+      "install-deps": "true",
+    },
+    writeConfig: false,
+  });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.equal(report.errors.length, 0);
+  assert.ok(
+    report.warnings.some((warning) =>
+      warning.includes('toolchain residue detected for marker prefix "example-team"'),
+    ),
+  );
+});
+
 test("idd-doctor skips residue warnings for idd-skill marker prefix", (t) => {
   const root = createDoctorFixtureRepoFromConfig({
     commands: {
@@ -235,9 +257,14 @@ function createDoctorFixtureRepoFromConfig(config, {
   packageJson = null,
   markerPrefix = DEFAULT_MARKER_PREFIX,
   overviewCommands = {},
+  writeConfig = true,
 } = {}) {
   const root = mkdtempSync(join(tmpdir(), "idd-helper-runtime-profile-"));
-  const configText = typeof config === "string" ? config : `${JSON.stringify(config, null, 2)}\n`;
+  const configText = typeof config === "string"
+    ? config
+    : config === null
+      ? ""
+      : `${JSON.stringify(config, null, 2)}\n`;
   const overviewText = buildOverviewText(markerPrefix, overviewCommands);
   const discoverText = buildDiscoverText(markerPrefix);
 
@@ -261,7 +288,9 @@ function createDoctorFixtureRepoFromConfig(config, {
     ".github/copilot-instructions.md",
     "This fixture uses fully_autonomous_merge and copilot advisory.\n",
   );
-  writeFixtureFile(root, ".github/idd/config.json", configText);
+  if (writeConfig) {
+    writeFixtureFile(root, ".github/idd/config.json", configText);
+  }
   writeFixtureFile(root, "AGENTS.md", "See docs/idd-workflow.md.\n");
   writeFixtureFile(root, "CLAUDE.md", "See docs/idd-workflow.md.\n");
   writeFixtureFile(root, "GEMINI.md", "See docs/idd-workflow.md.\n");


### PR DESCRIPTION
## Summary
- add an idd-doctor warning pass that detects source-repo markdown toolchain residue (dprint, markdownlint-cli2, cspell) when marker prefixes are not idd-skill
- compare concrete command values between .github/idd/config.json and the overview Project commands table and warn when they drift
- extend helper-runtime fixture tests to cover residue/no-residue and drift/no-drift scenarios

## Why
Adopter repositories can carry over source-repo command values during onboarding. These warnings surface mismatches early without failing adoption checks.

Closes #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for marker-prefix resolution and project command consistency.
  * Enhanced detection of configuration inconsistencies and potential toolchain issues with expanded warning coverage.

* **Tests**
  * Added comprehensive tests for command consistency and marker-prefix validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/534)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->