### PR TITLE
feat(ci): publish schemas via github pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+concurrency:
+  cancel-in-progress: false
+  group: pages
+name: Publish schemas to GitHub Pages
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - schemas/**
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Stage schemas-only artifact root
+        # The Pages strategy (docs/pages-strategy.md) publishes only
+        # schemas/ so canonical $id/$schema URLs resolve; the docs site
+        # stays deferred.
+        run: |
+          mkdir -p _site
+          cp -R schemas _site/schemas
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: _site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
 jobs:
   deploy:
+    # Guard workflow_dispatch runs from non-main refs: the published
+    # $id/$schema surface must never diverge from main.
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/pages-strategy.md
+++ b/docs/pages-strategy.md
@@ -1,8 +1,14 @@
 # GitHub Pages Readiness Strategy
 
 This page records the low-cost path for turning the `docs/` reference
-manual into a public GitHub Pages site later. It is a planning note, not
-an instruction to enable Pages in this issue.
+manual into a public GitHub Pages site later. It is a planning note for
+the docs site, which remains deferred.
+
+**Current state**: GitHub Pages is enabled with the Actions build type,
+publishing **only** `schemas/` so the canonical `$id`/`$schema` URLs
+under `https://kurone-kito.github.io/idd-skill/schemas/` resolve (see
+`.github/workflows/pages.yml`). The docs-site decisions below are
+unchanged by that schemas-only publication.
 
 ## Decision
 
@@ -76,7 +82,7 @@ traffic or maintainer feedback:
 
 This strategy does not:
 
-- enable GitHub Pages
+- publish `docs/` (or any non-schema path) to the Pages site
 - add a custom domain
 - add a site framework or generated build step
 - replace `idd-template/` as the portable package


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pages.yml`: deploys a **schemas-only** artifact to GitHub Pages on pushes to `main` touching `schemas/**`, plus `workflow_dispatch` for the initial deploy (this PR itself does not modify `schemas/**`). Actions are SHA-pinned per repo convention (`upload-pages-artifact` v4.0.0, `deploy-pages` v4.0.5, checkout v6.0.3 with `persist-credentials: false`).
- Update `docs/pages-strategy.md`: GitHub Pages enablement is no longer a blanket non-goal — the non-goal is now scoped to publishing `docs/` (or any non-schema path); the schemas-only current state is documented. The docs site remains deferred.

## Operational side effect (already applied)

GitHub Pages was enabled idempotently with the Actions build type via `gh api -X POST repos/kurone-kito/idd-skill/pages -f build_type=workflow` (per the wizard-resolved direction in #830). Nothing is served until the workflow deploys, so enablement before merge is inert.

## Post-merge verification plan (acceptance)

After merge, trigger `pages.yml` via `workflow_dispatch`, then verify every `$id` URL under `schemas/` (including `schemas/phase-graph.json`) returns HTTP 200 with a body identical to the repository content, and that the served `policy.schema.json` validates the shipped `config.json` files. Evidence will be posted on the issue.

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)
