### PR TITLE
feat(idd-doctor): add workshop cross-reference presence check

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -7,6 +7,13 @@ import { fileURLToPath } from "node:url"
 
 import { inspectHelperRuntimeConfig, parseProjectCommandRows } from "./policy-helpers.mjs"
 
+const WORKSHOP_ENTRY_POINTS = ["README.md", "README.ja.md", "docs/index.md"]
+const WORKSHOP_REL_PATH = "docs/workshop"
+const WORKSHOP_LINK_TARGET_PATTERNS = [
+  /(?:^|\/)docs\/workshop(?:\/|$)/,
+  /(?:^|\/)workshop(?:\/|$)/,
+]
+
 export { parseProjectCommandRows }
 
 if (isMainModule(import.meta.url)) {
@@ -22,6 +29,7 @@ if (isMainModule(import.meta.url)) {
     requireGithub: args.requireGithub,
     cleanupBacklogWindowDays: args.cleanupBacklogWindowDays,
     cleanupBacklogWarnThreshold: args.cleanupBacklogWarnThreshold,
+    workshopCrossRefAllowMissing: args.workshopCrossRefAllowMissing,
   })
 
   if (args.json) {
@@ -703,9 +711,6 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   )
 }
 
-const WORKSHOP_ENTRY_POINTS = ["README.md", "README.ja.md", "docs/index.md"]
-const WORKSHOP_REL_PATH = "docs/workshop"
-
 export function findMissingWorkshopReferences(entryFiles, allowMissing) {
   const allowSet = new Set(
     (Array.isArray(allowMissing) ? allowMissing : []).map((path) => String(path)),
@@ -713,6 +718,10 @@ export function findMissingWorkshopReferences(entryFiles, allowMissing) {
   const missing = []
   for (const entry of entryFiles) {
     if (allowSet.has(entry.path)) {
+      continue
+    }
+    if (entry.content === null) {
+      missing.push(entry.path)
       continue
     }
     if (typeof entry.content !== "string") {
@@ -729,9 +738,14 @@ export function containsWorkshopReference(content) {
   if (typeof content !== "string" || content.length === 0) {
     return false
   }
-  const linkPattern = /\[[^\]\n]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
+  // Strip fenced code blocks (``` and ~~~) before scanning so demo
+  // Markdown inside code samples does not count as a real link.
+  const stripped = stripFencedCodeBlocks(content)
+  // Accept any double-quoted, single-quoted, or no-title destination
+  // form per CommonMark inline-link grammar.
+  const linkPattern = /\[[^\]\n]*\]\(\s*([^()\s]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g
   let match
-  while ((match = linkPattern.exec(content)) !== null) {
+  while ((match = linkPattern.exec(stripped)) !== null) {
     const target = match[1]
     if (!target) continue
     if (matchesWorkshopPath(target)) {
@@ -741,9 +755,29 @@ export function containsWorkshopReference(content) {
   return false
 }
 
+function stripFencedCodeBlocks(content) {
+  const lines = String(content).split(/\r?\n/)
+  const out = []
+  let inFence = false
+  for (const line of lines) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
+    out.push(line)
+  }
+  return out.join("\n")
+}
+
 function matchesWorkshopPath(target) {
   const cleaned = String(target).replace(/^\.\/+/, "").replace(/^\/+/, "")
-  return cleaned.startsWith(`${WORKSHOP_REL_PATH}/`) || cleaned === WORKSHOP_REL_PATH
+  for (const pattern of WORKSHOP_LINK_TARGET_PATTERNS) {
+    if (pattern.test(`/${cleaned}`)) {
+      return true
+    }
+  }
+  return false
 }
 
 // Verifies that the workshop publication is discoverable from every

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process"
-import { readFileSync, readdirSync, statSync } from "node:fs"
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
 import { join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -38,6 +38,7 @@ export function runDoctor({
   requireGithub,
   cleanupBacklogWindowDays,
   cleanupBacklogWarnThreshold,
+  workshopCrossRefAllowMissing,
 }) {
   const files = listFiles(root)
   const textFiles = files.filter(isTextLikeFile)
@@ -65,6 +66,11 @@ export function runDoctor({
       warnThreshold: cleanupBacklogWarnThreshold ?? 2,
       requireGithub,
     },
+    report,
+  )
+  checkWorkshopCrossReferences(
+    root,
+    { allowMissing: workshopCrossRefAllowMissing ?? [] },
     report,
   )
   checkGithubReadiness(root, requireGithub, report)
@@ -697,6 +703,81 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   )
 }
 
+const WORKSHOP_ENTRY_POINTS = ["README.md", "README.ja.md", "docs/index.md"]
+const WORKSHOP_REL_PATH = "docs/workshop"
+
+export function findMissingWorkshopReferences(entryFiles, allowMissing) {
+  const allowSet = new Set(
+    (Array.isArray(allowMissing) ? allowMissing : []).map((path) => String(path)),
+  )
+  const missing = []
+  for (const entry of entryFiles) {
+    if (allowSet.has(entry.path)) {
+      continue
+    }
+    if (typeof entry.content !== "string") {
+      continue
+    }
+    if (!containsWorkshopReference(entry.content)) {
+      missing.push(entry.path)
+    }
+  }
+  return missing
+}
+
+export function containsWorkshopReference(content) {
+  if (typeof content !== "string" || content.length === 0) {
+    return false
+  }
+  const linkPattern = /\[[^\]\n]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
+  let match
+  while ((match = linkPattern.exec(content)) !== null) {
+    const target = match[1]
+    if (!target) continue
+    if (matchesWorkshopPath(target)) {
+      return true
+    }
+  }
+  return false
+}
+
+function matchesWorkshopPath(target) {
+  const cleaned = String(target).replace(/^\.\/+/, "").replace(/^\/+/, "")
+  return cleaned.startsWith(`${WORKSHOP_REL_PATH}/`) || cleaned === WORKSHOP_REL_PATH
+}
+
+// Verifies that the workshop publication is discoverable from every
+// known entry point (README.md, README.ja.md, docs/index.md).
+// Skipped silently when docs/workshop/ does not exist (adopter repos
+// that never published a workshop should not see noise). The example
+// repository's back-link is intentionally out of scope here because
+// verifying it requires fetching a remote repository's README; that
+// is a separate concern under the helper-runtime profile work.
+function checkWorkshopCrossReferences(root, options, report) {
+  const allowMissing = options.allowMissing ?? []
+  const workshopDir = resolve(root, WORKSHOP_REL_PATH)
+  if (!existsSync(workshopDir)) {
+    return
+  }
+  const entryFiles = WORKSHOP_ENTRY_POINTS.map((relPath) => {
+    const abs = resolve(root, relPath)
+    if (!existsSync(abs)) {
+      return { path: relPath, content: null }
+    }
+    try {
+      return { path: relPath, content: readFileSync(abs, "utf8") }
+    } catch {
+      return { path: relPath, content: null }
+    }
+  })
+  const missing = findMissingWorkshopReferences(entryFiles, allowMissing)
+  for (const path of missing) {
+    report.warnings.push(
+      `workshop cross-reference missing in ${path}: expected a Markdown link whose target starts with ${WORKSHOP_REL_PATH}/. See acceptance criteria on issue #611 (CP-E).`,
+    )
+  }
+}
+
 function checkGithubReadiness(root, requireGithub, report) {
   const repoView = runCommand("gh", ["repo", "view", "--json", "owner,name,defaultBranchRef"], root)
   if (!repoView.ok) {
@@ -857,6 +938,18 @@ function parseArgs(argv) {
       index += 1
       continue
     }
+    if (arg === "--workshop-cross-ref-allow-missing") {
+      const value = argv[index + 1]
+      if (value === undefined) {
+        throw new Error("--workshop-cross-ref-allow-missing requires a value")
+      }
+      args.workshopCrossRefAllowMissing = value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+      index += 1
+      continue
+    }
     throw new Error(`unknown argument: ${arg}`)
   }
 
@@ -890,6 +983,7 @@ options:
   --require-github                         treat GitHub API check failures as errors
   --cleanup-backlog-window-days <N>        merged-PR window for the cleanup backlog check (default: 14)
   --cleanup-backlog-warn-threshold <N>     backlog count above which the check warns (default: 2)
+  --workshop-cross-ref-allow-missing <list> comma-separated entry-point paths to skip in the workshop cross-reference check (default: none)
   --help, -h                               show this help
 
 The merged-PR backlog scan caps at gh's per-query maximum of 1000

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -5,7 +5,9 @@ import {
   classifyBacklog,
   classifyPrimaryHead,
   computeWindowStartIso,
+  containsWorkshopReference,
   extractMarkerPrefixes,
+  findMissingWorkshopReferences,
   findPlaceholders,
   parsePrimaryWorktreePath,
   parseProjectCommandRows,
@@ -163,4 +165,69 @@ test("computeWindowStartIso returns null for windows that overflow Date range", 
   // would historically throw RangeError before this guard landed.
   assert.equal(computeWindowStartIso(now, 1e9), null)
   assert.equal(computeWindowStartIso(now, Number.MAX_SAFE_INTEGER), null)
+})
+
+test("containsWorkshopReference accepts canonical, dotted, and absolute link targets", () => {
+  assert.equal(
+    containsWorkshopReference("see [workshop](docs/workshop/README.md)"),
+    true,
+  )
+  assert.equal(
+    containsWorkshopReference("see [workshop](./docs/workshop/)"),
+    true,
+  )
+  assert.equal(
+    containsWorkshopReference("see [workshop](/docs/workshop/README.md#intro)"),
+    true,
+  )
+})
+
+test("containsWorkshopReference rejects unrelated targets and empty content", () => {
+  assert.equal(containsWorkshopReference("see [other](docs/index.md)"), false)
+  assert.equal(containsWorkshopReference("plain prose without links"), false)
+  assert.equal(containsWorkshopReference(""), false)
+  assert.equal(containsWorkshopReference(null), false)
+  assert.equal(containsWorkshopReference(undefined), false)
+})
+
+test("findMissingWorkshopReferences names entry files lacking workshop links", () => {
+  const entries = [
+    { path: "README.md", content: "see [workshop](docs/workshop/README.md)" },
+    { path: "README.ja.md", content: "ワークショップは [こちら](docs/workshop/)" },
+    { path: "docs/index.md", content: "no workshop link here" },
+  ]
+  assert.deepEqual(findMissingWorkshopReferences(entries, []), ["docs/index.md"])
+})
+
+test("findMissingWorkshopReferences flags all three entries when none link the workshop", () => {
+  const entries = [
+    { path: "README.md", content: "no link" },
+    { path: "README.ja.md", content: "リンクなし" },
+    { path: "docs/index.md", content: "no link" },
+  ]
+  assert.deepEqual(findMissingWorkshopReferences(entries, []), [
+    "README.md",
+    "README.ja.md",
+    "docs/index.md",
+  ])
+})
+
+test("findMissingWorkshopReferences skips entries whose content is null (missing files)", () => {
+  const entries = [
+    { path: "README.md", content: null },
+    { path: "README.ja.md", content: "see [workshop](docs/workshop/)" },
+  ]
+  assert.deepEqual(findMissingWorkshopReferences(entries, []), [])
+})
+
+test("findMissingWorkshopReferences honors the allow-missing list", () => {
+  const entries = [
+    { path: "README.md", content: "no link" },
+    { path: "README.ja.md", content: "see [workshop](docs/workshop/)" },
+    { path: "docs/index.md", content: "no link" },
+  ]
+  assert.deepEqual(
+    findMissingWorkshopReferences(entries, ["README.md", "docs/index.md"]),
+    [],
+  )
 })

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -182,6 +182,41 @@ test("containsWorkshopReference accepts canonical, dotted, and absolute link tar
   )
 })
 
+test("containsWorkshopReference accepts docs/index.md-relative workshop links", () => {
+  // docs/index.md naturally links with `workshop/README.md` because
+  // it lives inside docs/ itself. The cross-ref check must accept
+  // this shape too.
+  assert.equal(
+    containsWorkshopReference("see [workshop](workshop/README.md)"),
+    true,
+  )
+  assert.equal(
+    containsWorkshopReference("see [workshop](./workshop/)"),
+    true,
+  )
+})
+
+test("containsWorkshopReference accepts single-quoted and parenthesized title forms", () => {
+  assert.equal(
+    containsWorkshopReference("[w](docs/workshop/README.md 'title')"),
+    true,
+  )
+  assert.equal(
+    containsWorkshopReference("[w](docs/workshop/README.md (title))"),
+    true,
+  )
+})
+
+test("containsWorkshopReference ignores workshop links inside fenced code blocks", () => {
+  const md = "Demo:\n```md\n[workshop](docs/workshop/README.md)\n```\nreal prose"
+  assert.equal(containsWorkshopReference(md), false)
+})
+
+test("containsWorkshopReference also ignores tilde-fence code blocks", () => {
+  const md = "Demo:\n~~~md\n[workshop](docs/workshop/README.md)\n~~~\nreal prose"
+  assert.equal(containsWorkshopReference(md), false)
+})
+
 test("containsWorkshopReference rejects unrelated targets and empty content", () => {
   assert.equal(containsWorkshopReference("see [other](docs/index.md)"), false)
   assert.equal(containsWorkshopReference("plain prose without links"), false)
@@ -212,12 +247,28 @@ test("findMissingWorkshopReferences flags all three entries when none link the w
   ])
 })
 
-test("findMissingWorkshopReferences skips entries whose content is null (missing files)", () => {
+test("findMissingWorkshopReferences flags missing entry-point files (content: null)", () => {
   const entries = [
     { path: "README.md", content: null },
     { path: "README.ja.md", content: "see [workshop](docs/workshop/)" },
   ]
-  assert.deepEqual(findMissingWorkshopReferences(entries, []), [])
+  // Missing required entry-point file is a real warning signal —
+  // an adopter who removes README.md needs to know the workshop
+  // cross-reference is also gone.
+  assert.deepEqual(findMissingWorkshopReferences(entries, []), ["README.md"])
+})
+
+test("findMissingWorkshopReferences honors allow-missing for genuinely absent files", () => {
+  const entries = [
+    { path: "README.md", content: null },
+    { path: "README.ja.md", content: "see [workshop](docs/workshop/)" },
+  ]
+  // If the adopter intentionally has no README.md, allow-missing
+  // suppresses the warning.
+  assert.deepEqual(
+    findMissingWorkshopReferences(entries, ["README.md"]),
+    [],
+  )
 })
 
 test("findMissingWorkshopReferences honors the allow-missing list", () => {


### PR DESCRIPTION
## Summary

Adds `checkWorkshopCrossReferences` to `scripts/idd-doctor.mjs` so
the CP-E (#611) discoverability criterion is caught during routine
local doctor runs.

For each of the three entry-point files (`README.md`,
`README.ja.md`, `docs/index.md`), the check verifies that at least
one Markdown link target starts with `docs/workshop/` (canonical,
`./docs/workshop/`, `/docs/workshop/`, or deep-link variations all
match). Missing references emit a warning naming the file and the
expected target.

The check skips silently when `docs/workshop/` does not exist, so
adopter repositories that never published a workshop get no noise.
New `--workshop-cross-ref-allow-missing <comma-list>` flag lets
adopters suppress warnings for entry-point files they intentionally
omit.

The example-repo back-link verification (which would need a remote
README fetch) is intentionally out of scope; a code comment
documents the deferral.

## Test plan

- [x] `node --test tests/idd-doctor.test.mjs` passes (23/23, +8
      new cases over the prior 15).
- [x] `node scripts/idd-doctor.mjs` against current `main`
      produces no new warning (all three entry points link to
      the workshop).
- [x] `npx dprint check`, `npx markdownlint-cli2`,
      `npx cspell lint`, `node scripts/audit-docs.mjs --check`
      all pass.
- [ ] CI green on this PR.

Closes #738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation that checks workshop documentation is referenced from entry Markdown files.
  * Added a CLI option to allowlisting specific missing workshop references to suppress warnings.

* **Tests**
  * Added unit tests for detecting workshop references (including edge cases like code fences) and for reporting/suppressing missing references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->