### PR TITLE
docs(idd-work): harden B1 against primary-worktree branch creation

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -5,7 +5,7 @@ planning (B2), implementation (B3), and the self-review loop (C).
 
 ---
 
-## B1 — Create branch and worktree
+## B1 — Create worktree (with branch)
 
 Before creating, check for local conflicts in this order:
 
@@ -25,6 +25,13 @@ Before creating, check for local conflicts in this order:
    git merge --ff-only origin/main
    ```
 
+   After this `main` fast-forward, leave the primary worktree on
+   `main`. Every remaining B1 step must run either from the primary
+   worktree (for read-only inspection commands such as `git worktree
+   list`) or from the new sibling worktree once it is created. Do
+   **not** change the primary worktree's HEAD off `main` for any
+   reason during B1. See Anti-patterns below.
+
 2. Run `git worktree list` — if a worktree for the branch already
    exists, either reuse it (takeover) or remove it first using the exact
    path shown in the list: `git worktree remove <path-from-list>`. (Must
@@ -43,6 +50,24 @@ Before creating, check for local conflicts in this order:
 Then create the worktree as described below. If this is a takeover,
 reuse the exact branch name from the existing claim comment — do not
 generate a new one.
+
+### Anti-patterns
+
+The following commands MUST NOT be used to create the implementation
+branch in the primary worktree:
+
+- `git switch -c <branch-name>` — switches the primary worktree to
+  the issue branch and skips worktree creation entirely.
+- `git checkout -b <branch-name>` — equivalent failure mode.
+- A standalone `git branch <branch-name>` followed by in-place commits
+  in the primary worktree — defeats the sibling-worktree invariant
+  even though `git branch` alone does not move HEAD.
+
+The primary worktree's HEAD MUST remain on `main` throughout B1. The
+implementation branch exists only inside the sibling worktree created
+by `git worktree add` (or WorkTrunk's `wt new`). If the primary
+worktree ever leaves `main` during B1, stop immediately and follow the
+B1 self-check repair path below.
 
 ### Worktree creation
 
@@ -84,6 +109,23 @@ are installed:
 
 `install-deps` must remain safe to rerun during retries, takeovers, and
 recreated worktrees without manual cleanup.
+
+### B1 self-check
+
+Before continuing to B2, verify all of the following:
+
+- `git -C <primary-worktree-root> rev-parse --abbrev-ref HEAD` returns
+  `main`.
+- `git worktree list` includes the new sibling worktree path.
+- The agent's current working directory is the new sibling worktree
+  path, not the primary worktree.
+
+If any check fails, the B1 worktree-creation contract has been
+violated. Stop and post a hold note on the issue describing which
+check failed; do not continue to B2 from the primary worktree. Repair
+by removing the misplaced branch from the primary worktree (after
+confirming no work is lost) and recreating the sibling worktree
+through the Worktree creation steps above.
 
 ## B2 — Create and refine plan
 

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -1,6 +1,6 @@
 # IDD — Work and Self-Review Phase (B + C)
 
-Read this file after a successful claim. It covers branch creation (B1),
+Read this file after a successful claim. It covers worktree creation (B1),
 planning (B2), implementation (B3), and the self-review loop (C).
 
 ---

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -25,12 +25,15 @@ Before creating, check for local conflicts in this order:
    git merge --ff-only origin/main
    ```
 
-   After this `main` fast-forward, leave the primary worktree on
-   `main`. Every remaining B1 step must run either from the primary
-   worktree (for read-only inspection commands such as `git worktree
-   list`) or from the new sibling worktree once it is created. Do
-   **not** change the primary worktree's HEAD off `main` for any
-   reason during B1. See Anti-patterns below.
+   After this `main` fast-forward, do **not** change the primary
+   worktree's HEAD off `main` for any reason during B1. Commands that
+   run from the primary worktree are allowed as long as HEAD stays on
+   `main` — these include read-only inspection (`git worktree list`)
+   and the HEAD-preserving branch/worktree commands used by Steps 2-3
+   below and by Worktree creation
+   (`git branch -d <stale-branch>`, `git worktree add`, `wt new`).
+   What must not happen is the primary worktree's HEAD switching to
+   the issue branch. See Anti-patterns below.
 
 2. Run `git worktree list` — if a worktree for the branch already
    exists, either reuse it (takeover) or remove it first using the exact

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -5,7 +5,7 @@ planning (B2), implementation (B3), and the self-review loop (C).
 
 ---
 
-## B1 — Create branch and worktree
+## B1 — Create worktree (with branch)
 
 Before creating, check for local conflicts in this order:
 
