### PR TITLE
feat(helpers): diagnose self-codeowner deadlocks

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -171,12 +171,20 @@ must align with every F2 condition below.
   same resolved `ciWait.runningTimeout`, `ciWait.generationTimeout`, and
   `ciWait.rerunPolicy` values; on-success → re-evaluate F2)
 - **Required reviews**: Required approvals count is satisfied and all
-  CODEOWNER approvals are obtained. If approvals are absent but there
-  are no open actionable review items (ReviewItems_snapshot is empty), do **not**
-  route to E1 — instead, request CODEOWNER/required reviewers directly
-  (if not already requested), post a hold comment, and stop. Return to
-  E1 only when there are actual review threads or comments to address (→
-  go to `idd-review-snapshot.instructions.md` only in that case).
+  CODEOWNER approvals are obtained. If helper evidence includes
+  `reviewerStates.codeownerSelfApproval`, include that diagnostic in the
+  F2 evidence and any hold comment when its `status` is `deadlock` or
+  `possible_deadlock`. `deadlock` means the current PR/ruleset/CODEOWNER
+  topology cannot be satisfied by ordinary self-approval; `possible_deadlock`
+  means the helper could not prove an eligible non-author CODEOWNER or
+  applicable pull-request bypass, so fail closed. This diagnostic is
+  evidence only and never permission to bypass the Required reviews
+  gate. If approvals are absent but there are no open actionable review
+  items (ReviewItems_snapshot is empty), do **not** route to E1 —
+  instead, request CODEOWNER/required reviewers directly (if not already
+  requested), post a hold comment, and stop. Return to E1 only when
+  there are actual review threads or comments to address (→ go to
+  `idd-review-snapshot.instructions.md` only in that case).
 - **No `CHANGES_REQUESTED`** (human/required/CODEOWNER reviewers only):
   No human, required, or CODEOWNER reviewer's latest state is
   `CHANGES_REQUESTED` (→ if not yet addressed, return to review triage;

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -508,6 +508,11 @@ default `instructions-only` profile keep using the written shell /
   `threads`, `unrepliedComments`, `reviewerStates`,
   `advisoryWait` (including the effective advisory policy fields), `ci`,
   `claim`, and optional `dispositionEvidence`
+- `reviewerStates.codeownerSelfApproval` diagnoses whether CODEOWNER
+  approval can be satisfied by an eligible non-author owner or an
+  applicable pull-request-only ruleset bypass. `deadlock` and
+  `possible_deadlock` statuses should be surfaced in F2 evidence and
+  hold comments, but they do not grant bypass permission.
 - `reviewCurrency.comparisonRoute` remains advisory evidence only. Agents
   must still apply written instruction checks against live GitHub state.
 - Fail closed: if helper execution fails, output is invalid JSON,

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -510,7 +510,7 @@ default `instructions-only` profile keep using the written shell /
   `claim`, and optional `dispositionEvidence`
 - `reviewerStates.codeownerSelfApproval` diagnoses whether CODEOWNER
   approval can be satisfied by an eligible non-author owner or an
-  applicable pull-request-only ruleset bypass. `deadlock` and
+  applicable ruleset or classic pull-request bypass. `deadlock` and
   `possible_deadlock` statuses should be surfaced in F2 evidence and
   hold comments, but they do not grant bypass permission. The
   `currentUserCanBypass` token records the known GitHub ruleset value

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -512,7 +512,10 @@ default `instructions-only` profile keep using the written shell /
   approval can be satisfied by an eligible non-author owner or an
   applicable pull-request-only ruleset bypass. `deadlock` and
   `possible_deadlock` statuses should be surfaced in F2 evidence and
-  hold comments, but they do not grant bypass permission.
+  hold comments, but they do not grant bypass permission. The
+  `currentUserCanBypass` token records the known GitHub ruleset value
+  (`unknown`, `never`, `always`, `pull_requests_only`, `exempt`, or
+  `mixed`).
 - `reviewCurrency.comparisonRoute` remains advisory evidence only. Agents
   must still apply written instruction checks against live GitHub state.
 - Fail closed: if helper execution fails, output is invalid JSON,

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -154,6 +154,18 @@
       "humanApprovedCount": 0,
       "requiredApprovalsSatisfied": false,
       "codeownerApprovalSatisfied": false,
+      "codeownerSelfApproval": {
+        "status": "clear",
+        "reason": "non-author-codeowner-available",
+        "prAuthorLogin": "contributor",
+        "directCodeownerUserLogins": ["owner-reviewer"],
+        "codeownerTeamSlugs": [],
+        "requireCodeOwnerReview": true,
+        "codeownerApprovalSatisfied": false,
+        "bypassDetected": false,
+        "bypassMode": "none",
+        "currentUserCanBypass": "unknown"
+      },
       "humanChangesRequestedCount": 1,
       "blockingChangesRequestedLogins": ["owner-reviewer"]
     },

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -154,6 +154,18 @@
       "humanApprovedCount": 1,
       "requiredApprovalsSatisfied": true,
       "codeownerApprovalSatisfied": true,
+      "codeownerSelfApproval": {
+        "status": "not_applicable",
+        "reason": "codeowner-approval-satisfied",
+        "prAuthorLogin": "contributor",
+        "directCodeownerUserLogins": ["owner-reviewer"],
+        "codeownerTeamSlugs": [],
+        "requireCodeOwnerReview": true,
+        "codeownerApprovalSatisfied": true,
+        "bypassDetected": false,
+        "bypassMode": "none",
+        "currentUserCanBypass": "unknown"
+      },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []
     },

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -178,6 +178,18 @@
       "humanApprovedCount": 1,
       "requiredApprovalsSatisfied": true,
       "codeownerApprovalSatisfied": true,
+      "codeownerSelfApproval": {
+        "status": "not_applicable",
+        "reason": "codeowner-approval-satisfied",
+        "prAuthorLogin": "contributor",
+        "directCodeownerUserLogins": ["owner-reviewer"],
+        "codeownerTeamSlugs": [],
+        "requireCodeOwnerReview": true,
+        "codeownerApprovalSatisfied": true,
+        "bypassDetected": false,
+        "bypassMode": "none",
+        "currentUserCanBypass": "unknown"
+      },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []
     },

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -178,6 +178,18 @@
       "humanApprovedCount": 1,
       "requiredApprovalsSatisfied": true,
       "codeownerApprovalSatisfied": true,
+      "codeownerSelfApproval": {
+        "status": "not_applicable",
+        "reason": "codeowner-approval-satisfied",
+        "prAuthorLogin": "contributor",
+        "directCodeownerUserLogins": ["owner-reviewer"],
+        "codeownerTeamSlugs": [],
+        "requireCodeOwnerReview": true,
+        "codeownerApprovalSatisfied": true,
+        "bypassDetected": false,
+        "bypassMode": "none",
+        "currentUserCanBypass": "unknown"
+      },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []
     },

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -178,6 +178,18 @@
       "humanApprovedCount": 1,
       "requiredApprovalsSatisfied": true,
       "codeownerApprovalSatisfied": true,
+      "codeownerSelfApproval": {
+        "status": "not_applicable",
+        "reason": "codeowner-approval-satisfied",
+        "prAuthorLogin": "contributor",
+        "directCodeownerUserLogins": ["owner-reviewer"],
+        "codeownerTeamSlugs": [],
+        "requireCodeOwnerReview": true,
+        "codeownerApprovalSatisfied": true,
+        "bypassDetected": false,
+        "bypassMode": "none",
+        "currentUserCanBypass": "unknown"
+      },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []
     },

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -168,6 +168,18 @@
       "humanApprovedCount": 1,
       "requiredApprovalsSatisfied": true,
       "codeownerApprovalSatisfied": true,
+      "codeownerSelfApproval": {
+        "status": "not_applicable",
+        "reason": "codeowner-approval-satisfied",
+        "prAuthorLogin": "contributor",
+        "directCodeownerUserLogins": ["owner-reviewer"],
+        "codeownerTeamSlugs": [],
+        "requireCodeOwnerReview": true,
+        "codeownerApprovalSatisfied": true,
+        "bypassDetected": false,
+        "bypassMode": "none",
+        "currentUserCanBypass": "unknown"
+      },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []
     },

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -178,6 +178,18 @@
       "humanApprovedCount": 1,
       "requiredApprovalsSatisfied": true,
       "codeownerApprovalSatisfied": true,
+      "codeownerSelfApproval": {
+        "status": "not_applicable",
+        "reason": "codeowner-approval-satisfied",
+        "prAuthorLogin": "contributor",
+        "directCodeownerUserLogins": ["owner-reviewer"],
+        "codeownerTeamSlugs": [],
+        "requireCodeOwnerReview": true,
+        "codeownerApprovalSatisfied": true,
+        "bypassDetected": false,
+        "bypassMode": "none",
+        "currentUserCanBypass": "unknown"
+      },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []
     },

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -79,6 +79,18 @@
     "humanApprovedCount": 1,
     "requiredApprovalsSatisfied": true,
     "codeownerApprovalSatisfied": true,
+    "codeownerSelfApproval": {
+      "status": "not_applicable",
+      "reason": "codeowner-approval-satisfied",
+      "prAuthorLogin": "pr-author",
+      "directCodeownerUserLogins": ["owner-reviewer"],
+      "codeownerTeamSlugs": [],
+      "requireCodeOwnerReview": true,
+      "codeownerApprovalSatisfied": true,
+      "bypassDetected": false,
+      "bypassMode": "none",
+      "currentUserCanBypass": "never"
+    },
     "humanChangesRequestedCount": 0,
     "blockingChangesRequestedLogins": []
   },

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -171,12 +171,20 @@ must align with every F2 condition below.
   same resolved `ciWait.runningTimeout`, `ciWait.generationTimeout`, and
   `ciWait.rerunPolicy` values; on-success → re-evaluate F2)
 - **Required reviews**: Required approvals count is satisfied and all
