### PR TITLE
docs(idd-claim): codify forced-handoff handling rule in claim-state parsing

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -370,6 +370,30 @@ chronologically and apply these rules:
    whose `{agent-id}` differs, or whose `{claim-id}` was already
    superseded, or whose `supersedes:` value does not match the current
    active claim when one exists, is ignored as a stale or invalid event.
+7. A `<!-- forced-handoff: { … } -->` marker (parsed by
+   `parseForcedHandoffComment` in `scripts/protocol-helpers.mjs`)
+   transfers the active claim to the named successor only when **all**
+   hold:
+   - the comment **author** is a trusted marker actor (rule 2);
+   - the author **equals** the marker's `forcedBy` (case-insensitive);
+     the GitHub author is authoritative, the payload field alone is
+     not (a mismatch is rejected as forged);
+   - that author is an authorized maintainer under
+     `forcedHandoff.authorityPolicy` — `owners-and-maintainers-only`
+     accepts `role_name == admin / maintain` or `permission == admin`;
+     `all-write-permission-actors` additionally accepts
+     `role_name == write` or `permission == write` so custom write-base
+     roles still satisfy the loose policy (reference implementation:
+     `isAuthorizedForcedHandoffActor`);
+   - `forcedHandoff.mode` is `human-gated` (default `disabled`);
+   - `oldAgentId` / `oldClaimId` / `branch` all match the active claim.
+
+   When all hold, replace the active claim with the successor
+   (`newAgentId` / `newClaimId`, same `branch`, `supersedes =
+   oldClaimId`). On any failure — typically an unauthorized
+   `forcedBy`, an author/`forcedBy` mismatch, or `mode != human-gated`
+   — leave the active claim unchanged and warn if it affects a routing
+   decision.
 
 Same-agent restarts never silently inherit or supersede an active
 non-stale claim. If the current session already recorded and verified
@@ -378,6 +402,9 @@ and use heartbeats; do not post a fresh takeover claim. If the session
 cannot prove ownership of the active `{claim-id}`, the active claim is
 treated as owned by another live session until it is released or stale,
 even when `{agent-id}` matches.
+Self-signed forced-handoff markers from the same identity never
+transfer ownership: rule 7 rejects them unless the author is itself
+an authorized maintainer.
 If a successor posts a fresh claim after forced handoff, later
 heartbeats from the displaced old `{claim-id}` are ignored as stale
 events; they do not reclaim ownership or refresh the stale clock.

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -377,7 +377,14 @@ chronologically and apply these rules:
    - the comment **author** is a trusted marker actor (rule 2);
    - the author **equals** the marker's `forcedBy` (case-insensitive);
      the GitHub author is authoritative, the payload field alone is
-     not (a mismatch is rejected as forged);
+     not (a mismatch is rejected as forged). The Resume routing
+     parser (`resolveClaimState` in `scripts/resume-claim-routing.mjs`)
+     enforces this binding at the library level. The shared
+     revalidation parser (`applyClaimEvent` in
+     `scripts/protocol-helpers.mjs`) currently delegates the binding
+     to each caller's `isAuthorizedForcedHandoff` callback; callers
+     that use `summarizeClaimValidation` MUST verify the binding
+     themselves until the parsers consolidate;
    - that author is an authorized maintainer under
      `forcedHandoff.authorityPolicy` — `owners-and-maintainers-only`
      accepts `role_name == admin / maintain` or `permission == admin`;

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -370,6 +370,30 @@ chronologically and apply these rules:
    whose `{agent-id}` differs, or whose `{claim-id}` was already
    superseded, or whose `supersedes:` value does not match the current
    active claim when one exists, is ignored as a stale or invalid event.
+7. A `<!-- forced-handoff: { … } -->` marker (parsed by
+   `parseForcedHandoffComment` in `scripts/protocol-helpers.mjs`)
+   transfers the active claim to the named successor only when **all**
+   hold:
+   - the comment **author** is a trusted marker actor (rule 2);
+   - the author **equals** the marker's `forcedBy` (case-insensitive);
+     the GitHub author is authoritative, the payload field alone is
+     not (a mismatch is rejected as forged);
+   - that author is an authorized maintainer under
+     `forcedHandoff.authorityPolicy` — `owners-and-maintainers-only`
+     accepts `role_name == admin / maintain` or `permission == admin`;
+     `all-write-permission-actors` additionally accepts
+     `role_name == write` or `permission == write` so custom write-base
+     roles still satisfy the loose policy (reference implementation:
+     `isAuthorizedForcedHandoffActor`);
+   - `forcedHandoff.mode` is `human-gated` (default `disabled`);
+   - `oldAgentId` / `oldClaimId` / `branch` all match the active claim.
+
+   When all hold, replace the active claim with the successor
+   (`newAgentId` / `newClaimId`, same `branch`, `supersedes =
+   oldClaimId`). On any failure — typically an unauthorized
+   `forcedBy`, an author/`forcedBy` mismatch, or `mode != human-gated`
+   — leave the active claim unchanged and warn if it affects a routing
+   decision.
 
 Same-agent restarts never silently inherit or supersede an active
 non-stale claim. If the current session already recorded and verified
