### PR TITLE
docs: add workshop to docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # IDD Reference Manual
 
+<!-- cspell:words VRC VRChat -->
+
 This directory is the deeper reference manual for idd-skill. The root
 README is the adopter landing page; use this page when you need the
 operational details, maintenance notes, or background material behind
@@ -10,19 +12,20 @@ also serve as the source for a future GitHub Pages site.
 
 ## Start Here
 
-| Need                      | Read first                                              | Why it helps                                                    |
-| ------------------------- | ------------------------------------------------------- | --------------------------------------------------------------- |
-| Start adopting IDD        | [Getting started](getting-started.md)                   | Gives the shortest safe path from import to first loop.         |
-| Learn IDD vocabulary      | [Core concepts](concepts.md)                            | Explains the loop's claims, review, merge, and cleanup terms.   |
-| Customize IDD safely      | [Customization](customization.md)                       | Names the adopter policy surfaces and workflow edit points.     |
-| Inspect policy defaults   | [Policy constants](policy-constants.md)                 | Inventories distributed timing, wait, and loop defaults.        |
-| Run the IDD loop          | [IDD workflow guide](idd-workflow.md)                   | Maps agent entry points, phase files, and Copilot advisory use. |
-| Find detailed references  | [Detailed reference](reference.md)                      | Lists phase files and policy pages without duplicating rules.   |
-| Import IDD into a repo    | [Template onboarding][template-onboarding]              | Explains the portable template copy and placeholder flow.       |
-| Grant agent credentials   | [Permissions](permissions.md)                           | Defines access profiles, forbidden scopes, and threat controls. |
-| Choose PR review policy   | [Review policy profiles](idd-review-policy-profiles.md) | Names the default Copilot advisory policy and alternatives.     |
-| Understand the value prop | [Positioning](positioning.md)                           | Summarizes where idd-skill fits among adjacent tools.           |
-| Plan future publication   | [Pages strategy](pages-strategy.md)                     | Records the low-cost path toward GitHub Pages.                  |
+| Need                      | Read first                                                           | Why it helps                                                                |
+| ------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Follow a complete example | [Build a VRC Event Calendar with IDD (Workshop)](workshop/README.md) | Demonstrates the IDD loop by building a VRChat event calendar from scratch. |
+| Start adopting IDD        | [Getting started](getting-started.md)                                | Gives the shortest safe path from import to first loop.                     |
+| Learn IDD vocabulary      | [Core concepts](concepts.md)                                         | Explains the loop's claims, review, merge, and cleanup terms.               |
+| Customize IDD safely      | [Customization](customization.md)                                    | Names the adopter policy surfaces and workflow edit points.                 |
+| Inspect policy defaults   | [Policy constants](policy-constants.md)                              | Inventories distributed timing, wait, and loop defaults.                    |
+| Run the IDD loop          | [IDD workflow guide](idd-workflow.md)                                | Maps agent entry points, phase files, and Copilot advisory use.             |
+| Find detailed references  | [Detailed reference](reference.md)                                   | Lists phase files and policy pages without duplicating rules.               |
+| Import IDD into a repo    | [Template onboarding][template-onboarding]                           | Explains the portable template copy and placeholder flow.                   |
+| Grant agent credentials   | [Permissions](permissions.md)                                        | Defines access profiles, forbidden scopes, and threat controls.             |
+| Choose PR review policy   | [Review policy profiles](idd-review-policy-profiles.md)              | Names the default Copilot advisory policy and alternatives.                 |
+| Understand the value prop | [Positioning](positioning.md)                                        | Summarizes where idd-skill fits among adjacent tools.                       |
+| Plan future publication   | [Pages strategy](pages-strategy.md)                                  | Records the low-cost path toward GitHub Pages.                              |
 
 ## Reference Map
 


### PR DESCRIPTION
## Summary

- Add the workshop as the first entry in the docs `Start Here` table.
- Link `Build a VRC Event Calendar with IDD (Workshop)` to `docs/workshop/README.md` via `workshop/README.md`.
- Add a file-local cspell word list for the required VRC/VRChat terms.

## Self-review notes

- Scope is limited to `docs/index.md`.
- The target workshop file exists on the branch, so the relative link resolves.
- Root README files and community documents are untouched.

## Validation

- `pnpm install --frozen-lockfile`
- `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`
- `node scripts/audit-docs.mjs --check`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- `pnpm lint:minimum` (includes 539 node tests)
- `node scripts/validate-schemas.mjs`
- `test -f docs/workshop/README.md && rg -n '\[Build a VRC Event Calendar with IDD \(Workshop\)\]\(workshop/README\.md\)' docs/index.md`
- `git diff --check origin/main...HEAD`

Closes #603


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned the "Start Here" section with an improved three-column table layout for better readability and organization.
  * Added guidance for following a complete example with a Workshop resource link.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->