### PR TITLE
feat(idd): guard discover against authored issues

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -15,6 +15,25 @@ missing or disagrees.
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
 **Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).
 
+## Authoring label guard
+
+The configured authoring label is `issueAuthoring.authoringLabelName`
+(default: `status:authoring`); the stale threshold is
+`issueAuthoring.authoringStaleAge` (default: `PT4H`).
+
+A0-T, A0-O, and A3 must treat a matching label as not startable. A0-T
+reports `Issue #N is currently being authored` and stops before claim;
+A0-O and A3 filter the issue out. For each skipped issue, fetch the
+latest matching `labeled` timeline event. If the label age exceeds
+`authoringStaleAge`, emit:
+
+```text
+Warning: Issue #N has carried the authoring label for {duration}; the authoring session may be stalled.
+```
+
+If the timestamp is unavailable, still skip the issue and report that the
+stale-authoring age could not be checked.
+
 ## A0-T — Explicit issue target shortcut
 
 Use this shortcut only when the current operator request contains one
@@ -34,7 +53,10 @@ selection. Before A5, run targeted readiness and viability checks against
 that issue only:
 
 1. Re-fetch the target issue.
-2. Apply the same readiness intent as A3 to the target:
+2. If the target issue carries the configured authoring label, report
+   `Issue #N is currently being authored`, run the stale-authoring
+   warning check above, and stop without claiming.
+3. Apply the same readiness intent as A3 to the target:
    - no `status:blocked-by-human` or `status:needs-decision` label;
    - no open dependent issues, except parent epics or aggregate issues
      that are acceptable under A3;
@@ -44,11 +66,11 @@ that issue only:
      resolve through the same scoped body-content lookup used by A3, and
      the matching roadmap work is closed or otherwise complete;
    - no external human coordination is required to start.
-3. Run the normal A4 viability gate against the target only.
-4. If `.github/idd/config.json` exists and is valid and
+4. Run the normal A4 viability gate against the target only.
+5. If `.github/idd/config.json` exists and is valid and
    `skipIssueAuthorApprovalGate` is `true`, skip the issue-author
    approval gate and keep the target selected.
-5. Otherwise, apply the same issue-author approval evaluation used in
+6. Otherwise, apply the same issue-author approval evaluation used in
    **A3.5**:
    - use `maintainerApprovalActorPolicy` from `.github/idd/config.json`
      when present; if absent, default to
@@ -108,6 +130,7 @@ body satisfies **all** of the following:
 - Does NOT contain any `<!-- idd-skill-blocked-by: … -->` marker.
 - Does NOT have a `status:blocked-by-human` or `status:needs-decision`
   label.
+- Does NOT have the configured authoring label.
 - Does NOT contain visible `Blocked by #NNN` lines where the referenced
   issue is open (apply the same fail-safe as A3: if a reference cannot
   be resolved, treat as blocked).
@@ -271,6 +294,7 @@ unresolvable references encountered during traversal.
 From A2, keep only issues that satisfy **all** of the following:
 
 - No `status:blocked-by-human` or `status:needs-decision` label
+- No configured authoring label
 - No open dependent issues (parent epics / aggregate issues that are
   still open are acceptable)
 - All dependency issues are closed or otherwise completed. Check both
@@ -496,30 +520,10 @@ separate, prior roadmap to close before they can start (cross-phase
 sequential dependency). Using it for grouping causes A3 to block every
 sub-task for the entire lifetime of the roadmap.
 
-## Scope invariant (detailed query allowlist)
+## Scope invariant (summary)
 
-Agents must not widen issue-selection scope beyond what the roadmap
-explicitly references (directly or transitively) without explicit
-operator instruction. Specifically:
-
-- A single explicit issue target provided by the operator in the current
-  run is explicit operator instruction for that one issue only. Use the
-  A0-T path; do not use the target as permission to search for alternate
-  issues.
-- Repo-wide searches (`gh issue list`, `gh search`, label-based queries)
-  are permitted only in **A1** (to locate the roadmap itself), in
-  **A0-T** for the scoped body-content lookup needed to resolve the
-  explicit target's `idd-skill-blocked-by` markers, in
-  **A0-O** when `issue-scope` is `orphan-first` (body-content filter to
-  find issues lacking `idd-skill-roadmap-id` and
-  `idd-skill-blocked-by` markers), and for the scoped
-  `idd-skill-roadmap-id` body-content lookup required by A3's
-  dependency-marker check. A1.5 may also run a narrow repo-wide
-  duplicate/reuse check for a specific autonomous gap before creating a
-  follow-up issue; the result may only prevent a duplicate or link an
-  existing issue back to the selected roadmap, not expand the candidate
-  set.
-- After a zero-result report at A3, an operator may grant a one-time
-  opt-in for the current run, specifying an alternate scope.
-- Opt-in must be granted interactively during the current run. Prior or
-  standing instructions do not count as opt-in.
+Do not widen issue-selection scope beyond the roadmap traversal except
+for the explicit query allowlist already defined in A0-T, A0-O, A1,
+A1.5, A3, and A4.5, or for a same-run operator opt-in after a
+zero-result report. A single explicit target authorizes only that issue;
+prior or standing instructions do not count as opt-in.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -15,6 +15,25 @@ missing or disagrees.
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
 **Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).
 
