### PR TITLE
fix(resume-claim-routing): enforce forcedBy authorization on forced-handoff transitions

### DIFF
--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -572,36 +572,49 @@ function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
   if (!normalized) {
     return false;
   }
-  const permission = collaboratorPermission(owner, repo, normalized, cache);
+  const { permission, roleName } = collaboratorPermission(owner, repo, normalized, cache);
+  // GitHub's legacy `permission` is one of admin|write|read|none and
+  // collapses maintain->write / triage->read. `role_name` is the
+  // granular role (admin|maintain|write|triage|read|none) but may also
+  // be a custom repository role name, in which case its literal value
+  // is not in the standard set. Check both fields so that:
+  //   - the strict policy honours role_name=maintain (otherwise
+  //     maintainers are demoted to write and rejected), and
+  //   - the loose policy honours permission=write (so custom roles
+  //     whose base permission is write still satisfy it).
   if (policy === "all-write-permission-actors") {
-    return permission === "admin" || permission === "maintain" || permission === "write";
+    return roleName === "admin"
+      || roleName === "maintain"
+      || roleName === "write"
+      || permission === "admin"
+      || permission === "write";
   }
-  return permission === "admin" || permission === "maintain";
+  return roleName === "admin" || roleName === "maintain" || permission === "admin";
 }
 
 function collaboratorPermission(owner, repo, login, cache) {
   if (cache.has(login)) {
     return cache.get(login);
   }
-  // GitHub's `permission` field is the legacy base permission and
-  // collapses `maintain` -> `write` and `triage` -> `read`, which would
-  // reject legitimate `maintain`-role maintainers under the default
-  // `owners-and-maintainers-only` authority policy. Read `role_name`
-  // to recover the granular role; fall back to `permission` only if
-  // `role_name` is unavailable.
+  // Return both the legacy `permission` and the granular `role_name`
+  // so the caller can apply each policy against the field that matches
+  // its semantics. See isAuthorizedForcedHandoffActor for the rationale.
   let permission = "";
+  let roleName = "";
   try {
-    permission = ghText([
+    const raw = ghText([
       "api",
       `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-      "--jq",
-      ".role_name // .permission // \"\"",
-    ]).toLowerCase();
+    ]);
+    const parsed = JSON.parse(raw);
+    permission = String(parsed?.permission ?? "").trim().toLowerCase();
+    roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
   } catch {
-    permission = "";
+    // both stay empty
   }
-  cache.set(login, permission);
-  return permission;
+  const result = { permission, roleName };
+  cache.set(login, result);
+  return result;
 }
 
 function parseDurationToMs(value) {

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -258,6 +258,19 @@ function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
         );
         continue;
       }
+      const authorLogin = String(event.author?.login ?? "").trim().toLowerCase();
+      const forcedByLogin = String(forcedHandoff.forcedBy ?? "").trim().toLowerCase();
+      // Bind the asserted forcedBy identity to the comment author so a
+      // trusted-marker actor cannot self-attest a handoff by naming an
+      // unrelated maintainer in the payload. Without this binding the
+      // collaborator-permission lookup downstream would happily authorize
+      // any maintainer login the attacker types into the payload.
+      if (!authorLogin || authorLogin !== forcedByLogin) {
+        warnings.push(
+          `ignored forced-handoff for ${forcedHandoff.oldClaimId}: comment author ${event.author?.login ?? "(unknown)"} does not match forcedBy ${forcedHandoff.forcedBy}`,
+        );
+        continue;
+      }
       if (!isAuthorizedForcedHandoff(forcedHandoff.forcedBy, forcedHandoff, event)) {
         warnings.push(
           `ignored forced-handoff for ${forcedHandoff.oldClaimId}: forcedBy ${forcedHandoff.forcedBy} is not an authorized maintainer`,

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -583,13 +583,19 @@ function collaboratorPermission(owner, repo, login, cache) {
   if (cache.has(login)) {
     return cache.get(login);
   }
+  // GitHub's `permission` field is the legacy base permission and
+  // collapses `maintain` and `triage` down to `write` and `read`
+  // respectively, which would reject legitimate maintainers under the
+  // default `owners-and-maintainers-only` authority policy. Read
+  // `role_name` to recover the granular role; fall back to `permission`
+  // only if `role_name` is unavailable.
   let permission = "";
   try {
     permission = ghText([
       "api",
       `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
       "--jq",
-      ".permission",
+      ".role_name // .permission // \"\"",
     ]).toLowerCase();
   } catch {
     permission = "";

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -584,11 +584,11 @@ function collaboratorPermission(owner, repo, login, cache) {
     return cache.get(login);
   }
   // GitHub's `permission` field is the legacy base permission and
-  // collapses `maintain` and `triage` down to `write` and `read`
-  // respectively, which would reject legitimate maintainers under the
-  // default `owners-and-maintainers-only` authority policy. Read
-  // `role_name` to recover the granular role; fall back to `permission`
-  // only if `role_name` is unavailable.
+  // collapses `maintain` -> `write` and `triage` -> `read`, which would
+  // reject legitimate `maintain`-role maintainers under the default
+  // `owners-and-maintainers-only` authority policy. Read `role_name`
+  // to recover the granular role; fall back to `permission` only if
+  // `role_name` is unavailable.
   let permission = "";
   try {
     permission = ghText([

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -6,6 +6,7 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { isStaleAt, parseClaimComment, parseForcedHandoffComment, parseReleaseComment } from "./protocol-helpers.mjs";
+import { normalizePolicyConfig } from "./policy-helpers.mjs";
 
 const DEFAULT_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 const LEGACY_CLAIM_PATTERN = /^<!--\s*claimed-by:\s+(\S+)\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s+branch:\s+([^\s>]+)\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i;
@@ -21,9 +22,18 @@ export function evaluateResumeClaimRouting(input, options = {}) {
   const trustedAuthor = typeof options.isTrustedAuthor === "function"
     ? options.isTrustedAuthor
     : () => true;
+  const isForcedHandoffEnabled = typeof options.isForcedHandoffEnabled === "function"
+    ? options.isForcedHandoffEnabled
+    : () => false;
+  const isAuthorizedForcedHandoff = typeof options.isAuthorizedForcedHandoff === "function"
+    ? options.isAuthorizedForcedHandoff
+    : () => false;
 
   const events = normalizeEvents(input.events).filter((event) => trustedAuthor(event.author?.login ?? ""));
-  const state = resolveClaimState(events, nowIso, staleAgeMs);
+  const state = resolveClaimState(events, nowIso, staleAgeMs, {
+    isForcedHandoffEnabled,
+    isAuthorizedForcedHandoff,
+  });
   const claimIdChecked = normalizeToken(input.claimId);
   const sameSecondContenders = state.activeClaim
     ? findSameSecondContenders(events, state.activeClaim)
@@ -143,6 +153,9 @@ function runCli() {
   const trustedSet = new Set(trustedLogins.map((login) => login.toLowerCase()));
   const comments = fetchIssueComments(repository, args.issue);
   const issue = ghJson(["api", `repos/${repository}/issues/${args.issue}`]);
+  const forcedHandoffEnabled = policy.forcedHandoff.mode === "human-gated";
+  const forcedHandoffAuthorityPolicy = policy.forcedHandoff.authorityPolicy;
+  const permissionCache = new Map();
 
   const result = evaluateResumeClaimRouting(
     {
@@ -157,6 +170,14 @@ function runCli() {
     },
     {
       isTrustedAuthor: (login) => trustedSet.has(String(login ?? "").trim().toLowerCase()),
+      isForcedHandoffEnabled: () => forcedHandoffEnabled,
+      isAuthorizedForcedHandoff: (forcedBy) => isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy,
+        permissionCache,
+      ),
     },
   );
 
@@ -172,13 +193,21 @@ function runCli() {
       source: policy.source,
       stale_age_ms: staleAgeMs,
       trusted_marker_logins: trustedLogins,
+      forced_handoff_mode: policy.forcedHandoff.mode,
+      forced_handoff_authority_policy: forcedHandoffAuthorityPolicy,
     },
     ...result,
   };
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }
 
-function resolveClaimState(events, nowIso, staleAgeMs) {
+function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
+  const isForcedHandoffEnabled = typeof options.isForcedHandoffEnabled === "function"
+    ? options.isForcedHandoffEnabled
+    : () => false;
+  const isAuthorizedForcedHandoff = typeof options.isAuthorizedForcedHandoff === "function"
+    ? options.isAuthorizedForcedHandoff
+    : () => false;
   const orderedEvents = [...events].sort(compareEvents);
   const warnings = [];
   let activeClaim = null;
@@ -223,6 +252,18 @@ function resolveClaimState(events, nowIso, staleAgeMs) {
       && forcedHandoff.oldClaimId === activeClaim.claimId
       && forcedHandoff.branch === activeClaim.branch
     ) {
+      if (!isForcedHandoffEnabled(forcedHandoff, event)) {
+        warnings.push(
+          `ignored forced-handoff for ${forcedHandoff.oldClaimId}: forced-handoff mode is not enabled`,
+        );
+        continue;
+      }
+      if (!isAuthorizedForcedHandoff(forcedHandoff.forcedBy, forcedHandoff, event)) {
+        warnings.push(
+          `ignored forced-handoff for ${forcedHandoff.oldClaimId}: forcedBy ${forcedHandoff.forcedBy} is not an authorized maintainer`,
+        );
+        continue;
+      }
       activeClaim = {
         agentId: forcedHandoff.newAgentId,
         claimId: forcedHandoff.newClaimId,
@@ -484,23 +525,64 @@ function loadPolicy(policyPath, { strict = false } = {}) {
   const source = policyPath ? resolve(process.cwd(), policyPath) : resolve(process.cwd(), ".github/idd/config.json");
   try {
     const config = JSON.parse(readFileSync(source, "utf8"));
+    const normalized = normalizePolicyConfig(config);
     return {
       source,
       staleAgeMs: parseDurationToMs(config?.claimTiming?.staleAge) ?? DEFAULT_STALE_AGE_MS,
       trustedMarkerActors: Array.isArray(config?.trustedMarkerActors)
         ? config.trustedMarkerActors.map((value) => String(value ?? "").trim()).filter(Boolean)
         : [],
+      forcedHandoff: {
+        mode: normalized.forcedHandoff.mode,
+        authorityPolicy: normalized.forcedHandoff.authorityPolicy,
+      },
     };
   } catch (error) {
     if (strict) {
       throw new Error(`failed to load policy from ${source}: ${String(error?.message ?? error)}`);
     }
+    const normalized = normalizePolicyConfig({});
     return {
       source,
       staleAgeMs: DEFAULT_STALE_AGE_MS,
       trustedMarkerActors: [],
+      forcedHandoff: {
+        mode: normalized.forcedHandoff.mode,
+        authorityPolicy: normalized.forcedHandoff.authorityPolicy,
+      },
     };
   }
+}
+
+function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
+  const normalized = String(login ?? "").trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const permission = collaboratorPermission(owner, repo, normalized, cache);
+  if (policy === "all-write-permission-actors") {
+    return permission === "admin" || permission === "maintain" || permission === "write";
+  }
+  return permission === "admin" || permission === "maintain";
+}
+
+function collaboratorPermission(owner, repo, login, cache) {
+  if (cache.has(login)) {
+    return cache.get(login);
+  }
+  let permission = "";
+  try {
+    permission = ghText([
+      "api",
+      `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+      "--jq",
+      ".permission",
+    ]).toLowerCase();
+  } catch {
+    permission = "";
+  }
+  cache.set(login, permission);
+  return permission;
 }
 
 function parseDurationToMs(value) {

--- a/tests/resume-claim-routing.test.mjs
+++ b/tests/resume-claim-routing.test.mjs
@@ -313,6 +313,49 @@ test("forced-handoff is ignored when forcedBy is not an authorized maintainer", 
   );
 });
 
+test("forced-handoff is ignored when comment author does not match forcedBy", () => {
+  // A trusted-marker actor (here `copilot`) posts a forged handoff that
+  // names a real maintainer as the forcing authority. Without the
+  // author-vs-forcedBy binding, the downstream collaborator-permission
+  // lookup would happily authorize "real-maintainer". The library must
+  // reject the marker before reaching that lookup.
+  const result = evaluateResumeClaimRouting(
+    {
+      claimId: "claim-B",
+      now: "2026-05-23T10:05:00Z",
+      events: [
+        {
+          createdAt: "2026-05-23T10:00:00Z",
+          author: { login: "copilot" },
+          body: "<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->",
+        },
+        {
+          createdAt: "2026-05-23T10:02:00Z",
+          author: { login: "copilot" },
+          body:
+            "<!-- forced-handoff: {\"oldAgentId\":\"copilot\",\"oldClaimId\":\"claim-A\",\"newAgentId\":\"copilot\",\"newClaimId\":\"claim-B\",\"branch\":\"issue/100-task\",\"forcedBy\":\"real-maintainer\",\"reason\":\"forged\",\"timestamp\":\"2026-05-23T10:02:00Z\",\"contextScope\":\"issue-only\"} -->\n\n_copilot: forced handoff — IDD automation marker. Do not edit._",
+        },
+      ],
+    },
+    {
+      isTrustedAuthor: trusted(["copilot"]),
+      isForcedHandoffEnabled: () => true,
+      // The forcedBy string passes a naive collaborator-permission lookup
+      // but the author binding inside the library must reject the marker
+      // before this callback is even consulted.
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "real-maintainer",
+    },
+  );
+
+  assert.equal(result.state, "non_inheritable");
+  assert.equal(result.active_claim?.claim_id, "claim-A");
+  assert.ok(
+    result.warnings.some((message) =>
+      message.includes("comment author copilot does not match forcedBy real-maintainer")),
+    "expected a warning naming the author/forcedBy mismatch",
+  );
+});
+
 test("self-signed forced-handoff from same identity does not transfer ownership", () => {
   // The PoC scenario: Session B running under the same GitHub login as
   // Session A posts a forced-handoff with `forcedBy: copilot` (its own

--- a/tests/resume-claim-routing.test.mjs
+++ b/tests/resume-claim-routing.test.mjs
@@ -228,30 +228,128 @@ test("legacy stale claim routes to takeover", () => {
   assert.equal(result.reason, "legacy-claim-stale");
 });
 
-test("forced-handoff marker promotes successor claim before routing", () => {
+const FORCED_HANDOFF_EVENTS = [
+  {
+    createdAt: "2026-05-12T10:00:00Z",
+    author: { login: "maintainer" },
+    body: "<!-- claimed-by: copilot claim-old supersedes: none 2026-05-12T10:00:00Z branch: issue/11-task -->",
+  },
+  {
+    createdAt: "2026-05-12T10:01:00Z",
+    author: { login: "maintainer" },
+    body:
+      "<!-- forced-handoff: {\"oldAgentId\":\"copilot\",\"oldClaimId\":\"claim-old\",\"newAgentId\":\"copilot\",\"newClaimId\":\"claim-new\",\"branch\":\"issue/11-task\",\"forcedBy\":\"maintainer\",\"reason\":\"handoff\",\"timestamp\":\"2026-05-12T10:01:00Z\",\"contextScope\":\"issue-only\"} -->\n\n_maintainer: forced handoff — IDD automation marker. Do not edit._",
+  },
+];
+
+test("authorized forced-handoff marker promotes successor claim before routing", () => {
   const result = evaluateResumeClaimRouting(
     {
       claimId: "claim-new",
       now: "2026-05-12T11:00:00Z",
-      events: [
-        {
-          createdAt: "2026-05-12T10:00:00Z",
-          author: { login: "maintainer" },
-          body: "<!-- claimed-by: copilot claim-old supersedes: none 2026-05-12T10:00:00Z branch: issue/11-task -->",
-        },
-        {
-          createdAt: "2026-05-12T10:01:00Z",
-          author: { login: "maintainer" },
-          body:
-            "<!-- forced-handoff: {\"oldAgentId\":\"copilot\",\"oldClaimId\":\"claim-old\",\"newAgentId\":\"copilot\",\"newClaimId\":\"claim-new\",\"branch\":\"issue/11-task\",\"forcedBy\":\"maintainer\",\"reason\":\"handoff\",\"timestamp\":\"2026-05-12T10:01:00Z\",\"contextScope\":\"issue-only\"} -->\n\n_maintainer: forced handoff — IDD automation marker. Do not edit._",
-        },
-      ],
+      events: FORCED_HANDOFF_EVENTS,
     },
-    { isTrustedAuthor: trusted(["maintainer"]) },
+    {
+      isTrustedAuthor: trusted(["maintainer"]),
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "maintainer",
+    },
   );
 
   assert.equal(result.state, "already_owned");
   assert.equal(result.active_claim?.claim_id, "claim-new");
+});
+
+test("forced-handoff is ignored when forced-handoff mode is disabled", () => {
+  const result = evaluateResumeClaimRouting(
+    {
+      claimId: "claim-new",
+      now: "2026-05-12T11:00:00Z",
+      events: FORCED_HANDOFF_EVENTS,
+    },
+    {
+      isTrustedAuthor: trusted(["maintainer"]),
+      // isForcedHandoffEnabled omitted -> defaults to () => false
+      isAuthorizedForcedHandoff: () => true,
+    },
+  );
+
+  assert.equal(result.state, "non_inheritable");
+  assert.equal(result.action, "stop");
+  assert.equal(result.reason, "active-claim-non-stale");
+  assert.equal(result.active_claim?.claim_id, "claim-old");
+  assert.ok(
+    result.warnings.some((message) => message.includes("forced-handoff mode is not enabled")),
+    "expected a warning naming the disabled forced-handoff mode",
+  );
+});
+
+test("forced-handoff is ignored when forcedBy is not an authorized maintainer", () => {
+  // Reproduces the same-identity self-signed hijack scenario: a second
+  // session running under the trusted marker login posts a forged
+  // forced-handoff naming itself as the forcing authority. The
+  // authorization callback rejects unauthorized forcedBy actors.
+  const result = evaluateResumeClaimRouting(
+    {
+      claimId: "claim-new",
+      now: "2026-05-12T11:00:00Z",
+      events: FORCED_HANDOFF_EVENTS,
+    },
+    {
+      isTrustedAuthor: trusted(["maintainer"]),
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "owner-account",
+    },
+  );
+
+  assert.equal(result.state, "non_inheritable");
+  assert.equal(result.action, "stop");
+  assert.equal(result.reason, "active-claim-non-stale");
+  assert.equal(result.active_claim?.claim_id, "claim-old");
+  assert.ok(
+    result.warnings.some((message) =>
+      message.includes("forcedBy maintainer is not an authorized maintainer")),
+    "expected a warning naming the unauthorized forcedBy actor",
+  );
+});
+
+test("self-signed forced-handoff from same identity does not transfer ownership", () => {
+  // The PoC scenario: Session B running under the same GitHub login as
+  // Session A posts a forced-handoff with `forcedBy: copilot` (its own
+  // login). Even though the comment author is trusted (auto-trusted as
+  // viewer in the CLI path), `copilot` is not an authorized maintainer,
+  // so the handoff must be ignored.
+  const result = evaluateResumeClaimRouting(
+    {
+      claimId: "claim-B",
+      now: "2026-05-23T10:05:00Z",
+      events: [
+        {
+          createdAt: "2026-05-23T10:00:00Z",
+          author: { login: "copilot" },
+          body: "<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->",
+        },
+        {
+          createdAt: "2026-05-23T10:02:00Z",
+          author: { login: "copilot" },
+          body:
+            "<!-- forced-handoff: {\"oldAgentId\":\"copilot\",\"oldClaimId\":\"claim-A\",\"newAgentId\":\"copilot\",\"newClaimId\":\"claim-B\",\"branch\":\"issue/100-task\",\"forcedBy\":\"copilot\",\"reason\":\"unilateral\",\"timestamp\":\"2026-05-23T10:02:00Z\",\"contextScope\":\"issue-only\"} -->\n\n_copilot: forced handoff — IDD automation marker. Do not edit._",
+        },
+      ],
+    },
+    {
+      isTrustedAuthor: trusted(["copilot"]),
+      isForcedHandoffEnabled: () => true,
+      // The shipped CLI builds this from the collaborator permission
+      // policy. Here we hard-code: only `maintainer-account` is
+      // authorized. The self-signed `copilot` actor is rejected.
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === "maintainer-account",
+    },
+  );
+
+  assert.notEqual(result.state, "already_owned");
+  assert.equal(result.state, "non_inheritable");
+  assert.equal(result.active_claim?.claim_id, "claim-A");
 });
 
 test("legacy freshness uses marker timestamp over comment metadata timestamp", () => {


### PR DESCRIPTION
## Summary

Closes #746 (part of roadmap #745).

`scripts/resume-claim-routing.mjs` `resolveClaimState` previously
accepted any parseable `<!-- forced-handoff: … -->` comment from
a trusted marker author and rewrote the active claim, **without
checking** whether the `forcedBy` field belonged to an authorized
maintainer. The companion `applyClaimEvent` in
`scripts/protocol-helpers.mjs` already gates the same transition
behind `isAuthorizedForcedHandoff` / `isForcedHandoffEnabled`
callbacks — but the Resume phase never went through it.

Because `resolveTrustedLogins` auto-adds the current
`gh api user` login to trusted markers, a second session running
under the same GitHub identity could post a self-signed handoff
(`forcedBy: <own-login>`) and immediately receive
`state=already_owned, action=keep` from
`evaluateResumeClaimRouting` — without 24 h staleness and
without any maintainer involvement. PoC reproduced against
`main` on 2026-05-23.

## What changed

- `evaluateResumeClaimRouting` and `resolveClaimState` accept
  `isForcedHandoffEnabled` and `isAuthorizedForcedHandoff`
  callbacks. Both default to `() => false` so callers must opt
  in explicitly. Rejected handoffs leave the active claim
  unchanged and emit a warning naming the reason.
- The CLI wrapper resolves `forcedHandoff.mode` and
  `forcedHandoff.authorityPolicy` from
  `.github/idd/config.json` via `normalizePolicyConfig` and
  builds the callbacks using a collaborator-permission lookup
  that mirrors the helpers in `live-status-digest`,
  `audit-pr-cleanup`, `pre-merge-readiness`, and
  `forced-handoff-marker`.
- The CLI output `policy` block now surfaces
  `forced_handoff_mode` and `forced_handoff_authority_policy`
  so operators can see which policy was active when a
  forced-handoff was rejected.
- The existing forced-handoff test is updated to opt into both
  callbacks; new tests cover the disabled-mode path, the
  unauthorized-`forcedBy` path, and the original self-signed
  hijack PoC scenario.

The factoring is deliberately copy-pasted from the existing
helper duplications in `audit-pr-cleanup.mjs`,
`pre-merge-readiness.mjs`, and `forced-handoff-marker.mjs`.
Roadmap #745 Track 3 (#748) consolidates all four copies into a
single shared module after this fix and #747 land.

## Test plan

- [x] `node --test tests/*.mjs` — 761/761 pass.
- [x] `npx dprint check "**/*.md"` — clean.
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors.
- [x] `npx cspell lint "**" --no-progress` — 0 issues.
- [x] `node scripts/audit-docs.mjs --check` — passes.
- [x] `node scripts/sync-docs.mjs --check` — up to date.
- [x] PoC repro from the audit (`Session B forges
      `forcedBy: copilot` against Session A's non-stale claim) now
      returns `state=non_inheritable` (covered by the
      `self-signed forced-handoff from same identity does not
      transfer ownership` test).
- [x] Authorized maintainer-signed handoff still transfers
      ownership (regression-covered).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Policy-driven, configurable forced-handoff controls with authority-based authorization and explicit enable/disable modes
  * CLI now reports forced-handoff mode and authority policy and emits warnings when forced-handoffs are ignored

* **Tests**
  * Expanded coverage for enabled/disabled modes, authorized/unauthorized actors, author/forcedBy mismatches, and self-signed handoff prevention

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/750?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->