### PR TITLE
feat(helpers): emit structural ack-only review-currency evidence

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -9,7 +9,13 @@
     "staleAge": "PT24H",
     "heartbeatInterval": "PT12H"
   },
-  "trustedMarkerActors": ["kurone-kito"],
+  "trustedMarkerActors": [
+    "kurone-kito"
+  ],
+  "advisoryBotLogins": [
+    "coderabbitai[bot]",
+    "chatgpt-codex-connector[bot]"
+  ],
   "workshop": {
     "exampleRepository": "kurone-kito/vrc-event-calendar"
   },

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.2.0",
+  "iddVersion": "0.3.0",
   "markerPrefix": "idd-skill",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -56,6 +56,12 @@ Before any mutating action in F3, apply the
      after F2's snapshot; if `{f2-latest-ci-completed-at}` is `none`,
      any current CI pass triggers re-evaluation).
 
+   The structural ack-only carve-out from F2 applies here verbatim:
+   newer activity or count growth that the helper evidence proves to be
+   post-disposition advisory-bot acknowledgement only
+   (`ack-only-post-disposition`) does not force the return to E1; all
+   other triggers above are unaffected.
+
    From that same final fetch, compute `F3_UNRESOLVED_ACTIONABLE_COUNT`
    using the exact F2 unresolved-thread rule and exceptions
    (non-awaiting-reviewer unresolved threads only; awaiting-reviewer

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -112,6 +112,16 @@ Codex connectors, and CI bots).
     `{latest-ci-completed-at}` in the watermark (a new CI run completed
     after E1's snapshot; if watermark value is `none`, any current CI
     pass triggers re-evaluation).
+
+  Structural ack-only carve-out: when the only trigger above is newer
+  activity or count growth, and the helper evidence proves it consists
+  solely of post-disposition acknowledgements from the configured
+  advisory bots (`reviewCurrency.live.ackOnly` items with the
+  `effective` values current; `comparisonReason:
+  ack-only-post-disposition`), the advisory courtesy-ack convergence
+  rule in `idd-review-triage.instructions.md` applies: do not return to
+  E1 for that activity alone. The agent still confirms the semantic
+  residual, and every other trigger and gate is unaffected.
 - **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
   already available from the review-currency check above. Apply the
   advisory-wait protocol (`idd-advisory-wait.instructions.md`):

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -394,6 +394,16 @@ CodeRabbit replies "Thanks for confirming." on that same thread. No new thread
 or finding is introduced, so the `updatedAt` advance is ignored: do not re-run
 E1; continue to F-phase on the current HEAD SHA.
 
+**Helper evidence**: when helper runtime is enabled and the advisory-bot
+identity is configured (`advisoryBotLogins` in `.github/idd/config.json`,
+the `--advisory-bot-logins` flag, or `IDD_ADVISORY_BOT_LOGINS`), the
+activity-snapshot and `pre-merge-readiness` evidence emits the structural
+part of this classification (`ackOnly` items, `effective` activity values,
+and `comparisonReason: ack-only-post-disposition`). The agent still owns
+the semantic residual — confirming the ack raises no new actionable
+finding — and the evidence never weakens the disposition-evidence or
+unreplied-comment gates, which remain the backstop.
+
 ## Review item classes
 
 During E-phase review triage, classify each ReviewItems_snapshot item

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ from 0.2.0 onward is also published as an annotated `v<iddVersion>`
 git tag once its release pull request merges; 0.1.0 predates the tag
 discipline and has no tag.
 