+## Authoring label guard
+
+The configured authoring label is `issueAuthoring.authoringLabelName`
+(default: `status:authoring`); the stale threshold is
+`issueAuthoring.authoringStaleAge` (default: `PT4H`).
+
+A0-T, A0-O, and A3 must treat a matching label as not startable. A0-T
+reports `Issue #N is currently being authored` and stops before claim;
+A0-O and A3 filter the issue out. For each skipped issue, fetch the
+latest matching `labeled` timeline event. If the label age exceeds
+`authoringStaleAge`, emit:
+
+```text
+Warning: Issue #N has carried the authoring label for {duration}; the authoring session may be stalled.
+```
+
+If the timestamp is unavailable, still skip the issue and report that the
+stale-authoring age could not be checked.
+
 ## A0-T — Explicit issue target shortcut
 
 Use this shortcut only when the current operator request contains one
@@ -34,7 +53,10 @@ selection. Before A5, run targeted readiness and viability checks against
 that issue only:
 
 1. Re-fetch the target issue.
-2. Apply the same readiness intent as A3 to the target:
+2. If the target issue carries the configured authoring label, report
+   `Issue #N is currently being authored`, run the stale-authoring
+   warning check above, and stop without claiming.
+3. Apply the same readiness intent as A3 to the target:
    - no `status:blocked-by-human` or `status:needs-decision` label;
    - no open dependent issues, except parent epics or aggregate issues
      that are acceptable under A3;
@@ -45,11 +67,11 @@ that issue only:
      markers resolve through the same scoped body-content lookup used by
      A3, and the matching roadmap work is closed or otherwise complete;
    - no external human coordination is required to start.
-3. Run the normal A4 viability gate against the target only.
-4. If `.github/idd/config.json` exists and is valid and
+4. Run the normal A4 viability gate against the target only.
+5. If `.github/idd/config.json` exists and is valid and
    `skipIssueAuthorApprovalGate` is `true`, skip the issue-author
    approval gate and keep the target selected.
-5. Otherwise, apply the same issue-author approval evaluation used in
+6. Otherwise, apply the same issue-author approval evaluation used in
    **A3.5**:
    - use `maintainerApprovalActorPolicy` from `.github/idd/config.json`
      when present; if absent, default to
@@ -111,6 +133,7 @@ body satisfies **all** of the following:
   `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: … -->` marker.
 - Does NOT have a `status:blocked-by-human` or `status:needs-decision`
   label.
+- Does NOT have the configured authoring label.
 - Does NOT contain visible `Blocked by #NNN` lines where the referenced
   issue is open (apply the same fail-safe as A3: if a reference cannot
   be resolved, treat as blocked).
@@ -277,6 +300,7 @@ unresolvable references encountered during traversal.
 From A2, keep only issues that satisfy **all** of the following:
 
 - No `status:blocked-by-human` or `status:needs-decision` label
+- No configured authoring label
 - No open dependent issues (parent epics / aggregate issues that are
   still open are acceptable)
 - All dependency issues are closed or otherwise completed. Check both
@@ -504,30 +528,10 @@ for a separate, prior roadmap to close before they can start (cross-
 phase sequential dependency). Using it for grouping causes A3 to block
 every sub-task for the entire lifetime of the roadmap.
 
-## Scope invariant (detailed query allowlist)
+## Scope invariant (summary)
 
