### PR TITLE
test(waiver): add missing fail-closed cases for external-check waiver

### DIFF
--- a/tests/external-check-waiver.test.mjs
+++ b/tests/external-check-waiver.test.mjs
@@ -189,3 +189,27 @@ test("extractGhHttpStatus prefers HTTP status codes from gh stderr", () => {
   assert.equal(extractGhHttpStatus({ status: 1, stderr: "" }), 1);
   assert.equal(extractGhHttpStatus({ status: 0, stderr: "" }), 0);
 });
+
+test("parseExternalCheckWaiverComment returns null for empty or non-marker bodies", () => {
+  assert.equal(parseExternalCheckWaiverComment("", "2026-05-17T00:00:00Z"), null);
+  assert.equal(parseExternalCheckWaiverComment("some random text", "2026-05-17T00:00:00Z"), null);
+  assert.equal(parseExternalCheckWaiverComment("<!-- idd-external-check-waiver: bad-format -->", "2026-05-17T00:00:00Z"), null);
+});
+
+test("parseExternalCheckWaiverComment returns null when required fields are missing", () => {
+  const truncated = `<!-- idd-external-check-waiver: agent claim-id ${"a".repeat(40)} check:CodeRabbit -->`;
+  assert.equal(parseExternalCheckWaiverComment(truncated, "2026-05-17T00:00:00Z"), null);
+});
+
+test("planExternalCheckWaiver fails closed when authority lookup returns unknown", () => {
+  const input = buildBaseInput();
+  input.authority = { known: false };
+
+  const report = planExternalCheckWaiver(
+    input,
+    { now: new Date("2026-05-17T06:00:00Z"), repoOwner: "kurone-kito" },
+  );
+
+  assert.equal(report.canApply, false);
+  assert.ok(report.blockingReasons.some((r) => /authority|proven/.test(r)));
+});

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -1681,6 +1681,41 @@ test("summarizeRequiredChecks: waiver does not affect already-passing check", ()
   assert.equal(result.status, "success");
 });
 
+test("summarizeExternalCheckWaivers: multiple valid waivers for different checks both land in valid bucket", () => {
+  const head = "b".repeat(40);
+  const comment1 = { body: makeWaiverComment({ headSha: head, claimId: "claim-123", checkSelector: "CodeRabbit" }), user: { login: "owner" }, created_at: "2026-05-17T10:00:00Z" };
+  const comment2 = { body: makeWaiverComment({ headSha: head, claimId: "claim-123", checkSelector: "Copilot*" }), user: { login: "owner" }, created_at: "2026-05-17T10:01:00Z" };
+
+  const result = summarizeExternalCheckWaivers([comment1, comment2], {
+    prHeadSha: head,
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["owner"],
+    now: "2026-05-17T12:00:00Z",
+  });
+
+  assert.equal(result.valid.length, 2);
+  assert.equal(result.expired.length, 0);
+  assert.ok(result.valid.some((w) => w.checkSelector === "CodeRabbit"));
+  assert.ok(result.valid.some((w) => w.checkSelector === "Copilot*"));
+});
+
+test("summarizeExternalCheckWaivers: suspicious marker-shaped comment from untrusted actor never becomes valid", () => {
+  const head = "c".repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: "claim-123" });
+  const comment = { body, user: { login: "untrusted-actor" }, created_at: "2026-05-17T10:00:00Z" };
+
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["trusted-only"],
+    now: "2026-05-17T12:00:00Z",
+  });
+
+  assert.equal(result.valid.length, 0);
+  assert.equal(result.unauthorized.length, 1);
+  assert.equal(result.unauthorized[0].authorLogin, "untrusted-actor");
+});
+
 function readJson(relativePath) {
   return JSON.parse(readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8"));
 }

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -1716,6 +1716,82 @@ test("summarizeExternalCheckWaivers: suspicious marker-shaped comment from untru
   assert.equal(result.unauthorized[0].authorLogin, "untrusted-actor");
 });
 