+## [0.3.0] - 2026-06-11
+
+Structural ack-only review-currency evidence release.
+
+### Added
+
+- Structural classification of post-disposition advisory-bot
+  acknowledgements in the helper evidence layer: the activity snapshot
+  and `pre-merge-readiness` emit `ackOnly` (configured bots, trust
+  source, per-item list) and `effective` activity values, and the
+  review-currency comparison proceeds with reason
+  `ack-only-post-disposition` when the only newer activity is that
+  evidence. The semantic residual stays with the agent, and the
+  disposition-evidence and unreplied-comment gates are unchanged.
+- Optional `advisoryBotLogins` policy field
+  (`schemas/policy.schema.json`) plus the
+  `--advisory-bot-logins` flag / `IDD_ADVISORY_BOT_LOGINS` environment
+  ladder for `review-activity-snapshot` and `pre-merge-readiness`;
+  absence keeps the classification disabled (fail-closed).
+- Structural ack-only carve-out paragraphs in the F2 review-currency
+  bullet, the F3 final-fetch list, and the advisory courtesy-ack
+  convergence section of the distributed instructions.
+
+### Changed
+
+- `schemas/pre-merge-readiness.schema.json` now requires the `ackOnly`
+  and `effective` evidence under `reviewCurrency.live`; validating
+  output from older helper copies against the published schema fails
+  until the helpers are re-synced.
+
 ## [0.2.0] - 2026-06-07
 
 Worktree-guard enforcement release.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -634,12 +634,24 @@ Interpretation rules:
 - Snapshot command: `node scripts/review-activity-snapshot.mjs`
   with `--pr <pr-number>` and
   `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
+  (optionally `--advisory-bot-logins "<bot-1>,<bot-2>"`; the identity
+  also resolves from `IDD_ADVISORY_BOT_LOGINS` or the config
+  `advisoryBotLogins` field, with the source echoed in
+  `ackOnly.source`)
 - Stable E1/F2/F3 snapshot tuple: `headSha`,
   `maxActivityUpdatedAt`, `totalItemCount`,
   `latestPassingCiCompletedAt`, and `counts`
 - Additional CI completion field: `latestCiCompletedAt` reports the
   latest terminal run of any state; watermark and merge-gate checks use
   `latestPassingCiCompletedAt`
+- Structural ack-only evidence (requires a current helper copy): the
+  snapshot and `reviewCurrency.live` emit `ackOnly` (configured bots,
+  source, `dispositionsPresent`, `latestDispositionAt`, per-item list)
+  and `effective` activity values; `comparisonReason:
+  ack-only-post-disposition` marks a review-currency pass that relied
+  on them. The semantic residual stays with the agent per the
+  courtesy-ack convergence rule, and the disposition-evidence and
+  unreplied-comment gates are unaffected
 - Readiness command: `node scripts/pre-merge-readiness.mjs`
   with `--pr <pr-number>`, `--claim-issue <issue-number>`,
   `--claim-id <claim-id>`, and

--- a/fixtures/pre-merge-readiness/ack-only-current.json
+++ b/fixtures/pre-merge-readiness/ack-only-current.json
@@ -1,0 +1,335 @@
+{
+  "input": {
+    "prHeadSha": "1111111111111111111111111111111111111111",
+    "comments": [
+      {
+        "id": "watermark-clean",
+        "author": {
+          "login": "kurone-kito"
+        },
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 5 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
+        "createdAt": "2026-05-11T23:58:00Z",
+        "updatedAt": "2026-05-11T23:58:00Z"
+      },
+      {
+        "id": 9001,
+        "author": {
+          "login": "kurone-kito"
+        },
+        "body": "**Accepted** — advisory summary confirmed; no action required.",
+        "createdAt": "2026-05-11T23:55:30Z",
+        "updatedAt": "2026-05-11T23:55:30Z"
+      },
+      {
+        "id": 9002,
+        "author": {
+          "login": "coderabbitai[bot]"
+        },
+        "body": "Thanks for confirming!",
+        "createdAt": "2026-05-11T23:50:00Z",
+        "updatedAt": "2026-05-11T23:59:00Z"
+      }
+    ],
+    "reviews": [
+      {
+        "author": {
+          "login": "copilot-pull-request-reviewer[bot]"
+        },
+        "state": "APPROVED",
+        "commitId": "1111111111111111111111111111111111111111",
+        "submittedAt": "2026-05-11T23:54:00Z",
+        "createdAt": "2026-05-11T23:54:00Z",
+        "updatedAt": "2026-05-11T23:54:00Z"
+      },
+      {
+        "author": {
+          "login": "owner-reviewer"
+        },
+        "state": "APPROVED",
+        "commitId": "",
+        "submittedAt": "2026-05-11T23:55:00Z",
+        "createdAt": "2026-05-11T23:55:00Z",
+        "updatedAt": "2026-05-11T23:55:00Z"
+      }
+    ],
+    "threads": [
+      {
+        "id": "thread-awaiting",
+        "isResolved": false,
+        "updatedAt": "",
+        "reviewerReopenedAt": "",
+        "comments": {
+          "pageInfo": {
+            "hasNextPage": false
+          },
+          "nodes": [
+            {
+              "author": {
+                "login": "kurone-kito"
+              },
+              "body": "Fixed in the latest commit.",
+              "createdAt": "2026-05-11T23:56:00Z",
+              "updatedAt": "2026-05-11T23:56:00Z",
+              "pullRequestReview": {
+                "id": "review-1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "checks": [
+      {
+        "name": "lint",
+        "state": "SUCCESS",
+        "completedAt": "2026-05-11T23:57:00Z"
+      }
+    ],
+    "branchRules": [
+      {
+        "type": "pull_request",
+        "parameters": {
+          "required_approving_review_count": 0,
+          "required_reviewers": [],
+          "require_code_owner_review": true,
+          "required_review_thread_resolution": false
+        }
+      },
+      {
+        "type": "required_status_checks",
+        "parameters": {
+          "required_status_checks": [
+            {
+              "context": "lint"
+            }
+          ]
+        }
+      }
+    ],
+    "requestedReviewers": [],
+    "timelineEvents": [],
+    "claimEvents": [
+      {
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
+        "createdAt": "2026-05-11T23:20:00Z",
+        "author": {
+          "login": "kurone-kito"
+        }
+      }
+    ],
+    "changedFiles": [
+      "README.md"
+    ],
+    "codeownersText": "* @owner-reviewer\n",
+    "reviewDecision": "APPROVED"
+  },
+  "options": {
+    "now": "2026-05-12T00:00:00Z",
+    "trustedMarkerLogins": [
+      "kurone-kito"
+    ],
+    "iddAgentLogins": [
+      "kurone-kito"
+    ],
+    "advisoryBotLogins": [
+      "coderabbitai[bot]"
+    ],
+    "prAuthorLogin": "contributor",
+    "expectedClaimId": "claim-123",
+    "expectedAgentId": "github-copilot-cli",
+    "viewerLogin": "kurone-kito",
+    "configuredTrustedActors": [],
+    "collaboratorTrustEnabled": false,
+    "advisoryBotLoginsSource": "config"
+  },
+  "expected": {
+    "protocolVersion": "1",
+    "decisionAuthority": "instructions",
+    "prHeadSha": "1111111111111111111111111111111111111111",
+    "now": "2026-05-12T00:00:00Z",
+    "reviewCurrency": {
+      "watermarkPresent": true,
+      "watermark": {
+        "agentId": "github-copilot-cli",
+        "claimId": "claim-123",
+        "headSha": "1111111111111111111111111111111111111111",
+        "maxActivityUpdatedAt": "2026-05-11T23:56:00Z",
+        "totalItemCount": 5,
+        "latestCiCompletedAt": "2026-05-11T23:57:00Z",
+        "createdAt": "2026-05-11T23:58:00Z"
+      },
+      "live": {
+        "totalItemCount": 5,
+        "maxActivityUpdatedAt": "2026-05-11T23:59:00Z",
+        "latestCiCompletedAt": "2026-05-11T23:57:00Z",
+        "latestPassingCiCompletedAt": "2026-05-11T23:57:00Z",
+        "counts": {
+          "comments": 2,
+          "reviews": 2,
+          "threads": 1
+        },
+        "ackOnly": {
+          "advisoryBotLogins": [
+            "coderabbitai[bot]"
+          ],
+          "source": "config",
+          "dispositionsPresent": true,
+          "latestDispositionAt": "2026-05-11T23:55:30Z",
+          "items": [
+            {
+              "kind": "comment",
+              "id": "9002",
+              "author": "coderabbitai[bot]",
+              "activityAt": "2026-05-11T23:59:00Z",
+              "bodyPreview": "Thanks for confirming!"
+            }
+          ]
+        },
+        "effective": {
+          "maxActivityUpdatedAt": "2026-05-11T23:56:00Z",
+          "totalItemCount": 4
+        }
+      },
+      "comparisonRoute": "proceed",
+      "comparisonReason": "ack-only-post-disposition"
+    },
+    "threads": {
+      "unresolvedCount": 1,
+      "actionableCount": 0,
+      "awaitingReviewerCount": 1,
+      "amdBlockingCount": 0,
+      "conversationResolveAgentCount": 0,
+      "conversationResolveAuthorCount": 0,
+      "classifications": [
+        {
+          "id": "thread-awaiting",
+          "classification": "awaiting-reviewer"
+        }
+      ]
+    },
+    "unrepliedComments": {
+      "count": 1,
+      "items": [
+        {
+          "id": "9002",
+          "authorLogin": "coderabbitai[bot]",
+          "createdAt": "2026-05-11T23:50:00Z",
+          "bodyPreview": "Thanks for confirming!"
+        }
+      ]
+    },
+    "reviewerStates": {
+      "reviewDecision": "APPROVED",
+      "requiredApprovingReviewCount": 0,
+      "requireCodeOwnerReview": true,
+      "requiresConversationResolution": false,
+      "requiredReviewerLogins": [],
+      "requiredReviewerTeams": [],
+      "codeownerUserLogins": [
+        "owner-reviewer"
+      ],
+      "codeownerTeamSlugs": [],
+      "unmatchedCodeownerFiles": [],
+      "latestByAuthor": [
+        {
+          "login": "copilot-pull-request-reviewer[bot]",
+          "state": "APPROVED",
+          "submittedAt": "2026-05-11T23:54:00Z",
+          "isHuman": false,
+          "isAdvisoryBot": true,
+          "isCodeowner": false,
+          "isRequiredReviewer": false
+        },
+        {
+          "login": "owner-reviewer",
+          "state": "APPROVED",
+          "submittedAt": "2026-05-11T23:55:00Z",
+          "isHuman": true,
+          "isAdvisoryBot": false,
+          "isCodeowner": true,
+          "isRequiredReviewer": false
+        }
+      ],
+      "humanApprovedCount": 1,
+      "requiredApprovalsSatisfied": true,
+      "codeownerApprovalSatisfied": true,
+      "codeownerSelfApproval": {
+        "status": "not_applicable",
+        "reason": "codeowner-approval-satisfied",
+        "prAuthorLogin": "contributor",
+        "directCodeownerUserLogins": [
+          "owner-reviewer"
+        ],
+        "codeownerTeamSlugs": [],
+        "requireCodeOwnerReview": true,
+        "codeownerApprovalSatisfied": true,
+        "bypassDetected": false,
+        "bypassMode": "none",
+        "currentUserCanBypass": "unknown"
+      },
+      "humanChangesRequestedCount": 0,
+      "blockingChangesRequestedLogins": []
+    },
+    "advisoryWait": {
+      "outcome": "SATISFIED",
+      "f3Outcome": "SATISFIED",
+      "lastCopilotCommit": "1111111111111111111111111111111111111111",
+      "copilotPending": false,
+      "copilotPendingCoversHead": false,
+      "sameHeadMarkerPresent": false,
+      "earliestSameHeadAt": "",
+      "sameHeadMarkerCount": 0,
+      "requestMarkerCount": 0,
+      "requestCap": 30,
+      "pendingWindowMinutes": 30,
+      "settledWindowMinutes": 10,
+      "pollIntervalMinutes": 2,
+      "capExhaustedRoute": "phase-specific",
+      "elapsedMinutes": 0
+    },
+    "ci": {
+      "status": "success",
+      "noRequiredChecksConfigured": false,
+      "presentRunConclusion": "all-passing",
+      "requiredCheckCount": 1,
+      "generatedRequiredCheckCount": 1,
+      "requiredChecksGenerated": true,
+      "requiredChecksPassing": true,
+      "requiredCheckNames": [
+        "lint"
+      ],
+      "missingRequiredCheckNames": [],
+      "checks": [
+        {
+          "name": "lint",
+          "state": "SUCCESS",
+          "completedAt": "2026-05-11T23:57:00Z",
+          "required": true
+        }
+      ]
+    },
+    "claim": {
+      "expectedClaimId": "claim-123",
+      "expectedAgentId": "github-copilot-cli",
+      "activeClaimPresent": true,
+      "activeClaim": {
+        "agentId": "github-copilot-cli",
+        "claimId": "claim-123",
+        "supersedes": "none",
+        "branch": "issue/309-pre-merge-readiness",
+        "createdAt": "2026-05-11T23:20:00Z"
+      },
+      "matchesExpectedClaim": true,
+      "claimLost": false,
+      "reason": "match"
+    },
+    "waiverEvidence": {
+      "valid": [],
+      "expired": [],
+      "wrongHead": [],
+      "wrongClaim": [],
+      "unauthorized": [],
+      "malformed": []
+    }
+  }
+}

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -7,7 +7,7 @@
         "author": {
           "login": "kurone-kito"
         },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
@@ -67,7 +67,7 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
         "author": {
           "login": "kurone-kito"
@@ -121,6 +121,17 @@
           "comments": 0,
           "reviews": 2,
           "threads": 0
+        },
+        "ackOnly": {
+          "advisoryBotLogins": [],
+          "source": "none",
+          "dispositionsPresent": false,
+          "latestDispositionAt": "none",
+          "items": []
+        },
+        "effective": {
+          "maxActivityUpdatedAt": "2026-05-11T23:55:00Z",
+          "totalItemCount": 2
         }
       },
       "comparisonRoute": "proceed",

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -7,7 +7,7 @@
         "author": {
           "login": "kurone-kito"
         },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
@@ -70,7 +70,7 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
         "author": {
           "login": "kurone-kito"
@@ -124,6 +124,17 @@
           "comments": 0,
           "reviews": 2,
           "threads": 0
+        },
+        "ackOnly": {
+          "advisoryBotLogins": [],
+          "source": "none",
+          "dispositionsPresent": false,
+          "latestDispositionAt": "none",
+          "items": []
+        },
+        "effective": {
+          "maxActivityUpdatedAt": "2026-05-11T23:55:00Z",
+          "totalItemCount": 2
         }
       },
       "comparisonRoute": "proceed",

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -7,7 +7,7 @@
         "author": {
           "login": "kurone-kito"
         },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
@@ -92,7 +92,7 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-999 supersedes: none 2026-05-11T23:30:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-999 supersedes: none 2026-05-11T23:30:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:30:00Z",
         "author": {
           "login": "kurone-kito"
@@ -146,6 +146,17 @@
           "comments": 0,
           "reviews": 2,
           "threads": 1
+        },
+        "ackOnly": {
+          "advisoryBotLogins": [],
+          "source": "none",
+          "dispositionsPresent": false,
+          "latestDispositionAt": "none",
+          "items": []
+        },
+        "effective": {
+          "maxActivityUpdatedAt": "2026-05-11T23:56:00Z",
+          "totalItemCount": 3
         }
       },
       "comparisonRoute": "proceed",

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -7,7 +7,7 @@
         "author": {
           "login": "kurone-kito"
         },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
@@ -92,7 +92,7 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
         "author": {
           "login": "kurone-kito"
@@ -146,6 +146,17 @@
           "comments": 0,
           "reviews": 2,
           "threads": 1
+        },
+        "ackOnly": {
+          "advisoryBotLogins": [],
+          "source": "none",
+          "dispositionsPresent": false,
+          "latestDispositionAt": "none",
+          "items": []
+        },
+        "effective": {
+          "maxActivityUpdatedAt": "2026-05-11T23:56:00Z",
+          "totalItemCount": 3
         }
       },
       "comparisonRoute": "proceed",

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -7,7 +7,7 @@
         "author": {
           "login": "kurone-kito"
         },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:55:00Z 2 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
@@ -92,7 +92,7 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
         "author": {
           "login": "kurone-kito"
@@ -146,6 +146,17 @@
           "comments": 0,
           "reviews": 2,
           "threads": 1
+        },
+        "ackOnly": {
+          "advisoryBotLogins": [],
+          "source": "none",
+          "dispositionsPresent": false,
+          "latestDispositionAt": "none",
+          "items": []
+        },
+        "effective": {
+          "maxActivityUpdatedAt": "2026-05-11T23:56:00Z",
+          "totalItemCount": 3
         }
       },
       "comparisonRoute": "return-to-e1",

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -16,7 +16,7 @@
         "author": {
           "login": "kurone-kito"
         },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
@@ -76,7 +76,7 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
         "author": {
           "login": "kurone-kito"
@@ -130,6 +130,17 @@
           "comments": 1,
           "reviews": 2,
           "threads": 0
+        },
+        "ackOnly": {
+          "advisoryBotLogins": [],
+          "source": "none",
+          "dispositionsPresent": false,
+          "latestDispositionAt": "none",
+          "items": []
+        },
+        "effective": {
+          "maxActivityUpdatedAt": "2026-05-11T23:56:00Z",
+          "totalItemCount": 3
         }
       },
       "comparisonRoute": "proceed",

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -7,7 +7,7 @@
         "author": {
           "login": "kurone-kito"
         },
-        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- review-watermark: github-copilot-cli claim-123 1111111111111111111111111111111111111111 2026-05-11T23:56:00Z 3 2026-05-11T23:57:00Z -->\n\n_github-copilot-cli: review triage snapshot — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:58:00Z",
         "updatedAt": "2026-05-11T23:58:00Z"
       }
@@ -92,7 +92,7 @@
     "timelineEvents": [],
     "claimEvents": [
       {
-        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim \u2014 IDD automation marker. Do not edit._",
+        "body": "<!-- claimed-by: github-copilot-cli claim-123 supersedes: none 2026-05-11T23:20:00Z branch: issue/309-pre-merge-readiness -->\n\n_github-copilot-cli: issue claim — IDD automation marker. Do not edit._",
         "createdAt": "2026-05-11T23:20:00Z",
         "author": {
           "login": "kurone-kito"
@@ -146,6 +146,17 @@
           "comments": 0,
           "reviews": 2,
           "threads": 1
+        },
+        "ackOnly": {
+          "advisoryBotLogins": [],
+          "source": "none",
+          "dispositionsPresent": false,
+          "latestDispositionAt": "none",
+          "items": []
+        },
+        "effective": {
+          "maxActivityUpdatedAt": "2026-05-11T23:56:00Z",
+          "totalItemCount": 3
         }
       },
       "comparisonRoute": "proceed",

--- a/fixtures/review-gate/snapshot-diff-routes.json
+++ b/fixtures/review-gate/snapshot-diff-routes.json
@@ -188,5 +188,245 @@
       "route": "return-to-e1",
       "reason": "newer-activity"
     }
+  },
+  {
+    "name": "proceed when the only newer activity is a post-disposition ack edit",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:05Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z",
+      "ackOnly": {
+        "advisoryBotLogins": [
+          "advisory-bot"
+        ],
+        "source": "config",
+        "dispositionsPresent": true,
+        "latestDispositionAt": "2026-05-11T07:59:00Z",
+        "items": [
+          {
+            "kind": "comment",
+            "id": "C-ACK",
+            "author": "advisory-bot",
+            "activityAt": "2026-05-11T08:00:05Z",
+            "bodyPreview": "Thanks for confirming!"
+          }
+        ]
+      },
+      "effective": {
+        "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+        "totalItemCount": 5
+      }
+    },
+    "expected": {
+      "route": "proceed",
+      "reason": "ack-only-post-disposition"
+    }
+  },
+  {
+    "name": "proceed when count growth is fully explained by new ack comments",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:05Z",
+      "totalItemCount": 6,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z",
+      "ackOnly": {
+        "advisoryBotLogins": [
+          "advisory-bot"
+        ],
+        "source": "config",
+        "dispositionsPresent": true,
+        "latestDispositionAt": "2026-05-11T07:59:00Z",
+        "items": [
+          {
+            "kind": "comment",
+            "id": "C-ACK",
+            "author": "advisory-bot",
+            "activityAt": "2026-05-11T08:00:05Z",
+            "bodyPreview": "Thanks for confirming!"
+          }
+        ]
+      },
+      "effective": {
+        "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+        "totalItemCount": 5
+      }
+    },
+    "expected": {
+      "route": "proceed",
+      "reason": "ack-only-post-disposition"
+    }
+  },
+  {
+    "name": "return to E1 when newer activity has no disposition evidence",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:05Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z",
+      "ackOnly": {
+        "advisoryBotLogins": [
+          "advisory-bot"
+        ],
+        "source": "config",
+        "dispositionsPresent": false,
+        "latestDispositionAt": "none",
+        "items": [
+          {
+            "kind": "comment",
+            "id": "C-ACK",
+            "author": "advisory-bot",
+            "activityAt": "2026-05-11T08:00:05Z",
+            "bodyPreview": "Thanks for confirming!"
+          }
+        ]
+      },
+      "effective": {
+        "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+        "totalItemCount": 5
+      }
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "newer-activity"
+    }
+  },
+  {
+    "name": "return to E1 when effective activity is still newer than the snapshot",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:10Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z",
+      "ackOnly": {
+        "advisoryBotLogins": [
+          "advisory-bot"
+        ],
+        "source": "config",
+        "dispositionsPresent": true,
+        "latestDispositionAt": "2026-05-11T07:59:00Z",
+        "items": [
+          {
+            "kind": "comment",
+            "id": "C-ACK",
+            "author": "advisory-bot",
+            "activityAt": "2026-05-11T08:00:05Z",
+            "bodyPreview": "Thanks for confirming!"
+          }
+        ]
+      },
+      "effective": {
+        "maxActivityUpdatedAt": "2026-05-11T08:00:10Z",
+        "totalItemCount": 5
+      }
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "newer-activity"
+    }
+  },
+  {
+    "name": "return to E1 when count growth exceeds the new ack comments",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:05Z",
+      "totalItemCount": 7,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z",
+      "ackOnly": {
+        "advisoryBotLogins": [
+          "advisory-bot"
+        ],
+        "source": "config",
+        "dispositionsPresent": true,
+        "latestDispositionAt": "2026-05-11T07:59:00Z",
+        "items": [
+          {
+            "kind": "comment",
+            "id": "C-ACK",
+            "author": "advisory-bot",
+            "activityAt": "2026-05-11T08:00:05Z",
+            "bodyPreview": "Thanks for confirming!"
+          }
+        ]
+      },
+      "effective": {
+        "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+        "totalItemCount": 6
+      }
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "same-timestamp-count-growth"
+    }
+  },
+  {
+    "name": "return to E1 on CI drift even when activity is ack-only",
+    "snapshot": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:05:00Z"
+    },
+    "live": {
+      "headSha": "abc123",
+      "maxActivityUpdatedAt": "2026-05-11T08:00:05Z",
+      "totalItemCount": 5,
+      "latestPassingCiCompletedAt": "2026-05-11T08:09:00Z",
+      "ackOnly": {
+        "advisoryBotLogins": [
+          "advisory-bot"
+        ],
+        "source": "config",
+        "dispositionsPresent": true,
+        "latestDispositionAt": "2026-05-11T07:59:00Z",
+        "items": [
+          {
+            "kind": "comment",
+            "id": "C-ACK",
+            "author": "advisory-bot",
+            "activityAt": "2026-05-11T08:00:05Z",
+            "bodyPreview": "Thanks for confirming!"
+          }
+        ]
+      },
+      "effective": {
+        "maxActivityUpdatedAt": "2026-05-11T08:00:00Z",
+        "totalItemCount": 5
+      }
+    },
+    "expected": {
+      "route": "return-to-e1",
+      "reason": "ci-pass-drift"
+    }
   }
 ]

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -23,6 +23,19 @@
         "comments": 0,
         "reviews": 2,
         "threads": 1
+      },
+      "ackOnly": {
+        "advisoryBotLogins": [
+          "coderabbitai[bot]"
+        ],
+        "source": "config",
+        "dispositionsPresent": true,
+        "latestDispositionAt": "2026-05-11T23:56:00Z",
+        "items": []
+      },
+      "effective": {
+        "maxActivityUpdatedAt": "2026-05-11T23:56:00Z",
+        "totalItemCount": 3
       }
     },
     "comparisonRoute": "proceed",
@@ -53,7 +66,9 @@
     "requiresConversationResolution": false,
     "requiredReviewerLogins": [],
     "requiredReviewerTeams": [],
-    "codeownerUserLogins": ["owner-reviewer"],
+    "codeownerUserLogins": [
+      "owner-reviewer"
+    ],
     "codeownerTeamSlugs": [],
     "unmatchedCodeownerFiles": [],
     "latestByAuthor": [
@@ -83,7 +98,9 @@
       "status": "not_applicable",
       "reason": "codeowner-approval-satisfied",
       "prAuthorLogin": "pr-author",
-      "directCodeownerUserLogins": ["owner-reviewer"],
+      "directCodeownerUserLogins": [
+        "owner-reviewer"
+      ],
       "codeownerTeamSlugs": [],
       "requireCodeOwnerReview": true,
       "codeownerApprovalSatisfied": true,
@@ -119,7 +136,9 @@
     "generatedRequiredCheckCount": 1,
     "requiredChecksGenerated": true,
     "requiredChecksPassing": true,
-    "requiredCheckNames": ["lint"],
+    "requiredCheckNames": [
+      "lint"
+    ],
     "missingRequiredCheckNames": [],
     "checks": [
       {

--- a/idd-template/.github/idd/config.json
+++ b/idd-template/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.2.0",
+  "iddVersion": "0.3.0",
   "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -56,6 +56,12 @@ Before any mutating action in F3, apply the
      after F2's snapshot; if `{f2-latest-ci-completed-at}` is `none`,
      any current CI pass triggers re-evaluation).
 
+   The structural ack-only carve-out from F2 applies here verbatim:
+   newer activity or count growth that the helper evidence proves to be
+   post-disposition advisory-bot acknowledgement only
+   (`ack-only-post-disposition`) does not force the return to E1; all
+   other triggers above are unaffected.
+
    From that same final fetch, compute `F3_UNRESOLVED_ACTIONABLE_COUNT`
    using the exact F2 unresolved-thread rule and exceptions
    (non-awaiting-reviewer unresolved threads only; awaiting-reviewer

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -112,6 +112,16 @@ Codex connectors, and CI bots).
     `{latest-ci-completed-at}` in the watermark (a new CI run completed
     after E1's snapshot; if watermark value is `none`, any current CI
     pass triggers re-evaluation).
+
+  Structural ack-only carve-out: when the only trigger above is newer
+  activity or count growth, and the helper evidence proves it consists
+  solely of post-disposition acknowledgements from the configured
+  advisory bots (`reviewCurrency.live.ackOnly` items with the
+  `effective` values current; `comparisonReason:
+  ack-only-post-disposition`), the advisory courtesy-ack convergence
+  rule in `idd-review-triage.instructions.md` applies: do not return to
+  E1 for that activity alone. The agent still confirms the semantic
+  residual, and every other trigger and gate is unaffected.
 - **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
   already available from the review-currency check above. Apply the
   advisory-wait protocol (`idd-advisory-wait.instructions.md`):

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -394,6 +394,16 @@ CodeRabbit replies "Thanks for confirming." on that same thread. No new thread
 or finding is introduced, so the `updatedAt` advance is ignored: do not re-run
 E1; continue to F-phase on the current HEAD SHA.
 
+**Helper evidence**: when helper runtime is enabled and the advisory-bot
+identity is configured (`advisoryBotLogins` in `.github/idd/config.json`,
+the `--advisory-bot-logins` flag, or `IDD_ADVISORY_BOT_LOGINS`), the
+activity-snapshot and `pre-merge-readiness` evidence emits the structural
+part of this classification (`ackOnly` items, `effective` activity values,
+and `comparisonReason: ack-only-post-disposition`). The agent still owns
+the semantic residual — confirming the ack raises no new actionable
+finding — and the evidence never weakens the disposition-evidence or
+unreplied-comment gates, which remain the backstop.
+
 ## Review item classes
 
 During E-phase review triage, classify each ReviewItems_snapshot item

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -634,12 +634,24 @@ Interpretation rules:
 - Snapshot command: `node scripts/review-activity-snapshot.mjs`
   with `--pr <pr-number>` and
   `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
