### PR TITLE
docs(worktree): per-mutation branch assertion + cherry-pick recovery

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -272,6 +272,12 @@ unresolvable references before passing to A3.
 
 ## A3 — Filter to ready-to-start
 
+Under concurrency, check a candidate's **active-claim eligibility** (the
+non-stale claim filter below) **first**, before investing in its viability
+or scope analysis: a parallel agent may already hold the issue, and scope
+work that displaces the claim check produces redundant PRs. The claim check
+is cheap — run it first per candidate.
+
 From A2, keep only issues that satisfy **all** of the following:
 
 - No `status:blocked-by-human` or `status:needs-decision` label

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -183,6 +183,22 @@ When in scope, run:
    worktree-HEAD symptom that this gate catches at mutation time) and
    either remove the stale primary-HEAD branch or rerun B1 cleanly in
    a fresh worktree.
+4. Also assert the worktree is **on the claimed branch**:
+   `git branch --show-current` must equal the active claim's `branch:`
+   value. Under concurrency a worktree can be in the right directory but
+   switched onto a different branch; if the current branch differs, stop
+   and report — do not `add`, `commit`, or `push` from a worktree that is
+   not on the claimed branch.
+
+**Recovery if a commit already landed on the wrong branch.** If this gate
+or `idd-doctor` finds that a commit already landed on the wrong branch —
+typically the primary worktree's `main`, or another issue's branch —
+recover by **cherry-picking** the misplaced commit onto the correct issue
+branch (in its own sibling worktree), then restore the contaminated branch
+to its intended state (e.g. `git reset --hard` the contaminated branch back
+to its upstream). Do **not** force-push the contaminated branch as a
+shortcut: preserve that branch's real history and move only the misplaced
+commit.
 
 Out of scope and explicitly **not** blocked:
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -290,6 +290,12 @@ unresolvable references before passing to A3.
 
 ## A3 — Filter to ready-to-start
 
+Under concurrency, check a candidate's **active-claim eligibility** (the
+non-stale claim filter below) **first**, before investing in its viability
+or scope analysis: a parallel agent may already hold the issue, and scope
+work that displaces the claim check produces redundant PRs. The claim check
+is cheap — run it first per candidate.
+
 From A2, keep only issues that satisfy **all** of the following:
 
 - No `status:blocked-by-human` or `status:needs-decision` label

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -183,6 +183,22 @@ When in scope, run:
    worktree-HEAD symptom that this gate catches at mutation time) and
    either remove the stale primary-HEAD branch or rerun B1 cleanly in
    a fresh worktree.
+4. Also assert the worktree is **on the claimed branch**:
+   `git branch --show-current` must equal the active claim's `branch:`
+   value. Under concurrency a worktree can be in the right directory but
+   switched onto a different branch; if the current branch differs, stop
+   and report — do not `add`, `commit`, or `push` from a worktree that is
+   not on the claimed branch.
+
+**Recovery if a commit already landed on the wrong branch.** If this gate
+or `idd-doctor` finds that a commit already landed on the wrong branch —
+typically the primary worktree's `main`, or another issue's branch —
+recover by **cherry-picking** the misplaced commit onto the correct issue
+branch (in its own sibling worktree), then restore the contaminated branch
+to its intended state (e.g. `git reset --hard` the contaminated branch back
+to its upstream). Do **not** force-push the contaminated branch as a
+shortcut: preserve that branch's real history and move only the misplaced
+commit.
 
 Out of scope and explicitly **not** blocked:
 


### PR DESCRIPTION
## Summary

Parallel worktrees can let a `git switch` move a checkout out from under another run, so a commit lands on the wrong issue branch/PR. #797 added a cwd-vs-claim check; this extends it.

- **Per-mutation branch assertion**: the shared claim-revalidation gate now also asserts `git branch --show-current` equals the claimed `branch:` before any add/commit/push (a worktree can be in the right directory but on the wrong branch).
- **Cherry-pick recovery**: documents moving a misplaced commit to the correct branch rather than force-pushing the contaminated branch.
- **Discover A3**: restates that active-claim eligibility is checked first per candidate under concurrency (folds the former 3.1).

The assertion lives in the shared gate (which idd-work/idd-pr-submit already invoke before every mutation) rather than being duplicated per phase.

## Verification

- Template sources edited first; `idd-overview-core` auto-synced; `idd-discover` (a structure/contains pair) updated in template and root mirror.
- `audit-docs --check`, `dprint`, `markdownlint`, `cspell` all green.

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
