### PR TITLE
docs(advisory-wait): document Copilot-only scope and safety net

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -10,6 +10,26 @@ Policy constants (cap and windows) are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md). This file
 owns behavior.
 
+## Scope — Copilot-only settle/wait window
+
+This protocol's settle/wait window covers **Copilot only**. Other
+advisory reviewers configured through `.github/idd/config.json`
+`advisoryBotLogins` (for example CodeRabbit or a Codex connector) are
+**not** given a wait window by this protocol. That Copilot-only scope is
+deliberate: see the `external-bot` profile in
+[`docs/idd-review-policy-profiles.md`](../../docs/idd-review-policy-profiles.md),
+which swaps the single advisory bot by manual customization instead of
+gating on every configured bot.
+
+In a repository that configures non-Copilot `advisoryBotLogins`, the
+load-bearing safety net for their late-arriving findings is the **E1
+activity-universe snapshot + `review-watermark` delta**
+(`idd-review-snapshot.instructions.md`), re-checked by the F2/F3
+merge-readiness gate — not this advisory-wait window. See
+[`idd-pre-merge.instructions.md`](idd-pre-merge.instructions.md) for the
+merge-gate requirement that forbids a bare CI-green merge without a fresh
+covering snapshot.
+
 ## 1. Canonical path (helper-first)
 
 When helper support is installed, use the profile-selected

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -64,6 +64,15 @@ condition checks must cover the full activity universe (human
 reviewers plus advisory bot surfaces such as Copilot, CodeRabbit,
 Codex connectors, and CI bots).
 
+When the repository configures non-Copilot `advisoryBotLogins` (for
+example CodeRabbit or a Codex connector), the advisory-wait window does
+**not** cover those bots (`idd-advisory-wait.instructions.md` — that
+window is Copilot-only). F2/F3 MUST NOT merge on a bare CI-green signal:
+the **Review currency** check below must confirm a fresh activity
+snapshot whose `review-watermark` covers the latest activity timestamp,
+so a non-Copilot finding that lands shortly after CI completes still
+returns the workflow to E1 instead of merging over it.
+
 - **Review currency** (live re-fetch required, freshness gate): read the
   most recent `<!-- review-watermark: {agent-id} {claim-id} … -->`
   comment whose embedded `{claim-id}` matches the current active claim

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -61,6 +61,17 @@ Additionally, fetch the **current CI state** for `{head-SHA}`:
 treated-as-passed) CI run as `{latest-ci-completed-at}`, or `none` if no
 CI pass exists yet for this HEAD.
 
+**Non-Copilot advisory safety net.** The advisory-wait protocol
+(`idd-advisory-wait.instructions.md`) gives a settle/wait window to
+**Copilot only**. In a repository that configures non-Copilot
+`advisoryBotLogins` (for example CodeRabbit or a Codex connector), this
+E1 activity-universe snapshot plus the `review-watermark` delta is the
+**load-bearing safety net** for their late-arriving findings: a finding
+that lands after CI goes green is caught here and by the F2/F3 currency
+re-check, not by the Copilot advisory-wait window. This is why Step 1
+fetches the entire activity universe and Step 2 records a watermark over
+all of it.
+
 **Step 2 — Record the watermark.** Using the `{head-SHA}` stored at the
 start of Step 1, compute `{max-activity-updatedAt}` as the highest
 `updatedAt` server timestamp across the **entire snapshot** (not just

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -10,6 +10,26 @@ Policy constants (cap and windows) are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md). This file
 owns behavior.
 
