### PR TITLE
refactor(idd-pre-merge): collapse F2 evidence checklist into condition descriptions

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -54,37 +54,15 @@ This check is read-only — F1 does not rebase, merge, or push.
 
 ## F2 — Pre-merge condition check
 
-Verify **all** of the following. If any condition is not met, follow the
-bracketed action:
+Verify **all** of the conditions below. Each condition states the
+evidence it requires and where to route on failure; the F2 snapshot
+at the end of this section records the final activity-universe values
+that the handoff phase consumes.
 
-Before running F3, record explicit F2 evidence for this pass. At
-minimum, capture:
-
-1. Activity-universe snapshot evidence:
-   `{head-SHA}`, `{max-activity-updatedAt|none}`,
-   `{total-item-count}`, `{latest-ci-completed-at|none}`.
-2. Unresolved-thread evidence: total unresolved thread count, the
-   non-awaiting-reviewer unresolved count used by the gate, and whether
-   any AMD (`**Awaiting maintainer decision**`) threads remain.
-3. Unreplied regular-comment evidence: the count of non-IDD-agent
-   comments that still lack a later IDD-agent reply.
-4. Reviewer-state evidence: latest `CHANGES_REQUESTED` status for human,
-   required, and CODEOWNER reviewers, plus required approval/CODEOWNER
-   satisfaction status.
-5. Advisory-wait evidence: current AW outcome (`SATISFIED`/`WAIT`/etc),
-   marker presence (`EARLIEST_SAME_HEAD_AT`), and whether the current
-   state satisfies the advisory gate for merge.
-6. CI evidence: required-check generation state and pass/fail status for
-   all required checks on the current PR HEAD.
-7. E7 disposition evidence: whether each actionable PATH A item and
-   advisory PATH B item has a fresh `**Accepted**`/`**Rejected**`
-   disposition marker, plus the exact missing-thread and
-   missing-regular-comment blocker items when incomplete.
-
-Do not treat "one bot says clean" as sufficient evidence. The checklist
-must cover the full activity universe (human reviewers plus advisory bot
-surfaces such as Copilot, CodeRabbit, Codex connectors, and CI bots) and
-must align with every F2 condition below.
+Do not treat "one bot says clean" as sufficient evidence. The
+condition checks must cover the full activity universe (human
+reviewers plus advisory bot surfaces such as Copilot, CodeRabbit,
+Codex connectors, and CI bots).
 
 - **Review currency** (live re-fetch required, freshness gate): read the
   most recent `<!-- review-watermark: {agent-id} {claim-id} … -->`

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -54,37 +54,15 @@ This check is read-only — F1 does not rebase, merge, or push.
 
 ## F2 — Pre-merge condition check
 
-Verify **all** of the following. If any condition is not met, follow the
-bracketed action:
+Verify **all** of the conditions below. Each condition states the
+evidence it requires and where to route on failure; the F2 snapshot
+at the end of this section records the final activity-universe values
+that the handoff phase consumes.
 
-Before running F3, record explicit F2 evidence for this pass. At
-minimum, capture:
-
-1. Activity-universe snapshot evidence:
-   `{head-SHA}`, `{max-activity-updatedAt|none}`,
-   `{total-item-count}`, `{latest-ci-completed-at|none}`.
-2. Unresolved-thread evidence: total unresolved thread count, the
-   non-awaiting-reviewer unresolved count used by the gate, and whether
-   any AMD (`**Awaiting maintainer decision**`) threads remain.
-3. Unreplied regular-comment evidence: the count of non-IDD-agent
-   comments that still lack a later IDD-agent reply.
-4. Reviewer-state evidence: latest `CHANGES_REQUESTED` status for human,
-   required, and CODEOWNER reviewers, plus required approval/CODEOWNER
-   satisfaction status.
-5. Advisory-wait evidence: current AW outcome (`SATISFIED`/`WAIT`/etc),
-   marker presence (`EARLIEST_SAME_HEAD_AT`), and whether the current
-   state satisfies the advisory gate for merge.
-6. CI evidence: required-check generation state and pass/fail status for
-   all required checks on the current PR HEAD.
-7. E7 disposition evidence: whether each actionable PATH A item and
-   advisory PATH B item has a fresh `**Accepted**`/`**Rejected**`
-   disposition marker, plus the exact missing-thread and
-   missing-regular-comment blocker items when incomplete.
-
-Do not treat "one bot says clean" as sufficient evidence. The checklist
-must cover the full activity universe (human reviewers plus advisory bot
-surfaces such as Copilot, CodeRabbit, Codex connectors, and CI bots) and
-must align with every F2 condition below.
+Do not treat "one bot says clean" as sufficient evidence. The
+condition checks must cover the full activity universe (human
+reviewers plus advisory bot surfaces such as Copilot, CodeRabbit,
+Codex connectors, and CI bots).
 
 - **Review currency** (live re-fetch required, freshness gate): read the
   most recent `<!-- review-watermark: {agent-id} {claim-id} … -->`


### PR DESCRIPTION
## Summary

Removes the 7-item F2 evidence bullet list (Activity-universe,
Unresolved-thread, Unreplied regular-comment, Reviewer-state,
Advisory-wait, CI, E7 disposition) that duplicated what each F2
condition already states in its own body. The F2 intro now points
at the per-condition descriptions directly, and the bot-coverage
warning ("Do not treat 'one bot says clean'...") stays as a single
reminder paragraph.

The F2 snapshot output paragraph at the end of the section, the
condition-level evidence requirements, and all routing rules remain
unchanged.

Net change: -22 lines per mirror (live + template), -44 lines total.
Slightly below the 25-line-per-file target stated in #714 because
the duplicated checklist was the single biggest win and the
remaining conditions still need their full evidence descriptions to
be self-contained.

Mirrored into `idd-template/`. `audit-docs --check` passes.

## Test plan

- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [x] `node scripts/audit-docs.mjs --check` passes.
- [x] F2 evidence checklist is gone; each F2 condition still
      specifies its evidence and routing.
- [x] F2 snapshot output paragraph (`{f2-head-SHA}` etc.) remains.
- [ ] CI green on this PR.

Closes #714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development process documentation to clarify verification requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->