### PR TITLE
fix(helpers): use role_name fallback in four isAuthorizedForcedHandoffActor copies

### DIFF
--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -731,11 +731,15 @@ function isAuthorizedForcedHandoffActor(owner, repo, login, policy = forcedHando
   if (!normalized) {
     return false;
   }
-  const permission = collaboratorPermission(owner, repo, normalized);
+  const { permission, roleName } = collaboratorPermission(owner, repo, normalized);
   if (policy === "all-write-permission-actors") {
-    return permission === "admin" || permission === "maintain" || permission === "write";
+    return roleName === "admin"
+      || roleName === "maintain"
+      || roleName === "write"
+      || permission === "admin"
+      || permission === "write";
   }
-  return permission === "admin" || permission === "maintain";
+  return roleName === "admin" || roleName === "maintain" || permission === "admin";
 }
 
 function isTrustedMarkerAuthor(owner, repo, login) {
@@ -830,24 +834,33 @@ function collaboratorPermission(owner, repo, login) {
     return collaboratorPermissionCache.get(cacheKey);
   }
 
+  // Return both the legacy `permission` and the granular `role_name`.
+  // `permission` collapses maintain -> write / triage -> read, so a
+  // literal `maintain` check on it would silently reject legitimate
+  // maintainers. Callers apply each policy against the matching
+  // field. Mirrored from `scripts/resume-claim-routing.mjs`
+  // (PR #750 / #753).
   let permission = "";
+  let roleName = "";
   try {
-    permission = execFileSync(
+    const raw = execFileSync(
       "gh",
       [
         "api",
         `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        "--jq",
-        ".permission",
       ],
       { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-    ).trim().toLowerCase();
+    );
+    const parsed = JSON.parse(raw);
+    permission = String(parsed?.permission ?? "").trim().toLowerCase();
+    roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
   } catch {
-    permission = "";
+    // both stay empty
   }
 
-  collaboratorPermissionCache.set(cacheKey, permission);
-  return permission;
+  const result = { permission, roleName };
+  collaboratorPermissionCache.set(cacheKey, result);
+  return result;
 }
 
 function ghGraphql(query, variables, options = {}) {

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -523,14 +523,32 @@ function collaboratorPermission(owner, repo, login, cache) {
   if (cache.has(login)) {
     return cache.get(login);
   }
-  const permission = safeGhText([
+  // GitHub's legacy `permission` field collapses `maintain` -> `write`
+  // and `triage` -> `read`, so a literal `maintain` check would reject
+  // legitimate maintainers under the default `owners-and-maintainers-
+  // only` authority policy. Read `role_name` too so the strict policy
+  // can honour the granular role; `permission` also stays in scope so
+  // the loose policy can still accept custom write-base roles whose
+  // `role_name` is a custom string. Mirrored from
+  // `scripts/resume-claim-routing.mjs` (PR #750 / #753).
+  let permission = "";
+  let roleName = "";
+  const raw = safeGhText([
     "api",
     `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-    "--jq",
-    ".permission",
-  ]).toLowerCase();
-  cache.set(login, permission);
-  return permission;
+  ]);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      permission = String(parsed?.permission ?? "").trim().toLowerCase();
+      roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
+    } catch {
+      // leave both empty
+    }
+  }
+  const result = { permission, roleName };
+  cache.set(login, result);
+  return result;
 }
 
 function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
@@ -538,11 +556,15 @@ function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
   if (!normalized) {
     return false;
   }
-  const permission = collaboratorPermission(owner, repo, normalized, cache);
+  const { permission, roleName } = collaboratorPermission(owner, repo, normalized, cache);
   if (policy === "all-write-permission-actors") {
-    return permission === "admin" || permission === "maintain" || permission === "write";
+    return roleName === "admin"
+      || roleName === "maintain"
+      || roleName === "write"
+      || permission === "admin"
+      || permission === "write";
   }
-  return permission === "admin" || permission === "maintain";
+  return roleName === "admin" || roleName === "maintain" || permission === "admin";
 }
 
 export function currentIsoTimestamp() {

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -251,11 +251,15 @@ function isAuthorizedForcedHandoffActor(owner, repo, login, policy = forcedHando
   if (!normalized) {
     return false;
   }
-  const permission = collaboratorPermission(owner, repo, normalized);
+  const { permission, roleName } = collaboratorPermission(owner, repo, normalized);
   if (policy === "all-write-permission-actors") {
-    return permission === "admin" || permission === "maintain" || permission === "write";
+    return roleName === "admin"
+      || roleName === "maintain"
+      || roleName === "write"
+      || permission === "admin"
+      || permission === "write";
   }
-  return permission === "admin" || permission === "maintain";
+  return roleName === "admin" || roleName === "maintain" || permission === "admin";
 }
 
 function forcedHandoffAuthorityPolicy() {
@@ -315,7 +319,7 @@ function isTrustedMarkerAuthor(owner, repo, login) {
     return trustedMarkerAuthorCache.get(cacheKey);
   }
 
-  const trusted = TRUSTED_MARKER_PERMISSIONS.has(collaboratorPermission(owner, repo, normalized));
+  const trusted = TRUSTED_MARKER_PERMISSIONS.has(collaboratorPermission(owner, repo, normalized).permission);
 
   trustedMarkerAuthorCache.set(cacheKey, trusted);
   return trusted;
@@ -344,24 +348,35 @@ function collaboratorPermission(owner, repo, login) {
     return collaboratorPermissionCache.get(cacheKey);
   }
 
+  // Return both the legacy `permission` and the granular `role_name`.
+  // `permission` collapses maintain -> write / triage -> read, so a
+  // literal `maintain` check on it would silently reject legitimate
+  // maintainers. Callers apply each policy against the matching field
+  // (isAuthorizedForcedHandoffActor checks both; isTrustedMarkerAuthor
+  // keeps the legacy-permission check via .permission since
+  // TRUSTED_MARKER_PERMISSIONS already accepts write).
+  // Mirrored from `scripts/resume-claim-routing.mjs` (PR #750 / #753).
   let permission = "";
+  let roleName = "";
   try {
-    permission = execFileSync(
+    const raw = execFileSync(
       "gh",
       [
         "api",
         `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        "--jq",
-        ".permission",
       ],
       { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-    ).trim().toLowerCase();
+    );
+    const parsed = JSON.parse(raw);
+    permission = String(parsed?.permission ?? "").trim().toLowerCase();
+    roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
   } catch {
-    permission = "";
+    // both stay empty
   }
 
-  collaboratorPermissionCache.set(cacheKey, permission);
-  return permission;
+  const result = { permission, roleName };
+  collaboratorPermissionCache.set(cacheKey, result);
+  return result;
 }
 
 function configuredTrustedMarkerAuthors() {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -647,15 +647,37 @@ function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
     return cache.get(normalized);
   }
 
-  const permission = safeGhText([
+  // GitHub's legacy `permission` field collapses `maintain` -> `write`
+  // and `triage` -> `read`, which would reject `maintain`-role
+  // maintainers under the default `owners-and-maintainers-only`
+  // policy. Read the full collaborators-permission JSON and apply each
+  // policy against the field that matches its semantics: the strict
+  // policy honours role_name == admin / maintain (plus permission ==
+  // admin as a backstop); the loose policy additionally honours
+  // permission == write so custom write-base roles still satisfy it.
+  // Mirrored from `scripts/resume-claim-routing.mjs` (PR #750 / #753).
+  let permission = "";
+  let roleName = "";
+  const raw = safeGhText([
     "api",
     `repos/${owner}/${repo}/collaborators/${encodeURIComponent(normalized)}/permission`,
-    "--jq",
-    ".permission",
-  ]).toLowerCase();
+  ]);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      permission = String(parsed?.permission ?? "").trim().toLowerCase();
+      roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
+    } catch {
+      // both stay empty
+    }
+  }
   const isAuthorized = policy === "all-write-permission-actors"
-    ? permission === "admin" || permission === "maintain" || permission === "write"
-    : permission === "admin" || permission === "maintain";
+    ? roleName === "admin"
+      || roleName === "maintain"
+      || roleName === "write"
+      || permission === "admin"
+      || permission === "write"
+    : roleName === "admin" || roleName === "maintain" || permission === "admin";
 
   cache.set(normalized, isAuthorized);
   return isAuthorized;


### PR DESCRIPTION
## Summary

Closes #755 (Track 1 of roadmap #754).

#746 / PR #750 found that GitHub's legacy `permission` field
collapses `maintain` → `write` and `triage` → `read`, so a
literal `maintain` check rejects legitimate `maintain`-role
maintainers under the default `owners-and-maintainers-only`
authority policy. #748 / PR #753 consolidated the claim
**parser** but left the same legacy bug in four copy-pasted
`isAuthorizedForcedHandoffActor` / `collaboratorPermission`
helpers:

- `scripts/forced-handoff-marker.mjs`
- `scripts/audit-pr-cleanup.mjs`
- `scripts/pre-merge-readiness.mjs`
- `scripts/live-status-digest.mjs`

## What changed

Mirror the corrected reference implementation from
`scripts/resume-claim-routing.mjs` into each copy: read both
`permission` and `role_name` from the full collaborators-
permission JSON response, then apply each policy against the
field that matches its semantics:

- `owners-and-maintainers-only`: `role_name == admin / maintain`
  OR `permission == admin` (admin maps cleanly to both)
- `all-write-permission-actors`: above OR `role_name == write`
  OR `permission == write` (legacy field catches custom write-
  base roles whose `role_name` is a custom string)

### Helper-specific notes

- `audit-pr-cleanup.mjs` and `live-status-digest.mjs` each had a
  shared `collaboratorPermission` helper that returned a single
  string. Updated the return shape to `{ permission, roleName }`
  and updated the one other caller in `live-status-digest`
  (`isTrustedMarkerAuthor`) to read `.permission` off the new
  shape. Behaviour there is unchanged because
  `TRUSTED_MARKER_PERMISSIONS` already accepts the legacy
  `write` mapping. `audit-pr-cleanup.mjs`'s
  `isTrustedMarkerAuthor` makes its own inline `gh` call and is
  untouched.
- `pre-merge-readiness.mjs` inlines the lookup inside
  `isAuthorizedForcedHandoffActor`; updated in place. The other
  `.permission` consumers in that file
  (`resolveTrustedCollaboratorMarkerLogins`,
  `resolveEligibleCodeownerUserLogins`, lines 338-360) are
  explicitly out of roadmap #754's scope and are NOT touched.

## Test plan

- [x] `node --test tests/*.mjs` — 766/766 pass.
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors.
- [x] `npx cspell lint "**" --no-progress` — 0 issues.
- [x] `node scripts/audit-docs.mjs --check` — passes.
- [x] `node scripts/sync-docs.mjs --check` — up to date.

The changed `isAuthorizedForcedHandoffActor` functions are gh-CLI
wrappers without direct unit tests (consistent with the existing
codebase pattern; the function reaches over the network and
already has integration coverage via the callers' end-to-end
flows). The behaviour change is narrowly scoped:
"maintain-role maintainers now accepted; everything else
identical". The full test suite (766/766) verifies no regression
in dependent code.

Roadmap #754 Track 2 (#756) will follow to extract the corrected
implementation into a single shared module so the next change
lands in one place rather than five copies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authorization validation for collaborators with "maintain" role access by incorporating granular permission data alongside legacy permission information across internal authorization scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->