### PR TITLE
docs(idd): define recursive roadmap audit lifecycle

### DIFF
--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -32,7 +32,7 @@ not to widen A2 candidates.
 
 When the selected roadmap graph includes descendant issues that are
 themselves roadmap nodes, such as descendants carrying the `roadmap`
-label or a `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker, treat those
+label or a `idd-skill-roadmap-id` marker, treat those
 descendants as **nested roadmaps** rather than as normal execution
 leaves. A nested roadmap is a coordination/audit node in the recursive
 hierarchy: it may remain open while its own leaf descendants are still

--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -30,6 +30,15 @@ a specific autonomous gap before creating a follow-up issue; use those
 results only to link existing gap work or avoid creating a duplicate,
 not to widen A2 candidates.
 
+When the selected roadmap graph includes descendant issues that are
+themselves roadmap nodes, such as descendants carrying the `roadmap`
+label or an `idd-skill-roadmap-id` marker, treat those descendants as
+**nested roadmaps** rather than as normal execution leaves. A nested
+roadmap is a coordination/audit node in the recursive hierarchy: it may
+remain open while its own leaf descendants are still executing, and its
+presence does not by itself widen A2 candidates outside the selected
+roadmap graph.
+
 - If the roadmap itself has `status:blocked-by-human` or
   `status:needs-decision`, report the blocker and stop before A2. Do
   not continue selecting child issues under a blocked roadmap.
@@ -45,6 +54,25 @@ not to widen A2 candidates.
   ready-to-start rules. Do not treat stale blocker labels on closed
   children as audit blockers when their referenced descendants are
   resolved.
+- If an open leaf issue sits under an open nested roadmap, treat the
+  nested roadmap and every ancestor roadmap on that provenance path as
+  unresolved. Report the deepest blocking path and continue to A2.
+- If a nested roadmap remains open after all of its reachable leaf
+  descendants are closed or otherwise complete, treat that nested
+  roadmap as the **next completion target**. Do not close its parent
+  first. Re-evaluate the graph bottom-up so the deepest completed nested
+  roadmap is audited and closed before its parent roadmap is considered
+  complete.
+- If a nested roadmap appears closed but still has an open, inaccessible,
+  or otherwise unresolved descendant, treat that descendant as the
+  controlling unresolved state. Report the contradictory provenance path
+  and continue to A2; do not infer parent completion from the nested
+  roadmap's closed state alone.
+- If traversal or helper output reports a cycle or duplicate reference
+  inside the recursive roadmap graph, preserve that evidence and treat
+  the affected path as unresolved until the graph can be interpreted
+  safely. Do not guess at a closure order when the traversal graph is
+  ambiguous.
 - If all referenced child and descendant work is closed or otherwise
   complete, compare the roadmap success criteria against the closed
   child issues, linked merged PRs, task-list state, follow-up comments,
@@ -52,8 +80,10 @@ not to widen A2 candidates.
   completion from checkbox state alone.
 
 A1.5 can publish roadmap-level GitHub side effects before a child task
-issue is selected. Before any such side effect, coordinate on the
-roadmap issue itself:
+issue is selected. In recursive hierarchies, the immediate audit target
+may be the selected roadmap or the deepest completed nested roadmap
+discovered beneath it. Before any such side effect, coordinate on the
+**exact roadmap issue being mutated**:
 
 Treat `stale` and `non-stale` in this section using the
 `claim-stale-age` policy default from `docs/policy-constants.md`
@@ -79,6 +109,10 @@ Treat `stale` and `non-stale` in this section using the
   coordination name, not a work branch, and it does not require
   creating a branch or worktree unless the audit also needs git
   changes.
+- In recursive hierarchies, do not reuse one roadmap-audit claim across
+  parent, child, or sibling roadmap mutations. Each roadmap comment,
+  follow-up issue link, body edit, label change, or close action must
+  be scoped to the roadmap issue being mutated at that moment.
 - If the active roadmap claim already uses this current session's
   previously recorded and verified `{claim-id}`, continue with that same
   claim and do not post a new claim.
@@ -99,9 +133,13 @@ input still matches the evidence.
 Apply one outcome:
 
 - **Audit passes**: post an `IDD roadmap completion audit` comment with
-  a concise evidence summary, then close the roadmap. No child task
-  issue is claimed. Return to `idd-discover.instructions.md` (A1) and
-  select the next open roadmap, if any.
+  a concise evidence summary, then close the roadmap. In recursive
+  hierarchies, this outcome applies only when the selected roadmap is
+  the deepest remaining open roadmap on its path whose descendants are
+  all complete. After closing a nested roadmap, release that
+  roadmap-audit claim, re-fetch the ancestor graph, and return to
+  `idd-discover.instructions.md` (A1) so the parent roadmap can be
+  re-evaluated from fresh state. No child task issue is claimed.
 - **Autonomous gaps found**: create or link follow-up issues using the
   repository's issue-authoring rules, update the roadmap task list with
   those links, and continue to A2 so the new work can be discovered.

--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -44,7 +44,10 @@ roadmap graph.
   not continue selecting child issues under a blocked roadmap.
 - If any referenced child or descendant issue is open, inaccessible, or
   unresolved, report the provenance path and reason, then continue to
-  A2.
+  A2, unless the open descendant is a nested roadmap whose reachable
+  leaf descendants are all closed or otherwise complete. In that
+  special case, treat the nested roadmap as the next completion target
+  and continue applying the bottom-up rules below before routing to A2.
 - If any referenced child or descendant has an open linked or closing
   PR that is not merged or otherwise obsolete, treat that child work as
   unresolved, report the PR, and continue to A2.

--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -32,12 +32,12 @@ not to widen A2 candidates.
 
 When the selected roadmap graph includes descendant issues that are
 themselves roadmap nodes, such as descendants carrying the `roadmap`
-label or an `idd-skill-roadmap-id` marker, treat those descendants as
-**nested roadmaps** rather than as normal execution leaves. A nested
-roadmap is a coordination/audit node in the recursive hierarchy: it may
-remain open while its own leaf descendants are still executing, and its
-presence does not by itself widen A2 candidates outside the selected
-roadmap graph.
+label or a `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker, treat those
+descendants as **nested roadmaps** rather than as normal execution
+leaves. A nested roadmap is a coordination/audit node in the recursive
+hierarchy: it may remain open while its own leaf descendants are still
+executing, and its presence does not by itself widen A2 candidates
+outside the selected roadmap graph.
 
 - If the roadmap itself has `status:blocked-by-human` or
   `status:needs-decision`, report the blocker and stop before A2. Do

