### PR TITLE
docs(idd-workflow): document recursive roadmap usage patterns

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,6 +70,13 @@ Use task-list links to group active roadmap work. Reserve
 `idd-skill-blocked-by` markers for true sequential dependencies on a
 separate roadmap.
 
+When a project has genuine parallel tracks or multi-session coordination
+boundaries, nested roadmap hierarchies let each track close
+independently before the parent roadmap closes. See
+[Recursive Roadmap Hierarchies](idd-workflow.md#recursive-roadmap-hierarchies)
+in the workflow guide for structure examples, the grouping-versus-dependency
+distinction, and how discovery and bottom-up audit behave across levels.
+
 ## 4. Start the Loop
 
 Ask the agent to start the IDD workflow in the target repository. The

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -200,6 +200,111 @@ limited to the PR that just merged and the local cleanup for that child
 issue. F5 then loops back to Discover, where roadmap completion can be
 checked with the broader parent context.
 
+## Recursive Roadmap Hierarchies
+
+IDD's roadmap traversal already follows transitive issue references, so
+nested structures such as `root roadmap → track roadmap → leaf execution
+issues` work without any extra configuration. This section explains when
+to use them, how to structure them, and how discovery and audit behave at
+each level.
+
+### When to keep a roadmap flat
+
+Start with a single-level roadmap. A flat task list inside one roadmap
+issue is the right default when all sub-tasks belong to the same
+implementation cycle, run at the same cadence, and can merge without
+coordination across teams or phases. Adding nesting for its own sake
+introduces unnecessary coordination overhead.
+
+### When nesting adds value
+
+Introduce a nested roadmap when the work genuinely needs a coordination
+boundary that a flat task list cannot express cleanly:
+
+- **Parallel tracks**: two sub-roadmaps that operate independently and
+  merge on different schedules (for example, a data-layer track and a UI
+  track that each have their own checkpoints before the parent can close).
+- **Multi-session handoff**: a sub-roadmap that a different team or agent
+  pool owns, where the parent roadmap should stay open until that team
+  signals completion at the sub-roadmap level.
+- **Phase gates**: a project that has a documented checkpoint issue
+  (CP-A, CP-B, …) after which a group of sub-tasks becomes relevant.
+
+If the only reason to nest is that the task list feels long, keep the
+flat structure and use numbered sections inside the roadmap body instead.
+
+### Structuring a two-level hierarchy
+
+A two-level hierarchy has one parent roadmap with nested track roadmaps
+as children:
+
+```text
+Parent roadmap (#100)
+├─ Track A — roadmap (#110)
+│   ├─ Leaf issue #111
+│   └─ Leaf issue #112
+└─ Track B — roadmap (#120)
+    ├─ Leaf issue #121
+    └─ Leaf issue #122
+```
+
+Reference child roadmaps from the parent's task list using standard
+`- [ ] #NNN` entries. Do not use `idd-skill-blocked-by` markers to group
+sub-tasks under an active roadmap — that marker is reserved for true
+sequential dependencies on a _separate, prior_ roadmap that must close
+before the dependent work can start.
+
+### Grouping versus sequential dependency
+
+| Mechanism             | Syntax                                        | Meaning                                                    |
+| --------------------- | --------------------------------------------- | ---------------------------------------------------------- |
+| Task-list grouping    | `- [ ] #NNN` in roadmap body                  | Active parallel work; all items may proceed simultaneously |
+| Sequential dependency | `<!-- idd-skill-blocked-by: {roadmap-id} -->` | This issue must wait until the named roadmap is closed     |
+
+Use task-list links when you want concurrent execution. Use
+`idd-skill-blocked-by` only when one roadmap phase must completely finish
+before another can start.
+
+### How discovery treats nested roadmap nodes
+
+Discover (A2) traverses the full outbound reference graph from the
+selected roadmap. Open nested roadmap nodes are traversal-only
+coordination nodes: the agent walks through them to reach leaf execution
+issues but never advances a roadmap node itself into the
+readiness/claim/viability gates. Only non-roadmap leaf issues become
+execution candidates.
+
+The no-candidate diagnostic distinguishes "no reachable leaf execution
+issues" from "only open roadmap nodes remain", so operators can tell
+whether the tree is still healthy or whether leaf issues are missing.
+
+When the recursive graph helper (#642) is available, it can enumerate
+the full traversal graph, classify roadmap nodes separately from
+execution candidates, and report provenance paths and cycle detection for
+Discover and roadmap audit use.
+
+### Bottom-up completion
+
+Roadmaps close bottom-up. When discovery loops back after a child merge,
+the audit evaluates the deepest roadmap whose referenced descendants are
+all closed. That roadmap closes first. Its parent roadmap remains open
+until all of its nested roadmap children are also closed or otherwise
+complete.
+
+Each roadmap-side mutation (comment, label, close) uses a
+`roadmap-audit/*` coordination claim scoped to the roadmap issue being
+mutated. These claims are coordination locks for roadmap-side effects
+only and do not block child execution in other branches of the same tree.
+
+### Issue-scope default
+
+Nested roadmap support does not change the repository's default
+`issue-scope`. The `roadmap` default means Discover always starts with
+the selected roadmap and traverses its full graph, including nested
+roadmap nodes, to find leaf execution candidates. Adopters who want
+unblocked orphan issues to be considered before roadmap traversal must
+choose `orphan-first` explicitly in `.github/idd/config.json`.
+
 ## Resume routing model
 
 Resume now starts with a deterministic external-signal classifier before

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -223,12 +223,10 @@ boundary that a flat task list cannot express cleanly:
 
 - **Parallel tracks**: two sub-roadmaps that operate independently and
   merge on different schedules (for example, a data-layer track and a UI
-  track that each have their own checkpoints before the parent can close).
+  track that each need their own lifecycle before the parent can close).
 - **Multi-session handoff**: a sub-roadmap that a different team or agent
   pool owns, where the parent roadmap should stay open until that team
   signals completion at the sub-roadmap level.
-- **Phase gates**: a project that has a documented checkpoint issue
-  (CP-A, CP-B, …) after which a group of sub-tasks becomes relevant.
 
 If the only reason to nest is that the task list feels long, keep the
 flat structure and use numbered sections inside the roadmap body instead.

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -266,11 +266,14 @@ before another can start.
 ### How discovery treats nested roadmap nodes
 
 Discover (A2) traverses the full outbound reference graph from the
-selected roadmap. Open nested roadmap nodes are traversal-only
-coordination nodes: the agent walks through them to reach leaf execution
-issues but never advances a roadmap node itself into the
+selected roadmap. The intended design treats open nested roadmap nodes as
+traversal-only coordination nodes: the agent walks through them to reach
+leaf execution issues without advancing roadmap nodes themselves into the
 readiness/claim/viability gates. Only non-roadmap leaf issues become
-execution candidates.
+execution candidates. The Discover instruction rules that formally
+classify roadmap nodes are being specified in #640; until those rules
+land, a nested roadmap node that passes the current A3/A4 filters could
+theoretically enter the candidate set.
 
 The no-candidate diagnostic distinguishes "no reachable leaf execution
 issues" from "only open roadmap nodes remain", so operators can tell
@@ -283,12 +286,15 @@ Discover and roadmap audit use.
 
 ### Bottom-up completion
 
-Nested roadmaps create a natural bottom-up closing order. A nested
-roadmap (for example, a track roadmap) is eligible to close as soon as
-all of its own referenced leaf issues and any further descendants are
-resolved. Its parent roadmap remains open while any nested roadmap child
-is still open; only after all nested roadmap children close can the
-parent roadmap itself be audited and closed.
+Nested roadmaps create a natural bottom-up closing order. When all of a
+nested roadmap's referenced leaf issues and further descendants are
+resolved, the A1.5 roadmap audit evaluates its success criteria against
+the closed issues, merged PRs, task-list state, and repository state. If
+the audit finds autonomous gaps, it creates or links follow-up issues
+before closing. The parent roadmap remains open while any nested roadmap
+child is still open or has an unresolved autonomous gap; only after all
+nested roadmap children pass their own A1.5 audits can the parent
+roadmap itself be evaluated and closed.
 
 Each roadmap-side mutation (comment, label, close) uses a
 `roadmap-audit/*` coordination claim scoped to the roadmap issue being
@@ -302,7 +308,12 @@ Nested roadmap support does not change the repository's default
 the selected roadmap and traverses its full graph, including nested
 roadmap nodes, to find leaf execution candidates. Adopters who want
 unblocked orphan issues to be considered before roadmap traversal must
-choose `orphan-first` explicitly in `.github/idd/config.json`.
+set `orphan-first` in both the `"orphanFirstPolicy"` key in
+`.github/idd/config.json` and the `orphan-first-policy` row in the
+project commands table in
+`.github/instructions/idd-overview.instructions.md`. See
+[IDD policy constants](policy-constants.md) for the synchronization
+requirement between these two sources.
 
 ## Resume routing model
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -283,11 +283,12 @@ Discover and roadmap audit use.
 
 ### Bottom-up completion
 
-Roadmaps close bottom-up. When discovery loops back after a child merge,
-the audit evaluates the deepest roadmap whose referenced descendants are
-all closed. That roadmap closes first. Its parent roadmap remains open
-until all of its nested roadmap children are also closed or otherwise
-complete.
+Nested roadmaps create a natural bottom-up closing order. A nested
+roadmap (for example, a track roadmap) is eligible to close as soon as
+all of its own referenced leaf issues and any further descendants are
+resolved. Its parent roadmap remains open while any nested roadmap child
+is still open; only after all nested roadmap children close can the
+parent roadmap itself be audited and closed.
 
 Each roadmap-side mutation (comment, label, close) uses a
 `roadmap-audit/*` coordination claim scoped to the roadmap issue being

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -70,6 +70,13 @@ Use task-list links to group active roadmap work. Reserve
 `idd-skill-blocked-by` markers for true sequential dependencies on a
 separate roadmap.
 
+When a project has genuine parallel tracks or multi-session coordination
+boundaries, nested roadmap hierarchies let each track close
+independently before the parent roadmap closes. See
+[Recursive Roadmap Hierarchies](idd-workflow.md#recursive-roadmap-hierarchies)
+in the workflow guide for structure examples, the grouping-versus-dependency
+distinction, and how discovery and bottom-up audit behave across levels.
+
 ## 4. Start the Loop
 
 Ask the agent to start the IDD workflow in the target repository. The

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -247,11 +247,14 @@ before another can start.
 ### How discovery treats nested roadmap nodes
 
 Discover (A2) traverses the full outbound reference graph from the
-selected roadmap. Open nested roadmap nodes are traversal-only
-coordination nodes: the agent walks through them to reach leaf execution
-issues but never advances a roadmap node itself into the
+selected roadmap. The intended design treats open nested roadmap nodes as
+traversal-only coordination nodes: the agent walks through them to reach
+leaf execution issues without advancing roadmap nodes themselves into the
 readiness/claim/viability gates. Only non-roadmap leaf issues become
-execution candidates.
+execution candidates. Check whether the Discover instruction files in
+your installed version already enforce this formal classification; if
+not, a nested roadmap node that passes the current A3/A4 filters could
+theoretically enter the candidate set.
 
 The no-candidate diagnostic distinguishes "no reachable leaf execution
 issues" from "only open roadmap nodes remain", so operators can tell
@@ -264,12 +267,15 @@ and roadmap audit use.
 
 ### Bottom-up completion
 
-Nested roadmaps create a natural bottom-up closing order. A nested
-roadmap (for example, a track roadmap) is eligible to close as soon as
-all of its own referenced leaf issues and any further descendants are
-resolved. Its parent roadmap remains open while any nested roadmap child
-is still open; only after all nested roadmap children close can the
-parent roadmap itself be audited and closed.
+Nested roadmaps create a natural bottom-up closing order. When all of a
+nested roadmap's referenced leaf issues and further descendants are
+resolved, the A1.5 roadmap audit evaluates its success criteria against
+the closed issues, merged PRs, task-list state, and repository state. If
+the audit finds autonomous gaps, it creates or links follow-up issues
+before closing. The parent roadmap remains open while any nested roadmap
+child is still open or has an unresolved autonomous gap; only after all
+nested roadmap children pass their own A1.5 audits can the parent
+roadmap itself be evaluated and closed.
 
 Each roadmap-side mutation (comment, label, close) uses a
 `roadmap-audit/*` coordination claim scoped to the roadmap issue being
@@ -283,7 +289,12 @@ Nested roadmap support does not change the repository's default
 the selected roadmap and traverses its full graph, including nested
 roadmap nodes, to find leaf execution candidates. Adopters who want
 unblocked orphan issues to be considered before roadmap traversal must
-choose `orphan-first` explicitly in `.github/idd/config.json`.
+set `orphan-first` in both the `"orphanFirstPolicy"` key in
+`.github/idd/config.json` and the `orphan-first-policy` row in the
+project commands table in
+`.github/instructions/idd-overview.instructions.md`. See
+[IDD policy constants](policy-constants.md) for the synchronization
+requirement between these two sources.
 
 ## Resume routing model
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -181,6 +181,110 @@ limited to the PR that just merged and the local cleanup for that child
 issue. F5 then loops back to Discover, where roadmap completion can be
 checked with the broader parent context.
 
+## Recursive Roadmap Hierarchies
+
+IDD's roadmap traversal already follows transitive issue references, so
+nested structures such as `root roadmap → track roadmap → leaf execution
+issues` work without any extra configuration. This section explains when
+to use them, how to structure them, and how discovery and audit behave at
+each level.
+
+### When to keep a roadmap flat
+
+Start with a single-level roadmap. A flat task list inside one roadmap
+issue is the right default when all sub-tasks belong to the same
+implementation cycle, run at the same cadence, and can merge without
+coordination across teams or phases. Adding nesting for its own sake
+introduces unnecessary coordination overhead.
+
+### When nesting adds value
+
+Introduce a nested roadmap when the work genuinely needs a coordination
+boundary that a flat task list cannot express cleanly:
+
+- **Parallel tracks**: two sub-roadmaps that operate independently and
+  merge on different schedules (for example, a data-layer track and a UI
+  track that each need their own lifecycle before the parent can close).
+- **Multi-session handoff**: a sub-roadmap that a different team or agent
+  pool owns, where the parent roadmap should stay open until that team
+  signals completion at the sub-roadmap level.
+
+If the only reason to nest is that the task list feels long, keep the
+flat structure and use numbered sections inside the roadmap body instead.
+
+### Structuring a two-level hierarchy
+
+A two-level hierarchy has one parent roadmap with nested track roadmaps
+as children:
+
+```text
+Parent roadmap (#100)
+├─ Track A — roadmap (#110)
+│   ├─ Leaf issue #111
+│   └─ Leaf issue #112
+└─ Track B — roadmap (#120)
+    ├─ Leaf issue #121
+    └─ Leaf issue #122
+```
+
+Reference child roadmaps from the parent's task list using standard
+`- [ ] #NNN` entries. Do not use `idd-skill-blocked-by` markers to group
+sub-tasks under an active roadmap — that marker is reserved for true
+sequential dependencies on a _separate, prior_ roadmap that must close
+before the dependent work can start.
+
+### Grouping versus sequential dependency
+
+| Mechanism             | Syntax                                        | Meaning                                                    |
+| --------------------- | --------------------------------------------- | ---------------------------------------------------------- |
+| Task-list grouping    | `- [ ] #NNN` in roadmap body                  | Active parallel work; all items may proceed simultaneously |
+| Sequential dependency | `<!-- idd-skill-blocked-by: {roadmap-id} -->` | This issue must wait until the named roadmap is closed     |
+
+Use task-list links when you want concurrent execution. Use
+`idd-skill-blocked-by` only when one roadmap phase must completely finish
+before another can start.
+
+### How discovery treats nested roadmap nodes
+
+Discover (A2) traverses the full outbound reference graph from the
+selected roadmap. Open nested roadmap nodes are traversal-only
+coordination nodes: the agent walks through them to reach leaf execution
+issues but never advances a roadmap node itself into the
+readiness/claim/viability gates. Only non-roadmap leaf issues become
+execution candidates.
+
+The no-candidate diagnostic distinguishes "no reachable leaf execution
+issues" from "only open roadmap nodes remain", so operators can tell
+whether the tree is still healthy or whether leaf issues are missing.
+
+When the recursive graph helper is available, it can enumerate the full
+traversal graph, classify roadmap nodes separately from execution
+candidates, and report provenance paths and cycle detection for Discover
+and roadmap audit use.
+
+### Bottom-up completion
+
+Nested roadmaps create a natural bottom-up closing order. A nested
+roadmap (for example, a track roadmap) is eligible to close as soon as
+all of its own referenced leaf issues and any further descendants are
+resolved. Its parent roadmap remains open while any nested roadmap child
+is still open; only after all nested roadmap children close can the
+parent roadmap itself be audited and closed.
+
+Each roadmap-side mutation (comment, label, close) uses a
+`roadmap-audit/*` coordination claim scoped to the roadmap issue being
+mutated. These claims are coordination locks for roadmap-side effects
+only and do not block child execution in other branches of the same tree.
+
+### Issue-scope default
+
+Nested roadmap support does not change the repository's default
+`issue-scope`. The `roadmap` default means Discover always starts with
+the selected roadmap and traverses its full graph, including nested
+roadmap nodes, to find leaf execution candidates. Adopters who want
+unblocked orphan issues to be considered before roadmap traversal must
+choose `orphan-first` explicitly in `.github/idd/config.json`.
+
 ## Resume routing model
 
 Resume now starts with a deterministic external-signal classifier before


### PR DESCRIPTION
## Summary

Add a \"Recursive Roadmap Hierarchies\" section to `docs/idd-workflow.md`
and a supporting pointer in `docs/getting-started.md` for issue #643.

Key content:

- **When to use nested roadmaps**: only when a genuine coordination
  boundary exists (parallel tracks with different lifecycles, multi-session
  handoff). A long task list is not a reason to nest.
- **Structure example**: two-level tree diagram (parent roadmap →
  track roadmap → leaf execution issues) with task-list notation.
- **Grouping vs. dependency**: table distinguishing `- [ ] #NNN`
  (active parallel work) from `idd-skill-blocked-by` (true sequential
  dependency on a prior roadmap).
- **Discovery behavior**: nested roadmap nodes are traversal-only
  coordination nodes; only leaf execution issues advance to claim gates.
  Forward reference to the graph helper when #642 lands.
- **Bottom-up completion**: a nested roadmap closes as soon as its own
  descendants are resolved; its parent stays open until all nested
  children close.
- **Issue-scope default**: nested roadmap support does not change the
  `roadmap` default; `orphan-first` must be opted into explicitly.

## Non-goals

Does not change execution instruction files or helper scripts — this is
operator-facing guidance only. Formal classification rules for A2 are in
#640; helper automation is in #642.

Closes #643