### PR TITLE
docs(idd): document maintainer external-check waivers

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -247,6 +247,19 @@ replace ruleset bypass or branch protection. Treat GitHub-required
 checks as a separate merge-topology question that later F-phase logic
 must still prove.
 
+When enabling this policy surface:
+
+- classify only repo-external checks whose failure modes are outside the
+  feature branch's normal control
+- keep repository-owned lint, test, build, and release checks out of
+  both `advisory` and `waivable` selector lists
+- prefer narrow selectors plus short expiries so a waiver applies to one
+  PR head, not as a blanket exception
+- document the helper-first operator path for maintainers; do not tell
+  humans to hand-write raw waiver markers
+- in solo-maintainer repositories, use the helper-generated waiver
+  comment instead of PR self-approval as the authorization surface
+
 ## Phase ID Compatibility Contract
 
 Treat phase IDs as a compatibility surface, not as presentation text.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -415,6 +415,30 @@ Interpretation rules:
 - Repo-owned required checks and GitHub-required checks remain
   non-waivable at the contract layer. An IDD waiver never substitutes
   for GitHub ruleset bypass.
+- When the optional facade is installed, prefer helper-first usage:
+  - dry-run:
+
+    ```sh
+    idd-external-check-waiver --pr 123 \
+      --check "CodeRabbit" \
+      --reason "rate limit" \
+      --expires-in PT2H
+    ```
+
+  - apply after review:
+
+    ```sh
+    idd-external-check-waiver --pr 123 \
+      --check "CodeRabbit" \
+      --reason "rate limit" \
+      --expires-in PT2H \
+      --apply --yes
+    ```
+
+  - inspect the rendered body first; do not hand-write or copy raw
+    marker comments into the PR
+  - in solo-maintainer repositories, this helper-generated comment is
+    the authorization path; a normal PR approval is not equivalent
 
 ### A4 viability gate
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -476,7 +476,7 @@ not an automatic merge bypass.
 
 High-level maintainer flow:
 
-1. Let IDD reach a D4 or F2 hold and confirm that the blocker is a
+1. Let IDD reach an F2 hold and confirm that the blocker is a
    configured external check rather than a repository-owned or
    GitHub-required gate.
 2. Run the optional waiver facade in dry-run mode to inspect the exact
@@ -507,7 +507,8 @@ This source repository currently ships the following optional helper scripts:
 - `scripts/advisory-wait-state.mjs` (read-only advisory-wait evidence
   and AW outcome reporting)
 - `scripts/external-check-waiver.mjs` (maintainer dry-run/apply facade
-  for canonical external-check waiver comments on the current PR head)
+  for canonical external-check waiver comments on the current PR head;
+  added in this release)
 - `scripts/pre-merge-readiness.mjs` (read-only F2/F3 readiness evidence
   collection)
 - `scripts/review-disposition-verify.mjs` (read-only E7 disposition

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -466,6 +466,34 @@ Non-Copilot agents can still drive the workflow end to end, but they
 should expect those later phases to interact with Copilot as a GitHub
 reviewer because that is part of this repository's current PR policy.
 
+## Maintainer-Authorized External-Check Waivers
+
+Some repositories classify a small set of repo-external checks as
+waivable so IDD can recover when a third-party integration becomes
+stuck, unavailable, or rate-limited even though repository-owned
+validation is already healthy. This is a human-authorized escape hatch,
+not an automatic merge bypass.
+
+High-level maintainer flow:
+
+1. Let IDD reach a D4 or F2 hold and confirm that the blocker is a
+   configured external check rather than a repository-owned or
+   GitHub-required gate.
+2. Run the optional waiver facade in dry-run mode to inspect the exact
+   comment body, matched check, active claim, current PR HEAD, and
+   expiry before any mutation.
+3. Post the canonical waiver comment only through the helper's apply
+   path, then resume IDD on the same PR head.
+4. Keep every other gate intact: review currency, unresolved threads,
+   unreplied comments, required reviews, claim ownership, and GitHub
+   merge topology still have to pass normally.
+
+Normal PR approvals or casual maintainer comments such as "continue" are
+not sufficient waiver evidence. In solo-maintainer repositories, this
+helper-generated comment is the auditable authorization surface because
+self-approval cannot express the required claim, head, check, and expiry
+proof.
+
 ## Optional helper scripts
 
 This source repository currently ships the following optional helper scripts:
@@ -478,6 +506,8 @@ This source repository currently ships the following optional helper scripts:
   snapshot metrics)
 - `scripts/advisory-wait-state.mjs` (read-only advisory-wait evidence
   and AW outcome reporting)
