### PR TITLE
refactor(claim): unify resume resolveClaimState with protocol-helpers.applyClaimEvent

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -375,16 +375,15 @@ chronologically and apply these rules:
    transfers the active claim to the named successor only when **all**
    hold:
    - the comment **author** is a trusted marker actor (rule 2);
-   - the author **equals** the marker's `forcedBy` (case-insensitive);
-     the GitHub author is authoritative, the payload field alone is
-     not (a mismatch is rejected as forged). The Resume routing
-     parser (`resolveClaimState` in `scripts/resume-claim-routing.mjs`)
-     enforces this binding at the library level. The shared
-     revalidation parser (`applyClaimEvent` in
-     `scripts/protocol-helpers.mjs`) currently delegates the binding
-     to each caller's `isAuthorizedForcedHandoff` callback; callers
-     that use `summarizeClaimValidation` MUST verify the binding
-     themselves until the parsers consolidate;
+   - the author **equals** the marker's `forcedBy` (case-insensitive)
+     when the caller opts in to strict binding. The shared
+     `applyClaimEvent` parser in `scripts/protocol-helpers.mjs`
+     enforces this when `requireAuthorMatchesForcedBy: true` is set
+     (Resume routing opts in by default to block the same-identity
+     self-signed hijack path). Callers that need to accept
+     maintainer-authorized handoffs posted by a separate automation
+     actor leave it off and rely on the `isAuthorizedForcedHandoff`
+     callback alone;
    - that author is an authorized maintainer under
      `forcedHandoff.authorityPolicy` — `owners-and-maintainers-only`
      accepts `role_name == admin / maintain` or `permission == admin`;

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -375,16 +375,15 @@ chronologically and apply these rules:
    transfers the active claim to the named successor only when **all**
    hold:
    - the comment **author** is a trusted marker actor (rule 2);
-   - the author **equals** the marker's `forcedBy` (case-insensitive);
-     the GitHub author is authoritative, the payload field alone is
-     not (a mismatch is rejected as forged). The Resume routing
-     parser (`resolveClaimState` in `scripts/resume-claim-routing.mjs`)
-     enforces this binding at the library level. The shared
-     revalidation parser (`applyClaimEvent` in
-     `scripts/protocol-helpers.mjs`) currently delegates the binding
-     to each caller's `isAuthorizedForcedHandoff` callback; callers
-     that use `summarizeClaimValidation` MUST verify the binding
-     themselves until the parsers consolidate;
+   - the author **equals** the marker's `forcedBy` (case-insensitive)
+     when the caller opts in to strict binding. The shared
+     `applyClaimEvent` parser in `scripts/protocol-helpers.mjs`
+     enforces this when `requireAuthorMatchesForcedBy: true` is set
+     (Resume routing opts in by default to block the same-identity
+     self-signed hijack path). Callers that need to accept
+     maintainer-authorized handoffs posted by a separate automation
+     actor leave it off and rely on the `isAuthorizedForcedHandoff`
+     callback alone;
    - that author is an authorized maintainer under
      `forcedHandoff.authorityPolicy` — `owners-and-maintainers-only`
      accepts `role_name == admin / maintain` or `permission == admin`;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2635,7 +2635,10 @@ export function applyClaimEvent(activeClaim, event, options = {}) {
       };
     }
 