-Agents must not widen issue-selection scope beyond what the roadmap
-explicitly references (directly or transitively) without explicit
-operator instruction. Specifically:
-
-- A single explicit issue target provided by the operator in the current
-  run is explicit operator instruction for that one issue only. Use the
-  A0-T path; do not use the target as permission to search for alternate
-  issues.
-- Repo-wide searches (`gh issue list`, `gh search`, label-based queries)
-  are permitted only in **A1** (to locate the roadmap itself), in
-  **A0-T** for the scoped body-content lookup needed to resolve the
-  explicit target's `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers, in
-  **A0-O** when `issue-scope` is `orphan-first` (body-content filter to
-  find issues lacking `{{PROJECT_MARKER_PREFIX}}-roadmap-id` and
-  `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers), and for the scoped
-  `{{PROJECT_MARKER_PREFIX}}-roadmap-id` body-content lookup required by
-  A3's dependency-marker check. A1.5 may also run a narrow repo-wide
-  duplicate/reuse check for a specific autonomous gap before creating a
-  follow-up issue; the result may only prevent a duplicate or link an
-  existing issue back to the selected roadmap, not expand the candidate
-  set.
-- After a zero-result report at A3, an operator may grant a one-time
-  opt-in for the current run, specifying an alternate scope.
-- Opt-in must be granted interactively during the current run. Prior or
-  standing instructions do not count as opt-in.
+Do not widen issue-selection scope beyond the roadmap traversal except
+for the explicit query allowlist already defined in A0-T, A0-O, A1,
+A1.5, A3, and A4.5, or for a same-run operator opt-in after a
+zero-result report. A single explicit target authorizes only that issue;
+prior or standing instructions do not count as opt-in.

--- a/scripts/authoring-label-guard.mjs
+++ b/scripts/authoring-label-guard.mjs
@@ -94,7 +94,7 @@ export function formatElapsedDuration(durationMs) {
 }
 
 function isMatchingLabeledEvent(event, labelName) {
-  if (!event || (event.event ?? "labeled") !== "labeled") {
+  if (!event || event.event !== "labeled") {
     return false;
   }
   const eventLabel = typeof event.label === "string" ? event.label : event.label?.name;

--- a/scripts/authoring-label-guard.mjs
+++ b/scripts/authoring-label-guard.mjs
@@ -1,0 +1,102 @@
+import { POLICY_DEFAULTS, normalizePolicyConfig, parseIsoDurationToMs } from "./policy-helpers.mjs";
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+export function resolveAuthoringGuardPolicy(config) {
+  const normalized = normalizePolicyConfig(config);
+  const fallbackMs = parseIsoDurationToMs(POLICY_DEFAULTS.issueAuthoring.authoringStaleAge);
+  return {
+    labelName: normalized.issueAuthoring.authoringLabelName,
+    staleAge: normalized.issueAuthoring.authoringStaleAge,
+    staleAgeMs: parseIsoDurationToMs(normalized.issueAuthoring.authoringStaleAge) ?? fallbackMs,
+  };
+}
+
+export function buildAuthoringLabelWarning({
+  issueNumber,
+  labelName,
+  labelEvents,
+  now = new Date(),
+  staleAgeMs,
+}) {
+  const labeledAt = findLatestLabeledAt(labelEvents, labelName);
+  if (!labeledAt) {
+    return {
+      issueNumber,
+      labelName,
+      status: "timestamp_unavailable",
+      labeledAt: null,
+      ageMs: null,
+      staleAgeMs,
+      message:
+        `Warning: Issue #${issueNumber} carries the authoring label, ` +
+        "but the labeled event timestamp could not be resolved; " +
+        "the stale-authoring age could not be checked.",
+    };
+  }
+
+  const labeledAtMs = Date.parse(labeledAt);
+  const nowMs = now instanceof Date ? now.getTime() : Date.parse(String(now));
+  const ageMs = nowMs - labeledAtMs;
+  if (!Number.isFinite(ageMs) || ageMs < staleAgeMs) {
+    return null;
+  }
+
+  return {
+    issueNumber,
+    labelName,
+    status: "stale",
+    labeledAt,
+    ageMs,
+    staleAgeMs,
+    message:
+      `Warning: Issue #${issueNumber} has carried the authoring label for ` +
+      `${formatElapsedDuration(ageMs)}; the authoring session may be stalled.`,
+  };
+}
+
+export function findLatestLabeledAt(events, labelName) {
+  let latest = "";
+  for (const event of events ?? []) {
+    if (!isMatchingLabeledEvent(event, labelName)) {
+      continue;
+    }
+    const createdAt = String(event.created_at ?? event.createdAt ?? "");
+    if (!createdAt || Number.isNaN(Date.parse(createdAt))) {
+      continue;
+    }
+    if (!latest || Date.parse(createdAt) > Date.parse(latest)) {
+      latest = createdAt;
+    }
+  }
+  return latest;
+}
+
+export function formatElapsedDuration(durationMs) {
+  const clamped = Math.max(0, Math.floor(durationMs));
+  const days = Math.floor(clamped / DAY_MS);
+  const hours = Math.floor((clamped % DAY_MS) / HOUR_MS);
+  const minutes = Math.floor((clamped % HOUR_MS) / MINUTE_MS);
+
+  const parts = [];
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0 || parts.length === 0) {
+    parts.push(`${minutes}m`);
+  }
+  return parts.join(" ");
+}
+
+function isMatchingLabeledEvent(event, labelName) {
+  if (!event || (event.event ?? "labeled") !== "labeled") {
+    return false;
+  }
+  const eventLabel = typeof event.label === "string" ? event.label : event.label?.name;
+  return eventLabel === labelName;
+}

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -5,6 +5,11 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  buildAuthoringLabelWarning,
+  resolveAuthoringGuardPolicy,
+} from "./authoring-label-guard.mjs";
+
 const DEFAULT_MARKER_PREFIX = "idd-skill";
 const BLOCKED_LABELS = new Set(["status:blocked-by-human", "status:needs-decision"]);
 
