### PR TITLE
feat(helpers): default marker helpers to config trusted actors

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -571,6 +571,12 @@
       "source": "skills/issue-authoring/references/workflow-boundary.md",
       "target": ".claude/skills/issue-authoring/references/workflow-boundary.md",
       "mode": "exact"
+    },
+    {
+      "id": "minimize-superseded-markers-helper",
+      "source": "idd-template/scripts/minimize-superseded-markers.mjs",
+      "target": "scripts/minimize-superseded-markers.mjs",
+      "mode": "exact"
     }
   ],
   "forbiddenPatterns": [

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -314,8 +314,11 @@ claim may use `--skip-claim-check`, but ordinary IDD agents should not.
 
 During claim verification, the helper ignores `claimed-by` and
 `unclaimed-by` markers whose GitHub author is not trusted. By default,
-trusted marker authors are the current authenticated GitHub actor and
-the logins listed in `IDD_TRUSTED_MARKER_ACTORS`. Set
+trusted marker authors are the current authenticated GitHub actor plus
+the union of the logins listed in `IDD_TRUSTED_MARKER_ACTORS` and the
+`trustedMarkerActors` list in `.github/idd/config.json`; the resolved
+list and its source mix are emitted in the report
+(`trustedMarkerActors`, `trustedMarkerActorsSources`). Set
 `IDD_TRUST_COLLABORATOR_MARKERS=true` only when the repository
 explicitly allows any Write, Maintain, or Admin collaborator to post
 operational markers.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -61,6 +61,20 @@ In the idd-skill source repository, the following optional helpers were adopted:
   `advisory-wait`, or `claimed-by` markers — called by E1 (Step 2),
   advisory-wait AW3-H, and claim takeover after the replacement
   marker is verified
+
+  Per-helper trust model: `minimize-superseded-markers` resolves its
+  trusted-author gate with the same `flag > env > config` ladder as the
+  evidence helpers (the singular `trustedMarkerActorsSource` names the
+  winning source) and stays self-contained so the template copy works
+  without `protocol-helpers.mjs`. `audit-pr-cleanup` and
+  `forced-handoff-marker` instead **union** the configured sources —
+  viewer, flag (where accepted), `IDD_TRUSTED_MARKER_ACTORS`, and the
+  config `trustedMarkerActors` list — with the optional
+  collaborator-permission trust; their JSON evidence reports the
+  resolved list plus the plural `trustedMarkerActorsSources` mix, so
+  config-listed actors widen trust explicitly while
+  collaborator-permission trust stays opt-in
+  (`IDD_TRUST_COLLABORATOR_MARKERS` / `trustCollaboratorMarkers`)
 - `scripts/review-disposition-verify.mjs` for read-only E7 disposition
   marker presence verification across PATH A and PATH B items
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -72,12 +72,14 @@ In the idd-skill source repository, the following optional helpers were adopted:
   config `trustedMarkerActors` list — with the optional
   collaborator-permission trust; their JSON evidence reports the
   resolved viewer-plus-configured list and the plural
-  `trustedMarkerActorsSources` mix (collaborator trust is evaluated
-  lazily per author and surfaces as `collaboratorTrustEnabled` /
-  the `collaborators` source tag rather than in the list), so
-  config-listed actors widen trust explicitly while
-  collaborator-permission trust stays opt-in
-  (`IDD_TRUST_COLLABORATOR_MARKERS` / `trustCollaboratorMarkers`)
+  `trustedMarkerActorsSources` mix. Collaborator trust never appears in
+  the list itself: both helpers add a `collaborators` source tag when
+  collaborator permission actually trusted an author, and
+  `audit-pr-cleanup` additionally reports the capability as
+  `collaboratorTrustEnabled`. Config-listed actors therefore widen
+  trust explicitly while collaborator-permission trust stays opt-in
+  (the `IDD_TRUST_COLLABORATOR_MARKERS` environment variable or the
+  `trustCollaboratorMarkers` config field)
 - `scripts/review-disposition-verify.mjs` for read-only E7 disposition
   marker presence verification across PATH A and PATH B items
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -71,7 +71,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
   viewer, flag (where accepted), `IDD_TRUSTED_MARKER_ACTORS`, and the
   config `trustedMarkerActors` list — with the optional
   collaborator-permission trust; their JSON evidence reports the
-  resolved list plus the plural `trustedMarkerActorsSources` mix, so
+  resolved viewer-plus-configured list and the plural
+  `trustedMarkerActorsSources` mix (collaborator trust is evaluated
+  lazily per author and surfaces as `collaboratorTrustEnabled` /
+  the `collaborators` source tag rather than in the list), so
   config-listed actors widen trust explicitly while
   collaborator-permission trust stays opt-in
   (`IDD_TRUST_COLLABORATOR_MARKERS` / `trustCollaboratorMarkers`)

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -314,8 +314,11 @@ claim may use `--skip-claim-check`, but ordinary IDD agents should not.
 
 During claim verification, the helper ignores `claimed-by` and
 `unclaimed-by` markers whose GitHub author is not trusted. By default,
-trusted marker authors are the current authenticated GitHub actor and
-the logins listed in `IDD_TRUSTED_MARKER_ACTORS`. Set
+trusted marker authors are the current authenticated GitHub actor plus
+the union of the logins listed in `IDD_TRUSTED_MARKER_ACTORS` and the
+`trustedMarkerActors` list in `.github/idd/config.json`; the resolved
+list and its source mix are emitted in the report
+(`trustedMarkerActors`, `trustedMarkerActorsSources`). Set
 `IDD_TRUST_COLLABORATOR_MARKERS=true` only when the repository
 explicitly allows any Write, Maintain, or Admin collaborator to post
 operational markers.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -61,6 +61,20 @@ In the idd-skill source repository, the following optional helpers were adopted:
   `advisory-wait`, or `claimed-by` markers — called by E1 (Step 2),
   advisory-wait AW3-H, and claim takeover after the replacement
   marker is verified
+
+  Per-helper trust model: `minimize-superseded-markers` resolves its
+  trusted-author gate with the same `flag > env > config` ladder as the
+  evidence helpers (the singular `trustedMarkerActorsSource` names the
+  winning source) and stays self-contained so the template copy works
+  without `protocol-helpers.mjs`. `audit-pr-cleanup` and
+  `forced-handoff-marker` instead **union** the configured sources —
+  viewer, flag (where accepted), `IDD_TRUSTED_MARKER_ACTORS`, and the
+  config `trustedMarkerActors` list — with the optional
+  collaborator-permission trust; their JSON evidence reports the
+  resolved list plus the plural `trustedMarkerActorsSources` mix, so
+  config-listed actors widen trust explicitly while
+  collaborator-permission trust stays opt-in
+  (`IDD_TRUST_COLLABORATOR_MARKERS` / `trustCollaboratorMarkers`)
 - `scripts/review-disposition-verify.mjs` for read-only E7 disposition
   marker presence verification across PATH A and PATH B items
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -72,12 +72,14 @@ In the idd-skill source repository, the following optional helpers were adopted:
   config `trustedMarkerActors` list — with the optional
   collaborator-permission trust; their JSON evidence reports the
   resolved viewer-plus-configured list and the plural
-  `trustedMarkerActorsSources` mix (collaborator trust is evaluated
-  lazily per author and surfaces as `collaboratorTrustEnabled` /
-  the `collaborators` source tag rather than in the list), so
-  config-listed actors widen trust explicitly while
-  collaborator-permission trust stays opt-in
-  (`IDD_TRUST_COLLABORATOR_MARKERS` / `trustCollaboratorMarkers`)
+  `trustedMarkerActorsSources` mix. Collaborator trust never appears in
+  the list itself: both helpers add a `collaborators` source tag when
+  collaborator permission actually trusted an author, and
+  `audit-pr-cleanup` additionally reports the capability as
+  `collaboratorTrustEnabled`. Config-listed actors therefore widen
+  trust explicitly while collaborator-permission trust stays opt-in
+  (the `IDD_TRUST_COLLABORATOR_MARKERS` environment variable or the
+  `trustCollaboratorMarkers` config field)
 - `scripts/review-disposition-verify.mjs` for read-only E7 disposition
   marker presence verification across PATH A and PATH B items
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -71,7 +71,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
   viewer, flag (where accepted), `IDD_TRUSTED_MARKER_ACTORS`, and the
   config `trustedMarkerActors` list — with the optional
   collaborator-permission trust; their JSON evidence reports the
-  resolved list plus the plural `trustedMarkerActorsSources` mix, so
+  resolved viewer-plus-configured list and the plural
+  `trustedMarkerActorsSources` mix (collaborator trust is evaluated
+  lazily per author and surfaces as `collaboratorTrustEnabled` /
+  the `collaborators` source tag rather than in the list), so
   config-listed actors widen trust explicitly while
   collaborator-permission trust stays opt-in
   (`IDD_TRUST_COLLABORATOR_MARKERS` / `trustCollaboratorMarkers`)

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 const ALLOWED_CLASSIFIERS = new Set(['OUTDATED', 'RESOLVED']);
 const ALLOWED_FORMATS = new Set(['json', 'table']);
@@ -43,10 +44,16 @@ if (isMainModule(import.meta.url)) {
     process.exit(2);
   }
 
-  const trustedSet = buildTrustedSet(args.trustedMarkerLogins);
+  const { actors: trustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config: loadIddConfig(),
+    });
+  const trustedSet = new Set(trustedActors);
   if (trustedSet.size === 0 && !args.allowUntrusted) {
     console.error(
-      'error: no trusted marker logins supplied. Pass --trusted-marker-logins (or set IDD_TRUSTED_MARKER_ACTORS), or pass --allow-untrusted to explicitly opt out of the author gate.',
+      'error: no trusted marker logins supplied. Pass --trusted-marker-logins, set IDD_TRUSTED_MARKER_ACTORS, or list trustedMarkerActors in .github/idd/config.json; or pass --allow-untrusted to explicitly opt out of the author gate.',
     );
     process.exit(2);
   }
