### PR TITLE
docs(authoring): define nested roadmap contract

### DIFF
--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -426,6 +426,36 @@ for a separate roadmap to close before it becomes startable:
 Do not use `idd-skill-blocked-by` to group children under the roadmap
 that already owns them. Grouping belongs in the roadmap task list.
 
+## Nested roadmap nodes
+
+Use a nested roadmap when one roadmap track needs its own coordination
+boundary, active child list, or multi-session handoff. A nested roadmap
+is still a roadmap node, not a normal execution candidate.
+
+Authoring rules:
+
+- reference the nested roadmap from the parent roadmap task list instead
+  of hiding it in prose
+- give the nested roadmap its own roadmap marker and `## Tracks` section
+  that links the active child work it coordinates
+- treat the nested roadmap as a coordination/audit node for discovery
+  and roadmap audit; do not draft it as normal A3/A4/A5 execution work
+- use two-level or three-level nesting only when the intermediate
+  roadmap has its own active child work or handoff boundary
+- do not use `Blocked by #NNN` or
+  `<!-- <marker-prefix>-blocked-by: ... -->` only to group leaf issues
+  under an active nested roadmap; reserve those encodings for true
+  execution dependencies or sequential roadmap dependencies between
+  separate roadmaps
+
+Validation expectations:
+
+- each nested roadmap node is linked from its parent roadmap task list
+- each nested roadmap node links its own active child work from its body
+- cycles, duplicate references, and closed intermediate roadmaps with
+  hidden open descendants must be surfaced as validation failures or
+  explicit follow-up notes, not silently normalized away
+
 ## Draft schemas
 
 The following schemas are normative. The skill may add small
@@ -486,12 +516,15 @@ Recommended content inside `## Tracks`:
 
 Validation expectations:
 
-- every active child issue is referenced from the roadmap body
+- every active child issue or nested roadmap node is referenced from the
+  roadmap body
 - the roadmap explains why multiple issues exist instead of hiding them
   as narrative text
 - dependency notes distinguish between active grouping and true
   sequential blocking
 - each dependency edge is justified and preserves natural cohesion
+- nested roadmap entries stay identifiable as coordination/audit nodes
+  instead of normal execution leaves
 - the roadmap can survive multi-session handoffs without relying on
   private session memory
 
@@ -533,10 +566,15 @@ Before reporting or publishing issue drafts, the skill should verify:
   stable bucket instead of being dropped
 - each roadmap has one roadmap marker and uses task-list links for child
   issues
+- each nested roadmap node is linked from the parent roadmap task list
+  and links its own active child work
+- each nested roadmap remains identifiable as a coordination/audit node
+  instead of a normal execution candidate
 - each dependency edge is justified and preserves natural cohesion
 - each `Blocked by #NNN` reference resolves to the intended issue
 - each `idd-skill-blocked-by` marker points to a real roadmap and is
-  used only for true sequential dependencies
+  used only for true sequential dependencies, never to group nested
+  roadmap children
 - each issue body is explicit enough that a later discover pass can
   decide whether the issue is ready without reconstructing hidden
   context

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -194,6 +194,36 @@ When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves
 natural cohesion.
 
+## Nested roadmap nodes
+
+Use a nested roadmap when one roadmap track needs its own coordination
+boundary, active child list, or multi-session handoff. A nested roadmap
+is still a roadmap node, not a normal execution candidate.
+
+Authoring rules:
+
+- reference the nested roadmap from the parent roadmap task list instead
+  of hiding it in prose
+- give the nested roadmap its own roadmap marker and `## Tracks` section
+  that links the active child work it coordinates
+- treat the nested roadmap as a coordination/audit node for discovery
+  and roadmap audit; do not draft it as normal A3/A4/A5 execution work
+- use two-level or three-level nesting only when the intermediate
+  roadmap has its own active child work or handoff boundary
+- do not use `Blocked by #NNN` or
+  `<!-- <marker-prefix>-blocked-by: ... -->` only to group leaf issues
+  under an active nested roadmap; reserve those encodings for true
+  execution dependencies or sequential roadmap dependencies between
+  separate roadmaps
+
+Validation expectations:
+
+- each nested roadmap node is linked from its parent roadmap task list
+- each nested roadmap node links its own active child work from its body
+- cycles, duplicate references, and closed intermediate roadmaps with
+  hidden open descendants must be surfaced as validation failures or
+  explicit follow-up notes, not silently normalized away
+
 ## Required dependency encoding
 
 - Roadmap identity via `<!-- <marker-prefix>-roadmap-id: ... -->`
@@ -232,10 +262,13 @@ Validation expectations:
 
 Validation expectations:
 
-- every active child issue is referenced from the roadmap body
+- every active child issue or nested roadmap node is referenced from the
+  roadmap body
 - the roadmap explains why multiple issues exist
 - sequencing and blocking are explicit
 - each dependency edge is justified and preserves natural cohesion
+- nested roadmap entries stay identifiable as coordination/audit nodes
+  instead of normal execution leaves
 
 ### Child issue under a roadmap
 

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -111,6 +111,31 @@ Child issue:
 Keep ready child issues in the roadmap task list rather than grouping
 them with hidden dependency markers.
 
