### PR TITLE
docs(issue-authoring): add hidden human dependency checks

### DIFF
--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -251,6 +251,41 @@ This principle complements the execution axes rather than replacing
 them: it is a practical way to protect autonomous completion and clear
 verification during issue drafting.
 
+## Hidden human-dependency validation
+
+Before publishing a `ready` issue, run a short pre-publication check for
+hidden human dependency. Treat this as a routing aid, not a rigid
+wording linter: the question is whether the work still depends on
+unresolved human action, not whether the draft used one forbidden
+phrase.
+
+Ask these checks:
+
+1. Does implementation require credentials, external access, hardware,
+   or infrastructure that the executing agent cannot already reach? If
+   yes, route the work to `blocked-by-human` unless that dependency can
+   be front-loaded into a separate prerequisite issue.
+2. Does any implementation step or acceptance criterion depend on a
+   product, policy, or design decision that has not been made? If yes,
+   route the work to `needs-decision`.
+3. Do the acceptance criteria require subjective human approval instead
+   of objective verification? If yes, rewrite the ready issue around
+   measurable checks and back-load the optional review or publication
+   judgment.
+4. Does a roadmap narrative hide human-dependent work inside prose while
+   the visible task list presents the item as execution-ready? If yes,
+   preserve that work in an explicit stable bucket, approval-needed
+   hold, or blocking issue instead of burying it in the narrative.
+5. Is any dependency marker being used only to group related work or
+   express preference order? If yes, remove the fake blocker and use
+   task-list structure or sequencing notes instead. Keep dependency
+   edges only for true start blockers.
+
+Normal post-implementation code review, merge approval, or publication
+choice does not by itself make an otherwise autonomous issue non-ready.
+The ready issue should still carry its own objective verification even
+when a human will look at the result afterward.
+
 ## Alignment with A4.5 Suitability Gate
 
 The IDD discover phase uses an A4.5 pre-claim suitability gate that

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -207,6 +207,41 @@ This principle complements the execution axes rather than replacing
 them: it is a practical way to protect autonomous completion and clear
 verification during issue drafting.
 
+## Hidden human-dependency validation
+
+Before publishing a `ready` issue, run a short pre-publication check for
+hidden human dependency. Treat this as a routing aid, not a rigid
+wording linter: the question is whether the work still depends on
+unresolved human action, not whether the draft used one forbidden
+phrase.
+
+Ask these checks:
+
+1. Does implementation require credentials, external access, hardware,
+   or infrastructure that the executing agent cannot already reach? If
+   yes, route the work to `blocked-by-human` unless that dependency can
+   be front-loaded into a separate prerequisite issue.
+2. Does any implementation step or acceptance criterion depend on a
+   product, policy, or design decision that has not been made? If yes,
+   route the work to `needs-decision`.
+3. Do the acceptance criteria require subjective human approval instead
+   of objective verification? If yes, rewrite the ready issue around
+   measurable checks and back-load the optional review or publication
+   judgment.
+4. Does a roadmap narrative hide human-dependent work inside prose while
+   the visible task list presents the item as execution-ready? If yes,
+   preserve that work in an explicit stable bucket, approval-needed
+   hold, or blocking issue instead of burying it in the narrative.
+5. Is any dependency marker being used only to group related work or
+   express preference order? If yes, remove the fake blocker and use
+   task-list structure or sequencing notes instead. Keep dependency
+   edges only for true start blockers.
+
+Normal post-implementation code review, merge approval, or publication
+choice does not by itself make an otherwise autonomous issue non-ready.
+The ready issue should still carry its own objective verification even
+when a human will look at the result afterward.
+
 ## Dependency minimization
 
 Encode a dependency edge only when it reflects a true correctness,

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -77,6 +77,21 @@ Before you publish a ready issue, confirm:
   while adding more detail would start turning it into a lightweight
   model script
 
+## Hidden human-dependency quick check
+
+Before you publish a `ready` issue, confirm:
+
+- the implementation does not still depend on unresolved credentials,
+  access, or unavailable infrastructure
+- unresolved product, policy, or design choices have been routed to
+  `needs-decision` instead of being buried in implementation steps
+- acceptance criteria use objective verification, while optional
+  post-implementation review stays optional
+- roadmap narrative does not hide human-dependent work that belongs in a
+  stable bucket or approval-needed hold
+- dependency markers represent true start blockers rather than grouping
+  related work
+
 ## Example orphan issue
 
 - `## Background` or `## Goal`
