### PR TITLE
refactor(helpers): extract isAuthorizedForcedHandoffActor into a shared module

### DIFF
--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -3,7 +3,12 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { computeReportSummary } from "./audit-pr-cleanup-summary.mjs";
-import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
+import { resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from "./collaborator-permission.mjs";
 import {
   classifyRegularBotComment,
   hasFreshDisposition,
@@ -22,9 +27,6 @@ const trustedMarkerAuthorCache = new Map();
 const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerAuthors = null;
 let cachedCurrentViewerLogin = null;
-let cachedForcedHandoffAuthorityPolicy = null;
-let cachedForcedHandoffMode = null;
-let cachedNormalizedPolicy = null;
 
 const args = parseArgs(process.argv.slice(2));
 
@@ -661,14 +663,13 @@ function readActiveClaim(owner, repo, issueNumber, options = {}) {
     trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
     forcedHandoffEnabled: readForcedHandoffMode() === "human-gated",
     expectedLinkedPrs: options.expectedLinkedPrs ?? [],
-    isAuthorizedForcedHandoff: (forcedBy) => {
-      return isAuthorizedForcedHandoffActor(
-        owner,
-        repo,
-        forcedBy,
-        forcedHandoffAuthorityPolicy(),
-      );
-    },
+    isAuthorizedForcedHandoff: (forcedBy) => isAuthorizedForcedHandoffActor(
+      owner,
+      repo,
+      forcedBy,
+      readForcedHandoffAuthorityPolicy(),
+      collaboratorPermissionCache,
+    ),
   });
 
   return summary.activeClaimPresent ? summary.activeClaim : null;
@@ -693,53 +694,6 @@ function resolveTrustedMarkerLogins(owner, repo, comments) {
       .filter(Boolean)
       .filter((login) => isTrustedMarkerAuthor(owner, repo, login)),
   );
-}
-
-function forcedHandoffAuthorityPolicy() {
-  if (cachedForcedHandoffAuthorityPolicy !== null) {
-    return cachedForcedHandoffAuthorityPolicy;
-  }
-  cachedForcedHandoffAuthorityPolicy = readNormalizedPolicy().forcedHandoff.authorityPolicy;
-  return cachedForcedHandoffAuthorityPolicy;
-}
-
-function readForcedHandoffMode() {
-  if (cachedForcedHandoffMode !== null) {
-    return cachedForcedHandoffMode;
-  }
-  cachedForcedHandoffMode = readNormalizedPolicy().forcedHandoff.mode;
-  return cachedForcedHandoffMode;
-}
-
-function readNormalizedPolicy() {
-  if (cachedNormalizedPolicy !== null) {
-    return cachedNormalizedPolicy;
-  }
-  try {
-    cachedNormalizedPolicy = normalizePolicyConfig(
-      JSON.parse(readFileSync(".github/idd/config.json", "utf8")),
-    );
-    return cachedNormalizedPolicy;
-  } catch {
-    cachedNormalizedPolicy = normalizePolicyConfig({});
-    return cachedNormalizedPolicy;
-  }
-}
-
-function isAuthorizedForcedHandoffActor(owner, repo, login, policy = forcedHandoffAuthorityPolicy()) {
-  const normalized = String(login ?? "").trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  const { permission, roleName } = collaboratorPermission(owner, repo, normalized);
-  if (policy === "all-write-permission-actors") {
-    return roleName === "admin"
-      || roleName === "maintain"
-      || roleName === "write"
-      || permission === "admin"
-      || permission === "write";
-  }
-  return roleName === "admin" || roleName === "maintain" || permission === "admin";
 }
 
 function isTrustedMarkerAuthor(owner, repo, login) {
@@ -826,41 +780,6 @@ function trustCollaboratorMarkers() {
     // Fall through to env-var fallback.
   }
   return /^(1|true|yes)$/i.test(process.env.IDD_TRUST_COLLABORATOR_MARKERS ?? "");
-}
-
-function collaboratorPermission(owner, repo, login) {
-  const cacheKey = `${owner}/${repo}:${login}`;
-  if (collaboratorPermissionCache.has(cacheKey)) {
-    return collaboratorPermissionCache.get(cacheKey);
-  }
-
-  // Return both the legacy `permission` and the granular `role_name`.
-  // `permission` collapses maintain -> write / triage -> read, so a
-  // literal `maintain` check on it would silently reject legitimate
-  // maintainers. Callers apply each policy against the matching
-  // field. Mirrored from `scripts/resume-claim-routing.mjs`
-  // (PR #750 / #753).
-  let permission = "";
-  let roleName = "";
-  try {
-    const raw = execFileSync(
-      "gh",
-      [
-        "api",
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-      ],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-    );
-    const parsed = JSON.parse(raw);
-    permission = String(parsed?.permission ?? "").trim().toLowerCase();
-    roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
-  } catch {
-    // both stay empty
-  }
-
-  const result = { permission, roleName };
-  collaboratorPermissionCache.set(cacheKey, result);
-  return result;
 }
 
 function ghGraphql(query, variables, options = {}) {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -659,6 +659,11 @@ function readActiveClaim(owner, repo, issueNumber, options = {}) {
     author: { login: comment.author?.login ?? "" },
   }));
 
