### PR TITLE
docs(workshop): add workshop skeleton

### DIFF
--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -1,0 +1,76 @@
+# Build a VRChat Event Calendar with IDD
+
+<!-- cspell:words Defang VRChat -->
+
+This workshop follows an end-to-end IDD session that builds a realistic
+VRChat event calendar example. This page is currently a skeleton: later
+issues will replace the `[TODO]` stubs with edited log segments, visual
+assets, and full prose.
+
+Use the [workshop log format](LOG-FORMAT.md) when adding captured agent
+session excerpts.
+
+## What You Will Build
+
+By the end of the workshop, readers will understand how IDD turns a
+blank repository into a working event calendar application.
+
+Screenshot: [TODO: add example app screenshot from #601].
+
+Log segment: [TODO: link the unified build overview after #589].
+
+## Prerequisites
+
+This section will list the required local tools, GitHub access, and IDD
+setup assumptions before readers begin the workshop.
+
+Checklist: [TODO: fill in prerequisites in #591].
+
+## Prologue: Bootstrap
+
+This section will explain the chicken-and-egg bootstrap flow for applying
+idd-skill to a new example repository.
+
+Log segment: [TODO: link the Track A bootstrap log after #583].
+
+## Step 1: Development Environment
+
+This section will establish the local development foundation: Docker
+Compose, Next.js, TypeScript, Tailwind CSS, Prisma, tests, and CI.
+
+Log segment: [TODO: link the Track B infrastructure log after #584].
+
+## Step 2: Data Layer
+
+This section will introduce the event model, database migration, seed
+data, and Prisma client utility.
+
+Log segment: [TODO: link the Track C data layer log after #585].
+
+## Step 3: Backend API
+
+This section will walk through the event API routes, validation, creator
+token behavior, and update/delete flow.
+
+Log segment: [TODO: link the Track D backend API log after #586].
+
+## Step 4: Frontend
+
+This section will cover the event list, detail view, create/edit forms,
+delete behavior, filters, calendar view, and quality hardening work.
+
+Log segment: [TODO: link the Tracks E and F frontend log after #587].
+
+## Conclusion: What Was Built
+
+This section will summarize the finished application, the IDD loop
+metrics, and the example repository outcome.
+
+Metrics: [TODO: add final implementation metrics in #595].
+
+## What's Next
+
+This section will point readers toward deployment and extension ideas,
+including the optional Defang track.
+
+Next steps: [TODO: add Defang and feature-extension ideas in #596].


### PR DESCRIPTION
## Summary

- Add `docs/workshop/README.md` as the workshop entry point.
- Include the nine required sections in the #590 acceptance order.
- Leave future log segments, screenshots, metrics, and follow-up content as explicit `[TODO]` stubs.

## Self-review notes

- Scope is intentionally limited to the new workshop skeleton file.
- The only real Markdown link points to the existing `LOG-FORMAT.md`; future artifacts are non-link TODO stubs so this PR does not create broken links.
- Root README files and community documents are untouched.

## Validation

- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `node scripts/audit-docs.mjs --check`
- `node scripts/validate-schemas.mjs`
- `node --test tests/*.mjs` (539 tests)
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `git diff --check origin/main...HEAD`
- `test -f docs/workshop/README.md && rg -n '^## ' docs/workshop/README.md`

Closes #590


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a new workshop guide for "Build a VRChat Event Calendar with IDD" with a complete structure including prerequisites, bootstrap prologue, four main steps, conclusion, and optional advanced learning. The guide provides end-to-end instructions for building an event calendar application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->