+  (optionally `--advisory-bot-logins "<bot-1>,<bot-2>"`; the identity
+  also resolves from `IDD_ADVISORY_BOT_LOGINS` or the config
+  `advisoryBotLogins` field, with the source echoed in
+  `ackOnly.source`)
 - Stable E1/F2/F3 snapshot tuple: `headSha`,
   `maxActivityUpdatedAt`, `totalItemCount`,
   `latestPassingCiCompletedAt`, and `counts`
 - Additional CI completion field: `latestCiCompletedAt` reports the
   latest terminal run of any state; watermark and merge-gate checks use
   `latestPassingCiCompletedAt`
+- Structural ack-only evidence (requires a current helper copy): the
+  snapshot and `reviewCurrency.live` emit `ackOnly` (configured bots,
+  source, `dispositionsPresent`, `latestDispositionAt`, per-item list)
+  and `effective` activity values; `comparisonReason:
+  ack-only-post-disposition` marks a review-currency pass that relied
+  on them. The semantic residual stays with the agent per the
+  courtesy-ack convergence rule, and the disposition-evidence and
+  unreplied-comment gates are unaffected
 - Readiness command: `node scripts/pre-merge-readiness.mjs`
   with `--pr <pr-number>`, `--claim-issue <issue-number>`,
   `--claim-id <claim-id>`, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/idd-skill",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Issue-Driven Development workflow assets",
   "license": "MIT",

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -71,6 +71,15 @@
         "minLength": 1
       }
     },