+  // Read the authority policy once per call; the
+  // isAuthorizedForcedHandoff callback may fire multiple times during
+  // claim parsing and re-reading .github/idd/config.json on each call
+  // would be a needless I/O hot path.
+  const forcedHandoffAuthorityPolicyValue = readForcedHandoffAuthorityPolicy();
   const summary = summarizeClaimValidation(comments, {
     trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
     forcedHandoffEnabled: readForcedHandoffMode() === "human-gated",
@@ -667,7 +672,7 @@ function readActiveClaim(owner, repo, issueNumber, options = {}) {
       owner,
       repo,
       forcedBy,
-      readForcedHandoffAuthorityPolicy(),
+      forcedHandoffAuthorityPolicyValue,
       collaboratorPermissionCache,
     ),
   });

--- a/scripts/collaborator-permission.mjs
+++ b/scripts/collaborator-permission.mjs
@@ -1,0 +1,131 @@
+// Shared collaborator-permission lookups and forced-handoff authority
+// helpers consumed by:
+//
+// - scripts/forced-handoff-marker.mjs
+// - scripts/audit-pr-cleanup.mjs
+// - scripts/pre-merge-readiness.mjs
+// - scripts/live-status-digest.mjs
+// - scripts/resume-claim-routing.mjs
+//
+// Replaces the five copy-pasted implementations that drifted in
+// roadmap #745 / #748 / #754. Single source of truth so the next
+// behavioural change lands in one place rather than five.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+import { normalizePolicyConfig } from "./policy-helpers.mjs";
+
+const DEFAULT_POLICY_PATH = ".github/idd/config.json";
+
+/**
+ * Fetch a collaborator's permission triple from the GitHub
+ * collaborators-permission endpoint. Returns both the legacy
+ * `permission` field (admin|write|read|none) and the granular
+ * `role_name` (admin|maintain|write|triage|read|none or a custom
+ * repository-role name). Callers apply each policy against the field
+ * that matches its semantics — see `isAuthorizedForcedHandoffActor`.
+ *
+ * Failures (unreachable GitHub, missing collaborator, malformed JSON)
+ * are swallowed and yield empty strings so the calling policy check
+ * returns false (fail-closed).
+ *
+ * The `cache` is a per-caller Map so concurrent calls within one
+ * script share lookups, but separate scripts don't share state.
+ */
+export function collaboratorPermission(owner, repo, login, cache) {
+  const key = String(login ?? "").trim().toLowerCase();
+  if (cache && cache.has(key)) {
+    return cache.get(key);
+  }
+  let permission = "";
+  let roleName = "";
+  try {
+    const raw = execFileSync(
+      "gh",
+      [
+        "api",
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(key)}/permission`,
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const parsed = JSON.parse(raw);
+    permission = String(parsed?.permission ?? "").trim().toLowerCase();
+    roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
+  } catch {
+    // both stay empty
+  }
+  const result = { permission, roleName };
+  if (cache) {
+    cache.set(key, result);
+  }
+  return result;
+}
+
+/**
+ * Returns true when `login` is authorized to act as the `forcedBy`
+ * actor for a forced-handoff marker under the given policy:
+ *
+ *   - `owners-and-maintainers-only` (default policy semantics):
+ *     accepts `role_name == admin / maintain` and `permission == admin`
+ *     as a backstop. Maintain role recognition requires `role_name`
+ *     because the legacy `permission` field collapses maintain to
+ *     write.
+ *
+ *   - `all-write-permission-actors`: above plus `role_name == write`
+ *     and `permission == write` so custom write-base roles (whose
+ *     `role_name` may be a custom string) still satisfy the loose
+ *     policy via the legacy field.
+ */
+export function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
+  const normalized = String(login ?? "").trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const { permission, roleName } = collaboratorPermission(owner, repo, normalized, cache);
+  if (policy === "all-write-permission-actors") {
+    return roleName === "admin"
+      || roleName === "maintain"
+      || roleName === "write"
+      || permission === "admin"
+      || permission === "write";
+  }
+  return roleName === "admin" || roleName === "maintain" || permission === "admin";
+}
+
+/**
+ * Read `.github/idd/config.json` and return the normalized
+ * forcedHandoff policy block, falling back to schema defaults
+ * (`{ mode: "disabled", authorityPolicy: "owners-and-maintainers-only" }`)
+ * when the file is missing or malformed. Pass a custom `configPath`
+ * to read from a different location (useful for tests).
+ */
+export function readForcedHandoffPolicy(configPath = DEFAULT_POLICY_PATH) {
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch {
+    raw = {};
+  }
+  const normalized = normalizePolicyConfig(raw);
+  return {
+    mode: normalized.forcedHandoff.mode,
+    authorityPolicy: normalized.forcedHandoff.authorityPolicy,
+  };
+}
+
+/**
+ * Convenience helper that returns the forcedHandoff mode string
+ * ("disabled" or "human-gated") from the configured policy file.
+ */
+export function readForcedHandoffMode(configPath = DEFAULT_POLICY_PATH) {
+  return readForcedHandoffPolicy(configPath).mode;
+}
+
+/**
+ * Convenience helper that returns the forcedHandoff authority policy
+ * string from the configured policy file.
+ */
+export function readForcedHandoffAuthorityPolicy(configPath = DEFAULT_POLICY_PATH) {
+  return readForcedHandoffPolicy(configPath).authorityPolicy;
+}

--- a/scripts/collaborator-permission.mjs
+++ b/scripts/collaborator-permission.mjs
@@ -34,9 +34,13 @@ const DEFAULT_POLICY_PATH = ".github/idd/config.json";
  * script share lookups, but separate scripts don't share state.
  */
 export function collaboratorPermission(owner, repo, login, cache) {
-  const key = String(login ?? "").trim().toLowerCase();
-  if (cache && cache.has(key)) {
-    return cache.get(key);
+  const normalizedLogin = String(login ?? "").trim().toLowerCase();
+  // Scope the cache key by repository so a single Map can be safely
+  // reused across owner/repo pairs without cross-repo poisoning of
+  // authorization decisions.
+  const cacheKey = `${owner}/${repo}:${normalizedLogin}`;
+  if (cache && cache.has(cacheKey)) {
+    return cache.get(cacheKey);
   }
   let permission = "";
   let roleName = "";
@@ -45,7 +49,7 @@ export function collaboratorPermission(owner, repo, login, cache) {
       "gh",
       [
         "api",
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(key)}/permission`,
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(normalizedLogin)}/permission`,
       ],
       { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
     );
@@ -57,7 +61,7 @@ export function collaboratorPermission(owner, repo, login, cache) {
   }
   const result = { permission, roleName };
   if (cache) {
-    cache.set(key, result);
+    cache.set(cacheKey, result);
   }
   return result;
 }

--- a/scripts/force-handoff.mjs
+++ b/scripts/force-handoff.mjs
@@ -7,14 +7,11 @@ import { pathToFileURL } from "node:url";
 
 import { planHandoff } from "./forced-handoff-marker.mjs";
 import { parsePaginatedGhNdjson } from "./protocol-helpers.mjs";
-
-const APPROVAL_ACTOR_POLICIES = new Set([
-  "owners-and-maintainers-only",
-  "all-write-permission-actors",
-]);
-const APPROVAL_ACTOR_POLICY_DEFAULT = "owners-and-maintainers-only";
-const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);
-const FORCED_HANDOFF_MODE_DEFAULT = "disabled";
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from "./collaborator-permission.mjs";
 
 export const NON_TTY_ERROR =
   "operator interaction is required; run idd-force-handoff in an interactive TTY";
@@ -276,72 +273,8 @@ function isTruthy(value) {
   return /^(1|true|yes)$/i.test(String(value ?? "").trim());
 }
 
-function readForcedHandoffMode() {
-  try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const mode = String(
-      config?.forcedHandoff?.mode ??
-        config?.["forced-handoff"]?.mode ??
-        config?.forcedHandoffMode ??
-        config?.["forced-handoff-mode"] ??
-        "",
-    ).trim();
-    if (FORCED_HANDOFF_MODES.has(mode)) {
-      return mode;
-    }
-  } catch {
-    // Default mode remains disabled.
-  }
-  return FORCED_HANDOFF_MODE_DEFAULT;
-}
-
 function splitCsv(value) {
   return String(value ?? "").split(",").map((s) => s.trim()).filter(Boolean);
-}
-
-function readForcedHandoffAuthorityPolicy() {
-  try {
-    const config = JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
-    const policy = String(
-      config?.forcedHandoff?.authorityPolicy ??
-        config?.["forced-handoff"]?.authorityPolicy ??
-        config?.forcedHandoffAuthority ??
-        config?.["forced-handoff-authority"] ??
-        "",
-    ).trim();
-    if (APPROVAL_ACTOR_POLICIES.has(policy)) {
-      return policy;
-    }
-  } catch {
-    // default
-  }
-  return APPROVAL_ACTOR_POLICY_DEFAULT;
-}
-
-function collaboratorPermission(owner, repo, login, cache) {
-  if (cache.has(login)) {
-    return cache.get(login);
-  }
-  const permission = safeGhText([
-    "api",
-    `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-    "--jq",
-    ".permission",
-  ]).toLowerCase();
-  cache.set(login, permission);
-  return permission;
-}
-
-function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
-  const normalized = String(login ?? "").trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  const permission = collaboratorPermission(owner, repo, normalized, cache);
-  if (policy === "all-write-permission-actors") {
-    return permission === "admin" || permission === "maintain" || permission === "write";
-  }
-  return permission === "admin" || permission === "maintain";
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -10,7 +10,12 @@ import {
   renderForcedHandoffComment,
   summarizeClaimValidation,
 } from "./protocol-helpers.mjs";
