### PR TITLE
feat(helpers): add external-check waiver consumption to F phase CI gate

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -171,7 +171,23 @@ must align with every F2 condition below.
 - **CI**: Current PR head SHA has all required CI checks generated and
   all passing (→ run CI wait per `idd-ci.instructions.md` using the
   same resolved `ciWait.runningTimeout`, `ciWait.generationTimeout`, and
-  `ciWait.rerunPolicy` values; on-success → re-evaluate F2)
+  `ciWait.rerunPolicy` values; on-success → re-evaluate F2).
+
+  **External-check waivers**: When `pre-merge-readiness` reports a check
+  as `coveredByWaiver: true` in its output, a trusted maintainer has
+  authorized skipping that specific check under the current head SHA and
+  active claim. Treat it as passing for F2/F3 routing **only when**:
+  - `waiverEvidence.valid` is non-empty for that check's selector
+  - The waiver actor is a trusted marker login
+  - The waiver `headSha` matches the current PR HEAD
+  - The waiver `claimId` matches the active claim
+  - The waiver `expiresAt` is in the future
+
+  Waivers never bypass review currency, advisory wait, unresolved
+  threads, unreplied comments, required reviews, disposition evidence,
+  or claim ownership. If `waiverEvidence.wrongHead`, `wrongClaim`,
+  `unauthorized`, `expired`, or `malformed` are non-empty, report them
+  as suspicious context and do not treat them as valid permissions.
 - **Required reviews**: Required approvals count is satisfied and all
   CODEOWNER approvals are obtained. If helper evidence includes
   `reviewerStates.codeownerSelfApproval`, include that diagnostic in the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -356,8 +356,12 @@ The adopted helper boundaries are intentionally narrow:
 
 - `pre-merge-readiness.mjs` is read-only, emits machine-readable F2/F3
   evidence including review currency, unresolved-thread state,
-  unreplied comments, reviewer states, advisory state, CI, and claim
-  validation
+  unreplied comments, reviewer states, advisory state, CI, claim
+  validation, and `waiverEvidence` (parsed external-check waiver comments
+  classified as `valid`, `expired`, `wrongHead`, `wrongClaim`,
+  `unauthorized`, or `malformed`; checks covered by a valid waiver are
+  reported with `coveredByWaiver: true` and treated as passing by the CI
+  gate)
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -4,15 +4,19 @@
     "comments": [
       {
         "id": "watermark-changes",
-        "author": { "login": "kurone-kito" },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
+        "author": {
+          "login": "kurone-kito"
+        },
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
     ],
     "reviews": [
       {
-        "author": { "login": "copilot-pull-request-reviewer[bot]" },
+        "author": {
+          "login": "copilot-pull-request-reviewer[bot]"
+        },
         "state": "APPROVED",
         "commitId": "1111111111111111111111111111111111111111",
         "submittedAt": "2026-05-11T23:54:00Z",
@@ -20,7 +24,9 @@
         "updatedAt": "2026-05-11T23:54:00Z"
       },
       {
-        "author": { "login": "owner-reviewer" },
+        "author": {
+          "login": "owner-reviewer"
+        },
         "state": "CHANGES_REQUESTED",
         "commitId": "",
         "submittedAt": "2026-05-11T23:55:00Z",
@@ -49,7 +55,11 @@
       {
         "type": "required_status_checks",
         "parameters": {
-          "required_status_checks": [{ "context": "lint" }]
+          "required_status_checks": [
+            {
+              "context": "lint"
+            }
+          ]
         }
       }
     ],
@@ -57,19 +67,27 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
-        "author": { "login": "kurone-kito" }
+        "author": {
+          "login": "kurone-kito"
+        }
       }
     ],
