### PR TITLE
feat(claim): add helper computing the canonical issue branch name

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -131,7 +131,18 @@ Check both linked issues and closing keywords in PR bodies.
 **(e) Branch collision** — Compute the branch name using the IDD naming
 convention: `issue/<number>-<slug>`. Generate `<slug>` deterministically
 from the issue title so parallel sessions converge on the same branch
-name:
+name.
+
+When helper runtime is enabled, compute the slug with the branch-name
+helper instead of hand-tracing it:
+
+```sh
+node scripts/branch-name.mjs --number <issue-number> --title <issue-title>
+```
+
+It prints `issue/<number>-<slug>` and implements the algorithm below
+exactly. The written algorithm remains the canonical spec and fallback;
+use it when the helper is unavailable or its output is malformed:
 
 1. Convert the issue title to lowercase.
 2. Replace every character outside ASCII `a-z` and `0-9` with `-`.
@@ -144,6 +155,19 @@ name:
    character 40, trim back to the last such `-`; if there is no `-`,
    keep the hard 40-character cut. Then strip any trailing `-`.
 6. If the result is empty, use `task`.
+
+**Worked examples** (shared verbatim with the helper's drift test in
+`tests/branch-name.test.mts`) — stop-word removal, a 40-char cut on a
+token boundary, a 40-char cut trimming back mid-token, the empty-slug
+`task` fallback, and non-ASCII drop-out:
+
+- `Add the OAuth login flow` → `issue/42-add-oauth-login-flow`
+- `Add a helper that computes the canonical issue/<number>-<slug> branch name`
+  → `issue/901-add-helper-that-computes-canonical-issue`
+- `Implement comprehensive authentication authorization middleware system`
+  → `issue/123-implement-comprehensive-authentication`
+- `!!!` → `issue/7-task`
+- `日本語 calendar 機能` → `issue/99-calendar`
 
 No remote branch with that name may exist, unless it matches the
 `branch` field in an inheritable claim comment or trusted

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -134,7 +134,9 @@ from the issue title so parallel sessions converge on the same branch
 name.
 
 When helper runtime is enabled, compute the slug with the branch-name
-helper instead of hand-tracing it:
+helper (resolve the profile-selected command from
+`docs/idd-helper-scripts.md`; non-vendored profiles use `idd:branch-name`,
+not the `node scripts/...` form) instead of hand-tracing it:
 
 ```sh
 node scripts/branch-name.mjs --number <issue-number> --title <issue-title>
@@ -157,9 +159,7 @@ use it when the helper is unavailable or its output is malformed:
 6. If the result is empty, use `task`.
 
 **Worked examples** (shared verbatim with the helper's drift test in
-`tests/branch-name.test.mts`) — stop-word removal, a 40-char cut on a
-token boundary, a 40-char cut trimming back mid-token, the empty-slug
-`task` fallback, and non-ASCII drop-out:
+`tests/branch-name.test.mts`):
 
 - `Add the OAuth login flow` → `issue/42-add-oauth-login-flow`
 - `Add a helper that computes the canonical issue/<number>-<slug> branch name`

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -134,17 +134,22 @@ from the issue title so parallel sessions converge on the same branch
 name.
 
 When helper runtime is enabled, compute the slug with the branch-name
-helper (resolve the profile-selected command from
-`docs/idd-helper-scripts.md`; non-vendored profiles use `idd:branch-name`,
-not the `node scripts/...` form) instead of hand-tracing it:
+helper instead of hand-tracing it:
 
 ```sh
+# source repo / vendored-node
 node scripts/branch-name.mjs --number <issue-number> --title <issue-title>
