### PR TITLE
docs(issue-authoring): sequence docs/help children after implementation

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -276,6 +276,14 @@ availability, or ordering constraint.
   reviewed and verified independently
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
+- when authoring a **docs or operator-help child that documents
+  behavior implemented by sibling issues**, encode `Blocked by` those
+  implementation issues (or otherwise sequence the docs child to run
+  after they merge) so the documentation is written against **shipped**
+  behavior. Describing designed-but-unshipped behavior in the present
+  tense is a recurring advisory-review-thrash pattern; "describe shipped
+  behavior" is a true ordering constraint, so this edge is consistent
+  with the encode-only-a-real-constraint rule above
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -480,6 +480,14 @@ availability, or ordering constraint.
   reviewed and verified independently
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
+- when authoring a **docs or operator-help child that documents
+  behavior implemented by sibling issues**, encode `Blocked by` those
+  implementation issues (or otherwise sequence the docs child to run
+  after they merge) so the documentation is written against **shipped**
+  behavior. Describing designed-but-unshipped behavior in the present
+  tense is a recurring advisory-review-thrash pattern; "describe shipped
+  behavior" is a true ordering constraint, so this edge is consistent
+  with the encode-only-a-real-constraint rule above
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -276,6 +276,14 @@ availability, or ordering constraint.
   reviewed and verified independently
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
+- when authoring a **docs or operator-help child that documents
+  behavior implemented by sibling issues**, encode `Blocked by` those
+  implementation issues (or otherwise sequence the docs child to run
+  after they merge) so the documentation is written against **shipped**
+  behavior. Describing designed-but-unshipped behavior in the present
+  tense is a recurring advisory-review-thrash pattern; "describe shipped
+  behavior" is a true ordering constraint, so this edge is consistent
+  with the encode-only-a-real-constraint rule above
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves


### PR DESCRIPTION
## Summary

Records a docs/help-child sequencing rule in the issue-authoring contract's **"Dependency minimization"** section: when a docs / operator-help child documents behavior implemented by sibling issues, encode `Blocked by` those implementation issues (or otherwise sequence the docs child to run after they merge), so the documentation is authored against **shipped** behavior.

Documenting designed-but-unshipped behavior in the present tense is a recurring advisory-review-thrash pattern — each forward-looking statement reads as "already shipped" and draws repeated review churn until the implementation catches up. "Describe shipped behavior" is a true ordering constraint, so it is consistent with the existing encode-only-a-real-constraint guidance.

Applied to the canonical `docs/issue-authoring-skill.md` and both bundled `references/contract.md` copies (`skills/issue-authoring/` and `.claude/skills/issue-authoring/`) so they stay in sync.

## Verification

- `pnpm run lint:minimum` passes, including the "dependency minimization guidance stays synced between canonical and bundled contract" test.

Closes #894
