### PR TITLE
docs(instructions): fix clarity nits from a v0.3.0 downstream adoption

### DIFF
--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -66,9 +66,10 @@ assumptions that did not hold when published may fail A4.5 checks
 waste agent time during work.
 
 **Prevention during drafting**: This bundle is where coherence, safety,
-and uniqueness should be validated **before** publishing. The three
-A4.5 prevention checks (coherence, safety, uniqueness) correspond to
-bucket escalation triggers during drafting:
+and uniqueness should be validated **before** publishing. A4.5 runs
+seven suitability checks; the three that drafting can most directly
+prevent (coherence, safety, uniqueness) correspond to bucket escalation
+triggers during drafting:
 
 - If an issue might be incoherent → escalate to `needs-decision` during
   drafting

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -95,8 +95,10 @@ Read the **issue-scope** value from the Project commands table in
   normal. When the
   roadmap path yields **zero candidates reaching A3.5** — i.e. A2
   enumerated no open execution leaves, or A3 filtered them all out as
-  blocked — fall back to **A0-O** before entering the A3 decision tree
-  (mirror of `orphan-first`). If candidates do reach A3.5 but it holds
+  blocked — fall back to **A0-O** before entering the A3 decision tree.
+  This reuses the A0-O orphan search **only** as a post-roadmap fallback;
+  the roadmap path stays primary (unlike `orphan-first`, where A0-O is the
+  first path). If candidates do reach A3.5 but it holds
   them all as
   approval-needed, do **not** fall back: A3.5's stop/ask behavior
   governs, so the fallback never re-scopes around the approval gate.
@@ -150,10 +152,15 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 If at least one orphan issue remains after the configured policy is
 applied: pass the remaining set directly to **A3.5**. Skip A1–A3.
 
-If no orphan issues remain after the configured policy is applied: fall
-back to the roadmap path. Proceed to **A1** and continue with the normal
-A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence. (For the `roadmap-first`
-fallback, the guard above redirects this exit to A3.)
+If no orphan issues remain after the configured policy is applied, the
+next step depends on which path invoked A0-O:
+
+- **`orphan-first` primary path**: fall back to the roadmap path. Proceed
+  to **A1** and continue with the normal
+  A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence.
+- **`roadmap-first` fallback**: the roadmap path already ran, so do **not**
+  re-enter A1. Per the guard at the top of A0-O, this exit goes straight to
+  the **A3 decision tree**.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: for

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -194,10 +194,13 @@ When in scope, run:
 or `idd-doctor` finds that a commit already landed on the wrong branch —
 typically the primary worktree's `main`, or another issue's branch —
 recover by **cherry-picking** the misplaced commit onto the correct issue
