### PR TITLE
fix(review-triage): guard advisory non-review notices in PATH B

### DIFF
--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -172,7 +172,9 @@ requested in a previous E13/E14 pass.
 **Regular comments** where the last speaker is not any IDD agent, and no
 reply from **you** (the current agent) exists after that comment's
 timestamp — exclude periodic notification bots (Renovate, etc.). Include
-Copilot and CI advisory bot comments; they follow PATH B in E4-E7.
+Copilot and CI advisory bot comments; they follow PATH B in E4-E7
+(advisory non-review notices — rate-limit / quota / queued / bare ack /
+error — are dispositioned under the E6 non-review-notice rule).
 
 ## E2 — Critique pass
 

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -173,8 +173,9 @@ requested in a previous E13/E14 pass.
 reply from **you** (the current agent) exists after that comment's
 timestamp — exclude periodic notification bots (Renovate, etc.). Include
 Copilot and CI advisory bot comments; they follow PATH B in E4-E7
-(advisory non-review notices — rate-limit / quota / queued / bare ack /
-error — are dispositioned under the E6 non-review-notice rule).
+(advisory non-review notices — rate-limit / quota / queued / bare
+request acknowledgement / error — are dispositioned under the E6
+non-review-notice rule).
 
 ## E2 — Critique pass
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -62,7 +62,7 @@ Record a path-specific disposition for every item:
   - `Rejected` means the advisory is noted, but no action is required.
   - An advisory non-review notice (E4) is **not scored** here; it is
     still recorded, but always as `Rejected` per the E6 non-review-notice
-    rule (it is not a scorable advisory result).
+    rule (it carries no advisory result to score).
 
 Accepted PATH B items do **not** enter review-fix. They are fully
 handled in E6-E7.

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -204,9 +204,13 @@ PATH B — Advisory items (completed review of the current HEAD):
 PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
 ack / error, as defined in E4):
 
-- A non-review notice means **no review of the current HEAD exists**, so
-  it must never be dispositioned as a confirmation, "no findings", or
-  "no action required because reviewed".
+- A non-review notice is **not itself a completed review** of the
+  current HEAD and must never be treated as evidence of one, so it must
+  never be dispositioned as a confirmation, "no findings", or "no action
+  required because reviewed". (A non-review notice does not by itself
+  prove that no review exists — if a separate _completed_ review of the
+  current HEAD is also present, disposition that review under the
+  completed-review rules above.)
 - When the advisory bot supports an on-demand trigger (e.g.
   `@coderabbitai review`), you **SHOULD** re-request the review for the
   current HEAD **at most once per HEAD**. Do **not** disposition on the

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -212,11 +212,13 @@ ack / error, as defined in E4):
   current HEAD is also present, disposition that review under the
   completed-review rules above.)
 - **Disposition it deterministically in the current pass — no
-  re-request, no wait.** Record `**Accepted**` only if a completed
-  review of the current HEAD is independently present (dispositioned per
-  the completed-review rules above); otherwise record the _not produced_
-  rejection with the existing prefix: `**Rejected** — {bot} did not
-  review HEAD {sha} ({reason}); this is not a completed review`. This
+  re-request, no wait.** The notice item itself is **always rejected**,
+  because it carries no advisory result — never record `**Accepted**` on
+  the notice: `**Rejected** — {bot} did not review HEAD {sha}
+  ({reason}); this is not a completed review`. A separate _completed_
+  review of the current HEAD, if one is present, is a **distinct**
+  ReviewItems_snapshot item dispositioned `**Accepted**` under the
+  completed-review rules above — accept that review, not the notice. This
   keeps the disposition vocabulary unchanged for the E7 verifier and the
   F2/F3 gates, and never leaves the item pending across snapshots.
 - **Do not auto-request a fresh review from triage** to "upgrade" a

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -23,6 +23,17 @@ For each item in ReviewItems_snapshot, first classify it:
   change.
 - If classification is ambiguous, default to PATH A.
 
+**Advisory non-review notice.** Before scoring a PATH B item, decide
+whether it is a _completed_ advisory review of the current HEAD or an
+**advisory non-review notice** — an advisory bot comment reporting that
+it did **not** review the current HEAD. Treat these as non-review
+notices: rate-limit-exceeded warnings, usage / quota / credit
+exhaustion, queued / in-progress / "reviewing" status, a bare request
+acknowledgement (e.g. CodeRabbit "Actions performed"), and error or
+"temporarily unavailable" notices. A non-review notice carries no
+advisory result to score; handle it with the E6 non-review-notice rule
+instead of the normal PATH B disposition.
+
 Then apply path-specific scoring:
 
 - **PATH A**: assess severity and relevance to PR intent.
@@ -31,9 +42,11 @@ Then apply path-specific scoring:
   - **Low** (minor improvements unrelated to PR intent) → **Reject
     recommended**
   - **Medium** → judge by context
-- **PATH B**: do **not** assign High / Medium / Low. Instead, decide
-  whether the advisory should be treated as `Accepted` (confirmed /
-  useful context) or `Rejected` (noted, no action required).
+- **PATH B**: do **not** assign High / Medium / Low. Score only a
+  _completed_ advisory review of the current HEAD here — decide whether
+  it should be treated as `Accepted` (confirmed / useful context) or
+  `Rejected` (noted, no action required). Route an advisory non-review
+  notice (defined above) to the E6 non-review-notice rule instead.
 
 ## E5 — Record Accept / Reject decisions
 
