### PR TITLE
docs: name authoritative phase-source for final-merge CI/activity

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -639,6 +639,12 @@ Interpretation rules:
   `threads`, `unrepliedComments`, `reviewerStates`,
   `advisoryWait` (including the effective advisory policy fields), `ci`,
   `claim`, and optional `dispositionEvidence`
+- Authoritative phase role: the live `pre-merge-readiness` run on the
+  current HEAD is the **authoritative source for the final-merge CI and
+  activity fields** at F2/F3. The `review-activity-snapshot` helper builds
+  the **E-phase** activity universe (E1) for review currency; do not reuse
+  its CI/activity values as the F-phase merge decision (they can diverge in
+  the pre-merge window)
 - `reviewerStates.codeownerSelfApproval` diagnoses whether CODEOWNER
   approval can be satisfied by an eligible non-author owner or an
   applicable ruleset or classic pull-request bypass. `deadlock` and

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -326,6 +326,17 @@ across human reviews and advisory bot surfaces (Copilot, CodeRabbit,
 Codex connectors, CI bots); "one bot says clean" is never sufficient by
 itself.
 
+**Authoritative source for the final-merge fields.** Bind every CI and
+activity value in this checklist to the **live `pre-merge-readiness` run on
+the current HEAD** — that helper is the authoritative source for the
+F2/F3 merge decision. The `review-activity-snapshot` helper builds the
+**E-phase** activity universe (E1) and must **not** be reused as the
+F-phase merge decision: the two can disagree in the window just before
+merge ("ci-pass-drift"), so reading CI/activity from the E-phase snapshot
+instead of the live pre-merge run risks merging on stale evidence. See
+[IDD helper script evaluation](idd-helper-scripts.md) for each helper's
+phase role.
+
 ## Review Policy Profiles
 
 The execution loop is cross-agent, while PR review policy is a

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -639,6 +639,12 @@ Interpretation rules:
   `threads`, `unrepliedComments`, `reviewerStates`,
   `advisoryWait` (including the effective advisory policy fields), `ci`,
   `claim`, and optional `dispositionEvidence`
+- Authoritative phase role: the live `pre-merge-readiness` run on the
+  current HEAD is the **authoritative source for the final-merge CI and
+  activity fields** at F2/F3. The `review-activity-snapshot` helper builds
+  the **E-phase** activity universe (E1) for review currency; do not reuse
+  its CI/activity values as the F-phase merge decision (they can diverge in
+  the pre-merge window)
 - `reviewerStates.codeownerSelfApproval` diagnoses whether CODEOWNER
   approval can be satisfied by an eligible non-author owner or an
   applicable ruleset or classic pull-request bypass. `deadlock` and

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -303,6 +303,17 @@ across human reviews and advisory bot surfaces (Copilot, CodeRabbit,
 Codex connectors, CI bots); "one bot says clean" is never sufficient by
 itself.
 
+**Authoritative source for the final-merge fields.** Bind every CI and
+activity value in this checklist to the **live `pre-merge-readiness` run on
+the current HEAD** — that helper is the authoritative source for the
+F2/F3 merge decision. The `review-activity-snapshot` helper builds the
+**E-phase** activity universe (E1) and must **not** be reused as the
+F-phase merge decision: the two can disagree in the window just before
+merge ("ci-pass-drift"), so reading CI/activity from the E-phase snapshot
+instead of the live pre-merge run risks merging on stale evidence. See
+[IDD helper script evaluation](idd-helper-scripts.md) for each helper's
+phase role.
+
 ## Review Policy Profiles
 
 The execution loop is cross-agent, while PR review policy is a


### PR DESCRIPTION
## Summary

The F2 merge-readiness evidence checklist did not name which helper owns the
final-merge CI/activity fields, so F2 could read them from the **E-phase**
`review-activity-snapshot` and drift from the live `pre-merge-readiness` run
("ci-pass-drift").

This states that the **live `pre-merge-readiness` run on the current HEAD is
authoritative** for the F2/F3 merge decision, and that `review-activity-snapshot`
is the **E-phase activity universe only** — in both the F2 checklist
(`idd-workflow.md`) and the helper docs (`idd-helper-scripts.md`), with a
cross-link making the E-vs-F boundary explicit.

## Verification

- Template sources edited first; `idd-helper-scripts.md` regenerated via
  `sync-docs`; `idd-workflow.md` (a structure/contains pair) updated in both
  the template and the root mirror.
- `audit-docs --check`, `dprint`, `markdownlint`, `cspell` all green.

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)