+## Scope — Copilot-only settle/wait window
+
+This protocol's settle/wait window covers **Copilot only**. Other
+advisory reviewers configured through `.github/idd/config.json`
+`advisoryBotLogins` (for example CodeRabbit or a Codex connector) are
+**not** given a wait window by this protocol. That Copilot-only scope is
+deliberate: see the `external-bot` profile in
+[`docs/idd-review-policy-profiles.md`](../../docs/idd-review-policy-profiles.md),
+which swaps the single advisory bot by manual customization instead of
+gating on every configured bot.
+
+In a repository that configures non-Copilot `advisoryBotLogins`, the
+load-bearing safety net for their late-arriving findings is the **E1
+activity-universe snapshot + `review-watermark` delta**
+(`idd-review-snapshot.instructions.md`), re-checked by the F2/F3
+merge-readiness gate — not this advisory-wait window. See
+[`idd-pre-merge.instructions.md`](idd-pre-merge.instructions.md) for the
+merge-gate requirement that forbids a bare CI-green merge without a fresh
+covering snapshot.
+
 ## 1. Canonical path (helper-first)
 
 When helper support is installed, use the profile-selected

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -64,6 +64,15 @@ condition checks must cover the full activity universe (human
 reviewers plus advisory bot surfaces such as Copilot, CodeRabbit,
 Codex connectors, and CI bots).
 
+When the repository configures non-Copilot `advisoryBotLogins` (for
+example CodeRabbit or a Codex connector), the advisory-wait window does
+**not** cover those bots (`idd-advisory-wait.instructions.md` — that
+window is Copilot-only). F2/F3 MUST NOT merge on a bare CI-green signal:
+the **Review currency** check below must confirm a fresh activity
+snapshot whose `review-watermark` covers the latest activity timestamp,
+so a non-Copilot finding that lands shortly after CI completes still
+returns the workflow to E1 instead of merging over it.
+
 - **Review currency** (live re-fetch required, freshness gate): read the
   most recent `<!-- review-watermark: {agent-id} {claim-id} … -->`
   comment whose embedded `{claim-id}` matches the current active claim

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -61,6 +61,17 @@ Additionally, fetch the **current CI state** for `{head-SHA}`:
 treated-as-passed) CI run as `{latest-ci-completed-at}`, or `none` if no
 CI pass exists yet for this HEAD.
 
+**Non-Copilot advisory safety net.** The advisory-wait protocol
+(`idd-advisory-wait.instructions.md`) gives a settle/wait window to
+**Copilot only**. In a repository that configures non-Copilot
+`advisoryBotLogins` (for example CodeRabbit or a Codex connector), this
+E1 activity-universe snapshot plus the `review-watermark` delta is the
+**load-bearing safety net** for their late-arriving findings: a finding
+that lands after CI goes green is caught here and by the F2/F3 currency
+re-check, not by the Copilot advisory-wait window. This is why Step 1
+fetches the entire activity universe and Step 2 records a watermark over
+all of it.
+
 **Step 2 — Record the watermark.** Using the `{head-SHA}` stored at the
 start of Step 1, compute `{max-activity-updatedAt}` as the highest
 `updatedAt` server timestamp across the **entire snapshot** (not just


### PR DESCRIPTION
## Summary

Documentation-only change implementing the advisory-wait scope
clarification from the linked issue. The advisory-wait protocol gives a
settle/wait window to **Copilot only**; repositories that configure
non-Copilot `advisoryBotLogins` (e.g. CodeRabbit or a Codex connector —
including this source repo) get no wait window from it. This makes that
scope explicit and names the load-bearing safety net for those bots.

## Changes

Canonical sources under `idd-template/.github/instructions/` (the
`.github/instructions/` mirrors are regenerated byte-identically via
`pnpm run docs:sync`):

- **advisory-wait**: new top-of-file *Scope* note — Copilot-only window;
  non-Copilot `advisoryBotLogins` get no wait window; cross-links the
  `external-bot` profile and the `advisoryBotLogins` config key.
- **review-snapshot (E1)**: identifies the E1 activity-universe snapshot +
  `review-watermark` delta as the load-bearing safety net for
  late-arriving non-Copilot advisory findings.
- **pre-merge (F2)**: forbids a bare CI-green merge without a fresh
  covering snapshot when non-Copilot `advisoryBotLogins` are configured.

No change to advisory-wait enums, decision tables, or computation.

## Verification

- `node scripts/audit-docs.mjs --check` — passed (mirrors in sync)
- dprint / markdownlint / cspell — passed

Closes #899