@@ -216,6 +231,9 @@ common failures by validating before publish:
   issue body
 - **Uniqueness**: Reuse-first check passed; the work is not a duplicate
   or superseded
+- **Hidden human dependency**: Ready work does not still rely on
+  unresolved decisions, credentials, subjective approval, or
+  grouping-only dependency markers
 
 ## Specificity examples
 

--- a/tests/issue-authoring-specificity.test.mjs
+++ b/tests/issue-authoring-specificity.test.mjs
@@ -162,6 +162,62 @@ test("human-dependency isolation guidance keeps the front-load and back-load rul
   }
 });
 
+test("hidden human-dependency validation stays synced between canonical and bundled contract", () => {
+  const canonicalFile = "docs/issue-authoring-skill.md";
+  const bundledFile = "skills/issue-authoring/references/contract.md";
+  const canonical = readText(canonicalFile);
+  const bundled = readText(bundledFile);
+
+  assert.equal(
+    extractTopLevelSection(
+      canonical,
+      canonicalFile,
+      "## Hidden human-dependency validation",
+    ),
+    extractTopLevelSection(
+      bundled,
+      bundledFile,
+      "## Hidden human-dependency validation",
+    ),
+    `canonical and bundled hidden-human-dependency validation must stay in sync (${canonicalFile} vs ${bundledFile})`,
+  );
+});
+
+test("hidden human-dependency validation keeps the pre-publication routing checks", () => {
+  for (const file of [
+    "docs/issue-authoring-skill.md",
+    "skills/issue-authoring/references/contract.md",
+  ]) {
+    const section = extractTopLevelSection(
+      readText(file),
+      file,
+      "## Hidden human-dependency validation",
+    );
+    const normalizedSection = normalizeWhitespace(section);
+
+    for (const needle of [
+      "routing aid, not a rigid wording linter",
+      "credentials, external access, hardware, or infrastructure",
+      "`blocked-by-human`",
+      "product, policy, or design decision",
+      "`needs-decision`",
+      "subjective human approval",
+      "objective verification",
+      "optional review or publication judgment",
+      "roadmap narrative",
+      "approval-needed hold",
+      "dependency marker",
+      "true start blockers",
+      "post-implementation code review, merge approval, or publication choice",
+    ]) {
+      assert.ok(
+        normalizedSection.includes(normalizeWhitespace(needle)),
+        `${file} must keep hidden-human-dependency phrase: ${needle}`,
+      );
+    }
+  }
+});
+
 test("dependency minimization guidance keeps the edge-justification rules", () => {
   for (const file of [
     "docs/issue-authoring-skill.md",
@@ -187,6 +243,29 @@ test("dependency minimization guidance keeps the edge-justification rules", () =
         `${file} must keep dependency-minimization phrase: ${needle}`,
       );
     }
+  }
+});
+
+test("draft patterns keep the hidden human-dependency quick check", () => {
+  const file = "skills/issue-authoring/references/draft-patterns.md";
+  const text = readText(file);
+  const normalizedText = normalizeWhitespace(text);
+
+  for (const needle of [
+    "## Hidden human-dependency quick check",
+    "unresolved credentials, access, or unavailable infrastructure",
+    "`needs-decision`",
+    "objective verification",
+    "optional post-implementation review stays optional",
+    "approval-needed hold",
+    "true start blockers rather than grouping related work",
+    "subjective approval",
+    "grouping-only dependency markers",
+  ]) {
+    assert.ok(
+      normalizedText.includes(normalizeWhitespace(needle)),
+      `${file} must keep hidden human-dependency phrase: ${needle}`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary
- add a mirrored pre-publication hidden human dependency check to the canonical and bundled issue-authoring contracts
- add a draft-pattern quick check that separates true start blockers from optional post-implementation review
- extend the issue-authoring consistency tests so the new routing guidance stays pinned across both surfaces

## Validation
- `node --test tests/issue-authoring-specificity.test.mjs`
- `pnpm run docs:sync:check`
- `node scripts/audit-docs.mjs --check`
- `pnpm run lint:minimum`

Closes #648

## Follow-ups
- None.