--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -44,10 +44,11 @@ outside the selected roadmap graph.
   not continue selecting child issues under a blocked roadmap.
 - If any referenced child or descendant issue is open, inaccessible, or
   unresolved, report the provenance path and reason, then continue to
-  A2, unless the open descendant is a nested roadmap whose reachable
-  leaf descendants are all closed or otherwise complete. In that
-  special case, treat the nested roadmap as the next completion target
-  and continue applying the bottom-up rules below before routing to A2.
+  A2, unless the open descendant is a nested roadmap with at least one
+  reachable leaf descendant and all of those reachable leaf descendants
+  are closed or otherwise complete. In that special case, treat the
+  nested roadmap as the next completion target and continue applying
+  the bottom-up rules below before routing to A2.
 - If any referenced child or descendant has an open linked or closing
   PR that is not merged or otherwise obsolete, treat that child work as
   unresolved, report the PR, and continue to A2.
@@ -60,12 +61,15 @@ outside the selected roadmap graph.
 - If an open leaf issue sits under an open nested roadmap, treat the
   nested roadmap and every ancestor roadmap on that provenance path as
   unresolved. Report the deepest blocking path and continue to A2.
-- If a nested roadmap remains open after all of its reachable leaf
-  descendants are closed or otherwise complete, treat that nested
-  roadmap as the **next completion target**. Do not close its parent
-  first. Re-evaluate the graph bottom-up so the deepest completed nested
-  roadmap is audited and closed before its parent roadmap is considered
-  complete.
+- If a nested roadmap has no reachable leaf descendants after
+  traversal, treat it as childless or malformed and continue to A2. Do
+  not treat an empty reachable-leaf set as proof of completion.
+- If a nested roadmap remains open after at least one reachable leaf
+  descendant exists and all reachable leaf descendants are closed or
+  otherwise complete, treat that nested roadmap as the **next
+  completion target**. Do not close its parent first. Re-evaluate the
+  graph bottom-up so the deepest completed nested roadmap is audited and
+  closed before its parent roadmap is considered complete.
 - If a nested roadmap appears closed but still has an open, inaccessible,
   or otherwise unresolved descendant, treat that descendant as the
   controlling unresolved state. Report the contradictory provenance path

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -198,7 +198,13 @@
       "id": "idd-roadmap-audit-instructions",
       "source": "idd-template/.github/instructions/idd-roadmap-audit.instructions.md",
       "target": ".github/instructions/idd-roadmap-audit.instructions.md",
