### PR TITLE
docs: codify human-dependency isolation in issue authoring

### DIFF
--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -219,6 +219,38 @@ Recommended routing rules:
 - if the work does not belong in this repository, route to
   `out-of-scope`
 
+## Human-dependency isolation
+
+Treat unresolved human dependency as a side effect that should be
+isolated away from ready execution issues whenever possible.
+
+- **Front-load** human-dependent work when coding cannot start safely
+  until a person provides a decision, credential, permission,
+  maintainer-only action, external setup, or policy choice, or until an
+  unavailable system becomes usable again.
+- **Back-load** human-dependent work when the remaining dependency is
+  subjective review, publication choice, optional polish, or another
+  post-implementation judgment that should not block an otherwise
+  autonomous core change.
+- Keep the central execution issue as close as possible to a pure
+  autonomous unit: clear repository-local scope, no hidden human handoff
+  in the implementation steps or acceptance criteria, and objective
+  verification.
+- Preserve unavoidable human-dependent work in an explicit stable
+  bucket, dependency edge, or approval-needed hold rather than mixing it
+  into a ready issue.
+- Route unresolved choices to `needs-decision`, route waiting on people,
+  credentials, maintainer-only actions, or unavailable systems to
+  `blocked-by-human`, use `deferred` when timing or decomposition is not
+  strong enough yet, and keep approval-gated ready work in the
+  approval-needed hold instead of the normal ready-to-start set.
+- If a task cannot be expressed without unresolved human coordination in
+  the middle of implementation, it is not yet `ready`.
+
+This principle complements the execution axes rather than replacing
+them: it is a practical way to protect autonomous completion and clear
+verification during issue drafting.
+
 ## Alignment with A4.5 Suitability Gate
 
 The IDD discover phase uses an A4.5 pre-claim suitability gate that
@@ -562,6 +594,9 @@ Before reporting or publishing issue drafts, the skill should verify:
 
 - each execution-ready issue passes limited scope, clear verification,
   and autonomous completion
+- no execution-ready issue hides unresolved human dependency that
+  belongs in `needs-decision`, `blocked-by-human`, `deferred`, or the
+  approval-needed fallback
 - each deferred, blocked, or decision-dependent item was preserved in a
   stable bucket instead of being dropped
 - each roadmap has one roadmap marker and uses task-list links for child

--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -96,6 +96,8 @@ needs-decision, blocked-by-human, and out-of-scope.
 
 - Preserve low-readiness work in stable buckets instead of dropping it.
 - Keep acceptance criteria explicitly verifiable.
+- Keep human-dependent setup, review, and approval work isolated from
+  ready execution issues whenever possible.
 - Link every active child issue from its roadmap body.
 - Justify each dependency edge and keep independent sibling work as
   roadmap task-list entries.

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -175,6 +175,38 @@ route the draft to the
 approval-needed fallback bucket instead of the normal ready-to-start
 set.
 
+## Human-dependency isolation
+
+Treat unresolved human dependency as a side effect that should be
+isolated away from ready execution issues whenever possible.
+
+- **Front-load** human-dependent work when coding cannot start safely
+  until a person provides a decision, credential, permission,
+  maintainer-only action, external setup, or policy choice, or until an
+  unavailable system becomes usable again.
+- **Back-load** human-dependent work when the remaining dependency is
+  subjective review, publication choice, optional polish, or another
+  post-implementation judgment that should not block an otherwise
+  autonomous core change.
+- Keep the central execution issue as close as possible to a pure
+  autonomous unit: clear repository-local scope, no hidden human handoff
+  in the implementation steps or acceptance criteria, and objective
+  verification.
+- Preserve unavoidable human-dependent work in an explicit stable
+  bucket, dependency edge, or approval-needed hold rather than mixing it
+  into a ready issue.
+- Route unresolved choices to `needs-decision`, route waiting on people,
+  credentials, maintainer-only actions, or unavailable systems to
+  `blocked-by-human`, use `deferred` when timing or decomposition is not
+  strong enough yet, and keep approval-gated ready work in the
+  approval-needed hold instead of the normal ready-to-start set.
+- If a task cannot be expressed without unresolved human coordination in
+  the middle of implementation, it is not yet `ready`.
+
+This principle complements the execution axes rather than replacing
+them: it is a practical way to protect autonomous completion and clear
+verification during issue drafting.
+
 ## Dependency minimization
 
 Encode a dependency edge only when it reflects a true correctness,