+    "advisoryBotLogins": {
+      "type": "array",
+      "description": "GitHub logins of advisory review bots whose post-disposition acknowledgement comments may be classified as structurally ack-only by the helper evidence layer. Optional; absence disables the classification (fail-closed).",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "workshop": {
       "type": "object",
       "additionalProperties": false,

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -21,11 +21,15 @@
   "properties": {
     "protocolVersion": {
       "type": "string",
-      "enum": ["1"]
+      "enum": [
+        "1"
+      ]
     },
     "decisionAuthority": {
       "type": "string",
-      "enum": ["instructions"]
+      "enum": [
+        "instructions"
+      ]
     },
     "prHeadSha": {
       "type": "string",
@@ -98,7 +102,9 @@
             "maxActivityUpdatedAt",
             "latestCiCompletedAt",
             "latestPassingCiCompletedAt",
-            "counts"
+            "counts",
+            "ackOnly",
+            "effective"
           ],
           "additionalProperties": false,
           "properties": {
@@ -120,19 +126,125 @@
             },
             "counts": {
               "type": "object",
-              "required": ["comments", "reviews", "threads"],
+              "required": [
+                "comments",
+                "reviews",
+                "threads"
+              ],
               "additionalProperties": false,
               "properties": {
-                "comments": { "type": "integer", "minimum": 0 },
-                "reviews": { "type": "integer", "minimum": 0 },
-                "threads": { "type": "integer", "minimum": 0 }
+                "comments": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "reviews": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "threads": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            },
+            "ackOnly": {
+              "type": "object",
+              "required": [
+                "advisoryBotLogins",
+                "source",
+                "dispositionsPresent",
+                "latestDispositionAt",
+                "items"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "advisoryBotLogins": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "source": {
+                  "type": "string",
+                  "enum": [
+                    "flag",
+                    "env",
+                    "config",
+                    "none"
+                  ]
+                },
+                "dispositionsPresent": {
+                  "type": "boolean"
+                },
+                "latestDispositionAt": {
+                  "type": "string",
+                  "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
+                },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "id",
+                      "author",
+                      "activityAt",
+                      "bodyPreview"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "comment",
+                          "thread-reply"
+                        ]
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "author": {
+                        "type": "string"
+                      },
+                      "activityAt": {
+                        "type": "string",
+                        "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
+                      },
+                      "bodyPreview": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "effective": {
+              "type": "object",
+              "required": [
+                "maxActivityUpdatedAt",
+                "totalItemCount"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "maxActivityUpdatedAt": {
+                  "type": "string",
+                  "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
+                },
+                "totalItemCount": {
+                  "type": "integer",
+                  "minimum": 0
+                }
               }
             }
           }
         },
         "comparisonRoute": {
           "type": "string",
-          "enum": ["proceed", "return-to-e1"]
+          "enum": [
+            "proceed",
+            "return-to-e1"
+          ]
         },
         "comparisonReason": {
           "type": "string",
@@ -153,17 +265,38 @@
       ],
       "additionalProperties": false,
       "properties": {
-        "unresolvedCount": { "type": "integer", "minimum": 0 },
-        "actionableCount": { "type": "integer", "minimum": 0 },
-        "awaitingReviewerCount": { "type": "integer", "minimum": 0 },
-        "amdBlockingCount": { "type": "integer", "minimum": 0 },
-        "conversationResolveAgentCount": { "type": "integer", "minimum": 0 },
-        "conversationResolveAuthorCount": { "type": "integer", "minimum": 0 },
+        "unresolvedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "actionableCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "awaitingReviewerCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "amdBlockingCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "conversationResolveAgentCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "conversationResolveAuthorCount": {
+          "type": "integer",
+          "minimum": 0
+        },
         "classifications": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["id", "classification"],
+            "required": [
+              "id",
+              "classification"
+            ],
             "additionalProperties": false,
             "properties": {
               "id": {
@@ -187,25 +320,44 @@
     },
     "unrepliedComments": {
       "type": "object",
-      "required": ["count", "items"],
+      "required": [
+        "count",
+        "items"
+      ],
       "additionalProperties": false,
       "properties": {
-        "count": { "type": "integer", "minimum": 0 },
+        "count": {
+          "type": "integer",
+          "minimum": 0
+        },
         "items": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["id", "authorLogin", "createdAt", "bodyPreview"],
+            "required": [
+              "id",
+              "authorLogin",
+              "createdAt",
+              "bodyPreview"
+            ],
             "additionalProperties": false,
             "properties": {
-              "id": { "type": "string", "minLength": 1 },
-              "authorLogin": { "type": "string", "minLength": 1 },
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "authorLogin": {
+                "type": "string",
+                "minLength": 1
+              },
               "createdAt": {
                 "type": "string",
                 "format": "date-time",
                 "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
               },
-              "bodyPreview": { "type": "string" }
+              "bodyPreview": {
+                "type": "string"
+              }
             }
           }
         }
@@ -233,29 +385,53 @@
       ],
       "additionalProperties": false,
       "properties": {
-        "reviewDecision": { "type": "string" },
-        "requiredApprovingReviewCount": { "type": "integer", "minimum": 0 },
-        "requireCodeOwnerReview": { "type": "boolean" },
-        "requiresConversationResolution": { "type": "boolean" },
+        "reviewDecision": {
+          "type": "string"
+        },
+        "requiredApprovingReviewCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "requireCodeOwnerReview": {
+          "type": "boolean"
+        },
+        "requiresConversationResolution": {
+          "type": "boolean"
+        },
         "requiredReviewerLogins": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "requiredReviewerTeams": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "codeownerUserLogins": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "codeownerTeamSlugs": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "unmatchedCodeownerFiles": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "latestByAuthor": {
           "type": "array",
@@ -272,23 +448,44 @@
             ],
             "additionalProperties": false,
             "properties": {
-              "login": { "type": "string", "minLength": 1 },
-              "state": { "type": "string", "minLength": 1 },
+              "login": {
+                "type": "string",
+                "minLength": 1
+              },
+              "state": {
+                "type": "string",
+                "minLength": 1
+              },
               "submittedAt": {
                 "type": "string",
                 "format": "date-time",
                 "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
               },
-              "isHuman": { "type": "boolean" },
-              "isAdvisoryBot": { "type": "boolean" },
-              "isCodeowner": { "type": "boolean" },
-              "isRequiredReviewer": { "type": "boolean" }
+              "isHuman": {
+                "type": "boolean"
+              },
+              "isAdvisoryBot": {
+                "type": "boolean"
+              },
+              "isCodeowner": {
+                "type": "boolean"
+              },
+              "isRequiredReviewer": {
+                "type": "boolean"
+              }
             }
           }
         },
-        "humanApprovedCount": { "type": "integer", "minimum": 0 },
-        "requiredApprovalsSatisfied": { "type": "boolean" },
-        "codeownerApprovalSatisfied": { "type": "boolean" },
+        "humanApprovedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "requiredApprovalsSatisfied": {
+          "type": "boolean"
+        },
+        "codeownerApprovalSatisfied": {
+          "type": "boolean"
+        },
         "codeownerSelfApproval": {
           "type": "object",
           "required": [
@@ -307,35 +504,76 @@
           "properties": {
             "status": {
               "type": "string",
-              "enum": ["not_applicable", "clear", "possible_deadlock", "deadlock"]
+              "enum": [
+                "not_applicable",
+                "clear",
+                "possible_deadlock",
+                "deadlock"
+              ]
             },
-            "reason": { "type": "string", "minLength": 1 },
-            "prAuthorLogin": { "type": "string" },
+            "reason": {
+              "type": "string",
+              "minLength": 1
+            },
+            "prAuthorLogin": {
+              "type": "string"
+            },
             "directCodeownerUserLogins": {
               "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
             },
             "codeownerTeamSlugs": {
               "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
             },
-            "requireCodeOwnerReview": { "type": "boolean" },
-            "codeownerApprovalSatisfied": { "type": "boolean" },
-            "bypassDetected": { "type": "boolean" },
+            "requireCodeOwnerReview": {
+              "type": "boolean"
+            },
+            "codeownerApprovalSatisfied": {
+              "type": "boolean"
+            },
+            "bypassDetected": {
+              "type": "boolean"
+            },
             "bypassMode": {
               "type": "string",
-              "enum": ["none", "pull_request", "always", "exempt", "mixed"]
+              "enum": [
+                "none",
+                "pull_request",
+                "always",
+                "exempt",
+                "mixed"
+              ]
             },
             "currentUserCanBypass": {
               "type": "string",
-              "enum": ["unknown", "never", "always", "pull_requests_only", "exempt", "mixed"]
+              "enum": [
+                "unknown",
+                "never",
+                "always",
+                "pull_requests_only",
+                "exempt",
+                "mixed"
+              ]
             }
           }
         },
-        "humanChangesRequestedCount": { "type": "integer", "minimum": 0 },
+        "humanChangesRequestedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
         "blockingChangesRequestedLogins": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     },
