### PR TITLE
refactor(idd-overview-appendix): move project-commands / template-sync / critique-pass tables to docs/

### DIFF
--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -119,85 +119,28 @@ handling rules, see `idd-review-triage.instructions.md`.
 
 ## Project commands
 
-When a phase refers to a named command set, run the corresponding
-commands. **Adapt this section when applying this workflow to a
-different project.**
-
-If `.github/idd/config.json` exists and validates against the canonical
-schema at
-<https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json>, its `commands`
-object overrides the table below. Policy fields such as
-`skipIssueAuthorApprovalGate` and `maintainerApprovalActorPolicy` are
-the recorded machine-readable policy. Absent values keep the gate
-enabled and default approval actors to
-`owners-and-maintainers-only`.
-
-| Name                    | Commands                                                                                                                                     |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| **fix-validate**        | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
-| **pre-push-validate**   | `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                        |
-| **post-fix-validate**   | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
-| **install-deps**        | `true`                                                                                                                                       |
-| **issue-scope**         | `roadmap`                                                                                                                                    |
-| **orphan-first-policy** | `none`                                                                                                                                       |
-
-Non-shell rows such as **issue-scope** and **orphan-first-policy** are
-workflow settings. Read them literally, not as commands.
-
-`pre-push-validate` omits auto-fix. If lint fails, run
-**fix-validate**, commit, then re-run **pre-push-validate**.
-
-If **fix-validate** or **post-fix-validate** changes files, stage and
-commit them before any push, rebase, or step that requires a clean
-tree.
-
-`install-deps` must be idempotent. Re-running it in fresh, reused, or
-recreated worktrees must not require manual cleanup and should not leave
-unexpected tracked changes.
-
-**Tool availability**: run commands only when tools exist. For Node.js:
-prefer project scripts; use `npx <tool>` only when `npx` is available
-and no relevant script exists; else use `true`. For other tools, use
-`true` when absent.
+The Project commands table (`fix-validate`, `pre-push-validate`,
+`post-fix-validate`, `install-deps`, `issue-scope`,
+`orphan-first-policy`) and its override rules live in
+[`docs/customization.md` → Project commands reference](../../docs/customization.md#project-commands-reference).
+`.github/idd/config.json` `commands` overrides the table.
 
 ## Critique pass
 
 A **critique pass** is an independent review of a plan or diff that
 produces a list of issues with severity, correctness, and coverage
-assessment. The goal and expected output are the same regardless of
-agent; only the mechanism differs.
-
-| Agent       | How to run a critique pass                                                                |
-| ----------- | ----------------------------------------------------------------------------------------- |
-| Copilot     | Launch a subagent in Agent mode; use the calling phase's critique checklist as the prompt |
-| Claude Code | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist      |
-| Codex CLI   | Self-critique: add a "review the above for issues" step in the next response              |
-| Gemini CLI  | Self-critique or use Gemini's native multi-step task mechanism if available               |
-
-When a phase file says "run a critique pass", apply the row for your
-agent above. If no subagent mechanism is available, perform the critique
-as a structured self-review step within the same response.
+assessment. For the per-agent invocation table (Copilot / Claude Code /
+Codex CLI / Gemini CLI), see
+[`docs/idd-workflow.md` → Critique pass invocation](../../docs/idd-workflow.md#critique-pass-invocation).
 
 ## Template sync
 
 This repository is the canonical source of the IDD template distributed
 via `idd-template/`. When modifying any `idd-*.instructions.md` file,
 `docs/idd-workflow.md`, or `docs/customization.md`, apply the equivalent
-change to the corresponding file in `idd-template/`, replacing resolved
-project-specific values with their `{{placeholder}}` forms:
-
-| Live value (`.github/instructions/`)                                | Template form (`idd-template/`)  |
-| ------------------------------------------------------------------- | -------------------------------- |
-| `idd-skill` in repo-name contexts                                   | `{{REPO_NAME}}`                  |
-| `idd-skill` in marker-prefix contexts (e.g. `idd-skill-roadmap-id`) | `{{PROJECT_MARKER_PREFIX}}`      |
-| **fix-validate** command string                                     | `{{FIX_VALIDATE_COMMANDS}}`      |
-| **pre-push-validate** command string                                | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |
-| **post-fix-validate** command string                                | `{{POST_FIX_VALIDATE_COMMANDS}}` |
-| **install-deps** command string                                     | `{{INSTALL_DEPS_COMMAND}}`       |
-
-Match by the named command row in the Project commands table, not by
-command prefix, to avoid confusing commands that share the same
-executable.
+change to the corresponding file in `idd-template/`. For the live ↔
+template placeholder mapping, see
+[`docs/customization.md` → Template sync mapping](../../docs/customization.md#template-sync-mapping).
 
 Commits that modify live instruction files without updating the template
 are incomplete; include both changes in the same atomic commit.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -370,6 +370,72 @@ When WorkTrunk uses a pre-start install hook, that hook may satisfy
 `install-deps` automatically. The underlying command contract is the
 same: repeated runs must stay safe and predictable.
 
+### Project commands reference
+
+When a phase refers to a named command set, run the corresponding
+commands. **Adapt this table when applying this workflow to a
+different project.**
+
+If `.github/idd/config.json` exists and validates against the canonical
+schema at
+<https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json>,
+its `commands` object overrides the table below. Policy fields such as
+`skipIssueAuthorApprovalGate` and `maintainerApprovalActorPolicy` are
+the recorded machine-readable policy. Absent values keep the gate
+enabled and default approval actors to `owners-and-maintainers-only`.
+
+| Name                    | Commands                                                                                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **fix-validate**        | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
+| **pre-push-validate**   | `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                        |
+| **post-fix-validate**   | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
+| **install-deps**        | `true`                                                                                                                                       |
+| **issue-scope**         | `roadmap`                                                                                                                                    |
+| **orphan-first-policy** | `none`                                                                                                                                       |
+
+Non-shell rows such as **issue-scope** and **orphan-first-policy** are
+workflow settings. Read them literally, not as commands.
+
+`pre-push-validate` omits auto-fix. If lint fails, run
+**fix-validate**, commit, then re-run **pre-push-validate**.
+
+If **fix-validate** or **post-fix-validate** changes files, stage and
+commit them before any push, rebase, or step that requires a clean
+tree.
+
+`install-deps` must be idempotent. Re-running it in fresh, reused, or
+recreated worktrees must not require manual cleanup and should not leave
+unexpected tracked changes.
+
+**Tool availability**: run commands only when tools exist. For Node.js:
+prefer project scripts; use `npx <tool>` only when `npx` is available
+and no relevant script exists; else use `true`. For other tools, use
+`true` when absent.
+
+### Template sync mapping
+
+This repository is the canonical source of the IDD template distributed
+via `idd-template/`. When modifying any `idd-*.instructions.md` file,
+`docs/idd-workflow.md`, or `docs/customization.md`, apply the equivalent
+change to the corresponding file in `idd-template/`, replacing resolved
+project-specific values with their `{{placeholder}}` forms:
+
+| Live value (`.github/instructions/`)                                | Template form (`idd-template/`)  |
+| ------------------------------------------------------------------- | -------------------------------- |
+| `idd-skill` in repo-name contexts                                   | `{{REPO_NAME}}`                  |
+| `idd-skill` in marker-prefix contexts (e.g. `idd-skill-roadmap-id`) | `{{PROJECT_MARKER_PREFIX}}`      |
+| **fix-validate** command string                                     | `{{FIX_VALIDATE_COMMANDS}}`      |
+| **pre-push-validate** command string                                | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |
+| **post-fix-validate** command string                                | `{{POST_FIX_VALIDATE_COMMANDS}}` |
+| **install-deps** command string                                     | `{{INSTALL_DEPS_COMMAND}}`       |
+
+Match by the named command row in the Project commands table, not by
+command prefix, to avoid confusing commands that share the same
+executable.
+
+Commits that modify live instruction files without updating the template
+are incomplete; include both changes in the same atomic commit.
+
 ## Tooling Boundary
 
 IDD workflow files are tooling-agnostic. The only tooling contract is

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -426,3 +426,21 @@ See [IDD comment minimization](idd-comment-minimization.md) for the live
 status digest helper, post-merge cleanup helper, GraphQL fallback command
 shape, and merged-PR experiment for hiding completed feedback and stale
 operational markers without deleting the audit trail.
