### PR TITLE
feat(ci): add idd-doctor repository-health gate + adopter opt-in doc

### DIFF
--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -28,5 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
+          # Read-only health check: no need to persist the token in git config.
+          persist-credentials: false
       - name: Run idd-doctor repository-health check
         run: node scripts/idd-doctor.mjs

--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -21,6 +21,12 @@ jobs:
   idd-doctor:
     runs-on: ubuntu-slim
     steps:
+      # Check out the exact commit (detached HEAD) so idd-doctor's
+      # local-only primary-worktree-HEAD check never false-positives on a
+      # push-event checkout, where actions/checkout would otherwise leave
+      # HEAD on the issue/* branch and trip the (enabled) worktree guard.
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
       - name: Run idd-doctor repository-health check
         run: node scripts/idd-doctor.mjs

--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -1,0 +1,26 @@
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+name: IDD doctor health gate
+# Repository-health gate: runs idd-doctor and fails the build on any
+# idd-doctor error (config/doc/marker-prefix/required-file regressions).
+# This does NOT enforce the disposable-worktree rule — a primary-worktree
+# B1 violation leaves no trace in pushed history and CI checks out a
+# detached HEAD, so the worktree-head check never fires here. Worktree
+# enforcement is local only (idd-doctor --strict, the core.hooksPath
+# hook, the cwd-vs-claim gate, and the B1 self-check).
+on:
+  push:
+    branches:
+      - '**'
+      - '!main'
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  idd-doctor:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run idd-doctor repository-health check
+        run: node scripts/idd-doctor.mjs

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -585,6 +585,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }} # detached HEAD keeps the worktree check inert
+          persist-credentials: false
       - run: node scripts/idd-doctor.mjs
 ```
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -565,6 +565,36 @@ primary-worktree mistake leaves no trace in the pushed history — so
 this local hook, together with `idd-doctor --strict`, is the practical
 enforcement surface.
 
+### Optional — run idd-doctor as a CI health gate
+
+For repositories that vendor the IDD helper scripts, running `idd-doctor`
+in CI catches repository-health regressions (config/schema drift,
+unresolved placeholders, marker-prefix inconsistency, missing required
+files) on every change. It is opt-in — add a workflow such as:
+
+```yaml
+name: IDD doctor health gate
+on:
+  pull_request:
+  push:
+    branches: ['**', '!main']
+permissions:
+  contents: read
+jobs:
+  idd-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: node scripts/idd-doctor.mjs
+```
+
+Adjust the command to your helper-runtime profile. This gate checks
+repository **health**, not the disposable-worktree rule: CI cannot detect
+a primary-worktree B1 violation (it leaves no trace in pushed history and
+CI checks out a detached HEAD), so worktree enforcement stays local — the
+`core.hooksPath` hook above, the cwd-vs-claim gate, and
+`idd-doctor --strict` run on a developer's machine.
+
 ---
 
 ## Step 3 — Record policy decisions


### PR DESCRIPTION
## Summary

Add a repo-local CI gate that runs `idd-doctor` as a **repository-health**
check (the re-scoped #796), now that #804 makes idd-doctor exit clean on
a healthy `main`.

Closes #796

## What changed

- `.github/workflows/idd-doctor.yml` (new): runs `node scripts/idd-doctor.mjs`
  on pull_request/push; fails on idd-doctor errors.
- `idd-template/ONBOARDING.md`: opt-in CI snippet for adopters.
- Both the workflow comment and the ONBOARDING note state this gate
  checks repository **health**, not the disposable-worktree rule.

## Why re-scoped (not worktree enforcement)

CI cannot detect a primary-worktree B1 violation: it leaves no trace in
pushed history, and CI checks out a detached HEAD so
`checkPrimaryWorktreeHead` never fires. Worktree enforcement is therefore
local — `idd-doctor --strict` (#794), the `core.hooksPath` hook (#795),
the cwd-vs-claim gate (#791), and the B1 self-check.

## Verification

- `node scripts/idd-doctor.mjs` exits 0 on this branch.
- Full `lint:minimum` — 833 tests pass; audit-docs/dprint/markdownlint/cspell clean.
- The new workflow runs on this PR (dogfood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated health gate for CI/CD pipelines that checks repository health during push and pull request events.

* **Documentation**
  * Added onboarding documentation explaining how to configure and use the health gate in CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->