### PR TITLE
feat(issue-authoring): emit autopilot-suitability marker when drafting issues

### DIFF
--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -136,13 +136,13 @@ issue, a roadmap plus sub-issues, or a non-ready bucket.
 The **Autonomous completion** axis is also persisted as a graded
 **autopilot-suitability score** (1-5, higher = more
 autopilot-suitable) so the discover phase can rank and route
-candidates without re-deriving the judgment. This is a **planned
-contract**: the score is _defined_ here and in the contract, while
-authoring emission lands in T2 (#761) and discover ranking +
-routing in T3 (#762) of roadmap #759. Once T2 lands, authoring
-will score every drafted issue and emit it as an end-of-body
-footer (a visible line plus a hidden, prefix-aware marker
-`<!-- {marker-prefix}-autopilot-suitability: N -->`). See the
+candidates without re-deriving the judgment. **Score every drafted
+issue and emit it** as an end-of-body footer (a visible line plus
+a hidden, prefix-aware marker
+`<!-- {marker-prefix}-autopilot-suitability: N -->`). Discover
+ranking + routing by the score is still planned (T3 / #762 of
+roadmap #759); until it lands the score is recorded but does not
+yet influence candidate selection. See the
 [Autopilot-suitability score](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#autopilot-suitability-score)
 section of the contract for the rubric, footer format, and binding
 rules.

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -309,6 +309,9 @@ Validation expectations:
 - `## Background` or `## Goal`
 - `## Proposed change`
 - `## Acceptance criteria`
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker;
+  see [Autopilot-suitability score](#autopilot-suitability-score))
 
 Validation expectations:
 
@@ -317,6 +320,8 @@ Validation expectations:
 - acceptance criteria are explicitly verifiable
 - the issue stays discoverable under the target repository's
   `issue-scope` setting
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
 
 ### Roadmap issue
 
@@ -326,6 +331,8 @@ Validation expectations:
 - `## Tracks`
 - `## Success criteria`
 - one `<!-- <marker-prefix>-roadmap-id: <roadmap-id> -->` marker
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
 
 Validation expectations:
 
@@ -336,6 +343,8 @@ Validation expectations:
 - each dependency edge is justified and preserves natural cohesion
 - nested roadmap entries stay identifiable as coordination/audit nodes
   instead of normal execution leaves
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
 
 ### Child issue under a roadmap
 
@@ -344,6 +353,8 @@ Validation expectations:
 - `## Proposed change`
 - `## Acceptance criteria`
 - optional dependency line or sequential roadmap marker when needed
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
 
 Validation expectations:
 
@@ -352,6 +363,8 @@ Validation expectations:
 - any dependency marker is resolvable, intentionally chosen, and
   justified
 - the issue can be claimed independently without absorbing sibling work
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
 
 ## A4.5 Suitability Gate Alignment
 
@@ -387,21 +400,17 @@ marginally-ready issue.
 
 ## Autopilot-suitability score
 
-> **Status — planned contract.** This section _defines_ the score
-> (rubric, footer format, binding rules). The active behavior is
-> wired up by follow-up work in roadmap #759: authoring emission
-> (T2 / #761) and Discover ranking + routing (T3 / #762). Until
-> those land, this is the stable spec — authoring does not yet
-> auto-emit the marker and Discover does not yet rank or route by
-> it.
+> **Status.** Authoring **emits** the score footer now (this is
+> the active contract). Discover ranking + routing by the score is
+> still planned (T3 / #762 of roadmap #759); until it lands the
+> score is recorded but does not yet influence candidate selection.
 
-Authored issues are intended to carry a persisted
-**autopilot-suitability score** from 1 to 5 (higher = more
-autopilot-suitable). It is the durable, graded form of the
-**Autonomous completion** execution axis: the author makes the
-judgment once, while context is fresh, so the Discover phase can
-rank and route candidates by a cheap read instead of re-deriving
-autonomy per candidate.
+Authored issues carry a persisted **autopilot-suitability score**
+from 1 to 5 (higher = more autopilot-suitable). It is the durable,
+graded form of the **Autonomous completion** execution axis: the
+author makes the judgment once, while context is fresh, so the
+Discover phase can rank and route candidates by a cheap read
+instead of re-deriving autonomy per candidate.
 
 | Score | Meaning                     | Typical signals                                                                                                          |
 | ----- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
@@ -451,6 +460,10 @@ Binding rules:
   out-of-range marker means "no score": Discover evaluates the
   issue the normal way and never skips it. Pre-existing issues
   with no score keep flowing.
+
+Backfill is opportunistic: when an existing open issue without a
+score footer is next edited by the authoring flow, add one. No
+bulk backfill of the existing backlog is required.
 
 ## Publication boundary
 

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -98,6 +98,8 @@ Before you publish a `ready` issue, confirm:
 - `## Proposed change`
 - `## Acceptance criteria`
 - optional `## Candidate files`
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
 
 Use this shape when the work is narrow enough to pass the IDD viability
 gate on its own and the target repository can actually discover orphan
@@ -114,6 +116,7 @@ Roadmap issue:
 - `## Tracks`
 - `## Success criteria`
 - one `<!-- <marker-prefix>-roadmap-id: ... -->` marker
+- an autopilot-suitability footer at the end of the body
 
 Child issue:
 
@@ -122,6 +125,7 @@ Child issue:
 - `## Proposed change`
 - `## Acceptance criteria`
 - optional dependency line or sequential roadmap marker when needed
+- an autopilot-suitability footer at the end of the body
 
 Keep ready child issues in the roadmap task list rather than grouping
 them with hidden dependency markers.


### PR DESCRIPTION
## Summary

Closes #761 (Track 2 of roadmap #759). Builds on #760's contract:
authoring now **actively** assigns and emits the autopilot-
suitability score footer.

## What changed

- The autopilot-suitability footer (visible line + hidden
  `<!-- <marker-prefix>-autopilot-suitability: N -->` marker) is
  now a required content item and validation expectation for all
  three issue shapes (orphan / roadmap / child) in the contract,
  and is shown in the example shapes in `draft-patterns.md`.
- Contract + skill-doc framing flips from "planned" to active for
  **emission**: authoring scores every drafted issue and emits the
  footer now. Discover ranking/routing stays planned (T3 / #762).
- Score `1` must also carry `status:blocked-by-human` (the one-
  source-of-truth rule), validated per issue shape.
- Opportunistic backfill guidance added (score existing issues
  when next edited; no bulk backfill required).

Docs-only — the issue-authoring skill is doc-driven. No
schema/config or discovery behavior change. Mirrors + companion
blocks re-synced (no drift).

## Test plan

- [x] `node --test tests/*.mjs` — 771/771 pass.
- [x] `node scripts/audit-docs.mjs --check` — passes.
- [x] `node scripts/sync-docs.mjs --check` — mirrors up to date.
- [x] `npx dprint check`, `npx markdownlint-cli2`, `npx cspell lint`
      — clean.

SSH-signed commit (`git commit-ssh`) because configured GPG
signing times out locally.