### PR TITLE
feat(audit): add type-suppression budget guards to the audit pipeline

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -12,7 +12,7 @@
       "languageLinks": [
         {
           "file": "README.md",
-          "text": "[日本語](./README.ja.md)"
+          "text": "[\u65e5\u672c\u8a9e](./README.ja.md)"
         },
         {
           "file": "README.ja.md",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -12,7 +12,7 @@
       "languageLinks": [
         {
           "file": "README.md",
-          "text": "[\u65e5\u672c\u8a9e](./README.ja.md)"
+          "text": "[日本語](./README.ja.md)"
         },
         {
           "file": "README.ja.md",
@@ -598,5 +598,15 @@
       "README.md",
       "SECURITY.md"
     ]
+  },
+  "typeSuppressionBudgets": {
+    "id": "type-suppression-budgets",
+    "description": "Ratchet rule (mirrors bundleBudgets): raising a limit requires an explicit callout in the PR description; lowering is always allowed. The ts-ignore directive is forbidden outright; ts-expect-error is the only allowed escape and must carry a same-line reason. Limits record the measured current counts, not aspirations.",
+    "globs": [
+      "src/**/*.mts",
+      "tests/**/*.mjs"
+    ],
+    "tsExpectErrorLimit": 0,
+    "explicitAnyLimit": 0
   }
 }

--- a/docs/typescript-sources.md
+++ b/docs/typescript-sources.md
@@ -60,6 +60,27 @@ bare-node lane additionally runs `node scripts/audit-docs.mjs --check`,
 whose pairing guard fails when a source is missing its generated artifact
 or a banner-marked artifact is missing its source.
 
+## Type-suppression budgets
+
+Strict mode only protects quality if suppressions do not accumulate, so
+`audit-docs --check` also enforces the `typeSuppressionBudgets` entry in
+`audit/sync-manifest.json` (a pure `node:` text scan, mirroring the
+`bundleBudgets` ratchet shape):
+
+- the `@ts-ignore` directive is forbidden outright — `@ts-expect-error`
+  is the only allowed escape because it self-expires when the error
+  disappears;
+- every `@ts-expect-error` must carry a same-line reason;
+- `@ts-expect-error` occurrences and explicit `any` occurrences across
+  `src/` and `tests/` are counted against the recorded budgets.
+
+The budgets record the **measured** current counts (zero at landing
+time). Ratchet rule: raising a limit requires an explicit callout in the
+PR description; lowering is always allowed. In the installed lane,
+Biome's `lint/suspicious/noExplicitAny` (enabled via the shared config's
+recommended set) is the precise `any` enforcement; the bare-node count is
+the install-free backstop.
+
 The migration converts modules in dependency-ordered waves; only the
 sources listed in `tsconfig.json`'s `include` set are type-checked, so
 unconverted hand-written `.mjs` stay untyped and CI is green throughout.

--- a/docs/typescript-sources.md
+++ b/docs/typescript-sources.md
@@ -77,9 +77,9 @@ Strict mode only protects quality if suppressions do not accumulate, so
 The budgets record the **measured** current counts (zero at landing
 time). Ratchet rule: raising a limit requires an explicit callout in the
 PR description; lowering is always allowed. In the installed lane,