@@ -384,24 +622,54 @@
           "type": "string",
           "pattern": "^$|^[0-9a-f]{40}$"
         },
-        "copilotPending": { "type": "boolean" },
-        "copilotPendingCoversHead": { "type": "boolean" },
-        "sameHeadMarkerPresent": { "type": "boolean" },
+        "copilotPending": {
+          "type": "boolean"
+        },
+        "copilotPendingCoversHead": {
+          "type": "boolean"
+        },
+        "sameHeadMarkerPresent": {
+          "type": "boolean"
+        },
         "earliestSameHeadAt": {
           "type": "string",
           "pattern": "^$|^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
         },
-        "sameHeadMarkerCount": { "type": "integer", "minimum": 0 },
-        "requestMarkerCount": { "type": "integer", "minimum": 0 },
-        "requestCap": { "type": "integer", "minimum": 1 },
-        "pendingWindowMinutes": { "type": "number", "exclusiveMinimum": 0 },
-        "settledWindowMinutes": { "type": "number", "exclusiveMinimum": 0 },
-        "pollIntervalMinutes": { "type": "number", "exclusiveMinimum": 0 },
+        "sameHeadMarkerCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "requestMarkerCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "requestCap": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "pendingWindowMinutes": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "settledWindowMinutes": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "pollIntervalMinutes": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
         "capExhaustedRoute": {
           "type": "string",
-          "enum": ["phase-specific", "hold"]
+          "enum": [
+            "phase-specific",
+            "hold"
+          ]
         },
-        "elapsedMinutes": { "type": "integer", "minimum": 0 }
+        "elapsedMinutes": {
+          "type": "integer",
+          "minimum": 0
+        }
       }
     },
     "ci": {
@@ -422,40 +690,84 @@
       "properties": {
         "status": {
           "type": "string",
-          "enum": ["missing", "success", "pending", "failed", "unknown"]
+          "enum": [
+            "missing",
+            "success",
+            "pending",
+            "failed",
+            "unknown"
+          ]
         },
-        "noRequiredChecksConfigured": { "type": "boolean" },
+        "noRequiredChecksConfigured": {
+          "type": "boolean"
+        },
         "presentRunConclusion": {
           "type": "string",
-          "enum": ["all-passing", "some-failing", "pending", "none"]
+          "enum": [
+            "all-passing",
+            "some-failing",
+            "pending",
+            "none"
+          ]
         },
-        "requiredCheckCount": { "type": "integer", "minimum": 0 },
-        "generatedRequiredCheckCount": { "type": "integer", "minimum": 0 },
-        "requiredChecksGenerated": { "type": "boolean" },
-        "requiredChecksPassing": { "type": "boolean" },
+        "requiredCheckCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "generatedRequiredCheckCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "requiredChecksGenerated": {
+          "type": "boolean"
+        },
+        "requiredChecksPassing": {
+          "type": "boolean"
+        },
         "requiredCheckNames": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "missingRequiredCheckNames": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "checks": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["name", "state", "completedAt", "required"],
+            "required": [
+              "name",
+              "state",
+              "completedAt",
+              "required"
+            ],
             "additionalProperties": false,
             "properties": {
-              "name": { "type": "string", "minLength": 1 },
-              "state": { "type": "string", "minLength": 1 },
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "state": {
+                "type": "string",
+                "minLength": 1
+              },
               "completedAt": {
                 "type": "string",
                 "pattern": "^$|^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
               },
-              "required": { "type": "boolean" },
-              "coveredByWaiver": { "type": "boolean" }
+              "required": {
+                "type": "boolean"
+              },
+              "coveredByWaiver": {
+                "type": "boolean"
+              }
             }
           }
         }
@@ -474,29 +786,58 @@
       ],
       "additionalProperties": false,
       "properties": {
-        "expectedClaimId": { "type": "string" },
-        "expectedAgentId": { "type": "string" },
-        "activeClaimPresent": { "type": "boolean" },
+        "expectedClaimId": {
+          "type": "string"
+        },
+        "expectedAgentId": {
+          "type": "string"
+        },
+        "activeClaimPresent": {
+          "type": "boolean"
+        },
         "activeClaim": {
           "type": "object",
-          "required": ["agentId", "claimId", "supersedes", "branch", "createdAt"],
+          "required": [
+            "agentId",
+            "claimId",
+            "supersedes",
+            "branch",
+            "createdAt"
+          ],
           "additionalProperties": false,
           "properties": {
-            "agentId": { "type": "string" },
-            "claimId": { "type": "string" },
-            "supersedes": { "type": "string" },
-            "branch": { "type": "string" },
+            "agentId": {
+              "type": "string"
+            },
+            "claimId": {
+              "type": "string"
+            },
+            "supersedes": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
             "createdAt": {
               "type": "string",
               "pattern": "^$|^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
             }
           }
         },
-        "matchesExpectedClaim": { "type": "boolean" },
-        "claimLost": { "type": "boolean" },
+        "matchesExpectedClaim": {
+          "type": "boolean"
+        },
+        "claimLost": {
+          "type": "boolean"
+        },
         "reason": {
           "type": "string",
-          "enum": ["match", "missing-active-claim", "claim-id-mismatch", "agent-id-mismatch"]
+          "enum": [
+            "match",
+            "missing-active-claim",
+            "claim-id-mismatch",
+            "agent-id-mismatch"
+          ]
         }
       }
     },
@@ -515,30 +856,58 @@
       "properties": {
         "route": {
           "type": "string",
-          "enum": ["proceed", "return-to-e1"]
+          "enum": [
+            "proceed",
+            "return-to-e1"
+          ]
         },
         "reason": {
           "type": "string",
-          "enum": ["complete", "missing-disposition-evidence"]
+          "enum": [
+            "complete",
+            "missing-disposition-evidence"
+          ]
         },
-        "blockingCount": { "type": "integer", "minimum": 0 },
-        "missingRegularCommentCount": { "type": "integer", "minimum": 0 },
-        "missingThreadCount": { "type": "integer", "minimum": 0 },
+        "blockingCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "missingRegularCommentCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "missingThreadCount": {
+          "type": "integer",
+          "minimum": 0
+        },
         "missingRegularComments": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["id", "authorLogin", "createdAt", "bodyPreview"],
+            "required": [
+              "id",
+              "authorLogin",
+              "createdAt",
+              "bodyPreview"
+            ],
             "additionalProperties": false,
             "properties": {
-              "id": { "type": "string", "minLength": 1 },
-              "authorLogin": { "type": "string", "minLength": 1 },
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "authorLogin": {
+                "type": "string",
+                "minLength": 1
+              },
               "createdAt": {
                 "type": "string",
                 "format": "date-time",
                 "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
               },
-              "bodyPreview": { "type": "string" }
+              "bodyPreview": {
+                "type": "string"
+              }
             }
           }
         },
@@ -546,11 +915,20 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["id", "isResolved", "reason"],
+            "required": [
+              "id",
+              "isResolved",
+              "reason"
+            ],
             "additionalProperties": false,
             "properties": {
-              "id": { "type": "string", "minLength": 1 },
-              "isResolved": { "type": "boolean" },
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "isResolved": {
+                "type": "boolean"
+              },
               "reason": {
                 "type": "string",
                 "enum": [
@@ -566,20 +944,40 @@
     },
     "waiverEvidence": {
       "type": "object",
-      "required": ["valid", "expired", "wrongHead", "wrongClaim", "unauthorized", "malformed"],
+      "required": [
+        "valid",
+        "expired",
+        "wrongHead",
+        "wrongClaim",
+        "unauthorized",
+        "malformed"
+      ],
       "additionalProperties": false,
       "properties": {
         "valid": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["authorLogin", "checkSelector", "reason", "expiresAt"],
+            "required": [
+              "authorLogin",
+              "checkSelector",
+              "reason",
+              "expiresAt"
+            ],
             "additionalProperties": false,
             "properties": {
-              "authorLogin": { "type": "string" },
-              "checkSelector": { "type": "string" },
-              "reason": { "type": "string" },
-              "expiresAt": { "type": "string" }
+              "authorLogin": {
+                "type": "string"
+              },
+              "checkSelector": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "expiresAt": {
+                "type": "string"
+              }
             }
           }
         },
@@ -587,12 +985,22 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["authorLogin", "checkSelector", "expiresAt"],
+            "required": [
+              "authorLogin",
+              "checkSelector",
+              "expiresAt"
+            ],
             "additionalProperties": false,
             "properties": {
-              "authorLogin": { "type": "string" },
-              "checkSelector": { "type": "string" },
-              "expiresAt": { "type": "string" }
+              "authorLogin": {
+                "type": "string"
+              },
+              "checkSelector": {
+                "type": "string"
+              },
+              "expiresAt": {
+                "type": "string"
+              }
             }
           }
         },
