### PR TITLE
feat(policy): add roadmap-first issue-scope value

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -92,13 +92,13 @@ Read the **issue-scope** value from the Project commands table in
 
 - If `issue-scope` is `roadmap` (the default): skip A0-O and proceed to
   A1 as normal.
-- If `issue-scope` is `roadmap-first`: proceed to A1 as normal. Fall
-  back to **A0-O** before the A3 decision tree aborts (mirror of
-  `orphan-first`) **only when the roadmap path found no candidates at
-  all** — i.e. A2 enumerated zero open execution leaves. If the roadmap
-  path produced candidates that A3.5 then held as approval-needed, do
-  **not** fall back: A3.5's stop/ask behavior governs, so the fallback
-  never re-scopes around the approval gate.
+- If `issue-scope` is `roadmap-first`: proceed to A1 as normal. When the
+  roadmap path yields **zero candidates reaching A3.5** — i.e. A2
+  enumerated no open execution leaves, or A3 filtered them all out as
+  blocked — fall back to **A0-O** before aborting (mirror of
+  `orphan-first`). If candidates do reach A3.5 but it holds them all as
+  approval-needed, do **not** fall back: A3.5's stop/ask behavior
+  governs, so the fallback never re-scopes around the approval gate.
 - If `issue-scope` is `orphan-first`: proceed to A0-O.
 
 ## A0-O — Discover orphan issues

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -227,7 +227,7 @@ touch issues outside the roadmap traversal graph:
 - **A0-O only** (when `issue-scope` is `orphan-first`, or when
   `issue-scope` is `roadmap-first` and A0-O runs as the roadmap-path
   fallback): a repo-wide open-issue query to find issues without
-  `roadmap-id` or `blocked-by` markers.
+  `idd-skill-roadmap-id` or `idd-skill-blocked-by` markers.
 - **A1 only**: any method (including `gh issue list`, `gh search`, or
   label-based queries) to locate the roadmap issue itself.
 - **A1.5 only**: a narrow duplicate/reuse lookup for one specific

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -95,8 +95,9 @@ Read the **issue-scope** value from the Project commands table in
 - If `issue-scope` is `roadmap-first`: proceed to A1 as normal. When the
   roadmap path yields **zero candidates reaching A3.5** — i.e. A2
   enumerated no open execution leaves, or A3 filtered them all out as
-  blocked — fall back to **A0-O** before aborting (mirror of
-  `orphan-first`). If candidates do reach A3.5 but it holds them all as
+  blocked — fall back to **A0-O** before entering the A3 decision tree
+  (mirror of `orphan-first`). If candidates do reach A3.5 but it holds
+  them all as
   approval-needed, do **not** fall back: A3.5's stop/ask behavior
   governs, so the fallback never re-scopes around the approval gate.
 - If `issue-scope` is `orphan-first`: proceed to A0-O.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -92,10 +92,13 @@ Read the **issue-scope** value from the Project commands table in
 
 - If `issue-scope` is `roadmap` (the default): skip A0-O and proceed to
   A1 as normal.
-- If `issue-scope` is `roadmap-first`: proceed to A1 as normal, but if
-  the roadmap path (A1 → A3) yields zero startable candidates, fall back
-  to **A0-O** before the A3 decision tree aborts (mirror of
-  `orphan-first`).
+- If `issue-scope` is `roadmap-first`: proceed to A1 as normal. Fall
+  back to **A0-O** before the A3 decision tree aborts (mirror of
+  `orphan-first`) **only when the roadmap path found no candidates at
+  all** — i.e. A2 enumerated zero open execution leaves. If the roadmap
+  path produced candidates that A3.5 then held as approval-needed, do
+  **not** fall back: A3.5's stop/ask behavior governs, so the fallback
+  never re-scopes around the approval gate.
 - If `issue-scope` is `orphan-first`: proceed to A0-O.
 
 ## A0-O — Discover orphan issues
@@ -103,6 +106,12 @@ Read the **issue-scope** value from the Project commands table in
 Read the **orphan-first-policy** value from the Project commands table
 in `idd-overview.instructions.md` before any repo-wide orphan issue
 search.
+
+When A0-O runs as the `roadmap-first` fallback (not the `orphan-first`
+primary path), every "proceed to A1" / "skip to A1" exit below instead
+goes to the **A3 decision tree** — the roadmap path already ran and must
+not be re-entered (this prevents an A1 ↔ A0-O loop, e.g. under
+`public-disabled` on a public repo).
 
 - If `orphan-first-policy` is `public-disabled`, first determine the
   repository visibility. If the repository is public, skip A0-O without
