### PR TITLE
docs(workshop): add prerequisites overview

### DIFF
--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -27,7 +27,8 @@ IDD decisions, while the repository shows the app those loops created.
 Screenshot placeholder for #601: the final event-list screenshot will be
 inserted here after the example app screenshots are captured.
 
-Log segment: [TODO: link the unified build overview after #589].
+Build overview placeholder for #589: the unified workshop log link will
+be inserted here after the master log is compiled.
 
 ## Prerequisites
 

--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -37,12 +37,19 @@ agents use during the workshop:
 
 - Docker Desktop, or an equivalent Docker Engine setup with Docker
   Compose support, for PostgreSQL and the local app stack.
-- Node.js 22 or newer, including the bundled npm CLI, matching the
-  example app and this repository's supported runtime.
+- Node.js 22.22.2 or newer on the 22.x line, or Node.js 24 or newer,
+  matching this repository's supported runtime.
+- Corepack with pnpm 10 enabled for this repository's validation
+  commands; Node.js also includes npm for example-app commands that use
+  npm.
 - Git and a GitHub account that can create branches, open pull requests,
-  and read CI results.
+  post issue and PR comments for IDD markers, request reviews, and read
+  CI results.
 - GitHub CLI (`gh`), authenticated for the account you will use during
   the workshop.
+- `jq` and `curl`, or equivalent JSON and REST-client tools, for the IDD
+  phases that inspect GitHub API responses or post operational markers
+  directly.
 - Copilot, Codex, or another coding agent that can follow the IDD phase
   instructions and operate through GitHub issues and pull requests.
 

--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -17,12 +17,12 @@ repository into a working VRChat Event Calendar MVP. The app lists
 events, shows event details, supports creator-owned edits, and gives
 readers enough local infrastructure to run tests before each merge.
 
-The example repository target is
+The planned example repository URL is
 [`kurone-kito/vrc-event-calendar`](https://github.com/kurone-kito/vrc-event-calendar),
-the real artifact produced by the workshop roadmap. Treat it as the
-"look over the shoulder" companion to the edited narrative once Track A
-has published it: the workshop explains the IDD decisions, while the
-repository shows the app those loops created.
+the real artifact produced by the workshop roadmap after #547 publishes
+it. Treat that repository as the "look over the shoulder" companion to
+the edited narrative once Track A is complete: the workshop explains the
+IDD decisions, while the repository shows the app those loops created.
 
 Screenshot placeholder for #601: the final event-list screenshot will be
 inserted here after the example app screenshots are captured.
@@ -36,8 +36,8 @@ agents use during the workshop:
 
 - Docker Desktop, or an equivalent Docker Engine setup with Docker
   Compose support, for PostgreSQL and the local app stack.
-- Node.js 22 or newer, matching the example app and this repository's
-  supported runtime.
+- Node.js 22 or newer, including the bundled npm CLI, matching the
+  example app and this repository's supported runtime.
 - Git and a GitHub account that can create branches, open pull requests,
   and read CI results.
 - GitHub CLI (`gh`), authenticated for the account you will use during

--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -12,19 +12,43 @@ session excerpts.
 
 ## What You Will Build
 
-By the end of the workshop, readers will understand how IDD turns a
-blank repository into a working event calendar application.
+By the end of the workshop, you will have watched IDD turn a blank
+repository into a working VRChat Event Calendar MVP. The app lists
+events, shows event details, supports creator-owned edits, and gives
+readers enough local infrastructure to run tests before each merge.
 
-Screenshot: [TODO: add example app screenshot from #601].
+The example repository target is
+[`kurone-kito/vrc-event-calendar`](https://github.com/kurone-kito/vrc-event-calendar),
+the real artifact produced by the workshop roadmap. Treat it as the
+"look over the shoulder" companion to the edited narrative once Track A
+has published it: the workshop explains the IDD decisions, while the
+repository shows the app those loops created.
+
+Screenshot placeholder for #601: the final event-list screenshot will be
+inserted here after the example app screenshots are captured.
 
 Log segment: [TODO: link the unified build overview after #589].
 
 ## Prerequisites
 
-This section will list the required local tools, GitHub access, and IDD
-setup assumptions before readers begin the workshop.
+Before starting, make sure you can run the same baseline tools the
+agents use during the workshop:
 
-Checklist: [TODO: fill in prerequisites in #591].
+- Docker Desktop, or an equivalent Docker Engine setup with Docker
+  Compose support, for PostgreSQL and the local app stack.
+- Node.js 22 or newer, matching the example app and this repository's
+  supported runtime.
+- Git and a GitHub account that can create branches, open pull requests,
+  and read CI results.
+- GitHub CLI (`gh`), authenticated for the account you will use during
+  the workshop.
+- Copilot, Codex, or another coding agent that can follow the IDD phase
+  instructions and operate through GitHub issues and pull requests.
+
+The workshop also introduces PostgreSQL, Prisma, Tailwind CSS, Vitest,
+and Playwright as it builds the app. You do not need to install each of
+those separately before reading; the setup steps explain where they enter
+the project.
 
 ## Prologue: Bootstrap
 


### PR DESCRIPTION
## Summary

- Writes the workshop's "What You Will Build" section with the VRC Event Calendar MVP scope and intended example repository link.
- Replaces the prerequisites stub with a reader checklist covering Docker, Node.js 22+, Git/GitHub access, `gh`, and agent access.
- Converts the screenshot and build-log placeholders into explicit follow-up placeholders tied to #601 and #589.

Closes #591

## Validation

- `pnpm run lint:fix`
- commit hook: `pnpm run lint:minimum` (542 tests, cspell, markdownlint)
- `pnpm exec dprint check "**/*.md"`
- `pnpm exec markdownlint-cli2 "**/*.md"`
- `pnpm exec cspell lint "**" --no-progress`
- C-phase self-review acceptance script for #591 checklist

## Follow-up Issues

- #547 publishes the planned `kurone-kito/vrc-event-calendar` repository URL referenced here.
- #589 will provide the unified workshop log link placeholder.
- #601 will provide the final screenshot placeholder.

## Notes

The example repository URL is intentionally described as planned because the linked repository is produced by Track A and is not assumed to exist before #547 closes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded workshop README with a concrete end-to-end outcome and execution plan for building the VRChat Event Calendar MVP
  * Added reference to a companion example repository and placeholders for final screenshots and build logs
  * Rewrote prerequisites into a specific baseline tooling and setup checklist and clarified which technologies will be introduced during the workshop

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->