-    "changedFiles": ["README.md"],
+    "changedFiles": [
+      "README.md"
+    ],
     "codeownersText": "* @owner-reviewer\n",
     "reviewDecision": "CHANGES_REQUESTED"
   },
   "options": {
     "now": "2026-05-12T00:00:00Z",
-    "trustedMarkerLogins": ["kurone-kito"],
-    "iddAgentLogins": ["kurone-kito"],
+    "trustedMarkerLogins": [
+      "kurone-kito"
+    ],
+    "iddAgentLogins": [
+      "kurone-kito"
+    ],
     "advisoryBotLogins": [],
     "prAuthorLogin": "contributor",
     "expectedClaimId": "claim-123",
@@ -128,7 +146,9 @@
       "requiresConversationResolution": false,
       "requiredReviewerLogins": [],
       "requiredReviewerTeams": [],
-      "codeownerUserLogins": ["owner-reviewer"],
+      "codeownerUserLogins": [
+        "owner-reviewer"
+      ],
       "codeownerTeamSlugs": [],
       "unmatchedCodeownerFiles": [],
       "latestByAuthor": [
@@ -158,7 +178,9 @@
         "status": "clear",
         "reason": "non-author-codeowner-available",
         "prAuthorLogin": "contributor",
-        "directCodeownerUserLogins": ["owner-reviewer"],
+        "directCodeownerUserLogins": [
+          "owner-reviewer"
+        ],
         "codeownerTeamSlugs": [],
         "requireCodeOwnerReview": true,
         "codeownerApprovalSatisfied": false,
@@ -167,7 +189,9 @@
         "currentUserCanBypass": "unknown"
       },
       "humanChangesRequestedCount": 1,
-      "blockingChangesRequestedLogins": ["owner-reviewer"]
+      "blockingChangesRequestedLogins": [
+        "owner-reviewer"
+      ]
     },
     "advisoryWait": {
       "outcome": "SATISFIED",
@@ -192,7 +216,9 @@
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,
       "requiredChecksPassing": true,
-      "requiredCheckNames": ["lint"],
+      "requiredCheckNames": [
+        "lint"
+      ],
       "missingRequiredCheckNames": [],
       "checks": [
         {
@@ -217,6 +243,14 @@
       "matchesExpectedClaim": true,
       "claimLost": false,
       "reason": "match"
+    },
+    "waiverEvidence": {
+      "valid": [],
+      "expired": [],
+      "wrongHead": [],
+      "wrongClaim": [],
+      "unauthorized": [],
+      "malformed": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -4,15 +4,19 @@
     "comments": [
       {
         "id": "watermark-ci",
-        "author": { "login": "kurone-kito" },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
+        "author": {
+          "login": "kurone-kito"
+        },
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
     ],
     "reviews": [
       {
-        "author": { "login": "copilot-pull-request-reviewer[bot]" },
+        "author": {
+          "login": "copilot-pull-request-reviewer[bot]"
+        },
         "state": "APPROVED",
         "commitId": "1111111111111111111111111111111111111111",
         "submittedAt": "2026-05-11T23:54:00Z",
@@ -20,7 +24,9 @@
         "updatedAt": "2026-05-11T23:54:00Z"
       },
       {
-        "author": { "login": "owner-reviewer" },
+        "author": {
+          "login": "owner-reviewer"
+        },
         "state": "APPROVED",
         "commitId": "",
         "submittedAt": "2026-05-11T23:55:00Z",
@@ -49,7 +55,14 @@
       {
         "type": "required_status_checks",
         "parameters": {
-          "required_status_checks": [{ "context": "lint" }, { "context": "test" }]
+          "required_status_checks": [
+            {
+              "context": "lint"
+            },
+            {
+              "context": "test"
+            }
+          ]
         }
       }
     ],
@@ -57,19 +70,27 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
-        "author": { "login": "kurone-kito" }
+        "author": {
+          "login": "kurone-kito"
+        }
       }
     ],
-    "changedFiles": ["README.md"],
+    "changedFiles": [
+      "README.md"
+    ],
     "codeownersText": "* @owner-reviewer\n",
     "reviewDecision": "APPROVED"
   },
   "options": {
     "now": "2026-05-12T00:00:00Z",
-    "trustedMarkerLogins": ["kurone-kito"],
-    "iddAgentLogins": ["kurone-kito"],
+    "trustedMarkerLogins": [
+      "kurone-kito"
+    ],
+    "iddAgentLogins": [
+      "kurone-kito"
+    ],
     "advisoryBotLogins": [],
     "prAuthorLogin": "contributor",
     "expectedClaimId": "claim-123",
@@ -128,7 +149,9 @@
       "requiresConversationResolution": false,
       "requiredReviewerLogins": [],
       "requiredReviewerTeams": [],
-      "codeownerUserLogins": ["owner-reviewer"],
+      "codeownerUserLogins": [
+        "owner-reviewer"
+      ],
       "codeownerTeamSlugs": [],
       "unmatchedCodeownerFiles": [],
       "latestByAuthor": [
@@ -158,7 +181,9 @@
         "status": "not_applicable",
         "reason": "codeowner-approval-satisfied",
         "prAuthorLogin": "contributor",
-        "directCodeownerUserLogins": ["owner-reviewer"],
+        "directCodeownerUserLogins": [
+          "owner-reviewer"
+        ],
         "codeownerTeamSlugs": [],
         "requireCodeOwnerReview": true,
         "codeownerApprovalSatisfied": true,
@@ -192,8 +217,13 @@
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": false,
       "requiredChecksPassing": false,
-      "requiredCheckNames": ["lint", "test"],
-      "missingRequiredCheckNames": ["test"],
+      "requiredCheckNames": [
+        "lint",
+        "test"
+      ],
+      "missingRequiredCheckNames": [
+        "test"
+      ],
       "checks": [
         {
           "name": "lint",
@@ -217,6 +247,14 @@
       "matchesExpectedClaim": true,
       "claimLost": false,
       "reason": "match"
+    },
+    "waiverEvidence": {
+      "valid": [],
+      "expired": [],
+      "wrongHead": [],
+      "wrongClaim": [],
+      "unauthorized": [],
+      "malformed": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -4,15 +4,19 @@
     "comments": [
       {
         "id": "watermark-claim",
-        "author": { "login": "kurone-kito" },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
+        "author": {
+          "login": "kurone-kito"
+        },
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
     ],
     "reviews": [
       {
-        "author": { "login": "copilot-pull-request-reviewer[bot]" },
+        "author": {
+          "login": "copilot-pull-request-reviewer[bot]"
+        },
         "state": "APPROVED",
         "commitId": "1111111111111111111111111111111111111111",
         "submittedAt": "2026-05-11T23:54:00Z",
@@ -20,7 +24,9 @@
         "updatedAt": "2026-05-11T23:54:00Z"
       },
       {
-        "author": { "login": "owner-reviewer" },
+        "author": {
+          "login": "owner-reviewer"
+        },
         "state": "APPROVED",
         "commitId": "",
         "submittedAt": "2026-05-11T23:55:00Z",
@@ -35,14 +41,20 @@
         "updatedAt": "",
         "reviewerReopenedAt": "",
         "comments": {
-          "pageInfo": { "hasNextPage": false },
+          "pageInfo": {
+            "hasNextPage": false
+          },
           "nodes": [
             {
-              "author": { "login": "kurone-kito" },
+              "author": {
+                "login": "kurone-kito"
+              },
               "body": "Fixed in the latest commit.",
               "createdAt": "2026-05-11T23:56:00Z",
               "updatedAt": "2026-05-11T23:56:00Z",
-              "pullRequestReview": { "id": "review-1" }
+              "pullRequestReview": {
+                "id": "review-1"
+              }
             }
           ]
         }
@@ -68,7 +80,11 @@
       {
         "type": "required_status_checks",
         "parameters": {
-          "required_status_checks": [{ "context": "lint" }]
+          "required_status_checks": [
+            {
+              "context": "lint"
+            }
+          ]
         }
       }
     ],
@@ -76,19 +92,27 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-999 supersedes: none 2026-05-11T23:30:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-999 supersedes: none 2026-05-11T23:30:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:30:00Z",
-        "author": { "login": "kurone-kito" }
+        "author": {
+          "login": "kurone-kito"
+        }
       }
     ],
-    "changedFiles": ["README.md"],
+    "changedFiles": [
+      "README.md"
+    ],
     "codeownersText": "* @owner-reviewer\n",
     "reviewDecision": "APPROVED"
   },
   "options": {
     "now": "2026-05-12T00:00:00Z",
-    "trustedMarkerLogins": ["kurone-kito"],
-    "iddAgentLogins": ["kurone-kito"],
+    "trustedMarkerLogins": [
+      "kurone-kito"
+    ],
+    "iddAgentLogins": [
+      "kurone-kito"
+    ],
     "advisoryBotLogins": [],
     "prAuthorLogin": "contributor",
     "expectedClaimId": "claim-123",
@@ -152,7 +176,9 @@
       "requiresConversationResolution": false,
       "requiredReviewerLogins": [],
       "requiredReviewerTeams": [],
-      "codeownerUserLogins": ["owner-reviewer"],
+      "codeownerUserLogins": [
+        "owner-reviewer"
+      ],
       "codeownerTeamSlugs": [],
       "unmatchedCodeownerFiles": [],
       "latestByAuthor": [
@@ -182,7 +208,9 @@
         "status": "not_applicable",
         "reason": "codeowner-approval-satisfied",
         "prAuthorLogin": "contributor",
-        "directCodeownerUserLogins": ["owner-reviewer"],
+        "directCodeownerUserLogins": [
+          "owner-reviewer"
+        ],
         "codeownerTeamSlugs": [],
         "requireCodeOwnerReview": true,
         "codeownerApprovalSatisfied": true,
@@ -216,7 +244,9 @@
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,
       "requiredChecksPassing": true,
-      "requiredCheckNames": ["lint"],
+      "requiredCheckNames": [
+        "lint"
+      ],
       "missingRequiredCheckNames": [],
       "checks": [
         {
@@ -241,6 +271,14 @@
       "matchesExpectedClaim": false,
       "claimLost": true,
       "reason": "claim-id-mismatch"
+    },
+    "waiverEvidence": {
+      "valid": [],
+      "expired": [],
+      "wrongHead": [],
+      "wrongClaim": [],
+      "unauthorized": [],
+      "malformed": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -4,15 +4,19 @@
     "comments": [
       {
         "id": "watermark-clean",
-        "author": { "login": "kurone-kito" },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
+        "author": {
+          "login": "kurone-kito"
+        },
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
     ],
     "reviews": [
       {
-        "author": { "login": "copilot-pull-request-reviewer[bot]" },
+        "author": {
+          "login": "copilot-pull-request-reviewer[bot]"
+        },
         "state": "APPROVED",
         "commitId": "1111111111111111111111111111111111111111",
         "submittedAt": "2026-05-11T23:54:00Z",
@@ -20,7 +24,9 @@
         "updatedAt": "2026-05-11T23:54:00Z"
       },
       {
-        "author": { "login": "owner-reviewer" },
+        "author": {
+          "login": "owner-reviewer"
+        },
         "state": "APPROVED",
         "commitId": "",
         "submittedAt": "2026-05-11T23:55:00Z",
@@ -35,14 +41,20 @@
         "updatedAt": "",
         "reviewerReopenedAt": "",
         "comments": {
-          "pageInfo": { "hasNextPage": false },
+          "pageInfo": {
+            "hasNextPage": false
+          },
           "nodes": [
             {
-              "author": { "login": "kurone-kito" },
+              "author": {
+                "login": "kurone-kito"
+              },
               "body": "Fixed in the latest commit.",
               "createdAt": "2026-05-11T23:56:00Z",
               "updatedAt": "2026-05-11T23:56:00Z",
-              "pullRequestReview": { "id": "review-1" }
+              "pullRequestReview": {
+                "id": "review-1"
+              }
             }
           ]
         }
@@ -68,7 +80,11 @@
       {
         "type": "required_status_checks",
         "parameters": {
-          "required_status_checks": [{ "context": "lint" }]
+          "required_status_checks": [
+            {
+              "context": "lint"
+            }
+          ]
         }
       }
     ],
@@ -76,19 +92,27 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
-        "author": { "login": "kurone-kito" }
+        "author": {
+          "login": "kurone-kito"
+        }
       }
     ],
-    "changedFiles": ["README.md"],
+    "changedFiles": [
+      "README.md"
+    ],
     "codeownersText": "* @owner-reviewer\n",
     "reviewDecision": "APPROVED"
   },
   "options": {
     "now": "2026-05-12T00:00:00Z",
-    "trustedMarkerLogins": ["kurone-kito"],
-    "iddAgentLogins": ["kurone-kito"],
+    "trustedMarkerLogins": [
+      "kurone-kito"
+    ],
+    "iddAgentLogins": [
+      "kurone-kito"
+    ],
     "advisoryBotLogins": [],
     "prAuthorLogin": "contributor",
     "expectedClaimId": "claim-123",
@@ -152,7 +176,9 @@
       "requiresConversationResolution": false,
       "requiredReviewerLogins": [],
       "requiredReviewerTeams": [],
-      "codeownerUserLogins": ["owner-reviewer"],
+      "codeownerUserLogins": [
+        "owner-reviewer"
+      ],
       "codeownerTeamSlugs": [],
       "unmatchedCodeownerFiles": [],
       "latestByAuthor": [
@@ -182,7 +208,9 @@
         "status": "not_applicable",
         "reason": "codeowner-approval-satisfied",
         "prAuthorLogin": "contributor",
-        "directCodeownerUserLogins": ["owner-reviewer"],
+        "directCodeownerUserLogins": [
+          "owner-reviewer"
+        ],
         "codeownerTeamSlugs": [],
         "requireCodeOwnerReview": true,
         "codeownerApprovalSatisfied": true,
@@ -216,7 +244,9 @@
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,
       "requiredChecksPassing": true,
-      "requiredCheckNames": ["lint"],
+      "requiredCheckNames": [
+        "lint"
+      ],
       "missingRequiredCheckNames": [],
       "checks": [
         {
@@ -241,6 +271,14 @@
       "matchesExpectedClaim": true,
       "claimLost": false,
       "reason": "match"
+    },
+    "waiverEvidence": {
+      "valid": [],
+      "expired": [],
+      "wrongHead": [],
+      "wrongClaim": [],
+      "unauthorized": [],
+      "malformed": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -4,15 +4,19 @@
     "comments": [
       {
         "id": "watermark-stale",
-        "author": { "login": "kurone-kito" },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
+        "author": {
+          "login": "kurone-kito"
+        },
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
     ],
     "reviews": [
       {
-        "author": { "login": "copilot-pull-request-reviewer[bot]" },
+        "author": {
+          "login": "copilot-pull-request-reviewer[bot]"
+        },
         "state": "APPROVED",
         "commitId": "1111111111111111111111111111111111111111",
         "submittedAt": "2026-05-11T23:54:00Z",
@@ -20,7 +24,9 @@
         "updatedAt": "2026-05-11T23:54:00Z"
       },
       {
-        "author": { "login": "owner-reviewer" },
+        "author": {
+          "login": "owner-reviewer"
+        },
         "state": "APPROVED",
         "commitId": "",
         "submittedAt": "2026-05-11T23:55:00Z",
@@ -35,14 +41,20 @@
         "updatedAt": "",
         "reviewerReopenedAt": "",
         "comments": {
-          "pageInfo": { "hasNextPage": false },
+          "pageInfo": {
+            "hasNextPage": false
+          },
           "nodes": [
             {
-              "author": { "login": "kurone-kito" },
+              "author": {
+                "login": "kurone-kito"
+              },
               "body": "Fixed in the latest commit.",
               "createdAt": "2026-05-11T23:56:00Z",
               "updatedAt": "2026-05-11T23:56:00Z",
-              "pullRequestReview": { "id": "review-1" }
+              "pullRequestReview": {
+                "id": "review-1"
+              }
             }
           ]
         }
@@ -68,7 +80,11 @@
       {
         "type": "required_status_checks",
         "parameters": {
-          "required_status_checks": [{ "context": "lint" }]
+          "required_status_checks": [
+            {
+              "context": "lint"
+            }
+          ]
         }
       }
     ],
@@ -76,19 +92,27 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
-        "author": { "login": "kurone-kito" }
+        "author": {
+          "login": "kurone-kito"
+        }
       }
     ],
-    "changedFiles": ["README.md"],
+    "changedFiles": [
+      "README.md"
+    ],
     "codeownersText": "* @owner-reviewer\n",
     "reviewDecision": "APPROVED"
   },
   "options": {
     "now": "2026-05-12T00:00:00Z",
-    "trustedMarkerLogins": ["kurone-kito"],
-    "iddAgentLogins": ["kurone-kito"],
+    "trustedMarkerLogins": [
+      "kurone-kito"
+    ],
+    "iddAgentLogins": [
+      "kurone-kito"
+    ],
     "advisoryBotLogins": [],
     "prAuthorLogin": "contributor",
     "expectedClaimId": "claim-123",
@@ -152,7 +176,9 @@
       "requiresConversationResolution": false,
       "requiredReviewerLogins": [],
       "requiredReviewerTeams": [],
-      "codeownerUserLogins": ["owner-reviewer"],
+      "codeownerUserLogins": [
+        "owner-reviewer"
+      ],
       "codeownerTeamSlugs": [],
       "unmatchedCodeownerFiles": [],
       "latestByAuthor": [
@@ -182,7 +208,9 @@
         "status": "not_applicable",
         "reason": "codeowner-approval-satisfied",
         "prAuthorLogin": "contributor",
-        "directCodeownerUserLogins": ["owner-reviewer"],
+        "directCodeownerUserLogins": [
+          "owner-reviewer"
+        ],
         "codeownerTeamSlugs": [],
         "requireCodeOwnerReview": true,
         "codeownerApprovalSatisfied": true,
@@ -216,7 +244,9 @@
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,
       "requiredChecksPassing": true,
-      "requiredCheckNames": ["lint"],
+      "requiredCheckNames": [
+        "lint"
+      ],
       "missingRequiredCheckNames": [],
       "checks": [
         {
@@ -241,6 +271,14 @@
       "matchesExpectedClaim": true,
       "claimLost": false,
       "reason": "match"
+    },
+    "waiverEvidence": {
+      "valid": [],
+      "expired": [],
+      "wrongHead": [],
+      "wrongClaim": [],
+      "unauthorized": [],
+      "malformed": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -4,22 +4,28 @@
     "comments": [
       {
         "id": "comment-reviewer",
-        "author": { "login": "reviewer" },
+        "author": {
+          "login": "reviewer"
+        },
         "body": "Please confirm this path.",
         "createdAt": "2026-05-11T23:56:00Z",
         "updatedAt": "2026-05-11T23:56:00Z"
       },
       {
         "id": "watermark-comment",
-        "author": { "login": "kurone-kito" },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
+        "author": {
+          "login": "kurone-kito"
+        },
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
     ],
     "reviews": [
       {
-        "author": { "login": "copilot-pull-request-reviewer[bot]" },
+        "author": {
+          "login": "copilot-pull-request-reviewer[bot]"
+        },
         "state": "APPROVED",
         "commitId": "1111111111111111111111111111111111111111",
         "submittedAt": "2026-05-11T23:54:00Z",
@@ -27,7 +33,9 @@
         "updatedAt": "2026-05-11T23:54:00Z"
       },
       {
-        "author": { "login": "owner-reviewer" },
+        "author": {
+          "login": "owner-reviewer"
+        },
         "state": "APPROVED",
         "commitId": "",
         "submittedAt": "2026-05-11T23:55:00Z",
@@ -56,7 +64,11 @@
       {
         "type": "required_status_checks",
         "parameters": {
-          "required_status_checks": [{ "context": "lint" }]
+          "required_status_checks": [
+            {
+              "context": "lint"
+            }
+          ]
         }
       }
     ],
@@ -64,19 +76,27 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
-        "author": { "login": "kurone-kito" }
+        "author": {
+          "login": "kurone-kito"
+        }
       }
     ],
-    "changedFiles": ["README.md"],
+    "changedFiles": [
+      "README.md"
+    ],
     "codeownersText": "* @owner-reviewer\n",
     "reviewDecision": "APPROVED"
   },
   "options": {
     "now": "2026-05-12T00:00:00Z",
-    "trustedMarkerLogins": ["kurone-kito"],
-    "iddAgentLogins": ["kurone-kito"],
+    "trustedMarkerLogins": [
+      "kurone-kito"
+    ],
+    "iddAgentLogins": [
+      "kurone-kito"
+    ],
     "advisoryBotLogins": [],
     "prAuthorLogin": "contributor",
     "expectedClaimId": "claim-123",
@@ -142,7 +162,9 @@
       "requiresConversationResolution": false,
       "requiredReviewerLogins": [],
       "requiredReviewerTeams": [],
-      "codeownerUserLogins": ["owner-reviewer"],
+      "codeownerUserLogins": [
+        "owner-reviewer"
+      ],
       "codeownerTeamSlugs": [],
       "unmatchedCodeownerFiles": [],
       "latestByAuthor": [
@@ -172,7 +194,9 @@
         "status": "not_applicable",
         "reason": "codeowner-approval-satisfied",
         "prAuthorLogin": "contributor",
-        "directCodeownerUserLogins": ["owner-reviewer"],
+        "directCodeownerUserLogins": [
+          "owner-reviewer"
+        ],
         "codeownerTeamSlugs": [],
         "requireCodeOwnerReview": true,
         "codeownerApprovalSatisfied": true,
@@ -206,7 +230,9 @@
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,
       "requiredChecksPassing": true,
-      "requiredCheckNames": ["lint"],
+      "requiredCheckNames": [
+        "lint"
+      ],
       "missingRequiredCheckNames": [],
       "checks": [
         {
@@ -231,6 +257,14 @@
       "matchesExpectedClaim": true,
       "claimLost": false,
       "reason": "match"
+    },
+    "waiverEvidence": {
+      "valid": [],
+      "expired": [],
+      "wrongHead": [],
+      "wrongClaim": [],
+      "unauthorized": [],
+      "malformed": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -4,15 +4,19 @@
     "comments": [
       {
         "id": "watermark-thread",
-        "author": { "login": "kurone-kito" },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
+        "author": {
+          "login": "kurone-kito"
+        },
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
     ],
     "reviews": [
       {
-        "author": { "login": "copilot-pull-request-reviewer[bot]" },
+        "author": {
+          "login": "copilot-pull-request-reviewer[bot]"
+        },
         "state": "APPROVED",
         "commitId": "1111111111111111111111111111111111111111",
         "submittedAt": "2026-05-11T23:54:00Z",
@@ -20,7 +24,9 @@
         "updatedAt": "2026-05-11T23:54:00Z"
       },
       {
-        "author": { "login": "owner-reviewer" },
+        "author": {
+          "login": "owner-reviewer"
+        },
         "state": "APPROVED",
         "commitId": "",
         "submittedAt": "2026-05-11T23:55:00Z",
@@ -35,14 +41,20 @@
         "updatedAt": "",
         "reviewerReopenedAt": "",
         "comments": {
-          "pageInfo": { "hasNextPage": false },
+          "pageInfo": {
+            "hasNextPage": false
+          },
           "nodes": [
             {
-              "author": { "login": "reviewer" },
+              "author": {
+                "login": "reviewer"
+              },
               "body": "Please tighten this guard.",
               "createdAt": "2026-05-11T23:56:00Z",
               "updatedAt": "2026-05-11T23:56:00Z",
-              "pullRequestReview": { "id": "review-2" }
+              "pullRequestReview": {
+                "id": "review-2"
+              }
             }
           ]
         }
@@ -68,7 +80,11 @@
       {
         "type": "required_status_checks",
         "parameters": {
-          "required_status_checks": [{ "context": "lint" }]
+          "required_status_checks": [
+            {
+              "context": "lint"
+            }
+          ]
         }
       }
     ],
@@ -76,19 +92,27 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
-        "author": { "login": "kurone-kito" }
+        "author": {
+          "login": "kurone-kito"
+        }
       }
     ],
-    "changedFiles": ["README.md"],
+    "changedFiles": [
+      "README.md"
+    ],
     "codeownersText": "* @owner-reviewer\n",
     "reviewDecision": "APPROVED"
   },
   "options": {
     "now": "2026-05-12T00:00:00Z",
-    "trustedMarkerLogins": ["kurone-kito"],
-    "iddAgentLogins": ["kurone-kito"],
+    "trustedMarkerLogins": [
+      "kurone-kito"
+    ],
+    "iddAgentLogins": [
+      "kurone-kito"
+    ],
     "advisoryBotLogins": [],
     "prAuthorLogin": "contributor",
     "expectedClaimId": "claim-123",
@@ -152,7 +176,9 @@
       "requiresConversationResolution": false,
       "requiredReviewerLogins": [],
       "requiredReviewerTeams": [],
-      "codeownerUserLogins": ["owner-reviewer"],
+      "codeownerUserLogins": [
+        "owner-reviewer"
+      ],
       "codeownerTeamSlugs": [],
       "unmatchedCodeownerFiles": [],
       "latestByAuthor": [
@@ -182,7 +208,9 @@
         "status": "not_applicable",
         "reason": "codeowner-approval-satisfied",
         "prAuthorLogin": "contributor",
-        "directCodeownerUserLogins": ["owner-reviewer"],
+        "directCodeownerUserLogins": [
+          "owner-reviewer"
+        ],
         "codeownerTeamSlugs": [],
         "requireCodeOwnerReview": true,
         "codeownerApprovalSatisfied": true,
@@ -216,7 +244,9 @@
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,
       "requiredChecksPassing": true,
-      "requiredCheckNames": ["lint"],
+      "requiredCheckNames": [
+        "lint"
+      ],
       "missingRequiredCheckNames": [],
       "checks": [
         {
@@ -241,6 +271,14 @@
       "matchesExpectedClaim": true,
       "claimLost": false,
       "reason": "match"
+    },
+    "waiverEvidence": {
+      "valid": [],
+      "expired": [],
+      "wrongHead": [],
+      "wrongClaim": [],
+      "unauthorized": [],
+      "malformed": []
     }
   }
 }

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -142,5 +142,13 @@
     "matchesExpectedClaim": true,
     "claimLost": false,
     "reason": "match"
+  },
+  "waiverEvidence": {
+    "valid": [],
+    "expired": [],
+    "wrongHead": [],
+    "wrongClaim": [],
+    "unauthorized": [],
+    "malformed": []
   }
 }

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -171,7 +171,23 @@ must align with every F2 condition below.
 - **CI**: Current PR head SHA has all required CI checks generated and
   all passing (→ run CI wait per `idd-ci.instructions.md` using the
   same resolved `ciWait.runningTimeout`, `ciWait.generationTimeout`, and
-  `ciWait.rerunPolicy` values; on-success → re-evaluate F2)
+  `ciWait.rerunPolicy` values; on-success → re-evaluate F2).
+
+  **External-check waivers**: When `pre-merge-readiness` reports a check
+  as `coveredByWaiver: true` in its output, a trusted maintainer has
+  authorized skipping that specific check under the current head SHA and
+  active claim. Treat it as passing for F2/F3 routing **only when**:
+  - `waiverEvidence.valid` is non-empty for that check's selector
+  - The waiver actor is a trusted marker login
+  - The waiver `headSha` matches the current PR HEAD
+  - The waiver `claimId` matches the active claim
+  - The waiver `expiresAt` is in the future
+
+  Waivers never bypass review currency, advisory wait, unresolved
+  threads, unreplied comments, required reviews, disposition evidence,
+  or claim ownership. If `waiverEvidence.wrongHead`, `wrongClaim`,
+  `unauthorized`, `expired`, or `malformed` are non-empty, report them
+  as suspicious context and do not treat them as valid permissions.
 - **Required reviews**: Required approvals count is satisfied and all
   CODEOWNER approvals are obtained. If helper evidence includes
   `reviewerStates.codeownerSelfApproval`, include that diagnostic in the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -356,8 +356,12 @@ The adopted helper boundaries are intentionally narrow:
 
 - `pre-merge-readiness.mjs` is read-only, emits machine-readable F2/F3
   evidence including review currency, unresolved-thread state,
-  unreplied comments, reviewer states, advisory state, CI, and claim
-  validation
+  unreplied comments, reviewer states, advisory state, CI, claim
+  validation, and `waiverEvidence` (parsed external-check waiver comments
+  classified as `valid`, `expired`, `wrongHead`, `wrongClaim`,
+  `unauthorized`, or `malformed`; checks covered by a valid waiver are
+  reported with `coveredByWaiver: true` and treated as passing by the CI
+  gate)
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -447,7 +447,8 @@
                 "type": "string",
                 "pattern": "^$|^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
               },
-              "required": { "type": "boolean" }
+              "required": { "type": "boolean" },
+              "coveredByWaiver": { "type": "boolean" }
             }
           }
         }
@@ -551,6 +552,91 @@
                   "unresolved-without-fresh-disposition"
                 ]
               }
+            }
+          }
+        }
+      }
+    },
+    "waiverEvidence": {
+      "type": "object",
+      "required": ["valid", "expired", "wrongHead", "wrongClaim", "unauthorized", "malformed"],
+      "additionalProperties": false,
+      "properties": {
+        "valid": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["authorLogin", "checkSelector", "reason", "expiresAt"],
+            "additionalProperties": false,
+            "properties": {
+              "authorLogin": { "type": "string" },
+              "checkSelector": { "type": "string" },
+              "reason": { "type": "string" },
+              "expiresAt": { "type": "string" }
+            }
+          }
+        },
+        "expired": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["authorLogin", "checkSelector", "expiresAt"],
+            "additionalProperties": false,
+            "properties": {
+              "authorLogin": { "type": "string" },
+              "checkSelector": { "type": "string" },
+              "expiresAt": { "type": "string" }
+            }
+          }
+        },
+        "wrongHead": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["authorLogin", "checkSelector", "waiverHeadSha"],
+            "additionalProperties": false,
+            "properties": {
+              "authorLogin": { "type": "string" },
+              "checkSelector": { "type": "string" },
+              "waiverHeadSha": { "type": "string" }
+            }
+          }
+        },
+        "wrongClaim": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["authorLogin", "checkSelector", "waiverClaimId"],
+            "additionalProperties": false,
+            "properties": {
+              "authorLogin": { "type": "string" },
+              "checkSelector": { "type": "string" },
+              "waiverClaimId": { "type": "string" }
+            }
+          }
+        },
+        "unauthorized": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["authorLogin", "checkSelector", "expiresAt"],
+            "additionalProperties": false,
+            "properties": {
+              "authorLogin": { "type": "string" },
+              "checkSelector": { "type": "string" },
+              "expiresAt": { "type": "string" }
+            }
+          }
+        },
+        "malformed": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["authorLogin", "bodyPreview"],
+            "additionalProperties": false,
+            "properties": {
+              "authorLogin": { "type": "string" },
+              "bodyPreview": { "type": "string" }
             }
           }
         }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -351,6 +351,82 @@ export function renderExternalCheckWaiverComment(payload) {
   ].join("\n");
 }
 