@@ -58,6 +65,8 @@ if (isMainModule(import.meta.url)) {
     apply: args.apply,
     allowUntrusted: args.allowUntrusted,
   });
+  report.trustedMarkerActors = [...trustedSet].sort();
+  report.trustedMarkerActorsSource = trustedMarkerActorsSource;
 
   if (args.format === 'table') {
     printTable(report);
@@ -309,12 +318,47 @@ export function normalizeTrustedMarkerLogins(logins) {
   ].sort();
 }
 
-function buildTrustedSet(logins) {
-  const list = String(logins ?? '')
+// Local flag > env > config ladder mirroring the shared
+// resolveTrustedMarkerActors() contract. This helper stays
+// self-contained because the template mirror ships without
+// protocol-helpers.mjs.
+export function resolveTrustedActors({
+  flagValue = '',
+  envValue = '',
+  config = null,
+} = {}) {
+  const fromFlag = normalizeTrustedMarkerLogins(splitLoginCsv(flagValue));
+  if (fromFlag.length > 0) {
+    return { actors: fromFlag, source: 'flag' };
+  }
+  const fromEnv = normalizeTrustedMarkerLogins(splitLoginCsv(envValue));
+  if (fromEnv.length > 0) {
+    return { actors: fromEnv, source: 'env' };
+  }
+  const fromConfig = normalizeTrustedMarkerLogins(
+    Array.isArray(config?.trustedMarkerActors)
+      ? config.trustedMarkerActors
+      : [],
+  );
+  if (fromConfig.length > 0) {
+    return { actors: fromConfig, source: 'config' };
+  }
+  return { actors: [], source: 'none' };
+}
+
+function splitLoginCsv(value) {
+  return String(value ?? '')
     .split(',')
     .map((login) => login.trim())
     .filter((login) => login.length > 0);
-  return new Set(normalizeTrustedMarkerLogins(list));
+}
+
+function loadIddConfig() {
+  try {
+    return JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    return null;
+  }
 }
 
 export function isTrustedAuthor(author, trustedSet) {
@@ -363,7 +407,7 @@ function parseArgs(argv) {
   const args = {
     subjectIds: [],
     classifier: 'OUTDATED',
-    trustedMarkerLogins: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    trustedMarkerLogins: '',
     apply: false,
     allowUntrusted: false,
     format: 'json',
@@ -433,12 +477,13 @@ function printUsage() {
   console.log(
     `Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table]
 
-The trusted-author gate is mandatory by default: pass a non-empty
---trusted-marker-logins list (or set IDD_TRUSTED_MARKER_ACTORS) so the
-helper rejects markers from untrusted GitHub actors. Use
---allow-untrusted only when you intentionally want to minimize markers
-regardless of author, and the caller has already verified the subject
-IDs are operationally safe to hide.`,
+The trusted-author gate is mandatory by default: supply trusted logins
+via --trusted-marker-logins, IDD_TRUSTED_MARKER_ACTORS, or the
+trustedMarkerActors list in .github/idd/config.json (flag > env >
+config precedence) so the helper rejects markers from untrusted GitHub
+actors. Use --allow-untrusted only when you intentionally want to
+minimize markers regardless of author, and the caller has already
+verified the subject IDs are operationally safe to hide.`,
   );
 }
 

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -168,7 +168,10 @@ async function buildReport(owner, repo, prNumber, options = {}) {
     prUrl: pr.url,
     merged: pr.merged,
     mode: 'dry-run',
-    trustedMarkerActors: [...configuredTrust.actors].sort(),
+    trustedMarkerActors: normalizeTrustedMarkerLogins([
+      currentViewerLogin(),
+      ...configuredTrust.actors,
+    ]),
     trustedMarkerActorsSources: [
       ...(currentViewerLogin() ? ['viewer'] : []),
       ...configuredTrust.sources,

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -200,6 +200,16 @@ async function buildReport(owner, repo, prNumber, options = {}) {
     evaluateReviewParent(review, pr, threadIndex, latestGatingReviews, report);
   }
 
+  // Collaborator trust is evaluated lazily per author; record it in the
+  // source mix only when the collaborator path actually trusted someone
+  // during this report's evaluation.
+  if (
+    report.collaboratorTrustEnabled &&
+    [...trustedMarkerAuthorCache.values()].some(Boolean)
+  ) {
+    report.trustedMarkerActorsSources.push('collaborators');
+  }
+
   return report;
 }
 

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -19,13 +19,14 @@ import {
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   summarizeClaimValidation,
+  unionTrustedMarkerActorSources,
   unsafeTextReason,
 } from './protocol-helpers.mjs';
 
 const TRUSTED_MARKER_PERMISSIONS = new Set(['admin', 'maintain', 'write']);
 const trustedMarkerAuthorCache = new Map();
 const collaboratorPermissionCache = new Map();
-let cachedConfiguredTrustedMarkerAuthors = null;
+let cachedConfiguredTrustedMarkerActorSources = null;
 let cachedCurrentViewerLogin = null;
 
 const args = parseArgs(process.argv.slice(2));
@@ -160,12 +161,19 @@ async function buildReport(owner, repo, prNumber, options = {}) {
   const threadIndex = indexThreadsByReview(threads);
   const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
 
+  const configuredTrust = configuredTrustedMarkerActorSources();
   const report = {
     repository: `${owner}/${repo}`,
     pr: prNumber,
     prUrl: pr.url,
     merged: pr.merged,
     mode: 'dry-run',
+    trustedMarkerActors: [...configuredTrust.actors].sort(),
+    trustedMarkerActorsSources: [
+      ...(currentViewerLogin() ? ['viewer'] : []),
+      ...configuredTrust.sources,
+    ],
+    collaboratorTrustEnabled: trustCollaboratorMarkers(),
     candidates: [],
     skipped: [],
     applied: [],
@@ -890,18 +898,30 @@ function currentViewerLogin() {
   return cachedCurrentViewerLogin;
 }
 
-function configuredTrustedMarkerAuthors() {
-  if (cachedConfiguredTrustedMarkerAuthors) {
-    return cachedConfiguredTrustedMarkerAuthors;
+function configuredTrustedMarkerActorSources() {
+  if (cachedConfiguredTrustedMarkerActorSources) {
+    return cachedConfiguredTrustedMarkerActorSources;
   }
 
-  cachedConfiguredTrustedMarkerAuthors = new Set(
-    (process.env.IDD_TRUSTED_MARKER_ACTORS ?? '')
-      .split(',')
-      .map((login) => login.trim().toLowerCase())
-      .filter(Boolean),
-  );
-  return cachedConfiguredTrustedMarkerAuthors;
+  let config = null;
+  try {
+    config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    config = null;
+  }
+  const { actors, sources } = unionTrustedMarkerActorSources({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config,
+  });
+  cachedConfiguredTrustedMarkerActorSources = {
+    actors: new Set(actors),
+    sources,
+  };
+  return cachedConfiguredTrustedMarkerActorSources;
+}
+
+function configuredTrustedMarkerAuthors() {
+  return configuredTrustedMarkerActorSources().actors;
 }
 
 function trustCollaboratorMarkers() {
@@ -1127,6 +1147,7 @@ Options:
 
 Environment:
   IDD_TRUSTED_MARKER_ACTORS         comma-separated trusted bot/app logins
+                                    (combined with config.json trustedMarkerActors)
   IDD_TRUST_COLLABORATOR_MARKERS    set true to trust Write/Maintain/Admin collaborators
 `);
 }

--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -14,6 +14,7 @@ import {
   parsePaginatedGhNdjson,
   renderForcedHandoffComment,
   summarizeClaimValidation,
+  unionTrustedMarkerActorSources,
 } from './protocol-helpers.mjs';
 
 export function generateSuccessorIds(baseAgentId) {
@@ -176,13 +177,14 @@ export function main(argv = process.argv.slice(2)) {
       '--jq',
       '.login',
     ]).toLowerCase();
-    const trustedMarkerLogins = buildTrustedMarkerLogins(
-      owner,
-      name,
-      viewerLogin,
-      args.trustedMarkerLogins,
-      issueComments,
-    );
+    const { logins: trustedMarkerLogins, sources: trustedMarkerActorsSources } =
+      buildTrustedMarkerLogins(
+        owner,
+        name,
+        viewerLogin,
+        args.trustedMarkerLogins,
+        issueComments,
+      );
     const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
     const permissionCache = new Map();
 
@@ -242,6 +244,8 @@ export function main(argv = process.argv.slice(2)) {
           repository: `${owner}/${name}`,
           issueNumber: args.issueNumber,
           modeEnabled,
+          trustedMarkerActors: [...trustedMarkerLogins].sort(),
+          trustedMarkerActorsSources,
           ...plan,
         },
         null,
@@ -288,13 +292,14 @@ export function main(argv = process.argv.slice(2)) {
     '--jq',
     '.login',
   ]).toLowerCase();
-  const trustedMarkerLogins = buildTrustedMarkerLogins(
-    owner,
-    name,
-    viewerLogin,
-    args.trustedMarkerLogins,
-    issueComments,
-  );
+  const { logins: trustedMarkerLogins, sources: trustedMarkerActorsSources } =
+    buildTrustedMarkerLogins(
+      owner,
+      name,
+      viewerLogin,
+      args.trustedMarkerLogins,
+      issueComments,
+    );
   const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
   const permissionCache = new Map();
   const activeClaim = resolveHelperActiveClaim(
@@ -378,6 +383,8 @@ export function main(argv = process.argv.slice(2)) {
         {
           repository: `${owner}/${name}`,
           issueNumber: args.issueNumber,
+          trustedMarkerActors: [...trustedMarkerLogins].sort(),
+          trustedMarkerActorsSources,
           activeClaim,
           payload,
           commentBody,
@@ -494,26 +501,35 @@ function buildTrustedMarkerLogins(
   cliLogins,
   issueComments,
 ) {
-  const configured = [
-    viewerLogin,
-    ...splitCsv(cliLogins),
-    ...splitCsv(process.env.IDD_TRUSTED_MARKER_ACTORS),
-  ];
-  if (!readCollaboratorTrustEnabled()) {
-    return new Set(
-      configured.filter(Boolean).map((login) => login.toLowerCase()),
-    );
+  // Parse the config once and share it between the actor union and the
+  // collaborator-trust toggle.
+  const config = loadIddConfig();
+  const sources = [];
+  if (String(viewerLogin ?? '').trim()) {
+    sources.push('viewer');
+  }
+  const flagActors = splitCsv(cliLogins);
+  if (flagActors.length > 0) {
+    sources.push('flag');
+  }
+  const union = unionTrustedMarkerActorSources({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config,
+    extraActors: [viewerLogin, ...flagActors],
+  });
+  sources.push(...union.sources);
+  const trusted = new Set(union.actors);
+  if (!readCollaboratorTrustEnabled(config)) {
+    return { logins: trusted, sources };
   }
 
-  const trusted = new Set(
-    configured.filter(Boolean).map((login) => login.toLowerCase()),
-  );
   const permissionCache = new Map();
   const uniqueLogins = new Set(
     issueComments
       .map((comment) => String(comment.user?.login ?? '').toLowerCase())
       .filter(Boolean),
   );
+  let collaboratorAdded = false;
   for (const login of uniqueLogins) {
     if (trusted.has(login)) {
       continue;
@@ -533,9 +549,21 @@ function buildTrustedMarkerLogins(
       permission === 'write'
     ) {
       trusted.add(login);
+      collaboratorAdded = true;
     }
   }
-  return trusted;
+  if (collaboratorAdded) {
+    sources.push('collaborators');
+  }
+  return { logins: trusted, sources };
+}
+
+function loadIddConfig() {
+  try {
+    return JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    return null;
+  }
 }
 
 function normalizeIssueComment(comment) {
@@ -613,10 +641,10 @@ function safeGhText(args) {
   }
 }
 
-function readCollaboratorTrustEnabled() {
+function readCollaboratorTrustEnabled(config = null) {
   try {
     return resolveCollaboratorMarkerTrust(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+      config ?? JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
       process.env.IDD_TRUST_COLLABORATOR_MARKERS,
     );
   } catch {
@@ -648,6 +676,7 @@ Options:
 
 Environment:
   IDD_TRUSTED_MARKER_ACTORS        comma-separated trusted bot/app logins
+                                   (combined with config.json trustedMarkerActors)
   IDD_TRUST_COLLABORATOR_MARKERS   set true to trust Write/Maintain/Admin collaborators
 `);
 }

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 const ALLOWED_CLASSIFIERS = new Set(['OUTDATED', 'RESOLVED']);
 const ALLOWED_FORMATS = new Set(['json', 'table']);
@@ -43,10 +44,16 @@ if (isMainModule(import.meta.url)) {
     process.exit(2);
   }
 
-  const trustedSet = buildTrustedSet(args.trustedMarkerLogins);
+  const { actors: trustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config: loadIddConfig(),
+    });
+  const trustedSet = new Set(trustedActors);
   if (trustedSet.size === 0 && !args.allowUntrusted) {
     console.error(
-      'error: no trusted marker logins supplied. Pass --trusted-marker-logins (or set IDD_TRUSTED_MARKER_ACTORS), or pass --allow-untrusted to explicitly opt out of the author gate.',
+      'error: no trusted marker logins supplied. Pass --trusted-marker-logins, set IDD_TRUSTED_MARKER_ACTORS, or list trustedMarkerActors in .github/idd/config.json; or pass --allow-untrusted to explicitly opt out of the author gate.',
     );
     process.exit(2);
   }
@@ -58,6 +65,8 @@ if (isMainModule(import.meta.url)) {
     apply: args.apply,
     allowUntrusted: args.allowUntrusted,
   });
+  report.trustedMarkerActors = [...trustedSet].sort();
+  report.trustedMarkerActorsSource = trustedMarkerActorsSource;
 
   if (args.format === 'table') {
     printTable(report);
@@ -309,12 +318,47 @@ export function normalizeTrustedMarkerLogins(logins) {
   ].sort();
 }
 
-function buildTrustedSet(logins) {
-  const list = String(logins ?? '')
+// Local flag > env > config ladder mirroring the shared
+// resolveTrustedMarkerActors() contract. This helper stays
+// self-contained because the template mirror ships without
+// protocol-helpers.mjs.
+export function resolveTrustedActors({
+  flagValue = '',
+  envValue = '',
+  config = null,
+} = {}) {
+  const fromFlag = normalizeTrustedMarkerLogins(splitLoginCsv(flagValue));
+  if (fromFlag.length > 0) {
+    return { actors: fromFlag, source: 'flag' };
+  }
+  const fromEnv = normalizeTrustedMarkerLogins(splitLoginCsv(envValue));
+  if (fromEnv.length > 0) {
+    return { actors: fromEnv, source: 'env' };
+  }
+  const fromConfig = normalizeTrustedMarkerLogins(
+    Array.isArray(config?.trustedMarkerActors)
+      ? config.trustedMarkerActors
+      : [],
+  );
+  if (fromConfig.length > 0) {
+    return { actors: fromConfig, source: 'config' };
+  }
+  return { actors: [], source: 'none' };
+}
+
+function splitLoginCsv(value) {
+  return String(value ?? '')
     .split(',')
     .map((login) => login.trim())
     .filter((login) => login.length > 0);
-  return new Set(normalizeTrustedMarkerLogins(list));
+}
+
+function loadIddConfig() {
+  try {
+    return JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    return null;
+  }
 }
 
 export function isTrustedAuthor(author, trustedSet) {
@@ -363,7 +407,7 @@ function parseArgs(argv) {
   const args = {
     subjectIds: [],
     classifier: 'OUTDATED',
-    trustedMarkerLogins: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    trustedMarkerLogins: '',
     apply: false,
     allowUntrusted: false,
     format: 'json',
@@ -433,12 +477,13 @@ function printUsage() {
   console.log(
     `Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table]
 
-The trusted-author gate is mandatory by default: pass a non-empty
---trusted-marker-logins list (or set IDD_TRUSTED_MARKER_ACTORS) so the
-helper rejects markers from untrusted GitHub actors. Use
---allow-untrusted only when you intentionally want to minimize markers
-regardless of author, and the caller has already verified the subject
-IDs are operationally safe to hide.`,
+The trusted-author gate is mandatory by default: supply trusted logins
+via --trusted-marker-logins, IDD_TRUSTED_MARKER_ACTORS, or the
+trustedMarkerActors list in .github/idd/config.json (flag > env >
+config precedence) so the helper rejects markers from untrusted GitHub
+actors. Use --allow-untrusted only when you intentionally want to
+minimize markers regardless of author, and the caller has already
+verified the subject IDs are operationally safe to hide.`,
   );
 }
 

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1355,6 +1355,40 @@ function trustedMarkerActorTokens(value) {
   return Array.isArray(value) ? value : String(value ?? '').split(',');
 }
 
+export function unionTrustedMarkerActorSources({
+  envValue = '',
+  config = null,
+  extraActors = [],
+  extraSource = '',
+} = {}) {
+  const sources = [];
+  const actors = [];
+  const extras = normalizeTrustedMarkerLogins(extraActors);
+  if (extras.length > 0) {
+    actors.push(...extras);
+    if (extraSource) {
+      sources.push(extraSource);
+    }
+  }
+  const fromEnv = normalizeTrustedMarkerLogins(
+    trustedMarkerActorTokens(envValue),
+  );
+  if (fromEnv.length > 0) {
+    actors.push(...fromEnv);
+    sources.push('env');
+  }
+  const fromConfig = normalizeTrustedMarkerLogins(
+    Array.isArray(config?.trustedMarkerActors)
+      ? config.trustedMarkerActors
+      : [],
+  );
+  if (fromConfig.length > 0) {
+    actors.push(...fromConfig);
+    sources.push('config');
+  }
+  return { actors: normalizeTrustedMarkerLogins(actors), sources };
+}
+
 export function resolveAdvisoryBotLogins({
   flagValue = '',
   envValue = '',

--- a/tests/minimize-superseded-markers.test.mjs
+++ b/tests/minimize-superseded-markers.test.mjs
@@ -1,9 +1,21 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   computeExitCode,
   isTrustedAuthor,
+  resolveTrustedActors,
 } from '../scripts/minimize-superseded-markers.mjs';
 
 test('computeExitCode returns 0 when no failures', () => {
@@ -72,4 +84,73 @@ test('isTrustedAuthor rejects unknown logins', () => {
 test('isTrustedAuthor returns false when trusted set is empty', () => {
   const trusted = new Set();
   assert.equal(isTrustedAuthor('kurone-kito', trusted), false);
+});
+
+test('resolveTrustedActors follows flag > env > config precedence', () => {
+  const config = { trustedMarkerActors: ['config-actor'] };
+  assert.deepEqual(
+    resolveTrustedActors({
+      flagValue: 'Flag-Actor',
+      envValue: 'env-actor',
+      config,
+    }),
+    { actors: ['flag-actor'], source: 'flag' },
+  );
+  assert.deepEqual(
+    resolveTrustedActors({ flagValue: '', envValue: 'Env-Actor', config }),
+    { actors: ['env-actor'], source: 'env' },
+  );
+  assert.deepEqual(
+    resolveTrustedActors({ flagValue: '', envValue: '', config }),
+    { actors: ['config-actor'], source: 'config' },
+  );
+  assert.deepEqual(
+    resolveTrustedActors({ flagValue: '', envValue: '', config: null }),
+    { actors: [], source: 'none' },
+  );
+});
+
+test('config-only resolution passes the author gate end to end', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-minimize-'));
+  try {
+    mkdirSync(join(sandbox, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(sandbox, '.github/idd/config.json'),
+      JSON.stringify({ trustedMarkerActors: ['kurone-kito'] }),
+    );
+    // Stub gh so the run is deterministic and offline: probe failures
+    // surface as per-item failures (exit 1), never the author-gate
+    // configuration error (exit 2).
+    const binDir = join(sandbox, 'bin');
+    mkdirSync(binDir);
+    writeFileSync(join(binDir, 'gh'), '#!/bin/sh\nexit 1\n');
+    chmodSync(join(binDir, 'gh'), 0o755);
+
+    const script = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'scripts',
+      'minimize-superseded-markers.mjs',
+    );
+    const result = spawnSync(
+      process.execPath,
+      [script, '--subject-ids', 'IC_test', '--format', 'json'],
+      {
+        cwd: sandbox,
+        env: {
+          ...process.env,
+          PATH: binDir,
+          IDD_TRUSTED_MARKER_ACTORS: '',
+        },
+        encoding: 'utf8',
+      },
+    );
+
+    assert.notEqual(result.status, 2, result.stderr);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.trustedMarkerActorsSource, 'config');
+    assert.deepEqual(report.trustedMarkerActors, ['kurone-kito']);
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
 });

--- a/tests/minimize-superseded-markers.test.mjs
+++ b/tests/minimize-superseded-markers.test.mjs
@@ -146,7 +146,7 @@ test('config-only resolution passes the author gate end to end', () => {
       },
     );
 
-    assert.notEqual(result.status, 2, result.stderr);
+    assert.equal(result.status, 1, result.stderr);
     const report = JSON.parse(result.stdout);
     assert.equal(report.trustedMarkerActorsSource, 'config');
     assert.deepEqual(report.trustedMarkerActors, ['kurone-kito']);

--- a/tests/resolve-trusted-marker-actors.test.mjs
+++ b/tests/resolve-trusted-marker-actors.test.mjs
@@ -1,7 +1,9 @@
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
 
-import { resolveTrustedMarkerActors } from '../scripts/protocol-helpers.mjs';
+import * as protocolHelpers from '../scripts/protocol-helpers.mjs';
+
+const { resolveTrustedMarkerActors } = protocolHelpers;
 
 test('resolveTrustedMarkerActors: config.json is the default source', () => {
   const result = resolveTrustedMarkerActors({
@@ -71,5 +73,44 @@ test('resolveTrustedMarkerActors: accepts array inputs and ignores non-array con
       config: { trustedMarkerActors: 'not-an-array' },
     }),
     { actors: [], source: 'none' },
+  );
+});
+
+test('unionTrustedMarkerActorSources: unions env and config with source mix', () => {
+  const { unionTrustedMarkerActorSources } = protocolHelpers;
+  assert.deepEqual(
+    unionTrustedMarkerActorSources({
+      envValue: 'Env-Bot',
+      config: { trustedMarkerActors: ['kurone-kito', 'env-bot'] },
+    }),
+    { actors: ['env-bot', 'kurone-kito'], sources: ['env', 'config'] },
+  );
+});
+
+test('unionTrustedMarkerActorSources: config-only and empty cases', () => {
+  const { unionTrustedMarkerActorSources } = protocolHelpers;
+  assert.deepEqual(
+    unionTrustedMarkerActorSources({
+      envValue: '',
+      config: { trustedMarkerActors: ['kurone-kito'] },
+    }),
+    { actors: ['kurone-kito'], sources: ['config'] },
+  );
+  assert.deepEqual(
+    unionTrustedMarkerActorSources({ envValue: '', config: null }),
+    { actors: [], sources: [] },
+  );
+});
+
+test('unionTrustedMarkerActorSources: extra actors join with their source tag', () => {
+  const { unionTrustedMarkerActorSources } = protocolHelpers;
+  assert.deepEqual(
+    unionTrustedMarkerActorSources({
+      envValue: '',
+      config: null,
+      extraActors: ['Viewer-Login'],
+      extraSource: 'viewer',
+    }),
+    { actors: ['viewer-login'], sources: ['viewer'] },
   );
 });


### PR DESCRIPTION
## Summary

- `minimize-superseded-markers` no longer hard-errors when neither `--trusted-marker-logins` nor `IDD_TRUSTED_MARKER_ACTORS` is supplied: a local `flag > env > config` ladder (mirroring the shared `resolveTrustedMarkerActors` contract, kept self-contained because the template mirror ships without `protocol-helpers.mjs`) reads `config.json` `trustedMarkerActors` as the default source, and the author gate errors only when all three sources are empty without `--allow-untrusted`. The report emits the resolved list and the singular `trustedMarkerActorsSource`.
- The template mirror is now **mechanically enforced**: a new `mode: exact` syncPairs entry covers `idd-template/scripts/minimize-superseded-markers.mjs` → `scripts/minimize-superseded-markers.mjs`, closing the manual-copy blind spot flagged in #860's review.
- `audit-pr-cleanup` and `forced-handoff-marker` **union** the config `trustedMarkerActors` into their existing viewer/env(/collaborator) trust via a new shared `unionTrustedMarkerActorSources()` (ladder-vs-union asymmetry follows the issue wording), and emit `trustedMarkerActors` (viewer-plus-configured) + `trustedMarkerActorsSources` (source mix incl. `viewer`/`flag`/`env`/`config`/`collaborators`) in their JSON evidence — `forced-handoff-marker` only at the CLI top level, never inside the marker `payload` (its schema is `additionalProperties: false`). Collaborator-permission trust behavior is unchanged and `forced-handoff-marker` now parses `config.json` once per resolution.
- Usage/`Environment:` texts and the helper docs (`idd-helper-scripts.md` per-helper trust-model note, `idd-comment-minimization.md` trust-default sentence) updated template-first with regenerated mirrors.

## Verification

- Full suite green (879+ tests), Biome, audit-docs, dprint/cspell/markdownlint.
- New tests: ladder precedence (flag wins > env wins > config wins > none; empty-flag fallthrough), shared union resolver cases, and an **offline end-to-end acceptance test** that runs the minimize CLI in a sandbox with only `config.json` set and a deterministic failing `gh` stub — exit code is exactly 1 (per-item probe failure), never the author-gate 2, with `trustedMarkerActorsSource: "config"` in the report.
- Already-migrated #809 trio untouched (their ladder tests still pass unchanged).
- Note: the feature commit also carries its documentation (a staging mishap merged the planned docs commit into it; content-wise it is the same logical change). Per-CLI wiring fixtures for the two top-level-executing helpers are covered at the shared-resolver level; their CLIs are exercised by the existing live helper usage.

Closes #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trusted marker authors can be resolved from CLI flag > environment variable > .github/idd/config.json; some helpers union multiple sources and may record collaborator-based trust
  * Reports now include resolved trusted marker authors and their contributing source labels

* **Documentation**
  * Clarified per-helper trust models, precedence, union behavior, and reporting of trust sources

* **Tests**
  * Added unit and end-to-end tests for trusted-actor resolution and reporting

* **Chores**
  * Added sync entry for the marker minimization script
<!-- end of auto-generated comment: release notes by coderabbit.ai -->