@@ -43,10 +56,12 @@ Record a path-specific disposition for every item:
   - High-severity items are Accepted automatically.
   - Medium- and Low-severity items require an explicit Accept or Reject
     decision.
-- **PATH B**:
+- **PATH B** (a _completed_ review of the current HEAD):
   - `Accepted` means the advisory confirms the current implementation or
     captures useful context.
   - `Rejected` means the advisory is noted, but no action is required.
+  - An advisory non-review notice (E4) is **not** recorded here;
+    disposition it under the E6 non-review-notice rule.
 
 Accepted PATH B items do **not** enter review-fix. They are fully
 handled in E6-E7.
@@ -167,22 +182,49 @@ For each Rejected PATH A item whose source is reviewer feedback:
 
 Use these prefixes so that disposition is always unambiguous:
 
-- PATH B acceptance marker:
-  `**Accepted** — {what the advisory comment confirmed}`
+- PATH B acceptance marker (only for a _completed_ review of the current
+  HEAD): `**Accepted** — {what the advisory comment confirmed}`
 - Ordinary rejection: `**Rejected** — {reason}`
 - CODEOWNER / required reviewer exception:
   `**Awaiting maintainer decision** — {reasoning}`
 
-PATH B — Advisory items:
+PATH B — Advisory items (completed review of the current HEAD):
 
 - Reply immediately with a decision marker, even when no code change is
-  needed:
+  needed. Use `**Accepted**` / "no findings / no action required"
+  framing **only** when the advisory is a completed review of the
+  current HEAD:
   - `**Accepted** — {what the advisory comment confirmed}`
   - `**Rejected** — {why no action is required}`
 - **Review threads**: resolve immediately after posting the marker.
 - **Regular comments**: reply only.
 - Do not send PATH B items to review-fix. Their work is complete once
   the marker is posted and any thread resolution is done.
+
+PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
+ack / error, as defined in E4):
+
+- A non-review notice means **no review of the current HEAD exists**, so
+  it must never be dispositioned as a confirmation, "no findings", or
+  "no action required because reviewed".
+- When the advisory bot supports an on-demand trigger (e.g.
+  `@coderabbitai review`), you **SHOULD** re-request the review for the
+  current HEAD **at most once per HEAD**. Do **not** disposition on the
+  re-request acknowledgement, and do **not** merge on it; wait for a
+  completed review of the current HEAD, or for the advisory window to
+  elapse, before recording any disposition.
+- If no completed review of the current HEAD arrives, disposition the
+  item explicitly as _not produced_ with the existing rejection prefix:
+  `**Rejected** — {bot} did not review HEAD {sha} ({reason}); this is
+  not a completed review`. This keeps the disposition vocabulary
+  unchanged for the E7 verifier and the F2/F3 gates.
+- **Fail-closed honesty**: never cite a non-review notice as evidence
+  that the advisory reviewer reviewed the current HEAD — not in the
+  disposition reply, the `Authoritative by` line, or the PR live status
+  digest.
+- **Non-blocking boundary**: this rule does not make PATH B a merge
+  blocker. The blocking advisory gate remains the Copilot advisory-wait
+  protocol in `idd-advisory-wait.instructions.md`, which is unchanged.
 
 ## E7 — Verify recorded dispositions
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -60,8 +60,9 @@ Record a path-specific disposition for every item:
   - `Accepted` means the advisory confirms the current implementation or
     captures useful context.
   - `Rejected` means the advisory is noted, but no action is required.
-  - An advisory non-review notice (E4) is **not** recorded here;
-    disposition it under the E6 non-review-notice rule.
+  - An advisory non-review notice (E4) is **not scored** here; it is
+    still recorded, but always as `Rejected` per the E6 non-review-notice
+    rule (it is not a scorable advisory result).
 
 Accepted PATH B items do **not** enter review-fix. They are fully
 handled in E6-E7.
