### PR TITLE
ci: sha-pin all workflow actions and add codeql scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+name: CodeQL
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '30 3 * * 1'
+permissions:
+  contents: read
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          # The repository's previous CodeQL default setup scanned both
+          # languages; keep parity so the advanced workflow is not a
+          # coverage regression.
+          - actions
+          - javascript-typescript
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          build-mode: none
+          languages: ${{ matrix.language }}
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,8 @@ jobs:
           - javascript-typescript
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:

--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -25,7 +25,7 @@ jobs:
       # local-only primary-worktree-HEAD check never false-positives on a
       # push-event checkout, where actions/checkout would otherwise leave
       # HEAD on the issue/* branch and trip the (enabled) worktree guard.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.sha }}
           # Read-only health check: no need to persist the token in git config.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Run documentation audit
@@ -28,6 +28,6 @@ jobs:
       - name: Run workshop integrity check
         run: node scripts/verify-workshop-integrity.mjs --format table
       - name: Run cspell
-        uses: streetsidesoftware/cspell-action@v8
+        uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Run documentation audit
         env:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}

--- a/.github/workflows/pnpm-boundary.yml
+++ b/.github/workflows/pnpm-boundary.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:

--- a/.github/workflows/pnpm-boundary.yml
+++ b/.github/workflows/pnpm-boundary.yml
@@ -39,15 +39,15 @@ jobs:
     runs-on: ${{ inputs.runner || 'ubuntu-slim' }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           run_install: false
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           check-latest: true
           cache: pnpm

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           check-latest: true
           node-version: 24.x

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           # IDD rationale: StaleBot is a visibility tool only. The stale
           # label is a human signal; closing is reserved for humans and


### PR DESCRIPTION
## Summary

- Pin every `uses:` reference in `.github/workflows/*.yml` to a full 40-character commit SHA with a trailing version comment (`actions/checkout` v6.0.3, `actions/setup-node` v6.4.0, `pnpm/action-setup` v6.0.8, `streetsidesoftware/cspell-action` v8.4.0, `actions/stale` v10.3.0). `DavidAnson/markdownlint-cli2-action` was already pinned and is unchanged. Dependabot already watches `github-actions`, so the pins stay maintained.
- Add `.github/workflows/codeql.yml`: CodeQL advanced setup (default query suite, build-mode `none`) running on pull requests targeting `main` and a weekly Monday schedule, on a standard `ubuntu-latest` runner.

## Rationale / trade-offs

- The CodeQL language matrix covers `javascript-typescript` **and** `actions`. The issue names only `javascript-typescript`, but the repository's CodeQL **default setup** (enabled at implementation time) scanned both languages; the matrix keeps coverage parity instead of regressing the workflow-file scan.
- CodeQL default setup was switched off via the code-scanning API immediately before this PR was opened, because GitHub rejects advanced-workflow SARIF uploads while default setup is enabled. This workflow is the durable replacement (see the B2 plan comment on #834).
- #832 (CI dedup) edits the same workflow files — no dependency edge; whichever lands second rebases.

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated CodeQL security analysis on pull requests to main and on a weekly schedule to surface potential security issues.

* **Chores**
  * Standardized CI workflows by pinning action versions to fixed commits, improving reproducibility and stability of automated checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->