-branch (in its own sibling worktree), then restore the contaminated branch
-to its intended state (e.g. `git reset --hard` the contaminated branch back
-to its upstream). Do **not** force-push the contaminated branch as a
-shortcut: preserve that branch's real history and move only the misplaced
+branch (in its own sibling worktree), then restore the contaminated
+branch. If the contaminated branch is **unpushed** (typically the primary
+worktree's `main`), `git reset --hard` it back to its upstream. If it was
+**already pushed or shared**, do **not** `git reset --hard` then force-push
+to erase the misplaced commit — that is the forbidden force-push; instead
+`git revert` the misplaced change, or let the operator evacuate the branch.
+Either way, preserve that branch's real history and move only the misplaced
 commit.
 
 Out of scope and explicitly **not** blocked:

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -125,8 +125,9 @@ returns the workflow to E1 instead of merging over it.
   Structural ack-only carve-out: when the only trigger above is newer
   activity or count growth, and the helper evidence proves it consists
   solely of post-disposition acknowledgements from the configured
-  advisory bots (`reviewCurrency.live.ackOnly` items with the
-  `effective` values current; `comparisonReason:
+  advisory bots (the `reviewCurrency.live.ackOnly.items` are all
+  ack-only, with the sibling `reviewCurrency.live.effective` values
+  current and `reviewCurrency.comparisonReason:
   ack-only-post-disposition`), the advisory courtesy-ack convergence
   rule in `idd-review-triage.instructions.md` applies: do not return to
   E1 for that activity alone. The agent still confirms the semantic

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -398,8 +398,10 @@ E1; continue to F-phase on the current HEAD SHA.
 identity is configured (`advisoryBotLogins` in `.github/idd/config.json`,
 the `--advisory-bot-logins` flag, or `IDD_ADVISORY_BOT_LOGINS`), the
 activity-snapshot and `pre-merge-readiness` evidence emits the structural
-part of this classification (`ackOnly` items, `effective` activity values,
-and `comparisonReason: ack-only-post-disposition`). The agent still owns
+part of this classification (the `reviewCurrency.live.ackOnly.items`, the
+sibling `reviewCurrency.live.effective` activity values, and
+`reviewCurrency.comparisonReason: ack-only-post-disposition`). The agent
+still owns
 the semantic residual — confirming the ack raises no new actionable
 finding — and the evidence never weakens the disposition-evidence or
 unreplied-comment gates, which remain the backstop.

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 82466
+      "limitBytes": 83018
     },
     {
       "id": "bundle-resume",

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -96,8 +96,10 @@ Read the **issue-scope** value from the Project commands table in
   normal. When the
   roadmap path yields **zero candidates reaching A3.5** — i.e. A2
   enumerated no open execution leaves, or A3 filtered them all out as
-  blocked — fall back to **A0-O** before entering the A3 decision tree
-  (mirror of `orphan-first`). If candidates do reach A3.5 but it holds
+  blocked — fall back to **A0-O** before entering the A3 decision tree.
+  This reuses the A0-O orphan search **only** as a post-roadmap fallback;
+  the roadmap path stays primary (unlike `orphan-first`, where A0-O is the
+  first path). If candidates do reach A3.5 but it holds
   them all as
   approval-needed, do **not** fall back: A3.5's stop/ask behavior
   governs, so the fallback never re-scopes around the approval gate.
@@ -153,10 +155,15 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 If at least one orphan issue remains after the configured policy is
 applied: pass the remaining set directly to **A3.5**. Skip A1–A3.
 
-If no orphan issues remain after the configured policy is applied: fall
-back to the roadmap path. Proceed to **A1** and continue with the normal
-A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence. (For the `roadmap-first`
-fallback, the guard above redirects this exit to A3.)
+If no orphan issues remain after the configured policy is applied, the
+next step depends on which path invoked A0-O:
+
+- **`orphan-first` primary path**: fall back to the roadmap path. Proceed
+  to **A1** and continue with the normal
+  A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence.
+- **`roadmap-first` fallback**: the roadmap path already ran, so do **not**
+  re-enter A1. Per the guard at the top of A0-O, this exit goes straight to
+  the **A3 decision tree**.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: for

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -194,10 +194,13 @@ When in scope, run:
 or `idd-doctor` finds that a commit already landed on the wrong branch —
 typically the primary worktree's `main`, or another issue's branch —
 recover by **cherry-picking** the misplaced commit onto the correct issue
-branch (in its own sibling worktree), then restore the contaminated branch
-to its intended state (e.g. `git reset --hard` the contaminated branch back
-to its upstream). Do **not** force-push the contaminated branch as a
-shortcut: preserve that branch's real history and move only the misplaced
+branch (in its own sibling worktree), then restore the contaminated
+branch. If the contaminated branch is **unpushed** (typically the primary
+worktree's `main`), `git reset --hard` it back to its upstream. If it was
+**already pushed or shared**, do **not** `git reset --hard` then force-push
+to erase the misplaced commit — that is the forbidden force-push; instead
+`git revert` the misplaced change, or let the operator evacuate the branch.
+Either way, preserve that branch's real history and move only the misplaced
 commit.
 
 Out of scope and explicitly **not** blocked:

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -125,8 +125,9 @@ returns the workflow to E1 instead of merging over it.
   Structural ack-only carve-out: when the only trigger above is newer
   activity or count growth, and the helper evidence proves it consists
   solely of post-disposition acknowledgements from the configured
-  advisory bots (`reviewCurrency.live.ackOnly` items with the
-  `effective` values current; `comparisonReason:
+  advisory bots (the `reviewCurrency.live.ackOnly.items` are all
+  ack-only, with the sibling `reviewCurrency.live.effective` values
+  current and `reviewCurrency.comparisonReason:
   ack-only-post-disposition`), the advisory courtesy-ack convergence
   rule in `idd-review-triage.instructions.md` applies: do not return to
   E1 for that activity alone. The agent still confirms the semantic

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -398,8 +398,10 @@ E1; continue to F-phase on the current HEAD SHA.
 identity is configured (`advisoryBotLogins` in `.github/idd/config.json`,
 the `--advisory-bot-logins` flag, or `IDD_ADVISORY_BOT_LOGINS`), the
 activity-snapshot and `pre-merge-readiness` evidence emits the structural
-part of this classification (`ackOnly` items, `effective` activity values,
-and `comparisonReason: ack-only-post-disposition`). The agent still owns
+part of this classification (the `reviewCurrency.live.ackOnly.items`, the
+sibling `reviewCurrency.live.effective` activity values, and
+`reviewCurrency.comparisonReason: ack-only-post-disposition`). The agent
+still owns
 the semantic residual — confirming the ack raises no new actionable
 finding — and the evidence never weakens the disposition-evidence or
 unreplied-comment gates, which remain the backstop.

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -66,9 +66,10 @@ assumptions that did not hold when published may fail A4.5 checks
 waste agent time during work.
 
 **Prevention during drafting**: This bundle is where coherence, safety,
-and uniqueness should be validated **before** publishing. The three
-A4.5 prevention checks (coherence, safety, uniqueness) correspond to
-bucket escalation triggers during drafting:
+and uniqueness should be validated **before** publishing. A4.5 runs
+seven suitability checks; the three that drafting can most directly
+prevent (coherence, safety, uniqueness) correspond to bucket escalation
+triggers during drafting:
 
 - If an issue might be incoherent → escalate to `needs-decision` during
   drafting


### PR DESCRIPTION
## Summary

Apply the five prose-only clarity nits returned from adopting v0.3.0 into
a downstream repository. No behavioral change.

## Nits

1. **discover A0** — reword the `(mirror of orphan-first)` parenthetical
   so A0-O reads as a post-roadmap fallback only (roadmaps stay primary).
2. **discover A0-O "If no orphan issues remain"** — split into explicit
   orphan-first (→ A1) vs roadmap-first (→ A3 decision tree) branches,
   removing the self-contradiction.
3. **pre-merge / review-triage** — correct the ack-only evidence field
   paths: `reviewCurrency.live.ackOnly.items`, the sibling
   `reviewCurrency.live.effective`, and `reviewCurrency.comparisonReason`
   (the last two are not properties of the ackOnly items).
4. **overview-core wrong-branch recovery** — distinguish the unpushed case
   (`git reset --hard` is fine) from the already-pushed/shared case (no
   force-push; `git revert` or operator evacuate).
5. **issue-authoring workflow-boundary** — clarify A4.5 has seven checks;
   the three named (coherence/safety/uniqueness) are the
   drafting-preventable subset.

The issue's "Recorded telephono structure choices" section is explicitly
*no upstream change requested* and is untouched.

## Bundle budget

Nits 1/2/4 land in the `bundle-discovery` budget, which sat at exactly its
limit. Following the existing ratchet convention (e.g. #897 bumped
81920→82466), `audit/sync-manifest.json` `bundle-discovery.limitBytes` is
bumped to the new exact size (82466→83018).

## Verification

- `node scripts/audit-docs.mjs --check`, dprint / markdownlint / cspell,
  `biome check`, and `node --test` (952 pass) all pass.
- Canonical sources under `idd-template/` and `skills/issue-authoring/`;
  mirrors regenerated via `pnpm run docs:sync`.

Closes #893
