### PR TITLE
refactor(idd-instructions): extract discover Diagnostic + Rationale to docs/idd-design-rationale.md

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -297,12 +297,8 @@ scope:
    filtered out): report each candidate and the filter criterion it
    failed, then proceed to step 5.
 
-   **Diagnostic — all candidates blocked by an open roadmap**: if every
-   candidate is blocked by a `<!-- idd-skill-blocked-by: X -->` marker
-   that points to an open roadmap, the markers may be misused as
-   grouping tags. Sub-tasks that run while the roadmap is open belong in
-   the task list (`- [ ] #NNN`); the `blocked-by` marker is for issues
-   that must wait for a separate roadmap to close first.
+   See [Discover — A3 Diagnostic](../../docs/idd-design-rationale.md#a3---diagnostic-all-candidates-blocked-by-an-open-roadmap)
+   for the marker-misuse pattern this case typically indicates.
 
 5. **Request explicit opt-in** — ask the operator: "No roadmap-scoped
    issues are available. Do you want to expand the search scope for this
@@ -458,9 +454,8 @@ Before selecting from the surviving viable issues, perform an
      session may retry Discover later if new viable candidates appear or
      claims become stale.
 
-**Rationale**: Active-claim pre-scans eliminate known collisions
-deterministically and reduce wasted claim-post-recheck cycles, improving
-scale-out efficiency when multiple sessions start simultaneously.
+See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
+for why this pre-scan exists.
 
 ### Step 2 — Select
 

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -83,6 +83,7 @@
         "idd-template/docs/idd-comment-minimization.md",
         "idd-template/docs/idd-resume-detail.md",
         "idd-template/docs/idd-advisory-wait-shell-fallback.md",
+        "idd-template/docs/idd-design-rationale.md",
         "idd-template/docs/permissions.md",
         "idd-template/docs/getting-started.md",
         "idd-template/docs/concepts.md",
@@ -320,6 +321,12 @@
       "source": "idd-template/docs/idd-advisory-wait-shell-fallback.md",
       "target": "docs/idd-advisory-wait-shell-fallback.md",
       "mode": "exact"
+    },
+    {
+      "id": "idd-design-rationale-doc",
+      "source": "idd-template/docs/idd-design-rationale.md",
+      "target": "docs/idd-design-rationale.md",
+      "mode": "structure"
     },
     {
       "id": "idd-helper-scripts-doc",

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -1,0 +1,36 @@
+# IDD — Design Rationale and Maintainer Notes
+
+This document collects maintainer-facing rationale, diagnostics, and
+narrative justifications that explain _why_ IDD phase rules exist as
+they do. The rules themselves stay in
+`.github/instructions/*.instructions.md`; this file is the place to
+record the context that helps future maintainers evaluate edits to
+those rules without bloating the auto-loaded instruction surface.
+
+Each section corresponds to one phase file. Add new rationale entries
+under the matching phase heading. Behavior-changing constraints
+(fail-closed defaults, claim revalidation, marker authority) must
+remain in the instruction files.
+
+## Discover
+
+### A3 — Diagnostic: all candidates blocked by an open roadmap
+
+When the A3 decision tree reports zero ready-to-start candidates and
+every candidate is blocked by an
+`<!-- idd-skill-blocked-by: X -->` marker that points to an open
+roadmap, the markers may be misused as grouping tags. Sub-tasks that
+run while the roadmap is open belong in the task list
+(`- [ ] #NNN`); the `blocked-by` marker is reserved for issues that
+must wait for a separate roadmap to close first. Treat this pattern
+as a likely authoring defect, not a real dependency stall.
+
+### A4 Step 1.5 — Rationale: active-claim pre-scan
+
+Active-claim pre-scans eliminate known collisions deterministically
+and reduce wasted claim-post-recheck cycles, improving scale-out
+efficiency when multiple sessions start simultaneously. Without the
+pre-scan, parallel sessions all claim the lowest-numbered viable
+candidate at the same second, then race the same-second tie-break;
+the pre-scan moves the resolution earlier in the pipeline so most
+sessions never touch the same issue.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -316,13 +316,8 @@ scope:
    filtered out): report each candidate and the filter criterion it
    failed, then proceed to step 5.
 