@@ -47,6 +52,7 @@ export function classifyIssue(issue, options) {
   const labels = new Set(normalizeLabels(issue.labels));
   const body = String(issue.body ?? "");
   const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  const authoringLabelName = normalizeAuthoringLabelName(options.authoringLabelName);
   const roadmapMarkerRegex = createMarkerRegex(markerPrefix, "roadmap-id");
   const blockedMarkerRegex = createMarkerRegex(markerPrefix, "blocked-by");
 
@@ -61,6 +67,10 @@ export function classifyIssue(issue, options) {
   const blockedLabel = [...labels].find((label) => BLOCKED_LABELS.has(label));
   if (blockedLabel) {
     return { orphan: false, reason: "blocked_label", details: blockedLabel };
+  }
+
+  if (labels.has(authoringLabelName)) {
+    return { orphan: false, reason: "authoring_label", details: authoringLabelName };
   }
 
   const refs = extractBlockedByReferences(body);
@@ -95,17 +105,20 @@ export function filterOrphanIssues(issues, options = {}) {
     roadmap_marker: [],
     blocked_by_marker: [],
     blocked_label: [],
+    authoring_label: [],
     blocked_by_open_reference: [],
     unresolvable_reference: [],
   };
   const orphans = [];
   const unresolvable = [];
+  const warnings = [];
 
   for (const issue of issues) {
     const result = classifyIssue(issue, {
       issueStateByNumber,
       fetchIssueStateByNumber,
       markerPrefix: options.markerPrefix,
+      authoringLabelName: options.authoringLabelName,
     });
     const entry = {
       number: issue.number,
@@ -123,6 +136,18 @@ export function filterOrphanIssues(issues, options = {}) {
           reference: number,
           reason: "issue-not-found-or-inaccessible",
         });
+      }
+    }
+    if (result.reason === "authoring_label") {
+      const warning = buildAuthoringLabelWarning({
+        issueNumber: issue.number,
+        labelName: result.details,
+        labelEvents: resolveIssueLabelEvents(issue, options.fetchLabelEventsByIssueNumber),
+        now: options.now ?? new Date(),
+        staleAgeMs: options.authoringStaleAgeMs ?? (4 * 60 * 60 * 1000),
+      });
+      if (warning) {
+        warnings.push(warning);
       }
     }
 
@@ -153,6 +178,7 @@ export function filterOrphanIssues(issues, options = {}) {
     orphans,
     filtered,
     unresolvable,
+    warnings,
     counts,
   };
 }
