### PR TITLE
docs(advisory-wait): make F3 outcome/f3Outcome precedence explicit

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -92,12 +92,13 @@ to the distributed defaults named in `docs/policy-constants.md`:
 
 **Precedence**: when valid helper output is available, **F3 uses
 `f3Outcome` exclusively**, so the **F3** column in the Caller-mapping table
-above is read from `f3Outcome`. The `Outcome` column and its
-`REQUEST_NEEDED → return to E14` routing govern **E14, F2, and the
-shell-fallback path** (where no `f3Outcome` exists). This is why the helper
-can legitimately emit `outcome: REQUEST_NEEDED` together with `f3Outcome:
-SATISFIED` (when `copilotPending` is `false`) and F3 still merges rather
-than returning to E14.
+above is read from `f3Outcome`. The `Outcome` column governs the **E14**,
+**F2**, and shell-fallback rows (the shell-fallback path has no
+`f3Outcome`); on `REQUEST_NEEDED`, F2 returns to E14 while E14 itself
+requests Copilot and polls. This is why the helper can legitimately emit
+`outcome: REQUEST_NEEDED` together with `f3Outcome: SATISFIED` (when
+`copilotPending` is `false`) and F3 still merges on `f3Outcome` rather than
+taking the `Outcome`-driven F2 route back to E14.
 
 - F3 must use `f3Outcome` when helper output is available.
 - If `copilotPending` is `false`, F3 treats advisory wait as satisfied.

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -90,6 +90,15 @@ to the distributed defaults named in `docs/policy-constants.md`:
 
 ### F3-specific interpretation
 
+**Precedence**: when valid helper output is available, **F3 uses
+`f3Outcome` exclusively**, so the **F3** column in the Caller-mapping table
+above is read from `f3Outcome`. The `Outcome` column and its
+`REQUEST_NEEDED → return to E14` routing govern **E14, F2, and the
+shell-fallback path** (where no `f3Outcome` exists). This is why the helper
+can legitimately emit `outcome: REQUEST_NEEDED` together with `f3Outcome:
+SATISFIED` (when `copilotPending` is `false`) and F3 still merges rather
+than returning to E14.
+
 - F3 must use `f3Outcome` when helper output is available.
 - If `copilotPending` is `false`, F3 treats advisory wait as satisfied.
 - If `copilotPending` is `true`, F3 must not merge on `WAIT`,

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -92,12 +92,13 @@ to the distributed defaults named in `docs/policy-constants.md`:
 
 **Precedence**: when valid helper output is available, **F3 uses
 `f3Outcome` exclusively**, so the **F3** column in the Caller-mapping table
-above is read from `f3Outcome`. The `Outcome` column and its
-`REQUEST_NEEDED → return to E14` routing govern **E14, F2, and the
-shell-fallback path** (where no `f3Outcome` exists). This is why the helper
-can legitimately emit `outcome: REQUEST_NEEDED` together with `f3Outcome:
-SATISFIED` (when `copilotPending` is `false`) and F3 still merges rather
-than returning to E14.
+above is read from `f3Outcome`. The `Outcome` column governs the **E14**,
+**F2**, and shell-fallback rows (the shell-fallback path has no
+`f3Outcome`); on `REQUEST_NEEDED`, F2 returns to E14 while E14 itself
+requests Copilot and polls. This is why the helper can legitimately emit
+`outcome: REQUEST_NEEDED` together with `f3Outcome: SATISFIED` (when
+`copilotPending` is `false`) and F3 still merges on `f3Outcome` rather than
+taking the `Outcome`-driven F2 route back to E14.
 
 - F3 must use `f3Outcome` when helper output is available.
 - If `copilotPending` is `false`, F3 treats advisory wait as satisfied.

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -90,6 +90,15 @@ to the distributed defaults named in `docs/policy-constants.md`:
 
 ### F3-specific interpretation
 
+**Precedence**: when valid helper output is available, **F3 uses
+`f3Outcome` exclusively**, so the **F3** column in the Caller-mapping table
+above is read from `f3Outcome`. The `Outcome` column and its
+`REQUEST_NEEDED → return to E14` routing govern **E14, F2, and the
+shell-fallback path** (where no `f3Outcome` exists). This is why the helper
+can legitimately emit `outcome: REQUEST_NEEDED` together with `f3Outcome:
+SATISFIED` (when `copilotPending` is `false`) and F3 still merges rather
+than returning to E14.
+
 - F3 must use `f3Outcome` when helper output is available.
 - If `copilotPending` is `false`, F3 treats advisory wait as satisfied.
 - If `copilotPending` is `true`, F3 must not merge on `WAIT`,