@@ -218,7 +219,12 @@ ack / error, as defined in E4):
   ({reason}); this is not a completed review`. A separate _completed_
   review of the current HEAD, if one is present, is a **distinct**
   ReviewItems_snapshot item dispositioned `**Accepted**` under the
-  completed-review rules above — accept that review, not the notice. This
+  completed-review rules above — accept that review, not the notice.
+  **Re-validate just before posting the rejection**: a completed review
+  can race in after the E1 snapshot but before this rejection. If one
+  has, disposition that review (Accepted) and take a fresh E1 snapshot,
+  so the rejection's later timestamp does not filter the completed
+  review out of the next pass. This
   keeps the disposition vocabulary unchanged for the E7 verifier and the
   F2/F3 gates, and never leaves the item pending across snapshots.
 - **Do not auto-request a fresh review from triage** to "upgrade" a

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -214,15 +214,23 @@ ack / error, as defined in E4):
 - **Re-request (non-Copilot advisory bots only).** When a non-Copilot
   advisory bot supports an on-demand trigger (e.g. `@coderabbitai
   review`), you **MAY** re-request the review for the current HEAD **at
-  most once per HEAD**. Do **not** record a disposition on the
-  re-request acknowledgement, and do **not** merge on it. Posting the
-  re-request makes the agent the last speaker, so E1's regular-comment
-  filter will drop the original notice on the next snapshot — do **not**
-  rely on a later E1 pass to re-surface it. Keep the item in the current
-  ReviewItems_snapshot and, bounded, wait for a completed review of the
-  current HEAD or for the advisory window to elapse; the current pass
-  owns the terminal disposition (next bullet) and must record it before
-  E7.
+  most once per HEAD**. To keep that cap enforceable across restarts,
+  first record a durable, restart-visible `advisory-wait` marker for the
+  current HEAD (per the AW2 / AW3-R marker conventions in
+  `idd-advisory-wait.instructions.md`); if such a marker already exists
+  for this HEAD, or you cannot record one, do **not** re-request again —
+  go straight to the terminal disposition below. Do **not** record a
+  disposition on the re-request acknowledgement, and do **not** merge on
+  it. Posting the re-request makes the agent the last speaker, so E1's
+  regular-comment filter will drop the original notice on the next
+  snapshot — do **not** rely on a later E1 pass to re-surface it.
+- After re-requesting, wait at most the advisory **settled window**
+  (`advisoryWait.settledWindow`), polling every
+  `advisoryWait.pollInterval` (see
+  [policy constants](../../docs/policy-constants.md)), for a completed
+  review of the current HEAD. Reusing these existing advisory constants
+  — rather than an undefined "advisory window" — keeps the bound
+  deterministic.
 - **Copilot non-review notices** do not use the re-request above; route
   them through the advisory-wait protocol in
   `idd-advisory-wait.instructions.md` (AW3 `REQUEST_NEEDED` → E14, with
@@ -230,14 +238,14 @@ ack / error, as defined in E4):
   route `REQUEST_NEEDED` back to E14). Requesting Copilot directly from
   triage would leave a pending review with no request marker and
   under-count the per-PR cap across restarts.
-- If no completed review of the current HEAD arrives within the wait,
-  disposition the item explicitly as _not produced_ with the existing
-  rejection prefix: `**Rejected** — {bot} did not review HEAD {sha}
-  ({reason}); this is not a completed review`. Every non-review-notice
-  item must carry this terminal disposition (or `**Accepted**` for an
-  arriving completed review) before E7 — it is never left pending across
-  snapshots. This keeps the disposition vocabulary unchanged for the E7
-  verifier and the F2/F3 gates.
+- The current triage pass **owns the terminal disposition** and must
+  record it before E7 — a non-review-notice item is never left pending
+  across snapshots: `**Accepted**` if a completed review of the current
+  HEAD is now present (dispositioned per the completed-review rules
+  above), otherwise the _not produced_ rejection with the existing
+  prefix: `**Rejected** — {bot} did not review HEAD {sha} ({reason});
+  this is not a completed review`. This keeps the disposition vocabulary
+  unchanged for the E7 verifier and the F2/F3 gates.
 - **Fail-closed honesty**: never cite a non-review notice as evidence
   that the advisory reviewer reviewed the current HEAD — not in the
   disposition reply, the `Authoritative by` line, or the PR live status

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -211,41 +211,25 @@ ack / error, as defined in E4):
   prove that no review exists — if a separate _completed_ review of the
   current HEAD is also present, disposition that review under the
   completed-review rules above.)
-- **Re-request (non-Copilot advisory bots only).** When a non-Copilot
-  advisory bot supports an on-demand trigger (e.g. `@coderabbitai
-  review`), you **MAY** re-request the review for the current HEAD **at
-  most once per HEAD**. To keep that cap enforceable across restarts,
-  first record a durable, restart-visible `advisory-wait` marker for the
-  current HEAD (per the AW2 / AW3-R marker conventions in
-  `idd-advisory-wait.instructions.md`); if such a marker already exists
-  for this HEAD, or you cannot record one, do **not** re-request again —
-  go straight to the terminal disposition below. Do **not** record a
-  disposition on the re-request acknowledgement, and do **not** merge on
-  it. Posting the re-request makes the agent the last speaker, so E1's
-  regular-comment filter will drop the original notice on the next
-  snapshot — do **not** rely on a later E1 pass to re-surface it.
-- After re-requesting, wait at most the advisory **settled window**
-  (`advisoryWait.settledWindow`), polling every
-  `advisoryWait.pollInterval` (see
-  [policy constants](../../docs/policy-constants.md)), for a completed
-  review of the current HEAD. Reusing these existing advisory constants
-  — rather than an undefined "advisory window" — keeps the bound
-  deterministic.
-- **Copilot non-review notices** do not use the re-request above; route
-  them through the advisory-wait protocol in
-  `idd-advisory-wait.instructions.md` (AW3 `REQUEST_NEEDED` → E14, with
-  the trusted request marker and request-cap accounting; F2/F3 already
-  route `REQUEST_NEEDED` back to E14). Requesting Copilot directly from
-  triage would leave a pending review with no request marker and
-  under-count the per-PR cap across restarts.
-- The current triage pass **owns the terminal disposition** and must
-  record it before E7 — a non-review-notice item is never left pending
-  across snapshots: `**Accepted**` if a completed review of the current
-  HEAD is now present (dispositioned per the completed-review rules
-  above), otherwise the _not produced_ rejection with the existing
-  prefix: `**Rejected** — {bot} did not review HEAD {sha} ({reason});
-  this is not a completed review`. This keeps the disposition vocabulary
-  unchanged for the E7 verifier and the F2/F3 gates.
+- **Disposition it deterministically in the current pass — no
+  re-request, no wait.** Record `**Accepted**` only if a completed
+  review of the current HEAD is independently present (dispositioned per
+  the completed-review rules above); otherwise record the _not produced_
+  rejection with the existing prefix: `**Rejected** — {bot} did not
+  review HEAD {sha} ({reason}); this is not a completed review`. This
+  keeps the disposition vocabulary unchanged for the E7 verifier and the
+  F2/F3 gates, and never leaves the item pending across snapshots.
+- **Do not auto-request a fresh review from triage** to "upgrade" a
+  non-review notice. Triggering a new review is a separate concern:
+  Copilot advisory state is owned solely by the advisory-wait protocol
+  in `idd-advisory-wait.instructions.md` (AW3 `REQUEST_NEEDED` → E14),
+  and a maintainer may manually re-trigger a non-Copilot bot. Any review
+  that later completes for the current HEAD is picked up and
+  dispositioned normally on a subsequent E1 pass. **Never** post an
+  `advisory-wait` marker for a non-Copilot bot — AW2/AW3 treat any
+  trusted same-HEAD `advisory-wait` marker as Copilot evidence, so doing
+  so could wrongly satisfy the Copilot advisory gate and consume its
+  request cap.
 - **Fail-closed honesty**: never cite a non-review notice as evidence
   that the advisory reviewer reviewed the current HEAD — not in the
   disposition reply, the `Authoritative by` line, or the PR live status

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -211,17 +211,33 @@ ack / error, as defined in E4):
   prove that no review exists — if a separate _completed_ review of the
   current HEAD is also present, disposition that review under the
   completed-review rules above.)
-- When the advisory bot supports an on-demand trigger (e.g.
-  `@coderabbitai review`), you **SHOULD** re-request the review for the
-  current HEAD **at most once per HEAD**. Do **not** disposition on the
-  re-request acknowledgement, and do **not** merge on it; wait for a
-  completed review of the current HEAD, or for the advisory window to
-  elapse, before recording any disposition.
-- If no completed review of the current HEAD arrives, disposition the
-  item explicitly as _not produced_ with the existing rejection prefix:
-  `**Rejected** — {bot} did not review HEAD {sha} ({reason}); this is
-  not a completed review`. This keeps the disposition vocabulary
-  unchanged for the E7 verifier and the F2/F3 gates.
+- **Re-request (non-Copilot advisory bots only).** When a non-Copilot
+  advisory bot supports an on-demand trigger (e.g. `@coderabbitai
+  review`), you **MAY** re-request the review for the current HEAD **at
+  most once per HEAD**. Do **not** record a disposition on the
+  re-request acknowledgement, and do **not** merge on it. Posting the
+  re-request makes the agent the last speaker, so E1's regular-comment
+  filter will drop the original notice on the next snapshot — do **not**
+  rely on a later E1 pass to re-surface it. Keep the item in the current
+  ReviewItems_snapshot and, bounded, wait for a completed review of the
+  current HEAD or for the advisory window to elapse; the current pass
+  owns the terminal disposition (next bullet) and must record it before
+  E7.
+- **Copilot non-review notices** do not use the re-request above; route
+  them through the advisory-wait protocol in
+  `idd-advisory-wait.instructions.md` (AW3 `REQUEST_NEEDED` → E14, with
+  the trusted request marker and request-cap accounting; F2/F3 already
+  route `REQUEST_NEEDED` back to E14). Requesting Copilot directly from
+  triage would leave a pending review with no request marker and
+  under-count the per-PR cap across restarts.
+- If no completed review of the current HEAD arrives within the wait,
+  disposition the item explicitly as _not produced_ with the existing
+  rejection prefix: `**Rejected** — {bot} did not review HEAD {sha}
+  ({reason}); this is not a completed review`. Every non-review-notice
+  item must carry this terminal disposition (or `**Accepted**` for an
+  arriving completed review) before E7 — it is never left pending across
+  snapshots. This keeps the disposition vocabulary unchanged for the E7
+  verifier and the F2/F3 gates.
 - **Fail-closed honesty**: never cite a non-review notice as evidence
   that the advisory reviewer reviewed the current HEAD — not in the
   disposition reply, the `Authoritative by` line, or the PR live status

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -172,7 +172,9 @@ requested in a previous E13/E14 pass.
 **Regular comments** where the last speaker is not any IDD agent, and no
 reply from **you** (the current agent) exists after that comment's
 timestamp — exclude periodic notification bots (Renovate, etc.). Include
-Copilot and CI advisory bot comments; they follow PATH B in E4-E7.
+Copilot and CI advisory bot comments; they follow PATH B in E4-E7
+(advisory non-review notices — rate-limit / quota / queued / bare ack /
+error — are dispositioned under the E6 non-review-notice rule).
 
 ## E2 — Critique pass
 

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -173,8 +173,9 @@ requested in a previous E13/E14 pass.
 reply from **you** (the current agent) exists after that comment's
 timestamp — exclude periodic notification bots (Renovate, etc.). Include
 Copilot and CI advisory bot comments; they follow PATH B in E4-E7
-(advisory non-review notices — rate-limit / quota / queued / bare ack /
-error — are dispositioned under the E6 non-review-notice rule).
+(advisory non-review notices — rate-limit / quota / queued / bare
+request acknowledgement / error — are dispositioned under the E6
+non-review-notice rule).
 
 ## E2 — Critique pass
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -62,7 +62,7 @@ Record a path-specific disposition for every item:
   - `Rejected` means the advisory is noted, but no action is required.
   - An advisory non-review notice (E4) is **not scored** here; it is
     still recorded, but always as `Rejected` per the E6 non-review-notice
-    rule (it is not a scorable advisory result).
+    rule (it carries no advisory result to score).
 
 Accepted PATH B items do **not** enter review-fix. They are fully
 handled in E6-E7.

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -204,9 +204,13 @@ PATH B — Advisory items (completed review of the current HEAD):
 PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
 ack / error, as defined in E4):
 
-- A non-review notice means **no review of the current HEAD exists**, so
-  it must never be dispositioned as a confirmation, "no findings", or
-  "no action required because reviewed".
+- A non-review notice is **not itself a completed review** of the
+  current HEAD and must never be treated as evidence of one, so it must
+  never be dispositioned as a confirmation, "no findings", or "no action
+  required because reviewed". (A non-review notice does not by itself
+  prove that no review exists — if a separate _completed_ review of the
+  current HEAD is also present, disposition that review under the
+  completed-review rules above.)
 - When the advisory bot supports an on-demand trigger (e.g.
   `@coderabbitai review`), you **SHOULD** re-request the review for the
   current HEAD **at most once per HEAD**. Do **not** disposition on the

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -212,11 +212,13 @@ ack / error, as defined in E4):
   current HEAD is also present, disposition that review under the
   completed-review rules above.)
 - **Disposition it deterministically in the current pass — no
-  re-request, no wait.** Record `**Accepted**` only if a completed
-  review of the current HEAD is independently present (dispositioned per
-  the completed-review rules above); otherwise record the _not produced_
-  rejection with the existing prefix: `**Rejected** — {bot} did not
-  review HEAD {sha} ({reason}); this is not a completed review`. This
+  re-request, no wait.** The notice item itself is **always rejected**,
+  because it carries no advisory result — never record `**Accepted**` on
+  the notice: `**Rejected** — {bot} did not review HEAD {sha}
+  ({reason}); this is not a completed review`. A separate _completed_
+  review of the current HEAD, if one is present, is a **distinct**
+  ReviewItems_snapshot item dispositioned `**Accepted**` under the
+  completed-review rules above — accept that review, not the notice. This
   keeps the disposition vocabulary unchanged for the E7 verifier and the
   F2/F3 gates, and never leaves the item pending across snapshots.
 - **Do not auto-request a fresh review from triage** to "upgrade" a

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -23,6 +23,17 @@ For each item in ReviewItems_snapshot, first classify it:
   change.
 - If classification is ambiguous, default to PATH A.
 
+**Advisory non-review notice.** Before scoring a PATH B item, decide
+whether it is a _completed_ advisory review of the current HEAD or an
+**advisory non-review notice** — an advisory bot comment reporting that
+it did **not** review the current HEAD. Treat these as non-review
+notices: rate-limit-exceeded warnings, usage / quota / credit
+exhaustion, queued / in-progress / "reviewing" status, a bare request
+acknowledgement (e.g. CodeRabbit "Actions performed"), and error or
+"temporarily unavailable" notices. A non-review notice carries no
+advisory result to score; handle it with the E6 non-review-notice rule
+instead of the normal PATH B disposition.
+
 Then apply path-specific scoring:
 
 - **PATH A**: assess severity and relevance to PR intent.
@@ -31,9 +42,11 @@ Then apply path-specific scoring:
   - **Low** (minor improvements unrelated to PR intent) → **Reject
     recommended**
   - **Medium** → judge by context
-- **PATH B**: do **not** assign High / Medium / Low. Instead, decide
-  whether the advisory should be treated as `Accepted` (confirmed /
-  useful context) or `Rejected` (noted, no action required).
+- **PATH B**: do **not** assign High / Medium / Low. Score only a
+  _completed_ advisory review of the current HEAD here — decide whether
+  it should be treated as `Accepted` (confirmed / useful context) or
+  `Rejected` (noted, no action required). Route an advisory non-review
+  notice (defined above) to the E6 non-review-notice rule instead.
 
 ## E5 — Record Accept / Reject decisions
 
@@ -43,10 +56,12 @@ Record a path-specific disposition for every item:
   - High-severity items are Accepted automatically.
   - Medium- and Low-severity items require an explicit Accept or Reject
     decision.
-- **PATH B**:
+- **PATH B** (a _completed_ review of the current HEAD):
   - `Accepted` means the advisory confirms the current implementation or
     captures useful context.
   - `Rejected` means the advisory is noted, but no action is required.
+  - An advisory non-review notice (E4) is **not** recorded here;
+    disposition it under the E6 non-review-notice rule.
 
 Accepted PATH B items do **not** enter review-fix. They are fully
 handled in E6-E7.
@@ -167,22 +182,49 @@ For each Rejected PATH A item whose source is reviewer feedback:
 
 Use these prefixes so that disposition is always unambiguous:
 
-- PATH B acceptance marker:
-  `**Accepted** — {what the advisory comment confirmed}`
+- PATH B acceptance marker (only for a _completed_ review of the current
+  HEAD): `**Accepted** — {what the advisory comment confirmed}`
 - Ordinary rejection: `**Rejected** — {reason}`
 - CODEOWNER / required reviewer exception:
   `**Awaiting maintainer decision** — {reasoning}`
 
-PATH B — Advisory items:
+PATH B — Advisory items (completed review of the current HEAD):
 
 - Reply immediately with a decision marker, even when no code change is
-  needed:
+  needed. Use `**Accepted**` / "no findings / no action required"
+  framing **only** when the advisory is a completed review of the
+  current HEAD:
   - `**Accepted** — {what the advisory comment confirmed}`
   - `**Rejected** — {why no action is required}`
 - **Review threads**: resolve immediately after posting the marker.
 - **Regular comments**: reply only.
 - Do not send PATH B items to review-fix. Their work is complete once
   the marker is posted and any thread resolution is done.
+
+PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
+ack / error, as defined in E4):
+
+- A non-review notice means **no review of the current HEAD exists**, so
+  it must never be dispositioned as a confirmation, "no findings", or
+  "no action required because reviewed".
+- When the advisory bot supports an on-demand trigger (e.g.
+  `@coderabbitai review`), you **SHOULD** re-request the review for the
+  current HEAD **at most once per HEAD**. Do **not** disposition on the
+  re-request acknowledgement, and do **not** merge on it; wait for a
+  completed review of the current HEAD, or for the advisory window to
+  elapse, before recording any disposition.
+- If no completed review of the current HEAD arrives, disposition the
+  item explicitly as _not produced_ with the existing rejection prefix:
+  `**Rejected** — {bot} did not review HEAD {sha} ({reason}); this is
+  not a completed review`. This keeps the disposition vocabulary
+  unchanged for the E7 verifier and the F2/F3 gates.
+- **Fail-closed honesty**: never cite a non-review notice as evidence
+  that the advisory reviewer reviewed the current HEAD — not in the
+  disposition reply, the `Authoritative by` line, or the PR live status
+  digest.
+- **Non-blocking boundary**: this rule does not make PATH B a merge
+  blocker. The blocking advisory gate remains the Copilot advisory-wait
+  protocol in `idd-advisory-wait.instructions.md`, which is unchanged.
 
 ## E7 — Verify recorded dispositions
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -60,8 +60,9 @@ Record a path-specific disposition for every item:
   - `Accepted` means the advisory confirms the current implementation or
     captures useful context.
   - `Rejected` means the advisory is noted, but no action is required.
-  - An advisory non-review notice (E4) is **not** recorded here;
-    disposition it under the E6 non-review-notice rule.
+  - An advisory non-review notice (E4) is **not scored** here; it is
+    still recorded, but always as `Rejected` per the E6 non-review-notice
+    rule (it is not a scorable advisory result).
 
 Accepted PATH B items do **not** enter review-fix. They are fully
 handled in E6-E7.
@@ -218,7 +219,12 @@ ack / error, as defined in E4):
   ({reason}); this is not a completed review`. A separate _completed_
   review of the current HEAD, if one is present, is a **distinct**
   ReviewItems_snapshot item dispositioned `**Accepted**` under the
