### PR TITLE
fix(discover-roadmap-graph): exclude root from roadmapNodes output

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -169,7 +169,8 @@ roadmap graph for one selected roadmap issue.
   - `edges`: `[{ source: number, target: number, relationship: string,`
     `evidence: string }]`
   - `provenancePaths`: `[{ target: number, path: number[] }]`
-  - `roadmapNodes`: `number[]`
+  - `roadmapNodes`: `number[]` — nested roadmap nodes discovered through
+    traversal; **excludes** the root roadmap (A1 traversal entry point)
   - `executionCandidates`: `number[]`
   - `diagnostics`: `{ duplicateReferences: object[], cycles: object[],`
     `inaccessibleReferences: object[], unresolvedReferences: object[] }`

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -169,7 +169,8 @@ roadmap graph for one selected roadmap issue.
   - `edges`: `[{ source: number, target: number, relationship: string,`
     `evidence: string }]`
   - `provenancePaths`: `[{ target: number, path: number[] }]`
-  - `roadmapNodes`: `number[]`
+  - `roadmapNodes`: `number[]` — nested roadmap nodes discovered through
+    traversal; **excludes** the root roadmap (A1 traversal entry point)
   - `executionCandidates`: `number[]`
   - `diagnostics`: `{ duplicateReferences: object[], cycles: object[],`
     `inaccessibleReferences: object[], unresolvedReferences: object[] }`

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -490,7 +490,7 @@ Output schema (JSON mode):
       "rootNumber": 638,
       "nodeCount": 2,
       "edgeCount": 1,
-      "roadmapNodeCount": 1,
+      "roadmapNodeCount": 0,
       "executionCandidateCount": 1,
       "duplicateReferenceCount": 0,
       "cycleCount": 0,

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -105,7 +105,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   const sortedEdges = [...edges].sort(compareEdges);
   const sortedProvenancePaths = [...provenancePaths].sort(comparePaths);
   const roadmapNodes = nodes
-    .filter((node) => node.classification === "roadmap")
+    .filter((node) => node.classification === "roadmap" && node.number !== rootIssue.number)
     .map((node) => node.number);
   const executionCandidates = nodes
     .filter((node) => node.classification === "execution" && node.state === "OPEN")
@@ -478,7 +478,7 @@ Output schema (JSON mode):
     "nodes": [{ "number": 638, "title": "...", "state": "OPEN", "labels": ["roadmap"], "classification": "roadmap", "roadmapMarkerId": "...", "depth": 0 }],
     "edges": [{ "source": 638, "target": 640, "relationship": "task-list", "evidence": "- [ ] #640" }],
     "provenancePaths": [{ "target": 640, "path": [638, 640] }],
-    "roadmapNodes": [638],
+    "roadmapNodes": [],
     "executionCandidates": [640],
     "diagnostics": {
       "duplicateReferences": [],

--- a/tests/discover-roadmap-graph.test.mjs
+++ b/tests/discover-roadmap-graph.test.mjs
@@ -116,7 +116,7 @@ test("enumerates a flat roadmap graph and separates execution candidates", async
     loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
   });
 
-  assert.deepEqual(graph.roadmapNodes, [100]);
+  assert.deepEqual(graph.roadmapNodes, []);
   assert.deepEqual(graph.executionCandidates, [101, 102]);
   assert.deepEqual(graph.edges, [
     { source: 100, target: 101, relationship: "task-list", evidence: "- [ ] #101" },
@@ -141,7 +141,7 @@ test("enumerates a two-level nested roadmap graph", async () => {
     loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
   });
 
-  assert.deepEqual(graph.roadmapNodes, [150, 151]);
+  assert.deepEqual(graph.roadmapNodes, [151]);
   assert.deepEqual(graph.executionCandidates, [152]);
   assert.deepEqual(graph.provenancePaths, [
     { target: 150, path: [150] },
@@ -163,7 +163,7 @@ test("enumerates a three-level nested roadmap graph", async () => {
     loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
   });
 
-  assert.deepEqual(graph.roadmapNodes, [175, 176, 177]);
+  assert.deepEqual(graph.roadmapNodes, [176, 177]);
   assert.deepEqual(graph.executionCandidates, [178]);
   assert.deepEqual(graph.provenancePaths, [
     { target: 175, path: [175] },
@@ -185,7 +185,7 @@ test("forces the selected root issue to remain a roadmap", async () => {
   });
 
   assert.equal(graph.root.classification, "roadmap");
-  assert.deepEqual(graph.roadmapNodes, [180]);
+  assert.deepEqual(graph.roadmapNodes, []);
   assert.deepEqual(graph.executionCandidates, [181]);
 });
 
@@ -200,7 +200,7 @@ test("keeps traversing through a closed intermediate roadmap to an open descenda
     loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
   });
 
-  assert.deepEqual(graph.roadmapNodes, [200, 201]);
+  assert.deepEqual(graph.roadmapNodes, [201]);
   assert.deepEqual(graph.executionCandidates, [202]);
   assert.deepEqual(graph.provenancePaths, [
     { target: 200, path: [200] },
@@ -494,7 +494,7 @@ process.exit(1);
   );
   const parsed = JSON.parse(output);
 
-  assert.deepEqual(parsed.roadmapNodes, [700]);
+  assert.deepEqual(parsed.roadmapNodes, []);
   assert.deepEqual(parsed.executionCandidates, [701]);
   assert.deepEqual(parsed.edges, [
     {
@@ -625,7 +625,7 @@ test("reports when only roadmap nodes remain open", async () => {
     loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
   });
 
-  assert.deepEqual(graph.roadmapNodes, [600, 601]);
+  assert.deepEqual(graph.roadmapNodes, [601]);
   assert.deepEqual(graph.executionCandidates, []);
   assert.equal(graph.summary.executionCandidateCount, 0);
 });


### PR DESCRIPTION
## Summary

- Excludes the root roadmap (A1 traversal entry point) from the `roadmapNodes` array in `scripts/discover-roadmap-graph.mjs`.
- The root was already distinguished via `graph.root`; including it in `roadmapNodes` contradicted the A2 instruction guidance from PR #679.
- Updates 7 test assertions in `tests/discover-roadmap-graph.test.mjs`.
- Documents the root-exclusion semantics in `idd-template/docs/idd-helper-scripts.md` (synced to live `docs/`).

## Issue

Closes #681

## Background

CodeRabbit flagged this in PR #679 review. The fix was deferred from that PR to keep it focused on documentation-only changes.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected roadmap node discovery to exclude the root roadmap node from results, ensuring cleaner and more consistent output.

* **Documentation**
  * Clarified the `roadmapNodes` field definition in the roadmap graph contract schema.

* **Tests**
  * Updated test assertions to reflect the corrected roadmap discovery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->