### PR TITLE
feat(idd-overview-core): add cwd-vs-claim revalidation pre-mutation gate

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -293,6 +293,13 @@ current `{agent-id}` / `{claim-id}`, `Branch` to the verified branch,
 worktree`. If multiple marked digests exist, report their URLs and
 continue from the verified claim without editing a digest.
 
+The verified `branch:` field is also the input to the cwd-vs-claim
+check that every later mutation must satisfy. See the
+[Claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate)
+for the full algorithm (stop and report if a mutation would run from
+the primary worktree while the active claim names a non-`main`
+implementation branch).
+
 Then continue to `idd-work.instructions.md`.
 
 ## Claim-state parsing

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -154,26 +154,50 @@ comment, resolve reviews, request reviewers, or merge.
 
 In addition to the `{claim-id}` check, verify that the mutation is
 about to run from the worktree named in the active claim's `branch:`
-field, not from the primary worktree:
+field. This **cwd-vs-claim check** applies only to mutations made
+from inside the implementation worktree contract (B3, D, E phases):
+
+Scope — the check runs **only** when **all** of the following are
+true:
+
+- The active claim's `branch:` field matches the `issue/*` pattern
+  (excluding `roadmap-audit/*` coordination claims, which do not
+  create a worktree).
+- The sibling worktree expected by the B1 naming convention is
+  already present in `git worktree list` (the check does not fire
+  during B1 setup before the worktree exists, or during F4 cleanup
+  after the worktree has been removed by intent).
+
+When in scope, run:
 
 1. Resolve the mutation's working directory:
    `git rev-parse --show-toplevel`.
-2. Resolve the active claim's expected sibling-path form from its
+2. Resolve the expected sibling-path from the active claim's
    `branch:` field, using the B1 naming convention
-   (`../<repo-name>.<normalized-branch>`, with `/` in the branch name
-   replaced by `-`; see
+   (`../<repo-name>.<normalized-branch>`, with `/` in the branch
+   name replaced by `-`; see
    [B1 Worktree creation](idd-work.instructions.md#worktree-creation)).
-3. If the mutation would run from the primary worktree (i.e.,
-   `git rev-parse --git-common-dir` equals `git rev-parse --git-dir`)
-   while the active claim names a non-`main` implementation branch,
-   stop and report. Do not auto-relocate the agent; the operator
-   should investigate (`scripts/idd-doctor.mjs` warns on the same
-   condition) and either remove the stale primary-HEAD branch or
-   rerun B1 cleanly in a fresh worktree.
+3. If the cwd does **not** equal the expected sibling path, stop and
+   report. Do not auto-relocate the agent; the operator should
+   investigate (`scripts/idd-doctor.mjs` warns on the same primary-
+   worktree-HEAD symptom that this gate catches at mutation time) and
+   either remove the stale primary-HEAD branch or rerun B1 cleanly in
+   a fresh worktree.
 
-This check is read-only and pre-mutation. It must run before any push,
-rebase, comment, label change, reply, resolve, reviewer request, or
-merge.
+Out of scope and explicitly **not** blocked:
+
+- B1 setup commands run from the primary worktree on `main` (per the
+  B1 Anti-patterns rule — those commands must keep primary HEAD on
+  `main`).
+- A1.5 roadmap-audit coordination operations (claims whose `branch:`
+  starts with `roadmap-audit/`).
+- F4 post-merge cleanup (the sibling worktree is removed by F4
+  itself; subsequent local `main` updates run from the primary
+  worktree by design).
+
+This check is read-only and pre-mutation. When in scope, it must run
+before any push, rebase, comment, label change, reply, resolve,
+reviewer request, or merge.
 
 A1.5 roadmap completion audit side effects use the roadmap issue itself
 as the claim target (see `idd-roadmap-audit.instructions.md`). Even

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -152,6 +152,29 @@ post further operational comments, and report the handoff or race. If
 loss came from handoff, the displaced session must not push,
 comment, resolve reviews, request reviewers, or merge.
 
+In addition to the `{claim-id}` check, verify that the mutation is
+about to run from the worktree named in the active claim's `branch:`
+field, not from the primary worktree:
+
+1. Resolve the mutation's working directory:
+   `git rev-parse --show-toplevel`.
+2. Resolve the active claim's expected sibling-path form from its
+   `branch:` field, using the B1 naming convention
+   (`../<repo-name>.<normalized-branch>`, with `/` in the branch name
+   replaced by `-`; see
+   [B1 Worktree creation](idd-work.instructions.md#worktree-creation)).
+3. If the mutation would run from the primary worktree (i.e.,
+   `git rev-parse --git-common-dir` equals `git rev-parse --git-dir`)
+   while the active claim names a non-`main` implementation branch,
+   stop and report. Do not auto-relocate the agent; the operator
+   should investigate (`scripts/idd-doctor.mjs` warns on the same
+   condition) and either remove the stale primary-HEAD branch or
+   rerun B1 cleanly in a fresh worktree.
+
+This check is read-only and pre-mutation. It must run before any push,
+rebase, comment, label change, reply, resolve, reviewer request, or
+merge.
+
 A1.5 roadmap completion audit side effects use the roadmap issue itself
 as the claim target (see `idd-roadmap-audit.instructions.md`). Even
 when the audit is GitHub-only and does not create a worktree, claim and

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -293,6 +293,13 @@ current `{agent-id}` / `{claim-id}`, `Branch` to the verified branch,
 worktree`. If multiple marked digests exist, report their URLs and
 continue from the verified claim without editing a digest.
 
+The verified `branch:` field is also the input to the cwd-vs-claim
+check that every later mutation must satisfy. See the
+[Claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate)
+for the full algorithm (stop and report if a mutation would run from
+the primary worktree while the active claim names a non-`main`
+implementation branch).
+
 Then continue to `idd-work.instructions.md`.
 
 ## Claim-state parsing

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -154,26 +154,50 @@ comment, resolve reviews, request reviewers, or merge.
 
 In addition to the `{claim-id}` check, verify that the mutation is
 about to run from the worktree named in the active claim's `branch:`
-field, not from the primary worktree:
+field. This **cwd-vs-claim check** applies only to mutations made
+from inside the implementation worktree contract (B3, D, E phases):
+
+Scope — the check runs **only** when **all** of the following are
+true:
+
+- The active claim's `branch:` field matches the `issue/*` pattern
+  (excluding `roadmap-audit/*` coordination claims, which do not
+  create a worktree).
+- The sibling worktree expected by the B1 naming convention is
+  already present in `git worktree list` (the check does not fire
+  during B1 setup before the worktree exists, or during F4 cleanup
+  after the worktree has been removed by intent).
+
+When in scope, run:
 
 1. Resolve the mutation's working directory:
    `git rev-parse --show-toplevel`.
-2. Resolve the active claim's expected sibling-path form from its
+2. Resolve the expected sibling-path from the active claim's
    `branch:` field, using the B1 naming convention
-   (`../<repo-name>.<normalized-branch>`, with `/` in the branch name
-   replaced by `-`; see
+   (`../<repo-name>.<normalized-branch>`, with `/` in the branch
+   name replaced by `-`; see
    [B1 Worktree creation](idd-work.instructions.md#worktree-creation)).
-3. If the mutation would run from the primary worktree (i.e.,
-   `git rev-parse --git-common-dir` equals `git rev-parse --git-dir`)
-   while the active claim names a non-`main` implementation branch,
-   stop and report. Do not auto-relocate the agent; the operator
-   should investigate (`scripts/idd-doctor.mjs` warns on the same
-   condition) and either remove the stale primary-HEAD branch or
-   rerun B1 cleanly in a fresh worktree.
+3. If the cwd does **not** equal the expected sibling path, stop and
+   report. Do not auto-relocate the agent; the operator should
+   investigate (`scripts/idd-doctor.mjs` warns on the same primary-
+   worktree-HEAD symptom that this gate catches at mutation time) and
+   either remove the stale primary-HEAD branch or rerun B1 cleanly in
+   a fresh worktree.
 
-This check is read-only and pre-mutation. It must run before any push,
-rebase, comment, label change, reply, resolve, reviewer request, or
-merge.
+Out of scope and explicitly **not** blocked:
+
+- B1 setup commands run from the primary worktree on `main` (per the
+  B1 Anti-patterns rule — those commands must keep primary HEAD on
+  `main`).
+- A1.5 roadmap-audit coordination operations (claims whose `branch:`
+  starts with `roadmap-audit/`).
+- F4 post-merge cleanup (the sibling worktree is removed by F4
+  itself; subsequent local `main` updates run from the primary
+  worktree by design).
+
+This check is read-only and pre-mutation. When in scope, it must run
+before any push, rebase, comment, label change, reply, resolve,
+reviewer request, or merge.
 
 A1.5 roadmap completion audit side effects use the roadmap issue itself
 as the claim target (see `idd-roadmap-audit.instructions.md`). Even

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -152,6 +152,29 @@ post further operational comments, and report the handoff or race. If
 loss came from handoff, the displaced session must not push,
 comment, resolve reviews, request reviewers, or merge.
 
+In addition to the `{claim-id}` check, verify that the mutation is
+about to run from the worktree named in the active claim's `branch:`
+field, not from the primary worktree:
+
+1. Resolve the mutation's working directory:
+   `git rev-parse --show-toplevel`.
+2. Resolve the active claim's expected sibling-path form from its
+   `branch:` field, using the B1 naming convention
+   (`../<repo-name>.<normalized-branch>`, with `/` in the branch name
+   replaced by `-`; see
+   [B1 Worktree creation](idd-work.instructions.md#worktree-creation)).
+3. If the mutation would run from the primary worktree (i.e.,
+   `git rev-parse --git-common-dir` equals `git rev-parse --git-dir`)
+   while the active claim names a non-`main` implementation branch,
+   stop and report. Do not auto-relocate the agent; the operator
+   should investigate (`scripts/idd-doctor.mjs` warns on the same
+   condition) and either remove the stale primary-HEAD branch or
+   rerun B1 cleanly in a fresh worktree.
+
+This check is read-only and pre-mutation. It must run before any push,
+rebase, comment, label change, reply, resolve, reviewer request, or
+merge.
+
 A1.5 roadmap completion audit side effects use the roadmap issue itself
 as the claim target (see `idd-roadmap-audit.instructions.md`). Even
 when the audit is GitHub-only and does not create a worktree, claim and


### PR DESCRIPTION
## Summary

Extends the Claim revalidation gate in
`idd-overview-core.instructions.md` with a cwd-vs-claim check so a
session whose primary worktree HEAD drifted off `main` (the recurring
multi-agent failure documented in roadmap #705) cannot push or post
side effects from the wrong location.

The new check runs alongside the existing `{claim-id}` check:

1. Resolve `git rev-parse --show-toplevel` for the mutation cwd.
2. Resolve the active claim's expected sibling-path form from its
   `branch:` field using the B1 naming convention.
3. If cwd is the primary worktree
   (`git rev-parse --git-common-dir` equals `git rev-parse --git-dir`)
   while the active claim names a non-`main` branch, stop and
   report. No auto-relocation. `scripts/idd-doctor.mjs` (#703) warns
   on the same symptom; the operator removes the stale primary-HEAD
   branch or reruns B1 cleanly.

`idd-claim.instructions.md` now points to the gate from its claim
verification close so the verified `branch:` field is documented as
the input.

Mirrored into `idd-template/`.

## Test plan

- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [x] `node scripts/audit-docs.mjs --check` passes.
- [x] Both `idd-overview-core.instructions.md` and
      `idd-claim.instructions.md` document the cwd-vs-claim check
      as part of the revalidation gate.
- [x] Failure mode is stop-and-report (no auto-relocation).
- [ ] CI green on this PR.

Closes #704