-  completed-review rules above — accept that review, not the notice. This
+  completed-review rules above — accept that review, not the notice.
+  **Re-validate just before posting the rejection**: a completed review
+  can race in after the E1 snapshot but before this rejection. If one
+  has, disposition that review (Accepted) and take a fresh E1 snapshot,
+  so the rejection's later timestamp does not filter the completed
+  review out of the next pass. This
   keeps the disposition vocabulary unchanged for the E7 verifier and the
   F2/F3 gates, and never leaves the item pending across snapshots.
 - **Do not auto-request a fresh review from triage** to "upgrade" a

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -214,15 +214,23 @@ ack / error, as defined in E4):
 - **Re-request (non-Copilot advisory bots only).** When a non-Copilot
   advisory bot supports an on-demand trigger (e.g. `@coderabbitai
   review`), you **MAY** re-request the review for the current HEAD **at
-  most once per HEAD**. Do **not** record a disposition on the
-  re-request acknowledgement, and do **not** merge on it. Posting the
-  re-request makes the agent the last speaker, so E1's regular-comment
-  filter will drop the original notice on the next snapshot — do **not**
-  rely on a later E1 pass to re-surface it. Keep the item in the current
-  ReviewItems_snapshot and, bounded, wait for a completed review of the
-  current HEAD or for the advisory window to elapse; the current pass
-  owns the terminal disposition (next bullet) and must record it before
-  E7.
+  most once per HEAD**. To keep that cap enforceable across restarts,
+  first record a durable, restart-visible `advisory-wait` marker for the
+  current HEAD (per the AW2 / AW3-R marker conventions in
+  `idd-advisory-wait.instructions.md`); if such a marker already exists
+  for this HEAD, or you cannot record one, do **not** re-request again —
+  go straight to the terminal disposition below. Do **not** record a
+  disposition on the re-request acknowledgement, and do **not** merge on
+  it. Posting the re-request makes the agent the last speaker, so E1's
+  regular-comment filter will drop the original notice on the next
+  snapshot — do **not** rely on a later E1 pass to re-surface it.
+- After re-requesting, wait at most the advisory **settled window**
+  (`advisoryWait.settledWindow`), polling every
+  `advisoryWait.pollInterval` (see
+  [policy constants](../../docs/policy-constants.md)), for a completed
+  review of the current HEAD. Reusing these existing advisory constants
+  — rather than an undefined "advisory window" — keeps the bound
+  deterministic.
 - **Copilot non-review notices** do not use the re-request above; route
   them through the advisory-wait protocol in
   `idd-advisory-wait.instructions.md` (AW3 `REQUEST_NEEDED` → E14, with
@@ -230,14 +238,14 @@ ack / error, as defined in E4):
   route `REQUEST_NEEDED` back to E14). Requesting Copilot directly from
   triage would leave a pending review with no request marker and
   under-count the per-PR cap across restarts.
