### PR TITLE
feat(helpers): add emit-marker helper for the per-cycle marker bodies

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -257,7 +257,10 @@ Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
 - **Fresh claim** or claim after a released / unclaimed state → `none`
 
 Post the claim comment to the issue. Keep the HTML token at the start
-of the body, followed by the visible note:
+of the body, followed by the visible note. When helper runtime is enabled,
+render this body with the profile-selected emit-marker command
+(`--type claimed-by`, emit-only; see `docs/idd-helper-scripts.md`); the
+written format below stays the canonical fallback:
 
 ```markdown
 <!-- claimed-by: {agent-id} {claim-id} supersedes: {prior-claim-id|none} {ISO8601-timestamp} branch: {branch-name} -->

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -68,7 +68,9 @@ the items that will appear in ReviewItems_snapshot). Write `none` if
 the snapshot is
 empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
-PR comment with this format:
+PR comment with this format (when helper runtime is enabled, render the
+body with the profile-selected emit-marker command — `--type
+review-watermark`, emit-only; see `docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-watermark: {agent-id} {claim-id} {head-SHA} {max-activity-updatedAt|none} {total-item-count} {latest-ci-completed-at|none} -->
@@ -198,7 +200,9 @@ critique findings unless they were persisted as reviewer-visible
 comments.
 
 After the critique pass completes, post a new `review-baseline` comment