+- `scripts/external-check-waiver.mjs` (maintainer dry-run/apply facade
+  for canonical external-check waiver comments on the current PR head)
 - `scripts/pre-merge-readiness.mjs` (read-only F2/F3 readiness evidence
   collection)
 - `scripts/review-disposition-verify.mjs` (read-only E7 disposition

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -122,6 +122,14 @@ never bypasses stale review currency, unresolved threads, missing
 required approvals, claim ownership, repo-owned failing checks, or a
 GitHub-required check that the merge API would still reject.
 
+In a solo-maintainer repository, the waiver comment is the auditable
+authorization path for a stuck external check. The PR author cannot rely
+on self-approval, and an ordinary approval would still be too weak
+because it does not bind a check selector, active claim, PR HEAD, or
+expiry. The maintainer should inspect the helper's dry-run output and
+post the canonical comment through the facade instead of hand-writing
+marker text.
+
 ## Phase Permissions
 
 Each IDD phase needs a different subset of access:

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -247,6 +247,19 @@ replace ruleset bypass or branch protection. Treat GitHub-required
 checks as a separate merge-topology question that later F-phase logic
 must still prove.
 
+When enabling this policy surface:
+
+- classify only repo-external checks whose failure modes are outside the
+  feature branch's normal control
+- keep repository-owned lint, test, build, and release checks out of
+  both `advisory` and `waivable` selector lists
+- prefer narrow selectors plus short expiries so a waiver applies to one
+  PR head, not as a blanket exception
+- document the helper-first operator path for maintainers; do not tell
+  humans to hand-write raw waiver markers
+- in solo-maintainer repositories, use the helper-generated waiver
+  comment instead of PR self-approval as the authorization surface
+
 ## Phase ID Compatibility Contract
 
 Treat phase IDs as a compatibility surface, not as presentation text.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -415,6 +415,30 @@ Interpretation rules:
 - Repo-owned required checks and GitHub-required checks remain
   non-waivable at the contract layer. An IDD waiver never substitutes
   for GitHub ruleset bypass.
+- When the optional facade is installed, prefer helper-first usage:
+  - dry-run:
+
+    ```sh
+    idd-external-check-waiver --pr 123 \
+      --check "CodeRabbit" \
+      --reason "rate limit" \
+      --expires-in PT2H
+    ```
+
+  - apply after review:
+
+    ```sh
+    idd-external-check-waiver --pr 123 \
+      --check "CodeRabbit" \
+      --reason "rate limit" \
+      --expires-in PT2H \
+      --apply --yes
+    ```
+
+  - inspect the rendered body first; do not hand-write or copy raw
+    marker comments into the PR
+  - in solo-maintainer repositories, this helper-generated comment is
+    the authorization path; a normal PR approval is not equivalent
 
 ### A4 viability gate
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -453,7 +453,7 @@ not an automatic merge bypass.
 
 High-level maintainer flow:
 
-1. Let IDD reach a D4 or F2 hold and confirm that the blocker is a
+1. Let IDD reach an F2 hold and confirm that the blocker is a
    configured external check rather than a repository-owned or
    GitHub-required gate.
 2. Run the optional waiver facade in dry-run mode to inspect the exact
@@ -485,7 +485,8 @@ following optional helper scripts:
 - `scripts/advisory-wait-state.mjs` (read-only advisory-wait evidence
   and AW outcome reporting)
 - `scripts/external-check-waiver.mjs` (maintainer dry-run/apply facade
-  for canonical external-check waiver comments on the current PR head)
+  for canonical external-check waiver comments on the current PR head;
+  added in this release)
 - `scripts/pre-merge-readiness.mjs` (read-only F2/F3 readiness evidence
   collection)
 - `scripts/review-disposition-verify.mjs` (read-only E7 disposition

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -443,6 +443,34 @@ Non-Copilot agents can still drive the workflow end to end, but they
 should expect those later phases to interact with Copilot as a GitHub
 reviewer because that is part of this repository's current PR policy.
 
+## Maintainer-Authorized External-Check Waivers
+
+Some repositories classify a small set of repo-external checks as
+waivable so IDD can recover when a third-party integration becomes
+stuck, unavailable, or rate-limited even though repository-owned
+validation is already healthy. This is a human-authorized escape hatch,
+not an automatic merge bypass.
+
+High-level maintainer flow:
+
+1. Let IDD reach a D4 or F2 hold and confirm that the blocker is a
+   configured external check rather than a repository-owned or
+   GitHub-required gate.
+2. Run the optional waiver facade in dry-run mode to inspect the exact
+   comment body, matched check, active claim, current PR HEAD, and
+   expiry before any mutation.
+3. Post the canonical waiver comment only through the helper's apply
+   path, then resume IDD on the same PR head.
+4. Keep every other gate intact: review currency, unresolved threads,
+   unreplied comments, required reviews, claim ownership, and GitHub
+   merge topology still have to pass normally.
+
+Normal PR approvals or casual maintainer comments such as "continue" are
+not sufficient waiver evidence. In solo-maintainer repositories, this
+helper-generated comment is the auditable authorization surface because
+self-approval cannot express the required claim, head, check, and expiry
+proof.
+
 ## Optional helper scripts
 
 The idd-skill source repository that ships this template currently includes the
@@ -456,6 +484,8 @@ following optional helper scripts:
   snapshot metrics)
 - `scripts/advisory-wait-state.mjs` (read-only advisory-wait evidence
   and AW outcome reporting)
