### PR TITLE
feat(helpers): default trustedMarkerActors from config.json

### DIFF
--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 import { readAdvisoryWaitPolicy } from "./advisory-wait-policy.mjs";
 import {
   buildAdvisoryWaitSummary,
   normalizeTrustedMarkerLogins,
   parsePaginatedGhNdjson,
+  resolveTrustedMarkerActors,
 } from "./protocol-helpers.mjs";
 
 const args = parseArgs(process.argv.slice(2));
@@ -18,10 +20,11 @@ const owner = args.owner || ghText(["repo", "view", "--json", "owner", "--jq", "
 const repo = args.repo || ghText(["repo", "view", "--json", "name", "--jq", ".name"]);
 const repoRef = `${owner}/${repo}`;
 const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
-const configuredTrustedActors = normalizeTrustedMarkerLogins([
-  ...splitCsv(args.trustedMarkerLogins),
-  ...splitCsv(process.env.IDD_TRUSTED_MARKER_ACTORS),
-]);
+const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } = resolveTrustedMarkerActors({
+  flagValue: args.trustedMarkerLogins,
+  envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+  config: loadIddConfig(),
+});
 
 const prHeadSha = ghText([
   "pr",
@@ -82,7 +85,9 @@ const summary = buildAdvisoryWaitSummary(
   },
 );
 
-process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+process.stdout.write(`${
+  JSON.stringify({ ...summary, trustedMarkerActors: configuredTrustedActors, trustedMarkerActorsSource }, null, 2)
+}\n`);
 
 function parseArgs(argv) {
   const parsed = {
@@ -176,15 +181,16 @@ function advisoryMarkerComment(body) {
     || normalized.startsWith("<!-- advisory-wait:");
 }
 
-function splitCsv(value) {
-  return String(value ?? "")
-    .split(",")
-    .map((token) => token.trim())
-    .filter(Boolean);
-}
-
 function isTruthy(value) {
   return /^(1|true|yes)$/i.test(String(value ?? "").trim());
+}
+
+function loadIddConfig() {
+  try {
+    return JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+  } catch {
+    return null;
+  }
 }
 
 function ghText(args) {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -12,6 +12,7 @@ import {
   parsePaginatedGhNdjson,
   resolveCodeownersForFiles,
   resolveRulesetDetailPath,
+  resolveTrustedMarkerActors,
   selectCodeownersText,
 } from "./protocol-helpers.mjs";
 import { resolveCollaboratorMarkerTrust } from "./policy-helpers.mjs";
@@ -34,10 +35,11 @@ const repo = args.repo || ghText(["repo", "view", "--json", "name", "--jq", ".na
 const repoRef = `${owner}/${repo}`;
 const viewerLogin = safeGhText(["api", "user", "--jq", ".login"]).toLowerCase();
 const viewerAppSlug = safeGhText(["api", "app", "--jq", ".slug // .app_slug // empty"]).toLowerCase();
-const configuredTrustedActors = normalizeTrustedMarkerLogins([
-  ...splitCsv(args.trustedMarkerLogins),
-  ...splitCsv(process.env.IDD_TRUSTED_MARKER_ACTORS),
-]);
+const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } = resolveTrustedMarkerActors({
+  flagValue: args.trustedMarkerLogins,
+  envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+  config: loadIddConfig(),
+});
 const advisoryBotLogins = normalizeTrustedMarkerLogins(splitCsv(args.advisoryBotLogins));
 
 const pr = ghJson([
@@ -181,7 +183,9 @@ const summary = buildPreMergeReadinessSummary(
   },
 );
 
-process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+process.stdout.write(`${
+  JSON.stringify({ ...summary, trustedMarkerActors: configuredTrustedActors, trustedMarkerActorsSource }, null, 2)
+}\n`);
 
 function parseArgs(argv) {
   const parsed = {
@@ -618,5 +622,13 @@ function readCollaboratorTrustEnabled() {
     // Fall through to env-var fallback.
   }
   return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
+}
+
+function loadIddConfig() {
+  try {
+    return JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+  } catch {
+    return null;
+  }
 }
 

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1115,6 +1115,41 @@ export function normalizeTrustedMarkerLogins(logins) {
   )].sort();
 }
 
+/**
+ * Resolve the trusted marker actors for a read-only evidence helper.
+ *
+ * Precedence is strict: an explicit `--trusted-marker-logins` flag wins over
+ * the `IDD_TRUSTED_MARKER_ACTORS` env var, which wins over the
+ * `trustedMarkerActors` array declared in `.github/idd/config.json`. The flag
+ * and env var are CSV strings (or arrays); `config` is the parsed policy
+ * object. The returned `source` records which input supplied the value so the
+ * helper can emit it as auditable JSON evidence.
+ *
+ * @param {{ flagValue?: string|string[], envValue?: string|string[], config?: object|null }} input
+ * @returns {{ actors: string[], source: "flag"|"env"|"config"|"none" }}
+ */
+export function resolveTrustedMarkerActors({ flagValue = "", envValue = "", config = null } = {}) {
+  const fromFlag = normalizeTrustedMarkerLogins(trustedMarkerActorTokens(flagValue));
+  if (fromFlag.length > 0) {
+    return { actors: fromFlag, source: "flag" };
+  }
+  const fromEnv = normalizeTrustedMarkerLogins(trustedMarkerActorTokens(envValue));
+  if (fromEnv.length > 0) {
+    return { actors: fromEnv, source: "env" };
+  }
+  const fromConfig = normalizeTrustedMarkerLogins(
+    Array.isArray(config?.trustedMarkerActors) ? config.trustedMarkerActors : [],
+  );
+  if (fromConfig.length > 0) {
+    return { actors: fromConfig, source: "config" };
+  }
+  return { actors: [], source: "none" };
+}
+
+function trustedMarkerActorTokens(value) {
+  return Array.isArray(value) ? value : String(value ?? "").split(",");
+}
+
 export function deriveIddAgentLogins({
   viewerLogin = "",
   iddAgentLogins = [],

--- a/scripts/review-activity-snapshot.mjs
+++ b/scripts/review-activity-snapshot.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
-import { buildActivitySnapshotSummary } from "./protocol-helpers.mjs";
+import { buildActivitySnapshotSummary, resolveTrustedMarkerActors } from "./protocol-helpers.mjs";
 
 const args = parseArgs(process.argv.slice(2));
 if (!args.prNumber) {
@@ -12,10 +13,11 @@ if (!args.prNumber) {
 const owner = args.owner || ghText(["repo", "view", "--json", "owner", "--jq", ".owner.login"]);
 const repo = args.repo || ghText(["repo", "view", "--json", "name", "--jq", ".name"]);
 const repoRef = `${owner}/${repo}`;
-const trustedMarkerLogins = args.trustedMarkerLogins
-  .split(",")
-  .map((login) => login.trim())
-  .filter(Boolean);
+const { actors: trustedMarkerLogins, source: trustedMarkerActorsSource } = resolveTrustedMarkerActors({
+  flagValue: args.trustedMarkerLogins,
+  envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+  config: loadIddConfig(),
+});
 
 const headSha = ghText([
   "pr",
@@ -64,12 +66,22 @@ const summary = buildActivitySnapshotSummary(
 
 process.stdout.write(`${JSON.stringify({
   headSha,
+  trustedMarkerActors: trustedMarkerLogins,
+  trustedMarkerActorsSource,
   totalItemCount: summary.totalItemCount,
   maxActivityUpdatedAt: summary.maxActivityUpdatedAt,
   latestCiCompletedAt: summary.latestCiCompletedAt,
   latestPassingCiCompletedAt: summary.latestPassingCiCompletedAt,
   counts: summary.counts,
 }, null, 2)}\n`);
+
+function loadIddConfig() {
+  try {
+    return JSON.parse(readFileSync(".github/idd/config.json", "utf8"));
+  } catch {
+    return null;
+  }
+}
 
 function parseArgs(argv) {
   const parsed = {

--- a/tests/resolve-trusted-marker-actors.test.mjs
+++ b/tests/resolve-trusted-marker-actors.test.mjs
@@ -1,0 +1,63 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { resolveTrustedMarkerActors } from "../scripts/protocol-helpers.mjs";
+
+test("resolveTrustedMarkerActors: config.json is the default source", () => {
+  const result = resolveTrustedMarkerActors({
+    flagValue: "",
+    envValue: "",
+    config: { trustedMarkerActors: ["Kurone-Kito", "idd-bot"] },
+  });
+  assert.deepEqual(result, { actors: ["idd-bot", "kurone-kito"], source: "config" });
+});
+
+test("resolveTrustedMarkerActors: env overrides config", () => {
+  const result = resolveTrustedMarkerActors({
+    flagValue: "",
+    envValue: "env-actor",
+    config: { trustedMarkerActors: ["config-actor"] },
+  });
+  assert.deepEqual(result, { actors: ["env-actor"], source: "env" });
+});
+
+test("resolveTrustedMarkerActors: flag overrides env and config", () => {
+  const result = resolveTrustedMarkerActors({
+    flagValue: "flag-actor",
+    envValue: "env-actor",
+    config: { trustedMarkerActors: ["config-actor"] },
+  });
+  assert.deepEqual(result, { actors: ["flag-actor"], source: "flag" });
+});
+
+test("resolveTrustedMarkerActors: flag wins over env when both are set", () => {
+  const result = resolveTrustedMarkerActors({ flagValue: "a,b", envValue: "c", config: null });
+  assert.deepEqual(result, { actors: ["a", "b"], source: "flag" });
+});
+
+test("resolveTrustedMarkerActors: returns none when nothing is configured", () => {
+  assert.deepEqual(
+    resolveTrustedMarkerActors({ flagValue: "", envValue: "", config: {} }),
+    { actors: [], source: "none" },
+  );
+  assert.deepEqual(resolveTrustedMarkerActors({}), { actors: [], source: "none" });
+});
+
+test("resolveTrustedMarkerActors: normalizes, lowercases, dedups, and sorts", () => {
+  const result = resolveTrustedMarkerActors({
+    flagValue: " Beta , alpha, Alpha ,",
+    config: { trustedMarkerActors: ["ignored"] },
+  });
+  assert.deepEqual(result, { actors: ["alpha", "beta"], source: "flag" });
+});
+
+test("resolveTrustedMarkerActors: accepts array inputs and ignores non-array config", () => {
+  assert.deepEqual(
+    resolveTrustedMarkerActors({ flagValue: ["x", "Y"] }),
+    { actors: ["x", "y"], source: "flag" },
+  );
+  assert.deepEqual(
+    resolveTrustedMarkerActors({ config: { trustedMarkerActors: "not-an-array" } }),
+    { actors: [], source: "none" },
+  );
+});


### PR DESCRIPTION
## Summary

Read-only evidence helpers resolved trusted marker actors only from the
`--trusted-marker-logins` flag and the `IDD_TRUSTED_MARKER_ACTORS` env var, so a
marker authored by an actor declared in `.github/idd/config.json`
`trustedMarkerActors` was dropped unless the operator re-supplied the list on
every invocation.

This adds a pure `resolveTrustedMarkerActors({ flagValue, envValue, config }) ->
{ actors, source }` to `protocol-helpers` with strict precedence
**flag > env > config**, mirroring the config-reading pattern already used by
`external-check-waiver` / `resume-claim-routing` / `force-handoff`. The three
helpers (`review-activity-snapshot`, `advisory-wait-state`,
`pre-merge-readiness`) now default to config and emit the resolved
`trustedMarkerActors` list plus `trustedMarkerActorsSource`
(`flag`|`env`|`config`|`none`) in their JSON evidence.

## Note on the issue background

The issue named `live-status-digest` as the model; that helper actually trusts
the viewer + env, not config. The real config-reading model is
`external-check-waiver` / `resume-claim-routing` / `force-handoff`, which this PR
follows. Precedence is strict (flag overrides env overrides config) rather than
the previous flag+env union — a minor, documented behaviour change.

## Verification

- New `tests/resolve-trusted-marker-actors.test.mjs` covers config-default,
  env-override, flag-override, none, and normalization (7 cases).
- `pnpm run lint:minimum` green: **840/840 tests**, cspell 0, markdownlint 0,
  audit-docs no drift.

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for loading trusted marker actor configuration from `.github/idd/config.json` file
  * Scripts now output trusted marker actor source information alongside results
  * Implemented strict precedence handling: CLI flag overrides environment variable, which overrides config file

* **Tests**
  * Added comprehensive test suite for trusted marker actor resolution with precedence validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->