### PR TITLE
docs(customization): optional CI cost discipline appendix

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1141,3 +1141,25 @@ checks as a repository-local convention:
 Keep this guidance tool-neutral: it is keyed on "numeric-prefix versioning plus
 out-of-band apply", not on any specific database or migration framework. Do not
 wire it into the default F-phase merge gate.
+
+## Optional: CI cost discipline on billed runners
+
+This is an **optional** appendix for adopters running on metered or private
+Actions runners. The core, cross-agent workflow does not require it.
+
+IDD's frequent **main-into-feature re-sync cadence** is the dominant driver of
+CI minutes — every sync re-runs the PR's checks. Uncached container builds and
+per-PR multi-arch builds compound it. Levers to control the cost:
+
+- **Gate heavy jobs behind a paths-filter** so expensive builds run only when
+  the paths they cover actually change.
+- **Cache build layers** (image layer cache, dependency cache) so re-syncs
+  reuse prior work instead of rebuilding from scratch.
+- **Keep multi-arch / publish jobs on integration-branch pushes only**, not on
+  every PR head, so per-PR cost stays low.
+- Remember that **re-sync cadence is the main cost lever**: the
+  merge-from-`main` freshness model trades CI minutes for merge safety, so tune
+  the heavy jobs rather than loosening the freshness gate.
+
+These are repository-local optimizations; they do not change the IDD merge gate
+or the cross-agent workflow.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1141,3 +1141,25 @@ checks as a repository-local convention:
 Keep this guidance tool-neutral: it is keyed on "numeric-prefix versioning plus
 out-of-band apply", not on any specific database or migration framework. Do not
 wire it into the default F-phase merge gate.
+
+## Optional: CI cost discipline on billed runners
+
+This is an **optional** appendix for adopters running on metered or private
+Actions runners. The core, cross-agent workflow does not require it.
+
+IDD's frequent **main-into-feature re-sync cadence** is the dominant driver of
+CI minutes — every sync re-runs the PR's checks. Uncached container builds and
+per-PR multi-arch builds compound it. Levers to control the cost:
+
+- **Gate heavy jobs behind a paths-filter** so expensive builds run only when
+  the paths they cover actually change.
+- **Cache build layers** (image layer cache, dependency cache) so re-syncs
+  reuse prior work instead of rebuilding from scratch.
+- **Keep multi-arch / publish jobs on integration-branch pushes only**, not on
+  every PR head, so per-PR cost stays low.
+- Remember that **re-sync cadence is the main cost lever**: the
+  merge-from-`main` freshness model trades CI minutes for merge safety, so tune
+  the heavy jobs rather than loosening the freshness gate.
+
+These are repository-local optimizations; they do not change the IDD merge gate
+or the cross-agent workflow.


### PR DESCRIPTION
## Summary

IDD's frequent main-into-feature re-sync cadence is the dominant driver of CI minutes on metered/private runners; uncached container builds and per-PR multi-arch builds compound it.

This adds an **optional** CI cost-discipline appendix to `customization.md`: gate heavy jobs behind a paths-filter, cache build layers, keep multi-arch/publish on integration-branch pushes only, and note re-sync cadence as the main cost lever. Repository-local optimizations; the core merge gate and cross-agent workflow are unchanged.

## Verification

- Template source edited first; `docs/customization.md` regenerated via `sync-docs`.
- `audit-docs --check`, `dprint`, `markdownlint`, `cspell` all green.

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)
