### PR TITLE
fix(protocol-helpers): enforce heartbeat branch invariant in applyClaimEvent

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2613,6 +2613,22 @@ export function applyClaimEvent(activeClaim, event, options = {}) {
     }
 
     if (claim.agentId === activeClaim.agentId && claim.claimId === activeClaim.claimId) {
+      // Enforce the heartbeat branch invariant (idd-claim.instructions.md
+      // rule 3.5): a heartbeat candidate whose {branch} does not exactly
+      // match the active claim's {branch} is anomalous and must not
+      // refresh the stale clock. Without this guard, a spurious heartbeat
+      // could extend the stale clock indefinitely and block the 24h
+      // stale-takeover recovery path that audit-pr-cleanup depends on.
+      if (claim.branch !== activeClaim.branch) {
+        normalizedOptions.onAnomalousHeartbeat({
+          agentId: claim.agentId,
+          claimId: claim.claimId,
+          activeBranch: activeClaim.branch,
+          heartbeatBranch: claim.branch,
+          createdAt: event.createdAt,
+        });
+        return activeClaim;
+      }
       return {
         ...activeClaim,
         createdAt: event.createdAt ?? activeClaim.createdAt,
@@ -2659,6 +2675,7 @@ function normalizeClaimResolutionOptions(optionsOrPredicate) {
       isTrustedAuthor: optionsOrPredicate,
       isForcedHandoffEnabled: () => false,
       isAuthorizedForcedHandoff: () => false,
+      onAnomalousHeartbeat: () => {},
     };
   }
 
@@ -2674,6 +2691,10 @@ function normalizeClaimResolutionOptions(optionsOrPredicate) {
       typeof options.isAuthorizedForcedHandoff === "function"
         ? options.isAuthorizedForcedHandoff
         : () => false,
+    onAnomalousHeartbeat:
+      typeof options.onAnomalousHeartbeat === "function"
+        ? options.onAnomalousHeartbeat
+        : () => {},
   };
 }
 

--- a/tests/claim-parser.test.mjs
+++ b/tests/claim-parser.test.mjs
@@ -98,6 +98,77 @@ test("applies claim transitions across heartbeat, takeover, and release", () => 
   assert.equal(released, null);
 });
 
+test("matching-branch heartbeat refreshes the active claim's createdAt", () => {
+  const active = parseClaimComment(
+    "<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->",
+    "2026-05-23T10:00:00Z",
+  );
+  const after = applyClaimEvent(active, {
+    body: "<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T13:00:00Z branch: issue/100-task -->",
+    createdAt: "2026-05-23T13:00:00Z",
+  });
+  assert.equal(after.createdAt, "2026-05-23T13:00:00Z");
+  assert.equal(after.branch, "issue/100-task");
+  assert.equal(after.claimId, "claim-A");
+});
+
+test("branch-mismatched heartbeat is anomalous and does not refresh the stale clock", () => {
+  // idd-claim.instructions.md rule 3.5: heartbeat whose {branch} does
+  // not match the active claim's branch is anomalous and must not
+  // refresh the stale clock. Without this guard, a spurious heartbeat
+  // could extend the stale clock indefinitely and block stale-takeover
+  // recovery.
+  const active = parseClaimComment(
+    "<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->",
+    "2026-05-23T10:00:00Z",
+  );
+  const after = applyClaimEvent(active, {
+    body: "<!-- claimed-by: copilot claim-A supersedes: none 2026-05-24T11:00:00Z branch: issue/999-WRONG -->",
+    createdAt: "2026-05-24T11:00:00Z",
+  });
+  // createdAt unchanged: still 10:00, not 11:00 (which would be ~25 h
+  // newer and would have masked staleness).
+  assert.equal(after.createdAt, "2026-05-23T10:00:00Z");
+  assert.equal(after.branch, "issue/100-task");
+});
+
+test("onAnomalousHeartbeat callback receives the anomalous heartbeat metadata", () => {
+  const active = parseClaimComment(
+    "<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->",
+    "2026-05-23T10:00:00Z",
+  );
+  const seen = [];
+  applyClaimEvent(active, {
+    body: "<!-- claimed-by: copilot claim-A supersedes: none 2026-05-24T11:00:00Z branch: issue/999-WRONG -->",
+    createdAt: "2026-05-24T11:00:00Z",
+  }, {
+    onAnomalousHeartbeat: (info) => seen.push(info),
+  });
+  assert.equal(seen.length, 1);
+  assert.deepEqual(seen[0], {
+    agentId: "copilot",
+    claimId: "claim-A",
+    activeBranch: "issue/100-task",
+    heartbeatBranch: "issue/999-WRONG",
+    createdAt: "2026-05-24T11:00:00Z",
+  });
+});
+
+test("matching heartbeat does not invoke the onAnomalousHeartbeat callback", () => {
+  const active = parseClaimComment(
+    "<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->",
+    "2026-05-23T10:00:00Z",
+  );
+  const seen = [];
+  applyClaimEvent(active, {
+    body: "<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T13:00:00Z branch: issue/100-task -->",
+    createdAt: "2026-05-23T13:00:00Z",
+  }, {
+    onAnomalousHeartbeat: (info) => seen.push(info),
+  });
+  assert.equal(seen.length, 0);
+});
+
 function readText(relativePath) {
   return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
 }


### PR DESCRIPTION
## Summary

Closes #747 (part of roadmap #745).

`applyClaimEvent` in `scripts/protocol-helpers.mjs` previously
refreshed an active claim's stale clock whenever the incoming
claim's `agentId` and `claimId` matched, regardless of `branch`.
`idd-claim.instructions.md` rule 3.5 requires the heartbeat's
`{branch}` to exactly match the active claim's `{branch}`;
otherwise the heartbeat is anomalous and must not refresh the
stale clock.

The Resume phase parser (`resolveClaimState` in
`resume-claim-routing.mjs`) already enforced this rule, but the
canonical `applyClaimEvent` did not. That helper is the parser
used by `summarizeClaimValidation` → the Claim Revalidation
Gate → `live-status-digest`, `audit-pr-cleanup`,
`pre-merge-readiness`, and `forced-handoff-marker`. A spurious
heartbeat with a wrong branch could therefore extend the stale
clock indefinitely from the revalidation gate's point of view,
masking staleness and blocking the 24h stale-takeover recovery
path that audit-pr-cleanup depends on. PoC reproduced 2026-05-23.

## What changed

- `applyClaimEvent` now requires `claim.branch === activeClaim.branch`
  before refreshing `createdAt`. A branch-mismatched heartbeat
  returns the active claim unchanged.
- Added an optional `options.onAnomalousHeartbeat?: (info) => void`
  callback so callers that want to surface the warning can do so.
  Default is silent to preserve existing call signatures.
- `normalizeClaimResolutionOptions` accepts and defaults the new
  option to a no-op.

## Test plan

- [x] `node --test tests/*.mjs` — 766/766 pass.
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors.
- [x] `npx cspell lint "**" --no-progress` — 0 issues.
- [x] PoC repro (25h-later branch-mismatched heartbeat against
      `issue/100-task`) now leaves `createdAt` unchanged.
- [x] Matching-branch heartbeat still refreshes (regression-covered).
- [x] `onAnomalousHeartbeat` callback receives the anomalous
      metadata when supplied, never fires on matching heartbeats.