### PR TITLE
chore(version): bump iddVersion to 0.2.0 and document the bump rule

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.1.0",
+  "iddVersion": "0.2.0",
   "markerPrefix": "idd-skill",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -51,6 +51,25 @@ Use the always-loaded overview and the policy constants page as the
 source of truth for these rules. Configuration can tune defaults, but it
 cannot disable the gates above.
 
+## Template Version and Staleness
+
+`iddVersion` in `.github/idd/config.json` records which release of the
+distributed IDD workflow a repository imported.
+
+- **Source-template maintainers** bump `iddVersion` whenever a change to
+  the distributed instruction set, schema, or safety surface — for
+  example a new guardrail, hardening section, or default change — would
+  matter to an adopter who re-syncs. Follow semantic-versioning intent: a
+  new opt-in capability or hardening is a minor bump; a breaking change
+  to existing defaults is a major bump. Keep the template config and this
+  repository's own `.github/idd/config.json` on the same value.
+- **Adopters** can compare their `iddVersion` against the source release
+  to see whether a re-sync is worthwhile. Because the value only moves
+  when maintainers bump it, it is a coarse signal — so `idd-doctor` also
+  runs a content-based stale-import check that warns when the imported
+  files lack the current worktree-hardening sections, catching a missed
+  bump.
+
 ## Helper Runtime Profile
 
 Keep helper support optional. During onboarding, start from

--- a/idd-template/.github/idd/config.json
+++ b/idd-template/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.1.0",
+  "iddVersion": "0.2.0",
   "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -51,6 +51,25 @@ Use the always-loaded overview and the policy constants page as the
 source of truth for these rules. Configuration can tune defaults, but it
 cannot disable the gates above.
 
+## Template Version and Staleness
+
+`iddVersion` in `.github/idd/config.json` records which release of the
+distributed IDD workflow a repository imported.
+
+- **Source-template maintainers** bump `iddVersion` whenever a change to
+  the distributed instruction set, schema, or safety surface — for
+  example a new guardrail, hardening section, or default change — would
+  matter to an adopter who re-syncs. Follow semantic-versioning intent: a
+  new opt-in capability or hardening is a minor bump; a breaking change
+  to existing defaults is a major bump. Keep the template config and this
+  repository's own `.github/idd/config.json` on the same value.
+- **Adopters** can compare their `iddVersion` against the source release
+  to see whether a re-sync is worthwhile. Because the value only moves
+  when maintainers bump it, it is a coarse signal — so `idd-doctor` also
+  runs a content-based stale-import check that warns when the imported
+  files lack the current worktree-hardening sections, catching a missed
+  bump.
+
 ## Helper Runtime Profile
 
 Keep helper support optional. During onboarding, start from


### PR DESCRIPTION
## Summary

Mark the worktree-guard release and give adopters a version signal for
staleness (complementing the #792 content-based detector).

Closes #793

## What changed

- `iddVersion` bumped `0.1.0` → `0.2.0` in `.github/idd/config.json` and
  `idd-template/.github/idd/config.json` (a new opt-in capability + B1
  hardening = minor bump).
- `docs/customization.md` (+ template source): new "Template Version and
  Staleness" section documenting when maintainers bump `iddVersion` and
  how it pairs with `idd-doctor`'s content-based stale-import check.

## Verification

- `validate-schemas`, `audit-docs`, `dprint`, `markdownlint`, `cspell` — clean.
- 821 tests pass (no test hardcodes the live config `iddVersion`).

## Sequencing

Lands last in the worktree-guard roadmap (#797), after the enforcement
work (#790, #794, #795) and the gate fix (#791), so the bump reflects
the fully shipped guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
