### PR TITLE
feat(idd-doctor): warn on autopilot-suitability score/label contradictions

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -6,6 +6,10 @@ import { join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { inspectHelperRuntimeConfig, parseProjectCommandRows } from "./policy-helpers.mjs"
+import {
+  isAutopilotSuitabilityScore,
+  normalizeAutopilotSuitabilityFloor,
+} from "./autopilot-suitability.mjs"
 
 const WORKSHOP_ENTRY_POINTS = ["README.md", "README.ja.md", "docs/index.md"]
 const WORKSHOP_REL_PATH = "docs/workshop"
@@ -84,8 +88,115 @@ export function runDoctor({
   )
   checkWorkshopExampleRepoBackLink(root, { requireGithub }, report)
   checkGithubReadiness(root, requireGithub, report)
+  checkAutopilotSuitabilityConsistency(root, { requireGithub, markerPrefix }, report)
 
   return report
+}
+
+/**
+ * Classify each open issue's authored autopilot-suitability marker and
+ * emit warning strings for contradictions, without any I/O. Exported
+ * for unit testing. Issues are `{ number, body, labels }` where labels
+ * are strings or `{ name }` objects.
+ */
+export function evaluateAutopilotSuitabilityConsistency(issues, options = {}) {
+  const floor = normalizeAutopilotSuitabilityFloor(options.floor)
+  const prefix =
+    typeof options.markerPrefix === "string" && options.markerPrefix.length > 0
+      ? options.markerPrefix
+      : "idd-skill"
+  const warnings = []
+  for (const issue of Array.isArray(issues) ? issues : []) {
+    const labelNames = new Set(
+      (issue?.labels ?? []).map((label) =>
+        typeof label === "string" ? label : label?.name ?? "",
+      ),
+    )
+    const blockedByHuman = labelNames.has("status:blocked-by-human")
+    const marker = detectAutopilotSuitabilityMarker(issue?.body, prefix)
+    if (!marker.present) {
+      continue
+    }
+    const number = issue?.number
+    if (marker.malformed) {
+      warnings.push(
+        `autopilot-suitability: issue #${number} has a malformed or out-of-range score marker (expected a single integer 1-5)`,
+      )
+      continue
+    }
+    if (marker.value === 1 && !blockedByHuman) {
+      warnings.push(
+        `autopilot-suitability: issue #${number} is scored 1 (human-only) but is missing the status:blocked-by-human label`,
+      )
+    } else if (marker.value >= floor && blockedByHuman) {
+      warnings.push(
+        `autopilot-suitability: issue #${number} is scored ${marker.value} (>= floor ${floor}) but carries status:blocked-by-human; the score and label disagree`,
+      )
+    }
+  }
+  return { warnings }
+}
+
+function detectAutopilotSuitabilityMarker(body, prefix) {
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
+    "gi",
+  )
+  const raws = [...String(body ?? "").matchAll(regex)].map((match) => match[1])
+  if (raws.length === 0) {
+    return { present: false, value: null, malformed: false }
+  }
+  const values = raws.map((raw) => (/^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN))
+  const distinct = new Set(values)
+  if (!values.every(isAutopilotSuitabilityScore) || distinct.size !== 1) {
+    return { present: true, value: null, malformed: true }
+  }
+  return { present: true, value: [...distinct][0], malformed: false }
+}
+
+function checkAutopilotSuitabilityConsistency(root, options, report) {
+  const requireGithub = options.requireGithub === true
+  const recordGhFailure = (message) => {
+    if (requireGithub) {
+      report.errors.push(`autopilot-suitability consistency check: ${message}`)
+    }
+  }
+
+  const list = runCommand(
+    "gh",
+    ["issue", "list", "--state", "open", "--json", "number,labels,body", "--limit", "1000"],
+    root,
+  )
+  if (!list.ok) {
+    recordGhFailure("gh issue list unavailable")
+    return
+  }
+  let issues
+  try {
+    issues = JSON.parse(list.stdout)
+  } catch {
+    recordGhFailure("gh issue list returned invalid JSON")
+    return
+  }
+  if (!Array.isArray(issues) || issues.length === 0) {
+    return
+  }
+
+  let floor
+  try {
+    const config = JSON.parse(readFileSync(join(root, ".github/idd/config.json"), "utf8"))
+    floor = config?.autopilotSuitability?.floor
+  } catch {
+    floor = undefined
+  }
+
+  const { warnings } = evaluateAutopilotSuitabilityConsistency(issues, {
+    floor,
+    markerPrefix: options.markerPrefix,
+  })
+  for (const warning of warnings) {
+    report.warnings.push(warning)
+  }
 }
 
 export function parsePrimaryWorktreePath(porcelain) {

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -9,6 +9,7 @@ import {
   containsExampleRepoBackLink,
   containsWorkshopReference,
   decodeGithubReadmeBase64,
+  evaluateAutopilotSuitabilityConsistency,
   extractMarkerPrefixes,
   findMissingWorkshopReferences,
   findPlaceholders,
@@ -17,6 +18,68 @@ import {
   parseProjectCommandRows,
   stripMarkdownNonText,
 } from "../scripts/idd-doctor.mjs"
+
+const ap = (n) => `<!-- idd-skill-autopilot-suitability: ${n} -->`
+
+test("autopilot-suitability consistency: valid score+label combinations produce no warnings", () => {
+  const issues = [
+    { number: 1, body: `task\n${ap(5)}`, labels: [] },
+    { number: 2, body: `task\n${ap(4)}`, labels: [{ name: "enhancement" }] },
+    { number: 3, body: `human-only\n${ap(1)}`, labels: ["status:blocked-by-human"] },
+    { number: 4, body: "no score marker at all", labels: [] },
+  ]
+  const { warnings } = evaluateAutopilotSuitabilityConsistency(issues, { floor: 3 })
+  assert.deepEqual(warnings, [])
+})
+
+test("autopilot-suitability consistency: score 1 without blocked-by-human warns", () => {
+  const { warnings } = evaluateAutopilotSuitabilityConsistency(
+    [{ number: 7, body: `task\n${ap(1)}`, labels: [] }],
+    { floor: 3 },
+  )
+  assert.equal(warnings.length, 1)
+  assert.match(warnings[0], /issue #7 is scored 1 .* missing the status:blocked-by-human label/)
+})
+
+test("autopilot-suitability consistency: score >= floor with blocked-by-human warns", () => {
+  const { warnings } = evaluateAutopilotSuitabilityConsistency(
+    [{ number: 8, body: `task\n${ap(4)}`, labels: ["status:blocked-by-human"] }],
+    { floor: 3 },
+  )
+  assert.equal(warnings.length, 1)
+  assert.match(warnings[0], /issue #8 is scored 4 \(>= floor 3\) but carries status:blocked-by-human/)
+})
+
+test("autopilot-suitability consistency: malformed or conflicting markers warn", () => {
+  const issues = [
+    { number: 9, body: `task\n${ap(6)}`, labels: [] },
+    { number: 10, body: `task\n${ap("high")}`, labels: [] },
+    { number: 11, body: `task\n${ap(4)}\n${ap(2)}`, labels: [] },
+  ]
+  const { warnings } = evaluateAutopilotSuitabilityConsistency(issues, { floor: 3 })
+  assert.equal(warnings.length, 3)
+  assert.ok(warnings.every((w) => /malformed or out-of-range score marker/.test(w)))
+})
+
+test("autopilot-suitability consistency: missing marker never warns (fail-safe)", () => {
+  const { warnings } = evaluateAutopilotSuitabilityConsistency(
+    [{ number: 12, body: "ordinary issue, no score", labels: ["status:blocked-by-human"] }],
+    { floor: 3 },
+  )
+  assert.deepEqual(warnings, [])
+})
+
+test("autopilot-suitability consistency: honors a custom floor and marker prefix", () => {
+  const issues = [
+    // floor 4: score 3 with blocked-by-human is NOT >= floor, so no warning.
+    { number: 13, body: `t\n<!-- my-org-autopilot-suitability: 3 -->`, labels: ["status:blocked-by-human"] },
+    // floor 4: score 4 with blocked-by-human warns.
+    { number: 14, body: `t\n<!-- my-org-autopilot-suitability: 4 -->`, labels: ["status:blocked-by-human"] },
+  ]
+  const { warnings } = evaluateAutopilotSuitabilityConsistency(issues, { floor: 4, markerPrefix: "my-org" })
+  assert.equal(warnings.length, 1)
+  assert.match(warnings[0], /issue #14 is scored 4 \(>= floor 4\)/)
+})
 
 test("findPlaceholders returns template tokens", () => {
   const placeholders = findPlaceholders(`


### PR DESCRIPTION
## Summary

Closes #763 (Track 4, final, of roadmap #759). An advisory
`idd-doctor` check that surfaces authored-score problems rather
than silently trusting them.

## What changed

- New exported **`evaluateAutopilotSuitabilityConsistency(issues, {floor, markerPrefix})`**
  (pure, unit-tested) warns on:
  - a malformed / out-of-range / conflicting-duplicate score marker;
  - score `1` (human-only) missing `status:blocked-by-human`;
  - score `>= floor` carrying `status:blocked-by-human` (score and
    label disagree).
  A **missing marker never warns** (fail-safe), matching the
  feature's "absence is fine" rule.
- **`checkAutopilotSuitabilityConsistency`** wires it into
  `runDoctor`: fetches open issues via `gh issue list`, reads the
  floor from `.github/idd/config.json` and the prefix from the
  existing marker-prefix probe, and pushes warn-level messages.
  GitHub failures degrade softly (silent unless `--require-github`),
  like the other gh-dependent doctor checks; it never blocks
  execution.

Floor/range validation reuses the shared
`normalizeAutopilotSuitabilityFloor` / `isAutopilotSuitabilityScore`
(from #762) so the 1-5 rule lives in one place.

## Test plan

- [x] `node --test tests/*.mjs` — 794/794 (+6 evaluator tests:
      valid combos, both contradiction directions,
      malformed/conflicting, missing-marker fail-safe, custom
      floor + prefix).
- [x] `npx markdownlint-cli2`, `npx cspell lint`,
      `node scripts/audit-docs.mjs --check`,
      `node scripts/sync-docs.mjs --check` — clean.

The check's `gh issue list` path mirrors the existing gh-dependent
doctor checks (soft-degrade); the logic is covered by the pure
evaluator unit tests. SSH-signed commit (GPG times out locally).