-      "mode": "exact"
+      "mode": "concreted",
+      "replacements": [
+        {
+          "from": "{{PROJECT_MARKER_PREFIX}}",
+          "to": "idd-skill"
+        }
+      ]
     },
     {
       "id": "idd-suitability-instructions",

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -640,6 +640,9 @@ roadmap-claim contention policy during onboarding:
   rules; local policy should not weaken them.
 - If a claim is fresh and owned by another live session, treat it as not
   inheritable and stop or defer under the shared claim-state rules.
+- In recursive hierarchies, audit and close nested roadmaps bottom-up,
+  and claim the exact roadmap node being mutated rather than holding one
+  parent claim across the whole hierarchy.
 - Operators should release roadmap-audit claims promptly after roadmap
   mutations complete.
 
@@ -652,6 +655,12 @@ same pull request.
 Roadmap-audit claims are coordination-only. Use them only while editing
 the roadmap issue itself, then release them once the roadmap-side effect
 is complete. They are not an execution lock for child issues.
+
+When recursive roadmap hierarchies are in play, this means the deepest
+completed nested roadmap is closed first under its own claim, then the
+parent roadmap is re-evaluated from fresh state. Do not reuse one
+roadmap-audit claim to comment on, edit, or close multiple roadmap
+nodes.
 
 If a roadmap claim stays open long after the roadmap mutation is done,
 or if it appears to block child work, treat that as a misuse signal:

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -39,26 +39,26 @@ entry file should be an explicit operator choice, not the default.
 
 ## IDD file map
 
-| File                                                       | Role                                                                                 |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping               |
-| `.github/instructions/idd-discover.instructions.md`        | A0-T–A4.5: find a viable issue, route roadmap audits, run suitability, and hand off  |
-| `.github/instructions/idd-roadmap-audit.instructions.md`   | A1.5: audit roadmap completion and run roadmap-side coordination before A2           |
-| `.github/instructions/idd-claim.instructions.md`           | A5: run claim pre-checks and claim verification                                      |
-| `.github/instructions/idd-work.instructions.md`            | B1-B3 + C1-C6: create worktree, plan, implement, and self-review                     |
-| `.github/instructions/idd-pr-submit.instructions.md`       | D1-D4: pre-publication main sync, validate, push, open PR, and wait for CI           |
-| `.github/instructions/idd-ci.instructions.md`              | D4/E15 helper: shared CI polling helper used by later phases                         |
-| `.github/instructions/idd-advisory-wait.instructions.md`   | AW1-AW5 helper: shared Copilot advisory-wait protocol (E14, F2, F3)                  |
-| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if ReviewItems_snapshot is empty |
-| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, and record dispositions                                |
-| `.github/instructions/idd-review-fix.instructions.md`      | E9-E15: fix accepted review items and push follow-up commits                         |
-| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions                         |
-| `.github/instructions/idd-merge-handoff.instructions.md`   | F2.5: resolve merge-policy handoff vs autonomous merge routing                       |
-| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover                        |
-| `.github/instructions/idd-resume.instructions.md`          | Resume Step 0-3: route crash, stalled, stale-takeover, or clean continuation         |
-| `.github/instructions/idd-resume-stall.instructions.md`    | Resume S1-S5: handle stalled-session recovery with a dedicated safety gate           |
-| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                                 |
-| `docs/idd-comment-minimization.md`                         | Live status digest contract and post-merge comment minimization policy               |
+| File                                                       | Role                                                                                     |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping                   |
+| `.github/instructions/idd-discover.instructions.md`        | A0-T–A4.5: find a viable issue, route roadmap audits, run suitability, and hand off      |
+| `.github/instructions/idd-roadmap-audit.instructions.md`   | A1.5: audit roadmap completion, including bottom-up recursive roadmap closure, before A2 |
+| `.github/instructions/idd-claim.instructions.md`           | A5: run claim pre-checks and claim verification                                          |
+| `.github/instructions/idd-work.instructions.md`            | B1-B3 + C1-C6: create worktree, plan, implement, and self-review                         |
+| `.github/instructions/idd-pr-submit.instructions.md`       | D1-D4: rebase, validate, push, open PR, and wait for CI                                  |
+| `.github/instructions/idd-ci.instructions.md`              | D4/E15 helper: shared CI polling helper used by later phases                             |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | AW1-AW5 helper: shared Copilot advisory-wait protocol (E14, F2, F3)                      |
+| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if ReviewItems_snapshot is empty     |
+| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, and record dispositions                                    |
+| `.github/instructions/idd-review-fix.instructions.md`      | E9-E15: fix accepted review items and push follow-up commits                             |
+| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions                             |
+| `.github/instructions/idd-merge-handoff.instructions.md`   | F2.5: resolve merge-policy handoff vs autonomous merge routing                           |
+| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover                            |
+| `.github/instructions/idd-resume.instructions.md`          | Resume Step 0-3: route crash, stalled, stale-takeover, or clean continuation             |
+| `.github/instructions/idd-resume-stall.instructions.md`    | Resume S1-S5: handle stalled-session recovery with a dedicated safety gate               |
+| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                                     |
+| `docs/idd-comment-minimization.md`                         | Live status digest contract and post-merge comment minimization policy                   |
 
 ## ReviewItems_snapshot lifecycle
 
@@ -114,40 +114,6 @@ instruction template first. Native skills can sit beside it as helpers,
 but the synchronization contract for the portable workflow remains
 between the live `.github/instructions/` files and `idd-template/`.
 
-## Branch publication and synchronization
-
-IDD treats branch-state classification as a separate concern from branch
-mutation. Read-only probes may classify a PR branch as
-`current-clean`, `behind-clean`, `content-conflicting`,
-`dirty-or-unknown`, `protected-update-required`, or
-`force-push-exception`, but the classification itself must not dirty the
-worktree or rewrite history.
-
-The first D-phase push is the publication boundary:
-
-- Before that push, D1 is the routine place to rebase onto `main`.
-- After that push, the branch becomes published review history.
-- `behind-clean` is evidence only. It does not trigger a branch update
-  by itself unless branch protection or explicit repository policy
-  requires an up-to-date head before merge.
-- `content-conflicting` and `protected-update-required` route back
-  through the E-phase review loop so the synchronization change is
-  reviewed, validated, pushed normally, and re-checked.
-- The default post-push synchronization action is a normal merge from
-  `main` into the PR branch.
-- Rebase plus force-push after publication is an exceptional recovery
-  path only.
-- F remains the final freshness and merge gate, not the first routine
-  place where branch-sync edits should happen.
-
-This section defines the workflow contract first. Repositories adopting
-it should align later-phase conflict-handling instructions, pre-merge
-instructions, and any resume-routing helpers before treating the
-merge-based post-publication sync path as fully active end to end.
-Until that alignment lands, remaining rebase-oriented wording in those
-downstream surfaces is follow-up implementation debt rather than a
-competing policy contract.
-
 If you need to understand or change distributed timing defaults, start
 with [IDD policy constants](policy-constants.md). It names the claim,
 advisory, CI, and critique-loop defaults and points to the instruction
@@ -177,12 +143,10 @@ gate ahead of Claim. The distributed discover and claim instructions
 already enforce this behavior: explicit-target runs stop before claim
 when the selected issue lacks the required approval, and discovery keeps
 underprivileged unapproved issues in an approval-needed fallback bucket
-instead of treating them as ready to start or silently dropping them
-from view. That fallback preserves unattended progress: Discover can
-keep scanning autonomous candidates until only approval-gated work
-remains. Approval actors are a repository-local policy choice and
-remain distinct from trusted operational marker actors; operator
-attention and CODEOWNERS mismatch do not replace this pre-start gate.
+instead of treating them as ready to start. Approval actors are a
+repository-local policy choice and remain distinct from trusted
+operational marker actors; CODEOWNERS mismatch does not replace this
+pre-start gate.
 
 ## CODEOWNERS and Merge Gates
 
@@ -210,10 +174,6 @@ for labels, comment-and-stop defaults, and close boundaries:
 - uncertain outcomes (`unclear`, `needs-decision`, `blocked-by-human`)
   stay open by default with a concise routing comment, then A4.5 keeps
   scanning remaining candidates in the same run;
-- approval-needed fallback is separate from `needs-decision` and
-  `blocked-by-human`: it means the issue may be otherwise ready, but it
-  still lacks permission to start unattended and therefore remains a
-  stop bucket rather than a claimable candidate;
 - high-confidence `duplicate`, `invalid`, and `out-of-scope` outcomes
   are read-only by default and require explicit A4.5 mutation-policy
   customization before close/label side effects;
@@ -226,8 +186,7 @@ Discover owns roadmap-level state. After it finds an open roadmap, it
 can audit whether all explicitly referenced child work is complete
 before selecting the next issue. Passing audits post a concise evidence
 summary and close the roadmap; failing audits either add/link
-autonomous follow-up issues when a missing step can still run
-unattended, or route genuinely human-dependent gaps to an explicit
+autonomous follow-up issues or route human-dependent gaps to an explicit
 blocked or needs-decision state. Roadmap-level side effects still use a
 temporary claim on the roadmap issue itself, so concurrent agents do not
 close or edit the same roadmap at the same time.
@@ -240,121 +199,6 @@ This audit intentionally lives before A2 rather than in F4. F4 is
 limited to the PR that just merged and the local cleanup for that child
 issue. F5 then loops back to Discover, where roadmap completion can be
 checked with the broader parent context.
-
-## Recursive Roadmap Hierarchies
-
-IDD's roadmap traversal already follows transitive issue references, so
-nested structures such as `root roadmap → track roadmap → leaf execution
-issues` work without any extra configuration. This section explains when
-to use them, how to structure them, and how discovery and audit behave at
-each level.
-
-### When to keep a roadmap flat
-
-Start with a single-level roadmap. A flat task list inside one roadmap
-issue is the right default when all sub-tasks belong to the same
-implementation cycle, run at the same cadence, and can merge without
-coordination across teams or phases. Adding nesting for its own sake
-introduces unnecessary coordination overhead.
-
-### When nesting adds value
-
-Introduce a nested roadmap when the work genuinely needs a coordination
-boundary that a flat task list cannot express cleanly:
-
-- **Parallel tracks**: two sub-roadmaps that operate independently and
-  merge on different schedules (for example, a data-layer track and a UI
-  track that each need their own lifecycle before the parent can close).
-- **Multi-session handoff**: a sub-roadmap that a different team or agent
-  pool owns, where the parent roadmap should stay open until that team
-  signals completion at the sub-roadmap level.
-
-If the only reason to nest is that the task list feels long, keep the
-flat structure and use numbered sections inside the roadmap body instead.
-
-### Structuring a two-level hierarchy
-
-A two-level hierarchy has one parent roadmap with nested track roadmaps
-as children:
-
-```text
-Parent roadmap (#100)
-├─ Track A — roadmap (#110)
-│   ├─ Leaf issue #111
-│   └─ Leaf issue #112
-└─ Track B — roadmap (#120)
-    ├─ Leaf issue #121
-    └─ Leaf issue #122
-```
-
-Reference child roadmaps from the parent's task list using standard
-`- [ ] #NNN` entries. Do not use `idd-skill-blocked-by` markers to group
-sub-tasks under an active roadmap — that marker is reserved for true
-sequential dependencies on a _separate, prior_ roadmap that must close
-before the dependent work can start.
-
-### Grouping versus sequential dependency
-
-| Mechanism             | Syntax                                        | Meaning                                                    |
-| --------------------- | --------------------------------------------- | ---------------------------------------------------------- |
-| Task-list grouping    | `- [ ] #NNN` in roadmap body                  | Active parallel work; all items may proceed simultaneously |
-| Sequential dependency | `<!-- idd-skill-blocked-by: {roadmap-id} -->` | This issue must wait until the named roadmap is closed     |
-
-Use task-list links when you want concurrent execution. Use
-`idd-skill-blocked-by` only when one roadmap phase must completely finish
-before another can start.
-
-### How discovery treats nested roadmap nodes
-
-Discover (A2) traverses the full outbound reference graph from the
-selected roadmap. The intended design treats open nested roadmap nodes as
-traversal-only coordination nodes: the agent walks through them to reach
-leaf execution issues without advancing roadmap nodes themselves into the
-readiness/claim/viability gates. Only non-roadmap leaf issues become
-execution candidates. The Discover instruction rules that formally
-classify roadmap nodes are being specified in #640; until those rules
-land, a nested roadmap node that passes the current A3/A4 filters could
-theoretically enter the candidate set.
-
-The no-candidate diagnostic distinguishes "no reachable leaf execution
-issues" from "only open roadmap nodes remain", so operators can tell
-whether the tree is still healthy or whether leaf issues are missing.
-
-When the recursive graph helper (#642) is available, it can enumerate
-the full traversal graph, classify roadmap nodes separately from
-execution candidates, and report provenance paths and cycle detection for
-Discover and roadmap audit use.
-
-### Bottom-up completion
-
-Nested roadmaps create a natural bottom-up closing order. When all of a
-nested roadmap's referenced leaf issues and further descendants are
-resolved, the A1.5 roadmap audit evaluates its success criteria against
-the closed issues, merged PRs, task-list state, and repository state. If
-the audit finds autonomous gaps, it creates or links follow-up issues
-before closing. The parent roadmap remains open while any nested roadmap
-child is still open or has an unresolved autonomous gap; only after all
-nested roadmap children pass their own A1.5 audits can the parent
-roadmap itself be evaluated and closed.
-
-Each roadmap-side mutation (comment, label, close) uses a
-`roadmap-audit/*` coordination claim scoped to the roadmap issue being
-mutated. These claims are coordination locks for roadmap-side effects
-only and do not block child execution in other branches of the same tree.
-
-### Issue-scope default
-
-Nested roadmap support does not change the repository's default
-`issue-scope`. The `roadmap` default means Discover always starts with
-the selected roadmap and traverses its full graph, including nested
-roadmap nodes, to find leaf execution candidates. Adopters who want
-unblocked orphan issues to be considered before roadmap traversal must
-set `orphan-first` in both the `"orphanFirstPolicy"` key in
-`.github/idd/config.json` and the `orphan-first-policy` row in the
-project commands table in
-`.github/instructions/idd-overview.instructions.md`. See
-[IDD policy constants](policy-constants.md) for the synchronization
-requirement between these two sources.
 
 ## Resume routing model
 
@@ -420,6 +264,13 @@ Roadmap-audit claims are coordination-only. Use them only while the
 roadmap issue itself is being mutated, then release them once that
 roadmap-side effect is complete. They are not a proxy lock for child
 claims.
+
+Recursive roadmap hierarchies still follow that rule. Leaf execution
+issues finish first, then the deepest completed nested roadmap is
+audited and closed under its own `roadmap-audit/*` claim, and only then
+is the parent roadmap re-evaluated. Bottom-up closure keeps roadmap
+claims scoped to the exact roadmap issue being mutated instead of
+turning one parent claim into a lock over child or sibling work.
 
 If the roadmap claim remains open after the roadmap-side effect is done,
 or if it appears to serialize child execution, treat that as a misuse

--- a/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
@@ -32,19 +32,22 @@ not to widen A2 candidates.
 
 When the selected roadmap graph includes descendant issues that are
 themselves roadmap nodes, such as descendants carrying the `roadmap`
-label or an `idd-skill-roadmap-id` marker, treat those descendants as
-**nested roadmaps** rather than as normal execution leaves. A nested
-roadmap is a coordination/audit node in the recursive hierarchy: it may
-remain open while its own leaf descendants are still executing, and its
-presence does not by itself widen A2 candidates outside the selected
-roadmap graph.
+label or a `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker, treat those
+descendants as **nested roadmaps** rather than as normal execution
+leaves. A nested roadmap is a coordination/audit node in the recursive
+hierarchy: it may remain open while its own leaf descendants are still
+executing, and its presence does not by itself widen A2 candidates
+outside the selected roadmap graph.
 
 - If the roadmap itself has `status:blocked-by-human` or
   `status:needs-decision`, report the blocker and stop before A2. Do
   not continue selecting child issues under a blocked roadmap.
 - If any referenced child or descendant issue is open, inaccessible, or
   unresolved, report the provenance path and reason, then continue to
-  A2.
+  A2, unless the open descendant is a nested roadmap whose reachable
+  leaf descendants are all closed or otherwise complete. In that
+  special case, treat the nested roadmap as the next completion target
+  and continue applying the bottom-up rules below before routing to A2.
 - If any referenced child or descendant has an open linked or closing
   PR that is not merged or otherwise obsolete, treat that child work as
   unresolved, report the PR, and continue to A2.

--- a/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
@@ -30,6 +30,15 @@ a specific autonomous gap before creating a follow-up issue; use those
 results only to link existing gap work or avoid creating a duplicate,
 not to widen A2 candidates.
 
+When the selected roadmap graph includes descendant issues that are
+themselves roadmap nodes, such as descendants carrying the `roadmap`
+label or an `idd-skill-roadmap-id` marker, treat those descendants as
+**nested roadmaps** rather than as normal execution leaves. A nested
+roadmap is a coordination/audit node in the recursive hierarchy: it may
+remain open while its own leaf descendants are still executing, and its
+presence does not by itself widen A2 candidates outside the selected
+roadmap graph.
+
 - If the roadmap itself has `status:blocked-by-human` or
   `status:needs-decision`, report the blocker and stop before A2. Do
   not continue selecting child issues under a blocked roadmap.
@@ -45,6 +54,25 @@ not to widen A2 candidates.
   ready-to-start rules. Do not treat stale blocker labels on closed
   children as audit blockers when their referenced descendants are
   resolved.
+- If an open leaf issue sits under an open nested roadmap, treat the
+  nested roadmap and every ancestor roadmap on that provenance path as
+  unresolved. Report the deepest blocking path and continue to A2.
+- If a nested roadmap remains open after all of its reachable leaf
+  descendants are closed or otherwise complete, treat that nested
+  roadmap as the **next completion target**. Do not close its parent
+  first. Re-evaluate the graph bottom-up so the deepest completed nested
+  roadmap is audited and closed before its parent roadmap is considered
+  complete.
+- If a nested roadmap appears closed but still has an open, inaccessible,
+  or otherwise unresolved descendant, treat that descendant as the
+  controlling unresolved state. Report the contradictory provenance path
+  and continue to A2; do not infer parent completion from the nested
+  roadmap's closed state alone.
+- If traversal or helper output reports a cycle or duplicate reference
+  inside the recursive roadmap graph, preserve that evidence and treat
+  the affected path as unresolved until the graph can be interpreted
+  safely. Do not guess at a closure order when the traversal graph is
+  ambiguous.
 - If all referenced child and descendant work is closed or otherwise
   complete, compare the roadmap success criteria against the closed
   child issues, linked merged PRs, task-list state, follow-up comments,
@@ -52,8 +80,10 @@ not to widen A2 candidates.
   completion from checkbox state alone.
 
 A1.5 can publish roadmap-level GitHub side effects before a child task
-issue is selected. Before any such side effect, coordinate on the
-roadmap issue itself:
+issue is selected. In recursive hierarchies, the immediate audit target
+may be the selected roadmap or the deepest completed nested roadmap
+discovered beneath it. Before any such side effect, coordinate on the
+**exact roadmap issue being mutated**:
 
 Treat `stale` and `non-stale` in this section using the
 `claim-stale-age` policy default from `docs/policy-constants.md`
@@ -79,6 +109,10 @@ Treat `stale` and `non-stale` in this section using the
   coordination name, not a work branch, and it does not require
   creating a branch or worktree unless the audit also needs git
   changes.
+- In recursive hierarchies, do not reuse one roadmap-audit claim across
+  parent, child, or sibling roadmap mutations. Each roadmap comment,
+  follow-up issue link, body edit, label change, or close action must
+  be scoped to the roadmap issue being mutated at that moment.
 - If the active roadmap claim already uses this current session's
   previously recorded and verified `{claim-id}`, continue with that same
   claim and do not post a new claim.
@@ -99,9 +133,13 @@ input still matches the evidence.
 Apply one outcome:
 
 - **Audit passes**: post an `IDD roadmap completion audit` comment with
-  a concise evidence summary, then close the roadmap. No child task
-  issue is claimed. Return to `idd-discover.instructions.md` (A1) and
-  select the next open roadmap, if any.
+  a concise evidence summary, then close the roadmap. In recursive
+  hierarchies, this outcome applies only when the selected roadmap is
+  the deepest remaining open roadmap on its path whose descendants are
+  all complete. After closing a nested roadmap, release that
+  roadmap-audit claim, re-fetch the ancestor graph, and return to
+  `idd-discover.instructions.md` (A1) so the parent roadmap can be
+  re-evaluated from fresh state. No child task issue is claimed.
 - **Autonomous gaps found**: create or link follow-up issues using the
   repository's issue-authoring rules, update the roadmap task list with
   those links, and continue to A2 so the new work can be discovered.

--- a/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
@@ -44,10 +44,11 @@ outside the selected roadmap graph.
   not continue selecting child issues under a blocked roadmap.
 - If any referenced child or descendant issue is open, inaccessible, or
   unresolved, report the provenance path and reason, then continue to
-  A2, unless the open descendant is a nested roadmap whose reachable
-  leaf descendants are all closed or otherwise complete. In that
-  special case, treat the nested roadmap as the next completion target
-  and continue applying the bottom-up rules below before routing to A2.
+  A2, unless the open descendant is a nested roadmap with at least one
+  reachable leaf descendant and all of those reachable leaf descendants
+  are closed or otherwise complete. In that special case, treat the
+  nested roadmap as the next completion target and continue applying
+  the bottom-up rules below before routing to A2.
 - If any referenced child or descendant has an open linked or closing
   PR that is not merged or otherwise obsolete, treat that child work as
   unresolved, report the PR, and continue to A2.
@@ -60,12 +61,15 @@ outside the selected roadmap graph.
 - If an open leaf issue sits under an open nested roadmap, treat the
   nested roadmap and every ancestor roadmap on that provenance path as
   unresolved. Report the deepest blocking path and continue to A2.
-- If a nested roadmap remains open after all of its reachable leaf
-  descendants are closed or otherwise complete, treat that nested
-  roadmap as the **next completion target**. Do not close its parent
-  first. Re-evaluate the graph bottom-up so the deepest completed nested
-  roadmap is audited and closed before its parent roadmap is considered
-  complete.
+- If a nested roadmap has no reachable leaf descendants after
+  traversal, treat it as childless or malformed and continue to A2. Do
+  not treat an empty reachable-leaf set as proof of completion.
+- If a nested roadmap remains open after at least one reachable leaf
+  descendant exists and all reachable leaf descendants are closed or
+  otherwise complete, treat that nested roadmap as the **next
+  completion target**. Do not close its parent first. Re-evaluate the
+  graph bottom-up so the deepest completed nested roadmap is audited and
+  closed before its parent roadmap is considered complete.
 - If a nested roadmap appears closed but still has an open, inaccessible,
   or otherwise unresolved descendant, treat that descendant as the
   controlling unresolved state. Report the contradictory provenance path

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -640,6 +640,9 @@ roadmap-claim contention policy during onboarding:
   rules; local policy should not weaken them.
 - If a claim is fresh and owned by another live session, treat it as not
   inheritable and stop or defer under the shared claim-state rules.
+- In recursive hierarchies, audit and close nested roadmaps bottom-up,
+  and claim the exact roadmap node being mutated rather than holding one
+  parent claim across the whole hierarchy.
 - Operators should release roadmap-audit claims promptly after roadmap
   mutations complete.
 
@@ -652,6 +655,12 @@ same pull request.
 Roadmap-audit claims are coordination-only. Use them only while editing
 the roadmap issue itself, then release them once the roadmap-side effect
 is complete. They are not an execution lock for child issues.
+
+When recursive roadmap hierarchies are in play, this means the deepest
+completed nested roadmap is closed first under its own claim, then the
+parent roadmap is re-evaluated from fresh state. Do not reuse one
+roadmap-audit claim to comment on, edit, or close multiple roadmap
+nodes.
 
 If a roadmap claim stays open long after the roadmap mutation is done,
 or if it appears to block child work, treat that as a misuse signal:

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -39,26 +39,26 @@ entry file should be an explicit operator choice, not the default.
 
 ## IDD file map
 
-| File                                                       | Role                                                                                 |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping               |
-| `.github/instructions/idd-discover.instructions.md`        | A0-T–A4.5: find a viable issue, route roadmap audits, run suitability, and hand off  |
-| `.github/instructions/idd-roadmap-audit.instructions.md`   | A1.5: audit roadmap completion and run roadmap-side coordination before A2           |
-| `.github/instructions/idd-claim.instructions.md`           | A5: run claim pre-checks and claim verification                                      |
-| `.github/instructions/idd-work.instructions.md`            | B1-B3 + C1-C6: create worktree, plan, implement, and self-review                     |
-| `.github/instructions/idd-pr-submit.instructions.md`       | D1-D4: pre-publication main sync, validate, push, open PR, and wait for CI           |
-| `.github/instructions/idd-ci.instructions.md`              | D4/E15 helper: shared CI polling helper used by later phases                         |
-| `.github/instructions/idd-advisory-wait.instructions.md`   | AW1-AW5 helper: shared Copilot advisory-wait protocol (E14, F2, F3)                  |
-| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if ReviewItems_snapshot is empty |
-| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, and record dispositions                                |
-| `.github/instructions/idd-review-fix.instructions.md`      | E9-E15: fix accepted review items and push follow-up commits                         |
-| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions                         |
-| `.github/instructions/idd-merge-handoff.instructions.md`   | F2.5: resolve merge-policy handoff vs autonomous merge routing                       |
-| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover                        |
-| `.github/instructions/idd-resume.instructions.md`          | Resume Step 0-3: route crash, stalled, stale-takeover, or clean continuation         |
-| `.github/instructions/idd-resume-stall.instructions.md`    | Resume S1-S5: handle stalled-session recovery with a dedicated safety gate           |
-| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                                 |
-| `docs/idd-comment-minimization.md`                         | Live status digest contract and post-merge comment minimization policy               |
+| File                                                       | Role                                                                                     |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `.github/instructions/idd-overview.instructions.md`        | Shared definitions, command sets, routing table, critique-pass mapping                   |
+| `.github/instructions/idd-discover.instructions.md`        | A0-T–A4.5: find a viable issue, route roadmap audits, run suitability, and hand off      |
+| `.github/instructions/idd-roadmap-audit.instructions.md`   | A1.5: audit roadmap completion, including bottom-up recursive roadmap closure, before A2 |
+| `.github/instructions/idd-claim.instructions.md`           | A5: run claim pre-checks and claim verification                                          |
+| `.github/instructions/idd-work.instructions.md`            | B1-B3 + C1-C6: create worktree, plan, implement, and self-review                         |
+| `.github/instructions/idd-pr-submit.instructions.md`       | D1-D4: rebase, validate, push, open PR, and wait for CI                                  |
+| `.github/instructions/idd-ci.instructions.md`              | D4/E15 helper: shared CI polling helper used by later phases                             |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | AW1-AW5 helper: shared Copilot advisory-wait protocol (E14, F2, F3)                      |
+| `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if ReviewItems_snapshot is empty     |
+| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, and record dispositions                                    |
+| `.github/instructions/idd-review-fix.instructions.md`      | E9-E15: fix accepted review items and push follow-up commits                             |
+| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions                             |
+| `.github/instructions/idd-merge-handoff.instructions.md`   | F2.5: resolve merge-policy handoff vs autonomous merge routing                           |
+| `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover                            |
+| `.github/instructions/idd-resume.instructions.md`          | Resume Step 0-3: route crash, stalled, stale-takeover, or clean continuation             |
+| `.github/instructions/idd-resume-stall.instructions.md`    | Resume S1-S5: handle stalled-session recovery with a dedicated safety gate               |
+| `docs/idd-review-policy-profiles.md`                       | PR review policy profiles and customization surfaces                                     |
+| `docs/idd-comment-minimization.md`                         | Live status digest contract and post-merge comment minimization policy                   |
 
 ## ReviewItems_snapshot lifecycle
 
@@ -101,40 +101,6 @@ The distributed workflow remains an instruction template first. Native
 skills can sit beside it as optional helpers, but they do not replace
 these execution-layer files.
 
-## Branch publication and synchronization
-
-IDD treats branch-state classification as a separate concern from branch
-mutation. Read-only probes may classify a PR branch as
-`current-clean`, `behind-clean`, `content-conflicting`,
-`dirty-or-unknown`, `protected-update-required`, or
-`force-push-exception`, but the classification itself must not dirty the
-worktree or rewrite history.
-
-The first D-phase push is the publication boundary:
-
-- Before that push, D1 is the routine place to rebase onto `main`.
-- After that push, the branch becomes published review history.
-- `behind-clean` is evidence only. It does not trigger a branch update
-  by itself unless branch protection or explicit repository policy
-  requires an up-to-date head before merge.
-- `content-conflicting` and `protected-update-required` route back
-  through the E-phase review loop so the synchronization change is
-  reviewed, validated, pushed normally, and re-checked.
-- The default post-push synchronization action is a normal merge from
-  `main` into the PR branch.
-- Rebase plus force-push after publication is an exceptional recovery
-  path only.
-- F remains the final freshness and merge gate, not the first routine
-  place where branch-sync edits should happen.
-
-This section defines the workflow contract first. Repositories adopting
-it should align later-phase conflict-handling instructions, pre-merge
-instructions, and any resume-routing helpers before treating the
-merge-based post-publication sync path as fully active end to end.
-Until that alignment lands, remaining rebase-oriented wording in those
-downstream surfaces is follow-up implementation debt rather than a
-competing policy contract.
-
 If you need to understand or change distributed timing defaults, start
 with [IDD policy constants](policy-constants.md). It names the claim,
 advisory, CI, and critique-loop defaults and points to the instruction
@@ -158,12 +124,10 @@ gate ahead of Claim. The distributed discover and claim instructions
 already enforce this behavior: explicit-target runs stop before claim
 when the selected issue lacks the required approval, and discovery keeps
 underprivileged unapproved issues in an approval-needed fallback bucket
-instead of treating them as ready to start or silently dropping them
-from view. That fallback preserves unattended progress: Discover can
-keep scanning autonomous candidates until only approval-gated work
-remains. Approval actors are a repository-local policy choice and
-remain distinct from trusted operational marker actors; operator
-attention and CODEOWNERS mismatch do not replace this pre-start gate.
+instead of treating them as ready to start. Approval actors are a
+repository-local policy choice and remain distinct from trusted
+operational marker actors; CODEOWNERS mismatch does not replace this
+pre-start gate.
 
 ## CODEOWNERS and Merge Gates
 
@@ -191,10 +155,6 @@ for labels, comment-and-stop defaults, and close boundaries:
 - uncertain outcomes (`unclear`, `needs-decision`, `blocked-by-human`)
   stay open by default with a concise routing comment, then A4.5 keeps
   scanning remaining candidates in the same run;
-- approval-needed fallback is separate from `needs-decision` and
-  `blocked-by-human`: it means the issue may be otherwise ready, but it
-  still lacks permission to start unattended and therefore remains a
-  stop bucket rather than a claimable candidate;
 - high-confidence `duplicate`, `invalid`, and `out-of-scope` outcomes
   are read-only by default and require explicit A4.5 mutation-policy
   customization before close/label side effects;
@@ -207,8 +167,7 @@ Discover owns roadmap-level state. After it finds an open roadmap, it
 can audit whether all explicitly referenced child work is complete
 before selecting the next issue. Passing audits post a concise evidence
 summary and close the roadmap; failing audits either add/link
-autonomous follow-up issues when a missing step can still run
-unattended, or route genuinely human-dependent gaps to an explicit
+autonomous follow-up issues or route human-dependent gaps to an explicit
 blocked or needs-decision state. Roadmap-level side effects still use a
 temporary claim on the roadmap issue itself, so concurrent agents do not
 close or edit the same roadmap at the same time.
@@ -221,121 +180,6 @@ This audit intentionally lives before A2 rather than in F4. F4 is
 limited to the PR that just merged and the local cleanup for that child
 issue. F5 then loops back to Discover, where roadmap completion can be
 checked with the broader parent context.
-
-## Recursive Roadmap Hierarchies
-
-IDD's roadmap traversal already follows transitive issue references, so
-nested structures such as `root roadmap → track roadmap → leaf execution
-issues` work without any extra configuration. This section explains when
-to use them, how to structure them, and how discovery and audit behave at
-each level.
-
-### When to keep a roadmap flat
-
-Start with a single-level roadmap. A flat task list inside one roadmap
-issue is the right default when all sub-tasks belong to the same
-implementation cycle, run at the same cadence, and can merge without
-coordination across teams or phases. Adding nesting for its own sake
-introduces unnecessary coordination overhead.
-
-### When nesting adds value
-
-Introduce a nested roadmap when the work genuinely needs a coordination
-boundary that a flat task list cannot express cleanly:
-
-- **Parallel tracks**: two sub-roadmaps that operate independently and
-  merge on different schedules (for example, a data-layer track and a UI
-  track that each need their own lifecycle before the parent can close).
-- **Multi-session handoff**: a sub-roadmap that a different team or agent
-  pool owns, where the parent roadmap should stay open until that team
-  signals completion at the sub-roadmap level.
-
-If the only reason to nest is that the task list feels long, keep the
-flat structure and use numbered sections inside the roadmap body instead.
-
-### Structuring a two-level hierarchy
-
-A two-level hierarchy has one parent roadmap with nested track roadmaps
-as children:
-
-```text
-Parent roadmap (#100)
-├─ Track A — roadmap (#110)
-│   ├─ Leaf issue #111
-│   └─ Leaf issue #112
-└─ Track B — roadmap (#120)
-    ├─ Leaf issue #121
-    └─ Leaf issue #122
-```
-
-Reference child roadmaps from the parent's task list using standard
-`- [ ] #NNN` entries. Do not use `idd-skill-blocked-by` markers to group
-sub-tasks under an active roadmap — that marker is reserved for true
-sequential dependencies on a _separate, prior_ roadmap that must close
-before the dependent work can start.
-
-### Grouping versus sequential dependency
-
-| Mechanism             | Syntax                                        | Meaning                                                    |
-| --------------------- | --------------------------------------------- | ---------------------------------------------------------- |
-| Task-list grouping    | `- [ ] #NNN` in roadmap body                  | Active parallel work; all items may proceed simultaneously |
-| Sequential dependency | `<!-- idd-skill-blocked-by: {roadmap-id} -->` | This issue must wait until the named roadmap is closed     |
-
-Use task-list links when you want concurrent execution. Use
-`idd-skill-blocked-by` only when one roadmap phase must completely finish
-before another can start.
-
-### How discovery treats nested roadmap nodes
-
-Discover (A2) traverses the full outbound reference graph from the
-selected roadmap. The intended design treats open nested roadmap nodes as
-traversal-only coordination nodes: the agent walks through them to reach
-leaf execution issues without advancing roadmap nodes themselves into the
-readiness/claim/viability gates. Only non-roadmap leaf issues become
-execution candidates. Check whether the Discover instruction files in
-your installed version already enforce this formal classification; if
-not, a nested roadmap node that passes the current A3/A4 filters could
-theoretically enter the candidate set.
-
-The no-candidate diagnostic distinguishes "no reachable leaf execution
-issues" from "only open roadmap nodes remain", so operators can tell
-whether the tree is still healthy or whether leaf issues are missing.
-
-When the recursive graph helper is available, it can enumerate the full
-traversal graph, classify roadmap nodes separately from execution
-candidates, and report provenance paths and cycle detection for Discover
-and roadmap audit use.
-
-### Bottom-up completion
-
-Nested roadmaps create a natural bottom-up closing order. When all of a
-nested roadmap's referenced leaf issues and further descendants are
-resolved, the A1.5 roadmap audit evaluates its success criteria against
-the closed issues, merged PRs, task-list state, and repository state. If
-the audit finds autonomous gaps, it creates or links follow-up issues
-before closing. The parent roadmap remains open while any nested roadmap
-child is still open or has an unresolved autonomous gap; only after all
-nested roadmap children pass their own A1.5 audits can the parent
-roadmap itself be evaluated and closed.
-
-Each roadmap-side mutation (comment, label, close) uses a
-`roadmap-audit/*` coordination claim scoped to the roadmap issue being
-mutated. These claims are coordination locks for roadmap-side effects
-only and do not block child execution in other branches of the same tree.
-
-### Issue-scope default
-
-Nested roadmap support does not change the repository's default
-`issue-scope`. The `roadmap` default means Discover always starts with
-the selected roadmap and traverses its full graph, including nested
-roadmap nodes, to find leaf execution candidates. Adopters who want
-unblocked orphan issues to be considered before roadmap traversal must
-set `orphan-first` in both the `"orphanFirstPolicy"` key in
-`.github/idd/config.json` and the `orphan-first-policy` row in the
-project commands table in
-`.github/instructions/idd-overview.instructions.md`. See
-[IDD policy constants](policy-constants.md) for the synchronization
-requirement between these two sources.
 
 ## Resume routing model
 
@@ -401,6 +245,13 @@ Roadmap-audit claims are coordination-only. Use them only while the
 roadmap issue itself is being mutated, then release them once that
 roadmap-side effect is complete. They are not a proxy lock for child
 claims.
+
+Recursive roadmap hierarchies still follow that rule. Leaf execution
+issues finish first, then the deepest completed nested roadmap is
+audited and closed under its own `roadmap-audit/*` claim, and only then
+is the parent roadmap re-evaluated. Bottom-up closure keeps roadmap
+claims scoped to the exact roadmap issue being mutated instead of
+turning one parent claim into a lock over child or sibling work.
 
 If the roadmap claim remains open after the roadmap-side effect is done,
 or if it appears to serialize child execution, treat that as a misuse

--- a/tests/consistency.test.mjs
+++ b/tests/consistency.test.mjs
@@ -14,6 +14,9 @@ import { findPlaceholders } from "../scripts/idd-doctor.mjs";
 
 const FIXTURE_ROOT = new URL("./fixtures/", import.meta.url);
 const SUITABILITY_PATH = new URL("../.github/instructions/idd-suitability.instructions.md", import.meta.url);
+const ROADMAP_AUDIT_PATH = new URL("../.github/instructions/idd-roadmap-audit.instructions.md", import.meta.url);
+const WORKFLOW_PATH = new URL("../docs/idd-workflow.md", import.meta.url);
+const CUSTOMIZATION_PATH = new URL("../docs/customization.md", import.meta.url);
 
 test("placeholder scenarios detect clean and dirty post-onboarding fixtures", () => {
   const clean = collectPlaceholderHits(new URL("./fixtures/consistency/placeholders/clean", import.meta.url));
@@ -412,6 +415,20 @@ test("A4.5 outcome fixtures match the documented check-to-outcome mapping", () =
     ["blocked-by-human", "duplicate", "invalid", "needs-decision", "out-of-scope", "unclear"],
   );
   assert.match(outcomes.get("invalid"), /do not retry/i);
+});
+
+test("recursive roadmap audit guidance stays aligned across instruction and docs surfaces", () => {
+  const audit = readFileSync(ROADMAP_AUDIT_PATH, "utf8");
+  const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+  const customization = readFileSync(CUSTOMIZATION_PATH, "utf8");
+
+  assert.match(audit, /nested roadmaps?/i);
+  assert.match(audit, /bottom-up/i);
+  assert.match(audit, /exact roadmap issue being mutated/i);
+  assert.match(workflow, /nested roadmap/i);
+  assert.match(workflow, /bottom-up/i);
+  assert.match(customization, /bottom-up/i);
+  assert.match(customization, /exact roadmap node being mutated/i);
 });
 
 function collectPlaceholderHits(url) {


### PR DESCRIPTION
## Summary
- define bottom-up recursive roadmap audit behavior in A1.5
- mirror the recursive roadmap claim lifecycle in canonical and template workflow docs
- add a consistency guard for the recursive roadmap audit wording

## Testing
- `node --test tests/consistency.test.mjs tests/idd-workflow-phase-map-sync.test.mjs`
- `npx dprint check "**/*.md"`
- `npx markdownlint-cli2 "**/*.md"`
- `npx cspell lint "**" --no-progress`

Closes #641

## Follow-up Issues
- none

## Background
- This keeps roadmap audits bottom-up for nested roadmap hierarchies without turning roadmap-audit claims into parent-level execution locks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance for nested/recursive roadmap hierarchies and contradictory/cycle cases
  * Clarified bottom-up completion: deepest completed nested roadmap closed first; refined "Audit passes" outcome to require releasing claim and re-fetching ancestor state before parent re-evaluation
  * Tightened claim scoping and coordination for roadmap-level side effects—claims must target the exact roadmap node and cannot be reused

* **Tests**
  * Added consistency validation to ensure roadmap audit guidance remains aligned across documentation surfaces

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->