+test("summarizeExternalCheckWaivers: mixed valid, expired, and wrongClaim in separate buckets", () => {
+  const head = "d".repeat(40);
+  const validBody = makeWaiverComment({ headSha: head, claimId: "claim-123", checkSelector: "CodeRabbit" });
+  const expiredBody = makeWaiverComment({ headSha: head, claimId: "claim-123", checkSelector: "lint", expiresAt: "2020-01-01T00:00:00Z" });
+  const wrongClaimBody = makeWaiverComment({ headSha: head, claimId: "claim-other", checkSelector: "Analyze" });
+  const comments = [
+    { body: validBody, author: { login: "kurone-kito" }, createdAt: "2026-05-17T00:00:00Z" },
+    { body: expiredBody, author: { login: "kurone-kito" }, createdAt: "2026-05-17T00:01:00Z" },
+    { body: wrongClaimBody, author: { login: "kurone-kito" }, createdAt: "2026-05-17T00:02:00Z" },
+  ];
+  const result = summarizeExternalCheckWaivers(comments, {
+    prHeadSha: head,
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["kurone-kito"],
+    now: "2026-05-17T00:10:00Z",
+  });
+  assert.equal(result.valid.length, 1, "only one valid waiver");
+  assert.equal(result.expired.length, 1, "one expired waiver");
+  assert.equal(result.wrongClaim.length, 1, "one wrong-claim waiver");
+});
+
+test("summarizeExternalCheckWaivers: non-waiver comments are skipped without error", () => {
+  const comments = [
+    { body: "This is a regular PR comment", author: { login: "kurone-kito" }, createdAt: "2026-05-17T00:00:00Z" },
+    { body: "<!-- review-watermark: claude-code c " + "a".repeat(40) + " 2026-05-17T00:00:00Z 1 none -->", author: { login: "kurone-kito" }, createdAt: "2026-05-17T00:01:00Z" },
+  ];
+  const result = summarizeExternalCheckWaivers(comments, {
+    prHeadSha: "a".repeat(40),
+    activeClaimId: "claim-123",
+    trustedMarkerLogins: ["kurone-kito"],
+    now: "2026-05-17T00:10:00Z",
+  });
+  assert.deepEqual(result, { valid: [], expired: [], wrongHead: [], wrongClaim: [], unauthorized: [], malformed: [] });
+});
+
+test("summarizeRequiredChecks: waiver with glob selector covers matching failing check", () => {
+  const waivers = {
+    valid: [{ authorLogin: "kurone-kito", checkSelector: "Code*", reason: "test", expiresAt: "2099-01-01T00:00:00Z" }],
+    expired: [], wrongHead: [], wrongClaim: [], unauthorized: [], malformed: [],
+  };
+  const result = summarizeRequiredChecks(
+    [
+      { name: "CodeQL", state: "FAILURE", completedAt: "2026-05-17T00:00:00Z" },
+      { name: "lint", state: "FAILURE", completedAt: "2026-05-17T00:00:00Z" },
+    ],
+    [],
+    { required_status_checks: { contexts: ["CodeQL", "lint"] } },
+    { waivers },
+  );
+  const codeQL = result.checks.find((c) => c.name === "CodeQL");
+  const lint = result.checks.find((c) => c.name === "lint");
+  assert.equal(codeQL.coveredByWaiver, true, "CodeQL matched by Code* glob");
+  assert.equal(lint.coveredByWaiver, undefined, "lint not matched by Code* glob");
+});
+
+test("buildPreMergeReadinessSummary: waiverEvidence always present and validates against schema", () => {
+  const fixture = readJson("fixtures/pre-merge-readiness/clean.json");
+  const summary = buildPreMergeReadinessSummary(fixture.input, fixture.options);
+  assert.ok(Object.hasOwn(summary, "waiverEvidence"), "waiverEvidence must be present");
+  assert.ok(Array.isArray(summary.waiverEvidence.valid));
+  assert.ok(Array.isArray(summary.waiverEvidence.expired));
+  assert.ok(Array.isArray(summary.waiverEvidence.wrongHead));
+  assert.ok(Array.isArray(summary.waiverEvidence.wrongClaim));
+  assert.ok(Array.isArray(summary.waiverEvidence.unauthorized));
+  assert.ok(Array.isArray(summary.waiverEvidence.malformed));
+  assert.deepEqual(validate(summary, readinessSchema), []);
+});
+
+test("waiverEvidence with wrong-shape valid item fails schema validation", () => {
+  const fixture = readJson("fixtures/pre-merge-readiness/clean.json");
+  const summary = buildPreMergeReadinessSummary(fixture.input, fixture.options);
+  const bad = JSON.parse(JSON.stringify(summary));
+  bad.waiverEvidence.valid = [{ wrong: "shape", missing: "required fields" }];
+  assert.ok(validate(bad, readinessSchema).length > 0, "invalid waiverEvidence.valid shape must fail schema");
+});
+
 function readJson(relativePath) {
   return JSON.parse(readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8"));
 }


### PR DESCRIPTION
## Summary

- Adds direct tests for `parseExternalCheckWaiverComment` returning null for empty, non-marker, and truncated/malformed bodies
- Tests `planExternalCheckWaiver` failing closed when `authority.known === false` (permission lookup ambiguity)
- Tests `summarizeExternalCheckWaivers` collecting multiple valid waivers for different checks into the `valid` bucket
- Tests `summarizeExternalCheckWaivers` classifying suspicious marker-shaped comments from untrusted actors as `unauthorized` (never `valid`)

These tests cover gaps in the #669 acceptance criteria not addressed by the #668 implementation. All other specified cases (expired, wrongHead, wrongClaim, malformed, unauthorized, repo-owned check rejection, GitHub-required check waiver behavior) were already covered by tests added in #668.

Closes #669

## Test plan

- [ ] All 637 tests pass (`npm test`)
- [ ] CSpell and dprint both pass
- [ ] parseExternalCheckWaiverComment null-returns verified for 3 malformed forms
- [ ] planExternalCheckWaiver fails closed for unknown authority
- [ ] Multiple waivers in valid bucket verified
- [ ] Untrusted actor marker classified as unauthorized

🤖 Generated with [Claude Code](https://claude.com/claude-code)