### PR TITLE
docs(workshop): add recording toolchain smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,9 @@ pnpm-lock.yaml.*
 # OpenAI Codex sandbox
 .codex/
 
+### Workshop recording outputs ###
+docs/workshop/assets/recordings/*.gif
+
 ### NeoVim ###
 # Project-local NeoVim config
 .nvim.lua

--- a/docs/workshop/assets/recordings/README.md
+++ b/docs/workshop/assets/recordings/README.md
@@ -1,0 +1,32 @@
+# Workshop Recording Toolchain
+
+This directory stores source tapes for workshop terminal recordings.
+Commit `.tape` files so recordings can be reproduced, but keep generated
+GIF files out of git.
+
+## Prerequisites
+
+- [VHS](https://github.com/charmbracelet/vhs)
+- FFmpeg, installed automatically by most VHS package-manager options
+
+On macOS or Linux with Homebrew:
+
+```shell
+brew install vhs
+```
+
+## Smoke Test
+
+Render the smoke-test recording from this directory:
+
+```shell
+cd docs/workshop/assets/recordings
+vhs test.tape
+```
+
+The command writes `test.gif` next to `test.tape`. The generated GIF is
+ignored by git because recordings are build artifacts; only the tape
+source should be committed.
+
+Use this smoke test before creating longer workshop animations so local
+font, terminal, and encoder settings are known to work.

--- a/docs/workshop/assets/recordings/README.md
+++ b/docs/workshop/assets/recordings/README.md
@@ -28,5 +28,9 @@ The command writes `test.gif` next to `test.tape`. The generated GIF is
 ignored by git because recordings are build artifacts; only the tape
 source should be committed.
 
+The first VHS run on a new machine may take longer while it prepares a
+browser cache. After that one-time setup, the smoke test should render
+in a few seconds.
+
 Use this smoke test before creating longer workshop animations so local
 font, terminal, and encoder settings are known to work.

--- a/docs/workshop/assets/recordings/test.tape
+++ b/docs/workshop/assets/recordings/test.tape
@@ -1,0 +1,13 @@
+Output test.gif
+
+Set Shell "bash"
+Set FontSize 16
+Set Width 640
+Set Height 240
+Set Framerate 8
+Set PlaybackSpeed 4.0
+Set TypingSpeed 1ms
+
+Type "printf 'idd-skill VHS smoke test\\nclaim -> work -> PR -> merge\\n'"
+Enter
+Sleep 250ms


### PR DESCRIPTION
## Summary

- Add a workshop recording workspace under `docs/workshop/assets/recordings/`.
- Document the local VHS render workflow, prerequisites, output location, and generated-artifact rule.
- Add a deterministic `test.tape` smoke test and ignore generated recording GIFs.

## Validation

- `pnpm lint:minimum`
- `cd docs/workshop/assets/recordings && vhs validate test.tape`
- `cd docs/workshop/assets/recordings && vhs test.tape` (`render_ms=2371`, `bytes=8391`)
- `git diff --check origin/main...HEAD`

## Follow-up issues

None recommended.

## Background

The first VHS run on a fresh machine may take longer while browser cache is prepared, so the README documents that one-time warmup. The committed tape remains intentionally small; generated GIFs are ignored and should be rebuilt locally.

Closes #598


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for the workshop recording toolchain, including setup instructions and contribution guidelines.

* **Chores**
  * Configured version control to exclude auto-generated recording output files.
  * Added test configuration for the workshop recording system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->