-Biome's `lint/suspicious/noExplicitAny` (enabled via the shared config's
-recommended set) is the precise `any` enforcement; the bare-node count is
-the install-free backstop.
+Biome's `lint/suspicious/noExplicitAny` (on via the recommended set)
+surfaces explicit `any` as a warning during development; this audit
+budget is the **blocking** enforcement in both CI lanes.
 
 The migration converts modules in dependency-ordered waves; only the
 sources listed in `tsconfig.json`'s `include` set are type-checked, so

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -377,9 +377,20 @@ function checkTypeSuppressionBudgets(config) {
   if (!config) {
     return;
   }
+  // A present budget entry with missing or empty globs would scan zero
+  // files and report success — fail closed on the misconfiguration
+  // instead of silently passing a CI quality gate.
   const globs = Array.isArray(config.globs)
-    ? config.globs.map((glob) => String(glob))
+    ? config.globs
+        .map((glob) => String(glob))
+        .filter((glob) => glob.trim().length > 0)
     : [];
+  if (globs.length === 0) {
+    errors.push(
+      `${String(config.id ?? 'type-suppression-budgets')}: globs must be a non-empty array of glob strings`,
+    );
+    return;
+  }
   const files = uniqueSorted(globs.flatMap(globFiles)).map((path) => ({
     path,
     text: readText(path),

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import {
   collectPolicyConfigDrift,
   collectRootMarkdownAllowlistViolations,
+  collectTypeSuppressionViolations,
 } from './consistency-helpers.mjs';
 
 const root = process.cwd();
@@ -36,6 +37,7 @@ checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? null);
 checkBundleBudgets(manifest.bundleBudgets ?? []);
 checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
 checkRootMarkdownAllowlist(manifest.rootMarkdownAllowlist ?? null);
+checkTypeSuppressionBudgets(manifest.typeSuppressionBudgets ?? null);
 checkConfigInstructionDrift();
 checkGeneratedSourcePairs();
 if (errors.length > 0) {
@@ -366,6 +368,23 @@ function checkForbiddenPatterns(patterns) {
 }
 function checkRootMarkdownAllowlist(config) {
   errors.push(...collectRootMarkdownAllowlistViolations(repoFiles, config));
+}
+// Type-suppression budget guard (ratchet, mirroring bundleBudgets): a
+// pure `node:` text scan so the bare-node lane enforces the budgets with
+// no typescript dependency. The collector lives in consistency-helpers so
+// it can be unit-tested without I/O.
+function checkTypeSuppressionBudgets(config) {
+  if (!config) {
+    return;
+  }
+  const globs = Array.isArray(config.globs)
+    ? config.globs.map((glob) => String(glob))
+    : [];
+  const files = uniqueSorted(globs.flatMap(globFiles)).map((path) => ({
+    path,
+    text: readText(path),
+  }));
+  errors.push(...collectTypeSuppressionViolations(files, config));
 }
 function checkConfigInstructionDrift() {
   const pairs = [

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -377,17 +377,19 @@ function checkTypeSuppressionBudgets(config) {
   if (!config) {
     return;
   }
-  // A present budget entry with missing or empty globs would scan zero
-  // files and report success — fail closed on the misconfiguration
-  // instead of silently passing a CI quality gate.
-  const globs = Array.isArray(config.globs)
-    ? config.globs
-        .map((glob) => String(glob))
-        .filter((glob) => glob.trim().length > 0)
-    : [];
-  if (globs.length === 0) {
+  // A present budget entry with missing, empty, or non-string globs
+  // would scan zero (or the wrong) files and report success — fail
+  // closed on the misconfiguration instead of silently passing a CI
+  // quality gate. Non-string entries are rejected, not coerced: a
+  // stringified object would otherwise become a pseudo-glob matching
+  // nothing.
+  const rawGlobs = Array.isArray(config.globs) ? config.globs : [];
+  const globs = rawGlobs.filter(
+    (glob) => typeof glob === 'string' && glob.trim().length > 0,
+  );
+  if (globs.length === 0 || globs.length !== rawGlobs.length) {
     errors.push(
-      `${String(config.id ?? 'type-suppression-budgets')}: globs must be a non-empty array of glob strings`,
+      `${String(config.id ?? 'type-suppression-budgets')}: globs must be a non-empty array of non-empty glob strings`,
     );
     return;
   }

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -101,11 +101,15 @@ const TS_IGNORE_TOKEN = `@ts-${'ignore'}`;
 const TS_EXPECT_ERROR_TOKEN = `@ts-${'expect'}-error`;
 // The explicit-`any` matcher is likewise assembled from fragments so its
 // own pattern text never trips the scan when this file is scanned.
+// It counts every standalone `any` word in stripped code — annotations,
+// casts, and type arguments in any nesting (`Set<any[]>`,
+// `Map<string, any>`, unions) — excluding only property access
+// (`.any`) and larger identifiers. Deliberately conservative: an
+// unusual identifier literally named `any` would over-count, which
+// fails loud for a budget gate rather than letting a wrapped type
+// argument bypass it.
 const ANY_TOKEN = 'any';
-const EXPLICIT_ANY_PATTERN = new RegExp(
-  `(?::\\s*${ANY_TOKEN}\\b|\\bas\\s+${ANY_TOKEN}\\b|<${ANY_TOKEN}>)`,
-  'g',
-);
+const EXPLICIT_ANY_PATTERN = new RegExp(`(?<![.$\\w])${ANY_TOKEN}\\b`, 'g');
 /**
  * Collect type-suppression budget violations across the given files.
  * Pure (no I/O) so it can be unit-tested; the audit pipeline feeds it

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -93,3 +93,175 @@ export function collectRootMarkdownAllowlistViolations(repoFiles, config) {
   }
   return violations;
 }
+// The directive tokens are assembled from fragments so this file (and the
+// generated scripts/consistency-helpers.mjs) never contains the literal
+// tokens itself — the guard scans raw text, and a literal here or in a
+// test fixture would count against the budget.
+const TS_IGNORE_TOKEN = `@ts-${'ignore'}`;
+const TS_EXPECT_ERROR_TOKEN = `@ts-${'expect'}-error`;
+// The explicit-`any` matcher is likewise assembled from fragments so its
+// own pattern text never trips the scan when this file is scanned.
+const ANY_TOKEN = 'any';
+const EXPLICIT_ANY_PATTERN = new RegExp(
+  `(?::\\s*${ANY_TOKEN}\\b|\\bas\\s+${ANY_TOKEN}\\b|<${ANY_TOKEN}>)`,
+  'g',
+);
+/**
+ * Collect type-suppression budget violations across the given files.
+ * Pure (no I/O) so it can be unit-tested; the audit pipeline feeds it
+ * file text read in the bare-node lane.
+ *
+ * Rules (the ratchet rule lives in the manifest entry's description):
+ * - The ts-ignore directive is forbidden outright; the expect-error
+ *   directive is the only allowed escape because it self-expires.
+ * - Every expect-error directive must carry a same-line reason.
+ * - Expect-error occurrences and explicit `any` occurrences are counted
+ *   against the recorded budgets; exceeding either is a violation.
+ *
+ * The explicit-`any` scan strips comments and string/template-literal
+ * contents first (a text-level approximation, not a parser), so prose
+ * such as "Fail-safe: any invalid token" in a comment is not counted.
+ * Directive scanning runs on the raw text because directives live in
+ * comments.
+ */
+export function collectTypeSuppressionViolations(files, config) {
+  if (!config) {
+    return [];
+  }
+  const id = String(config.id ?? 'type-suppression-budgets');
+  const tsExpectErrorLimit = normalizeBudgetLimit(config.tsExpectErrorLimit);
+  const explicitAnyLimit = normalizeBudgetLimit(config.explicitAnyLimit);
+  if (tsExpectErrorLimit === null) {
+    return [`${id}: tsExpectErrorLimit must be a non-negative integer`];
+  }
+  if (explicitAnyLimit === null) {
+    return [`${id}: explicitAnyLimit must be a non-negative integer`];
+  }
+  const violations = [];
+  let tsExpectErrorCount = 0;
+  let explicitAnyCount = 0;
+  for (const file of files) {
+    const lines = String(file.text ?? '').split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      if (line.includes(TS_IGNORE_TOKEN)) {
+        violations.push(
+          `${id}: ${file.path}:${index + 1} uses the forbidden ${TS_IGNORE_TOKEN} directive; use ${TS_EXPECT_ERROR_TOKEN} with a same-line reason instead`,
+        );
+      }
+      let searchFrom = 0;
+      while (true) {
+        const at = line.indexOf(TS_EXPECT_ERROR_TOKEN, searchFrom);
+        if (at === -1) {
+          break;
+        }
+        tsExpectErrorCount += 1;
+        const trailing = line
+          .slice(at + TS_EXPECT_ERROR_TOKEN.length)
+          .replace(/^\s*(?:--|—|:)?\s*/u, '')
+          .trim();
+        if (trailing.length < 3) {
+          violations.push(
+            `${id}: ${file.path}:${index + 1} has a ${TS_EXPECT_ERROR_TOKEN} directive without a same-line reason`,
+          );
+        }
+        searchFrom = at + TS_EXPECT_ERROR_TOKEN.length;
+      }
+    }
+    const codeOnly = stripCommentsAndStrings(String(file.text ?? ''));
+    const anyMatches = codeOnly.match(EXPLICIT_ANY_PATTERN);
+    explicitAnyCount += anyMatches ? anyMatches.length : 0;
+  }
+  if (tsExpectErrorCount > tsExpectErrorLimit) {
+    violations.push(
+      `${id}: ${tsExpectErrorCount} ${TS_EXPECT_ERROR_TOKEN} directive(s) exceed the recorded budget of ${tsExpectErrorLimit}; remove suppressions or raise the budget with an explicit PR callout (lowering is always allowed)`,
+    );
+  }
+  if (explicitAnyCount > explicitAnyLimit) {
+    violations.push(
+      `${id}: ${explicitAnyCount} explicit any occurrence(s) exceed the recorded budget of ${explicitAnyLimit}; remove suppressions or raise the budget with an explicit PR callout (lowering is always allowed)`,
+    );
+  }
+  return violations;
+}
+function normalizeBudgetLimit(value) {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+// Text-level stripper for the explicit-`any` scan: blanks line comments,
+// block comments, and string/template-literal contents while preserving
+// line structure. An approximation (regex literals containing quote
+// characters can over-strip a short span), which is acceptable for a
+// budget backstop — the installed lane's Biome noExplicitAny rule is the
+// precise enforcement.
+function stripCommentsAndStrings(text) {
+  let out = '';
+  let i = 0;
+  let state = 'code';
+  while (i < text.length) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (state === 'code') {
+      if (ch === '/' && next === '/') {
+        state = 'line-comment';
+        i += 2;
+        continue;
+      }
+      if (ch === '/' && next === '*') {
+        state = 'block-comment';
+        i += 2;
+        continue;
+      }
+      if (ch === "'") {
+        state = 'single';
+        i += 1;
+        continue;
+      }
+      if (ch === '"') {
+        state = 'double';
+        i += 1;
+        continue;
+      }
+      if (ch === '`') {
+        state = 'template';
+        i += 1;
+        continue;
+      }
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === '\n') {
+      out += '\n';
+      if (state === 'line-comment') {
+        state = 'code';
+      }
+      i += 1;
+      continue;
+    }
+    if (state === 'block-comment' && ch === '*' && next === '/') {
+      state = 'code';
+      i += 2;
+      continue;
+    }
+    if (state === 'single' && ch === "'" && text[i - 1] !== '\\') {
+      state = 'code';
+      i += 1;
+      continue;
+    }
+    if (state === 'double' && ch === '"' && text[i - 1] !== '\\') {
+      state = 'code';
+      i += 1;
+      continue;
+    }
+    if (state === 'template' && ch === '`' && text[i - 1] !== '\\') {
+      state = 'code';
+      i += 1;
+      continue;
+    }
+    i += 1;
+  }
+  return out;
+}

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -190,16 +190,39 @@ function normalizeBudgetLimit(value) {
   }
   return value;
 }
+// Words after which a `/` must start a regex literal, not division.
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  'return',
+  'typeof',
+  'case',
+  'in',
+  'of',
+  'delete',
+  'void',
+  'instanceof',
+  'new',
+  'do',
+  'else',
+  'yield',
+  'await',
+]);
 // Text-level stripper for the explicit-`any` scan: blanks line comments,
-// block comments, and string/template-literal contents while preserving
-// line structure. An approximation (regex literals containing quote
-// characters can over-strip a short span), which is acceptable for a
-// budget backstop — the installed lane's Biome noExplicitAny rule is the
-// precise enforcement.
+// block comments, string/template-literal contents, and regex-literal
+// contents while preserving line structure. Escape sequences are
+// consumed as pairs so a string ending in a literal backslash closes
+// correctly, and regex literals (detected by the standard
+// last-significant-token heuristic, with bracket classes handled) cannot
+// open phantom strings. Template interpolation is the remaining
+// approximation: `${...}` code inside a template is stripped with the
+// template, so an explicit `any` inside an interpolation is not counted.
 function stripCommentsAndStrings(text) {
   let out = '';
   let i = 0;
   let state = 'code';
+  // Last non-whitespace character and last identifier word emitted in
+  // code state, used to decide whether `/` starts a regex literal.
+  let lastCodeChar = '';
+  let lastWord = '';
   while (i < text.length) {
     const ch = text[i];
     const next = text[i + 1];
@@ -212,6 +235,11 @@ function stripCommentsAndStrings(text) {
       if (ch === '/' && next === '*') {
         state = 'block-comment';
         i += 2;
+        continue;
+      }
+      if (ch === '/' && regexCanStartAfter(lastCodeChar, lastWord)) {
+        state = 'regex';
+        i += 1;
         continue;
       }
       if (ch === "'") {
@@ -230,6 +258,10 @@ function stripCommentsAndStrings(text) {
         continue;
       }
       out += ch;
+      if (!/\s/.test(ch)) {
+        lastCodeChar = ch;
+        lastWord = /[A-Za-z0-9_$]/.test(ch) ? lastWord + ch : '';
+      }
       i += 1;
       continue;
     }
@@ -241,27 +273,83 @@ function stripCommentsAndStrings(text) {
       i += 1;
       continue;
     }
-    if (state === 'block-comment' && ch === '*' && next === '/') {
-      state = 'code';
+    if (state === 'block-comment') {
+      if (ch === '*' && next === '/') {
+        state = 'code';
+        i += 2;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+    // Consume escape sequences as pairs in string and regex states so an
+    // escaped delimiter (or a literal backslash before the closing
+    // delimiter, e.g. '\\') cannot flip the state machine. Comments have
+    // no escapes. A line-continuation backslash still preserves the
+    // newline so line structure survives.
+    if (state !== 'line-comment' && ch === '\\') {
+      if (next === '\n') {
+        out += '\n';
+      }
       i += 2;
       continue;
     }
-    if (state === 'single' && ch === "'" && text[i - 1] !== '\\') {
+    if (state === 'single' && ch === "'") {
       state = 'code';
+      lastCodeChar = "'";
+      lastWord = '';
       i += 1;
       continue;
     }
-    if (state === 'double' && ch === '"' && text[i - 1] !== '\\') {
+    if (state === 'double' && ch === '"') {
       state = 'code';
+      lastCodeChar = '"';
+      lastWord = '';
       i += 1;
       continue;
     }
-    if (state === 'template' && ch === '`' && text[i - 1] !== '\\') {
+    if (state === 'template' && ch === '`') {
       state = 'code';
+      lastCodeChar = '`';
+      lastWord = '';
+      i += 1;
+      continue;
+    }
+    if (state === 'regex') {
+      if (ch === '[') {
+        state = 'regex-class';
+        i += 1;
+        continue;
+      }
+      if (ch === '/') {
+        state = 'code';
+        lastCodeChar = '/';
+        lastWord = '';
+        i += 1;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+    if (state === 'regex-class' && ch === ']') {
+      state = 'regex';
       i += 1;
       continue;
     }
     i += 1;
   }
   return out;
+}
+// A `/` begins a regex literal when the previous significant token cannot
+// end an expression: at the start of the scan, after an operator or
+// opening punctuator, or after a keyword such as `return`. After an
+// identifier character, a closing bracket, or a literal it is division.
+function regexCanStartAfter(lastCodeChar, lastWord) {
+  if (lastCodeChar === '') {
+    return true;
+  }
+  if (REGEX_PRECEDING_KEYWORDS.has(lastWord)) {
+    return true;
+  }
+  return !/[\w$)\]'"`/]/.test(lastCodeChar);
 }

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -228,11 +228,16 @@ function stripCommentsAndStrings(text) {
     const next = text[i + 1];
     if (state === 'code') {
       if (ch === '/' && next === '/') {
+        // Emit one space so a comment between tokens cannot splice them
+        // together (a block comment between `as` and `any` must not
+        // produce a single merged token that dodges the matcher).
+        out += ' ';
         state = 'line-comment';
         i += 2;
         continue;
       }
       if (ch === '/' && next === '*') {
+        out += ' ';
         state = 'block-comment';
         i += 2;
         continue;

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -160,7 +160,10 @@ export function collectTypeSuppressionViolations(files, config) {
           .slice(at + TS_EXPECT_ERROR_TOKEN.length)
           .replace(/^\s*(?:--|—|:)?\s*/u, '')
           .trim();
-        if (trailing.length < 3) {
+        // Any non-empty trailing text counts as a reason (terse but
+        // legitimate reasons like an issue reference must pass); only a
+        // truly absent reason is a violation.
+        if (trailing.length === 0) {
           violations.push(
             `${id}: ${file.path}:${index + 1} has a ${TS_EXPECT_ERROR_TOKEN} directive without a same-line reason`,
           );

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -511,17 +511,20 @@ function checkTypeSuppressionBudgets(
   if (!config) {
     return;
   }
-  // A present budget entry with missing or empty globs would scan zero
-  // files and report success — fail closed on the misconfiguration
-  // instead of silently passing a CI quality gate.
-  const globs = Array.isArray(config.globs)
-    ? config.globs
-        .map((glob) => String(glob))
-        .filter((glob) => glob.trim().length > 0)
-    : [];
-  if (globs.length === 0) {
+  // A present budget entry with missing, empty, or non-string globs
+  // would scan zero (or the wrong) files and report success — fail
+  // closed on the misconfiguration instead of silently passing a CI
+  // quality gate. Non-string entries are rejected, not coerced: a
+  // stringified object would otherwise become a pseudo-glob matching
+  // nothing.
+  const rawGlobs = Array.isArray(config.globs) ? config.globs : [];
+  const globs = rawGlobs.filter(
+    (glob): glob is string =>
+      typeof glob === 'string' && glob.trim().length > 0,
+  );
+  if (globs.length === 0 || globs.length !== rawGlobs.length) {
     errors.push(
-      `${String(config.id ?? 'type-suppression-budgets')}: globs must be a non-empty array of glob strings`,
+      `${String(config.id ?? 'type-suppression-budgets')}: globs must be a non-empty array of non-empty glob strings`,
     );
     return;
   }

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -8,10 +8,14 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import type { RootMarkdownAllowlistConfig } from './consistency-helpers.mts';
+import type {
+  RootMarkdownAllowlistConfig,
+  TypeSuppressionBudgetConfig,
+} from './consistency-helpers.mts';
 import {
   collectPolicyConfigDrift,
   collectRootMarkdownAllowlistViolations,
+  collectTypeSuppressionViolations,
 } from './consistency-helpers.mts';
 
 interface ReadmePair {
@@ -90,6 +94,7 @@ interface AuditManifest {
   bundleBudgets?: BundleBudget[];
   forbiddenPatterns?: ForbiddenPattern[];
   rootMarkdownAllowlist?: RootMarkdownAllowlistConfig | null;
+  typeSuppressionBudgets?: TypeSuppressionBudgetConfig | null;
 }
 
 const root = process.cwd();
@@ -119,6 +124,7 @@ checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? null);
 checkBundleBudgets(manifest.bundleBudgets ?? []);
 checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
 checkRootMarkdownAllowlist(manifest.rootMarkdownAllowlist ?? null);
+checkTypeSuppressionBudgets(manifest.typeSuppressionBudgets ?? null);
 checkConfigInstructionDrift();
 checkGeneratedSourcePairs();
 
@@ -493,6 +499,26 @@ function checkRootMarkdownAllowlist(
   config: RootMarkdownAllowlistConfig | null,
 ) {
   errors.push(...collectRootMarkdownAllowlistViolations(repoFiles, config));
+}
+
+// Type-suppression budget guard (ratchet, mirroring bundleBudgets): a
+// pure `node:` text scan so the bare-node lane enforces the budgets with
+// no typescript dependency. The collector lives in consistency-helpers so
+// it can be unit-tested without I/O.
+function checkTypeSuppressionBudgets(
+  config: TypeSuppressionBudgetConfig | null,
+) {
+  if (!config) {
+    return;
+  }
+  const globs = Array.isArray(config.globs)
+    ? config.globs.map((glob) => String(glob))
+    : [];
+  const files = uniqueSorted(globs.flatMap(globFiles)).map((path) => ({
+    path,
+    text: readText(path),
+  }));
+  errors.push(...collectTypeSuppressionViolations(files, config));
 }
 
 function checkConfigInstructionDrift() {

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -511,9 +511,20 @@ function checkTypeSuppressionBudgets(
   if (!config) {
     return;
   }
+  // A present budget entry with missing or empty globs would scan zero
+  // files and report success — fail closed on the misconfiguration
+  // instead of silently passing a CI quality gate.
   const globs = Array.isArray(config.globs)
-    ? config.globs.map((glob) => String(glob))
+    ? config.globs
+        .map((glob) => String(glob))
+        .filter((glob) => glob.trim().length > 0)
     : [];
+  if (globs.length === 0) {
+    errors.push(
+      `${String(config.id ?? 'type-suppression-budgets')}: globs must be a non-empty array of glob strings`,
+    );
+    return;
+  }
   const files = uniqueSorted(globs.flatMap(globFiles)).map((path) => ({
     path,
     text: readText(path),

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -251,12 +251,32 @@ function normalizeBudgetLimit(value: unknown): number | null {
   return value;
 }
 
+// Words after which a `/` must start a regex literal, not division.
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  'return',
+  'typeof',
+  'case',
+  'in',
+  'of',
+  'delete',
+  'void',
+  'instanceof',
+  'new',
+  'do',
+  'else',
+  'yield',
+  'await',
+]);
+
 // Text-level stripper for the explicit-`any` scan: blanks line comments,
-// block comments, and string/template-literal contents while preserving
-// line structure. An approximation (regex literals containing quote
-// characters can over-strip a short span), which is acceptable for a
-// budget backstop — the installed lane's Biome noExplicitAny rule is the
-// precise enforcement.
+// block comments, string/template-literal contents, and regex-literal
+// contents while preserving line structure. Escape sequences are
+// consumed as pairs so a string ending in a literal backslash closes
+// correctly, and regex literals (detected by the standard
+// last-significant-token heuristic, with bracket classes handled) cannot
+// open phantom strings. Template interpolation is the remaining
+// approximation: `${...}` code inside a template is stripped with the
+// template, so an explicit `any` inside an interpolation is not counted.
 function stripCommentsAndStrings(text: string): string {
   let out = '';
   let i = 0;
@@ -266,7 +286,13 @@ function stripCommentsAndStrings(text: string): string {
     | 'block-comment'
     | 'single'
     | 'double'
-    | 'template' = 'code';
+    | 'template'
+    | 'regex'
+    | 'regex-class' = 'code';
+  // Last non-whitespace character and last identifier word emitted in
+  // code state, used to decide whether `/` starts a regex literal.
+  let lastCodeChar = '';
+  let lastWord = '';
   while (i < text.length) {
     const ch = text[i];
     const next = text[i + 1];
@@ -279,6 +305,11 @@ function stripCommentsAndStrings(text: string): string {
       if (ch === '/' && next === '*') {
         state = 'block-comment';
         i += 2;
+        continue;
+      }
+      if (ch === '/' && regexCanStartAfter(lastCodeChar, lastWord)) {
+        state = 'regex';
+        i += 1;
         continue;
       }
       if (ch === "'") {
@@ -297,6 +328,10 @@ function stripCommentsAndStrings(text: string): string {
         continue;
       }
       out += ch;
+      if (!/\s/.test(ch)) {
+        lastCodeChar = ch;
+        lastWord = /[A-Za-z0-9_$]/.test(ch) ? lastWord + ch : '';
+      }
       i += 1;
       continue;
     }
@@ -308,27 +343,84 @@ function stripCommentsAndStrings(text: string): string {
       i += 1;
       continue;
     }
-    if (state === 'block-comment' && ch === '*' && next === '/') {
-      state = 'code';
+    if (state === 'block-comment') {
+      if (ch === '*' && next === '/') {
+        state = 'code';
+        i += 2;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+    // Consume escape sequences as pairs in string and regex states so an
+    // escaped delimiter (or a literal backslash before the closing
+    // delimiter, e.g. '\\') cannot flip the state machine. Comments have
+    // no escapes. A line-continuation backslash still preserves the
+    // newline so line structure survives.
+    if (state !== 'line-comment' && ch === '\\') {
+      if (next === '\n') {
+        out += '\n';
+      }
       i += 2;
       continue;
     }
-    if (state === 'single' && ch === "'" && text[i - 1] !== '\\') {
+    if (state === 'single' && ch === "'") {
       state = 'code';
+      lastCodeChar = "'";
+      lastWord = '';
       i += 1;
       continue;
     }
-    if (state === 'double' && ch === '"' && text[i - 1] !== '\\') {
+    if (state === 'double' && ch === '"') {
       state = 'code';
+      lastCodeChar = '"';
+      lastWord = '';
       i += 1;
       continue;
     }
-    if (state === 'template' && ch === '`' && text[i - 1] !== '\\') {
+    if (state === 'template' && ch === '`') {
       state = 'code';
+      lastCodeChar = '`';
+      lastWord = '';
+      i += 1;
+      continue;
+    }
+    if (state === 'regex') {
+      if (ch === '[') {
+        state = 'regex-class';
+        i += 1;
+        continue;
+      }
+      if (ch === '/') {
+        state = 'code';
+        lastCodeChar = '/';
+        lastWord = '';
+        i += 1;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+    if (state === 'regex-class' && ch === ']') {
+      state = 'regex';
       i += 1;
       continue;
     }
     i += 1;
   }
   return out;
+}
+
+// A `/` begins a regex literal when the previous significant token cannot
+// end an expression: at the start of the scan, after an operator or
+// opening punctuator, or after a keyword such as `return`. After an
+// identifier character, a closing bracket, or a literal it is division.
+function regexCanStartAfter(lastCodeChar: string, lastWord: string): boolean {
+  if (lastCodeChar === '') {
+    return true;
+  }
+  if (REGEX_PRECEDING_KEYWORDS.has(lastWord)) {
+    return true;
+  }
+  return !/[\w$)\]'"`/]/.test(lastCodeChar);
 }

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -216,7 +216,10 @@ export function collectTypeSuppressionViolations(
           .slice(at + TS_EXPECT_ERROR_TOKEN.length)
           .replace(/^\s*(?:--|—|:)?\s*/u, '')
           .trim();
-        if (trailing.length < 3) {
+        // Any non-empty trailing text counts as a reason (terse but
+        // legitimate reasons like an issue reference must pass); only a
+        // truly absent reason is a violation.
+        if (trailing.length === 0) {
           violations.push(
             `${id}: ${file.path}:${index + 1} has a ${TS_EXPECT_ERROR_TOKEN} directive without a same-line reason`,
           );

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -150,11 +150,15 @@ const TS_IGNORE_TOKEN = `@ts-${'ignore'}`;
 const TS_EXPECT_ERROR_TOKEN = `@ts-${'expect'}-error`;
 // The explicit-`any` matcher is likewise assembled from fragments so its
 // own pattern text never trips the scan when this file is scanned.
+// It counts every standalone `any` word in stripped code — annotations,
+// casts, and type arguments in any nesting (`Set<any[]>`,
+// `Map<string, any>`, unions) — excluding only property access
+// (`.any`) and larger identifiers. Deliberately conservative: an
+// unusual identifier literally named `any` would over-count, which
+// fails loud for a budget gate rather than letting a wrapped type
+// argument bypass it.
 const ANY_TOKEN = 'any';
-const EXPLICIT_ANY_PATTERN = new RegExp(
-  `(?::\\s*${ANY_TOKEN}\\b|\\bas\\s+${ANY_TOKEN}\\b|<${ANY_TOKEN}>)`,
-  'g',
-);
+const EXPLICIT_ANY_PATTERN = new RegExp(`(?<![.$\\w])${ANY_TOKEN}\\b`, 'g');
 
 /**
  * Collect type-suppression budget violations across the given files.

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -126,3 +126,209 @@ export function collectRootMarkdownAllowlistViolations(
   }
   return violations;
 }
+
+/** Declarative config for the type-suppression budget guard. */
+export interface TypeSuppressionBudgetConfig {
+  id?: unknown;
+  description?: unknown;
+  globs?: unknown;
+  tsExpectErrorLimit?: unknown;
+  explicitAnyLimit?: unknown;
+}
+
+/** One scanned file: repo-relative path plus its full text. */
+export interface TypeSuppressionFileInput {
+  path: string;
+  text: string;
+}
+
+// The directive tokens are assembled from fragments so this file (and the
+// generated scripts/consistency-helpers.mjs) never contains the literal
+// tokens itself — the guard scans raw text, and a literal here or in a
+// test fixture would count against the budget.
+const TS_IGNORE_TOKEN = `@ts-${'ignore'}`;
+const TS_EXPECT_ERROR_TOKEN = `@ts-${'expect'}-error`;
+// The explicit-`any` matcher is likewise assembled from fragments so its
+// own pattern text never trips the scan when this file is scanned.
+const ANY_TOKEN = 'any';
+const EXPLICIT_ANY_PATTERN = new RegExp(
+  `(?::\\s*${ANY_TOKEN}\\b|\\bas\\s+${ANY_TOKEN}\\b|<${ANY_TOKEN}>)`,
+  'g',
+);
+
+/**
+ * Collect type-suppression budget violations across the given files.
+ * Pure (no I/O) so it can be unit-tested; the audit pipeline feeds it
+ * file text read in the bare-node lane.
+ *
+ * Rules (the ratchet rule lives in the manifest entry's description):
+ * - The ts-ignore directive is forbidden outright; the expect-error
+ *   directive is the only allowed escape because it self-expires.
+ * - Every expect-error directive must carry a same-line reason.
+ * - Expect-error occurrences and explicit `any` occurrences are counted
+ *   against the recorded budgets; exceeding either is a violation.
+ *
+ * The explicit-`any` scan strips comments and string/template-literal
+ * contents first (a text-level approximation, not a parser), so prose
+ * such as "Fail-safe: any invalid token" in a comment is not counted.
+ * Directive scanning runs on the raw text because directives live in
+ * comments.
+ */
+export function collectTypeSuppressionViolations(
+  files: readonly TypeSuppressionFileInput[],
+  config: TypeSuppressionBudgetConfig | null | undefined,
+): string[] {
+  if (!config) {
+    return [];
+  }
+
+  const id = String(config.id ?? 'type-suppression-budgets');
+  const tsExpectErrorLimit = normalizeBudgetLimit(config.tsExpectErrorLimit);
+  const explicitAnyLimit = normalizeBudgetLimit(config.explicitAnyLimit);
+  if (tsExpectErrorLimit === null) {
+    return [`${id}: tsExpectErrorLimit must be a non-negative integer`];
+  }
+  if (explicitAnyLimit === null) {
+    return [`${id}: explicitAnyLimit must be a non-negative integer`];
+  }
+
+  const violations: string[] = [];
+  let tsExpectErrorCount = 0;
+  let explicitAnyCount = 0;
+
+  for (const file of files) {
+    const lines = String(file.text ?? '').split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      if (line.includes(TS_IGNORE_TOKEN)) {
+        violations.push(
+          `${id}: ${file.path}:${index + 1} uses the forbidden ${TS_IGNORE_TOKEN} directive; use ${TS_EXPECT_ERROR_TOKEN} with a same-line reason instead`,
+        );
+      }
+      let searchFrom = 0;
+      while (true) {
+        const at = line.indexOf(TS_EXPECT_ERROR_TOKEN, searchFrom);
+        if (at === -1) {
+          break;
+        }
+        tsExpectErrorCount += 1;
+        const trailing = line
+          .slice(at + TS_EXPECT_ERROR_TOKEN.length)
+          .replace(/^\s*(?:--|—|:)?\s*/u, '')
+          .trim();
+        if (trailing.length < 3) {
+          violations.push(
+            `${id}: ${file.path}:${index + 1} has a ${TS_EXPECT_ERROR_TOKEN} directive without a same-line reason`,
+          );
+        }
+        searchFrom = at + TS_EXPECT_ERROR_TOKEN.length;
+      }
+    }
+
+    const codeOnly = stripCommentsAndStrings(String(file.text ?? ''));
+    const anyMatches = codeOnly.match(EXPLICIT_ANY_PATTERN);
+    explicitAnyCount += anyMatches ? anyMatches.length : 0;
+  }
+
+  if (tsExpectErrorCount > tsExpectErrorLimit) {
+    violations.push(
+      `${id}: ${tsExpectErrorCount} ${TS_EXPECT_ERROR_TOKEN} directive(s) exceed the recorded budget of ${tsExpectErrorLimit}; remove suppressions or raise the budget with an explicit PR callout (lowering is always allowed)`,
+    );
+  }
+  if (explicitAnyCount > explicitAnyLimit) {
+    violations.push(
+      `${id}: ${explicitAnyCount} explicit any occurrence(s) exceed the recorded budget of ${explicitAnyLimit}; remove suppressions or raise the budget with an explicit PR callout (lowering is always allowed)`,
+    );
+  }
+
+  return violations;
+}
+
+function normalizeBudgetLimit(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+// Text-level stripper for the explicit-`any` scan: blanks line comments,
+// block comments, and string/template-literal contents while preserving
+// line structure. An approximation (regex literals containing quote
+// characters can over-strip a short span), which is acceptable for a
+// budget backstop — the installed lane's Biome noExplicitAny rule is the
+// precise enforcement.
+function stripCommentsAndStrings(text: string): string {
+  let out = '';
+  let i = 0;
+  let state:
+    | 'code'
+    | 'line-comment'
+    | 'block-comment'
+    | 'single'
+    | 'double'
+    | 'template' = 'code';
+  while (i < text.length) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (state === 'code') {
+      if (ch === '/' && next === '/') {
+        state = 'line-comment';
+        i += 2;
+        continue;
+      }
+      if (ch === '/' && next === '*') {
+        state = 'block-comment';
+        i += 2;
+        continue;
+      }
+      if (ch === "'") {
+        state = 'single';
+        i += 1;
+        continue;
+      }
+      if (ch === '"') {
+        state = 'double';
+        i += 1;
+        continue;
+      }
+      if (ch === '`') {
+        state = 'template';
+        i += 1;
+        continue;
+      }
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === '\n') {
+      out += '\n';
+      if (state === 'line-comment') {
+        state = 'code';
+      }
+      i += 1;
+      continue;
+    }
+    if (state === 'block-comment' && ch === '*' && next === '/') {
+      state = 'code';
+      i += 2;
+      continue;
+    }
+    if (state === 'single' && ch === "'" && text[i - 1] !== '\\') {
+      state = 'code';
+      i += 1;
+      continue;
+    }
+    if (state === 'double' && ch === '"' && text[i - 1] !== '\\') {
+      state = 'code';
+      i += 1;
+      continue;
+    }
+    if (state === 'template' && ch === '`' && text[i - 1] !== '\\') {
+      state = 'code';
+      i += 1;
+      continue;
+    }
+    i += 1;
+  }
+  return out;
+}

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -298,11 +298,16 @@ function stripCommentsAndStrings(text: string): string {
     const next = text[i + 1];
     if (state === 'code') {
       if (ch === '/' && next === '/') {
+        // Emit one space so a comment between tokens cannot splice them
+        // together (a block comment between `as` and `any` must not
+        // produce a single merged token that dodges the matcher).
+        out += ' ';
         state = 'line-comment';
         i += 2;
         continue;
       }
       if (ch === '/' && next === '*') {
+        out += ' ';
         state = 'block-comment';
         i += 2;
         continue;

--- a/tests/type-suppression-budgets.test.mjs
+++ b/tests/type-suppression-budgets.test.mjs
@@ -177,6 +177,21 @@ test('regex literals containing quotes do not open phantom strings', () => {
   assert.match(violations[0], /1 explicit any occurrence/);
 });
 
+test('a block comment between tokens cannot hide an explicit any', () => {
+  // Regression: stripping a comment must leave a token boundary so a
+  // block comment between `as` and `any` cannot splice them into one
+  // merged token that dodges the matcher.
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: 'const v = value as/* hidden */any;\nconst w: /* gap */ any = 1;\n',
+    },
+  ];
+  const violations = collectTypeSuppressionViolations(files, BUDGET_ZERO);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /2 explicit any occurrence/);
+});
+
 test('division is not mistaken for a regex literal', () => {
   const files = [
     {

--- a/tests/type-suppression-budgets.test.mjs
+++ b/tests/type-suppression-budgets.test.mjs
@@ -108,6 +108,31 @@ test('fails when the explicit any budget is exceeded', () => {
   );
 });
 
+test('wrapped type arguments cannot bypass the explicit any budget', () => {
+  // Regression: `any` nested inside generics, arrays, or unions must
+  // count, not just the bare annotation/cast/argument shapes.
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: [
+        'const a = new Set<any[]>();',
+        'const b = new Map<string, any>();',
+        'const c = parse<any | unknown>();',
+        'const ok = obj.any;',
+      ].join('\n'),
+    },
+  ];
+  const violations = collectTypeSuppressionViolations(files, {
+    ...BUDGET_ZERO,
+    explicitAnyLimit: 2,
+  });
+  assert.equal(violations.length, 1);
+  assert.match(
+    violations[0],
+    /3 explicit any occurrence\(s\) exceed the recorded budget of 2/,
+  );
+});
+
 test('does not count any-like prose in comments or strings', () => {
   const files = [
     {

--- a/tests/type-suppression-budgets.test.mjs
+++ b/tests/type-suppression-budgets.test.mjs
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { collectTypeSuppressionViolations } from '../scripts/consistency-helpers.mjs';
+
+// Fixture text is assembled from fragments so this test file's raw text
+// never contains the suppression tokens itself — the audit pipeline
+// scans tests/**/*.mjs, and a literal directive here would count
+// against the budgets this suite exists to protect.
+const TS_IGNORE = `@ts-${'ignore'}`;
+const TS_EXPECT_ERROR = `@ts-${'expect'}-error`;
+
+const BUDGET_ZERO = {
+  id: 'type-suppression-budgets',
+  globs: ['src/**/*.mts', 'tests/**/*.mjs'],
+  tsExpectErrorLimit: 0,
+  explicitAnyLimit: 0,
+};
+
+test('passes on a clean current-tree-shaped input', () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: [
+        "import { x } from './x.mts';",
+        '// Fail-safe: any invalid token, or conflicting values, yields no score.',
+        'const value: unknown = x;',
+        "const text = ': any inside a string is not counted';",
+      ].join('\n'),
+    },
+  ];
+  assert.deepEqual(collectTypeSuppressionViolations(files, BUDGET_ZERO), []);
+});
+
+test(`fails when a ${TS_IGNORE} directive is introduced`, () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: `// ${TS_IGNORE}\nconst v = broken();\n`,
+    },
+  ];
+  const violations = collectTypeSuppressionViolations(files, BUDGET_ZERO);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /sample\.mts:1 uses the forbidden/);
+});
+
+test(`fails when a ${TS_EXPECT_ERROR} lacks a same-line reason`, () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: `// ${TS_EXPECT_ERROR}\nconst v = broken();\n`,
+    },
+  ];
+  const violations = collectTypeSuppressionViolations(files, {
+    ...BUDGET_ZERO,
+    tsExpectErrorLimit: 1,
+  });
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /without a same-line reason/);
+});
+
+test(`accepts a within-budget ${TS_EXPECT_ERROR} with a reason`, () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: `// ${TS_EXPECT_ERROR} -- upstream types lag the runtime shape\nconst v = broken();\n`,
+    },
+  ];
+  assert.deepEqual(
+    collectTypeSuppressionViolations(files, {
+      ...BUDGET_ZERO,
+      tsExpectErrorLimit: 1,
+    }),
+    [],
+  );
+});
+
+test(`fails when the ${TS_EXPECT_ERROR} budget is exceeded`, () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: `// ${TS_EXPECT_ERROR} -- reason one\n// ${TS_EXPECT_ERROR} -- reason two\n`,
+    },
+  ];
+  const violations = collectTypeSuppressionViolations(files, {
+    ...BUDGET_ZERO,
+    tsExpectErrorLimit: 1,
+  });
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /2 .* exceed the recorded budget of 1/);
+});
+
+test('fails when the explicit any budget is exceeded', () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: 'const v: any = parse();\nconst w = value as any;\nconst s = new Set<any>();\n',
+    },
+  ];
+  const violations = collectTypeSuppressionViolations(files, {
+    ...BUDGET_ZERO,
+    explicitAnyLimit: 2,
+  });
+  assert.equal(violations.length, 1);
+  assert.match(
+    violations[0],
+    /3 explicit any occurrence\(s\) exceed the recorded budget of 2/,
+  );
+});
+
+test('does not count any-like prose in comments or strings', () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: [
+        '// setupRepo commits succeeding is the no-signing proof: any signing',
+        '/* block: any text here, even as any phrase */',
+        'const s = `template: any inside template`;',
+        "const t = 'literal as any literal';",
+      ].join('\n'),
+    },
+  ];
+  assert.deepEqual(collectTypeSuppressionViolations(files, BUDGET_ZERO), []);
+});
+
+test('counts occurrences across multiple files against one budget', () => {
+  const files = [
+    { path: 'src/scripts/a.mts', text: 'const a: any = 1;\n' },
+    { path: 'tests/b.test.mjs', text: 'const b = x as any;\n' },
+  ];
+  const violations = collectTypeSuppressionViolations(files, {
+    ...BUDGET_ZERO,
+    explicitAnyLimit: 1,
+  });
+  assert.equal(violations.length, 1);
+  assert.match(
+    violations[0],
+    /2 explicit any occurrence\(s\) exceed the recorded budget of 1/,
+  );
+});
+
+test('rejects malformed budget limits instead of failing open', () => {
+  const files = [];
+  assert.match(
+    collectTypeSuppressionViolations(files, {
+      ...BUDGET_ZERO,
+      tsExpectErrorLimit: -1,
+    })[0],
+    /tsExpectErrorLimit must be a non-negative integer/,
+  );
+  assert.match(
+    collectTypeSuppressionViolations(files, {
+      ...BUDGET_ZERO,
+      explicitAnyLimit: '0',
+    })[0],
+    /explicitAnyLimit must be a non-negative integer/,
+  );
+});
+
+test('returns no violations when the config is absent', () => {
+  assert.deepEqual(collectTypeSuppressionViolations([], null), []);
+});

--- a/tests/type-suppression-budgets.test.mjs
+++ b/tests/type-suppression-budgets.test.mjs
@@ -139,6 +139,57 @@ test('counts occurrences across multiple files against one budget', () => {
   );
 });
 
+test('a string ending in a literal backslash does not blind the scan', () => {
+  // Regression: the '\\' idiom (string whose content is one backslash)
+  // must close the string state, so real code after it is still scanned
+  // and string interiors after it are still ignored.
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: [
+        "const sep = '\\\\';",
+        "const msg = 'value as any here';",
+        'const leak: any = parse();',
+      ].join('\n'),
+    },
+  ];
+  const violations = collectTypeSuppressionViolations(files, BUDGET_ZERO);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /1 explicit any occurrence/);
+});
+
+test('regex literals containing quotes do not open phantom strings', () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: [
+        'const re = /[\'"]/;',
+        'const classed = /[/]/;',
+        'function f(x) {',
+        '  return /["`]/.test(x);',
+        '}',
+        'const leak = value as any;',
+      ].join('\n'),
+    },
+  ];
+  const violations = collectTypeSuppressionViolations(files, BUDGET_ZERO);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /1 explicit any occurrence/);
+});
+
+test('division is not mistaken for a regex literal', () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: [
+        'const ratio = total / count;',
+        "const after = ratio / 2; const s = 'as any in string';",
+      ].join('\n'),
+    },
+  ];
+  assert.deepEqual(collectTypeSuppressionViolations(files, BUDGET_ZERO), []);
+});
+
 test('rejects malformed budget limits instead of failing open', () => {
   const files = [];
   assert.match(

--- a/tests/type-suppression-budgets.test.mjs
+++ b/tests/type-suppression-budgets.test.mjs
@@ -226,3 +226,34 @@ test('rejects malformed budget limits instead of failing open', () => {
 test('returns no violations when the config is absent', () => {
   assert.deepEqual(collectTypeSuppressionViolations([], null), []);
 });
+
+test('a terse same-line reason such as an issue reference is accepted', () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: `// ${TS_EXPECT_ERROR} #1\nconst v = broken();\n`,
+    },
+  ];
+  assert.deepEqual(
+    collectTypeSuppressionViolations(files, {
+      ...BUDGET_ZERO,
+      tsExpectErrorLimit: 1,
+    }),
+    [],
+  );
+});
+
+test('a bare separator with no reason text is still a violation', () => {
+  const files = [
+    {
+      path: 'src/scripts/sample.mts',
+      text: `// ${TS_EXPECT_ERROR} --\nconst v = broken();\n`,
+    },
+  ];
+  const violations = collectTypeSuppressionViolations(files, {
+    ...BUDGET_ZERO,
+    tsExpectErrorLimit: 1,
+  });
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /without a same-line reason/);
+});


### PR DESCRIPTION
## Summary

Adds the type-suppression budget guard from the #864 quality-gate track: a `bundleBudgets`-style ratchet that keeps strict TypeScript honest by blocking suppression accumulation in the bare-node audit lane.

- **`@ts-ignore` is forbidden outright** — `@ts-expect-error` is the only allowed escape (it self-expires when the error disappears), and every occurrence must carry a same-line reason.
- **`@ts-expect-error` and explicit `any`** (`: any` annotations, `as any` casts, `<any>` arguments) across `src/**/*.mts` and `tests/**/*.mjs` are counted against budgets recorded declaratively in `audit/sync-manifest.json` (`typeSuppressionBudgets`), with the ratchet rule in its `description`: raising a limit requires an explicit PR callout; lowering is always allowed.
- **Initial budgets are the measured current counts: 0 and 0.**
- The collector is a pure function in `consistency-helpers` (audit-docs wires it via `globFiles` + `readText`), so the check runs install-free in the bare-node `lint.yml` lane and every failure mode is unit-tested.
- The explicit-`any` scan is lexer-accurate: it strips line/block comments, string/template contents, and regex literals (escape pairs consumed; regex detected by the last-significant-token heuristic with bracket classes), so prose like "Fail-safe: any invalid token" in comments and quotes inside regexes do not corrupt the count. Verified against all 64 currently scanned files.

Closes #873

## Verification

- 13 new unit tests in `tests/type-suppression-budgets.test.mjs` demonstrate each acceptance criterion: introduced `@ts-ignore` fails, reason-less `@ts-expect-error` fails, either budget exceeded fails, clean current-tree-shaped input passes, plus lexer regressions (escaped-backslash strings, quoted regex literals, division-vs-regex).
- `node scripts/audit-docs.mjs --check` passes on the current tree; the C1 critique pass independently confirmed each probe (`const blindProbe: any = 1;` appended to previously lexer-blind files) now fails the audit end-to-end.
- `pnpm run typecheck`, `pnpm run build:check`, full `node --test tests/*.mjs` (892/892), dprint/markdownlint/cspell — all green.

## Notes for review

- Biome's `lint/suspicious/noExplicitAny` (on via the recommended set) only **warns** in the installed lane, so this audit budget is the blocking enforcement in both CI lanes; the docs section states this explicitly.
- Disclosed residual: `${...}` interpolation code inside template literals is stripped with the template, so an explicit `any` inside an interpolation is not counted (stated in the stripper's comment; no such occurrence exists today).
- Directive tokens and the `any` matcher are assembled from string fragments so the scanner's own source, its emitted artifact, and the test fixtures never trip the scan they implement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TypeScript suppression budget enforcement to audits: configurable limits for `@ts-expect-error` and explicit `any`, applied across source and test files; `@ts-ignore` is forbidden and `@ts-expect-error` requires a same-line reason; budgets are ratcheted and validated fail-closed.

* **Documentation**
  * Added docs describing budgets, counting rules, prohibition/requirements, and limit-adjustment process.

* **Tests**
  * Added comprehensive tests covering detection, counting, edge cases, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->