### PR TITLE
feat(idd-doctor): enforce the worktree guard with --strict and config

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -665,7 +665,7 @@ export function classifyWorktreeHeadFinding(classification, branch, primaryPath,
     ? "an issue branch"
     : "a roadmap-audit branch"
   const severity = enforce
-    ? "B1 violation (worktree guard enabled): this branch must live in a sibling worktree, not the primary worktree"
+    ? "B1 violation: this branch must live in a sibling worktree, not the primary worktree (worktree guard enforced)"
     : "likely a past B1 violation"
   return {
     level: enforce ? "error" : "warning",

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -21,37 +21,13 @@ const BASE64_PATTERN = /^[A-Za-z0-9+/=\s]+$/
 
 export { parseProjectCommandRows }
 
-if (isMainModule(import.meta.url)) {
-  const args = parseArgs(process.argv.slice(2))
-
-  if (args.help) {
-    printUsage()
-    process.exit(0)
-  }
-
-  const report = runDoctor({
-    root: resolve(args.root),
-    requireGithub: args.requireGithub,
-    cleanupBacklogWindowDays: args.cleanupBacklogWindowDays,
-    cleanupBacklogWarnThreshold: args.cleanupBacklogWarnThreshold,
-    workshopCrossRefAllowMissing: args.workshopCrossRefAllowMissing,
-  })
-
-  if (args.json) {
-    console.log(JSON.stringify(report, null, 2))
-  } else {
-    printHumanReport(report)
-  }
-
-  process.exit(report.errors.length > 0 ? 1 : 0)
-}
-
 export function runDoctor({
   root,
   requireGithub,
   cleanupBacklogWindowDays,
   cleanupBacklogWarnThreshold,
   workshopCrossRefAllowMissing,
+  strict,
 }) {
   const files = listFiles(root)
   const textFiles = files.filter(isTextLikeFile)
@@ -71,7 +47,8 @@ export function runDoctor({
   checkHelperRuntimeConfig(root, report)
   checkAgentEntryFiles(root, report)
   checkTemplateVersionSignal(root, report)
-  checkPrimaryWorktreeHead(root, report)
+  const worktreeGuardEnforced = strict === true || readWorktreeGuardEnabled(root)
+  checkPrimaryWorktreeHead(root, report, { enforce: worktreeGuardEnforced })
   checkPostMergeCleanupBacklog(
     root,
     {
@@ -625,7 +602,16 @@ function checkTemplateVersionSignal(root, report) {
   report.warnings.push("template version signal not found (iddVersion/template version)")
 }
 
-function checkPrimaryWorktreeHead(root, report) {
+export function readWorktreeGuardEnabled(root) {
+  try {
+    const config = JSON.parse(readFileSync(join(root, ".github/idd/config.json"), "utf8"))
+    return config?.worktreeGuard?.enabled === true
+  } catch {
+    return false
+  }
+}
+
+function checkPrimaryWorktreeHead(root, report, options = {}) {
   const listResult = runCommand("git", ["worktree", "list", "--porcelain"], root)
   if (!listResult.ok) {
     return
@@ -643,17 +629,49 @@ function checkPrimaryWorktreeHead(root, report) {
 
   const branch = headResult.stdout.trim()
   const classification = classifyPrimaryHead(branch)
-  if (!classification.isB1Violation) {
+  const finding = classifyWorktreeHeadFinding(
+    classification,
+    branch,
+    primaryPath,
+    options.enforce === true,
+  )
+  if (!finding) {
     return
   }
+  if (finding.level === "error") {
+    report.errors.push(finding.message)
+  } else {
+    report.warnings.push(finding.message)
+  }
+}
 
-  const kindLabel =
-    classification.kind === "issue"
-      ? "an issue branch"
-      : "a roadmap-audit branch"
-  report.warnings.push(
-    `primary worktree HEAD is on ${kindLabel} (${branch}) at ${primaryPath} — likely a past B1 violation. See B1 in .github/instructions/idd-work.instructions.md.`,
-  )
+/**
+ * Decide whether a primary-worktree HEAD classification is a finding and,
+ * if so, at what level. Pure (no I/O) so it can be unit-tested directly.
+ *
+ * @param {{ isB1Violation: boolean, kind?: string }} classification
+ * @param {string} branch       current primary-worktree branch name
+ * @param {string} primaryPath  primary worktree path (for the message)
+ * @param {boolean} enforce     true when the worktree guard is enabled or
+ *                              --strict was passed; promotes the finding
+ *                              from a warning to a blocking error
+ * @returns {{ level: "error"|"warning", message: string } | null}
+ */
+export function classifyWorktreeHeadFinding(classification, branch, primaryPath, enforce) {
+  if (!classification || !classification.isB1Violation) {
+    return null
+  }
+  const kindLabel = classification.kind === "issue"
+    ? "an issue branch"
+    : "a roadmap-audit branch"
+  const severity = enforce
+    ? "B1 violation (worktree guard enabled): this branch must live in a sibling worktree, not the primary worktree"
+    : "likely a past B1 violation"
+  return {
+    level: enforce ? "error" : "warning",
+    message:
+      `primary worktree HEAD is on ${kindLabel} (${branch}) at ${primaryPath} — ${severity}. See B1 in .github/instructions/idd-work.instructions.md.`,
+  }
 }
 
 export function computeWindowStartIso(now, windowDays) {
@@ -1362,6 +1380,7 @@ function parseArgs(argv) {
     json: false,
     help: false,
     requireGithub: false,
+    strict: false,
   }
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -1376,6 +1395,10 @@ function parseArgs(argv) {
     }
     if (arg === "--require-github") {
       args.requireGithub = true
+      continue
+    }
+    if (arg === "--strict") {
+      args.strict = true
       continue
     }
     if (arg === "--repo-root") {
@@ -1460,6 +1483,7 @@ options:
   --repo-root <path>                       repository root to inspect (default: cwd)
   --json                                   print JSON report
   --require-github                         treat GitHub API check failures as errors
+  --strict                                 treat a primary-worktree implementation-branch HEAD as an error (also enabled by worktreeGuard.enabled in config)
   --cleanup-backlog-window-days <N>        merged-PR window for the cleanup backlog check (default: 14)
   --cleanup-backlog-warn-threshold <N>     backlog count above which the check warns (default: 2)
   --workshop-cross-ref-allow-missing <list> comma-separated entry-point paths to skip in the workshop cross-reference check (default: none)
@@ -1538,4 +1562,34 @@ function isMainModule(moduleUrl) {
     return false
   }
   return fileURLToPath(moduleUrl) === resolve(process.argv[1])
+}
+
+// Run as a CLI only after the whole module (including consts used by the
+// checks above) has finished evaluating. Keeping this block at the end of
+// the file avoids a temporal-dead-zone crash when runDoctor reaches a check
+// that reads a `const` declared later in the file.
+if (isMainModule(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2))
+
+  if (args.help) {
+    printUsage()
+    process.exit(0)
+  }
+
+  const report = runDoctor({
+    root: resolve(args.root),
+    requireGithub: args.requireGithub,
+    cleanupBacklogWindowDays: args.cleanupBacklogWindowDays,
+    cleanupBacklogWarnThreshold: args.cleanupBacklogWarnThreshold,
+    workshopCrossRefAllowMissing: args.workshopCrossRefAllowMissing,
+    strict: args.strict,
+  })
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2))
+  } else {
+    printHumanReport(report)
+  }
+
+  process.exit(report.errors.length > 0 ? 1 : 0)
 }

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -209,7 +209,7 @@ test("classifyWorktreeHeadFinding promotes to an error when the guard is enforce
     true,
   )
   assert.equal(finding.level, "error")
-  assert.match(finding.message, /worktree guard enabled/)
+  assert.match(finding.message, /worktree guard enforced/)
 })
 
 test("classifyWorktreeHeadFinding labels roadmap-audit branches", () => {

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { test } from "node:test"
 
 import {
   backLinkPatternFor,
   classifyBacklog,
   classifyPrimaryHead,
+  classifyWorktreeHeadFinding,
   computeWindowStartIso,
   containsExampleRepoBackLink,
   containsWorkshopReference,
@@ -16,6 +20,7 @@ import {
   isGithubBackLinkHost,
   parsePrimaryWorktreePath,
   parseProjectCommandRows,
+  readWorktreeGuardEnabled,
   stripMarkdownNonText,
 } from "../scripts/idd-doctor.mjs"
 
@@ -175,6 +180,77 @@ test("classifyPrimaryHead handles empty or non-string input as unknown", () => {
   assert.deepEqual(classifyPrimaryHead(""), { isB1Violation: false, kind: "unknown" })
   assert.deepEqual(classifyPrimaryHead(null), { isB1Violation: false, kind: "unknown" })
   assert.deepEqual(classifyPrimaryHead(undefined), { isB1Violation: false, kind: "unknown" })
+})
+
+test("classifyWorktreeHeadFinding returns null when HEAD is not a violation", () => {
+  assert.equal(
+    classifyWorktreeHeadFinding({ isB1Violation: false, kind: "other" }, "main", "/repo", true),
+    null,
+  )
+})
+
+test("classifyWorktreeHeadFinding warns (not errors) when the guard is not enforced", () => {
+  const finding = classifyWorktreeHeadFinding(
+    { isB1Violation: true, kind: "issue" },
+    "issue/123-foo",
+    "/repo",
+    false,
+  )
+  assert.equal(finding.level, "warning")
+  assert.match(finding.message, /an issue branch \(issue\/123-foo\)/)
+  assert.match(finding.message, /likely a past B1 violation/)
+})
+
+test("classifyWorktreeHeadFinding promotes to an error when the guard is enforced", () => {
+  const finding = classifyWorktreeHeadFinding(
+    { isB1Violation: true, kind: "issue" },
+    "issue/123-foo",
+    "/repo",
+    true,
+  )
+  assert.equal(finding.level, "error")
+  assert.match(finding.message, /worktree guard enabled/)
+})
+
+test("classifyWorktreeHeadFinding labels roadmap-audit branches", () => {
+  const finding = classifyWorktreeHeadFinding(
+    { isB1Violation: true, kind: "roadmap-audit" },
+    "roadmap-audit/456-bar",
+    "/repo",
+    true,
+  )
+  assert.equal(finding.level, "error")
+  assert.match(finding.message, /a roadmap-audit branch/)
+})
+
+test("readWorktreeGuardEnabled reads worktreeGuard.enabled from config", () => {
+  const dir = mkdtempSync(join(tmpdir(), "idd-guard-"))
+  try {
+    const writeConfig = (obj) => {
+      mkdirSync(join(dir, ".github/idd"), { recursive: true })
+      writeFileSync(join(dir, ".github/idd/config.json"), JSON.stringify(obj))
+    }
+    writeConfig({ worktreeGuard: { enabled: true } })
+    assert.equal(readWorktreeGuardEnabled(dir), true)
+    writeConfig({ worktreeGuard: { enabled: false } })
+    assert.equal(readWorktreeGuardEnabled(dir), false)
+    writeConfig({ markerPrefix: "idd-skill" })
+    assert.equal(readWorktreeGuardEnabled(dir), false)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("readWorktreeGuardEnabled returns false when config is missing or invalid", () => {
+  const dir = mkdtempSync(join(tmpdir(), "idd-guard-"))
+  try {
+    assert.equal(readWorktreeGuardEnabled(dir), false)
+    mkdirSync(join(dir, ".github/idd"), { recursive: true })
+    writeFileSync(join(dir, ".github/idd/config.json"), "{ not json")
+    assert.equal(readWorktreeGuardEnabled(dir), false)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test("computeWindowStartIso subtracts the given number of days from now", () => {


### PR DESCRIPTION
## Summary

Turn the advisory-only `idd-doctor` primary-worktree-HEAD finding into a
real, opt-in blocking error, so the worktree guard added in #790 can be
enforced.

Closes #794

## What changed

- `idd-doctor` promotes the primary-worktree-HEAD finding to an
  **error** (`report.errors`, exit 1) when `worktreeGuard.enabled` is set
  in `.github/idd/config.json` **or** the new `--strict` flag is passed.
  Off/absent + no `--strict` keeps the historical warning + exit 0
  (fail-safe, non-breaking).
- Sink/severity decision extracted into the pure, unit-tested
  `classifyWorktreeHeadFinding`; `readWorktreeGuardEnabled` reads the
  opt-in flag.
- New `--strict` CLI flag + usage text.
- **Bug fix (prerequisite):** moved the CLI entry block to the end of the
  file. It previously ran at the top during module evaluation and hit a
  temporal-dead-zone `ReferenceError` (`PUBLIC_GITHUB_HOSTS`) the moment a
  check read a `const` declared later, crashing `node scripts/idd-doctor.mjs`
  outright in repos that trigger the workshop back-link check. The strict
  gate is meaningless while the script cannot finish, so the fix ships
  here.

## Verification

- `node --test tests/idd-doctor.test.mjs` — 78 pass / 0 fail (6 new).
- Full `lint:minimum` chain — 806 tests pass; audit-docs, dprint,
  workshop, cspell, markdownlint all clean.
- `node scripts/idd-doctor.mjs` now runs to completion (no TDZ crash).

## Heads-up for #796 (not in scope here)

With the TDZ crash fixed, `node scripts/idd-doctor.mjs` now runs to
completion and surfaces two **pre-existing** errors that the crash was
masking: an `unresolved placeholders` report over docs that intentionally
document `{{…}}` template syntax, and `discover marker prefixes differ
between roadmap-id and blocked-by`. These are unrelated to the worktree
guard. #796 (wire `idd-doctor --strict` into CI) will need them resolved
(or the checks adjusted) before a clean-main CI gate can pass; flagging
here so #796 accounts for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--strict` flag to promote worktree HEAD violations from warnings to blocking errors.
  * Worktree guard enforcement can now be configured via `.github/idd/config.json`.

* **Tests**
  * Added comprehensive test coverage for worktree guard classification and configuration reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->