### PR TITLE
feat(pre-merge): distinguish "no required checks" from a passing CI gate

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -151,6 +151,17 @@ Codex connectors, and CI bots).
   same resolved `ciWait.runningTimeout`, `ciWait.generationTimeout`, and
   `ciWait.rerunPolicy` values; on-success → re-evaluate F2).
 
+  **No required checks configured**: When `pre-merge-readiness` reports
+  `ci.noRequiredChecksConfigured: true` (an unprotected branch, or a branch
+  with no required status checks), the CI gate is **not** satisfied
+  vacuously — that state is reported distinctly from "all required checks
+  passed". Route by `ci.presentRunConclusion` over the actual runs on the
+  current HEAD:
+  - `all-passing` → the CI gate may pass (every present run completed green).
+  - `pending` → wait per `idd-ci.instructions.md`, then re-evaluate F2.
+  - `some-failing`, or `none` (no runs exist at all) → **hold**; do not
+    merge on a vacuous green. Route to an operator or blocked state.
+
   **External-check waivers**: When `pre-merge-readiness` reports a check
   as `coveredByWaiver: true` in its output, a trusted maintainer has
   authorized skipping that specific check under the current head SHA and

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -212,6 +212,8 @@
     },
     "ci": {
       "status": "success",
+      "noRequiredChecksConfigured": false,
+      "presentRunConclusion": "all-passing",
       "requiredCheckCount": 1,
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -213,6 +213,8 @@
     },
     "ci": {
       "status": "missing",
+      "noRequiredChecksConfigured": false,
+      "presentRunConclusion": "all-passing",
       "requiredCheckCount": 2,
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": false,

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -240,6 +240,8 @@
     },
     "ci": {
       "status": "success",
+      "noRequiredChecksConfigured": false,
+      "presentRunConclusion": "all-passing",
       "requiredCheckCount": 1,
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -240,6 +240,8 @@
     },
     "ci": {
       "status": "success",
+      "noRequiredChecksConfigured": false,
+      "presentRunConclusion": "all-passing",
       "requiredCheckCount": 1,
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -240,6 +240,8 @@
     },
     "ci": {
       "status": "success",
+      "noRequiredChecksConfigured": false,
+      "presentRunConclusion": "all-passing",
       "requiredCheckCount": 1,
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -226,6 +226,8 @@
     },
     "ci": {
       "status": "success",
+      "noRequiredChecksConfigured": false,
+      "presentRunConclusion": "all-passing",
       "requiredCheckCount": 1,
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -240,6 +240,8 @@
     },
     "ci": {
       "status": "success",
+      "noRequiredChecksConfigured": false,
+      "presentRunConclusion": "all-passing",
       "requiredCheckCount": 1,
       "generatedRequiredCheckCount": 1,
       "requiredChecksGenerated": true,

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -113,6 +113,8 @@
   },
   "ci": {
     "status": "success",
+    "noRequiredChecksConfigured": false,
+    "presentRunConclusion": "all-passing",
     "requiredCheckCount": 1,
     "generatedRequiredCheckCount": 1,
     "requiredChecksGenerated": true,

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -151,6 +151,17 @@ Codex connectors, and CI bots).
   same resolved `ciWait.runningTimeout`, `ciWait.generationTimeout`, and
   `ciWait.rerunPolicy` values; on-success → re-evaluate F2).
 
