### PR TITLE
fix(idd-doctor): eliminate false-positive errors so it exits clean

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -205,6 +205,23 @@ export function findPlaceholders(text) {
   return [...text.matchAll(/\{\{\s*[A-Za-z0-9_-]+\s*\}\}/g)].map((match) => match[0])
 }
 
+/**
+ * Find unresolved `{{…}}` placeholders in one file's text. Markdown docs
+ * under `docs/` legitimately *document* placeholder names inside code
+ * spans, so those are stripped first to avoid false positives. Every
+ * other file (including `.github/instructions/*.md`, whose marker
+ * examples may contain unsubstituted placeholders inside inline code or
+ * HTML comments) is scanned raw, so a real leftover is still detected.
+ *
+ * @param {string} file relative file path
+ * @param {string} text file contents
+ * @returns {string[]}
+ */
+export function scanFileForPlaceholders(file, text) {
+  const documentsPlaceholders = file.startsWith("docs/") && file.endsWith(".md")
+  return findPlaceholders(documentsPlaceholders ? stripMarkdownNonText(text) : text)
+}
+
 export function extractMarkerPrefixes(text) {
   // The negative lookahead keeps each match to a complete marker token
   // (e.g. `idd-skill-blocked-by:` or `idd-skill-roadmap-id`), so a
@@ -303,11 +320,7 @@ function checkPlaceholders(root, files, report) {
     } catch {
       continue
     }
-    // Strip code spans/blocks and HTML comments first: docs legitimately
-    // document the `{{…}}` placeholder names inside code spans, and those
-    // are not unresolved substitutions. A genuine leftover placeholder in
-    // prose (or in a non-markdown file) is still detected.
-    const placeholders = findPlaceholders(stripMarkdownNonText(text))
+    const placeholders = scanFileForPlaceholders(file, text)
     if (placeholders.length === 0) {
       continue
     }

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -206,10 +206,15 @@ export function findPlaceholders(text) {
 }
 
 export function extractMarkerPrefixes(text) {
-  const roadmap = [...text.matchAll(/([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)-roadmap-id/g)].map(
+  // The negative lookahead keeps each match to a complete marker token
+  // (e.g. `idd-skill-blocked-by:` or `idd-skill-roadmap-id`), so a
+  // prose/heading slug such as
+  // `diagnostic-all-candidates-blocked-by-an-open-roadmap` is not
+  // mis-read as a marker prefix.
+  const roadmap = [...text.matchAll(/([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)-roadmap-id(?![A-Za-z0-9-])/g)].map(
     (match) => match[1],
   )
-  const blockedBy = [...text.matchAll(/([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)-blocked-by/g)].map(
+  const blockedBy = [...text.matchAll(/([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)-blocked-by(?![A-Za-z0-9-])/g)].map(
     (match) => match[1],
   )
   return {
@@ -298,7 +303,11 @@ function checkPlaceholders(root, files, report) {
     } catch {
       continue
     }
-    const placeholders = findPlaceholders(text)
+    // Strip code spans/blocks and HTML comments first: docs legitimately
+    // document the `{{…}}` placeholder names inside code spans, and those
+    // are not unresolved substitutions. A genuine leftover placeholder in
+    // prose (or in a non-markdown file) is still detected.
+    const placeholders = findPlaceholders(stripMarkdownNonText(text))
     if (placeholders.length === 0) {
       continue
     }
@@ -345,17 +354,25 @@ function checkMarkerPrefixes(root, report) {
     return null
   }
 
-  if (!sameMembers(discoverPrefixes.roadmap, discoverPrefixes.blockedBy)) {
+  // Compare only sets that are actually populated: a file that does not
+  // reference roadmap-id/blocked-by markers at all (e.g. overview-core,
+  // which defines claim markers, not roadmap markers) imposes no
+  // constraint and must not trip a spurious "differ" error. Real
+  // mismatches between two populated sets still error.
+  const consistent = (left, right) =>
+    left.length === 0 || right.length === 0 || sameMembers(left, right)
+
+  if (!consistent(discoverPrefixes.roadmap, discoverPrefixes.blockedBy)) {
     report.errors.push("discover marker prefixes differ between roadmap-id and blocked-by")
     return null
   }
-  if (!sameMembers(overviewPrefixes.roadmap, overviewPrefixes.blockedBy)) {
+  if (!consistent(overviewPrefixes.roadmap, overviewPrefixes.blockedBy)) {
     report.errors.push("overview marker prefixes differ between roadmap-id and blocked-by")
     return null
   }
   if (
-    !sameMembers(discoverPrefixes.roadmap, overviewPrefixes.roadmap) ||
-    !sameMembers(discoverPrefixes.blockedBy, overviewPrefixes.blockedBy)
+    !consistent(discoverPrefixes.roadmap, overviewPrefixes.roadmap) ||
+    !consistent(discoverPrefixes.blockedBy, overviewPrefixes.blockedBy)
   ) {
     report.errors.push("marker prefixes differ between discover and overview instructions")
     return null

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -347,52 +347,75 @@ function checkMarkerPrefixes(root, report) {
     return null
   }
 
-  const discoverPrefixes = extractMarkerPrefixes(discover)
-  const overviewPrefixes = extractMarkerPrefixes(overview)
+  const result = evaluateMarkerPrefixConsistency(
+    extractMarkerPrefixes(discover),
+    extractMarkerPrefixes(overview),
+  )
+  if (result.skip) {
+    report.warnings.push("marker-prefix checks skipped because no resolved marker prefixes were found")
+    return null
+  }
+  if (result.error) {
+    report.errors.push(result.error)
+    return null
+  }
+  report.passes.push(`marker prefix is valid and consistent (${result.prefix})`)
+  return result.prefix
+}
+
+/**
+ * Decide whether the marker prefixes extracted from the discover and
+ * overview instruction files are valid and consistent. Pure (no I/O), so
+ * it can be unit-tested. Empty sets impose no constraint (a file may not
+ * reference roadmap-id/blocked-by markers at all — e.g. overview-core,
+ * which defines claim markers, not roadmap markers), but an explicit
+ * all-prefixes guard still catches a mismatch hidden across different
+ * marker types (e.g. discover uses `a-roadmap-id` while overview uses
+ * `b-blocked-by`).
+ *
+ * @param {{ roadmap: string[], blockedBy: string[] }} discoverPrefixes
+ * @param {{ roadmap: string[], blockedBy: string[] }} overviewPrefixes
+ * @returns {{ skip: true } | { error: string } | { prefix: string }}
+ */
+export function evaluateMarkerPrefixConsistency(discoverPrefixes, overviewPrefixes) {
   const allPrefixes = unique([
     ...discoverPrefixes.roadmap,
     ...discoverPrefixes.blockedBy,
     ...overviewPrefixes.roadmap,
     ...overviewPrefixes.blockedBy,
   ])
-
   if (allPrefixes.length === 0) {
-    report.warnings.push("marker-prefix checks skipped because no resolved marker prefixes were found")
-    return null
+    return { skip: true }
   }
-
   const invalid = allPrefixes.filter((prefix) => !/^[a-z][a-z0-9-]{1,31}$/.test(prefix))
   if (invalid.length > 0) {
-    report.errors.push(`invalid marker prefixes: ${invalid.join(", ")}`)
-    return null
+    return { error: `invalid marker prefixes: ${invalid.join(", ")}` }
   }
-
-  // Compare only sets that are actually populated: a file that does not
-  // reference roadmap-id/blocked-by markers at all (e.g. overview-core,
-  // which defines claim markers, not roadmap markers) imposes no
-  // constraint and must not trip a spurious "differ" error. Real
-  // mismatches between two populated sets still error.
+  // Compare only populated sets so a file that does not reference these
+  // markers at all imposes no constraint.
   const consistent = (left, right) =>
     left.length === 0 || right.length === 0 || sameMembers(left, right)
-
   if (!consistent(discoverPrefixes.roadmap, discoverPrefixes.blockedBy)) {
-    report.errors.push("discover marker prefixes differ between roadmap-id and blocked-by")
-    return null
+    return { error: "discover marker prefixes differ between roadmap-id and blocked-by" }
   }
   if (!consistent(overviewPrefixes.roadmap, overviewPrefixes.blockedBy)) {
-    report.errors.push("overview marker prefixes differ between roadmap-id and blocked-by")
-    return null
+    return { error: "overview marker prefixes differ between roadmap-id and blocked-by" }
   }
   if (
-    !consistent(discoverPrefixes.roadmap, overviewPrefixes.roadmap) ||
-    !consistent(discoverPrefixes.blockedBy, overviewPrefixes.blockedBy)
+    !consistent(discoverPrefixes.roadmap, overviewPrefixes.roadmap)
+    || !consistent(discoverPrefixes.blockedBy, overviewPrefixes.blockedBy)
   ) {
-    report.errors.push("marker prefixes differ between discover and overview instructions")
-    return null
+    return { error: "marker prefixes differ between discover and overview instructions" }
   }
-
-  report.passes.push(`marker prefix is valid and consistent (${allPrefixes[0]})`)
-  return allPrefixes[0]
+  // Catch a mismatch the empty-tolerant pairwise checks miss: two files
+  // referencing different marker types with different prefixes.
+  if (allPrefixes.length > 1) {
+    return {
+      error:
+        `marker prefixes are inconsistent across discover/overview instructions: ${allPrefixes.join(", ")}`,
+    }
+  }
+  return { prefix: allPrefixes[0] }
 }
 
 function checkProjectCommands(root, report) {

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -14,6 +14,7 @@ import {
   containsWorkshopReference,
   decodeGithubReadmeBase64,
   evaluateAutopilotSuitabilityConsistency,
+  evaluateMarkerPrefixConsistency,
   extractMarkerPrefixes,
   findMissingWorkshopReferences,
   findMissingWorktreeHardening,
@@ -135,6 +136,40 @@ test("extractMarkerPrefixes returns roadmap and blocked-by prefixes", () => {
 
   assert.deepEqual(markers.roadmap, ["idd-skill", "my-team"])
   assert.deepEqual(markers.blockedBy, ["idd-skill", "MyTeam"])
+})
+
+test("evaluateMarkerPrefixConsistency accepts one consistent prefix with an empty overview set", () => {
+  const result = evaluateMarkerPrefixConsistency(
+    { roadmap: ["idd-skill"], blockedBy: ["idd-skill"] },
+    { roadmap: [], blockedBy: [] },
+  )
+  assert.deepEqual(result, { prefix: "idd-skill" })
+})
+
+test("evaluateMarkerPrefixConsistency skips when no prefixes are present", () => {
+  assert.deepEqual(
+    evaluateMarkerPrefixConsistency({ roadmap: [], blockedBy: [] }, { roadmap: [], blockedBy: [] }),
+    { skip: true },
+  )
+})
+
+test("evaluateMarkerPrefixConsistency catches a cross-type prefix mismatch hidden by empty sets", () => {
+  // discover only has a roadmap-id prefix, overview only a blocked-by
+  // prefix, and they differ — the pairwise empty-tolerant checks all
+  // pass, so the all-prefixes guard must catch it.
+  const result = evaluateMarkerPrefixConsistency(
+    { roadmap: ["a"], blockedBy: [] },
+    { roadmap: [], blockedBy: ["b"] },
+  )
+  assert.ok(result.error && /inconsistent/.test(result.error), result.error)
+})
+
+test("evaluateMarkerPrefixConsistency reports a within-file roadmap/blocked-by mismatch", () => {
+  const result = evaluateMarkerPrefixConsistency(
+    { roadmap: ["a"], blockedBy: ["a", "b"] },
+    { roadmap: [], blockedBy: [] },
+  )
+  assert.equal(result.error, "discover marker prefixes differ between roadmap-id and blocked-by")
 })
 
 test("extractMarkerPrefixes ignores prose/heading slugs and status labels", () => {

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -22,6 +22,7 @@ import {
   parsePrimaryWorktreePath,
   parseProjectCommandRows,
   readWorktreeGuardEnabled,
+  scanFileForPlaceholders,
   stripMarkdownNonText,
 } from "../scripts/idd-doctor.mjs"
 
@@ -147,21 +148,35 @@ test("extractMarkerPrefixes ignores prose/heading slugs and status labels", () =
   assert.deepEqual(markers.blockedBy, ["idd-skill"])
 })
 
-test("findPlaceholders + stripMarkdownNonText ignores placeholders documented in code", () => {
-  // Documented in an inline code span — not an unresolved substitution.
+test("scanFileForPlaceholders ignores placeholder names documented in docs code spans", () => {
+  // A docs/*.md file documents the placeholder name in an inline code
+  // span — not an unresolved substitution.
   assert.deepEqual(
-    findPlaceholders(stripMarkdownNonText("Set `{{REPO_NAME}}` during onboarding.")),
+    scanFileForPlaceholders("docs/customization.md", "Set `{{REPO_NAME}}` during onboarding."),
     [],
   )
-  // Documented in a fenced code block — likewise ignored.
+  // A genuine leftover in docs prose is still detected.
   assert.deepEqual(
-    findPlaceholders(stripMarkdownNonText("```\n{{PROJECT_MARKER_PREFIX}}\n```\n")),
-    [],
-  )
-  // A genuine leftover in prose is still detected.
-  assert.deepEqual(
-    findPlaceholders(stripMarkdownNonText("Welcome to {{REPO_NAME}} (oops, unsubstituted).")),
+    scanFileForPlaceholders("docs/customization.md", "Welcome to {{REPO_NAME}} (oops)."),
     ["{{REPO_NAME}}"],
+  )
+})
+
+test("scanFileForPlaceholders scans non-docs files raw so code-span leftovers are caught", () => {
+  // An instruction file's marker example with an UNSUBSTITUTED
+  // placeholder inside inline code / an HTML comment must still be
+  // flagged (stripping is not applied outside docs/).
+  assert.deepEqual(
+    scanFileForPlaceholders(
+      ".github/instructions/idd-discover.instructions.md",
+      "example: `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: x -->`",
+    ),
+    ["{{PROJECT_MARKER_PREFIX}}"],
+  )
+  // A non-markdown file is also scanned raw.
+  assert.deepEqual(
+    scanFileForPlaceholders(".github/idd/config.json", "{ \"markerPrefix\": \"{{PROJECT_MARKER_PREFIX}}\" }"),
+    ["{{PROJECT_MARKER_PREFIX}}"],
   )
 })
 

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -136,6 +136,35 @@ test("extractMarkerPrefixes returns roadmap and blocked-by prefixes", () => {
   assert.deepEqual(markers.blockedBy, ["idd-skill", "MyTeam"])
 })
 
+test("extractMarkerPrefixes ignores prose/heading slugs and status labels", () => {
+  const markers = extractMarkerPrefixes(
+    "## A3.5 — diagnostic-all-candidates-blocked-by-an-open-roadmap\n"
+      + "see `status:blocked-by-human`, idd-skill-roadmap-id and idd-skill-blocked-by here\n",
+  )
+  // The heading slug (`...-blocked-by-an-...`) and the `status:` label
+  // must not contribute a bogus prefix; only the real markers count.
+  assert.deepEqual(markers.roadmap, ["idd-skill"])
+  assert.deepEqual(markers.blockedBy, ["idd-skill"])
+})
+
+test("findPlaceholders + stripMarkdownNonText ignores placeholders documented in code", () => {
+  // Documented in an inline code span — not an unresolved substitution.
+  assert.deepEqual(
+    findPlaceholders(stripMarkdownNonText("Set `{{REPO_NAME}}` during onboarding.")),
+    [],
+  )
+  // Documented in a fenced code block — likewise ignored.
+  assert.deepEqual(
+    findPlaceholders(stripMarkdownNonText("```\n{{PROJECT_MARKER_PREFIX}}\n```\n")),
+    [],
+  )
+  // A genuine leftover in prose is still detected.
+  assert.deepEqual(
+    findPlaceholders(stripMarkdownNonText("Welcome to {{REPO_NAME}} (oops, unsubstituted).")),
+    ["{{REPO_NAME}}"],
+  )
+})
+
 test("parsePrimaryWorktreePath returns the first worktree entry", () => {
   const porcelain = [
     "worktree /repo/idd-skill",

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -156,17 +156,18 @@ test("evaluateMarkerPrefixConsistency skips when no prefixes are present", () =>
 test("evaluateMarkerPrefixConsistency catches a cross-type prefix mismatch hidden by empty sets", () => {
   // discover only has a roadmap-id prefix, overview only a blocked-by
   // prefix, and they differ — the pairwise empty-tolerant checks all
-  // pass, so the all-prefixes guard must catch it.
+  // pass, so the all-prefixes guard must catch it. (Prefixes must be
+  // valid multi-character tokens or the format guard fires first.)
   const result = evaluateMarkerPrefixConsistency(
-    { roadmap: ["a"], blockedBy: [] },
-    { roadmap: [], blockedBy: ["b"] },
+    { roadmap: ["alpha"], blockedBy: [] },
+    { roadmap: [], blockedBy: ["beta"] },
   )
   assert.ok(result.error && /inconsistent/.test(result.error), result.error)
 })
 
 test("evaluateMarkerPrefixConsistency reports a within-file roadmap/blocked-by mismatch", () => {
   const result = evaluateMarkerPrefixConsistency(
-    { roadmap: ["a"], blockedBy: ["a", "b"] },
+    { roadmap: ["alpha"], blockedBy: ["alpha", "beta"] },
     { roadmap: [], blockedBy: [] },
   )
   assert.equal(result.error, "discover marker prefixes differ between roadmap-id and blocked-by")


### PR DESCRIPTION
## Summary

`idd-doctor` exited 1 on a healthy `main` from false positives that the
#794 TDZ fix unmasked. This makes it exit 0 on a healthy repo,
unblocking the re-scoped #796 CI health gate — without weakening real
detection.

Closes #804

## What changed (3 false positives)

1. **Placeholder check** flagged docs that **document** the `{{…}}`
   placeholder names in code spans. Now strips code/HTML-comment regions
   (`stripMarkdownNonText`) before scanning; a real leftover in prose or
   a non-markdown file is still caught.
2. **Marker-prefix regex** mis-read prose/heading slugs like
   `diagnostic-all-candidates-blocked-by-an-open-roadmap` as a prefix. A
   negative lookahead now keeps matches to complete marker tokens.
3. **discover-vs-overview comparison** errored because `overview-core`
   defines claim markers, not roadmap markers (empty set). Now compares
   only populated sets; real mismatches still error.

## Verification

- `node scripts/idd-doctor.mjs` exits 0 with zero errors on `main`.
- `node --test tests/idd-doctor.test.mjs` — 88 pass (2 new covering the
  documented-placeholder and prose-`blocked-by` false positives).
- Full `lint:minimum` — 823 tests pass; audit-docs/dprint/cspell/markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false-positive marker-prefix detections by tightening matching rules.
  * Improved placeholder detection to ignore occurrences inside inline code and other non-text Markdown regions while still scanning non-markdown files raw.
  * Adjusted consistency checks so empty/absent metadata sides are not treated as mismatches.

* **Refactor**
  * Simplified and clarified marker-prefix validation logic for more accurate reporting.

* **Tests**
  * Added unit tests covering marker-prefix edge cases and placeholder scanning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->