+
+# package-manager / ephemeral-npx
+<profile-selected-branch-name-command> --number <issue-number> --title <issue-title>
 ```
 
-It prints `issue/<number>-<slug>` and implements the algorithm below
-exactly. The written algorithm remains the canonical spec and fallback;
-use it when the helper is unavailable or its output is malformed:
+Resolve `<profile-selected-branch-name-command>` from
+`docs/idd-helper-scripts.md`; do not hardcode `node scripts/...` for
+non-vendored profiles. It prints `issue/<number>-<slug>` and implements
+the algorithm below exactly. The written algorithm remains the canonical
+spec and fallback; use it when the helper is unavailable or its output is
+malformed:
 
 1. Convert the issue title to lowercase.
 2. Replace every character outside ASCII `a-z` and `0-9` with `-`.
@@ -164,8 +169,6 @@ use it when the helper is unavailable or its output is malformed:
 - `Add the OAuth login flow` → `issue/42-add-oauth-login-flow`
 - `Add a helper that computes the canonical issue/<number>-<slug> branch name`
   → `issue/901-add-helper-that-computes-canonical-issue`
-- `Implement comprehensive authentication authorization middleware system`
-  → `issue/123-implement-comprehensive-authentication`
 - `!!!` → `issue/7-task`
 - `日本語 calendar 機能` → `issue/99-calendar`
 

--- a/bin/idd-branch-name.mjs
+++ b/bin/idd-branch-name.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-branch-name.mts
+//
+// The bin/idd-branch-name.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/branch-name.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -29,6 +29,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
   verification; A5(d) open-PR conflict checks remain manual by design
   (referenced in
   [kurone-kito/idd-skill#393](https://github.com/kurone-kito/idd-skill/issues/393))
+- `scripts/branch-name.mjs` for the A5(e) canonical
+  `issue/<number>-<slug>` branch-name slug computation; deterministic and
+  network-free (referenced in
+  [kurone-kito/idd-skill#901](https://github.com/kurone-kito/idd-skill/issues/901))
 - `scripts/resume-claim-routing.mjs` for Resume Step 1 claim-state
   evaluation and takeover routing (referenced in
   [kurone-kito/idd-skill#394](https://github.com/kurone-kito/idd-skill/issues/394))
@@ -603,6 +607,20 @@ Interpretation rules:
   checks stay on the written live GitHub path because inheritable-branch
   and linked-issue exceptions do not yet have a supported helper
   contract
+
+### Canonical branch name
+
+- Source repo / vendored-node command:
+  `node scripts/branch-name.mjs --number <issue-number> --title <issue-title>`
+- Prints a single plain line `issue/<number>-<slug>`, implementing the
+  `idd-claim.instructions.md` pre-check (e) slug algorithm exactly
+  (lowercase, replace `[^a-z0-9]` with `-`, drop empty tokens and the
+  whole-token stop-words, rejoin with `-`, apply the 40-character
+  mid-token-aware cut, then fall back to `task` when empty)
+- Deterministic and network-free; the agent keeps branch-naming authority
+  and the written algorithm stays the canonical fallback
+- The `tests/branch-name.test.mts` drift test re-derives the pre-check (e)
+  "Worked examples" table, so the prose and the helper cannot diverge
 
 ### Resume claim and route evidence
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -612,6 +612,8 @@ Interpretation rules:
 
 - Source repo / vendored-node command:
   `node scripts/branch-name.mjs --number <issue-number> --title <issue-title>`
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd:branch-name` command from the helper runtime manifest wiring above
 - Prints a single plain line `issue/<number>-<slug>`, implementing the
   `idd-claim.instructions.md` pre-check (e) slug algorithm exactly
   (lowercase, replace `[^a-z0-9]` with `-`, drop empty tokens and the

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -131,7 +131,18 @@ Check both linked issues and closing keywords in PR bodies.
 **(e) Branch collision** — Compute the branch name using the IDD naming
 convention: `issue/<number>-<slug>`. Generate `<slug>` deterministically
 from the issue title so parallel sessions converge on the same branch
-name:
+name.
+
+When helper runtime is enabled, compute the slug with the branch-name
+helper instead of hand-tracing it:
+
+```sh
+node scripts/branch-name.mjs --number <issue-number> --title <issue-title>
+```
+
+It prints `issue/<number>-<slug>` and implements the algorithm below
+exactly. The written algorithm remains the canonical spec and fallback;
+use it when the helper is unavailable or its output is malformed:
 
 1. Convert the issue title to lowercase.
 2. Replace every character outside ASCII `a-z` and `0-9` with `-`.
@@ -144,6 +155,19 @@ name:
    character 40, trim back to the last such `-`; if there is no `-`,
    keep the hard 40-character cut. Then strip any trailing `-`.
 6. If the result is empty, use `task`.
+
+**Worked examples** (shared verbatim with the helper's drift test in
+`tests/branch-name.test.mts`) — stop-word removal, a 40-char cut on a
+token boundary, a 40-char cut trimming back mid-token, the empty-slug
+`task` fallback, and non-ASCII drop-out:
+
+- `Add the OAuth login flow` → `issue/42-add-oauth-login-flow`
+- `Add a helper that computes the canonical issue/<number>-<slug> branch name`
+  → `issue/901-add-helper-that-computes-canonical-issue`
+- `Implement comprehensive authentication authorization middleware system`
+  → `issue/123-implement-comprehensive-authentication`
+- `!!!` → `issue/7-task`
+- `日本語 calendar 機能` → `issue/99-calendar`
 
 No remote branch with that name may exist, unless it matches the
 `branch` field in an inheritable claim comment or trusted

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -134,7 +134,9 @@ from the issue title so parallel sessions converge on the same branch
 name.
 
 When helper runtime is enabled, compute the slug with the branch-name
-helper instead of hand-tracing it:
+helper (resolve the profile-selected command from
+`docs/idd-helper-scripts.md`; non-vendored profiles use `idd:branch-name`,
+not the `node scripts/...` form) instead of hand-tracing it:
 
 ```sh
 node scripts/branch-name.mjs --number <issue-number> --title <issue-title>
@@ -157,9 +159,7 @@ use it when the helper is unavailable or its output is malformed:
 6. If the result is empty, use `task`.
 
 **Worked examples** (shared verbatim with the helper's drift test in
-`tests/branch-name.test.mts`) — stop-word removal, a 40-char cut on a
-token boundary, a 40-char cut trimming back mid-token, the empty-slug
-`task` fallback, and non-ASCII drop-out:
+`tests/branch-name.test.mts`):
 
 - `Add the OAuth login flow` → `issue/42-add-oauth-login-flow`
 - `Add a helper that computes the canonical issue/<number>-<slug> branch name`

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -134,17 +134,22 @@ from the issue title so parallel sessions converge on the same branch
 name.
 
 When helper runtime is enabled, compute the slug with the branch-name
-helper (resolve the profile-selected command from
-`docs/idd-helper-scripts.md`; non-vendored profiles use `idd:branch-name`,
-not the `node scripts/...` form) instead of hand-tracing it:
+helper instead of hand-tracing it:
 
 ```sh
+# source repo / vendored-node
 node scripts/branch-name.mjs --number <issue-number> --title <issue-title>
+
+# package-manager / ephemeral-npx
+<profile-selected-branch-name-command> --number <issue-number> --title <issue-title>
 ```
 
-It prints `issue/<number>-<slug>` and implements the algorithm below
-exactly. The written algorithm remains the canonical spec and fallback;
-use it when the helper is unavailable or its output is malformed:
+Resolve `<profile-selected-branch-name-command>` from
+`docs/idd-helper-scripts.md`; do not hardcode `node scripts/...` for
+non-vendored profiles. It prints `issue/<number>-<slug>` and implements
+the algorithm below exactly. The written algorithm remains the canonical
+spec and fallback; use it when the helper is unavailable or its output is
+malformed:
 
 1. Convert the issue title to lowercase.
 2. Replace every character outside ASCII `a-z` and `0-9` with `-`.
@@ -164,8 +169,6 @@ use it when the helper is unavailable or its output is malformed:
 - `Add the OAuth login flow` → `issue/42-add-oauth-login-flow`
 - `Add a helper that computes the canonical issue/<number>-<slug> branch name`
   → `issue/901-add-helper-that-computes-canonical-issue`
-- `Implement comprehensive authentication authorization middleware system`
-  → `issue/123-implement-comprehensive-authentication`
 - `!!!` → `issue/7-task`
 - `日本語 calendar 機能` → `issue/99-calendar`
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -29,6 +29,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
   verification; A5(d) open-PR conflict checks remain manual by design
   (referenced in
   [kurone-kito/idd-skill#393](https://github.com/kurone-kito/idd-skill/issues/393))
+- `scripts/branch-name.mjs` for the A5(e) canonical
+  `issue/<number>-<slug>` branch-name slug computation; deterministic and
+  network-free (referenced in
+  [kurone-kito/idd-skill#901](https://github.com/kurone-kito/idd-skill/issues/901))
 - `scripts/resume-claim-routing.mjs` for Resume Step 1 claim-state
   evaluation and takeover routing (referenced in
   [kurone-kito/idd-skill#394](https://github.com/kurone-kito/idd-skill/issues/394))
@@ -603,6 +607,20 @@ Interpretation rules:
   checks stay on the written live GitHub path because inheritable-branch
   and linked-issue exceptions do not yet have a supported helper
   contract
+
+### Canonical branch name
+
+- Source repo / vendored-node command:
+  `node scripts/branch-name.mjs --number <issue-number> --title <issue-title>`
+- Prints a single plain line `issue/<number>-<slug>`, implementing the
+  `idd-claim.instructions.md` pre-check (e) slug algorithm exactly
+  (lowercase, replace `[^a-z0-9]` with `-`, drop empty tokens and the
+  whole-token stop-words, rejoin with `-`, apply the 40-character
+  mid-token-aware cut, then fall back to `task` when empty)
+- Deterministic and network-free; the agent keeps branch-naming authority
+  and the written algorithm stays the canonical fallback
+- The `tests/branch-name.test.mts` drift test re-derives the pre-check (e)
+  "Worked examples" table, so the prose and the helper cannot diverge
 
 ### Resume claim and route evidence
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -612,6 +612,8 @@ Interpretation rules:
 
 - Source repo / vendored-node command:
   `node scripts/branch-name.mjs --number <issue-number> --title <issue-title>`
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd:branch-name` command from the helper runtime manifest wiring above
 - Prints a single plain line `issue/<number>-<slug>`, implementing the
   `idd-claim.instructions.md` pre-check (e) slug algorithm exactly
   (lowercase, replace `[^a-z0-9]` with `-`, drop empty tokens and the

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "idd-advisory-wait-state": "./bin/idd-advisory-wait-state.mjs",
     "idd-audit-pr-cleanup": "./bin/idd-audit-pr-cleanup.mjs",
     "idd-branch-conflict-state": "./bin/idd-branch-conflict-state.mjs",
+    "idd-branch-name": "./bin/idd-branch-name.mjs",
     "idd-claim-approval-gate": "./bin/idd-claim-approval-gate.mjs",
     "idd-ci-wait-policy": "./bin/idd-ci-wait-policy.mjs",
     "idd-cleanup-hygiene-report": "./bin/idd-cleanup-hygiene-report.mjs",

--- a/scripts/branch-name.mjs
+++ b/scripts/branch-name.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/branch-name.mts
+//
+// The scripts/branch-name.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Deterministic, network-free helper for the canonical IDD branch name.
+//
+// It implements the `issue/<number>-<slug>` slug algorithm defined in
+// `.github/instructions/idd-claim.instructions.md` pre-check (e) exactly,
+// so parallel sessions converge on a byte-identical branch name and the
+// pre-check (e) collision detection can recognize two sessions as working
+// the same issue. The written algorithm remains the canonical spec and
+// fallback; this helper only removes the hand-tracing error surface.
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The fixed stop-word set from pre-check (e). Whole-token matches only.
+const STOP_WORDS = new Set([
+  'a',
+  'an',
+  'the',
+  'and',
+  'or',
+  'in',
+  'for',
+  'to',
+  'with',
+  'from',
+]);
+const MAX_SLUG_LENGTH = 40;
+const FALLBACK_SLUG = 'task';
+if (isCliExecution()) {
+  runCli();
+}
+/**
+ * Compute the deterministic slug for an issue title per pre-check (e):
+ *
+ * 1. lowercase the title;
+ * 2. replace every character outside ASCII `a-z`/`0-9` with `-`;
+ * 3. split on `-`, drop empty tokens, drop whole-token stop-words;
+ * 4. rejoin with single `-`;
+ * 5. if longer than 40 chars, cut to 40 — when that cut lands mid-token
+ *    and a `-` exists before char 40, trim back to that `-`, else keep
+ *    the hard 40-char cut — then strip any trailing `-`;
+ * 6. if empty, fall back to `task`.
+ */
+export function computeBranchSlug(title) {
+  const normalized = String(title ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-');
+  const tokens = normalized
+    .split('-')
+    .filter((token) => token.length > 0 && !STOP_WORDS.has(token));
+  let slug = tokens.join('-');
+  if (slug.length > MAX_SLUG_LENGTH) {
+    const cut = slug.slice(0, MAX_SLUG_LENGTH);
+    // The cut lands mid-token only when the character at the cut boundary
+    // and the last kept character are both token characters (not `-`).
+    const boundaryChar = slug.charAt(MAX_SLUG_LENGTH);
+    const endsMidToken =
+      boundaryChar !== '' && boundaryChar !== '-' && !cut.endsWith('-');
+    if (endsMidToken) {
+      const lastHyphen = cut.lastIndexOf('-');
+      slug = lastHyphen >= 0 ? cut.slice(0, lastHyphen) : cut;
+    } else {
+      slug = cut;
+    }
+  }
+  slug = slug.replace(/-+$/, '');
+  return slug.length > 0 ? slug : FALLBACK_SLUG;
+}
+/**
+ * Compute the canonical `issue/<number>-<slug>` branch name. The caller is
+ * responsible for passing a positive integer issue number; the CLI
+ * validates this before calling.
+ */
+export function computeBranchName(issueNumber, title) {
+  return `issue/${issueNumber}-${computeBranchSlug(title)}`;
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!Number.isInteger(args.number) || (args.number ?? 0) <= 0) {
+    throw new Error('--number is required and must be a positive integer');
+  }
+  if (args.title === null) {
+    throw new Error('--title is required');
+  }
+  process.stdout.write(`${computeBranchName(args.number, args.title)}\n`);
+}
+function parseArgs(argv) {
+  const parsed = { number: null, title: null, help: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    const requireValue = () => {
+      if (value === undefined) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    if (token === '--number') {
+      parsed.number = Number.parseInt(String(requireValue()), 10);
+      index += 1;
+      continue;
+    }
+    if (token === '--title') {
+      parsed.title = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/branch-name.mjs --number <issue-number> --title <issue-title>
+
+Prints the canonical IDD branch name \`issue/<number>-<slug>\` for the given
+issue number and title, applying the deterministic slug algorithm from
+idd-claim.instructions.md pre-check (e). Deterministic and network-free.
+
+Example:
+  node scripts/branch-name.mjs --number 42 --title "Add the OAuth login flow"
+  => issue/42-add-oauth-login-flow
+`);
+}
+function isCliExecution() {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}

--- a/scripts/branch-name.mjs
+++ b/scripts/branch-name.mjs
@@ -99,7 +99,7 @@ function parseArgs(argv) {
     const token = argv[index];
     const value = argv[index + 1];
     const requireValue = () => {
-      if (value === undefined) {
+      if (value === undefined || value.startsWith('--')) {
         throw new Error(`missing value for argument: ${token}`);
       }
       return value;

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -183,6 +183,15 @@ const HELPER_COMMANDS = [
       'Evaluate the A5(a) issue-author approval gate against issue state.',
   },
   {
+    id: 'branch-name',
+    scriptName: 'idd:branch-name',
+    binName: 'idd-branch-name',
+    entryPath: 'scripts/branch-name.mjs',
+    vendoredCommand: 'node scripts/branch-name.mjs',
+    description:
+      'Compute the canonical A5(e) issue/<number>-<slug> branch name from an issue number and title.',
+  },
+  {
     id: 'ci-wait-policy',
     scriptName: 'idd:ci-wait-policy',
     binName: 'idd-ci-wait-policy',

--- a/src/bin/idd-branch-name.mts
+++ b/src/bin/idd-branch-name.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-branch-name.mts
+//
+// The bin/idd-branch-name.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/branch-name.mjs');

--- a/src/scripts/branch-name.mts
+++ b/src/scripts/branch-name.mts
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/branch-name.mts
+//
+// The scripts/branch-name.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Deterministic, network-free helper for the canonical IDD branch name.
+//
+// It implements the `issue/<number>-<slug>` slug algorithm defined in
+// `.github/instructions/idd-claim.instructions.md` pre-check (e) exactly,
+// so parallel sessions converge on a byte-identical branch name and the
+// pre-check (e) collision detection can recognize two sessions as working
+// the same issue. The written algorithm remains the canonical spec and
+// fallback; this helper only removes the hand-tracing error surface.
+
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The fixed stop-word set from pre-check (e). Whole-token matches only.
+const STOP_WORDS: ReadonlySet<string> = new Set([
+  'a',
+  'an',
+  'the',
+  'and',
+  'or',
+  'in',
+  'for',
+  'to',
+  'with',
+  'from',
+]);
+
+const MAX_SLUG_LENGTH = 40;
+const FALLBACK_SLUG = 'task';
+
+if (isCliExecution()) {
+  runCli();
+}
+
+/**
+ * Compute the deterministic slug for an issue title per pre-check (e):
+ *
+ * 1. lowercase the title;
+ * 2. replace every character outside ASCII `a-z`/`0-9` with `-`;
+ * 3. split on `-`, drop empty tokens, drop whole-token stop-words;
+ * 4. rejoin with single `-`;
+ * 5. if longer than 40 chars, cut to 40 — when that cut lands mid-token
+ *    and a `-` exists before char 40, trim back to that `-`, else keep
+ *    the hard 40-char cut — then strip any trailing `-`;
+ * 6. if empty, fall back to `task`.
+ */
+export function computeBranchSlug(title: unknown): string {
+  const normalized = String(title ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-');
+  const tokens = normalized
+    .split('-')
+    .filter((token) => token.length > 0 && !STOP_WORDS.has(token));
+  let slug = tokens.join('-');
+
+  if (slug.length > MAX_SLUG_LENGTH) {
+    const cut = slug.slice(0, MAX_SLUG_LENGTH);
+    // The cut lands mid-token only when the character at the cut boundary
+    // and the last kept character are both token characters (not `-`).
+    const boundaryChar = slug.charAt(MAX_SLUG_LENGTH);
+    const endsMidToken =
+      boundaryChar !== '' && boundaryChar !== '-' && !cut.endsWith('-');
+    if (endsMidToken) {
+      const lastHyphen = cut.lastIndexOf('-');
+      slug = lastHyphen >= 0 ? cut.slice(0, lastHyphen) : cut;
+    } else {
+      slug = cut;
+    }
+  }
+
+  slug = slug.replace(/-+$/, '');
+  return slug.length > 0 ? slug : FALLBACK_SLUG;
+}
+
+/**
+ * Compute the canonical `issue/<number>-<slug>` branch name. The caller is
+ * responsible for passing a positive integer issue number; the CLI
+ * validates this before calling.
+ */
+export function computeBranchName(issueNumber: number, title: unknown): string {
+  return `issue/${issueNumber}-${computeBranchSlug(title)}`;
+}
+
+interface ParsedArgs {
+  number: number | null;
+  title: string | null;
+  help: boolean;
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!Number.isInteger(args.number) || (args.number ?? 0) <= 0) {
+    throw new Error('--number is required and must be a positive integer');
+  }
+  if (args.title === null) {
+    throw new Error('--title is required');
+  }
+  process.stdout.write(
+    `${computeBranchName(args.number as number, args.title)}\n`,
+  );
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { number: null, title: null, help: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    const requireValue = (): string => {
+      if (value === undefined) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    if (token === '--number') {
+      parsed.number = Number.parseInt(String(requireValue()), 10);
+      index += 1;
+      continue;
+    }
+    if (token === '--title') {
+      parsed.title = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+
+  return parsed;
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/branch-name.mjs --number <issue-number> --title <issue-title>
+
+Prints the canonical IDD branch name \`issue/<number>-<slug>\` for the given
+issue number and title, applying the deterministic slug algorithm from
+idd-claim.instructions.md pre-check (e). Deterministic and network-free.
+
+Example:
+  node scripts/branch-name.mjs --number 42 --title "Add the OAuth login flow"
+  => issue/42-add-oauth-login-flow
+`);
+}
+
+function isCliExecution(): boolean {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}

--- a/src/scripts/branch-name.mts
+++ b/src/scripts/branch-name.mts
@@ -117,7 +117,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     const token = argv[index];
     const value = argv[index + 1];
     const requireValue = (): string => {
-      if (value === undefined) {
+      if (value === undefined || value.startsWith('--')) {
         throw new Error(`missing value for argument: ${token}`);
       }
       return value;

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -255,6 +255,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
       'Evaluate the A5(a) issue-author approval gate against issue state.',
   },
   {
+    id: 'branch-name',
+    scriptName: 'idd:branch-name',
+    binName: 'idd-branch-name',
+    entryPath: 'scripts/branch-name.mjs',
+    vendoredCommand: 'node scripts/branch-name.mjs',
+    description:
+      'Compute the canonical A5(e) issue/<number>-<slug> branch name from an issue number and title.',
+  },
+  {
     id: 'ci-wait-policy',
     scriptName: 'idd:ci-wait-policy',
     binName: 'idd-ci-wait-policy',

--- a/tests/branch-name.test.mts
+++ b/tests/branch-name.test.mts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  computeBranchName,
+  computeBranchSlug,
+} from '../src/scripts/branch-name.mts';
+
+// Worked examples shared verbatim with the "Worked examples" block in
+// `.github/instructions/idd-claim.instructions.md` pre-check (e). This is
+// the drift guard: the helper and the written algorithm must agree on
+// these, so prose and code cannot silently diverge.
+const WORKED_EXAMPLES: ReadonlyArray<{
+  number: number;
+  title: string;
+  branch: string;
+}> = [
+  // stop-word removal (`the`)
+  {
+    number: 42,
+    title: 'Add the OAuth login flow',
+    branch: 'issue/42-add-oauth-login-flow',
+  },
+  // 40-char cut that lands exactly on a token boundary (this issue's own
+  // branch — the helper computes the branch of the issue that introduced
+  // it)
+  {
+    number: 901,
+    title:
+      'Add a helper that computes the canonical issue/<number>-<slug> branch name',
+    branch: 'issue/901-add-helper-that-computes-canonical-issue',
+  },
+  // 40-char cut that lands mid-token and trims back to the last hyphen
+  {
+    number: 123,
+    title:
+      'Implement comprehensive authentication authorization middleware system',
+    branch: 'issue/123-implement-comprehensive-authentication',
+  },
+  // empty slug falls back to `task`
+  { number: 7, title: '!!!', branch: 'issue/7-task' },
+  // non-ASCII characters drop out, ASCII tokens remain
+  { number: 99, title: '日本語 calendar 機能', branch: 'issue/99-calendar' },
+];
+
+test('drift: helper reproduces the instruction worked examples', () => {
+  for (const example of WORKED_EXAMPLES) {
+    assert.equal(
+      computeBranchName(example.number, example.title),
+      example.branch,
+      `${example.number} / ${example.title}`,
+    );
+  }
+});
+
+test('lowercases and replaces every non-[a-z0-9] run with hyphens', () => {
+  assert.equal(computeBranchSlug('Add OAuth Login'), 'add-oauth-login');
+  assert.equal(computeBranchSlug('Fix API/DB sync'), 'fix-api-db-sync');
+});
+
+test('removes whole-token stop-words only (not substrings)', () => {
+  assert.equal(
+    computeBranchSlug('Refactor for the API and DB'),
+    'refactor-api-db',
+  );
+  // "android" contains "and" but is not the whole token, so it stays
+  assert.equal(computeBranchSlug('Android theme'), 'android-theme');
+});
+
+test('40-char cut trims back to the last hyphen when it lands mid-token', () => {
+  assert.equal(
+    computeBranchSlug('aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd'),
+    'aaaaaaaaaa-bbbbbbbbbb-cccccccccc',
+  );
+});
+
+test('40-char cut keeps the hard cut when there is no hyphen to trim to', () => {
+  const slug = computeBranchSlug('a'.repeat(50));
+  assert.equal(slug, 'a'.repeat(40));
+  assert.equal(slug.length, 40);
+});
+
+test('a slug of exactly 40 characters is returned unchanged', () => {
+  // Exercises the `slug.length > 40` boundary (the `>` vs `>=` guard): a
+  // 40-char slug must not enter the cut path.
+  const slug = computeBranchSlug('aaaaaaaaa bbbbbbbbb ccccccccc dddddddddd');
+  assert.equal(slug, 'aaaaaaaaa-bbbbbbbbb-ccccccccc-dddddddddd');
+  assert.equal(slug.length, 40);
+});
+
+test('cut on a hyphen boundary keeps whole tokens and strips the trailing hyphen', () => {
+  assert.equal(
+    computeBranchSlug('aaaaaaaaa bbbbbbbbb ccccccccc ddddddddd eee'),
+    'aaaaaaaaa-bbbbbbbbb-ccccccccc-ddddddddd',
+  );
+});
+
+test('falls back to `task` when nothing survives normalization', () => {
+  for (const title of ['!!!', '---', '   ', '🎉', '日本語', '', '/<>-']) {
+    assert.equal(computeBranchSlug(title), 'task', JSON.stringify(title));
+  }
+});
+
+test('drops non-ASCII characters while keeping ASCII tokens', () => {
+  assert.equal(computeBranchSlug('日本語 calendar 機能'), 'calendar');
+  assert.equal(computeBranchSlug('Update 設定 page'), 'update-page');
+});
+
+test('computeBranchName composes issue/<number>-<slug>', () => {
+  assert.equal(computeBranchName(5, 'Hello World'), 'issue/5-hello-world');
+});
+
+test('handles nullish and non-string titles defensively', () => {
+  assert.equal(computeBranchSlug(null), 'task');
+  assert.equal(computeBranchSlug(undefined), 'task');
+  assert.equal(computeBranchName(8, null), 'issue/8-task');
+});

--- a/tests/branch-name.test.mts
+++ b/tests/branch-name.test.mts
@@ -30,13 +30,6 @@ const WORKED_EXAMPLES: ReadonlyArray<{
       'Add a helper that computes the canonical issue/<number>-<slug> branch name',
     branch: 'issue/901-add-helper-that-computes-canonical-issue',
   },
-  // 40-char cut that lands mid-token and trims back to the last hyphen
-  {
-    number: 123,
-    title:
-      'Implement comprehensive authentication authorization middleware system',
-    branch: 'issue/123-implement-comprehensive-authentication',
-  },
   // empty slug falls back to `task`
   { number: 7, title: '!!!', branch: 'issue/7-task' },
   // non-ASCII characters drop out, ASCII tokens remain


### PR DESCRIPTION
## Summary

Adds a deterministic, network-free helper that prints the canonical
`issue/<number>-<slug>` per `idd-claim.instructions.md` pre-check (e),
removing the hand-tracing error surface for the 40-char slug cut. The
written algorithm stays the canonical spec and fallback.

- `src/scripts/branch-name.mts`: pure `computeBranchSlug` / `computeBranchName` plus a `--number`/`--title` CLI; `src/bin` wrapper and generated `.mjs` artifacts
- `tests/branch-name.test.mts`: table-driven coverage of every branch (stop-word removal, 40-char mid-token trim-back, no-hyphen hard cut, exact-40 boundary, hyphen-boundary trailing strip, `task` fallback, non-ASCII drop-out) plus a drift test that re-derives the instruction worked examples
- `idd-claim.instructions.md` pre-check (e): a helper-first pointer and a Worked examples block, with the written algorithm retained as the canonical fallback (mirrored into `idd-template`)
- `helper-runtime-manifest` + `package.json` bin: registered as `idd:branch-name` so package-manager / vendored-node adopter profiles resolve it; `docs/idd-helper-scripts.md` documents it

## Verification

`pnpm run build` regenerates the committed `scripts/branch-name.mjs` / `bin/idd-branch-name.mjs` with zero drift; `node scripts/audit-docs.mjs --check`, full `pnpm run lint` (952 tests), and the helper's own tests pass.

Closes #901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `idd-branch-name` CLI command for computing deterministic branch names in the format `issue/<number>-<slug>`
  * Branch slug computation applies intelligent stop-word removal, character normalization, and length constraints for consistent naming during the Discover & Claim phase

* **Documentation**
  * Updated helper documentation with command usage and worked examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->