### PR TITLE
feat(audit): add bundle budgets for work, review, and merge paths

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -40,3 +40,17 @@ new allowed concrete mapping, add a `concreted` sync pair with a
 `structure` and document why in the pair's `note` field. For generated
 file lists, update the manifest paths or globs first, then rerun the
 audit so the marked block can be refreshed deliberately.
+
+## Bundle Budgets
+
+The `bundleBudgets` entries cap the combined byte size of the
+instruction files loaded together on each phase path (discovery,
+resume, work, review, and merge), so context re-bloat fails the audit
+instead of silently degrading unattended loops.
+
+Each `limitBytes` value encodes at most roughly 10% headroom over the
+bundle size measured when the entry was added or last adjusted.
+**Ratchet rule**: raising any `limitBytes` value requires an explicit
+callout in the pull request description explaining why the growth is
+justified; shrinking a limit after an instruction diet needs no
+callout.

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -172,6 +172,44 @@
         ".github/instructions/idd-resume.instructions.md"
       ],
       "limitBytes": 46000
+    },
+    {
+      "id": "bundle-work",
+      "description": "Work path: idd-overview-core + idd-overview-appendix + idd-work",
+      "files": [
+        ".github/instructions/idd-overview-core.instructions.md",
+        ".github/instructions/idd-overview-appendix.instructions.md",
+        ".github/instructions/idd-work.instructions.md"
+      ],
+      "limitBytes": 34900
+    },
+    {
+      "id": "bundle-review",
+      "description": "Review path: idd-overview-core + idd-overview-appendix + idd-review-snapshot + idd-review-triage + idd-review-fix + idd-advisory-wait + idd-ci",
+      "files": [
+        ".github/instructions/idd-overview-core.instructions.md",
+        ".github/instructions/idd-overview-appendix.instructions.md",
+        ".github/instructions/idd-review-snapshot.instructions.md",
+        ".github/instructions/idd-review-triage.instructions.md",
+        ".github/instructions/idd-review-fix.instructions.md",
+        ".github/instructions/idd-advisory-wait.instructions.md",
+        ".github/instructions/idd-ci.instructions.md"
+      ],
+      "limitBytes": 92400
+    },
+    {
+      "id": "bundle-merge",
+      "description": "Merge path: idd-overview-core + idd-overview-appendix + idd-pre-merge + idd-merge-handoff + idd-merge + idd-advisory-wait + idd-ci",
+      "files": [
+        ".github/instructions/idd-overview-core.instructions.md",
+        ".github/instructions/idd-overview-appendix.instructions.md",
+        ".github/instructions/idd-pre-merge.instructions.md",
+        ".github/instructions/idd-merge-handoff.instructions.md",
+        ".github/instructions/idd-merge.instructions.md",
+        ".github/instructions/idd-advisory-wait.instructions.md",
+        ".github/instructions/idd-ci.instructions.md"
+      ],
+      "limitBytes": 80600
     }
   ],
   "syncPairs": [


### PR DESCRIPTION
## Summary

- Add three `bundleBudgets` entries to `audit/sync-manifest.json` covering the work, review, and merge phase paths, mirroring the existing `bundle-discovery` / `bundle-resume` shape.
- Document the ratchet rule in a new "Bundle Budgets" section of `audit/README.md`: raising any `limitBytes` requires an explicit callout in the PR description.

## Limits (measured at head `0eb92ae`, ≤ 10% headroom)

| Bundle | Measured | Limit | Headroom |
| --- | --- | --- | --- |
| `bundle-work` | 31,774 B | 34,900 | 9.84% |
| `bundle-review` | 84,015 B | 92,400 | 9.98% |
| `bundle-merge` | 73,308 B | 80,600 | 9.95% |

## Acceptance demonstration (temporary local change, not committed)

With each new `limitBytes` temporarily lowered to 1,000, `node scripts/audit-docs.mjs --check` failed with one error per bundle, e.g.:

```text
- bundle-work: bundle total is 31774 bytes (limit 1000); files: …idd-overview-core… …idd-overview-appendix… …idd-work…
- bundle-review: bundle total is 84015 bytes (limit 1000); …
- bundle-merge: bundle total is 73308 bytes (limit 1000); …
```

After restoring the committed limits, the audit passes on the current tree, and the full `node --test tests/*.mjs` suite is green.

`audit/` is repo-local (not part of `idd-template/`), so no template mirroring is required.

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)