-  CODEOWNER approvals are obtained. If approvals are absent but there
-  are no open actionable review items (ReviewItems_snapshot is empty), do **not**
-  route to E1 — instead, request CODEOWNER/required reviewers directly
-  (if not already requested), post a hold comment, and stop. Return to
-  E1 only when there are actual review threads or comments to address (→
-  go to `idd-review-snapshot.instructions.md` only in that case).
+  CODEOWNER approvals are obtained. If helper evidence includes
+  `reviewerStates.codeownerSelfApproval`, include that diagnostic in the
+  F2 evidence and any hold comment when its `status` is `deadlock` or
+  `possible_deadlock`. `deadlock` means the current PR/ruleset/CODEOWNER
+  topology cannot be satisfied by ordinary self-approval; `possible_deadlock`
+  means the helper could not prove an eligible non-author CODEOWNER or
+  applicable pull-request bypass, so fail closed. This diagnostic is
+  evidence only and never permission to bypass the Required reviews
+  gate. If approvals are absent but there are no open actionable review
+  items (ReviewItems_snapshot is empty), do **not** route to E1 —
+  instead, request CODEOWNER/required reviewers directly (if not already
+  requested), post a hold comment, and stop. Return to E1 only when
+  there are actual review threads or comments to address (→ go to
+  `idd-review-snapshot.instructions.md` only in that case).
 - **No `CHANGES_REQUESTED`** (human/required/CODEOWNER reviewers only):
   No human, required, or CODEOWNER reviewer's latest state is
   `CHANGES_REQUESTED` (→ if not yet addressed, return to review triage;

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -508,6 +508,11 @@ default `instructions-only` profile keep using the written shell /
   `threads`, `unrepliedComments`, `reviewerStates`,
   `advisoryWait` (including the effective advisory policy fields), `ci`,
   `claim`, and optional `dispositionEvidence`
+- `reviewerStates.codeownerSelfApproval` diagnoses whether CODEOWNER
+  approval can be satisfied by an eligible non-author owner or an
+  applicable pull-request-only ruleset bypass. `deadlock` and
+  `possible_deadlock` statuses should be surfaced in F2 evidence and
+  hold comments, but they do not grant bypass permission.
 - `reviewCurrency.comparisonRoute` remains advisory evidence only. Agents
   must still apply written instruction checks against live GitHub state.
 - Fail closed: if helper execution fails, output is invalid JSON,

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -510,7 +510,7 @@ default `instructions-only` profile keep using the written shell /
   `claim`, and optional `dispositionEvidence`
 - `reviewerStates.codeownerSelfApproval` diagnoses whether CODEOWNER
   approval can be satisfied by an eligible non-author owner or an
-  applicable pull-request-only ruleset bypass. `deadlock` and
+  applicable ruleset or classic pull-request bypass. `deadlock` and
   `possible_deadlock` statuses should be surfaced in F2 evidence and
   hold comments, but they do not grant bypass permission. The
   `currentUserCanBypass` token records the known GitHub ruleset value

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -512,7 +512,10 @@ default `instructions-only` profile keep using the written shell /
   approval can be satisfied by an eligible non-author owner or an
   applicable pull-request-only ruleset bypass. `deadlock` and
   `possible_deadlock` statuses should be surfaced in F2 evidence and
-  hold comments, but they do not grant bypass permission.
+  hold comments, but they do not grant bypass permission. The
+  `currentUserCanBypass` token records the known GitHub ruleset value
+  (`unknown`, `never`, `always`, `pull_requests_only`, `exempt`, or
+  `mixed`).
 - `reviewCurrency.comparisonRoute` remains advisory evidence only. Agents
   must still apply written instruction checks against live GitHub state.
 - Fail closed: if helper execution fails, output is invalid JSON,

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -324,7 +324,7 @@
             "bypassDetected": { "type": "boolean" },
             "bypassMode": {
               "type": "string",
-              "enum": ["none", "pull_request"]
+              "enum": ["none", "pull_request", "always", "exempt", "mixed"]
             },
             "currentUserCanBypass": {
               "type": "string",

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -227,6 +227,7 @@
         "humanApprovedCount",
         "requiredApprovalsSatisfied",
         "codeownerApprovalSatisfied",
+        "codeownerSelfApproval",
         "humanChangesRequestedCount",
         "blockingChangesRequestedLogins"
       ],
@@ -288,6 +289,46 @@
         "humanApprovedCount": { "type": "integer", "minimum": 0 },
         "requiredApprovalsSatisfied": { "type": "boolean" },
         "codeownerApprovalSatisfied": { "type": "boolean" },
+        "codeownerSelfApproval": {
+          "type": "object",
+          "required": [
+            "status",
+            "reason",
+            "prAuthorLogin",
+            "directCodeownerUserLogins",
+            "codeownerTeamSlugs",
+            "requireCodeOwnerReview",
+            "codeownerApprovalSatisfied",
+            "bypassDetected",
+            "bypassMode",
+            "currentUserCanBypass"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["not_applicable", "clear", "possible_deadlock", "deadlock"]
+            },
+            "reason": { "type": "string", "minLength": 1 },
+            "prAuthorLogin": { "type": "string" },
+            "directCodeownerUserLogins": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "codeownerTeamSlugs": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "requireCodeOwnerReview": { "type": "boolean" },
+            "codeownerApprovalSatisfied": { "type": "boolean" },
+            "bypassDetected": { "type": "boolean" },
+            "bypassMode": {
+              "type": "string",
+              "enum": ["none", "pull_request"]
+            },
+            "currentUserCanBypass": { "type": "string", "minLength": 1 }
+          }
+        },
         "humanChangesRequestedCount": { "type": "integer", "minimum": 0 },
         "blockingChangesRequestedLogins": {
           "type": "array",

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -326,7 +326,10 @@
               "type": "string",
               "enum": ["none", "pull_request"]
             },
-            "currentUserCanBypass": { "type": "string", "minLength": 1 }
+            "currentUserCanBypass": {
+              "type": "string",
+              "enum": ["unknown", "never", "always", "pull_requests_only", "mixed"]
+            }
           }
         },
         "humanChangesRequestedCount": { "type": "integer", "minimum": 0 },

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -328,7 +328,7 @@
             },
             "currentUserCanBypass": {
               "type": "string",
-              "enum": ["unknown", "never", "always", "pull_requests_only", "mixed"]
+              "enum": ["unknown", "never", "always", "pull_requests_only", "exempt", "mixed"]
             }
           }
         },

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -9,6 +9,7 @@ import {
   deriveIddAgentLogins,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
+  resolveCodeownersForFiles,
   selectCodeownersText,
 } from "./protocol-helpers.mjs";
 import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
@@ -102,6 +103,11 @@ const changedFiles = ghApiJson(`repos/${owner}/${repo}/pulls/${args.prNumber}/fi
   .map((file) => String(file.filename ?? ""))
   .filter(Boolean);
 const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
+const eligibleCodeownerUserLogins = resolveEligibleCodeownerUserLogins(
+  owner,
+  repo,
+  resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
+);
 
 const collaboratorTrustEnabled = readCollaboratorTrustEnabled();
 const trustedMarkerLogins = normalizeTrustedMarkerLogins([
@@ -137,6 +143,7 @@ const summary = buildPreMergeReadinessSummary(
     claimEvents: claimComments.map(normalizeClaimComment),
     changedFiles,
     codeownersText,
+    eligibleCodeownerUserLogins,
     reviewDecision,
   },
   {
@@ -331,6 +338,20 @@ function resolveTrustedCollaboratorMarkerLogins(owner, repo, comments) {
 
     return permission === "admin" || permission === "maintain" || permission === "write";
   });
+}
+
+function resolveEligibleCodeownerUserLogins(owner, repo, logins) {
+  return normalizeTrustedMarkerLogins(logins)
+    .filter((login) => {
+      const permission = safeGhText([
+        "api",
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        "--jq",
+        ".permission",
+      ]).toLowerCase();
+
+      return permission === "admin" || permission === "maintain" || permission === "write";
+    });
 }
 
 function fetchCodeownersText(owner, repo, ref) {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -576,7 +576,7 @@ function ghApiJson(path, paginate = false, extraArgs = [], options = {}) {
 
 function runGh(args, options = {}) {
   try {
-    return execFileSync("gh", args, { encoding: "utf8" });
+    return execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
   } catch (error) {
     const status = Number(error?.status ?? -1);
     if ((options.allowStatuses ?? []).includes(status)) {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -75,6 +75,7 @@ const branchRules = ghApiJson(
   [],
   { allowHttpStatuses: [404] },
 );
+const branchRulesets = fetchBranchRulesets(owner, repo, branchRules);
 const branchProtection = ghApiJson(
   `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
   false,
@@ -129,6 +130,7 @@ const summary = buildPreMergeReadinessSummary(
     threads: threads.map(normalizeThread),
     checks,
     branchRules,
+    branchRulesets,
     branchProtection,
     requestedReviewers: requestedReviewers.users ?? [],
     timelineEvents,
@@ -341,6 +343,25 @@ function fetchCodeownersText(owner, repo, ref) {
     );
   });
   return selectCodeownersText(payloads);
