### PR TITLE
feat(helper): add roadmap graph helper

### DIFF
--- a/bin/idd-discover-roadmap-graph.mjs
+++ b/bin/idd-discover-roadmap-graph.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runHelper } from "./run-helper.mjs";
+
+runHelper("../scripts/discover-roadmap-graph.mjs");

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -13,6 +13,8 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/discover-orphan-filter.mjs` for A0-O orphan issue detection and
   filtering (referenced in
   [kurone-kito/idd-skill#390](https://github.com/kurone-kito/idd-skill/issues/390))
+- `scripts/discover-roadmap-graph.mjs` for A1.5/A2 recursive roadmap graph
+  enumeration and classification
 - `scripts/discover-readiness-check.mjs` for A3 readiness criterion
   evaluation (referenced in
   [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391))
@@ -147,6 +149,40 @@ rules remain authoritative when outputs diverge.
 For discover and suitability, use the adopted helpers first when helper
 support is enabled, then fall back to the portable instructions if a
 helper is unavailable or its output does not match the written rules.
+
+### Discover Roadmap Graph Contract
+
+`scripts/discover-roadmap-graph.mjs` evaluates the recursive A1.5/A2
+roadmap graph for one selected roadmap issue.
+
+- **Inputs**: `--issue <number>`, with optional `--owner <owner>`,
+  `--repo <repo>`, and `--policy <path>`.
+- **JSON output**:
+  - `root`: `{ number: number, title: string, state: string,`
+    `classification: "roadmap" | "execution", roadmapMarkerId: string }`
+  - `nodes`: `[{ number: number, title: string, state: string,`
+    `labels: string[], classification: "roadmap" | "execution",`
+    `roadmapMarkerId: string, depth: number }]`
+  - `edges`: `[{ source: number, target: number, relationship: string,`
+    `evidence: string }]`
+  - `provenancePaths`: `[{ target: number, path: number[] }]`
+  - `roadmapNodes`: `number[]`
+  - `executionCandidates`: `number[]`
+  - `diagnostics`: `{ duplicateReferences: object[], cycles: object[],`
+    `inaccessibleReferences: object[], unresolvedReferences: object[] }`
+  - `summary`: `{ rootNumber: number, nodeCount: number, edgeCount: number,`
+    `roadmapNodeCount: number, executionCandidateCount: number,`
+    `duplicateReferenceCount: number, cycleCount: number,`
+    `inaccessibleReferenceCount: number, unresolvedReferenceCount: number,`
+    `maxDepth: number }`
+- **Error conditions**: missing `--issue`, unknown flags, an unreadable
+  root roadmap, or incomplete `subIssues` GraphQL data throw. Missing or
+  inaccessible descendants are reported in `diagnostics` instead of
+  crashing.
+- **Behavior boundary**: the helper is evidence-only. It may read issue
+  bodies and GitHub sub-issue relationships, but it must not claim
+  issues, edit roadmap bodies, close roadmap nodes, or decide readiness
+  by itself.
 
 ### Discover Viability Gate Contract
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -13,6 +13,8 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/discover-orphan-filter.mjs` for A0-O orphan issue detection and
   filtering (referenced in
   [kurone-kito/idd-skill#390](https://github.com/kurone-kito/idd-skill/issues/390))
+- `scripts/discover-roadmap-graph.mjs` for A1.5/A2 recursive roadmap graph
+  enumeration and classification
 - `scripts/discover-readiness-check.mjs` for A3 readiness criterion
   evaluation (referenced in
   [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391))
@@ -147,6 +149,40 @@ rules remain authoritative when outputs diverge.
 For discover and suitability, use the adopted helpers first when helper
 support is enabled, then fall back to the portable instructions if a
 helper is unavailable or its output does not match the written rules.
+
+### Discover Roadmap Graph Contract
+
+`scripts/discover-roadmap-graph.mjs` evaluates the recursive A1.5/A2
+roadmap graph for one selected roadmap issue.
+
+- **Inputs**: `--issue <number>`, with optional `--owner <owner>`,
+  `--repo <repo>`, and `--policy <path>`.
+- **JSON output**:
+  - `root`: `{ number: number, title: string, state: string,`
+    `classification: "roadmap" | "execution", roadmapMarkerId: string }`
+  - `nodes`: `[{ number: number, title: string, state: string,`
+    `labels: string[], classification: "roadmap" | "execution",`
+    `roadmapMarkerId: string, depth: number }]`
+  - `edges`: `[{ source: number, target: number, relationship: string,`
+    `evidence: string }]`
+  - `provenancePaths`: `[{ target: number, path: number[] }]`
+  - `roadmapNodes`: `number[]`
+  - `executionCandidates`: `number[]`
+  - `diagnostics`: `{ duplicateReferences: object[], cycles: object[],`
+    `inaccessibleReferences: object[], unresolvedReferences: object[] }`
+  - `summary`: `{ rootNumber: number, nodeCount: number, edgeCount: number,`
+    `roadmapNodeCount: number, executionCandidateCount: number,`
+    `duplicateReferenceCount: number, cycleCount: number,`
+    `inaccessibleReferenceCount: number, unresolvedReferenceCount: number,`
+    `maxDepth: number }`
+- **Error conditions**: missing `--issue`, unknown flags, an unreadable
+  root roadmap, or incomplete `subIssues` GraphQL data throw. Missing or
+  inaccessible descendants are reported in `diagnostics` instead of
+  crashing.
+- **Behavior boundary**: the helper is evidence-only. It may read issue
+  bodies and GitHub sub-issue relationships, but it must not claim
+  issues, edit roadmap bodies, close roadmap nodes, or decide readiness
+  by itself.
 
 ### Discover Viability Gate Contract
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "idd-claim-approval-gate": "./bin/idd-claim-approval-gate.mjs",
     "idd-ci-wait-policy": "./bin/idd-ci-wait-policy.mjs",
     "idd-cleanup-hygiene-report": "./bin/idd-cleanup-hygiene-report.mjs",
+    "idd-discover-roadmap-graph": "./bin/idd-discover-roadmap-graph.mjs",
     "idd-discover-readiness-check": "./bin/idd-discover-readiness-check.mjs",
     "idd-discover-orphan-filter": "./bin/idd-discover-orphan-filter.mjs",
     "idd-discover-viability-gate": "./bin/idd-discover-viability-gate.mjs",

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 const DEFAULT_MARKER_PREFIX = "idd-skill";
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({ __iddLookupStatus: "inaccessible" });
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
+const KEYWORD_REFERENCE_REGEX = /\b(Closes|Close|Closed|Fixes|Fixed|Resolves|Resolved|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
@@ -67,12 +68,13 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
     unresolvedReferences: [],
   };
   const pathKeys = new Set();
+  const visitedIssuePaths = new Set();
   const edgeKeys = new Set();
   const duplicateKeys = new Set();
   const cycleKeys = new Set();
   const inaccessibleKeys = new Set();
   const unresolvedKeys = new Set();
-  const expanded = new Set();
+  const referenceCache = new Map();
   const firstReferenceByTarget = new Map();
 
   const rootIssue = await getIssue(rootIssueNumber, issueCache, loadIssue);
@@ -145,17 +147,14 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
       return;
     }
 
-    recordNode(issue, path);
-    if (expanded.has(issue.number)) {
+    const visitKey = `${issue.number}:${path.join(">")}`;
+    if (visitedIssuePaths.has(visitKey)) {
       return;
     }
-    expanded.add(issue.number);
+    visitedIssuePaths.add(visitKey);
 
-    const references = [
-      ...extractTaskListReferences(issue.body),
-      ...extractKeywordReferences(issue.body),
-      ...normalizeSubIssueReferences(await loadSubIssues(issue.number)),
-    ];
+    recordNode(issue, path);
+    const references = await getReferences(issue);
     const seenSourceTargets = new Set();
 
     for (const reference of references) {
@@ -213,6 +212,19 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
       recordProvenancePath(edge.target, nextPath);
       await visitIssue(edge.target, nextPath);
     }
+  }
+
+  async function getReferences(issue) {
+    if (referenceCache.has(issue.number)) {
+      return referenceCache.get(issue.number);
+    }
+    const references = [
+      ...extractTaskListReferences(issue.body),
+      ...extractKeywordReferences(issue.body),
+      ...normalizeSubIssueReferences(await loadSubIssues(issue.number)),
+    ];
+    referenceCache.set(issue.number, references);
+    return references;
   }
 
   function recordNode(issue, path) {
@@ -300,17 +312,23 @@ export function extractTaskListReferences(body) {
 export function extractKeywordReferences(body) {
   const references = [];
   for (const line of String(body ?? "").split(/\r?\n/u)) {
-    const regex = /\b(Closes|Close|Closed|Fixes|Fixed|Resolves|Resolved|Refs|Ref|Depends on|Sub-issue|Sub issue)\s+#(\d+)\b/giu;
-    for (const match of line.matchAll(regex)) {
-      const target = Number.parseInt(match[2], 10);
-      if (!Number.isInteger(target) || target <= 0) {
-        continue;
+    const keywordMatches = [...line.matchAll(KEYWORD_REFERENCE_REGEX)];
+    for (let index = 0; index < keywordMatches.length; index += 1) {
+      const match = keywordMatches[index];
+      const segmentStart = (match.index ?? 0) + match[0].length;
+      const segmentEnd = keywordMatches[index + 1]?.index ?? line.length;
+      const segment = line.slice(segmentStart, segmentEnd);
+      for (const targetMatch of segment.matchAll(/#(\d+)\b/gu)) {
+        const target = Number.parseInt(targetMatch[1], 10);
+        if (!Number.isInteger(target) || target <= 0) {
+          continue;
+        }
+        references.push({
+          target,
+          relationship: classifyKeywordRelationship(match[1]),
+          evidence: line.trim(),
+        });
       }
-      references.push({
-        target,
-        relationship: classifyKeywordRelationship(match[1]),
-        evidence: line.trim(),
-      });
     }
   }
   return references;
@@ -318,7 +336,7 @@ export function extractKeywordReferences(body) {
 
 function classifyKeywordRelationship(keyword) {
   const normalized = String(keyword ?? "").toLowerCase();
-  if (normalized.startsWith("depend")) {
+  if (normalized.startsWith("depend") || normalized.startsWith("blocked")) {
     return "dependency";
   }
   if (normalized.startsWith("sub")) {
@@ -443,17 +461,21 @@ function normalizeLabels(labelsInput) {
     return new Set();
   }
   if (labelsInput instanceof Set) {
-    return new Set([...labelsInput].map((label) => String(label ?? "")).filter(Boolean));
+    return new Set([...labelsInput].map(normalizeLabelName).filter(Boolean));
   }
   if (Array.isArray(labelsInput)) {
     return new Set(labelsInput.map((label) => {
       if (typeof label === "string") {
-        return label;
+        return normalizeLabelName(label);
       }
-      return String(label?.name ?? "");
+      return normalizeLabelName(label?.name);
     }).filter(Boolean));
   }
   return new Set();
+}
+
+function normalizeLabelName(label) {
+  return String(label ?? "").trim().toLowerCase();
 }
 
 function normalizeMarkerPrefix(markerPrefix) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1,0 +1,677 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_MARKER_PREFIX = "idd-skill";
+const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({ __iddLookupStatus: "inaccessible" });
+const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
+const SUB_ISSUES_QUERY = `
+query($owner:String!, $repo:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$repo) {
+    issue(number:$number) {
+      subIssues(first:100, after:$after) {
+        nodes {
+          number
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+`;
+
+if (isMainModule(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2));
+  if (!Number.isInteger(args.issue) || args.issue <= 0) {
+    throw new Error("missing required --issue <number>");
+  }
+
+  const owner = args.owner || ghText(["repo", "view", "--json", "owner", "--jq", ".owner.login"]);
+  const repo = args.repo || ghText(["repo", "view", "--json", "name", "--jq", ".name"]);
+  const policy = loadPolicy(args.policy);
+
+  const graph = await enumerateRoadmapGraph(args.issue, {
+    markerPrefix: policy.markerPrefix,
+    loadIssue: buildIssueLoader(owner, repo),
+    loadSubIssues: buildSubIssueLoader(owner, repo),
+  });
+
+  process.stdout.write(`${JSON.stringify(graph, null, 2)}\n`);
+}
+
+export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
+  const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  const loadIssue = options.loadIssue;
+  const loadSubIssues = typeof options.loadSubIssues === "function"
+    ? options.loadSubIssues
+    : async () => [];
+
+  if (typeof loadIssue !== "function") {
+    throw new Error("enumerateRoadmapGraph requires loadIssue(issueNumber)");
+  }
+
+  const issueCache = new Map();
+  const nodeRecords = new Map();
+  const edges = [];
+  const provenancePaths = [];
+  const diagnostics = {
+    duplicateReferences: [],
+    cycles: [],
+    inaccessibleReferences: [],
+    unresolvedReferences: [],
+  };
+  const pathKeys = new Set();
+  const edgeKeys = new Set();
+  const duplicateKeys = new Set();
+  const cycleKeys = new Set();
+  const inaccessibleKeys = new Set();
+  const unresolvedKeys = new Set();
+  const expanded = new Set();
+  const firstReferenceByTarget = new Map();
+
+  const rootIssue = await getIssue(rootIssueNumber, issueCache, loadIssue);
+  if (!rootIssue) {
+    throw new Error(`root issue #${rootIssueNumber} was not found`);
+  }
+  if (isInaccessibleIssue(rootIssue)) {
+    throw new Error(`root issue #${rootIssueNumber} is inaccessible`);
+  }
+
+  await visitIssue(rootIssue.number, [rootIssue.number]);
+
+  const nodes = [...nodeRecords.values()]
+    .map((node) => ({
+      number: node.number,
+      title: node.title,
+      state: node.state,
+      labels: [...node.labels].sort(),
+      classification: node.classification,
+      roadmapMarkerId: node.roadmapMarkerId,
+      depth: node.depth,
+    }))
+    .sort(compareByNumber);
+  const sortedEdges = [...edges].sort(compareEdges);
+  const sortedProvenancePaths = [...provenancePaths].sort(comparePaths);
+  const roadmapNodes = nodes
+    .filter((node) => node.classification === "roadmap")
+    .map((node) => node.number);
+  const executionCandidates = nodes
+    .filter((node) => node.classification === "execution" && node.state === "OPEN")
+    .map((node) => node.number);
+  const rootNode = nodeRecords.get(rootIssue.number);
+
+  return {
+    root: {
+      number: rootNode.number,
+      title: rootNode.title,
+      state: rootNode.state,
+      classification: rootNode.classification,
+      roadmapMarkerId: rootNode.roadmapMarkerId,
+    },
+    nodes,
+    edges: sortedEdges,
+    provenancePaths: sortedProvenancePaths,
+    roadmapNodes,
+    executionCandidates,
+    diagnostics: {
+      duplicateReferences: diagnostics.duplicateReferences.sort(compareDiagnostics),
+      cycles: diagnostics.cycles.sort(compareCycles),
+      inaccessibleReferences: diagnostics.inaccessibleReferences.sort(compareDiagnostics),
+      unresolvedReferences: diagnostics.unresolvedReferences.sort(compareDiagnostics),
+    },
+    summary: {
+      rootNumber: rootNode.number,
+      nodeCount: nodes.length,
+      edgeCount: sortedEdges.length,
+      roadmapNodeCount: roadmapNodes.length,
+      executionCandidateCount: executionCandidates.length,
+      duplicateReferenceCount: diagnostics.duplicateReferences.length,
+      cycleCount: diagnostics.cycles.length,
+      inaccessibleReferenceCount: diagnostics.inaccessibleReferences.length,
+      unresolvedReferenceCount: diagnostics.unresolvedReferences.length,
+      maxDepth: nodes.reduce((maxDepth, node) => Math.max(maxDepth, node.depth), 0),
+    },
+  };
+
+  async function visitIssue(issueNumber, path) {
+    const issue = await getIssue(issueNumber, issueCache, loadIssue);
+    if (!issue || isInaccessibleIssue(issue)) {
+      return;
+    }
+
+    recordNode(issue, path);
+    if (expanded.has(issue.number)) {
+      return;
+    }
+    expanded.add(issue.number);
+
+    const references = [
+      ...extractTaskListReferences(issue.body),
+      ...extractKeywordReferences(issue.body),
+      ...normalizeSubIssueReferences(await loadSubIssues(issue.number)),
+    ];
+    const seenSourceTargets = new Set();
+
+    for (const reference of references) {
+      const edge = {
+        source: issue.number,
+        target: reference.target,
+        relationship: reference.relationship,
+        evidence: reference.evidence,
+      };
+      const edgeKey = buildEdgeKey(edge);
+      if (!edgeKeys.has(edgeKey)) {
+        edgeKeys.add(edgeKey);
+        edges.push(edge);
+      }
+
+      const sourceTargetKey = `${edge.source}:${edge.target}`;
+      if (seenSourceTargets.has(sourceTargetKey)) {
+        recordDuplicateReference(edge, firstReferenceByTarget.get(edge.target) ?? edge);
+      }
+      seenSourceTargets.add(sourceTargetKey);
+
+      const firstReference = firstReferenceByTarget.get(edge.target);
+      if (firstReference) {
+        recordDuplicateReference(edge, firstReference);
+      } else {
+        firstReferenceByTarget.set(edge.target, edge);
+      }
+
+      if (path.includes(edge.target)) {
+        const cyclePath = [...path, edge.target];
+        const cycleKey = cyclePath.join(">");
+        if (!cycleKeys.has(cycleKey)) {
+          cycleKeys.add(cycleKey);
+          diagnostics.cycles.push({
+            source: edge.source,
+            target: edge.target,
+            relationship: edge.relationship,
+            path: cyclePath,
+          });
+        }
+        continue;
+      }
+
+      const targetIssue = await getIssue(edge.target, issueCache, loadIssue);
+      if (!targetIssue) {
+        recordReferenceDiagnostic(diagnostics.unresolvedReferences, unresolvedKeys, edge, "issue_not_found");
+        continue;
+      }
+      if (isInaccessibleIssue(targetIssue)) {
+        recordReferenceDiagnostic(diagnostics.inaccessibleReferences, inaccessibleKeys, edge, "issue_inaccessible");
+        continue;
+      }
+
+      const nextPath = [...path, edge.target];
+      recordProvenancePath(edge.target, nextPath);
+      await visitIssue(edge.target, nextPath);
+    }
+  }
+
+  function recordNode(issue, path) {
+    const existing = nodeRecords.get(issue.number);
+    const classification = classifyIssue(issue, markerPrefix);
+    const depth = path.length - 1;
+    if (existing) {
+      existing.depth = Math.min(existing.depth, depth);
+      return;
+    }
+
+    nodeRecords.set(issue.number, {
+      number: issue.number,
+      title: issue.title,
+      state: issue.state,
+      labels: issue.labels,
+      classification: classification.kind,
+      roadmapMarkerId: classification.roadmapMarkerId,
+      depth,
+    });
+    recordProvenancePath(issue.number, path);
+  }
+
+  function recordProvenancePath(target, path) {
+    const pathKey = `${target}:${path.join(">")}`;
+    if (pathKeys.has(pathKey)) {
+      return;
+    }
+    pathKeys.add(pathKey);
+    provenancePaths.push({ target, path });
+  }
+
+  function recordDuplicateReference(edge, firstReference) {
+    const key = `${edge.source}:${edge.target}:${edge.relationship}:${edge.evidence}`;
+    if (duplicateKeys.has(key)) {
+      return;
+    }
+    duplicateKeys.add(key);
+    diagnostics.duplicateReferences.push({
+      source: edge.source,
+      target: edge.target,
+      relationship: edge.relationship,
+      evidence: edge.evidence,
+      firstSeenFrom: firstReference.source,
+    });
+  }
+}
+
+export function extractRoadmapMarkerId(body, markerPrefix = DEFAULT_MARKER_PREFIX) {
+  const regex = new RegExp(`<!--\\s*${escapeRegex(markerPrefix)}-roadmap-id:\\s*([^\\s>]+)\\s*-->`, "i");
+  const match = regex.exec(String(body ?? ""));
+  return match ? match[1] : "";
+}
+
+export function classifyIssue(issue, markerPrefix = DEFAULT_MARKER_PREFIX) {
+  const roadmapMarkerId = extractRoadmapMarkerId(issue.body, markerPrefix);
+  const labels = normalizeLabels(issue.labels);
+  if (roadmapMarkerId || labels.has("roadmap")) {
+    return {
+      kind: "roadmap",
+      roadmapMarkerId,
+    };
+  }
+  return {
+    kind: "execution",
+    roadmapMarkerId: "",
+  };
+}
+
+export function extractTaskListReferences(body) {
+  return String(body ?? "")
+    .split(/\r?\n/u)
+    .flatMap((line) => {
+      const match = line.match(/^\s*-\s*\[(?: |x)\]\s+#(\d+)\b/u);
+      if (!match) {
+        return [];
+      }
+      const target = Number.parseInt(match[1], 10);
+      return Number.isInteger(target) && target > 0
+        ? [{ target, relationship: "task-list", evidence: line.trim() }]
+        : [];
+    });
+}
+
+export function extractKeywordReferences(body) {
+  const references = [];
+  for (const line of String(body ?? "").split(/\r?\n/u)) {
+    const regex = /\b(Closes|Close|Closed|Fixes|Fixed|Resolves|Resolved|Refs|Ref|Depends on|Sub-issue|Sub issue)\s+#(\d+)\b/giu;
+    for (const match of line.matchAll(regex)) {
+      const target = Number.parseInt(match[2], 10);
+      if (!Number.isInteger(target) || target <= 0) {
+        continue;
+      }
+      references.push({
+        target,
+        relationship: classifyKeywordRelationship(match[1]),
+        evidence: line.trim(),
+      });
+    }
+  }
+  return references;
+}
+
+function classifyKeywordRelationship(keyword) {
+  const normalized = String(keyword ?? "").toLowerCase();
+  if (normalized.startsWith("depend")) {
+    return "dependency";
+  }
+  if (normalized.startsWith("sub")) {
+    return "sub-issue-reference";
+  }
+  if (normalized.startsWith("ref")) {
+    return "reference";
+  }
+  return "closing-keyword";
+}
+
+function normalizeSubIssueReferences(subIssues) {
+  return normalizeSubIssueNumbers(subIssues).map((target) => ({
+    target,
+    relationship: "sub-issue",
+    evidence: `GitHub sub-issue #${target}`,
+  }));
+}
+
+function normalizeSubIssueNumbers(subIssues) {
+  if (!Array.isArray(subIssues)) {
+    return [];
+  }
+  return [...new Set(subIssues
+    .map((entry) => {
+      if (typeof entry === "number") {
+        return entry;
+      }
+      return Number.parseInt(String(entry?.number ?? entry), 10);
+    })
+    .filter((value) => Number.isInteger(value) && value > 0))];
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    issue: 0,
+    owner: "",
+    repo: "",
+    policy: "",
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === "--issue") {
+      parsed.issue = Number.parseInt(String(value ?? ""), 10);
+      index += 1;
+      continue;
+    }
+    if (token === "--owner") {
+      parsed.owner = value ?? "";
+      index += 1;
+      continue;
+    }
+    if (token === "--repo") {
+      parsed.repo = value ?? "";
+      index += 1;
+      continue;
+    }
+    if (token === "--policy") {
+      parsed.policy = value ?? "";
+      index += 1;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>]
+
+Output schema (JSON mode):
+  {
+    "root": { "number": 638, "title": "...", "state": "OPEN", "classification": "roadmap", "roadmapMarkerId": "..." },
+    "nodes": [{ "number": 638, "title": "...", "state": "OPEN", "labels": ["roadmap"], "classification": "roadmap", "roadmapMarkerId": "...", "depth": 0 }],
+    "edges": [{ "source": 638, "target": 640, "relationship": "task-list", "evidence": "- [ ] #640" }],
+    "provenancePaths": [{ "target": 640, "path": [638, 640] }],
+    "roadmapNodes": [638],
+    "executionCandidates": [640],
+    "diagnostics": {
+      "duplicateReferences": [],
+      "cycles": [],
+      "inaccessibleReferences": [],
+      "unresolvedReferences": []
+    },
+    "summary": {
+      "rootNumber": 638,
+      "nodeCount": 2,
+      "edgeCount": 1,
+      "roadmapNodeCount": 1,
+      "executionCandidateCount": 1,
+      "duplicateReferenceCount": 0,
+      "cycleCount": 0,
+      "inaccessibleReferenceCount": 0,
+      "unresolvedReferenceCount": 0,
+      "maxDepth": 1
+    }
+  }
+`);
+}
+
+function normalizeIssue(issue) {
+  return {
+    number: Number.parseInt(String(issue.number ?? issue.id ?? 0), 10),
+    title: String(issue.title ?? ""),
+    state: String(issue.state ?? "").toUpperCase(),
+    body: String(issue.body ?? ""),
+    labels: normalizeLabels(issue.labels),
+  };
+}
+
+function normalizeLabels(labelsInput) {
+  if (!labelsInput) {
+    return new Set();
+  }
+  if (labelsInput instanceof Set) {
+    return new Set([...labelsInput].map((label) => String(label ?? "")).filter(Boolean));
+  }
+  if (Array.isArray(labelsInput)) {
+    return new Set(labelsInput.map((label) => {
+      if (typeof label === "string") {
+        return label;
+      }
+      return String(label?.name ?? "");
+    }).filter(Boolean));
+  }
+  return new Set();
+}
+
+function normalizeMarkerPrefix(markerPrefix) {
+  const normalized = String(markerPrefix ?? "").trim();
+  return normalized || DEFAULT_MARKER_PREFIX;
+}
+
+async function getIssue(issueNumber, cache, loadIssue) {
+  if (cache.has(issueNumber)) {
+    return cache.get(issueNumber);
+  }
+  const rawIssue = await loadIssue(issueNumber);
+  const issue = isInaccessibleIssue(rawIssue)
+    ? INACCESSIBLE_ISSUE_SENTINEL
+    : (rawIssue ? normalizeIssue(rawIssue) : null);
+  cache.set(issueNumber, issue);
+  return issue;
+}
+
+function buildIssueLoader(owner, repo) {
+  return async (issueNumber) => {
+    const args = [
+      "api",
+      `repos/${owner}/${repo}/issues/${issueNumber}`,
+      "--jq",
+      ".",
+    ];
+    try {
+      const result = runGh(args, { allowStatuses: [404] }).trim();
+      if (!result || result === "null") {
+        return null;
+      }
+      return JSON.parse(result);
+    } catch (error) {
+      if (isInaccessibleIssueLookupError(error)) {
+        return INACCESSIBLE_ISSUE_SENTINEL;
+      }
+      throw error;
+    }
+  };
+}
+
+function buildSubIssueLoader(owner, repo) {
+  return async (issueNumber) => {
+    const numbers = [];
+    let after = "";
+
+    while (true) {
+      const variables = {
+        owner,
+        repo,
+        number: issueNumber,
+      };
+      if (after) {
+        variables.after = after;
+      }
+      const result = runGraphqlQuery(SUB_ISSUES_QUERY, variables);
+      const connection = result?.data?.repository?.issue?.subIssues;
+      if (!connection || !Array.isArray(connection.nodes) || !connection.pageInfo) {
+        throw new Error(`subIssues connection missing for issue #${issueNumber}`);
+      }
+
+      numbers.push(...normalizeSubIssueNumbers(connection.nodes));
+      if (!connection.pageInfo.hasNextPage) {
+        break;
+      }
+      if (!connection.pageInfo.endCursor) {
+        throw new Error(`subIssues pagination cursor missing for issue #${issueNumber}`);
+      }
+      after = connection.pageInfo.endCursor;
+    }
+
+    return [...new Set(numbers)];
+  };
+}
+
+function runGraphqlQuery(query, variables) {
+  const args = ["api", "graphql", "-f", `query=${query}`];
+  for (const [name, value] of Object.entries(variables)) {
+    if (value === "" || value === null || value === undefined) {
+      continue;
+    }
+    const flag = typeof value === "number" ? "-F" : "-f";
+    args.push(flag, `${name}=${value}`);
+  }
+
+  try {
+    const raw = execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+    const parsed = JSON.parse(raw || "{}");
+    if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+      throw new Error(formatGraphqlErrors(parsed.errors));
+    }
+    return parsed;
+  } catch (error) {
+    const stderr = String(error.stderr ?? "").trim();
+    const detail = stderr || error.message;
+    throw new Error(`gh api graphql failed: ${detail}`);
+  }
+}
+
+function loadPolicy(policyPath) {
+  const targetPath = policyPath
+    ? resolve(process.cwd(), policyPath)
+    : resolve(process.cwd(), ".github/idd/config.json");
+  try {
+    return JSON.parse(readFileSync(targetPath, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function ghText(args) {
+  return runGh(args).trim();
+}
+
+function runGh(args, options = {}) {
+  const { allowStatuses = [] } = options;
+
+  try {
+    return execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (error) {
+    const status = typeof error.status === "number" ? error.status : null;
+    if (status !== null && allowStatuses.includes(status)) {
+      return "";
+    }
+    const stderr = String(error.stderr ?? "").trim();
+    const prefix = `gh ${args.join(" ")}`;
+    const wrapped = new Error(stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`);
+    wrapped.status = status;
+    wrapped.stderr = stderr;
+    throw wrapped;
+  }
+}
+
+function isInaccessibleIssue(value) {
+  return value?.__iddLookupStatus === "inaccessible";
+}
+
+function isInaccessibleIssueLookupError(error) {
+  if (!error) {
+    return false;
+  }
+  const status = typeof error.status === "number" ? error.status : null;
+  if (status !== null && INACCESSIBLE_HTTP_STATUSES.has(status)) {
+    return true;
+  }
+  const stderr = String(error.stderr ?? "");
+  return /Resource not accessible|access denied|Forbidden|Unavailable for legal reasons/i.test(stderr);
+}
+
+function isMainModule(importMetaUrl) {
+  return process.argv[1] === fileURLToPath(importMetaUrl);
+}
+
+function buildEdgeKey(edge) {
+  return `${edge.source}:${edge.target}:${edge.relationship}:${edge.evidence}`;
+}
+
+function recordReferenceDiagnostic(collection, dedupeKeys, edge, reason) {
+  const key = `${edge.source}:${edge.target}:${edge.relationship}:${reason}`;
+  if (dedupeKeys.has(key)) {
+    return;
+  }
+  dedupeKeys.add(key);
+  collection.push({
+    source: edge.source,
+    target: edge.target,
+    relationship: edge.relationship,
+    evidence: edge.evidence,
+    reason,
+  });
+}
+
+function compareByNumber(left, right) {
+  return left.number - right.number;
+}
+
+function compareEdges(left, right) {
+  return (
+    left.source - right.source
+    || left.target - right.target
+    || left.relationship.localeCompare(right.relationship)
+    || left.evidence.localeCompare(right.evidence)
+  );
+}
+
+function comparePaths(left, right) {
+  return (
+    left.target - right.target
+    || left.path.length - right.path.length
+    || left.path.join(">").localeCompare(right.path.join(">"))
+  );
+}
+
+function compareDiagnostics(left, right) {
+  return (
+    left.source - right.source
+    || left.target - right.target
+    || String(left.relationship ?? "").localeCompare(String(right.relationship ?? ""))
+    || String(left.reason ?? "").localeCompare(String(right.reason ?? ""))
+  );
+}
+
+function compareCycles(left, right) {
+  return (
+    left.source - right.source
+    || left.target - right.target
+    || left.path.length - right.path.length
+    || left.path.join(">").localeCompare(right.path.join(">"))
+  );
+}
+
+function formatGraphqlErrors(errors) {
+  return errors
+    .map((error) => String(error?.message ?? "unknown GraphQL error"))
+    .join("; ");
+}
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -39,6 +39,8 @@ if (isMainModule(import.meta.url)) {
 
   const graph = await enumerateRoadmapGraph(args.issue, {
     markerPrefix: policy.markerPrefix,
+    owner,
+    repo,
     loadIssue: buildIssueLoader(owner, repo),
     loadSubIssues: buildSubIssueLoader(owner, repo),
   });
@@ -52,6 +54,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   const loadSubIssues = typeof options.loadSubIssues === "function"
     ? options.loadSubIssues
     : async () => [];
+  const currentRepoRef = normalizeRepoRef(options.owner, options.repo);
 
   if (typeof loadIssue !== "function") {
     throw new Error("enumerateRoadmapGraph requires loadIssue(issueNumber)");
@@ -159,6 +162,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
     recordNode(issue, path);
     const references = await getReferences(issue);
     const seenSourceTargets = new Set();
+    const seenSourceEdgeKeys = new Set();
 
     for (const reference of references) {
       const edge = {
@@ -168,6 +172,11 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
         evidence: reference.evidence,
       };
       const edgeKey = buildEdgeKey(edge);
+      if (seenSourceEdgeKeys.has(edgeKey)) {
+        recordDuplicateReference(edge, edge);
+        continue;
+      }
+      seenSourceEdgeKeys.add(edgeKey);
       if (!edgeKeys.has(edgeKey)) {
         edgeKeys.add(edgeKey);
         edges.push(edge);
@@ -227,7 +236,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
     }
     const references = [
       ...extractTaskListReferences(issue.body),
-      ...extractKeywordReferences(issue.body),
+      ...extractKeywordReferences(issue.body, { currentRepoRef }),
       ...normalizeSubIssueReferences(await loadSubIssues(issue.number)),
     ];
     referenceCache.set(issue.number, references);
@@ -319,8 +328,12 @@ export function extractTaskListReferences(body) {
     });
 }
 
-export function extractKeywordReferences(body) {
+export function extractKeywordReferences(body, options = {}) {
   const references = [];
+  const currentRepoRef = normalizeRepoRef(
+    options.currentRepoRef ? options.currentRepoRef.split("/")[0] : options.owner,
+    options.currentRepoRef ? options.currentRepoRef.split("/")[1] : options.repo,
+  );
   for (const line of String(body ?? "").split(/\r?\n/u)) {
     const keywordMatches = [...line.matchAll(KEYWORD_REFERENCE_REGEX)];
     for (let index = 0; index < keywordMatches.length; index += 1) {
@@ -328,12 +341,7 @@ export function extractKeywordReferences(body) {
       const segmentStart = (match.index ?? 0) + match[0].length;
       const segmentEnd = keywordMatches[index + 1]?.index ?? line.length;
       const segment = line.slice(segmentStart, segmentEnd);
-      for (const targetMatch of segment.matchAll(/#(\d+)\b/gu)) {
-        const hashIndex = targetMatch.index ?? -1;
-        if (hashIndex >= 0 && isCrossRepositoryReference(segment, hashIndex)) {
-          continue;
-        }
-        const target = Number.parseInt(targetMatch[1], 10);
+      for (const target of extractKeywordReferenceTargets(segment, currentRepoRef)) {
         if (!Number.isInteger(target) || target <= 0) {
           continue;
         }
@@ -362,9 +370,39 @@ function classifyKeywordRelationship(keyword) {
   return "closing-keyword";
 }
 
-function isCrossRepositoryReference(segment, hashIndex) {
-  const prefix = segment.slice(0, hashIndex);
-  return /[\w.-]+\/[\w.-]+$/u.test(prefix.trimEnd());
+function extractKeywordReferenceTargets(segment, currentRepoRef) {
+  const targets = [];
+  let remaining = String(segment ?? "").trimStart();
+
+  while (remaining) {
+    const match = remaining.match(/^(?:([\w.-]+\/[\w.-]+)#(\d+)|#(\d+))/u);
+    if (!match) {
+      break;
+    }
+
+    const qualifiedRepoRef = match[1] ? normalizeRepoRef(...match[1].split("/")) : "";
+    const target = Number.parseInt(match[2] ?? match[3] ?? "", 10);
+    if ((!qualifiedRepoRef || qualifiedRepoRef === currentRepoRef)
+      && Number.isInteger(target)
+      && target > 0) {
+      targets.push(target);
+    }
+
+    remaining = remaining.slice(match[0].length);
+    const separatorMatch = remaining.match(/^\s*(?:,\s*|\band\b\s*)/iu);
+    if (!separatorMatch) {
+      break;
+    }
+    remaining = remaining.slice(separatorMatch[0].length);
+  }
+
+  return targets;
+}
+
+function normalizeRepoRef(owner, repo) {
+  const normalizedOwner = String(owner ?? "").trim().toLowerCase();
+  const normalizedRepo = String(repo ?? "").trim().toLowerCase();
+  return normalizedOwner && normalizedRepo ? `${normalizedOwner}/${normalizedRepo}` : "";
 }
 
 function normalizeSubIssueReferences(subIssues) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const DEFAULT_MARKER_PREFIX = "idd-skill";
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({ __iddLookupStatus: "inaccessible" });
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
-const KEYWORD_REFERENCE_REGEX = /\b(Closes|Close|Closed|Fixes|Fixed|Resolves|Resolved|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
+const KEYWORD_REFERENCE_REGEX = /\b(Closes|Close|Closed|Fixes|Fixed|Fix|Resolves|Resolved|Resolve|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
@@ -78,8 +78,6 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   const inaccessibleKeys = new Set();
   const unresolvedKeys = new Set();
   const referenceCache = new Map();
-  const firstReferenceByTarget = new Map();
-
   const rootIssue = await getIssue(rootIssueNumber, issueCache, loadIssue);
   if (!rootIssue) {
     throw new Error(`root issue #${rootIssueNumber} was not found`);
@@ -163,6 +161,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
     const references = await getReferences(issue);
     const seenSourceTargets = new Set();
     const seenSourceEdgeKeys = new Set();
+    const firstReferenceBySourceTarget = new Map();
 
     for (const reference of references) {
       const edge = {
@@ -183,15 +182,15 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
 
         const sourceTargetKey = `${edge.source}:${edge.target}`;
         if (seenSourceTargets.has(sourceTargetKey)) {
-          recordDuplicateReference(edge, firstReferenceByTarget.get(edge.target) ?? edge);
+          recordDuplicateReference(edge, firstReferenceBySourceTarget.get(sourceTargetKey) ?? edge);
         }
         seenSourceTargets.add(sourceTargetKey);
 
-        const firstReference = firstReferenceByTarget.get(edge.target);
+        const firstReference = firstReferenceBySourceTarget.get(sourceTargetKey);
         if (firstReference) {
           recordDuplicateReference(edge, firstReference);
         } else {
-          firstReferenceByTarget.set(edge.target, edge);
+          firstReferenceBySourceTarget.set(sourceTargetKey, edge);
         }
       }
 
@@ -317,7 +316,7 @@ export function extractTaskListReferences(body) {
   return String(body ?? "")
     .split(/\r?\n/u)
     .flatMap((line) => {
-      const match = line.match(/^\s*-\s*\[(?: |x)\]\s+#(\d+)\b/u);
+      const match = line.match(/^\s*-\s*\[(?: |x|X)\]\s+#(\d+)\b/u);
       if (!match) {
         return [];
       }
@@ -372,7 +371,7 @@ function classifyKeywordRelationship(keyword) {
 
 function extractKeywordReferenceTargets(segment, currentRepoRef) {
   const targets = [];
-  let remaining = String(segment ?? "").trimStart();
+  let remaining = String(segment ?? "").trimStart().replace(/^:\s*/u, "");
 
   while (remaining) {
     const match = remaining.match(/^(?:([\w.-]+\/[\w.-]+)#(\d+)|#(\d+))/u);
@@ -389,7 +388,7 @@ function extractKeywordReferenceTargets(segment, currentRepoRef) {
     }
 
     remaining = remaining.slice(match[0].length);
-    const separatorMatch = remaining.match(/^\s*(?:,\s*|\band\b\s*)/iu);
+    const separatorMatch = remaining.match(/^\s*(?:,\s*(?:and\s*)?|\band\b\s*)/iu);
     if (!separatorMatch) {
       break;
     }
@@ -643,8 +642,12 @@ function loadPolicy(policyPath) {
     : resolve(process.cwd(), ".github/idd/config.json");
   try {
     return JSON.parse(readFileSync(targetPath, "utf8"));
-  } catch {
-    return {};
+  } catch (error) {
+    if (!policyPath) {
+      return {};
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to load policy from ${targetPath}: ${detail}`);
   }
 }
 

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -171,19 +171,19 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
       if (!edgeKeys.has(edgeKey)) {
         edgeKeys.add(edgeKey);
         edges.push(edge);
-      }
 
-      const sourceTargetKey = `${edge.source}:${edge.target}`;
-      if (seenSourceTargets.has(sourceTargetKey)) {
-        recordDuplicateReference(edge, firstReferenceByTarget.get(edge.target) ?? edge);
-      }
-      seenSourceTargets.add(sourceTargetKey);
+        const sourceTargetKey = `${edge.source}:${edge.target}`;
+        if (seenSourceTargets.has(sourceTargetKey)) {
+          recordDuplicateReference(edge, firstReferenceByTarget.get(edge.target) ?? edge);
+        }
+        seenSourceTargets.add(sourceTargetKey);
 
-      const firstReference = firstReferenceByTarget.get(edge.target);
-      if (firstReference) {
-        recordDuplicateReference(edge, firstReference);
-      } else {
-        firstReferenceByTarget.set(edge.target, edge);
+        const firstReference = firstReferenceByTarget.get(edge.target);
+        if (firstReference) {
+          recordDuplicateReference(edge, firstReference);
+        } else {
+          firstReferenceByTarget.set(edge.target, edge);
+        }
       }
 
       if (path.includes(edge.target)) {
@@ -237,6 +237,9 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   function recordNode(issue, path) {
     const existing = nodeRecords.get(issue.number);
     const classification = classifyIssue(issue, markerPrefix);
+    if (issue.number === rootIssue.number) {
+      classification.kind = "roadmap";
+    }
     const depth = path.length - 1;
     if (existing) {
       existing.depth = Math.min(existing.depth, depth);
@@ -326,6 +329,10 @@ export function extractKeywordReferences(body) {
       const segmentEnd = keywordMatches[index + 1]?.index ?? line.length;
       const segment = line.slice(segmentStart, segmentEnd);
       for (const targetMatch of segment.matchAll(/#(\d+)\b/gu)) {
+        const hashIndex = targetMatch.index ?? -1;
+        if (hashIndex >= 0 && isCrossRepositoryReference(segment, hashIndex)) {
+          continue;
+        }
         const target = Number.parseInt(targetMatch[1], 10);
         if (!Number.isInteger(target) || target <= 0) {
           continue;
@@ -353,6 +360,11 @@ function classifyKeywordRelationship(keyword) {
     return "reference";
   }
   return "closing-keyword";
+}
+
+function isCrossRepositoryReference(segment, hashIndex) {
+  const prefix = segment.slice(0, hashIndex);
+  return /[\w.-]+\/[\w.-]+$/u.test(prefix.trimEnd());
 }
 
 function normalizeSubIssueReferences(subIssues) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -84,6 +84,9 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   if (isInaccessibleIssue(rootIssue)) {
     throw new Error(`root issue #${rootIssueNumber} is inaccessible`);
   }
+  if (rootIssue.isPullRequest) {
+    throw new Error(`root issue #${rootIssueNumber} is a pull request`);
+  }
 
   await visitIssue(rootIssue.number, [rootIssue.number]);
 
@@ -205,6 +208,10 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
       }
       if (isInaccessibleIssue(targetIssue)) {
         recordReferenceDiagnostic(diagnostics.inaccessibleReferences, inaccessibleKeys, edge, "issue_inaccessible");
+        continue;
+      }
+      if (targetIssue.isPullRequest) {
+        recordReferenceDiagnostic(diagnostics.unresolvedReferences, unresolvedKeys, edge, "issue_not_found");
         continue;
       }
 
@@ -453,6 +460,7 @@ function normalizeIssue(issue) {
     state: String(issue.state ?? "").toUpperCase(),
     body: String(issue.body ?? ""),
     labels: normalizeLabels(issue.labels),
+    isPullRequest: Boolean(issue.pull_request),
   };
 }
 
@@ -510,6 +518,9 @@ function buildIssueLoader(owner, repo) {
       }
       return JSON.parse(result);
     } catch (error) {
+      if (isNotFoundIssueLookupError(error)) {
+        return null;
+      }
       if (isInaccessibleIssueLookupError(error)) {
         return INACCESSIBLE_ISSUE_SENTINEL;
       }
@@ -624,6 +635,14 @@ function isInaccessibleIssueLookupError(error) {
   }
   const stderr = String(error.stderr ?? "");
   return /Resource not accessible|access denied|Forbidden|Unavailable for legal reasons/i.test(stderr);
+}
+
+function isNotFoundIssueLookupError(error) {
+  if (!error) {
+    return false;
+  }
+  const stderr = String(error.stderr ?? error.message ?? "");
+  return stderr.includes("HTTP 404");
 }
 
 function isMainModule(importMetaUrl) {

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -67,6 +67,14 @@ const HELPER_COMMANDS = [
     description: "Collect read-only A3 readiness filtering evidence for candidate issues.",
   },
   {
+    id: "discover-roadmap-graph",
+    scriptName: "idd:discover-roadmap-graph",
+    binName: "idd-discover-roadmap-graph",
+    entryPath: "scripts/discover-roadmap-graph.mjs",
+    vendoredCommand: "node scripts/discover-roadmap-graph.mjs",
+    description: "Collect read-only A1.5/A2 recursive roadmap graph evidence.",
+  },
+  {
     id: "discover-viability-gate",
     scriptName: "idd:discover-viability-gate",
     binName: "idd-discover-viability-gate",

--- a/tests/discover-roadmap-graph.test.mjs
+++ b/tests/discover-roadmap-graph.test.mjs
@@ -63,6 +63,17 @@ Sub issue #206
   ]);
 });
 
+test("extractKeywordReferences ignores cross-repository references", () => {
+  const body = `
+Refs other/repo#301, #302
+Depends on kurone-kito/idd-skill#303
+`;
+
+  assert.deepEqual(extractKeywordReferences(body), [
+    { target: 302, relationship: "reference", evidence: "Refs other/repo#301, #302" },
+  ]);
+});
+
 test("enumerates a flat roadmap graph and separates execution candidates", async () => {
   const issues = new Map([
     [100, roadmapIssue(100, "- [ ] #101\n- [ ] #102", "root-roadmap")],
@@ -130,6 +141,21 @@ test("enumerates a three-level nested roadmap graph", async () => {
     { target: 178, path: [175, 176, 177, 178] },
   ]);
   assert.equal(graph.summary.maxDepth, 3);
+});
+
+test("forces the selected root issue to remain a roadmap", async () => {
+  const issues = new Map([
+    [180, executionIssue(180, "- [ ] #181")],
+    [181, executionIssue(181, "leaf execution")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(180, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.equal(graph.root.classification, "roadmap");
+  assert.deepEqual(graph.roadmapNodes, [180]);
+  assert.deepEqual(graph.executionCandidates, [181]);
 });
 
 test("keeps traversing through a closed intermediate roadmap to an open descendant", async () => {
@@ -200,6 +226,15 @@ test("keeps traversing descendants when a shared node is reached through multipl
       { target: 354, path: [350, 352, 353, 354] },
     ],
   );
+  assert.deepEqual(graph.diagnostics.duplicateReferences, [
+    {
+      source: 352,
+      target: 353,
+      relationship: "reference",
+      evidence: "Refs #353",
+      firstSeenFrom: 351,
+    },
+  ]);
 });
 
 test("re-expands descendants when a shorter ancestry path appears later", async () => {

--- a/tests/discover-roadmap-graph.test.mjs
+++ b/tests/discover-roadmap-graph.test.mjs
@@ -1,0 +1,368 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import {
+  classifyIssue,
+  enumerateRoadmapGraph,
+  extractKeywordReferences,
+  extractRoadmapMarkerId,
+  extractTaskListReferences,
+} from "../scripts/discover-roadmap-graph.mjs";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+test("extractors classify roadmap markers and outbound references", () => {
+  const body = `
+<!-- idd-skill-roadmap-id: root-roadmap -->
+- [ ] #101
+Refs #102
+Depends on #103
+Closes #104
+Sub-issue #105
+`;
+
+  assert.equal(extractRoadmapMarkerId(body), "root-roadmap");
+  assert.deepEqual(extractTaskListReferences(body), [
+    { target: 101, relationship: "task-list", evidence: "- [ ] #101" },
+  ]);
+  assert.deepEqual(extractKeywordReferences(body), [
+    { target: 102, relationship: "reference", evidence: "Refs #102" },
+    { target: 103, relationship: "dependency", evidence: "Depends on #103" },
+    { target: 104, relationship: "closing-keyword", evidence: "Closes #104" },
+    { target: 105, relationship: "sub-issue-reference", evidence: "Sub-issue #105" },
+  ]);
+  assert.deepEqual(
+    classifyIssue({
+      body,
+      labels: [{ name: "roadmap" }],
+    }),
+    { kind: "roadmap", roadmapMarkerId: "root-roadmap" },
+  );
+});
+
+test("enumerates a flat roadmap graph and separates execution candidates", async () => {
+  const issues = new Map([
+    [100, roadmapIssue(100, "- [ ] #101\n- [ ] #102", "root-roadmap")],
+    [101, executionIssue(101, "alpha")],
+    [102, executionIssue(102, "beta")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(100, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.roadmapNodes, [100]);
+  assert.deepEqual(graph.executionCandidates, [101, 102]);
+  assert.deepEqual(graph.edges, [
+    { source: 100, target: 101, relationship: "task-list", evidence: "- [ ] #101" },
+    { source: 100, target: 102, relationship: "task-list", evidence: "- [ ] #102" },
+  ]);
+  assert.deepEqual(graph.provenancePaths, [
+    { target: 100, path: [100] },
+    { target: 101, path: [100, 101] },
+    { target: 102, path: [100, 102] },
+  ]);
+  assert.equal(graph.summary.executionCandidateCount, 2);
+});
+
+test("enumerates a two-level nested roadmap graph", async () => {
+  const issues = new Map([
+    [150, roadmapIssue(150, "- [ ] #151", "root-roadmap")],
+    [151, roadmapIssue(151, "- [ ] #152", "nested-roadmap")],
+    [152, executionIssue(152, "leaf execution")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(150, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.roadmapNodes, [150, 151]);
+  assert.deepEqual(graph.executionCandidates, [152]);
+  assert.deepEqual(graph.provenancePaths, [
+    { target: 150, path: [150] },
+    { target: 151, path: [150, 151] },
+    { target: 152, path: [150, 151, 152] },
+  ]);
+  assert.equal(graph.summary.maxDepth, 2);
+});
+
+test("enumerates a three-level nested roadmap graph", async () => {
+  const issues = new Map([
+    [175, roadmapIssue(175, "- [ ] #176", "root-roadmap")],
+    [176, roadmapIssue(176, "- [ ] #177", "nested-roadmap-a")],
+    [177, roadmapIssue(177, "- [ ] #178", "nested-roadmap-b")],
+    [178, executionIssue(178, "leaf execution")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(175, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.roadmapNodes, [175, 176, 177]);
+  assert.deepEqual(graph.executionCandidates, [178]);
+  assert.deepEqual(graph.provenancePaths, [
+    { target: 175, path: [175] },
+    { target: 176, path: [175, 176] },
+    { target: 177, path: [175, 176, 177] },
+    { target: 178, path: [175, 176, 177, 178] },
+  ]);
+  assert.equal(graph.summary.maxDepth, 3);
+});
+
+test("keeps traversing through a closed intermediate roadmap to an open descendant", async () => {
+  const issues = new Map([
+    [200, roadmapIssue(200, "- [ ] #201", "root-roadmap")],
+    [201, roadmapIssue(201, "- [ ] #202", "nested-roadmap", "closed")],
+    [202, executionIssue(202, "leaf execution")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(200, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.roadmapNodes, [200, 201]);
+  assert.deepEqual(graph.executionCandidates, [202]);
+  assert.deepEqual(graph.provenancePaths, [
+    { target: 200, path: [200] },
+    { target: 201, path: [200, 201] },
+    { target: 202, path: [200, 201, 202] },
+  ]);
+});
+
+test("records duplicate references and cycles without recursing forever", async () => {
+  const issues = new Map([
+    [300, roadmapIssue(300, "- [ ] #301\nRefs #301", "root-roadmap")],
+    [301, executionIssue(301, "- [ ] #300")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(300, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.equal(graph.diagnostics.duplicateReferences.length, 1);
+  assert.deepEqual(graph.diagnostics.duplicateReferences[0], {
+    source: 300,
+    target: 301,
+    relationship: "reference",
+    evidence: "Refs #301",
+    firstSeenFrom: 300,
+  });
+  assert.deepEqual(graph.diagnostics.cycles, [
+    {
+      source: 301,
+      target: 300,
+      relationship: "task-list",
+      path: [300, 301, 300],
+    },
+  ]);
+});
+
+test("reports inaccessible and unresolved references fail-safe", async () => {
+  const issues = new Map([
+    [400, roadmapIssue(400, "- [ ] #401\n- [ ] #402", "root-roadmap")],
+    [401, { __iddLookupStatus: "inaccessible" }],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(400, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.executionCandidates, []);
+  assert.deepEqual(graph.diagnostics.inaccessibleReferences, [
+    {
+      source: 400,
+      target: 401,
+      relationship: "task-list",
+      evidence: "- [ ] #401",
+      reason: "issue_inaccessible",
+    },
+  ]);
+  assert.deepEqual(graph.diagnostics.unresolvedReferences, [
+    {
+      source: 400,
+      target: 402,
+      relationship: "task-list",
+      evidence: "- [ ] #402",
+      reason: "issue_not_found",
+    },
+  ]);
+});
+
+test("includes GitHub sub-issue relationships in the graph", async () => {
+  const issues = new Map([
+    [500, roadmapIssue(500, "", "root-roadmap")],
+    [501, executionIssue(501, "sub-issue leaf")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(500, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    loadSubIssues: async (issueNumber) => (
+      issueNumber === 500 ? [501] : []
+    ),
+  });
+
+  assert.deepEqual(graph.edges, [
+    {
+      source: 500,
+      target: 501,
+      relationship: "sub-issue",
+      evidence: "GitHub sub-issue #501",
+    },
+  ]);
+  assert.deepEqual(graph.executionCandidates, [501]);
+});
+
+test("surfaces incomplete descendant lookups instead of silently dropping them", async () => {
+  const issues = new Map([
+    [550, roadmapIssue(550, "", "root-roadmap")],
+  ]);
+
+  await assert.rejects(
+    () => enumerateRoadmapGraph(550, {
+      loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+      loadSubIssues: async () => {
+        throw new Error("subIssues connection missing for issue #550");
+      },
+    }),
+    /subIssues connection missing for issue #550/,
+  );
+});
+
+test("CLI path can enumerate GitHub sub-issues without top-level await initialization bugs", () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), "idd-discover-roadmap-graph-cli-"));
+  const ghPath = join(tempRoot, "gh");
+
+  writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "repo" && args[1] === "view") {
+  const jq = args[args.indexOf("--jq") + 1];
+  process.stdout.write(jq === ".owner.login" ? "kurone-kito\\n" : "idd-skill\\n");
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/kurone-kito/idd-skill/issues/700") {
+  process.stdout.write(JSON.stringify({
+    number: 700,
+    title: "roadmap 700",
+    state: "open",
+    body: "<!-- idd-skill-roadmap-id: root-roadmap -->",
+    labels: [{ name: "roadmap" }],
+  }));
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/kurone-kito/idd-skill/issues/701") {
+  process.stdout.write(JSON.stringify({
+    number: 701,
+    title: "issue 701",
+    state: "open",
+    body: "",
+    labels: [],
+  }));
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "graphql") {
+  const numberArg = args.find((entry) => entry.startsWith("number="));
+  const issueNumber = Number.parseInt(String(numberArg ?? "").slice("number=".length), 10);
+  const payload = issueNumber === 700
+    ? {
+        data: {
+          repository: {
+            issue: {
+              subIssues: {
+                nodes: [{ number: 701 }],
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null,
+                },
+              },
+            },
+          },
+        },
+      }
+    : {
+        data: {
+          repository: {
+            issue: {
+              subIssues: {
+                nodes: [],
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null,
+                },
+              },
+            },
+          },
+        },
+      };
+  process.stdout.write(JSON.stringify(payload));
+  process.exit(0);
+}
+process.stderr.write("unexpected gh invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`);
+  chmodSync(ghPath, 0o755);
+
+  const output = execFileSync(
+    process.execPath,
+    [join(REPO_ROOT, "scripts/discover-roadmap-graph.mjs"), "--issue", "700"],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${tempRoot}:${process.env.PATH ?? ""}`,
+      },
+    },
+  );
+  const parsed = JSON.parse(output);
+
+  assert.deepEqual(parsed.roadmapNodes, [700]);
+  assert.deepEqual(parsed.executionCandidates, [701]);
+  assert.deepEqual(parsed.edges, [
+    {
+      source: 700,
+      target: 701,
+      relationship: "sub-issue",
+      evidence: "GitHub sub-issue #701",
+    },
+  ]);
+});
+
+test("reports when only roadmap nodes remain open", async () => {
+  const issues = new Map([
+    [600, roadmapIssue(600, "- [ ] #601", "root-roadmap")],
+    [601, roadmapIssue(601, "", "nested-roadmap")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(600, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.roadmapNodes, [600, 601]);
+  assert.deepEqual(graph.executionCandidates, []);
+  assert.equal(graph.summary.executionCandidateCount, 0);
+});
+
+function roadmapIssue(number, body, markerId, state = "open") {
+  return {
+    number,
+    title: `roadmap ${number}`,
+    state,
+    body: `<!-- idd-skill-roadmap-id: ${markerId} -->\n${body}`.trim(),
+    labels: [{ name: "roadmap" }],
+  };
+}
+
+function executionIssue(number, body, state = "open") {
+  return {
+    number,
+    title: `issue ${number}`,
+    state,
+    body,
+    labels: [],
+  };
+}

--- a/tests/discover-roadmap-graph.test.mjs
+++ b/tests/discover-roadmap-graph.test.mjs
@@ -202,6 +202,29 @@ test("keeps traversing descendants when a shared node is reached through multipl
   );
 });
 
+test("re-expands descendants when a shorter ancestry path appears later", async () => {
+  const issues = new Map([
+    [360, roadmapIssue(360, "- [ ] #361\n- [ ] #363", "root-roadmap")],
+    [361, executionIssue(361, "Refs #362")],
+    [362, executionIssue(362, "Refs #363")],
+    [363, executionIssue(363, "Refs #364")],
+    [364, executionIssue(364, "leaf execution")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(360, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(
+    graph.provenancePaths.filter((entry) => entry.target === 364),
+    [
+      { target: 364, path: [360, 363, 364] },
+      { target: 364, path: [360, 361, 362, 363, 364] },
+    ],
+  );
+  assert.equal(graph.nodes.find((node) => node.number === 363)?.depth, 1);
+});
+
 test("reports inaccessible and unresolved references fail-safe", async () => {
   const issues = new Map([
     [400, roadmapIssue(400, "- [ ] #401\n- [ ] #402", "root-roadmap")],
@@ -228,6 +251,35 @@ test("reports inaccessible and unresolved references fail-safe", async () => {
       target: 402,
       relationship: "task-list",
       evidence: "- [ ] #402",
+      reason: "issue_not_found",
+    },
+  ]);
+});
+
+test("treats pull request references as unresolved issue targets", async () => {
+  const issues = new Map([
+    [410, roadmapIssue(410, "- [ ] #411", "root-roadmap")],
+    [411, {
+      number: 411,
+      title: "pull request 411",
+      state: "open",
+      body: "",
+      labels: [],
+      pull_request: { url: "https://example.test/pulls/411" },
+    }],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(410, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.executionCandidates, []);
+  assert.deepEqual(graph.diagnostics.unresolvedReferences, [
+    {
+      source: 410,
+      target: 411,
+      relationship: "task-list",
+      evidence: "- [ ] #411",
       reason: "issue_not_found",
     },
   ]);
@@ -368,6 +420,80 @@ process.exit(1);
       target: 701,
       relationship: "sub-issue",
       evidence: "GitHub sub-issue #701",
+    },
+  ]);
+});
+
+test("CLI path treats gh 404 descendants as unresolved references", () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), "idd-discover-roadmap-graph-404-"));
+  const ghPath = join(tempRoot, "gh");
+
+  writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "repo" && args[1] === "view") {
+  const jq = args[args.indexOf("--jq") + 1];
+  process.stdout.write(jq === ".owner.login" ? "kurone-kito\\n" : "idd-skill\\n");
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/kurone-kito/idd-skill/issues/720") {
+  process.stdout.write(JSON.stringify({
+    number: 720,
+    title: "roadmap 720",
+    state: "open",
+    body: "<!-- idd-skill-roadmap-id: root-roadmap -->\\n- [ ] #721",
+    labels: [{ name: "roadmap" }],
+  }));
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/kurone-kito/idd-skill/issues/721") {
+  process.stderr.write("gh: Not Found (HTTP 404)\\n");
+  process.exit(1);
+}
+if (args[0] === "api" && args[1] === "graphql") {
+  process.stdout.write(JSON.stringify({
+    data: {
+      repository: {
+        issue: {
+          subIssues: {
+            nodes: [],
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null,
+            },
+          },
+        },
+      },
+    },
+  }));
+  process.exit(0);
+}
+process.stderr.write("unexpected gh invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`);
+  chmodSync(ghPath, 0o755);
+
+  const output = execFileSync(
+    process.execPath,
+    [join(REPO_ROOT, "scripts/discover-roadmap-graph.mjs"), "--issue", "720"],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${tempRoot}:${process.env.PATH ?? ""}`,
+      },
+    },
+  );
+  const parsed = JSON.parse(output);
+
+  assert.deepEqual(parsed.executionCandidates, []);
+  assert.deepEqual(parsed.diagnostics.unresolvedReferences, [
+    {
+      source: 720,
+      target: 721,
+      relationship: "task-list",
+      evidence: "- [ ] #721",
+      reason: "issue_not_found",
     },
   ]);
 });

--- a/tests/discover-roadmap-graph.test.mjs
+++ b/tests/discover-roadmap-graph.test.mjs
@@ -39,10 +39,28 @@ Sub-issue #105
   assert.deepEqual(
     classifyIssue({
       body,
-      labels: [{ name: "roadmap" }],
+      labels: [{ name: "Roadmap" }],
     }),
     { kind: "roadmap", roadmapMarkerId: "root-roadmap" },
   );
+});
+
+test("extractKeywordReferences parses blocked dependencies and multi-target lists", () => {
+  const body = `
+Refs #201, #202
+Blocked by #203
+Depends on #204, #205
+Sub issue #206
+`;
+
+  assert.deepEqual(extractKeywordReferences(body), [
+    { target: 201, relationship: "reference", evidence: "Refs #201, #202" },
+    { target: 202, relationship: "reference", evidence: "Refs #201, #202" },
+    { target: 203, relationship: "dependency", evidence: "Blocked by #203" },
+    { target: 204, relationship: "dependency", evidence: "Depends on #204, #205" },
+    { target: 205, relationship: "dependency", evidence: "Depends on #204, #205" },
+    { target: 206, relationship: "sub-issue-reference", evidence: "Sub issue #206" },
+  ]);
 });
 
 test("enumerates a flat roadmap graph and separates execution candidates", async () => {
@@ -160,6 +178,28 @@ test("records duplicate references and cycles without recursing forever", async 
       path: [300, 301, 300],
     },
   ]);
+});
+
+test("keeps traversing descendants when a shared node is reached through multiple paths", async () => {
+  const issues = new Map([
+    [350, roadmapIssue(350, "- [ ] #351\n- [ ] #352", "root-roadmap")],
+    [351, executionIssue(351, "Refs #353")],
+    [352, executionIssue(352, "Refs #353")],
+    [353, executionIssue(353, "Refs #354")],
+    [354, executionIssue(354, "leaf execution")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(350, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(
+    graph.provenancePaths.filter((entry) => entry.target === 354),
+    [
+      { target: 354, path: [350, 351, 353, 354] },
+      { target: 354, path: [350, 352, 353, 354] },
+    ],
+  );
 });
 
 test("reports inaccessible and unresolved references fail-safe", async () => {

--- a/tests/discover-roadmap-graph.test.mjs
+++ b/tests/discover-roadmap-graph.test.mjs
@@ -63,14 +63,32 @@ Sub issue #206
   ]);
 });
 
-test("extractKeywordReferences ignores cross-repository references", () => {
+test("extractKeywordReferences ignores cross-repository references but keeps same-repo qualified refs", () => {
   const body = `
 Refs other/repo#301, #302
 Depends on kurone-kito/idd-skill#303
 `;
 
-  assert.deepEqual(extractKeywordReferences(body), [
+  assert.deepEqual(extractKeywordReferences(body, {
+    owner: "kurone-kito",
+    repo: "idd-skill",
+  }), [
     { target: 302, relationship: "reference", evidence: "Refs other/repo#301, #302" },
+    { target: 303, relationship: "dependency", evidence: "Depends on kurone-kito/idd-skill#303" },
+  ]);
+});
+
+test("extractKeywordReferences stops before incidental narrative mentions", () => {
+  const body = `
+Refs #401; similar to #402
+Depends on #403, #404 and #405
+`;
+
+  assert.deepEqual(extractKeywordReferences(body), [
+    { target: 401, relationship: "reference", evidence: "Refs #401; similar to #402" },
+    { target: 403, relationship: "dependency", evidence: "Depends on #403, #404 and #405" },
+    { target: 404, relationship: "dependency", evidence: "Depends on #403, #404 and #405" },
+    { target: 405, relationship: "dependency", evidence: "Depends on #403, #404 and #405" },
   ]);
 });
 
@@ -202,6 +220,30 @@ test("records duplicate references and cycles without recursing forever", async 
       target: 300,
       relationship: "task-list",
       path: [300, 301, 300],
+    },
+  ]);
+});
+
+test("counts exact duplicate references from the same issue body", async () => {
+  const issues = new Map([
+    [320, roadmapIssue(320, "- [ ] #321\n- [ ] #321", "root-roadmap")],
+    [321, executionIssue(321, "leaf execution")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(320, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.edges, [
+    { source: 320, target: 321, relationship: "task-list", evidence: "- [ ] #321" },
+  ]);
+  assert.deepEqual(graph.diagnostics.duplicateReferences, [
+    {
+      source: 320,
+      target: 321,
+      relationship: "task-list",
+      evidence: "- [ ] #321",
+      firstSeenFrom: 320,
     },
   ]);
 });

--- a/tests/discover-roadmap-graph.test.mjs
+++ b/tests/discover-roadmap-graph.test.mjs
@@ -24,6 +24,8 @@ Refs #102
 Depends on #103
 Closes #104
 Sub-issue #105
+Fix #106
+Resolve #107
 `;
 
   assert.equal(extractRoadmapMarkerId(body), "root-roadmap");
@@ -35,6 +37,8 @@ Sub-issue #105
     { target: 103, relationship: "dependency", evidence: "Depends on #103" },
     { target: 104, relationship: "closing-keyword", evidence: "Closes #104" },
     { target: 105, relationship: "sub-issue-reference", evidence: "Sub-issue #105" },
+    { target: 106, relationship: "closing-keyword", evidence: "Fix #106" },
+    { target: 107, relationship: "closing-keyword", evidence: "Resolve #107" },
   ]);
   assert.deepEqual(
     classifyIssue({
@@ -49,17 +53,26 @@ test("extractKeywordReferences parses blocked dependencies and multi-target list
   const body = `
 Refs #201, #202
 Blocked by #203
-Depends on #204, #205
-Sub issue #206
+Depends on #204, #205, and #206
+Refs: #207
+Sub issue: #208
 `;
 
   assert.deepEqual(extractKeywordReferences(body), [
     { target: 201, relationship: "reference", evidence: "Refs #201, #202" },
     { target: 202, relationship: "reference", evidence: "Refs #201, #202" },
     { target: 203, relationship: "dependency", evidence: "Blocked by #203" },
-    { target: 204, relationship: "dependency", evidence: "Depends on #204, #205" },
-    { target: 205, relationship: "dependency", evidence: "Depends on #204, #205" },
-    { target: 206, relationship: "sub-issue-reference", evidence: "Sub issue #206" },
+    { target: 204, relationship: "dependency", evidence: "Depends on #204, #205, and #206" },
+    { target: 205, relationship: "dependency", evidence: "Depends on #204, #205, and #206" },
+    { target: 206, relationship: "dependency", evidence: "Depends on #204, #205, and #206" },
+    { target: 207, relationship: "reference", evidence: "Refs: #207" },
+    { target: 208, relationship: "sub-issue-reference", evidence: "Sub issue: #208" },
+  ]);
+});
+
+test("extractTaskListReferences accepts uppercase checked items", () => {
+  assert.deepEqual(extractTaskListReferences("- [X] #211"), [
+    { target: 211, relationship: "task-list", evidence: "- [X] #211" },
   ]);
 });
 
@@ -268,15 +281,7 @@ test("keeps traversing descendants when a shared node is reached through multipl
       { target: 354, path: [350, 352, 353, 354] },
     ],
   );
-  assert.deepEqual(graph.diagnostics.duplicateReferences, [
-    {
-      source: 352,
-      target: 353,
-      relationship: "reference",
-      evidence: "Refs #353",
-      firstSeenFrom: 351,
-    },
-  ]);
+  assert.deepEqual(graph.diagnostics.duplicateReferences, []);
 });
 
 test("re-expands descendants when a shorter ancestry path appears later", async () => {
@@ -573,6 +578,41 @@ process.exit(1);
       reason: "issue_not_found",
     },
   ]);
+});
+
+test("CLI path fails when an explicit policy file is invalid", () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), "idd-discover-roadmap-graph-policy-"));
+  const ghPath = join(tempRoot, "gh");
+  const policyPath = join(tempRoot, "bad-policy.json");
+
+  writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "repo" && args[1] === "view") {
+  const jq = args[args.indexOf("--jq") + 1];
+  process.stdout.write(jq === ".owner.login" ? "kurone-kito\\n" : "idd-skill\\n");
+  process.exit(0);
+}
+process.stderr.write("unexpected gh invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`);
+  writeFileSync(policyPath, "{not-json");
+  chmodSync(ghPath, 0o755);
+
+  assert.throws(
+    () => execFileSync(
+      process.execPath,
+      [join(REPO_ROOT, "scripts/discover-roadmap-graph.mjs"), "--issue", "700", "--policy", policyPath],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${tempRoot}:${process.env.PATH ?? ""}`,
+        },
+      },
+    ),
+    /failed to load policy from .*bad-policy\.json/,
+  );
 });
 
 test("reports when only roadmap nodes remain open", async () => {

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -292,6 +292,28 @@ test("helper bundle manifest publishes the forced handoff helper command", () =>
   assert.equal(existsSync(join(REPO_ROOT, "bin/idd-forced-handoff-marker.mjs")), true);
 });
 
+test("helper bundle manifest publishes the discover roadmap graph helper command", () => {
+  const packageManagerManifest = buildHelperRuntimeManifest({
+    profile: "package-manager",
+    packageManager: "pnpm",
+    targetRoot: REPO_ROOT,
+  });
+  const vendoredManifest = buildHelperRuntimeManifest({
+    profile: "vendored-node",
+    targetRoot: REPO_ROOT,
+  });
+
+  assert.equal(
+    packageManagerManifest.profiles["package-manager"].commands["idd:discover-roadmap-graph"],
+    "idd-discover-roadmap-graph",
+  );
+  assert.equal(
+    vendoredManifest.profiles["vendored-node"].commands["idd:discover-roadmap-graph"],
+    "node scripts/discover-roadmap-graph.mjs",
+  );
+  assert.equal(existsSync(join(REPO_ROOT, "bin/idd-discover-roadmap-graph.mjs")), true);
+});
+
 test("helper bundle manifest publishes the phase ID resolver helper command", () => {
   const packageManagerManifest = buildHelperRuntimeManifest({
     profile: "package-manager",

--- a/tests/helper-runtime-profiles.test.mjs
+++ b/tests/helper-runtime-profiles.test.mjs
@@ -256,6 +256,8 @@ test("helper script docs keep the discover viability gate helper in sync", () =>
   );
 
   assert.equal(template, live);
+  assert.match(live, /discover-roadmap-graph\.mjs/);
+  assert.match(live, /Discover Roadmap Graph Contract/);
   assert.match(live, /discover-viability-gate\.mjs/);
   assert.match(live, /suitability-triage\.mjs/);
 });


### PR DESCRIPTION
## Summary
- add the read-only `idd-discover-roadmap-graph` helper to enumerate recursive roadmap graphs
- cover nested roadmaps, duplicates, cycles, inaccessible references, unresolved references, and CLI sub-issue traversal with tests
- document the helper contract and wire it into the package bin and helper runtime manifest

Closes #642

## Follow-up
- none

## Background
- Discover and roadmap audit both need a shared, machine-readable view of recursive roadmap structure without mutating GitHub state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to discover and enumerate roadmap/execution graphs from GitHub issues; registered as a package executable.

* **Documentation**
  * Added a detailed "Discover Roadmap Graph" contract and usage spec to project and template docs; updated helper inventory.

* **Tests**
  * Added comprehensive tests covering graph extraction/classification, traversal rules, diagnostics, CLI execution, and manifest entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->