@@ -140,12 +149,10 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 If at least one orphan issue remains after the configured policy is
 applied: pass the remaining set directly to **A3.5**. Skip A1–A3.
 
-If no orphan issues remain after the configured policy is applied:
-when A0-O ran as the `orphan-first` primary path, fall back to the
-roadmap path (proceed to **A1**, normal A1 → A1.5 → A2 → A3 → A3.5 → A4
-sequence); when A0-O ran as the `roadmap-first` fallback (the roadmap
-path already returned zero), do **not** re-run it — proceed to the A3
-decision tree.
+If no orphan issues remain after the configured policy is applied: fall
+back to the roadmap path. Proceed to **A1** and continue with the normal
+A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence. (For the `roadmap-first`
+fallback, the guard above redirects this exit to A3.)
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: for
@@ -163,7 +170,8 @@ umbrella issue. If no roadmap issue exists, report and abort.
 **Note**: Repo-wide or label-based issue queries are permitted only in
 **A0-T** (the scoped `idd-skill-roadmap-id` lookup needed to resolve the
 explicit target's `idd-skill-blocked-by` markers),
-**A0-O** (when `issue-scope` is `orphan-first`, to find orphan issues),
+**A0-O** (when `issue-scope` is `orphan-first`, or `roadmap-first` as
+the roadmap-path fallback, to find orphan issues),
 **A1** (to locate the roadmap), **A1.5** (narrow duplicate/reuse lookup
 for one specific autonomous gap), and **A3** (narrow body-content lookup
 for `idd-skill-roadmap-id` to resolve `idd-skill-blocked-by`
@@ -216,9 +224,10 @@ touch issues outside the roadmap traversal graph:
   `idd-skill-blocked-by` markers on the explicit target. The result is
   used solely to determine targeted readiness and is not added to any
   candidate set.
-- **A0-O only** (when `issue-scope` is `orphan-first`): a repo-wide
-  open-issue query to find issues without `roadmap-id` or `blocked-by`
-  markers.
+- **A0-O only** (when `issue-scope` is `orphan-first`, or when
+  `issue-scope` is `roadmap-first` and A0-O runs as the roadmap-path
+  fallback): a repo-wide open-issue query to find issues without
+  `roadmap-id` or `blocked-by` markers.
 - **A1 only**: any method (including `gh issue list`, `gh search`, or
   label-based queries) to locate the roadmap issue itself.
 - **A1.5 only**: a narrow duplicate/reuse lookup for one specific

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -92,6 +92,10 @@ Read the **issue-scope** value from the Project commands table in
 
 - If `issue-scope` is `roadmap` (the default): skip A0-O and proceed to
   A1 as normal.
+- If `issue-scope` is `roadmap-first`: proceed to A1 as normal, but if
+  the roadmap path (A1 → A3) yields zero startable candidates, fall back
+  to **A0-O** before the A3 decision tree aborts (mirror of
+  `orphan-first`).
 - If `issue-scope` is `orphan-first`: proceed to A0-O.
 
 ## A0-O — Discover orphan issues
@@ -136,15 +140,19 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 If at least one orphan issue remains after the configured policy is
 applied: pass the remaining set directly to **A3.5**. Skip A1–A3.
 
-If no orphan issues remain after the configured policy is applied: fall
-back to the roadmap path. Proceed to **A1** and continue with the normal
-A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence.
+If no orphan issues remain after the configured policy is applied:
+when A0-O ran as the `orphan-first` primary path, fall back to the
+roadmap path (proceed to **A1**, normal A1 → A1.5 → A2 → A3 → A3.5 → A4
+sequence); when A0-O ran as the `roadmap-first` fallback (the roadmap
+path already returned zero), do **not** re-run it — proceed to the A3
+decision tree.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
-reached when the active discovery path(s) produce zero results: when
-`orphan-first` is active, this means both the orphan path and the
-roadmap fallback returned zero; when `issue-scope` is `roadmap`, only
-the roadmap path runs and A3 applies when it returns zero.
+reached when the active discovery path(s) produce zero results: for
+`orphan-first`, both the orphan path and the roadmap fallback returned
+zero; for `roadmap-first`, both the roadmap path and the orphan fallback
+returned zero; for `roadmap`, only the roadmap path runs and A3 applies
+when it returns zero.
 
 ## A1 — Find the roadmap
 

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -158,7 +158,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 76000
+      "limitBytes": 76400
     },
     {
       "id": "bundle-resume",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -158,7 +158,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 76700
+      "limitBytes": 76800
     },
     {
       "id": "bundle-resume",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -158,7 +158,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 77000
+      "limitBytes": 76700
     },
     {
       "id": "bundle-resume",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -158,7 +158,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 76400
+      "limitBytes": 77000
     },
     {
       "id": "bundle-resume",

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -93,13 +93,13 @@ Read the **issue-scope** value from the Project commands table in
 
 - If `issue-scope` is `roadmap` (the default): skip A0-O and proceed to
   A1 as normal.
-- If `issue-scope` is `roadmap-first`: proceed to A1 as normal. Fall
-  back to **A0-O** before the A3 decision tree aborts (mirror of
-  `orphan-first`) **only when the roadmap path found no candidates at
-  all** — i.e. A2 enumerated zero open execution leaves. If the roadmap
-  path produced candidates that A3.5 then held as approval-needed, do
-  **not** fall back: A3.5's stop/ask behavior governs, so the fallback
-  never re-scopes around the approval gate.
+- If `issue-scope` is `roadmap-first`: proceed to A1 as normal. When the
+  roadmap path yields **zero candidates reaching A3.5** — i.e. A2
+  enumerated no open execution leaves, or A3 filtered them all out as
+  blocked — fall back to **A0-O** before aborting (mirror of
+  `orphan-first`). If candidates do reach A3.5 but it holds them all as
+  approval-needed, do **not** fall back: A3.5's stop/ask behavior
+  governs, so the fallback never re-scopes around the approval gate.
 - If `issue-scope` is `orphan-first`: proceed to A0-O.
 
 ## A0-O — Discover orphan issues

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -96,8 +96,9 @@ Read the **issue-scope** value from the Project commands table in
 - If `issue-scope` is `roadmap-first`: proceed to A1 as normal. When the
   roadmap path yields **zero candidates reaching A3.5** — i.e. A2
   enumerated no open execution leaves, or A3 filtered them all out as
-  blocked — fall back to **A0-O** before aborting (mirror of
-  `orphan-first`). If candidates do reach A3.5 but it holds them all as
+  blocked — fall back to **A0-O** before entering the A3 decision tree
+  (mirror of `orphan-first`). If candidates do reach A3.5 but it holds
+  them all as
   approval-needed, do **not** fall back: A3.5's stop/ask behavior
   governs, so the fallback never re-scopes around the approval gate.
 - If `issue-scope` is `orphan-first`: proceed to A0-O.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -93,10 +93,13 @@ Read the **issue-scope** value from the Project commands table in
 
 - If `issue-scope` is `roadmap` (the default): skip A0-O and proceed to
   A1 as normal.
-- If `issue-scope` is `roadmap-first`: proceed to A1 as normal, but if
-  the roadmap path (A1 → A3) yields zero startable candidates, fall back
-  to **A0-O** before the A3 decision tree aborts (mirror of
-  `orphan-first`).
+- If `issue-scope` is `roadmap-first`: proceed to A1 as normal. Fall
+  back to **A0-O** before the A3 decision tree aborts (mirror of
+  `orphan-first`) **only when the roadmap path found no candidates at
+  all** — i.e. A2 enumerated zero open execution leaves. If the roadmap
+  path produced candidates that A3.5 then held as approval-needed, do
+  **not** fall back: A3.5's stop/ask behavior governs, so the fallback
+  never re-scopes around the approval gate.
 - If `issue-scope` is `orphan-first`: proceed to A0-O.
 
 ## A0-O — Discover orphan issues
@@ -104,6 +107,12 @@ Read the **issue-scope** value from the Project commands table in
 Read the **orphan-first-policy** value from the Project commands table
 in `idd-overview.instructions.md` before any repo-wide orphan issue
 search.
+
+When A0-O runs as the `roadmap-first` fallback (not the `orphan-first`
+primary path), every "proceed to A1" / "skip to A1" exit below instead
+goes to the **A3 decision tree** — the roadmap path already ran and must
+not be re-entered (this prevents an A1 ↔ A0-O loop, e.g. under
+`public-disabled` on a public repo).
 
 - If `orphan-first-policy` is `public-disabled`, first determine the
   repository visibility. If the repository is public, skip A0-O without
@@ -143,12 +152,10 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 If at least one orphan issue remains after the configured policy is
 applied: pass the remaining set directly to **A3.5**. Skip A1–A3.
 
-If no orphan issues remain after the configured policy is applied:
-when A0-O ran as the `orphan-first` primary path, fall back to the
-roadmap path (proceed to **A1**, normal A1 → A1.5 → A2 → A3 → A3.5 → A4
-sequence); when A0-O ran as the `roadmap-first` fallback (the roadmap
-path already returned zero), do **not** re-run it — proceed to the A3
-decision tree.
+If no orphan issues remain after the configured policy is applied: fall
+back to the roadmap path. Proceed to **A1** and continue with the normal
+A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence. (For the `roadmap-first`
+fallback, the guard above redirects this exit to A3.)
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: for
@@ -167,7 +174,8 @@ umbrella issue. If no roadmap issue exists, report and abort.
 **A0-T** (the scoped `{{PROJECT_MARKER_PREFIX}}-roadmap-id` lookup
 needed to resolve the explicit target's
 `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers),
-**A0-O** (when `issue-scope` is `orphan-first`, to find orphan issues),
+**A0-O** (when `issue-scope` is `orphan-first`, or `roadmap-first` as
+the roadmap-path fallback, to find orphan issues),
 **A1** (to locate the roadmap), **A1.5** (narrow duplicate/reuse lookup
 for one specific autonomous gap), and **A3** (narrow body-content lookup
 for `{{PROJECT_MARKER_PREFIX}}-roadmap-id` to resolve
@@ -233,8 +241,9 @@ touch issues outside the roadmap traversal graph:
   `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers on the explicit target.
   The result is used solely to determine targeted readiness and is not
   added to any candidate set.
-- **A0-O only** (when `issue-scope` is `orphan-first`): a repo-wide
-  open-issue query to find issues without
+- **A0-O only** (when `issue-scope` is `orphan-first`, or when
+  `issue-scope` is `roadmap-first` and A0-O runs as the roadmap-path
+  fallback): a repo-wide open-issue query to find issues without
   `{{PROJECT_MARKER_PREFIX}}-roadmap-id` or
   `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers.
 - **A1 only**: any method (including `gh issue list`, `gh search`, or

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -93,6 +93,10 @@ Read the **issue-scope** value from the Project commands table in
 
 - If `issue-scope` is `roadmap` (the default): skip A0-O and proceed to
   A1 as normal.
+- If `issue-scope` is `roadmap-first`: proceed to A1 as normal, but if
+  the roadmap path (A1 → A3) yields zero startable candidates, fall back
+  to **A0-O** before the A3 decision tree aborts (mirror of
+  `orphan-first`).
 - If `issue-scope` is `orphan-first`: proceed to A0-O.
 
 ## A0-O — Discover orphan issues
@@ -139,15 +143,19 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 If at least one orphan issue remains after the configured policy is
 applied: pass the remaining set directly to **A3.5**. Skip A1–A3.
 
-If no orphan issues remain after the configured policy is applied: fall
-back to the roadmap path. Proceed to **A1** and continue with the normal
-A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence.
+If no orphan issues remain after the configured policy is applied:
+when A0-O ran as the `orphan-first` primary path, fall back to the
+roadmap path (proceed to **A1**, normal A1 → A1.5 → A2 → A3 → A3.5 → A4
+sequence); when A0-O ran as the `roadmap-first` fallback (the roadmap
+path already returned zero), do **not** re-run it — proceed to the A3
+decision tree.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
-reached when the active discovery path(s) produce zero results: when
-`orphan-first` is active, this means both the orphan path and the
-roadmap fallback returned zero; when `issue-scope` is `roadmap`, only
-the roadmap path runs and A3 applies when it returns zero.
+reached when the active discovery path(s) produce zero results: for
+`orphan-first`, both the orphan path and the roadmap fallback returned
+zero; for `roadmap-first`, both the roadmap path and the orphan fallback
+returned zero; for `roadmap`, only the roadmap path runs and A3 applies
+when it returns zero.
 
 ## A1 — Find the roadmap
 

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -124,7 +124,7 @@
     },
     "issueScope": {
       "type": "string",
-      "enum": ["roadmap", "orphan-first"]
+      "enum": ["roadmap", "roadmap-first", "orphan-first"]
     },
     "orphanFirstPolicy": {
       "type": "string",

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -5,7 +5,7 @@ const HELPER_RUNTIME_PROFILES = new Set([
   "instructions-only",
 ]);
 const HELPER_RUNTIME_KEYS = new Set(["profile"]);
-const ISSUE_SCOPES = new Set(["roadmap", "orphan-first"]);
+const ISSUE_SCOPES = new Set(["roadmap", "roadmap-first", "orphan-first"]);
 const ORPHAN_FIRST_POLICIES = new Set(["none", "maintainer-approved", "public-disabled"]);
 const APPROVAL_ACTOR_POLICIES = new Set(["owners-and-maintainers-only", "all-write-permission-actors"]);
 const FORCED_HANDOFF_MODES = new Set(["disabled", "human-gated"]);

--- a/tests/policy-helpers.test.mjs
+++ b/tests/policy-helpers.test.mjs
@@ -2,9 +2,28 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  POLICY_DEFAULTS,
   getReviewEscalationChangesRequestedPolicy,
+  normalizePolicyConfig,
   parseIsoDurationToMs,
 } from "../scripts/policy-helpers.mjs";
+
+test("issueScope accepts roadmap-first while default stays roadmap", () => {
+  assert.equal(POLICY_DEFAULTS.issueScope, "roadmap");
+  assert.equal(normalizePolicyConfig({}).issueScope, "roadmap");
+  assert.equal(
+    normalizePolicyConfig({ issueScope: "roadmap-first" }).issueScope,
+    "roadmap-first",
+  );
+  assert.equal(
+    normalizePolicyConfig({ issueScope: "orphan-first" }).issueScope,
+    "orphan-first",
+  );
+  assert.equal(
+    normalizePolicyConfig({ issueScope: "bogus" }).issueScope,
+    "roadmap",
+  );
+});
 
 test("parseIsoDurationToMs parses supported ISO durations", () => {
   assert.equal(parseIsoDurationToMs("PT5S"), 5000);

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -272,7 +272,7 @@ test("policy schema accepts every issueScope value including roadmap-first", () 
     );
     instance.issueScope = issueScope;
     const errors = validate(instance, schema);
-    assert.deepEqual(errors, [], `${issueScope}: ${errors.join("\n")}`);
+    assert.deepEqual(errors, [], `${issueScope}: ${JSON.stringify(errors)}`);
   }
 });
 

--- a/tests/schema-validation.test.mjs
+++ b/tests/schema-validation.test.mjs
@@ -264,6 +264,31 @@ test("policy schema rejects non-boolean issue-author approval opt-out", () => {
   );
 });
 
+test("policy schema accepts every issueScope value including roadmap-first", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  for (const issueScope of ["roadmap", "roadmap-first", "orphan-first"]) {
+    const instance = JSON.parse(
+      JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")),
+    );
+    instance.issueScope = issueScope;
+    const errors = validate(instance, schema);
+    assert.deepEqual(errors, [], `${issueScope}: ${errors.join("\n")}`);
+  }
+});
+
+test("policy schema rejects an unknown issueScope value", () => {
+  const schema = loadJson("schemas/policy.schema.json");
+  const instance = JSON.parse(
+    JSON.stringify(loadJson("fixtures/schemas/policy.valid.json")),
+  );
+  instance.issueScope = "roadmap-only";
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) => error.includes("$.issueScope")),
+    errors.join("\n"),
+  );
+});
+
 test("policy schema accepts an in-range autopilotSuitability floor", () => {
   const schema = loadJson("schemas/policy.schema.json");
   for (const floor of [1, 2, 3, 4, 5]) {


### PR DESCRIPTION
## Summary

Adds a third `issue-scope` value, **`roadmap-first`** — the mirror image of `orphan-first`: run the roadmap path first, fall back to **A0-O** orphan discovery only when the roadmap path yields zero startable candidates. The A3.5 issue-author approval gate still runs on every surfaced candidate, so the fallback never widens the auto-claim queue to unapproved authors.

**Non-breaking:** the distributed default stays `roadmap` (roadmap-only); flipping the default to `roadmap-first` is the follow-up track (#772).

## Changes

- `schemas/policy.schema.json` — `issueScope` enum += `roadmap-first`
- `scripts/policy-helpers.mjs` — `ISSUE_SCOPES` += `roadmap-first` (default unchanged)
- `idd-discover.instructions.md` (template + root) — A0 semantics: roadmap-first runs A1→A3 first, A0-O fallback on zero startable; A3 reconciliation note covers all three scopes; guards against re-running the roadmap path in the fallback
- `audit/sync-manifest.json` — bundle-discovery `limitBytes` 76000 → 76800 (deliberate prose growth from the roadmap-first semantics + review hardening; smallest round-100 budget that passes audit-docs for the current bundle)
- tests: schema accepts all three scopes + rejects unknown; policy-helpers parses `roadmap-first` and keeps `roadmap` default

## Verification

- `node --test tests/*.mjs` — 797 pass
- `node scripts/audit-docs.mjs --check`, `node scripts/sync-docs.mjs --check`, `markdownlint-cli2`, `cspell` — all clean

Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "roadmap-first" discovery scope: roadmap path now falls back to orphan discovery when it yields no startable candidates; decision-tree and query-scope behavior updated to prevent looped re-entry and handle approval-held candidates.

* **Chores**
  * Schema and config normalization updated to support "roadmap-first".
  * Added validation and unit tests for the new scope.
  * Increased bundle discovery budget limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/idd-skill/pull/773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

