### PR TITLE
refactor(idd-instructions): convert awaiting-reviewer + Step 1.5 prose to compact decision tables

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -401,58 +401,27 @@ If **no issue** survives the gate:
 
 ### Step 1.5 — Active-claim pre-scan
 
-**Purpose**: Reduce thundering-herd collisions in scale-out deployments by
-identifying and skipping issues that are already claimed by other sessions.
+Before selecting from the surviving viable issues, eliminate
+candidates that already carry a concurrent active non-stale claim,
+in ascending issue-number order:
 
-Before selecting from the surviving viable issues, perform an
-**active-claim pre-scan** to eliminate candidates with concurrent claims:
+- Scan the **top N** survivors (ordered by ascending issue number),
+  where `N` is `.github/idd/config.json`
+  `discover.activeClaimPreScanBatchSize` (distributed default: `10`).
+- For each candidate, fetch the issue and parse comments per the
+  shared claim-state rules. A candidate is **ineligible** when a
+  trusted `claimed-by` comment exists with GitHub `created_at`
+  newer than the `claim-stale-age` policy default
+  (`docs/policy-constants.md`; distributed default: `24 h`).
+  Otherwise the candidate **remains eligible**.
 
-1. **Identify scan scope**: From the viable survivors (ordered by ascending
-   issue number), define the scan set as the **top N candidates** (or fewer if
-   fewer than N viable candidates exist). `N` comes from
-   `.github/idd/config.json` `discover.activeClaimPreScanBatchSize`
-   (distributed default: `10`).
+After scanning the current batch:
 
-2. **Scan each candidate for active claims**: For each issue in the scan set,
-   in ascending issue number order:
-
-   - **Fetch the issue** and parse its comments using the shared claim-state
-     rules (defined in `idd-claim.instructions.md`).
-   - **Detect active non-stale claims**: Use the `claim-stale-age` policy
-     default from `docs/policy-constants.md` (distributed default: `24 h`).
-     An issue has an **active non-stale claim** if:
-     - A trusted `claimed-by` comment exists, and
-     - That comment's GitHub `created_at` timestamp is **less than** the
-       `claim-stale-age` threshold (e.g., created less than 24 hours ago), and
-     - The comment matches the `claimed-by` format defined in
-       `idd-claim.instructions.md`.
-
-   - **Remove claimed candidates**: If an active non-stale claim is detected,
-     **mark this candidate as ineligible** and proceed to the next issue in
-     the scan set.
-
-   - **Skip stale or unclaimed candidates**: If the latest `claimed-by`
-     comment is stale (≥ 24 h old) or no claim exists, this candidate
-     **remains eligible**.
-
-3. **Determine selection candidate**: After scanning the top N:
-
-   - **If at least one eligible (unclaimed) candidate remains** in the scan
-     set: proceed to **Step 2** and select the lowest-numbered eligible
-     candidate.
-
-   - **If all top N are claimed**: the scan set is fully saturated with
-     concurrent work. Proceed to **Step 2** with the **next batch**: scan
-     candidates `N+1`–`2N`, then `2N+1`–`3N`, and so on, until an
-     unclaimed candidate is found or the viable candidate set is
-     exhausted.
-
-   - **If the entire viable candidate set is exhausted** (all issues up to the
-     highest viable candidate are claimed): report that all viable issues are
-     currently claimed by other sessions, then stop. Do not post
-     `unclaimed-by` because no claim was made. This is not an abort; the
-     session may retry Discover later if new viable candidates appear or
-     claims become stale.
+| Batch outcome                                                                       | Action                                                                                                                                                                                                  |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| At least one eligible candidate in the batch                                        | Proceed to Step 2 and pick the lowest-numbered eligible candidate.                                                                                                                                      |
+| All `N` in this batch are claimed but viable survivors remain                       | Continue with the next batch (`N+1`–`2N`, then `2N+1`–`3N`, …) until an eligible candidate is found.                                                                                                    |
+| Entire viable candidate set exhausted (all surviving viable candidates are claimed) | Report that all viable issues are currently claimed; stop. Do not post `unclaimed-by` (no claim was made). Not an abort; retry later when claims may have become stale or new viable candidates appear. |
 
 See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
 for why this pre-scan exists.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -409,11 +409,15 @@ in ascending issue-number order:
   where `N` is `.github/idd/config.json`
   `discover.activeClaimPreScanBatchSize` (distributed default: `10`).
 - For each candidate, fetch the issue and parse comments per the
