### PR TITLE
docs(workshop): align example repo wording with live repo

### DIFF
--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -12,17 +12,20 @@ session excerpts.
 
 ## What You Will Build
 
-By the end of the workshop, you will have watched IDD turn a blank
+By the end of the workshop, you will have watched IDD turn a fresh
 repository into a working VRChat Event Calendar MVP. The app lists
 events, shows event details, supports creator-owned edits, and gives
 readers enough local infrastructure to run tests before each merge.
 
-The planned example repository URL is
-[`kurone-kito/vrc-event-calendar`](https://github.com/kurone-kito/vrc-event-calendar),
-the real artifact produced by the workshop roadmap after #547 publishes
-it. Treat that repository as the "look over the shoulder" companion to
-the edited narrative once Track A is complete: the workshop explains the
-IDD decisions, while the repository shows the app those loops created.
+The example repository lives at
+[`kurone-kito/vrc-event-calendar`](https://github.com/kurone-kito/vrc-event-calendar).
+Track A now treats that public repository as the live companion
+artifact for the workshop. It starts from a template baseline and will
+evolve into the final VRChat Event Calendar app as the workshop issues
+land. Treat it as the "look over the shoulder" counterpart to this
+edited narrative: the workshop explains the IDD decisions, while the
+repository shows the code and configuration those loops build over
+time.
 
 Screenshot placeholder for #601: the final event-list screenshot will be
 inserted here after the example app screenshots are captured.


### PR DESCRIPTION
## Summary
- update the workshop overview so `kurone-kito/vrc-event-calendar` is described as a live public repository instead of a future artifact
- clarify that the example repo starts from the template baseline and will evolve as Track A issues land
- tighten the surrounding wording so the workshop promise stays truthful for a template-derived starting point

## Acceptance evidence
- `https://github.com/kurone-kito/vrc-event-calendar` exists
- the repository visibility is public
- the default branch is `main`
- baseline template files such as `README.md` and `.gitignore` are present

## Background
The repository for #547 now exists, but `docs/workshop/README.md` still carried wording that only made sense before the repository was created. This PR keeps the workshop narrative aligned with the live external artifact without absorbing later Track A implementation work.

## Follow-ups
- none in this PR; later Track A issues will add the example app implementation itself

Closes #547


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced workshop documentation to clarify the relationship between the example repository and workshop content. Updated narrative describes building a VRChat Event Calendar MVP, with the example repository serving as the live artifact alongside workshop instructions for hands-on learning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->