@@ -310,6 +342,9 @@ Pre-publish validation checklist:
    in issue body
 3. **Uniqueness**: Reuse-first check passed; no duplicate or superseded
    work
+4. **Human dependency isolation**: Ready issues do not hide unresolved
+   decisions, credentials, subjective approvals, or mid-implementation
+   human handoffs
 
 If any check is uncertain, route the issue to `needs-decision` or
 `blocked-by-human` during drafting instead of publishing a

--- a/tests/issue-authoring-specificity.test.mjs
+++ b/tests/issue-authoring-specificity.test.mjs
@@ -108,6 +108,60 @@ test("nested roadmap guidance keeps coordination-node rules", () => {
   }
 });
 
+test("human-dependency isolation guidance stays synced between canonical and bundled contract", () => {
+  const canonicalFile = "docs/issue-authoring-skill.md";
+  const bundledFile = "skills/issue-authoring/references/contract.md";
+  const canonical = readText(canonicalFile);
+  const bundled = readText(bundledFile);
+
+  assert.equal(
+    extractTopLevelSection(
+      canonical,
+      canonicalFile,
+      "## Human-dependency isolation",
+    ),
+    extractTopLevelSection(
+      bundled,
+      bundledFile,
+      "## Human-dependency isolation",
+    ),
+    `canonical and bundled human-dependency isolation guidance must stay in sync (${canonicalFile} vs ${bundledFile})`,
+  );
+});
+
+test("human-dependency isolation guidance keeps the front-load and back-load rules", () => {
+  for (const file of [
+    "docs/issue-authoring-skill.md",
+    "skills/issue-authoring/references/contract.md",
+  ]) {
+    const section = extractTopLevelSection(
+      readText(file),
+      file,
+      "## Human-dependency isolation",
+    );
+    const normalizedSection = normalizeWhitespace(section);
+
+    for (const needle of [
+      "Treat unresolved human dependency as a side effect",
+      "**Front-load** human-dependent work",
+      "**Back-load** human-dependent work",
+      "maintainer-only action",
+      "unavailable system becomes usable again",
+      "Route unresolved choices to `needs-decision`",
+      "`blocked-by-human`",
+      "`deferred`",
+      "approval-needed hold",
+      "it is not yet `ready`",
+      "protect autonomous completion and clear verification",
+    ]) {
+      assert.ok(
+        normalizedSection.includes(normalizeWhitespace(needle)),
+        `${file} must keep human-dependency-isolation phrase: ${needle}`,
+      );
+    }
+  }
+});
+
 test("dependency minimization guidance keeps the edge-justification rules", () => {
   for (const file of [
     "docs/issue-authoring-skill.md",


### PR DESCRIPTION
## Summary
- add a named human-dependency isolation principle to the canonical and bundled issue-authoring contracts
- connect the principle directly to `needs-decision`, `blocked-by-human`, `deferred`, and the approval-needed fallback
- extend the issue-authoring sync tests so the shared guidance stays aligned

## Validation
- `pnpm run lint:minimum`
- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`

## Self-review
- checked the issue acceptance criteria against the final text and tightened the principle so it explicitly covers unavailable systems and maintainer-only actions
- kept scope inside #646 and avoided draft-pattern or discover-policy changes that belong in follow-up issues

Closes #646

## Follow-up
- #647 adds concrete authoring patterns built on this contract language
- #648 can extend validation around hidden human dependencies
- Parent roadmap: #645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance to isolate unresolved human dependencies from execution-ready issues, with routing recommendations for blocked work, decisions, deferrals, and approval needs.
  * Extended the pre-publish validation checklist to ensure ready issues do not hide human-dependent work or mid-implementation handoffs.

* **Tests**
  * Added tests to validate consistency of the human-dependency isolation guidance across documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->