### PR TITLE
feat(hooks): add opt-in core.hooksPath worktree guard

### DIFF
--- a/.githooks/_idd-worktree-guard.sh
+++ b/.githooks/_idd-worktree-guard.sh
@@ -40,12 +40,32 @@ idd_worktree_guard_check() {
   [ -n "$primary" ] || return 0
   [ "$primary" = "$repo_root" ] || return 0
 
-  # Only implementation branches are guarded.
+  # Only implementation branches are guarded. The globs come from
+  # worktreeGuard.branchPatterns, defaulting to issue/* and
+  # roadmap-audit/* when the key is absent. (A detached HEAD reports
+  # "HEAD" and never matches.)
   branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-  case "$branch" in
-    issue/* | roadmap-audit/*) ;;
-    *) return 0 ;;
+  [ -n "$branch" ] && [ "$branch" != "HEAD" ] || return 0
+
+  patterns='issue/* roadmap-audit/*'
+  case "$guard_body" in
+    *'"branchPatterns":['*)
+      raw=${guard_body#*'"branchPatterns":['}
+      raw=${raw%%]*}
+      patterns=$(printf '%s' "$raw" | tr ',' ' ' | tr -d '"')
+      ;;
   esac
+
+  matched=0
+  for pattern in $patterns; do
+    # Unquoted $pattern is intentional: it enables glob matching of the
+    # configured branch pattern against the branch name.
+    # shellcheck disable=SC2254
+    case "$branch" in
+      $pattern) matched=1; break ;;
+    esac
+  done
+  [ "$matched" = 1 ] || return 0
 
   printf 'IDD worktree guard: refusing to %s on "%s" from the primary worktree (%s).\n' \
     "$action" "$branch" "$repo_root" >&2

--- a/.githooks/_idd-worktree-guard.sh
+++ b/.githooks/_idd-worktree-guard.sh
@@ -1,0 +1,58 @@
+# shellcheck shell=sh
+# IDD disposable-worktree guard — shared check for the pre-commit and
+# pre-push hooks. Pure POSIX sh: no node, jq, python, or other runtime
+# dependency, so it works in any repository that adopts the IDD template.
+#
+# The guard is opt-in. It does nothing unless worktreeGuard.enabled is
+# true in .github/idd/config.json. When enabled, it refuses a commit or
+# push made from the PRIMARY worktree while HEAD is on an implementation
+# branch (issue/* or roadmap-audit/*), because B1 requires that work to
+# live in a sibling worktree. Run git with --no-verify to bypass it
+# intentionally.
+
+idd_worktree_guard_check() {
+  # $1: human-readable action word ("commit" or "push").
+  action="$1"
+
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  config="$repo_root/.github/idd/config.json"
+  [ -f "$config" ] || return 0
+
+  # Opt-in gate: worktreeGuard.enabled must be true. Collapse whitespace
+  # so both pretty-printed and minified JSON parse, then inspect only the
+  # worktreeGuard object body so key order does not matter.
+  compact=$(tr -d ' \t\r\n' < "$config")
+  case "$compact" in
+    *'"worktreeGuard":{'*) ;;
+    *) return 0 ;;
+  esac
+  guard_body=${compact#*'"worktreeGuard":{'}
+  guard_body=${guard_body%%\}*}
+  case "$guard_body" in
+    *'"enabled":true'*) ;;
+    *) return 0 ;;
+  esac
+
+  # Only the primary worktree is guarded. The primary worktree is the
+  # first entry reported by `git worktree list`; sibling worktrees are
+  # exactly where implementation branches are supposed to live.
+  primary=$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -n 1)
+  [ -n "$primary" ] || return 0
+  [ "$primary" = "$repo_root" ] || return 0
+
+  # Only implementation branches are guarded.
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  case "$branch" in
+    issue/* | roadmap-audit/*) ;;
+    *) return 0 ;;
+  esac
+
+  printf 'IDD worktree guard: refusing to %s on "%s" from the primary worktree (%s).\n' \
+    "$action" "$branch" "$repo_root" >&2
+  printf 'B1 requires implementation branches to live in a sibling worktree, not the primary worktree.\n' >&2
+  printf 'Create one, e.g.:  git worktree add ../<repo>.%s %s\n' \
+    "$(printf '%s' "$branch" | tr '/' '-')" "$branch" >&2
+  printf 'See B1 in .github/instructions/idd-work.instructions.md.\n' >&2
+  printf '(To bypass intentionally, re-run the git command with --no-verify.)\n' >&2
+  return 1
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+# IDD disposable-worktree guard (pre-commit). Opt-in via
+# worktreeGuard.enabled in .github/idd/config.json. See
+# _idd-worktree-guard.sh for the full behavior. Enable the hooks with:
+#   git config core.hooksPath .githooks
+. "$(dirname "$0")/_idd-worktree-guard.sh"
+idd_worktree_guard_check commit || exit 1
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/sh
+# IDD disposable-worktree guard (pre-push). Opt-in via
+# worktreeGuard.enabled in .github/idd/config.json. See
+# _idd-worktree-guard.sh for the full behavior. Enable the hooks with:
+#   git config core.hooksPath .githooks
+. "$(dirname "$0")/_idd-worktree-guard.sh"
+idd_worktree_guard_check push || exit 1
+exit 0

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -45,6 +45,7 @@
       "stripPrefix": "idd-template/",
       "sourceGlobs": [
         "idd-template/.github/idd/*.json",
+        "idd-template/.githooks/*",
         "idd-template/.github/instructions/idd-*.instructions.md",
         "idd-template/docs/idd-*.md",
         "idd-template/docs/permissions.md",
@@ -58,6 +59,9 @@
       ],
       "paths": [
         "idd-template/.github/idd/config.json",
+        "idd-template/.githooks/_idd-worktree-guard.sh",
+        "idd-template/.githooks/pre-commit",
+        "idd-template/.githooks/pre-push",
         "idd-template/.github/instructions/idd-overview-core.instructions.md",
         "idd-template/.github/instructions/idd-overview-appendix.instructions.md",
         "idd-template/.github/instructions/idd-discover.instructions.md",

--- a/idd-template/.githooks/_idd-worktree-guard.sh
+++ b/idd-template/.githooks/_idd-worktree-guard.sh
@@ -40,12 +40,32 @@ idd_worktree_guard_check() {
   [ -n "$primary" ] || return 0
   [ "$primary" = "$repo_root" ] || return 0
 
-  # Only implementation branches are guarded.
+  # Only implementation branches are guarded. The globs come from
+  # worktreeGuard.branchPatterns, defaulting to issue/* and
+  # roadmap-audit/* when the key is absent. (A detached HEAD reports
+  # "HEAD" and never matches.)
   branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-  case "$branch" in
-    issue/* | roadmap-audit/*) ;;
-    *) return 0 ;;
+  [ -n "$branch" ] && [ "$branch" != "HEAD" ] || return 0
+
+  patterns='issue/* roadmap-audit/*'
+  case "$guard_body" in
+    *'"branchPatterns":['*)
+      raw=${guard_body#*'"branchPatterns":['}
+      raw=${raw%%]*}
+      patterns=$(printf '%s' "$raw" | tr ',' ' ' | tr -d '"')
+      ;;
   esac
+
+  matched=0
+  for pattern in $patterns; do
+    # Unquoted $pattern is intentional: it enables glob matching of the
+    # configured branch pattern against the branch name.
+    # shellcheck disable=SC2254
+    case "$branch" in
+      $pattern) matched=1; break ;;
+    esac
+  done
+  [ "$matched" = 1 ] || return 0
 
   printf 'IDD worktree guard: refusing to %s on "%s" from the primary worktree (%s).\n' \
     "$action" "$branch" "$repo_root" >&2

--- a/idd-template/.githooks/_idd-worktree-guard.sh
+++ b/idd-template/.githooks/_idd-worktree-guard.sh
@@ -1,0 +1,58 @@
+# shellcheck shell=sh
+# IDD disposable-worktree guard — shared check for the pre-commit and
+# pre-push hooks. Pure POSIX sh: no node, jq, python, or other runtime
+# dependency, so it works in any repository that adopts the IDD template.
+#
+# The guard is opt-in. It does nothing unless worktreeGuard.enabled is
+# true in .github/idd/config.json. When enabled, it refuses a commit or
+# push made from the PRIMARY worktree while HEAD is on an implementation
+# branch (issue/* or roadmap-audit/*), because B1 requires that work to
+# live in a sibling worktree. Run git with --no-verify to bypass it
+# intentionally.
+
+idd_worktree_guard_check() {
+  # $1: human-readable action word ("commit" or "push").
+  action="$1"
+
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  config="$repo_root/.github/idd/config.json"
+  [ -f "$config" ] || return 0
+
+  # Opt-in gate: worktreeGuard.enabled must be true. Collapse whitespace
+  # so both pretty-printed and minified JSON parse, then inspect only the
+  # worktreeGuard object body so key order does not matter.
+  compact=$(tr -d ' \t\r\n' < "$config")
+  case "$compact" in
+    *'"worktreeGuard":{'*) ;;
+    *) return 0 ;;
+  esac
+  guard_body=${compact#*'"worktreeGuard":{'}
+  guard_body=${guard_body%%\}*}
+  case "$guard_body" in
+    *'"enabled":true'*) ;;
+    *) return 0 ;;
+  esac
+
+  # Only the primary worktree is guarded. The primary worktree is the
+  # first entry reported by `git worktree list`; sibling worktrees are
+  # exactly where implementation branches are supposed to live.
+  primary=$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -n 1)
+  [ -n "$primary" ] || return 0
+  [ "$primary" = "$repo_root" ] || return 0
+
+  # Only implementation branches are guarded.
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  case "$branch" in
+    issue/* | roadmap-audit/*) ;;
+    *) return 0 ;;
+  esac
+
+  printf 'IDD worktree guard: refusing to %s on "%s" from the primary worktree (%s).\n' \
+    "$action" "$branch" "$repo_root" >&2
+  printf 'B1 requires implementation branches to live in a sibling worktree, not the primary worktree.\n' >&2
+  printf 'Create one, e.g.:  git worktree add ../<repo>.%s %s\n' \
+    "$(printf '%s' "$branch" | tr '/' '-')" "$branch" >&2
+  printf 'See B1 in .github/instructions/idd-work.instructions.md.\n' >&2
+  printf '(To bypass intentionally, re-run the git command with --no-verify.)\n' >&2
+  return 1
+}

--- a/idd-template/.githooks/pre-commit
+++ b/idd-template/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+# IDD disposable-worktree guard (pre-commit). Opt-in via
+# worktreeGuard.enabled in .github/idd/config.json. See
+# _idd-worktree-guard.sh for the full behavior. Enable the hooks with:
+#   git config core.hooksPath .githooks
+. "$(dirname "$0")/_idd-worktree-guard.sh"
+idd_worktree_guard_check commit || exit 1
+exit 0

--- a/idd-template/.githooks/pre-push
+++ b/idd-template/.githooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/sh
+# IDD disposable-worktree guard (pre-push). Opt-in via
+# worktreeGuard.enabled in .github/idd/config.json. See
+# _idd-worktree-guard.sh for the full behavior. Enable the hooks with:
+#   git config core.hooksPath .githooks
+. "$(dirname "$0")/_idd-worktree-guard.sh"
+idd_worktree_guard_check push || exit 1
+exit 0

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -270,6 +270,9 @@ recording template you will apply in Step 3.
 
 ```text
 .github/idd/config.json
+.githooks/_idd-worktree-guard.sh
+.githooks/pre-commit
+.githooks/pre-push
 .github/instructions/idd-overview-core.instructions.md
 .github/instructions/idd-overview-appendix.instructions.md
 .github/instructions/idd-discover.instructions.md
@@ -348,6 +351,9 @@ mkdir -p "${DEST}/.github/idd" "${DEST}/.github/instructions" "${DEST}/docs" \
 
 for FILE in \
   ".github/idd/config.json" \
+  ".githooks/_idd-worktree-guard.sh" \
+  ".githooks/pre-commit" \
+  ".githooks/pre-push" \
   ".github/instructions/idd-overview-core.instructions.md" \
   ".github/instructions/idd-overview-appendix.instructions.md" \
   ".github/instructions/idd-discover.instructions.md" \
@@ -434,6 +440,9 @@ mkdir -p "${DEST}/.github/idd" "${DEST}/.github/instructions" "${DEST}/docs" \
 
 for FILE in \
   ".github/idd/config.json" \
+  ".githooks/_idd-worktree-guard.sh" \
+  ".githooks/pre-commit" \
+  ".githooks/pre-push" \
   ".github/instructions/idd-overview-core.instructions.md" \
   ".github/instructions/idd-overview-appendix.instructions.md" \
   ".github/instructions/idd-discover.instructions.md" \
@@ -528,6 +537,33 @@ Keep the companion separate from the execution instructions:
 - In the source `idd-skill` repository, maintainers must keep
   `skills/issue-authoring/` and its bundled references aligned with
   `docs/issue-authoring-skill.md`.
+
+### Optional — enable the local worktree guard
+
+The template ships an opt-in git hook set under `.githooks/` that
+refuses commits and pushes made from the **primary** worktree while
+HEAD is on an implementation branch (`issue/*` or `roadmap-audit/*`),
+enforcing the B1 disposable-worktree rule locally. The hooks are pure
+POSIX sh — no Node, `jq`, or other runtime dependency.
+
+To enable it in the target repository:
+
+1. Set `worktreeGuard.enabled` to `true` in `.github/idd/config.json`
+   (the guard is off by default).
+2. Point git at the shipped hooks. `core.hooksPath` is local and not
+   committed, so each clone runs this once:
+
+   ```sh
+   git config core.hooksPath .githooks
+   chmod +x .githooks/pre-commit .githooks/pre-push
+   ```
+
+When `worktreeGuard.enabled` is absent or `false`, the hooks are a
+no-op. To bypass the guard for a single intentional commit or push,
+pass `--no-verify`. CI cannot detect this class of violation — a
+primary-worktree mistake leaves no trace in the pushed history — so
+this local hook, together with `idd-doctor --strict`, is the practical
+enforcement surface.
 
 ---
 

--- a/tests/worktree-guard-hook.test.mjs
+++ b/tests/worktree-guard-hook.test.mjs
@@ -91,6 +91,20 @@ test("hook is a no-op on issue/* when worktreeGuard is absent (default)", () => 
   }
 })
 
+test("hook honors a custom worktreeGuard.branchPatterns override", () => {
+  const repo = setupRepo({
+    worktreeGuard: { enabled: true, branchPatterns: ["release/*"] },
+  })
+  try {
+    git(repo, ["checkout", "-q", "-b", "release/1"])
+    assert.equal(runHook(repo, "pre-commit"), 1) // matches the custom glob
+    git(repo, ["checkout", "-q", "-b", "issue/9-example"])
+    assert.equal(runHook(repo, "pre-commit"), 0) // default issue/* no longer applies
+  } finally {
+    rmSync(repo, { recursive: true, force: true })
+  }
+})
+
 test("hook allows issue/* commits from a sibling worktree", () => {
   const repo = setupRepo({ worktreeGuard: { enabled: true } })
   const sibling = `${repo}-sibling`

--- a/tests/worktree-guard-hook.test.mjs
+++ b/tests/worktree-guard-hook.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { test } from "node:test"
+
+// The hooks under test, shipped at the repository root.
+const HOOKS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", ".githooks")
+
+function git(repo, args) {
+  execFileSync("git", args, { cwd: repo, stdio: "pipe" })
+}
+
+/** Run a hook script directly and return its exit code. */
+function runHook(repo, hook, cwd = repo) {
+  try {
+    execFileSync("sh", [join(repo, ".githooks", hook)], { cwd, stdio: "pipe" })
+    return 0
+  } catch (err) {
+    return typeof err.status === "number" ? err.status : 1
+  }
+}
+
+/** Create a throwaway git repo carrying the shipped hooks and a config. */
+function setupRepo(configObj) {
+  const dir = mkdtempSync(join(tmpdir(), "idd-hook-"))
+  git(dir, ["init", "-b", "main"])
+  git(dir, ["config", "user.email", "test@example.com"])
+  git(dir, ["config", "user.name", "Test"])
+  mkdirSync(join(dir, ".github/idd"), { recursive: true })
+  if (configObj !== null) {
+    writeFileSync(join(dir, ".github/idd/config.json"), JSON.stringify(configObj, null, 2))
+  }
+  cpSync(HOOKS_DIR, join(dir, ".githooks"), { recursive: true })
+  writeFileSync(join(dir, "README.md"), "placeholder\n")
+  git(dir, ["add", "-A"])
+  git(dir, ["commit", "--no-verify", "-m", "init"])
+  return dir
+}
+
+test("hook allows commit and push from the primary worktree on main", () => {
+  const repo = setupRepo({ worktreeGuard: { enabled: true } })
+  try {
+    assert.equal(runHook(repo, "pre-commit"), 0)
+    assert.equal(runHook(repo, "pre-push"), 0)
+  } finally {
+    rmSync(repo, { recursive: true, force: true })
+  }
+})
+
+test("hook blocks commit and push from the primary worktree on issue/* when enabled", () => {
+  const repo = setupRepo({ worktreeGuard: { enabled: true } })
+  try {
+    git(repo, ["checkout", "-q", "-b", "issue/123-example"])
+    assert.equal(runHook(repo, "pre-commit"), 1)
+    assert.equal(runHook(repo, "pre-push"), 1)
+  } finally {
+    rmSync(repo, { recursive: true, force: true })
+  }
+})
+
+test("hook blocks roadmap-audit/* branches in the primary worktree", () => {
+  const repo = setupRepo({ worktreeGuard: { enabled: true } })
+  try {
+    git(repo, ["checkout", "-q", "-b", "roadmap-audit/9-example"])
+    assert.equal(runHook(repo, "pre-commit"), 1)
+  } finally {
+    rmSync(repo, { recursive: true, force: true })
+  }
+})
+
+test("hook is a no-op on issue/* when the guard is disabled", () => {
+  const repo = setupRepo({ worktreeGuard: { enabled: false } })
+  try {
+    git(repo, ["checkout", "-q", "-b", "issue/123-example"])
+    assert.equal(runHook(repo, "pre-commit"), 0)
+  } finally {
+    rmSync(repo, { recursive: true, force: true })
+  }
+})
+
+test("hook is a no-op on issue/* when worktreeGuard is absent (default)", () => {
+  const repo = setupRepo({ markerPrefix: "idd-skill" })
+  try {
+    git(repo, ["checkout", "-q", "-b", "issue/123-example"])
+    assert.equal(runHook(repo, "pre-commit"), 0)
+  } finally {
+    rmSync(repo, { recursive: true, force: true })
+  }
+})
+
+test("hook allows issue/* commits from a sibling worktree", () => {
+  const repo = setupRepo({ worktreeGuard: { enabled: true } })
+  const sibling = `${repo}-sibling`
+  try {
+    git(repo, ["worktree", "add", "-q", sibling, "-b", "issue/123-example"])
+    assert.equal(runHook(repo, "pre-commit", sibling), 0)
+  } finally {
+    try {
+      git(repo, ["worktree", "remove", "--force", sibling])
+    } catch {
+      // best-effort cleanup
+    }
+    rmSync(repo, { recursive: true, force: true })
+    rmSync(sibling, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

Ship the opt-in, portable git hook that enforces the B1
disposable-worktree rule **locally** — the practical enforcement
surface, since CI cannot detect a primary-worktree violation (it leaves
no trace in pushed history).

Closes #795

## What changed

- `.githooks/` (root) + `idd-template/.githooks/` (distributed): a
  shared `_idd-worktree-guard.sh` plus `pre-commit` and `pre-push`
  hooks, **pure POSIX sh** (no node/jq/python). They refuse a commit or
  push from the **primary** worktree while HEAD is on `issue/*` or
  `roadmap-audit/*`.
- Opt-in: a no-op unless `worktreeGuard.enabled` is `true` in
  `.github/idd/config.json` (the flag added in #790). Bypass a single
  intentional action with `--no-verify`.
- `audit/sync-manifest.json`: added `.githooks/*` to the template file
  list so adopters fetch the hooks; `idd-template/ONBOARDING.md`
  regenerated.
- `idd-template/ONBOARDING.md`: documents the one-time
  `git config core.hooksPath .githooks` setup and the `--no-verify`
  escape (and notes CI cannot catch this class of violation).
- `tests/worktree-guard-hook.test.mjs`: integration tests covering
  block on `issue/*` & `roadmap-audit/*`, allow on `main`, no-op when
  the guard is off/absent, and allow from a sibling worktree.

## Verification

- `node --test tests/*.mjs` — 812 pass / 0 fail (6 new).
- `audit-docs`, `dprint`, workshop, `cspell`, `markdownlint` — clean.
- `shellcheck -s sh` on the hooks — clean (only SC1091 info for the
  sourced helper).

## Notes

`core.hooksPath` is local and not committed, so enabling the guard is a
one-time per-clone step. The hooks detect the primary worktree as the
first entry of `git worktree list`; sibling worktrees (where
implementation work belongs) are always allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