+function matchCheckSelectorLocal(name, selector) {
+  const n = String(name ?? "").trim();
+  const s = String(selector ?? "").trim();
+  if (!n || !s) return false;
+  if (s.includes("*")) {
+    const source = s.replace(/[|\\{}()[\]^$+?.]/g, "\\$&").replace(/\*/g, ".*");
+    return new RegExp(`^${source}$`).test(n);
+  }
+  return n === s;
+}
+
+export function summarizeExternalCheckWaivers(comments, {
+  prHeadSha = "",
+  activeClaimId = "",
+  trustedMarkerLogins = [],
+  now = "",
+} = {}) {
+  const trustedSet = new Set(normalizeTrustedMarkerLogins(trustedMarkerLogins));
+  const nowMs = isValidIsoTimestamp(now) ? new Date(now).getTime() : Date.now();
+  const headShaLower = String(prHeadSha).toLowerCase();
+  const activeClaimLower = String(activeClaimId);
+
+  const valid = [];
+  const expired = [];
+  const wrongHead = [];
+  const wrongClaim = [];
+  const unauthorized = [];
+  const malformed = [];
+
+  for (const comment of comments ?? []) {
+    const body = String(comment?.body ?? "");
+    if (!body.includes("idd-external-check-waiver")) continue;
+
+    const authorLogin = String(
+      comment?.author?.login ?? comment?.user?.login ?? "",
+    ).trim().toLowerCase();
+    const createdAt = String(comment?.created_at ?? comment?.createdAt ?? "");
+    const parsed = parseExternalCheckWaiverComment(body, createdAt);
+
+    if (!parsed) {
+      malformed.push({ authorLogin, bodyPreview: body.slice(0, 120) });
+      continue;
+    }
+
+    if (!trustedSet.has(authorLogin)) {
+      unauthorized.push({ authorLogin, checkSelector: parsed.checkSelector, expiresAt: parsed.expiresAt });
+      continue;
+    }
+
+    if (headShaLower && parsed.headSha !== headShaLower) {
+      wrongHead.push({ authorLogin, checkSelector: parsed.checkSelector, waiverHeadSha: parsed.headSha });
+      continue;
+    }
+
+    if (activeClaimLower && parsed.claimId !== activeClaimLower) {
+      wrongClaim.push({ authorLogin, checkSelector: parsed.checkSelector, waiverClaimId: parsed.claimId });
+      continue;
+    }
+
+    const expiresMs = new Date(parsed.expiresAt).getTime();
+    if (!Number.isFinite(expiresMs) || expiresMs <= nowMs) {
+      expired.push({ authorLogin, checkSelector: parsed.checkSelector, expiresAt: parsed.expiresAt });
+      continue;
+    }
+
+    valid.push({
+      authorLogin,
+      checkSelector: parsed.checkSelector,
+      reason: parsed.reason,
+      expiresAt: parsed.expiresAt,
+    });
+  }
+
+  return { valid, expired, wrongHead, wrongClaim, unauthorized, malformed };
+}
+
 export function parseExternalCheckWaiverComment(body, createdAt) {
   const match = body.trimEnd().match(
     new RegExp(
@@ -1649,22 +1725,31 @@ export function summarizeBranchReviewRequirements(branchRules = [], branchProtec
   };
 }
 
-export function summarizeRequiredChecks(checks = [], branchRules = [], branchProtection = {}) {
+export function summarizeRequiredChecks(checks = [], branchRules = [], branchProtection = {}, { waivers = null } = {}) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(branchRules, branchProtection);
   const requiredCheckNames = branchReviewRequirements.requiredCheckNames;
   const requiredCheckNameSet = new Set(requiredCheckNames);
-  const normalizedChecks = checks.map((check) => ({
-    name: String(check.name ?? ""),
-    state: String(check.state ?? "").toUpperCase(),
-    completedAt: String(check.completedAt ?? ""),
-  }));
+  const validWaivers = waivers?.valid ?? [];
+  const SUCCESS_STATES = new Set(["SUCCESS", "SKIPPED", "NEUTRAL", "NOT_APPLICABLE"]);
+
+  const normalizedChecks = checks.map((check) => {
+    const name = String(check.name ?? "");
+    const state = String(check.state ?? "").toUpperCase();
+    const coveredByWaiver = !SUCCESS_STATES.has(state)
+      && validWaivers.some((w) => matchCheckSelectorLocal(name, w.checkSelector));
+    return { name, state, completedAt: String(check.completedAt ?? ""), coveredByWaiver };
+  });
+
   const matchedRequiredChecks = normalizedChecks.filter((check) => requiredCheckNameSet.has(check.name));
   const presentNames = new Set(matchedRequiredChecks.map((check) => check.name));
   const missingRequiredCheckNames = requiredCheckNames.filter((name) => !presentNames.has(name));
 
   let status = "unknown";
   if (requiredCheckNames.length > 0) {
-    const ciClassification = classifyCiChecks(matchedRequiredChecks);
+    const effectiveChecks = matchedRequiredChecks.map((c) =>
+      c.coveredByWaiver ? { ...c, state: "SKIPPED" } : c,
+    );
+    const ciClassification = classifyCiChecks(effectiveChecks);
     status = missingRequiredCheckNames.length > 0
       ? "missing"
       : ciClassification.status;
@@ -1686,6 +1771,7 @@ export function summarizeRequiredChecks(checks = [], branchRules = [], branchPro
       state: check.state,
       completedAt: isValidIsoTimestamp(check.completedAt) ? check.completedAt : "",
       required: requiredCheckNameSet.has(check.name),
+      ...(check.coveredByWaiver ? { coveredByWaiver: true } : {}),
     })),
   };
 }
