### PR TITLE
docs(onboarding): codify named-gap re-import methodology

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -55,6 +55,29 @@ a new repository.
 > First-time adopters can ignore this section — the flow below already
 > references the new file.
 
+### Re-importing: import named gaps, not a blind resync
+
+When you pull a newer upstream template into a repository that already adopted
+IDD, treat the upgrade as a **named-gap import**, not a blind resync:
+
+1. **Resolve placeholders first** so the new template carries your repository's
+   real values, not upstream defaults.
+2. **Reconcile only the enumerated gaps** — the specific changes between your
+   current version and the new template — **against your recorded local policy**
+   (the policy section from Step 3). Do not overwrite intentional local
+   divergence with upstream defaults; a blind file-for-file resync silently
+   reverts your customizations.
+3. Re-run the Step 2 import checklist and `idd-doctor` after reconciling.
+
+When you then audit whether re-imported roadmap work is actually done, judge
+**completion by auditing the implementation against the acceptance criteria**,
+not by a child issue's closed state — a skeleton or scaffold PR can merge and
+close a child while leaving its acceptance criteria unimplemented. See the
+roadmap-audit rule in
+`.github/instructions/idd-roadmap-audit.instructions.md` (compare the roadmap
+success criteria against the merged PRs; do not infer completion from
+checkbox state alone).
+
 ## What you are setting up
 
 IDD is a multi-agent GitHub automation workflow. Agents work through a

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -67,7 +67,8 @@ IDD, treat the upgrade as a **named-gap import**, not a blind resync:
    (the policy section from Step 3). Do not overwrite intentional local
    divergence with upstream defaults; a blind file-for-file resync silently
    reverts your customizations.
-3. Re-run the Step 2 import checklist and `idd-doctor` after reconciling.
+3. Re-apply the Step 2 file import for the changed files, then re-run the
+   Step 6 verification checklist and `idd-doctor` after reconciling.
 
 When you then audit whether re-imported roadmap work is actually done, judge
 **completion by auditing the implementation against the acceptance criteria**,


### PR DESCRIPTION
## Summary

Two recurring re-import hazards: (a) treating re-import as a **blind resync** clobbers an adopter's intentional local divergence; (b) judging a roadmap "complete" from a child issue's closed state is unsound (a scaffold PR can merge and close a child while leaving its acceptance criteria unimplemented).

This documents the upstream re-import as a **named-gap import** in the ONBOARDING "Upgrading" section: resolve placeholders, then reconcile only the enumerated gaps against recorded local policy — never blind-resync. It cross-links the existing roadmap-audit rule (judge completion by auditing implementation vs acceptance criteria, not closed-state), so both hazards are discoverable from one place.

## Verification

- `audit-docs --check`, `dprint`, `markdownlint`, `cspell` all green.

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
