### PR TITLE
feat(idd): hide superseded operational markers at post time

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -41,4 +41,5 @@ words:
   - unpushed
   - unreplied
   - Esync
+  - minimizable
   - waivable

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -188,6 +188,35 @@ Rules:
 - advisory clock starts from marker comment `created_at`
 - if marker cannot be posted/read, route to `AW4` recovery-failed hold
 
+### AW3-H — Hide superseded advisory-wait markers
+
+After any new `advisory-wait` or `advisory-wait-recovery` marker is
+verified to exist on GitHub for the current `PR_HEAD_SHA`, minimize
+every trusted prior `advisory-wait*` marker on this PR whose embedded
+HEAD SHA does **not** match the current `PR_HEAD_SHA` as `OUTDATED`.
+The current-HEAD wait clock no longer needs the prior-HEAD markers
+to be visible, and hiding them reduces F4 backlog and review-page
+noise.
+
+Find candidate subject IDs (trusted `advisory-wait*` markers whose
+embedded SHA differs from `PR_HEAD_SHA`), then call:
+
+```sh
+node scripts/minimize-superseded-markers.mjs \
+  --subject-ids "<id1>,<id2>,..." \
+  --classifier OUTDATED \
+  --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>" \
+  --apply
+```
+
+Skip this step entirely if the new marker was not verified on
+GitHub, the candidate set is empty (no prior-HEAD trusted markers),
+or the helper is unavailable — F4 cleanup still catches them later.
+
+Never hide a marker for the **current** `PR_HEAD_SHA`. The
+`EARLIEST_SAME_HEAD_AT` anchor in AW2 relies on at least one
+visible same-head marker.
+
 ### AW4 — Hold templates
 
 #### Pending refresh failed

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -285,6 +285,40 @@ forced-handoff evidence in the issue digest or resume report's
 `Authoritative by` field. Do not invent ad hoc `claimed-by` fields and
 do not reuse the displaced `{claim-id}`.
 
+### Hide displaced claim chain on takeover
+
+When the verified new claim was posted with `supersedes: <prior-id>`
+(stale takeover, legacy migration with prior-id, or forced-handoff
+recovery), minimize the displaced claim's marker chain on the issue
+as `OUTDATED` after this session has recorded its own verified
+`{claim-id}`. Find every trusted `claimed-by` / `unclaimed-by` /
+heartbeat comment whose embedded `{claim-id}` equals `<prior-id>`
+and call:
+
+```sh
+node scripts/minimize-superseded-markers.mjs \
+  --subject-ids "<id1>,<id2>,..." \
+  --classifier OUTDATED \
+  --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>" \
+  --apply
+```
+
+Skip this step entirely if:
+
+- the new claim has `supersedes: none` (fresh claim — there is no
+  displaced chain to hide);
+- the takeover claim was not verified (do not hide the prior chain
+  until the successor is observable as the active claim);
+- the candidate set is empty (no trusted markers carry the prior
+  `{claim-id}`);
+- the helper is unavailable. Subsequent F4 cleanup still picks up
+  any missed candidates.
+
+**Do not** hide a same-`{claim-id}` heartbeat chain from a normal
+heartbeat post; heartbeats refresh the stale clock but do not
+supersede prior markers, and the visible heartbeat chain is the
+active-claim audit trail.
+
 After claim verification, upsert the issue live status digest when there
 is exactly one marked digest or none. Use the verified `claimed-by`
 comment as the authority: set `Phase` to `A5 claimed`, `Claim` to the

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -288,9 +288,11 @@ do not reuse the displaced `{claim-id}`.
 ### Hide displaced claim chain on takeover
 
 When the verified new claim was posted with `supersedes: <prior-id>`
-(stale takeover, legacy migration with prior-id, or forced-handoff
-recovery), minimize the displaced claim's marker chain on the issue
-as `OUTDATED` after this session has recorded its own verified
+naming a concrete prior `{claim-id}` (stale takeover or forced-handoff
+recovery; **not** the legacy-migration path, which always uses
+`supersedes: none` per the Legacy claim migration section below),
+minimize the displaced claim's marker chain on the issue as
+`OUTDATED` after this session has recorded its own verified
 `{claim-id}`. Find every trusted `claimed-by` / `unclaimed-by` /
 heartbeat comment whose embedded `{claim-id}` equals `<prior-id>`
 and call:

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -116,6 +116,31 @@ markers. Do not delete, hide, minimize, or otherwise unmark them on an
 open PR to "clear" state; ignore them and rerun E1 under the successor
 claim instead.
 