-import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
+import { resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from "./collaborator-permission.mjs";
 
 export function generateSuccessorIds(baseAgentId) {
   return {
@@ -496,75 +501,6 @@ function readCollaboratorTrustEnabled() {
     // Fall through to env-var fallback.
   }
   return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
-}
-
-function readForcedHandoffAuthorityPolicy() {
-  return readNormalizedPolicy().forcedHandoff.authorityPolicy;
-}
-
-function readForcedHandoffMode() {
-  try {
-    return readNormalizedPolicy().forcedHandoff.mode;
-  } catch {
-    // Default mode remains disabled.
-    return "disabled";
-  }
-}
-
-function readNormalizedPolicy() {
-  try {
-    return normalizePolicyConfig(JSON.parse(readFileSync(".github/idd/config.json", "utf8")));
-  } catch {
-    return normalizePolicyConfig({});
-  }
-}
-
-function collaboratorPermission(owner, repo, login, cache) {
-  if (cache.has(login)) {
-    return cache.get(login);
-  }
-  // GitHub's legacy `permission` field collapses `maintain` -> `write`
-  // and `triage` -> `read`, so a literal `maintain` check would reject
-  // legitimate maintainers under the default `owners-and-maintainers-
-  // only` authority policy. Read `role_name` too so the strict policy
-  // can honour the granular role; `permission` also stays in scope so
-  // the loose policy can still accept custom write-base roles whose
-  // `role_name` is a custom string. Mirrored from
-  // `scripts/resume-claim-routing.mjs` (PR #750 / #753).
-  let permission = "";
-  let roleName = "";
-  const raw = safeGhText([
-    "api",
-    `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-  ]);
-  if (raw) {
-    try {
-      const parsed = JSON.parse(raw);
-      permission = String(parsed?.permission ?? "").trim().toLowerCase();
-      roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
-    } catch {
-      // leave both empty
-    }
-  }
-  const result = { permission, roleName };
-  cache.set(login, result);
-  return result;
-}
-
-function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
-  const normalized = String(login ?? "").trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  const { permission, roleName } = collaboratorPermission(owner, repo, normalized, cache);
-  if (policy === "all-write-permission-actors") {
-    return roleName === "admin"
-      || roleName === "maintain"
-      || roleName === "write"
-      || permission === "admin"
-      || permission === "write";
-  }
-  return roleName === "admin" || roleName === "maintain" || permission === "admin";
 }
 
 export function currentIsoTimestamp() {

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -211,6 +211,11 @@ function readActiveClaim(owner, repo, issueNumber, options = {}) {
     };
   });
 
+  // Read the authority policy once per call; the
+  // isAuthorizedForcedHandoff callback may fire multiple times during
+  // claim parsing and re-reading .github/idd/config.json on each call
+  // would be a needless I/O hot path.
+  const forcedHandoffAuthorityPolicyValue = readForcedHandoffAuthorityPolicy();
   const summary = summarizeClaimValidation(comments, {
     trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
     forcedHandoffEnabled: readForcedHandoffMode() === "human-gated",
@@ -219,7 +224,7 @@ function readActiveClaim(owner, repo, issueNumber, options = {}) {
       owner,
       repo,
       forcedBy,
-      readForcedHandoffAuthorityPolicy(),
+      forcedHandoffAuthorityPolicyValue,
       collaboratorPermissionCache,
     ),
   });

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -9,16 +9,19 @@ import {
   planLiveStatusDigestUpsert,
   summarizeClaimValidation,
 } from "./protocol-helpers.mjs";
-import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
+import { resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
+import {
+  collaboratorPermission,
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from "./collaborator-permission.mjs";
 
 const TRUSTED_MARKER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 const trustedMarkerAuthorCache = new Map();
 const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerAuthors = null;
 let cachedCurrentViewerLogin = null;
-let cachedForcedHandoffAuthorityPolicy = null;
-let cachedForcedHandoffMode = null;
-let cachedNormalizedPolicy = null;
 
 const args = parseArgs(process.argv.slice(2));
 
@@ -212,14 +215,13 @@ function readActiveClaim(owner, repo, issueNumber, options = {}) {
     trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
     forcedHandoffEnabled: readForcedHandoffMode() === "human-gated",
     expectedLinkedPrs: options.expectedLinkedPrs ?? [],
-    isAuthorizedForcedHandoff: (forcedBy) => {
-      return isAuthorizedForcedHandoffActor(
-        owner,
-        repo,
-        forcedBy,
-        forcedHandoffAuthorityPolicy(),
-      );
-    },
+    isAuthorizedForcedHandoff: (forcedBy) => isAuthorizedForcedHandoffActor(
+      owner,
+      repo,
+      forcedBy,
+      readForcedHandoffAuthorityPolicy(),
+      collaboratorPermissionCache,
+    ),
   });
 
   return summary.activeClaimPresent ? summary.activeClaim : null;
@@ -246,57 +248,6 @@ function buildExpectedLinkedPrReferences(owner, repo, prNumber) {
   ];
 }
 
-function isAuthorizedForcedHandoffActor(owner, repo, login, policy = forcedHandoffAuthorityPolicy()) {
-  const normalized = String(login ?? "").trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  const { permission, roleName } = collaboratorPermission(owner, repo, normalized);
-  if (policy === "all-write-permission-actors") {
-    return roleName === "admin"
-      || roleName === "maintain"
-      || roleName === "write"
-      || permission === "admin"
-      || permission === "write";
-  }
-  return roleName === "admin" || roleName === "maintain" || permission === "admin";
-}
-
-function forcedHandoffAuthorityPolicy() {
-  if (cachedForcedHandoffAuthorityPolicy !== null) {
-    return cachedForcedHandoffAuthorityPolicy;
-  }
-  cachedForcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
-  return cachedForcedHandoffAuthorityPolicy;
-}
-
-function readForcedHandoffAuthorityPolicy() {
-  return readNormalizedPolicy().forcedHandoff.authorityPolicy;
-}
-
-function readForcedHandoffMode() {
-  if (cachedForcedHandoffMode !== null) {
-    return cachedForcedHandoffMode;
-  }
-  cachedForcedHandoffMode = readNormalizedPolicy().forcedHandoff.mode;
-  return cachedForcedHandoffMode;
-}
-
-function readNormalizedPolicy() {
-  if (cachedNormalizedPolicy !== null) {
-    return cachedNormalizedPolicy;
-  }
-  try {
-    cachedNormalizedPolicy = normalizePolicyConfig(
-      JSON.parse(readFileSync(".github/idd/config.json", "utf8")),
-    );
-    return cachedNormalizedPolicy;
-  } catch {
-    cachedNormalizedPolicy = normalizePolicyConfig({});
-    return cachedNormalizedPolicy;
-  }
-}
-
 function isTrustedMarkerAuthor(owner, repo, login) {
   if (!login) {
     return false;
@@ -319,7 +270,9 @@ function isTrustedMarkerAuthor(owner, repo, login) {
     return trustedMarkerAuthorCache.get(cacheKey);
   }
 
-  const trusted = TRUSTED_MARKER_PERMISSIONS.has(collaboratorPermission(owner, repo, normalized).permission);
+  const trusted = TRUSTED_MARKER_PERMISSIONS.has(
+    collaboratorPermission(owner, repo, normalized, collaboratorPermissionCache).permission,
+  );
 
   trustedMarkerAuthorCache.set(cacheKey, trusted);
   return trusted;
@@ -340,43 +293,6 @@ function currentViewerLogin() {
     cachedCurrentViewerLogin = "";
   }
   return cachedCurrentViewerLogin;
-}
-
-function collaboratorPermission(owner, repo, login) {
-  const cacheKey = `${owner}/${repo}:${login}`;
-  if (collaboratorPermissionCache.has(cacheKey)) {
-    return collaboratorPermissionCache.get(cacheKey);
-  }
-
-  // Return both the legacy `permission` and the granular `role_name`.
-  // `permission` collapses maintain -> write / triage -> read, so a
-  // literal `maintain` check on it would silently reject legitimate
-  // maintainers. Callers apply each policy against the matching field
-  // (isAuthorizedForcedHandoffActor checks both; isTrustedMarkerAuthor
-  // keeps the legacy-permission check via .permission since
-  // TRUSTED_MARKER_PERMISSIONS already accepts write).
-  // Mirrored from `scripts/resume-claim-routing.mjs` (PR #750 / #753).
-  let permission = "";
-  let roleName = "";
-  try {
-    const raw = execFileSync(
-      "gh",
-      [
-        "api",
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-      ],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-    );
-    const parsed = JSON.parse(raw);
-    permission = String(parsed?.permission ?? "").trim().toLowerCase();
-    roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
-  } catch {
-    // both stay empty
-  }
-
-  const result = { permission, roleName };
-  collaboratorPermissionCache.set(cacheKey, result);
-  return result;
 }
 
 function configuredTrustedMarkerAuthors() {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -14,13 +14,12 @@ import {
   resolveRulesetDetailPath,
   selectCodeownersText,
 } from "./protocol-helpers.mjs";
-import { normalizePolicyConfig, resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
-
-const APPROVAL_ACTOR_POLICY = new Set([
-  "owners-and-maintainers-only",
-  "all-write-permission-actors",
-]);
-const APPROVAL_ACTOR_POLICY_DEFAULT = "owners-and-maintainers-only";
+import { resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from "./collaborator-permission.mjs";
 
 const args = parseArgs(process.argv.slice(2));
 if (!args.prNumber) {
@@ -621,64 +620,3 @@ function readCollaboratorTrustEnabled() {
   return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
 }
 
-function readForcedHandoffAuthorityPolicy() {
-  const policy = readNormalizedPolicy().forcedHandoff.authorityPolicy;
-  return APPROVAL_ACTOR_POLICY.has(policy) ? policy : APPROVAL_ACTOR_POLICY_DEFAULT;
-}
-
-function readForcedHandoffMode() {
-  return readNormalizedPolicy().forcedHandoff.mode;
-}
-
-function readNormalizedPolicy() {
-  try {
-    return normalizePolicyConfig(JSON.parse(readFileSync(".github/idd/config.json", "utf8")));
-  } catch {
-    return normalizePolicyConfig({});
-  }
-}
-
-function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
-  const normalized = String(login ?? "").trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  if (cache.has(normalized)) {
-    return cache.get(normalized);
-  }
-
-  // GitHub's legacy `permission` field collapses `maintain` -> `write`
-  // and `triage` -> `read`, which would reject `maintain`-role
-  // maintainers under the default `owners-and-maintainers-only`
-  // policy. Read the full collaborators-permission JSON and apply each
-  // policy against the field that matches its semantics: the strict
-  // policy honours role_name == admin / maintain (plus permission ==
-  // admin as a backstop); the loose policy additionally honours
-  // permission == write so custom write-base roles still satisfy it.
-  // Mirrored from `scripts/resume-claim-routing.mjs` (PR #750 / #753).
-  let permission = "";
-  let roleName = "";
-  const raw = safeGhText([
-    "api",
-    `repos/${owner}/${repo}/collaborators/${encodeURIComponent(normalized)}/permission`,
-  ]);
-  if (raw) {
-    try {
-      const parsed = JSON.parse(raw);
-      permission = String(parsed?.permission ?? "").trim().toLowerCase();
-      roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
-    } catch {
-      // both stay empty
-    }
-  }
-  const isAuthorized = policy === "all-write-permission-actors"
-    ? roleName === "admin"
-      || roleName === "maintain"
-      || roleName === "write"
-      || permission === "admin"
-      || permission === "write"
-    : roleName === "admin" || roleName === "maintain" || permission === "admin";
-
-  cache.set(normalized, isAuthorized);
-  return isAuthorized;
-}

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -11,6 +11,7 @@ import {
   resolveActiveClaim,
 } from "./protocol-helpers.mjs";
 import { normalizePolicyConfig } from "./policy-helpers.mjs";
+import { isAuthorizedForcedHandoffActor } from "./collaborator-permission.mjs";
 
 const DEFAULT_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 const LEGACY_CLAIM_PATTERN = /^<!--\s*claimed-by:\s+(\S+)\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s+branch:\s+([^\s>]+)\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i;
@@ -543,56 +544,6 @@ function loadPolicy(policyPath, { strict = false } = {}) {
       },
     };
   }
-}
-
-function isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache) {
-  const normalized = String(login ?? "").trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  const { permission, roleName } = collaboratorPermission(owner, repo, normalized, cache);
-  // GitHub's legacy `permission` is one of admin|write|read|none and
-  // collapses maintain->write / triage->read. `role_name` is the
-  // granular role (admin|maintain|write|triage|read|none) but may also
-  // be a custom repository role name, in which case its literal value
-  // is not in the standard set. Check both fields so that:
-  //   - the strict policy honours role_name=maintain (otherwise
-  //     maintainers are demoted to write and rejected), and
-  //   - the loose policy honours permission=write (so custom roles
-  //     whose base permission is write still satisfy it).
-  if (policy === "all-write-permission-actors") {
-    return roleName === "admin"
-      || roleName === "maintain"
-      || roleName === "write"
-      || permission === "admin"
-      || permission === "write";
-  }
-  return roleName === "admin" || roleName === "maintain" || permission === "admin";
-}
-
-function collaboratorPermission(owner, repo, login, cache) {
-  if (cache.has(login)) {
-    return cache.get(login);
-  }
-  // Return both the legacy `permission` and the granular `role_name`
-  // so the caller can apply each policy against the field that matches
-  // its semantics. See isAuthorizedForcedHandoffActor for the rationale.
-  let permission = "";
-  let roleName = "";
-  try {
-    const raw = ghText([
-      "api",
-      `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-    ]);
-    const parsed = JSON.parse(raw);
-    permission = String(parsed?.permission ?? "").trim().toLowerCase();
-    roleName = String(parsed?.role_name ?? "").trim().toLowerCase();
-  } catch {
-    // both stay empty
-  }
-  const result = { permission, roleName };
-  cache.set(login, result);
-  return result;
 }
 
 function parseDurationToMs(value) {


### PR DESCRIPTION
## Summary

Closes #756 (Track 2 of roadmap #754).

Roadmaps #745 / #754 left `isAuthorizedForcedHandoffActor` +
`collaboratorPermission` + `readForcedHandoffMode` +
`readForcedHandoffAuthorityPolicy` duplicated as near-identical
copies in five scripts:

- `scripts/forced-handoff-marker.mjs`
- `scripts/audit-pr-cleanup.mjs`
- `scripts/pre-merge-readiness.mjs`
- `scripts/live-status-digest.mjs`
- `scripts/resume-claim-routing.mjs`

That duplication produced the original drift roadmap #745
addressed (heartbeat branch invariant + author binding fixed in
one copy but not the others) and the legacy `.permission`
regression #755 just closed. Collapse the five copies into one
shared module so the next change lands in one place.

## What changed

Add `scripts/collaborator-permission.mjs` exporting:

- `collaboratorPermission(owner, repo, login, cache)` →
  `{ permission, roleName }` — fetches the full collaborator
  permission JSON and returns both fields so callers can apply
  each policy against the matching semantics.
- `isAuthorizedForcedHandoffActor(owner, repo, login, policy, cache)`
  — strict (`owners-and-maintainers-only`) and loose
  (`all-write-permission-actors`) authority checks with per-
  policy field bookkeeping (`role_name` vs legacy `permission`).
- `readForcedHandoffPolicy(configPath?)` →
  `{ mode, authorityPolicy }` — normalized policy read with
  schema-default fallback.
- `readForcedHandoffMode(configPath?)` and
  `readForcedHandoffAuthorityPolicy(configPath?)` — convenience
  wrappers.

Update the five callers to import from the shared module and
delete their local copies. Net diff: 6 files changed, +174,
-383 (~209 lines removed). Each caller keeps its own
permission cache `Map` and passes it as the `cache` argument so
within-script lookups still share state but scripts don't share
state with each other.

`audit-pr-cleanup.mjs` / `live-status-digest.mjs`
`isTrustedMarkerAuthor` keeps working by reading the new
`{permission, roleName}` shape and continuing to check
`TRUSTED_MARKER_PERMISSIONS` against `.permission` (the legacy
field still maps `maintain` → `write` which is in the set).

## Test plan

- [x] `node --test tests/*.mjs` — 766/766 pass.
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors.
- [x] `npx cspell lint "**" --no-progress` — 0 issues.
- [x] `node scripts/audit-docs.mjs --check` — passes.
- [x] `node scripts/sync-docs.mjs --check` — up to date.

No new shared-module tests are added in this PR because:
- the functions are thin wrappers over the `gh` CLI without a
  mock surface (consistent with the untested wrappers they
  replace);
- behavioural coverage is preserved end-to-end by the existing
  callers' tests;
- adding mocks just for this would require restructuring the
  module to inject the gh runner, which is out of #756's
  refactor-only scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated collaborator authorization and permission resolution logic into a centralized shared module for improved code organization.
  * Refactored multiple internal scripts to utilize the new shared module, eliminating code duplication and enhancing maintainability.
  * Streamlined authorization policy configuration handling for consistency across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->