-  shared claim-state rules. A candidate is **ineligible** when a
-  trusted `claimed-by` comment exists with GitHub `created_at`
+  shared claim-state rules in `idd-claim.instructions.md`. A
+  candidate is **ineligible** when parsing yields an **active claim**
+  whose latest valid `claimed-by` comment (matching the documented
+  format, authored by a trusted marker actor) has GitHub `created_at`
   newer than the `claim-stale-age` policy default
   (`docs/policy-constants.md`; distributed default: `24 h`).
-  Otherwise the candidate **remains eligible**.
+  Otherwise (no active claim, the active claim is already stale, or
+  no comment satisfies the trusted-marker + format requirements) the
+  candidate **remains eligible**.
 
 After scanning the current batch:
 

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -198,6 +198,7 @@ Codex connectors, and CI bots).
   | Latest substantive comment is from an IDD agent or the PR author **and** no later reviewer comment **and** no later reviewer reopen **and** no AMD reply | `awaiting-reviewer`         |
   | Thread contains an IDD-agent reply starting with `**Awaiting maintainer decision**`                                                                      | `AMD-thread` (not awaiting) |
   | Reviewer added a comment or reopened (with or without new text) after the latest IDD-agent/PR-author comment                                             | `not awaiting-reviewer`     |
+  | Latest substantive comment is from a reviewer (no IDD-agent or PR-author reply yet)                                                                      | `not awaiting-reviewer`     |
 
   `→ return to review triage` if any non-awaiting-reviewer (including
   AMD-thread) unresolved threads remain — E6 will detect any pending

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -191,35 +191,30 @@ Codex connectors, and CI bots).
   window completes.
 - **Unresolved threads = 0** (backlog gate, orthogonal to the currency
   check above): No unresolved review threads remain, excluding