+  **No required checks configured**: When `pre-merge-readiness` reports
+  `ci.noRequiredChecksConfigured: true` (an unprotected branch, or a branch
+  with no required status checks), the CI gate is **not** satisfied
+  vacuously — that state is reported distinctly from "all required checks
+  passed". Route by `ci.presentRunConclusion` over the actual runs on the
+  current HEAD:
+  - `all-passing` → the CI gate may pass (every present run completed green).
+  - `pending` → wait per `idd-ci.instructions.md`, then re-evaluate F2.
+  - `some-failing`, or `none` (no runs exist at all) → **hold**; do not
+    merge on a vacuous green. Route to an operator or blocked state.
+
   **External-check waivers**: When `pre-merge-readiness` reports a check
   as `coveredByWaiver: true` in its output, a trusted maintainer has
   authorized skipping that specific check under the current head SHA and

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -408,6 +408,8 @@
       "type": "object",
       "required": [
         "status",
+        "noRequiredChecksConfigured",
+        "presentRunConclusion",
         "requiredCheckCount",
         "generatedRequiredCheckCount",
         "requiredChecksGenerated",
@@ -421,6 +423,11 @@
         "status": {
           "type": "string",
           "enum": ["missing", "success", "pending", "failed", "unknown"]
+        },
+        "noRequiredChecksConfigured": { "type": "boolean" },
+        "presentRunConclusion": {
+          "type": "string",
+          "enum": ["all-passing", "some-failing", "pending", "none"]
         },
         "requiredCheckCount": { "type": "integer", "minimum": 0 },
         "generatedRequiredCheckCount": { "type": "integer", "minimum": 0 },

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1795,7 +1795,8 @@ export function summarizeRequiredChecks(checks = [], branchRules = [], branchPro
 
   return {
     status,
-    noRequiredChecksConfigured: requiredCheckNames.length === 0,
+    noRequiredChecksConfigured: requiredCheckNames.length === 0
+      && !branchReviewRequirements.requiredCheckSourcePinned,
     presentRunConclusion: resolvePresentRunConclusion(normalizedChecks),
     requiredCheckCount: requiredCheckNames.length,
     generatedRequiredCheckCount: matchedRequiredChecks.length,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1795,6 +1795,8 @@ export function summarizeRequiredChecks(checks = [], branchRules = [], branchPro
 
   return {
     status,
+    noRequiredChecksConfigured: requiredCheckNames.length === 0,
+    presentRunConclusion: resolvePresentRunConclusion(normalizedChecks),
     requiredCheckCount: requiredCheckNames.length,
     generatedRequiredCheckCount: matchedRequiredChecks.length,
     requiredChecksGenerated: requiredCheckNames.length > 0 && missingRequiredCheckNames.length === 0,
@@ -1809,6 +1811,27 @@ export function summarizeRequiredChecks(checks = [], branchRules = [], branchPro
       ...(check.coveredByWaiver ? { coveredByWaiver: true } : {}),
     })),
   };
+}
+
+// Conclusion over *all* present check runs (waiver-covered runs count as
+// skipped), used for the F2 fallback when no required checks are configured:
+// an unprotected branch must not satisfy CI vacuously, so the gate inspects the
+// real run conclusions instead.
+function resolvePresentRunConclusion(normalizedChecks) {
+  if (normalizedChecks.length === 0) {
+    return "none";
+  }
+  const effective = normalizedChecks.map((check) =>
+    check.coveredByWaiver ? { ...check, state: "SKIPPED" } : check,
+  );
+  const { status } = classifyCiChecks(effective);
+  if (status === "success") {
+    return "all-passing";
+  }
+  if (status === "pending") {
+    return "pending";
+  }
+  return "some-failing";
 }
 
 export function resolveCodeownersForFiles(codeownersText, changedFiles = []) {

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -101,6 +101,8 @@ test("pre-merge readiness exposes effective advisory policy", () => {
 test("required check summaries block when no merge-gate policy evidence exists", () => {
   assert.deepEqual(summarizeRequiredChecks([], [], {}), {
     status: "unknown",
+    noRequiredChecksConfigured: true,
+    presentRunConclusion: "none",
     requiredCheckCount: 0,
     generatedRequiredCheckCount: 0,
     requiredChecksGenerated: false,

--- a/tests/required-checks-summary.test.mjs
+++ b/tests/required-checks-summary.test.mjs
@@ -1,0 +1,51 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { summarizeRequiredChecks } from "../scripts/protocol-helpers.mjs";
+
+// A branch ruleset that requires the "lint" status check.
+const protectedRules = [
+  { type: "required_status_checks", parameters: { required_status_checks: [{ context: "lint" }] } },
+];
+
+function summarize(checks, rules = []) {
+  return summarizeRequiredChecks(checks, rules, {});
+}
+
+test("protected branch with passing required checks: required gate passes", () => {
+  const r = summarize([{ name: "lint", state: "SUCCESS" }], protectedRules);
+  assert.equal(r.noRequiredChecksConfigured, false);
+  assert.equal(r.requiredChecksPassing, true);
+});
+
+test("protected branch with a failing required check: gate does not pass", () => {
+  const r = summarize([{ name: "lint", state: "FAILURE" }], protectedRules);
+  assert.equal(r.noRequiredChecksConfigured, false);
+  assert.equal(r.requiredChecksPassing, false);
+});
+
+test("unprotected + green runs: reported distinctly from a passing required gate", () => {
+  const r = summarize([{ name: "build", state: "SUCCESS" }], []);
+  assert.equal(r.noRequiredChecksConfigured, true);
+  assert.equal(r.requiredChecksPassing, false);
+  assert.equal(r.presentRunConclusion, "all-passing");
+});
+
+test("unprotected + a failing run: presentRunConclusion is some-failing", () => {
+  const r = summarize([{ name: "build", state: "FAILURE" }], []);
+  assert.equal(r.noRequiredChecksConfigured, true);
+  assert.equal(r.presentRunConclusion, "some-failing");
+});
+
+test("unprotected + no runs: presentRunConclusion is none, never vacuously passing", () => {
+  const r = summarize([], []);
+  assert.equal(r.noRequiredChecksConfigured, true);
+  assert.equal(r.presentRunConclusion, "none");
+  assert.equal(r.requiredChecksPassing, false);
+});
+
+test("unprotected + pending runs: presentRunConclusion is pending", () => {
+  const r = summarize([{ name: "build", state: "IN_PROGRESS" }], []);
+  assert.equal(r.noRequiredChecksConfigured, true);
+  assert.equal(r.presentRunConclusion, "pending");
+});

--- a/tests/required-checks-summary.test.mjs
+++ b/tests/required-checks-summary.test.mjs
@@ -49,3 +49,17 @@ test("unprotected + pending runs: presentRunConclusion is pending", () => {
   assert.equal(r.noRequiredChecksConfigured, true);
   assert.equal(r.presentRunConclusion, "pending");
 });
+
+// A pinned/indeterminate required-check source (workflows rule, or an app-pinned
+// classic check with no enumerable context) must NOT be reported as "no required
+// checks configured" — there may be required checks we cannot enumerate, so F2
+// must stay conservative rather than fall back to verifying raw run conclusions.
+test("a workflows-based required-check rule is not treated as no-required-checks", () => {
+  const r = summarizeRequiredChecks([], [{ type: "workflows", parameters: {} }], {});
+  assert.equal(r.noRequiredChecksConfigured, false);
+});
+
+test("an app-pinned classic required check with no context is not no-required-checks", () => {
+  const r = summarizeRequiredChecks([], [], { required_status_checks: { checks: [{ context: "", app_id: 1 }] } });
+  assert.equal(r.noRequiredChecksConfigured, false);
+});


### PR DESCRIPTION
## Summary

When a base branch has **no required status checks** (no branch protection),
`summarizeRequiredChecks` returned `status: "unknown"` with
`requiredChecksPassing: false` — conflating the no-checks case with the
pinned-source `"unknown"` and giving F2 no clean signal. An unprotected branch
could be treated as if CI verified it, or blocked indeterminately.

This emits a distinct **`ci.noRequiredChecksConfigured`** boolean plus
**`ci.presentRunConclusion`** (`all-passing` | `some-failing` | `pending` |
`none`) computed over the actual runs. The F2 CI gate (idd-pre-merge) now routes
the no-required-checks case by the real run conclusions:

- `all-passing` → the CI gate may pass,
- `pending` → wait,
- `some-failing` / `none` (no runs) → **hold** (no vacuous green).

## Scope decision

Resolved with the maintainer at authoring: verify actual run conclusions rather
than auto-satisfy or hard-require branch protection.

## Verification

- New `tests/required-checks-summary.test.mjs` covers the five CI states
  (protected+pass, protected+fail, unprotected+green, unprotected+fail,
  unprotected+none) plus pending; the unprotected states report
  `noRequiredChecksConfigured: true` distinctly from a passing required gate.
- Instruction edited in the template source, root mirror regenerated via
  `sync-docs`.
- `pnpm run lint:minimum` green (tests, audit-docs no drift, cspell, markdownlint).

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CI gate now explicitly handles cases where required checks are not configured, routing decisions based on the current CI run conclusion (pass, pending, fail/none) instead of treating the gate as vacuously satisfied.

* **Tests**
  * Expanded test coverage for required-checks summary and CI readiness, including scenarios for no configured checks and various run conclusions.

* **Documentation**
  * Updated pre-merge checklist guidance to reflect the new CI routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->