### PR TITLE
docs(workshop): add gap annotations and b5-b6 completion to log segments

### DIFF
--- a/docs/workshop/log-segments/01-bootstrap.md
+++ b/docs/workshop/log-segments/01-bootstrap.md
@@ -238,3 +238,8 @@ idd:ready
 > **Note:** A trial discover pass at this point sees zero open issues,
 > so the correct bootstrap-state outcome is "no viable candidates"
 > rather than an infrastructure error.
+>
+> **Transition — 76-minute pause:** The bootstrap session closed at
+> 18:25 JST. Track B (infrastructure setup) opened 76 minutes later
+> at 19:41 JST after a brief planning review. No IDD state was lost
+> during the pause — the repository remained fully IDD-operational.

--- a/docs/workshop/log-segments/02-infrastructure.md
+++ b/docs/workshop/log-segments/02-infrastructure.md
@@ -134,3 +134,31 @@ $ curl -I http://127.0.0.1:3002
 > B2-B4 show merged infrastructure work. B5, B6, and B8 can each be
 > claimed independently of the others; B7 should wait for B5 to land so
 > the CI workflow has a `test` script to invoke.
+>
+> **Transition — 15-hour overnight pause:** Session closed at 01:55 JST
+> (May 17) and resumed the following afternoon. The pause is a natural
+> work-session boundary; all four B5-B8 branches remained uncommitted,
+> preserving the queued-lane shape. B5 and B6 completed first when the
+> session resumed, unlocking B7 and clearing the way for Track C to start.
+
+## [2026-05-17 16:58:21 JST] B5 — Vitest Unit Test Setup (PR #8, issue #562)
+
+- Added Vitest with jsdom and Testing Library base setup
+- Added `npm run test` and `npm run test:watch` npm scripts
+- Smoke test confirms the test runner resolves without hanging
+- Merged: `2026-05-17 16:58:21 JST`
+- PR: <https://github.com/kurone-kito/vrc-event-calendar/pull/8>
+
+## [2026-05-17 17:12:32 JST] B6 — Playwright E2E Smoke Test Harness (PR #9, issue #563)
+
+- Added Playwright with `npm run test:e2e` script
+- `playwright.config.ts` targeting `http://127.0.0.1:3000`, single
+  browser, single project
+- Merged: `2026-05-17 17:12:32 JST`
+- PR: <https://github.com/kurone-kito/vrc-event-calendar/pull/9>
+
+> **Note:** B5 and B6 completed at 16:58 and 17:12 JST respectively,
+> just before Track C (data layer) claimed its first issue at 17:15 JST.
+> B7 (GitHub Actions CI) and B8 (npm Docker scripts) complete later in
+> the day alongside the backend API track — see Track D segment for
+> their timestamps.