-- If no completed review of the current HEAD arrives within the wait,
-  disposition the item explicitly as _not produced_ with the existing
-  rejection prefix: `**Rejected** — {bot} did not review HEAD {sha}
-  ({reason}); this is not a completed review`. Every non-review-notice
-  item must carry this terminal disposition (or `**Accepted**` for an
-  arriving completed review) before E7 — it is never left pending across
-  snapshots. This keeps the disposition vocabulary unchanged for the E7
-  verifier and the F2/F3 gates.
+- The current triage pass **owns the terminal disposition** and must
+  record it before E7 — a non-review-notice item is never left pending
+  across snapshots: `**Accepted**` if a completed review of the current
+  HEAD is now present (dispositioned per the completed-review rules
+  above), otherwise the _not produced_ rejection with the existing
+  prefix: `**Rejected** — {bot} did not review HEAD {sha} ({reason});
+  this is not a completed review`. This keeps the disposition vocabulary
+  unchanged for the E7 verifier and the F2/F3 gates.
 - **Fail-closed honesty**: never cite a non-review notice as evidence
   that the advisory reviewer reviewed the current HEAD — not in the
   disposition reply, the `Authoritative by` line, or the PR live status

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -211,41 +211,25 @@ ack / error, as defined in E4):
   prove that no review exists — if a separate _completed_ review of the
   current HEAD is also present, disposition that review under the
   completed-review rules above.)
