### PR TITLE
fix(ci): make stalebot mark-only so it never auto-closes issues or prs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,10 +11,13 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          days-before-close: 14
+          # IDD rationale: StaleBot is a visibility tool only. The stale
+          # label is a human signal; closing is reserved for humans and
+          # roadmap audits, because a StaleBot close is indistinguishable
+          # from completed work to the A1.5 roadmap audit and auto-closed
+          # PRs can fight legitimate IDD holds. Never auto-close.
+          days-before-close: -1
           days-before-stale: 60
-          close-issue-message: StaleBot closed the issue due to prolonged inactivity.
-          close-pr-message: StaleBot closed the pull request due to prolonged inactivity.
           exempt-issue-labels: bug,enhancement
           exempt-pr-labels: bug,enhancement
           stale-issue-label: stale


### PR DESCRIPTION
## Summary

Make StaleBot a visibility-only tool: keep the 60-day stale labeling but never auto-close issues or PRs.

- Set days-before-close: -1 in .github/workflows/stale.yml so neither issues nor PRs are ever auto-closed.
- Drop the now-unused close-issue-message / close-pr-message inputs.
- Add a workflow comment explaining the IDD rationale: a StaleBot close is indistinguishable from completed work to the A1.5 roadmap audit, and auto-closing PRs can fight legitimate IDD holds (advisory waits, F2 blocks). Closing stays reserved for humans and roadmap audits.

## Rationale

IDD's freshness model (24 h claim staleness, roadmap audits) already owns lifecycle hygiene; open issues without bug/enhancement labels (e.g. #553, #611, #815) were eligible for silent auto-close, which would corrupt roadmap-audit state.

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to disable automatic closing of stale issues and pull requests. Issues and PRs will now be marked as stale after 60 days but will not be automatically closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->