+**Hide superseded same-claim watermarks.** After the new watermark is
+verified to exist on GitHub, minimize every strictly older trusted
+**same-claim** `review-watermark` and `review-baseline` comment on
+this PR as `OUTDATED`. The new watermark covers their data, and
+hiding them reduces F4 backlog and review-page noise.
+
+Find candidate subject IDs (trusted same-claim watermarks older than
+the new one), then call:
+
+```sh
+node scripts/minimize-superseded-markers.mjs \
+  --subject-ids "<id1>,<id2>,..." \
+  --classifier OUTDATED \
+  --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>" \
+  --apply
+```
+
+Skip this step entirely if the new watermark was not verified to
+exist on GitHub, the candidate set is empty, or the helper is
+unavailable — F4 cleanup still catches the superseded markers later.
+
+Different-claim watermarks (forced-handoff successors, takeovers)
+must not be hidden here — that is covered separately by the claim
+takeover hide path in `idd-claim.instructions.md`.
+
 Do not create or edit the PR live status digest after posting this
 watermark unless the next route is to E1, to an F3 blocked reroute that
 leaves the F2 restart path (F1/D4), to a hold/stop, or to post-merge

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -56,6 +56,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/live-status-digest.mjs` for issue or PR live status digest
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
+- `scripts/minimize-superseded-markers.mjs` for in-flight per-marker
+  `minimizeComment` of strictly superseded `review-watermark`,
+  `advisory-wait`, or `claimed-by` markers — called by E1 (Step 2),
+  advisory-wait AW3-H, and claim takeover after the replacement
+  marker is verified
 - `scripts/review-disposition-verify.mjs` for read-only E7 disposition
   marker presence verification across PATH A and PATH B items
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -188,6 +188,35 @@ Rules:
 - advisory clock starts from marker comment `created_at`
 - if marker cannot be posted/read, route to `AW4` recovery-failed hold
 
+### AW3-H — Hide superseded advisory-wait markers
+
+After any new `advisory-wait` or `advisory-wait-recovery` marker is
+verified to exist on GitHub for the current `PR_HEAD_SHA`, minimize
+every trusted prior `advisory-wait*` marker on this PR whose embedded
+HEAD SHA does **not** match the current `PR_HEAD_SHA` as `OUTDATED`.
+The current-HEAD wait clock no longer needs the prior-HEAD markers
+to be visible, and hiding them reduces F4 backlog and review-page
+noise.
+
+Find candidate subject IDs (trusted `advisory-wait*` markers whose
+embedded SHA differs from `PR_HEAD_SHA`), then call:
+
+```sh
+node scripts/minimize-superseded-markers.mjs \
+  --subject-ids "<id1>,<id2>,..." \
+  --classifier OUTDATED \
+  --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>" \
+  --apply
+```
+
+Skip this step entirely if the new marker was not verified on
+GitHub, the candidate set is empty (no prior-HEAD trusted markers),
+or the helper is unavailable — F4 cleanup still catches them later.
+
+Never hide a marker for the **current** `PR_HEAD_SHA`. The
+`EARLIEST_SAME_HEAD_AT` anchor in AW2 relies on at least one
+visible same-head marker.
+
 ### AW4 — Hold templates
 
 #### Pending refresh failed

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -285,6 +285,40 @@ forced-handoff evidence in the issue digest or resume report's
 `Authoritative by` field. Do not invent ad hoc `claimed-by` fields and
 do not reuse the displaced `{claim-id}`.
 
+### Hide displaced claim chain on takeover
+
+When the verified new claim was posted with `supersedes: <prior-id>`
+(stale takeover, legacy migration with prior-id, or forced-handoff
+recovery), minimize the displaced claim's marker chain on the issue
+as `OUTDATED` after this session has recorded its own verified
+`{claim-id}`. Find every trusted `claimed-by` / `unclaimed-by` /
+heartbeat comment whose embedded `{claim-id}` equals `<prior-id>`
+and call:
+
+```sh
+node scripts/minimize-superseded-markers.mjs \
+  --subject-ids "<id1>,<id2>,..." \
+  --classifier OUTDATED \
+  --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>" \
+  --apply
+```
+
+Skip this step entirely if:
+
+- the new claim has `supersedes: none` (fresh claim — there is no
+  displaced chain to hide);
+- the takeover claim was not verified (do not hide the prior chain
+  until the successor is observable as the active claim);
+- the candidate set is empty (no trusted markers carry the prior
+  `{claim-id}`);
+- the helper is unavailable. Subsequent F4 cleanup still picks up
+  any missed candidates.
+
+**Do not** hide a same-`{claim-id}` heartbeat chain from a normal
+heartbeat post; heartbeats refresh the stale clock but do not
+supersede prior markers, and the visible heartbeat chain is the
+active-claim audit trail.
+
 After claim verification, upsert the issue live status digest when there
 is exactly one marked digest or none. Use the verified `claimed-by`
 comment as the authority: set `Phase` to `A5 claimed`, `Claim` to the

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -288,9 +288,11 @@ do not reuse the displaced `{claim-id}`.
 ### Hide displaced claim chain on takeover
 
 When the verified new claim was posted with `supersedes: <prior-id>`
-(stale takeover, legacy migration with prior-id, or forced-handoff
-recovery), minimize the displaced claim's marker chain on the issue
-as `OUTDATED` after this session has recorded its own verified
+naming a concrete prior `{claim-id}` (stale takeover or forced-handoff
+recovery; **not** the legacy-migration path, which always uses
+`supersedes: none` per the Legacy claim migration section below),
+minimize the displaced claim's marker chain on the issue as
+`OUTDATED` after this session has recorded its own verified
 `{claim-id}`. Find every trusted `claimed-by` / `unclaimed-by` /
 heartbeat comment whose embedded `{claim-id}` equals `<prior-id>`
 and call:

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -116,6 +116,31 @@ markers. Do not delete, hide, minimize, or otherwise unmark them on an
 open PR to "clear" state; ignore them and rerun E1 under the successor
 claim instead.
 
+**Hide superseded same-claim watermarks.** After the new watermark is
+verified to exist on GitHub, minimize every strictly older trusted
+**same-claim** `review-watermark` and `review-baseline` comment on
+this PR as `OUTDATED`. The new watermark covers their data, and
+hiding them reduces F4 backlog and review-page noise.
+
+Find candidate subject IDs (trusted same-claim watermarks older than
+the new one), then call:
+
+```sh
+node scripts/minimize-superseded-markers.mjs \
+  --subject-ids "<id1>,<id2>,..." \
+  --classifier OUTDATED \
+  --trusted-marker-logins "<trusted-login-1>,<trusted-login-2>" \
+  --apply
+```
+
+Skip this step entirely if the new watermark was not verified to
+exist on GitHub, the candidate set is empty, or the helper is
+unavailable — F4 cleanup still catches the superseded markers later.
+
+Different-claim watermarks (forced-handoff successors, takeovers)
+must not be hidden here — that is covered separately by the claim
+takeover hide path in `idd-claim.instructions.md`.
+
 Do not create or edit the PR live status digest after posting this
 watermark unless the next route is to E1, to an F3 blocked reroute that
 leaves the F2 restart path (F1/D4), to a hold/stop, or to post-merge

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -56,6 +56,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/live-status-digest.mjs` for issue or PR live status digest
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
+- `scripts/minimize-superseded-markers.mjs` for in-flight per-marker
+  `minimizeComment` of strictly superseded `review-watermark`,
+  `advisory-wait`, or `claimed-by` markers — called by E1 (Step 2),
+  advisory-wait AW3-H, and claim takeover after the replacement
+  marker is verified
 - `scripts/review-disposition-verify.mjs` for read-only E7 disposition
   marker presence verification across PATH A and PATH B items
 

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -2,12 +2,22 @@
 
 import { execFileSync } from "node:child_process"
 
-import { normalizeTrustedMarkerLogins } from "./protocol-helpers.mjs"
-
 const ALLOWED_CLASSIFIERS = new Set(["OUTDATED", "RESOLVED"])
