### PR TITLE
docs(onboarding): note issue-branch glob vs CI-trigger interaction

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -598,6 +598,15 @@ CI checks out a detached HEAD), so worktree enforcement stays local — the
 `core.hooksPath` hook above, the cwd-vs-claim gate, and
 `idd-doctor --strict` run on a developer's machine.
 
+**Branch-glob vs CI-trigger.** Put PR-gating checks in the
+`pull_request`-triggered workflow (as above). A `push` workflow filtered to a
+**top-level branch glob** such as `'*'` silently skips the slash-namespaced
+IDD branches (`issue/*`, `roadmap-audit/*`): a single-star glob does not match
+across the `/`, so a gating job placed only under `on: push` with `'*'` never
+runs on IDD branches. Use `pull_request` triggers (which fire on the PR
+regardless of branch name), or a push filter that matches the slash namespace
+(`'**'` or `'issue/**'`), for any check that must gate IDD pull requests.
+
 ---
 
 ## Step 3 — Record policy decisions


### PR DESCRIPTION
## Summary

The recommended IDD branch naming uses a slash namespace (`issue/*`). A `push` CI workflow filtered to a **top-level branch glob** such as `'*'` silently skips those branches — a single-star glob does not match across the `/` — so any PR-gating job placed only there never runs on IDD branches.

This adds an onboarding note (next to the idd-doctor CI gate example): PR-gating checks belong in the `pull_request`-triggered workflow (which fires on the PR regardless of branch name), or under a slash-matching push filter (`'**'` or `'issue/**'`).

## Verification

- `audit-docs --check`, `dprint`, `markdownlint`, `cspell` all green.

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)
