### PR TITLE
docs(advisory): codify the courtesy-ack no-reopen rule

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -110,6 +110,11 @@ re-review:
 gh pr edit {pr-number} --add-reviewer {reviewer-login}
 ```
 
+For an **advisory bot**, pass the bot's reviewer **slug** to this
+add-reviewer command (the reliable trigger). The REST `requested_reviewers`
+endpoint called with a bot's **display name** silently no-ops and wastes a
+full advisory-wait cycle, so do not use that path to request a re-review.
+
 **Copilot**: after every push, regardless of any reviewer's state,
 request a Copilot re-review if Copilot has not yet reviewed the current
 HEAD SHA. Subject to the configured Copilot re-review request cap

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -344,6 +344,31 @@ Route based on `branchState` from the helper (or `mergeable` /
    commits).
 6. Return to `idd-review-snapshot.instructions.md` (E1).
 
+## Advisory courtesy-ack convergence
+
+A trusted advisory bot may reply with a courtesy/acknowledgement comment
+after dispositions are posted (e.g. "thanks for confirming"). Because the
+reply advances the PR's `updatedAt`, a naive review-currency re-check can
+re-stale the watermark and loop the review/snapshot cycle without end if the
+bot keeps acking.
+
+**Rule**: once a `**Accepted**` / `**Rejected**` disposition exists for every
+`ReviewItems_snapshot` item at the **current HEAD SHA**, a later **ack-only**
+comment from a configured trusted advisory bot does **not** reopen the review
+loop. Bind the merge to the current HEAD SHA and proceed rather than chasing a
+moving watermark.
+
+An **ack-only** comment is one from a trusted advisory bot (the configured
+advisory-bot / trusted-marker identity) that, relative to the current HEAD,
+opens no new review thread, carries no `CHANGES_REQUESTED`, and raises no new
+actionable finding. A comment that adds a thread, requests changes, or raises a
+new finding is **not** ack-only and re-opens the loop normally.
+
+**Worked example**: after you disposition a CodeRabbit thread `**Rejected**`,
+CodeRabbit replies "Thanks for confirming." on that same thread. No new thread
+or finding is introduced, so the `updatedAt` advance is ignored: do not re-run
+E1; continue to F-phase on the current HEAD SHA.
+
 ## Review item classes
 
 During E-phase review triage, classify each ReviewItems_snapshot item

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -110,6 +110,11 @@ re-review:
 gh pr edit {pr-number} --add-reviewer {reviewer-login}
 ```
 
+For an **advisory bot**, pass the bot's reviewer **slug** to this
+add-reviewer command (the reliable trigger). The REST `requested_reviewers`
+endpoint called with a bot's **display name** silently no-ops and wastes a
+full advisory-wait cycle, so do not use that path to request a re-review.
+
 **Copilot**: after every push, regardless of any reviewer's state,
 request a Copilot re-review if Copilot has not yet reviewed the current
 HEAD SHA. Subject to the configured Copilot re-review request cap

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -344,6 +344,31 @@ Route based on `branchState` from the helper (or `mergeable` /
    commits).
 6. Return to `idd-review-snapshot.instructions.md` (E1).
 
+## Advisory courtesy-ack convergence
+
+A trusted advisory bot may reply with a courtesy/acknowledgement comment
+after dispositions are posted (e.g. "thanks for confirming"). Because the
+reply advances the PR's `updatedAt`, a naive review-currency re-check can
+re-stale the watermark and loop the review/snapshot cycle without end if the
+bot keeps acking.
+
+**Rule**: once a `**Accepted**` / `**Rejected**` disposition exists for every
+`ReviewItems_snapshot` item at the **current HEAD SHA**, a later **ack-only**
+comment from a configured trusted advisory bot does **not** reopen the review
+loop. Bind the merge to the current HEAD SHA and proceed rather than chasing a
+moving watermark.
+
+An **ack-only** comment is one from a trusted advisory bot (the configured
+advisory-bot / trusted-marker identity) that, relative to the current HEAD,
+opens no new review thread, carries no `CHANGES_REQUESTED`, and raises no new
+actionable finding. A comment that adds a thread, requests changes, or raises a
+new finding is **not** ack-only and re-opens the loop normally.
+
+**Worked example**: after you disposition a CodeRabbit thread `**Rejected**`,
+CodeRabbit replies "Thanks for confirming." on that same thread. No new thread
+or finding is introduced, so the `updatedAt` advance is ignored: do not re-run
+E1; continue to F-phase on the current HEAD SHA.
+
 ## Review item classes
 
 During E-phase review triage, classify each ReviewItems_snapshot item


### PR DESCRIPTION
## Summary

A trusted advisory bot's courtesy/ack reply after dispositions advances the PR
`updatedAt`, which can re-stale the review watermark and loop the
review/snapshot cycle without end if the bot keeps acking.

This codifies the maintainer-decided rule (resolved at authoring): once a
`**Accepted**` / `**Rejected**` disposition exists for every
`ReviewItems_snapshot` item at the **current HEAD SHA**, an **ack-only** comment
from a configured trusted advisory bot does **not** reopen the review loop —
bind the merge to the current HEAD and proceed. An ack-only comment opens no new
thread, carries no `CHANGES_REQUESTED`, and raises no new finding; anything else
re-opens normally. Includes a worked example.

Folds in the former 2.3 item: the reliable re-review trigger is
`gh pr edit --add-reviewer <bot-slug>`; the REST `requested_reviewers`
display-name path silently no-ops (noted in E14).

## Scope note

This is the **documented playbook** the gist proposed ("add an advisory-wait
rule … documented playbook"). A helper-level mechanical ack-only classifier with
a snapshot fixture is a reasonable **follow-up**; this PR keeps the change atomic
and instruction-scoped.

## Verification

- Template sources edited first; both root mirrors regenerated via `sync-docs`.
- `audit-docs --check`, `dprint`, `markdownlint`, `cspell` all green.

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
