### PR TITLE
feat(scripts): add workshop link & asset integrity check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,8 @@ jobs:
         run: npx dprint@0.54.0 check "**/*.md"
       - name: Run protocol tests
         run: node --test tests/*.mjs
+      - name: Run workshop integrity check
+        run: node scripts/verify-workshop-integrity.mjs --format table
       - name: Run cspell
         uses: streetsidesoftware/cspell-action@v8
       - name: Run markdownlint

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "prepare": "husky",
     "lint": "pnpm run lint:minimum",
-    "lint:minimum": "node scripts/audit-docs.mjs --check && dprint check \"**/*.md\" && node --test tests/*.mjs && cspell lint \"**\" --no-progress && markdownlint-cli2 \"**/*.md\"",
+    "lint:minimum": "node scripts/audit-docs.mjs --check && dprint check \"**/*.md\" && node --test tests/*.mjs && node scripts/verify-workshop-integrity.mjs --format table && cspell lint \"**\" --no-progress && markdownlint-cli2 \"**/*.md\"",
     "lint:fix": "dprint fmt \"**/*.md\" && markdownlint-cli2 --fix \"**/*.md\" && markdownlint-cli2 \"**/*.md\" && cspell lint \"**\" --no-progress",
     "test": "pnpm run test:scripts",
     "test:scripts": "node --test tests/*.mjs",

--- a/scripts/verify-workshop-integrity.mjs
+++ b/scripts/verify-workshop-integrity.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
-import { dirname, extname, join, normalize, relative, resolve } from "node:path"
+import { dirname, extname, join, normalize, relative, resolve, sep } from "node:path"
 
 const WORKSHOP_ROOTS = ["docs/workshop"]
 
@@ -39,9 +39,15 @@ export function runVerification(repoRoot, options = {}) {
     }
   }
 