-with the current HEAD SHA using this format:
+with the current HEAD SHA using this format (when helper runtime is
+enabled, render the body with the profile-selected emit-marker command —
+`--type review-baseline`, emit-only; see `docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-baseline: {agent-id} {claim-id} {SHA} -->

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 82466
+      "limitBytes": 82684
     },
     {
       "id": "bundle-resume",

--- a/bin/idd-emit-marker.mjs
+++ b/bin/idd-emit-marker.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-emit-marker.mts
+//
+// The bin/idd-emit-marker.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/emit-marker.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -33,6 +33,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
   `issue/<number>-<slug>` branch-name slug computation; deterministic and
   network-free (referenced in
   [kurone-kito/idd-skill#901](https://github.com/kurone-kito/idd-skill/issues/901))
+- `scripts/emit-marker.mjs` for emitting the per-cycle `claimed-by` /
+  `review-watermark` / `review-baseline` marker bodies (emit-only, no
+  network write; referenced in
+  [kurone-kito/idd-skill#900](https://github.com/kurone-kito/idd-skill/issues/900))
 - `scripts/resume-claim-routing.mjs` for Resume Step 1 claim-state
   evaluation and takeover routing (referenced in
   [kurone-kito/idd-skill#394](https://github.com/kurone-kito/idd-skill/issues/394))
@@ -623,6 +627,24 @@ Interpretation rules:
   and the written algorithm stays the canonical fallback
 - The `tests/branch-name.test.mts` drift test re-derives the pre-check (e)
   "Worked examples" table, so the prose and the helper cannot diverge
+
+### Per-cycle marker bodies
+
+- Source repo / vendored-node command:
+  `node scripts/emit-marker.mjs --type <type> <fields...>` where `<type>` is
+  `claimed-by`, `review-watermark`, or `review-baseline`
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd:emit-marker` command from the helper runtime manifest wiring above
+- Prints the exact ready-to-post marker body (HTML token + visible "Do not
+  edit" note) to stdout; **emit-only, no network write** — the agent posts
+  it via the documented HTTP path
+- Fields per type: `claimed-by` takes `--agent-id --claim-id --supersedes
+  --timestamp --branch`; `review-watermark` takes `--agent-id --claim-id
+  --head-sha --max-activity-at --total-item-count --ci-completed-at`;
+  `review-baseline` takes `--agent-id --claim-id --sha`
+- The written marker formats in `idd-overview-core` (claim) and
+  `idd-review-snapshot` (watermark/baseline) stay canonical; the render
+  functions live in `protocol-helpers` with byte-shape tests
 
 ### Resume claim and route evidence
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -257,7 +257,10 @@ Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
 - **Fresh claim** or claim after a released / unclaimed state → `none`
 
 Post the claim comment to the issue. Keep the HTML token at the start
-of the body, followed by the visible note:
+of the body, followed by the visible note. When helper runtime is enabled,
+render this body with the profile-selected emit-marker command
+(`--type claimed-by`, emit-only; see `docs/idd-helper-scripts.md`); the
+written format below stays the canonical fallback:
 
 ```markdown
 <!-- claimed-by: {agent-id} {claim-id} supersedes: {prior-claim-id|none} {ISO8601-timestamp} branch: {branch-name} -->

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -68,7 +68,9 @@ the items that will appear in ReviewItems_snapshot). Write `none` if
 the snapshot is
 empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
-PR comment with this format:
+PR comment with this format (when helper runtime is enabled, render the
+body with the profile-selected emit-marker command — `--type
+review-watermark`, emit-only; see `docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-watermark: {agent-id} {claim-id} {head-SHA} {max-activity-updatedAt|none} {total-item-count} {latest-ci-completed-at|none} -->
@@ -198,7 +200,9 @@ critique findings unless they were persisted as reviewer-visible
 comments.
 
 After the critique pass completes, post a new `review-baseline` comment
-with the current HEAD SHA using this format:
+with the current HEAD SHA using this format (when helper runtime is
+enabled, render the body with the profile-selected emit-marker command —
+`--type review-baseline`, emit-only; see `docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-baseline: {agent-id} {claim-id} {SHA} -->

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -33,6 +33,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
   `issue/<number>-<slug>` branch-name slug computation; deterministic and
   network-free (referenced in
   [kurone-kito/idd-skill#901](https://github.com/kurone-kito/idd-skill/issues/901))
+- `scripts/emit-marker.mjs` for emitting the per-cycle `claimed-by` /
+  `review-watermark` / `review-baseline` marker bodies (emit-only, no
+  network write; referenced in
+  [kurone-kito/idd-skill#900](https://github.com/kurone-kito/idd-skill/issues/900))
 - `scripts/resume-claim-routing.mjs` for Resume Step 1 claim-state
   evaluation and takeover routing (referenced in
   [kurone-kito/idd-skill#394](https://github.com/kurone-kito/idd-skill/issues/394))
@@ -623,6 +627,24 @@ Interpretation rules:
   and the written algorithm stays the canonical fallback
 - The `tests/branch-name.test.mts` drift test re-derives the pre-check (e)
   "Worked examples" table, so the prose and the helper cannot diverge
+
+### Per-cycle marker bodies
+
+- Source repo / vendored-node command:
+  `node scripts/emit-marker.mjs --type <type> <fields...>` where `<type>` is
+  `claimed-by`, `review-watermark`, or `review-baseline`
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd:emit-marker` command from the helper runtime manifest wiring above
+- Prints the exact ready-to-post marker body (HTML token + visible "Do not
+  edit" note) to stdout; **emit-only, no network write** — the agent posts
+  it via the documented HTTP path
+- Fields per type: `claimed-by` takes `--agent-id --claim-id --supersedes
+  --timestamp --branch`; `review-watermark` takes `--agent-id --claim-id
+  --head-sha --max-activity-at --total-item-count --ci-completed-at`;
+  `review-baseline` takes `--agent-id --claim-id --sha`
+- The written marker formats in `idd-overview-core` (claim) and
+  `idd-review-snapshot` (watermark/baseline) stay canonical; the render
+  functions live in `protocol-helpers` with byte-shape tests
 
 ### Resume claim and route evidence
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "idd-discover-orphan-filter": "./bin/idd-discover-orphan-filter.mjs",
     "idd-discover-viability-gate": "./bin/idd-discover-viability-gate.mjs",
     "idd-doctor": "./bin/idd-doctor.mjs",
+    "idd-emit-marker": "./bin/idd-emit-marker.mjs",
     "idd-external-check-waiver": "./bin/idd-external-check-waiver.mjs",
     "idd-force-handoff": "./bin/idd-force-handoff.mjs",
     "idd-forced-handoff-marker": "./bin/idd-forced-handoff-marker.mjs",

--- a/scripts/emit-marker.mjs
+++ b/scripts/emit-marker.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/emit-marker.mts
+//
+// The scripts/emit-marker.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Emit-only CLI for the three per-cycle operational marker bodies
+// (claimed-by / review-watermark / review-baseline). It prints the
+// ready-to-post body string to stdout and performs NO network write; the
+// agent posts it via the documented HTTP path. The render logic lives in
+// protocol-helpers; this is the thin CLI surface.
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  renderClaimedByMarker,
+  renderReviewBaselineMarker,
+  renderReviewWatermarkMarker,
+} from './protocol-helpers.mjs';
+
+const MARKER_TYPES = ['claimed-by', 'review-watermark', 'review-baseline'];
+if (isCliExecution()) {
+  runCli();
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const type = args.type;
+  if (!type || !MARKER_TYPES.includes(type)) {
+    throw new Error(
+      `--type is required and must be one of: ${MARKER_TYPES.join(', ')}`,
+    );
+  }
+  let body;
+  if (type === 'claimed-by') {
+    body = renderClaimedByMarker({
+      agentId: args['agent-id'],
+      claimId: args['claim-id'],
+      supersedes: args.supersedes,
+      timestamp: args.timestamp,
+      branch: args.branch,
+    });
+  } else if (type === 'review-watermark') {
+    body = renderReviewWatermarkMarker({
+      agentId: args['agent-id'],
+      claimId: args['claim-id'],
+      headSha: args['head-sha'],
+      maxActivityAt: args['max-activity-at'],
+      totalItemCount: args['total-item-count'],
+      ciCompletedAt: args['ci-completed-at'],
+    });
+  } else {
+    body = renderReviewBaselineMarker({
+      agentId: args['agent-id'],
+      claimId: args['claim-id'],
+      sha: args.sha,
+    });
+  }
+  process.stdout.write(`${body}\n`);
+}
+function parseArgs(argv) {
+  const parsed = { type: '', help: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    if (!token.startsWith('--')) {
+      throw new Error(`unknown argument: ${token}`);
+    }
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`missing value for argument: ${token}`);
+    }
+    parsed[key] = value;
+    index += 1;
+  }
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/emit-marker.mjs --type claimed-by --agent-id <id> --claim-id <id> --supersedes <id|none> --timestamp <ISO8601> --branch <name>
+  node scripts/emit-marker.mjs --type review-watermark --agent-id <id> --claim-id <id> --head-sha <sha> --max-activity-at <ISO8601|none> --total-item-count <n> --ci-completed-at <ISO8601|none>
+  node scripts/emit-marker.mjs --type review-baseline --agent-id <id> --claim-id <id> --sha <sha>
+
+Prints the exact ready-to-post marker body (HTML token + visible note) to
+stdout. Emit-only: performs no network write. Post it via the documented
+HTTP path. The written marker formats remain the canonical fallback.
+`);
+}
+function isCliExecution() {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -192,6 +192,15 @@ const HELPER_COMMANDS = [
       'Compute the canonical A5(e) issue/<number>-<slug> branch name from an issue number and title.',
   },
   {
+    id: 'emit-marker',
+    scriptName: 'idd:emit-marker',
+    binName: 'idd-emit-marker',
+    entryPath: 'scripts/emit-marker.mjs',
+    vendoredCommand: 'node scripts/emit-marker.mjs',
+    description:
+      'Emit a per-cycle claimed-by / review-watermark / review-baseline marker body (emit-only, no network write).',
+  },
+  {
     id: 'ci-wait-policy',
     scriptName: 'idd:ci-wait-policy',
     binName: 'idd-ci-wait-policy',

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -368,11 +368,19 @@ export function renderExternalCheckWaiverComment(payload) {
 // fallback is unaffected. The written formats in idd-overview-core (claim)
 // and idd-review-snapshot (watermark/baseline) remain canonical.
 function normalizeMarkerCount(value) {
-  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
-    return String(value);
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : null;
   }
   const trimmed = String(value ?? '').trim();
-  return /^\d+$/.test(trimmed) ? trimmed : null;
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+  // The watermark parser reads the count back with Number.parseInt; reject
+  // magnitudes beyond the safe-integer range, which would not round-trip to
+  // the same value (and as a JS number would stringify to exponential form
+  // that the parser's `\d+` count pattern rejects outright).
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? trimmed : null;
 }
 // `none` or a valid ISO timestamp (matching the watermark parser's
 // none-or-ISO contract); null signals an invalid value the caller rejects.

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -359,6 +359,81 @@ export function renderExternalCheckWaiverComment(payload) {
     }),
   ].join('\n');
 }
+// --- Per-cycle marker body renderers (#900) ---
+//
+// Pure, network-free renderers for the three operational markers an agent
+// posts every cycle. Each returns the exact ready-to-post body (HTML marker
+// token + visible "Do not edit" note); the agent still posts it via the
+// documented HTTP path, so the read-only-by-default / instructions-only
+// fallback is unaffected. The written formats in idd-overview-core (claim)
+// and idd-review-snapshot (watermark/baseline) remain canonical.
+function normalizeMarkerCount(value) {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+    return String(value);
+  }
+  const trimmed = String(value ?? '').trim();
+  return /^\d+$/.test(trimmed) ? trimmed : null;
+}
+// `none` or a valid ISO timestamp (matching the watermark parser's
+// none-or-ISO contract); null signals an invalid value the caller rejects.
+function normalizeMarkerIsoOrNone(value) {
+  const token = normalizeNonWhitespaceToken(value);
+  if (token === '' || token === 'none') {
+    return 'none';
+  }
+  return normalizeIsoTimestamp(token) || null;
+}
+export function renderClaimedByMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const supersedes = normalizeNonWhitespaceToken(payload?.supersedes) || 'none';
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  const branch = normalizeBranchToken(payload?.branch);
+  if (!agentId || !claimId || !timestamp || !branch) {
+    throw new Error('invalid claimed-by marker payload');
+  }
+  return [
+    `<!-- claimed-by: ${agentId} ${claimId} supersedes: ${supersedes} ${timestamp} branch: ${branch} -->`,
+    '',
+    `_${agentId}: issue claim — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+export function renderReviewWatermarkMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const maxActivityAt = normalizeMarkerIsoOrNone(payload?.maxActivityAt);
+  const totalItemCount = normalizeMarkerCount(payload?.totalItemCount);
+  const ciCompletedAt = normalizeMarkerIsoOrNone(payload?.ciCompletedAt);
+  if (
+    !agentId ||
+    !claimId ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    maxActivityAt === null ||
+    totalItemCount === null ||
+    ciCompletedAt === null
+  ) {
+    throw new Error('invalid review-watermark marker payload');
+  }
+  return [
+    `<!-- review-watermark: ${agentId} ${claimId} ${headSha} ${maxActivityAt} ${totalItemCount} ${ciCompletedAt} -->`,
+    '',
+    `_${agentId}: review triage snapshot — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+export function renderReviewBaselineMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const sha = normalizeNonWhitespaceToken(payload?.sha);
+  if (!agentId || !claimId || !sha) {
+    throw new Error('invalid review-baseline marker payload');
+  }
+  return [
+    `<!-- review-baseline: ${agentId} ${claimId} ${sha} -->`,
+    '',
+    `_${agentId}: critique baseline — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
 function matchCheckSelectorLocal(name, selector) {
   const n = String(name ?? '').trim();
   const s = String(selector ?? '').trim();

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -386,7 +386,17 @@ function normalizeMarkerIsoOrNone(value) {
 export function renderClaimedByMarker(payload) {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const supersedes = normalizeNonWhitespaceToken(payload?.supersedes) || 'none';
+  const supersedesToken = normalizeNonWhitespaceToken(payload?.supersedes);
+  // Normalize any case-variant of the sentinel to lowercase `none`. The claim
+  // parser matches case-insensitively, but the claim lifecycle
+  // (`applyClaimEvent`) accepts a fresh claim only when `supersedes === 'none'`
+  // exactly, so an emitted `None`/`NONE` would round-trip into a claim that is
+  // silently ignored. Real claim IDs (never a case-variant of `none`) pass
+  // through verbatim.
+  const supersedes =
+    supersedesToken === '' || supersedesToken.toLowerCase() === 'none'
+      ? 'none'
+      : supersedesToken;
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
   const branch = normalizeBranchToken(payload?.branch);
   if (!agentId || !claimId || !timestamp || !branch) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -424,8 +424,8 @@ export function renderReviewWatermarkMarker(payload) {
 export function renderReviewBaselineMarker(payload) {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const sha = normalizeNonWhitespaceToken(payload?.sha);
-  if (!agentId || !claimId || !sha) {
+  const sha = normalizeNonWhitespaceToken(payload?.sha).toLowerCase();
+  if (!agentId || !claimId || !/^[0-9a-f]{40}$/.test(sha)) {
     throw new Error('invalid review-baseline marker payload');
   }
   return [

--- a/src/bin/idd-emit-marker.mts
+++ b/src/bin/idd-emit-marker.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-emit-marker.mts
+//
+// The bin/idd-emit-marker.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/emit-marker.mjs');

--- a/src/scripts/emit-marker.mts
+++ b/src/scripts/emit-marker.mts
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/emit-marker.mts
+//
+// The scripts/emit-marker.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Emit-only CLI for the three per-cycle operational marker bodies
+// (claimed-by / review-watermark / review-baseline). It prints the
+// ready-to-post body string to stdout and performs NO network write; the
+// agent posts it via the documented HTTP path. The render logic lives in
+// protocol-helpers; this is the thin CLI surface.
+
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  renderClaimedByMarker,
+  renderReviewBaselineMarker,
+  renderReviewWatermarkMarker,
+} from './protocol-helpers.mts';
+
+const MARKER_TYPES = ['claimed-by', 'review-watermark', 'review-baseline'];
+
+if (isCliExecution()) {
+  runCli();
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const type = args.type;
+  if (!type || !MARKER_TYPES.includes(type)) {
+    throw new Error(
+      `--type is required and must be one of: ${MARKER_TYPES.join(', ')}`,
+    );
+  }
+
+  let body: string;
+  if (type === 'claimed-by') {
+    body = renderClaimedByMarker({
+      agentId: args['agent-id'],
+      claimId: args['claim-id'],
+      supersedes: args.supersedes,
+      timestamp: args.timestamp,
+      branch: args.branch,
+    });
+  } else if (type === 'review-watermark') {
+    body = renderReviewWatermarkMarker({
+      agentId: args['agent-id'],
+      claimId: args['claim-id'],
+      headSha: args['head-sha'],
+      maxActivityAt: args['max-activity-at'],
+      totalItemCount: args['total-item-count'],
+      ciCompletedAt: args['ci-completed-at'],
+    });
+  } else {
+    body = renderReviewBaselineMarker({
+      agentId: args['agent-id'],
+      claimId: args['claim-id'],
+      sha: args.sha,
+    });
+  }
+
+  process.stdout.write(`${body}\n`);
+}
+
+interface ParsedArgs {
+  type: string;
+  help: boolean;
+  [key: string]: string | boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { type: '', help: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    if (!token.startsWith('--')) {
+      throw new Error(`unknown argument: ${token}`);
+    }
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`missing value for argument: ${token}`);
+    }
+    parsed[key] = value;
+    index += 1;
+  }
+  return parsed;
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/emit-marker.mjs --type claimed-by --agent-id <id> --claim-id <id> --supersedes <id|none> --timestamp <ISO8601> --branch <name>
+  node scripts/emit-marker.mjs --type review-watermark --agent-id <id> --claim-id <id> --head-sha <sha> --max-activity-at <ISO8601|none> --total-item-count <n> --ci-completed-at <ISO8601|none>
+  node scripts/emit-marker.mjs --type review-baseline --agent-id <id> --claim-id <id> --sha <sha>
+
+Prints the exact ready-to-post marker body (HTML token + visible note) to
+stdout. Emit-only: performs no network write. Post it via the documented
+HTTP path. The written marker formats remain the canonical fallback.
+`);
+}
+
+function isCliExecution(): boolean {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -264,6 +264,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
       'Compute the canonical A5(e) issue/<number>-<slug> branch name from an issue number and title.',
   },
   {
+    id: 'emit-marker',
+    scriptName: 'idd:emit-marker',
+    binName: 'idd-emit-marker',
+    entryPath: 'scripts/emit-marker.mjs',
+    vendoredCommand: 'node scripts/emit-marker.mjs',
+    description:
+      'Emit a per-cycle claimed-by / review-watermark / review-baseline marker body (emit-only, no network write).',
+  },
+  {
     id: 'ci-wait-policy',
     scriptName: 'idd:ci-wait-policy',
     binName: 'idd-ci-wait-policy',

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -865,6 +865,104 @@ export function renderExternalCheckWaiverComment(
   ].join('\n');
 }
 
+// --- Per-cycle marker body renderers (#900) ---
+//
+// Pure, network-free renderers for the three operational markers an agent
+// posts every cycle. Each returns the exact ready-to-post body (HTML marker
+// token + visible "Do not edit" note); the agent still posts it via the
+// documented HTTP path, so the read-only-by-default / instructions-only
+// fallback is unaffected. The written formats in idd-overview-core (claim)
+// and idd-review-snapshot (watermark/baseline) remain canonical.
+
+function normalizeMarkerCount(value: unknown): string | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+    return String(value);
+  }
+  const trimmed = String(value ?? '').trim();
+  return /^\d+$/.test(trimmed) ? trimmed : null;
+}
+
+// `none` or a valid ISO timestamp (matching the watermark parser's
+// none-or-ISO contract); null signals an invalid value the caller rejects.
+function normalizeMarkerIsoOrNone(value: unknown): string | null {
+  const token = normalizeNonWhitespaceToken(value);
+  if (token === '' || token === 'none') {
+    return 'none';
+  }
+  return normalizeIsoTimestamp(token) || null;
+}
+
+export function renderClaimedByMarker(payload: {
+  agentId?: unknown;
+  claimId?: unknown;
+  supersedes?: unknown;
+  timestamp?: unknown;
+  branch?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const supersedes = normalizeNonWhitespaceToken(payload?.supersedes) || 'none';
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  const branch = normalizeBranchToken(payload?.branch);
+  if (!agentId || !claimId || !timestamp || !branch) {
+    throw new Error('invalid claimed-by marker payload');
+  }
+  return [
+    `<!-- claimed-by: ${agentId} ${claimId} supersedes: ${supersedes} ${timestamp} branch: ${branch} -->`,
+    '',
+    `_${agentId}: issue claim — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+
+export function renderReviewWatermarkMarker(payload: {
+  agentId?: unknown;
+  claimId?: unknown;
+  headSha?: unknown;
+  maxActivityAt?: unknown;
+  totalItemCount?: unknown;
+  ciCompletedAt?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const maxActivityAt = normalizeMarkerIsoOrNone(payload?.maxActivityAt);
+  const totalItemCount = normalizeMarkerCount(payload?.totalItemCount);
+  const ciCompletedAt = normalizeMarkerIsoOrNone(payload?.ciCompletedAt);
+  if (
+    !agentId ||
+    !claimId ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    maxActivityAt === null ||
+    totalItemCount === null ||
+    ciCompletedAt === null
+  ) {
+    throw new Error('invalid review-watermark marker payload');
+  }
+  return [
+    `<!-- review-watermark: ${agentId} ${claimId} ${headSha} ${maxActivityAt} ${totalItemCount} ${ciCompletedAt} -->`,
+    '',
+    `_${agentId}: review triage snapshot — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+
+export function renderReviewBaselineMarker(payload: {
+  agentId?: unknown;
+  claimId?: unknown;
+  sha?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const sha = normalizeNonWhitespaceToken(payload?.sha);
+  if (!agentId || !claimId || !sha) {
+    throw new Error('invalid review-baseline marker payload');
+  }
+  return [
+    `<!-- review-baseline: ${agentId} ${claimId} ${sha} -->`,
+    '',
+    `_${agentId}: critique baseline — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+
 function matchCheckSelectorLocal(name: unknown, selector: unknown): boolean {
   const n = String(name ?? '').trim();
   const s = String(selector ?? '').trim();

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -952,8 +952,8 @@ export function renderReviewBaselineMarker(payload: {
 }): string {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const sha = normalizeNonWhitespaceToken(payload?.sha);
-  if (!agentId || !claimId || !sha) {
+  const sha = normalizeNonWhitespaceToken(payload?.sha).toLowerCase();
+  if (!agentId || !claimId || !/^[0-9a-f]{40}$/.test(sha)) {
     throw new Error('invalid review-baseline marker payload');
   }
   return [

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -901,7 +901,17 @@ export function renderClaimedByMarker(payload: {
 }): string {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const supersedes = normalizeNonWhitespaceToken(payload?.supersedes) || 'none';
+  const supersedesToken = normalizeNonWhitespaceToken(payload?.supersedes);
+  // Normalize any case-variant of the sentinel to lowercase `none`. The claim
+  // parser matches case-insensitively, but the claim lifecycle
+  // (`applyClaimEvent`) accepts a fresh claim only when `supersedes === 'none'`
+  // exactly, so an emitted `None`/`NONE` would round-trip into a claim that is
+  // silently ignored. Real claim IDs (never a case-variant of `none`) pass
+  // through verbatim.
+  const supersedes =
+    supersedesToken === '' || supersedesToken.toLowerCase() === 'none'
+      ? 'none'
+      : supersedesToken;
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
   const branch = normalizeBranchToken(payload?.branch);
   if (!agentId || !claimId || !timestamp || !branch) {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -875,11 +875,19 @@ export function renderExternalCheckWaiverComment(
 // and idd-review-snapshot (watermark/baseline) remain canonical.
 
 function normalizeMarkerCount(value: unknown): string | null {
-  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
-    return String(value);
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : null;
   }
   const trimmed = String(value ?? '').trim();
-  return /^\d+$/.test(trimmed) ? trimmed : null;
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+  // The watermark parser reads the count back with Number.parseInt; reject
+  // magnitudes beyond the safe-integer range, which would not round-trip to
+  // the same value (and as a JS number would stringify to exponential form
+  // that the parser's `\d+` count pattern rejects outright).
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? trimmed : null;
 }
 
 // `none` or a valid ISO timestamp (matching the watermark parser's

--- a/tests/emit-marker.test.mts
+++ b/tests/emit-marker.test.mts
@@ -175,4 +175,8 @@ test('renderers reject payloads that would not round-trip', () => {
   assert.throws(() =>
     renderReviewBaselineMarker({ agentId: 'a', claimId: 'c', sha: '' }),
   );
+  // non-40-hex baseline SHA (baseline tracks HEAD; must be a real commit SHA)
+  assert.throws(() =>
+    renderReviewBaselineMarker({ agentId: 'a', claimId: 'c', sha: 'deadbeef' }),
+  );
 });

--- a/tests/emit-marker.test.mts
+++ b/tests/emit-marker.test.mts
@@ -102,6 +102,19 @@ test('renderReviewWatermarkMarker accepts a numeric-string count and defaults no
   );
 });
 
+test('renderReviewWatermarkMarker accepts a count up to the safe-integer max', () => {
+  const max = Number.MAX_SAFE_INTEGER;
+  assert.match(
+    renderReviewWatermarkMarker({
+      agentId: 'a',
+      claimId: 'c',
+      headSha: SHA,
+      totalItemCount: max,
+    }),
+    new RegExp(` ${max} none `),
+  );
+});
+
 test('renderReviewBaselineMarker emits the exact baseline body', () => {
   assert.equal(
     renderReviewBaselineMarker({ agentId: 'a', claimId: 'c', sha: SHA }),
@@ -198,6 +211,24 @@ test('renderers reject payloads that would not round-trip', () => {
       claimId: 'c',
       headSha: SHA,
       totalItemCount: -1,
+    }),
+  );
+  // count beyond the safe-integer range (watermark parser reads it back with
+  // Number.parseInt; a huge digit string or exponential number cannot round-trip)
+  assert.throws(() =>
+    renderReviewWatermarkMarker({
+      agentId: 'a',
+      claimId: 'c',
+      headSha: SHA,
+      totalItemCount: '99999999999999999999',
+    }),
+  );
+  assert.throws(() =>
+    renderReviewWatermarkMarker({
+      agentId: 'a',
+      claimId: 'c',
+      headSha: SHA,
+      totalItemCount: 1e21,
     }),
   );
   assert.throws(() =>

--- a/tests/emit-marker.test.mts
+++ b/tests/emit-marker.test.mts
@@ -48,6 +48,34 @@ test('renderClaimedByMarker defaults supersedes to none and carries a takeover i
   );
 });
 
+test('renderClaimedByMarker normalizes any case-variant of the none sentinel', () => {
+  // applyClaimEvent only treats `supersedes === 'none'` (exact lowercase) as a
+  // fresh claim, so the renderer must fold case-variants down to lowercase.
+  for (const variant of ['None', 'NONE', 'nOnE']) {
+    assert.match(
+      renderClaimedByMarker({
+        agentId: 'a',
+        claimId: 'c',
+        supersedes: variant,
+        timestamp: '2026-06-17T09:47:08Z',
+        branch: 'b',
+      }),
+      /supersedes: none /,
+    );
+  }
+  // a real prior claim id (never a case-variant of none) passes through verbatim
+  assert.match(
+    renderClaimedByMarker({
+      agentId: 'a',
+      claimId: 'c',
+      supersedes: 'AbCdEf12',
+      timestamp: '2026-06-17T09:47:08Z',
+      branch: 'b',
+    }),
+    /supersedes: AbCdEf12 /,
+  );
+});
+
 test('renderReviewWatermarkMarker emits the exact watermark body', () => {
   assert.equal(
     renderReviewWatermarkMarker({

--- a/tests/emit-marker.test.mts
+++ b/tests/emit-marker.test.mts
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  parseClaimComment,
+  parseReviewWatermarkComment,
+  renderClaimedByMarker,
+  renderReviewBaselineMarker,
+  renderReviewWatermarkMarker,
+} from '../src/scripts/protocol-helpers.mts';
+
+// A real 40-hex commit SHA — the watermark/claim parsers and the published
+// schemas require this exact shape, so the tests must use one.
+const SHA = '0123456789abcdef0123456789abcdef01234567';
+
+test('renderClaimedByMarker emits the exact claimed-by body', () => {
+  assert.equal(
+    renderClaimedByMarker({
+      agentId: 'claude-1cab217a',
+      claimId: 'abc123',
+      supersedes: 'none',
+      timestamp: '2026-06-17T09:47:08Z',
+      branch: 'issue/901-add-foo',
+    }),
+    '<!-- claimed-by: claude-1cab217a abc123 supersedes: none 2026-06-17T09:47:08Z branch: issue/901-add-foo -->\n\n_claude-1cab217a: issue claim — IDD automation marker. Do not edit._',
+  );
+});
+
+test('renderClaimedByMarker defaults supersedes to none and carries a takeover id', () => {
+  assert.match(
+    renderClaimedByMarker({
+      agentId: 'a',
+      claimId: 'c',
+      timestamp: '2026-06-17T09:47:08Z',
+      branch: 'b',
+    }),
+    /supersedes: none /,
+  );
+  assert.match(
+    renderClaimedByMarker({
+      agentId: 'a',
+      claimId: 'c',
+      supersedes: 'prior9',
+      timestamp: '2026-06-17T09:47:08Z',
+      branch: 'b',
+    }),
+    /supersedes: prior9 /,
+  );
+});
+
+test('renderReviewWatermarkMarker emits the exact watermark body', () => {
+  assert.equal(
+    renderReviewWatermarkMarker({
+      agentId: 'a',
+      claimId: 'c',
+      headSha: SHA,
+      maxActivityAt: '2026-06-17T10:00:00Z',
+      totalItemCount: 7,
+      ciCompletedAt: '2026-06-17T09:59:00Z',
+    }),
+    `<!-- review-watermark: a c ${SHA} 2026-06-17T10:00:00Z 7 2026-06-17T09:59:00Z -->\n\n_a: review triage snapshot — IDD automation marker. Do not edit._`,
+  );
+});
+
+test('renderReviewWatermarkMarker accepts a numeric-string count and defaults none fields', () => {
+  assert.equal(
+    renderReviewWatermarkMarker({
+      agentId: 'a',
+      claimId: 'c',
+      headSha: SHA,
+      totalItemCount: '0',
+    }),
+    `<!-- review-watermark: a c ${SHA} none 0 none -->\n\n_a: review triage snapshot — IDD automation marker. Do not edit._`,
+  );
+});
+
+test('renderReviewBaselineMarker emits the exact baseline body', () => {
+  assert.equal(
+    renderReviewBaselineMarker({ agentId: 'a', claimId: 'c', sha: SHA }),
+    `<!-- review-baseline: a c ${SHA} -->\n\n_a: critique baseline — IDD automation marker. Do not edit._`,
+  );
+});
+
+test('round-trip: rendered claim and watermark bodies satisfy their own parsers', () => {
+  const claimBody = renderClaimedByMarker({
+    agentId: 'claude-1cab217a',
+    claimId: 'abc123',
+    supersedes: 'none',
+    timestamp: '2026-06-17T09:47:08Z',
+    branch: 'issue/901-add-foo',
+  });
+  assert.ok(
+    parseClaimComment(claimBody, '2026-06-17T09:47:08Z'),
+    'claimed-by must round-trip',
+  );
+
+  const watermarkBody = renderReviewWatermarkMarker({
+    agentId: 'a',
+    claimId: 'c',
+    headSha: SHA,
+    maxActivityAt: '2026-06-17T10:00:00Z',
+    totalItemCount: 7,
+    ciCompletedAt: '2026-06-17T09:59:00Z',
+  });
+  assert.ok(
+    parseReviewWatermarkComment(watermarkBody, '2026-06-17T10:00:00Z'),
+    'review-watermark must round-trip',
+  );
+});
+
+test('renderers reject payloads that would not round-trip', () => {
+  // blank required tokens
+  assert.throws(() =>
+    renderClaimedByMarker({
+      agentId: '',
+      claimId: 'c',
+      timestamp: '2026-06-17T09:47:08Z',
+      branch: 'b',
+    }),
+  );
+  // fractional-second timestamp (claim parser requires second precision)
+  assert.throws(() =>
+    renderClaimedByMarker({
+      agentId: 'a',
+      claimId: 'c',
+      timestamp: '2026-06-17T09:47:08.123Z',
+      branch: 'b',
+    }),
+  );
+  // branch containing `>` (parser/schema forbid it)
+  assert.throws(() =>
+    renderClaimedByMarker({
+      agentId: 'a',
+      claimId: 'c',
+      timestamp: '2026-06-17T09:47:08Z',
+      branch: 'feat/>x',
+    }),
+  );
+  // non-40-hex head SHA (watermark parser requires [0-9a-f]{40})
+  assert.throws(() =>
+    renderReviewWatermarkMarker({
+      agentId: 'a',
+      claimId: 'c',
+      headSha: 'deadbeef',
+      totalItemCount: 0,
+    }),
+  );
+  // non-ISO activity timestamp
+  assert.throws(() =>
+    renderReviewWatermarkMarker({
+      agentId: 'a',
+      claimId: 'c',
+      headSha: SHA,
+      maxActivityAt: 'garbage',
+      totalItemCount: 0,
+    }),
+  );
+  // non-numeric / negative count
+  assert.throws(() =>
+    renderReviewWatermarkMarker({
+      agentId: 'a',
+      claimId: 'c',
+      headSha: SHA,
+      totalItemCount: 'abc',
+    }),
+  );
+  assert.throws(() =>
+    renderReviewWatermarkMarker({
+      agentId: 'a',
+      claimId: 'c',
+      headSha: SHA,
+      totalItemCount: -1,
+    }),
+  );
+  assert.throws(() =>
+    renderReviewBaselineMarker({ agentId: 'a', claimId: 'c', sha: '' }),
+  );
+});


### PR DESCRIPTION
## Summary

Adds pure render functions (`renderClaimedByMarker` / `renderReviewWatermarkMarker` / `renderReviewBaselineMarker`) in `protocol-helpers` plus an **emit-only** CLI so agents stop hand-formatting the `claimed-by` / `review-watermark` / `review-baseline` markers. Each renderer **validates its fields to the parser/schema contract** (40-hex head SHA, second-precision ISO timestamp, branch without `>`, case-folded `none` supersedes sentinel, non-negative count, `none`-or-ISO activity), so a rendered body always round-trips through its own parser.

- `protocol-helpers`: three renderers + field validation; byte-shape **and** render→parse round-trip tests
- `emit-marker` CLI (+ bin), registered in `HELPER_COMMANDS` and `package.json` bin so it resolves on package-manager / vendored-node profiles
- `idd-claim` + `idd-review-snapshot` reference the profile-selected emit-marker command helper-first; the hand-formatted bodies stay the canonical fallback
- `docs/idd-helper-scripts.md` documents it

Emit-only — no network write; the agent posts via the documented HTTP path.

## Bundle ratchet (callout)

Sets `bundle-discovery` `limitBytes` to **83236** (the measured merged bundle total). On the original branch the change was **82466 → 82684** (+218 for the idd-claim helper-first reference). After syncing `main` (#905, #907 expanded `idd-overview-core` / `idd-discover`, moving the base to **83018**), and because both deltas land on disjoint files, the merged bundle measures **83236** — so the diff now reads **83018 → 83236**, per the sync-manifest ratchet rule (limit records the measured count).

## Verification

`pnpm run build`, schema validation, `audit-docs --check`, and full lint (incl. 8 emit-marker tests with round-trip assertions) pass.

Closes #900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `idd-emit-marker` CLI utility for generating formatted marker comments in the IDD workflow.

* **Documentation**
  * Updated workflow instructions to leverage the new helper for rendering claim execution, review watermark, and review baseline marker comments.

* **Tests**
  * Added comprehensive test coverage for marker rendering and validation.

* **Chores**
  * Updated build and helper manifests to include the new marker emission utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->