### PR TITLE
refactor(idd-overview-core): add fail-closed default; cite revalidation gate from phase preludes

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -8,8 +8,8 @@ The final merge-gate timing defaults are named in
 [IDD policy constants](../../docs/policy-constants.md). Use that inventory
 when you need the canonical values; the merge logic itself stays here.
 
-Before any mutating action in F3, apply the shared claim revalidation
-gate. The active claim must still use your current `{claim-id}`.
+Before any mutating action in F3, apply the
+[shared claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 ## F3 — Merge
 

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -132,13 +132,13 @@ Ownership timing in this workflow uses the policy defaults
 
 ## Fail-closed default
 
-IDD gates and pre-checks fail closed when state is ambiguous,
-unresolvable, or otherwise unavailable, unless a gate explicitly opts
-out. Phase files cite this default in the gate description instead of
-restating "fail closed" / "treat as missing" / "default to the safer
-outcome" for every condition. When a phase deliberately opts out
-(e.g., `skipIssueAuthorApprovalGate`), it states the opt-out
-explicitly.
+IDD gates and pre-checks **must** fail closed when state is ambiguous,
+unresolvable, or otherwise unavailable, unless the specific gate
+explicitly opts out. Phase files **should** cite this default in the
+gate description instead of restating "fail closed" / "treat as
+missing" / "default to the safer outcome" for every condition. When a
+phase deliberately opts out (e.g., `skipIssueAuthorApprovalGate`), it
+states the opt-out explicitly.
 
 ## Claim revalidation gate
 

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -130,6 +130,16 @@ Ownership timing in this workflow uses the policy defaults
   `{claim-id}` resets the stale clock. Embed timestamps are ignored;
   only the GitHub `created_at` of the comment itself counts.
 
+## Fail-closed default
+
+IDD gates and pre-checks fail closed when state is ambiguous,
+unresolvable, or otherwise unavailable, unless a gate explicitly opts
+out. Phase files cite this default in the gate description instead of
+restating "fail closed" / "treat as missing" / "default to the safer
+outcome" for every condition. When a phase deliberately opts out
+(e.g., `skipIssueAuthorApprovalGate`), it states the opt-out
+explicitly.
+
 ## Claim revalidation gate
 
 Before any step that can mutate git state or publish GitHub side effects

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -4,8 +4,8 @@ Read this file after the self-review loop passes. It covers
 pre-publication main sync, claim verification, tests, pushing, PR
 creation, and waiting for CI.
 
-Before the D1 rebase and D2 push, apply the shared claim revalidation
-gate. The active claim must still use your current `{claim-id}`.
+Before the D1 rebase and D2 push, apply the
+[shared claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 ## D1 — Sync main before first push
 

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -13,8 +13,8 @@ The merge-gate timing defaults referenced by F2 are named in
 [IDD policy constants](../../docs/policy-constants.md). Use that inventory
 for the canonical values, not as a behavior override.
 
-Before any F-phase mutating action, apply the shared claim revalidation
-gate. The active claim must still use your current `{claim-id}`.
+Before any F-phase mutating action, apply the
+[shared claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 After a forced handoff on an open PR, the successor must rebuild review
 state through E1/E2 under its own `{claim-id}` before merge-bound

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -13,9 +13,11 @@ The advisory-review timing defaults used by E14 are named in
 [IDD policy constants](../../docs/policy-constants.md). Refer there when
 you need the values, but keep the phase logic here unchanged.
 
-Apply the shared claim revalidation gate before E9, before the E12 push,
-and before each E13/E14/E15 GitHub side effect (reply, resolve,
-reviewer request, hold comment, or digest update).
+Apply the
+[shared claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate)
+before E9, before the E12 push, and before each E13/E14/E15 GitHub
+side effect (reply, resolve, reviewer request, hold comment, or digest
+update).
 
 ## E9 — Fix accepted issues
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -8,8 +8,8 @@ The final merge-gate timing defaults are named in
 [IDD policy constants](../../docs/policy-constants.md). Use that inventory
 when you need the canonical values; the merge logic itself stays here.
 
-Before any mutating action in F3, apply the shared claim revalidation
-gate. The active claim must still use your current `{claim-id}`.
+Before any mutating action in F3, apply the
+[shared claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 ## F3 — Merge
 

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -132,13 +132,13 @@ Ownership timing in this workflow uses the policy defaults
 
 ## Fail-closed default
 
-IDD gates and pre-checks fail closed when state is ambiguous,
-unresolvable, or otherwise unavailable, unless a gate explicitly opts
-out. Phase files cite this default in the gate description instead of
-restating "fail closed" / "treat as missing" / "default to the safer
-outcome" for every condition. When a phase deliberately opts out
-(e.g., `skipIssueAuthorApprovalGate`), it states the opt-out
-explicitly.
+IDD gates and pre-checks **must** fail closed when state is ambiguous,
+unresolvable, or otherwise unavailable, unless the specific gate
+explicitly opts out. Phase files **should** cite this default in the
+gate description instead of restating "fail closed" / "treat as
+missing" / "default to the safer outcome" for every condition. When a
+phase deliberately opts out (e.g., `skipIssueAuthorApprovalGate`), it
+states the opt-out explicitly.
 
 ## Claim revalidation gate
 

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -130,6 +130,16 @@ Ownership timing in this workflow uses the policy defaults
   `{claim-id}` resets the stale clock. Embed timestamps are ignored;
   only the GitHub `created_at` of the comment itself counts.
 
+## Fail-closed default
+
+IDD gates and pre-checks fail closed when state is ambiguous,
+unresolvable, or otherwise unavailable, unless a gate explicitly opts
+out. Phase files cite this default in the gate description instead of
+restating "fail closed" / "treat as missing" / "default to the safer
+outcome" for every condition. When a phase deliberately opts out
+(e.g., `skipIssueAuthorApprovalGate`), it states the opt-out
+explicitly.
+
 ## Claim revalidation gate
 
 Before any step that can mutate git state or publish GitHub side effects

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -4,8 +4,8 @@ Read this file after the self-review loop passes. It covers
 pre-publication main sync, claim verification, tests, pushing, PR
 creation, and waiting for CI.
 
-Before the D1 rebase and D2 push, apply the shared claim revalidation
-gate. The active claim must still use your current `{claim-id}`.
+Before the D1 rebase and D2 push, apply the
+[shared claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 ## D1 — Sync main before first push
 

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -13,8 +13,8 @@ The merge-gate timing defaults referenced by F2 are named in
 [IDD policy constants](../../docs/policy-constants.md). Use that inventory
 for the canonical values, not as a behavior override.
 
-Before any F-phase mutating action, apply the shared claim revalidation
-gate. The active claim must still use your current `{claim-id}`.
+Before any F-phase mutating action, apply the
+[shared claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 After a forced handoff on an open PR, the successor must rebuild review
 state through E1/E2 under its own `{claim-id}` before merge-bound

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -13,9 +13,11 @@ The advisory-review timing defaults used by E14 are named in
 [IDD policy constants](../../docs/policy-constants.md). Refer there when
 you need the values, but keep the phase logic here unchanged.
 
-Apply the shared claim revalidation gate before E9, before the E12 push,
-and before each E13/E14/E15 GitHub side effect (reply, resolve,
-reviewer request, hold comment, or digest update).
+Apply the
+[shared claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate)
+before E9, before the E12 push, and before each E13/E14/E15 GitHub
+side effect (reply, resolve, reviewer request, hold comment, or digest
+update).
 
 ## E9 — Fix accepted issues
 


### PR DESCRIPTION
## Summary

Adds a new "Fail-closed default" section to
`idd-overview-core.instructions.md` so phase gates can reference one
canonical statement instead of restating
"fail closed" / "treat as missing" / "default to the safer outcome"
for every condition. Phases that deliberately opt out (e.g.,
`skipIssueAuthorApprovalGate`) still state the opt-out explicitly.

Replaces the verbose claim-revalidation prelude in five phase files
with a single-line link to the existing
`idd-overview-core.instructions.md#claim-revalidation-gate` anchor:

- `idd-pre-merge.instructions.md`
- `idd-merge.instructions.md`
- `idd-review-fix.instructions.md`
- `idd-pr-submit.instructions.md`
- (`idd-claim.instructions.md` already cites the gate.)

## Scope deviation from #712

The issue named a ≥ 30-line net reduction across all instruction
files. This PR delivers the foundational structure (canonical
fail-closed + revalidation citations) at roughly net-zero line count:
the new "Fail-closed default" section adds ~10 lines per file × 2
mirrors, and prelude shortening removes ~3 lines × 5 phase files × 2
mirrors. The structural win is having one canonical source for both
rules, which unblocks the planned line reductions in #714 and
follow-up phase trims.

Mirrored into `idd-template/`. `node scripts/audit-docs.mjs --check`
passes.

## Test plan

- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [x] `node scripts/audit-docs.mjs --check` passes.
- [x] `idd-overview-core.instructions.md` has a top-level
      "Fail-closed default" section.
- [x] Each modified phase file links to the revalidation-gate anchor
      instead of restating it.
- [ ] CI green on this PR.

Closes #712