@@ -175,7 +201,11 @@ function runCli() {
   const result = filterOrphanIssues(openIssues, {
     issueStateByNumber: openStateByNumber,
     fetchIssueStateByNumber: (issueNumber) => fetchIssueState(repoRef, issueNumber),
+    fetchLabelEventsByIssueNumber: (issueNumber) => fetchIssueLabelEvents(repoRef, issueNumber),
     markerPrefix: policy.markerPrefix,
+    authoringLabelName: policy.authoringLabelName,
+    authoringStaleAgeMs: policy.authoringStaleAgeMs,
+    now: args.now || new Date(),
   });
 
   const output = {
@@ -187,6 +217,8 @@ function runCli() {
       source: policy.source,
       orphanFirstPolicy: policy.orphanFirstPolicy,
       markerPrefix: policy.markerPrefix,
+      authoringLabelName: policy.authoringLabelName,
+      authoringStaleAge: policy.authoringStaleAge,
     },
     ...result,
   };
@@ -201,6 +233,7 @@ function parseArgs(argv) {
     policy: "",
     pr: null,
     help: false,
+    now: "",
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -230,6 +263,11 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (token === "--now") {
+      parsed.now = value ?? "";
+      index += 1;
+      continue;
+    }
     if (token === "--help" || token === "-h") {
       parsed.help = true;
       continue;
@@ -241,22 +279,24 @@ function parseArgs(argv) {
 
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/discover-orphan-filter.mjs [--owner <owner>] [--repo <repo>] [--policy <path>] [--pr <number>]
+  node scripts/discover-orphan-filter.mjs [--owner <owner>] [--repo <repo>] [--policy <path>] [--pr <number>] [--now <ISO8601>]
 
 Output schema:
 {
   "repository": {"owner": "...", "repo": "..."},
   "diagnostics": {"pr": 404},
-  "policy": {"source": "...", "orphanFirstPolicy": "none|maintainer-approved|public-disabled", "markerPrefix": "..."},
+  "policy": {"source": "...", "orphanFirstPolicy": "none|maintainer-approved|public-disabled", "markerPrefix": "...", "authoringLabelName": "...", "authoringStaleAge": "..."},
   "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|blocked_references_closed", "url": "..."}],
   "filtered": {
     "roadmap_marker": [...],
     "blocked_by_marker": [...],
     "blocked_label": [...],
+    "authoring_label": [...],
     "blocked_by_open_reference": [...],
     "unresolvable_reference": [...]
   },
   "unresolvable": [{"issue": 1, "reference": 2, "reason": "issue-not-found-or-inaccessible"}],
+  "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
   "counts": {"scanned": 0, "orphans": 0, "filtered": {...}, "unresolvable": 0}
 }
 `);
@@ -267,16 +307,24 @@ function loadPolicy(policyPath) {
   const targetPath = policyPath ? resolve(process.cwd(), policyPath) : defaultPath;
   try {
     const config = JSON.parse(readFileSync(targetPath, "utf8"));
+    const authoringPolicy = resolveAuthoringGuardPolicy(config);
     return {
       source: targetPath,
       orphanFirstPolicy: getOrphanFirstPolicy(config),
       markerPrefix: normalizeMarkerPrefix(config.markerPrefix),
+      authoringLabelName: authoringPolicy.labelName,
+      authoringStaleAge: authoringPolicy.staleAge,
+      authoringStaleAgeMs: authoringPolicy.staleAgeMs,
     };
   } catch {
+    const authoringPolicy = resolveAuthoringGuardPolicy({});
     return {
       source: targetPath,
       orphanFirstPolicy: "none",
       markerPrefix: DEFAULT_MARKER_PREFIX,
+      authoringLabelName: authoringPolicy.labelName,
+      authoringStaleAge: authoringPolicy.staleAge,
+      authoringStaleAgeMs: authoringPolicy.staleAgeMs,
     };
   }
 }
@@ -287,9 +335,24 @@ function normalizeIssue(issue) {
     title: issue.title ?? "",
     state: issue.state ?? "",
     labels: normalizeLabels(issue.labels),
+    labelEvents: Array.isArray(issue.labelEvents) ? issue.labelEvents : [],
     body: issue.body ?? "",
     url: issue.url ?? issue.html_url ?? "",
   };
+}
+
+function resolveIssueLabelEvents(issue, fetchLabelEventsByIssueNumber) {
+  if (Array.isArray(issue.labelEvents) && issue.labelEvents.length > 0) {
+    return issue.labelEvents;
+  }
+  if (typeof fetchLabelEventsByIssueNumber !== "function") {
+    return [];
+  }
+  try {
+    return fetchLabelEventsByIssueNumber(issue.number);
+  } catch {
+    return [];
+  }
 }
 
 function normalizeLabels(labels) {
@@ -334,6 +397,22 @@ function fetchIssueState(repoRef, issueNumber) {
   }
 }
 
+function fetchIssueLabelEvents(repoRef, issueNumber) {
+  const events = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const rawPage = ghJson([
+      "api",
+      `repos/${repoRef}/issues/${issueNumber}/timeline?per_page=${pageSize}&page=${page}`,
+    ]);
+    events.push(...rawPage.filter((event) => event?.event === "labeled"));
+    if (rawPage.length < pageSize) {
+      break;
+    }
+  }
+  return events;
+}
+
 function ghJson(args) {
   return JSON.parse(runGh(args).trim() || "[]");
 }
@@ -371,6 +450,10 @@ function normalizeMarkerPrefix(prefix) {
     return DEFAULT_MARKER_PREFIX;
   }
   return prefix;
+}
+
+function normalizeAuthoringLabelName(labelName) {
+  return typeof labelName === "string" && labelName.length > 0 ? labelName : "status:authoring";
 }
 
 function escapeRegex(value) {

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  buildAuthoringLabelWarning,
+  resolveAuthoringGuardPolicy,
+} from "./authoring-label-guard.mjs";
 
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({ __iddLookupStatus: "inaccessible" });
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
@@ -13,11 +20,16 @@ if (isMainModule(import.meta.url)) {
 
   const owner = args.owner || ghText(["repo", "view", "--json", "owner", "--jq", ".owner.login"]);
   const repo = args.repo || ghText(["repo", "view", "--json", "name", "--jq", ".name"]);
+  const authoringPolicy = resolveAuthoringGuardPolicy(loadPolicy(args.policy));
 
   const summary = await evaluateDiscoverReadiness(args.issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
     loadIssue: buildIssueLoader(owner, repo),
+    loadIssueLabelEvents: buildIssueLabelEventsLoader(owner, repo),
     findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo),
+    authoringLabelName: authoringPolicy.labelName,
+    authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+    now: args.now || new Date(),
   });
 
   if (args.csv) {
@@ -32,6 +44,10 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     includeUnresolvable = false,
     loadIssue,
     findRoadmapsByMarker,
+    loadIssueLabelEvents,
+    authoringLabelName = "status:authoring",
+    authoringStaleAgeMs = 4 * 60 * 60 * 1000,
+    now = new Date(),
   } = options ?? {};
   if (typeof loadIssue !== "function") {
     throw new Error("evaluateDiscoverReadiness requires loadIssue(issueNumber)");
@@ -43,6 +59,7 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
   const ready = [];
   const filteredOut = [];
   const unresolvable = [];
+  const warnings = [];
   const issueCache = new Map();
   const markerCache = new Map();
 
@@ -79,6 +96,19 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     }
     if (labels.has("status:needs-decision")) {
       reasons.add("label:status:needs-decision");
+    }
+    if (labels.has(authoringLabelName)) {
+      reasons.add(`label:${authoringLabelName}`);
+      const warning = buildAuthoringLabelWarning({
+        issueNumber: issue.number,
+        labelName: authoringLabelName,
+        labelEvents: await resolveLabelEvents(issue, loadIssueLabelEvents),
+        now,
+        staleAgeMs: authoringStaleAgeMs,
+      });
+      if (warning) {
+        warnings.push(warning);
+      }
     }
 
     for (const dependencyNumber of extractDependencyIssueNumbers(issue.body)) {
@@ -160,6 +190,7 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     ready,
     filteredOut,
     unresolvable: includeUnresolvable ? unresolvable : [],
+    warnings,
     summary: {
       total: ready.length + filteredOut.length,
       readyCount: ready.length,
@@ -196,6 +227,8 @@ function parseArgs(argv) {
     csv: false,
     owner: "",
     repo: "",
+    policy: "",
+    now: "",
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -218,6 +251,16 @@ function parseArgs(argv) {
     }
     if (token === "--repo") {
       parsed.repo = value ?? "";
+      index += 1;
+      continue;
+    }
+    if (token === "--policy") {
+      parsed.policy = value ?? "";
+      index += 1;
+      continue;
+    }
+    if (token === "--now") {
+      parsed.now = value ?? "";
       index += 1;
       continue;
     }
@@ -244,13 +287,14 @@ function printHelp() {
   process.stdout.write(`Usage:
   node scripts/discover-readiness-check.mjs --issue <number> [--issue <number> ...]
   node scripts/discover-readiness-check.mjs --issues <n1,n2,...>
-    [--include-unresolvable] [--csv] [--owner <owner>] [--repo <repo>]
+    [--include-unresolvable] [--csv] [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>]
 
 Output schema (JSON mode):
   {
     "ready": [{ "number": 123, "title": "..." }],
     "filteredOut": [{ "number": 124, "title": "...", "reasons": ["..."] }],
     "unresolvable": [{ "issueNumber": 124, "kind": "...", "reference": "...", "reason": "..." }],
+    "warnings": [{ "issueNumber": 124, "message": "Warning: ..." }],
     "summary": { "total": 2, "readyCount": 1, "filteredCount": 1, "unresolvableCount": 0, "filteredByReason": { "...": 1 } }
   }
 `);
@@ -274,6 +318,7 @@ function normalizeIssue(issue) {
     state: String(issue.state ?? "").toUpperCase(),
     body: String(issue.body ?? ""),
     labels: normalizeLabels(issue.labels),
+    labelEvents: Array.isArray(issue.labelEvents) ? issue.labelEvents : [],
     url: String(issue.url ?? ""),
   };
 }
@@ -325,6 +370,17 @@ async function getRoadmapsByMarker(marker, cache, findRoadmapsByMarker) {
     .filter((issue) => Number.isInteger(issue.number) && issue.number > 0);
   cache.set(marker, matches);
   return matches;
+}
+
+async function resolveLabelEvents(issue, loadIssueLabelEvents) {
+  if (issue.labelEvents.length > 0 || typeof loadIssueLabelEvents !== "function") {
+    return issue.labelEvents;
+  }
+  try {
+    return await loadIssueLabelEvents(issue.number);
+  } catch {
+    return [];
+  }
 }
 
 function countReasons(filteredOut) {
@@ -379,6 +435,30 @@ function buildIssueLoader(owner, repo) {
   };
 }
 
+function buildIssueLabelEventsLoader(owner, repo) {
+  return async (issueNumber) => {
+    const repoRef = `${owner}/${repo}`;
+    return fetchIssueLabelEvents(repoRef, issueNumber);
+  };
+}
+
+function fetchIssueLabelEvents(repoRef, issueNumber) {
+  const events = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const rawPage = JSON.parse(runGh([
+      "api",
+      `repos/${repoRef}/issues/${issueNumber}/timeline?per_page=${pageSize}&page=${page}`,
+    ]).trim() || "[]");
+    const labeled = rawPage.filter((event) => event?.event === "labeled");
+    events.push(...labeled);
+    if (rawPage.length < pageSize) {
+      break;
+    }
+  }
+  return events;
+}
+
 function buildRoadmapMarkerResolver(owner, repo) {
   return async (marker) => {
     const query = `repo:${owner}/${repo} is:issue in:body "<!-- idd-skill-roadmap-id: ${marker} -->"`;
@@ -395,6 +475,15 @@ function buildRoadmapMarkerResolver(owner, repo) {
 
 function ghText(args) {
   return runGh(args).trim();
+}
+
+function loadPolicy(policyPath) {
+  const targetPath = policyPath ? resolve(process.cwd(), policyPath) : resolve(process.cwd(), ".github/idd/config.json");
+  try {
+    return JSON.parse(readFileSync(targetPath, "utf8"));
+  } catch {
+    return {};
+  }
 }
 
 function runGh(args, options = {}) {

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -72,6 +72,8 @@ export const POLICY_DEFAULTS = Object.freeze({
   }),
   issueAuthoring: Object.freeze({
     maxClarificationRounds: 3,
+    authoringLabelName: "status:authoring",
+    authoringStaleAge: "PT4H",
   }),
 });
 
@@ -250,6 +252,14 @@ export function normalizePolicyConfig(config) {
       maxClarificationRounds: parsePositiveInteger(
         config?.issueAuthoring?.maxClarificationRounds,
         POLICY_DEFAULTS.issueAuthoring.maxClarificationRounds,
+      ),
+      authoringLabelName: parseNonEmptyString(
+        config?.issueAuthoring?.authoringLabelName,
+        POLICY_DEFAULTS.issueAuthoring.authoringLabelName,
+      ),
+      authoringStaleAge: parseDuration(
+        config?.issueAuthoring?.authoringStaleAge,
+        POLICY_DEFAULTS.issueAuthoring.authoringStaleAge,
       ),
     },
   };

--- a/tests/authoring-label-guard.test.mjs
+++ b/tests/authoring-label-guard.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildAuthoringLabelWarning,
+  findLatestLabeledAt,
+} from "../scripts/authoring-label-guard.mjs";
+
+test("findLatestLabeledAt only accepts explicit labeled events", () => {
+  const latest = findLatestLabeledAt([
+    {
+      label: { name: "status:authoring" },
+      created_at: "2026-05-15T08:00:00Z",
+    },
+    {
+      event: "unlabeled",
+      label: { name: "status:authoring" },
+      created_at: "2026-05-15T09:00:00Z",
+    },
+    {
+      event: "labeled",
+      label: { name: "status:authoring" },
+      created_at: "2026-05-15T07:00:00Z",
+    },
+  ], "status:authoring");
+
+  assert.equal(latest, "2026-05-15T07:00:00Z");
+});
+
+test("buildAuthoringLabelWarning treats implicit events as timestamp unavailable", () => {
+  const warning = buildAuthoringLabelWarning({
+    issueNumber: 536,
+    labelName: "status:authoring",
+    labelEvents: [{
+      label: { name: "status:authoring" },
+      created_at: "2026-05-15T07:00:00Z",
+    }],
+    now: "2026-05-15T12:00:00Z",
+    staleAgeMs: 4 * 60 * 60 * 1000,
+  });
+
+  assert.equal(warning.status, "timestamp_unavailable");
+  assert.match(warning.message, /timestamp could not be resolved/);
+});

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -156,6 +156,8 @@ test("policy normalization provides default-safe values and supports aliases", (
     },
     issueAuthoring: {
       maxClarificationRounds: 3,
+      authoringLabelName: "status:authoring",
+      authoringStaleAge: "PT4H",
     },
   });
 
@@ -212,6 +214,8 @@ test("policy normalization provides default-safe values and supports aliases", (
     },
     issueAuthoring: {
       maxClarificationRounds: 4,
+      authoringLabelName: "status:drafting",
+      authoringStaleAge: "PT3H",
     },
   }), {
     issueScope: "orphan-first",
@@ -260,6 +264,8 @@ test("policy normalization provides default-safe values and supports aliases", (
     },
     issueAuthoring: {
       maxClarificationRounds: 4,
+      authoringLabelName: "status:drafting",
+      authoringStaleAge: "PT3H",
     },
   });
 

--- a/tests/discover-orphan-filter.test.mjs
+++ b/tests/discover-orphan-filter.test.mjs
@@ -149,6 +149,38 @@ test("filterOrphanIssues excludes blocked labels and open blockers", () => {
   assert.equal(result.filtered.blocked_label.length, 1);
 });
 
+test("filterOrphanIssues excludes custom authoring label and warns when stale", () => {
+  const issues = [
+    {
+      number: 21,
+      title: "being drafted",
+      state: "OPEN",
+      labels: [{ name: "status:drafting" }],
+      labelEvents: [{
+        event: "labeled",
+        label: { name: "status:drafting" },
+        created_at: "2026-05-15T07:00:00Z",
+      }],
+      body: "",
+      url: "https://example.com/21",
+    },
+  ];
+
+  const result = filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => "UNRESOLVABLE",
+    authoringLabelName: "status:drafting",
+    authoringStaleAgeMs: 4 * 60 * 60 * 1000,
+    now: "2026-05-15T12:00:00Z",
+  });
+
+  assert.equal(result.orphans.length, 0);
+  assert.equal(result.filtered.authoring_label.length, 1);
+  assert.equal(result.filtered.authoring_label[0].details, "status:drafting");
+  assert.equal(result.warnings[0].status, "stale");
+  assert.match(result.warnings[0].message, /Issue #21 has carried the authoring label for 5h/);
+});
+
 test("filterOrphanIssues keeps closed-blocker issues as orphan candidates", () => {
   const issues = [
     {

--- a/tests/discover-readiness-check.test.mjs
+++ b/tests/discover-readiness-check.test.mjs
@@ -37,6 +37,31 @@ test("filters issue with blocked labels", async () => {
   assert.deepEqual(summary.filteredOut[0].reasons, ["label:status:blocked-by-human"]);
 });
 
+test("filters authoring-labeled issue and emits stale warning", async () => {
+  const summary = await evaluateDiscoverReadiness([151], {
+    now: "2026-05-15T12:00:00Z",
+    authoringStaleAgeMs: 4 * 60 * 60 * 1000,
+    loadIssue: async () => ({
+      number: 151,
+      title: "candidate being authored",
+      state: "OPEN",
+      body: "",
+      labels: [{ name: "status:authoring" }],
+      labelEvents: [{
+        event: "labeled",
+        label: { name: "status:authoring" },
+        created_at: "2026-05-15T07:00:00Z",
+      }],
+    }),
+    findRoadmapsByMarker: async () => [],
+  });
+
+  assert.equal(summary.ready.length, 0);
+  assert.deepEqual(summary.filteredOut[0].reasons, ["label:status:authoring"]);
+  assert.equal(summary.warnings[0].status, "stale");
+  assert.match(summary.warnings[0].message, /Issue #151 has carried the authoring label for 5h/);
+});
+
 test("fails safe when blocked-by issue cannot be resolved", async () => {
   const issues = new Map([
     [201, { number: 201, title: "candidate", state: "OPEN", body: "Blocked by #202", labels: [] }],


### PR DESCRIPTION
## Summary
- Add the authoring-label guard to A0-T, A0-O, and A3 Discover instructions in both live and template copies.
- Teach discover helpers to read `issueAuthoring.authoringLabelName` / `authoringStaleAge`, skip authoring-labeled issues, and emit stale-authoring warnings from label timeline evidence.
- Add focused tests for default/custom authoring labels, stale warning output, and policy normalization.

## Verification
- `node --test tests/*.mjs`
- `node scripts/validate-schemas.mjs`
- `node scripts/audit-docs.mjs --check`
- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`
- `git diff --check`

## Follow-up
- None.

## Background
The helper changes intentionally keep the helper-first Discover path aligned with the written rule so an authoring-labeled issue cannot be reported as ready by helper evidence alone. The Discover scope-invariant summary was compacted to keep the runtime bundle under the documented size limit while preserving the earlier query allowlist.

Closes #536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authoring-label protection: issues marked as authoring are excluded from discovery, orphaning, and readiness/start selection.
  * Staleness warnings and timestamp checks for authoring labels surface when labels exceed configured age or timestamp is unavailable.
  * Readiness/orphan reports and CLI outputs now include authoring warnings.

* **Documentation**
  * Updated instructions documenting authoring label rules and scope-invariant summary.

* **Tests**
  * Added tests covering label filtering, staleness detection, and timestamp-unavailable handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/618)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->