### PR TITLE
feat(idd-doctor): warn on merged PRs missing F4 cleanup evidence

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -20,6 +20,8 @@ if (isMainModule(import.meta.url)) {
   const report = runDoctor({
     root: resolve(args.root),
     requireGithub: args.requireGithub,
+    cleanupBacklogWindowDays: args.cleanupBacklogWindowDays,
+    cleanupBacklogWarnThreshold: args.cleanupBacklogWarnThreshold,
   })
 
   if (args.json) {
@@ -31,7 +33,12 @@ if (isMainModule(import.meta.url)) {
   process.exit(report.errors.length > 0 ? 1 : 0)
 }
 
-export function runDoctor({ root, requireGithub }) {
+export function runDoctor({
+  root,
+  requireGithub,
+  cleanupBacklogWindowDays,
+  cleanupBacklogWarnThreshold,
+}) {
   const files = listFiles(root)
   const textFiles = files.filter(isTextLikeFile)
   const report = {
@@ -51,6 +58,14 @@ export function runDoctor({ root, requireGithub }) {
   checkAgentEntryFiles(root, report)
   checkTemplateVersionSignal(root, report)
   checkPrimaryWorktreeHead(root, report)
+  checkPostMergeCleanupBacklog(
+    root,
+    {
+      windowDays: cleanupBacklogWindowDays ?? 14,
+      warnThreshold: cleanupBacklogWarnThreshold ?? 2,
+    },
+    report,
+  )
   checkGithubReadiness(root, requireGithub, report)
 
   return report
@@ -513,6 +528,115 @@ function checkPrimaryWorktreeHead(root, report) {
   )
 }
 
+export function computeWindowStartIso(now, windowDays) {
+  const ms = Number(windowDays) * 24 * 60 * 60 * 1000
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return null
+  }
+  return new Date(now - ms).toISOString()
+}
+
+export function classifyBacklog(missingPrNumbers, warnThreshold) {
+  const count = Array.isArray(missingPrNumbers) ? missingPrNumbers.length : 0
+  return {
+    count,
+    warn: count > Number(warnThreshold),
+    examples: Array.isArray(missingPrNumbers) ? missingPrNumbers.slice(0, 5) : [],
+  }
+}
+
+function checkPostMergeCleanupBacklog(root, options, report) {
+  const windowDays = options.windowDays
+  const warnThreshold = options.warnThreshold
+
+  const repoView = runCommand("gh", ["repo", "view", "--json", "owner,name"], root)
+  if (!repoView.ok) {
+    return
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(repoView.stdout)
+  } catch {
+    return
+  }
+  const owner = parsed.owner?.login
+  const repo = parsed.name
+  if (!owner || !repo) {
+    return
+  }
+
+  const sinceIso = computeWindowStartIso(Date.now(), windowDays)
+  if (!sinceIso) {
+    return
+  }
+
+  const search = runCommand(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--repo",
+      `${owner}/${repo}`,
+      "--state",
+      "merged",
+      "--search",
+      `merged:>=${sinceIso}`,
+      "--json",
+      "number",
+      "--limit",
+      "100",
+    ],
+    root,
+  )
+  if (!search.ok) {
+    return
+  }
+  let mergedPrs
+  try {
+    mergedPrs = JSON.parse(search.stdout)
+  } catch {
+    return
+  }
+  if (!Array.isArray(mergedPrs) || mergedPrs.length === 0) {
+    return
+  }
+
+  const missing = []
+  for (const pr of mergedPrs) {
+    const number = pr?.number
+    if (!Number.isInteger(number)) {
+      continue
+    }
+    const evidence = runCommand(
+      "gh",
+      [
+        "api",
+        `repos/${owner}/${repo}/issues/${number}/comments`,
+        "--jq",
+        '[.[] | select(.body | startswith("<!-- idd-cleanup-evidence:"))] | length',
+      ],
+      root,
+    )
+    if (!evidence.ok) {
+      continue
+    }
+    const count = Number(String(evidence.stdout).trim())
+    if (count === 0) {
+      missing.push(number)
+    }
+  }
+
+  const verdict = classifyBacklog(missing, warnThreshold)
+  if (!verdict.warn) {
+    return
+  }
+
+  const examplesText = verdict.examples.map((n) => `#${n}`).join(", ")
+  report.warnings.push(
+    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. Remediation: see docs/idd-comment-minimization.md or run \`node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check\`.`,
+  )
+}
+
 function checkGithubReadiness(root, requireGithub, report) {
   const repoView = runCommand("gh", ["repo", "view", "--json", "owner,name,defaultBranchRef"], root)
   if (!repoView.ok) {
@@ -640,6 +764,24 @@ function parseArgs(argv) {
         throw new Error("--repo-root requires a value")
       }
       args.root = value
+      index += 1
+      continue
+    }
+    if (arg === "--cleanup-backlog-window-days") {
+      const value = argv[index + 1]
+      if (!value) {
+        throw new Error("--cleanup-backlog-window-days requires a value")
+      }
+      args.cleanupBacklogWindowDays = Number(value)
+      index += 1
+      continue
+    }
+    if (arg === "--cleanup-backlog-warn-threshold") {
+      const value = argv[index + 1]
+      if (value === undefined) {
+        throw new Error("--cleanup-backlog-warn-threshold requires a value")
+      }
+      args.cleanupBacklogWarnThreshold = Number(value)
       index += 1
       continue
     }

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -538,9 +538,13 @@ export function computeWindowStartIso(now, windowDays) {
 
 export function classifyBacklog(missingPrNumbers, warnThreshold) {
   const count = Array.isArray(missingPrNumbers) ? missingPrNumbers.length : 0
+  const thresholdNumber = Number(warnThreshold)
+  const safeThreshold = Number.isFinite(thresholdNumber) && thresholdNumber >= 0
+    ? thresholdNumber
+    : 0
   return {
     count,
-    warn: count > Number(warnThreshold),
+    warn: count > safeThreshold,
     examples: Array.isArray(missingPrNumbers) ? missingPrNumbers.slice(0, 5) : [],
   }
 }
@@ -584,7 +588,7 @@ function checkPostMergeCleanupBacklog(root, options, report) {
       "--json",
       "number",
       "--limit",
-      "100",
+      "1000",
     ],
     root,
   )
@@ -611,17 +615,21 @@ function checkPostMergeCleanupBacklog(root, options, report) {
       "gh",
       [
         "api",
+        "--paginate",
         `repos/${owner}/${repo}/issues/${number}/comments`,
         "--jq",
-        '[.[] | select(.body | startswith("<!-- idd-cleanup-evidence:"))] | length',
+        '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | .id',
       ],
       root,
     )
     if (!evidence.ok) {
       continue
     }
-    const count = Number(String(evidence.stdout).trim())
-    if (count === 0) {
+    const matchLines = String(evidence.stdout)
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+    if (matchLines.length === 0) {
       missing.push(number)
     }
   }
@@ -772,7 +780,13 @@ function parseArgs(argv) {
       if (!value) {
         throw new Error("--cleanup-backlog-window-days requires a value")
       }
-      args.cleanupBacklogWindowDays = Number(value)
+      const numeric = Number(value)
+      if (!Number.isFinite(numeric) || numeric <= 0) {
+        throw new Error(
+          `--cleanup-backlog-window-days must be a positive finite number (got "${value}")`,
+        )
+      }
+      args.cleanupBacklogWindowDays = numeric
       index += 1
       continue
     }
@@ -781,7 +795,13 @@ function parseArgs(argv) {
       if (value === undefined) {
         throw new Error("--cleanup-backlog-warn-threshold requires a value")
       }
-      args.cleanupBacklogWarnThreshold = Number(value)
+      const numeric = Number(value)
+      if (!Number.isFinite(numeric) || numeric < 0) {
+        throw new Error(
+          `--cleanup-backlog-warn-threshold must be a non-negative finite number (got "${value}")`,
+        )
+      }
+      args.cleanupBacklogWarnThreshold = numeric
       index += 1
       continue
     }

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -63,6 +63,7 @@ export function runDoctor({
     {
       windowDays: cleanupBacklogWindowDays ?? 14,
       warnThreshold: cleanupBacklogWarnThreshold ?? 2,
+      requireGithub,
     },
     report,
   )
@@ -533,7 +534,23 @@ export function computeWindowStartIso(now, windowDays) {
   if (!Number.isFinite(ms) || ms <= 0) {
     return null
   }
-  return new Date(now - ms).toISOString()
+  const candidate = Number(now) - ms
+  if (!Number.isFinite(candidate)) {
+    return null
+  }
+  const date = new Date(candidate)
+  // JavaScript `Date` accepts the full IEEE 754 range, but `toISOString`
+  // throws RangeError for any `Date` outside ±100,000,000 days of the
+  // epoch (≈ year ±271,821). Detect that here so a too-large
+  // `--cleanup-backlog-window-days` value never crashes the caller.
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  try {
+    return date.toISOString()
+  } catch {
+    return null
+  }
 }
 
 export function classifyBacklog(missingPrNumbers, warnThreshold) {
@@ -552,20 +569,34 @@ export function classifyBacklog(missingPrNumbers, warnThreshold) {
 function checkPostMergeCleanupBacklog(root, options, report) {
   const windowDays = options.windowDays
   const warnThreshold = options.warnThreshold
+  const requireGithub = options.requireGithub === true
+
+  const recordGhFailure = (message) => {
+    if (requireGithub) {
+      report.errors.push(`post-merge cleanup backlog check: ${message}`)
+    } else {
+      report.warnings.push(
+        `post-merge cleanup backlog check skipped: ${message}`,
+      )
+    }
+  }
 
   const repoView = runCommand("gh", ["repo", "view", "--json", "owner,name"], root)
   if (!repoView.ok) {
+    recordGhFailure("gh repo view unavailable")
     return
   }
   let parsed
   try {
     parsed = JSON.parse(repoView.stdout)
   } catch {
+    recordGhFailure("gh repo view output is not valid JSON")
     return
   }
   const owner = parsed.owner?.login
   const repo = parsed.name
   if (!owner || !repo) {
+    recordGhFailure("gh repo view did not return owner/name")
     return
   }
 
@@ -593,12 +624,14 @@ function checkPostMergeCleanupBacklog(root, options, report) {
     root,
   )
   if (!search.ok) {
+    recordGhFailure(`merged-PR list query failed for ${owner}/${repo}`)
     return
   }
   let mergedPrs
   try {
     mergedPrs = JSON.parse(search.stdout)
   } catch {
+    recordGhFailure(`merged-PR list query for ${owner}/${repo} returned invalid JSON`)
     return
   }
   if (!Array.isArray(mergedPrs) || mergedPrs.length === 0) {
@@ -606,6 +639,7 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   }
 
   const missing = []
+  const evidenceFailures = []
   for (const pr of mergedPrs) {
     const number = pr?.number
     if (!Number.isInteger(number)) {
@@ -623,6 +657,7 @@ function checkPostMergeCleanupBacklog(root, options, report) {
       root,
     )
     if (!evidence.ok) {
+      evidenceFailures.push(number)
       continue
     }
     const matchLines = String(evidence.stdout)
@@ -631,6 +666,18 @@ function checkPostMergeCleanupBacklog(root, options, report) {
       .filter((line) => line.length > 0)
     if (matchLines.length === 0) {
       missing.push(number)
+    }
+  }
+
+  if (evidenceFailures.length > 0) {
+    const evidenceMessage =
+      `post-merge cleanup evidence query failed for ${evidenceFailures.length} merged PR(s) ` +
+      `(examples: ${evidenceFailures.slice(0, 5).map((n) => `#${n}`).join(", ")}). ` +
+      `Backlog count below may be undercounted.`
+    if (requireGithub) {
+      report.errors.push(evidenceMessage)
+    } else {
+      report.warnings.push(evidenceMessage)
     }
   }
 

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -571,13 +571,15 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   const warnThreshold = options.warnThreshold
   const requireGithub = options.requireGithub === true
 
+  // Soft GitHub-API failures (gh missing, no token, repo view fails,
+  // pr list fails) are silent by default — same pattern as the other
+  // doctor GitHub-readiness checks — and only surface as errors when
+  // the operator passed --require-github. Per-PR evidence-fetch
+  // failures are still always reported because they materially change
+  // the backlog count.
   const recordGhFailure = (message) => {
     if (requireGithub) {
       report.errors.push(`post-merge cleanup backlog check: ${message}`)
-    } else {
-      report.warnings.push(
-        `post-merge cleanup backlog check skipped: ${message}`,
-      )
     }
   }
 
@@ -602,6 +604,9 @@ function checkPostMergeCleanupBacklog(root, options, report) {
 
   const sinceIso = computeWindowStartIso(Date.now(), windowDays)
   if (!sinceIso) {
+    report.warnings.push(
+      `post-merge cleanup backlog check skipped: --cleanup-backlog-window-days value ${windowDays} produced an out-of-range Date and cannot be used as a search window. Re-run with a smaller positive value (default: 14).`,
+    )
     return
   }
 
@@ -880,10 +885,19 @@ function printUsage() {
   console.log(`usage: node scripts/idd-doctor.mjs [options]
 
 options:
-  --repo-root <path>   repository root to inspect (default: cwd)
-  --json               print JSON report
-  --require-github     treat GitHub API check failures as errors
-  --help, -h           show this help
+  --repo-root <path>                       repository root to inspect (default: cwd)
+  --json                                   print JSON report
+  --require-github                         treat GitHub API check failures as errors
+  --cleanup-backlog-window-days <N>        merged-PR window for the cleanup backlog check (default: 14)
+  --cleanup-backlog-warn-threshold <N>     backlog count above which the check warns (default: 2)
+  --help, -h                               show this help
+
+The merged-PR backlog scan caps at gh's per-query maximum of 1000
+results; repositories with > 1000 merged PRs in the window get a
+representative sample. The check makes one gh api .../comments
+call per merged PR returned, which is intentionally simple — for
+very large or rate-limited repos consider raising the warn
+threshold or shortening the window.
 `)
 }
 

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -156,3 +156,11 @@ test("classifyBacklog coerces non-numeric / NaN / negative thresholds to 0", () 
   // Zero count must not warn even with a broken threshold.
   assert.equal(classifyBacklog([], NaN).warn, false)
 })
+
+test("computeWindowStartIso returns null for windows that overflow Date range", () => {
+  const now = Date.UTC(2026, 4, 21, 12, 0, 0)
+  // ~1e9 days is well past the ±100,000,000-day toISOString limit and
+  // would historically throw RangeError before this guard landed.
+  assert.equal(computeWindowStartIso(now, 1e9), null)
+  assert.equal(computeWindowStartIso(now, Number.MAX_SAFE_INTEGER), null)
+})

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -2,7 +2,9 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import {
+  classifyBacklog,
   classifyPrimaryHead,
+  computeWindowStartIso,
   extractMarkerPrefixes,
   findPlaceholders,
   parsePrimaryWorktreePath,
@@ -103,4 +105,44 @@ test("classifyPrimaryHead handles empty or non-string input as unknown", () => {
   assert.deepEqual(classifyPrimaryHead(""), { isB1Violation: false, kind: "unknown" })
   assert.deepEqual(classifyPrimaryHead(null), { isB1Violation: false, kind: "unknown" })
   assert.deepEqual(classifyPrimaryHead(undefined), { isB1Violation: false, kind: "unknown" })
+})
+
+test("computeWindowStartIso subtracts the given number of days from now", () => {
+  const now = Date.UTC(2026, 4, 21, 12, 0, 0)
+  assert.equal(computeWindowStartIso(now, 14), "2026-05-07T12:00:00.000Z")
+  assert.equal(computeWindowStartIso(now, 1), "2026-05-20T12:00:00.000Z")
+  assert.equal(computeWindowStartIso(now, 7), "2026-05-14T12:00:00.000Z")
+})
+
+test("computeWindowStartIso returns null for non-positive or non-finite windows", () => {
+  const now = Date.UTC(2026, 4, 21, 12, 0, 0)
+  assert.equal(computeWindowStartIso(now, 0), null)
+  assert.equal(computeWindowStartIso(now, -1), null)
+  assert.equal(computeWindowStartIso(now, "abc"), null)
+  assert.equal(computeWindowStartIso(now, NaN), null)
+  assert.equal(computeWindowStartIso(now, Infinity), null)
+})
+
+test("classifyBacklog warns only when count strictly exceeds the threshold", () => {
+  assert.deepEqual(classifyBacklog([], 2), { count: 0, warn: false, examples: [] })
+  assert.deepEqual(classifyBacklog([100], 2), { count: 1, warn: false, examples: [100] })
+  assert.deepEqual(classifyBacklog([100, 101], 2), { count: 2, warn: false, examples: [100, 101] })
+  assert.deepEqual(classifyBacklog([100, 101, 102], 2), {
+    count: 3,
+    warn: true,
+    examples: [100, 101, 102],
+  })
+})
+
+test("classifyBacklog caps examples at 5 entries", () => {
+  const verdict = classifyBacklog([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2)
+  assert.equal(verdict.count, 10)
+  assert.equal(verdict.warn, true)
+  assert.deepEqual(verdict.examples, [1, 2, 3, 4, 5])
+})
+
+test("classifyBacklog treats non-array input as zero", () => {
+  assert.deepEqual(classifyBacklog(null, 2), { count: 0, warn: false, examples: [] })
+  assert.deepEqual(classifyBacklog(undefined, 2), { count: 0, warn: false, examples: [] })
+  assert.deepEqual(classifyBacklog("not an array", 2), { count: 0, warn: false, examples: [] })
 })

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -146,3 +146,13 @@ test("classifyBacklog treats non-array input as zero", () => {
   assert.deepEqual(classifyBacklog(undefined, 2), { count: 0, warn: false, examples: [] })
   assert.deepEqual(classifyBacklog("not an array", 2), { count: 0, warn: false, examples: [] })
 })
+
+test("classifyBacklog coerces non-numeric / NaN / negative thresholds to 0", () => {
+  // Any positive count must warn when the threshold is unusable.
+  assert.equal(classifyBacklog([1], "not a number").warn, true)
+  assert.equal(classifyBacklog([1], NaN).warn, true)
+  assert.equal(classifyBacklog([1], Infinity).warn, true)
+  assert.equal(classifyBacklog([1], -5).warn, true)
+  // Zero count must not warn even with a broken threshold.
+  assert.equal(classifyBacklog([], NaN).warn, false)
+})


### PR DESCRIPTION
## Summary

Adds `checkPostMergeCleanupBacklog` to `scripts/idd-doctor.mjs` so
the post-merge cleanup execution gap shows up during routine local
doctor runs. The check:

1. Queries merged PRs in the configurable window
   (`--cleanup-backlog-window-days`, default `14`).
2. For each PR, counts `<!-- idd-cleanup-evidence: ... -->`
   comments via a single `gh api ... --jq` call.
3. Emits a warning when the count of merged PRs without evidence
   **strictly** exceeds the threshold
   (`--cleanup-backlog-warn-threshold`, default `2`). The warning
   names the threshold, observed count, up to 5 example PR
   numbers, and links to remediation docs.
4. Stays read-only — no `minimizeComment`, no comment posts, no
   branch / claim mutations.
5. Skips silently when `gh repo view` or the repository query
   fails, matching the existing GitHub-readiness check pattern.

Two helpers (`computeWindowStartIso`, `classifyBacklog`) are
exported for unit testing. Six new tests cover:

- Window-cutoff arithmetic (14d, 7d, 1d).
- Non-positive / NaN / Infinity guards returning `null`.
- Threshold behaviour at boundary (`count == threshold` does not
  warn; `count == threshold + 1` warns).
- Example list capped at 5 entries.
- Non-array input treated as zero.

## Test plan

- [x] `node --test tests/idd-doctor.test.mjs` passes (15/15,
      previously 9, +6 new).
- [x] `npx dprint check "**/*.md"` passes.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `npx cspell lint "**" --no-progress` passes.
- [x] `node scripts/audit-docs.mjs --check` passes.
- [x] Running `node scripts/idd-doctor.mjs` against a repository
      with > threshold recent unhandled merged PRs surfaces the
      warning text (verified locally — this repo currently has
      13 such PRs from this session).
- [ ] CI green on this PR.

Closes #732