### PR TITLE
docs(skill): document authoring label lifecycle

### DIFF
--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -265,18 +265,26 @@ publication flow, create a missing label with `gh label create` before
 applying it. Failure to create or apply the label is a publishing
 blocker, not a warning.
 
-Apply the authoring label immediately after each issue is created or
-updated. This keeps partially published issue sets visible to the IDD
+For existing issues, apply the authoring label before updating issue
+content. For new issues, prefer creating the issue with the authoring
+label in the same publication command, such as `gh issue create --label`
+when the bundled GitHub CLI flow can use it. If the flow cannot label
+the issue atomically, apply the label immediately after creation. If
+post-create label application fails, close, delete, or otherwise make
+the created issue undiscoverable before stopping.
+
+These guards keep partially published issue sets visible to the IDD
 discover guard while the full set is still being authored. Remove the
 label from all published issues only after the complete issue set is
-published and the user confirms the published result. If publishing is
-interrupted before that confirmation, leave the label in place so later
-discover passes route the issue through authoring-label handling instead
-of normal ready-work discovery.
+published, the user confirms the published result, and the user
+explicitly requests release from the authoring hold for IDD execution.
+If publishing is interrupted before that release, leave the label in
+place so later discover passes route the issue through authoring-label
+handling instead of normal ready-work discovery.
 
-Removing the authoring label after publication confirmation does not
-start the IDD execution loop. Starting Discover, Claim, and Work still
-requires a separate explicit user request.
+Removing the authoring label releases the discover guard. Do it only as
+part of the explicit execution handoff; publication confirmation alone
+does not start Discover, Claim, and Work.
 
 ## Reuse-first issue policy
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -271,7 +271,8 @@ discover guard while the full set is still being authored. Remove the
 label from all published issues only after the complete issue set is
 published and the user confirms the published result. If publishing is
 interrupted before that confirmation, leave the label in place so later
-discover passes continue to treat the issue as actively authored.
+discover passes route the issue through authoring-label handling instead
+of normal ready-work discovery.
 
 Removing the authoring label after publication confirmation does not
 start the IDD execution loop. Starting Discover, Claim, and Work still

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -252,6 +252,31 @@ during drafting:
 it will not fail A4.5 for coherence, safety, or uniqueness. If it would,
 resolve the issue during drafting instead of publishing it.
 
+## Authoring label lifecycle
+
+The issue authoring skill must use the configured authoring label as a
+publication guard while it creates or updates issues. The label name
+comes from `issueAuthoring.authoringLabelName`, with `status:authoring`
+as the distributed default.
+
+During Phase 2 publishing, the skill should ensure the label exists in
+the target repository before first use. For the bundled GitHub CLI
+publication flow, create a missing label with `gh label create` before
+applying it. Failure to create or apply the label is a publishing
+blocker, not a warning.
+
+Apply the authoring label immediately after each issue is created or
+updated. This keeps partially published issue sets visible to the IDD
+discover guard while the full set is still being authored. Remove the
+label from all published issues only after the complete issue set is
+published and the user confirms the published result. If publishing is
+interrupted before that confirmation, leave the label in place so later
+discover passes continue to treat the issue as actively authored.
+
+Removing the authoring label after publication confirmation does not
+start the IDD execution loop. Starting Discover, Claim, and Work still
+requires a separate explicit user request.
+
 ## Reuse-first issue policy
 
 Before creating any new issue, the skill should check whether the work

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -259,7 +259,7 @@ publication guard while it creates or updates issues. The label name
 comes from `issueAuthoring.authoringLabelName`, with `status:authoring`
 as the distributed default.
 
-During Phase 2 publishing, the skill should ensure the label exists in
+During Phase 2 publishing, the skill must ensure the label exists in
 the target repository before first use. For the bundled GitHub CLI
 publication flow, create a missing label with `gh label create` before
 applying it. Failure to create or apply the label is a publishing
@@ -282,7 +282,7 @@ If publishing is interrupted before that release, leave the label in
 place so later discover passes route the issue through authoring-label
 handling instead of normal ready-work discovery.
 
-Removing the authoring label releases the discover guard. Do it only as
+Removing the authoring label releases the Discover guard. Do it only as
 part of the explicit execution handoff; publication confirmation alone
 does not start Discover, Claim, and Work.
 

--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -58,7 +58,19 @@ needs-decision, blocked-by-human, and out-of-scope.
    - keep independent sibling work in roadmap task lists unless a true
      correctness, availability, or ordering constraint requires a
      dependency edge
