### PR TITLE
docs(workshop): define log format conventions

### DIFF
--- a/docs/workshop/LOG-FORMAT.md
+++ b/docs/workshop/LOG-FORMAT.md
@@ -53,7 +53,7 @@ Example:
 
 ````markdown
 ```shell
-$ git status --short
+$ git status --short --branch
 ## issue/582-define-workshop-log-format-capture
 ```
 ````

--- a/docs/workshop/LOG-FORMAT.md
+++ b/docs/workshop/LOG-FORMAT.md
@@ -1,0 +1,113 @@
+# Workshop Log Format
+
+Workshop logs use the conventions below so separately captured segments
+can be assembled, rendered, and reviewed without reformatting. Treat each
+literal form as canonical unless a later workshop document explicitly
+changes it.
+
+## Timestamp Token
+
+Use this token anywhere a captured moment needs a timestamp:
+
+```text
+[YYYY-MM-DD HH:mm:ss JST]
+```
+
+Rules:
+
+- Use a four-digit year, two-digit month, two-digit day, and 24-hour
+  time.
+- Zero-pad every numeric field.
+- Use `JST` exactly; it means UTC+09:00 for workshop logs.
+- Do not replace the space with `T`, and do not replace `JST` with
+  `Z`, `+09:00`, or a local time zone name.
+
+Example:
+
+```text
+[2026-05-16 14:32:15 JST]
+```
+
+## Agent Response Block
+
+Wrap each captured agent response in a fenced code block with the
+`agent` info string. Do not add a prompt, speaker label, or timestamp
+inside the block.
+
+Example:
+
+````markdown
+```agent
+I will verify the claim before editing.
+```
+````
+
+## Command Block
+
+Wrap terminal commands and their relevant output in a fenced code block
+with the `shell` info string. Prefix every command entered by the
+operator with a dollar sign followed by one U+0020 space. Output lines,
+when included, immediately follow the command without a prompt prefix.
+
+Example:
+
+````markdown
+```shell
+$ git status --short
+## issue/582-define-workshop-log-format-capture
+```
+````
+
+## Section Header
+
+Start each major captured segment with a level-two heading that combines
+the timestamp token and a concise title:
+
+```text
+## [YYYY-MM-DD HH:mm:ss JST] Section Title
+```
+
+Use title case for the section title. Keep the timestamp in the same
+line as the heading text.
+
+Example:
+
+```markdown
+## [2026-05-16 14:35:00 JST] Claim Verification
+```
+
+## Abridgment Marker
+
+Use this marker when omitting consecutive output lines from a captured
+block:
+
+```text
+[... output truncated — N lines omitted ...]
+```
+
+Replace `N` with the exact decimal count of omitted lines. Keep the
+three dots, spaces, and em dash exactly as shown.
+
+Example:
+
+```text
+[... output truncated — 42 lines omitted ...]
+```
+
+## Annotation Note
+
+Use a blockquote note for short editorial comments that explain capture
+context without becoming part of the command or agent output:
+
+```text
+> **Note:** ...
+```
+
+Keep `Note` capitalized, keep the colon inside the bold text, and place
+one space after the colon before the note body.
+
+Example:
+
+```markdown
+> **Note:** The command was rerun after rebasing.
+```


### PR DESCRIPTION
## Summary

- Add `docs/workshop/LOG-FORMAT.md` with canonical workshop log conventions.
- Document exact examples for timestamps, agent response blocks, command blocks, section headings, abridgment markers, and note annotations.
- Clarify that the workshop timestamp token follows the issue example, with `JST` meaning UTC+09:00.

## Follow-up issues

None.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `node scripts/audit-docs.mjs --check`
- `node scripts/validate-schemas.mjs`
- `node --test tests/*.mjs`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `git diff --check origin/main...HEAD`

Closes #582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a workshop log format standards guide detailing timestamp conventions (JST, zero-padded), required section header structure (timestamp + title), formatting rules for agent response blocks and shell command/output blocks, an abridgment marker for omitted output lines, and a standardized annotation note style for inline notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->