### PR TITLE
docs(workshop): CP-D — replace placeholders with screenshot and log link

### DIFF
--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -27,11 +27,11 @@ edited narrative: the workshop explains the IDD decisions, while the
 repository shows the code and configuration those loops build over
 time.
 
-Screenshot placeholder for #601: the final event-list screenshot will be
-inserted here after the example app screenshots are captured.
+![VRChat Events — event list page with category filter
+panel](assets/screenshots/event-list.png)
 
-Build overview placeholder for #589: the unified workshop log link will
-be inserted here after the master log is compiled.
+For the complete timestamped build log, see the
+[VRChat Event Calendar IDD Workshop Log](workshop-log.md).
 
 ## Prerequisites
 
@@ -194,8 +194,8 @@ Log segment: [Tracks E and F — Frontend and Quality](log-segments/05-frontend-
 **[`kurone-kito/vrc-event-calendar`](https://github.com/kurone-kito/vrc-event-calendar)
 — This is what we built.**
 
-<!-- Screenshot placeholder for #601: replace with the final event-list
-screenshot once the example app screenshots are captured. -->
+![VRChat Events — event detail page showing full event
+information](assets/screenshots/event-detail.png)
 
 Over the course of the workshop, IDD turned an empty repository into a
 working VRChat Event Calendar with:


### PR DESCRIPTION
## Summary

- Replace screenshot placeholder (referencing #601) with the captured
  `event-list.png` and `event-detail.png` screenshots
- Replace log overview placeholder (referencing #589) with a link to
  the assembled `workshop-log.md`

## CP-D Verification Evidence

All Track G sub-issues closed: #582 ✓ #583 ✓ #584 ✓ #585 ✓ #586 ✓ #587 ✓ #588 ✓ #589 ✓

`docs/workshop/workshop-log.md` exists and assembles all 5 segments:
- 01-bootstrap.md ✓
- 02-infrastructure.md ✓
- 03-data-layer.md ✓
- 04-backend-api.md ✓
- 05-frontend-quality.md ✓

No `[TODO]` or `[PLACEHOLDER]` markers found in workshop files ✓

Metadata block in workshop-log.md:
- First log entry: 2026-05-16 17:27:50 JST ✓
- Last log entry: 2026-05-18 01:02:42 JST ✓
- Total wall time: ~31.6 hours ✓

## Validation

- markdownlint-cli2: 0 errors
- cspell: 0 issues
- dprint: formatted

Closes #610