--- a/schemas/advisory-wait-state.schema.json
+++ b/schemas/advisory-wait-state.schema.json
@@ -46,7 +46,7 @@
     },
     "outcome": {
       "type": "string",
-      "description": "Shared routing outcome consumed by E14, F2, and the shell-fallback path (AW1-AW5). Its REQUEST_NEEDED -> return-to-E14 routing governs E14 and F2; F3 reads f3Outcome instead.",
+      "description": "Shared routing outcome consumed by E14, F2, and the shell-fallback path (AW1-AW5). On REQUEST_NEEDED, F2 returns to E14 while E14 itself requests Copilot and polls; F3 reads f3Outcome instead.",
       "enum": [
         "SATISFIED",
         "REQUEST_NEEDED",

--- a/schemas/advisory-wait-state.schema.json
+++ b/schemas/advisory-wait-state.schema.json
@@ -46,6 +46,7 @@
     },
     "outcome": {
       "type": "string",
+      "description": "Shared routing outcome consumed by E14, F2, and the shell-fallback path (AW1-AW5). Its REQUEST_NEEDED -> return-to-E14 routing governs E14 and F2; F3 reads f3Outcome instead.",
       "enum": [
         "SATISFIED",
         "REQUEST_NEEDED",
@@ -56,6 +57,7 @@
     },
     "f3Outcome": {
       "type": "string",
+      "description": "F3-authoritative outcome; treats copilotPending=false as SATISFIED so F3 may merge a settled-but-not-re-reviewed advisory state. F3 uses this field exclusively when helper output is valid, which is why it can diverge from outcome.",
       "enum": [
         "SATISFIED",
         "REQUEST_NEEDED",

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1401,6 +1401,12 @@ export function evaluateAdvisoryWaitOutcome(input) {
   }
   return input.elapsedMinutes >= settledWindowMinutes ? 'SATISFIED' : 'WAIT';
 }
+// F3 deliberately has a separate outcome from evaluateAdvisoryWaitOutcome:
+// once Copilot is no longer pending (review submitted or cancelled), F3
+// treats the advisory wait as SATISFIED so a settled-but-not-re-reviewed
+// HEAD can merge, even while the shared `outcome` still routes E14/F2 to
+// REQUEST_NEEDED. F3 reads f3Outcome exclusively when helper output is
+// valid; see idd-advisory-wait.instructions.md §1 (F3-specific interpretation).
 export function evaluateAdvisoryWaitF3Outcome(input) {
   if (input.lastCopilotCommit === input.prHeadSha || !input.copilotPending) {
     return 'SATISFIED';

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2118,6 +2118,12 @@ export function evaluateAdvisoryWaitOutcome(
   return input.elapsedMinutes >= settledWindowMinutes ? 'SATISFIED' : 'WAIT';
 }
 
+// F3 deliberately has a separate outcome from evaluateAdvisoryWaitOutcome:
+// once Copilot is no longer pending (review submitted or cancelled), F3
+// treats the advisory wait as SATISFIED so a settled-but-not-re-reviewed
+// HEAD can merge, even while the shared `outcome` still routes E14/F2 to
+// REQUEST_NEEDED. F3 reads f3Outcome exclusively when helper output is
+// valid; see idd-advisory-wait.instructions.md §1 (F3-specific interpretation).
 export function evaluateAdvisoryWaitF3Outcome(
   input: AdvisoryWaitOutcomeInput,
 ): string {


### PR DESCRIPTION
## Summary

Resolves the `outcome` vs `f3Outcome` precedence ambiguity in `idd-advisory-wait.instructions.md` §1 (clarity only, **no computation change**). The helper legitimately emits `outcome: REQUEST_NEEDED` with `f3Outcome: SATISFIED` when `copilotPending` is `false`; §1 now states **F3 reads `f3Outcome` exclusively** (the `Outcome` column + `REQUEST_NEEDED → E14` govern E14/F2 and the shell-fallback path).

- idd-advisory-wait §1: precedence sentence + the table's F3 column clarified as `f3Outcome`-keyed
- `schemas/advisory-wait-state.schema.json`: non-empty `description` for `outcome` and `f3Outcome`
- `src/scripts/protocol-helpers.mts`: comment above `evaluateAdvisoryWaitF3Outcome`

No logic change (the two `evaluate*` bodies are untouched; `scripts/protocol-helpers.mjs` only mirrors the comment). Mirrored to `idd-template` via `docs:sync`. Out of scope: renaming the fields.

## Verification

Schema validation (existing fixtures still validate), `pnpm run build` (no logic diff), `audit-docs --check`, and full lint pass.

Closes #898