@@ -25,6 +25,13 @@ Before creating, check for local conflicts in this order:
    git merge --ff-only origin/main
    ```
 
+   After this `main` fast-forward, leave the primary worktree on
+   `main`. Every remaining B1 step must run either from the primary
+   worktree (for read-only inspection commands such as `git worktree
+   list`) or from the new sibling worktree once it is created. Do
+   **not** change the primary worktree's HEAD off `main` for any
+   reason during B1. See Anti-patterns below.
+
 2. Run `git worktree list` — if a worktree for the branch already
    exists, either reuse it (takeover) or remove it first using the exact
    path shown in the list: `git worktree remove <path-from-list>`. (Must
@@ -43,6 +50,24 @@ Before creating, check for local conflicts in this order:
 Then create the worktree as described below. If this is a takeover,
 reuse the exact branch name from the existing claim comment — do not
 generate a new one.
+
+### Anti-patterns
+
+The following commands MUST NOT be used to create the implementation
+branch in the primary worktree:
+
+- `git switch -c <branch-name>` — switches the primary worktree to
+  the issue branch and skips worktree creation entirely.
+- `git checkout -b <branch-name>` — equivalent failure mode.
+- A standalone `git branch <branch-name>` followed by in-place commits
+  in the primary worktree — defeats the sibling-worktree invariant
+  even though `git branch` alone does not move HEAD.
+
+The primary worktree's HEAD MUST remain on `main` throughout B1. The
+implementation branch exists only inside the sibling worktree created
+by `git worktree add` (or WorkTrunk's `wt new`). If the primary
+worktree ever leaves `main` during B1, stop immediately and follow the
+B1 self-check repair path below.
 
 ### Worktree creation
 
@@ -84,6 +109,23 @@ are installed:
 
 `install-deps` must remain safe to rerun during retries, takeovers, and
 recreated worktrees without manual cleanup.
+
+### B1 self-check
+
+Before continuing to B2, verify all of the following:
+
+- `git -C <primary-worktree-root> rev-parse --abbrev-ref HEAD` returns
+  `main`.
+- `git worktree list` includes the new sibling worktree path.
+- The agent's current working directory is the new sibling worktree
+  path, not the primary worktree.
+
+If any check fails, the B1 worktree-creation contract has been
+violated. Stop and post a hold note on the issue describing which
+check failed; do not continue to B2 from the primary worktree. Repair
+by removing the misplaced branch from the primary worktree (after
+confirming no work is lost) and recreating the sibling worktree
+through the Worktree creation steps above.
 
 ## B2 — Create and refine plan
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -1,6 +1,6 @@
 # IDD — Work and Self-Review Phase (B + C)
 
-Read this file after a successful claim. It covers branch creation (B1),
+Read this file after a successful claim. It covers worktree creation (B1),
 planning (B2), implementation (B3), and the self-review loop (C).
 
 ---

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -25,12 +25,15 @@ Before creating, check for local conflicts in this order:
    git merge --ff-only origin/main
    ```
 
-   After this `main` fast-forward, leave the primary worktree on
-   `main`. Every remaining B1 step must run either from the primary
-   worktree (for read-only inspection commands such as `git worktree
-   list`) or from the new sibling worktree once it is created. Do
-   **not** change the primary worktree's HEAD off `main` for any
-   reason during B1. See Anti-patterns below.
+   After this `main` fast-forward, do **not** change the primary
+   worktree's HEAD off `main` for any reason during B1. Commands that
+   run from the primary worktree are allowed as long as HEAD stays on
+   `main` — these include read-only inspection (`git worktree list`)
+   and the HEAD-preserving branch/worktree commands used by Steps 2-3
+   below and by Worktree creation
+   (`git branch -d <stale-branch>`, `git worktree add`, `wt new`).
+   What must not happen is the primary worktree's HEAD switching to
+   the issue branch. See Anti-patterns below.
 
 2. Run `git worktree list` — if a worktree for the branch already
    exists, either reuse it (takeover) or remove it first using the exact


### PR DESCRIPTION
## Summary

Hardens the B1 phase in `idd-work.instructions.md` to prevent the
recurring multi-agent failure where agents run `git switch -c` inside
the `.git`-bearing primary worktree instead of creating a sibling
worktree via `git worktree add`.

Four edits, mirrored into `idd-template/`:

- Rename `## B1 — Create branch and worktree` → `## B1 — Create
  worktree (with branch)`.
- Add an explicit cwd-shift cue after the Step 1 `main` fast-forward
  so agents do not stay on the primary worktree's HEAD by inertia.
- Add an Anti-patterns block forbidding `git switch -c`,
  `git checkout -b`, and standalone `git branch <branch>` for the
  implementation branch in the primary worktree.
- Add a B1 self-check (primary HEAD == `main`; new sibling worktree
  listed; cwd is the new worktree) and a short repair path.

## Test plan

- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [ ] CI green on this PR.
- [ ] Reviewer confirms the new Anti-patterns block and self-check
      are reachable from the table of contents / section flow.

Closes #701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed B1 header to "Create worktree (with branch)" and tightened B1 guidance to enforce keeping the primary worktree on main.
  * Clarified that remaining B1 steps must be run from either the primary (read-only inspection) or the new sibling worktree.
  * Added an "Anti-patterns" section forbidding workflows that move the primary off main.
  * Added a "B1 self-check" with mandatory verification, hold-and-repair instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->