### PR TITLE
docs(customization): optional out-of-band migration safety appendix

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1112,3 +1112,32 @@ For further details, see:
 - `idd-overview-core.instructions.md` for the always-loaded pointer that
   keeps the forced-handoff policy discoverable to agents.
 - `docs/policy-constants.md` for distributed policy defaults.
+
+## Optional: out-of-band schema migration safety
+
+This is an **optional, adopter-conditional** appendix. It applies **only when
+your schema migrations are versioned by a numeric/monotonic prefix and applied
+out-of-band** — at merge or deploy — rather than by PR CI. If PR CI applies
+your migrations, or you do not use prefix-versioned migrations, skip this
+section entirely: it is **not** part of the default IDD merge gate, and the
+core, stack-neutral workflow does not depend on it.
+
+Under parallel worktrees, two concurrent runs can each author a new migration
+with the **same version prefix**. PR CI usually does not apply migrations, so
+the collision stays invisible until the out-of-band apply fails at deploy — a
+duplicate primary key can wedge the pipeline for hours.
+
+When migrations are applied out-of-band, adopters can add two conditional
+checks as a repository-local convention:
+
+1. **Before authoring a migration**, confirm the latest committed migration
+   version on the integration branch and number the new migration strictly
+   above it (re-check just before pushing, since a sibling run may have landed
+   one meanwhile).
+2. **Before merge**, dry-run the migration inside a transaction that is rolled
+   back, so a version collision or a broken migration is caught locally rather
+   than at out-of-band apply time.
+
+Keep this guidance tool-neutral: it is keyed on "numeric-prefix versioning plus
+out-of-band apply", not on any specific database or migration framework. Do not
+wire it into the default F-phase merge gate.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1112,3 +1112,32 @@ For further details, see:
 - `idd-overview-core.instructions.md` for the always-loaded pointer that
   keeps the forced-handoff policy discoverable to agents.
 - `docs/policy-constants.md` for distributed policy defaults.
+
+## Optional: out-of-band schema migration safety
+
+This is an **optional, adopter-conditional** appendix. It applies **only when
+your schema migrations are versioned by a numeric/monotonic prefix and applied
+out-of-band** — at merge or deploy — rather than by PR CI. If PR CI applies
+your migrations, or you do not use prefix-versioned migrations, skip this
+section entirely: it is **not** part of the default IDD merge gate, and the
+core, stack-neutral workflow does not depend on it.
+
+Under parallel worktrees, two concurrent runs can each author a new migration
+with the **same version prefix**. PR CI usually does not apply migrations, so
+the collision stays invisible until the out-of-band apply fails at deploy — a
+duplicate primary key can wedge the pipeline for hours.
+
+When migrations are applied out-of-band, adopters can add two conditional
+checks as a repository-local convention:
+
+1. **Before authoring a migration**, confirm the latest committed migration
+   version on the integration branch and number the new migration strictly
+   above it (re-check just before pushing, since a sibling run may have landed
+   one meanwhile).
+2. **Before merge**, dry-run the migration inside a transaction that is rolled
+   back, so a version collision or a broken migration is caught locally rather
+   than at out-of-band apply time.
+
+Keep this guidance tool-neutral: it is keyed on "numeric-prefix versioning plus
+out-of-band apply", not on any specific database or migration framework. Do not
+wire it into the default F-phase merge gate.


### PR DESCRIPTION
## Summary

Two concurrent worktrees can author migrations sharing the same monotonic version prefix; PR CI does not apply migrations, so the duplicate primary key only surfaces (and wedges the pipeline) at the out-of-band apply.

Per the maintainer decision at authoring (**optional appendix**, not out-of-scope), this adds a clearly-fenced, adopter-conditional appendix to `customization.md`: it applies **only when migrations are prefix-versioned and applied out-of-band**, recommends numbering above the latest committed version before authoring and a dry-run-in-rolled-back-transaction before merge, stays tool-neutral, and is explicitly **not** part of the default F-phase merge gate.

## Verification

- Template source edited first; `docs/customization.md` regenerated via `sync-docs`.
- `audit-docs --check`, `dprint`, `markdownlint`, `cspell` all green.

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)
