### PR TITLE
feat(helpers): standardize claim-id and agent-id CLI flags

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -631,7 +631,7 @@ Interpretation rules:
   `latestPassingCiCompletedAt`
 - Readiness command: `node scripts/pre-merge-readiness.mjs`
   with `--pr <pr-number>`, `--claim-issue <issue-number>`,
-  `--expected-claim-id <claim-id>`, and
+  `--claim-id <claim-id>`, and
   `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
 - Stable contract:
   [`pre-merge-readiness.schema.json`][pre-merge-readiness-schema]

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -631,7 +631,7 @@ Interpretation rules:
   `latestPassingCiCompletedAt`
 - Readiness command: `node scripts/pre-merge-readiness.mjs`
   with `--pr <pr-number>`, `--claim-issue <issue-number>`,
-  `--expected-claim-id <claim-id>`, and
+  `--claim-id <claim-id>`, and
   `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
 - Stable contract:
   [`pre-merge-readiness.schema.json`][pre-merge-readiness-schema]

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -187,6 +187,10 @@ process.stdout.write(`${
   JSON.stringify({ ...summary, trustedMarkerActors: configuredTrustedActors, trustedMarkerActorsSource }, null, 2)
 }\n`);
 
+function warnDeprecatedFlag(deprecated, canonical) {
+  process.stderr.write(`warning: ${deprecated} is deprecated; use ${canonical} instead.\n`);
+}
+
 function parseArgs(argv) {
   const parsed = {
     prNumber: null,
@@ -239,12 +243,24 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
-    if (token === "--expected-claim-id") {
+    if (token === "--claim-id") {
       parsed.expectedClaimId = value ?? "";
       index += 1;
       continue;
     }
+    if (token === "--expected-claim-id") {
+      warnDeprecatedFlag("--expected-claim-id", "--claim-id");
+      parsed.expectedClaimId = value ?? "";
+      index += 1;
+      continue;
+    }
+    if (token === "--agent-id") {
+      parsed.expectedAgentId = value ?? "";
+      index += 1;
+      continue;
+    }
     if (token === "--expected-agent-id") {
+      warnDeprecatedFlag("--expected-agent-id", "--agent-id");
       parsed.expectedAgentId = value ?? "";
       index += 1;
       continue;
@@ -273,7 +289,8 @@ function parseArgs(argv) {
 
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/pre-merge-readiness.mjs --pr <number> --claim-issue <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--expected-claim-id <claim-id>] [--expected-agent-id <agent-id>] [--now <ISO8601>]
+  node scripts/pre-merge-readiness.mjs --pr <number> --claim-issue <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--claim-id <claim-id>] [--agent-id <agent-id>] [--now <ISO8601>]
+  Deprecated aliases (one release): --expected-claim-id -> --claim-id, --expected-agent-id -> --agent-id
 `);
 }
 

--- a/tests/flag-name-matrix.test.mjs
+++ b/tests/flag-name-matrix.test.mjs
@@ -11,17 +11,48 @@ function readScript(name) {
   return readFileSync(join(scriptsDir, name), "utf8");
 }
 
-// One canonical CLI flag name per shared concept. Helpers may keep the prior
-// name as a deprecated alias for one release, but the canonical flag must
-// always be accepted wherever the concept is, so a working invocation copied
-// from one phase keeps working in the next.
+// One canonical CLI flag name per shared concept. `helpers` is the explicit set
+// of scripts that accept the concept, so the test catches a canonical flag being
+// renamed or removed (not only a stray deprecated alias). A `deprecated` name
+// may be kept as an alias for one release but must always warn on stderr and
+// coexist with the canonical flag.
 const FLAG_CONCEPTS = [
-  { concept: "claim id", canonical: "--claim-id", deprecated: "--expected-claim-id" },
-  { concept: "agent id", canonical: "--agent-id", deprecated: "--expected-agent-id" },
+  {
+    concept: "claim id",
+    canonical: "--claim-id",
+    deprecated: "--expected-claim-id",
+    helpers: [
+      "audit-pr-cleanup.mjs",
+      "external-check-waiver.mjs",
+      "live-status-digest.mjs",
+      "pre-merge-readiness.mjs",
+      "resume-claim-routing.mjs",
+    ],
+  },
+  {
+    concept: "agent id",
+    canonical: "--agent-id",
+    deprecated: "--expected-agent-id",
+    helpers: [
+      "audit-pr-cleanup.mjs",
+      "live-status-digest.mjs",
+      "pre-merge-readiness.mjs",
+    ],
+  },
 ];
 
-for (const { concept, canonical, deprecated } of FLAG_CONCEPTS) {
-  test(`every helper accepting a ${concept} flag accepts the canonical ${canonical}`, () => {
+for (const { concept, canonical, deprecated, helpers } of FLAG_CONCEPTS) {
+  test(`every ${concept} helper exposes the canonical ${canonical}`, () => {
+    for (const helper of helpers) {
+      const src = readScript(helper);
+      assert.ok(
+        src.includes(`"${canonical}"`),
+        `${helper} must accept the canonical ${canonical}`,
+      );
+    }
+  });
+
+  test(`no helper accepts ${deprecated} without the canonical ${canonical}`, () => {
     for (const file of scriptFiles) {
       const src = readScript(file);
       if (src.includes(`"${deprecated}"`)) {
@@ -33,20 +64,26 @@ for (const { concept, canonical, deprecated } of FLAG_CONCEPTS) {
     }
   });
 
-  test(`${deprecated} is only a deprecated alias that warns`, () => {
+  test(`${deprecated} alias emits a stderr deprecation warning`, () => {
     for (const file of scriptFiles) {
       const src = readScript(file);
-      if (src.includes(`"${deprecated}"`)) {
-        assert.ok(
-          src.includes("is deprecated") || src.includes("warnDeprecatedFlag"),
-          `${file} accepts the deprecated ${deprecated} without emitting a deprecation warning`,
-        );
+      if (!src.includes(`"${deprecated}"`)) {
+        continue;
       }
+      assert.ok(
+        src.includes(`warnDeprecatedFlag("${deprecated}"`),
+        `${file} should route ${deprecated} through warnDeprecatedFlag()`,
+      );
+      assert.match(
+        src,
+        /function warnDeprecatedFlag[\s\S]*?process\.stderr\.write/,
+        `${file} warnDeprecatedFlag() should write the deprecation warning to stderr`,
+      );
     }
   });
 }
 
-test("pre-merge-readiness accepts both canonical claim/agent flags", () => {
+test("pre-merge-readiness accepts both canonical and deprecated claim/agent flags", () => {
   const src = readScript("pre-merge-readiness.mjs");
   for (const flag of ["--claim-id", "--agent-id", "--expected-claim-id", "--expected-agent-id"]) {
     assert.ok(src.includes(`"${flag}"`), `pre-merge-readiness.mjs should accept ${flag}`);

--- a/tests/flag-name-matrix.test.mjs
+++ b/tests/flag-name-matrix.test.mjs
@@ -1,0 +1,54 @@
+import { strict as assert } from "node:assert";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptsDir = join(dirname(fileURLToPath(import.meta.url)), "..", "scripts");
+const scriptFiles = readdirSync(scriptsDir).filter((file) => file.endsWith(".mjs"));
+
+function readScript(name) {
+  return readFileSync(join(scriptsDir, name), "utf8");
+}
+
+// One canonical CLI flag name per shared concept. Helpers may keep the prior
+// name as a deprecated alias for one release, but the canonical flag must
+// always be accepted wherever the concept is, so a working invocation copied
+// from one phase keeps working in the next.
+const FLAG_CONCEPTS = [
+  { concept: "claim id", canonical: "--claim-id", deprecated: "--expected-claim-id" },
+  { concept: "agent id", canonical: "--agent-id", deprecated: "--expected-agent-id" },
+];
+
+for (const { concept, canonical, deprecated } of FLAG_CONCEPTS) {
+  test(`every helper accepting a ${concept} flag accepts the canonical ${canonical}`, () => {
+    for (const file of scriptFiles) {
+      const src = readScript(file);
+      if (src.includes(`"${deprecated}"`)) {
+        assert.ok(
+          src.includes(`"${canonical}"`),
+          `${file} accepts ${deprecated} but not the canonical ${canonical}`,
+        );
+      }
+    }
+  });
+
+  test(`${deprecated} is only a deprecated alias that warns`, () => {
+    for (const file of scriptFiles) {
+      const src = readScript(file);
+      if (src.includes(`"${deprecated}"`)) {
+        assert.ok(
+          src.includes("is deprecated") || src.includes("warnDeprecatedFlag"),
+          `${file} accepts the deprecated ${deprecated} without emitting a deprecation warning`,
+        );
+      }
+    }
+  });
+}
+
+test("pre-merge-readiness accepts both canonical claim/agent flags", () => {
+  const src = readScript("pre-merge-readiness.mjs");
+  for (const flag of ["--claim-id", "--agent-id", "--expected-claim-id", "--expected-agent-id"]) {
+    assert.ok(src.includes(`"${flag}"`), `pre-merge-readiness.mjs should accept ${flag}`);
+  }
+});


### PR DESCRIPTION
## Summary

`pre-merge-readiness` used `--expected-claim-id` and `--expected-agent-id`, while
the other helpers (`audit-pr-cleanup`, `live-status-digest`,
`external-check-waiver`, `resume-claim-routing`) use the canonical `--claim-id`
and `--agent-id`. An operator copying a working invocation across phases hit
`unknown argument`.

This makes `--claim-id` and `--agent-id` canonical in `pre-merge-readiness`,
keeps `--expected-claim-id` / `--expected-agent-id` as **deprecated aliases for
one release** (still functional, but they print a stderr deprecation warning),
updates the usage string and `docs/idd-helper-scripts.md`, and adds a flag-name
matrix test asserting every helper accepting a claim/agent id uses the canonical
flag.

## Verification

- New `tests/flag-name-matrix.test.mjs` (5 cases) guards the canonical-flag
  contract and the deprecation-warning requirement.
- Template source edited first; `docs/idd-helper-scripts.md` regenerated via
  `sync-docs`.
- `pnpm run lint:minimum` green: **845/845 tests**, audit-docs no drift, cspell
  0, markdownlint 0.

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command examples to use canonical flag names (`--claim-id`, `--agent-id`).

* **New Features**
  * Emit deprecation warnings when legacy CLI flags are used; legacy flags continue to work for compatibility.

* **Tests**
  * Added tests to enforce CLI flag consistency and validate deprecation-warning behavior across helper scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->