-  **awaiting-reviewer threads**. A thread is awaiting-reviewer if
-  **all** of the following hold: (1) the latest substantive thread
-  comment is from any IDD agent or the PR author; (2) no reviewer has
-  added a comment after that latest IDD-agent/PR-author comment; (3) the
-  reviewer has **not** reopened the thread after that latest comment — a
-  reopen action with no new text still counts as reviewer activity and
-  disqualifies the thread from awaiting-reviewer status; (4) the thread
-  does **not** contain an IDD-agent reply starting with
-  `**Awaiting maintainer decision**`. (→ return to review triage if any
-  non-awaiting-reviewer unresolved threads remain). Any remaining
-  unresolved thread that is not awaiting-reviewer indicates a new
-  reviewer comment or a thread the reviewer reopened — both require
-  attention. Exception: if the repo's branch protection requires
-  conversation resolution, the awaiting-reviewer exclusion does not
-  apply — all unresolved awaiting-reviewer threads must be resolved.
-  Note: AMD threads (those containing an IDD agent reply starting with
-  `**Awaiting maintainer decision**`) are **not** awaiting-reviewer by
-  definition; they are handled by the standard "non-awaiting-reviewer →
-  return to review triage" path, where E6 will detect the pending
-  maintainer response and post a hold. For each remaining unresolved
-  awaiting-reviewer thread under this exception: **(a)** if its latest
-  reply is from an **IDD agent** and it does **NOT** contain an AMD
-  reply — resolve it directly (direct resolution is permitted under this
-  constraint), then restart F2 from the beginning; **(b)** if the latest
-  reply is from the **PR author** (not an IDD agent) — post a brief
-  acknowledgement reply (e.g., "Acknowledging thread state to satisfy
-  conversation-resolution requirement") then resolve it directly, then
-  restart F2. Do **not** route to E1; E1 filters out awaiting-reviewer
-  threads and would surface no actionable item.
+  **awaiting-reviewer threads**. Classify each unresolved thread:
+
+  | Condition                                                                                                                                                | Classification              |
+  | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+  | Latest substantive comment is from an IDD agent or the PR author **and** no later reviewer comment **and** no later reviewer reopen **and** no AMD reply | `awaiting-reviewer`         |
+  | Thread contains an IDD-agent reply starting with `**Awaiting maintainer decision**`                                                                      | `AMD-thread` (not awaiting) |
+  | Reviewer added a comment or reopened (with or without new text) after the latest IDD-agent/PR-author comment                                             | `not awaiting-reviewer`     |
+
+  `→ return to review triage` if any non-awaiting-reviewer (including
+  AMD-thread) unresolved threads remain — E6 will detect any pending
+  maintainer response and post a hold.
+
+  Exception: if the repo's branch protection requires conversation
+  resolution, the awaiting-reviewer exclusion does not apply and all
+  unresolved awaiting-reviewer threads must be resolved here. For each
+  remaining unresolved awaiting-reviewer thread under that exception:
+
+  | Latest reply author                        | Action                                                                                                                                                         |
+  | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | IDD agent (and no AMD reply on the thread) | resolve directly, then restart F2 from the beginning                                                                                                           |
+  | PR author (not an IDD agent)               | post a brief acknowledgement reply (e.g., "Acknowledging thread state to satisfy conversation-resolution requirement"), then resolve directly, then restart F2 |
+
+  Do **not** route to E1; E1 filters out awaiting-reviewer threads
+  and would surface no actionable item.
 - **Unreplied comments = 0**: No regular comment from a non-IDD-agent
   lacks a subsequent IDD-agent comment — where "subsequent" means any
   IDD-agent regular comment posted at a strictly later timestamp than

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -428,11 +428,15 @@ in ascending issue-number order:
   where `N` is `.github/idd/config.json`
   `discover.activeClaimPreScanBatchSize` (distributed default: `10`).
 - For each candidate, fetch the issue and parse comments per the
-  shared claim-state rules. A candidate is **ineligible** when a
-  trusted `claimed-by` comment exists with GitHub `created_at`
+  shared claim-state rules in `idd-claim.instructions.md`. A
+  candidate is **ineligible** when parsing yields an **active claim**
+  whose latest valid `claimed-by` comment (matching the documented
+  format, authored by a trusted marker actor) has GitHub `created_at`
   newer than the `claim-stale-age` policy default
   (`docs/policy-constants.md`; distributed default: `24 h`).
-  Otherwise the candidate **remains eligible**.
+  Otherwise (no active claim, the active claim is already stale, or
+  no comment satisfies the trusted-marker + format requirements) the
+  candidate **remains eligible**.
 
 After scanning the current batch:
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -420,58 +420,27 @@ If **no issue** survives the gate:
 
 ### Step 1.5 — Active-claim pre-scan
 
-**Purpose**: Reduce thundering-herd collisions in scale-out deployments by
-identifying and skipping issues that are already claimed by other sessions.
+Before selecting from the surviving viable issues, eliminate
+candidates that already carry a concurrent active non-stale claim,
+in ascending issue-number order:
 
-Before selecting from the surviving viable issues, perform an
-**active-claim pre-scan** to eliminate candidates with concurrent claims:
+- Scan the **top N** survivors (ordered by ascending issue number),
+  where `N` is `.github/idd/config.json`
+  `discover.activeClaimPreScanBatchSize` (distributed default: `10`).
+- For each candidate, fetch the issue and parse comments per the
+  shared claim-state rules. A candidate is **ineligible** when a
+  trusted `claimed-by` comment exists with GitHub `created_at`
+  newer than the `claim-stale-age` policy default
+  (`docs/policy-constants.md`; distributed default: `24 h`).
+  Otherwise the candidate **remains eligible**.
 
-1. **Identify scan scope**: From the viable survivors (ordered by ascending
-   issue number), define the scan set as the **top N candidates** (or fewer if
-   fewer than N viable candidates exist). `N` comes from
-   `.github/idd/config.json` `discover.activeClaimPreScanBatchSize`
-   (distributed default: `10`).
+After scanning the current batch:
 
-2. **Scan each candidate for active claims**: For each issue in the scan set,
-   in ascending issue number order:
-
-   - **Fetch the issue** and parse its comments using the shared claim-state
-     rules (defined in `idd-claim.instructions.md`).
-   - **Detect active non-stale claims**: Use the `claim-stale-age` policy
-     default from `docs/policy-constants.md` (distributed default: `24 h`).
-     An issue has an **active non-stale claim** if:
-     - A trusted `claimed-by` comment exists, and
-     - That comment's GitHub `created_at` timestamp is **less than** the
-       `claim-stale-age` threshold (e.g., created less than 24 hours ago), and
-     - The comment matches the `claimed-by` format defined in
-       `idd-claim.instructions.md`.
-
-   - **Remove claimed candidates**: If an active non-stale claim is detected,
-     **mark this candidate as ineligible** and proceed to the next issue in
-     the scan set.
-
-   - **Skip stale or unclaimed candidates**: If the latest `claimed-by`
-     comment is stale (≥ 24 h old) or no claim exists, this candidate
-     **remains eligible**.
-
-3. **Determine selection candidate**: After scanning the top N:
-
-   - **If at least one eligible (unclaimed) candidate remains** in the scan
-     set: proceed to **Step 2** and select the lowest-numbered eligible
-     candidate.
-
-   - **If all top N are claimed**: the scan set is fully saturated with
-     concurrent work. Proceed to **Step 2** with the **next batch**: scan
-     candidates `N+1`–`2N`, then `2N+1`–`3N`, and so on, until an
-     unclaimed candidate is found or the viable candidate set is
-     exhausted.
-
-   - **If the entire viable candidate set is exhausted** (all issues up to the
-     highest viable candidate are claimed): report that all viable issues are
-     currently claimed by other sessions, then stop. Do not post
-     `unclaimed-by` because no claim was made. This is not an abort; the
-     session may retry Discover later if new viable candidates appear or
-     claims become stale.
+| Batch outcome                                                                       | Action                                                                                                                                                                                                  |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| At least one eligible candidate in the batch                                        | Proceed to Step 2 and pick the lowest-numbered eligible candidate.                                                                                                                                      |
+| All `N` in this batch are claimed but viable survivors remain                       | Continue with the next batch (`N+1`–`2N`, then `2N+1`–`3N`, …) until an eligible candidate is found.                                                                                                    |
+| Entire viable candidate set exhausted (all surviving viable candidates are claimed) | Report that all viable issues are currently claimed; stop. Do not post `unclaimed-by` (no claim was made). Not an abort; retry later when claims may have become stale or new viable candidates appear. |
 
 See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
 for why this pre-scan exists.

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -198,6 +198,7 @@ Codex connectors, and CI bots).
   | Latest substantive comment is from an IDD agent or the PR author **and** no later reviewer comment **and** no later reviewer reopen **and** no AMD reply | `awaiting-reviewer`         |
   | Thread contains an IDD-agent reply starting with `**Awaiting maintainer decision**`                                                                      | `AMD-thread` (not awaiting) |
   | Reviewer added a comment or reopened (with or without new text) after the latest IDD-agent/PR-author comment                                             | `not awaiting-reviewer`     |
