### PR TITLE
feat(schema): add issue authoring policy fields

### DIFF
--- a/fixtures/schemas/policy.invalid.json
+++ b/fixtures/schemas/policy.invalid.json
@@ -15,6 +15,10 @@
     "pre-push-validate": "npx dprint check",
     "post-fix-validate": "npx dprint fmt && npx markdownlint-cli2"
   },
+  "issueAuthoring": {
+    "maxClarificationRounds": 3,
+    "authoringLabelName": ""
+  },
   "advisoryWait": {
     "requestCap": 0
   }

--- a/fixtures/schemas/policy.valid.json
+++ b/fixtures/schemas/policy.valid.json
@@ -56,6 +56,8 @@
     "labelFreshnessMode": "presence-only"
   },
   "issueAuthoring": {
-    "maxClarificationRounds": 3
+    "maxClarificationRounds": 3,
+    "authoringLabelName": "status:authoring",
+    "authoringStaleAge": "PT4H"
   }
 }

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -328,6 +328,14 @@
         "maxClarificationRounds": {
           "type": "integer",
           "minimum": 1
+        },
+        "authoringLabelName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authoringStaleAge": {
+          "type": "string",
+          "pattern": "^P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$"
         }
       }
     }

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -815,6 +815,56 @@ test("policy schema rejects stallRecovery.quietWindow empty time marker (PT)", (
   assert.ok(errors.some((e) => e.includes("stallRecovery")), errors.join("\n"));
 });
 
+test("policy schema accepts issueAuthoring authoring label and stale age", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.issueAuthoring = {
+    maxClarificationRounds: 3,
+    authoringLabelName: "status:authoring",
+    authoringStaleAge: "PT4H",
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema rejects issueAuthoring authoringLabelName empty string", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.issueAuthoring = {
+    maxClarificationRounds: 3,
+    authoringLabelName: "",
+  };
+  const errors = validate(instance, schema);
+  assert.ok(errors.some((e) => e.includes("issueAuthoring.authoringLabelName")), errors.join("\n"));
+});
+
+test("policy schema rejects issueAuthoring authoringStaleAge non-duration string", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.issueAuthoring = {
+    maxClarificationRounds: 3,
+    authoringStaleAge: "not-a-duration",
+  };
+  const errors = validate(instance, schema);
+  assert.ok(errors.some((e) => e.includes("issueAuthoring.authoringStaleAge")), errors.join("\n"));
+});
+
+test("policy schema rejects issueAuthoring unexpected extra keys", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.issueAuthoring = {
+    maxClarificationRounds: 3,
+    authoringLabelName: "status:authoring",
+    authoringStaleAge: "PT4H",
+    unexpectedKey: true,
+  };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((e) => e.includes("$.issueAuthoring") && e.includes("\"unexpectedKey\"")),
+    errors.join("\n"),
+  );
+});
+
 test("policy schema accepts forcedHandoff.mode human-gated", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -827,6 +827,47 @@ test("policy schema accepts issueAuthoring authoring label and stale age", () =>
   assert.deepEqual(errors, []);
 });
 
+test("policy schema accepts missing issueAuthoring object", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  delete instance.issueAuthoring;
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema accepts issueAuthoring without maxClarificationRounds", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.issueAuthoring = {
+    authoringLabelName: "status:authoring",
+    authoringStaleAge: "PT4H",
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema accepts issueAuthoring without authoringLabelName", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.issueAuthoring = {
+    maxClarificationRounds: 3,
+    authoringStaleAge: "PT4H",
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test("policy schema accepts issueAuthoring without authoringStaleAge", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));
+  instance.issueAuthoring = {
+    maxClarificationRounds: 3,
+    authoringLabelName: "status:authoring",
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
 test("policy schema rejects issueAuthoring authoringLabelName empty string", () => {
   const schema = loadJson("schemas/policy.schema.json");
   const instance = JSON.parse(JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")));


### PR DESCRIPTION
## Summary

- add `issueAuthoring.authoringLabelName` and `issueAuthoring.authoringStaleAge` to the policy schema
- extend the valid and invalid policy fixtures to cover the new issue-authoring keys
- add focused schema validation tests for valid values, malformed durations, empty labels, and unexpected extra keys

Closes #535
Closes #545

## Follow-up Issues

- None identified.

## Background

This issue is scoped to the schema contract only so later discover and
issue-authoring changes can rely on the new settings without mixing in
runtime or documentation changes here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two configuration options for issue authoring: authoringLabelName (custom label) and authoringStaleAge (staleness duration in ISO-8601 format).

* **Bug Fixes / Validation**
  * Policy schema updated to validate the new fields and reject invalid or unexpected values for issue authoring.

* **Tests**
  * Added schema validation tests covering valid and invalid issue-authoring configurations, including format and extra-field checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/540)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->