-- **Re-request (non-Copilot advisory bots only).** When a non-Copilot
-  advisory bot supports an on-demand trigger (e.g. `@coderabbitai
-  review`), you **MAY** re-request the review for the current HEAD **at
-  most once per HEAD**. To keep that cap enforceable across restarts,
-  first record a durable, restart-visible `advisory-wait` marker for the
-  current HEAD (per the AW2 / AW3-R marker conventions in
-  `idd-advisory-wait.instructions.md`); if such a marker already exists
-  for this HEAD, or you cannot record one, do **not** re-request again —
-  go straight to the terminal disposition below. Do **not** record a
-  disposition on the re-request acknowledgement, and do **not** merge on
-  it. Posting the re-request makes the agent the last speaker, so E1's
-  regular-comment filter will drop the original notice on the next
-  snapshot — do **not** rely on a later E1 pass to re-surface it.
-- After re-requesting, wait at most the advisory **settled window**
-  (`advisoryWait.settledWindow`), polling every
-  `advisoryWait.pollInterval` (see
-  [policy constants](../../docs/policy-constants.md)), for a completed
-  review of the current HEAD. Reusing these existing advisory constants
-  — rather than an undefined "advisory window" — keeps the bound
-  deterministic.
-- **Copilot non-review notices** do not use the re-request above; route
-  them through the advisory-wait protocol in
-  `idd-advisory-wait.instructions.md` (AW3 `REQUEST_NEEDED` → E14, with
-  the trusted request marker and request-cap accounting; F2/F3 already
-  route `REQUEST_NEEDED` back to E14). Requesting Copilot directly from
-  triage would leave a pending review with no request marker and
-  under-count the per-PR cap across restarts.
-- The current triage pass **owns the terminal disposition** and must
-  record it before E7 — a non-review-notice item is never left pending
-  across snapshots: `**Accepted**` if a completed review of the current
-  HEAD is now present (dispositioned per the completed-review rules
-  above), otherwise the _not produced_ rejection with the existing
-  prefix: `**Rejected** — {bot} did not review HEAD {sha} ({reason});
-  this is not a completed review`. This keeps the disposition vocabulary
-  unchanged for the E7 verifier and the F2/F3 gates.
+- **Disposition it deterministically in the current pass — no
+  re-request, no wait.** Record `**Accepted**` only if a completed
+  review of the current HEAD is independently present (dispositioned per
+  the completed-review rules above); otherwise record the _not produced_
+  rejection with the existing prefix: `**Rejected** — {bot} did not
+  review HEAD {sha} ({reason}); this is not a completed review`. This
+  keeps the disposition vocabulary unchanged for the E7 verifier and the
+  F2/F3 gates, and never leaves the item pending across snapshots.
+- **Do not auto-request a fresh review from triage** to "upgrade" a
+  non-review notice. Triggering a new review is a separate concern:
+  Copilot advisory state is owned solely by the advisory-wait protocol
+  in `idd-advisory-wait.instructions.md` (AW3 `REQUEST_NEEDED` → E14),
+  and a maintainer may manually re-trigger a non-Copilot bot. Any review
+  that later completes for the current HEAD is picked up and
+  dispositioned normally on a subsequent E1 pass. **Never** post an
+  `advisory-wait` marker for a non-Copilot bot — AW2/AW3 treat any
+  trusted same-HEAD `advisory-wait` marker as Copilot evidence, so doing
+  so could wrongly satisfy the Copilot advisory gate and consume its
+  request cap.
 - **Fail-closed honesty**: never cite a non-review notice as evidence
   that the advisory reviewer reviewed the current HEAD — not in the
   disposition reply, the `Authoritative by` line, or the PR live status

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -211,17 +211,33 @@ ack / error, as defined in E4):
   prove that no review exists — if a separate _completed_ review of the
   current HEAD is also present, disposition that review under the
   completed-review rules above.)
