### PR TITLE
feat(idd-doctor): detect a stale import missing the worktree guard

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -49,6 +49,7 @@ export function runDoctor({
   checkTemplateVersionSignal(root, report)
   const worktreeGuardEnforced = strict === true || readWorktreeGuardEnabled(root)
   checkPrimaryWorktreeHead(root, report, { enforce: worktreeGuardEnforced })
+  checkWorktreeHardeningPresence(root, report)
   checkPostMergeCleanupBacklog(
     root,
     {
@@ -609,6 +610,63 @@ export function readWorktreeGuardEnabled(root) {
   } catch {
     return false
   }
+}
+
+/**
+ * Decide which worktree-hardening signals are missing from the consuming
+ * repository's imported files. Pure (no I/O): each argument is the file's
+ * text, or `null`/`undefined` when the file is absent (absent files are
+ * skipped, not reported, so this never double-reports a missing required
+ * file). Returns a list of human-readable missing-signal labels.
+ *
+ * @param {{ work?: string|null, core?: string|null, doctor?: string|null }} files
+ * @returns {string[]}
+ */
+export function findMissingWorktreeHardening({ work, core, doctor } = {}) {
+  const missing = []
+  if (typeof work === "string") {
+    if (!/^###\s+Anti-patterns\b/m.test(work)) {
+      missing.push("idd-work B1 Anti-patterns section")
+    }
+    if (!/^###\s+B1 self-check\b/m.test(work)) {
+      missing.push("idd-work B1 self-check section")
+    }
+  }
+  if (typeof core === "string") {
+    if (!/cwd-vs-claim/.test(core)) {
+      missing.push("overview-core cwd-vs-claim gate")
+    } else if (!/local commit/.test(core)) {
+      missing.push("overview-core cwd-vs-claim local-commit coverage")
+    }
+  }
+  // Only meaningful when idd-doctor is vendored into the repo at all.
+  if (typeof doctor === "string" && !/checkPrimaryWorktreeHead/.test(doctor)) {
+    missing.push("idd-doctor checkPrimaryWorktreeHead detector")
+  }
+  return missing
+}
+
+function checkWorktreeHardeningPresence(root, report) {
+  const read = (relativePath) => {
+    try {
+      return readFileSync(join(root, relativePath), "utf8")
+    } catch {
+      return null
+    }
+  }
+  const missing = findMissingWorktreeHardening({
+    work: read(".github/instructions/idd-work.instructions.md"),
+    core: read(".github/instructions/idd-overview-core.instructions.md"),
+    doctor: read("scripts/idd-doctor.mjs"),
+  })
+  if (missing.length === 0) {
+    return
+  }
+  report.warnings.push(
+    `stale import — missing worktree-hardening: ${missing.join("; ")}. `
+      + "Re-sync the IDD template to adopt the B1 worktree guard; see B1 in "
+      + ".github/instructions/idd-work.instructions.md.",
+  )
 }
 
 function checkPrimaryWorktreeHead(root, report, options = {}) {

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -635,7 +635,12 @@ export function findMissingWorktreeHardening({ work, core, doctor } = {}) {
   if (typeof core === "string") {
     if (!/cwd-vs-claim/.test(core)) {
       missing.push("overview-core cwd-vs-claim gate")
-    } else if (!/local commit/.test(core)) {
+    } else if (!/\(local commit,/.test(core) && !/before any local commit\b/.test(core)) {
+      // Scope the local-commit signal to the gate's own mutation
+      // enumeration (the opening "(local commit, ..." list and the
+      // closing "before any local commit, ..." sentence) so an unrelated
+      // "local commit" mention elsewhere in the file cannot mask a gate
+      // that still omits commit coverage.
       missing.push("overview-core cwd-vs-claim local-commit coverage")
     }
   }

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -16,6 +16,7 @@ import {
   evaluateAutopilotSuitabilityConsistency,
   extractMarkerPrefixes,
   findMissingWorkshopReferences,
+  findMissingWorktreeHardening,
   findPlaceholders,
   isGithubBackLinkHost,
   parsePrimaryWorktreePath,
@@ -251,6 +252,64 @@ test("readWorktreeGuardEnabled returns false when config is missing or invalid",
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
+})
+
+const HARDENED_WORK = "## B1\n\n### Anti-patterns\n\ntext\n\n### B1 self-check\n\ntext\n"
+const HARDENED_CORE = "The cwd-vs-claim check runs before any local commit, push, or merge.\n"
+const HARDENED_DOCTOR = "function checkPrimaryWorktreeHead(root, report) {}\n"
+
+test("findMissingWorktreeHardening reports nothing when all signals are present", () => {
+  assert.deepEqual(
+    findMissingWorktreeHardening({
+      work: HARDENED_WORK,
+      core: HARDENED_CORE,
+      doctor: HARDENED_DOCTOR,
+    }),
+    [],
+  )
+})
+
+test("findMissingWorktreeHardening flags a stale instruction set missing the B1 sections", () => {
+  const missing = findMissingWorktreeHardening({
+    work: "## B1\n\nno guardrails here\n",
+    core: HARDENED_CORE,
+    doctor: HARDENED_DOCTOR,
+  })
+  assert.ok(missing.some((m) => /Anti-patterns/.test(m)))
+  assert.ok(missing.some((m) => /B1 self-check/.test(m)))
+})
+
+test("findMissingWorktreeHardening flags cwd-vs-claim present but lacking local-commit coverage", () => {
+  const missing = findMissingWorktreeHardening({
+    work: HARDENED_WORK,
+    core: "The cwd-vs-claim check runs before any push or merge.\n",
+    doctor: HARDENED_DOCTOR,
+  })
+  assert.deepEqual(missing, ["overview-core cwd-vs-claim local-commit coverage"])
+})
+
+test("findMissingWorktreeHardening flags a missing cwd-vs-claim gate", () => {
+  const missing = findMissingWorktreeHardening({
+    work: HARDENED_WORK,
+    core: "no gate at all\n",
+    doctor: HARDENED_DOCTOR,
+  })
+  assert.deepEqual(missing, ["overview-core cwd-vs-claim gate"])
+})
+
+test("findMissingWorktreeHardening flags a vendored idd-doctor without the detector", () => {
+  const missing = findMissingWorktreeHardening({
+    work: HARDENED_WORK,
+    core: HARDENED_CORE,
+    doctor: "function somethingElse() {}\n",
+  })
+  assert.deepEqual(missing, ["idd-doctor checkPrimaryWorktreeHead detector"])
+})
+
+test("findMissingWorktreeHardening skips absent files instead of reporting them", () => {
+  // null/undefined (file not present) must not be treated as a stale signal.
+  assert.deepEqual(findMissingWorktreeHardening({ work: null, core: null, doctor: null }), [])
+  assert.deepEqual(findMissingWorktreeHardening({}), [])
 })
 
 test("computeWindowStartIso subtracts the given number of days from now", () => {

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -288,6 +288,27 @@ test("findMissingWorktreeHardening flags cwd-vs-claim present but lacking local-
   assert.deepEqual(missing, ["overview-core cwd-vs-claim local-commit coverage"])
 })
 
+test("findMissingWorktreeHardening is not fooled by an unrelated 'local commit' mention", () => {
+  const missing = findMissingWorktreeHardening({
+    work: HARDENED_WORK,
+    // "local commit" appears, but not in the gate's mutation enumeration.
+    core: "A local commit is just a commit. The cwd-vs-claim check runs before any push or merge.\n",
+    doctor: HARDENED_DOCTOR,
+  })
+  assert.deepEqual(missing, ["overview-core cwd-vs-claim local-commit coverage"])
+})
+
+test("findMissingWorktreeHardening accepts the opening '(local commit,' enumeration", () => {
+  assert.deepEqual(
+    findMissingWorktreeHardening({
+      work: HARDENED_WORK,
+      core: "The cwd-vs-claim gate covers (local commit, claim heartbeat, push, merge).\n",
+      doctor: HARDENED_DOCTOR,
+    }),
+    [],
+  )
+})
+
 test("findMissingWorktreeHardening flags a missing cwd-vs-claim gate", () => {
   const missing = findMissingWorktreeHardening({
     work: HARDENED_WORK,


### PR DESCRIPTION
## Summary

Because `iddVersion` does not move per hardening change, adopters cannot
detect a stale import by version. Add a content-based `idd-doctor` check
that warns when the worktree-hardening signals are missing.

Closes #792

## What changed

- `scripts/idd-doctor.mjs`: new `checkWorktreeHardeningPresence` (advisory
  warning) backed by the pure, exported `findMissingWorktreeHardening`.
  It checks the B1 Anti-patterns + B1 self-check sections (idd-work), the
  cwd-vs-claim gate and its local-commit coverage (idd-overview-core), and
  the `checkPrimaryWorktreeHead` detector when idd-doctor is vendored.
  Absent files are skipped (never double-reported); the check only warns.
- `tests/idd-doctor.test.mjs`: present / partially-missing / fully-missing
  / absent-file cases.

## Verification

- `node --test tests/idd-doctor.test.mjs` — 84 pass (6 new).
- `node scripts/idd-doctor.mjs` on this repo emits **no** stale-import
  warning (all signals present).
- Full `lint:minimum` — 819 tests pass; audit-docs/dprint/cspell/markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostic tool now includes a worktree-hardening presence check to identify missing configuration signals.

* **Tests**
  * Added comprehensive test coverage for worktree-hardening detection, validating behavior across scenarios with missing sections, gates, detectors, and absent file contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->