@@ -2284,7 +2370,6 @@ export function buildPreMergeReadinessSummary(
     viewerTeamSlugs: options.viewerTeamSlugs,
     viewerAppSlug: options.viewerAppSlug,
   });
-  const ci = summarizeRequiredChecks(checks, branchRules, branchProtection);
   const advisoryWaitOptions = normalizeAdvisoryWaitRuntimeOptions(options);
   const advisoryWait = buildAdvisoryWaitSummary(
     {
@@ -2313,6 +2398,13 @@ export function buildPreMergeReadinessSummary(
     expectedClaimId: options.expectedClaimId,
     expectedAgentId: options.expectedAgentId,
   });
+  const waiverEvidence = summarizeExternalCheckWaivers(comments, {
+    prHeadSha,
+    activeClaimId: claim.activeClaim?.claimId ?? options.activeClaimId ?? "",
+    trustedMarkerLogins,
+    now,
+  });
+  const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, { waivers: waiverEvidence });
 
   const dispositionEvidence = options.includeDispositionEvidence
     ? summarizeDispositionEvidenceForGate(
@@ -2382,6 +2474,7 @@ export function buildPreMergeReadinessSummary(
     },
     ci,
     claim,
+    waiverEvidence,
   };
 
   if (dispositionEvidence) {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -15,6 +15,7 @@ import {
   summarizeDispositionEvidenceForGate,
   summarizeAdvisoryWaitMarkers,
   summarizeClaimValidation,
+  summarizeExternalCheckWaivers,
   summarizeRegularCommentsForGate,
   summarizeRequiredChecks,
   summarizeReviewerStates,
@@ -1550,6 +1551,134 @@ test("advisory wait summary keeps F2 and F3 outcomes distinct when Copilot is no
 
   assert.equal(summary.outcome, "REQUEST_NEEDED");
   assert.equal(summary.f3Outcome, "SATISFIED");
+});
+
+function makeWaiverComment(fields) {
+  const { agentId = "a", claimId = "c", headSha = "a".repeat(40), checkSelector = "CodeRabbit", reason = "rate-limit", expiresAt = "2099-01-01T00:00:00Z" } = fields;
+  const enc = (s) => encodeURIComponent(s);
+  return `<!-- idd-external-check-waiver: ${agentId} ${claimId} ${headSha} check:${enc(checkSelector)} reason:${enc(reason)} expires:${expiresAt} -->\n\n_${agentId}: external check waiver for IDD F phase on \`${checkSelector}\`_`;
+}
+
+test("summarizeExternalCheckWaivers: empty comments returns all-empty evidence", () => {
+  const result = summarizeExternalCheckWaivers([], {
+    prHeadSha: "a".repeat(40),
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["kurone-kito"],
+    now: "2026-05-17T00:00:00Z",
+  });
+  assert.deepEqual(result, { valid: [], expired: [], wrongHead: [], wrongClaim: [], unauthorized: [], malformed: [] });
+});
+
+test("summarizeExternalCheckWaivers: valid waiver is placed in valid bucket", () => {
+  const head = "b".repeat(40);
+  const body = makeWaiverComment({ claimId: "claim-123", headSha: head });
+  const comment = { body, author: { login: "kurone-kito" }, createdAt: "2026-05-17T00:00:00Z" };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["kurone-kito"],
+    now: "2026-05-17T00:00:00Z",
+  });
+  assert.equal(result.valid.length, 1);
+  assert.equal(result.valid[0].checkSelector, "CodeRabbit");
+  assert.equal(result.valid[0].authorLogin, "kurone-kito");
+});
+
+test("summarizeExternalCheckWaivers: expired waiver goes to expired bucket", () => {
+  const head = "c".repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: "claim-123", expiresAt: "2020-01-01T00:00:00Z" });
+  const comment = { body, author: { login: "kurone-kito" }, createdAt: "2026-05-17T00:00:00Z" };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["kurone-kito"],
+    now: "2026-05-17T00:00:00Z",
+  });
+  assert.equal(result.expired.length, 1);
+  assert.equal(result.valid.length, 0);
+});
+
+test("summarizeExternalCheckWaivers: wrong head SHA goes to wrongHead bucket", () => {
+  const body = makeWaiverComment({ headSha: "a".repeat(40), claimId: "claim-123" });
+  const comment = { body, author: { login: "kurone-kito" }, createdAt: "2026-05-17T00:00:00Z" };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: "b".repeat(40),
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["kurone-kito"],
+    now: "2026-05-17T00:00:00Z",
+  });
+  assert.equal(result.wrongHead.length, 1);
+});
+
+test("summarizeExternalCheckWaivers: wrong claim ID goes to wrongClaim bucket", () => {
+  const head = "d".repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: "claim-wrong" });
+  const comment = { body, author: { login: "kurone-kito" }, createdAt: "2026-05-17T00:00:00Z" };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["kurone-kito"],
+    now: "2026-05-17T00:00:00Z",
+  });
+  assert.equal(result.wrongClaim.length, 1);
+});
+
+test("summarizeExternalCheckWaivers: unauthorized actor goes to unauthorized bucket", () => {
+  const head = "e".repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: "claim-123" });
+  const comment = { body, author: { login: "unknown-actor" }, createdAt: "2026-05-17T00:00:00Z" };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["kurone-kito"],
+    now: "2026-05-17T00:00:00Z",
+  });
+  assert.equal(result.unauthorized.length, 1);
+});
+
+test("summarizeExternalCheckWaivers: malformed waiver comment goes to malformed bucket", () => {
+  const comment = {
+    body: "<!-- idd-external-check-waiver: bad-format -->",
+    author: { login: "kurone-kito" },
+    createdAt: "2026-05-17T00:00:00Z",
+  };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: "a".repeat(40),
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["kurone-kito"],
+    now: "2026-05-17T00:00:00Z",
+  });
+  assert.equal(result.malformed.length, 1);
+});
+
+test("summarizeRequiredChecks: waiver covers failing required check", () => {
+  const waivers = {
+    valid: [{ authorLogin: "kurone-kito", checkSelector: "CodeRabbit", reason: "rate-limit", expiresAt: "2099-01-01T00:00:00Z" }],
+    expired: [], wrongHead: [], wrongClaim: [], unauthorized: [], malformed: [],
+  };
+  const result = summarizeRequiredChecks(
+    [{ name: "CodeRabbit", state: "PENDING", completedAt: "" }],
+    [],
+    { required_status_checks: { contexts: ["CodeRabbit"] } },
+    { waivers },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, true);
+  assert.equal(result.status, "success");
+});
+
+test("summarizeRequiredChecks: waiver does not affect already-passing check", () => {
+  const waivers = {
+    valid: [{ authorLogin: "kurone-kito", checkSelector: "lint", reason: "test", expiresAt: "2099-01-01T00:00:00Z" }],
+    expired: [], wrongHead: [], wrongClaim: [], unauthorized: [], malformed: [],
+  };
+  const result = summarizeRequiredChecks(
+    [{ name: "lint", state: "SUCCESS", completedAt: "2026-05-17T00:00:00Z" }],
+    [],
+    { required_status_checks: { contexts: ["lint"] } },
+    { waivers },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.equal(result.status, "success");
 });
 
 function readJson(relativePath) {


### PR DESCRIPTION
Closes #668

## Summary

- Adds `summarizeExternalCheckWaivers()` to `protocol-helpers.mjs` that parses `<!-- idd-external-check-waiver: ... -->` comments and classifies them as `valid`, `expired`, `wrongHead`, `wrongClaim`, `unauthorized`, or `malformed`
- Updates `summarizeRequiredChecks()` to annotate failing/pending checks covered by a valid waiver with `coveredByWaiver: true` and treat them as passing for CI gate status
- Updates `buildPreMergeReadinessSummary()` to include `waiverEvidence` in the output (resolved after active claim is determined)
- Extends `pre-merge-readiness.schema.json` with `waiverEvidence` and `coveredByWaiver` fields
- Documents the waiver behavior in F2 CI gate instructions (live + template mirror)
- Adds 9 targeted unit tests for `summarizeExternalCheckWaivers` and waiver-covered CI checks

## Test plan

- [ ] `node --test tests/*.test.mjs` passes (622 tests, 0 failures)
- [ ] `pnpm run lint` passes
- [ ] Schema fixtures validated against updated schema
- [ ] Waivers with wrong head/claim/expired/unauthorized correctly classified as non-valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)