### PR TITLE
fix(helpers): fail closed when planHandoff lacks an authorizer

### DIFF
--- a/scripts/forced-handoff-marker.mjs
+++ b/scripts/forced-handoff-marker.mjs
@@ -93,9 +93,9 @@ export function planHandoff(issueComments, linkedPrs, options = {}) {
   if (forcedBy && reason) {
     // Validate the approving actor before rendering the marker body so that
     // plan output cannot preview a marker that claim resolution would reject.
-    const authorized =
-      typeof isAuthorizedForcedHandoff !== 'function' ||
-      isAuthorizedForcedHandoff(forcedBy);
+    // Reuse the fail-closed-defaulted callback so a missing authorizer is
+    // unauthorized here exactly as it is during claim resolution.
+    const authorized = resolveOpts.isAuthorizedForcedHandoff(forcedBy);
     if (authorized) {
       const resolvedLinkedPr =
         prNumber !== undefined ? String(prNumber) : prReferences[0];

--- a/src/scripts/forced-handoff-marker.mts
+++ b/src/scripts/forced-handoff-marker.mts
@@ -183,9 +183,9 @@ export function planHandoff(
   if (forcedBy && reason) {
     // Validate the approving actor before rendering the marker body so that
     // plan output cannot preview a marker that claim resolution would reject.
-    const authorized =
-      typeof isAuthorizedForcedHandoff !== 'function' ||
-      isAuthorizedForcedHandoff(forcedBy);
+    // Reuse the fail-closed-defaulted callback so a missing authorizer is
+    // unauthorized here exactly as it is during claim resolution.
+    const authorized = resolveOpts.isAuthorizedForcedHandoff(forcedBy);
     if (authorized) {
       const resolvedLinkedPr =
         prNumber !== undefined ? String(prNumber) : prReferences[0];

--- a/tests/forced-handoff-marker.test.mjs
+++ b/tests/forced-handoff-marker.test.mjs
@@ -658,11 +658,13 @@ test('planHandoff and generateSuccessorIds — integration fixture', () => {
   ];
 
   const trustedLogins = ['kurone-kito', 'github-copilot-cli-old'];
+  const authorizeKuroneKito = (actor) => actor === 'kurone-kito';
 
   const resultIssueOnly = planHandoff(issueComments, [], {
     trustedMarkerLogins: trustedLogins,
     forcedBy: 'kurone-kito',
     reason: 'operator-approved-recovery',
+    isAuthorizedForcedHandoff: authorizeKuroneKito,
   });
 
   assert.equal(resultIssueOnly.contextScope, 'issue-only');
@@ -692,6 +694,7 @@ test('planHandoff and generateSuccessorIds — integration fixture', () => {
     trustedMarkerLogins: trustedLogins,
     forcedBy: 'kurone-kito',
     reason: 'operator-approved-recovery',
+    isAuthorizedForcedHandoff: authorizeKuroneKito,
   });
 
   assert.equal(resultWithPr.contextScope, 'issue-plus-pr');
@@ -712,6 +715,7 @@ test('planHandoff and generateSuccessorIds — integration fixture', () => {
         trustedMarkerLogins: trustedLogins,
         forcedBy: 'kurone-kito',
         reason: 'operator-approved-recovery',
+        isAuthorizedForcedHandoff: authorizeKuroneKito,
       }),
     /PR #999 does not match any open PR on claim branch issue\/496-feat-force-handoff-derive-live-pr/,
   );
@@ -761,6 +765,47 @@ test('planHandoff omits markerBody when forcedBy actor is not authorized', () =>
   assert.ok(
     result.successorIds.newAgentId,
     'successorIds should still be generated',
+  );
+});
+
+test('planHandoff fails closed for the marker preview when no authorizer callback is supplied', () => {
+  const planClaimBody = [
+    '<!-- claimed-by: github-copilot-cli-old claim-plan-test-old supersedes: none 2026-05-13T10:00:00Z branch: issue/496-feat-force-handoff-derive-live-pr -->',
+    '',
+    '_github-copilot-cli-old: issue claim — IDD automation marker. Do not edit._',
+  ].join('\n');
+
+  const issueComments = [
+    {
+      body: planClaimBody,
+      created_at: '2026-05-13T10:00:00Z',
+      user: { login: 'kurone-kito' },
+    },
+  ];
+
+  const baseOptions = {
+    trustedMarkerLogins: ['kurone-kito', 'github-copilot-cli-old'],
+    forcedBy: 'kurone-kito',
+    reason: 'operator-approved-recovery',
+  };
+
+  // Missing callback must be treated as unauthorized for the preview,
+  // matching the fail-closed default used during claim resolution.
+  const withoutCallback = planHandoff(issueComments, [], baseOptions);
+  assert.equal(
+    withoutCallback.markerBody,
+    null,
+    'markerBody should be null when no authorizer callback is supplied',
+  );
+
+  // An authorizing callback leaves the rendering behavior unchanged.
+  const withCallback = planHandoff(issueComments, [], {
+    ...baseOptions,
+    isAuthorizedForcedHandoff: (actor) => actor === 'kurone-kito',
+  });
+  assert.ok(
+    withCallback.markerBody,
+    'markerBody should render when the forcedBy actor is authorized',
   );
 });
 


### PR DESCRIPTION
## Summary

`planHandoff` (`src/scripts/forced-handoff-marker.mts`) had an
authorization asymmetry flagged by Copilot on PR #884: claim
resolution defaults a missing `isAuthorizedForcedHandoff` callback to
`() => false` (fail closed), but the marker-body **preview** check
treated a missing callback as authorized
(`typeof cb !== 'function' || cb(forcedBy)`). A caller that omitted
the callback could preview a marker body that claim resolution would
reject.

This is preview-only (no marker is posted, and the in-repo CLI always
supplies the callback), so the behavior was byte-identical to the
pre-conversion helper and PR #884 deliberately left it unchanged.

## Change

- Reuse the already fail-closed-defaulted callback
  (`resolveOpts.isAuthorizedForcedHandoff`) for the preview check, so a
  missing authorizer is unauthorized in the preview exactly as it is
  during claim resolution.
- Update the integration fixture to supply an authorizer (the
  realistic CLI usage) and add a regression test asserting the
  missing-callback case renders no marker body while an authorizing
  callback is unchanged.
- No schema or wire format changes; production callers already pass the
  callback via `resolveOpts`, so their behavior is unchanged.

## Verification

- `pnpm run lint:minimum` passes (898 tests, typecheck, build drift
  gate, biome, cspell, markdownlint).

## Notes

- Commit is unsigned: GPG signing stalls (no pinentry/TTY) and no SSH
  agent key is available in this environment, so per the signing
  fallback ladder the change is committed unsigned.

Closes #885


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forced-handoff marker authorization to enforce stricter security validation, preventing unauthorized marker rendering when authorization is not explicitly provided.

* **Tests**
  * Added test coverage to verify proper authorization enforcement and fail-closed behavior for forced-handoff markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->