-  const headingIndex = new Map()
+  const fileContents = new Map()
+  const fileMeta = new Map()
   for (const file of files) {
-    headingIndex.set(file, extractHeadingSlugs(readFileSync(file, "utf8")))
+    const content = readFileSync(file, "utf8")
+    fileContents.set(file, content)
+    fileMeta.set(file, {
+      headingSlugs: extractHeadingSlugs(content),
+      refDefs: extractReferenceDefinitions(content),
+    })
   }
 
   const report = {
@@ -53,19 +59,34 @@ export function runVerification(repoRoot, options = {}) {
       missingFile: 0,
       missingAnchor: 0,
       invalidUrl: 0,
+      escapedRepo: 0,
+      unresolvedRef: 0,
     },
   }
 
   for (const file of files) {
-    const content = readFileSync(file, "utf8")
-    const refs = extractReferences(content)
+    const content = fileContents.get(file)
+    const { refDefs } = fileMeta.get(file)
+    const refs = extractReferences(content, refDefs)
     for (const ref of refs) {
       if (ref.kind === "image") {
         report.counts.checkedImages += 1
       } else {
         report.counts.checkedLinks += 1
       }
-      const result = classifyAndCheck(ref.target, file, repoRoot, headingIndex)
+      if (ref.status === "unresolved-reference") {
+        report.counts.unresolvedRef += 1
+        report.issues.push({
+          file: relative(repoRoot, file),
+          kind: ref.kind,
+          target: ref.label,
+          line: ref.line,
+          status: "unresolved-reference",
+          detail: `reference label "${ref.label}" has no [id]: target definition`,
+        })
+        continue
+      }
+      const result = classifyAndCheck(ref.target, file, repoRoot, fileMeta)
       if (result.status === "ok") {
         continue
       }
@@ -75,6 +96,8 @@ export function runVerification(repoRoot, options = {}) {
         report.counts.missingAnchor += 1
       } else if (result.status === "invalid-url") {
         report.counts.invalidUrl += 1
+      } else if (result.status === "escapes-repo") {
+        report.counts.escapedRepo += 1
       }
       report.issues.push({
         file: relative(repoRoot, file),
@@ -89,57 +112,161 @@ export function runVerification(repoRoot, options = {}) {
   return report
 }
 
-export function extractReferences(markdown) {
+// Strips fenced code blocks (``` and ~~~) before pattern scanning so
+// example Markdown inside code samples is never interpreted as a real
+// link or heading.
+export function stripFencedCodeBlocks(content) {
+  const lines = String(content).split(/\r?\n/)
+  const out = []
+  let fenceChar = null
+  for (const line of lines) {
+    const match = line.match(/^\s*(```+|~~~+)/)
+    if (match) {
+      const open = match[1][0]
+      if (fenceChar === null) {
+        fenceChar = open
+        out.push("")
+        continue
+      }
+      if (open === fenceChar) {
+        fenceChar = null
+        out.push("")
+        continue
+      }
+    }
+    out.push(fenceChar === null ? line : "")
+  }
+  return out.join("\n")
+}
+
+export function extractReferenceDefinitions(markdown) {
+  const stripped = stripFencedCodeBlocks(markdown)
+  const map = new Map()
+  const lines = stripped.split(/\r?\n/)
+  for (const line of lines) {
+    const match = line.match(/^\s{0,3}\[([^\]]+)\]:\s*(\S+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*$/)
+    if (!match) continue
+    const label = match[1].trim().toLowerCase()
+    map.set(label, match[2])
+  }
+  return map
+}
+
+export function extractReferences(markdown, refDefs = new Map()) {
   const refs = []
-  const linkPattern = /(!?)\[([^\]\n]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
-  const lines = markdown.split(/\r?\n/)
-  let lineStart = 0
+  const stripped = stripFencedCodeBlocks(markdown)
+  const lines = stripped.split(/\r?\n/)
   for (let lineNumber = 0; lineNumber < lines.length; lineNumber += 1) {
     const line = lines[lineNumber]
-    let match
-    const localPattern = new RegExp(linkPattern.source, "g")
-    while ((match = localPattern.exec(line)) !== null) {
-      const isImage = match[1] === "!"
-      const target = match[3]
-      refs.push({
-        kind: isImage ? "image" : "link",
-        target,
-        line: lineNumber + 1,
-      })
-    }
-    lineStart += line.length + 1
+    extractInlineFromLine(line, lineNumber + 1, refs)
+    extractReferenceStyleFromLine(line, lineNumber + 1, refs, refDefs)
   }
   return refs
 }
 
-export function extractHeadingSlugs(markdown) {
-  const slugs = new Set()
-  const lines = markdown.split(/\r?\n/)
-  let inFence = false
-  for (const line of lines) {
-    if (/^\s*```/.test(line)) {
-      inFence = !inFence
+function extractInlineFromLine(line, lineNumber, refs) {
+  // CommonMark inline link / image. Single-line only; balanced
+  // parentheses inside the destination are not supported (rare in
+  // this codebase). Optional title accepts double-quoted,
+  // single-quoted, or parenthesized form.
+  const pattern = /(!?)\[([^\]\n]*)\]\(\s*([^()\s]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g
+  let match
+  while ((match = pattern.exec(line)) !== null) {
+    refs.push({
+      kind: match[1] === "!" ? "image" : "link",
+      target: match[3],
+      line: lineNumber,
+    })
+  }
+}
+
+function extractReferenceStyleFromLine(line, lineNumber, refs, refDefs) {
+  // Skip reference-definition lines themselves so [id]: target lines
+  // are not mistaken for references.
+  if (/^\s{0,3}\[[^\]]+\]:\s*\S+/.test(line)) {
+    return
+  }
+  // [text][label] or ![alt][label]. Empty label (`[text][]`)
+  // resolves against the text itself.
+  const pattern = /(!?)\[([^\]\n]+)\]\[([^\]\n]*)\]/g
+  let match
+  while ((match = pattern.exec(line)) !== null) {
+    const isImage = match[1] === "!"
+    const text = match[2]
+    const labelRaw = match[3].trim().length === 0 ? text : match[3]
+    const label = labelRaw.trim().toLowerCase()
+    const target = refDefs.get(label)
+    if (!target) {
+      refs.push({
+        kind: isImage ? "image" : "link",
+        label: labelRaw,
+        line: lineNumber,
+        status: "unresolved-reference",
+      })
       continue
     }
-    if (inFence) continue
-    const match = line.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/)
-    if (!match) continue
-    const slug = slugifyHeading(match[2])
-    if (slug) {
-      slugs.add(slug)
+    refs.push({
+      kind: isImage ? "image" : "link",
+      target,
+      line: lineNumber,
+    })
+  }
+}
+
+export function extractHeadingSlugs(markdown) {
+  const slugs = new Set()
+  const counts = new Map()
+  const stripped = stripFencedCodeBlocks(markdown)
+  const lines = stripped.split(/\r?\n/)
+  const consider = (raw) => {
+    const slug = slugifyHeading(raw)
+    if (!slug) return
+    const count = counts.get(slug) ?? 0
+    counts.set(slug, count + 1)
+    const final = count === 0 ? slug : `${slug}-${count}`
+    slugs.add(final)
+  }
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]
+    const atx = line.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/)
+    if (atx) {
+      consider(atx[2])
+      continue
+    }
+    // Setext: a non-blank text line followed by ==... or --...
+    if (i + 1 < lines.length) {
+      const next = lines[i + 1]
+      const isSetextUnderline = /^\s{0,3}(=+|-+)\s*$/.test(next)
+      if (isSetextUnderline && line.trim().length > 0 && !/^\s*$/.test(line)) {
+        // Guard: ensure the current line is not itself a list bullet
+        // or fence; treat plain text only as a Setext heading.
+        if (!/^\s{0,3}(```|~~~|[-*+]\s|\d+\.\s|#)/.test(line)) {
+          consider(line.trim())
+        }
+      }
     }
   }
   return slugs
 }
 
-// GitHub heading slug algorithm (simplified): strip HTML, drop most
-// punctuation, lowercase, replace spaces with hyphens, keep Unicode
-// letters/digits, underscore, and hyphen. See
-// https://gist.github.com/asabaylus/3071099 for the reference.
+// GitHub heading slug algorithm (simplified): strip HTML tags,
+// drop most punctuation, lowercase, replace spaces with hyphens,
+// keep Unicode letters/digits, underscore, and hyphen. See
+// https://gist.github.com/asabaylus/3071099 for the reference
+// algorithm.
 export function slugifyHeading(text) {
   if (!text) return ""
   let s = String(text)
-  s = s.replace(/<[^>]+>/g, "")
+  // Strip HTML tags. Loop until no further change so payloads like
+  // `<<script>foo</script>>` collapse instead of leaving fragments
+  // such as `<script>foo</script>` after a single pass.
+  let prev
+  do {
+    prev = s
+    s = s.replace(/<[^<>]*>/g, "")
+  } while (s !== prev)
+  // Drop any remaining angle brackets defensively.
+  s = s.replace(/[<>]/g, "")
   s = s.replace(/`([^`]*)`/g, "$1")
   s = s.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
   s = s.toLowerCase()
@@ -149,7 +276,7 @@ export function slugifyHeading(text) {
   return s
 }
 
-export function classifyAndCheck(target, fromFile, repoRoot, headingIndex) {
+export function classifyAndCheck(target, fromFile, repoRoot, fileMeta) {
   const trimmed = String(target).trim()
   if (trimmed.length === 0) {
     return { status: "missing-file", detail: "empty target" }
@@ -182,15 +309,30 @@ export function classifyAndCheck(target, fromFile, repoRoot, headingIndex) {
     anchorPart = trimmed.slice(hashIndex + 1)
   }
 
+  let decodedPath = pathPart
+  try {
+    decodedPath = decodeURIComponent(pathPart)
+  } catch {
+    // Leave as-is when not valid percent-encoding.
+  }
+
   let resolvedPath
-  if (pathPart.length === 0) {
+  if (decodedPath.length === 0) {
     resolvedPath = fromFile
-  } else if (pathPart.startsWith("/")) {
-    resolvedPath = resolve(repoRoot, pathPart.replace(/^\/+/, ""))
+  } else if (decodedPath.startsWith("/")) {
+    resolvedPath = resolve(repoRoot, decodedPath.replace(/^\/+/, ""))
   } else {
-    resolvedPath = resolve(dirname(fromFile), pathPart)
+    resolvedPath = resolve(dirname(fromFile), decodedPath)
   }
   resolvedPath = normalize(resolvedPath)
+
+  const repoRootNormalized = normalize(repoRoot)
+  if (!isInside(resolvedPath, repoRootNormalized)) {
+    return {
+      status: "escapes-repo",
+      detail: `${decodedPath} resolves outside ${relative(process.cwd(), repoRootNormalized) || "."}`,
+    }
+  }
 
   if (!existsSync(resolvedPath)) {
     return {
@@ -217,18 +359,28 @@ export function classifyAndCheck(target, fromFile, repoRoot, headingIndex) {
     return { status: "ok" }
   }
 
-  let slugs = headingIndex.get(resolvedPath)
-  if (!slugs) {
-    slugs = extractHeadingSlugs(readFileSync(resolvedPath, "utf8"))
-    headingIndex.set(resolvedPath, slugs)
+  let meta = fileMeta.get(resolvedPath)
+  if (!meta) {
+    const content = readFileSync(resolvedPath, "utf8")
+    meta = {
+      headingSlugs: extractHeadingSlugs(content),
+      refDefs: extractReferenceDefinitions(content),
+    }
+    fileMeta.set(resolvedPath, meta)
   }
-  if (!slugs.has(anchorPart.toLowerCase())) {
+  if (!meta.headingSlugs.has(anchorPart.toLowerCase())) {
     return {
       status: "missing-anchor",
       detail: `anchor "#${anchorPart}" not found in ${relative(repoRoot, resolvedPath)}`,
     }
   }
   return { status: "ok" }
+}
+
+function isInside(targetPath, rootPath) {
+  if (targetPath === rootPath) return true
+  const rootWithSep = rootPath.endsWith(sep) ? rootPath : `${rootPath}${sep}`
+  return targetPath.startsWith(rootWithSep)
 }
 
 export function computeExitCode(report) {
@@ -289,9 +441,11 @@ options:
   --format json|table  output format (default: table)
   --help, -h           show this help
 
-Scans docs/workshop/**/*.md for broken local link targets and
-missing heading anchors. Absolute URLs are validated for syntax
-only (no live HTTP fetch — the check stays offline-safe).
+Scans docs/workshop/**/*.md for broken local link targets, missing
+heading anchors, and unresolved reference labels. Absolute URLs are
+validated for syntax only (no live HTTP fetch — the check stays
+offline-safe). Targets that resolve outside the repository root via
+path traversal are reported as errors.
 `)
 }
 

--- a/scripts/verify-workshop-integrity.mjs
+++ b/scripts/verify-workshop-integrity.mjs
@@ -115,24 +115,33 @@ export function runVerification(repoRoot, options = {}) {
 // Strips fenced code blocks (``` and ~~~) before pattern scanning so
 // example Markdown inside code samples is never interpreted as a real
 // link or heading. Tracks both fence character and opening length so a
-// 4-backtick block is not closed by a later 3-backtick line (the
-// closing fence must use the same character and be at least as long).
+// 4-backtick block is not closed by a later 3-backtick line. Closing
+// fences must contain ONLY optional whitespace after the fence marker
+// (per CommonMark §4.5), so a line like ```js inside a fenced block
+// is treated as content, not as a close.
 export function stripFencedCodeBlocks(content) {
   const lines = String(content).split(/\r?\n/)
   const out = []
   let fence = null
   for (const line of lines) {
-    const match = line.match(/^\s*(`{3,}|~{3,})/)
-    if (match) {
-      const open = match[1]
-      const openChar = open[0]
-      const openLen = open.length
+    const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/)
+    if (openMatch) {
+      const fenceMarker = openMatch[1]
+      const afterFence = openMatch[2]
+      const fenceChar = fenceMarker[0]
+      const fenceLen = fenceMarker.length
+      const onlyWhitespaceAfter = /^\s*$/.test(afterFence)
       if (fence === null) {
-        fence = { char: openChar, length: openLen }
+        // Opening fence: info string after the marker is allowed.
+        fence = { char: fenceChar, length: fenceLen }
         out.push("")
         continue
       }
-      if (openChar === fence.char && openLen >= fence.length) {
+      if (
+        fenceChar === fence.char
+        && fenceLen >= fence.length
+        && onlyWhitespaceAfter
+      ) {
         fence = null
         out.push("")
         continue
@@ -141,6 +150,14 @@ export function stripFencedCodeBlocks(content) {
     out.push(fence === null ? line : "")
   }
   return out.join("\n")
+}
+
+// Strips inline code spans (`...`, ``...``, etc.) from a single
+// line so `[demo](./missing.md)` inside backticks is not extracted
+// as a real link. Conservative: only handles single-line spans; a
+// span that opens and never closes is left as-is.
+export function stripInlineCodeSpans(line) {
+  return String(line).replace(/(`+)((?:(?!\1).)+?)\1/g, (_match, fence) => " ".repeat(fence.length * 2))
 }
 
 export function extractReferenceDefinitions(markdown) {
@@ -161,27 +178,52 @@ export function extractReferences(markdown, refDefs = new Map()) {
   const stripped = stripFencedCodeBlocks(markdown)
   const lines = stripped.split(/\r?\n/)
   for (let lineNumber = 0; lineNumber < lines.length; lineNumber += 1) {
-    const line = lines[lineNumber]
-    extractInlineFromLine(line, lineNumber + 1, refs)
-    extractReferenceStyleFromLine(line, lineNumber + 1, refs, refDefs)
-    extractShortcutReferencesFromLine(line, lineNumber + 1, refs, refDefs)
+    // Mask inline code spans and backslash-escaped link delimiters so
+    // that `[demo](./missing.md)` inside backticks and \[demo](./x.md)
+    // in escaped prose are not parsed as real links.
+    const sanitized = maskBackslashEscapes(stripInlineCodeSpans(lines[lineNumber]))
+    extractInlineFromLine(sanitized, lineNumber + 1, refs)
+    extractReferenceStyleFromLine(sanitized, lineNumber + 1, refs, refDefs)
+    extractShortcutReferencesFromLine(sanitized, lineNumber + 1, refs, refDefs)
+    extractAutolinksFromLine(sanitized, lineNumber + 1, refs)
   }
   return refs
 }
 
+function maskBackslashEscapes(line) {
+  // Replace \[ and \] with two-char filler so the link/reference
+  // patterns do not consume them. Other escapes are left intact.
+  return String(line).replace(/\\([\[\]])/g, "  ")
+}
+
 function extractInlineFromLine(line, lineNumber, refs) {
-  // CommonMark inline link / image. Single-line only; balanced
-  // parentheses inside the destination are not supported (rare in
-  // this codebase). Optional title accepts double-quoted,
-  // single-quoted, or parenthesized form.
-  const pattern = /(!?)\[([^\]\n]*)\]\(\s*([^()\s]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g
+  // CommonMark inline link / image. Single-line only. Destination can
+  // be either a bare token (no whitespace, no balanced parens) or
+  // angle-bracket wrapped (`<./b.md>`), per CommonMark §6.6 destination
+  // grammar. Optional title accepts double-quoted, single-quoted, or
+  // parenthesized form.
+  const pattern = /(!?)\[([^\]\n]*)\]\(\s*(<[^>\n]*>|[^()\s]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g
   let match
   while ((match = pattern.exec(line)) !== null) {
+    let target = match[3]
+    if (target.startsWith("<") && target.endsWith(">")) {
+      target = target.slice(1, -1)
+    }
     refs.push({
       kind: match[1] === "!" ? "image" : "link",
-      target: match[3],
+      target,
       line: lineNumber,
     })
+  }
+}
+
+function extractAutolinksFromLine(line, lineNumber, refs) {
+  // CommonMark autolink: <scheme://...>. We only validate the URL
+  // syntax (no live HTTP), so we treat them as link references.
+  const pattern = /<([a-z][a-z0-9+.-]*:[^>\s]+)>/gi
+  let match
+  while ((match = pattern.exec(line)) !== null) {
+    refs.push({ kind: "link", target: match[1], line: lineNumber })
   }
 }
 
@@ -347,9 +389,23 @@ export function classifyAndCheck(target, fromFile, repoRoot, fileMeta) {
     anchorPart = trimmed.slice(hashIndex + 1)
   }
 
+  // Strip query string from the local path; existsSync does not
+  // understand `?plain=1` and would falsely report missing.
+  const queryIndex = pathPart.indexOf("?")
+  if (queryIndex >= 0) {
+    pathPart = pathPart.slice(0, queryIndex)
+  }
+
   let decodedPath = pathPart
   try {
     decodedPath = decodeURIComponent(pathPart)
+  } catch {
+    // Leave as-is when not valid percent-encoding.
+  }
+
+  let decodedAnchor = anchorPart
+  try {
+    decodedAnchor = decodeURIComponent(anchorPart)
   } catch {
     // Leave as-is when not valid percent-encoding.
   }
@@ -406,7 +462,7 @@ export function classifyAndCheck(target, fromFile, repoRoot, fileMeta) {
     }
     fileMeta.set(resolvedPath, meta)
   }
-  if (!meta.headingSlugs.has(anchorPart.toLowerCase())) {
+  if (!meta.headingSlugs.has(decodedAnchor.toLowerCase())) {
     return {
       status: "missing-anchor",
       detail: `anchor "#${anchorPart}" not found in ${relative(repoRoot, resolvedPath)}`,

--- a/scripts/verify-workshop-integrity.mjs
+++ b/scripts/verify-workshop-integrity.mjs
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "n
 import { dirname, extname, join, normalize, relative, resolve, sep } from "node:path"
 
 const WORKSHOP_ROOTS = ["docs/workshop"]
+const WORKSHOP_ASSET_DIRS = ["docs/workshop/assets"]
 
 if (isMainModule(import.meta.url)) {
   let args
@@ -61,8 +62,12 @@ export function runVerification(repoRoot, options = {}) {
       invalidUrl: 0,
       escapedRepo: 0,
       unresolvedRef: 0,
+      assetOutsideAssetsDir: 0,
     },
   }
+  const assetDirs = (options.assetDirs ?? WORKSHOP_ASSET_DIRS).map((dir) =>
+    normalize(resolve(repoRoot, dir)),
+  )
 
   for (const file of files) {
     const content = fileContents.get(file)
@@ -88,6 +93,23 @@ export function runVerification(repoRoot, options = {}) {
       }
       const result = classifyAndCheck(ref.target, file, repoRoot, fileMeta)
       if (result.status === "ok") {
+        if (ref.kind === "image" && result.resolvedPath) {
+          const assetCheck = checkAssetUnderAssetsDir(
+            result.resolvedPath,
+            assetDirs,
+          )
+          if (!assetCheck.ok) {
+            report.counts.assetOutsideAssetsDir += 1
+            report.issues.push({
+              file: relative(repoRoot, file),
+              kind: ref.kind,
+              target: ref.target,
+              line: ref.line,
+              status: "asset-outside-assets-dir",
+              detail: assetCheck.detail,
+            })
+          }
+        }
         continue
       }
       if (result.status === "missing-file") {
@@ -250,15 +272,49 @@ function extractInlineFromContent(content, refs) {
 function extractAutolinksFromContent(content, refs) {
   // CommonMark autolink: <scheme://...>. We only validate the URL
   // syntax (no live HTTP), so we treat them as link references.
+  // Skip matches that overlap an inline-link destination such as
+  // [text](<https://x>) or a reference definition's destination,
+  // both of which already account for the URL.
+  const consumedRanges = collectAngleBracketDestinationRanges(content)
   const pattern = /<([a-z][a-z0-9+.-]*:[^>\s]+)>/gi
   let match
   while ((match = pattern.exec(content)) !== null) {
+    if (rangeOverlaps(consumedRanges, match.index, match.index + match[0].length)) {
+      continue
+    }
     refs.push({
       kind: "link",
       target: match[1],
       line: lineNumberAtOffset(content, match.index),
     })
   }
+}
+
+function collectAngleBracketDestinationRanges(content) {
+  const ranges = []
+  // Inline link/image destination wrapped in <...>.
+  const inlinePattern = /(!?)\[([^\]]*)\]\(\s*(<[^>\n]*>)/g
+  let match
+  while ((match = inlinePattern.exec(content)) !== null) {
+    const destStart = match.index + match[0].length - match[3].length
+    ranges.push([destStart, destStart + match[3].length])
+  }
+  // Reference definition destination wrapped in <...>.
+  const defPattern = /^\s{0,3}\[[^\]]+\]:\s*(<[^>\n]+>)/gm
+  while ((match = defPattern.exec(content)) !== null) {
+    const destStart = match.index + match[0].length - match[1].length
+    ranges.push([destStart, destStart + match[1].length])
+  }
+  return ranges
+}
+
+function rangeOverlaps(ranges, start, end) {
+  for (const [rangeStart, rangeEnd] of ranges) {
+    if (start < rangeEnd && end > rangeStart) {
+      return true
+    }
+  }
+  return false
 }
 
 function extractReferenceStyleFromContent(content, refs, refDefs) {
@@ -506,12 +562,12 @@ export function classifyAndCheck(target, fromFile, repoRoot, fileMeta) {
   }
 
   if (anchorPart.length === 0) {
-    return { status: "ok" }
+    return { status: "ok", resolvedPath }
   }
 
   const isMarkdown = extname(resolvedPath).toLowerCase() === ".md"
   if (!isMarkdown) {
-    return { status: "ok" }
+    return { status: "ok", resolvedPath }
   }
 
   let meta = fileMeta.get(resolvedPath)
@@ -529,7 +585,22 @@ export function classifyAndCheck(target, fromFile, repoRoot, fileMeta) {
       detail: `anchor "#${anchorPart}" not found in ${relative(repoRoot, resolvedPath)}`,
     }
   }
-  return { status: "ok" }
+  return { status: "ok", resolvedPath }
+}
+
+export function checkAssetUnderAssetsDir(resolvedPath, assetDirs) {
+  if (!Array.isArray(assetDirs) || assetDirs.length === 0) {
+    return { ok: true }
+  }
+  for (const dir of assetDirs) {
+    if (isInside(normalize(resolvedPath), normalize(dir))) {
+      return { ok: true }
+    }
+  }
+  return {
+    ok: false,
+    detail: `image target resolves outside ${assetDirs[0]}; image references should live under docs/workshop/assets/ or be absolute URLs`,
+  }
 }
 
 function isInside(targetPath, rootPath) {

--- a/scripts/verify-workshop-integrity.mjs
+++ b/scripts/verify-workshop-integrity.mjs
@@ -168,7 +168,12 @@ export function extractReferenceDefinitions(markdown) {
     const match = line.match(/^\s{0,3}\[([^\]]+)\]:\s*(\S+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*$/)
     if (!match) continue
     const label = match[1].trim().toLowerCase()
-    map.set(label, match[2])
+    let target = match[2]
+    // Unwrap angle-bracket destinations per CommonMark §6.6.
+    if (target.startsWith("<") && target.endsWith(">")) {
+      target = target.slice(1, -1)
+    }
+    map.set(label, target)
   }
   return map
 }
@@ -191,9 +196,10 @@ export function extractReferences(markdown, refDefs = new Map()) {
 }
 
 function maskBackslashEscapes(line) {
-  // Replace \[ and \] with two-char filler so the link/reference
-  // patterns do not consume them. Other escapes are left intact.
-  return String(line).replace(/\\([\[\]])/g, "  ")
+  // Replace \[, \], and \! with two-char filler so the link / image
+  // / reference patterns do not consume them. Other escapes are left
+  // intact.
+  return String(line).replace(/\\([\[\]!])/g, "  ")
 }
 
 function extractInlineFromLine(line, lineNumber, refs) {
@@ -361,20 +367,21 @@ export function classifyAndCheck(target, fromFile, repoRoot, fileMeta) {
   if (trimmed.length === 0) {
     return { status: "missing-file", detail: "empty target" }
   }
-  if (trimmed.startsWith("mailto:") || trimmed.startsWith("tel:")) {
-    return { status: "ok" }
-  }
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+  if (trimmed.startsWith("//")) {
     try {
-      new URL(trimmed)
+      new URL(`https:${trimmed}`)
       return { status: "ok" }
     } catch (error) {
       return { status: "invalid-url", detail: error.message }
     }
   }
-  if (trimmed.startsWith("//")) {
+  // Any absolute URI scheme — hierarchical (with `//`) or
+  // non-hierarchical (`urn:`, `data:`, `mailto:`, `tel:`, ...). The
+  // URL constructor parses both shapes; we validate syntax only,
+  // never fetch.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && !trimmed.startsWith("//")) {
     try {
-      new URL(`https:${trimmed}`)
+      new URL(trimmed)
       return { status: "ok" }
     } catch (error) {
       return { status: "invalid-url", detail: error.message }

--- a/scripts/verify-workshop-integrity.mjs
+++ b/scripts/verify-workshop-integrity.mjs
@@ -163,16 +163,20 @@ export function stripHtmlComments(content) {
   )
 }
 
-// Strips inline code spans (`...`, ``...``, etc.) from a single
-// line so `[demo](./missing.md)` inside backticks is not extracted
-// as a real link. Conservative: only handles single-line spans; a
-// span that opens and never closes is left as-is.
-export function stripInlineCodeSpans(line) {
-  return String(line).replace(/(`+)((?:(?!\1).)+?)\1/g, (_match, fence) => " ".repeat(fence.length * 2))
+// Strips inline code spans (`...`, ``...``, etc.) so
+// `[demo](./missing.md)` inside backticks is not extracted as a
+// real link. The lazy `[\s\S]+?` allows code spans to cross
+// newlines so multi-line spans are also covered. The replacement
+// preserves newlines so downstream offset → line numbers stay
+// accurate.
+export function stripInlineCodeSpans(content) {
+  return String(content).replace(/(`+)((?:(?!\1)[\s\S])+?)\1/g, (match, fence) =>
+    `${fence}${match.slice(fence.length, -fence.length).replace(/[^\r\n]/g, " ")}${fence}`,
+  )
 }
 
 export function extractReferenceDefinitions(markdown) {
-  const stripped = stripFencedCodeBlocks(markdown)
+  const stripped = stripHtmlComments(stripFencedCodeBlocks(markdown))
   const map = new Map()
   const lines = stripped.split(/\r?\n/)
   for (const line of lines) {
@@ -329,7 +333,7 @@ function lineContaining(content, offset) {
 export function extractHeadingSlugs(markdown) {
   const slugs = new Set()
   const counts = new Map()
-  const stripped = stripFencedCodeBlocks(markdown)
+  const stripped = stripHtmlComments(stripFencedCodeBlocks(markdown))
   const lines = stripped.split(/\r?\n/)
   const consider = (raw) => {
     const slug = slugifyHeading(raw)

--- a/scripts/verify-workshop-integrity.mjs
+++ b/scripts/verify-workshop-integrity.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs"
 import { dirname, extname, join, normalize, relative, resolve, sep } from "node:path"
 
 const WORKSHOP_ROOTS = ["docs/workshop"]
@@ -118,7 +118,9 @@ export function runVerification(repoRoot, options = {}) {
 // 4-backtick block is not closed by a later 3-backtick line. Closing
 // fences must contain ONLY optional whitespace after the fence marker
 // (per CommonMark §4.5), so a line like ```js inside a fenced block
-// is treated as content, not as a close.
+// is treated as content, not as a close. Replaces masked lines with
+// blank lines (same line count) so downstream offset → line-number
+// calculations remain correct.
 export function stripFencedCodeBlocks(content) {
   const lines = String(content).split(/\r?\n/)
   const out = []
@@ -152,6 +154,15 @@ export function stripFencedCodeBlocks(content) {
   return out.join("\n")
 }
 
+// Replaces HTML-comment regions (`<!-- ... -->`, possibly multi-line)
+// with whitespace, preserving newlines so offset → line numbers
+// remain accurate. Markdown links inside comments are not real.
+export function stripHtmlComments(content) {
+  return String(content).replace(/<!--[\s\S]*?-->/g, (match) =>
+    match.replace(/[^\r\n]/g, " "),
+  )
+}
+
 // Strips inline code spans (`...`, ``...``, etc.) from a single
 // line so `[demo](./missing.md)` inside backticks is not extracted
 // as a real link. Conservative: only handles single-line spans; a
@@ -180,37 +191,46 @@ export function extractReferenceDefinitions(markdown) {
 
 export function extractReferences(markdown, refDefs = new Map()) {
   const refs = []
-  const stripped = stripFencedCodeBlocks(markdown)
-  const lines = stripped.split(/\r?\n/)
-  for (let lineNumber = 0; lineNumber < lines.length; lineNumber += 1) {
-    // Mask inline code spans and backslash-escaped link delimiters so
-    // that `[demo](./missing.md)` inside backticks and \[demo](./x.md)
-    // in escaped prose are not parsed as real links.
-    const sanitized = maskBackslashEscapes(stripInlineCodeSpans(lines[lineNumber]))
-    extractInlineFromLine(sanitized, lineNumber + 1, refs)
-    extractReferenceStyleFromLine(sanitized, lineNumber + 1, refs, refDefs)
-    extractShortcutReferencesFromLine(sanitized, lineNumber + 1, refs, refDefs)
-    extractAutolinksFromLine(sanitized, lineNumber + 1, refs)
-  }
+  const stripped = stripHtmlComments(stripFencedCodeBlocks(markdown))
+  // Mask inline code spans and backslash-escaped link delimiters
+  // before any pattern matching so `[demo](./x.md)` inside backticks
+  // and \[demo](./x.md) in escaped prose are not parsed as real
+  // links. Both passes preserve newlines so offset → line numbers
+  // computed below remain accurate.
+  const sanitized = maskBackslashEscapes(stripInlineCodeSpans(stripped))
+  extractInlineFromContent(sanitized, refs)
+  extractReferenceStyleFromContent(sanitized, refs, refDefs)
+  extractShortcutReferencesFromContent(sanitized, refs, refDefs)
+  extractAutolinksFromContent(sanitized, refs)
   return refs
 }
 
-function maskBackslashEscapes(line) {
+function maskBackslashEscapes(content) {
   // Replace \[, \], and \! with two-char filler so the link / image
   // / reference patterns do not consume them. Other escapes are left
   // intact.
-  return String(line).replace(/\\([\[\]!])/g, "  ")
+  return String(content).replace(/\\([\[\]!])/g, "  ")
 }
 
-function extractInlineFromLine(line, lineNumber, refs) {
-  // CommonMark inline link / image. Single-line only. Destination can
-  // be either a bare token (no whitespace, no balanced parens) or
-  // angle-bracket wrapped (`<./b.md>`), per CommonMark §6.6 destination
-  // grammar. Optional title accepts double-quoted, single-quoted, or
+function lineNumberAtOffset(content, offset) {
+  let line = 1
+  const cap = Math.min(offset, content.length)
+  for (let i = 0; i < cap; i += 1) {
+    if (content.charCodeAt(i) === 10) line += 1
+  }
+  return line
+}
+
+function extractInlineFromContent(content, refs) {
+  // CommonMark inline link / image. Link text may span newlines
+  // (`[^\]]*` matches `\n`), but destinations and titles stay on
+  // one line. Destination can be either a bare token (no whitespace,
+  // no balanced parens) or angle-bracket wrapped (`<./b.md>`).
+  // Optional title accepts double-quoted, single-quoted, or
   // parenthesized form.
-  const pattern = /(!?)\[([^\]\n]*)\]\(\s*(<[^>\n]*>|[^()\s]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g
+  const pattern = /(!?)\[([^\]]*)\]\(\s*(<[^>\n]*>|[^()\s]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g
   let match
-  while ((match = pattern.exec(line)) !== null) {
+  while ((match = pattern.exec(content)) !== null) {
     let target = match[3]
     if (target.startsWith("<") && target.endsWith(">")) {
       target = target.slice(1, -1)
@@ -218,32 +238,35 @@ function extractInlineFromLine(line, lineNumber, refs) {
     refs.push({
       kind: match[1] === "!" ? "image" : "link",
       target,
-      line: lineNumber,
+      line: lineNumberAtOffset(content, match.index),
     })
   }
 }
 
-function extractAutolinksFromLine(line, lineNumber, refs) {
+function extractAutolinksFromContent(content, refs) {
   // CommonMark autolink: <scheme://...>. We only validate the URL
   // syntax (no live HTTP), so we treat them as link references.
   const pattern = /<([a-z][a-z0-9+.-]*:[^>\s]+)>/gi
   let match
-  while ((match = pattern.exec(line)) !== null) {
-    refs.push({ kind: "link", target: match[1], line: lineNumber })
+  while ((match = pattern.exec(content)) !== null) {
+    refs.push({
+      kind: "link",
+      target: match[1],
+      line: lineNumberAtOffset(content, match.index),
+    })
   }
 }
 
-function extractReferenceStyleFromLine(line, lineNumber, refs, refDefs) {
-  // Skip reference-definition lines themselves so [id]: target lines
-  // are not mistaken for references.
-  if (/^\s{0,3}\[[^\]]+\]:\s*\S+/.test(line)) {
-    return
-  }
+function extractReferenceStyleFromContent(content, refs, refDefs) {
   // [text][label] or ![alt][label]. Empty label (`[text][]`)
   // resolves against the text itself.
-  const pattern = /(!?)\[([^\]\n]+)\]\[([^\]\n]*)\]/g
+  const definitionLineCheck = /^\s{0,3}\[[^\]]+\]:\s*\S+/
+  const pattern = /(!?)\[([^\]]+)\]\[([^\]\n]*)\]/g
   let match
-  while ((match = pattern.exec(line)) !== null) {
+  while ((match = pattern.exec(content)) !== null) {
+    const lineNumber = lineNumberAtOffset(content, match.index)
+    const lineText = lineContaining(content, match.index)
+    if (definitionLineCheck.test(lineText)) continue
     const isImage = match[1] === "!"
     const text = match[2]
     const labelRaw = match[3].trim().length === 0 ? text : match[3]
@@ -266,26 +289,23 @@ function extractReferenceStyleFromLine(line, lineNumber, refs, refDefs) {
   }
 }
 
-function extractShortcutReferencesFromLine(line, lineNumber, refs, refDefs) {
-  // Skip reference-definition lines themselves.
-  if (/^\s{0,3}\[[^\]]+\]:\s*\S+/.test(line)) {
-    return
-  }
-  if (refDefs.size === 0) {
-    return
-  }
+function extractShortcutReferencesFromContent(content, refs, refDefs) {
+  if (refDefs.size === 0) return
+  const definitionLineCheck = /^\s{0,3}\[[^\]]+\]:\s*\S+/
   // CommonMark shortcut reference: [label] alone, not followed by
   // (target), [other-label], or : (which would be a definition).
   // The (?<!\]) lookbehind excludes the trailing [label] portion of
   // a full reference-style link like [text][label], which is already
-  // captured by extractReferenceStyleFromLine.
+  // captured by extractReferenceStyleFromContent.
   // We only emit refs whose label resolves against refDefs — bare
   // bracketed text without a matching definition is not flagged so
   // ordinary prose like `the [example] above` does not produce false
   // positives.
   const pattern = /(?<!\])(!?)\[([^\]\n]+)\](?!\(|\[|:)/g
   let match
-  while ((match = pattern.exec(line)) !== null) {
+  while ((match = pattern.exec(content)) !== null) {
+    const lineText = lineContaining(content, match.index)
+    if (definitionLineCheck.test(lineText)) continue
     const isImage = match[1] === "!"
     const labelRaw = match[2]
     const label = labelRaw.trim().toLowerCase()
@@ -294,9 +314,16 @@ function extractShortcutReferencesFromLine(line, lineNumber, refs, refDefs) {
     refs.push({
       kind: isImage ? "image" : "link",
       target,
-      line: lineNumber,
+      line: lineNumberAtOffset(content, match.index),
     })
   }
+}
+
+function lineContaining(content, offset) {
+  const lineStart = content.lastIndexOf("\n", offset - 1) + 1
+  const lineEndIdx = content.indexOf("\n", offset)
+  const lineEnd = lineEndIdx === -1 ? content.length : lineEndIdx
+  return content.slice(lineStart, lineEnd)
 }
 
 export function extractHeadingSlugs(markdown) {
@@ -428,10 +455,33 @@ export function classifyAndCheck(target, fromFile, repoRoot, fileMeta) {
   resolvedPath = normalize(resolvedPath)
 
   const repoRootNormalized = normalize(repoRoot)
+  // Lexical containment first (catches `..` and root-relative
+  // escapes before any disk I/O).
   if (!isInside(resolvedPath, repoRootNormalized)) {
     return {
       status: "escapes-repo",
       detail: `${decodedPath} resolves outside ${relative(process.cwd(), repoRootNormalized) || "."}`,
+    }
+  }
+  // Realpath containment second: if `resolvedPath` is a symlink that
+  // points outside the repo, the lexical check would not notice. We
+  // resolve both sides via realpathSync when possible and re-verify.
+  // Failing realpath (non-existent path, EACCES, …) leaves the
+  // lexical check as the only guard.
+  if (existsSync(resolvedPath)) {
+    let realTarget
+    let realRoot
+    try {
+      realTarget = realpathSync(resolvedPath)
+      realRoot = realpathSync(repoRootNormalized)
+    } catch {
+      // Fall through to lexical containment only.
+    }
+    if (realTarget && realRoot && !isInside(realTarget, realRoot)) {
+      return {
+        status: "escapes-repo",
+        detail: `${decodedPath} symlink target resolves outside ${relative(process.cwd(), realRoot) || "."}`,
+      }
     }
   }
 

--- a/scripts/verify-workshop-integrity.mjs
+++ b/scripts/verify-workshop-integrity.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
+import { dirname, extname, join, normalize, relative, resolve } from "node:path"
+
+const WORKSHOP_ROOTS = ["docs/workshop"]
+
+if (isMainModule(import.meta.url)) {
+  let args
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(`error: ${error.message}`)
+    process.exit(2)
+  }
+  if (args.help) {
+    printUsage()
+    process.exit(0)
+  }
+
+  const repoRoot = resolve(args.root)
+  const report = runVerification(repoRoot, args)
+
+  if (args.format === "table") {
+    printTable(report)
+  } else {
+    console.log(JSON.stringify(report, null, 2))
+  }
+  process.exit(computeExitCode(report))
+}
+
+export function runVerification(repoRoot, options = {}) {
+  const workshopRoots = options.workshopRoots ?? WORKSHOP_ROOTS
+  const files = []
+  for (const root of workshopRoots) {
+    const abs = resolve(repoRoot, root)
+    if (existsSync(abs) && statSync(abs).isDirectory()) {
+      collectMarkdown(abs, files)
+    }
+  }
+
+  const headingIndex = new Map()
+  for (const file of files) {
+    headingIndex.set(file, extractHeadingSlugs(readFileSync(file, "utf8")))
+  }
+
+  const report = {
+    scanned: files.length,
+    issues: [],
+    counts: {
+      checkedLinks: 0,
+      checkedImages: 0,
+      missingFile: 0,
+      missingAnchor: 0,
+      invalidUrl: 0,
+    },
+  }
+
+  for (const file of files) {
+    const content = readFileSync(file, "utf8")
+    const refs = extractReferences(content)
+    for (const ref of refs) {
+      if (ref.kind === "image") {
+        report.counts.checkedImages += 1
+      } else {
+        report.counts.checkedLinks += 1
+      }
+      const result = classifyAndCheck(ref.target, file, repoRoot, headingIndex)
+      if (result.status === "ok") {
+        continue
+      }
+      if (result.status === "missing-file") {
+        report.counts.missingFile += 1
+      } else if (result.status === "missing-anchor") {
+        report.counts.missingAnchor += 1
+      } else if (result.status === "invalid-url") {
+        report.counts.invalidUrl += 1
+      }
+      report.issues.push({
+        file: relative(repoRoot, file),
+        kind: ref.kind,
+        target: ref.target,
+        line: ref.line,
+        status: result.status,
+        detail: result.detail,
+      })
+    }
+  }
+  return report
+}
+
+export function extractReferences(markdown) {
+  const refs = []
+  const linkPattern = /(!?)\[([^\]\n]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
+  const lines = markdown.split(/\r?\n/)
+  let lineStart = 0
+  for (let lineNumber = 0; lineNumber < lines.length; lineNumber += 1) {
+    const line = lines[lineNumber]
+    let match
+    const localPattern = new RegExp(linkPattern.source, "g")
+    while ((match = localPattern.exec(line)) !== null) {
+      const isImage = match[1] === "!"
+      const target = match[3]
+      refs.push({
+        kind: isImage ? "image" : "link",
+        target,
+        line: lineNumber + 1,
+      })
+    }
+    lineStart += line.length + 1
+  }
+  return refs
+}
+
+export function extractHeadingSlugs(markdown) {
+  const slugs = new Set()
+  const lines = markdown.split(/\r?\n/)
+  let inFence = false
+  for (const line of lines) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
+    const match = line.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/)
+    if (!match) continue
+    const slug = slugifyHeading(match[2])
+    if (slug) {
+      slugs.add(slug)
+    }
+  }
+  return slugs
+}
+
+// GitHub heading slug algorithm (simplified): strip HTML, drop most
+// punctuation, lowercase, replace spaces with hyphens, keep Unicode
+// letters/digits, underscore, and hyphen. See
+// https://gist.github.com/asabaylus/3071099 for the reference.
+export function slugifyHeading(text) {
+  if (!text) return ""
+  let s = String(text)
+  s = s.replace(/<[^>]+>/g, "")
+  s = s.replace(/`([^`]*)`/g, "$1")
+  s = s.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+  s = s.toLowerCase()
+  s = s.replace(/[^\p{L}\p{N}\s_-]/gu, "")
+  s = s.replace(/\s+/g, "-")
+  s = s.replace(/^-+|-+$/g, "")
+  return s
+}
+
+export function classifyAndCheck(target, fromFile, repoRoot, headingIndex) {
+  const trimmed = String(target).trim()
+  if (trimmed.length === 0) {
+    return { status: "missing-file", detail: "empty target" }
+  }
+  if (trimmed.startsWith("mailto:") || trimmed.startsWith("tel:")) {
+    return { status: "ok" }
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    try {
+      new URL(trimmed)
+      return { status: "ok" }
+    } catch (error) {
+      return { status: "invalid-url", detail: error.message }
+    }
+  }
+  if (trimmed.startsWith("//")) {
+    try {
+      new URL(`https:${trimmed}`)
+      return { status: "ok" }
+    } catch (error) {
+      return { status: "invalid-url", detail: error.message }
+    }
+  }
+
+  let pathPart = trimmed
+  let anchorPart = ""
+  const hashIndex = trimmed.indexOf("#")
+  if (hashIndex >= 0) {
+    pathPart = trimmed.slice(0, hashIndex)
+    anchorPart = trimmed.slice(hashIndex + 1)
+  }
+
+  let resolvedPath
+  if (pathPart.length === 0) {
+    resolvedPath = fromFile
+  } else if (pathPart.startsWith("/")) {
+    resolvedPath = resolve(repoRoot, pathPart.replace(/^\/+/, ""))
+  } else {
+    resolvedPath = resolve(dirname(fromFile), pathPart)
+  }
+  resolvedPath = normalize(resolvedPath)
+
+  if (!existsSync(resolvedPath)) {
+    return {
+      status: "missing-file",
+      detail: relative(repoRoot, resolvedPath),
+    }
+  }
+  if (statSync(resolvedPath).isDirectory()) {
+    if (anchorPart.length === 0) {
+      return { status: "ok" }
+    }
+    return {
+      status: "missing-anchor",
+      detail: "anchor requested but target is a directory",
+    }
+  }
+
+  if (anchorPart.length === 0) {
+    return { status: "ok" }
+  }
+
+  const isMarkdown = extname(resolvedPath).toLowerCase() === ".md"
+  if (!isMarkdown) {
+    return { status: "ok" }
+  }
+
+  let slugs = headingIndex.get(resolvedPath)
+  if (!slugs) {
+    slugs = extractHeadingSlugs(readFileSync(resolvedPath, "utf8"))
+    headingIndex.set(resolvedPath, slugs)
+  }
+  if (!slugs.has(anchorPart.toLowerCase())) {
+    return {
+      status: "missing-anchor",
+      detail: `anchor "#${anchorPart}" not found in ${relative(repoRoot, resolvedPath)}`,
+    }
+  }
+  return { status: "ok" }
+}
+
+export function computeExitCode(report) {
+  return report.issues.length > 0 ? 1 : 0
+}
+
+function collectMarkdown(dir, out) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      collectMarkdown(full, out)
+    } else if (entry.isFile() && full.toLowerCase().endsWith(".md")) {
+      out.push(full)
+    }
+  }
+}
+
+function printTable(report) {
+  console.log(
+    `scanned: ${report.scanned}  links: ${report.counts.checkedLinks}  images: ${report.counts.checkedImages}  issues: ${report.issues.length}`,
+  )
+  for (const issue of report.issues) {
+    console.log(`  [${issue.status}] ${issue.file}:${issue.line} ${issue.kind} -> ${issue.target}  ${issue.detail ?? ""}`)
+  }
+}
+
+function parseArgs(argv) {
+  const args = { root: process.cwd(), format: "table", help: false }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === "--help" || arg === "-h") {
+      args.help = true
+    } else if (arg === "--repo-root") {
+      const value = argv[i + 1]
+      if (!value) throw new Error("--repo-root requires a value")
+      args.root = value
+      i += 1
+    } else if (arg === "--format") {
+      const value = argv[i + 1]
+      if (!value) throw new Error("--format requires a value")
+      if (value !== "json" && value !== "table") {
+        throw new Error(`--format must be one of json,table (got "${value}")`)
+      }
+      args.format = value
+      i += 1
+    } else {
+      throw new Error(`unknown argument: ${arg}`)
+    }
+  }
+  return args
+}
+
+function printUsage() {
+  console.log(`usage: node scripts/verify-workshop-integrity.mjs [options]
+
+options:
+  --repo-root <path>   repository root to scan (default: cwd)
+  --format json|table  output format (default: table)
+  --help, -h           show this help
+
+Scans docs/workshop/**/*.md for broken local link targets and
+missing heading anchors. Absolute URLs are validated for syntax
+only (no live HTTP fetch — the check stays offline-safe).
+`)
+}
+
+function isMainModule(metaUrl) {
+  const entry = process.argv[1]
+  if (!entry) return false
+  try {
+    const url = new URL(metaUrl)
+    return url.pathname === entry || url.pathname.endsWith(entry)
+  } catch {
+    return false
+  }
+}

--- a/scripts/verify-workshop-integrity.mjs
+++ b/scripts/verify-workshop-integrity.mjs
@@ -114,27 +114,31 @@ export function runVerification(repoRoot, options = {}) {
 
 // Strips fenced code blocks (``` and ~~~) before pattern scanning so
 // example Markdown inside code samples is never interpreted as a real
-// link or heading.
+// link or heading. Tracks both fence character and opening length so a
+// 4-backtick block is not closed by a later 3-backtick line (the
+// closing fence must use the same character and be at least as long).
 export function stripFencedCodeBlocks(content) {
   const lines = String(content).split(/\r?\n/)
   const out = []
-  let fenceChar = null
+  let fence = null
   for (const line of lines) {
-    const match = line.match(/^\s*(```+|~~~+)/)
+    const match = line.match(/^\s*(`{3,}|~{3,})/)
     if (match) {
-      const open = match[1][0]
-      if (fenceChar === null) {
-        fenceChar = open
+      const open = match[1]
+      const openChar = open[0]
+      const openLen = open.length
+      if (fence === null) {
+        fence = { char: openChar, length: openLen }
         out.push("")
         continue
       }
-      if (open === fenceChar) {
-        fenceChar = null
+      if (openChar === fence.char && openLen >= fence.length) {
+        fence = null
         out.push("")
         continue
       }
     }
-    out.push(fenceChar === null ? line : "")
+    out.push(fence === null ? line : "")
   }
   return out.join("\n")
 }
@@ -160,6 +164,7 @@ export function extractReferences(markdown, refDefs = new Map()) {
     const line = lines[lineNumber]
     extractInlineFromLine(line, lineNumber + 1, refs)
     extractReferenceStyleFromLine(line, lineNumber + 1, refs, refDefs)
+    extractShortcutReferencesFromLine(line, lineNumber + 1, refs, refDefs)
   }
   return refs
 }
@@ -205,6 +210,39 @@ function extractReferenceStyleFromLine(line, lineNumber, refs, refDefs) {
       })
       continue
     }
+    refs.push({
+      kind: isImage ? "image" : "link",
+      target,
+      line: lineNumber,
+    })
+  }
+}
+
+function extractShortcutReferencesFromLine(line, lineNumber, refs, refDefs) {
+  // Skip reference-definition lines themselves.
+  if (/^\s{0,3}\[[^\]]+\]:\s*\S+/.test(line)) {
+    return
+  }
+  if (refDefs.size === 0) {
+    return
+  }
+  // CommonMark shortcut reference: [label] alone, not followed by
+  // (target), [other-label], or : (which would be a definition).
+  // The (?<!\]) lookbehind excludes the trailing [label] portion of
+  // a full reference-style link like [text][label], which is already
+  // captured by extractReferenceStyleFromLine.
+  // We only emit refs whose label resolves against refDefs — bare
+  // bracketed text without a matching definition is not flagged so
+  // ordinary prose like `the [example] above` does not produce false
+  // positives.
+  const pattern = /(?<!\])(!?)\[([^\]\n]+)\](?!\(|\[|:)/g
+  let match
+  while ((match = pattern.exec(line)) !== null) {
+    const isImage = match[1] === "!"
+    const labelRaw = match[2]
+    const label = labelRaw.trim().toLowerCase()
+    const target = refDefs.get(label)
+    if (!target) continue
     refs.push({
       kind: isImage ? "image" : "link",
       target,

--- a/tests/verify-workshop-integrity.test.mjs
+++ b/tests/verify-workshop-integrity.test.mjs
@@ -8,9 +8,11 @@ import {
   classifyAndCheck,
   computeExitCode,
   extractHeadingSlugs,
+  extractReferenceDefinitions,
   extractReferences,
   runVerification,
   slugifyHeading,
+  stripFencedCodeBlocks,
 } from "../scripts/verify-workshop-integrity.mjs"
 
 function makeRepo() {
@@ -132,4 +134,105 @@ test("runVerification is a no-op when the workshop tree is absent", async (t) =>
 test("computeExitCode returns 1 when issues exist, 0 otherwise", () => {
   assert.equal(computeExitCode({ issues: [] }), 0)
   assert.equal(computeExitCode({ issues: [{}] }), 1)
+})
+
+test("slugifyHeading collapses nested HTML so <<script>>x</script>> becomes script-x", () => {
+  // CodeQL flagged a single-pass HTML strip as incomplete-multi-char
+  // sanitization. The loop should fully collapse nested tags.
+  assert.equal(slugifyHeading("<<script>>x</script>>"), "x")
+  assert.equal(slugifyHeading("plain <b>bold</b> text"), "plain-bold-text")
+})
+
+test("extractHeadingSlugs disambiguates duplicate headings with -1, -2 suffixes", () => {
+  const md = "# Notes\n\n# Notes\n\n# Notes\n"
+  const slugs = extractHeadingSlugs(md)
+  assert.equal(slugs.has("notes"), true)
+  assert.equal(slugs.has("notes-1"), true)
+  assert.equal(slugs.has("notes-2"), true)
+})
+
+test("extractHeadingSlugs recognizes Setext-style headings", () => {
+  const md = `Title\n=====\n\nSubtitle\n--------\n`
+  const slugs = extractHeadingSlugs(md)
+  assert.equal(slugs.has("title"), true)
+  assert.equal(slugs.has("subtitle"), true)
+})
+
+test("stripFencedCodeBlocks elides backtick and tilde fences alike", () => {
+  const md = "outside\n```\ninside-back\n```\nmiddle\n~~~\ninside-tilde\n~~~\nend"
+  const stripped = stripFencedCodeBlocks(md)
+  assert.equal(stripped.includes("inside-back"), false)
+  assert.equal(stripped.includes("inside-tilde"), false)
+  assert.equal(stripped.includes("outside"), true)
+  assert.equal(stripped.includes("middle"), true)
+  assert.equal(stripped.includes("end"), true)
+})
+
+test("extractReferences skips links inside fenced code blocks", () => {
+  const md = "real [link](./a.md)\n```md\nfake [link](./missing.md)\n```\n"
+  const refs = extractReferences(md)
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].target, "./a.md")
+})
+
+test("extractReferenceDefinitions reads [label]: target pairs", () => {
+  const md = `text\n\n[alpha]: ./a.md\n[beta]: https://example.com "Title"\n`
+  const defs = extractReferenceDefinitions(md)
+  assert.equal(defs.get("alpha"), "./a.md")
+  assert.equal(defs.get("beta"), "https://example.com")
+})
+
+test("extractReferences resolves [text][label] against the definition table", () => {
+  const md = `[click][alpha] and ![img][beta]\n\n[alpha]: ./a.md\n[beta]: ./img.png\n`
+  const defs = extractReferenceDefinitions(md)
+  const refs = extractReferences(md, defs)
+  assert.equal(refs.length, 2)
+  assert.equal(refs[0].target, "./a.md")
+  assert.equal(refs[0].kind, "link")
+  assert.equal(refs[1].target, "./img.png")
+  assert.equal(refs[1].kind, "image")
+})
+
+test("extractReferences reports unresolved reference labels", () => {
+  const md = `[click][nowhere]\n`
+  const refs = extractReferences(md, new Map())
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].status, "unresolved-reference")
+  assert.equal(refs[0].label, "nowhere")
+})
+
+test("extractReferences honors collapsed [text][] shape", () => {
+  const md = `[Alpha][]\n\n[alpha]: ./a.md\n`
+  const defs = extractReferenceDefinitions(md)
+  const refs = extractReferences(md, defs)
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].target, "./a.md")
+})
+
+test("classifyAndCheck flags path-traversal links as escapes-repo", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  const from = repo.write("docs/from.md", "# from\n")
+  const result = classifyAndCheck("/../../etc/hosts", from, repo.root, new Map())
+  assert.equal(result.status, "escapes-repo")
+})
+
+test("classifyAndCheck percent-decodes local paths before file checks", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  repo.write("docs/my file.md", "# title\n")
+  const from = repo.write("docs/from.md", "# from\n")
+  const result = classifyAndCheck("./my%20file.md", from, repo.root, new Map())
+  assert.equal(result.status, "ok")
+})
+
+test("classifyAndCheck accepts mailto: and tel: schemes", () => {
+  assert.equal(
+    classifyAndCheck("mailto:foo@example.com", "/tmp/x.md", "/tmp", new Map()).status,
+    "ok",
+  )
+  assert.equal(
+    classifyAndCheck("tel:+15555550123", "/tmp/x.md", "/tmp", new Map()).status,
+    "ok",
+  )
 })

--- a/tests/verify-workshop-integrity.test.mjs
+++ b/tests/verify-workshop-integrity.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict"
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { test } from "node:test"
+
+import {
+  classifyAndCheck,
+  computeExitCode,
+  extractHeadingSlugs,
+  extractReferences,
+  runVerification,
+  slugifyHeading,
+} from "../scripts/verify-workshop-integrity.mjs"
+
+function makeRepo() {
+  const root = mkdtempSync(join(tmpdir(), "workshop-integrity-"))
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    write: (relPath, content) => {
+      const full = join(root, relPath)
+      mkdirSync(join(full, ".."), { recursive: true })
+      writeFileSync(full, content)
+      return full
+    },
+  }
+}
+
+test("slugifyHeading mirrors GitHub heading slug algorithm", () => {
+  assert.equal(slugifyHeading("Hello World"), "hello-world")
+  assert.equal(slugifyHeading("Section: 1.0"), "section-10")
+  assert.equal(slugifyHeading("`code` heading"), "code-heading")
+  assert.equal(slugifyHeading("emoji 🎉 heading"), "emoji-heading")
+  assert.equal(slugifyHeading("multi   space"), "multi-space")
+  assert.equal(slugifyHeading("--trim--"), "trim")
+  assert.equal(slugifyHeading(""), "")
+})
+
+test("extractHeadingSlugs reads ATX headings outside code fences", () => {
+  const md = `# First\n\n## Second\n\n\`\`\`\n# inside fence\n\`\`\`\n\n### Third\n`
+  const slugs = extractHeadingSlugs(md)
+  assert.equal(slugs.has("first"), true)
+  assert.equal(slugs.has("second"), true)
+  assert.equal(slugs.has("third"), true)
+  assert.equal(slugs.has("inside-fence"), false)
+})
+
+test("extractReferences finds links and images with line numbers", () => {
+  const md = `line one\n[link](./a.md)\n![alt](b.png)\n[code](https://example.com)\n`
+  const refs = extractReferences(md)
+  assert.equal(refs.length, 3)
+  assert.deepEqual(refs[0], { kind: "link", target: "./a.md", line: 2 })
+  assert.deepEqual(refs[1], { kind: "image", target: "b.png", line: 3 })
+  assert.deepEqual(refs[2], { kind: "link", target: "https://example.com", line: 4 })
+})
+
+test("classifyAndCheck accepts absolute URLs without HTTP fetch", () => {
+  const result = classifyAndCheck("https://example.com/x", "/tmp/foo.md", "/tmp", new Map())
+  assert.equal(result.status, "ok")
+})
+
+test("classifyAndCheck rejects malformed absolute URLs as invalid-url", () => {
+  const result = classifyAndCheck("https://[bad-url", "/tmp/foo.md", "/tmp", new Map())
+  assert.equal(result.status, "invalid-url")
+})
+
+test("classifyAndCheck reports missing-file for unresolved local target", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  const from = repo.write("docs/a.md", "# a\n")
+  const result = classifyAndCheck("./missing.md", from, repo.root, new Map())
+  assert.equal(result.status, "missing-file")
+})
+
+test("classifyAndCheck resolves local file successfully", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  repo.write("docs/target.md", "# target\n")
+  const from = repo.write("docs/from.md", "# from\n")
+  const result = classifyAndCheck("./target.md", from, repo.root, new Map())
+  assert.equal(result.status, "ok")
+})
+
+test("classifyAndCheck accepts valid anchor in target file", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  repo.write("docs/target.md", "# Target\n\n## Sub Heading\n")
+  const from = repo.write("docs/from.md", "# from\n")
+  const result = classifyAndCheck("./target.md#sub-heading", from, repo.root, new Map())
+  assert.equal(result.status, "ok")
+})
+
+test("classifyAndCheck reports missing-anchor for unknown heading", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  repo.write("docs/target.md", "# Target\n")
+  const from = repo.write("docs/from.md", "# from\n")
+  const result = classifyAndCheck("./target.md#nonexistent", from, repo.root, new Map())
+  assert.equal(result.status, "missing-anchor")
+})
+
+test("classifyAndCheck resolves anchors against same-file (empty path)", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  const from = repo.write("docs/from.md", "# from\n\n## Local Heading\n")
+  const result = classifyAndCheck("#local-heading", from, repo.root, new Map())
+  assert.equal(result.status, "ok")
+})
+
+test("runVerification surfaces broken links across a workshop tree", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  repo.write("docs/workshop/README.md", `[ok](./log.md)\n[broken](./missing.md)\n![img](./assets/a.png)\n`)
+  repo.write("docs/workshop/log.md", "# log\n")
+  repo.write("docs/workshop/assets/a.png", "fake png")
+  const report = runVerification(repo.root)
+  assert.equal(report.scanned, 2)
+  assert.equal(report.issues.length, 1)
+  assert.equal(report.issues[0].status, "missing-file")
+  assert.equal(report.issues[0].target, "./missing.md")
+})
+
+test("runVerification is a no-op when the workshop tree is absent", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  const report = runVerification(repo.root)
+  assert.equal(report.scanned, 0)
+  assert.equal(report.issues.length, 0)
+})
+
+test("computeExitCode returns 1 when issues exist, 0 otherwise", () => {
+  assert.equal(computeExitCode({ issues: [] }), 0)
+  assert.equal(computeExitCode({ issues: [{}] }), 1)
+})

--- a/tests/verify-workshop-integrity.test.mjs
+++ b/tests/verify-workshop-integrity.test.mjs
@@ -226,6 +226,29 @@ test("classifyAndCheck percent-decodes local paths before file checks", async (t
   assert.equal(result.status, "ok")
 })
 
+test("stripFencedCodeBlocks requires closing fence to be at least as long as opening", () => {
+  const md = "outer\n````\nfake ``` close\nstill inside\n````\nafter"
+  const stripped = stripFencedCodeBlocks(md)
+  assert.equal(stripped.includes("fake ``` close"), false)
+  assert.equal(stripped.includes("still inside"), false)
+  assert.equal(stripped.includes("outer"), true)
+  assert.equal(stripped.includes("after"), true)
+})
+
+test("extractReferences resolves shortcut reference [label] against refDefs", () => {
+  const md = `see [alpha] for details\n\n[alpha]: ./a.md\n`
+  const defs = extractReferenceDefinitions(md)
+  const refs = extractReferences(md, defs)
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].target, "./a.md")
+})
+
+test("extractReferences leaves unmatched bracketed text alone (no false positives)", () => {
+  const md = `prose with [example] brackets\n`
+  const refs = extractReferences(md, new Map())
+  assert.equal(refs.length, 0)
+})
+
 test("classifyAndCheck accepts mailto: and tel: schemes", () => {
   assert.equal(
     classifyAndCheck("mailto:foo@example.com", "/tmp/x.md", "/tmp", new Map()).status,

--- a/tests/verify-workshop-integrity.test.mjs
+++ b/tests/verify-workshop-integrity.test.mjs
@@ -324,3 +324,32 @@ test("extractReferences extracts CommonMark angle-bracket autolinks", () => {
   assert.equal(refs.length, 1)
   assert.equal(refs[0].target, "https://example.com/x")
 })
+
+test("extractReferenceDefinitions unwraps angle-bracket destinations", () => {
+  const md = `[a]: <./b.md>\n[b]: <https://example.com>\n`
+  const defs = extractReferenceDefinitions(md)
+  assert.equal(defs.get("a"), "./b.md")
+  assert.equal(defs.get("b"), "https://example.com")
+})
+
+test("extractReferences treats backslash-escaped \\! as literal but keeps the link", () => {
+  // CommonMark §6.1: `\!` renders as a literal `!`, but the
+  // following `[text](target)` is still a valid inline link. So we
+  // should extract a link (not an image) pointing at the target.
+  const md = `\\![alt](./b.md) is rendered with a literal ! plus a link\n`
+  const refs = extractReferences(md)
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].kind, "link")
+  assert.equal(refs[0].target, "./b.md")
+})
+
+test("classifyAndCheck accepts non-hierarchical absolute URI schemes (urn:, data:)", () => {
+  assert.equal(
+    classifyAndCheck("urn:isbn:0451450523", "/tmp/x.md", "/tmp", new Map()).status,
+    "ok",
+  )
+  assert.equal(
+    classifyAndCheck("data:text/plain,hi", "/tmp/x.md", "/tmp", new Map()).status,
+    "ok",
+  )
+})

--- a/tests/verify-workshop-integrity.test.mjs
+++ b/tests/verify-workshop-integrity.test.mjs
@@ -133,6 +133,19 @@ test("runVerification is a no-op when the workshop tree is absent", async (t) =>
   assert.equal(report.issues.length, 0)
 })
 
+test("runVerification flags image references that resolve outside docs/workshop/assets", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  // Image points to a real file but outside the assets directory.
+  repo.write("docs/workshop/README.md", `![bad](../random.png)\n![ok](assets/a.png)\n`)
+  repo.write("docs/random.png", "fake png")
+  repo.write("docs/workshop/assets/a.png", "fake png")
+  const report = runVerification(repo.root)
+  const assetIssues = report.issues.filter((i) => i.status === "asset-outside-assets-dir")
+  assert.equal(assetIssues.length, 1)
+  assert.equal(assetIssues[0].target, "../random.png")
+})
+
 test("computeExitCode returns 1 when issues exist, 0 otherwise", () => {
   assert.equal(computeExitCode({ issues: [] }), 0)
   assert.equal(computeExitCode({ issues: [{}] }), 1)
@@ -325,6 +338,24 @@ test("extractReferences extracts CommonMark angle-bracket autolinks", () => {
   const refs = extractReferences(md)
   assert.equal(refs.length, 1)
   assert.equal(refs[0].target, "https://example.com/x")
+})
+
+test("extractReferences does not double-count autolinks inside inline-link destinations", () => {
+  const md = `[site](<https://example.com>)\n`
+  const refs = extractReferences(md)
+  // Exactly one ref — the inline link, NOT a duplicate autolink for
+  // the angle-bracket destination.
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].target, "https://example.com")
+})
+
+test("extractReferences does not duplicate when autolink sits in a reference definition's destination", () => {
+  const md = `[a]\n\n[a]: <https://example.com>\n`
+  const defs = extractReferenceDefinitions(md)
+  const refs = extractReferences(md, defs)
+  // One shortcut ref and the autolink should be suppressed.
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].target, "https://example.com")
 })
 
 test("extractReferenceDefinitions unwraps angle-bracket destinations", () => {

--- a/tests/verify-workshop-integrity.test.mjs
+++ b/tests/verify-workshop-integrity.test.mjs
@@ -136,9 +136,11 @@ test("computeExitCode returns 1 when issues exist, 0 otherwise", () => {
   assert.equal(computeExitCode({ issues: [{}] }), 1)
 })
 
-test("slugifyHeading collapses nested HTML so <<script>>x</script>> becomes script-x", () => {
+test("slugifyHeading fully collapses nested HTML to leave only the text", () => {
   // CodeQL flagged a single-pass HTML strip as incomplete-multi-char
-  // sanitization. The loop should fully collapse nested tags.
+  // sanitization. The loop should fully collapse nested tags so the
+  // remaining text is what survives — for `<<script>>x</script>>`
+  // that is the bare letter `x`.
   assert.equal(slugifyHeading("<<script>>x</script>>"), "x")
   assert.equal(slugifyHeading("plain <b>bold</b> text"), "plain-bold-text")
 })
@@ -235,6 +237,18 @@ test("stripFencedCodeBlocks requires closing fence to be at least as long as ope
   assert.equal(stripped.includes("after"), true)
 })
 
+test("stripFencedCodeBlocks treats fenced lines with info strings as content (not close)", () => {
+  // Per CommonMark §4.5, a closing fence may contain only optional
+  // whitespace after the fence marker. A line like ```js inside a
+  // fence is content, not a close.
+  const md = "outer\n```\n```js\nstill inside\n```\nafter"
+  const stripped = stripFencedCodeBlocks(md)
+  assert.equal(stripped.includes("```js"), false)
+  assert.equal(stripped.includes("still inside"), false)
+  assert.equal(stripped.includes("outer"), true)
+  assert.equal(stripped.includes("after"), true)
+})
+
 test("extractReferences resolves shortcut reference [label] against refDefs", () => {
   const md = `see [alpha] for details\n\n[alpha]: ./a.md\n`
   const defs = extractReferenceDefinitions(md)
@@ -258,4 +272,55 @@ test("classifyAndCheck accepts mailto: and tel: schemes", () => {
     classifyAndCheck("tel:+15555550123", "/tmp/x.md", "/tmp", new Map()).status,
     "ok",
   )
+})
+
+test("classifyAndCheck strips query strings before resolving local paths", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  repo.write("docs/b.md", "# title\n")
+  const from = repo.write("docs/from.md", "# from\n")
+  const result = classifyAndCheck("./b.md?plain=1", from, repo.root, new Map())
+  assert.equal(result.status, "ok")
+})
+
+test("classifyAndCheck percent-decodes anchors before slug comparison", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  // `日本語` percent-encoded.
+  repo.write("docs/target.md", "# 日本語\n")
+  const from = repo.write("docs/from.md", "# from\n")
+  const result = classifyAndCheck(
+    "./target.md#%E6%97%A5%E6%9C%AC%E8%AA%9E",
+    from,
+    repo.root,
+    new Map(),
+  )
+  assert.equal(result.status, "ok")
+})
+
+test("extractReferences ignores links inside inline code spans", () => {
+  const md = "real [a](./a.md) and `[demo](./missing.md)` in prose"
+  const refs = extractReferences(md)
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].target, "./a.md")
+})
+
+test("extractReferences ignores backslash-escaped link delimiters", () => {
+  const md = `\\[demo](./missing.md) is literal text\n`
+  const refs = extractReferences(md)
+  assert.equal(refs.length, 0)
+})
+
+test("extractReferences unwraps angle-bracket destinations", () => {
+  const md = `[ok](<./b.md>)\n`
+  const refs = extractReferences(md)
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].target, "./b.md")
+})
+
+test("extractReferences extracts CommonMark angle-bracket autolinks", () => {
+  const md = `See <https://example.com/x> for details\n`
+  const refs = extractReferences(md)
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].target, "https://example.com/x")
 })

--- a/tests/verify-workshop-integrity.test.mjs
+++ b/tests/verify-workshop-integrity.test.mjs
@@ -14,6 +14,7 @@ import {
   slugifyHeading,
   stripFencedCodeBlocks,
   stripHtmlComments,
+  stripInlineCodeSpans,
 } from "../scripts/verify-workshop-integrity.mjs"
 
 function makeRepo() {
@@ -371,6 +372,31 @@ test("extractReferences ignores links inside HTML comments", () => {
   const refs = extractReferences(md)
   assert.equal(refs.length, 1)
   assert.equal(refs[0].target, "./a.md")
+})
+
+test("extractReferenceDefinitions ignores definitions inside HTML comments", () => {
+  const md = `text\n\n<!--\n[hidden]: ./should-not-resolve.md\n-->\n[real]: ./a.md\n`
+  const defs = extractReferenceDefinitions(md)
+  assert.equal(defs.has("hidden"), false)
+  assert.equal(defs.get("real"), "./a.md")
+})
+
+test("extractHeadingSlugs ignores headings inside HTML comments", () => {
+  const md = `# Real\n\n<!-- # Hidden -->\n\n## Visible\n`
+  const slugs = extractHeadingSlugs(md)
+  assert.equal(slugs.has("real"), true)
+  assert.equal(slugs.has("visible"), true)
+  assert.equal(slugs.has("hidden"), false)
+})
+
+test("stripInlineCodeSpans masks multi-line backtick code spans", () => {
+  const md = "before `multi\nline span containing [demo](./x.md)\n` after"
+  const stripped = stripInlineCodeSpans(md)
+  assert.equal(stripped.includes("[demo]"), false)
+  assert.equal(stripped.includes("before"), true)
+  assert.equal(stripped.includes("after"), true)
+  // Newlines preserved.
+  assert.equal(stripped.split("\n").length, md.split("\n").length)
 })
 
 test("classifyAndCheck rejects symlinks that point outside the repo as escapes-repo", async (t) => {

--- a/tests/verify-workshop-integrity.test.mjs
+++ b/tests/verify-workshop-integrity.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { test } from "node:test"
@@ -13,6 +13,7 @@ import {
   runVerification,
   slugifyHeading,
   stripFencedCodeBlocks,
+  stripHtmlComments,
 } from "../scripts/verify-workshop-integrity.mjs"
 
 function makeRepo() {
@@ -341,6 +342,49 @@ test("extractReferences treats backslash-escaped \\! as literal but keeps the li
   assert.equal(refs.length, 1)
   assert.equal(refs[0].kind, "link")
   assert.equal(refs[0].target, "./b.md")
+})
+
+test("extractReferences handles multi-line inline image/link alt text and reports the opening line", () => {
+  const md = "before\n\n![long alt that\nwraps lines](./img.png)\nafter\n"
+  const refs = extractReferences(md)
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].kind, "image")
+  assert.equal(refs[0].target, "./img.png")
+  // The opening `[` lives on the third line of the document.
+  assert.equal(refs[0].line, 3)
+})
+
+test("stripHtmlComments masks single-line and multi-line HTML comments", () => {
+  const md = "before <!-- inline --> middle\nblock <!--\n[demo](./x.md)\n--> end"
+  const stripped = stripHtmlComments(md)
+  assert.equal(stripped.includes("[demo]"), false)
+  assert.equal(stripped.includes("inline"), false)
+  assert.equal(stripped.includes("before"), true)
+  assert.equal(stripped.includes("middle"), true)
+  assert.equal(stripped.includes("end"), true)
+  // Line count is preserved (newlines untouched).
+  assert.equal(stripped.split("\n").length, md.split("\n").length)
+})
+
+test("extractReferences ignores links inside HTML comments", () => {
+  const md = "real [a](./a.md)\n<!-- ignored [demo](./missing.md) -->\nend"
+  const refs = extractReferences(md)
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0].target, "./a.md")
+})
+
+test("classifyAndCheck rejects symlinks that point outside the repo as escapes-repo", async (t) => {
+  const repo = makeRepo()
+  t.after(() => repo.cleanup())
+  const outside = makeRepo()
+  t.after(() => outside.cleanup())
+  outside.write("secret.md", "# secret\n")
+  // Create a symlink inside the repo that points to a file outside.
+  mkdirSync(join(repo.root, "docs"), { recursive: true })
+  symlinkSync(join(outside.root, "secret.md"), join(repo.root, "docs/symlink.md"))
+  const from = repo.write("docs/from.md", "# from\n")
+  const result = classifyAndCheck("./symlink.md", from, repo.root, new Map())
+  assert.equal(result.status, "escapes-repo")
 })
 
 test("classifyAndCheck accepts non-hierarchical absolute URI schemes (urn:, data:)", () => {


### PR DESCRIPTION
## Summary

Adds `scripts/verify-workshop-integrity.mjs` so the link-resolution
and asset-presence pieces of CP-E (#611) are caught mechanically
before maintainer sign-off. The script walks
`docs/workshop/**/*.md`, extracts every Markdown link and image
reference, and verifies:

- Local file targets resolve relative to the containing file.
- Heading anchors (`./target.md#fragment`) match a slugified
  heading in the destination file using GitHub's slug algorithm.
- Absolute URLs are syntactically valid (no live HTTP fetch —
  offline-safe).
- `mailto:` / `tel:` schemes pass through.

Wired into `.github/workflows/lint.yml` as a separate step so
broken workshop links fail CI alongside markdownlint.

Against the current `main` workshop tree the helper reports
`scanned=10 links=24 images=4 issues=0`.

## Test plan

- [x] `node --test tests/verify-workshop-integrity.test.mjs`
      passes (13/13).
- [x] `node scripts/verify-workshop-integrity.mjs --format table`
      against current `main` reports 0 issues.
- [x] `npx dprint check`, `npx markdownlint-cli2`,
      `npx cspell lint`, `node scripts/audit-docs.mjs --check`
      all pass.
- [ ] CI green on this PR (the new lint step runs the script
      itself — self-test).

Closes #737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI tool to validate workshop documentation (checks local links, anchors and references; JSON/table output; repo-root/help flags; distinct exit codes).

* **Improvements**
  * More robust detection: ignores fenced/inline code and HTML comments, handles autolinks and angle-bracket destinations, strips queries, percent-decodes paths/anchors, and enforces directory-vs-anchor rules and repo containment.

* **Chores**
  * Added automated workshop integrity check into the linting workflow.

* **Tests**
  * Expanded tests covering parsing edge cases, resolution, normalization, and exit-code behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->