### PR TITLE
test: extend flag-name matrix to all shared helper flag concepts

### DIFF
--- a/tests/flag-name-matrix.test.mjs
+++ b/tests/flag-name-matrix.test.mjs
@@ -25,9 +25,10 @@ function readScript(name) {
 
 // One canonical CLI flag name per shared concept. `helpers` is the explicit set
 // of scripts that accept the concept, so the test catches a canonical flag being
-// renamed or removed (not only a stray deprecated alias). A `deprecated` name
-// may be kept as an alias for one release but must always warn on stderr and
-// coexist with the canonical flag.
+// renamed or removed (not only a stray deprecated alias). The optional
+// `deprecated` name may be kept as an alias for one release but must always
+// warn on stderr and coexist with the canonical flag; concepts without an
+// alias declare only the canonical spelling.
 const FLAG_CONCEPTS = [
   {
     concept: 'claim id',
@@ -51,6 +52,56 @@ const FLAG_CONCEPTS = [
       'pre-merge-readiness.mjs',
     ],
   },
+  {
+    // force-handoff.mjs is intentionally absent: its sole '--pr' literal is
+    // an error-message label inside an interactive prompt, not a parsed flag.
+    concept: 'pull request number',
+    canonical: '--pr',
+    helpers: [
+      'advisory-wait-state.mjs',
+      'audit-pr-cleanup.mjs',
+      'branch-conflict-state.mjs',
+      'discover-orphan-filter.mjs',
+      'external-check-waiver.mjs',
+      'forced-handoff-marker.mjs',
+      'live-status-digest.mjs',
+      'pre-merge-readiness.mjs',
+      'review-activity-snapshot.mjs',
+      'stalled-session-quiet-check.mjs',
+    ],
+  },
+  {
+    concept: 'trusted marker logins',
+    canonical: '--trusted-marker-logins',
+    helpers: [
+      'advisory-wait-state.mjs',
+      'forced-handoff-marker.mjs',
+      'minimize-superseded-markers.mjs',
+      'pre-merge-readiness.mjs',
+      'resume-claim-routing.mjs',
+      'review-activity-snapshot.mjs',
+    ],
+  },
+  {
+    concept: 'IDD agent logins',
+    canonical: '--idd-agent-logins',
+    helpers: ['pre-merge-readiness.mjs'],
+  },
+  {
+    concept: 'advisory bot logins',
+    canonical: '--advisory-bot-logins',
+    helpers: ['pre-merge-readiness.mjs'],
+  },
+];
+
+// Known near-miss spellings a future helper might plausibly introduce.
+// Keep this list small and mapped to the canonical flag the guard names.
+const NEAR_MISS_VARIANTS = [
+  { variant: '--pr-number', canonical: '--pr' },
+  { variant: '--pull-request', canonical: '--pr' },
+  { variant: '--trusted-actors', canonical: '--trusted-marker-logins' },
+  { variant: '--agent-logins', canonical: '--idd-agent-logins' },
+  { variant: '--bot-logins', canonical: '--advisory-bot-logins' },
 ];
 
 for (const { concept, canonical, deprecated, helpers } of FLAG_CONCEPTS) {
@@ -63,6 +114,10 @@ for (const { concept, canonical, deprecated, helpers } of FLAG_CONCEPTS) {
       );
     }
   });
+
+  if (!deprecated) {
+    continue;
+  }
 
   test(`no helper accepts ${deprecated} without the canonical ${canonical}`, () => {
     for (const file of scriptFiles) {
@@ -95,6 +150,20 @@ for (const { concept, canonical, deprecated, helpers } of FLAG_CONCEPTS) {
     }
   });
 }
+
+test('no helper introduces a near-miss variant of a canonical flag', () => {
+  for (const file of scriptFiles) {
+    const src = readScript(file);
+    for (const { variant, canonical } of NEAR_MISS_VARIANTS) {
+      if (includesQuotedFlag(src, variant)) {
+        assert.ok(
+          includesQuotedFlag(src, canonical),
+          `${file} quotes ${variant}; use the canonical ${canonical} (or accept both)`,
+        );
+      }
+    }
+  }
+});
 
 test('pre-merge-readiness accepts both canonical and deprecated claim/agent flags', () => {
   const src = readScript('pre-merge-readiness.mjs');

--- a/tests/flag-name-matrix.test.mjs
+++ b/tests/flag-name-matrix.test.mjs
@@ -54,7 +54,8 @@ const FLAG_CONCEPTS = [
   },
   {
     // force-handoff.mjs is intentionally absent: its sole '--pr' literal is
-    // an error-message label inside an interactive prompt, not a parsed flag.
+    // the error-message label used when validating the interactively
+    // prompted PR number, not a parsed CLI flag.
     concept: 'pull request number',
     canonical: '--pr',
     helpers: [


### PR DESCRIPTION
## Summary

- `tests/flag-name-matrix.test.mjs` now guards all shared helper flag concepts: `--pr` (10 helpers), `--trusted-marker-logins` (6), `--idd-agent-logins`, and `--advisory-bot-logins` (1 each), alongside the existing claim-id/agent-id concepts. The deprecated-alias tests become conditional — the new concepts ship no alias.
- A **near-miss guard** fails when any script under `scripts/` quotes a known variant spelling (`--pr-number`, `--pull-request`, `--trusted-actors`, `--agent-logins`, `--bot-logins`) without also accepting the canonical flag; the failure message names the canonical. The quoted-literal matcher prevents false positives from `--profile` or the variant literal itself.
- `force-handoff.mjs` is intentionally outside the `--pr` list (a deliberate divergence from the issue's count of 11): its sole `--pr` literal is an error-message label inside an interactive prompt, not a parsed CLI flag — an inline comment records this.

## Verification

- 12/12 matrix tests pass on the current tree; full `pnpm run lint:minimum` green (commit made with the pre-commit hook enabled).
- Acceptance demo executed: temporarily injecting a quoted `--pr-number` into `ci-wait-policy.mjs` (a helper without the canonical) failed the guard with `ci-wait-policy.mjs quotes --pr-number; use the canonical --pr (or accept both)`, then reverted to green.
- Known blind spot (out of scope): the manually mirrored `idd-template/scripts/minimize-superseded-markers.mjs` is not scanned; only root `scripts/` is.

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation for command-line flag variants to prevent misspelling-based errors.
  * Strengthened test coverage for flag deprecation and alias handling.
  * Expanded test matrix to include additional flag concepts and guard rails for helper scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->