+}
+
+function fetchBranchRulesets(owner, repo, branchRules) {
+  const rulesetIds = [...new Set(
+    (branchRules ?? [])
+      .map((rule) => Number.parseInt(String(rule?.ruleset_id ?? ""), 10))
+      .filter(Number.isInteger),
+  )];
+
+  return rulesetIds
+    .map((rulesetId) => {
+      return ghApiJson(
+        `repos/${owner}/${repo}/rulesets/${rulesetId}`,
+        false,
+        ["-H", "Accept: application/vnd.github+json"],
+        { allowHttpStatuses: [404] },
+      );
+    })
+    .filter((ruleset) => Object.keys(ruleset).length > 0);
 }
 
 function fetchReviewThreads(owner, repo, prNumber) {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -10,6 +10,7 @@ import {
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   resolveCodeownersForFiles,
+  resolveRulesetDetailPath,
   selectCodeownersText,
 } from "./protocol-helpers.mjs";
 import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
@@ -32,6 +33,7 @@ const owner = args.owner || ghText(["repo", "view", "--json", "owner", "--jq", "
 const repo = args.repo || ghText(["repo", "view", "--json", "name", "--jq", ".name"]);
 const repoRef = `${owner}/${repo}`;
 const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
+const viewerAppSlug = safeGhText(["api", "app", "--jq", ".slug // .app_slug // empty"]).toLowerCase();
 const configuredTrustedActors = normalizeTrustedMarkerLogins([
   ...splitCsv(args.trustedMarkerLogins),
   ...splitCsv(process.env.IDD_TRUSTED_MARKER_ACTORS),
@@ -108,6 +110,7 @@ const eligibleCodeownerUserLogins = resolveEligibleCodeownerUserLogins(
   repo,
   resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
 );
+const viewerTeamSlugs = resolveViewerClassicBypassTeamSlugs(owner, viewerLogin, branchProtection);
 
 const collaboratorTrustEnabled = readCollaboratorTrustEnabled();
 const trustedMarkerLogins = normalizeTrustedMarkerLogins([
@@ -171,6 +174,8 @@ const summary = buildPreMergeReadinessSummary(
         forcedHandoffPermissionCache,
       ),
     viewerLogin,
+    viewerTeamSlugs,
+    viewerAppSlug,
     configuredTrustedActors,
     collaboratorTrustEnabled,
   },
@@ -398,16 +403,37 @@ function fetchBranchRulesets(owner, repo, branchRules) {
     .filter((ruleset) => Object.keys(ruleset).length > 0);
 }
 
-function resolveRulesetDetailPath(owner, repo, rule, rulesetId) {
-  const sourceType = String(rule?.ruleset_source_type ?? rule?.source_type ?? "")
-    .trim()
-    .toLowerCase();
-  if (sourceType === "organization") {
-    const source = String(rule?.ruleset_source ?? rule?.source ?? owner).trim();
-    const org = source.split("/")[0] || owner;
-    return `orgs/${encodeURIComponent(org)}/rulesets/${rulesetId}`;
+function resolveViewerClassicBypassTeamSlugs(owner, viewerLogin, branchProtection) {
+  if (!viewerLogin) {
+    return [];
   }
-  return `repos/${owner}/${repo}/rulesets/${rulesetId}`;
+  const teams = branchProtection.required_pull_request_reviews?.bypass_pull_request_allowances?.teams ?? [];
+  const viewerTeams = new Set();
+  for (const team of teams) {
+    const slug = String(team?.slug ?? "").trim().toLowerCase();
+    if (!slug) {
+      continue;
+    }
+    const org = String(team?.organization?.login ?? extractTeamOrgFromHtmlUrl(team?.html_url) ?? owner)
+      .trim();
+    const state = safeGhText([
+      "api",
+      `orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(slug)}/memberships/${
+        encodeURIComponent(viewerLogin)
+      }`,
+      "--jq",
+      ".state",
+    ]).toLowerCase();
+    if (state === "active") {
+      viewerTeams.add(slug);
+    }
+  }
+  return [...viewerTeams].sort();
+}
+
+function extractTeamOrgFromHtmlUrl(htmlUrl) {
+  const match = String(htmlUrl ?? "").match(/\/orgs\/([^/]+)\/teams\//);
+  return match?.[1] ?? "";
 }
 
 function fetchReviewThreads(owner, repo, prNumber) {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -354,12 +354,16 @@ function fetchBranchRulesets(owner, repo, branchRules) {
 
   return rulesetIds
     .map((rulesetId) => {
-      return ghApiJson(
-        `repos/${owner}/${repo}/rulesets/${rulesetId}`,
-        false,
-        ["-H", "Accept: application/vnd.github+json"],
-        { allowHttpStatuses: [404] },
-      );
+      try {
+        return ghApiJson(
+          `repos/${owner}/${repo}/rulesets/${rulesetId}`,
+          false,
+          ["-H", "Accept: application/vnd.github+json"],
+          { allowHttpStatuses: [404] },
+        );
+      } catch {
+        return {};
+      }
     })
     .filter((ruleset) => Object.keys(ruleset).length > 0);
 }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -367,17 +367,26 @@ function fetchCodeownersText(owner, repo, ref) {
 }
 
 function fetchBranchRulesets(owner, repo, branchRules) {
-  const rulesetIds = [...new Set(
-    (branchRules ?? [])
-      .map((rule) => Number.parseInt(String(rule?.ruleset_id ?? ""), 10))
-      .filter(Number.isInteger),
-  )];
+  const rulesetPaths = [];
+  const seenPaths = new Set();
+  for (const rule of branchRules ?? []) {
+    const rulesetId = Number.parseInt(String(rule?.ruleset_id ?? ""), 10);
+    if (!Number.isInteger(rulesetId)) {
+      continue;
+    }
+    const path = resolveRulesetDetailPath(owner, repo, rule, rulesetId);
+    if (seenPaths.has(path)) {
+      continue;
+    }
+    seenPaths.add(path);
+    rulesetPaths.push(path);
+  }
 
-  return rulesetIds
-    .map((rulesetId) => {
+  return rulesetPaths
+    .map((path) => {
       try {
         return ghApiJson(
-          `repos/${owner}/${repo}/rulesets/${rulesetId}`,
+          path,
           false,
           ["-H", "Accept: application/vnd.github+json"],
           { allowHttpStatuses: [404] },
@@ -387,6 +396,18 @@ function fetchBranchRulesets(owner, repo, branchRules) {
       }
     })
     .filter((ruleset) => Object.keys(ruleset).length > 0);
+}
+
+function resolveRulesetDetailPath(owner, repo, rule, rulesetId) {
+  const sourceType = String(rule?.ruleset_source_type ?? rule?.source_type ?? "")
+    .trim()
+    .toLowerCase();
+  if (sourceType === "organization") {
+    const source = String(rule?.ruleset_source ?? rule?.source ?? owner).trim();
+    const org = source.split("/")[0] || owner;
+    return `orgs/${encodeURIComponent(org)}/rulesets/${rulesetId}`;
+  }
+  return `repos/${owner}/${repo}/rulesets/${rulesetId}`;
 }
 
 function fetchReviewThreads(owner, repo, prNumber) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1616,10 +1616,12 @@ export function summarizeReviewerStates(
   {
     reviewDecision = "",
     branchRules = [],
+    branchRulesets = [],
     branchProtection = {},
     codeownersText = "",
     changedFiles = [],
     advisoryBotLogins = [],
+    prAuthorLogin = "",
   } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(branchRules, branchProtection);
@@ -1691,6 +1693,20 @@ export function summarizeReviewerStates(
       }
       return latestByLogin.get(requirement.identity)?.state === "APPROVED";
     });
+  const codeownerSelfApproval = summarizeCodeownerSelfApproval({
+    requireCodeOwnerReview: branchReviewRequirements.requireCodeOwnerReview,
+    codeownerApprovalSatisfied:
+      !branchReviewRequirements.requireCodeOwnerReview
+        || !hasExplicitCodeownerMatches
+        || codeownerApproved
+        || normalizedReviewDecision === "APPROVED",
+    hasExplicitCodeownerMatches,
+    codeownerUserLogins: codeowners.codeownerUserLogins,
+    codeownerTeamSlugs: codeowners.codeownerTeamSlugs,
+    prAuthorLogin,
+    branchRules,
+    branchRulesets,
+  });
 
   return {
     reviewDecision: normalizedReviewDecision,
@@ -1721,8 +1737,139 @@ export function summarizeReviewerStates(
         || !hasExplicitCodeownerMatches
         || codeownerApproved
         || normalizedReviewDecision === "APPROVED",
+    codeownerSelfApproval,
     humanChangesRequestedCount: blockingChangesRequestedLogins.length,
     blockingChangesRequestedLogins,
+  };
+}
+
+function summarizeCodeownerSelfApproval({
+  requireCodeOwnerReview,
+  codeownerApprovalSatisfied,
+  hasExplicitCodeownerMatches,
+  codeownerUserLogins = [],
+  codeownerTeamSlugs = [],
+  prAuthorLogin = "",
+  branchRules = [],
+  branchRulesets = [],
+}) {
+  const normalizedAuthor = String(prAuthorLogin ?? "").trim().toLowerCase();
+  const directCodeownerUserLogins = normalizeTrustedMarkerLogins(codeownerUserLogins);
+  const normalizedCodeownerTeamSlugs = normalizeTrustedMarkerLogins(codeownerTeamSlugs);
+  const bypass = summarizeRulesetPullRequestBypass(branchRulesets, branchRules);
+  const base = {
+    status: "not_applicable",
+    reason: "codeowner-review-not-required",
+    prAuthorLogin: normalizedAuthor,
+    directCodeownerUserLogins,
+    codeownerTeamSlugs: normalizedCodeownerTeamSlugs,
+    requireCodeOwnerReview: Boolean(requireCodeOwnerReview),
+    codeownerApprovalSatisfied: Boolean(codeownerApprovalSatisfied),
+    bypassDetected: bypass.detected,
+    bypassMode: bypass.mode,
+    currentUserCanBypass: bypass.currentUserCanBypass,
+  };
+
+  if (!requireCodeOwnerReview) {
+    return base;
+  }
+  if (!hasExplicitCodeownerMatches) {
+    return {
+      ...base,
+      reason: "no-explicit-codeowner-match",
+    };
+  }
+  if (codeownerApprovalSatisfied) {
+    return {
+      ...base,
+      reason: "codeowner-approval-satisfied",
+    };
+  }
+  if (bypass.detected) {
+    return {
+      ...base,
+      status: "clear",
+      reason: "pull-request-bypass-available",
+    };
+  }
+  if (!normalizedAuthor) {
+    return {
+      ...base,
+      status: "possible_deadlock",
+      reason: "pr-author-unknown",
+    };
+  }
+
+  const allDirectUsersAreAuthor = directCodeownerUserLogins.length > 0
+    && directCodeownerUserLogins.every((login) => login === normalizedAuthor);
+  const hasNonAuthorDirectUser = directCodeownerUserLogins.some((login) => login !== normalizedAuthor);
+
+  if (hasNonAuthorDirectUser) {
+    return {
+      ...base,
+      status: "clear",
+      reason: "non-author-codeowner-available",
+    };
+  }
+  if (normalizedCodeownerTeamSlugs.length > 0) {
+    return {
+      ...base,
+      status: "possible_deadlock",
+      reason: "team-codeowner-ambiguous",
+    };
+  }
+  if (allDirectUsersAreAuthor) {
+    return {
+      ...base,
+      status: "deadlock",
+      reason: "pr-author-is-only-direct-codeowner",
+    };
+  }
+
+  return {
+    ...base,
+    status: "possible_deadlock",
+    reason: "no-reviewable-codeowner-identity",
+  };
+}
+
+function summarizeRulesetPullRequestBypass(branchRulesets = [], branchRules = []) {
+  const codeownerRulesetIds = new Set(
+    (branchRules ?? [])
+      .filter((rule) => {
+        return rule?.type === "pull_request"
+          && Boolean(rule?.parameters?.require_code_owner_review);
+      })
+      .map((rule) => Number.parseInt(String(rule?.ruleset_id ?? ""), 10))
+      .filter(Number.isInteger),
+  );
+  const relevantRulesets = (branchRulesets ?? [])
+    .filter((ruleset) => {
+      const rulesetId = Number.parseInt(String(ruleset?.id ?? ruleset?.ruleset_id ?? ""), 10);
+      return codeownerRulesetIds.has(rulesetId);
+    });
+  const values = relevantRulesets
+    .map((ruleset) => String(ruleset?.current_user_can_bypass ?? "").trim())
+    .filter(Boolean);
+  let currentUserCanBypass = "unknown";
+  if (values.length > 1 && new Set(values).size > 1) {
+    currentUserCanBypass = "mixed";
+  } else if (values.includes("pull_requests_only")) {
+    currentUserCanBypass = "pull_requests_only";
+  } else if (values.includes("always")) {
+    currentUserCanBypass = "always";
+  } else if (values.includes("never")) {
+    currentUserCanBypass = "never";
+  } else if (values.length > 0) {
+    currentUserCanBypass = values.sort()[0];
+  }
+  const detected = relevantRulesets.length > 0
+    && values.length === relevantRulesets.length
+    && values.every((value) => value === "pull_requests_only");
+  return {
+    detected,
+    mode: detected ? "pull_request" : "none",
+    currentUserCanBypass,
   };
 }
 
@@ -1808,6 +1955,7 @@ export function buildPreMergeReadinessSummary(
     threads = [],
     checks = [],
     branchRules = [],
+    branchRulesets = [],
     branchProtection = {},
     requestedReviewers = [],
     timelineEvents = [],
@@ -1875,10 +2023,12 @@ export function buildPreMergeReadinessSummary(
   const reviewerStates = summarizeReviewerStates(reviews, {
     reviewDecision,
     branchRules,
+    branchRulesets,
     branchProtection,
     codeownersText,
     changedFiles,
     advisoryBotLogins,
+    prAuthorLogin,
   });
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection);
   const advisoryWaitOptions = normalizeAdvisoryWaitRuntimeOptions(options);

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1441,6 +1441,8 @@ export function summarizeBranchReviewRequirements(branchRules = [], branchProtec
   const requiredReviewerTeams = new Set();
   const requiredReviewerRequirements = [];
   const classicBypassPullRequestUserLogins = new Set();
+  const classicBypassPullRequestTeamSlugs = new Set();
+  const classicBypassPullRequestAppSlugs = new Set();
 
   let requiredApprovingReviewCount = 0;
   let requireCodeOwnerReview = false;
@@ -1497,6 +1499,18 @@ export function summarizeBranchReviewRequirements(branchRules = [], branchProtec
       classicBypassPullRequestUserLogins.add(normalizedLogin);
     }
   }
+  for (const team of protectionReviews.bypass_pull_request_allowances?.teams ?? []) {
+    const slug = typeof team === "string" ? team : team?.slug;
+    for (const normalizedSlug of normalizeTrustedMarkerLogins([slug])) {
+      classicBypassPullRequestTeamSlugs.add(normalizedSlug);
+    }
+  }
+  for (const app of protectionReviews.bypass_pull_request_allowances?.apps ?? []) {
+    const slug = typeof app === "string" ? app : app?.slug ?? app?.app_slug;
+    for (const normalizedSlug of normalizeTrustedMarkerLogins([slug])) {
+      classicBypassPullRequestAppSlugs.add(normalizedSlug);
+    }
+  }
   requiredApprovingReviewCount = Math.max(
     requiredApprovingReviewCount,
     Number(protectionReviews.required_approving_review_count ?? 0) || 0,
@@ -1518,6 +1532,8 @@ export function summarizeBranchReviewRequirements(branchRules = [], branchProtec
     requireCodeOwnerReview,
     classicRequireCodeOwnerReview,
     classicBypassPullRequestUserLogins: [...classicBypassPullRequestUserLogins].sort(),
+    classicBypassPullRequestTeamSlugs: [...classicBypassPullRequestTeamSlugs].sort(),
+    classicBypassPullRequestAppSlugs: [...classicBypassPullRequestAppSlugs].sort(),
     requiresConversationResolution,
     requiredCheckSourcePinned,
     requiredReviewerLogins: [...requiredReviewerLogins].sort(),
@@ -1639,6 +1655,8 @@ export function summarizeReviewerStates(
     advisoryBotLogins = [],
     prAuthorLogin = "",
     viewerLogin = "",
+    viewerTeamSlugs = [],
+    viewerAppSlug = "",
   } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(branchRules, branchProtection);
@@ -1731,10 +1749,14 @@ export function summarizeReviewerStates(
     codeownerEmailAddresses: codeowners.codeownerEmailAddresses,
     prAuthorLogin,
     viewerLogin,
+    viewerTeamSlugs,
+    viewerAppSlug,
     branchRules,
     branchRulesets,
     classicRequireCodeOwnerReview: branchReviewRequirements.classicRequireCodeOwnerReview,
     classicBypassPullRequestUserLogins: branchReviewRequirements.classicBypassPullRequestUserLogins,
+    classicBypassPullRequestTeamSlugs: branchReviewRequirements.classicBypassPullRequestTeamSlugs,
+    classicBypassPullRequestAppSlugs: branchReviewRequirements.classicBypassPullRequestAppSlugs,
   });
 
   return {
@@ -1782,13 +1804,19 @@ function summarizeCodeownerSelfApproval({
   codeownerEmailAddresses = [],
   prAuthorLogin = "",
   viewerLogin = "",
+  viewerTeamSlugs = [],
+  viewerAppSlug = "",
   branchRules = [],
   branchRulesets = [],
   classicRequireCodeOwnerReview = false,
   classicBypassPullRequestUserLogins = [],
+  classicBypassPullRequestTeamSlugs = [],
+  classicBypassPullRequestAppSlugs = [],
 }) {
   const normalizedAuthor = String(prAuthorLogin ?? "").trim().toLowerCase();
   const normalizedViewer = String(viewerLogin ?? "").trim().toLowerCase();
+  const normalizedViewerAppSlug = String(viewerAppSlug ?? "").trim().toLowerCase();
+  const normalizedViewerTeamSlugs = normalizeTrustedMarkerLogins(viewerTeamSlugs);
   const directCodeownerUserLogins = normalizeTrustedMarkerLogins(codeownerUserLogins);
   const eligibleDirectCodeownerUserLogins = eligibleCodeownerUserLogins === null
     ? directCodeownerUserLogins
@@ -1798,8 +1826,19 @@ function summarizeCodeownerSelfApproval({
   const normalizedCodeownerEmailAddresses = normalizeTrustedMarkerLogins(codeownerEmailAddresses);
   const classicBypassDetected = Boolean(
     Boolean(classicRequireCodeOwnerReview)
-    && normalizedViewer
-    && normalizeTrustedMarkerLogins(classicBypassPullRequestUserLogins).includes(normalizedViewer),
+    && (
+      (
+        normalizedViewer
+        && normalizeTrustedMarkerLogins(classicBypassPullRequestUserLogins).includes(normalizedViewer)
+      )
+      || normalizedViewerTeamSlugs.some((slug) => {
+        return normalizeTrustedMarkerLogins(classicBypassPullRequestTeamSlugs).includes(slug);
+      })
+      || (
+        normalizedViewerAppSlug
+        && normalizeTrustedMarkerLogins(classicBypassPullRequestAppSlugs).includes(normalizedViewerAppSlug)
+      )
+    ),
   );
   const bypass = summarizeRulesetPullRequestBypass(branchRulesets, branchRules);
   const rulesetGateSatisfiedByBypass = bypass.relevantRulesetCount === 0 || bypass.detected;
@@ -1956,6 +1995,25 @@ function summarizeRulesetPullRequestBypass(branchRulesets = [], branchRules = []
     currentUserCanBypass,
     relevantRulesetCount: expectedRulesetCount,
   };
+}
+
+export function resolveRulesetDetailPath(owner, repo, rule, rulesetId) {
+  const sourceType = String(rule?.ruleset_source_type ?? rule?.source_type ?? "")
+    .trim()
+    .toLowerCase();
+  if (sourceType === "organization") {
+    const source = String(rule?.ruleset_source ?? rule?.source ?? owner).trim();
+    const org = source.split("/")[0] || owner;
+    return `orgs/${encodeURIComponent(org)}/rulesets/${rulesetId}`;
+  }
+  if (sourceType === "enterprise") {
+    const source = String(rule?.ruleset_source ?? rule?.source ?? "").trim();
+    const enterprise = source.split("/")[0];
+    if (enterprise) {
+      return `enterprises/${encodeURIComponent(enterprise)}/rulesets/${rulesetId}`;
+    }
+  }
+  return `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/rulesets/${rulesetId}`;
 }
 
 export function summarizeClaimValidation(claimEvents = [], options = {}) {
@@ -2117,6 +2175,8 @@ export function buildPreMergeReadinessSummary(
     advisoryBotLogins,
     prAuthorLogin,
     viewerLogin: options.viewerLogin,
+    viewerTeamSlugs: options.viewerTeamSlugs,
+    viewerAppSlug: options.viewerAppSlug,
   });
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection);
   const advisoryWaitOptions = normalizeAdvisoryWaitRuntimeOptions(options);

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1171,7 +1171,7 @@ export function buildActivitySnapshotSummary(
   const latestCiCompletedAt = maxIsoTimestamp(
     checks
       .map((check) => check.completedAt)
-      .filter(isValidIsoTimestamp),
+      .filter(isCompletedCiTimestamp),
   ) ?? "none";
 
   const latestPassingCiCompletedAt = maxIsoTimestamp(
@@ -1186,7 +1186,7 @@ export function buildActivitySnapshotSummary(
         ].includes(state);
       })
       .map((check) => check.completedAt)
-      .filter(isValidIsoTimestamp),
+      .filter(isCompletedCiTimestamp),
   ) ?? "none";
 
   const maxActivityUpdatedAt = maxIsoTimestamp([
@@ -3084,6 +3084,11 @@ function isValidIsoTimestamp(value) {
   if (!Number.isFinite(time)) return false;
   const normalize = (ts) => ts.replace(".000Z", "Z");
   return normalize(new Date(time).toISOString()) === normalize(value);
+}
+
+function isCompletedCiTimestamp(value) {
+  const timestamp = String(value ?? "");
+  return timestamp !== "0001-01-01T00:00:00Z" && isValidIsoTimestamp(timestamp);
 }
 
 function normalizeComparableTimestamp(value) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1443,6 +1443,7 @@ export function summarizeBranchReviewRequirements(branchRules = [], branchProtec
 
   let requiredApprovingReviewCount = 0;
   let requireCodeOwnerReview = false;
+  let classicRequireCodeOwnerReview = false;
   let requiresConversationResolution = false;
   let requiredCheckSourcePinned = false;
 
@@ -1487,13 +1488,13 @@ export function summarizeBranchReviewRequirements(branchRules = [], branchProtec
   }
 
   const protectionReviews = branchProtection.required_pull_request_reviews ?? {};
+  classicRequireCodeOwnerReview = Boolean(protectionReviews.require_code_owner_reviews)
+    || Boolean(protectionReviews.require_code_owner_review);
   requiredApprovingReviewCount = Math.max(
     requiredApprovingReviewCount,
     Number(protectionReviews.required_approving_review_count ?? 0) || 0,
   );
-  requireCodeOwnerReview = requireCodeOwnerReview
-    || Boolean(protectionReviews.require_code_owner_reviews)
-    || Boolean(protectionReviews.require_code_owner_review);
+  requireCodeOwnerReview = requireCodeOwnerReview || classicRequireCodeOwnerReview;
   requiresConversationResolution = requiresConversationResolution
     || Boolean(branchProtection.required_conversation_resolution?.enabled);
 
@@ -1508,6 +1509,7 @@ export function summarizeBranchReviewRequirements(branchRules = [], branchProtec
   return {
     requiredApprovingReviewCount,
     requireCodeOwnerReview,
+    classicRequireCodeOwnerReview,
     requiresConversationResolution,
     requiredCheckSourcePinned,
     requiredReviewerLogins: [...requiredReviewerLogins].sort(),
@@ -1706,6 +1708,7 @@ export function summarizeReviewerStates(
     prAuthorLogin,
     branchRules,
     branchRulesets,
+    classicRequireCodeOwnerReview: branchReviewRequirements.classicRequireCodeOwnerReview,
   });
 
   return {
@@ -1752,11 +1755,13 @@ function summarizeCodeownerSelfApproval({
   prAuthorLogin = "",
   branchRules = [],
   branchRulesets = [],
+  classicRequireCodeOwnerReview = false,
 }) {
   const normalizedAuthor = String(prAuthorLogin ?? "").trim().toLowerCase();
   const directCodeownerUserLogins = normalizeTrustedMarkerLogins(codeownerUserLogins);
   const normalizedCodeownerTeamSlugs = normalizeTrustedMarkerLogins(codeownerTeamSlugs);
   const bypass = summarizeRulesetPullRequestBypass(branchRulesets, branchRules);
+  const applicableBypassDetected = bypass.detected && !classicRequireCodeOwnerReview;
   const base = {
     status: "not_applicable",
     reason: "codeowner-review-not-required",
@@ -1765,8 +1770,8 @@ function summarizeCodeownerSelfApproval({
     codeownerTeamSlugs: normalizedCodeownerTeamSlugs,
     requireCodeOwnerReview: Boolean(requireCodeOwnerReview),
     codeownerApprovalSatisfied: Boolean(codeownerApprovalSatisfied),
-    bypassDetected: bypass.detected,
-    bypassMode: bypass.mode,
+    bypassDetected: applicableBypassDetected,
+    bypassMode: applicableBypassDetected ? bypass.mode : "none",
     currentUserCanBypass: bypass.currentUserCanBypass,
   };
 
@@ -1785,7 +1790,7 @@ function summarizeCodeownerSelfApproval({
       reason: "codeowner-approval-satisfied",
     };
   }
-  if (bypass.detected) {
+  if (applicableBypassDetected) {
     return {
       ...base,
       status: "clear",
@@ -1850,18 +1855,23 @@ function summarizeRulesetPullRequestBypass(branchRulesets = [], branchRules = []
     });
   const values = relevantRulesets
     .map((ruleset) => String(ruleset?.current_user_can_bypass ?? "").trim())
+    .map((value) => {
+      return ["always", "exempt", "never", "pull_requests_only"].includes(value)
+        ? value
+        : "unknown";
+    })
     .filter(Boolean);
   let currentUserCanBypass = "unknown";
   if (values.length > 1 && new Set(values).size > 1) {
     currentUserCanBypass = "mixed";
+  } else if (values.includes("exempt")) {
+    currentUserCanBypass = "exempt";
   } else if (values.includes("pull_requests_only")) {
     currentUserCanBypass = "pull_requests_only";
   } else if (values.includes("always")) {
     currentUserCanBypass = "always";
   } else if (values.includes("never")) {
     currentUserCanBypass = "never";
-  } else if (values.length > 0) {
-    currentUserCanBypass = values.sort()[0];
   }
   const detected = relevantRulesets.length > 0
     && values.length === relevantRulesets.length

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1440,6 +1440,7 @@ export function summarizeBranchReviewRequirements(branchRules = [], branchProtec
   const requiredReviewerLogins = new Set();
   const requiredReviewerTeams = new Set();
   const requiredReviewerRequirements = [];
+  const classicBypassPullRequestUserLogins = new Set();
 
   let requiredApprovingReviewCount = 0;
   let requireCodeOwnerReview = false;
@@ -1490,6 +1491,12 @@ export function summarizeBranchReviewRequirements(branchRules = [], branchProtec
   const protectionReviews = branchProtection.required_pull_request_reviews ?? {};
   classicRequireCodeOwnerReview = Boolean(protectionReviews.require_code_owner_reviews)
     || Boolean(protectionReviews.require_code_owner_review);
+  for (const user of protectionReviews.bypass_pull_request_allowances?.users ?? []) {
+    const login = typeof user === "string" ? user : user?.login;
+    for (const normalizedLogin of normalizeTrustedMarkerLogins([login])) {
+      classicBypassPullRequestUserLogins.add(normalizedLogin);
+    }
+  }
   requiredApprovingReviewCount = Math.max(
     requiredApprovingReviewCount,
     Number(protectionReviews.required_approving_review_count ?? 0) || 0,
@@ -1510,6 +1517,7 @@ export function summarizeBranchReviewRequirements(branchRules = [], branchProtec
     requiredApprovingReviewCount,
     requireCodeOwnerReview,
     classicRequireCodeOwnerReview,
+    classicBypassPullRequestUserLogins: [...classicBypassPullRequestUserLogins].sort(),
     requiresConversationResolution,
     requiredCheckSourcePinned,
     requiredReviewerLogins: [...requiredReviewerLogins].sort(),
@@ -1579,6 +1587,7 @@ export function selectCodeownersText(payloads = []) {
 function collectCodeownersForFiles(rules, changedFiles = []) {
   const codeownerUsers = new Set();
   const codeownerTeams = new Set();
+  const codeownerEmails = new Set();
   const unmatchedFiles = [];
 
   for (const filePath of changedFiles) {
@@ -1602,6 +1611,9 @@ function collectCodeownersForFiles(rules, changedFiles = []) {
     for (const owner of owners.teams) {
       codeownerTeams.add(owner);
     }
+    for (const owner of owners.emails) {
+      codeownerEmails.add(owner);
+    }
   }
 
   return {
@@ -1610,6 +1622,7 @@ function collectCodeownersForFiles(rules, changedFiles = []) {
     unmatchedFiles,
     codeownerUserLogins: [...codeownerUsers].sort(),
     codeownerTeamSlugs: [...codeownerTeams].sort(),
+    codeownerEmailAddresses: [...codeownerEmails].sort(),
   };
 }
 
@@ -1625,6 +1638,7 @@ export function summarizeReviewerStates(
     eligibleCodeownerUserLogins = null,
     advisoryBotLogins = [],
     prAuthorLogin = "",
+    viewerLogin = "",
   } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(branchRules, branchProtection);
@@ -1714,10 +1728,13 @@ export function summarizeReviewerStates(
     eligibleCodeownerUserLogins:
       eligibleCodeownerUserLogins === null ? null : [...eligibleCodeownerUsers].sort(),
     codeownerTeamSlugs: codeowners.codeownerTeamSlugs,
+    codeownerEmailAddresses: codeowners.codeownerEmailAddresses,
     prAuthorLogin,
+    viewerLogin,
     branchRules,
     branchRulesets,
     classicRequireCodeOwnerReview: branchReviewRequirements.classicRequireCodeOwnerReview,
+    classicBypassPullRequestUserLogins: branchReviewRequirements.classicBypassPullRequestUserLogins,
   });
 
   return {
@@ -1762,20 +1779,37 @@ function summarizeCodeownerSelfApproval({
   codeownerUserLogins = [],
   eligibleCodeownerUserLogins = null,
   codeownerTeamSlugs = [],
+  codeownerEmailAddresses = [],
   prAuthorLogin = "",
+  viewerLogin = "",
   branchRules = [],
   branchRulesets = [],
   classicRequireCodeOwnerReview = false,
+  classicBypassPullRequestUserLogins = [],
 }) {
   const normalizedAuthor = String(prAuthorLogin ?? "").trim().toLowerCase();
+  const normalizedViewer = String(viewerLogin ?? "").trim().toLowerCase();
   const directCodeownerUserLogins = normalizeTrustedMarkerLogins(codeownerUserLogins);
   const eligibleDirectCodeownerUserLogins = eligibleCodeownerUserLogins === null
     ? directCodeownerUserLogins
     : normalizeTrustedMarkerLogins(eligibleCodeownerUserLogins)
       .filter((login) => directCodeownerUserLogins.includes(login));
   const normalizedCodeownerTeamSlugs = normalizeTrustedMarkerLogins(codeownerTeamSlugs);
+  const normalizedCodeownerEmailAddresses = normalizeTrustedMarkerLogins(codeownerEmailAddresses);
+  const classicBypassDetected = Boolean(
+    Boolean(classicRequireCodeOwnerReview)
+    && normalizedViewer
+    && normalizeTrustedMarkerLogins(classicBypassPullRequestUserLogins).includes(normalizedViewer),
+  );
   const bypass = summarizeRulesetPullRequestBypass(branchRulesets, branchRules);
-  const applicableBypassDetected = bypass.detected && !classicRequireCodeOwnerReview;
+  const rulesetGateSatisfiedByBypass = bypass.relevantRulesetCount === 0 || bypass.detected;
+  const classicGateSatisfiedByBypass = !classicRequireCodeOwnerReview || classicBypassDetected;
+  const applicableBypassDetected = (bypass.detected || classicBypassDetected)
+    && rulesetGateSatisfiedByBypass
+    && classicGateSatisfiedByBypass;
+  const applicableBypassMode = applicableBypassDetected
+    ? (bypass.detected ? bypass.mode : "pull_request")
+    : "none";
   const base = {
     status: "not_applicable",
     reason: "codeowner-review-not-required",
@@ -1785,7 +1819,7 @@ function summarizeCodeownerSelfApproval({
     requireCodeOwnerReview: Boolean(requireCodeOwnerReview),
     codeownerApprovalSatisfied: Boolean(codeownerApprovalSatisfied),
     bypassDetected: applicableBypassDetected,
-    bypassMode: applicableBypassDetected ? bypass.mode : "none",
+    bypassMode: applicableBypassMode,
     currentUserCanBypass: bypass.currentUserCanBypass,
   };
 
@@ -1808,7 +1842,9 @@ function summarizeCodeownerSelfApproval({
     return {
       ...base,
       status: "clear",
-      reason: "pull-request-bypass-available",
+      reason: applicableBypassMode === "pull_request"
+        ? "pull-request-bypass-available"
+        : "ruleset-bypass-available",
     };
   }
   if (!normalizedAuthor) {
@@ -1835,6 +1871,13 @@ function summarizeCodeownerSelfApproval({
       ...base,
       status: "possible_deadlock",
       reason: "team-codeowner-ambiguous",
+    };
+  }
+  if (normalizedCodeownerEmailAddresses.length > 0) {
+    return {
+      ...base,
+      status: "possible_deadlock",
+      reason: "email-codeowner-ambiguous",
     };
   }
   if (allDirectUsersAreAuthor) {
@@ -1889,13 +1932,27 @@ function summarizeRulesetPullRequestBypass(branchRulesets = [], branchRules = []
   } else if (values.includes("never")) {
     currentUserCanBypass = "never";
   }
+  const bypassValues = new Set(["always", "exempt", "pull_requests_only"]);
   const detected = relevantRulesets.length > 0
     && values.length === relevantRulesets.length
-    && values.every((value) => value === "pull_requests_only");
+    && values.every((value) => bypassValues.has(value));
+  let mode = "none";
+  if (detected) {
+    if (new Set(values).size > 1) {
+      mode = "mixed";
+    } else if (values.includes("pull_requests_only")) {
+      mode = "pull_request";
+    } else if (values.includes("always")) {
+      mode = "always";
+    } else if (values.includes("exempt")) {
+      mode = "exempt";
+    }
+  }
   return {
     detected,
-    mode: detected ? "pull_request" : "none",
+    mode,
     currentUserCanBypass,
+    relevantRulesetCount: relevantRulesets.length,
   };
 }
 
@@ -2057,6 +2114,7 @@ export function buildPreMergeReadinessSummary(
     eligibleCodeownerUserLogins,
     advisoryBotLogins,
     prAuthorLogin,
+    viewerLogin: options.viewerLogin,
   });
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection);
   const advisoryWaitOptions = normalizeAdvisoryWaitRuntimeOptions(options);

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1622,6 +1622,7 @@ export function summarizeReviewerStates(
     branchProtection = {},
     codeownersText = "",
     changedFiles = [],
+    eligibleCodeownerUserLogins = null,
     advisoryBotLogins = [],
     prAuthorLogin = "",
   } = {},
@@ -1632,13 +1633,19 @@ export function summarizeReviewerStates(
   const codeownerRules = parseCodeownersRules(codeownersText);
   const codeowners = collectCodeownersForFiles(codeownerRules, changedFiles);
   const codeownerUsers = new Set(codeowners.codeownerUserLogins);
+  const eligibleCodeownerUsers = eligibleCodeownerUserLogins === null
+    ? codeownerUsers
+    : new Set(
+      normalizeTrustedMarkerLogins(eligibleCodeownerUserLogins)
+        .filter((login) => codeownerUsers.has(login)),
+    );
   const normalizedReviewDecision = String(reviewDecision ?? "");
 
   const latestByAuthor = [...indexLatestGatingReviewsByAuthor(reviews).values()]
     .map((review) => {
       const login = String(review.author?.login ?? "").trim().toLowerCase();
       const isAdvisoryBot = isGateAdvisoryBotLogin(login, advisoryBotLoginSet);
-      const isCodeowner = codeownerUsers.has(login);
+      const isCodeowner = eligibleCodeownerUsers.has(login);
       const isRequiredReviewer = requiredReviewerLogins.has(login);
       return {
         login,
@@ -1704,6 +1711,8 @@ export function summarizeReviewerStates(
         || normalizedReviewDecision === "APPROVED",
     hasExplicitCodeownerMatches,
     codeownerUserLogins: codeowners.codeownerUserLogins,
+    eligibleCodeownerUserLogins:
+      eligibleCodeownerUserLogins === null ? null : [...eligibleCodeownerUsers].sort(),
     codeownerTeamSlugs: codeowners.codeownerTeamSlugs,
     prAuthorLogin,
     branchRules,
@@ -1751,6 +1760,7 @@ function summarizeCodeownerSelfApproval({
   codeownerApprovalSatisfied,
   hasExplicitCodeownerMatches,
   codeownerUserLogins = [],
+  eligibleCodeownerUserLogins = null,
   codeownerTeamSlugs = [],
   prAuthorLogin = "",
   branchRules = [],
@@ -1759,6 +1769,10 @@ function summarizeCodeownerSelfApproval({
 }) {
   const normalizedAuthor = String(prAuthorLogin ?? "").trim().toLowerCase();
   const directCodeownerUserLogins = normalizeTrustedMarkerLogins(codeownerUserLogins);
+  const eligibleDirectCodeownerUserLogins = eligibleCodeownerUserLogins === null
+    ? directCodeownerUserLogins
+    : normalizeTrustedMarkerLogins(eligibleCodeownerUserLogins)
+      .filter((login) => directCodeownerUserLogins.includes(login));
   const normalizedCodeownerTeamSlugs = normalizeTrustedMarkerLogins(codeownerTeamSlugs);
   const bypass = summarizeRulesetPullRequestBypass(branchRulesets, branchRules);
   const applicableBypassDetected = bypass.detected && !classicRequireCodeOwnerReview;
@@ -1805,9 +1819,9 @@ function summarizeCodeownerSelfApproval({
     };
   }
 
-  const allDirectUsersAreAuthor = directCodeownerUserLogins.length > 0
-    && directCodeownerUserLogins.every((login) => login === normalizedAuthor);
-  const hasNonAuthorDirectUser = directCodeownerUserLogins.some((login) => login !== normalizedAuthor);
+  const allDirectUsersAreAuthor = eligibleDirectCodeownerUserLogins.length > 0
+    && eligibleDirectCodeownerUserLogins.every((login) => login === normalizedAuthor);
+  const hasNonAuthorDirectUser = eligibleDirectCodeownerUserLogins.some((login) => login !== normalizedAuthor);
 
   if (hasNonAuthorDirectUser) {
     return {
@@ -1827,7 +1841,9 @@ function summarizeCodeownerSelfApproval({
     return {
       ...base,
       status: "deadlock",
-      reason: "pr-author-is-only-direct-codeowner",
+      reason: eligibleCodeownerUserLogins === null
+        ? "pr-author-is-only-direct-codeowner"
+        : "pr-author-is-only-eligible-direct-codeowner",
     };
   }
 
@@ -1972,6 +1988,7 @@ export function buildPreMergeReadinessSummary(
     claimEvents = [],
     changedFiles = [],
     codeownersText = "",
+    eligibleCodeownerUserLogins = null,
     reviewDecision = "",
   },
   options = {},
@@ -2037,6 +2054,7 @@ export function buildPreMergeReadinessSummary(
     branchProtection,
     codeownersText,
     changedFiles,
+    eligibleCodeownerUserLogins,
     advisoryBotLogins,
     prAuthorLogin,
   });

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1907,6 +1907,7 @@ function summarizeRulesetPullRequestBypass(branchRulesets = [], branchRules = []
       .map((rule) => Number.parseInt(String(rule?.ruleset_id ?? ""), 10))
       .filter(Number.isInteger),
   );
+  const expectedRulesetCount = codeownerRulesetIds.size;
   const relevantRulesets = (branchRulesets ?? [])
     .filter((ruleset) => {
       const rulesetId = Number.parseInt(String(ruleset?.id ?? ruleset?.ruleset_id ?? ""), 10);
@@ -1933,7 +1934,8 @@ function summarizeRulesetPullRequestBypass(branchRulesets = [], branchRules = []
     currentUserCanBypass = "never";
   }
   const bypassValues = new Set(["always", "exempt", "pull_requests_only"]);
-  const detected = relevantRulesets.length > 0
+  const detected = expectedRulesetCount > 0
+    && relevantRulesets.length === expectedRulesetCount
     && values.length === relevantRulesets.length
     && values.every((value) => bypassValues.has(value));
   let mode = "none";
@@ -1952,7 +1954,7 @@ function summarizeRulesetPullRequestBypass(branchRulesets = [], branchRules = []
     detected,
     mode,
     currentUserCanBypass,
-    relevantRulesetCount: relevantRulesets.length,
+    relevantRulesetCount: expectedRulesetCount,
   };
 }
 

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -491,6 +491,35 @@ test("self-CODEOWNER diagnostic clears when pull-request bypass is available", (
   assert.equal(summary.codeownerSelfApproval.bypassMode, "pull_request");
 });
 
+test("self-CODEOWNER diagnostic keeps classic protection outside ruleset bypass", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      ruleset_id: 1,
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{
+      id: 1,
+      current_user_can_bypass: "pull_requests_only",
+      bypass_actors: [{ actor_id: 44661432, actor_type: "User", bypass_mode: "pull_request" }],
+    }],
+    branchProtection: {
+      required_pull_request_reviews: {
+        require_code_owner_reviews: true,
+      },
+    },
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "deadlock");
+  assert.equal(summary.codeownerSelfApproval.reason, "pr-author-is-only-direct-codeowner");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, false);
+  assert.equal(summary.codeownerSelfApproval.bypassMode, "none");
+  assert.equal(summary.codeownerSelfApproval.currentUserCanBypass, "pull_requests_only");
+});
+
 test("self-CODEOWNER diagnostic ignores unrelated ruleset bypasses", () => {
   const summary = summarizeReviewerStates([], {
     branchRules: [{
@@ -512,6 +541,29 @@ test("self-CODEOWNER diagnostic ignores unrelated ruleset bypasses", () => {
   assert.equal(summary.codeownerSelfApproval.reason, "pr-author-is-only-direct-codeowner");
   assert.equal(summary.codeownerSelfApproval.bypassDetected, false);
   assert.equal(summary.codeownerSelfApproval.currentUserCanBypass, "unknown");
+});
+
+test("self-CODEOWNER diagnostic accepts GitHub exempt bypass token", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      ruleset_id: 1,
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{
+      id: 1,
+      current_user_can_bypass: "exempt",
+      bypass_actors: [{ actor_id: 44661432, actor_type: "User", bypass_mode: "exempt" }],
+    }],
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "deadlock");
+  assert.equal(summary.codeownerSelfApproval.reason, "pr-author-is-only-direct-codeowner");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, false);
+  assert.equal(summary.codeownerSelfApproval.currentUserCanBypass, "exempt");
 });
 
 test("mixed-precision timestamps compare by time instead of string order", () => {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -436,6 +436,49 @@ test("self-CODEOWNER diagnostic clears when another direct owner exists", () => 
   assert.deepEqual(summary.codeownerSelfApproval.directCodeownerUserLogins, ["author", "reviewer"]);
 });
 
+test("self-CODEOWNER diagnostic requires eligible non-author direct owners when provided", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{ current_user_can_bypass: "never", bypass_actors: [] }],
+    codeownersText: "* @author @outside-user\n",
+    changedFiles: ["README.md"],
+    eligibleCodeownerUserLogins: ["author"],
+    prAuthorLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "deadlock");
+  assert.equal(summary.codeownerSelfApproval.reason, "pr-author-is-only-eligible-direct-codeowner");
+  assert.deepEqual(summary.codeownerSelfApproval.directCodeownerUserLogins, ["author", "outside-user"]);
+  assert.equal(summary.latestByAuthor.length, 0);
+});
+
+test("self-CODEOWNER diagnostic counts only eligible codeowner approvals when provided", () => {
+  const summary = summarizeReviewerStates(
+    [{
+      author: { login: "outside-user" },
+      state: "APPROVED",
+      submittedAt: "2026-05-12T00:00:00Z",
+    }],
+    {
+      branchRules: [{
+        type: "pull_request",
+        parameters: { require_code_owner_review: true },
+      }],
+      codeownersText: "* @author @outside-user\n",
+      changedFiles: ["README.md"],
+      eligibleCodeownerUserLogins: ["author"],
+      prAuthorLogin: "author",
+    },
+  );
+
+  assert.equal(summary.latestByAuthor[0].isCodeowner, false);
+  assert.equal(summary.codeownerApprovalSatisfied, false);
+  assert.equal(summary.codeownerSelfApproval.status, "deadlock");
+});
+
 test("self-CODEOWNER diagnostic stays conservative when a team owner is present", () => {
   const summary = summarizeReviewerStates([], {
     branchRules: [{

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -392,6 +392,128 @@ test("email-only CODEOWNERS rules still block codeowner approval", () => {
   assert.deepEqual(summary.unmatchedCodeownerFiles, []);
 });
 
+test("self-CODEOWNER diagnostic reports deadlock without bypass", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      ruleset_id: 1,
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{ id: 1, current_user_can_bypass: "never", bypass_actors: [] }],
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+  });
+
+  assert.deepEqual(summary.codeownerSelfApproval, {
+    status: "deadlock",
+    reason: "pr-author-is-only-direct-codeowner",
+    prAuthorLogin: "author",
+    directCodeownerUserLogins: ["author"],
+    codeownerTeamSlugs: [],
+    requireCodeOwnerReview: true,
+    codeownerApprovalSatisfied: false,
+    bypassDetected: false,
+    bypassMode: "none",
+    currentUserCanBypass: "never",
+  });
+});
+
+test("self-CODEOWNER diagnostic clears when another direct owner exists", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{ current_user_can_bypass: "never", bypass_actors: [] }],
+    codeownersText: "* @author @reviewer\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "clear");
+  assert.equal(summary.codeownerSelfApproval.reason, "non-author-codeowner-available");
+  assert.deepEqual(summary.codeownerSelfApproval.directCodeownerUserLogins, ["author", "reviewer"]);
+});
+
+test("self-CODEOWNER diagnostic stays conservative when a team owner is present", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{ current_user_can_bypass: "never", bypass_actors: [] }],
+    codeownersText: "* @author @org/reviewers\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "possible_deadlock");
+  assert.equal(summary.codeownerSelfApproval.reason, "team-codeowner-ambiguous");
+  assert.deepEqual(summary.codeownerSelfApproval.codeownerTeamSlugs, ["org/reviewers"]);
+});
+
+test("self-CODEOWNER diagnostic is not applicable when CODEOWNER review is disabled", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      parameters: { require_code_owner_review: false },
+    }],
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "not_applicable");
+  assert.equal(summary.codeownerSelfApproval.reason, "codeowner-review-not-required");
+});
+
+test("self-CODEOWNER diagnostic clears when pull-request bypass is available", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      ruleset_id: 1,
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{
+      id: 1,
+      current_user_can_bypass: "pull_requests_only",
+      bypass_actors: [{ actor_id: 44661432, actor_type: "User", bypass_mode: "pull_request" }],
+    }],
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "clear");
+  assert.equal(summary.codeownerSelfApproval.reason, "pull-request-bypass-available");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, true);
+  assert.equal(summary.codeownerSelfApproval.bypassMode, "pull_request");
+});
+
+test("self-CODEOWNER diagnostic ignores unrelated ruleset bypasses", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      ruleset_id: 1,
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{
+      id: 2,
+      current_user_can_bypass: "pull_requests_only",
+      bypass_actors: [{ actor_id: 44661432, actor_type: "User", bypass_mode: "pull_request" }],
+    }],
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "deadlock");
+  assert.equal(summary.codeownerSelfApproval.reason, "pr-author-is-only-direct-codeowner");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, false);
+  assert.equal(summary.codeownerSelfApproval.currentUserCanBypass, "unknown");
+});
+
 test("mixed-precision timestamps compare by time instead of string order", () => {
   const headSha = "a".repeat(40);
   assert.equal(

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -151,6 +151,7 @@ test("CODEOWNERS patterns with slashes stay root anchored", () => {
       unmatchedFiles: ["src/docs/file.md"],
       codeownerUserLogins: [],
       codeownerTeamSlugs: ["org/docs"],
+      codeownerEmailAddresses: [],
     },
   );
 });
@@ -164,6 +165,7 @@ test("CODEOWNERS **/ patterns match both root and nested files", () => {
       unmatchedFiles: [],
       codeownerUserLogins: [],
       codeownerTeamSlugs: ["org/docs"],
+      codeownerEmailAddresses: [],
     },
   );
 });
@@ -177,6 +179,7 @@ test("CODEOWNERS middle **/ segments match zero or more directories", () => {
       unmatchedFiles: [],
       codeownerUserLogins: [],
       codeownerTeamSlugs: ["org/docs"],
+      codeownerEmailAddresses: [],
     },
   );
 });
@@ -190,6 +193,7 @@ test("CODEOWNERS trailing slash patterns match directories at any depth", () => 
       unmatchedFiles: [],
       codeownerUserLogins: [],
       codeownerTeamSlugs: ["org/apps"],
+      codeownerEmailAddresses: [],
     },
   );
 });
@@ -203,6 +207,7 @@ test("CODEOWNERS directory-style patterns match descendants", () => {
       unmatchedFiles: [],
       codeownerUserLogins: [],
       codeownerTeamSlugs: ["org/ops"],
+      codeownerEmailAddresses: [],
     },
   );
 });
@@ -216,6 +221,7 @@ test("CODEOWNERS dot-prefixed directory patterns match descendants", () => {
       unmatchedFiles: [],
       codeownerUserLogins: [],
       codeownerTeamSlugs: ["org/automation"],
+      codeownerEmailAddresses: [],
     },
   );
 });
@@ -229,6 +235,7 @@ test("CODEOWNERS dotted literal patterns match descendant paths", () => {
       unmatchedFiles: [],
       codeownerUserLogins: [],
       codeownerTeamSlugs: ["org/api"],
+      codeownerEmailAddresses: [],
     },
   );
 });
@@ -242,6 +249,7 @@ test("CODEOWNERS patterns preserve escaped spaces", () => {
       unmatchedFiles: [],
       codeownerUserLogins: [],
       codeownerTeamSlugs: ["org/docs"],
+      codeownerEmailAddresses: [],
     },
   );
 });
@@ -255,6 +263,7 @@ test("CODEOWNERS ownerless overrides clear inherited ownership", () => {
       unmatchedFiles: [],
       codeownerUserLogins: [],
       codeownerTeamSlugs: [],
+      codeownerEmailAddresses: [],
     },
   );
 });
@@ -496,6 +505,22 @@ test("self-CODEOWNER diagnostic stays conservative when a team owner is present"
   assert.deepEqual(summary.codeownerSelfApproval.codeownerTeamSlugs, ["org/reviewers"]);
 });
 
+test("self-CODEOWNER diagnostic stays conservative when an email owner is present", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{ current_user_can_bypass: "never", bypass_actors: [] }],
+    codeownersText: "* @author reviewer@example.com\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "possible_deadlock");
+  assert.equal(summary.codeownerSelfApproval.reason, "email-codeowner-ambiguous");
+});
+
 test("self-CODEOWNER diagnostic is not applicable when CODEOWNER review is disabled", () => {
   const summary = summarizeReviewerStates([], {
     branchRules: [{
@@ -534,6 +559,29 @@ test("self-CODEOWNER diagnostic clears when pull-request bypass is available", (
   assert.equal(summary.codeownerSelfApproval.bypassMode, "pull_request");
 });
 
+test("self-CODEOWNER diagnostic clears when an always ruleset bypass is available", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      ruleset_id: 1,
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{
+      id: 1,
+      current_user_can_bypass: "always",
+      bypass_actors: [{ actor_id: 44661432, actor_type: "User", bypass_mode: "always" }],
+    }],
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "clear");
+  assert.equal(summary.codeownerSelfApproval.reason, "ruleset-bypass-available");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, true);
+  assert.equal(summary.codeownerSelfApproval.bypassMode, "always");
+});
+
 test("self-CODEOWNER diagnostic keeps classic protection outside ruleset bypass", () => {
   const summary = summarizeReviewerStates([], {
     branchRules: [{
@@ -561,6 +609,38 @@ test("self-CODEOWNER diagnostic keeps classic protection outside ruleset bypass"
   assert.equal(summary.codeownerSelfApproval.bypassDetected, false);
   assert.equal(summary.codeownerSelfApproval.bypassMode, "none");
   assert.equal(summary.codeownerSelfApproval.currentUserCanBypass, "pull_requests_only");
+});
+
+test("self-CODEOWNER diagnostic honors classic pull request bypass allowances", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      ruleset_id: 1,
+      parameters: { require_code_owner_review: true },
+    }],
+    branchRulesets: [{
+      id: 1,
+      current_user_can_bypass: "pull_requests_only",
+      bypass_actors: [{ actor_id: 44661432, actor_type: "User", bypass_mode: "pull_request" }],
+    }],
+    branchProtection: {
+      required_pull_request_reviews: {
+        require_code_owner_reviews: true,
+        bypass_pull_request_allowances: {
+          users: [{ login: "author" }],
+        },
+      },
+    },
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+    viewerLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "clear");
+  assert.equal(summary.codeownerSelfApproval.reason, "pull-request-bypass-available");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, true);
+  assert.equal(summary.codeownerSelfApproval.bypassMode, "pull_request");
 });
 
 test("self-CODEOWNER diagnostic ignores unrelated ruleset bypasses", () => {
@@ -603,9 +683,10 @@ test("self-CODEOWNER diagnostic accepts GitHub exempt bypass token", () => {
     prAuthorLogin: "author",
   });
 
-  assert.equal(summary.codeownerSelfApproval.status, "deadlock");
-  assert.equal(summary.codeownerSelfApproval.reason, "pr-author-is-only-direct-codeowner");
-  assert.equal(summary.codeownerSelfApproval.bypassDetected, false);
+  assert.equal(summary.codeownerSelfApproval.status, "clear");
+  assert.equal(summary.codeownerSelfApproval.reason, "ruleset-bypass-available");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, true);
+  assert.equal(summary.codeownerSelfApproval.bypassMode, "exempt");
   assert.equal(summary.codeownerSelfApproval.currentUserCanBypass, "exempt");
 });
 

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -643,6 +643,59 @@ test("self-CODEOWNER diagnostic honors classic pull request bypass allowances", 
   assert.equal(summary.codeownerSelfApproval.bypassMode, "pull_request");
 });
 
+test("self-CODEOWNER diagnostic honors classic bypass without ruleset gates", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      parameters: { require_code_owner_review: true },
+    }],
+    branchProtection: {
+      required_pull_request_reviews: {
+        require_code_owner_reviews: true,
+        bypass_pull_request_allowances: {
+          users: [{ login: "author" }],
+        },
+      },
+    },
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+    viewerLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "clear");
+  assert.equal(summary.codeownerSelfApproval.reason, "pull-request-bypass-available");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, true);
+  assert.equal(summary.codeownerSelfApproval.bypassMode, "pull_request");
+});
+
+test("self-CODEOWNER diagnostic fails closed when ruleset details are missing", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      ruleset_id: 1,
+      parameters: { require_code_owner_review: true },
+    }],
+    branchProtection: {
+      required_pull_request_reviews: {
+        require_code_owner_reviews: true,
+        bypass_pull_request_allowances: {
+          users: [{ login: "author" }],
+        },
+      },
+    },
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+    viewerLogin: "author",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "deadlock");
+  assert.equal(summary.codeownerSelfApproval.reason, "pr-author-is-only-direct-codeowner");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, false);
+  assert.equal(summary.codeownerSelfApproval.bypassMode, "none");
+});
+
 test("self-CODEOWNER diagnostic ignores unrelated ruleset bypasses", () => {
   const summary = summarizeReviewerStates([], {
     branchRules: [{

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -10,6 +10,7 @@ import {
   findLastCopilotReviewCommit,
   indexLatestGatingReviewsByAuthor,
   resolveCodeownersForFiles,
+  resolveRulesetDetailPath,
   selectCodeownersText,
   summarizeDispositionEvidenceForGate,
   summarizeAdvisoryWaitMarkers,
@@ -667,6 +668,81 @@ test("self-CODEOWNER diagnostic honors classic bypass without ruleset gates", ()
   assert.equal(summary.codeownerSelfApproval.reason, "pull-request-bypass-available");
   assert.equal(summary.codeownerSelfApproval.bypassDetected, true);
   assert.equal(summary.codeownerSelfApproval.bypassMode, "pull_request");
+});
+
+test("self-CODEOWNER diagnostic honors classic team bypass allowances", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      parameters: { require_code_owner_review: true },
+    }],
+    branchProtection: {
+      required_pull_request_reviews: {
+        require_code_owner_reviews: true,
+        bypass_pull_request_allowances: {
+          teams: [{ slug: "release-engineers" }],
+        },
+      },
+    },
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+    viewerTeamSlugs: ["release-engineers"],
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "clear");
+  assert.equal(summary.codeownerSelfApproval.reason, "pull-request-bypass-available");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, true);
+  assert.equal(summary.codeownerSelfApproval.bypassMode, "pull_request");
+});
+
+test("self-CODEOWNER diagnostic honors classic app bypass allowances", () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [{
+      type: "pull_request",
+      parameters: { require_code_owner_review: true },
+    }],
+    branchProtection: {
+      required_pull_request_reviews: {
+        require_code_owner_reviews: true,
+        bypass_pull_request_allowances: {
+          apps: [{ slug: "idd-helper" }],
+        },
+      },
+    },
+    codeownersText: "* @author\n",
+    changedFiles: ["README.md"],
+    prAuthorLogin: "author",
+    viewerAppSlug: "idd-helper",
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, "clear");
+  assert.equal(summary.codeownerSelfApproval.reason, "pull-request-bypass-available");
+  assert.equal(summary.codeownerSelfApproval.bypassDetected, true);
+  assert.equal(summary.codeownerSelfApproval.bypassMode, "pull_request");
+});
+
+test("ruleset detail path uses the source-specific endpoint", () => {
+  assert.equal(
+    resolveRulesetDetailPath("repo-owner", "example", {
+      ruleset_source_type: "Repository",
+    }, 101),
+    "repos/repo-owner/example/rulesets/101",
+  );
+  assert.equal(
+    resolveRulesetDetailPath("repo-owner", "example", {
+      ruleset_source_type: "Organization",
+      ruleset_source: "platform-org",
+    }, 102),
+    "orgs/platform-org/rulesets/102",
+  );
+  assert.equal(
+    resolveRulesetDetailPath("repo-owner", "example", {
+      ruleset_source_type: "Enterprise",
+      ruleset_source: "platform-enterprise",
+    }, 103),
+    "enterprises/platform-enterprise/rulesets/103",
+  );
 });
 
 test("self-CODEOWNER diagnostic fails closed when ruleset details are missing", () => {

--- a/tests/review-snapshot.test.mjs
+++ b/tests/review-snapshot.test.mjs
@@ -168,6 +168,24 @@ test("malformed forced-handoff comments remain visible activity", () => {
   assert.equal(summary.maxActivityUpdatedAt, "2026-05-10T10:40:00Z");
 });
 
+test("activity snapshot ignores pending check sentinel timestamps", () => {
+  const summary = buildActivitySnapshotSummary(
+    {
+      comments: [],
+      reviews: [],
+      threads: [],
+      checks: [
+        { name: "lint", state: "PENDING", completedAt: "0001-01-01T00:00:00Z" },
+        { name: "test", state: "SUCCESS", completedAt: "0001-01-01T00:00:00Z" },
+      ],
+    },
+    { trustedMarkerLogins: ["idd-bot"] },
+  );
+
+  assert.equal(summary.latestCiCompletedAt, "none");
+  assert.equal(summary.latestPassingCiCompletedAt, "none");
+});
+
 function readJson(relativePath) {
   return JSON.parse(readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8"));
 }


### PR DESCRIPTION
## Summary

- Add `reviewerStates.codeownerSelfApproval` to pre-merge readiness evidence so F2 can distinguish self-CODEOWNER deadlocks, ambiguous topologies, clear non-author owners, and PR-only bypass availability.
- Fetch detailed branch rulesets for applicable branch rules and bind bypass detection to CODEOWNER-review rulesets, avoiding unrelated bypass false positives.
- Update the readiness schema, fixtures, unit coverage, source/template helper docs, and F2 instructions so the diagnostic is surfaced as evidence without granting bypass permission.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `node scripts/validate-schemas.mjs`
- `node --test tests/pre-merge-readiness.test.mjs`
- `node --test tests/*.test.mjs`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- Live read-only check: PR #540 now reports `pull-request-bypass-available` for `reviewerStates.codeownerSelfApproval` after #542.

## Follow-up

- No new follow-up issues recommended. #545 remains the planned held-PR recovery step after #542/#543/#544 are complete.

Closes #543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Surfaces a codeowner self-approval diagnostic that records deadlock/possible_deadlock in F2 evidence and hold comments (explicitly does not grant bypass) and refines routing when approvals are missing but no review threads exist.

* **Documentation**
  * Expanded pre-merge guidance documenting the diagnostic, deadlock semantics, and bypass-state reporting.

* **Tests**
  * Added coverage for multiple codeowner self-approval and bypass scenarios.

* **Validation**
  * Schema and fixtures updated to require and include the new diagnostic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/546)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->