+- `scripts/external-check-waiver.mjs` (maintainer dry-run/apply facade
+  for canonical external-check waiver comments on the current PR head)
 - `scripts/pre-merge-readiness.mjs` (read-only F2/F3 readiness evidence
   collection)
 - `scripts/review-disposition-verify.mjs` (read-only E7 disposition

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -122,6 +122,14 @@ never bypasses stale review currency, unresolved threads, missing
 required approvals, claim ownership, repo-owned failing checks, or a
 GitHub-required check that the merge API would still reject.
 
+In a solo-maintainer repository, the waiver comment is the auditable
+authorization path for a stuck external check. The PR author cannot rely
+on self-approval, and an ordinary approval would still be too weak
+because it does not bind a check selector, active claim, PR HEAD, or
+expiry. The maintainer should inspect the helper's dry-run output and
+post the canonical comment through the facade instead of hand-writing
+marker text.
+
 ## Phase Permissions
 
 Each IDD phase needs a different subset of access:


### PR DESCRIPTION
## Summary
- document the maintainer/admin authority model for external-check waivers
- add helper-first dry-run and apply guidance, including solo-maintainer usage
- clarify that waivers do not bypass repo-owned checks, review state, or claim ownership

Closes #670

## Follow-up Issues
- #668 will wire the F-phase gate to consume this evidence

## Background
- keeps the policy contract in #666 and the helper implementation in #667
- does not change merge-gate semantics before #668 lands


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for maintainer-authorized external-check waivers, including step-by-step workflows and constraints.
  * Included helper script usage examples and guidance for dry-run and apply flows.
  * Clarified authorization paths for solo-maintainer repositories and waiver policy requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->