### PR TITLE
fix(config): align forcedHandoff setting with documented policy

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -20,5 +20,9 @@
     "profile": "package-manager"
   },
   "issueScope": "roadmap",
-  "orphanFirstPolicy": "none"
+  "orphanFirstPolicy": "none",
+  "forcedHandoff": {
+    "mode": "human-gated",
+    "authorityPolicy": "owners-and-maintainers-only"
+  }
 }


### PR DESCRIPTION
## Summary

- Add `forcedHandoff` key to `.github/idd/config.json` to match the
  `forced-handoff: human-gated` policy already declared in
  `docs/customization.md`
- This fixes a mismatch where the documented policy enabled human-gated
  forced handoff but the machine-readable config defaulted to `disabled`

## Background

The `idd-force-handoff` helper reads `forcedHandoff.mode` from
`config.json` and refuses to run when the mode is not `human-gated`.
The missing key caused the helper to reject valid forced-handoff
recovery flows even though the repository policy documentation already
declared the feature enabled.

## Test plan

- [ ] `pnpm run lint:minimum` passes
- [ ] `node scripts/force-handoff.mjs` no longer throws "forced-handoff
  mode is not human-gated" for this repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal process configuration for change handoff procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->