+const ALLOWED_FORMATS = new Set(["json", "table"])
+const MINIMIZABLE_TYPENAMES = new Set([
+  "IssueComment",
+  "PullRequestReview",
+  "PullRequestReviewComment",
+])
 
 if (isMainModule(import.meta.url)) {
-  const args = parseArgs(process.argv.slice(2))
+  let args
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(`error: ${error.message}`)
+    process.exit(2)
+  }
 
   if (args.help) {
     printUsage()
@@ -21,16 +31,32 @@ if (isMainModule(import.meta.url)) {
     process.exit(2)
   }
 
+  if (!ALLOWED_FORMATS.has(args.format)) {
+    console.error(
+      `error: --format must be one of ${[...ALLOWED_FORMATS].join(", ")} (got "${args.format}")`,
+    )
+    process.exit(2)
+  }
+
   if (args.subjectIds.length === 0) {
     console.error("error: --subject-ids must contain at least one ID")
+    process.exit(2)
+  }
+
+  const trustedSet = buildTrustedSet(args.trustedMarkerLogins)
+  if (trustedSet.size === 0 && !args.allowUntrusted) {
+    console.error(
+      "error: no trusted marker logins supplied. Pass --trusted-marker-logins (or set IDD_TRUSTED_MARKER_ACTORS), or pass --allow-untrusted to explicitly opt out of the author gate.",
+    )
     process.exit(2)
   }
 
   const report = runMinimize({
     subjectIds: args.subjectIds,
     classifier: args.classifier,
-    trustedMarkerLogins: args.trustedMarkerLogins,
+    trustedSet,
     apply: args.apply,
+    allowUntrusted: args.allowUntrusted,
   })
 
   if (args.format === "table") {
@@ -43,29 +69,43 @@ if (isMainModule(import.meta.url)) {
   process.exit(exitCode)
 }
 
-export function runMinimize({ subjectIds, classifier, trustedMarkerLogins, apply }) {
+export function runMinimize({ subjectIds, classifier, trustedSet, apply, allowUntrusted }) {
   const report = {
     mode: apply ? "apply" : "dry-run",
     classifier,
-    counts: { eligible: 0, alreadyMinimized: 0, cannotMinimize: 0, untrusted: 0, applied: 0, failed: 0 },
+    counts: {
+      eligible: 0,
+      alreadyMinimized: 0,
+      cannotMinimize: 0,
+      untrusted: 0,
+      unsupportedType: 0,
+      applied: 0,
+      failed: 0,
+    },
     items: [],
   }
-
-  const trustedSet = buildTrustedSet(trustedMarkerLogins)
 
   for (const subjectId of subjectIds) {
     const probe = probeSubject(subjectId)
     if (!probe.ok) {
-      report.items.push({
-        subjectId,
-        status: "failed",
-        reason: probe.reason,
-      })
+      report.items.push({ subjectId, status: "failed", reason: probe.reason })
       report.counts.failed += 1
       continue
     }
 
     const { author, isMinimized, viewerCanMinimize, url, typename } = probe.node
+
+    if (!MINIMIZABLE_TYPENAMES.has(typename)) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "skipped",
+        reason: "unsupported-type",
+      })
+      report.counts.unsupportedType += 1
+      continue
+    }
 
     if (isMinimized) {
       report.items.push({
@@ -91,7 +131,7 @@ export function runMinimize({ subjectIds, classifier, trustedMarkerLogins, apply
       continue
     }
 
-    if (trustedSet.size > 0 && !isTrustedAuthor(author, trustedSet)) {
+    if (!allowUntrusted && !isTrustedAuthor(author, trustedSet)) {
       report.items.push({
         subjectId,
         url,
@@ -107,25 +147,13 @@ export function runMinimize({ subjectIds, classifier, trustedMarkerLogins, apply
     report.counts.eligible += 1
 
     if (!apply) {
-      report.items.push({
-        subjectId,
-        url,
-        typename,
-        status: "would-apply",
-        author,
-      })
+      report.items.push({ subjectId, url, typename, status: "would-apply", author })
       continue
     }
 
     const mutation = applyMinimize(subjectId, classifier)
     if (mutation.ok) {
-      report.items.push({
-        subjectId,
-        url,
-        typename,
-        status: "applied",
-        author,
-      })
+      report.items.push({ subjectId, url, typename, status: "applied", author })
       report.counts.applied += 1
     } else {
       report.items.push({
@@ -142,7 +170,7 @@ export function runMinimize({ subjectIds, classifier, trustedMarkerLogins, apply
   return report
 }
 
-function probeSubject(subjectId) {
+export function probeSubject(subjectId) {
   const result = runGh(
     [
       "api",
@@ -169,6 +197,12 @@ function probeSubject(subjectId) {
   } catch (error) {
     return { ok: false, reason: `gh-graphql-parse: ${error.message}` }
   }
+  if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    return {
+      ok: false,
+      reason: `gh-graphql-errors: ${parsed.errors.map((e) => e.message ?? "").filter(Boolean).join("; ").slice(0, 200)}`,
+    }
+  }
   const node = parsed?.data?.node
   if (!node) {
     return { ok: false, reason: "node-missing" }
@@ -185,7 +219,7 @@ function probeSubject(subjectId) {
   }
 }
 
-function applyMinimize(subjectId, classifier) {
+export function applyMinimize(subjectId, classifier) {
   const result = runGh([
     "api",
     "graphql",
@@ -208,7 +242,36 @@ function applyMinimize(subjectId, classifier) {
   if (!result.ok) {
     return { ok: false, reason: `mutation-error: ${result.stderr.slice(0, 200)}` }
   }
+  let parsed
+  try {
+    parsed = JSON.parse(result.stdout)
+  } catch (error) {
+    return { ok: false, reason: `mutation-parse: ${error.message}` }
+  }
+  if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    return {
+      ok: false,
+      reason: `mutation-graphql-errors: ${parsed.errors.map((e) => e.message ?? "").filter(Boolean).join("; ").slice(0, 200)}`,
+    }
+  }
+  const minimized = parsed?.data?.minimizeComment?.minimizedComment
+  if (!minimized || minimized.isMinimized !== true) {
+    return {
+      ok: false,
+      reason: `mutation-no-confirmation: minimizedComment.isMinimized was not true`,
+    }
+  }
   return { ok: true }
+}
+
+export function normalizeTrustedMarkerLogins(logins) {
+  return [
+    ...new Set(
+      (Array.isArray(logins) ? logins : [])
+        .map((login) => String(login ?? "").trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ].sort()
 }
 
 function buildTrustedSet(logins) {
@@ -235,9 +298,9 @@ export function computeExitCode(report) {
 
 function printTable(report) {
   console.log(`mode: ${report.mode}  classifier: ${report.classifier}`)
-  const counts = report.counts
+  const c = report.counts
   console.log(
-    `counts: eligible=${counts.eligible} applied=${counts.applied} failed=${counts.failed} already=${counts.alreadyMinimized} blocked=${counts.cannotMinimize} untrusted=${counts.untrusted}`,
+    `counts: eligible=${c.eligible} applied=${c.applied} failed=${c.failed} already=${c.alreadyMinimized} blocked=${c.cannotMinimize} untrusted=${c.untrusted} unsupported=${c.unsupportedType}`,
   )
   for (const item of report.items) {
     const url = item.url ?? "(no url)"
@@ -267,6 +330,7 @@ function parseArgs(argv) {
     classifier: "OUTDATED",
     trustedMarkerLogins: process.env.IDD_TRUSTED_MARKER_ACTORS ?? "",
     apply: false,
+    allowUntrusted: false,
     format: "json",
     help: false,
   }
@@ -279,6 +343,10 @@ function parseArgs(argv) {
     }
     if (arg === "--apply") {
       args.apply = true
+      continue
+    }
+    if (arg === "--allow-untrusted") {
+      args.allowUntrusted = true
       continue
     }
     if (arg === "--subject-ids") {
@@ -328,7 +396,14 @@ function parseArgs(argv) {
 
 function printUsage() {
   console.log(
-    `Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--apply] [--format json|table]`,
+    `Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table]
+
+The trusted-author gate is mandatory by default: pass a non-empty
+--trusted-marker-logins list (or set IDD_TRUSTED_MARKER_ACTORS) so the
+helper rejects markers from untrusted GitHub actors. Use
+--allow-untrusted only when you intentionally want to minimize markers
+regardless of author, and the caller has already verified the subject
+IDs are operationally safe to hide.`,
   )
 }
 

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process"
+
+import { normalizeTrustedMarkerLogins } from "./protocol-helpers.mjs"
+
+const ALLOWED_CLASSIFIERS = new Set(["OUTDATED", "RESOLVED"])
+
+if (isMainModule(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2))
+
+  if (args.help) {
+    printUsage()
+    process.exit(0)
+  }
+
+  if (!ALLOWED_CLASSIFIERS.has(args.classifier)) {
+    console.error(
+      `error: --classifier must be one of ${[...ALLOWED_CLASSIFIERS].join(", ")} (got "${args.classifier}")`,
+    )
+    process.exit(2)
+  }
+
+  if (args.subjectIds.length === 0) {
+    console.error("error: --subject-ids must contain at least one ID")
+    process.exit(2)
+  }
+
+  const report = runMinimize({
+    subjectIds: args.subjectIds,
+    classifier: args.classifier,
+    trustedMarkerLogins: args.trustedMarkerLogins,
+    apply: args.apply,
+  })
+
+  if (args.format === "table") {
+    printTable(report)
+  } else {
+    console.log(JSON.stringify(report, null, 2))
+  }
+
+  const exitCode = computeExitCode(report)
+  process.exit(exitCode)
+}
+
+export function runMinimize({ subjectIds, classifier, trustedMarkerLogins, apply }) {
+  const report = {
+    mode: apply ? "apply" : "dry-run",
+    classifier,
+    counts: { eligible: 0, alreadyMinimized: 0, cannotMinimize: 0, untrusted: 0, applied: 0, failed: 0 },
+    items: [],
+  }
+
+  const trustedSet = buildTrustedSet(trustedMarkerLogins)
+
+  for (const subjectId of subjectIds) {
+    const probe = probeSubject(subjectId)
+    if (!probe.ok) {
+      report.items.push({
+        subjectId,
+        status: "failed",
+        reason: probe.reason,
+      })
+      report.counts.failed += 1
+      continue
+    }
+
+    const { author, isMinimized, viewerCanMinimize, url, typename } = probe.node
+
+    if (isMinimized) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "skipped",
+        reason: "already-minimized",
+      })
+      report.counts.alreadyMinimized += 1
+      continue
+    }
+
+    if (!viewerCanMinimize) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "skipped",
+        reason: "viewer-cannot-minimize",
+      })
+      report.counts.cannotMinimize += 1
+      continue
+    }
+
+    if (trustedSet.size > 0 && !isTrustedAuthor(author, trustedSet)) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "skipped",
+        reason: "untrusted-author",
+        author,
+      })
+      report.counts.untrusted += 1
+      continue
+    }
+
+    report.counts.eligible += 1
+
+    if (!apply) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "would-apply",
+        author,
+      })
+      continue
+    }
+
+    const mutation = applyMinimize(subjectId, classifier)
+    if (mutation.ok) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "applied",
+        author,
+      })
+      report.counts.applied += 1
+    } else {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "failed",
+        reason: mutation.reason,
+      })
+      report.counts.failed += 1
+    }
+  }
+
+  return report
+}
+
+function probeSubject(subjectId) {
+  const result = runGh(
+    [
+      "api",
+      "graphql",
+      "-f",
+      `query=query($id:ID!){
+        node(id:$id){
+          __typename
+          ... on IssueComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
+          ... on PullRequestReview{id url isMinimized minimizedReason viewerCanMinimize author{login}}
+          ... on PullRequestReviewComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
+        }
+      }`,
+      "-f",
+      `id=${subjectId}`,
+    ],
+  )
+  if (!result.ok) {
+    return { ok: false, reason: `gh-graphql-error: ${result.stderr.slice(0, 200)}` }
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(result.stdout)
+  } catch (error) {
+    return { ok: false, reason: `gh-graphql-parse: ${error.message}` }
+  }
+  const node = parsed?.data?.node
+  if (!node) {
+    return { ok: false, reason: "node-missing" }
+  }
+  return {
+    ok: true,
+    node: {
+      typename: node.__typename,
+      url: node.url,
+      isMinimized: node.isMinimized,
+      viewerCanMinimize: node.viewerCanMinimize,
+      author: node.author?.login,
+    },
+  }
+}
+
+function applyMinimize(subjectId, classifier) {
+  const result = runGh([
+    "api",
+    "graphql",
+    "-f",
+    `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){
+      minimizeComment(input:{subjectId:$id,classifier:$classifier}){
+        minimizedComment{
+          __typename
+          ... on IssueComment{id isMinimized minimizedReason}
+          ... on PullRequestReview{id isMinimized minimizedReason}
+          ... on PullRequestReviewComment{id isMinimized minimizedReason}
+        }
+      }
+    }`,
+    "-f",
+    `id=${subjectId}`,
+    "-f",
+    `classifier=${classifier}`,
+  ])
+  if (!result.ok) {
+    return { ok: false, reason: `mutation-error: ${result.stderr.slice(0, 200)}` }
+  }
+  return { ok: true }
+}
+
+function buildTrustedSet(logins) {
+  const list = String(logins ?? "")
+    .split(",")
+    .map((login) => login.trim())
+    .filter((login) => login.length > 0)
+  return new Set(normalizeTrustedMarkerLogins(list))
+}
+
+export function isTrustedAuthor(author, trustedSet) {
+  if (!author) {
+    return false
+  }
+  return trustedSet.has(String(author).toLowerCase())
+}
+
+export function computeExitCode(report) {
+  if (report.counts.failed > 0) {
+    return 1
+  }
+  return 0
+}
+
+function printTable(report) {
+  console.log(`mode: ${report.mode}  classifier: ${report.classifier}`)
+  const counts = report.counts
+  console.log(
+    `counts: eligible=${counts.eligible} applied=${counts.applied} failed=${counts.failed} already=${counts.alreadyMinimized} blocked=${counts.cannotMinimize} untrusted=${counts.untrusted}`,
+  )
+  for (const item of report.items) {
+    const url = item.url ?? "(no url)"
+    const reason = item.reason ?? ""
+    console.log(`  [${item.status}] ${item.subjectId}  ${url}  ${reason}`)
+  }
+}
+
+function runGh(argv) {
+  try {
+    const stdout = execFileSync("gh", argv, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    return { ok: true, stdout }
+  } catch (error) {
+    return {
+      ok: false,
+      stderr: error.stderr?.toString?.() ?? error.message ?? "unknown error",
+    }
+  }
+}
+
+function parseArgs(argv) {
+  const args = {
+    subjectIds: [],
+    classifier: "OUTDATED",
+    trustedMarkerLogins: process.env.IDD_TRUSTED_MARKER_ACTORS ?? "",
+    apply: false,
+    format: "json",
+    help: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--help" || arg === "-h") {
+      args.help = true
+      continue
+    }
+    if (arg === "--apply") {
+      args.apply = true
+      continue
+    }
+    if (arg === "--subject-ids") {
+      const value = argv[index + 1]
+      if (!value) {
+        throw new Error("--subject-ids requires a value")
+      }
+      args.subjectIds = value
+        .split(",")
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0)
+      index += 1
+      continue
+    }
+    if (arg === "--classifier") {
+      const value = argv[index + 1]
+      if (!value) {
+        throw new Error("--classifier requires a value")
+      }
+      args.classifier = value
+      index += 1
+      continue
+    }
+    if (arg === "--trusted-marker-logins") {
+      const value = argv[index + 1]
+      if (value === undefined) {
+        throw new Error("--trusted-marker-logins requires a value")
+      }
+      args.trustedMarkerLogins = value
+      index += 1
+      continue
+    }
+    if (arg === "--format") {
+      const value = argv[index + 1]
+      if (!value) {
+        throw new Error("--format requires a value")
+      }
+      args.format = value
+      index += 1
+      continue
+    }
+    throw new Error(`unknown argument: ${arg}`)
+  }
+
+  return args
+}
+
+function printUsage() {
+  console.log(
+    `Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--apply] [--format json|table]`,
+  )
+}
+
+function isMainModule(metaUrl) {
+  const entry = process.argv[1]
+  if (!entry) return false
+  try {
+    return new URL(metaUrl).pathname === entry || new URL(metaUrl).pathname.endsWith(entry)
+  } catch {
+    return false
+  }
+}

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -2,12 +2,22 @@
 
 import { execFileSync } from "node:child_process"
 
-import { normalizeTrustedMarkerLogins } from "./protocol-helpers.mjs"
-
 const ALLOWED_CLASSIFIERS = new Set(["OUTDATED", "RESOLVED"])
+const ALLOWED_FORMATS = new Set(["json", "table"])
+const MINIMIZABLE_TYPENAMES = new Set([
+  "IssueComment",
+  "PullRequestReview",
+  "PullRequestReviewComment",
+])
 
 if (isMainModule(import.meta.url)) {
-  const args = parseArgs(process.argv.slice(2))
+  let args
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(`error: ${error.message}`)
+    process.exit(2)
+  }
 
   if (args.help) {
     printUsage()
@@ -21,16 +31,32 @@ if (isMainModule(import.meta.url)) {
     process.exit(2)
   }
 
+  if (!ALLOWED_FORMATS.has(args.format)) {
+    console.error(
+      `error: --format must be one of ${[...ALLOWED_FORMATS].join(", ")} (got "${args.format}")`,
+    )
+    process.exit(2)
+  }
+
   if (args.subjectIds.length === 0) {
     console.error("error: --subject-ids must contain at least one ID")
+    process.exit(2)
+  }
+
+  const trustedSet = buildTrustedSet(args.trustedMarkerLogins)
+  if (trustedSet.size === 0 && !args.allowUntrusted) {
+    console.error(
+      "error: no trusted marker logins supplied. Pass --trusted-marker-logins (or set IDD_TRUSTED_MARKER_ACTORS), or pass --allow-untrusted to explicitly opt out of the author gate.",
+    )
     process.exit(2)
   }
 
   const report = runMinimize({
     subjectIds: args.subjectIds,
     classifier: args.classifier,
-    trustedMarkerLogins: args.trustedMarkerLogins,
+    trustedSet,
     apply: args.apply,
+    allowUntrusted: args.allowUntrusted,
   })
 
   if (args.format === "table") {
@@ -43,29 +69,43 @@ if (isMainModule(import.meta.url)) {
   process.exit(exitCode)
 }
 
-export function runMinimize({ subjectIds, classifier, trustedMarkerLogins, apply }) {
+export function runMinimize({ subjectIds, classifier, trustedSet, apply, allowUntrusted }) {
   const report = {
     mode: apply ? "apply" : "dry-run",
     classifier,
-    counts: { eligible: 0, alreadyMinimized: 0, cannotMinimize: 0, untrusted: 0, applied: 0, failed: 0 },
+    counts: {
+      eligible: 0,
+      alreadyMinimized: 0,
+      cannotMinimize: 0,
+      untrusted: 0,
+      unsupportedType: 0,
+      applied: 0,
+      failed: 0,
+    },
     items: [],
   }
-
-  const trustedSet = buildTrustedSet(trustedMarkerLogins)
 
   for (const subjectId of subjectIds) {
     const probe = probeSubject(subjectId)
     if (!probe.ok) {
-      report.items.push({
-        subjectId,
-        status: "failed",
-        reason: probe.reason,
-      })
+      report.items.push({ subjectId, status: "failed", reason: probe.reason })
       report.counts.failed += 1
       continue
     }
 
     const { author, isMinimized, viewerCanMinimize, url, typename } = probe.node
+
+    if (!MINIMIZABLE_TYPENAMES.has(typename)) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "skipped",
+        reason: "unsupported-type",
+      })
+      report.counts.unsupportedType += 1
+      continue
+    }
 
     if (isMinimized) {
       report.items.push({
@@ -91,7 +131,7 @@ export function runMinimize({ subjectIds, classifier, trustedMarkerLogins, apply
       continue
     }
 
-    if (trustedSet.size > 0 && !isTrustedAuthor(author, trustedSet)) {
+    if (!allowUntrusted && !isTrustedAuthor(author, trustedSet)) {
       report.items.push({
         subjectId,
         url,
@@ -107,25 +147,13 @@ export function runMinimize({ subjectIds, classifier, trustedMarkerLogins, apply
     report.counts.eligible += 1
 
     if (!apply) {
-      report.items.push({
-        subjectId,
-        url,
-        typename,
-        status: "would-apply",
-        author,
-      })
+      report.items.push({ subjectId, url, typename, status: "would-apply", author })
       continue
     }
 
     const mutation = applyMinimize(subjectId, classifier)
     if (mutation.ok) {
-      report.items.push({
-        subjectId,
-        url,
-        typename,
-        status: "applied",
-        author,
-      })
+      report.items.push({ subjectId, url, typename, status: "applied", author })
       report.counts.applied += 1
     } else {
       report.items.push({
@@ -142,7 +170,7 @@ export function runMinimize({ subjectIds, classifier, trustedMarkerLogins, apply
   return report
 }
 
-function probeSubject(subjectId) {
+export function probeSubject(subjectId) {
   const result = runGh(
     [
       "api",
@@ -169,6 +197,12 @@ function probeSubject(subjectId) {
   } catch (error) {
     return { ok: false, reason: `gh-graphql-parse: ${error.message}` }
   }
+  if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    return {
+      ok: false,
+      reason: `gh-graphql-errors: ${parsed.errors.map((e) => e.message ?? "").filter(Boolean).join("; ").slice(0, 200)}`,
+    }
+  }
   const node = parsed?.data?.node
   if (!node) {
     return { ok: false, reason: "node-missing" }
@@ -185,7 +219,7 @@ function probeSubject(subjectId) {
   }
 }
 
-function applyMinimize(subjectId, classifier) {
+export function applyMinimize(subjectId, classifier) {
   const result = runGh([
     "api",
     "graphql",
@@ -208,7 +242,36 @@ function applyMinimize(subjectId, classifier) {
   if (!result.ok) {
     return { ok: false, reason: `mutation-error: ${result.stderr.slice(0, 200)}` }
   }
+  let parsed
+  try {
+    parsed = JSON.parse(result.stdout)
+  } catch (error) {
+    return { ok: false, reason: `mutation-parse: ${error.message}` }
+  }
+  if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    return {
+      ok: false,
+      reason: `mutation-graphql-errors: ${parsed.errors.map((e) => e.message ?? "").filter(Boolean).join("; ").slice(0, 200)}`,
+    }
+  }
+  const minimized = parsed?.data?.minimizeComment?.minimizedComment
+  if (!minimized || minimized.isMinimized !== true) {
+    return {
+      ok: false,
+      reason: `mutation-no-confirmation: minimizedComment.isMinimized was not true`,
+    }
+  }
   return { ok: true }
+}
+
+export function normalizeTrustedMarkerLogins(logins) {
+  return [
+    ...new Set(
+      (Array.isArray(logins) ? logins : [])
+        .map((login) => String(login ?? "").trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ].sort()
 }
 
 function buildTrustedSet(logins) {
@@ -235,9 +298,9 @@ export function computeExitCode(report) {
 
 function printTable(report) {
   console.log(`mode: ${report.mode}  classifier: ${report.classifier}`)
-  const counts = report.counts
+  const c = report.counts
   console.log(
-    `counts: eligible=${counts.eligible} applied=${counts.applied} failed=${counts.failed} already=${counts.alreadyMinimized} blocked=${counts.cannotMinimize} untrusted=${counts.untrusted}`,
+    `counts: eligible=${c.eligible} applied=${c.applied} failed=${c.failed} already=${c.alreadyMinimized} blocked=${c.cannotMinimize} untrusted=${c.untrusted} unsupported=${c.unsupportedType}`,
   )
   for (const item of report.items) {
     const url = item.url ?? "(no url)"
@@ -267,6 +330,7 @@ function parseArgs(argv) {
     classifier: "OUTDATED",
     trustedMarkerLogins: process.env.IDD_TRUSTED_MARKER_ACTORS ?? "",
     apply: false,
+    allowUntrusted: false,
     format: "json",
     help: false,
   }
@@ -279,6 +343,10 @@ function parseArgs(argv) {
     }
     if (arg === "--apply") {
       args.apply = true
+      continue
+    }
+    if (arg === "--allow-untrusted") {
+      args.allowUntrusted = true
       continue
     }
     if (arg === "--subject-ids") {
@@ -328,7 +396,14 @@ function parseArgs(argv) {
 
 function printUsage() {
   console.log(
-    `Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--apply] [--format json|table]`,
+    `Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table]
+
+The trusted-author gate is mandatory by default: pass a non-empty
+--trusted-marker-logins list (or set IDD_TRUSTED_MARKER_ACTORS) so the
+helper rejects markers from untrusted GitHub actors. Use
+--allow-untrusted only when you intentionally want to minimize markers
+regardless of author, and the caller has already verified the subject
+IDs are operationally safe to hide.`,
   )
 }
 

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process"
+
+import { normalizeTrustedMarkerLogins } from "./protocol-helpers.mjs"
+
+const ALLOWED_CLASSIFIERS = new Set(["OUTDATED", "RESOLVED"])
+
+if (isMainModule(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2))
+
+  if (args.help) {
+    printUsage()
+    process.exit(0)
+  }
+
+  if (!ALLOWED_CLASSIFIERS.has(args.classifier)) {
+    console.error(
+      `error: --classifier must be one of ${[...ALLOWED_CLASSIFIERS].join(", ")} (got "${args.classifier}")`,
+    )
+    process.exit(2)
+  }
+
+  if (args.subjectIds.length === 0) {
+    console.error("error: --subject-ids must contain at least one ID")
+    process.exit(2)
+  }
+
+  const report = runMinimize({
+    subjectIds: args.subjectIds,
+    classifier: args.classifier,
+    trustedMarkerLogins: args.trustedMarkerLogins,
+    apply: args.apply,
+  })
+
+  if (args.format === "table") {
+    printTable(report)
+  } else {
+    console.log(JSON.stringify(report, null, 2))
+  }
+
+  const exitCode = computeExitCode(report)
+  process.exit(exitCode)
+}
+
+export function runMinimize({ subjectIds, classifier, trustedMarkerLogins, apply }) {
+  const report = {
+    mode: apply ? "apply" : "dry-run",
+    classifier,
+    counts: { eligible: 0, alreadyMinimized: 0, cannotMinimize: 0, untrusted: 0, applied: 0, failed: 0 },
+    items: [],
+  }
+
+  const trustedSet = buildTrustedSet(trustedMarkerLogins)
+
+  for (const subjectId of subjectIds) {
+    const probe = probeSubject(subjectId)
+    if (!probe.ok) {
+      report.items.push({
+        subjectId,
+        status: "failed",
+        reason: probe.reason,
+      })
+      report.counts.failed += 1
+      continue
+    }
+
+    const { author, isMinimized, viewerCanMinimize, url, typename } = probe.node
+
+    if (isMinimized) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "skipped",
+        reason: "already-minimized",
+      })
+      report.counts.alreadyMinimized += 1
+      continue
+    }
+
+    if (!viewerCanMinimize) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "skipped",
+        reason: "viewer-cannot-minimize",
+      })
+      report.counts.cannotMinimize += 1
+      continue
+    }
+
+    if (trustedSet.size > 0 && !isTrustedAuthor(author, trustedSet)) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "skipped",
+        reason: "untrusted-author",
+        author,
+      })
+      report.counts.untrusted += 1
+      continue
+    }
+
+    report.counts.eligible += 1
+
+    if (!apply) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "would-apply",
+        author,
+      })
+      continue
+    }
+
+    const mutation = applyMinimize(subjectId, classifier)
+    if (mutation.ok) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "applied",
+        author,
+      })
+      report.counts.applied += 1
+    } else {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: "failed",
+        reason: mutation.reason,
+      })
+      report.counts.failed += 1
+    }
+  }
+
+  return report
+}
+
+function probeSubject(subjectId) {
+  const result = runGh(
+    [
+      "api",
+      "graphql",
+      "-f",
+      `query=query($id:ID!){
+        node(id:$id){
+          __typename
+          ... on IssueComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
+          ... on PullRequestReview{id url isMinimized minimizedReason viewerCanMinimize author{login}}
+          ... on PullRequestReviewComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
+        }
+      }`,
+      "-f",
+      `id=${subjectId}`,
+    ],
+  )
+  if (!result.ok) {
+    return { ok: false, reason: `gh-graphql-error: ${result.stderr.slice(0, 200)}` }
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(result.stdout)
+  } catch (error) {
+    return { ok: false, reason: `gh-graphql-parse: ${error.message}` }
+  }
+  const node = parsed?.data?.node
+  if (!node) {
+    return { ok: false, reason: "node-missing" }
+  }
+  return {
+    ok: true,
+    node: {
+      typename: node.__typename,
+      url: node.url,
+      isMinimized: node.isMinimized,
+      viewerCanMinimize: node.viewerCanMinimize,
+      author: node.author?.login,
+    },
+  }
+}
+
+function applyMinimize(subjectId, classifier) {
+  const result = runGh([
+    "api",
+    "graphql",
+    "-f",
+    `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){
+      minimizeComment(input:{subjectId:$id,classifier:$classifier}){
+        minimizedComment{
+          __typename
+          ... on IssueComment{id isMinimized minimizedReason}
+          ... on PullRequestReview{id isMinimized minimizedReason}
+          ... on PullRequestReviewComment{id isMinimized minimizedReason}
+        }
+      }
+    }`,
+    "-f",
+    `id=${subjectId}`,
+    "-f",
+    `classifier=${classifier}`,
+  ])
+  if (!result.ok) {
+    return { ok: false, reason: `mutation-error: ${result.stderr.slice(0, 200)}` }
+  }
+  return { ok: true }
+}
+
+function buildTrustedSet(logins) {
+  const list = String(logins ?? "")
+    .split(",")
+    .map((login) => login.trim())
+    .filter((login) => login.length > 0)
+  return new Set(normalizeTrustedMarkerLogins(list))
+}
+
+export function isTrustedAuthor(author, trustedSet) {
+  if (!author) {
+    return false
+  }
+  return trustedSet.has(String(author).toLowerCase())
+}
+
+export function computeExitCode(report) {
+  if (report.counts.failed > 0) {
+    return 1
+  }
+  return 0
+}
+
+function printTable(report) {
+  console.log(`mode: ${report.mode}  classifier: ${report.classifier}`)
+  const counts = report.counts
+  console.log(
+    `counts: eligible=${counts.eligible} applied=${counts.applied} failed=${counts.failed} already=${counts.alreadyMinimized} blocked=${counts.cannotMinimize} untrusted=${counts.untrusted}`,
+  )
+  for (const item of report.items) {
+    const url = item.url ?? "(no url)"
+    const reason = item.reason ?? ""
+    console.log(`  [${item.status}] ${item.subjectId}  ${url}  ${reason}`)
+  }
+}
+
+function runGh(argv) {
+  try {
+    const stdout = execFileSync("gh", argv, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    return { ok: true, stdout }
+  } catch (error) {
+    return {
+      ok: false,
+      stderr: error.stderr?.toString?.() ?? error.message ?? "unknown error",
+    }
+  }
+}
+
+function parseArgs(argv) {
+  const args = {
+    subjectIds: [],
+    classifier: "OUTDATED",
+    trustedMarkerLogins: process.env.IDD_TRUSTED_MARKER_ACTORS ?? "",
+    apply: false,
+    format: "json",
+    help: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--help" || arg === "-h") {
+      args.help = true
+      continue
+    }
+    if (arg === "--apply") {
+      args.apply = true
+      continue
+    }
+    if (arg === "--subject-ids") {
+      const value = argv[index + 1]
+      if (!value) {
+        throw new Error("--subject-ids requires a value")
+      }
+      args.subjectIds = value
+        .split(",")
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0)
+      index += 1
+      continue
+    }
+    if (arg === "--classifier") {
+      const value = argv[index + 1]
+      if (!value) {
+        throw new Error("--classifier requires a value")
+      }
+      args.classifier = value
+      index += 1
+      continue
+    }
+    if (arg === "--trusted-marker-logins") {
+      const value = argv[index + 1]
+      if (value === undefined) {
+        throw new Error("--trusted-marker-logins requires a value")
+      }
+      args.trustedMarkerLogins = value
+      index += 1
+      continue
+    }
+    if (arg === "--format") {
+      const value = argv[index + 1]
+      if (!value) {
+        throw new Error("--format requires a value")
+      }
+      args.format = value
+      index += 1
+      continue
+    }
+    throw new Error(`unknown argument: ${arg}`)
+  }
+
+  return args
+}
+
+function printUsage() {
+  console.log(
+    `Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--apply] [--format json|table]`,
+  )
+}
+
+function isMainModule(metaUrl) {
+  const entry = process.argv[1]
+  if (!entry) return false
+  try {
+    return new URL(metaUrl).pathname === entry || new URL(metaUrl).pathname.endsWith(entry)
+  } catch {
+    return false
+  }
+}

--- a/tests/minimize-superseded-markers.test.mjs
+++ b/tests/minimize-superseded-markers.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  computeExitCode,
+  isTrustedAuthor,
+} from "../scripts/minimize-superseded-markers.mjs"
+
+test("computeExitCode returns 0 when no failures", () => {
+  assert.equal(
+    computeExitCode({
+      counts: { eligible: 2, applied: 2, failed: 0, alreadyMinimized: 0, cannotMinimize: 0, untrusted: 0 },
+    }),
+    0,
+  )
+})
+
+test("computeExitCode returns 1 when any item failed", () => {
+  assert.equal(
+    computeExitCode({
+      counts: { eligible: 2, applied: 1, failed: 1, alreadyMinimized: 0, cannotMinimize: 0, untrusted: 0 },
+    }),
+    1,
+  )
+})
+
+test("computeExitCode returns 0 even when all candidates were skipped", () => {
+  assert.equal(
+    computeExitCode({
+      counts: {
+        eligible: 0,
+        applied: 0,
+        failed: 0,
+        alreadyMinimized: 1,
+        cannotMinimize: 1,
+        untrusted: 1,
+      },
+    }),
+    0,
+  )
+})
+
+test("isTrustedAuthor matches case-insensitively", () => {
+  const trusted = new Set(["kurone-kito", "copilot"])
+  assert.equal(isTrustedAuthor("kurone-kito", trusted), true)
+  assert.equal(isTrustedAuthor("Kurone-Kito", trusted), true)
+  assert.equal(isTrustedAuthor("CoPilot", trusted), true)
+})
+
+test("isTrustedAuthor rejects unknown logins", () => {
+  const trusted = new Set(["kurone-kito"])
+  assert.equal(isTrustedAuthor("random-user", trusted), false)
+  assert.equal(isTrustedAuthor("", trusted), false)
+  assert.equal(isTrustedAuthor(null, trusted), false)
+  assert.equal(isTrustedAuthor(undefined, trusted), false)
+})
+
+test("isTrustedAuthor returns false when trusted set is empty", () => {
+  const trusted = new Set()
+  assert.equal(isTrustedAuthor("kurone-kito", trusted), false)
+})


### PR DESCRIPTION
## Summary

Adds `scripts/minimize-superseded-markers.mjs` — a low-level helper
that takes a comma-separated list of GraphQL subject IDs and runs
`minimizeComment` after the standard `viewerCanMinimize` /
`isMinimized` / trusted-marker-actor capability checks. Tests
(6 cases) cover exit-code semantics and trusted-author matching.

Wires the helper into the three marker-post sites identified in
issue #731:

- **`idd-review-snapshot.instructions.md` E1 (Step 2)** — new "Hide
  superseded same-claim watermarks" subsection. Minimizes strictly
  older trusted same-claim `review-watermark` /
  `review-baseline` comments after the new watermark is verified
  on GitHub. Different-claim watermarks remain visible per the
  existing forced-handoff foreign-marker rule.
- **`idd-advisory-wait.instructions.md`** — new `AW3-H` subsection.
  Minimizes prior trusted `advisory-wait*` markers on the same PR
  whose embedded HEAD SHA differs from the current `PR_HEAD_SHA`.
  Same-head markers are never hidden because the
  `EARLIEST_SAME_HEAD_AT` anchor needs at least one to remain
  visible.
- **`idd-claim.instructions.md`** — new "Hide displaced claim
  chain on takeover" subsection. Minimizes the displaced claim's
  `claimed-by` / `unclaimed-by` / heartbeat chain after the new
  takeover claim (with `supersedes: <prior-id>`) is verified.
  Same-`{claim-id}` heartbeats are explicitly preserved as the
  active-claim audit trail.

`docs/idd-helper-scripts.md` registers the new helper. Mirrored
into `idd-template/` including the script copy.

## Test plan

- [x] `node --test tests/minimize-superseded-markers.test.mjs`
      passes (6/6).
- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [x] `node scripts/audit-docs.mjs --check` passes.
- [x] Each of the three instruction files contains the new Hide
      subsection naming the helper invocation and explicit
      skip-when conditions.
- [x] Helper checks include `viewerCanMinimize=false` /
      `isMinimized=true` / untrusted-author short-circuits before
      `minimizeComment`.
- [ ] CI green on this PR.

Closes #731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated workflow instructions to document the process for identifying and managing superseded advisory-wait markers, claim chain takeovers, and review snapshot watermarks.
  * Added helper script documentation to support marker lifecycle operations.

* **New Features**
  * Introduced a new operational script to automatically identify and minimize outdated GitHub comment markers and reviews based on verification status.

* **Tests**
  * Added comprehensive test coverage for marker minimization functionality and trusted author validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->