+## Nested roadmap chooser note
+
+Use a nested roadmap when one roadmap track needs its own coordination
+boundary, active child list, or multi-session handoff. Keep the parent
+roadmap pointing to the nested roadmap, and keep the nested roadmap
+pointing to the leaf execution issues it coordinates.
+
+Parent roadmap `## Tracks` excerpt:
+
+```md
+- [ ] #510 — backend track roadmap
+```
+
+Nested roadmap `#510` `## Tracks` excerpt:
+
+```md
+- [ ] #511 — define the backend contract
+- [ ] #512 — wire the contract into Discover
+```
+
+Treat `#510` as a coordination/audit node, not as a normal execution
+issue. Do not replace that relationship with `Blocked by #NNN` or
+`<!-- <marker-prefix>-blocked-by: ... -->` only to group the leaf
+issues under the parent roadmap.
+
 ## Dependency minimization examples
 
 ### Natural parallel decomposition

--- a/tests/issue-authoring-specificity.test.mjs
+++ b/tests/issue-authoring-specificity.test.mjs
@@ -66,6 +66,48 @@ test("dependency minimization guidance stays synced between canonical and bundle
   );
 });
 
+test("nested roadmap guidance stays synced between canonical and bundled contract", () => {
+  const canonicalFile = "docs/issue-authoring-skill.md";
+  const bundledFile = "skills/issue-authoring/references/contract.md";
+  const canonical = readText(canonicalFile);
+  const bundled = readText(bundledFile);
+
+  assert.equal(
+    extractTopLevelSection(canonical, canonicalFile, "## Nested roadmap nodes"),
+    extractTopLevelSection(bundled, bundledFile, "## Nested roadmap nodes"),
+    `canonical and bundled nested-roadmap guidance must stay in sync (${canonicalFile} vs ${bundledFile})`,
+  );
+});
+
+test("nested roadmap guidance keeps coordination-node rules", () => {
+  for (const file of [
+    "docs/issue-authoring-skill.md",
+    "skills/issue-authoring/references/contract.md",
+  ]) {
+    const section = extractTopLevelSection(
+      readText(file),
+      file,
+      "## Nested roadmap nodes",
+    );
+    const normalizedSection = normalizeWhitespace(section);
+
+    for (const needle of [
+      "coordination boundary, active child list, or multi-session handoff",
+      "roadmap node, not a normal execution candidate",
+      "parent roadmap task list",
+      "links the active child work it coordinates",
+      "normal A3/A4/A5 execution work",
+      "true execution dependencies or sequential roadmap dependencies",
+      "closed intermediate roadmaps with hidden open descendants",
+    ]) {
+      assert.ok(
+        normalizedSection.includes(normalizeWhitespace(needle)),
+        `${file} must keep nested-roadmap phrase: ${needle}`,
+      );
+    }
+  }
+});
+
 test("dependency minimization guidance keeps the edge-justification rules", () => {
   for (const file of [
     "docs/issue-authoring-skill.md",
@@ -97,15 +139,41 @@ test("dependency minimization guidance keeps the edge-justification rules", () =
 test("draft patterns keep the dependency minimization examples", () => {
   const file = "skills/issue-authoring/references/draft-patterns.md";
   const text = readText(file);
+  const normalizedText = normalizeWhitespace(text);
 
   for (const needle of [
+    "## Nested roadmap chooser note",
+    "Parent roadmap `## Tracks` excerpt:",
+    "Nested roadmap `#510` `## Tracks` excerpt:",
+    "coordination/audit node",
+    "normal execution issue",
     "## Dependency minimization examples",
     "### Natural parallel decomposition",
     "### Artificial decomposition",
     "Bad serial chain:",
     "Bad split for parallelism:",
   ]) {
-    assert.ok(text.includes(needle), `${file} must keep example anchor: ${needle}`);
+    assert.ok(
+      normalizedText.includes(normalizeWhitespace(needle)),
+      `${file} must keep example anchor: ${needle}`,
+    );
+  }
+});
+
+test("canonical validation checklist keeps nested-roadmap link rules", () => {
+  const file = "docs/issue-authoring-skill.md";
+  const text = readText(file);
+  const normalizedText = normalizeWhitespace(text);
+
+  for (const needle of [
+    "each nested roadmap node is linked from the parent roadmap task list and links its own active child work",
+    "each nested roadmap remains identifiable as a coordination/audit node instead of a normal execution candidate",
+    "used only for true sequential dependencies, never to group nested roadmap children",
+  ]) {
+    assert.ok(
+      normalizedText.includes(normalizeWhitespace(needle)),
+      `${file} must keep validation-checklist phrase: ${needle}`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary
- add a normative nested-roadmap section to the canonical and bundled issue-authoring contracts
- extend validation guidance so nested roadmap nodes stay visible and auditable instead of becoming hidden execution leaves
- add a concise nested-roadmap chooser note plus sync tests that keep the new contract aligned

## Verification
- `node --test tests/issue-authoring-specificity.test.mjs`
- `pnpm run lint:minimum`
- `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`

## Follow-up issues
- none

## Background
- parent roadmap: #638
- this clarifies how recursive roadmap hierarchies should be authored so Discover can traverse intermediate roadmap nodes without treating them as normal A3/A4/A5 execution issues

Closes #639
