### PR TITLE
fix(tests): isolate worktree-guard fixtures from ambient git env

### DIFF
--- a/tests/worktree-guard-hook.test.mjs
+++ b/tests/worktree-guard-hook.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { devNull, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -13,17 +13,75 @@ const HOOKS_DIR = join(
   '.githooks',
 );
 
+// Fixture invariant: fixture git processes must never read the ambient
+// git environment or the developer's config. Hook runs export GIT_DIR /
+// GIT_INDEX_FILE (so an unsanitized fixture would mutate the HOST
+// repository when this suite runs inside a pre-commit hook), and a
+// global config may enable commit signing (stalling fixture commits on
+// pinentry). Build the sanitized env per call so tests can poison
+// process.env and prove the isolation holds. The GIT_CONFIG_GLOBAL /
+// GIT_CONFIG_SYSTEM overrides require git >= 2.32.
+function fixtureEnv() {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_CONFIG')) {
+      delete env[key];
+    }
+  }
+  delete env.GIT_DIR;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  env.GIT_CONFIG_GLOBAL = devNull;
+  env.GIT_CONFIG_SYSTEM = devNull;
+  return env;
+}
+
 function git(repo, args) {
-  execFileSync('git', args, { cwd: repo, stdio: 'pipe' });
+  execFileSync('git', args, { cwd: repo, env: fixtureEnv(), stdio: 'pipe' });
+}
+
+/** Run git for assertions and return its trimmed stdout. */
+function gitOut(repo, args) {
+  return execFileSync('git', args, {
+    cwd: repo,
+    env: fixtureEnv(),
+    encoding: 'utf8',
+    stdio: 'pipe',
+  }).trim();
 }
 
 /** Run a hook script directly and return its exit code. */
 function runHook(repo, hook, cwd = repo) {
   try {
-    execFileSync('sh', [join(repo, '.githooks', hook)], { cwd, stdio: 'pipe' });
+    execFileSync('sh', [join(repo, '.githooks', hook)], {
+      cwd,
+      env: fixtureEnv(),
+      stdio: 'pipe',
+    });
     return 0;
   } catch (err) {
     return typeof err.status === 'number' ? err.status : 1;
+  }
+}
+
+/** Poison process.env, run the synchronous callback, then restore keys. */
+function withPoisonedEnv(poison, callback) {
+  const saved = new Map(
+    Object.keys(poison).map((key) => [key, process.env[key]]),
+  );
+  try {
+    Object.assign(process.env, poison);
+    callback();
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
   }
 }
 
@@ -126,5 +184,66 @@ test('hook allows issue/* commits from a sibling worktree', () => {
     }
     rmSync(repo, { recursive: true, force: true });
     rmSync(sibling, { recursive: true, force: true });
+  }
+});
+
+test('fixture git operations cannot reach a sentinel repo via inherited env', () => {
+  const sentinel = mkdtempSync(join(tmpdir(), 'idd-sentinel-'));
+  let repo;
+  try {
+    git(sentinel, ['init', '-b', 'main']);
+    git(sentinel, ['config', 'user.email', 'sentinel@example.com']);
+    git(sentinel, ['config', 'user.name', 'Sentinel']);
+    writeFileSync(join(sentinel, 'README.md'), 'sentinel\n');
+    git(sentinel, ['add', '-A']);
+    git(sentinel, ['commit', '--no-verify', '-m', 'sentinel']);
+    const headBefore = gitOut(sentinel, ['rev-parse', 'HEAD']);
+    const branchesBefore = gitOut(sentinel, ['branch', '--list']);
+
+    withPoisonedEnv(
+      {
+        GIT_DIR: join(sentinel, '.git'),
+        GIT_INDEX_FILE: join(sentinel, '.git', 'index'),
+        GIT_WORK_TREE: sentinel,
+      },
+      () => {
+        repo = setupRepo({ worktreeGuard: { enabled: true } });
+        git(repo, ['checkout', '-q', '-b', 'issue/123-example']);
+        assert.equal(runHook(repo, 'pre-commit'), 1);
+      },
+    );
+
+    assert.equal(gitOut(sentinel, ['rev-parse', 'HEAD']), headBefore);
+    assert.equal(gitOut(sentinel, ['branch', '--list']), branchesBefore);
+    assert.equal(gitOut(sentinel, ['status', '--porcelain']), '');
+  } finally {
+    if (repo) {
+      rmSync(repo, { recursive: true, force: true });
+    }
+    rmSync(sentinel, { recursive: true, force: true });
+  }
+});
+
+test('fixture commits ignore a signing-enabled global git config', () => {
+  const configDir = mkdtempSync(join(tmpdir(), 'idd-gitconfig-'));
+  const configPath = join(configDir, 'gitconfig');
+  let repo;
+  try {
+    writeFileSync(
+      configPath,
+      '[commit]\n\tgpgsign = true\n[gpg]\n\tprogram = /bin/false\n',
+    );
+
+    withPoisonedEnv({ GIT_CONFIG_GLOBAL: configPath }, () => {
+      // setupRepo commits succeeding is the no-signing proof: any signing
+      // attempt would invoke /bin/false and fail the commit.
+      repo = setupRepo({ worktreeGuard: { enabled: true } });
+      assert.equal(runHook(repo, 'pre-commit'), 0);
+    });
+  } finally {
+    if (repo) {
+      rmSync(repo, { recursive: true, force: true });
+    }
+    rmSync(configDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

- `tests/worktree-guard-hook.test.mjs` fixture git processes now run with a per-call sanitized environment: every `GIT_CONFIG*` key plus `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, and `GIT_OBJECT_DIRECTORY` is stripped, and global/system config are pointed at the null device (git ≥ 2.32 idiom).
- This closes the defect observed on 2026-06-10 (PR #849): running the suite inside the husky pre-commit hook — which exports `GIT_DIR`/`GIT_INDEX_FILE`, notably from linked worktrees — let fixture `init`/`commit`/`checkout -b` operate on the **host** repository (truncated index, refs moved to fixture commits, stray `issue/123-example`/`release/1` branches, `core.bare` flip). It also removes the 60-second-per-commit pinentry stalls when the developer'\''s global config enables `commit.gpgsign`.
- Two regression tests prove both vectors: a `GIT_DIR`-family-poisoned run leaves a sentinel repository untouched (HEAD, branch list, porcelain status), and `setupRepo` succeeding under a gpgsign-enabled global config with `gpg.program=/bin/false` is itself the no-signing proof.

## Verification

- `node --test tests/worktree-guard-hook.test.mjs`: 9/9 in ~0.7 s **without any env wrapper** on a machine whose global config has `commit.gpgsign=true` (previously 7 stalls × 60 s).
- Full `pnpm run lint:minimum` green, and **both commits on this branch were created with the husky pre-commit hook fully enabled from a linked worktree** — the exact scenario that used to corrupt the repository — with the host repo verified intact afterwards (live dogfood of the fix).
- The critique pass empirically reproduced the pre-fix corruption in a sandbox, confirming the regression test fails without the fix.

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved environment isolation for Git operations to ensure reliable test execution across different developer configurations.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->