### PR TITLE
ci: run each check suite exactly once per change

### DIFF
--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -9,11 +9,9 @@ name: IDD doctor health gate
 # detached HEAD, so the worktree-head check never fires here. Worktree
 # enforcement is local only (idd-doctor --strict, the core.hooksPath
 # hook, the cwd-vs-claim gate, and the B1 self-check).
+# CI topology (#832): pull_request-only, mirroring lint.yml, so the
+# health gate runs exactly once per change.
 on:
-  push:
-    branches:
-      - '**'
-      - '!main'
   pull_request:
 permissions:
   contents: read
@@ -22,9 +20,9 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       # Check out the exact commit (detached HEAD) so idd-doctor's
-      # local-only primary-worktree-HEAD check never false-positives on a
-      # push-event checkout, where actions/checkout would otherwise leave
-      # HEAD on the issue/* branch and trip the (enabled) worktree guard.
+      # local-only primary-worktree-HEAD check never false-positives.
+      # pull_request checkouts are already detached merge commits;
+      # pinning the ref keeps that guaranteed even if triggers change.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,18 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
 name: Linting workflow
+# CI topology (#832): pull_request is the only CI trigger so each check
+# runs exactly once per change; the pre-PR push window is covered by the
+# local pre-push contract instead of a duplicate push trigger.
+#
+# This workflow dogfoods the toolless bare-node adopter path: it runs
+# with NO package-manager install, so every script and test it executes
+# must import only `node:` builtins. The same three commands also run
+# via `pnpm run lint:minimum` in pnpm-boundary.yml — that overlap is
+# intentional redundancy proving both the installed and the bare-node
+# runtimes. The formatting and spelling tools (dprint, cspell,
+# markdownlint) run exactly once, in pnpm-boundary.yml.
 on:
-  push:
-    branches:
-      - '**'
-      - '!main'
   pull_request:
 permissions:
   contents: read
@@ -14,21 +21,14 @@ jobs:
   lint:
     runs-on: ubuntu-slim
     steps:
+      # fetch-depth: 0 is required by audit-docs' changed-file diff bases.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Run documentation audit
-        env:
-          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
         run: node scripts/audit-docs.mjs --check
-      - name: Run dprint
-        run: npx dprint@0.54.0 check "**/*.md"
       - name: Run protocol tests
         run: node --test tests/*.mjs
       - name: Run workshop integrity check
         run: node scripts/verify-workshop-integrity.mjs --format table
-      - name: Run cspell
-        uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
-      - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23

--- a/.github/workflows/pnpm-boundary.yml
+++ b/.github/workflows/pnpm-boundary.yml
@@ -1,10 +1,11 @@
 name: Pnpm boundary guard
+# CI topology (#832): pull_request is the only CI trigger for this
+# repository so each check runs exactly once per change; workflow_call
+# remains for downstream callers. This workflow runs the full
+# `pnpm run lint:minimum` suite once with installed dependencies; the
+# bare-node subset intentionally also runs in lint.yml.
 on:
   pull_request:
-  push:
-    branches:
-      - "**"
-      - "!main"
   workflow_call:
     inputs:
       runner:
@@ -31,7 +32,9 @@ permissions:
   contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  # Always true: with pull_request-only triggers every ref is a PR merge
+  # ref, and callee-level concurrency is ignored under workflow_call.
+  cancel-in-progress: true
 jobs:
   pnpm-boundary:
     # Imported from kurone-kito/pnpm-project-template push workflow shape

--- a/.github/workflows/pnpm-boundary.yml
+++ b/.github/workflows/pnpm-boundary.yml
@@ -32,9 +32,12 @@ permissions:
   contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Always true: with pull_request-only triggers every ref is a PR merge
-  # ref, and callee-level concurrency is ignored under workflow_call.
-  cancel-in-progress: true
+  # For this repository's own pull_request runs the ref is always a PR
+  # merge ref, so this evaluates to true (same effect as lint.yml's
+  # unconditional setting). The conditional stays for workflow_call
+  # callers: github.ref then reflects the caller's ref, which may be a
+  # long-lived branch where auto-cancelling in-flight runs is unwanted.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   pnpm-boundary:
     # Imported from kurone-kito/pnpm-project-template push workflow shape

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -489,7 +489,8 @@ Decision points:
 
 This repository exposes `.github/workflows/pnpm-boundary.yml` as both:
 
-- a normal CI workflow (`push` and `pull_request`)
+- a normal CI workflow (`pull_request`-triggered, so each check runs
+  exactly once per change)
 - a reusable workflow (`workflow_call`) for downstream repositories
 
 The job shape is imported from

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -600,8 +600,6 @@ files) on every change. It is opt-in — add a workflow such as:
 name: IDD doctor health gate
 on:
   pull_request:
-  push:
-    branches: ['**', '!main']
 permissions:
   contents: read
 jobs:

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -489,7 +489,8 @@ Decision points:
 
 This repository exposes `.github/workflows/pnpm-boundary.yml` as both:
 
-- a normal CI workflow (`push` and `pull_request`)
+- a normal CI workflow (`pull_request`-triggered, so each check runs
+  exactly once per change)
 - a reusable workflow (`workflow_call`) for downstream repositories
 
 The job shape is imported from


### PR DESCRIPTION
## Summary

- `pull_request` becomes the only CI trigger for `lint.yml`, `pnpm-boundary.yml`, and `idd-doctor.yml`. The previous `push: ['**', '!main']` + `pull_request` dual triggers ran the same validation suite up to four times per change on an open-PR branch (differing concurrency groups — `refs/heads/...` vs `refs/pull/...` — meant nothing deduplicated across events).
- `lint.yml` is kept as the **bare-node dogfood** of the toolless adopter path, slimmed to the three steps `pnpm-boundary` cannot prove: `audit-docs`, `node --test`, and workshop integrity running with **no node_modules** (this is the only mechanical guard that helpers/tests import only `node:` builtins). The dropped dprint/cspell/markdownlint steps run exactly once via `pnpm run lint:minimum` in `pnpm-boundary.yml`; dropping the `npx dprint@0.54.0` step also removes its version-pin drift vs `package.json`.
- `cancel-in-progress` stays conditional in `pnpm-boundary.yml` (`startsWith(github.ref, 'refs/pull/')`): for this repository's own PR runs it evaluates to `true` (same effect as the unconditional setting in the other two workflows), while `workflow_call` callers — where `github.ref` reflects the caller's ref — keep long-lived branches safe from surprise auto-cancellations. The `workflow_call` surface and its inputs are unchanged.
- Workflow headers document the chosen topology and the intentionally kept bare-node/installed redundancy; `customization.md` (template + synced root mirror) and the ONBOARDING idd-doctor snippet no longer recommend the duplicating dual trigger.
- Check/job names (`lint`, `pnpm-boundary`, `idd-doctor`) are unchanged; verified live that no ruleset or branch protection references required status checks.

## Verification

- Local: documentation audit, dprint, 862/862 tests, cspell, markdownlint all green.
- Acceptance evidence (each distinct check exactly once per push to an open-PR branch) will be captured from this PR's Actions run list after the first post-PR push and posted as a comment.

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow triggers to run exclusively on pull requests, improving efficiency by eliminating redundant checks on push events.
  * Consolidated linting responsibilities across workflows and added concurrency controls to cancel duplicate runs.
  * Updated documentation to reflect the new pull-request-only CI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