-- When the advisory bot supports an on-demand trigger (e.g.
-  `@coderabbitai review`), you **SHOULD** re-request the review for the
-  current HEAD **at most once per HEAD**. Do **not** disposition on the
-  re-request acknowledgement, and do **not** merge on it; wait for a
-  completed review of the current HEAD, or for the advisory window to
-  elapse, before recording any disposition.
-- If no completed review of the current HEAD arrives, disposition the
-  item explicitly as _not produced_ with the existing rejection prefix:
-  `**Rejected** — {bot} did not review HEAD {sha} ({reason}); this is
-  not a completed review`. This keeps the disposition vocabulary
-  unchanged for the E7 verifier and the F2/F3 gates.
+- **Re-request (non-Copilot advisory bots only).** When a non-Copilot
+  advisory bot supports an on-demand trigger (e.g. `@coderabbitai
+  review`), you **MAY** re-request the review for the current HEAD **at
+  most once per HEAD**. Do **not** record a disposition on the
+  re-request acknowledgement, and do **not** merge on it. Posting the
+  re-request makes the agent the last speaker, so E1's regular-comment
+  filter will drop the original notice on the next snapshot — do **not**
+  rely on a later E1 pass to re-surface it. Keep the item in the current
+  ReviewItems_snapshot and, bounded, wait for a completed review of the
+  current HEAD or for the advisory window to elapse; the current pass
+  owns the terminal disposition (next bullet) and must record it before
+  E7.
+- **Copilot non-review notices** do not use the re-request above; route
+  them through the advisory-wait protocol in
+  `idd-advisory-wait.instructions.md` (AW3 `REQUEST_NEEDED` → E14, with
+  the trusted request marker and request-cap accounting; F2/F3 already
+  route `REQUEST_NEEDED` back to E14). Requesting Copilot directly from
+  triage would leave a pending review with no request marker and
+  under-count the per-PR cap across restarts.
+- If no completed review of the current HEAD arrives within the wait,
+  disposition the item explicitly as _not produced_ with the existing
+  rejection prefix: `**Rejected** — {bot} did not review HEAD {sha}
+  ({reason}); this is not a completed review`. Every non-review-notice
+  item must carry this terminal disposition (or `**Accepted**` for an
+  arriving completed review) before E7 — it is never left pending across
+  snapshots. This keeps the disposition vocabulary unchanged for the E7
+  verifier and the F2/F3 gates.
 - **Fail-closed honesty**: never cite a non-review notice as evidence
   that the advisory reviewer reviewed the current HEAD — not in the
   disposition reply, the `Authoritative by` line, or the PR live status