-   **Diagnostic — all candidates blocked by an open roadmap**: if every
-   candidate is blocked by a
-   `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: X -->` marker that points
-   to an open roadmap, the markers may be misused as grouping tags.
-   Sub-tasks that run while the roadmap is open belong in the task list
-   (`- [ ] #NNN`); the `blocked-by` marker is for issues that must wait
-   for a separate roadmap to close first.
+   See [Discover — A3 Diagnostic](../../docs/idd-design-rationale.md#a3---diagnostic-all-candidates-blocked-by-an-open-roadmap)
+   for the marker-misuse pattern this case typically indicates.
 
 5. **Request explicit opt-in** — ask the operator: "No roadmap-scoped
    issues are available. Do you want to expand the search scope for this
@@ -478,9 +473,8 @@ Before selecting from the surviving viable issues, perform an
      session may retry Discover later if new viable candidates appear or
      claims become stale.
 
-**Rationale**: Active-claim pre-scans eliminate known collisions
-deterministically and reduce wasted claim-post-recheck cycles, improving
-scale-out efficiency when multiple sessions start simultaneously.
+See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
+for why this pre-scan exists.
 
 ### Step 2 — Select
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -266,6 +266,7 @@ docs/idd-helper-scripts.md
 docs/idd-comment-minimization.md
 docs/idd-resume-detail.md
 docs/idd-advisory-wait-shell-fallback.md
+docs/idd-design-rationale.md
 docs/permissions.md
 docs/getting-started.md
 docs/concepts.md
@@ -344,6 +345,7 @@ for FILE in \
   "docs/idd-comment-minimization.md" \
   "docs/idd-resume-detail.md" \
   "docs/idd-advisory-wait-shell-fallback.md" \
+  "docs/idd-design-rationale.md" \
   "docs/permissions.md" \
   "docs/getting-started.md" \
   "docs/concepts.md" \
@@ -430,6 +432,7 @@ for FILE in \
   "docs/idd-comment-minimization.md" \
   "docs/idd-resume-detail.md" \
   "docs/idd-advisory-wait-shell-fallback.md" \
+  "docs/idd-design-rationale.md" \
   "docs/permissions.md" \
   "docs/getting-started.md" \
   "docs/concepts.md" \

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -1,0 +1,36 @@
+# IDD — Design Rationale and Maintainer Notes
+
+This document collects maintainer-facing rationale, diagnostics, and
+narrative justifications that explain _why_ IDD phase rules exist as
+they do. The rules themselves stay in
+`.github/instructions/*.instructions.md`; this file is the place to
+record the context that helps future maintainers evaluate edits to
+those rules without bloating the auto-loaded instruction surface.
+
+Each section corresponds to one phase file. Add new rationale entries
+under the matching phase heading. Behavior-changing constraints
+(fail-closed defaults, claim revalidation, marker authority) must
+remain in the instruction files.
+
+## Discover
+
+### A3 — Diagnostic: all candidates blocked by an open roadmap
+
+When the A3 decision tree reports zero ready-to-start candidates and
+every candidate is blocked by an
+`<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: X -->` marker that points
+to an open roadmap, the markers may be misused as grouping tags.
+Sub-tasks that run while the roadmap is open belong in the task list
+(`- [ ] #NNN`); the `blocked-by` marker is reserved for issues that
+must wait for a separate roadmap to close first. Treat this pattern
+as a likely authoring defect, not a real dependency stall.
+
+### A4 Step 1.5 — Rationale: active-claim pre-scan
+
+Active-claim pre-scans eliminate known collisions deterministically
+and reduce wasted claim-post-recheck cycles, improving scale-out
+efficiency when multiple sessions start simultaneously. Without the
+pre-scan, parallel sessions all claim the lowest-numbered viable
+candidate at the same second, then race the same-second tie-break;
+the pre-scan moves the resolution earlier in the pipeline so most
+sessions never touch the same issue.


### PR DESCRIPTION
## Summary

Adds `docs/idd-design-rationale.md` as a maintainer-rationale doc
and moves two clearly maintainer-facing blocks out of the auto-loaded
discover instructions:

- A3 step 4 "Diagnostic — all candidates blocked by an open roadmap"
  (6 lines): explains the marker-misuse pattern when blocked-by
  markers point to open roadmaps used as grouping tags.
- A4 Step 1.5 "Rationale: active-claim pre-scan" (3 lines): explains
  why the pre-scan exists and how it reduces collision races.

Each instruction site now carries a single-line link to the rationale
doc. Mirrored into `idd-template/`. New `audit/sync-manifest.json`
syncPair + paths entries register the new doc; `pnpm run docs:sync`
regenerated `idd-template/ONBOARDING.md` accordingly.

## Scope deviation from #711

The issue named a 30-line net reduction across all instruction
files. This PR delivers only the discover blocks (~9 lines net
inside instructions, smaller numbers across the mirror). The
remaining `Note:` blocks in other phase files are operational, not
maintainer-facing:

- `idd-review-snapshot.instructions.md` — HTML-comment marker
  tooling tip (tells the agent how to post markers reliably).
- `idd-pre-merge.instructions.md` — AMD-thread routing footnote
  (affects E6 handling).
- `idd-review-fix.instructions.md` — "advisory" definition
  (operational distinction from CHANGES_REQUESTED).
- `idd-suitability.instructions.md` — A4.5-vs-A4 differentiation
  inline notes (part of the check description).

Per the issue's scope guard ("when in doubt, prefer keeping a block
in the instruction file"), these stay in the instruction surface.

## Test plan

- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [x] `node scripts/audit-docs.mjs --check` passes.
- [x] `docs/idd-design-rationale.md` exists and the instruction-site
      links resolve.
- [ ] CI green on this PR.

Closes #711