### PR TITLE
feat(idd-doctor): warn when primary worktree HEAD is on issue/* or roadmap-audit/*

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -50,9 +50,34 @@ export function runDoctor({ root, requireGithub }) {
   checkHelperRuntimeConfig(root, report)
   checkAgentEntryFiles(root, report)
   checkTemplateVersionSignal(root, report)
+  checkPrimaryWorktreeHead(root, report)
   checkGithubReadiness(root, requireGithub, report)
 
   return report
+}
+
+export function parsePrimaryWorktreePath(porcelain) {
+  const lines = porcelain.split("\n")
+  for (const line of lines) {
+    const match = line.match(/^worktree (.+)$/)
+    if (match) {
+      return match[1]
+    }
+  }
+  return null
+}
+
+export function classifyPrimaryHead(branch) {
+  if (typeof branch !== "string" || branch.length === 0) {
+    return { isB1Violation: false, kind: "unknown" }
+  }
+  if (branch.startsWith("issue/")) {
+    return { isB1Violation: true, kind: "issue" }
+  }
+  if (branch.startsWith("roadmap-audit/")) {
+    return { isB1Violation: true, kind: "roadmap-audit" }
+  }
+  return { isB1Violation: false, kind: "other" }
 }
 
 export function findPlaceholders(text) {
@@ -455,6 +480,37 @@ function checkTemplateVersionSignal(root, report) {
     return
   }
   report.warnings.push("template version signal not found (iddVersion/template version)")
+}
+
+function checkPrimaryWorktreeHead(root, report) {
+  const listResult = runCommand("git", ["worktree", "list", "--porcelain"], root)
+  if (!listResult.ok) {
+    return
+  }
+
+  const primaryPath = parsePrimaryWorktreePath(listResult.stdout)
+  if (!primaryPath) {
+    return
+  }
+
+  const headResult = runCommand("git", ["-C", primaryPath, "rev-parse", "--abbrev-ref", "HEAD"], root)
+  if (!headResult.ok) {
+    return
+  }
+
+  const branch = headResult.stdout.trim()
+  const classification = classifyPrimaryHead(branch)
+  if (!classification.isB1Violation) {
+    return
+  }
+
+  const kindLabel =
+    classification.kind === "issue"
+      ? "an issue branch"
+      : "a roadmap-audit branch"
+  report.warnings.push(
+    `primary worktree HEAD is on ${kindLabel} (${branch}) at ${primaryPath} — likely a past B1 violation. See B1 in .github/instructions/idd-work.instructions.md.`,
+  )
 }
 
 function checkGithubReadiness(root, requireGithub, report) {

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -2,8 +2,10 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import {
+  classifyPrimaryHead,
   extractMarkerPrefixes,
   findPlaceholders,
+  parsePrimaryWorktreePath,
   parseProjectCommandRows,
 } from "../scripts/idd-doctor.mjs"
 
@@ -54,4 +56,51 @@ test("extractMarkerPrefixes returns roadmap and blocked-by prefixes", () => {
 
   assert.deepEqual(markers.roadmap, ["idd-skill", "my-team"])
   assert.deepEqual(markers.blockedBy, ["idd-skill", "MyTeam"])
+})
+
+test("parsePrimaryWorktreePath returns the first worktree entry", () => {
+  const porcelain = [
+    "worktree /repo/idd-skill",
+    "HEAD ec72ee60dea3b9eeeb6ca0d7717daa46b98dcc13",
+    "branch refs/heads/main",
+    "",
+    "worktree /repo/idd-skill.issue-703-foo",
+    "HEAD abc123",
+    "branch refs/heads/issue/703-foo",
+    "",
+  ].join("\n")
+
+  assert.equal(parsePrimaryWorktreePath(porcelain), "/repo/idd-skill")
+})
+
+test("parsePrimaryWorktreePath returns null when input has no worktree line", () => {
+  assert.equal(parsePrimaryWorktreePath(""), null)
+  assert.equal(parsePrimaryWorktreePath("HEAD abc\nbranch main\n"), null)
+})
+
+test("classifyPrimaryHead flags issue/* branches as B1 violations", () => {
+  assert.deepEqual(classifyPrimaryHead("issue/123-foo"), {
+    isB1Violation: true,
+    kind: "issue",
+  })
+})
+
+test("classifyPrimaryHead flags roadmap-audit/* branches as B1 violations", () => {
+  assert.deepEqual(classifyPrimaryHead("roadmap-audit/456-bar"), {
+    isB1Violation: true,
+    kind: "roadmap-audit",
+  })
+})
+
+test("classifyPrimaryHead accepts main as not a violation", () => {
+  assert.deepEqual(classifyPrimaryHead("main"), {
+    isB1Violation: false,
+    kind: "other",
+  })
+})
+
+test("classifyPrimaryHead handles empty or non-string input as unknown", () => {
+  assert.deepEqual(classifyPrimaryHead(""), { isB1Violation: false, kind: "unknown" })
+  assert.deepEqual(classifyPrimaryHead(null), { isB1Violation: false, kind: "unknown" })
+  assert.deepEqual(classifyPrimaryHead(undefined), { isB1Violation: false, kind: "unknown" })
 })


### PR DESCRIPTION
## Summary

Adds `checkPrimaryWorktreeHead` to `scripts/idd-doctor.mjs` so the
doctor surfaces the recurring B1 violation (primary worktree HEAD
drifted off `main` to an implementation branch) as a warning.

The check:

- Resolves the primary worktree via
  `git worktree list --porcelain` (the first entry is always the
  primary).
- Reads the primary HEAD via
  `git -C <primary-path> rev-parse --abbrev-ref HEAD`.
- Emits a warning when HEAD matches `issue/*` or `roadmap-audit/*`,
  naming the primary path, the offending branch, and the B1
  instruction file.

Read-only — no `git switch`, `git checkout`, `git branch`, or
`git worktree` mutations. Exit code is unchanged; the warning is
the signal.

Two helpers (`parsePrimaryWorktreePath`, `classifyPrimaryHead`) are
exported for unit testing; six new tests cover the porcelain parser,
the `issue/*` and `roadmap-audit/*` violation classifications, the
non-violation `main` case, and unknown / non-string inputs.

## Test plan

- [x] `node --test tests/idd-doctor.test.mjs` passes (10/10).
- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [x] `node scripts/audit-docs.mjs --check` passes.
- [x] Running `node scripts/idd-doctor.mjs --repo-root <primary>`
      against a repo where the primary HEAD is `main` produces no
      new warning (verified locally).
- [ ] CI green on this PR.

Closes #703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Development consistency checker now validates the repository's primary worktree HEAD, detecting branches with specific naming conventions and emitting guidance warnings when violations are identified.

* **Tests**
  * Comprehensive test coverage added for branch classification and worktree path detection functionality to ensure reliable operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->