@@ -600,12 +1008,22 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["authorLogin", "checkSelector", "waiverHeadSha"],
+            "required": [
+              "authorLogin",
+              "checkSelector",
+              "waiverHeadSha"
+            ],
             "additionalProperties": false,
             "properties": {
-              "authorLogin": { "type": "string" },
-              "checkSelector": { "type": "string" },
-              "waiverHeadSha": { "type": "string" }
+              "authorLogin": {
+                "type": "string"
+              },
+              "checkSelector": {
+                "type": "string"
+              },
+              "waiverHeadSha": {
+                "type": "string"
+              }
             }
           }
         },
@@ -613,12 +1031,22 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["authorLogin", "checkSelector", "waiverClaimId"],
+            "required": [
+              "authorLogin",
+              "checkSelector",
+              "waiverClaimId"
+            ],
             "additionalProperties": false,
             "properties": {
-              "authorLogin": { "type": "string" },
-              "checkSelector": { "type": "string" },
-              "waiverClaimId": { "type": "string" }
+              "authorLogin": {
+                "type": "string"
+              },
+              "checkSelector": {
+                "type": "string"
+              },
+              "waiverClaimId": {
+                "type": "string"
+              }
             }
           }
         },
@@ -626,12 +1054,22 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["authorLogin", "checkSelector", "expiresAt"],
+            "required": [
+              "authorLogin",
+              "checkSelector",
+              "expiresAt"
+            ],
             "additionalProperties": false,
             "properties": {
-              "authorLogin": { "type": "string" },
-              "checkSelector": { "type": "string" },
-              "expiresAt": { "type": "string" }
+              "authorLogin": {
+                "type": "string"
+              },
+              "checkSelector": {
+                "type": "string"
+              },
+              "expiresAt": {
+                "type": "string"
+              }
             }
           }
         },
@@ -639,11 +1077,18 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["authorLogin", "bodyPreview"],
+            "required": [
+              "authorLogin",
+              "bodyPreview"
+            ],
             "additionalProperties": false,
             "properties": {
-              "authorLogin": { "type": "string" },
-              "bodyPreview": { "type": "string" }
+              "authorLogin": {
+                "type": "string"
+              },
+              "bodyPreview": {
+                "type": "string"
+              }
             }
           }
         }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -16,6 +16,7 @@ import {
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   parsePaginatedGhNdjson,
+  resolveAdvisoryBotLogins,
   resolveCodeownersForFiles,
   resolveRulesetDetailPath,
   resolveTrustedMarkerActors,
@@ -49,9 +50,12 @@ const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
     envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
     config: loadIddConfig(),
   });