+
+## Critique pass invocation
+
+A **critique pass** is an independent review of a plan or diff that
+produces a list of issues with severity, correctness, and coverage
+assessment. The goal and expected output are the same regardless of
+agent; only the mechanism differs.
+
+| Agent       | How to run a critique pass                                                                |
+| ----------- | ----------------------------------------------------------------------------------------- |
+| Copilot     | Launch a subagent in Agent mode; use the calling phase's critique checklist as the prompt |
+| Claude Code | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist      |
+| Codex CLI   | Self-critique: add a "review the above for issues" step in the next response              |
+| Gemini CLI  | Self-critique or use Gemini's native multi-step task mechanism if available               |
+
+When a phase file says "run a critique pass", apply the row for your
+agent above. If no subagent mechanism is available, perform the critique
+as a structured self-review step within the same response.

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -119,85 +119,28 @@ handling rules, see `idd-review-triage.instructions.md`.
 
 ## Project commands
 
-When a phase refers to a named command set, run the corresponding
-commands. **Adapt this section when applying this workflow to a
-different project.**
-
-If `.github/idd/config.json` exists and validates against the canonical
-schema at
-<https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json>, its `commands`
-object overrides the table below. Policy fields such as
-`skipIssueAuthorApprovalGate` and `maintainerApprovalActorPolicy` are
-the recorded machine-readable policy. Absent values keep the gate
-enabled and default approval actors to
-`owners-and-maintainers-only`.
-
-| Name                    | Commands                                                                                                                                     |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| **fix-validate**        | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
-| **pre-push-validate**   | `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                        |
-| **post-fix-validate**   | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
-| **install-deps**        | `true`                                                                                                                                       |
-| **issue-scope**         | `roadmap`                                                                                                                                    |
-| **orphan-first-policy** | `none`                                                                                                                                       |
-
-Non-shell rows such as **issue-scope** and **orphan-first-policy** are
-workflow settings. Read them literally, not as commands.
-
-`pre-push-validate` omits auto-fix. If lint fails, run
-**fix-validate**, commit, then re-run **pre-push-validate**.
-
-If **fix-validate** or **post-fix-validate** changes files, stage and
-commit them before any push, rebase, or step that requires a clean
-tree.
-
-`install-deps` must be idempotent. Re-running it in fresh, reused, or
-recreated worktrees must not require manual cleanup and should not leave
-unexpected tracked changes.
-
-**Tool availability**: run commands only when tools exist. For Node.js:
-prefer project scripts; use `npx <tool>` only when `npx` is available
-and no relevant script exists; else use `true`. For other tools, use
-`true` when absent.
+The Project commands table (`fix-validate`, `pre-push-validate`,
+`post-fix-validate`, `install-deps`, `issue-scope`,
+`orphan-first-policy`) and its override rules live in
+[`docs/customization.md` → Project commands reference](../../docs/customization.md#project-commands-reference).
+`.github/idd/config.json` `commands` overrides the table.
 
 ## Critique pass
 
 A **critique pass** is an independent review of a plan or diff that
 produces a list of issues with severity, correctness, and coverage
-assessment. The goal and expected output are the same regardless of
-agent; only the mechanism differs.
-
-| Agent       | How to run a critique pass                                                                |
-| ----------- | ----------------------------------------------------------------------------------------- |
-| Copilot     | Launch a subagent in Agent mode; use the calling phase's critique checklist as the prompt |
-| Claude Code | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist      |
-| Codex CLI   | Self-critique: add a "review the above for issues" step in the next response              |
-| Gemini CLI  | Self-critique or use Gemini's native multi-step task mechanism if available               |
-
-When a phase file says "run a critique pass", apply the row for your
-agent above. If no subagent mechanism is available, perform the critique
-as a structured self-review step within the same response.
+assessment. For the per-agent invocation table (Copilot / Claude Code /
+Codex CLI / Gemini CLI), see
+[`docs/idd-workflow.md` → Critique pass invocation](../../docs/idd-workflow.md#critique-pass-invocation).
 
 ## Template sync
 
 This repository is the canonical source of the IDD template distributed
 via `idd-template/`. When modifying any `idd-*.instructions.md` file,
 `docs/idd-workflow.md`, or `docs/customization.md`, apply the equivalent
-change to the corresponding file in `idd-template/`, replacing resolved
-project-specific values with their `{{placeholder}}` forms:
-
-| Live value (`.github/instructions/`)                                | Template form (`idd-template/`)  |
-| ------------------------------------------------------------------- | -------------------------------- |
-| `idd-skill` in repo-name contexts                                   | `{{REPO_NAME}}`                  |
-| `idd-skill` in marker-prefix contexts (e.g. `idd-skill-roadmap-id`) | `{{PROJECT_MARKER_PREFIX}}`      |
-| **fix-validate** command string                                     | `{{FIX_VALIDATE_COMMANDS}}`      |
-| **pre-push-validate** command string                                | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |
-| **post-fix-validate** command string                                | `{{POST_FIX_VALIDATE_COMMANDS}}` |
-| **install-deps** command string                                     | `{{INSTALL_DEPS_COMMAND}}`       |
-
-Match by the named command row in the Project commands table, not by
-command prefix, to avoid confusing commands that share the same
-executable.
+change to the corresponding file in `idd-template/`. For the live ↔
+template placeholder mapping, see
+[`docs/customization.md` → Template sync mapping](../../docs/customization.md#template-sync-mapping).
 
 Commits that modify live instruction files without updating the template
 are incomplete; include both changes in the same atomic commit.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -370,6 +370,72 @@ When WorkTrunk uses a pre-start install hook, that hook may satisfy
 `install-deps` automatically. The underlying command contract is the
 same: repeated runs must stay safe and predictable.
 
+### Project commands reference
+
+When a phase refers to a named command set, run the corresponding
+commands. **Adapt this table when applying this workflow to a
+different project.**
+
+If `.github/idd/config.json` exists and validates against the canonical
+schema at
+<https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json>,
+its `commands` object overrides the table below. Policy fields such as
+`skipIssueAuthorApprovalGate` and `maintainerApprovalActorPolicy` are
+the recorded machine-readable policy. Absent values keep the gate
+enabled and default approval actors to `owners-and-maintainers-only`.
+
+| Name                    | Commands                                                                                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **fix-validate**        | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
+| **pre-push-validate**   | `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                        |
+| **post-fix-validate**   | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
+| **install-deps**        | `true`                                                                                                                                       |
+| **issue-scope**         | `roadmap`                                                                                                                                    |
+| **orphan-first-policy** | `none`                                                                                                                                       |
+
+Non-shell rows such as **issue-scope** and **orphan-first-policy** are
+workflow settings. Read them literally, not as commands.
+
+`pre-push-validate` omits auto-fix. If lint fails, run
+**fix-validate**, commit, then re-run **pre-push-validate**.
+
+If **fix-validate** or **post-fix-validate** changes files, stage and
+commit them before any push, rebase, or step that requires a clean
+tree.
+
+`install-deps` must be idempotent. Re-running it in fresh, reused, or
+recreated worktrees must not require manual cleanup and should not leave
+unexpected tracked changes.
+
+**Tool availability**: run commands only when tools exist. For Node.js:
+prefer project scripts; use `npx <tool>` only when `npx` is available
+and no relevant script exists; else use `true`. For other tools, use
+`true` when absent.
+
+### Template sync mapping
+
+This repository is the canonical source of the IDD template distributed
+via `idd-template/`. When modifying any `idd-*.instructions.md` file,
+`docs/idd-workflow.md`, or `docs/customization.md`, apply the equivalent
+change to the corresponding file in `idd-template/`, replacing resolved
+project-specific values with their `{{placeholder}}` forms:
+
+| Live value (`.github/instructions/`)                                | Template form (`idd-template/`)  |
+| ------------------------------------------------------------------- | -------------------------------- |
+| `idd-skill` in repo-name contexts                                   | `{{REPO_NAME}}`                  |
+| `idd-skill` in marker-prefix contexts (e.g. `idd-skill-roadmap-id`) | `{{PROJECT_MARKER_PREFIX}}`      |
+| **fix-validate** command string                                     | `{{FIX_VALIDATE_COMMANDS}}`      |
+| **pre-push-validate** command string                                | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |
+| **post-fix-validate** command string                                | `{{POST_FIX_VALIDATE_COMMANDS}}` |
+| **install-deps** command string                                     | `{{INSTALL_DEPS_COMMAND}}`       |
+
+Match by the named command row in the Project commands table, not by
+command prefix, to avoid confusing commands that share the same
+executable.
+
+Commits that modify live instruction files without updating the template
+are incomplete; include both changes in the same atomic commit.
+
 ## Tooling Boundary
 
 IDD workflow files are tooling-agnostic. The only tooling contract is

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -404,3 +404,21 @@ See [IDD comment minimization](idd-comment-minimization.md) for the live
 status digest helper, post-merge cleanup helper, GraphQL fallback command
 shape, and merged-PR experiment for hiding completed feedback and stale
 operational markers without deleting the audit trail.