### PR DESCRIPTION
## Summary

Guards the review-triage **PATH B** advisory flow against treating an
advisory bot **non-review notice** as a completed review.

A dogfooding audit of merged PRs (commit→merge with zero formal reviews)
found early-era escapes — #21, #164, #184 — where CodeRabbit/Codex
posted only a rate-limit or usage-exhausted notice and the agent
dispositioned it as a completed advisory review, then merged.

## Changes

- **E4** defines an *advisory non-review notice* (rate-limit, usage /
  quota / credit exhaustion, queued / in-progress, a bare request
  acknowledgement, error / "temporarily unavailable") and states it
  carries no advisory result to score.
- **E5** routes non-review notices away from normal PATH B recording.
- **E6** dispositions a non-review notice **deterministically in the
  current pass — no re-request, no wait**: the notice item itself is
  **always** `**Rejected**` (it carries no advisory result; never
  `**Accepted**`), while a separate *completed* review of the current
  HEAD is a distinct item that gets `**Accepted**`. Forbids posting an
  `advisory-wait` marker for a non-Copilot bot (AW2/AW3 would mistake it
  for Copilot evidence). Adds a fail-closed honesty rule and a
  non-blocking boundary note.
- **E1** (review-snapshot) PATH B inclusion note points to the new rule.

## Rationale / non-goals

- Normative-only change; reuses the existing `**Accepted**` /
  `**Rejected**` vocabulary so the E7 verifier and the F2/F3 disposition
  gates are untouched (no new prefix).
- **Re-request dropped during review:** an earlier revision had the
  agent re-request a fresh review (≤ 1 per HEAD) for non-Copilot bots.
  Review feedback (Codex P1) showed this required reusing the
  `advisory-wait` marker, which AW2/AW3 treat as **Copilot** evidence —
  it could wrongly satisfy the Copilot advisory gate and consume its
  request cap, plus add restart-fragility, for no merge-safety benefit
  (PATH B is advisory). The re-request was removed in favor of an
  immediate deterministic disposition; a review that completes later is
  picked up on a subsequent E1 pass.
- Does **not** make PATH B a merge blocker — the Copilot advisory-wait
  protocol in `idd-advisory-wait.instructions.md` remains the unchanged
  blocking advisory gate. This PR closes the remaining traceability /
  honesty gap only.
- Source edited in `idd-template/`; root `.github/` mirror regenerated
  via `pnpm run docs:sync` (verified by `docs:sync:check` + `pnpm lint`).

## Note

The implementation commits are **unsigned**: configured GPG signing
stalled on a pinentry/TTY prompt with no interactive terminal, and the
`git commit-ssh` SSH fallback also stalled because no ssh-agent was
available (`SSH_AUTH_SOCK` unset) to unlock the passphrase-protected key.
Per the bounded signing ladder, unsigned commits were created so work
was not blocked.

Closes #786