-const advisoryBotLogins = normalizeTrustedMarkerLogins(
-  splitCsv(args.advisoryBotLogins),
-);
+const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
+  resolveAdvisoryBotLogins({
+    flagValue: args.advisoryBotLogins,
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+    config: loadIddConfig(),
+  });
 
 const pr = ghJson([
   'pr',
@@ -183,6 +187,7 @@ const summary = buildPreMergeReadinessSummary(
     trustedMarkerLogins,
     iddAgentLogins,
     advisoryBotLogins,
+    advisoryBotLoginsSource,
     prAuthorLogin,
     expectedClaimId: args.expectedClaimId,
     expectedAgentId: args.expectedAgentId,

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -44,17 +44,18 @@ const viewerAppSlug = safeGhText([
   '--jq',
   '.slug // .app_slug // empty',
 ]).toLowerCase();
+const iddConfig = loadIddConfig();
 const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
   resolveTrustedMarkerActors({
     flagValue: args.trustedMarkerLogins,
     envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
-    config: loadIddConfig(),
+    config: iddConfig,
   });
 const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
   resolveAdvisoryBotLogins({
     flagValue: args.advisoryBotLogins,
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
-    config: loadIddConfig(),
+    config: iddConfig,
   });
 
 const pr = ghJson([

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -938,6 +938,17 @@ export function diffReviewSnapshot(snapshot, live) {
   const liveMax = normalizeComparableTimestamp(live.maxActivityUpdatedAt);
   const snapshotCount = Number(snapshot.totalItemCount ?? 0);
   const liveCount = Number(live.totalItemCount ?? 0);
+  // Structural ack-only carve-out (#858): when the only activity newer
+  // than the snapshot is post-disposition advisory-bot acknowledgement
+  // evidence, fall back to the effective values instead of re-opening.
+  // Absent evidence keeps the legacy behavior unchanged (fail-closed).
+  const ackItems = Array.isArray(live.ackOnly?.items) ? live.ackOnly.items : [];
+  const ackEvidencePresent =
+    live.ackOnly?.dispositionsPresent === true && ackItems.length > 0;
+  const effectiveMax = normalizeComparableTimestamp(
+    live.effective?.maxActivityUpdatedAt ?? 'none',
+  );
+  let ackOnlyApplied = false;
   if (snapshotMax === 'none' && liveCount > 0) {
     return { route: 'return-to-e1', reason: 'snapshot-was-empty-now-nonempty' };
   }
@@ -953,10 +964,30 @@ export function diffReviewSnapshot(snapshot, live) {
     typeof liveMax === 'number' &&
     liveMax > snapshotMax
   ) {
-    return { route: 'return-to-e1', reason: 'newer-activity' };
+    const effectiveCurrent =
+      ackEvidencePresent &&
+      (effectiveMax === 'none' ||
+        (typeof effectiveMax === 'number' && effectiveMax <= snapshotMax));
+    if (!effectiveCurrent) {
+      return { route: 'return-to-e1', reason: 'newer-activity' };
+    }
+    ackOnlyApplied = true;
   }
   if (liveCount > snapshotCount) {
-    return { route: 'return-to-e1', reason: 'same-timestamp-count-growth' };
+    // Only ack comments newer than the snapshot max may explain count
+    // growth; older acks were already inside the snapshot's count.
+    const ackNewerCount = ackItems.filter(
+      (item) =>
+        item.kind === 'comment' &&
+        isValidIsoTimestamp(item.activityAt) &&
+        typeof snapshotMax === 'number' &&
+        compareIsoTimestamps(item.activityAt, snapshot.maxActivityUpdatedAt) >
+          0,
+    ).length;
+    if (!(ackEvidencePresent && liveCount - ackNewerCount <= snapshotCount)) {
+      return { route: 'return-to-e1', reason: 'same-timestamp-count-growth' };
+    }
+    ackOnlyApplied = true;
   }
 
   const snapshotCi = normalizeComparableTimestamp(
@@ -972,7 +1003,10 @@ export function diffReviewSnapshot(snapshot, live) {
     return { route: 'return-to-e1', reason: 'ci-pass-drift' };
   }
 
-  return { route: 'proceed', reason: 'snapshot-current' };
+  return {
+    route: 'proceed',
+    reason: ackOnlyApplied ? 'ack-only-post-disposition' : 'snapshot-current',
+  };
 }
 
 export function classifyReviewThreadForGate(thread, options = {}) {
@@ -1319,6 +1353,32 @@ function trustedMarkerActorTokens(value) {
   return Array.isArray(value) ? value : String(value ?? '').split(',');
 }
 
+export function resolveAdvisoryBotLogins({
+  flagValue = '',
+  envValue = '',
+  config = null,
+} = {}) {
+  const fromFlag = normalizeTrustedMarkerLogins(
+    trustedMarkerActorTokens(flagValue),
+  );
+  if (fromFlag.length > 0) {
+    return { logins: fromFlag, source: 'flag' };
+  }
+  const fromEnv = normalizeTrustedMarkerLogins(
+    trustedMarkerActorTokens(envValue),
+  );
+  if (fromEnv.length > 0) {
+    return { logins: fromEnv, source: 'env' };
+  }
+  const fromConfig = normalizeTrustedMarkerLogins(
+    Array.isArray(config?.advisoryBotLogins) ? config.advisoryBotLogins : [],
+  );
+  if (fromConfig.length > 0) {
+    return { logins: fromConfig, source: 'config' };
+  }
+  return { logins: [], source: 'none' };
+}
+
 export function deriveIddAgentLogins({
   viewerLogin = '',
   iddAgentLogins = [],
@@ -1563,6 +1623,30 @@ export function buildActivitySnapshotSummary(
       )
       .filter(Boolean),
   );
+  const advisoryBotLogins = new Set(
+    normalizeTrustedMarkerLogins(options.advisoryBotLogins ?? []),
+  );
+  const dispositionAuthorLogins = new Set(
+    normalizeTrustedMarkerLogins(options.dispositionAuthorLogins ?? []),
+  );
+  // An advisory bot can never anchor "dispositions exist": its own
+  // **Accepted**/**Rejected**-shaped replies must not start the
+  // post-disposition window that classifies its later acks.
+  for (const login of advisoryBotLogins) {
+    dispositionAuthorLogins.delete(login);
+  }
+  const isAdvisoryBot = (login) =>
+    advisoryBotLogins.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+  const isDispositionAuthor = (login) =>
+    dispositionAuthorLogins.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
 
   const filteredComments = comments.filter((comment) => {
     if (!trustedMarkerLogins.has((comment.author?.login ?? '').toLowerCase())) {
@@ -1570,6 +1654,98 @@ export function buildActivitySnapshotSummary(
     }
     return operationalMarkerPrefixByStart(comment.body ?? '') === null;
   });
+
+  // Structural ack-only evidence (#858): the posting moment of the latest
+  // disposition by a configured disposition author opens the window;
+  // comments and resolved-thread replies are classified per item below.
+  // Dispositions are not SHA-bound here — the head-changed check in
+  // diffReviewSnapshot plus the unchanged disposition-evidence and
+  // unreplied-comment gates backstop that residual.
+  const dispositionCreatedAts = [
+    ...filteredComments
+      .filter(
+        (comment) =>
+          isDispositionAuthor(comment.author?.login) &&
+          isDispositionComment(comment),
+      )
+      .map((comment) => comment.createdAt),
+    ...threads.flatMap((thread) =>
+      (thread.comments?.nodes ?? [])
+        .filter(
+          (comment) =>
+            isDispositionAuthor(comment.author?.login) &&
+            isDispositionComment(comment),
+        )
+        .map((comment) => comment.createdAt),
+    ),
+  ].filter(isValidIsoTimestamp);
+  const latestDispositionAt = maxIsoTimestamp(dispositionCreatedAts) ?? null;
+
+  const isAckOnlyComment = (comment) => {
+    if (!latestDispositionAt) {
+      return false;
+    }
+    if (!isAdvisoryBot(comment.author?.login)) {
+      return false;
+    }
+    if (isDispositionComment(comment)) {
+      return false;
+    }
+    const activityAt = comment.updatedAt ?? comment.createdAt;
+    if (!isValidIsoTimestamp(activityAt)) {
+      return false;
+    }
+    return compareIsoTimestamps(activityAt, latestDispositionAt) > 0;
+  };
+  const ackOnlyComments = filteredComments.filter(isAckOnlyComment);
+  const ackOnlyCommentSet = new Set(ackOnlyComments);
+
+  // On a resolved thread whose latest reply chain contains a disposition,
+  // later advisory-bot replies are structurally ack-only; the effective
+  // thread activity is recomputed from the remaining replies. Reopened
+  // (unresolved) threads always keep their raw activity.
+  const threadEffective = threads.map((thread) => {
+    const nodes = thread.comments?.nodes ?? [];
+    const threadDispositionAt =
+      maxIsoTimestamp(
+        nodes
+          .filter(
+            (comment) =>
+              isDispositionAuthor(comment.author?.login) &&
+              isDispositionComment(comment),
+          )
+          .map((comment) => comment.createdAt)
+          .filter(isValidIsoTimestamp),
+      ) ?? null;
+    if (!thread.isResolved || !threadDispositionAt) {
+      return { activityAt: threadActivityAt(thread), ackReplies: [] };
+    }
+    const ackReplies = nodes.filter((comment) => {
+      if (!isAdvisoryBot(comment.author?.login)) {
+        return false;
+      }
+      if (isDispositionComment(comment)) {
+        return false;
+      }
+      const activityAt = effectiveThreadCommentActivityAt(comment);
+      return (
+        isValidIsoTimestamp(activityAt) &&
+        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
+      );
+    });
+    if (ackReplies.length === 0) {
+      return { activityAt: threadActivityAt(thread), ackReplies: [] };
+    }
+    const ackReplySet = new Set(ackReplies);
+    const keptActivities = nodes
+      .filter((comment) => !ackReplySet.has(comment))
+      .flatMap((comment) => [comment.updatedAt, comment.createdAt])
+      .filter(isValidIsoTimestamp);
+    return { activityAt: maxIsoTimestamp(keptActivities), ackReplies };
+  });
+  const ackOnlyThreadReplies = threadEffective.flatMap(
+    (entry) => entry.ackReplies,
+  );
 
   const commentActivities = filteredComments
     .map((comment) => comment.updatedAt ?? comment.createdAt)
@@ -1606,6 +1782,30 @@ export function buildActivitySnapshotSummary(
       ...threadActivities,
     ]) ?? 'none';
 
+  const effectiveCommentActivities = filteredComments
+    .filter((comment) => !ackOnlyCommentSet.has(comment))
+    .map((comment) => comment.updatedAt ?? comment.createdAt)
+    .filter(isValidIsoTimestamp);
+  const effectiveThreadActivities = threadEffective
+    .map((entry) => entry.activityAt)
+    .filter(isValidIsoTimestamp);
+  const effectiveMaxActivityUpdatedAt =
+    maxIsoTimestamp([
+      ...effectiveCommentActivities,
+      ...reviewActivities,
+      ...effectiveThreadActivities,
+    ]) ?? 'none';
+
+  const describeAckItem = (kind, comment, activityAt) => ({
+    kind,
+    id: String(comment.id ?? ''),
+    author: String(comment.author?.login ?? '')
+      .trim()
+      .toLowerCase(),
+    activityAt: isValidIsoTimestamp(activityAt) ? activityAt : 'none',
+    bodyPreview: String(comment.body ?? '').slice(0, 120),
+  });
+
   return {
     totalItemCount: filteredComments.length + reviews.length + threads.length,
     maxActivityUpdatedAt,
@@ -1615,6 +1815,36 @@ export function buildActivitySnapshotSummary(
       comments: filteredComments.length,
       reviews: reviews.length,
       threads: threads.length,
+    },
+    ackOnly: {
+      advisoryBotLogins: [...advisoryBotLogins].sort(),
+      source: String(options.advisoryBotLoginsSource ?? 'none'),
+      dispositionsPresent: Boolean(latestDispositionAt),
+      latestDispositionAt: latestDispositionAt ?? 'none',
+      items: [
+        ...ackOnlyComments.map((comment) =>
+          describeAckItem(
+            'comment',
+            comment,
+            comment.updatedAt ?? comment.createdAt,
+          ),
+        ),
+        ...ackOnlyThreadReplies.map((comment) =>
+          describeAckItem(
+            'thread-reply',
+            comment,
+            effectiveThreadCommentActivityAt(comment),
+          ),
+        ),
+      ],
+    },
+    effective: {
+      maxActivityUpdatedAt: effectiveMaxActivityUpdatedAt,
+      totalItemCount:
+        filteredComments.length -
+        ackOnlyComments.length +
+        reviews.length +
+        threads.length,
     },
   };
 }
@@ -2778,7 +3008,12 @@ export function buildPreMergeReadinessSummary(
       threads,
       checks,
     },
-    { trustedMarkerLogins },
+    {
+      trustedMarkerLogins,
+      advisoryBotLogins,
+      advisoryBotLoginsSource: options.advisoryBotLoginsSource,
+      dispositionAuthorLogins: iddAgentLogins,
+    },
   );
   const watermark = resolveLatestReviewWatermark(comments, {
     expectedClaimId: options.expectedClaimId,
@@ -2901,6 +3136,8 @@ export function buildPreMergeReadinessSummary(
         latestCiCompletedAt: liveSnapshot.latestCiCompletedAt,
         latestPassingCiCompletedAt: liveSnapshot.latestPassingCiCompletedAt,
         counts: liveSnapshot.counts,
+        ackOnly: liveSnapshot.ackOnly,
+        effective: liveSnapshot.effective,
       },
       comparisonRoute: reviewCurrency.route,
       comparisonReason: reviewCurrency.reason,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -966,6 +966,8 @@ export function diffReviewSnapshot(snapshot, live) {
   ) {
     const effectiveCurrent =
       ackEvidencePresent &&
+      typeof live.effective === 'object' &&
+      live.effective !== null &&
       (effectiveMax === 'none' ||
         (typeof effectiveMax === 'number' && effectiveMax <= snapshotMax));
     if (!effectiveCurrent) {
@@ -1717,7 +1719,15 @@ export function buildActivitySnapshotSummary(
           .map((comment) => comment.createdAt)
           .filter(isValidIsoTimestamp),
       ) ?? null;
-    if (!thread.isResolved || !threadDispositionAt) {
+    // Per-reply attribution needs the reply timeline: when a caller
+    // populates thread.updatedAt we cannot tell whether it reflects an
+    // ack or substantive activity, so fail closed and keep raw activity
+    // (production normalizers blank thread.updatedAt to opt in).
+    if (
+      !thread.isResolved ||
+      !threadDispositionAt ||
+      isValidIsoTimestamp(thread.updatedAt ?? '')
+    ) {
       return { activityAt: threadActivityAt(thread), ackReplies: [] };
     }
     const ackReplies = nodes.filter((comment) => {

--- a/scripts/review-activity-snapshot.mjs
+++ b/scripts/review-activity-snapshot.mjs
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs';
 
 import {
   buildActivitySnapshotSummary,
+  resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
 } from './protocol-helpers.mjs';
 
@@ -19,11 +20,18 @@ const owner =
 const repo =
   args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
 const repoRef = `${owner}/${repo}`;
+const iddConfig = loadIddConfig();
 const { actors: trustedMarkerLogins, source: trustedMarkerActorsSource } =
   resolveTrustedMarkerActors({
     flagValue: args.trustedMarkerLogins,
     envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
-    config: loadIddConfig(),
+    config: iddConfig,
+  });
+const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
+  resolveAdvisoryBotLogins({
+    flagValue: args.advisoryBotLogins,
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+    config: iddConfig,
   });
 
 const headSha = ghText([
@@ -68,7 +76,14 @@ const summary = buildActivitySnapshotSummary(
     threads: threads.map(normalizeThread),
     checks,
   },
-  { trustedMarkerLogins },
+  {
+    trustedMarkerLogins,
+    advisoryBotLogins,
+    advisoryBotLoginsSource,
+    // Advisory bots are excluded from disposition authorship inside the
+    // summary builder, so the trusted-marker set is a safe default here.
+    dispositionAuthorLogins: trustedMarkerLogins,
+  },
 );
 
 process.stdout.write(
@@ -82,6 +97,8 @@ process.stdout.write(
       latestCiCompletedAt: summary.latestCiCompletedAt,
       latestPassingCiCompletedAt: summary.latestPassingCiCompletedAt,
       counts: summary.counts,
+      ackOnly: summary.ackOnly,
+      effective: summary.effective,
     },
     null,
     2,
@@ -102,6 +119,7 @@ function parseArgs(argv) {
     owner: '',
     repo: '',
     trustedMarkerLogins: '',
+    advisoryBotLogins: '',
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -127,6 +145,11 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (token === '--advisory-bot-logins') {
+      parsed.advisoryBotLogins = value ?? '';
+      index += 1;
+      continue;
+    }
     if (token === '--help' || token === '-h') {
       printHelp();
       process.exit(0);
@@ -143,7 +166,7 @@ function parseArgs(argv) {
 
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/review-activity-snapshot.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>]
+  node scripts/review-activity-snapshot.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <login1,login2>]
 `);
 }
 

--- a/tests/flag-name-matrix.test.mjs
+++ b/tests/flag-name-matrix.test.mjs
@@ -91,7 +91,7 @@ const FLAG_CONCEPTS = [
   {
     concept: 'advisory bot logins',
     canonical: '--advisory-bot-logins',
-    helpers: ['pre-merge-readiness.mjs'],
+    helpers: ['pre-merge-readiness.mjs', 'review-activity-snapshot.mjs'],
   },
 ];
 

--- a/tests/pre-merge-readiness.test.mjs
+++ b/tests/pre-merge-readiness.test.mjs
@@ -26,6 +26,7 @@ const readinessSchema = loadJson('schemas/pre-merge-readiness.schema.json');
 
 for (const fixtureName of [
   'clean',
+  'ack-only-current',
   'stale-watermark',
   'unresolved-thread',
   'changes-requested',

--- a/tests/review-snapshot.test.mjs
+++ b/tests/review-snapshot.test.mjs
@@ -191,6 +191,168 @@ test('malformed forced-handoff comments remain visible activity', () => {
   assert.equal(summary.maxActivityUpdatedAt, '2026-05-10T10:40:00Z');
 });
 
+test('classifies post-disposition advisory-bot comments as ack-only', () => {
+  const summary = buildActivitySnapshotSummary(
+    {
+      comments: [
+        {
+          id: 'C-1',
+          author: { login: 'idd-bot' },
+          body: '**Rejected** — rate-limit notice is not a completed review.',
+          createdAt: '2026-05-10T10:00:00Z',
+          updatedAt: '2026-05-10T10:00:00Z',
+        },
+        {
+          id: 'C-2',
+          author: { login: 'advisory-bot' },
+          body: 'Thanks for confirming!',
+          createdAt: '2026-05-10T09:00:00Z',
+          updatedAt: '2026-05-10T10:05:00Z',
+        },
+      ],
+      reviews: [],
+      threads: [],
+      checks: [],
+    },
+    {
+      trustedMarkerLogins: ['idd-bot'],
+      advisoryBotLogins: ['advisory-bot'],
+      advisoryBotLoginsSource: 'config',
+      dispositionAuthorLogins: ['idd-bot'],
+    },
+  );
+
+  assert.equal(summary.ackOnly.dispositionsPresent, true);
+  assert.equal(summary.ackOnly.latestDispositionAt, '2026-05-10T10:00:00Z');
+  assert.equal(summary.ackOnly.source, 'config');
+  assert.deepEqual(
+    summary.ackOnly.items.map((item) => [item.kind, item.id]),
+    [['comment', 'C-2']],
+  );
+  assert.equal(summary.maxActivityUpdatedAt, '2026-05-10T10:05:00Z');
+  assert.equal(summary.effective.maxActivityUpdatedAt, '2026-05-10T10:00:00Z');
+  assert.equal(summary.totalItemCount, 2);
+  assert.equal(summary.effective.totalItemCount, 1);
+});
+
+test('ack-only classification fails closed without config or dispositions', () => {
+  const comments = [
+    {
+      id: 'C-1',
+      author: { login: 'advisory-bot' },
+      body: 'Thanks for confirming!',
+      createdAt: '2026-05-10T10:05:00Z',
+      updatedAt: '2026-05-10T10:05:00Z',
+    },
+  ];
+
+  const unconfigured = buildActivitySnapshotSummary(
+    { comments, reviews: [], threads: [], checks: [] },
+    {
+      trustedMarkerLogins: ['idd-bot'],
+      dispositionAuthorLogins: ['idd-bot'],
+    },
+  );
+  assert.deepEqual(unconfigured.ackOnly.items, []);
+  assert.equal(
+    unconfigured.effective.maxActivityUpdatedAt,
+    unconfigured.maxActivityUpdatedAt,
+  );
+
+  const noDisposition = buildActivitySnapshotSummary(
+    { comments, reviews: [], threads: [], checks: [] },
+    {
+      trustedMarkerLogins: ['idd-bot'],
+      advisoryBotLogins: ['advisory-bot'],
+      dispositionAuthorLogins: ['idd-bot'],
+    },
+  );
+  assert.equal(noDisposition.ackOnly.dispositionsPresent, false);
+  assert.deepEqual(noDisposition.ackOnly.items, []);
+
+  const botSelfDisposition = buildActivitySnapshotSummary(
+    {
+      comments: [
+        {
+          id: 'C-0',
+          author: { login: 'advisory-bot' },
+          body: '**Accepted** — looks good.',
+          createdAt: '2026-05-10T09:00:00Z',
+          updatedAt: '2026-05-10T09:00:00Z',
+        },
+        ...comments,
+      ],
+      reviews: [],
+      threads: [],
+      checks: [],
+    },
+    {
+      trustedMarkerLogins: ['idd-bot'],
+      advisoryBotLogins: ['advisory-bot'],
+      dispositionAuthorLogins: ['idd-bot', 'advisory-bot'],
+    },
+  );
+  assert.equal(botSelfDisposition.ackOnly.dispositionsPresent, false);
+  assert.deepEqual(botSelfDisposition.ackOnly.items, []);
+});
+
+test('resolved-thread advisory acks are excluded from effective activity', () => {
+  const buildThread = (isResolved) => ({
+    id: 'THREAD-1',
+    isResolved,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'TC-1',
+          author: { login: 'advisory-bot' },
+          body: 'Consider tightening this check.',
+          createdAt: '2026-05-10T09:00:00Z',
+          updatedAt: '2026-05-10T09:00:00Z',
+        },
+        {
+          id: 'TC-2',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — fixed in abc1234.',
+          createdAt: '2026-05-10T10:00:00Z',
+          updatedAt: '2026-05-10T10:00:00Z',
+        },
+        {
+          id: 'TC-3',
+          author: { login: 'advisory-bot' },
+          body: 'Thanks for confirming!',
+          createdAt: '2026-05-10T10:05:00Z',
+          updatedAt: '2026-05-10T10:05:00Z',
+        },
+      ],
+    },
+  });
+  const options = {
+    trustedMarkerLogins: ['idd-bot'],
+    advisoryBotLogins: ['advisory-bot'],
+    dispositionAuthorLogins: ['idd-bot'],
+  };
+
+  const resolved = buildActivitySnapshotSummary(
+    { comments: [], reviews: [], threads: [buildThread(true)], checks: [] },
+    options,
+  );
+  assert.equal(resolved.maxActivityUpdatedAt, '2026-05-10T10:05:00Z');
+  assert.equal(resolved.effective.maxActivityUpdatedAt, '2026-05-10T10:00:00Z');
+  assert.deepEqual(
+    resolved.ackOnly.items.map((item) => [item.kind, item.id]),
+    [['thread-reply', 'TC-3']],
+  );
+
+  const reopened = buildActivitySnapshotSummary(
+    { comments: [], reviews: [], threads: [buildThread(false)], checks: [] },
+    options,
+  );
+  assert.equal(reopened.effective.maxActivityUpdatedAt, '2026-05-10T10:05:00Z');
+  assert.deepEqual(reopened.ackOnly.items, []);
+});
+
 test('activity snapshot ignores pending check sentinel timestamps', () => {
   const summary = buildActivitySnapshotSummary(
     {


### PR DESCRIPTION
## Summary

- `buildActivitySnapshotSummary` now classifies **post-disposition advisory-bot acknowledgements** structurally: issue comments and resolved-thread replies authored by the configured advisory bots, active strictly after the latest `**Accepted**`/`**Rejected**` disposition posted by a disposition author (advisory bots can never anchor that window). Evidence is emitted per item (`ackOnly.items` with kind/id/author/activity/preview) plus `effective` activity values, with the identity trust source visible (`flag` > `IDD_ADVISORY_BOT_LOGINS` > config `advisoryBotLogins` > `none`; absence fail-closes the whole feature — no hard-coded bot names).
- `diffReviewSnapshot` proceeds with `comparisonReason: ack-only-post-disposition` when the only activity newer than the watermark is that evidence. Head changes, CI drift, missing `effective` evidence, reopened threads, `CHANGES_REQUESTED` reviews, and count growth beyond the newer ack comments all still re-open (fixture-pinned counter-cases).
- `pre-merge-readiness` binds its resolved advisory bots and `iddAgentLogins` into the live snapshot, exposing `ackOnly`/`effective` under `reviewCurrency.live`, so the F2/F3 review-currency evidence stops flipping to `return-to-e1` on courtesy ack edits — closing the deferred #813 acceptance bullet mechanically.
- Distributed instructions (template-first, mirrors regenerated): the F2 review-currency bullet, the F3 final-fetch list, and the courtesy-ack convergence section now cite the emitted evidence; the **semantic residual** ("raises no new actionable finding") stays with the agent, and the disposition-evidence and unreplied-comment gates are intentionally unchanged as the backstop (the positive E2E fixture demonstrates the backstop firing on a separate ack comment).
- Release discipline: `iddVersion`/package version bump to **0.3.0** + CHANGELOG entry (the pre-merge-readiness schema now requires the new evidence fields, which matters to adopters on older helper copies). The annotated `v0.3.0` tag follows after merge per the release rule.
- `--advisory-bot-logins` is now accepted by `review-activity-snapshot` too (flag-name matrix updated); dogfood config lists `coderabbitai[bot]` and `chatgpt-codex-connector[bot]`.

## Verification

- Full suite 874/874 (incl. 3 new inline classification tests, 6 new `diffReviewSnapshot` route fixtures, and a positive end-to-end `pre-merge-readiness` fixture asserting `ack-only-post-disposition`); Biome, audit, schema validation, dprint/cspell/markdownlint all green.
- Live smoke test on a real merged PR confirmed config-sourced classification (1 ack item; effective count 10 vs raw 11).
- Known residuals (documented in instructions/critique): dispositions are not SHA-bound (head-changed check + backstop gates cover it); `advisoryWait` outcome computation is untouched (the issue's "and/or" resolved to snapshot + readiness binding).
- Note: `schemas/pre-merge-readiness.schema.json` shows a large formatting-only diff from the JSON tooling; the semantic delta is exactly the two new required properties and their definitions.

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)
