### PR TITLE
fix: support gh pagination without --slurp

### DIFF
--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -6,6 +6,7 @@ import { readAdvisoryWaitPolicy } from "./advisory-wait-policy.mjs";
 import {
   buildAdvisoryWaitSummary,
   normalizeTrustedMarkerLogins,
+  parsePaginatedGhNdjson,
 } from "./protocol-helpers.mjs";
 
 const args = parseArgs(process.argv.slice(2));
@@ -201,8 +202,11 @@ function safeGhText(args) {
 function ghApiJson(path, paginate = false, extraArgs = []) {
   const args = ["api", path, ...extraArgs];
   if (paginate) {
-    args.splice(1, 0, "--paginate", "--slurp");
-    return JSON.parse(execFileSync("gh", args, { encoding: "utf8" })).flat();
+    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+    // via apt, so keep the NDJSON-compatible form here.
+    args.splice(1, 0, "--paginate", "--jq", ".[]");
+    return parsePaginatedGhNdjson(execFileSync("gh", args, { encoding: "utf8" }));
   }
   return JSON.parse(execFileSync("gh", args, { encoding: "utf8" }));
 }

--- a/scripts/force-handoff.mjs
+++ b/scripts/force-handoff.mjs
@@ -6,6 +6,7 @@ import { createInterface } from "node:readline";
 import { pathToFileURL } from "node:url";
 
 import { planHandoff } from "./forced-handoff-marker.mjs";
+import { parsePaginatedGhNdjson } from "./protocol-helpers.mjs";
 
 const APPROVAL_ACTOR_POLICIES = new Set([
   "owners-and-maintainers-only",
@@ -58,7 +59,7 @@ export async function runHandoff(options = {}) {
 
   const issueComments = fetchIssueComments
     ? await fetchIssueComments(issueNumber)
-    : ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${issueNumber}/comments`], true).flat();
+    : ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${issueNumber}/comments`], true);
 
   const trustedMarkerLogins = givenTrustedLogins
     ?? buildTrustedMarkerLogins(owner, name, forcedBy, issueComments);
@@ -197,7 +198,11 @@ function safeGhText(args) {
 function ghJson(args, slurp = false) {
   const finalArgs = [...args];
   if (slurp) {
-    finalArgs.splice(1, 0, "--slurp");
+    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+    // via apt, so keep the NDJSON-compatible form here.
+    finalArgs.splice(1, 0, "--jq", ".[]");
+    return parsePaginatedGhNdjson(execFileSync("gh", finalArgs, { encoding: "utf8" }));
   }
   return JSON.parse(execFileSync("gh", finalArgs, { encoding: "utf8" }));
 }

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -5,7 +5,11 @@ import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-import { renderForcedHandoffComment, summarizeClaimValidation } from "./protocol-helpers.mjs";
+import {
+  parsePaginatedGhNdjson,
+  renderForcedHandoffComment,
+  summarizeClaimValidation,
+} from "./protocol-helpers.mjs";
 import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
 
 export function generateSuccessorIds(baseAgentId) {
@@ -143,7 +147,7 @@ export function main(argv = process.argv.slice(2)) {
   if (args.plan) {
     const repoRef = args.repo ?? ghText(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
     const { owner, name } = parseOwnerRepo(repoRef);
-    const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true).flat();
+    const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true);
     const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
     const trustedMarkerLogins = buildTrustedMarkerLogins(owner, name, viewerLogin, args.trustedMarkerLogins, issueComments);
     const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
@@ -200,7 +204,7 @@ export function main(argv = process.argv.slice(2)) {
   if (readForcedHandoffMode() !== "human-gated") {
     throw new Error("forced-handoff mode is not human-gated; marker generation is disabled");
   }
-  const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true).flat();
+  const issueComments = ghJson(["api", "--paginate", `repos/${owner}/${name}/issues/${args.issueNumber}/comments`], true);
   const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
   const trustedMarkerLogins = buildTrustedMarkerLogins(owner, name, viewerLogin, args.trustedMarkerLogins, issueComments);
   const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
@@ -461,7 +465,11 @@ function parseOwnerRepo(value) {
 function ghJson(args, slurp = false) {
   const finalArgs = [...args];
   if (slurp) {
-    finalArgs.splice(1, 0, "--slurp");
+    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+    // via apt, so keep the NDJSON-compatible form here.
+    finalArgs.splice(1, 0, "--jq", ".[]");
+    return parsePaginatedGhNdjson(execFileSync("gh", finalArgs, { encoding: "utf8" }));
   }
   return JSON.parse(execFileSync("gh", finalArgs, { encoding: "utf8" }));
 }

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 
 import {
   normalizeTrustedMarkerLogins,
+  parsePaginatedGhNdjson,
   planLiveStatusDigestUpsert,
   summarizeClaimValidation,
 } from "./protocol-helpers.mjs";
@@ -147,13 +148,17 @@ function updateReportFromPlan(report, planned) {
 }
 
 function fetchIssueComments(owner, repo, number) {
-  const result = ghJson([
+  // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+  // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+  // via apt, so keep the NDJSON-compatible form here.
+  const result = parsePaginatedGhNdjson(execFileSync("gh", [
     "api",
     "--paginate",
-    "--slurp",
+    "--jq",
+    ".[]",
     `repos/${owner}/${repo}/issues/${number}/comments`,
-  ]);
-  return result.flat().map((comment) => ({
+  ], { encoding: "utf8" }));
+  return result.map((comment) => ({
     id: comment.id,
     url: comment.url,
     html_url: comment.html_url,

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -9,6 +9,7 @@ import {
   deriveIddAgentLogins,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
+  parsePaginatedGhNdjson,
   resolveCodeownersForFiles,
   resolveRulesetDetailPath,
   selectCodeownersText,
@@ -562,14 +563,17 @@ function safeGhText(args) {
 function ghApiJson(path, paginate = false, extraArgs = [], options = {}) {
   const args = ["api", path, ...extraArgs];
   if (paginate) {
-    args.push("--paginate", "--slurp");
+    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+    // via apt, so keep the NDJSON-compatible form here.
+    args.push("--paginate", "--jq", ".[]");
   }
   const raw = runGh(args, options).trim();
   if (!raw) {
     return paginate ? [] : {};
   }
   if (paginate) {
-    return JSON.parse(raw).flat();
+    return parsePaginatedGhNdjson(raw);
   }
   return JSON.parse(raw);
 }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -87,6 +87,20 @@ const AMD_MARKER_PATTERN = /^\*\*Awaiting maintainer decision\*\*/i;
 const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(["issue-only", "issue-plus-pr"]);
 const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/;
 
+export function parsePaginatedGhNdjson(raw) {
+  const text = String(raw ?? "").trim();
+  if (!text) {
+    return [];
+  }
+  return text
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .flatMap((line) => {
+      const value = JSON.parse(line);
+      return Array.isArray(value) ? value : [value];
+    });
+}
+
 export function parseClaimComment(body, createdAt) {
   const match = body.trimEnd().match(
     new RegExp(

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -4,6 +4,8 @@ import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 
+import { parsePaginatedGhNdjson } from "./protocol-helpers.mjs";
+
 const RUNNING_STATES = new Set(["queued", "in_progress", "pending", "waiting", "requested"]);
 const FAILURE_STATES = new Set(["failure", "cancelled", "timed_out"]);
 const PASS_EQUIVALENT_STATES = new Set(["success", "skipped", "neutral", "not_applicable"]);
@@ -401,17 +403,19 @@ function ghApiGraphqlJson({ query, variables }) {
 function ghApiJson(path, paginate = false) {
   const args = ["api", path];
   if (paginate) {
-    args.push("--paginate");
-    args.push("--slurp");
+    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
+    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
+    // via apt, so keep the NDJSON-compatible form here.
+    args.push("--paginate", "--jq", ".[]");
   }
-  const parsed = JSON.parse(runGh(args).trim() || "[]");
+  const raw = runGh(args).trim();
   if (!paginate) {
-    return parsed;
+    return JSON.parse(raw || "[]");
   }
-  if (!Array.isArray(parsed)) {
+  if (!raw) {
     return [];
   }
-  return parsed.flatMap((entry) => (Array.isArray(entry) ? entry : [entry]));
+  return parsePaginatedGhNdjson(raw);
 }
 
 function ghJson(args, options = {}) {

--- a/tests/protocol-helpers-gh-pagination.test.mjs
+++ b/tests/protocol-helpers-gh-pagination.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { parsePaginatedGhNdjson } from "../scripts/protocol-helpers.mjs";
+
+test("parsePaginatedGhNdjson preserves object order across lines", () => {
+  const raw = [
+    "{\"id\":1,\"name\":\"first\"}",
+    "{\"id\":2,\"name\":\"second\"}",
+    "{\"id\":3,\"name\":\"third\"}",
+  ].join("\n");
+
+  assert.deepEqual(parsePaginatedGhNdjson(raw), [
+    { id: 1, name: "first" },
+    { id: 2, name: "second" },
+    { id: 3, name: "third" },
+  ]);
+});
+
+test("parsePaginatedGhNdjson ignores blank lines and flattens arrays defensively", () => {
+  const raw = "\n{\"id\":1}\n\n[{\"id\":2},{\"id\":3}]\n";
+
+  assert.deepEqual(parsePaginatedGhNdjson(raw), [
+    { id: 1 },
+    { id: 2 },
+    { id: 3 },
+  ]);
+});
+
+test("parsePaginatedGhNdjson returns an empty array for empty output", () => {
+  assert.deepEqual(parsePaginatedGhNdjson(" \n "), []);
+});


### PR DESCRIPTION
## Summary
- replace the six affected `gh api --slurp` pagination paths with `--paginate --jq ".[]"` plus NDJSON parsing
- keep explicit compatibility comments at each changed helper boundary and add focused parser coverage
- preserve the existing flat-array output contracts for helper scripts that consume paginated GitHub API responses

## Background
Ubuntu 24.04 LTS ships `gh` v2.45.0 via `apt`, which predates `--slurp`. The affected helper paths failed before emitting evidence, which can stall the IDD loop on a supported environment.

## Validation
- `node scripts/audit-docs.mjs --check`
- `node --test tests/*.mjs`
- `node scripts/live-status-digest.mjs --help`
- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`

Closes #629
Refs #630

## Follow-up
- none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated GitHub API pagination handling across multiple deployment scripts to use a consistent NDJSON-based approach, improving compatibility with different GitHub CLI versions.

* **Tests**
  * Added comprehensive test coverage for pagination parsing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->