### PR TITLE
docs(workshop): editorial review pass on workshop README

### DIFF
--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -3,12 +3,7 @@
 <!-- cspell:words Defang VRChat -->
 
 This workshop follows an end-to-end IDD session that builds a realistic
-VRChat event calendar example. This page is currently a skeleton: later
-issues will replace the `[TODO]` stubs with edited log segments, visual
-assets, and full prose.
-
-Use the [workshop log format](LOG-FORMAT.md) when adding captured agent
-session excerpts.
+VRChat event calendar example.
 
 ## What You Will Build
 
@@ -27,11 +22,7 @@ edited narrative: the workshop explains the IDD decisions, while the
 repository shows the code and configuration those loops build over
 time.
 
-Screenshot placeholder for #601: the final event-list screenshot will be
-inserted here after the example app screenshots are captured.
-
-Build overview placeholder for #589: the unified workshop log link will
-be inserted here after the master log is compiled.
+![VRChat Event Calendar — event list page with category filters and calendar toggle](assets/screenshots/event-list.png)
 
 ## Prerequisites
 
@@ -187,15 +178,14 @@ four quality-hardening issues that run partly in parallel with Track D.
 - **F4** — README: prerequisites, Quick Start, and available-scripts table
   for the example repository.
 
-Log segment: [Tracks E and F — Frontend and Quality](log-segments/05-frontend-quality.md).
+Log segment: [Tracks E and F — Frontend and Quality](log-segments/05-frontend-quality.md)
 
 ## Conclusion: What Was Built
 
 **[`kurone-kito/vrc-event-calendar`](https://github.com/kurone-kito/vrc-event-calendar)
 — This is what we built.**
 
-<!-- Screenshot placeholder for #601: replace with the final event-list
-screenshot once the example app screenshots are captured. -->
+![VRChat Event Calendar — finished application event list](assets/screenshots/event-list.png)
 
 Over the course of the workshop, IDD turned an empty repository into a
 working VRChat Event Calendar with:


### PR DESCRIPTION
## Summary

Editorial review pass for the complete workshop documentation:

- Remove outdated 'skeleton' description (the workshop is now complete)
- Remove author-facing workshop log format instruction
- Replace screenshot placeholder in the What You Will Build section
  with `event-list.png` (screenshots were captured in PR #695)
- Replace screenshot placeholder in the Conclusion section with the
  same screenshot
- Remove workshop log placeholder (unified log is in PR #696, link
  will be available when merged)
- Fix trailing period on Track E/F log segment link for consistency

## Test plan

- [x] Zero broken links — all log segments and referenced files verified
- [x] Zero TODO/PLACEHOLDER markers remain
- [x] Terminology consistent throughout ("example repository")
- [x] Screenshot references point to existing files
- [x] `npx dprint check "**/*.md"` — no formatting issues
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] `npx cspell lint "**" --no-progress` — 0 issues

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved workshop README with clearer introductory content and added screenshots showing the event list page with filters and calendar toggle. Enhanced conclusion section with final application examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->