### PR TITLE
fix(helper-manifest): vendor validate-schemas runtime schema/fixture deps

### DIFF
--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -49,7 +49,8 @@ const SCRIPT_FILE_EXTENSIONS = ['.mjs', '.js', '.json'];
 // so the import-graph walk cannot discover them. A consumer that vendors
 // exactly `managedFiles` must still receive these or the helper crashes on a
 // missing path. The drift guard in tests/helper-runtime-manifest.test.mts
-// asserts each list stays a superset of every data path its helper references.
+// asserts the validate-schemas list below stays a superset of every data
+// path that helper references.
 const EXTRA_RUNTIME_FILES = new Map([
   ['scripts/advisory-wait-policy.mjs', ['schemas/policy.schema.json']],
   // validate-schemas validates every schema/fixture pair in its CLI `cases`

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -45,8 +45,42 @@ const PACKAGE_SPEC_PIN_HINT =
   'Pass --package-spec with a pinned tarball URL or reviewed commit archive when you need reproducible helper imports.';
 const NODE_ENGINES = '^22.22.2 || >=24';
 const SCRIPT_FILE_EXTENSIONS = ['.mjs', '.js', '.json'];
+// Runtime data files a helper reads at execution time (not via `import`),
+// so the import-graph walk cannot discover them. A consumer that vendors
+// exactly `managedFiles` must still receive these or the helper crashes on a
+// missing path. The drift guard in tests/helper-runtime-manifest.test.mts
+// asserts each list stays a superset of every data path its helper references.
 const EXTRA_RUNTIME_FILES = new Map([
   ['scripts/advisory-wait-policy.mjs', ['schemas/policy.schema.json']],
+  // validate-schemas validates every schema/fixture pair in its CLI `cases`
+  // table by reading the files directly; none of them are imported.
+  [
+    'scripts/validate-schemas.mjs',
+    [
+      'schemas/advisory-wait-state.schema.json',
+      'schemas/claim-marker.schema.json',
+      'schemas/forced-handoff-marker.schema.json',
+      'schemas/live-status-digest.schema.json',
+      'schemas/phase-graph.json',
+      'schemas/phase-graph.schema.json',
+      'schemas/policy.schema.json',
+      'schemas/pre-merge-readiness.schema.json',
+      'fixtures/schemas/advisory-wait-state.invalid.json',
+      'fixtures/schemas/advisory-wait-state.valid.json',
+      'fixtures/schemas/claim-marker.invalid.json',
+      'fixtures/schemas/claim-marker.valid.json',
+      'fixtures/schemas/forced-handoff-marker.invalid.json',
+      'fixtures/schemas/forced-handoff-marker.valid.json',
+      'fixtures/schemas/live-status-digest.invalid.json',
+      'fixtures/schemas/live-status-digest.valid.json',
+      'fixtures/schemas/phase-graph.invalid.json',
+      'fixtures/schemas/phase-graph.valid.json',
+      'fixtures/schemas/policy.invalid.json',
+      'fixtures/schemas/policy.valid.json',
+      'fixtures/schemas/pre-merge-readiness.invalid.json',
+      'fixtures/schemas/pre-merge-readiness.valid.json',
+    ],
+  ],
 ]);
 const HELPER_COMMANDS = [
   {

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -49,8 +49,8 @@ const SCRIPT_FILE_EXTENSIONS = ['.mjs', '.js', '.json'];
 // so the import-graph walk cannot discover them. A consumer that vendors
 // exactly `managedFiles` must still receive these or the helper crashes on a
 // missing path. The drift guard in tests/helper-runtime-manifest.test.mts
-// asserts the validate-schemas list below stays a superset of every data
-// path that helper references.
+// asserts the vendored-node managedFiles include every data path
+// validate-schemas references, so this list must stay complete.
 const EXTRA_RUNTIME_FILES = new Map([
   ['scripts/advisory-wait-policy.mjs', ['schemas/policy.schema.json']],
   // validate-schemas validates every schema/fixture pair in its CLI `cases`

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -116,8 +116,42 @@ const PACKAGE_SPEC_PIN_HINT =
   'Pass --package-spec with a pinned tarball URL or reviewed commit archive when you need reproducible helper imports.';
 const NODE_ENGINES = '^22.22.2 || >=24';
 const SCRIPT_FILE_EXTENSIONS = ['.mjs', '.js', '.json'];
+// Runtime data files a helper reads at execution time (not via `import`),
+// so the import-graph walk cannot discover them. A consumer that vendors
+// exactly `managedFiles` must still receive these or the helper crashes on a
+// missing path. The drift guard in tests/helper-runtime-manifest.test.mts
+// asserts each list stays a superset of every data path its helper references.
 const EXTRA_RUNTIME_FILES = new Map<string, string[]>([
   ['scripts/advisory-wait-policy.mjs', ['schemas/policy.schema.json']],
+  // validate-schemas validates every schema/fixture pair in its CLI `cases`
+  // table by reading the files directly; none of them are imported.
+  [
+    'scripts/validate-schemas.mjs',
+    [
+      'schemas/advisory-wait-state.schema.json',
+      'schemas/claim-marker.schema.json',
+      'schemas/forced-handoff-marker.schema.json',
+      'schemas/live-status-digest.schema.json',
+      'schemas/phase-graph.json',
+      'schemas/phase-graph.schema.json',
+      'schemas/policy.schema.json',
+      'schemas/pre-merge-readiness.schema.json',
+      'fixtures/schemas/advisory-wait-state.invalid.json',
+      'fixtures/schemas/advisory-wait-state.valid.json',
+      'fixtures/schemas/claim-marker.invalid.json',
+      'fixtures/schemas/claim-marker.valid.json',
+      'fixtures/schemas/forced-handoff-marker.invalid.json',
+      'fixtures/schemas/forced-handoff-marker.valid.json',
+      'fixtures/schemas/live-status-digest.invalid.json',
+      'fixtures/schemas/live-status-digest.valid.json',
+      'fixtures/schemas/phase-graph.invalid.json',
+      'fixtures/schemas/phase-graph.valid.json',
+      'fixtures/schemas/policy.invalid.json',
+      'fixtures/schemas/policy.valid.json',
+      'fixtures/schemas/pre-merge-readiness.invalid.json',
+      'fixtures/schemas/pre-merge-readiness.valid.json',
+    ],
+  ],
 ]);
 
 const HELPER_COMMANDS: HelperCommand[] = [

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -120,7 +120,8 @@ const SCRIPT_FILE_EXTENSIONS = ['.mjs', '.js', '.json'];
 // so the import-graph walk cannot discover them. A consumer that vendors
 // exactly `managedFiles` must still receive these or the helper crashes on a
 // missing path. The drift guard in tests/helper-runtime-manifest.test.mts
-// asserts each list stays a superset of every data path its helper references.
+// asserts the validate-schemas list below stays a superset of every data
+// path that helper references.
 const EXTRA_RUNTIME_FILES = new Map<string, string[]>([
   ['scripts/advisory-wait-policy.mjs', ['schemas/policy.schema.json']],
   // validate-schemas validates every schema/fixture pair in its CLI `cases`

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -120,8 +120,8 @@ const SCRIPT_FILE_EXTENSIONS = ['.mjs', '.js', '.json'];
 // so the import-graph walk cannot discover them. A consumer that vendors
 // exactly `managedFiles` must still receive these or the helper crashes on a
 // missing path. The drift guard in tests/helper-runtime-manifest.test.mts
-// asserts the validate-schemas list below stays a superset of every data
-// path that helper references.
+// asserts the vendored-node managedFiles include every data path
+// validate-schemas references, so this list must stay complete.
 const EXTRA_RUNTIME_FILES = new Map<string, string[]>([
   ['scripts/advisory-wait-policy.mjs', ['schemas/policy.schema.json']],
   // validate-schemas validates every schema/fixture pair in its CLI `cases`

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -91,6 +91,43 @@ test('vendored-node managed files match the canonical helper import closure', ()
   }
 });
 
+test('vendored-node managed files include every validate-schemas runtime data file', () => {
+  const managedFiles = new Set(
+    buildHelperRuntimeManifest({
+      profile: 'vendored-node',
+      targetRoot: REPO_ROOT,
+    }).profiles['vendored-node'].managedFiles.map((file) => file.targetPath),
+  );
+
+  // validate-schemas reads its schema/fixture pairs directly (its CLI `cases`
+  // table), not via `import`, so the import-graph walk cannot discover them.
+  // Parse the source for every data path it references and assert the vendored
+  // bundle ships all of them — a downstream that vendors exactly `managedFiles`
+  // must be able to run the validator. Guards the kurone-kito/idd-skill#891 drift.
+  const source = readFileSync(
+    join(REPO_ROOT, 'src/scripts/validate-schemas.mts'),
+    'utf8',
+  );
+  const referenced = [
+    ...new Set(
+      [
+        ...source.matchAll(/'((?:schemas|fixtures\/schemas)\/[^']+\.json)'/g),
+      ].map((match) => match[1]),
+    ),
+  ].sort();
+
+  assert.ok(
+    referenced.length > 0,
+    'expected validate-schemas to reference schema/fixture data files',
+  );
+  for (const dataFile of referenced) {
+    assert.ok(
+      managedFiles.has(dataFile),
+      `vendored-node managedFiles omits ${dataFile}, which validate-schemas reads at runtime`,
+    );
+  }
+});
+
 test('vendored-node recommends linguist-vendored per managed file; other profiles emit none', () => {
   const manifest = buildHelperRuntimeManifest({ targetRoot: REPO_ROOT });
   const vendored = manifest.profiles['vendored-node'];

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -111,8 +111,13 @@ test('vendored-node managed files include every validate-schemas runtime data fi
   const referenced = [
     ...new Set(
       [
-        ...source.matchAll(/'((?:schemas|fixtures\/schemas)\/[^']+\.json)'/g),
-      ].map((match) => match[1]),
+        // Match either quote style via a backreference so a future case
+        // written with double quotes is still captured (biome enforces single
+        // quotes today, but the guard must not silently depend on that).
+        ...source.matchAll(
+          /(['"])((?:schemas|fixtures\/schemas)\/[^'"]+\.json)\1/g,
+        ),
+      ].map((match) => match[2]),
     ),
   ].sort();
 


### PR DESCRIPTION
## Summary

`helper-runtime-manifest` derives the `vendored-node` `managedFiles` list
from the helper import graph, but `validate-schemas` reads its
schema/fixture pairs directly (its CLI `cases` table), not via `import`.
So a downstream that vendored exactly `managedFiles` got a
`validate-schemas` that crashed on the missing paths.

## Scope correction

The issue names `fixtures/schemas/*`, but validate-schemas reads **22**
data files and the manifest omitted **18** — the 14 fixtures it validates
**plus 4 schema files** (`claim-marker.schema.json`,
`live-status-digest.schema.json`, `phase-graph.json`,
`phase-graph.schema.json`). Adding only the fixtures would still crash on a
missing schema, so the fix registers validate-schemas' full runtime
dependency set.

## Changes

- `src/scripts/helper-runtime-manifest.mts`: add an `EXTRA_RUNTIME_FILES`
  entry for `scripts/validate-schemas.mjs` listing its 22 runtime
  schema + fixture paths (the existing mechanism for runtime data deps the
  import walk can't see). `scripts/helper-runtime-manifest.mjs` regenerated
  via `pnpm run build`.
- `tests/helper-runtime-manifest.test.mts`: a drift-guard test that parses
  validate-schemas for every schema/fixture path it references and asserts
  the vendored bundle ships all of them — prevents this omission class from
  recurring.

## Verification

- `node --test` (953 pass, incl. the new guard), `pnpm run build` (no
  diff), `tsc`, `biome check`, `node scripts/audit-docs.mjs --check`, and
  cspell all pass.
- End-to-end: vendoring only the new `managedFiles` into a clean dir and
  running `node scripts/validate-schemas.mjs` now passes (was crashing on
  the missing paths).

Closes #891
