### PR TITLE
feat(idd-doctor): honor worktreeGuard.branchPatterns in detection

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -188,17 +188,39 @@ export function parsePrimaryWorktreePath(porcelain) {
   return null
 }
 
-export function classifyPrimaryHead(branch) {
+export const DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS = ["issue/*", "roadmap-audit/*"]
+
+/**
+ * Convert a shell-style branch glob (only `*` and `?` are special) to an
+ * anchored RegExp, matching the core.hooksPath hook's `case` semantics.
+ */
+function branchGlobToRegExp(pattern) {
+  let out = "^"
+  for (const ch of pattern) {
+    if (ch === "*") out += ".*"
+    else if (ch === "?") out += "."
+    else out += ch.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+  }
+  return new RegExp(`${out}$`)
+}
+
+export function classifyPrimaryHead(branch, patterns = DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS) {
   if (typeof branch !== "string" || branch.length === 0) {
     return { isB1Violation: false, kind: "unknown" }
   }
+  const matches = patterns.some((pattern) => branchGlobToRegExp(pattern).test(branch))
+  if (!matches) {
+    return { isB1Violation: false, kind: "other" }
+  }
+  // Keep the familiar labels for the default prefixes; any other matched
+  // (custom) pattern is reported as a generic implementation branch.
   if (branch.startsWith("issue/")) {
     return { isB1Violation: true, kind: "issue" }
   }
   if (branch.startsWith("roadmap-audit/")) {
     return { isB1Violation: true, kind: "roadmap-audit" }
   }
-  return { isB1Violation: false, kind: "other" }
+  return { isB1Violation: true, kind: "implementation" }
 }
 
 export function findPlaceholders(text) {
@@ -666,6 +688,25 @@ export function readWorktreeGuardEnabled(root) {
 }
 
 /**
+ * Read `worktreeGuard.branchPatterns` from the repo config, falling back
+ * to the default implementation-branch globs when the key is absent,
+ * empty, or malformed. Matches the core.hooksPath hook so idd-doctor and
+ * the hook agree on which branches the guard covers.
+ */
+export function readWorktreeGuardBranchPatterns(root) {
+  try {
+    const config = JSON.parse(readFileSync(join(root, ".github/idd/config.json"), "utf8"))
+    const patterns = config?.worktreeGuard?.branchPatterns
+    if (Array.isArray(patterns) && patterns.length > 0 && patterns.every((p) => typeof p === "string")) {
+      return patterns
+    }
+  } catch {
+    // fall through to defaults
+  }
+  return DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS
+}
+
+/**
  * Decide which worktree-hardening signals are missing from the consuming
  * repository's imported files. Pure (no I/O): each argument is the file's
  * text, or `null`/`undefined` when the file is absent (absent files are
@@ -744,7 +785,7 @@ function checkPrimaryWorktreeHead(root, report, options = {}) {
   }
 
   const branch = headResult.stdout.trim()
-  const classification = classifyPrimaryHead(branch)
+  const classification = classifyPrimaryHead(branch, readWorktreeGuardBranchPatterns(root))
   const finding = classifyWorktreeHeadFinding(
     classification,
     branch,
@@ -779,7 +820,9 @@ export function classifyWorktreeHeadFinding(classification, branch, primaryPath,
   }
   const kindLabel = classification.kind === "issue"
     ? "an issue branch"
-    : "a roadmap-audit branch"
+    : classification.kind === "roadmap-audit"
+      ? "a roadmap-audit branch"
+      : "an implementation branch"
   const severity = enforce
     ? "B1 violation: this branch must live in a sibling worktree, not the primary worktree (worktree guard enforced)"
     : "likely a past B1 violation"

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -191,8 +191,10 @@ export function parsePrimaryWorktreePath(porcelain) {
 export const DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS = ["issue/*", "roadmap-audit/*"]
 
 /**
- * Convert a shell-style branch glob (only `*` and `?` are special) to an
- * anchored RegExp, matching the core.hooksPath hook's `case` semantics.
+ * Convert a shell-style branch glob to an anchored RegExp, matching the
+ * core.hooksPath hook's POSIX `case` semantics: `*` (any run), `?` (any
+ * one character), and bracket expressions (`[...]`, `[!...]`/`[^...]`).
+ * A malformed glob yields a never-matching RegExp rather than throwing.
  */
 function branchGlobToRegExp(pattern) {
   let out = "^"

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -196,28 +196,62 @@ export const DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS = ["issue/*", "roadmap-audit
  */
 function branchGlobToRegExp(pattern) {
   let out = "^"
-  for (const ch of pattern) {
-    if (ch === "*") out += ".*"
-    else if (ch === "?") out += "."
-    else out += ch.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+  let i = 0
+  while (i < pattern.length) {
+    const ch = pattern[i]
+    if (ch === "*") {
+      out += ".*"
+      i += 1
+    } else if (ch === "?") {
+      out += "."
+      i += 1
+    } else if (ch === "[") {
+      // POSIX glob bracket expression, matching the hook's `case`
+      // semantics. A `]` immediately after `[`, `[!`, or `[^` is a
+      // literal member rather than the terminator.
+      let j = i + 1
+      if (pattern[j] === "!" || pattern[j] === "^") j += 1
+      if (pattern[j] === "]") j += 1
+      while (j < pattern.length && pattern[j] !== "]") j += 1
+      if (j >= pattern.length) {
+        out += "\\[" // unterminated — treat the `[` as a literal
+        i += 1
+      } else {
+        const body = pattern.slice(i + 1, j)
+        const negated = body[0] === "!" || body[0] === "^"
+        const members = (negated ? body.slice(1) : body)
+          .replace(/\\/g, "\\\\")
+          .replace(/\]/g, "\\]")
+        out += `[${negated ? "^" : ""}${members}]`
+        i = j + 1
+      }
+    } else {
+      out += ch.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+      i += 1
+    }
   }
-  return new RegExp(`${out}$`)
+  try {
+    return new RegExp(`${out}$`)
+  } catch {
+    return /(?!)/ // malformed glob: never matches, never crashes
+  }
 }
 
 export function classifyPrimaryHead(branch, patterns = DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS) {
   if (typeof branch !== "string" || branch.length === 0) {
     return { isB1Violation: false, kind: "unknown" }
   }
-  const matches = patterns.some((pattern) => branchGlobToRegExp(pattern).test(branch))
-  if (!matches) {
+  const matchedPattern = patterns.find((pattern) => branchGlobToRegExp(pattern).test(branch))
+  if (matchedPattern === undefined) {
     return { isB1Violation: false, kind: "other" }
   }
-  // Keep the familiar labels for the default prefixes; any other matched
-  // (custom) pattern is reported as a generic implementation branch.
-  if (branch.startsWith("issue/")) {
+  // Derive the kind from the matched pattern, not the branch name, so a
+  // custom glob (e.g. "*") is reported as a generic implementation
+  // branch even when the branch happens to start with issue/.
+  if (matchedPattern === "issue/*") {
     return { isB1Violation: true, kind: "issue" }
   }
-  if (branch.startsWith("roadmap-audit/")) {
+  if (matchedPattern === "roadmap-audit/*") {
     return { isB1Violation: true, kind: "roadmap-audit" }
   }
   return { isB1Violation: true, kind: "implementation" }
@@ -697,7 +731,11 @@ export function readWorktreeGuardBranchPatterns(root) {
   try {
     const config = JSON.parse(readFileSync(join(root, ".github/idd/config.json"), "utf8"))
     const patterns = config?.worktreeGuard?.branchPatterns
-    if (Array.isArray(patterns) && patterns.length > 0 && patterns.every((p) => typeof p === "string")) {
+    if (
+      Array.isArray(patterns)
+      && patterns.length > 0
+      && patterns.every((p) => typeof p === "string" && p.trim().length > 0)
+    ) {
       return patterns
     }
   } catch {

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -9,6 +9,7 @@ import {
   classifyBacklog,
   classifyPrimaryHead,
   classifyWorktreeHeadFinding,
+  DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
   computeWindowStartIso,
   containsExampleRepoBackLink,
   containsWorkshopReference,
@@ -22,6 +23,7 @@ import {
   isGithubBackLinkHost,
   parsePrimaryWorktreePath,
   parseProjectCommandRows,
+  readWorktreeGuardBranchPatterns,
   readWorktreeGuardEnabled,
   scanFileForPlaceholders,
   stripMarkdownNonText,
@@ -411,6 +413,62 @@ test("findMissingWorktreeHardening skips absent files instead of reporting them"
   // null/undefined (file not present) must not be treated as a stale signal.
   assert.deepEqual(findMissingWorktreeHardening({ work: null, core: null, doctor: null }), [])
   assert.deepEqual(findMissingWorktreeHardening({}), [])
+})
+
+test("classifyPrimaryHead honors custom branchPatterns", () => {
+  // A custom pattern matches → violation, reported as a generic
+  // implementation branch.
+  assert.deepEqual(classifyPrimaryHead("release/1", ["release/*"]), {
+    isB1Violation: true,
+    kind: "implementation",
+  })
+  // The default issue/* is no longer guarded when patterns are overridden.
+  assert.deepEqual(classifyPrimaryHead("issue/9", ["release/*"]), {
+    isB1Violation: false,
+    kind: "other",
+  })
+  // Default prefixes keep their familiar kind labels.
+  assert.deepEqual(classifyPrimaryHead("issue/9", ["issue/*"]), {
+    isB1Violation: true,
+    kind: "issue",
+  })
+})
+
+test("classifyWorktreeHeadFinding labels a custom implementation branch", () => {
+  const finding = classifyWorktreeHeadFinding(
+    { isB1Violation: true, kind: "implementation" },
+    "release/1",
+    "/repo",
+    true,
+  )
+  assert.match(finding.message, /an implementation branch/)
+})
+
+test("readWorktreeGuardBranchPatterns returns config patterns or the default", () => {
+  const dir = mkdtempSync(join(tmpdir(), "idd-bp-"))
+  try {
+    const write = (obj) => {
+      mkdirSync(join(dir, ".github/idd"), { recursive: true })
+      writeFileSync(join(dir, ".github/idd/config.json"), JSON.stringify(obj))
+    }
+    write({ worktreeGuard: { branchPatterns: ["release/*", "wip/*"] } })
+    assert.deepEqual(readWorktreeGuardBranchPatterns(dir), ["release/*", "wip/*"])
+    write({ worktreeGuard: { enabled: true } }) // no branchPatterns → default
+    assert.deepEqual(readWorktreeGuardBranchPatterns(dir), DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS)
+    write({ worktreeGuard: { branchPatterns: [] } }) // empty → default
+    assert.deepEqual(readWorktreeGuardBranchPatterns(dir), DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("readWorktreeGuardBranchPatterns defaults when config is missing", () => {
+  const dir = mkdtempSync(join(tmpdir(), "idd-bp-"))
+  try {
+    assert.deepEqual(readWorktreeGuardBranchPatterns(dir), DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test("computeWindowStartIso subtracts the given number of days from now", () => {

--- a/tests/idd-doctor.test.mjs
+++ b/tests/idd-doctor.test.mjs
@@ -432,6 +432,21 @@ test("classifyPrimaryHead honors custom branchPatterns", () => {
     isB1Violation: true,
     kind: "issue",
   })
+  // kind is derived from the matched pattern, not the branch name: a
+  // catch-all glob reports a generic implementation branch even for an
+  // issue/ branch.
+  assert.deepEqual(classifyPrimaryHead("issue/9", ["*"]), {
+    isB1Violation: true,
+    kind: "implementation",
+  })
+})
+
+test("classifyPrimaryHead supports bracket-expression globs like the hook", () => {
+  assert.equal(classifyPrimaryHead("release/1", ["release/[0-9]*"]).isB1Violation, true)
+  assert.equal(classifyPrimaryHead("release/x", ["release/[0-9]*"]).isB1Violation, false)
+  // Negated bracket expression ([!…]).
+  assert.equal(classifyPrimaryHead("wip/a", ["wip/[!0-9]"]).isB1Violation, true)
+  assert.equal(classifyPrimaryHead("wip/5", ["wip/[!0-9]"]).isB1Violation, false)
 })
 
 test("classifyWorktreeHeadFinding labels a custom implementation branch", () => {
@@ -455,7 +470,11 @@ test("readWorktreeGuardBranchPatterns returns config patterns or the default", (
     assert.deepEqual(readWorktreeGuardBranchPatterns(dir), ["release/*", "wip/*"])
     write({ worktreeGuard: { enabled: true } }) // no branchPatterns → default
     assert.deepEqual(readWorktreeGuardBranchPatterns(dir), DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS)
-    write({ worktreeGuard: { branchPatterns: [] } }) // empty → default
+    write({ worktreeGuard: { branchPatterns: [] } }) // empty array → default
+    assert.deepEqual(readWorktreeGuardBranchPatterns(dir), DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS)
+    write({ worktreeGuard: { branchPatterns: ["", "issue/*"] } }) // empty entry → default
+    assert.deepEqual(readWorktreeGuardBranchPatterns(dir), DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS)
+    write({ worktreeGuard: { branchPatterns: ["   "] } }) // whitespace-only → default
     assert.deepEqual(readWorktreeGuardBranchPatterns(dir), DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS)
   } finally {
     rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

Make `idd-doctor` agree with the #795 `core.hooksPath` hook on which
branches the worktree guard covers, by honoring
`worktreeGuard.branchPatterns` instead of hard-coding `issue/*` +
`roadmap-audit/*`.

Closes #805

## What changed

- `classifyPrimaryHead(branch, patterns)` matches the branch against the
  configured globs (default `issue/*`, `roadmap-audit/*`). A custom
  pattern match is reported as a generic implementation branch.
- `checkPrimaryWorktreeHead` reads `worktreeGuard.branchPatterns` via the
  new `readWorktreeGuardBranchPatterns` (falls back to defaults on
  absent/empty/malformed).
- `classifyWorktreeHeadFinding` labels a custom match "an implementation
  branch".
- Defaults unchanged → no behavior change when `branchPatterns` is absent.

## Verification

- `node --test tests/idd-doctor.test.mjs` — 97 pass (custom-pattern,
  default-label, and config-reader cases added).
- Full `lint:minimum` — 832 tests pass; idd-doctor exits 0 on `main`;
  audit-docs/cspell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktree guard validation now supports configurable branch patterns from repository configuration
  * Branch patterns support glob syntax (* and ?) for flexible branch matching
  * Enhanced branch classification with improved handling for issue, roadmap-audit, and implementation branches

* **Tests**
  * Added comprehensive test coverage for branch pattern configuration and validation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->