### PR TITLE
docs(idd): document merge topology requirements

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -278,6 +278,25 @@ profile that lets the same agent session continue through F3 after the
 normal freshness, CI, review, advisory, unresolved-thread, and claim
 gates pass.
 
+Merge policy is not the same as merge topology. Before selecting or
+keeping `fully_autonomous_merge`, confirm that GitHub can satisfy the
+repository's required-review and CODEOWNER rules for PRs authored by the
+merge-capable actor. A solo account that authors the PR and is also the
+only matching CODEOWNER cannot approve its own PR, so required
+CODEOWNER review can block an otherwise valid IDD run.
+
+Choose the topology intentionally:
+
+- Use a non-author CODEOWNER or required reviewer when human or team
+  review is the intended safety gate.
+- Use a pull-request-only ruleset bypass for the trusted merge-capable
+  actor when the repository intentionally permits autonomous merge after
+  all IDD gates pass. This bypass must not be treated as permission to
+  skip branch freshness, CI, review, advisory, unresolved-thread, or
+  claim checks.
+- Change CODEOWNERS coverage or move to `human_merge` when the
+  repository wants CODEOWNER review to remain a human-owned policy gate.
+
 The distributed workflow expects merge commits. Changing the merge
 method, required review policy, or branch protection behavior is a
 repository policy change, not a copy edit.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -516,6 +516,11 @@ default `instructions-only` profile keep using the written shell /
   `currentUserCanBypass` token records the known GitHub ruleset value
   (`unknown`, `never`, `always`, `pull_requests_only`, `exempt`, or
   `mixed`).
+- A `clear` diagnostic means the helper found a GitHub topology that
+  appears satisfiable for the current actor; it is still evidence for
+  the written F2/F3 gates, not an IDD policy override or permission to
+  skip review, CI, freshness, advisory, unresolved-thread, or claim
+  checks.
 - `reviewCurrency.comparisonRoute` remains advisory evidence only. Agents
   must still apply written instruction checks against live GitHub state.
 - Fail closed: if helper execution fails, output is invalid JSON,

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -148,6 +148,23 @@ repository-local policy choice and remain distinct from trusted
 operational marker actors; CODEOWNERS mismatch does not replace this
 pre-start gate.
 
+## CODEOWNERS and Merge Gates
+
+CODEOWNERS are evaluated after work reaches the pull request, not during
+Discover or Claim. They become part of the PR review and merge gates in
+E and F phases: review snapshots must report required approval and
+CODEOWNER satisfaction, and F2/F3 must prove that unresolved review
+state, advisory state, CI, and branch freshness are all current for the
+same head.
+
+Autonomous operation therefore requires a satisfiable GitHub merge
+topology in addition to a recorded IDD merge policy. If the PR author is
+also the only matching CODEOWNER, GitHub's self-approval limit can make
+required CODEOWNER review impossible to satisfy. In that topology, IDD
+must wait for an eligible non-author reviewer, use a deliberately
+configured pull-request-only ruleset bypass for the trusted merge actor,
+or stop for a repository policy change.
+
 ## Suitability policy handoff
 
 A4.5 outcomes should map to explicit repository policy, not ad hoc

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -49,6 +49,46 @@ dedicated merge-capable session. If a recorded merge policy value is
 unknown, the merge phase must stop with a maintainer hold until the
 policy is corrected.
 
+## Merge Topology Requirements
+
+The merge policy records who IDD may trust to request or execute the
+final merge. It does not by itself make GitHub's required review,
+CODEOWNER, branch protection, or ruleset gates satisfiable. Before
+allowing unattended F3 execution, verify that the repository has a
+merge topology that GitHub can actually accept.
+
+GitHub required reviews need approving reviews from reviewers with
+write or admin permission, and pull request authors cannot approve their
+own pull requests. CODEOWNERS add another topology constraint: code
+owners must have write access, and when code-owner review is required,
+an affected pull request must be approved by an eligible code owner.
+
+A solo-maintainer repository can deadlock if the same account opens the
+PR, is the only wildcard CODEOWNER, and required CODEOWNER review is
+enabled. `fully_autonomous_merge` combines IDD worker and merge-capable
+authority, but it does not create a second eligible reviewer and it does
+not override GitHub's self-approval rule.
+
+Choose one of these merge topologies before relying on autonomous
+merges:
+
+- **Eligible non-author review**: list at least one non-author user or
+  team with write access as the relevant CODEOWNER or required reviewer,
+  and expect IDD to wait or hand off when that approval is missing.
+- **Pull-request-only ruleset bypass**: grant the trusted merge-capable
+  actor ruleset bypass for pull requests only. This preserves the PR
+  audit trail and should be used only after IDD's branch freshness, CI,
+  review, advisory, unresolved-thread, and claim gates pass. Prefer this
+  over broad `always` or `exempt` bypass unless a maintainer explicitly
+  accepts the wider risk.
+- **Deliberate CODEOWNERS policy change**: narrow CODEOWNERS coverage,
+  add another eligible owner, or move a repository to `human_merge` when
+  human review is the intended gate. Treat this as a repository policy
+  change, not a per-run workaround.
+
+Do not use issue-author approval, trusted operational markers, or
+CODEOWNERS mismatch as substitutes for a satisfiable GitHub merge gate.
+
 ## Phase Permissions
 
 Each IDD phase needs a different subset of access:
@@ -209,3 +249,7 @@ Keep approval labels and operational marker trust as separate controls:
 - [GitHub REST API permissions for fine-grained personal access tokens](https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens)
 - [GitHub `GITHUB_TOKEN` security model](https://docs.github.com/actions/concepts/security/github_token)
 - [GitHub Copilot agent skills guidance](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-skills)
+- [GitHub required pull request reviews](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews)
+- [GitHub CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+- [GitHub ruleset bypass permissions](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository#granting-bypass-permissions-for-your-branch-or-tag-ruleset)
+- [GitHub ruleset bypass modes API](https://docs.github.com/en/rest/repos/rules)

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -208,6 +208,12 @@ keys accept positive whole-minute ISO 8601 durations only.
 | Merge method                 | Merge commits (squash and rebase merge are disabled in repository settings) | [Merge](../.github/instructions/idd-merge.instructions.md), [GitHub Flow rules](./../.github/copilot-instructions.md)                                                                                    | Keep unless the repository has a different merge strategy; customize only with branch protection changes.                                           |
 | Post-merge comment cleanup   | Minimize operational markers and resolved feedback after merge succeeds     | [Merge](../.github/instructions/idd-merge.instructions.md), audit scripts, and helper tooling                                                                                                            | Keep as best-effort; safe cleanup candidates are enumerated in [comment minimization](idd-comment-minimization.md).                                 |
 
+Merge policy constants describe IDD authority and phase routing. They do
+not change GitHub's required-review, CODEOWNER, branch protection, or
+ruleset topology. A repository using `fully_autonomous_merge` still
+needs either an eligible non-author review path or an intentional
+pull-request-only bypass actor that can satisfy GitHub at F3.
+
 ## Critique And Review Loop Defaults
 
 | Policy default                          | Distributed value                                                                                                              | Owning surface                                                             | Onboarding expectation                                                                                                       |

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -278,6 +278,25 @@ profile that lets the same agent session continue through F3 after the
 normal freshness, CI, review, advisory, unresolved-thread, and claim
 gates pass.
 
+Merge policy is not the same as merge topology. Before selecting or
+keeping `fully_autonomous_merge`, confirm that GitHub can satisfy the
+repository's required-review and CODEOWNER rules for PRs authored by the
+merge-capable actor. A solo account that authors the PR and is also the
+only matching CODEOWNER cannot approve its own PR, so required
+CODEOWNER review can block an otherwise valid IDD run.
+
+Choose the topology intentionally:
+
+- Use a non-author CODEOWNER or required reviewer when human or team
+  review is the intended safety gate.
+- Use a pull-request-only ruleset bypass for the trusted merge-capable
+  actor when the repository intentionally permits autonomous merge after
+  all IDD gates pass. This bypass must not be treated as permission to
+  skip branch freshness, CI, review, advisory, unresolved-thread, or
+  claim checks.
+- Change CODEOWNERS coverage or move to `human_merge` when the
+  repository wants CODEOWNER review to remain a human-owned policy gate.
+
 The distributed workflow expects merge commits. Changing the merge
 method, required review policy, or branch protection behavior is a
 repository policy change, not a copy edit.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -516,6 +516,11 @@ default `instructions-only` profile keep using the written shell /
   `currentUserCanBypass` token records the known GitHub ruleset value
   (`unknown`, `never`, `always`, `pull_requests_only`, `exempt`, or
   `mixed`).
+- A `clear` diagnostic means the helper found a GitHub topology that
+  appears satisfiable for the current actor; it is still evidence for
+  the written F2/F3 gates, not an IDD policy override or permission to
+  skip review, CI, freshness, advisory, unresolved-thread, or claim
+  checks.
 - `reviewCurrency.comparisonRoute` remains advisory evidence only. Agents
   must still apply written instruction checks against live GitHub state.
 - Fail closed: if helper execution fails, output is invalid JSON,

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -129,6 +129,23 @@ repository-local policy choice and remain distinct from trusted
 operational marker actors; CODEOWNERS mismatch does not replace this
 pre-start gate.
 
+## CODEOWNERS and Merge Gates
+
+CODEOWNERS are evaluated after work reaches the pull request, not during
+Discover or Claim. They become part of the PR review and merge gates in
+E and F phases: review snapshots must report required approval and
+CODEOWNER satisfaction, and F2/F3 must prove that unresolved review
+state, advisory state, CI, and branch freshness are all current for the
+same head.
+
+Autonomous operation therefore requires a satisfiable GitHub merge
+topology in addition to a recorded IDD merge policy. If the PR author is
+also the only matching CODEOWNER, GitHub's self-approval limit can make
+required CODEOWNER review impossible to satisfy. In that topology, IDD
+must wait for an eligible non-author reviewer, use a deliberately
+configured pull-request-only ruleset bypass for the trusted merge actor,
+or stop for a repository policy change.
+
 ## Suitability policy handoff
 
 A4.5 outcomes should map to explicit repository policy, not ad hoc

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -49,6 +49,46 @@ dedicated merge-capable session. If a recorded merge policy value is
 unknown, the merge phase must stop with a maintainer hold until the
 policy is corrected.
 
+## Merge Topology Requirements
+
+The merge policy records who IDD may trust to request or execute the
+final merge. It does not by itself make GitHub's required review,
+CODEOWNER, branch protection, or ruleset gates satisfiable. Before
+allowing unattended F3 execution, verify that the repository has a
+merge topology that GitHub can actually accept.
+
+GitHub required reviews need approving reviews from reviewers with
+write or admin permission, and pull request authors cannot approve their
+own pull requests. CODEOWNERS add another topology constraint: code
+owners must have write access, and when code-owner review is required,
+an affected pull request must be approved by an eligible code owner.
+
+A solo-maintainer repository can deadlock if the same account opens the
+PR, is the only wildcard CODEOWNER, and required CODEOWNER review is
+enabled. `fully_autonomous_merge` combines IDD worker and merge-capable
+authority, but it does not create a second eligible reviewer and it does
+not override GitHub's self-approval rule.
+
+Choose one of these merge topologies before relying on autonomous
+merges:
+
+- **Eligible non-author review**: list at least one non-author user or
+  team with write access as the relevant CODEOWNER or required reviewer,
+  and expect IDD to wait or hand off when that approval is missing.
+- **Pull-request-only ruleset bypass**: grant the trusted merge-capable
+  actor ruleset bypass for pull requests only. This preserves the PR
+  audit trail and should be used only after IDD's branch freshness, CI,
+  review, advisory, unresolved-thread, and claim gates pass. Prefer this
+  over broad `always` or `exempt` bypass unless a maintainer explicitly
+  accepts the wider risk.
+- **Deliberate CODEOWNERS policy change**: narrow CODEOWNERS coverage,
+  add another eligible owner, or move a repository to `human_merge` when
+  human review is the intended gate. Treat this as a repository policy
+  change, not a per-run workaround.
+
+Do not use issue-author approval, trusted operational markers, or
+CODEOWNERS mismatch as substitutes for a satisfiable GitHub merge gate.
+
 ## Phase Permissions
 
 Each IDD phase needs a different subset of access:
@@ -209,3 +249,7 @@ Keep approval labels and operational marker trust as separate controls:
 - [GitHub REST API permissions for fine-grained personal access tokens](https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens)
 - [GitHub `GITHUB_TOKEN` security model](https://docs.github.com/actions/concepts/security/github_token)
 - [GitHub Copilot agent skills guidance](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-skills)
+- [GitHub required pull request reviews](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews)
+- [GitHub CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+- [GitHub ruleset bypass permissions](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository#granting-bypass-permissions-for-your-branch-or-tag-ruleset)
+- [GitHub ruleset bypass modes API](https://docs.github.com/en/rest/repos/rules)

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -208,6 +208,12 @@ keys accept positive whole-minute ISO 8601 durations only.
 | Merge method                 | Merge commits (squash and rebase merge are disabled in repository settings) | [Merge](../.github/instructions/idd-merge.instructions.md), [GitHub Flow rules](./../.github/copilot-instructions.md)                                                                                    | Keep unless the repository has a different merge strategy; customize only with branch protection changes.                                           |
 | Post-merge comment cleanup   | Minimize operational markers and resolved feedback after merge succeeds     | [Merge](../.github/instructions/idd-merge.instructions.md), audit scripts, and helper tooling                                                                                                            | Keep as best-effort; safe cleanup candidates are enumerated in [comment minimization](idd-comment-minimization.md).                                 |
 
+Merge policy constants describe IDD authority and phase routing. They do
+not change GitHub's required-review, CODEOWNER, branch protection, or
+ruleset topology. A repository using `fully_autonomous_merge` still
+needs either an eligible non-author review path or an intentional
+pull-request-only bypass actor that can satisfy GitHub at F3.
+
 ## Critique And Review Loop Defaults
 
 | Policy default                          | Distributed value                                                                                                              | Owning surface                                                             | Onboarding expectation                                                                                                       |


### PR DESCRIPTION
## Summary

- Document merge-topology requirements for autonomous IDD merges, including the solo CODEOWNER self-approval deadlock.
- Clarify the safe choices: eligible non-author CODEOWNER review, pull-request-only ruleset bypass for the trusted merge actor, or a deliberate CODEOWNERS/policy change.
- Clarify that CODEOWNERS are later PR review/merge gates, and sync the exported template docs.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `node scripts/validate-schemas.mjs`
- `git diff --check`

## Follow-up issues

None.

Closes #544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the relationship between merge policy and repository merge topology configuration requirements
  * Enhanced guidance on CODEOWNERS evaluation and merge gate behavior
  * Added requirements documentation for enabling autonomous merge execution
  * Expanded clarifications on diagnostic indicators and edge case handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/617)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->