### PR TITLE
feat(discover): rank and route by autopilot-suitability score with skip floor

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -40,6 +40,8 @@ words:
   - pyproject
   - unpushed
   - unreplied
+  - unrouted
+  - unscored
   - Esync
   - minimizable
   - waivable

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -423,7 +423,7 @@ After scanning the current batch:
 
 | Batch outcome                                                                       | Action                                                                                                                                                                                                  |
 | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| At least one eligible candidate in the batch                                        | Proceed to Step 2 and pick the lowest-numbered eligible candidate.                                                                                                                                      |
+| At least one eligible candidate in the batch                                        | Proceed to Step 2 to rank and select.                                                                                                                                                                   |
 | All `N` in this batch are claimed but viable survivors remain                       | Continue with the next batch (`N+1`–`2N`, then `2N+1`–`3N`, …) until an eligible candidate is found.                                                                                                    |
 | Entire viable candidate set exhausted (all surviving viable candidates are claimed) | Report that all viable issues are currently claimed; stop. Do not post `unclaimed-by` (no claim was made). Not an abort; retry later when claims may have become stale or new viable candidates appear. |
 
@@ -433,7 +433,14 @@ for why this pre-scan exists.
 ### Step 2 — Select
 
 Among the surviving viable and unclaimed issues (after Step 1.5), pick the