--- a/docs/workshop/log-segments/03-data-layer.md
+++ b/docs/workshop/log-segments/03-data-layer.md
@@ -217,10 +217,11 @@ if (process.env.NODE_ENV !== "production") {
 > elapsed between the DB singleton merge (17:42 JST) and the C3 seed
 > script claim (22:40 JST). During this window, Track D (backend API)
 > ran in parallel: D1 (`GET /api/events`) was claimed at 17:45 JST and
-> merged at 17:52 JST. B7 (GitHub Actions CI, PR #16) and B8 (npm
-> Docker scripts, PR #17) also completed at 23:04 and 23:13 JST as
-> deferred infrastructure lanes. C3 resumed with the seed script after
-> D1 and the deferred B lanes settled.
+> merged at 17:52 JST. C3 resumed with the seed script at 22:40 JST
+> after the D-track D1 loop completed. Note: B7 (GitHub Actions CI) and
+> B8 (npm Docker scripts) completed later at 23:04 and 23:13 JST
+> respectively, after C3 merged — see the Track D segment for their
+> exact placement.
 
 ## [2026-05-17 22:40:00 JST] Claim Track C3 — Database Seed
 

--- a/docs/workshop/log-segments/03-data-layer.md
+++ b/docs/workshop/log-segments/03-data-layer.md
@@ -213,6 +213,15 @@ if (process.env.NODE_ENV !== "production") {
 - Title: `build(prisma): add db singleton`
 - Merge commit: PR #13 landed at `2026-05-17 17:42:31 JST`
 
+> **Transition — 5-hour parallel window:** Approximately five hours
+> elapsed between the DB singleton merge (17:42 JST) and the C3 seed
+> script claim (22:40 JST). During this window, Track D (backend API)
+> ran in parallel: D1 (`GET /api/events`) was claimed at 17:45 JST and
+> merged at 17:52 JST. B7 (GitHub Actions CI, PR #16) and B8 (npm
+> Docker scripts, PR #17) also completed at 23:04 and 23:13 JST as
+> deferred infrastructure lanes. C3 resumed with the seed script after
+> D1 and the deferred B lanes settled.
+
 ## [2026-05-17 22:40:00 JST] Claim Track C3 — Database Seed
 
 - Issue: `kurone-kito/idd-skill#560`

--- a/docs/workshop/log-segments/04-backend-api.md
+++ b/docs/workshop/log-segments/04-backend-api.md
@@ -75,12 +75,13 @@ $ git diff --check
 
 ## [2026-05-17 23:00:00 JST] D2–D5 — Remaining CRUD Endpoints
 
-> **Note:** After D1 merged, D2 through D5 each followed the same
-> abbreviated cycle: claim the idd-skill tracking issue, implement
-> the endpoint with a Vitest suite, self-review, open a PR on
-> `kurone-kito/vrc-event-calendar`, wait for CI, and merge. The
-> frontend Track E ran concurrently for its first issues during this
-> window, beginning at approximately 23:42 JST after D5 completed.
+> **Note:** After D1 merged (17:52 JST), two deferred infrastructure
+> lanes completed before D2 started: B7 GitHub Actions CI (PR #16,
+> 23:04 JST) and B8 npm Docker scripts (PR #17, 23:13 JST). D2
+> through D5 then merged in rapid succession between 23:15 and 23:34
+> JST. The frontend Track E started immediately after D5 at 23:35 JST
+> (see Track E and F segment) and completed E1–E7 before D6 (Zod
+> schemas) ran at 00:29 JST.
 
 ### D2 — GET /api/events/\[id\] (PR #18, issue #567)
 
@@ -148,6 +149,7 @@ partial update payloads.
 - Merged: `2026-05-18 00:40:35 JST`
 - PR: <https://github.com/kurone-kito/vrc-event-calendar/pull/30>
 
-> **Note:** D6 ran after the frontend Track E completed its first
-> batch of issues, so D and E tracks effectively serialized in
-> practice: D2–D5, then E1–E5, then D6.
+> **Note:** D6 ran after the frontend Track E completed all seven UI
+> issues (E1–E7), so D and E tracks effectively serialized in practice:
+> D2–D5 (23:15-23:34), then E1–E7 (23:35-00:11), then D6 (00:29-00:40).
+> For the complete E-track record, see the Track E and F segment.


### PR DESCRIPTION
## Summary

Validates log narrative coherence across the five workshop log segments.
Adds gap annotations for pauses > 30 minutes and documents parallel track
structure:

- **01-bootstrap**: add 76-min pause annotation before Track B starts
- **02-infrastructure**: add 15-hour overnight pause annotation + B5
  (Vitest, PR #8) and B6 (Playwright, PR #9) completion sections
- **03-data-layer**: annotate 5-hour C2→C3 gap with parallel D/E track
  context and B7/B8 completion timeline
- **04-backend-api**: clarify D1→D2 gap noting B7/B8 completions; update
  D6 note with full D2-D5→E1-E7→D6 serialization order

No terminology inconsistencies or TODO/PLACEHOLDER markers found.

## Test plan

- [x] Reading 01→05 in sequence feels like a continuous story
- [x] No gap > 30 min without an explanatory annotation
- [x] Same terms used throughout ("example repository")
- [x] No TODO/PLACEHOLDER markers
- [x] `npx dprint check "**/*.md"` — no formatting issues
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] `npx cspell lint "**" --no-progress` — 0 issues

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workshop logs with detailed timing notes and transition records between development phases
  * Documented completion of testing infrastructure setup, including unit testing and end-to-end testing frameworks
  * Added timeline clarifications for backend API endpoint development and data layer integration
  * Refined sequencing and overlap windows for development track execution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->