### PR TITLE
feat(build): generate build-ts itself from a typed source

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@ scripts/discover-readiness-check.mjs linguist-generated=true
 scripts/idd-doctor.mjs linguist-generated=true
 scripts/check-pnpm-boundary.mjs linguist-generated=true
 scripts/audit-docs.mjs linguist-generated=true
+scripts/build-ts.mjs linguist-generated=true
 scripts/protocol-helpers.mjs linguist-generated=true
 scripts/advisory-wait-state.mjs linguist-generated=true
 scripts/live-status-digest.mjs linguist-generated=true

--- a/src/scripts/build-ts.mts
+++ b/src/scripts/build-ts.mts
@@ -21,19 +21,23 @@
 // Invoked via `pnpm run build`, so node_modules/.bin (tsc, biome) is on
 // PATH. Uses only node: builtins to stay compatible with the repository's
 // bare-node boundary.
+
 import { execFileSync } from 'node:child_process';
 
 const EMITTED_PREFIX = 'TSFILE: ';
-const tscOutput = execFileSync(
+
+const tscOutput: string = execFileSync(
   'tsc',
   ['-p', 'tsconfig.build.json', '--listEmittedFiles'],
   { encoding: 'utf8' },
 );
-const emittedFiles = tscOutput
+
+const emittedFiles: string[] = tscOutput
   .split(/\r?\n/)
   .filter((line) => line.startsWith(EMITTED_PREFIX))
   .map((line) => line.slice(EMITTED_PREFIX.length).trim())
   .filter((file) => file.endsWith('.mjs'));
+
 if (emittedFiles.length > 0) {
   execFileSync('biome', ['check', '--write', ...emittedFiles], {
     stdio: 'inherit',


### PR DESCRIPTION
## Summary

Closes the #864 completion-audit residual: `scripts/build-ts.mjs` — the build script itself — was the last hand-written file under `scripts/`. It is now emitted from a strict `src/scripts/build-ts.mts` source with the provenance banner and a `linguist-generated=true` attribute, taking the default route the issue prescribes.

The bootstrap is benign because the emitted artifact is committed: the committed `build-ts.mjs` runs the build that regenerates itself, and `pnpm run build:check` fails on drift exactly as for any other artifact. Regeneration was verified idempotent (two consecutive builds, no churn). With this change, **every `scripts/*.mjs` and `bin/*.mjs` is banner-paired with a `src/**/*.mts` source** — the migration contract in `docs/typescript-sources.md` ("`src/**/*.mts` will be the only hand-edited JavaScript surface") is now fully realized.

Closes #889

## Verification

- `pnpm run typecheck`, `pnpm run build:check` (idempotent), `node --test tests/*.test.mts` 941/941, `node scripts/audit-docs.mjs --check` — all pass
- Pairing sweep: zero `scripts/`/`bin/` artifacts without a source counterpart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build tooling to improve generated file management and tracking during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->