### PR TITLE
feat(helpers): recommend linguist-vendored attributes for the vendored bundle

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -313,7 +313,15 @@ Node.js helper path.
   assuming pnpm.
 - `vendored-node`: use the manifest's `managedFiles` list to copy the
   helper bundle into matching paths in the target repository, then run
-  the emitted local `node scripts/...` commands.
+  the emitted local `node scripts/...` commands. The profile output also
+  carries a `recommendedGitattributes` list — one
+  `<path> linguist-vendored` line per managed file — to append to the
+  adopter's `.gitattributes`, so the vendored bundle is treated as the
+  third-party code it is: `linguist-vendored` drops it from language
+  statistics and de-prioritizes it in code search. This is the
+  adopter-side counterpart of the source repository's own
+  `linguist-generated` artifacts; only `vendored-node` vends files, so
+  only it emits the recommendation.
 - `ephemeral-npx`: use the manifest's one-shot `npx --yes --package
   <helper-package-spec> idd-*` commands without copying helper files
   into the repository. The default helper package spec is an HTTPS

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -629,6 +629,32 @@ runs on IDD branches. Use `pull_request` triggers (which fire on the PR
 regardless of branch name), or a push filter that matches the slash namespace
 (`'**'` or `'issue/**'`), for any check that must gate IDD pull requests.
 
+### Optional — mark the vendored helper bundle `linguist-vendored`
+
+This step applies **only to the `vendored-node` profile** (the only
+profile that copies helper files into your repository). The vendored
+bundle is third-party code, so marking it `linguist-vendored` drops it
+from your repository's language statistics and de-prioritizes it in code
+search — useful when your own code is mostly docs or another language and
+you do not want the copied `.mjs`/schema files to dominate the language
+bar. (This is the adopter-side counterpart of the source repository's
+`linguist-generated` artifacts; the semantics differ deliberately:
+generated = first-party build output, vendored = copied third-party code.)
+
+The helper-runtime manifest emits the exact lines from the same
+`managedFiles` import-graph it uses to vend the bundle, so the attribute
+list never drifts from what you copied. Append them to your
+`.gitattributes`:
+
+```sh
+node scripts/helper-runtime-manifest.mjs --profile vendored-node \
+  | node -e 'const m=JSON.parse(require("node:fs").readFileSync(0,"utf8"));process.stdout.write(m.profiles["vendored-node"].recommendedGitattributes.join("\n")+"\n")' \
+  >> .gitattributes
+```
+
+Other profiles vend no files and emit no recommendation, so they need
+nothing here.
+
 ---
 
 ## Step 3 — Record policy decisions

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -313,7 +313,15 @@ Node.js helper path.
   assuming pnpm.
 - `vendored-node`: use the manifest's `managedFiles` list to copy the
   helper bundle into matching paths in the target repository, then run
-  the emitted local `node scripts/...` commands.
+  the emitted local `node scripts/...` commands. The profile output also
+  carries a `recommendedGitattributes` list — one
+  `<path> linguist-vendored` line per managed file — to append to the
+  adopter's `.gitattributes`, so the vendored bundle is treated as the
+  third-party code it is: `linguist-vendored` drops it from language
+  statistics and de-prioritizes it in code search. This is the
+  adopter-side counterpart of the source repository's own
+  `linguist-generated` artifacts; only `vendored-node` vends files, so
+  only it emits the recommendation.
 - `ephemeral-npx`: use the manifest's one-shot `npx --yes --package
   <helper-package-spec> idd-*` commands without copying helper files
   into the repository. The default helper package spec is an HTTPS

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -534,7 +534,11 @@ function buildProfileCatalog({
       notes: [
         'Copy the listed files into matching paths in the target repository.',
         'The managed file list is derived from the helper entrypoint import graph to avoid hand-maintained drift.',
+        'Append the recommendedGitattributes lines to the adopter .gitattributes so the vendored bundle is marked linguist-vendored (dropped from language statistics and de-prioritized in code search).',
       ],
+      recommendedGitattributes: managedFiles.map(
+        (file) => `${file.targetPath} linguist-vendored`,
+      ),
     },
     'ephemeral-npx': {
       profile: 'ephemeral-npx',

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -534,7 +534,7 @@ function buildProfileCatalog({
       notes: [
         'Copy the listed files into matching paths in the target repository.',
         'The managed file list is derived from the helper entrypoint import graph to avoid hand-maintained drift.',
-        'Append the recommendedGitattributes lines to the adopter .gitattributes so the vendored bundle is marked linguist-vendored (dropped from language statistics and de-prioritized in code search).',
+        "Append the recommendedGitattributes lines to the adopter's .gitattributes so the vendored bundle is marked linguist-vendored (dropped from language statistics and de-prioritized in code search).",
       ],
       recommendedGitattributes: managedFiles.map(
         (file) => `${file.targetPath} linguist-vendored`,

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -659,7 +659,7 @@ function buildProfileCatalog({
       notes: [
         'Copy the listed files into matching paths in the target repository.',
         'The managed file list is derived from the helper entrypoint import graph to avoid hand-maintained drift.',
-        'Append the recommendedGitattributes lines to the adopter .gitattributes so the vendored bundle is marked linguist-vendored (dropped from language statistics and de-prioritized in code search).',
+        "Append the recommendedGitattributes lines to the adopter's .gitattributes so the vendored bundle is marked linguist-vendored (dropped from language statistics and de-prioritized in code search).",
       ],
       recommendedGitattributes: managedFiles.map(
         (file) => `${file.targetPath} linguist-vendored`,

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -61,6 +61,11 @@ interface ProfileEntry {
   managedFiles: ManagedFile[];
   commands: Record<string, string>;
   notes: string[];
+  // Only the vendored-node profile vends files into the adopter
+  // repository, so only it recommends `<path> linguist-vendored`
+  // .gitattributes lines (one per managed file). Other profiles omit
+  // this field entirely.
+  recommendedGitattributes?: string[];
 }
 
 interface ManifestArgs {
@@ -654,7 +659,11 @@ function buildProfileCatalog({
       notes: [
         'Copy the listed files into matching paths in the target repository.',
         'The managed file list is derived from the helper entrypoint import graph to avoid hand-maintained drift.',
+        'Append the recommendedGitattributes lines to the adopter .gitattributes so the vendored bundle is marked linguist-vendored (dropped from language statistics and de-prioritized in code search).',
       ],
+      recommendedGitattributes: managedFiles.map(
+        (file) => `${file.targetPath} linguist-vendored`,
+      ),
     },
     'ephemeral-npx': {
       profile: 'ephemeral-npx',

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -119,9 +119,11 @@ test('vendored-node recommends linguist-vendored per managed file; other profile
     'ephemeral-npx',
     'instructions-only',
   ]) {
+    // Assert the key is genuinely absent, not merely `=== undefined`
+    // (which would also pass for a present-but-undefined property).
     assert.equal(
-      manifest.profiles[profileName].recommendedGitattributes,
-      undefined,
+      Object.hasOwn(manifest.profiles[profileName], 'recommendedGitattributes'),
+      false,
       profileName,
     );
   }

--- a/tests/helper-runtime-manifest.test.mjs
+++ b/tests/helper-runtime-manifest.test.mjs
@@ -91,6 +91,42 @@ test('vendored-node managed files match the canonical helper import closure', ()
   }
 });
 
+test('vendored-node recommends linguist-vendored per managed file; other profiles emit none', () => {
+  const manifest = buildHelperRuntimeManifest({ targetRoot: REPO_ROOT });
+  const vendored = manifest.profiles['vendored-node'];
+
+  // Exactly one `<path> linguist-vendored` line per managed file, in the
+  // same order, and nothing else. Adding a managed file without a matching
+  // attribute line (or vice versa) fails this deepEqual.
+  const expected = vendored.managedFiles.map(
+    (file) => `${file.targetPath} linguist-vendored`,
+  );
+  assert.deepEqual(vendored.recommendedGitattributes, expected);
+  assert.equal(
+    vendored.recommendedGitattributes.length,
+    vendored.managedFiles.length,
+  );
+  assert.ok(
+    vendored.recommendedGitattributes.includes(
+      'scripts/protocol-helpers.mjs linguist-vendored',
+    ),
+  );
+
+  // Only the vendored-node profile vends files, so only it carries a
+  // recommendation; the others omit the field entirely.
+  for (const profileName of [
+    'package-manager',
+    'ephemeral-npx',
+    'instructions-only',
+  ]) {
+    assert.equal(
+      manifest.profiles[profileName].recommendedGitattributes,
+      undefined,
+      profileName,
+    );
+  }
+});
+
 test('detectPackageManager respects package metadata and lockfiles', () => {
   const packageJsonRoot = mkdtempSync(
     join(tmpdir(), 'idd-helper-runtime-package-json-'),


### PR DESCRIPTION
## Summary

Closes #875. Adopters on the `vendored-node` profile copy the IDD helper
bundle (third-party code) into their repo; this adds a machine-readable
recommendation to mark it `linguist-vendored` so it drops out of the
adopter's language statistics and code search. Adopter-side counterpart
of the source repo's own `linguist-generated` artifacts.

## What changed

- `helper-runtime-manifest` (`src/scripts/helper-runtime-manifest.mts`):
  the `vendored-node` profile output now carries `recommendedGitattributes`
  — one `<path> linguist-vendored` line per `managedFiles` entry, derived
  from the same import-graph closure so it never drifts. Only
  `vendored-node` vends files, so only it emits the field.
- Unit test (`tests/helper-runtime-manifest.test.mjs`): asserts the list
  is 1:1 with `managedFiles` and that the other three profiles omit it.
- `idd-template/ONBOARDING.md`: optional step (same shape as the existing
  hook/doctor steps) showing how to append the lines.
- `docs/idd-helper-scripts.md` (via the `idd-template` source + synced
  mirror): documents the recommendation in the `vendored-node` section.

Out of scope (per the issue): this repo's own `.gitattributes` (owned by
#864) and any `idd-doctor` adopter-attribute check.

## Verification

- `pnpm run lint:minimum` green: typecheck, build:check, Biome, dprint,
  **879 tests** (incl. the new manifest assertion), workshop integrity,
  cspell, markdownlint; `sync-docs --check` reports mirrors up to date.

## Note on commit signing

Unsigned: configured GPG and the `git commit-ssh` fallback both stall on
interactive prompts in this non-interactive environment. Per the signing
ladder, unsigned is the accepted final fallback.

Closes #875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `.gitattributes` recommendations for the `vendored-node` profile to mark vendored bundles as third-party code for language statistics and search prioritization

* **Documentation**
  * Updated onboarding guide with step-by-step instructions for applying recommended `.gitattributes` entries
  * Enhanced helper scripts documentation explaining the new recommendations feature

* **Tests**
  * Added test coverage for `.gitattributes` recommendation generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->