### PR TITLE
refactor(idd-advisory-wait): extract AW1/AW2 shell fallback to docs/

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -119,27 +119,26 @@ Use this path whenever helper-first cannot be trusted.
 
 ### AW1 — Copilot review state
 
-Compute three variables consumed by AW3:
+AW3 inputs:
 
-- `LAST_COPILOT_COMMIT` — `commit_id` of the latest Copilot review on
-  this PR (empty if none).
-- `COPILOT_PENDING` — `true` when Copilot is in `requested_reviewers`.
-- `COPILOT_PENDING_COVERS_HEAD` — `true` when the latest Copilot
-  `review_requested` event follows the current HEAD's `committed`
-  event in the PR timeline.
+- `LAST_COPILOT_COMMIT` — `commit_id` of the latest Copilot review
+  (empty if none); equality with `PR_HEAD_SHA` short-circuits to
+  **SATISFIED**.
+- `COPILOT_PENDING` — `true` if Copilot is in `requested_reviewers`.
+- `COPILOT_PENDING_COVERS_HEAD` — `true` if the latest Copilot
+  `review_requested` event in the PR timeline follows the current
+  HEAD's `committed` event.
 
-If `LAST_COPILOT_COMMIT == PR_HEAD_SHA`, the outcome is **SATISFIED**.
-Never use commit author/committer timestamps as advisory proof. See
-[shell fallback AW1](../../docs/idd-advisory-wait-shell-fallback.md#aw1)
-for the exact `gh api` + `jq` commands.
+See [shell fallback AW1](../../docs/idd-advisory-wait-shell-fallback.md#aw1)
+for commands.
 
 ### AW2 — Advisory marker evidence
 
-Compute three variables consumed by AW3:
+AW3 inputs:
 
 - `TRUSTED_MARKER_LOGIN_JSON` — JSON list of trusted marker logins
-  (current actor, configured trusted actors, plus collaborators with
-  write/maintain/admin when `IDD_TRUST_COLLABORATOR_MARKERS` is on).
+  (current actor, configured trusted actors, plus write/maintain/admin
+  collaborators when `IDD_TRUST_COLLABORATOR_MARKERS` is on).
 - `EARLIEST_SAME_HEAD_AT` — earliest `created_at` of a trusted marker
   matching `advisory-wait`, `advisory-wait-recovery`, or
   `<!-- advisory-wait: … -->` for the current `PR_HEAD_SHA` (empty if
@@ -148,7 +147,7 @@ Compute three variables consumed by AW3:
   on this PR (excludes recovery markers).
 
 See [shell fallback AW2](../../docs/idd-advisory-wait-shell-fallback.md#aw2)
-for the exact `gh api` + `jq` commands.
+for commands.
 
 Rules:
 
@@ -156,6 +155,7 @@ Rules:
 - same-head clock anchor is marker `created_at` (not embedded text)
 - request-cap counting excludes recovery markers
 - refresh AW2 evidence at each polling cycle
+- never use commit author/committer timestamps as advisory proof
 
 ### AW3 — Decision table
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -119,119 +119,36 @@ Use this path whenever helper-first cannot be trusted.
 
 ### AW1 — Copilot review state
 
-```sh
-OWNER=$(gh repo view --json owner --jq '.owner.login')
-REPO=$(gh repo view --json name --jq '.name')
+Compute three variables consumed by AW3:
 
-LAST_COPILOT_COMMIT=$(
-  gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
-    --paginate \
-    --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
-               {sa: .submitted_at, cid: .commit_id}' \
-  | jq -rs 'sort_by(.sa) | last | .cid // ""'
-)
+- `LAST_COPILOT_COMMIT` — `commit_id` of the latest Copilot review on
+  this PR (empty if none).
+- `COPILOT_PENDING` — `true` when Copilot is in `requested_reviewers`.
+- `COPILOT_PENDING_COVERS_HEAD` — `true` when the latest Copilot
+  `review_requested` event follows the current HEAD's `committed`
+  event in the PR timeline.
 
-COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-  --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
-
-COPILOT_PENDING_COVERS_HEAD=$(
-  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \
-    -H "Accept: application/vnd.github+json" \
-    --paginate \
-    | jq -r -s --arg sha "${PR_HEAD_SHA}" '
-        (add // [])
-        | to_entries
-        | (map(select(.value.event == "committed"
-             and ((.value.sha // .value.commit_id // "") == $sha)))
-           | last | .key // null) as $head_index
-        | (map(select(.value.event == "review_requested"
-             and (((.value.requested_reviewer.login // "") == "Copilot")
-                  or ((.value.requested_reviewer.login // "")
-                      | startswith("copilot-pull-request-reviewer")))))
-           | last | .key // null) as $request_index
-        | ($head_index != null and $request_index != null and
-           $request_index > $head_index)
-      '
-)
-```
-
-If `LAST_COPILOT_COMMIT == PR_HEAD_SHA`, advisory state is
-**SATISFIED**.
-
-Never use commit author/committer timestamps as advisory proof.
+If `LAST_COPILOT_COMMIT == PR_HEAD_SHA`, the outcome is **SATISFIED**.
+Never use commit author/committer timestamps as advisory proof. See
+[shell fallback AW1](../../docs/idd-advisory-wait-shell-fallback.md#aw1)
+for the exact `gh api` + `jq` commands.
 
 ### AW2 — Advisory marker evidence
 
-```sh
-ADVISORY_COMMENTS_JSON=$(
-  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-    | jq -s 'add // []'
-)
-CURRENT_MARKER_ACTOR=$(gh api user --jq '.login' 2>/dev/null || true)
-TRUSTED_MARKER_ACTORS="${IDD_TRUSTED_MARKER_ACTORS:-}"
-TRUST_COLLABORATOR_MARKERS="${IDD_TRUST_COLLABORATOR_MARKERS:-}"
-TRUSTED_MARKER_LOGIN_JSON=$(
-  {
-    if [ -n "$CURRENT_MARKER_ACTOR" ]; then
-      printf '%s\n' "$CURRENT_MARKER_ACTOR"
-    fi
-    printf '%s\n' "$TRUSTED_MARKER_ACTORS" | tr ',' '\n'
-    if printf '%s\n' "$TRUST_COLLABORATOR_MARKERS" | grep -Eiq '^(1|true|yes)$'; then
-      printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
-        | jq -r '.[] | select((.body // "") | test("^advisory-wait:|^advisory-wait-recovery:|^<!-- advisory-wait:")) | .user.login // empty' \
-        | sort -fu \
-        | while IFS= read -r login; do
-          permission=$(
-            gh api "repos/${OWNER}/${REPO}/collaborators/${login}/permission" \
-              --jq '.permission' 2>/dev/null || true
-          )
-          case "$permission" in
-            admin | maintain | write) printf '%s\n' "$login" ;;
-          esac
-        done
-    fi
-  } | jq -R -s 'split("\n") | map(ascii_downcase | select(length > 0)) | unique'
-)
+Compute three variables consumed by AW3:
 
-EARLIEST_SAME_HEAD_AT=$(
-  printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
-    | jq -r \
-      --arg sha "$PR_HEAD_SHA" \
-      --argjson trusted_marker_logins "$TRUSTED_MARKER_LOGIN_JSON" '
-        def marker_login: (.user.login // "" | ascii_downcase);
-        def trusted_marker_actor:
-          marker_login as $login
-          | ($login | length > 0)
-          and (($trusted_marker_logins | index($login)) != null);
-        [.[] | select(
-          trusted_marker_actor
-          and (
-            ((.body // "") | test("^advisory-wait: [^ ]+ " + $sha + "(?: |$)")) or
-            ((.body // "") | test("^advisory-wait-recovery: [^ ]+ " + $sha + "(?: |$)")) or
-            ((.body // "") | test("^<!-- advisory-wait: [^ ]+ " + $sha + " [^ ]+ -->$"))
-          )
-        )]
-        | min_by(.created_at) | .created_at // ""
-      '
-)
+- `TRUSTED_MARKER_LOGIN_JSON` — JSON list of trusted marker logins
+  (current actor, configured trusted actors, plus collaborators with
+  write/maintain/admin when `IDD_TRUST_COLLABORATOR_MARKERS` is on).
+- `EARLIEST_SAME_HEAD_AT` — earliest `created_at` of a trusted marker
+  matching `advisory-wait`, `advisory-wait-recovery`, or
+  `<!-- advisory-wait: … -->` for the current `PR_HEAD_SHA` (empty if
+  none).
+- `REQUEST_MARKER_COUNT` — count of trusted `advisory-wait` markers
+  on this PR (excludes recovery markers).
 
-REQUEST_MARKER_COUNT=$(
-  printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
-    | jq -r \
-      --argjson trusted_marker_logins "$TRUSTED_MARKER_LOGIN_JSON" '
-        def marker_login: (.user.login // "" | ascii_downcase);
-        def trusted_marker_actor:
-          marker_login as $login
-          | ($login | length > 0)
-          and (($trusted_marker_logins | index($login)) != null);
-        [.[] | select(
-          trusted_marker_actor
-          and ((.body // "") | test("^advisory-wait:|^<!-- advisory-wait:"))
-        )]
-        | length
-      '
-)
-```
+See [shell fallback AW2](../../docs/idd-advisory-wait-shell-fallback.md#aw2)
+for the exact `gh api` + `jq` commands.
 
 Rules:
 

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -82,6 +82,7 @@
         "idd-template/docs/idd-helper-scripts.md",
         "idd-template/docs/idd-comment-minimization.md",
         "idd-template/docs/idd-resume-detail.md",
+        "idd-template/docs/idd-advisory-wait-shell-fallback.md",
         "idd-template/docs/permissions.md",
         "idd-template/docs/getting-started.md",
         "idd-template/docs/concepts.md",
@@ -312,6 +313,12 @@
       "id": "idd-resume-detail-doc",
       "source": "idd-template/docs/idd-resume-detail.md",
       "target": "docs/idd-resume-detail.md",
+      "mode": "exact"
+    },
+    {
+      "id": "idd-advisory-wait-shell-fallback-doc",
+      "source": "idd-template/docs/idd-advisory-wait-shell-fallback.md",
+      "target": "docs/idd-advisory-wait-shell-fallback.md",
       "mode": "exact"
     },
     {

--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -1,0 +1,124 @@
+# IDD — Advisory-Wait Shell Fallback (AW1 / AW2 detail)
+
+This document contains the verbatim `gh api` + `jq` snippets used by
+the shell fallback for [advisory-wait](../.github/instructions/idd-advisory-wait.instructions.md)
+AW1 and AW2 evidence collection.
+
+These snippets only apply when helper-first cannot be trusted — see
+the "Fail-closed fallback trigger" section in the instruction file.
+
+The instruction file owns the contract (what variables each step must
+produce and how AW3 consumes them); this document is the
+implementation reference. If the contract and these snippets diverge,
+the contract wins and these snippets must be updated.
+
+## AW1
+
+```sh
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+LAST_COPILOT_COMMIT=$(
+  gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
+    --paginate \
+    --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
+               {sa: .submitted_at, cid: .commit_id}' \
+  | jq -rs 'sort_by(.sa) | last | .cid // ""'
+)
+
+COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
+  --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
+
+COPILOT_PENDING_COVERS_HEAD=$(
+  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \
+    -H "Accept: application/vnd.github+json" \
+    --paginate \
+    | jq -r -s --arg sha "${PR_HEAD_SHA}" '
+        (add // [])
+        | to_entries
+        | (map(select(.value.event == "committed"
+             and ((.value.sha // .value.commit_id // "") == $sha)))
+           | last | .key // null) as $head_index
+        | (map(select(.value.event == "review_requested"
+             and (((.value.requested_reviewer.login // "") == "Copilot")
+                  or ((.value.requested_reviewer.login // "")
+                      | startswith("copilot-pull-request-reviewer")))))
+           | last | .key // null) as $request_index
+        | ($head_index != null and $request_index != null and
+           $request_index > $head_index)
+      '
+)
+```
+
+## AW2
+
+```sh
+ADVISORY_COMMENTS_JSON=$(
+  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
+    | jq -s 'add // []'
+)
+CURRENT_MARKER_ACTOR=$(gh api user --jq '.login' 2>/dev/null || true)
+TRUSTED_MARKER_ACTORS="${IDD_TRUSTED_MARKER_ACTORS:-}"
+TRUST_COLLABORATOR_MARKERS="${IDD_TRUST_COLLABORATOR_MARKERS:-}"
+TRUSTED_MARKER_LOGIN_JSON=$(
+  {
+    if [ -n "$CURRENT_MARKER_ACTOR" ]; then
+      printf '%s\n' "$CURRENT_MARKER_ACTOR"
+    fi
+    printf '%s\n' "$TRUSTED_MARKER_ACTORS" | tr ',' '\n'
+    if printf '%s\n' "$TRUST_COLLABORATOR_MARKERS" | grep -Eiq '^(1|true|yes)$'; then
+      printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
+        | jq -r '.[] | select((.body // "") | test("^advisory-wait:|^advisory-wait-recovery:|^<!-- advisory-wait:")) | .user.login // empty' \
+        | sort -fu \
+        | while IFS= read -r login; do
+          permission=$(
+            gh api "repos/${OWNER}/${REPO}/collaborators/${login}/permission" \
+              --jq '.permission' 2>/dev/null || true
+          )
+          case "$permission" in
+            admin | maintain | write) printf '%s\n' "$login" ;;
+          esac
+        done
+    fi
+  } | jq -R -s 'split("\n") | map(ascii_downcase | select(length > 0)) | unique'
+)
+
+EARLIEST_SAME_HEAD_AT=$(
+  printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
+    | jq -r \
+      --arg sha "$PR_HEAD_SHA" \
+      --argjson trusted_marker_logins "$TRUSTED_MARKER_LOGIN_JSON" '
+        def marker_login: (.user.login // "" | ascii_downcase);
+        def trusted_marker_actor:
+          marker_login as $login
+          | ($login | length > 0)
+          and (($trusted_marker_logins | index($login)) != null);
+        [.[] | select(
+          trusted_marker_actor
+          and (
+            ((.body // "") | test("^advisory-wait: [^ ]+ " + $sha + "(?: |$)")) or
+            ((.body // "") | test("^advisory-wait-recovery: [^ ]+ " + $sha + "(?: |$)")) or
+            ((.body // "") | test("^<!-- advisory-wait: [^ ]+ " + $sha + " [^ ]+ -->$"))
+          )
+        )]
+        | min_by(.created_at) | .created_at // ""
+      '
+)
+
+REQUEST_MARKER_COUNT=$(
+  printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
+    | jq -r \
+      --argjson trusted_marker_logins "$TRUSTED_MARKER_LOGIN_JSON" '
+        def marker_login: (.user.login // "" | ascii_downcase);
+        def trusted_marker_actor:
+          marker_login as $login
+          | ($login | length > 0)
+          and (($trusted_marker_logins | index($login)) != null);
+        [.[] | select(
+          trusted_marker_actor
+          and ((.body // "") | test("^advisory-wait:|^<!-- advisory-wait:"))
+        )]
+        | length
+      '
+)
+```

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -119,27 +119,26 @@ Use this path whenever helper-first cannot be trusted.
 
 ### AW1 — Copilot review state
 
-Compute three variables consumed by AW3:
+AW3 inputs:
 
-- `LAST_COPILOT_COMMIT` — `commit_id` of the latest Copilot review on
-  this PR (empty if none).
-- `COPILOT_PENDING` — `true` when Copilot is in `requested_reviewers`.
-- `COPILOT_PENDING_COVERS_HEAD` — `true` when the latest Copilot
-  `review_requested` event follows the current HEAD's `committed`
-  event in the PR timeline.
+- `LAST_COPILOT_COMMIT` — `commit_id` of the latest Copilot review
+  (empty if none); equality with `PR_HEAD_SHA` short-circuits to
+  **SATISFIED**.
+- `COPILOT_PENDING` — `true` if Copilot is in `requested_reviewers`.
+- `COPILOT_PENDING_COVERS_HEAD` — `true` if the latest Copilot
+  `review_requested` event in the PR timeline follows the current
+  HEAD's `committed` event.
 
-If `LAST_COPILOT_COMMIT == PR_HEAD_SHA`, the outcome is **SATISFIED**.
-Never use commit author/committer timestamps as advisory proof. See
-[shell fallback AW1](../../docs/idd-advisory-wait-shell-fallback.md#aw1)
-for the exact `gh api` + `jq` commands.
+See [shell fallback AW1](../../docs/idd-advisory-wait-shell-fallback.md#aw1)
+for commands.
 
 ### AW2 — Advisory marker evidence
 
-Compute three variables consumed by AW3:
+AW3 inputs:
 
 - `TRUSTED_MARKER_LOGIN_JSON` — JSON list of trusted marker logins
-  (current actor, configured trusted actors, plus collaborators with
-  write/maintain/admin when `IDD_TRUST_COLLABORATOR_MARKERS` is on).
+  (current actor, configured trusted actors, plus write/maintain/admin
+  collaborators when `IDD_TRUST_COLLABORATOR_MARKERS` is on).
 - `EARLIEST_SAME_HEAD_AT` — earliest `created_at` of a trusted marker
   matching `advisory-wait`, `advisory-wait-recovery`, or
   `<!-- advisory-wait: … -->` for the current `PR_HEAD_SHA` (empty if
@@ -148,7 +147,7 @@ Compute three variables consumed by AW3:
   on this PR (excludes recovery markers).
 
 See [shell fallback AW2](../../docs/idd-advisory-wait-shell-fallback.md#aw2)
-for the exact `gh api` + `jq` commands.
+for commands.
 
 Rules:
 
@@ -156,6 +155,7 @@ Rules:
 - same-head clock anchor is marker `created_at` (not embedded text)
 - request-cap counting excludes recovery markers
 - refresh AW2 evidence at each polling cycle
+- never use commit author/committer timestamps as advisory proof
 
 ### AW3 — Decision table
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -119,119 +119,36 @@ Use this path whenever helper-first cannot be trusted.
 
 ### AW1 — Copilot review state
 
-```sh
-OWNER=$(gh repo view --json owner --jq '.owner.login')
-REPO=$(gh repo view --json name --jq '.name')
+Compute three variables consumed by AW3:
 
-LAST_COPILOT_COMMIT=$(
-  gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
-    --paginate \
-    --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
-               {sa: .submitted_at, cid: .commit_id}' \
-  | jq -rs 'sort_by(.sa) | last | .cid // ""'
-)
+- `LAST_COPILOT_COMMIT` — `commit_id` of the latest Copilot review on
+  this PR (empty if none).
+- `COPILOT_PENDING` — `true` when Copilot is in `requested_reviewers`.
+- `COPILOT_PENDING_COVERS_HEAD` — `true` when the latest Copilot
+  `review_requested` event follows the current HEAD's `committed`
+  event in the PR timeline.
 
-COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-  --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
-
-COPILOT_PENDING_COVERS_HEAD=$(
-  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \
-    -H "Accept: application/vnd.github+json" \
-    --paginate \
-    | jq -r -s --arg sha "${PR_HEAD_SHA}" '
-        (add // [])
-        | to_entries
-        | (map(select(.value.event == "committed"
-             and ((.value.sha // .value.commit_id // "") == $sha)))
-           | last | .key // null) as $head_index
-        | (map(select(.value.event == "review_requested"
-             and (((.value.requested_reviewer.login // "") == "Copilot")
-                  or ((.value.requested_reviewer.login // "")
-                      | startswith("copilot-pull-request-reviewer")))))
-           | last | .key // null) as $request_index
-        | ($head_index != null and $request_index != null and
-           $request_index > $head_index)
-      '
-)
-```
-
-If `LAST_COPILOT_COMMIT == PR_HEAD_SHA`, advisory state is
-**SATISFIED**.
-
-Never use commit author/committer timestamps as advisory proof.
+If `LAST_COPILOT_COMMIT == PR_HEAD_SHA`, the outcome is **SATISFIED**.
+Never use commit author/committer timestamps as advisory proof. See
+[shell fallback AW1](../../docs/idd-advisory-wait-shell-fallback.md#aw1)
+for the exact `gh api` + `jq` commands.
 
 ### AW2 — Advisory marker evidence
 
-```sh
-ADVISORY_COMMENTS_JSON=$(
-  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
-    | jq -s 'add // []'
-)
-CURRENT_MARKER_ACTOR=$(gh api user --jq '.login' 2>/dev/null || true)
-TRUSTED_MARKER_ACTORS="${IDD_TRUSTED_MARKER_ACTORS:-}"
-TRUST_COLLABORATOR_MARKERS="${IDD_TRUST_COLLABORATOR_MARKERS:-}"
-TRUSTED_MARKER_LOGIN_JSON=$(
-  {
-    if [ -n "$CURRENT_MARKER_ACTOR" ]; then
-      printf '%s\n' "$CURRENT_MARKER_ACTOR"
-    fi
-    printf '%s\n' "$TRUSTED_MARKER_ACTORS" | tr ',' '\n'
-    if printf '%s\n' "$TRUST_COLLABORATOR_MARKERS" | grep -Eiq '^(1|true|yes)$'; then
-      printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
-        | jq -r '.[] | select((.body // "") | test("^advisory-wait:|^advisory-wait-recovery:|^<!-- advisory-wait:")) | .user.login // empty' \
-        | sort -fu \
-        | while IFS= read -r login; do
-          permission=$(
-            gh api "repos/${OWNER}/${REPO}/collaborators/${login}/permission" \
-              --jq '.permission' 2>/dev/null || true
-          )
-          case "$permission" in
-            admin | maintain | write) printf '%s\n' "$login" ;;
-          esac
-        done
-    fi
-  } | jq -R -s 'split("\n") | map(ascii_downcase | select(length > 0)) | unique'
-)
+Compute three variables consumed by AW3:
 
-EARLIEST_SAME_HEAD_AT=$(
-  printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
-    | jq -r \
-      --arg sha "$PR_HEAD_SHA" \
-      --argjson trusted_marker_logins "$TRUSTED_MARKER_LOGIN_JSON" '
-        def marker_login: (.user.login // "" | ascii_downcase);
-        def trusted_marker_actor:
-          marker_login as $login
-          | ($login | length > 0)
-          and (($trusted_marker_logins | index($login)) != null);
-        [.[] | select(
-          trusted_marker_actor
-          and (
-            ((.body // "") | test("^advisory-wait: [^ ]+ " + $sha + "(?: |$)")) or
-            ((.body // "") | test("^advisory-wait-recovery: [^ ]+ " + $sha + "(?: |$)")) or
-            ((.body // "") | test("^<!-- advisory-wait: [^ ]+ " + $sha + " [^ ]+ -->$"))
-          )
-        )]
-        | min_by(.created_at) | .created_at // ""
-      '
-)
+- `TRUSTED_MARKER_LOGIN_JSON` — JSON list of trusted marker logins
+  (current actor, configured trusted actors, plus collaborators with
+  write/maintain/admin when `IDD_TRUST_COLLABORATOR_MARKERS` is on).
+- `EARLIEST_SAME_HEAD_AT` — earliest `created_at` of a trusted marker
+  matching `advisory-wait`, `advisory-wait-recovery`, or
+  `<!-- advisory-wait: … -->` for the current `PR_HEAD_SHA` (empty if
+  none).
+- `REQUEST_MARKER_COUNT` — count of trusted `advisory-wait` markers
+  on this PR (excludes recovery markers).
 
-REQUEST_MARKER_COUNT=$(
-  printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
-    | jq -r \
-      --argjson trusted_marker_logins "$TRUSTED_MARKER_LOGIN_JSON" '
-        def marker_login: (.user.login // "" | ascii_downcase);
-        def trusted_marker_actor:
-          marker_login as $login
-          | ($login | length > 0)
-          and (($trusted_marker_logins | index($login)) != null);
-        [.[] | select(
-          trusted_marker_actor
-          and ((.body // "") | test("^advisory-wait:|^<!-- advisory-wait:"))
-        )]
-        | length
-      '
-)
-```
+See [shell fallback AW2](../../docs/idd-advisory-wait-shell-fallback.md#aw2)
+for the exact `gh api` + `jq` commands.
 
 Rules:
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -265,6 +265,7 @@ docs/idd-review-policy-profiles.md
 docs/idd-helper-scripts.md
 docs/idd-comment-minimization.md
 docs/idd-resume-detail.md
+docs/idd-advisory-wait-shell-fallback.md
 docs/permissions.md
 docs/getting-started.md
 docs/concepts.md
@@ -342,6 +343,7 @@ for FILE in \
   "docs/idd-helper-scripts.md" \
   "docs/idd-comment-minimization.md" \
   "docs/idd-resume-detail.md" \
+  "docs/idd-advisory-wait-shell-fallback.md" \
   "docs/permissions.md" \
   "docs/getting-started.md" \
   "docs/concepts.md" \
@@ -427,6 +429,7 @@ for FILE in \
   "docs/idd-helper-scripts.md" \
   "docs/idd-comment-minimization.md" \
   "docs/idd-resume-detail.md" \
+  "docs/idd-advisory-wait-shell-fallback.md" \
   "docs/permissions.md" \
   "docs/getting-started.md" \
   "docs/concepts.md" \

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -1,0 +1,124 @@
+# IDD — Advisory-Wait Shell Fallback (AW1 / AW2 detail)
+
+This document contains the verbatim `gh api` + `jq` snippets used by
+the shell fallback for [advisory-wait](../.github/instructions/idd-advisory-wait.instructions.md)
+AW1 and AW2 evidence collection.
+
+These snippets only apply when helper-first cannot be trusted — see
+the "Fail-closed fallback trigger" section in the instruction file.
+
+The instruction file owns the contract (what variables each step must
+produce and how AW3 consumes them); this document is the
+implementation reference. If the contract and these snippets diverge,
+the contract wins and these snippets must be updated.
+
+## AW1
+
+```sh
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+LAST_COPILOT_COMMIT=$(
+  gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
+    --paginate \
+    --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
+               {sa: .submitted_at, cid: .commit_id}' \
+  | jq -rs 'sort_by(.sa) | last | .cid // ""'
+)
+
+COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
+  --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
+
+COPILOT_PENDING_COVERS_HEAD=$(
+  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \
+    -H "Accept: application/vnd.github+json" \
+    --paginate \
+    | jq -r -s --arg sha "${PR_HEAD_SHA}" '
+        (add // [])
+        | to_entries
+        | (map(select(.value.event == "committed"
+             and ((.value.sha // .value.commit_id // "") == $sha)))
+           | last | .key // null) as $head_index
+        | (map(select(.value.event == "review_requested"
+             and (((.value.requested_reviewer.login // "") == "Copilot")
+                  or ((.value.requested_reviewer.login // "")
+                      | startswith("copilot-pull-request-reviewer")))))
+           | last | .key // null) as $request_index
+        | ($head_index != null and $request_index != null and
+           $request_index > $head_index)
+      '
+)
+```
+
+## AW2
+
+```sh
+ADVISORY_COMMENTS_JSON=$(
+  gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/comments" --paginate \
+    | jq -s 'add // []'
+)
+CURRENT_MARKER_ACTOR=$(gh api user --jq '.login' 2>/dev/null || true)
+TRUSTED_MARKER_ACTORS="${IDD_TRUSTED_MARKER_ACTORS:-}"
+TRUST_COLLABORATOR_MARKERS="${IDD_TRUST_COLLABORATOR_MARKERS:-}"
+TRUSTED_MARKER_LOGIN_JSON=$(
+  {
+    if [ -n "$CURRENT_MARKER_ACTOR" ]; then
+      printf '%s\n' "$CURRENT_MARKER_ACTOR"
+    fi
+    printf '%s\n' "$TRUSTED_MARKER_ACTORS" | tr ',' '\n'
+    if printf '%s\n' "$TRUST_COLLABORATOR_MARKERS" | grep -Eiq '^(1|true|yes)$'; then
+      printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
+        | jq -r '.[] | select((.body // "") | test("^advisory-wait:|^advisory-wait-recovery:|^<!-- advisory-wait:")) | .user.login // empty' \
+        | sort -fu \
+        | while IFS= read -r login; do
+          permission=$(
+            gh api "repos/${OWNER}/${REPO}/collaborators/${login}/permission" \
+              --jq '.permission' 2>/dev/null || true
+          )
+          case "$permission" in
+            admin | maintain | write) printf '%s\n' "$login" ;;
+          esac
+        done
+    fi
+  } | jq -R -s 'split("\n") | map(ascii_downcase | select(length > 0)) | unique'
+)
+
+EARLIEST_SAME_HEAD_AT=$(
+  printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
+    | jq -r \
+      --arg sha "$PR_HEAD_SHA" \
+      --argjson trusted_marker_logins "$TRUSTED_MARKER_LOGIN_JSON" '
+        def marker_login: (.user.login // "" | ascii_downcase);
+        def trusted_marker_actor:
+          marker_login as $login
+          | ($login | length > 0)
+          and (($trusted_marker_logins | index($login)) != null);
+        [.[] | select(
+          trusted_marker_actor
+          and (
+            ((.body // "") | test("^advisory-wait: [^ ]+ " + $sha + "(?: |$)")) or
+            ((.body // "") | test("^advisory-wait-recovery: [^ ]+ " + $sha + "(?: |$)")) or
+            ((.body // "") | test("^<!-- advisory-wait: [^ ]+ " + $sha + " [^ ]+ -->$"))
+          )
+        )]
+        | min_by(.created_at) | .created_at // ""
+      '
+)
+
+REQUEST_MARKER_COUNT=$(
+  printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
+    | jq -r \
+      --argjson trusted_marker_logins "$TRUSTED_MARKER_LOGIN_JSON" '
+        def marker_login: (.user.login // "" | ascii_downcase);
+        def trusted_marker_actor:
+          marker_login as $login
+          | ($login | length > 0)
+          and (($trusted_marker_logins | index($login)) != null);
+        [.[] | select(
+          trusted_marker_actor
+          and ((.body // "") | test("^advisory-wait:|^<!-- advisory-wait:"))
+        )]
+        | length
+      '
+)
+```


### PR DESCRIPTION
## Summary

Reduces auto-loaded context weight by moving the ~115-line `gh api` +
`jq` shell fallback bodies (AW1 + AW2) from
`.github/instructions/idd-advisory-wait.instructions.md` into a new
`docs/idd-advisory-wait-shell-fallback.md`. The instruction file
keeps:

- the AW1 / AW2 contracts (which variables each step must produce
  and which SATISFIED short-circuit applies);
- the Rules callout (trusted marker actors, same-head clock anchor,
  request-cap exclusions, polling refresh, no committer timestamp);
- the AW3 decision table, AW3-R recovery marker, AW4 hold templates,
  and AW5 missing-marker recovery.

The new docs file holds the verbatim shell-fallback snippets so they
remain runnable when helper-first cannot be trusted.

Sizes: `idd-advisory-wait.instructions.md` 12.5 KB → 9.5 KB (3.0 KB
saved, ≈ 24%); new `docs/idd-advisory-wait-shell-fallback.md` 4.7 KB.

Mirrored into `idd-template/`.

## Test plan

- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [x] `idd-advisory-wait.instructions.md` is at least 3 KB smaller
      than the pre-change size (delta = 3 013 bytes).
- [x] AW3 / AW3-R / AW4 / AW5 unchanged.
- [ ] CI green on this PR.

Closes #709

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized internal documentation for advisory workflow fallback procedures with improved structure and cross-references.
  * Added comprehensive reference documentation for shell fallback implementation specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->