+
+## Critique pass invocation
+
+A **critique pass** is an independent review of a plan or diff that
+produces a list of issues with severity, correctness, and coverage
+assessment. The goal and expected output are the same regardless of
+agent; only the mechanism differs.
+
+| Agent       | How to run a critique pass                                                                |
+| ----------- | ----------------------------------------------------------------------------------------- |
+| Copilot     | Launch a subagent in Agent mode; use the calling phase's critique checklist as the prompt |
+| Claude Code | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist      |
+| Codex CLI   | Self-critique: add a "review the above for issues" step in the next response              |
+| Gemini CLI  | Self-critique or use Gemini's native multi-step task mechanism if available               |
+
+When a phase file says "run a critique pass", apply the row for your
+agent above. If no subagent mechanism is available, perform the critique
+as a structured self-review step within the same response.


### PR DESCRIPTION
## Summary

Cuts auto-loaded `idd-overview-appendix.instructions.md` from 10.7 KB
to 6.7 KB (≈ 4 KB / 38% reduction) by moving three maintainer-facing
reference tables into existing docs:

| Table                 | Destination                                                   |
| --------------------- | ------------------------------------------------------------- |
| Project commands      | `docs/customization.md` → Project commands reference          |
| Template sync mapping | `docs/customization.md` → Template sync mapping               |
| Critique pass         | `docs/idd-workflow.md` → Critique pass invocation             |

Appendix retains short cross-reference paragraphs that link to each
new section, plus the existing template-sync atomic-commit rule.
Override rules (`.github/idd/config.json` `commands`), fallback
hierarchy, command identity, per-agent invocation choices, and the
live ↔ template placeholder mapping are all preserved in the docs.

Mirrored into `idd-template/`. `pnpm run docs:sync` and
`node scripts/audit-docs.mjs --check` both pass.

## Test plan

- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [x] `node scripts/audit-docs.mjs --check` passes.
- [x] Appendix is at least 3 KB smaller (delta = 4 073 bytes).
- [ ] CI green on this PR.

Closes #710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined documentation structure by consolidating project commands, critique pass invocation, and template sync guidance into centralized reference sections.
  * Added comprehensive "Project commands reference" explaining command configuration and override behavior.
  * Added "Critique pass invocation" instructions for supported agents.
  * Added "Template sync mapping" guidance for maintaining consistency across documentation files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->