### PR TITLE
docs(suitability): clarify A4.5 is independent of the autopilot score

### DIFF
--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -13,6 +13,17 @@ This gate evaluates whether an issue is **suitable for autonomous
 execution** independent of the current run's context. Where A4 asks "can
 we do this NOW?", A4.5 asks "SHOULD we do this at all?"
 
+## Relationship to the autopilot-suitability score
+
+The numeric `<!-- {{PROJECT_MARKER_PREFIX}}-autopilot-suitability: N -->`
+footer is a **discovery-time** ranking/routing hint consumed in
+`idd-discover.instructions.md` (its floor is `.github/idd/config.json`
+`autopilotSuitability.floor`, default `3`; see also
+`docs/policy-constants.md`). It is **not** one of the seven
+checks below: A4.5 PASS/FAIL is decided solely by the qualitative content
+checks and never reads the number. A low or missing score never fails this
+gate, and a high score never bypasses it.
+
 When helper support is enabled, use helper scripts from
 `docs/idd-helper-scripts.md` first for A4.5 evidence.
 Written checks and decision flow remain authoritative when helper output

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 81920
+      "limitBytes": 82466
     },
     {
       "id": "bundle-resume",

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -13,6 +13,17 @@ This gate evaluates whether an issue is **suitable for autonomous
 execution** independent of the current run's context. Where A4 asks "can
 we do this NOW?", A4.5 asks "SHOULD we do this at all?"
 
+## Relationship to the autopilot-suitability score
+
+The numeric `<!-- {{PROJECT_MARKER_PREFIX}}-autopilot-suitability: N -->`
+footer is a **discovery-time** ranking/routing hint consumed in
+`idd-discover.instructions.md` (its floor is `.github/idd/config.json`
+`autopilotSuitability.floor`, default `3`; see also
+`docs/policy-constants.md`). It is **not** one of the seven
+checks below: A4.5 PASS/FAIL is decided solely by the qualitative content
+checks and never reads the number. A low or missing score never fails this
+gate, and a high score never bypasses it.
+
 When helper support is enabled, use helper scripts from
 `docs/idd-helper-scripts.md` first for A4.5 evidence.
 Written checks and decision flow remain authoritative when helper output


### PR DESCRIPTION
## Summary

Adds a **"Relationship to the autopilot-suitability score"** subsection to the A4.5 instruction file (`idd-suitability.instructions.md`), stating that the numeric `autopilot-suitability: N` footer is a **discovery-time** ranking/routing hint — not one of the seven A4.5 content checks. A4.5 PASS/FAIL never reads the number; a low/missing score never fails the gate and a high score never bypasses it. Cross-links `idd-discover.instructions.md` and `docs/policy-constants.md`.

Documentation-only; no behavior change. Mirrored into `idd-template` via `docs:sync`.

## Bundle ratchet (callout)

Raises `bundle-discovery` `limitBytes` **81920 → 82466** (the measured total of the five discovery-path files) to fit the new subsection, per the sync-manifest ratchet rule.

## Verification

`pnpm run docs:sync`, `node scripts/audit-docs.mjs --check`, and the full `pnpm run lint` suite (incl. cspell/markdownlint) pass.

Closes #897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how autopilot-suitability scoring relates to the suitability assessment process across instruction files.

* **Chores**
  * Updated instruction size budget configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->