-6. Stop at the approval boundary. Drafting issues does not authorize
+6. When the user explicitly authorizes publication, manage the authoring
+   label for each created or updated issue:
+   - resolve `issueAuthoring.authoringLabelName`, defaulting to
+     `status:authoring`
+   - create the label with `gh label create` before first use when the
+     target repository does not already have it
+   - treat label creation or application failure as a publishing blocker
+   - apply the label immediately after each issue create/update
+   - remove the label from all published issues only after the full set is
+     published and the user confirms the result
+   - leave the label in place if publishing is interrupted before
+     confirmation
+7. Stop at the approval boundary. Drafting issues does not authorize
    publishing them or starting the IDD execution loop unless the user
    explicitly asked for that.
 

--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -65,11 +65,15 @@ needs-decision, blocked-by-human, and out-of-scope.
    - create the label with `gh label create` before first use when the
      target repository does not already have it
    - treat label creation or application failure as a publishing blocker
-   - apply the label immediately after each issue create/update
+   - apply the label before updating an existing issue
+   - create new issues with the label when supported, or apply the label
+     immediately after creation
+   - if post-create label application fails, close, delete, or otherwise
+     make the created issue undiscoverable before stopping
    - remove the label from all published issues only after the full set is
-     published and the user confirms the result
-   - leave the label in place if publishing is interrupted before
-     confirmation
+     published, the user confirms the result, and the user explicitly
+     requests release from the authoring hold for IDD execution
+   - leave the label in place if publishing is interrupted before release
 7. Stop at the approval boundary. Drafting issues does not authorize
    publishing them or starting the IDD execution loop unless the user
    explicitly asked for that.

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -16,8 +16,19 @@ The issue-authoring bundle fits into a three-phase handoff:
 ### Phase 2: Publishing (user-authorized handoff)
 
 - User explicitly asks for publication
+- Bundled skill resolves the authoring label from
+  `issueAuthoring.authoringLabelName`, defaulting to `status:authoring`
+- If the label does not exist in the target repository, bundled skill
+  creates it with `gh label create` before first use; label creation or
+  application failure blocks publishing
 - Bundled skill creates or updates issues in the target repository
+- Bundled skill applies the authoring label immediately after each issue
+  create/update
 - User verifies the published issues look correct
+- Bundled skill removes the authoring label from all published issues only
+  after the full issue set is published and the user confirms the result
+- If publishing is interrupted before confirmation, the authoring label
+  remains in place as the IDD discover guard signal
 - Published issues remain on hold until user explicitly requests IDD execution
 
 ### Phase 3: Execution (separate IDD loop)

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -21,14 +21,20 @@ The issue-authoring bundle fits into a three-phase handoff:
 - If the label does not exist in the target repository, bundled skill
   creates it with `gh label create` before first use; label creation or
   application failure blocks publishing
-- Bundled skill creates or updates issues in the target repository
-- Bundled skill applies the authoring label immediately after each issue
-  create/update
+- For existing issues, bundled skill applies the authoring label before
+  updating issue content
+- For new issues, bundled skill creates the issue with the authoring label
+  when the publication command supports that; otherwise it applies the
+  label immediately after creation
+- If post-create label application fails, bundled skill closes, deletes,
+  or otherwise makes the created issue undiscoverable before stopping
 - User verifies the published issues look correct
 - Bundled skill removes the authoring label from all published issues only
-  after the full issue set is published and the user confirms the result
-- If publishing is interrupted before confirmation, the authoring label
-  remains in place as the IDD discover guard signal
+  after the full issue set is published, the user confirms the result, and
+  the user explicitly requests release from the authoring hold for IDD
+  execution
+- If publishing is interrupted before release, the authoring label remains
+  in place as the IDD discover guard signal
 - Published issues remain on hold until user explicitly requests IDD execution
 
 ### Phase 3: Execution (separate IDD loop)


### PR DESCRIPTION
## Summary

- Document the Phase 2 authoring label lifecycle for the issue-authoring publication handoff.
- Add the same operational rule to the bundled `issue-authoring` skill workflow.
- Explain the discover-guard relationship, interruption behavior, and explicit execution boundary in the canonical issue-authoring docs.

Closes #537

## Recommended follow-up issues

- #538 should document the policy configuration keys for the authoring label name and stale age.

## Background

This change keeps publication-time label handling on the issue-authoring surface only. It intentionally does not change discover logic, schemas, or policy defaults.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `node scripts/audit-docs.mjs --check`
- `node scripts/validate-schemas.mjs`
- `node --test tests/*.mjs`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on the authoring label lifecycle in the issue authoring workflow: how the configured authoring label is resolved, ensured to exist before use, and applied to created or updated issues.
  * Clarified error and interrupt handling: label creation/application failures block publishing; issues must be made undiscoverable if post-create labeling fails; labels are removed only after the full set is published and explicit user confirmation to release the authoring hold.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/619)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->