-    if (claim.supersedes === activeClaim.claimId && isStaleAt(activeClaim.createdAt, event.createdAt ?? "")) {
+    if (
+      claim.supersedes === activeClaim.claimId
+      && normalizedOptions.isStale(activeClaim.createdAt, event.createdAt ?? "")
+    ) {
       return claim;
     }
 
@@ -2651,12 +2654,46 @@ export function applyClaimEvent(activeClaim, event, options = {}) {
   if (
     forcedHandoff
     && activeClaim
-    && normalizedOptions.isForcedHandoffEnabled(forcedHandoff, event)
-    && normalizedOptions.isAuthorizedForcedHandoff(forcedHandoff.forcedBy, forcedHandoff, event)
     && forcedHandoff.oldAgentId === activeClaim.agentId
     && forcedHandoff.oldClaimId === activeClaim.claimId
     && forcedHandoff.branch === activeClaim.branch
   ) {
+    if (!normalizedOptions.isForcedHandoffEnabled(forcedHandoff, event)) {
+      normalizedOptions.onIgnoredForcedHandoff({
+        reason: "mode-disabled",
+        forcedHandoff,
+        event,
+      });
+      return activeClaim;
+    }
+    // Optional: bind the asserted forcedBy identity to the comment
+    // author so a trusted-marker actor cannot self-attest a handoff by
+    // naming an unrelated maintainer in the payload. This is the
+    // strict mode used by the Resume routing path (idd-claim.instructions.md
+    // rule 7). The default is off because production forced-handoff
+    // markers can be posted on behalf of a maintainer by a separate
+    // automation account; callers that want the strict binding (e.g.
+    // resume-claim-routing.mjs) opt in via `requireAuthorMatchesForcedBy`.
+    if (normalizedOptions.requireAuthorMatchesForcedBy) {
+      const authorLoginLower = String(authorLogin).trim().toLowerCase();
+      const forcedByLower = String(forcedHandoff.forcedBy ?? "").trim().toLowerCase();
+      if (!authorLoginLower || authorLoginLower !== forcedByLower) {
+        normalizedOptions.onIgnoredForcedHandoff({
+          reason: "author-forced-by-mismatch",
+          forcedHandoff,
+          event,
+        });
+        return activeClaim;
+      }
+    }
+    if (!normalizedOptions.isAuthorizedForcedHandoff(forcedHandoff.forcedBy, forcedHandoff, event)) {
+      normalizedOptions.onIgnoredForcedHandoff({
+        reason: "forced-by-unauthorized",
+        forcedHandoff,
+        event,
+      });
+      return activeClaim;
+    }
     return {
       agentId: forcedHandoff.newAgentId,
       claimId: forcedHandoff.newClaimId,
@@ -2675,7 +2712,10 @@ function normalizeClaimResolutionOptions(optionsOrPredicate) {
       isTrustedAuthor: optionsOrPredicate,
       isForcedHandoffEnabled: () => false,
       isAuthorizedForcedHandoff: () => false,
+      isStale: isStaleAt,
+      requireAuthorMatchesForcedBy: false,
       onAnomalousHeartbeat: () => {},
+      onIgnoredForcedHandoff: () => {},
     };
   }
 
@@ -2691,9 +2731,18 @@ function normalizeClaimResolutionOptions(optionsOrPredicate) {
       typeof options.isAuthorizedForcedHandoff === "function"
         ? options.isAuthorizedForcedHandoff
         : () => false,
+    isStale:
+      typeof options.isStale === "function"
+        ? options.isStale
+        : isStaleAt,
+    requireAuthorMatchesForcedBy: Boolean(options.requireAuthorMatchesForcedBy),
     onAnomalousHeartbeat:
       typeof options.onAnomalousHeartbeat === "function"
         ? options.onAnomalousHeartbeat
+        : () => {},
+    onIgnoredForcedHandoff:
+      typeof options.onIgnoredForcedHandoff === "function"
+        ? options.onIgnoredForcedHandoff
         : () => {},
   };
 }

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -8,7 +8,6 @@ import { fileURLToPath } from "node:url";
 import {
   isStaleAt,
   parseClaimComment,
-  parseReleaseComment,
   resolveActiveClaim,
 } from "./protocol-helpers.mjs";
 import { normalizePolicyConfig } from "./policy-helpers.mjs";

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -5,7 +5,12 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { isStaleAt, parseClaimComment, parseForcedHandoffComment, parseReleaseComment } from "./protocol-helpers.mjs";
+import {
+  isStaleAt,
+  parseClaimComment,
+  parseReleaseComment,
+  resolveActiveClaim,
+} from "./protocol-helpers.mjs";
 import { normalizePolicyConfig } from "./policy-helpers.mjs";
 
 const DEFAULT_STALE_AGE_MS = 24 * 60 * 60 * 1000;
@@ -208,84 +213,57 @@ function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
   const isAuthorizedForcedHandoff = typeof options.isAuthorizedForcedHandoff === "function"
     ? options.isAuthorizedForcedHandoff
     : () => false;
-  const orderedEvents = [...events].sort(compareEvents);
+
+  // hasNewFormatClaim drives the new-format vs legacy-only mode. Detect
+  // it by scanning before delegating to the canonical parser so the
+  // wrapper can return the right legacy-fallback shape.
+  const hasNewFormatClaim = events.some(
+    (event) => parseClaimComment(event.body ?? "", event.createdAt ?? "") !== null,
+  );
+
   const warnings = [];
-  let activeClaim = null;
-  let hasNewFormatClaim = false;
-  for (const event of orderedEvents) {
-    const claim = parseClaimComment(event.body, event.createdAt);
-    if (claim) {
-      hasNewFormatClaim = true;
-      if (!activeClaim) {
-        if (claim.supersedes === "none") {
-          activeClaim = claim;
-        }
-        continue;
-      }
-      if (claim.agentId === activeClaim.agentId && claim.claimId === activeClaim.claimId) {
-        if (claim.branch === activeClaim.branch) {
-          activeClaim = { ...activeClaim, createdAt: event.createdAt };
-        } else {
-          warnings.push(
-            `ignored anomalous heartbeat for ${claim.claimId}: branch ${claim.branch} != ${activeClaim.branch}`,
-          );
-        }
-        continue;
-      }
-      if (claim.supersedes === activeClaim.claimId && isStaleByAge(activeClaim.createdAt, event.createdAt, staleAgeMs)) {
-        activeClaim = claim;
-      }
-      continue;
+  const onAnomalousHeartbeat = ({ claimId, activeBranch, heartbeatBranch }) => {
+    warnings.push(
+      `ignored anomalous heartbeat for ${claimId}: branch ${heartbeatBranch} != ${activeBranch}`,
+    );
+  };
+  const onIgnoredForcedHandoff = ({ reason, forcedHandoff, event }) => {
+    if (reason === "mode-disabled") {
+      warnings.push(
+        `ignored forced-handoff for ${forcedHandoff.oldClaimId}: forced-handoff mode is not enabled`,
+      );
+      return;
     }
+    if (reason === "author-forced-by-mismatch") {
+      warnings.push(
+        `ignored forced-handoff for ${forcedHandoff.oldClaimId}: comment author ${event.author?.login ?? "(unknown)"} does not match forcedBy ${forcedHandoff.forcedBy}`,
+      );
+      return;
+    }
+    if (reason === "forced-by-unauthorized") {
+      warnings.push(
+        `ignored forced-handoff for ${forcedHandoff.oldClaimId}: forcedBy ${forcedHandoff.forcedBy} is not an authorized maintainer`,
+      );
+    }
+  };
 
-    const release = parseReleaseComment(event.body);
-    if (release && activeClaim && release.agentId === activeClaim.agentId && release.claimId === activeClaim.claimId) {
-      activeClaim = null;
-      continue;
-    }
-
-    const forcedHandoff = parseForcedHandoffComment(event.body, event.createdAt);
-    if (
-      forcedHandoff
-      && activeClaim
-      && forcedHandoff.oldAgentId === activeClaim.agentId
-      && forcedHandoff.oldClaimId === activeClaim.claimId
-      && forcedHandoff.branch === activeClaim.branch
-    ) {
-      if (!isForcedHandoffEnabled(forcedHandoff, event)) {
-        warnings.push(
-          `ignored forced-handoff for ${forcedHandoff.oldClaimId}: forced-handoff mode is not enabled`,
-        );
-        continue;
-      }
-      const authorLogin = String(event.author?.login ?? "").trim().toLowerCase();
-      const forcedByLogin = String(forcedHandoff.forcedBy ?? "").trim().toLowerCase();
-      // Bind the asserted forcedBy identity to the comment author so a
-      // trusted-marker actor cannot self-attest a handoff by naming an
-      // unrelated maintainer in the payload. Without this binding the
-      // collaborator-permission lookup downstream would happily authorize
-      // any maintainer login the attacker types into the payload.
-      if (!authorLogin || authorLogin !== forcedByLogin) {
-        warnings.push(
-          `ignored forced-handoff for ${forcedHandoff.oldClaimId}: comment author ${event.author?.login ?? "(unknown)"} does not match forcedBy ${forcedHandoff.forcedBy}`,
-        );
-        continue;
-      }
-      if (!isAuthorizedForcedHandoff(forcedHandoff.forcedBy, forcedHandoff, event)) {
-        warnings.push(
-          `ignored forced-handoff for ${forcedHandoff.oldClaimId}: forcedBy ${forcedHandoff.forcedBy} is not an authorized maintainer`,
-        );
-        continue;
-      }
-      activeClaim = {
-        agentId: forcedHandoff.newAgentId,
-        claimId: forcedHandoff.newClaimId,
-        supersedes: forcedHandoff.oldClaimId,
-        branch: forcedHandoff.branch,
-        createdAt: forcedHandoff.createdAt ?? event.createdAt,
-      };
-    }
-  }
+  const activeClaim = hasNewFormatClaim
+    ? resolveActiveClaim(events, {
+      isTrustedAuthor: () => true, // events were already filtered by caller
+      isForcedHandoffEnabled,
+      isAuthorizedForcedHandoff,
+      isStale: (activeCreatedAt, nextCreatedAt) =>
+        isStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs),
+      // Resume routing enforces the rule-7 author/forcedBy binding to
+      // block the same-identity self-signed hijack path. Other callers
+      // of summarizeClaimValidation default to off because they may
+      // receive maintainer-authorized handoffs posted by a separate
+      // automation actor on behalf of the maintainer.
+      requireAuthorMatchesForcedBy: true,
+      onAnomalousHeartbeat,
+      onIgnoredForcedHandoff,
+    })
+    : null;
 
   if (hasNewFormatClaim) {
     return {
@@ -297,6 +275,7 @@ function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
     };
   }
 
+  const orderedEvents = [...events].sort(compareEvents);
   const legacy = resolveLegacyClaimState(orderedEvents, nowIso, staleAgeMs);
   return {
     mode: "legacy-only",


### PR DESCRIPTION
## Summary

Closes #748 (final track of roadmap #745).

The Resume routing parser (`resolveClaimState` in
`scripts/resume-claim-routing.mjs`) and the canonical
revalidation parser (`applyClaimEvent` in
`scripts/protocol-helpers.mjs`) had been two independent
implementations of the same claim-state state machine. Each had
fixed a rule the other missed — heartbeat branch invariant
landed in `applyClaimEvent` via #747; author binding +
forced-handoff authorization landed in `resolveClaimState` via
#746. Now that both behavioural fixes are in, collapse the
duplication so only one parser implements the state machine.

## What changed

Promote the resume-side features into `applyClaimEvent` as
opt-in options so existing callers see no behavioural change:

- `isStale`: custom stale predicate so callers with a
  non-default claim-stale-age policy can plug their own
  staleness check instead of the hardcoded 24 h `isStaleAt`.
- `requireAuthorMatchesForcedBy`: opt-in author/`forcedBy`
  binding for the rule-7 self-signed hijack defense. Resume
  routing opts in by default; other callers
  (`live-status-digest`, `audit-pr-cleanup`,
  `pre-merge-readiness`, `forced-handoff-marker`) leave it off
  because they may receive maintainer-authorized handoffs
  posted by a separate automation actor on behalf of the
  maintainer (covered by an existing
  `forced-handoff-marker.test.mjs` fixture).
- `onIgnoredForcedHandoff`: warning callback so callers can
  surface rejection reasons (`mode-disabled`,
  `author-forced-by-mismatch`, `forced-by-unauthorized`);
  default is silent.

`resume-claim-routing.mjs`'s `resolveClaimState` now delegates
the state-machine walk to `resolveActiveClaim` with the four
options wired up. The resume-phase-specific outer wrapping
(legacy-claim fallback, same-second contender enumeration,
later-competing claim detection) stays in
`resume-claim-routing.mjs` because those are routing-layer
concerns, not parser concerns.

Also update `idd-claim.instructions.md` rule 7 (originally
landed in #749) to describe the new opt-in semantics now that
the parsers no longer diverge.

## Test plan

- [x] `node --test tests/*.mjs` — 766/766 pass.
- [x] Resume routing 17/17 (includes #746 author-binding /
      self-signed-hijack tests).
- [x] Claim parser 7/7 (includes #747 branch-invariant tests).
- [x] Claim lifecycle 2/2.
- [x] `forced-handoff-marker.test.mjs` 24/24 — existing
      fixtures that assume legacy "maintainer-authorized
      handoff posted by a bot" semantics still pass because the
      new binding defaults to off.
- [x] `npx markdownlint-cli2`, `npx cspell lint`, sync-docs
      check, audit-docs all clean.