### PR TITLE
docs(readme): add workshop example section

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,6 +15,16 @@ IDD Skill は、リポジトリへ移植できる Issue-Driven Development
 選択したマージポリシーに従ってマージと後片づけまで進めます。ループ全体は、
 リポジトリ内の Markdown で書かれた指示ファイルとして管理されます。
 
+![IDD workshop preview](docs/workshop/assets/workshop-header.gif)
+
+## 実例で学ぶ
+
+[VRChat Event Calendar ワークショップ](docs/workshop/README.md) を読むと、
+IDD が実在のアプリを最初から最後まで組み上げる流れを追えます。実装結果は
+対応する実例リポジトリ
+[`kurone-kito/vrc-event-calendar`](https://github.com/kurone-kito/vrc-event-calendar)
+でも確認できます。
+
 ## 最初の入口（ペルソナ別ナビゲーション）
 
 初見の場合は、目的に合う入口から始めてください:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ branch, open a PR, handle review feedback, wait for CI, merge, and clean
 up according to the repository's selected merge policy. The whole loop
 lives in your repo as Markdown instruction files.
 
+![IDD workshop preview](docs/workshop/assets/workshop-header.gif)
+
+## Learn by Example
+
+Follow the [VRChat Event Calendar workshop](docs/workshop/README.md) to
+watch IDD build a real app end to end, then inspect the live companion
+repository at
+[`kurone-kito/vrc-event-calendar`](https://github.com/kurone-kito/vrc-event-calendar).
+
 ## Start here (persona navigation)
 
 If this is your first visit, choose the path that matches your goal:


### PR DESCRIPTION
## Summary

- add the workshop header GIF near the top of both README variants
- add a matching workshop discovery section in English and Japanese
- link both READMEs to the workshop document and the public example repository

Closes #604

## Background

A prior #604 attempt stopped because `kurone-kito/vrc-event-calendar` did not yet resolve. That blocker is now cleared: the companion example repository exists publicly on `main`, so the README links can ship without pointing readers at a broken destination.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Learn by Example" sections to both English and Japanese README files with references to workshop materials and a companion repository to guide users through practical examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->