-one with the **lowest issue number**.
+**highest authored autopilot-suitability score** (the
+`<!-- idd-skill-autopilot-suitability: N -->` footer, or the
+`discover-roadmap-graph` node's `autopilotSuitability`), tie-broken by
+**lowest issue number**. In autopilot runs, skip scores below
+`autopilotSuitability.floor` (default `3`) as human-oriented; a missing or
+out-of-range score is treated as no score — ranked at the floor and never
+skipped, so the unscored backlog flows as before. Advisory only: the pick
+still passes A4.5/A5 unchanged and the score never bypasses a gate.
 
 After picking, proceed to **A4.5** (`idd-suitability.instructions.md`).
 

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -158,7 +158,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 75300
+      "limitBytes": 76000
     },
     {
       "id": "bundle-resume",

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -275,7 +275,7 @@ CI enforces two layers of instruction file size limits via `audit/sync-manifest.
 
 | Bundle ID          | Files included                                                                                   | Limit        |
 | ------------------ | ------------------------------------------------------------------------------------------------ | ------------ |
-| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 75,300 bytes |
+| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 76,000 bytes |
 | `bundle-resume`    | `idd-overview-core` + `idd-overview-appendix` + `idd-resume`                                     | 46,000 bytes |
 
 Bundle checks run unconditionally (not filtered by changed files) and

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -442,7 +442,7 @@ After scanning the current batch:
 
 | Batch outcome                                                                       | Action                                                                                                                                                                                                  |
 | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| At least one eligible candidate in the batch                                        | Proceed to Step 2 and pick the lowest-numbered eligible candidate.                                                                                                                                      |
+| At least one eligible candidate in the batch                                        | Proceed to Step 2 to rank and select.                                                                                                                                                                   |
 | All `N` in this batch are claimed but viable survivors remain                       | Continue with the next batch (`N+1`–`2N`, then `2N+1`–`3N`, …) until an eligible candidate is found.                                                                                                    |
 | Entire viable candidate set exhausted (all surviving viable candidates are claimed) | Report that all viable issues are currently claimed; stop. Do not post `unclaimed-by` (no claim was made). Not an abort; retry later when claims may have become stale or new viable candidates appear. |
 
@@ -452,7 +452,14 @@ for why this pre-scan exists.
 ### Step 2 — Select
 
 Among the surviving viable and unclaimed issues (after Step 1.5), pick the
-one with the **lowest issue number**.
+**highest authored autopilot-suitability score** (the
+`<!-- {{PROJECT_MARKER_PREFIX}}-autopilot-suitability: N -->` footer, or the
+`discover-roadmap-graph` node's `autopilotSuitability`), tie-broken by
+**lowest issue number**. In autopilot runs, skip scores below
+`autopilotSuitability.floor` (default `3`) as human-oriented; a missing or
+out-of-range score is treated as no score — ranked at the floor and never
+skipped, so the unscored backlog flows as before. Advisory only: the pick
+still passes A4.5/A5 unchanged and the score never bypasses a gate.
 
 After picking, continue to **A4.5** (`idd-suitability.instructions.md`).
 

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -275,7 +275,7 @@ CI enforces two layers of instruction file size limits via `audit/sync-manifest.
 
 | Bundle ID          | Files included                                                                                   | Limit        |
 | ------------------ | ------------------------------------------------------------------------------------------------ | ------------ |
-| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 75,300 bytes |
+| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 76,000 bytes |
 | `bundle-resume`    | `idd-overview-core` + `idd-overview-appendix` + `idd-resume`                                     | 46,000 bytes |
 
 Bundle checks run unconditionally (not filtered by changed files) and

--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -93,27 +93,31 @@ export function rankAndRouteBySuitability(items, options = {}) {
   }
   const floor = normalizeAutopilotSuitabilityFloor(options.floor);
 
+  // Compute each item's score exactly once and reuse it for both routing
+  // and ranking, so a non-trivial or non-deterministic getScore cannot
+  // produce inconsistent decisions. Any non-finite value (null, NaN, …)
+  // is treated as "no score".
+  const scored = list.map((item, index) => {
+    const raw = getScore(item);
+    return { item, index, score: Number.isFinite(raw) ? raw : null };
+  });
+
   const routedToHuman = [];
   const eligible = [];
-  for (const item of list) {
-    const score = getScore(item);
-    if (typeof score === "number" && score < floor) {
-      routedToHuman.push(item);
+  for (const entry of scored) {
+    if (entry.score !== null && entry.score < floor) {
+      routedToHuman.push(entry);
     } else {
-      eligible.push(item);
+      eligible.push(entry);
     }
   }
 
   const ranked = eligible
-    .map((item, index) => ({ item, index, effective: effectiveScore(getScore(item), floor) }))
-    .sort((left, right) => (right.effective - left.effective) || (left.index - right.index))
+    .sort((left, right) =>
+      ((right.score ?? floor) - (left.score ?? floor)) || (left.index - right.index))
     .map((entry) => entry.item);
 
-  return { ranked, routedToHuman };
-}
-
-function effectiveScore(score, floor) {
-  return typeof score === "number" ? score : floor;
+  return { ranked, routedToHuman: routedToHuman.map((entry) => entry.item) };
 }
 
 function escapeRegex(value) {

--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -101,11 +101,13 @@ export function rankAndRouteBySuitability(items, options = {}) {
 
   // Compute each item's score exactly once and reuse it for both routing
   // and ranking, so a non-trivial or non-deterministic getScore cannot
-  // produce inconsistent decisions. Any non-finite value (null, NaN, …)
-  // is treated as "no score".
+  // produce inconsistent decisions. Defensively normalize here too:
+  // anything that is not an integer 1-5 (null, NaN, 0, 6, 2.5, …) is
+  // treated as "no score", upholding the fail-safe rule regardless of
+  // what the caller's getScore returns.
   const scored = list.map((item, index) => {
     const raw = getScore(item);
-    return { item, index, score: Number.isFinite(raw) ? raw : null };
+    return { item, index, score: isAutopilotSuitabilityScore(raw) ? raw : null };
   });
 
   const routedToHuman = [];
@@ -124,6 +126,14 @@ export function rankAndRouteBySuitability(items, options = {}) {
     .map((entry) => entry.item);
 
   return { ranked, routedToHuman: routedToHuman.map((entry) => entry.item) };
+}
+
+/**
+ * True when `value` is a valid authored autopilot-suitability score:
+ * an integer in the inclusive range 1-5.
+ */
+export function isAutopilotSuitabilityScore(value) {
+  return Number.isInteger(value) && value >= 1 && value <= 5;
 }
 
 function escapeRegex(value) {

--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -73,16 +73,21 @@ export function normalizeAutopilotSuitabilityFloor(floor) {
  *
  * - `enabled: false` is a kill-switch: the items are returned
  *   unchanged with an empty routedToHuman bucket.
- * - Candidates whose score is present and `< floor` are moved to
- *   `routedToHuman` (kept visible, never discarded), preserving their
- *   original relative order.
- * - The remaining candidates (score `>= floor`, or no score) are
- *   stable-sorted by effective score descending, where a missing
- *   score uses the floor as a neutral baseline so unscored (e.g.
- *   pre-existing) issues are never buried and never skipped.
+ * - Ranking always runs (when enabled): items are stable-sorted by
+ *   effective score descending, where a missing score uses the floor as
+ *   a neutral baseline so unscored (e.g. pre-existing) issues are never
+ *   buried. Ties keep input order, so callers that need a domain
+ *   tie-break (e.g. lowest issue number) pre-sort the input by that key.
+ * - Routing is **opt-in** via `routeBelowFloor` (the autopilot-run
+ *   behavior). When true, candidates whose score is present and
+ *   `< floor` are moved to `routedToHuman` (kept visible, never
+ *   discarded). When false (the attended-safe default), below-floor
+ *   candidates stay in `ranked` — they simply sort to the bottom by
+ *   their real score — so attended discovery never loses a selectable
+ *   issue.
  *
  * @param {Array} items
- * @param {{floor?: number, enabled?: boolean, getScore: (item: any) => (number|null)}} options
+ * @param {{floor?: number, enabled?: boolean, routeBelowFloor?: boolean, getScore: (item: any) => (number|null)}} options
  * @returns {{ranked: Array, routedToHuman: Array}}
  */
 export function rankAndRouteBySuitability(items, options = {}) {
@@ -92,6 +97,7 @@ export function rankAndRouteBySuitability(items, options = {}) {
     return { ranked: list, routedToHuman: [] };
   }
   const floor = normalizeAutopilotSuitabilityFloor(options.floor);
+  const routeBelowFloor = options.routeBelowFloor === true;
 
   // Compute each item's score exactly once and reuse it for both routing
   // and ranking, so a non-trivial or non-deterministic getScore cannot
@@ -105,7 +111,7 @@ export function rankAndRouteBySuitability(items, options = {}) {
   const routedToHuman = [];
   const eligible = [];
   for (const entry of scored) {
-    if (entry.score !== null && entry.score < floor) {
+    if (routeBelowFloor && entry.score !== null && entry.score < floor) {
       routedToHuman.push(entry);
     } else {
       eligible.push(entry);

--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -1,0 +1,121 @@
+// Shared autopilot-suitability score parsing and discovery
+// ranking/routing. Consumed by:
+//
+// - scripts/discover-orphan-filter.mjs (A0-O candidate list)
+// - scripts/discover-roadmap-graph.mjs (A1.5/A2 node enumeration)
+//
+// The score is the authored 1-5 autopilot-suitability marker defined
+// in skills/issue-authoring/references/contract.md. It is an
+// advisory ranking/routing hint only — it never replaces the A4.5
+// suitability gate or the A5 claim safety checks, which still run on
+// whatever candidate is selected.
+
+const DEFAULT_MARKER_PREFIX = "idd-skill";
+export const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
+
+/**
+ * Parse the authored autopilot-suitability score from an issue body.
+ *
+ * Returns an integer 1-5 when the body carries a single coherent
+ * `<!-- {prefix}-autopilot-suitability: N -->` marker. Returns null
+ * (fail-safe = "no score") when the marker is absent, non-integer,
+ * out of the 1-5 range, or present more than once with disagreeing
+ * values. A null score must never cause an issue to be skipped; the
+ * caller evaluates it the normal way.
+ */
+export function parseAutopilotSuitability(body, markerPrefix = DEFAULT_MARKER_PREFIX) {
+  const prefix = typeof markerPrefix === "string" && markerPrefix.length > 0
+    ? markerPrefix
+    : DEFAULT_MARKER_PREFIX;
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
+    "gi",
+  );
+  const text = String(body ?? "");
+  const values = new Set();
+  let sawInvalid = false;
+  let match = regex.exec(text);
+  while (match) {
+    const raw = match[1];
+    if (/^\d+$/.test(raw)) {
+      const value = Number.parseInt(raw, 10);
+      if (value >= 1 && value <= 5) {
+        values.add(value);
+      } else {
+        sawInvalid = true;
+      }
+    } else {
+      sawInvalid = true;
+    }
+    match = regex.exec(text);
+  }
+  // Fail-safe: any invalid token, or conflicting values, yields no score.
+  if (sawInvalid || values.size !== 1) {
+    return null;
+  }
+  return [...values][0];
+}
+
+/**
+ * Normalize a configured floor to an integer 1-5, falling back to the
+ * default (3) for anything out of range or non-integer.
+ */
+export function normalizeAutopilotSuitabilityFloor(floor) {
+  if (Number.isInteger(floor) && floor >= 1 && floor <= 5) {
+    return floor;
+  }
+  return DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+}
+
+/**
+ * Rank a candidate list by autopilot-suitability score and route
+ * below-floor candidates out to a human bucket.
+ *
+ * - `enabled: false` is a kill-switch: the items are returned
+ *   unchanged with an empty routedToHuman bucket.
+ * - Candidates whose score is present and `< floor` are moved to
+ *   `routedToHuman` (kept visible, never discarded), preserving their
+ *   original relative order.
+ * - The remaining candidates (score `>= floor`, or no score) are
+ *   stable-sorted by effective score descending, where a missing
+ *   score uses the floor as a neutral baseline so unscored (e.g.
+ *   pre-existing) issues are never buried and never skipped.
+ *
+ * @param {Array} items
+ * @param {{floor?: number, enabled?: boolean, getScore: (item: any) => (number|null)}} options
+ * @returns {{ranked: Array, routedToHuman: Array}}
+ */
+export function rankAndRouteBySuitability(items, options = {}) {
+  const list = Array.isArray(items) ? [...items] : [];
+  const getScore = typeof options.getScore === "function" ? options.getScore : () => null;
+  if (options.enabled === false) {
+    return { ranked: list, routedToHuman: [] };
+  }
+  const floor = normalizeAutopilotSuitabilityFloor(options.floor);
+
+  const routedToHuman = [];
+  const eligible = [];
+  for (const item of list) {
+    const score = getScore(item);
+    if (typeof score === "number" && score < floor) {
+      routedToHuman.push(item);
+    } else {
+      eligible.push(item);
+    }
+  }
+
+  const ranked = eligible
+    .map((item, index) => ({ item, index, effective: effectiveScore(getScore(item), floor) }))
+    .sort((left, right) => (right.effective - left.effective) || (left.index - right.index))
+    .map((entry) => entry.item);
+
+  return { ranked, routedToHuman };
+}
+
+function effectiveScore(score, floor) {
+  return typeof score === "number" ? score : floor;
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -172,12 +172,17 @@ export function filterOrphanIssues(issues, options = {}) {
   }
 
   // Rank the orphan candidate list by authored autopilot-suitability
-  // score and route below-floor candidates to a human bucket. This is
-  // advisory: the A4.5/A5 gates still run on any selected candidate,
-  // and unscored issues are never routed out (fail-safe).
-  const { ranked, routedToHuman } = rankAndRouteBySuitability(orphans, {
+  // score. Pre-sort by issue number so equal scores resolve by lowest
+  // number (the Step 2 tie-break) rather than by API fetch order.
+  // Below-floor routing is opt-in (autopilot runs only): in attended
+  // discovery the low-score issues stay selectable, just ranked last.
+  // Advisory throughout — the A4.5/A5 gates still run on any selected
+  // candidate, and unscored issues are never routed out (fail-safe).
+  const orphansByNumber = [...orphans].sort((left, right) => left.number - right.number);
+  const { ranked, routedToHuman } = rankAndRouteBySuitability(orphansByNumber, {
     floor: options.autopilotSuitabilityFloor ?? DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
     enabled: options.autopilotSuitabilityEnabled !== false,
+    routeBelowFloor: options.autopilot === true,
     getScore: (orphan) => orphan.autopilotSuitability,
   });
 
@@ -225,6 +230,7 @@ function runCli() {
     authoringStaleAgeMs: policy.authoringStaleAgeMs,
     autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
+    autopilot: args.autopilot,
     now: args.now || new Date(),
   });
 
@@ -256,6 +262,7 @@ function parseArgs(argv) {
     pr: null,
     help: false,
     now: "",
+    autopilot: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -290,6 +297,10 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (token === "--autopilot") {
+      parsed.autopilot = true;
+      continue;
+    }
     if (token === "--help" || token === "-h") {
       parsed.help = true;
       continue;
@@ -301,7 +312,7 @@ function parseArgs(argv) {
 
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/discover-orphan-filter.mjs [--owner <owner>] [--repo <repo>] [--policy <path>] [--pr <number>] [--now <ISO8601>]
+  node scripts/discover-orphan-filter.mjs [--owner <owner>] [--repo <repo>] [--policy <path>] [--pr <number>] [--now <ISO8601>] [--autopilot]
 
 Output schema:
 {
@@ -323,10 +334,12 @@ Output schema:
   "counts": {"scanned": 0, "orphans": 0, "routed_to_human": 0, "filtered": {...}, "unresolvable": 0}
 }
 
-orphans are ranked by authored autopilot-suitability score (high first);
-orphans whose score is below autopilotSuitabilityFloor (default 3) are
-moved to routed_to_human. A missing or out-of-range score is treated as
-no score: the issue stays in orphans and is never routed out.
+orphans are always ranked by authored autopilot-suitability score (high
+first; equal scores tie-break by lowest issue number). With --autopilot
+(autopilot runs), orphans whose score is below autopilotSuitabilityFloor
+(default 3) are moved to routed_to_human; without it (attended runs) they
+stay in orphans, ranked last. A missing or out-of-range score is treated
+as no score: the issue stays in orphans and is never routed out.
 `);
 }
 

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -9,6 +9,11 @@ import {
   buildAuthoringLabelWarning,
   resolveAuthoringGuardPolicy,
 } from "./authoring-label-guard.mjs";
+import {
+  DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+  parseAutopilotSuitability,
+  rankAndRouteBySuitability,
+} from "./autopilot-suitability.mjs";
 
 const DEFAULT_MARKER_PREFIX = "idd-skill";
 const BLOCKED_LABELS = new Set(["status:blocked-by-human", "status:needs-decision"]);
@@ -158,6 +163,7 @@ export function filterOrphanIssues(issues, options = {}) {
         state: issue.state,
         reason: result.reason,
         url: issue.url ?? "",
+        autopilotSuitability: parseAutopilotSuitability(issue.body, options.markerPrefix),
       });
       continue;
     }
@@ -165,9 +171,20 @@ export function filterOrphanIssues(issues, options = {}) {
     filtered[result.reason].push(entry);
   }
 
+  // Rank the orphan candidate list by authored autopilot-suitability
+  // score and route below-floor candidates to a human bucket. This is
+  // advisory: the A4.5/A5 gates still run on any selected candidate,
+  // and unscored issues are never routed out (fail-safe).
+  const { ranked, routedToHuman } = rankAndRouteBySuitability(orphans, {
+    floor: options.autopilotSuitabilityFloor ?? DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+    enabled: options.autopilotSuitabilityEnabled !== false,
+    getScore: (orphan) => orphan.autopilotSuitability,
+  });
+
   const counts = {
     scanned: issues.length,
-    orphans: orphans.length,
+    orphans: ranked.length,
+    routed_to_human: routedToHuman.length,
     filtered: Object.fromEntries(
       Object.entries(filtered).map(([reason, entries]) => [reason, entries.length]),
     ),
@@ -175,7 +192,8 @@ export function filterOrphanIssues(issues, options = {}) {
   };
 
   return {
-    orphans,
+    orphans: ranked,
+    routed_to_human: routedToHuman,
     filtered,
     unresolvable,
     warnings,
@@ -205,6 +223,8 @@ function runCli() {
     markerPrefix: policy.markerPrefix,
     authoringLabelName: policy.authoringLabelName,
     authoringStaleAgeMs: policy.authoringStaleAgeMs,
+    autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
+    autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
     now: args.now || new Date(),
   });
 
@@ -219,6 +239,8 @@ function runCli() {
       markerPrefix: policy.markerPrefix,
       authoringLabelName: policy.authoringLabelName,
       authoringStaleAge: policy.authoringStaleAge,
+      autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
+      autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
     },
     ...result,
   };
@@ -285,8 +307,9 @@ Output schema:
 {
   "repository": {"owner": "...", "repo": "..."},
   "diagnostics": {"pr": 404},
-  "policy": {"source": "...", "orphanFirstPolicy": "none|maintainer-approved|public-disabled", "markerPrefix": "...", "authoringLabelName": "...", "authoringStaleAge": "..."},
-  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|blocked_references_closed", "url": "..."}],
+  "policy": {"source": "...", "orphanFirstPolicy": "none|maintainer-approved|public-disabled", "markerPrefix": "...", "authoringLabelName": "...", "authoringStaleAge": "...", "autopilotSuitabilityFloor": 3, "autopilotSuitabilityEnabled": true},
+  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|blocked_references_closed", "url": "...", "autopilotSuitability": 4}],
+  "routed_to_human": [{"number": 2, "title": "...", "state": "OPEN", "reason": "orphan", "url": "...", "autopilotSuitability": 1}],
   "filtered": {
     "roadmap_marker": [...],
     "blocked_by_marker": [...],
@@ -297,8 +320,13 @@ Output schema:
   },
   "unresolvable": [{"issue": 1, "reference": 2, "reason": "issue-not-found-or-inaccessible"}],
   "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
-  "counts": {"scanned": 0, "orphans": 0, "filtered": {...}, "unresolvable": 0}
+  "counts": {"scanned": 0, "orphans": 0, "routed_to_human": 0, "filtered": {...}, "unresolvable": 0}
 }
+
+orphans are ranked by authored autopilot-suitability score (high first);
+orphans whose score is below autopilotSuitabilityFloor (default 3) are
+moved to routed_to_human. A missing or out-of-range score is treated as
+no score: the issue stays in orphans and is never routed out.
 `);
 }
 
@@ -315,6 +343,8 @@ function loadPolicy(policyPath) {
       authoringLabelName: authoringPolicy.labelName,
       authoringStaleAge: authoringPolicy.staleAge,
       authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+      autopilotSuitabilityFloor: resolveAutopilotSuitabilityFloor(config),
+      autopilotSuitabilityEnabled: resolveAutopilotSuitabilityEnabled(config),
     };
   } catch {
     const authoringPolicy = resolveAuthoringGuardPolicy({});
@@ -325,8 +355,21 @@ function loadPolicy(policyPath) {
       authoringLabelName: authoringPolicy.labelName,
       authoringStaleAge: authoringPolicy.staleAge,
       authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+      autopilotSuitabilityFloor: DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+      autopilotSuitabilityEnabled: true,
     };
   }
+}
+
+function resolveAutopilotSuitabilityFloor(config) {
+  const floor = config?.autopilotSuitability?.floor;
+  return Number.isInteger(floor) && floor >= 1 && floor <= 5
+    ? floor
+    : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+}
+
+function resolveAutopilotSuitabilityEnabled(config) {
+  return config?.autopilotSuitability?.enabled !== false;
 }
 
 function normalizeIssue(issue) {

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -11,6 +11,7 @@ import {
 } from "./authoring-label-guard.mjs";
 import {
   DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+  normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
   rankAndRouteBySuitability,
 } from "./autopilot-suitability.mjs";
@@ -375,10 +376,9 @@ function loadPolicy(policyPath) {
 }
 
 function resolveAutopilotSuitabilityFloor(config) {
-  const floor = config?.autopilotSuitability?.floor;
-  return Number.isInteger(floor) && floor >= 1 && floor <= 5
-    ? floor
-    : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  // Delegate range/default validation to the shared normalizer so the
+  // 1-5 rule and the default cannot drift between modules.
+  return normalizeAutopilotSuitabilityFloor(config?.autopilotSuitability?.floor);
 }
 
 function resolveAutopilotSuitabilityEnabled(config) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -479,7 +479,7 @@ function printHelp() {
 Output schema (JSON mode):
   {
     "root": { "number": 638, "title": "...", "state": "OPEN", "classification": "roadmap", "roadmapMarkerId": "..." },
-    "nodes": [{ "number": 638, "title": "...", "state": "OPEN", "labels": ["roadmap"], "classification": "roadmap", "roadmapMarkerId": "...", "depth": 0 }],
+    "nodes": [{ "number": 638, "title": "...", "state": "OPEN", "labels": ["roadmap"], "classification": "roadmap", "roadmapMarkerId": "...", "autopilotSuitability": null, "depth": 0 }],
     "edges": [{ "source": 638, "target": 640, "relationship": "task-list", "evidence": "- [ ] #640" }],
     "provenancePaths": [{ "target": 640, "path": [638, 640] }],
     "roadmapNodes": [],

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -5,6 +5,8 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { parseAutopilotSuitability } from "./autopilot-suitability.mjs";
+
 const DEFAULT_MARKER_PREFIX = "idd-skill";
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({ __iddLookupStatus: "inaccessible" });
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
@@ -99,6 +101,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
       labels: [...node.labels].sort(),
       classification: node.classification,
       roadmapMarkerId: node.roadmapMarkerId,
+      autopilotSuitability: node.autopilotSuitability ?? null,
       depth: node.depth,
     }))
     .sort(compareByNumber);
@@ -261,6 +264,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
       labels: issue.labels,
       classification: classification.kind,
       roadmapMarkerId: classification.roadmapMarkerId,
+      autopilotSuitability: parseAutopilotSuitability(issue.body, markerPrefix),
       depth,
     });
     recordProvenancePath(issue.number, path);

--- a/tests/autopilot-suitability.test.mjs
+++ b/tests/autopilot-suitability.test.mjs
@@ -3,10 +3,40 @@ import { test } from "node:test";
 
 import {
   DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+  isAutopilotSuitabilityScore,
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
   rankAndRouteBySuitability,
 } from "../scripts/autopilot-suitability.mjs";
+
+test("isAutopilotSuitabilityScore accepts only integers 1-5", () => {
+  for (const value of [1, 2, 3, 4, 5]) {
+    assert.equal(isAutopilotSuitabilityScore(value), true, `score ${value}`);
+  }
+  for (const value of [0, 6, 2.5, -1, NaN, null, undefined, "3", Infinity]) {
+    assert.equal(isAutopilotSuitabilityScore(value), false, `score ${String(value)}`);
+  }
+});
+
+test("rankAndRouteBySuitability treats invalid finite scores as no-score (fail-safe)", () => {
+  const items = [
+    { id: "zero", score: 0 },
+    { id: "six", score: 6 },
+    { id: "frac", score: 2.5 },
+    { id: "high", score: 5 },
+    { id: "low", score: 2 },
+  ];
+  const { ranked, routedToHuman } = rankAndRouteBySuitability(items, {
+    floor: 3,
+    routeBelowFloor: true,
+    getScore: (item) => item.score,
+  });
+  // Only the genuine below-floor integer (2) is routed; 0 and 6 and 2.5
+  // are no-score and stay (ranked at the floor baseline), not routed
+  // despite 0 < floor.
+  assert.deepEqual(routedToHuman.map((item) => item.id), ["low"]);
+  assert.deepEqual(ranked.map((item) => item.id), ["high", "zero", "six", "frac"]);
+});
 
 const marker = (n, prefix = "idd-skill") => `<!-- ${prefix}-autopilot-suitability: ${n} -->`;
 

--- a/tests/autopilot-suitability.test.mjs
+++ b/tests/autopilot-suitability.test.mjs
@@ -45,7 +45,24 @@ test("normalizeAutopilotSuitabilityFloor clamps to default for bad input", () =>
   assert.equal(normalizeAutopilotSuitabilityFloor(undefined), DEFAULT_AUTOPILOT_SUITABILITY_FLOOR);
 });
 
-test("rankAndRouteBySuitability ranks high first and routes below-floor to humans", () => {
+test("rankAndRouteBySuitability ranks high first and routes below-floor to humans (autopilot)", () => {
+  const items = [
+    { id: "a", score: 2 },
+    { id: "b", score: 5 },
+    { id: "c", score: 3 },
+    { id: "d", score: 1 },
+    { id: "e", score: 4 },
+  ];
+  const { ranked, routedToHuman } = rankAndRouteBySuitability(items, {
+    floor: 3,
+    routeBelowFloor: true,
+    getScore: (item) => item.score,
+  });
+  assert.deepEqual(ranked.map((item) => item.id), ["b", "e", "c"]);
+  assert.deepEqual(routedToHuman.map((item) => item.id), ["a", "d"]);
+});
+
+test("rankAndRouteBySuitability keeps below-floor items ranked last when routing is off (attended)", () => {
   const items = [
     { id: "a", score: 2 },
     { id: "b", score: 5 },
@@ -57,8 +74,9 @@ test("rankAndRouteBySuitability ranks high first and routes below-floor to human
     floor: 3,
     getScore: (item) => item.score,
   });
-  assert.deepEqual(ranked.map((item) => item.id), ["b", "e", "c"]);
-  assert.deepEqual(routedToHuman.map((item) => item.id), ["a", "d"]);
+  // Nothing routed out; below-floor (2, 1) sink to the bottom by real score.
+  assert.deepEqual(routedToHuman, []);
+  assert.deepEqual(ranked.map((item) => item.id), ["b", "e", "c", "a", "d"]);
 });
 
 test("rankAndRouteBySuitability never routes or buries unscored items (fail-safe)", () => {
@@ -70,6 +88,7 @@ test("rankAndRouteBySuitability never routes or buries unscored items (fail-safe
   ];
   const { ranked, routedToHuman } = rankAndRouteBySuitability(items, {
     floor: 3,
+    routeBelowFloor: true,
     getScore: (item) => item.score,
   });
   // Only the real below-floor score is routed out; unscored never are.

--- a/tests/autopilot-suitability.test.mjs
+++ b/tests/autopilot-suitability.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+  normalizeAutopilotSuitabilityFloor,
+  parseAutopilotSuitability,
+  rankAndRouteBySuitability,
+} from "../scripts/autopilot-suitability.mjs";
+
+const marker = (n, prefix = "idd-skill") => `<!-- ${prefix}-autopilot-suitability: ${n} -->`;
+
+test("parseAutopilotSuitability reads a single in-range marker", () => {
+  for (let n = 1; n <= 5; n += 1) {
+    assert.equal(parseAutopilotSuitability(`body\n\n${marker(n)}`), n);
+  }
+});
+
+test("parseAutopilotSuitability is prefix-aware", () => {
+  assert.equal(parseAutopilotSuitability(marker(4, "my-org"), "my-org"), 4);
+  // wrong prefix -> not found -> null
+  assert.equal(parseAutopilotSuitability(marker(4, "my-org"), "idd-skill"), null);
+});
+
+test("parseAutopilotSuitability fails safe on absent/invalid/out-of-range", () => {
+  assert.equal(parseAutopilotSuitability("no marker here"), null);
+  assert.equal(parseAutopilotSuitability(""), null);
+  assert.equal(parseAutopilotSuitability(marker(0)), null);
+  assert.equal(parseAutopilotSuitability(marker(6)), null);
+  assert.equal(parseAutopilotSuitability(marker("high")), null);
+  assert.equal(parseAutopilotSuitability(marker("3.5")), null);
+});
+
+test("parseAutopilotSuitability returns null on conflicting duplicate markers", () => {
+  assert.equal(parseAutopilotSuitability(`${marker(4)}\n${marker(2)}`), null);
+  // identical duplicates collapse to the single value
+  assert.equal(parseAutopilotSuitability(`${marker(4)}\n${marker(4)}`), 4);
+});
+
+test("normalizeAutopilotSuitabilityFloor clamps to default for bad input", () => {
+  assert.equal(normalizeAutopilotSuitabilityFloor(4), 4);
+  assert.equal(normalizeAutopilotSuitabilityFloor(0), DEFAULT_AUTOPILOT_SUITABILITY_FLOOR);
+  assert.equal(normalizeAutopilotSuitabilityFloor(6), DEFAULT_AUTOPILOT_SUITABILITY_FLOOR);
+  assert.equal(normalizeAutopilotSuitabilityFloor(2.5), DEFAULT_AUTOPILOT_SUITABILITY_FLOOR);
+  assert.equal(normalizeAutopilotSuitabilityFloor(undefined), DEFAULT_AUTOPILOT_SUITABILITY_FLOOR);
+});
+
+test("rankAndRouteBySuitability ranks high first and routes below-floor to humans", () => {
+  const items = [
+    { id: "a", score: 2 },
+    { id: "b", score: 5 },
+    { id: "c", score: 3 },
+    { id: "d", score: 1 },
+    { id: "e", score: 4 },
+  ];
+  const { ranked, routedToHuman } = rankAndRouteBySuitability(items, {
+    floor: 3,
+    getScore: (item) => item.score,
+  });
+  assert.deepEqual(ranked.map((item) => item.id), ["b", "e", "c"]);
+  assert.deepEqual(routedToHuman.map((item) => item.id), ["a", "d"]);
+});
+
+test("rankAndRouteBySuitability never routes or buries unscored items (fail-safe)", () => {
+  const items = [
+    { id: "scored5", score: 5 },
+    { id: "unscored1", score: null },
+    { id: "scored1", score: 1 },
+    { id: "unscored2", score: null },
+  ];
+  const { ranked, routedToHuman } = rankAndRouteBySuitability(items, {
+    floor: 3,
+    getScore: (item) => item.score,
+  });
+  // Only the real below-floor score is routed out; unscored never are.
+  assert.deepEqual(routedToHuman.map((item) => item.id), ["scored1"]);
+  // Unscored use the floor as a neutral baseline: ranked below 5, and
+  // stable relative to each other and to floor-level scores.
+  assert.deepEqual(ranked.map((item) => item.id), ["scored5", "unscored1", "unscored2"]);
+});
+
+test("rankAndRouteBySuitability honors the enabled kill-switch", () => {
+  const items = [{ id: "a", score: 1 }, { id: "b", score: 5 }];
+  const { ranked, routedToHuman } = rankAndRouteBySuitability(items, {
+    floor: 3,
+    enabled: false,
+    getScore: (item) => item.score,
+  });
+  assert.deepEqual(ranked.map((item) => item.id), ["a", "b"]);
+  assert.deepEqual(routedToHuman, []);
+});
+
+test("rankAndRouteBySuitability is stable for equal effective scores", () => {
+  const items = [
+    { id: "first", score: 4 },
+    { id: "second", score: 4 },
+    { id: "third", score: 4 },
+  ];
+  const { ranked } = rankAndRouteBySuitability(items, { floor: 3, getScore: (item) => item.score });
+  assert.deepEqual(ranked.map((item) => item.id), ["first", "second", "third"]);
+});

--- a/tests/discover-orphan-filter.test.mjs
+++ b/tests/discover-orphan-filter.test.mjs
@@ -311,3 +311,42 @@ test("filterOrphanIssues handles pagination with PR-heavy pages", () => {
   assert.equal(result.orphans.length, 1, "Issue should be orphan when blocker is closed");
   assert.equal(result.orphans[0].reason, "blocked_references_closed");
 });
+
+test("filterOrphanIssues ranks orphans by autopilot-suitability and routes below-floor to humans", () => {
+  const m = (n) => `<!-- idd-skill-autopilot-suitability: ${n} -->`;
+  const issues = [
+    { number: 1, title: "low", state: "OPEN", body: `task\n${m(1)}` },
+    { number: 2, title: "high", state: "OPEN", body: `task\n${m(5)}` },
+    { number: 3, title: "mid", state: "OPEN", body: `task\n${m(3)}` },
+    { number: 4, title: "unscored", state: "OPEN", body: "task with no score" },
+  ];
+  const result = filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => "UNRESOLVABLE",
+    autopilotSuitabilityFloor: 3,
+  });
+
+  // High first; unscored kept (floor baseline), below-floor routed out.
+  assert.deepEqual(result.orphans.map((o) => o.number), [2, 3, 4]);
+  assert.deepEqual(result.routed_to_human.map((o) => o.number), [1]);
+  assert.equal(result.counts.routed_to_human, 1);
+  assert.equal(result.orphans.find((o) => o.number === 2).autopilotSuitability, 5);
+  assert.equal(result.orphans.find((o) => o.number === 4).autopilotSuitability, null);
+});
+
+test("filterOrphanIssues leaves orphans unrouted when suitability is disabled", () => {
+  const m = (n) => `<!-- idd-skill-autopilot-suitability: ${n} -->`;
+  const issues = [
+    { number: 1, title: "low", state: "OPEN", body: `task\n${m(1)}` },
+    { number: 2, title: "high", state: "OPEN", body: `task\n${m(5)}` },
+  ];
+  const result = filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => "UNRESOLVABLE",
+    autopilotSuitabilityFloor: 3,
+    autopilotSuitabilityEnabled: false,
+  });
+
+  assert.deepEqual(result.orphans.map((o) => o.number), [1, 2]);
+  assert.deepEqual(result.routed_to_human, []);
+});

--- a/tests/discover-orphan-filter.test.mjs
+++ b/tests/discover-orphan-filter.test.mjs
@@ -312,7 +312,7 @@ test("filterOrphanIssues handles pagination with PR-heavy pages", () => {
   assert.equal(result.orphans[0].reason, "blocked_references_closed");
 });
 
-test("filterOrphanIssues ranks orphans by autopilot-suitability and routes below-floor to humans", () => {
+test("filterOrphanIssues ranks orphans by autopilot-suitability and routes below-floor to humans (autopilot)", () => {
   const m = (n) => `<!-- idd-skill-autopilot-suitability: ${n} -->`;
   const issues = [
     { number: 1, title: "low", state: "OPEN", body: `task\n${m(1)}` },
@@ -324,6 +324,7 @@ test("filterOrphanIssues ranks orphans by autopilot-suitability and routes below
     issueStateByNumber: new Map(),
     fetchIssueStateByNumber: () => "UNRESOLVABLE",
     autopilotSuitabilityFloor: 3,
+    autopilot: true,
   });
 
   // High first; unscored kept (floor baseline), below-floor routed out.
@@ -332,6 +333,37 @@ test("filterOrphanIssues ranks orphans by autopilot-suitability and routes below
   assert.equal(result.counts.routed_to_human, 1);
   assert.equal(result.orphans.find((o) => o.number === 2).autopilotSuitability, 5);
   assert.equal(result.orphans.find((o) => o.number === 4).autopilotSuitability, null);
+});
+
+test("filterOrphanIssues keeps below-floor orphans selectable in attended (default) mode", () => {
+  const m = (n) => `<!-- idd-skill-autopilot-suitability: ${n} -->`;
+  const issues = [
+    { number: 1, title: "low", state: "OPEN", body: `task\n${m(1)}` },
+    { number: 2, title: "high", state: "OPEN", body: `task\n${m(5)}` },
+  ];
+  const result = filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => "UNRESOLVABLE",
+    autopilotSuitabilityFloor: 3,
+    // autopilot omitted -> attended: nothing routed out; below-floor ranked last.
+  });
+
+  assert.deepEqual(result.orphans.map((o) => o.number), [2, 1]);
+  assert.deepEqual(result.routed_to_human, []);
+});
+
+test("filterOrphanIssues tie-breaks equal scores by lowest issue number", () => {
+  const m = (n) => `<!-- idd-skill-autopilot-suitability: ${n} -->`;
+  const issues = [
+    { number: 20, title: "twenty", state: "OPEN", body: `task\n${m(5)}` },
+    { number: 7, title: "seven", state: "OPEN", body: `task\n${m(5)}` },
+    { number: 13, title: "thirteen", state: "OPEN", body: `task\n${m(5)}` },
+  ];
+  const result = filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => "UNRESOLVABLE",
+  });
+  assert.deepEqual(result.orphans.map((o) => o.number), [7, 13, 20]);
 });
 
 test("filterOrphanIssues leaves orphans unrouted when suitability is disabled", () => {

--- a/tests/discover-roadmap-graph.test.mjs
+++ b/tests/discover-roadmap-graph.test.mjs
@@ -649,3 +649,19 @@ function executionIssue(number, body, state = "open") {
     labels: [],
   };
 }
+
+test("nodes carry the authored autopilot-suitability score (null when unscored)", async () => {
+  const issues = new Map([
+    [500, roadmapIssue(500, "- [ ] #501\n- [ ] #502", "score-roadmap")],
+    [501, executionIssue(501, "task one\n<!-- idd-skill-autopilot-suitability: 5 -->")],
+    [502, executionIssue(502, "task two with no score")],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(500, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  const byNumber = new Map(graph.nodes.map((node) => [node.number, node]));
+  assert.equal(byNumber.get(501).autopilotSuitability, 5);
+  assert.equal(byNumber.get(502).autopilotSuitability, null);
+});


### PR DESCRIPTION
## Summary

Closes #762 (Track 3 of roadmap #759) — the cost-saving consumer:
Discover reads the persisted autopilot-suitability score instead
of re-deriving autonomy per candidate.

## What changed

- **New `scripts/autopilot-suitability.mjs`** (shared, both discover
  helpers import it):
  - `parseAutopilotSuitability(body, prefix)` — prefix-aware, returns
    an integer 1-5 or `null`. **Fail-safe:** missing, non-integer,
    out-of-range, or conflicting-duplicate markers → `null`.
  - `rankAndRouteBySuitability(items, {floor, enabled, getScore})` —
    stable sort by effective score descending (a missing score uses
    the floor as a neutral baseline), routes `score < floor` to a
    human bucket, and honours an `enabled: false` kill-switch.
    Unscored items are never routed out and never buried.
- **`discover-orphan-filter.mjs`** — parses each orphan's score,
  ranks the orphan list, emits a `routed_to_human` bucket + counts,
  and reads `autopilotSuitability.floor` (default 3) / `.enabled`
  from policy.
- **`discover-roadmap-graph.mjs`** — exposes `autopilotSuitability`
  on every node so roadmap-mode A3/A4 selection can read it cheaply.
- **`idd-discover.instructions.md`** (root + template) — Step 2
  selects by highest score (tie-break: lowest issue number), skips
  below-floor as human-oriented, fail-safe on absent score; the
  A4.5/A5 gates still run on the selected candidate (advisory only).
- Bumped the `bundle-discovery` budget 75300 → 76000 in
  `audit/sync-manifest.json` (+ the policy-constants row) for the
  Step 2 rule — sanctioned deliberate growth per the page's "Bundle
  limits" note.
- `.cspell.config.yml` — added `unscored` / `unrouted` coinages.

## Test plan

- [x] `node --test tests/*.mjs` — 783/783 (+12 new).
- [x] `node scripts/validate-schemas.mjs` — pass.
- [x] `node scripts/audit-docs.mjs --check` — pass (bundle 75638 / 76000).
- [x] `node scripts/sync-docs.mjs --check` — mirrors up to date.
- [x] `npx dprint check`, `npx markdownlint-cli2`, `npx cspell lint` — clean.

New tests cover: parse valid/absent/out-of-range/non-integer/
conflicting + prefix-awareness; rank desc; below-floor routing;
**unscored never routed (fail-safe)**; enabled=false kill-switch;
sort stability; orphan-filter ranking + disabled path; roadmap-graph
node score. SSH-signed commit (GPG timed out locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced autopilot-suitability scoring system that ranks eligible candidates by authored suitability scores rather than issue number, with configurable floor thresholds and fallback handling for unscored items.

* **Documentation**
  * Updated discovery protocol and policy documentation to reflect the new suitability-based ranking logic.

* **Chores**
  * Updated bundle size limits and spell check configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->