@@ -378,6 +402,9 @@ and use heartbeats; do not post a fresh takeover claim. If the session
 cannot prove ownership of the active `{claim-id}`, the active claim is
 treated as owned by another live session until it is released or stale,
 even when `{agent-id}` matches.
+Self-signed forced-handoff markers from the same identity never
+transfer ownership: rule 7 rejects them unless the author is itself
+an authorized maintainer.
 If a successor posts a fresh claim after forced handoff, later
 heartbeats from the displaced old `{claim-id}` are ignored as stale
 events; they do not reclaim ownership or refresh the stale clock.

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -377,7 +377,14 @@ chronologically and apply these rules:
    - the comment **author** is a trusted marker actor (rule 2);
    - the author **equals** the marker's `forcedBy` (case-insensitive);
      the GitHub author is authoritative, the payload field alone is
-     not (a mismatch is rejected as forged);
+     not (a mismatch is rejected as forged). The Resume routing
+     parser (`resolveClaimState` in `scripts/resume-claim-routing.mjs`)
+     enforces this binding at the library level. The shared
+     revalidation parser (`applyClaimEvent` in
+     `scripts/protocol-helpers.mjs`) currently delegates the binding
+     to each caller's `isAuthorizedForcedHandoff` callback; callers
+     that use `summarizeClaimValidation` MUST verify the binding
+     themselves until the parsers consolidate;
    - that author is an authorized maintainer under
      `forcedHandoff.authorityPolicy` — `owners-and-maintainers-only`
      accepts `role_name == admin / maintain` or `permission == admin`;


### PR DESCRIPTION
## Summary

Closes #749 (part of roadmap #745).

The Claim-state parsing section in
`.github/instructions/idd-claim.instructions.md` (rules 1-6)
covered `claimed-by`, `unclaimed-by`, and heartbeats but said
nothing about `<!-- forced-handoff: { … } -->` markers. Agents
performing manual revalidation per the Claim Revalidation Gate
in `idd-overview-core.instructions.md` could therefore either
ignore legitimate handoffs or accept forged ones, because the
rule set never said what to verify.

## What changed

Add rule 7 covering the full forced-handoff transition contract
the script implementations now enforce after #746 (PR #750) and
#747 (PR #751):

- comment **author** must be a trusted marker actor (rule 2);
- author must **equal** the marker's `forcedBy` (case-insensitive);
  the GitHub author is authoritative — the payload field alone is
  not, and a mismatch is rejected as forged;
- that author must be an authorized maintainer under the
  configured `forcedHandoff.authorityPolicy`, including the
  `role_name` vs legacy `permission` distinction for both the
  strict (`owners-and-maintainers-only`) and loose
  (`all-write-permission-actors`) policies;
- `forcedHandoff.mode` must be `human-gated` (default `disabled`);
- the marker's `oldAgentId` / `oldClaimId` / `branch` must match
  the active claim.

Also extends the section's trailing prose with a parallel
sentence to the existing same-agent restart guard: self-signed
forced-handoff markers from the same identity never transfer
ownership.

Mirrored into `idd-template/`. Wording trimmed so the discovery
bundle stays within the 75300-byte audit-docs limit.

## Test plan

- [x] `node scripts/sync-docs.mjs --check` — all mirrored
      artifacts up to date.
- [x] `node scripts/audit-docs.mjs --check` — discovery bundle
      74775 / 75300 bytes.
- [x] `npx dprint check "**/*.md"` — clean.
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors.
- [x] `npx cspell lint "**" --no-progress` — 0 issues.
- [x] `node --test tests/*.mjs` — 766/766 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated claim-state parsing rules to document forced-handoff transfer conditions with authorization and consistency requirements.
  * Clarified restrictions on self-signed forced-handoff markers from the same identity.
  * Added details on failure handling and warning surfacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->