+  | Latest substantive comment is from a reviewer (no IDD-agent or PR-author reply yet)                                                                      | `not awaiting-reviewer`     |
 
   `→ return to review triage` if any non-awaiting-reviewer (including
   AMD-thread) unresolved threads remain — E6 will detect any pending

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -191,35 +191,30 @@ Codex connectors, and CI bots).
   window completes.
 - **Unresolved threads = 0** (backlog gate, orthogonal to the currency
   check above): No unresolved review threads remain, excluding
-  **awaiting-reviewer threads**. A thread is awaiting-reviewer if
-  **all** of the following hold: (1) the latest substantive thread
-  comment is from any IDD agent or the PR author; (2) no reviewer has
-  added a comment after that latest IDD-agent/PR-author comment; (3) the
-  reviewer has **not** reopened the thread after that latest comment — a
-  reopen action with no new text still counts as reviewer activity and
-  disqualifies the thread from awaiting-reviewer status; (4) the thread
-  does **not** contain an IDD-agent reply starting with
-  `**Awaiting maintainer decision**`. (→ return to review triage if any
-  non-awaiting-reviewer unresolved threads remain). Any remaining
-  unresolved thread that is not awaiting-reviewer indicates a new
-  reviewer comment or a thread the reviewer reopened — both require
-  attention. Exception: if the repo's branch protection requires
-  conversation resolution, the awaiting-reviewer exclusion does not
-  apply — all unresolved awaiting-reviewer threads must be resolved.
-  Note: AMD threads (those containing an IDD agent reply starting with
-  `**Awaiting maintainer decision**`) are **not** awaiting-reviewer by
-  definition; they are handled by the standard "non-awaiting-reviewer →
-  return to review triage" path, where E6 will detect the pending
-  maintainer response and post a hold. For each remaining unresolved
-  awaiting-reviewer thread under this exception: **(a)** if its latest
-  reply is from an **IDD agent** and it does **NOT** contain an AMD
-  reply — resolve it directly (direct resolution is permitted under this
-  constraint), then restart F2 from the beginning; **(b)** if the latest
-  reply is from the **PR author** (not an IDD agent) — post a brief
-  acknowledgement reply (e.g., "Acknowledging thread state to satisfy
-  conversation-resolution requirement") then resolve it directly, then
-  restart F2. Do **not** route to E1; E1 filters out awaiting-reviewer
-  threads and would surface no actionable item.
+  **awaiting-reviewer threads**. Classify each unresolved thread:
+
+  | Condition                                                                                                                                                | Classification              |
+  | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+  | Latest substantive comment is from an IDD agent or the PR author **and** no later reviewer comment **and** no later reviewer reopen **and** no AMD reply | `awaiting-reviewer`         |
+  | Thread contains an IDD-agent reply starting with `**Awaiting maintainer decision**`                                                                      | `AMD-thread` (not awaiting) |
+  | Reviewer added a comment or reopened (with or without new text) after the latest IDD-agent/PR-author comment                                             | `not awaiting-reviewer`     |
+
+  `→ return to review triage` if any non-awaiting-reviewer (including
+  AMD-thread) unresolved threads remain — E6 will detect any pending
+  maintainer response and post a hold.
+
+  Exception: if the repo's branch protection requires conversation
+  resolution, the awaiting-reviewer exclusion does not apply and all
+  unresolved awaiting-reviewer threads must be resolved here. For each
+  remaining unresolved awaiting-reviewer thread under that exception:
+
+  | Latest reply author                        | Action                                                                                                                                                         |
+  | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | IDD agent (and no AMD reply on the thread) | resolve directly, then restart F2 from the beginning                                                                                                           |
+  | PR author (not an IDD agent)               | post a brief acknowledgement reply (e.g., "Acknowledging thread state to satisfy conversation-resolution requirement"), then resolve directly, then restart F2 |
+
+  Do **not** route to E1; E1 filters out awaiting-reviewer threads
+  and would surface no actionable item.
 - **Unreplied comments = 0**: No regular comment from a non-IDD-agent
   lacks a subsequent IDD-agent comment — where "subsequent" means any
   IDD-agent regular comment posted at a strictly later timestamp than


### PR DESCRIPTION
## Summary

Replaces two verbose prose blocks with tables that preserve every
routing decision but trim duplicated discussion:

- `idd-pre-merge.instructions.md` "Unresolved threads = 0":
  awaiting-reviewer classification (4-condition AND + AMD exception)
  becomes a single classification table; the branch-protection
  exception's two sub-cases (IDD-agent vs PR-author latest reply)
  become a small action table.
- `idd-discover.instructions.md` Step 1.5 active-claim pre-scan:
  introductory bullets cover scan scope and per-candidate
  eligibility; a 3-row batch-outcome table replaces the
  "Identify scan scope / Scan each candidate / Determine selection
  candidate" prose. The rationale link to
  `docs/idd-design-rationale.md` already added by #711 stays in
  place.

Net change across the four files (live + template, pre-merge +
discover): **-72 lines** (90 insertions vs 162 deletions). Every
routing destination and exception remains reachable from the new
table representation.

Mirrored into `idd-template/`. `audit-docs --check` and all linters
pass.

## Test plan

- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [x] `node scripts/audit-docs.mjs --check` passes.
- [x] Pre-merge awaiting-reviewer determination is a single
      classification table + an exception-action table.
- [x] Discover Step 1.5 uses bullets + one batch-outcome decision
      table.
- [ ] CI green on this PR.

Closes #715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote the Active-claim pre-scan guidance into a compact description with a batch-outcome table; clarifies scanning the top N candidates and marking those with a recent active claim as ineligible.
  * Specifies batch progression rules and behavior when all viable candidates are claimed or exhausted.
  * Clarified F2 “Unresolved threads = 0” with a three-category classification table.
  * Added explicit per-thread conversation-resolution actions and routing behavior for non-awaiting-reviewer threads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->