### PR TITLE
feat(helpers): add merged-pr-feedback-sweep read-only detector

### DIFF
--- a/bin/idd-merged-pr-feedback-sweep.mjs
+++ b/bin/idd-merged-pr-feedback-sweep.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-merged-pr-feedback-sweep.mts
+//
+// The bin/idd-merged-pr-feedback-sweep.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/merged-pr-feedback-sweep.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -896,9 +896,9 @@ Interpretation rules:
     `advisoryBotLogins` author) so the operator can prioritize human feedback
     over capricious advisory-bot noise.
 - JSON output keys: `sweepWindow`, `trustedMarkerActors`,
-  `advisoryBotLogins`, `prs` (each entry has `number`, `mergedAt`,
-  `mergeCommit`, `unresolvedThreads`, and `unaddressedComments`), and
-  `summary` (`prCount`, `flaggedPrCount`, `unresolvedThreadCount`,
+  `advisoryBotLogins`, `iddAgentLogins`, `prs` (each entry has `number`,
+  `mergedAt`, `mergeCommit`, `unresolvedThreads`, and `unaddressedComments`),
+  and `summary` (`prCount`, `flaggedPrCount`, `unresolvedThreadCount`,
   `unaddressedCommentCount`).
 - Read-only boundary: the helper performs no minimization, no posting, and no
   issue creation. **Handoff**: the JSON is the input an operator hands to the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -108,6 +108,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/cleanup-hygiene-report.mjs` for post-merge cleanup hygiene
   metrics aggregation and trend reporting (referenced in
   [kurone-kito/idd-skill#438](https://github.com/kurone-kito/idd-skill/issues/438))
+- `scripts/merged-pr-feedback-sweep.mjs` for read-only detection of
+  unresolved / unaddressed advisory feedback on merged PRs, fed manually to
+  the issue-authoring skill (referenced in
+  [kurone-kito/idd-skill#931](https://github.com/kurone-kito/idd-skill/issues/931))
 
 **Utility and Diagnostic Commands:**
 
@@ -861,6 +865,41 @@ Interpretation rules:
   it with the written Resume/S2-S4 checks for the same active claim,
   stale-threshold gating, closed/merged guards, and A5 race-safe claim
   verification. `quiet_window_met = true` alone is never sufficient.
+
+### Merged-PR feedback sweep
+
+- Source repo / vendored-node command:
+  `node scripts/merged-pr-feedback-sweep.mjs`
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd-merged-pr-feedback-sweep` command
+- A **manually-invoked**, read-only detector (no schedule, no mutation). It
+  scans MERGED PRs and surfaces feedback that was left unattended at merge:
+  - **Window selector**: `--since <ISO8601>` and/or `--days <N>`, or
+    `--pr <n>` (repeatable) / `--prs <n1,n2,...>`; `--limit <N>` caps the
+    `--since`/`--days` enumeration. Optional `--owner`, `--repo`,
+    `--trusted-marker-logins`, and `--advisory-bot-logins` (same convention
+    as `review-activity-snapshot`).
+  - **Surfaces**: review threads with `isResolved == false` (excluding
+    threads the IDD agent itself opened; each carries a `dispositioned` flag
+    from the in-thread disposition check), and regular comments /
+    `CHANGES_REQUESTED` review bodies from non-IDD-agent authors that have
+    **no later IDD-agent disposition** (`**Accepted**` / `**Rejected**` /
+    `**Awaiting maintainer decision**`). Trusted IDD operational markers and
+    IDD disposition comments are excluded from the feedback set. Each finding
+    carries an `advisoryBot` flag (`isKnownReviewBot` or a configured
+    `advisoryBotLogins` author) so the operator can prioritize human feedback
+    over capricious advisory-bot noise.
+- JSON output keys: `sweepWindow`, `trustedMarkerActors`,
+  `advisoryBotLogins`, `prs` (each entry has `number`, `mergedAt`,
+  `mergeCommit`, `unresolvedThreads`, and `unaddressedComments`), and
+  `summary` (`prCount`, `flaggedPrCount`, `unresolvedThreadCount`,
+  `unaddressedCommentCount`).
+- Read-only boundary: the helper performs no minimization, no posting, and no
+  issue creation. **Handoff**: the JSON is the input an operator hands to the
+  issue-authoring skill, which re-verifies each candidate against current
+  `main` (reuse-first / not-already-fixed) and drafts follow-up issues
+  bucketed by readiness. The helper does deterministic detection; the
+  judgment-heavy re-verification, drafting, and publish stay operator-gated.
 
 ## Friction Inventory
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -890,11 +890,13 @@ Interpretation rules:
     from the in-thread disposition check), and regular comments /
     `CHANGES_REQUESTED` review bodies from non-IDD-agent authors that have
     **no later IDD-agent disposition** (`**Accepted**` / `**Rejected**` /
-    `**Awaiting maintainer decision**`). Trusted IDD operational markers and
-    IDD disposition comments are excluded from the feedback set. Each finding
-    carries an `advisoryBot` flag (`isKnownReviewBot` or a configured
-    `advisoryBotLogins` author) so the operator can prioritize human feedback
-    over capricious advisory-bot noise.
+    `**Awaiting maintainer decision**`). Trusted IDD operational markers, IDD
+    disposition comments, and any HTML comment beginning with `<!-- idd-` (for
+    example cleanup-evidence, excluded regardless of author — including CI
+    automation such as `github-actions[bot]`) are excluded from the feedback
+    set. Each finding carries an `advisoryBot` flag (`isKnownReviewBot` or a
+    configured `advisoryBotLogins` author) so the operator can prioritize human
+    feedback over capricious advisory-bot noise.
 - JSON output keys: `sweepWindow`, `trustedMarkerActors`,
   `advisoryBotLogins`, `iddAgentLogins`, `prs` (each entry has `number`,
   `mergedAt`, `mergeCommit`, `unresolvedThreads`, and `unaddressedComments`),

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -876,7 +876,11 @@ Interpretation rules:
   scans MERGED PRs and surfaces feedback that was left unattended at merge:
   - **Window selector**: `--since <ISO8601>` and/or `--days <N>`, or
     `--pr <n>` (repeatable) / `--prs <n1,n2,...>`; `--limit <N>` caps the
-    `--since`/`--days` enumeration. Optional `--owner`, `--repo`,
+    `--since`/`--days` enumeration. When both `--since` and `--days` are
+    given, the later (more recent) cutoff wins, narrowing the window to the
+    intersection; `--pr`/`--prs` bypass the date window entirely, so the
+    reported `sweepWindow.since` and `days` are then `null`. Optional
+    `--owner`, `--repo`,
     `--trusted-marker-logins`, and `--advisory-bot-logins` (same convention
     as `review-activity-snapshot`). `--idd-agent-logins` (or
     `IDD_AGENT_LOGINS`) names the agent accounts whose comments are

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -878,7 +878,13 @@ Interpretation rules:
     `--pr <n>` (repeatable) / `--prs <n1,n2,...>`; `--limit <N>` caps the
     `--since`/`--days` enumeration. Optional `--owner`, `--repo`,
     `--trusted-marker-logins`, and `--advisory-bot-logins` (same convention
-    as `review-activity-snapshot`).
+    as `review-activity-snapshot`). `--idd-agent-logins` (or
+    `IDD_AGENT_LOGINS`) names the agent accounts whose comments are
+    dispositions / are not feedback — distinct from trusted-marker actors so a
+    human maintainer who is a trusted-marker actor still has their review
+    feedback surfaced; it defaults to the trusted-marker actors. Numeric flags
+    reject non-integer values, and the PR connections are paged to completion
+    so large PRs do not silently truncate.
   - **Surfaces**: review threads with `isResolved == false` (excluding
     threads the IDD agent itself opened; each carries a `dispositioned` flag
     from the in-thread disposition check), and regular comments /

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -896,9 +896,9 @@ Interpretation rules:
     `advisoryBotLogins` author) so the operator can prioritize human feedback
     over capricious advisory-bot noise.
 - JSON output keys: `sweepWindow`, `trustedMarkerActors`,
-  `advisoryBotLogins`, `prs` (each entry has `number`, `mergedAt`,
-  `mergeCommit`, `unresolvedThreads`, and `unaddressedComments`), and
-  `summary` (`prCount`, `flaggedPrCount`, `unresolvedThreadCount`,
+  `advisoryBotLogins`, `iddAgentLogins`, `prs` (each entry has `number`,
+  `mergedAt`, `mergeCommit`, `unresolvedThreads`, and `unaddressedComments`),
+  and `summary` (`prCount`, `flaggedPrCount`, `unresolvedThreadCount`,
   `unaddressedCommentCount`).
 - Read-only boundary: the helper performs no minimization, no posting, and no
   issue creation. **Handoff**: the JSON is the input an operator hands to the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -108,6 +108,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/cleanup-hygiene-report.mjs` for post-merge cleanup hygiene
   metrics aggregation and trend reporting (referenced in
   [kurone-kito/idd-skill#438](https://github.com/kurone-kito/idd-skill/issues/438))
+- `scripts/merged-pr-feedback-sweep.mjs` for read-only detection of
+  unresolved / unaddressed advisory feedback on merged PRs, fed manually to
+  the issue-authoring skill (referenced in
+  [kurone-kito/idd-skill#931](https://github.com/kurone-kito/idd-skill/issues/931))
 
 **Utility and Diagnostic Commands:**
 
@@ -861,6 +865,41 @@ Interpretation rules:
   it with the written Resume/S2-S4 checks for the same active claim,
   stale-threshold gating, closed/merged guards, and A5 race-safe claim
   verification. `quiet_window_met = true` alone is never sufficient.
+
+### Merged-PR feedback sweep
+
+- Source repo / vendored-node command:
+  `node scripts/merged-pr-feedback-sweep.mjs`
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd-merged-pr-feedback-sweep` command
+- A **manually-invoked**, read-only detector (no schedule, no mutation). It
+  scans MERGED PRs and surfaces feedback that was left unattended at merge:
+  - **Window selector**: `--since <ISO8601>` and/or `--days <N>`, or
+    `--pr <n>` (repeatable) / `--prs <n1,n2,...>`; `--limit <N>` caps the
+    `--since`/`--days` enumeration. Optional `--owner`, `--repo`,
+    `--trusted-marker-logins`, and `--advisory-bot-logins` (same convention
+    as `review-activity-snapshot`).
+  - **Surfaces**: review threads with `isResolved == false` (excluding
+    threads the IDD agent itself opened; each carries a `dispositioned` flag
+    from the in-thread disposition check), and regular comments /
+    `CHANGES_REQUESTED` review bodies from non-IDD-agent authors that have
+    **no later IDD-agent disposition** (`**Accepted**` / `**Rejected**` /
+    `**Awaiting maintainer decision**`). Trusted IDD operational markers and
+    IDD disposition comments are excluded from the feedback set. Each finding
+    carries an `advisoryBot` flag (`isKnownReviewBot` or a configured
+    `advisoryBotLogins` author) so the operator can prioritize human feedback
+    over capricious advisory-bot noise.
+- JSON output keys: `sweepWindow`, `trustedMarkerActors`,
+  `advisoryBotLogins`, `prs` (each entry has `number`, `mergedAt`,
+  `mergeCommit`, `unresolvedThreads`, and `unaddressedComments`), and
+  `summary` (`prCount`, `flaggedPrCount`, `unresolvedThreadCount`,
+  `unaddressedCommentCount`).
+- Read-only boundary: the helper performs no minimization, no posting, and no
+  issue creation. **Handoff**: the JSON is the input an operator hands to the
+  issue-authoring skill, which re-verifies each candidate against current
+  `main` (reuse-first / not-already-fixed) and drafts follow-up issues
+  bucketed by readiness. The helper does deterministic detection; the
+  judgment-heavy re-verification, drafting, and publish stay operator-gated.
 
 ## Friction Inventory
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -890,11 +890,13 @@ Interpretation rules:
     from the in-thread disposition check), and regular comments /
     `CHANGES_REQUESTED` review bodies from non-IDD-agent authors that have
     **no later IDD-agent disposition** (`**Accepted**` / `**Rejected**` /
-    `**Awaiting maintainer decision**`). Trusted IDD operational markers and
-    IDD disposition comments are excluded from the feedback set. Each finding
-    carries an `advisoryBot` flag (`isKnownReviewBot` or a configured
-    `advisoryBotLogins` author) so the operator can prioritize human feedback
-    over capricious advisory-bot noise.
+    `**Awaiting maintainer decision**`). Trusted IDD operational markers, IDD
+    disposition comments, and any HTML comment beginning with `<!-- idd-` (for
+    example cleanup-evidence, excluded regardless of author — including CI
+    automation such as `github-actions[bot]`) are excluded from the feedback
+    set. Each finding carries an `advisoryBot` flag (`isKnownReviewBot` or a
+    configured `advisoryBotLogins` author) so the operator can prioritize human
+    feedback over capricious advisory-bot noise.
 - JSON output keys: `sweepWindow`, `trustedMarkerActors`,
   `advisoryBotLogins`, `iddAgentLogins`, `prs` (each entry has `number`,
   `mergedAt`, `mergeCommit`, `unresolvedThreads`, and `unaddressedComments`),

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -876,7 +876,11 @@ Interpretation rules:
   scans MERGED PRs and surfaces feedback that was left unattended at merge:
   - **Window selector**: `--since <ISO8601>` and/or `--days <N>`, or
     `--pr <n>` (repeatable) / `--prs <n1,n2,...>`; `--limit <N>` caps the
-    `--since`/`--days` enumeration. Optional `--owner`, `--repo`,
+    `--since`/`--days` enumeration. When both `--since` and `--days` are
+    given, the later (more recent) cutoff wins, narrowing the window to the
+    intersection; `--pr`/`--prs` bypass the date window entirely, so the
+    reported `sweepWindow.since` and `days` are then `null`. Optional
+    `--owner`, `--repo`,
     `--trusted-marker-logins`, and `--advisory-bot-logins` (same convention
     as `review-activity-snapshot`). `--idd-agent-logins` (or
     `IDD_AGENT_LOGINS`) names the agent accounts whose comments are

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -878,7 +878,13 @@ Interpretation rules:
     `--pr <n>` (repeatable) / `--prs <n1,n2,...>`; `--limit <N>` caps the
     `--since`/`--days` enumeration. Optional `--owner`, `--repo`,
     `--trusted-marker-logins`, and `--advisory-bot-logins` (same convention
-    as `review-activity-snapshot`).
+    as `review-activity-snapshot`). `--idd-agent-logins` (or
+    `IDD_AGENT_LOGINS`) names the agent accounts whose comments are
+    dispositions / are not feedback — distinct from trusted-marker actors so a
+    human maintainer who is a trusted-marker actor still has their review
+    feedback surfaced; it defaults to the trusted-marker actors. Numeric flags
+    reject non-integer values, and the PR connections are paged to completion
+    so large PRs do not silently truncate.
   - **Surfaces**: review threads with `isResolved == false` (excluding
     threads the IDD agent itself opened; each carries a `dispositioned` flag
     from the in-thread disposition check), and regular comments /

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "idd-forced-handoff-marker": "./bin/idd-forced-handoff-marker.mjs",
     "idd-helper-bundle-manifest": "./bin/idd-helper-bundle-manifest.mjs",
     "idd-live-status-digest": "./bin/idd-live-status-digest.mjs",
+    "idd-merged-pr-feedback-sweep": "./bin/idd-merged-pr-feedback-sweep.mjs",
     "idd-phase-id-resolver": "./bin/idd-phase-id-resolver.mjs",
     "idd-pre-merge-readiness": "./bin/idd-pre-merge-readiness.mjs",
     "idd-resume-claim-routing": "./bin/idd-resume-claim-routing.mjs",

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -230,11 +230,12 @@ function collectUnaddressedComments(
   const out = [];
   for (const comment of comments) {
     const author = authorLogin(comment);
-    // IDD-agent comments (incl. their dispositions) are excluded by author
-    // here, so a disposition marker is treated specially only when the agent
-    // wrote it. A non-IDD reviewer who opens a comment with "**Rejected**" is
-    // still surfaced as feedback.
-    if (!author || isIdd(author)) {
+    // Only IDD-agent comments are excluded by author (their dispositions are
+    // folded into `latestDispositionAt`); a non-IDD reviewer who opens a
+    // comment with "**Rejected**" is still surfaced as feedback. A
+    // missing/unknown author (deleted user / ghost comment) is surfaced with
+    // `author: null` rather than dropped, to avoid a false negative.
+    if (isIdd(author)) {
       continue;
     }
     // IDD bookkeeping is not feedback: a trusted operational-state marker,
@@ -248,7 +249,7 @@ function collectUnaddressedComments(
     }
     out.push({
       url: comment.url ?? comment.html_url ?? null,
-      author,
+      author: author || null,
       advisoryBot: isAdvisoryBot(author),
       kind: 'comment',
       bodyExcerpt: excerpt(comment.body),
@@ -259,7 +260,9 @@ function collectUnaddressedComments(
       continue;
     }
     const author = authorLogin(review);
-    if (!author || isIdd(author)) {
+    // Same author rule as comments: exclude only explicit IDD agents; a
+    // missing/unknown author is surfaced with `author: null`.
+    if (isIdd(author)) {
       continue;
     }
     if (isLaterThan(latestDispositionAt, review.submittedAt ?? null)) {
@@ -267,7 +270,7 @@ function collectUnaddressedComments(
     }
     out.push({
       url: review.url ?? null,
-      author,
+      author: author || null,
       advisoryBot: isAdvisoryBot(author),
       kind: 'review',
       bodyExcerpt: excerpt(review.body),

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -35,8 +35,18 @@ function authorLogin(node) {
     .trim()
     .toLowerCase();
 }
+// Prefer the edited (`updatedAt`) timestamp over the created one so an
+// IDD disposition or a reviewer comment edited after posting is ordered by
+// when it last changed — matching protocol-helpers' freshness semantics and
+// avoiding a false-positive "unaddressed" finding for an edited disposition.
 function commentTimestamp(node) {
-  return node.createdAt ?? node.created_at ?? null;
+  return (
+    node.updatedAt ??
+    node.updated_at ??
+    node.createdAt ??
+    node.created_at ??
+    null
+  );
 }
 function excerpt(body, max = 160) {
   const flat = String(body ?? '')
@@ -224,7 +234,7 @@ function collectUnaddressedComments(
           (comment) =>
             isIdd(authorLogin(comment)) && isDispositionBody(comment.body),
         )
-        .map((comment) => comment.createdAt ?? null),
+        .map((comment) => comment.updatedAt ?? comment.createdAt ?? null),
     ),
   ]);
   const out = [];
@@ -506,7 +516,7 @@ function fetchMergedPr(owner, repo, number) {
       repo,
       number,
       'comments',
-      'body url createdAt author{ login }',
+      'body url createdAt updatedAt author{ login }',
     ),
     reviews: fetchAllNodes(
       owner,
@@ -520,7 +530,7 @@ function fetchMergedPr(owner, repo, number) {
       repo,
       number,
       'reviewThreads',
-      'isResolved path comments(first:100){ nodes{ body url createdAt author{ login } } }',
+      'isResolved path comments(first:100){ nodes{ body url createdAt updatedAt author{ login } } }',
     ),
   };
 }

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -124,6 +124,7 @@ export function buildMergedPrFeedbackSweep(prs, options) {
     const unaddressedComments = collectUnaddressedComments(
       pr.comments ?? [],
       pr.reviews ?? [],
+      pr.threads ?? [],
       isIdd,
       isTrusted,
       isAdvisoryBot,
@@ -199,21 +200,33 @@ function threadHasIddAmd(thread, isIdd) {
 function collectUnaddressedComments(
   comments,
   reviews,
+  threads,
   isIdd,
   isTrusted,
   isAdvisoryBot,
 ) {
   // A non-IDD item counts as addressed only when a later IDD-agent
   // *disposition* (Accepted / Rejected / Awaiting maintainer decision)
-  // exists — markers and plain replies do not address feedback.
-  const latestDispositionAt = maxTimestamp(
-    comments
+  // exists — markers and plain replies do not address feedback. IDD
+  // dispositions can land either as a top-level PR comment or as a reply
+  // inside a review thread (the protocol treats thread dispositions as
+  // first-class), so fold both timestamp sources into `latestDispositionAt`.
+  const latestDispositionAt = maxTimestamp([
+    ...comments
       .filter(
         (comment) =>
           isIdd(authorLogin(comment)) && isDispositionBody(comment.body),
       )
       .map(commentTimestamp),
-  );
+    ...threads.flatMap((thread) =>
+      (thread.comments?.nodes ?? [])
+        .filter(
+          (comment) =>
+            isIdd(authorLogin(comment)) && isDispositionBody(comment.body),
+        )
+        .map((comment) => comment.createdAt ?? null),
+    ),
+  ]);
   const out = [];
   for (const comment of comments) {
     const author = authorLogin(comment);
@@ -423,9 +436,24 @@ function fetchAllNodes(owner, repo, number, field, nodeFields) {
       } }
     }`;
     const result = ghGraphql(query, { owner, repo, number, after });
-    const conn = result?.data?.repository?.pullRequest?.[field];
-    out.push(...(conn?.nodes ?? []));
-    if (!conn?.pageInfo?.hasNextPage) {
+    // Fail fast on a missing pullRequest node or connection: an absent node
+    // (e.g. a transient/permission anomaly) would otherwise be read as zero
+    // nodes, making a PR look "clean" — the silent false negative this
+    // helper's fail-fast posture exists to prevent.
+    const pr = result?.data?.repository?.pullRequest;
+    if (pr == null) {
+      throw new Error(
+        `pagination for ${field} on PR #${number} returned no pullRequest node`,
+      );
+    }
+    const conn = pr[field];
+    if (conn == null) {
+      throw new Error(
+        `pagination for ${field} on PR #${number} returned a null connection`,
+      );
+    }
+    out.push(...(conn.nodes ?? []));
+    if (!conn.pageInfo?.hasNextPage) {
       break;
     }
     // Fail fast rather than silently truncate: a missing cursor on a

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -362,15 +362,30 @@ function parseArgs(argv) {
   }
   return parsed;
 }
+// Resolve the merged-since cutoff from --since and/or --days. When both are
+// supplied the later (more recent) cutoff wins, narrowing the window to the
+// intersection of the two; --since is validated as an ISO8601 date.
 function resolveSinceDate(args) {
+  const candidates = [];
   if (args.since) {
-    return args.since;
+    const ms = Date.parse(args.since);
+    if (Number.isNaN(ms)) {
+      throw new Error(`--since expects an ISO8601 date, got "${args.since}"`);
+    }
+    candidates.push({ iso: args.since, ms });
   }
   if (args.days && args.days > 0) {
-    const cutoff = Date.now() - args.days * 24 * 60 * 60 * 1000;
-    return new Date(cutoff).toISOString().slice(0, 10);
+    const cutoffMs = Date.now() - args.days * 24 * 60 * 60 * 1000;
+    candidates.push({
+      iso: new Date(cutoffMs).toISOString().slice(0, 10),
+      ms: cutoffMs,
+    });
   }
-  return null;
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.reduce((later, next) => (next.ms > later.ms ? next : later))
+    .iso;
 }
 function loadIddConfig() {
   try {
@@ -539,11 +554,14 @@ function main() {
     resolveLoginList(args.iddAgentLogins) ??
     resolveLoginList(process.env.IDD_AGENT_LOGINS ?? '') ??
     trustedMarkerActors;
-  const sinceDate = resolveSinceDate(args);
-  const targets =
-    args.prNumbers.length > 0
-      ? args.prNumbers.map((number) => ({ number }))
-      : listMergedPrNumbers(repoRef, sinceDate, args.limit);
+  // --since/--days only drive the merged-PR enumeration; when explicit PR
+  // numbers are given they are unused, so resolve and report the window as
+  // null rather than implying the run was time-filtered.
+  const usingExplicitPrs = args.prNumbers.length > 0;
+  const sinceDate = usingExplicitPrs ? null : resolveSinceDate(args);
+  const targets = usingExplicitPrs
+    ? args.prNumbers.map((number) => ({ number }))
+    : listMergedPrNumbers(repoRef, sinceDate, args.limit);
   const prs = [];
   for (const target of targets) {
     const pr = fetchMergedPr(owner, repo, target.number);
@@ -561,8 +579,8 @@ function main() {
       {
         sweepWindow: {
           since: sinceDate,
-          days: args.days,
-          explicitPrs: args.prNumbers.length > 0 ? args.prNumbers : null,
+          days: usingExplicitPrs ? null : args.days,
+          explicitPrs: usingExplicitPrs ? args.prNumbers : null,
           prCount: result.summary.prCount,
         },
         trustedMarkerActors,

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 // idd-generated-from: src/scripts/merged-pr-feedback-sweep.mts
 //
+// The scripts/merged-pr-feedback-sweep.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
 // Read-only helper: scan MERGED PRs for unresolved / unaddressed advisory
 // feedback (review threads still open, and non-IDD-agent comments / review
 // bodies that never received a later IDD-agent disposition). It only DETECTS
@@ -397,8 +401,16 @@ function fetchAllNodes(owner, repo, number, field, nodeFields) {
     const result = ghGraphql(query, { owner, repo, number, after });
     const conn = result?.data?.repository?.pullRequest?.[field];
     out.push(...(conn?.nodes ?? []));
-    if (!conn?.pageInfo?.hasNextPage || !conn.pageInfo.endCursor) {
+    if (!conn?.pageInfo?.hasNextPage) {
       break;
+    }
+    // Fail fast rather than silently truncate: a missing cursor on a
+    // has-next-page response would reintroduce the false negative this
+    // pagination exists to prevent.
+    if (!conn.pageInfo.endCursor) {
+      throw new Error(
+        `pagination for ${field} on PR #${number} reported hasNextPage with no endCursor`,
+      );
     }
     after = conn.pageInfo.endCursor;
   }

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -175,13 +175,26 @@ function collectUnresolvedThreads(threads, isIdd, isAdvisoryBot) {
       advisoryBot: isAdvisoryBot(originAuthor),
       path: thread.path ?? null,
       bodyExcerpt: excerpt(origin?.body),
-      dispositioned: hasFreshDisposition(
-        { isResolved: thread.isResolved, comments: thread.comments },
-        { isDispositionAuthor: isIdd },
-      ),
+      // `hasFreshDisposition` recognizes Accepted/Rejected; OR-in an IDD
+      // `**Awaiting maintainer decision**` reply so AMD threads match the
+      // comment-path disposition handling.
+      dispositioned:
+        hasFreshDisposition(
+          { isResolved: thread.isResolved, comments: thread.comments },
+          { isDispositionAuthor: isIdd },
+        ) || threadHasIddAmd(thread, isIdd),
     });
   }
   return out;
+}
+function threadHasIddAmd(thread, isIdd) {
+  return (thread.comments?.nodes ?? []).some(
+    (comment) =>
+      isIdd(authorLogin(comment)) &&
+      String(comment.body ?? '')
+        .trimStart()
+        .startsWith('**Awaiting maintainer decision**'),
+  );
 }
 function collectUnaddressedComments(
   comments,

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -1,0 +1,419 @@
+// idd-generated-from: src/scripts/merged-pr-feedback-sweep.mts
+//
+// Read-only helper: scan MERGED PRs for unresolved / unaddressed advisory
+// feedback (review threads still open, and non-IDD-agent comments / review
+// bodies that never received a later IDD-agent disposition). It only DETECTS
+// and prints JSON — no minimization, no posting, no issue creation. The
+// output is the input an operator hands to the issue-authoring skill, which
+// re-verifies each candidate against current `main` and drafts follow-ups.
+//
+// This is the recurring counterpart of the one-time audit in #910 and the
+// chosen recovery path from #909 (advisory-wait stays Copilot-only).
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  hasFreshDisposition,
+  isDispositionComment,
+  isKnownReviewBot,
+  operationalMarkerPrefix,
+  resolveAdvisoryBotLogins,
+  resolveTrustedMarkerActors,
+} from './protocol-helpers.mjs';
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+function authorLogin(node) {
+  return String(node?.author?.login ?? node?.user?.login ?? '')
+    .trim()
+    .toLowerCase();
+}
+function commentTimestamp(node) {
+  return node.createdAt ?? node.created_at ?? null;
+}
+function excerpt(body, max = 160) {
+  const flat = String(body ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+function isLaterThan(a, b) {
+  if (!a || !b) {
+    return false;
+  }
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  if (Number.isNaN(ta) || Number.isNaN(tb)) {
+    return false;
+  }
+  return ta > tb;
+}
+function maxTimestamp(values) {
+  let best = null;
+  for (const value of values) {
+    if (value && (best === null || isLaterThan(value, best))) {
+      best = value;
+    }
+  }
+  return best;
+}
+function isDispositionBody(body) {
+  const trimmed = String(body ?? '').trimStart();
+  return (
+    isDispositionComment({ body }) ||
+    trimmed.startsWith('**Awaiting maintainer decision**')
+  );
+}
+// ---------------------------------------------------------------------------
+// Pure sweep builder (the testable core — no network)
+// ---------------------------------------------------------------------------
+export function buildMergedPrFeedbackSweep(prs, options) {
+  const idd = new Set(
+    options.iddAgentLogins.map((login) => login.toLowerCase()),
+  );
+  const trusted = new Set(
+    options.trustedMarkerActors.map((login) => login.toLowerCase()),
+  );
+  const advisory = new Set(
+    options.advisoryBotLogins.map((login) => login.toLowerCase()),
+  );
+  const isIdd = (login) => idd.has(login);
+  const isTrusted = (login) => trusted.has(login);
+  const isAdvisoryBot = (login) =>
+    isKnownReviewBot(login) || advisory.has(login);
+  const findings = [];
+  for (const pr of prs) {
+    const unresolvedThreads = collectUnresolvedThreads(
+      pr.threads ?? [],
+      isIdd,
+      isAdvisoryBot,
+    );
+    const unaddressedComments = collectUnaddressedComments(
+      pr.comments ?? [],
+      pr.reviews ?? [],
+      isIdd,
+      isTrusted,
+      isAdvisoryBot,
+    );
+    if (unresolvedThreads.length === 0 && unaddressedComments.length === 0) {
+      continue;
+    }
+    findings.push({
+      number: pr.number,
+      mergedAt: pr.mergedAt ?? null,
+      mergeCommit: pr.mergeCommit ?? null,
+      unresolvedThreads,
+      unaddressedComments,
+    });
+  }
+  return {
+    prs: findings,
+    summary: {
+      prCount: prs.length,
+      flaggedPrCount: findings.length,
+      unresolvedThreadCount: findings.reduce(
+        (total, pr) => total + pr.unresolvedThreads.length,
+        0,
+      ),
+      unaddressedCommentCount: findings.reduce(
+        (total, pr) => total + pr.unaddressedComments.length,
+        0,
+      ),
+    },
+  };
+}
+function collectUnresolvedThreads(threads, isIdd, isAdvisoryBot) {
+  const out = [];
+  for (const thread of threads) {
+    // Only threads left open at merge time.
+    if (thread.isResolved !== false) {
+      continue;
+    }
+    const nodes = thread.comments?.nodes ?? [];
+    const origin = nodes[0];
+    const originAuthor = authorLogin(origin);
+    // A thread the IDD agent itself opened is not reviewer feedback.
+    if (originAuthor && isIdd(originAuthor)) {
+      continue;
+    }
+    out.push({
+      url: origin?.url ?? null,
+      author: originAuthor || null,
+      advisoryBot: isAdvisoryBot(originAuthor),
+      path: thread.path ?? null,
+      bodyExcerpt: excerpt(origin?.body),
+      dispositioned: hasFreshDisposition(
+        { isResolved: thread.isResolved, comments: thread.comments },
+        { isDispositionAuthor: isIdd },
+      ),
+    });
+  }
+  return out;
+}
+function collectUnaddressedComments(
+  comments,
+  reviews,
+  isIdd,
+  isTrusted,
+  isAdvisoryBot,
+) {
+  // A non-IDD item counts as addressed only when a later IDD-agent
+  // *disposition* (Accepted / Rejected / Awaiting maintainer decision)
+  // exists — markers and plain replies do not address feedback.
+  const latestDispositionAt = maxTimestamp(
+    comments
+      .filter(
+        (comment) =>
+          isIdd(authorLogin(comment)) && isDispositionBody(comment.body),
+      )
+      .map(commentTimestamp),
+  );
+  const out = [];
+  for (const comment of comments) {
+    const author = authorLogin(comment);
+    if (!author || isIdd(author)) {
+      continue;
+    }
+    if (isDispositionBody(comment.body)) {
+      continue;
+    }
+    // A trusted IDD operational marker is bookkeeping, not feedback.
+    if (operationalMarkerPrefix(comment.body ?? '') && isTrusted(author)) {
+      continue;
+    }
+    if (isLaterThan(latestDispositionAt, commentTimestamp(comment))) {
+      continue;
+    }
+    out.push({
+      url: comment.url ?? comment.html_url ?? null,
+      author,
+      advisoryBot: isAdvisoryBot(author),
+      kind: 'comment',
+      bodyExcerpt: excerpt(comment.body),
+    });
+  }
+  for (const review of reviews) {
+    if (review.state !== 'CHANGES_REQUESTED') {
+      continue;
+    }
+    const author = authorLogin(review);
+    if (!author || isIdd(author)) {
+      continue;
+    }
+    if (isLaterThan(latestDispositionAt, review.submittedAt ?? null)) {
+      continue;
+    }
+    out.push({
+      url: review.url ?? null,
+      author,
+      advisoryBot: isAdvisoryBot(author),
+      kind: 'review',
+      bodyExcerpt: excerpt(review.body),
+    });
+  }
+  return out;
+}
+function parseArgs(argv) {
+  const parsed = {
+    since: null,
+    days: null,
+    prNumbers: [],
+    limit: 100,
+    owner: '',
+    repo: '',
+    trustedMarkerLogins: '',
+    advisoryBotLogins: '',
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const next = () => {
+      const value = argv[index + 1];
+      if (value === undefined) {
+        throw new Error(`missing value for ${token}`);
+      }
+      index += 1;
+      return value;
+    };
+    switch (token) {
+      case '--since':
+        parsed.since = next();
+        break;
+      case '--days':
+        parsed.days = Number.parseInt(next(), 10);
+        break;
+      case '--pr':
+        parsed.prNumbers.push(Number.parseInt(next(), 10));
+        break;
+      case '--prs':
+        for (const part of next().split(',')) {
+          const value = Number.parseInt(part.trim(), 10);
+          if (!Number.isNaN(value)) {
+            parsed.prNumbers.push(value);
+          }
+        }
+        break;
+      case '--limit':
+        parsed.limit = Number.parseInt(next(), 10);
+        break;
+      case '--owner':
+        parsed.owner = next();
+        break;
+      case '--repo':
+        parsed.repo = next();
+        break;
+      case '--trusted-marker-logins':
+        parsed.trustedMarkerLogins = next();
+        break;
+      case '--advisory-bot-logins':
+        parsed.advisoryBotLogins = next();
+        break;
+      default:
+        throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  return parsed;
+}
+function resolveSinceDate(args) {
+  if (args.since) {
+    return args.since;
+  }
+  if (args.days && args.days > 0) {
+    const cutoff = Date.now() - args.days * 24 * 60 * 60 * 1000;
+    return new Date(cutoff).toISOString().slice(0, 10);
+  }
+  return null;
+}
+function loadIddConfig() {
+  try {
+    return JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    return null;
+  }
+}
+function runGh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' });
+}
+function ghGraphql(query, variables) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
+  }
+  return JSON.parse(runGh(args).trim() || '{}');
+}
+function listMergedPrNumbers(repoRef, sinceDate, limit) {
+  const args = [
+    'pr',
+    'list',
+    '-R',
+    repoRef,
+    '--state',
+    'merged',
+    '--json',
+    'number,mergedAt',
+    '--limit',
+    String(limit),
+  ];
+  if (sinceDate) {
+    args.push('--search', `merged:>=${sinceDate}`);
+  }
+  const raw = runGh(args).trim();
+  const items = raw ? JSON.parse(raw) : [];
+  return items;
+}
+const PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      number
+      merged
+      mergedAt
+      mergeCommit{ oid }
+      comments(first:100){ nodes{ body url createdAt author{ login } } }
+      reviews(first:100){ nodes{ body url state submittedAt author{ login } } }
+      reviewThreads(first:100){ nodes{
+        isResolved
+        path
+        comments(first:100){ nodes{ body url createdAt author{ login } } }
+      } }
+    }
+  }
+}`;
+function fetchMergedPr(owner, repo, number) {
+  const result = ghGraphql(PR_QUERY, { owner, repo, number });
+  const pr = result?.data?.repository?.pullRequest;
+  if (!pr?.merged) {
+    return null;
+  }
+  return {
+    number: pr.number,
+    mergedAt: pr.mergedAt ?? null,
+    mergeCommit: pr.mergeCommit?.oid ?? null,
+    threads: pr.reviewThreads?.nodes ?? [],
+    comments: pr.comments?.nodes ?? [],
+    reviews: pr.reviews?.nodes ?? [],
+  };
+}
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const owner =
+    args.owner ||
+    runGh(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']).trim();
+  const repo =
+    args.repo ||
+    runGh(['repo', 'view', '--json', 'name', '--jq', '.name']).trim();
+  const repoRef = `${owner}/${repo}`;
+  const iddConfig = loadIddConfig();
+  const { actors: trustedMarkerActors } = resolveTrustedMarkerActors({
+    flagValue: args.trustedMarkerLogins,
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: iddConfig,
+  });
+  const { logins: advisoryBotLogins } = resolveAdvisoryBotLogins({
+    flagValue: args.advisoryBotLogins,
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+    config: iddConfig,
+  });
+  const sinceDate = resolveSinceDate(args);
+  const targets =
+    args.prNumbers.length > 0
+      ? args.prNumbers.map((number) => ({ number }))
+      : listMergedPrNumbers(repoRef, sinceDate, args.limit);
+  const prs = [];
+  for (const target of targets) {
+    const pr = fetchMergedPr(owner, repo, target.number);
+    if (pr) {
+      prs.push(pr);
+    }
+  }
+  const result = buildMergedPrFeedbackSweep(prs, {
+    trustedMarkerActors,
+    advisoryBotLogins,
+    // In this workflow the IDD agent posts dispositions under the trusted
+    // marker actor identity, so the disposition authors are those actors.
+    iddAgentLogins: trustedMarkerActors,
+  });
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        sweepWindow: {
+          since: sinceDate,
+          days: args.days,
+          explicitPrs: args.prNumbers.length > 0 ? args.prNumbers : null,
+          prCount: result.summary.prCount,
+        },
+        trustedMarkerActors,
+        advisoryBotLogins,
+        prs: result.prs,
+        summary: result.summary,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -374,7 +374,18 @@ function ghGraphql(query, variables) {
     }
     args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
   }
-  return JSON.parse(runGh(args).trim() || '{}');
+  const result = JSON.parse(runGh(args).trim() || '{}');
+  // A GraphQL call can return HTTP 200 with a top-level `errors` array and
+  // null `data`. Fail fast instead of treating it as empty data, which would
+  // be a silent false negative (a PR appearing "clean" because no nodes came
+  // back).
+  if (Array.isArray(result.errors) && result.errors.length > 0) {
+    const messages = result.errors
+      .map((entry) => entry?.message ?? 'unknown')
+      .join('; ');
+    throw new Error(`GraphQL query returned errors: ${messages}`);
+  }
+  return result;
 }
 function listMergedPrNumbers(repoRef, sinceDate, limit) {
   const args = [

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // idd-generated-from: src/scripts/merged-pr-feedback-sweep.mts
 //
 // Read-only helper: scan MERGED PRs for unresolved / unaddressed advisory
@@ -269,8 +270,12 @@ function parseArgs(argv) {
     const nextInt = () => {
       const raw = next();
       const value = Number.parseInt(raw, 10);
-      if (!Number.isFinite(value) || String(value) !== raw.trim()) {
-        throw new Error(`${token} expects an integer, got "${raw}"`);
+      if (
+        !Number.isFinite(value) ||
+        String(value) !== raw.trim() ||
+        value < 1
+      ) {
+        throw new Error(`${token} expects a positive integer, got "${raw}"`);
       }
       return value;
     };
@@ -288,9 +293,13 @@ function parseArgs(argv) {
         for (const part of next().split(',')) {
           const trimmed = part.trim();
           const value = Number.parseInt(trimmed, 10);
-          if (!Number.isFinite(value) || String(value) !== trimmed) {
+          if (
+            !Number.isFinite(value) ||
+            String(value) !== trimmed ||
+            value < 1
+          ) {
             throw new Error(
-              `--prs expects comma-separated integers, got "${part}"`,
+              `--prs expects comma-separated positive integers, got "${part}"`,
             );
           }
           parsed.prNumbers.push(value);

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -199,10 +199,11 @@ function collectUnaddressedComments(
   const out = [];
   for (const comment of comments) {
     const author = authorLogin(comment);
+    // IDD-agent comments (incl. their dispositions) are excluded by author
+    // here, so a disposition marker is treated specially only when the agent
+    // wrote it. A non-IDD reviewer who opens a comment with "**Rejected**" is
+    // still surfaced as feedback.
     if (!author || isIdd(author)) {
-      continue;
-    }
-    if (isDispositionBody(comment.body)) {
       continue;
     }
     // IDD bookkeeping is not feedback: a trusted operational-state marker,

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -16,6 +16,7 @@ import {
   hasFreshDisposition,
   isDispositionComment,
   isKnownReviewBot,
+  normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
@@ -64,6 +65,32 @@ function isDispositionBody(body) {
     isDispositionComment({ body }) ||
     trimmed.startsWith('**Awaiting maintainer decision**')
   );
+}
+// Normalize a comma-separated login list; returns null when empty so callers
+// can fall through to the next source in their precedence chain.
+function resolveLoginList(value) {
+  const tokens = value
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean);
+  return tokens.length > 0 ? normalizeTrustedMarkerLogins(tokens) : null;
+}
+// IDD bookkeeping comments are not reviewer feedback.
+function isIddBookkeeping(body, author, isTrusted) {
+  // IDD HTML-comment bookkeeping markers (cleanup-evidence, plan, digest,
+  // roadmap-audit, …) are posted by the agent or by CI automation such as
+  // github-actions, never by a reviewer; exclude them regardless of author.
+  if (
+    String(body ?? '')
+      .trimStart()
+      .startsWith('<!-- idd-')
+  ) {
+    return true;
+  }
+  // Operational-state markers (claimed-by / review-watermark / advisory-wait
+  // / …) count only from a trusted marker author; an untrusted look-alike is
+  // left in as surfacing context.
+  return operationalMarkerPrefix(body ?? '') !== null && isTrusted(author);
 }
 // ---------------------------------------------------------------------------
 // Pure sweep builder (the testable core — no network)
@@ -178,8 +205,10 @@ function collectUnaddressedComments(
     if (isDispositionBody(comment.body)) {
       continue;
     }
-    // A trusted IDD operational marker is bookkeeping, not feedback.
-    if (operationalMarkerPrefix(comment.body ?? '') && isTrusted(author)) {
+    // IDD bookkeeping is not feedback: a trusted operational-state marker,
+    // or any `<!-- idd-… -->` comment (e.g. cleanup-evidence / plan / digest,
+    // which CI automation such as github-actions also posts).
+    if (isIddBookkeeping(comment.body, author, isTrusted)) {
       continue;
     }
     if (isLaterThan(latestDispositionAt, commentTimestamp(comment))) {
@@ -224,6 +253,7 @@ function parseArgs(argv) {
     repo: '',
     trustedMarkerLogins: '',
     advisoryBotLogins: '',
+    iddAgentLogins: '',
   };
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -235,26 +265,38 @@ function parseArgs(argv) {
       index += 1;
       return value;
     };
+    const nextInt = () => {
+      const raw = next();
+      const value = Number.parseInt(raw, 10);
+      if (!Number.isFinite(value) || String(value) !== raw.trim()) {
+        throw new Error(`${token} expects an integer, got "${raw}"`);
+      }
+      return value;
+    };
     switch (token) {
       case '--since':
         parsed.since = next();
         break;
       case '--days':
-        parsed.days = Number.parseInt(next(), 10);
+        parsed.days = nextInt();
         break;
       case '--pr':
-        parsed.prNumbers.push(Number.parseInt(next(), 10));
+        parsed.prNumbers.push(nextInt());
         break;
       case '--prs':
         for (const part of next().split(',')) {
-          const value = Number.parseInt(part.trim(), 10);
-          if (!Number.isNaN(value)) {
-            parsed.prNumbers.push(value);
+          const trimmed = part.trim();
+          const value = Number.parseInt(trimmed, 10);
+          if (!Number.isFinite(value) || String(value) !== trimmed) {
+            throw new Error(
+              `--prs expects comma-separated integers, got "${part}"`,
+            );
           }
+          parsed.prNumbers.push(value);
         }
         break;
       case '--limit':
-        parsed.limit = Number.parseInt(next(), 10);
+        parsed.limit = nextInt();
         break;
       case '--owner':
         parsed.owner = next();
@@ -267,6 +309,9 @@ function parseArgs(argv) {
         break;
       case '--advisory-bot-logins':
         parsed.advisoryBotLogins = next();
+        break;
+      case '--idd-agent-logins':
+        parsed.iddAgentLogins = next();
         break;
       default:
         throw new Error(`unknown argument: ${token}`);
@@ -324,36 +369,67 @@ function listMergedPrNumbers(repoRef, sinceDate, limit) {
   const items = raw ? JSON.parse(raw) : [];
   return items;
 }
-const PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
-  repository(owner:$owner,name:$repo){
-    pullRequest(number:$number){
-      number
-      merged
-      mergedAt
-      mergeCommit{ oid }
-      comments(first:100){ nodes{ body url createdAt author{ login } } }
-      reviews(first:100){ nodes{ body url state submittedAt author{ login } } }
-      reviewThreads(first:100){ nodes{
-        isResolved
-        path
-        comments(first:100){ nodes{ body url createdAt author{ login } } }
+// Page a single `pullRequest` connection to completion so large PRs cannot
+// silently truncate at 100 items (which would hide unresolved threads or a
+// later disposition comment and produce a false negative). Per-thread reply
+// pagination is intentionally left at first:100 — a thread with 100+ replies
+// is pathological and only affects the advisory `dispositioned` flag, not
+// whether the thread surfaces.
+function fetchAllNodes(owner, repo, number, field, nodeFields) {
+  const out = [];
+  let after = null;
+  for (;;) {
+    const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+      repository(owner:$owner,name:$repo){ pullRequest(number:$number){
+        ${field}(first:100,after:$after){ pageInfo{ hasNextPage endCursor } nodes{ ${nodeFields} } }
       } }
+    }`;
+    const result = ghGraphql(query, { owner, repo, number, after });
+    const conn = result?.data?.repository?.pullRequest?.[field];
+    out.push(...(conn?.nodes ?? []));
+    if (!conn?.pageInfo?.hasNextPage || !conn.pageInfo.endCursor) {
+      break;
     }
+    after = conn.pageInfo.endCursor;
   }
-}`;
+  return out;
+}
 function fetchMergedPr(owner, repo, number) {
-  const result = ghGraphql(PR_QUERY, { owner, repo, number });
-  const pr = result?.data?.repository?.pullRequest;
+  const metaQuery = `query($owner:String!,$repo:String!,$number:Int!){
+    repository(owner:$owner,name:$repo){ pullRequest(number:$number){
+      number merged mergedAt mergeCommit{ oid }
+    } }
+  }`;
+  const meta = ghGraphql(metaQuery, { owner, repo, number });
+  const pr = meta?.data?.repository?.pullRequest;
   if (!pr?.merged) {
     return null;
   }
   return {
-    number: pr.number,
+    number: pr.number ?? number,
     mergedAt: pr.mergedAt ?? null,
     mergeCommit: pr.mergeCommit?.oid ?? null,
-    threads: pr.reviewThreads?.nodes ?? [],
-    comments: pr.comments?.nodes ?? [],
-    reviews: pr.reviews?.nodes ?? [],
+    comments: fetchAllNodes(
+      owner,
+      repo,
+      number,
+      'comments',
+      'body url createdAt author{ login }',
+    ),
+    reviews: fetchAllNodes(
+      owner,
+      repo,
+      number,
+      'reviews',
+      'body url state submittedAt author{ login }',
+    ),
+    threads: fetchAllNodes(
+      owner,
+      repo,
+      number,
+      'reviewThreads',
+      'isResolved path comments(first:100){ nodes{ body url createdAt author{ login } } }',
+    ),
   };
 }
 function main() {
@@ -376,6 +452,16 @@ function main() {
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config: iddConfig,
   });
+  // The IDD agent accounts whose comments are treated as dispositions and
+  // whose own comments are not feedback. Distinct from trusted-marker actors:
+  // a human maintainer can be a trusted-marker actor whose review feedback we
+  // still want to surface. Defaults to the trusted-marker actors (the agent
+  // posts under that identity in this repo); override with --idd-agent-logins
+  // or IDD_AGENT_LOGINS when the agent runs under a separate account.
+  const iddAgentLogins =
+    resolveLoginList(args.iddAgentLogins) ??
+    resolveLoginList(process.env.IDD_AGENT_LOGINS ?? '') ??
+    trustedMarkerActors;
   const sinceDate = resolveSinceDate(args);
   const targets =
     args.prNumbers.length > 0
@@ -391,9 +477,7 @@ function main() {
   const result = buildMergedPrFeedbackSweep(prs, {
     trustedMarkerActors,
     advisoryBotLogins,
-    // In this workflow the IDD agent posts dispositions under the trusted
-    // marker actor identity, so the disposition authors are those actors.
-    iddAgentLogins: trustedMarkerActors,
+    iddAgentLogins,
   });
   process.stdout.write(
     `${JSON.stringify(
@@ -406,6 +490,7 @@ function main() {
         },
         trustedMarkerActors,
         advisoryBotLogins,
+        iddAgentLogins,
         prs: result.prs,
         summary: result.summary,
       },

--- a/src/bin/idd-merged-pr-feedback-sweep.mts
+++ b/src/bin/idd-merged-pr-feedback-sweep.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-merged-pr-feedback-sweep.mts
+//
+// The bin/idd-merged-pr-feedback-sweep.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/merged-pr-feedback-sweep.mjs');

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -241,6 +241,7 @@ export function buildMergedPrFeedbackSweep(
     const unaddressedComments = collectUnaddressedComments(
       pr.comments ?? [],
       pr.reviews ?? [],
+      pr.threads ?? [],
       isIdd,
       isTrusted,
       isAdvisoryBot,
@@ -327,21 +328,33 @@ function threadHasIddAmd(
 function collectUnaddressedComments(
   comments: SweepCommentInput[],
   reviews: SweepReviewInput[],
+  threads: SweepThreadInput[],
   isIdd: (login: string) => boolean,
   isTrusted: (login: string) => boolean,
   isAdvisoryBot: (login: string) => boolean,
 ): SweepCommentFinding[] {
   // A non-IDD item counts as addressed only when a later IDD-agent
   // *disposition* (Accepted / Rejected / Awaiting maintainer decision)
-  // exists — markers and plain replies do not address feedback.
-  const latestDispositionAt = maxTimestamp(
-    comments
+  // exists — markers and plain replies do not address feedback. IDD
+  // dispositions can land either as a top-level PR comment or as a reply
+  // inside a review thread (the protocol treats thread dispositions as
+  // first-class), so fold both timestamp sources into `latestDispositionAt`.
+  const latestDispositionAt = maxTimestamp([
+    ...comments
       .filter(
         (comment) =>
           isIdd(authorLogin(comment)) && isDispositionBody(comment.body),
       )
       .map(commentTimestamp),
-  );
+    ...threads.flatMap((thread) =>
+      (thread.comments?.nodes ?? [])
+        .filter(
+          (comment) =>
+            isIdd(authorLogin(comment)) && isDispositionBody(comment.body),
+        )
+        .map((comment) => comment.createdAt ?? null),
+    ),
+  ]);
 
   const out: SweepCommentFinding[] = [];
 
@@ -615,9 +628,24 @@ function fetchAllNodes<T>(
         } | null;
       } | null;
     };
-    const conn = result?.data?.repository?.pullRequest?.[field];
-    out.push(...(conn?.nodes ?? []));
-    if (!conn?.pageInfo?.hasNextPage) {
+    // Fail fast on a missing pullRequest node or connection: an absent node
+    // (e.g. a transient/permission anomaly) would otherwise be read as zero
+    // nodes, making a PR look "clean" — the silent false negative this
+    // helper's fail-fast posture exists to prevent.
+    const pr = result?.data?.repository?.pullRequest;
+    if (pr == null) {
+      throw new Error(
+        `pagination for ${field} on PR #${number} returned no pullRequest node`,
+      );
+    }
+    const conn = pr[field];
+    if (conn == null) {
+      throw new Error(
+        `pagination for ${field} on PR #${number} returned a null connection`,
+      );
+    }
+    out.push(...(conn.nodes ?? []));
+    if (!conn.pageInfo?.hasNextPage) {
       break;
     }
     // Fail fast rather than silently truncate: a missing cursor on a

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -512,15 +512,30 @@ function parseArgs(argv: string[]): SweepArgs {
   return parsed;
 }
 
+// Resolve the merged-since cutoff from --since and/or --days. When both are
+// supplied the later (more recent) cutoff wins, narrowing the window to the
+// intersection of the two; --since is validated as an ISO8601 date.
 function resolveSinceDate(args: SweepArgs): string | null {
+  const candidates: { iso: string; ms: number }[] = [];
   if (args.since) {
-    return args.since;
+    const ms = Date.parse(args.since);
+    if (Number.isNaN(ms)) {
+      throw new Error(`--since expects an ISO8601 date, got "${args.since}"`);
+    }
+    candidates.push({ iso: args.since, ms });
   }
   if (args.days && args.days > 0) {
-    const cutoff = Date.now() - args.days * 24 * 60 * 60 * 1000;
-    return new Date(cutoff).toISOString().slice(0, 10);
+    const cutoffMs = Date.now() - args.days * 24 * 60 * 60 * 1000;
+    candidates.push({
+      iso: new Date(cutoffMs).toISOString().slice(0, 10),
+      ms: cutoffMs,
+    });
   }
-  return null;
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.reduce((later, next) => (next.ms > later.ms ? next : later))
+    .iso;
 }
 
 function loadIddConfig(): {
@@ -750,11 +765,14 @@ function main(): void {
     resolveLoginList(process.env.IDD_AGENT_LOGINS ?? '') ??
     trustedMarkerActors;
 
-  const sinceDate = resolveSinceDate(args);
-  const targets =
-    args.prNumbers.length > 0
-      ? args.prNumbers.map((number) => ({ number }))
-      : listMergedPrNumbers(repoRef, sinceDate, args.limit);
+  // --since/--days only drive the merged-PR enumeration; when explicit PR
+  // numbers are given they are unused, so resolve and report the window as
+  // null rather than implying the run was time-filtered.
+  const usingExplicitPrs = args.prNumbers.length > 0;
+  const sinceDate = usingExplicitPrs ? null : resolveSinceDate(args);
+  const targets = usingExplicitPrs
+    ? args.prNumbers.map((number) => ({ number }))
+    : listMergedPrNumbers(repoRef, sinceDate, args.limit);
 
   const prs: MergedPrInput[] = [];
   for (const target of targets) {
@@ -775,8 +793,8 @@ function main(): void {
       {
         sweepWindow: {
           since: sinceDate,
-          days: args.days,
-          explicitPrs: args.prNumbers.length > 0 ? args.prNumbers : null,
+          days: usingExplicitPrs ? null : args.days,
+          explicitPrs: usingExplicitPrs ? args.prNumbers : null,
           prCount: result.summary.prCount,
         },
         trustedMarkerActors,

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -42,6 +42,8 @@ export interface SweepCommentInput {
   user?: AuthorRef | null;
   createdAt?: string | null;
   created_at?: string | null;
+  updatedAt?: string | null;
+  updated_at?: string | null;
   url?: string | null;
   html_url?: string | null;
 }
@@ -136,8 +138,18 @@ function authorLogin(
     .toLowerCase();
 }
 
+// Prefer the edited (`updatedAt`) timestamp over the created one so an
+// IDD disposition or a reviewer comment edited after posting is ordered by
+// when it last changed — matching protocol-helpers' freshness semantics and
+// avoiding a false-positive "unaddressed" finding for an edited disposition.
 function commentTimestamp(node: SweepCommentInput): string | null {
-  return node.createdAt ?? node.created_at ?? null;
+  return (
+    node.updatedAt ??
+    node.updated_at ??
+    node.createdAt ??
+    node.created_at ??
+    null
+  );
 }
 
 function excerpt(body: string | null | undefined, max = 160): string {
@@ -352,7 +364,7 @@ function collectUnaddressedComments(
           (comment) =>
             isIdd(authorLogin(comment)) && isDispositionBody(comment.body),
         )
-        .map((comment) => comment.createdAt ?? null),
+        .map((comment) => comment.updatedAt ?? comment.createdAt ?? null),
     ),
   ]);
 
@@ -714,7 +726,7 @@ function fetchMergedPr(
       repo,
       number,
       'comments',
-      'body url createdAt author{ login }',
+      'body url createdAt updatedAt author{ login }',
     ),
     reviews: fetchAllNodes<SweepReviewInput>(
       owner,
@@ -728,7 +740,7 @@ function fetchMergedPr(
       repo,
       number,
       'reviewThreads',
-      'isResolved path comments(first:100){ nodes{ body url createdAt author{ login } } }',
+      'isResolved path comments(first:100){ nodes{ body url createdAt updatedAt author{ login } } }',
     ),
   };
 }

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -1,0 +1,607 @@
+// idd-generated-from: src/scripts/merged-pr-feedback-sweep.mts
+//
+// Read-only helper: scan MERGED PRs for unresolved / unaddressed advisory
+// feedback (review threads still open, and non-IDD-agent comments / review
+// bodies that never received a later IDD-agent disposition). It only DETECTS
+// and prints JSON — no minimization, no posting, no issue creation. The
+// output is the input an operator hands to the issue-authoring skill, which
+// re-verifies each candidate against current `main` and drafts follow-ups.
+//
+// This is the recurring counterpart of the one-time audit in #910 and the
+// chosen recovery path from #909 (advisory-wait stays Copilot-only).
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+  hasFreshDisposition,
+  isDispositionComment,
+  isKnownReviewBot,
+  operationalMarkerPrefix,
+  resolveAdvisoryBotLogins,
+  resolveTrustedMarkerActors,
+} from './protocol-helpers.mts';
+
+// ---------------------------------------------------------------------------
+// Types (the pure function's input/output — exported for tests)
+// ---------------------------------------------------------------------------
+
+interface AuthorRef {
+  login?: string | null;
+}
+
+export interface SweepCommentInput {
+  body?: string | null;
+  author?: AuthorRef | null;
+  user?: AuthorRef | null;
+  createdAt?: string | null;
+  created_at?: string | null;
+  url?: string | null;
+  html_url?: string | null;
+}
+
+export interface SweepReviewInput {
+  body?: string | null;
+  author?: AuthorRef | null;
+  state?: string | null;
+  submittedAt?: string | null;
+  url?: string | null;
+}
+
+export interface SweepThreadCommentInput {
+  body?: string | null;
+  author?: AuthorRef | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  url?: string | null;
+}
+
+export interface SweepThreadInput {
+  id?: string | null;
+  isResolved?: boolean | null;
+  path?: string | null;
+  comments?: { nodes?: SweepThreadCommentInput[] | null } | null;
+}
+
+export interface MergedPrInput {
+  number: number;
+  mergedAt?: string | null;
+  mergeCommit?: string | null;
+  threads?: SweepThreadInput[] | null;
+  comments?: SweepCommentInput[] | null;
+  reviews?: SweepReviewInput[] | null;
+}
+
+export interface MergedPrSweepOptions {
+  trustedMarkerActors: string[];
+  advisoryBotLogins: string[];
+  iddAgentLogins: string[];
+}
+
+export interface SweepThreadFinding {
+  url: string | null;
+  author: string | null;
+  advisoryBot: boolean;
+  path: string | null;
+  bodyExcerpt: string;
+  dispositioned: boolean;
+}
+
+export interface SweepCommentFinding {
+  url: string | null;
+  author: string | null;
+  advisoryBot: boolean;
+  kind: 'comment' | 'review';
+  bodyExcerpt: string;
+}
+
+export interface SweepPrFinding {
+  number: number;
+  mergedAt: string | null;
+  mergeCommit: string | null;
+  unresolvedThreads: SweepThreadFinding[];
+  unaddressedComments: SweepCommentFinding[];
+}
+
+export interface MergedPrSweepSummary {
+  prCount: number;
+  flaggedPrCount: number;
+  unresolvedThreadCount: number;
+  unaddressedCommentCount: number;
+}
+
+export interface MergedPrSweepResult {
+  prs: SweepPrFinding[];
+  summary: MergedPrSweepSummary;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function authorLogin(
+  node:
+    | { author?: AuthorRef | null; user?: AuthorRef | null }
+    | null
+    | undefined,
+): string {
+  return String(node?.author?.login ?? node?.user?.login ?? '')
+    .trim()
+    .toLowerCase();
+}
+
+function commentTimestamp(node: SweepCommentInput): string | null {
+  return node.createdAt ?? node.created_at ?? null;
+}
+
+function excerpt(body: string | null | undefined, max = 160): string {
+  const flat = String(body ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+
+function isLaterThan(a: string | null, b: string | null): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  if (Number.isNaN(ta) || Number.isNaN(tb)) {
+    return false;
+  }
+  return ta > tb;
+}
+
+function maxTimestamp(values: (string | null)[]): string | null {
+  let best: string | null = null;
+  for (const value of values) {
+    if (value && (best === null || isLaterThan(value, best))) {
+      best = value;
+    }
+  }
+  return best;
+}
+
+function isDispositionBody(body: string | null | undefined): boolean {
+  const trimmed = String(body ?? '').trimStart();
+  return (
+    isDispositionComment({ body }) ||
+    trimmed.startsWith('**Awaiting maintainer decision**')
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pure sweep builder (the testable core — no network)
+// ---------------------------------------------------------------------------
+
+export function buildMergedPrFeedbackSweep(
+  prs: MergedPrInput[],
+  options: MergedPrSweepOptions,
+): MergedPrSweepResult {
+  const idd = new Set(
+    options.iddAgentLogins.map((login) => login.toLowerCase()),
+  );
+  const trusted = new Set(
+    options.trustedMarkerActors.map((login) => login.toLowerCase()),
+  );
+  const advisory = new Set(
+    options.advisoryBotLogins.map((login) => login.toLowerCase()),
+  );
+  const isIdd = (login: string): boolean => idd.has(login);
+  const isTrusted = (login: string): boolean => trusted.has(login);
+  const isAdvisoryBot = (login: string): boolean =>
+    isKnownReviewBot(login) || advisory.has(login);
+
+  const findings: SweepPrFinding[] = [];
+  for (const pr of prs) {
+    const unresolvedThreads = collectUnresolvedThreads(
+      pr.threads ?? [],
+      isIdd,
+      isAdvisoryBot,
+    );
+    const unaddressedComments = collectUnaddressedComments(
+      pr.comments ?? [],
+      pr.reviews ?? [],
+      isIdd,
+      isTrusted,
+      isAdvisoryBot,
+    );
+    if (unresolvedThreads.length === 0 && unaddressedComments.length === 0) {
+      continue;
+    }
+    findings.push({
+      number: pr.number,
+      mergedAt: pr.mergedAt ?? null,
+      mergeCommit: pr.mergeCommit ?? null,
+      unresolvedThreads,
+      unaddressedComments,
+    });
+  }
+
+  return {
+    prs: findings,
+    summary: {
+      prCount: prs.length,
+      flaggedPrCount: findings.length,
+      unresolvedThreadCount: findings.reduce(
+        (total, pr) => total + pr.unresolvedThreads.length,
+        0,
+      ),
+      unaddressedCommentCount: findings.reduce(
+        (total, pr) => total + pr.unaddressedComments.length,
+        0,
+      ),
+    },
+  };
+}
+
+function collectUnresolvedThreads(
+  threads: SweepThreadInput[],
+  isIdd: (login: string) => boolean,
+  isAdvisoryBot: (login: string) => boolean,
+): SweepThreadFinding[] {
+  const out: SweepThreadFinding[] = [];
+  for (const thread of threads) {
+    // Only threads left open at merge time.
+    if (thread.isResolved !== false) {
+      continue;
+    }
+    const nodes = thread.comments?.nodes ?? [];
+    const origin = nodes[0];
+    const originAuthor = authorLogin(origin);
+    // A thread the IDD agent itself opened is not reviewer feedback.
+    if (originAuthor && isIdd(originAuthor)) {
+      continue;
+    }
+    out.push({
+      url: origin?.url ?? null,
+      author: originAuthor || null,
+      advisoryBot: isAdvisoryBot(originAuthor),
+      path: thread.path ?? null,
+      bodyExcerpt: excerpt(origin?.body),
+      dispositioned: hasFreshDisposition(
+        { isResolved: thread.isResolved, comments: thread.comments },
+        { isDispositionAuthor: isIdd },
+      ),
+    });
+  }
+  return out;
+}
+
+function collectUnaddressedComments(
+  comments: SweepCommentInput[],
+  reviews: SweepReviewInput[],
+  isIdd: (login: string) => boolean,
+  isTrusted: (login: string) => boolean,
+  isAdvisoryBot: (login: string) => boolean,
+): SweepCommentFinding[] {
+  // A non-IDD item counts as addressed only when a later IDD-agent
+  // *disposition* (Accepted / Rejected / Awaiting maintainer decision)
+  // exists — markers and plain replies do not address feedback.
+  const latestDispositionAt = maxTimestamp(
+    comments
+      .filter(
+        (comment) =>
+          isIdd(authorLogin(comment)) && isDispositionBody(comment.body),
+      )
+      .map(commentTimestamp),
+  );
+
+  const out: SweepCommentFinding[] = [];
+
+  for (const comment of comments) {
+    const author = authorLogin(comment);
+    if (!author || isIdd(author)) {
+      continue;
+    }
+    if (isDispositionBody(comment.body)) {
+      continue;
+    }
+    // A trusted IDD operational marker is bookkeeping, not feedback.
+    if (operationalMarkerPrefix(comment.body ?? '') && isTrusted(author)) {
+      continue;
+    }
+    if (isLaterThan(latestDispositionAt, commentTimestamp(comment))) {
+      continue;
+    }
+    out.push({
+      url: comment.url ?? comment.html_url ?? null,
+      author,
+      advisoryBot: isAdvisoryBot(author),
+      kind: 'comment',
+      bodyExcerpt: excerpt(comment.body),
+    });
+  }
+
+  for (const review of reviews) {
+    if (review.state !== 'CHANGES_REQUESTED') {
+      continue;
+    }
+    const author = authorLogin(review);
+    if (!author || isIdd(author)) {
+      continue;
+    }
+    if (isLaterThan(latestDispositionAt, review.submittedAt ?? null)) {
+      continue;
+    }
+    out.push({
+      url: review.url ?? null,
+      author,
+      advisoryBot: isAdvisoryBot(author),
+      kind: 'review',
+      bodyExcerpt: excerpt(review.body),
+    });
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CLI / I/O (not unit-tested; the detection lives in the pure builder above)
+// ---------------------------------------------------------------------------
+
+interface SweepArgs {
+  since: string | null;
+  days: number | null;
+  prNumbers: number[];
+  limit: number;
+  owner: string;
+  repo: string;
+  trustedMarkerLogins: string;
+  advisoryBotLogins: string;
+}
+
+function parseArgs(argv: string[]): SweepArgs {
+  const parsed: SweepArgs = {
+    since: null,
+    days: null,
+    prNumbers: [],
+    limit: 100,
+    owner: '',
+    repo: '',
+    trustedMarkerLogins: '',
+    advisoryBotLogins: '',
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const next = (): string => {
+      const value = argv[index + 1];
+      if (value === undefined) {
+        throw new Error(`missing value for ${token}`);
+      }
+      index += 1;
+      return value;
+    };
+    switch (token) {
+      case '--since':
+        parsed.since = next();
+        break;
+      case '--days':
+        parsed.days = Number.parseInt(next(), 10);
+        break;
+      case '--pr':
+        parsed.prNumbers.push(Number.parseInt(next(), 10));
+        break;
+      case '--prs':
+        for (const part of next().split(',')) {
+          const value = Number.parseInt(part.trim(), 10);
+          if (!Number.isNaN(value)) {
+            parsed.prNumbers.push(value);
+          }
+        }
+        break;
+      case '--limit':
+        parsed.limit = Number.parseInt(next(), 10);
+        break;
+      case '--owner':
+        parsed.owner = next();
+        break;
+      case '--repo':
+        parsed.repo = next();
+        break;
+      case '--trusted-marker-logins':
+        parsed.trustedMarkerLogins = next();
+        break;
+      case '--advisory-bot-logins':
+        parsed.advisoryBotLogins = next();
+        break;
+      default:
+        throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  return parsed;
+}
+
+function resolveSinceDate(args: SweepArgs): string | null {
+  if (args.since) {
+    return args.since;
+  }
+  if (args.days && args.days > 0) {
+    const cutoff = Date.now() - args.days * 24 * 60 * 60 * 1000;
+    return new Date(cutoff).toISOString().slice(0, 10);
+  }
+  return null;
+}
+
+function loadIddConfig(): {
+  trustedMarkerActors?: unknown;
+  advisoryBotLogins?: unknown;
+} | null {
+  try {
+    return JSON.parse(readFileSync('.github/idd/config.json', 'utf8')) as {
+      trustedMarkerActors?: unknown;
+      advisoryBotLogins?: unknown;
+    };
+  } catch {
+    return null;
+  }
+}
+
+function runGh(args: string[]): string {
+  return execFileSync('gh', args, { encoding: 'utf8' });
+}
+
+function ghGraphql(
+  query: string,
+  variables: Record<string, string | number | null | undefined>,
+): unknown {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
+  }
+  return JSON.parse(runGh(args).trim() || '{}');
+}
+
+interface MergedPrListItem {
+  number: number;
+  mergedAt?: string | null;
+}
+
+function listMergedPrNumbers(
+  repoRef: string,
+  sinceDate: string | null,
+  limit: number,
+): MergedPrListItem[] {
+  const args = [
+    'pr',
+    'list',
+    '-R',
+    repoRef,
+    '--state',
+    'merged',
+    '--json',
+    'number,mergedAt',
+    '--limit',
+    String(limit),
+  ];
+  if (sinceDate) {
+    args.push('--search', `merged:>=${sinceDate}`);
+  }
+  const raw = runGh(args).trim();
+  const items = raw ? (JSON.parse(raw) as MergedPrListItem[]) : [];
+  return items;
+}
+
+const PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      number
+      merged
+      mergedAt
+      mergeCommit{ oid }
+      comments(first:100){ nodes{ body url createdAt author{ login } } }
+      reviews(first:100){ nodes{ body url state submittedAt author{ login } } }
+      reviewThreads(first:100){ nodes{
+        isResolved
+        path
+        comments(first:100){ nodes{ body url createdAt author{ login } } }
+      } }
+    }
+  }
+}`;
+
+interface PullRequestNode {
+  number: number;
+  merged?: boolean | null;
+  mergedAt?: string | null;
+  mergeCommit?: { oid?: string | null } | null;
+  comments?: { nodes?: SweepCommentInput[] | null } | null;
+  reviews?: { nodes?: SweepReviewInput[] | null } | null;
+  reviewThreads?: { nodes?: SweepThreadInput[] | null } | null;
+}
+
+function fetchMergedPr(
+  owner: string,
+  repo: string,
+  number: number,
+): MergedPrInput | null {
+  const result = ghGraphql(PR_QUERY, { owner, repo, number }) as {
+    data?: {
+      repository?: { pullRequest?: PullRequestNode | null } | null;
+    } | null;
+  };
+  const pr = result?.data?.repository?.pullRequest;
+  if (!pr?.merged) {
+    return null;
+  }
+  return {
+    number: pr.number,
+    mergedAt: pr.mergedAt ?? null,
+    mergeCommit: pr.mergeCommit?.oid ?? null,
+    threads: pr.reviewThreads?.nodes ?? [],
+    comments: pr.comments?.nodes ?? [],
+    reviews: pr.reviews?.nodes ?? [],
+  };
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const owner =
+    args.owner ||
+    runGh(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']).trim();
+  const repo =
+    args.repo ||
+    runGh(['repo', 'view', '--json', 'name', '--jq', '.name']).trim();
+  const repoRef = `${owner}/${repo}`;
+  const iddConfig = loadIddConfig();
+
+  const { actors: trustedMarkerActors } = resolveTrustedMarkerActors({
+    flagValue: args.trustedMarkerLogins,
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: iddConfig,
+  });
+  const { logins: advisoryBotLogins } = resolveAdvisoryBotLogins({
+    flagValue: args.advisoryBotLogins,
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+    config: iddConfig,
+  });
+
+  const sinceDate = resolveSinceDate(args);
+  const targets =
+    args.prNumbers.length > 0
+      ? args.prNumbers.map((number) => ({ number }))
+      : listMergedPrNumbers(repoRef, sinceDate, args.limit);
+
+  const prs: MergedPrInput[] = [];
+  for (const target of targets) {
+    const pr = fetchMergedPr(owner, repo, target.number);
+    if (pr) {
+      prs.push(pr);
+    }
+  }
+
+  const result = buildMergedPrFeedbackSweep(prs, {
+    trustedMarkerActors,
+    advisoryBotLogins,
+    // In this workflow the IDD agent posts dispositions under the trusted
+    // marker actor identity, so the disposition authors are those actors.
+    iddAgentLogins: trustedMarkerActors,
+  });
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        sweepWindow: {
+          since: sinceDate,
+          days: args.days,
+          explicitPrs: args.prNumbers.length > 0 ? args.prNumbers : null,
+          prCount: result.summary.prCount,
+        },
+        trustedMarkerActors,
+        advisoryBotLogins,
+        prs: result.prs,
+        summary: result.summary,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -536,7 +536,20 @@ function ghGraphql(
     }
     args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
   }
-  return JSON.parse(runGh(args).trim() || '{}');
+  const result = JSON.parse(runGh(args).trim() || '{}') as {
+    errors?: { message?: string | null }[] | null;
+  };
+  // A GraphQL call can return HTTP 200 with a top-level `errors` array and
+  // null `data`. Fail fast instead of treating it as empty data, which would
+  // be a silent false negative (a PR appearing "clean" because no nodes came
+  // back).
+  if (Array.isArray(result.errors) && result.errors.length > 0) {
+    const messages = result.errors
+      .map((entry) => entry?.message ?? 'unknown')
+      .join('; ');
+    throw new Error(`GraphQL query returned errors: ${messages}`);
+  }
+  return result;
 }
 
 interface MergedPrListItem {

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // idd-generated-from: src/scripts/merged-pr-feedback-sweep.mts
 //
 // Read-only helper: scan MERGED PRs for unresolved / unaddressed advisory
@@ -414,8 +415,12 @@ function parseArgs(argv: string[]): SweepArgs {
     const nextInt = (): number => {
       const raw = next();
       const value = Number.parseInt(raw, 10);
-      if (!Number.isFinite(value) || String(value) !== raw.trim()) {
-        throw new Error(`${token} expects an integer, got "${raw}"`);
+      if (
+        !Number.isFinite(value) ||
+        String(value) !== raw.trim() ||
+        value < 1
+      ) {
+        throw new Error(`${token} expects a positive integer, got "${raw}"`);
       }
       return value;
     };
@@ -433,9 +438,13 @@ function parseArgs(argv: string[]): SweepArgs {
         for (const part of next().split(',')) {
           const trimmed = part.trim();
           const value = Number.parseInt(trimmed, 10);
-          if (!Number.isFinite(value) || String(value) !== trimmed) {
+          if (
+            !Number.isFinite(value) ||
+            String(value) !== trimmed ||
+            value < 1
+          ) {
             throw new Error(
-              `--prs expects comma-separated integers, got "${part}"`,
+              `--prs expects comma-separated positive integers, got "${part}"`,
             );
           }
           parsed.prNumbers.push(value);

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -325,10 +325,11 @@ function collectUnaddressedComments(
 
   for (const comment of comments) {
     const author = authorLogin(comment);
+    // IDD-agent comments (incl. their dispositions) are excluded by author
+    // here, so a disposition marker is treated specially only when the agent
+    // wrote it. A non-IDD reviewer who opens a comment with "**Rejected**" is
+    // still surfaced as feedback.
     if (!author || isIdd(author)) {
-      continue;
-    }
-    if (isDispositionBody(comment.body)) {
       continue;
     }
     // IDD bookkeeping is not feedback: a trusted operational-state marker,

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 // idd-generated-from: src/scripts/merged-pr-feedback-sweep.mts
 //
+// The scripts/merged-pr-feedback-sweep.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
 // Read-only helper: scan MERGED PRs for unresolved / unaddressed advisory
 // feedback (review threads still open, and non-IDD-agent comments / review
 // bodies that never received a later IDD-agent disposition). It only DETECTS
@@ -583,8 +587,16 @@ function fetchAllNodes<T>(
     };
     const conn = result?.data?.repository?.pullRequest?.[field];
     out.push(...(conn?.nodes ?? []));
-    if (!conn?.pageInfo?.hasNextPage || !conn.pageInfo.endCursor) {
+    if (!conn?.pageInfo?.hasNextPage) {
       break;
+    }
+    // Fail fast rather than silently truncate: a missing cursor on a
+    // has-next-page response would reintroduce the false negative this
+    // pagination exists to prevent.
+    if (!conn.pageInfo.endCursor) {
+      throw new Error(
+        `pagination for ${field} on PR #${number} reported hasNextPage with no endCursor`,
+      );
     }
     after = conn.pageInfo.endCursor;
   }

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -17,6 +17,7 @@ import {
   hasFreshDisposition,
   isDispositionComment,
   isKnownReviewBot,
+  normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
@@ -171,6 +172,38 @@ function isDispositionBody(body: string | null | undefined): boolean {
   );
 }
 
+// Normalize a comma-separated login list; returns null when empty so callers
+// can fall through to the next source in their precedence chain.
+function resolveLoginList(value: string): string[] | null {
+  const tokens = value
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean);
+  return tokens.length > 0 ? normalizeTrustedMarkerLogins(tokens) : null;
+}
+
+// IDD bookkeeping comments are not reviewer feedback.
+function isIddBookkeeping(
+  body: string | null | undefined,
+  author: string,
+  isTrusted: (login: string) => boolean,
+): boolean {
+  // IDD HTML-comment bookkeeping markers (cleanup-evidence, plan, digest,
+  // roadmap-audit, …) are posted by the agent or by CI automation such as
+  // github-actions, never by a reviewer; exclude them regardless of author.
+  if (
+    String(body ?? '')
+      .trimStart()
+      .startsWith('<!-- idd-')
+  ) {
+    return true;
+  }
+  // Operational-state markers (claimed-by / review-watermark / advisory-wait
+  // / …) count only from a trusted marker author; an untrusted look-alike is
+  // left in as surfacing context.
+  return operationalMarkerPrefix(body ?? '') !== null && isTrusted(author);
+}
+
 // ---------------------------------------------------------------------------
 // Pure sweep builder (the testable core — no network)
 // ---------------------------------------------------------------------------
@@ -298,8 +331,10 @@ function collectUnaddressedComments(
     if (isDispositionBody(comment.body)) {
       continue;
     }
-    // A trusted IDD operational marker is bookkeeping, not feedback.
-    if (operationalMarkerPrefix(comment.body ?? '') && isTrusted(author)) {
+    // IDD bookkeeping is not feedback: a trusted operational-state marker,
+    // or any `<!-- idd-… -->` comment (e.g. cleanup-evidence / plan / digest,
+    // which CI automation such as github-actions also posts).
+    if (isIddBookkeeping(comment.body, author, isTrusted)) {
       continue;
     }
     if (isLaterThan(latestDispositionAt, commentTimestamp(comment))) {
@@ -350,6 +385,7 @@ interface SweepArgs {
   repo: string;
   trustedMarkerLogins: string;
   advisoryBotLogins: string;
+  iddAgentLogins: string;
 }
 
 function parseArgs(argv: string[]): SweepArgs {
@@ -362,6 +398,7 @@ function parseArgs(argv: string[]): SweepArgs {
     repo: '',
     trustedMarkerLogins: '',
     advisoryBotLogins: '',
+    iddAgentLogins: '',
   };
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -373,26 +410,38 @@ function parseArgs(argv: string[]): SweepArgs {
       index += 1;
       return value;
     };
+    const nextInt = (): number => {
+      const raw = next();
+      const value = Number.parseInt(raw, 10);
+      if (!Number.isFinite(value) || String(value) !== raw.trim()) {
+        throw new Error(`${token} expects an integer, got "${raw}"`);
+      }
+      return value;
+    };
     switch (token) {
       case '--since':
         parsed.since = next();
         break;
       case '--days':
-        parsed.days = Number.parseInt(next(), 10);
+        parsed.days = nextInt();
         break;
       case '--pr':
-        parsed.prNumbers.push(Number.parseInt(next(), 10));
+        parsed.prNumbers.push(nextInt());
         break;
       case '--prs':
         for (const part of next().split(',')) {
-          const value = Number.parseInt(part.trim(), 10);
-          if (!Number.isNaN(value)) {
-            parsed.prNumbers.push(value);
+          const trimmed = part.trim();
+          const value = Number.parseInt(trimmed, 10);
+          if (!Number.isFinite(value) || String(value) !== trimmed) {
+            throw new Error(
+              `--prs expects comma-separated integers, got "${part}"`,
+            );
           }
+          parsed.prNumbers.push(value);
         }
         break;
       case '--limit':
-        parsed.limit = Number.parseInt(next(), 10);
+        parsed.limit = nextInt();
         break;
       case '--owner':
         parsed.owner = next();
@@ -405,6 +454,9 @@ function parseArgs(argv: string[]): SweepArgs {
         break;
       case '--advisory-bot-logins':
         parsed.advisoryBotLogins = next();
+        break;
+      case '--idd-agent-logins':
+        parsed.iddAgentLogins = next();
         break;
       default:
         throw new Error(`unknown argument: ${token}`);
@@ -486,32 +538,47 @@ function listMergedPrNumbers(
   return items;
 }
 
-const PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
-  repository(owner:$owner,name:$repo){
-    pullRequest(number:$number){
-      number
-      merged
-      mergedAt
-      mergeCommit{ oid }
-      comments(first:100){ nodes{ body url createdAt author{ login } } }
-      reviews(first:100){ nodes{ body url state submittedAt author{ login } } }
-      reviewThreads(first:100){ nodes{
-        isResolved
-        path
-        comments(first:100){ nodes{ body url createdAt author{ login } } }
-      } }
-    }
-  }
-}`;
+interface Connection<T> {
+  pageInfo?: { hasNextPage?: boolean | null; endCursor?: string | null } | null;
+  nodes?: T[] | null;
+}
 
-interface PullRequestNode {
-  number: number;
-  merged?: boolean | null;
-  mergedAt?: string | null;
-  mergeCommit?: { oid?: string | null } | null;
-  comments?: { nodes?: SweepCommentInput[] | null } | null;
-  reviews?: { nodes?: SweepReviewInput[] | null } | null;
-  reviewThreads?: { nodes?: SweepThreadInput[] | null } | null;
+// Page a single `pullRequest` connection to completion so large PRs cannot
+// silently truncate at 100 items (which would hide unresolved threads or a
+// later disposition comment and produce a false negative). Per-thread reply
+// pagination is intentionally left at first:100 — a thread with 100+ replies
+// is pathological and only affects the advisory `dispositioned` flag, not
+// whether the thread surfaces.
+function fetchAllNodes<T>(
+  owner: string,
+  repo: string,
+  number: number,
+  field: string,
+  nodeFields: string,
+): T[] {
+  const out: T[] = [];
+  let after: string | null = null;
+  for (;;) {
+    const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+      repository(owner:$owner,name:$repo){ pullRequest(number:$number){
+        ${field}(first:100,after:$after){ pageInfo{ hasNextPage endCursor } nodes{ ${nodeFields} } }
+      } }
+    }`;
+    const result = ghGraphql(query, { owner, repo, number, after }) as {
+      data?: {
+        repository?: {
+          pullRequest?: Record<string, Connection<T> | null> | null;
+        } | null;
+      } | null;
+    };
+    const conn = result?.data?.repository?.pullRequest?.[field];
+    out.push(...(conn?.nodes ?? []));
+    if (!conn?.pageInfo?.hasNextPage || !conn.pageInfo.endCursor) {
+      break;
+    }
+    after = conn.pageInfo.endCursor;
+  }
+  return out;
 }
 
 function fetchMergedPr(
@@ -519,22 +586,52 @@ function fetchMergedPr(
   repo: string,
   number: number,
 ): MergedPrInput | null {
-  const result = ghGraphql(PR_QUERY, { owner, repo, number }) as {
+  const metaQuery = `query($owner:String!,$repo:String!,$number:Int!){
+    repository(owner:$owner,name:$repo){ pullRequest(number:$number){
+      number merged mergedAt mergeCommit{ oid }
+    } }
+  }`;
+  const meta = ghGraphql(metaQuery, { owner, repo, number }) as {
     data?: {
-      repository?: { pullRequest?: PullRequestNode | null } | null;
+      repository?: {
+        pullRequest?: {
+          number?: number;
+          merged?: boolean | null;
+          mergedAt?: string | null;
+          mergeCommit?: { oid?: string | null } | null;
+        } | null;
+      } | null;
     } | null;
   };
-  const pr = result?.data?.repository?.pullRequest;
+  const pr = meta?.data?.repository?.pullRequest;
   if (!pr?.merged) {
     return null;
   }
   return {
-    number: pr.number,
+    number: pr.number ?? number,
     mergedAt: pr.mergedAt ?? null,
     mergeCommit: pr.mergeCommit?.oid ?? null,
-    threads: pr.reviewThreads?.nodes ?? [],
-    comments: pr.comments?.nodes ?? [],
-    reviews: pr.reviews?.nodes ?? [],
+    comments: fetchAllNodes<SweepCommentInput>(
+      owner,
+      repo,
+      number,
+      'comments',
+      'body url createdAt author{ login }',
+    ),
+    reviews: fetchAllNodes<SweepReviewInput>(
+      owner,
+      repo,
+      number,
+      'reviews',
+      'body url state submittedAt author{ login }',
+    ),
+    threads: fetchAllNodes<SweepThreadInput>(
+      owner,
+      repo,
+      number,
+      'reviewThreads',
+      'isResolved path comments(first:100){ nodes{ body url createdAt author{ login } } }',
+    ),
   };
 }
 
@@ -559,6 +656,16 @@ function main(): void {
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config: iddConfig,
   });
+  // The IDD agent accounts whose comments are treated as dispositions and
+  // whose own comments are not feedback. Distinct from trusted-marker actors:
+  // a human maintainer can be a trusted-marker actor whose review feedback we
+  // still want to surface. Defaults to the trusted-marker actors (the agent
+  // posts under that identity in this repo); override with --idd-agent-logins
+  // or IDD_AGENT_LOGINS when the agent runs under a separate account.
+  const iddAgentLogins =
+    resolveLoginList(args.iddAgentLogins) ??
+    resolveLoginList(process.env.IDD_AGENT_LOGINS ?? '') ??
+    trustedMarkerActors;
 
   const sinceDate = resolveSinceDate(args);
   const targets =
@@ -577,9 +684,7 @@ function main(): void {
   const result = buildMergedPrFeedbackSweep(prs, {
     trustedMarkerActors,
     advisoryBotLogins,
-    // In this workflow the IDD agent posts dispositions under the trusted
-    // marker actor identity, so the disposition authors are those actors.
-    iddAgentLogins: trustedMarkerActors,
+    iddAgentLogins,
   });
 
   process.stdout.write(
@@ -593,6 +698,7 @@ function main(): void {
         },
         trustedMarkerActors,
         advisoryBotLogins,
+        iddAgentLogins,
         prs: result.prs,
         summary: result.summary,
       },

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -298,13 +298,30 @@ function collectUnresolvedThreads(
       advisoryBot: isAdvisoryBot(originAuthor),
       path: thread.path ?? null,
       bodyExcerpt: excerpt(origin?.body),
-      dispositioned: hasFreshDisposition(
-        { isResolved: thread.isResolved, comments: thread.comments },
-        { isDispositionAuthor: isIdd },
-      ),
+      // `hasFreshDisposition` recognizes Accepted/Rejected; OR-in an IDD
+      // `**Awaiting maintainer decision**` reply so AMD threads match the
+      // comment-path disposition handling.
+      dispositioned:
+        hasFreshDisposition(
+          { isResolved: thread.isResolved, comments: thread.comments },
+          { isDispositionAuthor: isIdd },
+        ) || threadHasIddAmd(thread, isIdd),
     });
   }
   return out;
+}
+
+function threadHasIddAmd(
+  thread: SweepThreadInput,
+  isIdd: (login: string) => boolean,
+): boolean {
+  return (thread.comments?.nodes ?? []).some(
+    (comment) =>
+      isIdd(authorLogin(comment)) &&
+      String(comment.body ?? '')
+        .trimStart()
+        .startsWith('**Awaiting maintainer decision**'),
+  );
 }
 
 function collectUnaddressedComments(

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -360,11 +360,12 @@ function collectUnaddressedComments(
 
   for (const comment of comments) {
     const author = authorLogin(comment);
-    // IDD-agent comments (incl. their dispositions) are excluded by author
-    // here, so a disposition marker is treated specially only when the agent
-    // wrote it. A non-IDD reviewer who opens a comment with "**Rejected**" is
-    // still surfaced as feedback.
-    if (!author || isIdd(author)) {
+    // Only IDD-agent comments are excluded by author (their dispositions are
+    // folded into `latestDispositionAt`); a non-IDD reviewer who opens a
+    // comment with "**Rejected**" is still surfaced as feedback. A
+    // missing/unknown author (deleted user / ghost comment) is surfaced with
+    // `author: null` rather than dropped, to avoid a false negative.
+    if (isIdd(author)) {
       continue;
     }
     // IDD bookkeeping is not feedback: a trusted operational-state marker,
@@ -378,7 +379,7 @@ function collectUnaddressedComments(
     }
     out.push({
       url: comment.url ?? comment.html_url ?? null,
-      author,
+      author: author || null,
       advisoryBot: isAdvisoryBot(author),
       kind: 'comment',
       bodyExcerpt: excerpt(comment.body),
@@ -390,7 +391,9 @@ function collectUnaddressedComments(
       continue;
     }
     const author = authorLogin(review);
-    if (!author || isIdd(author)) {
+    // Same author rule as comments: exclude only explicit IDD agents; a
+    // missing/unknown author is surfaced with `author: null`.
+    if (isIdd(author)) {
       continue;
     }
     if (isLaterThan(latestDispositionAt, review.submittedAt ?? null)) {
@@ -398,7 +401,7 @@ function collectUnaddressedComments(
     }
     out.push({
       url: review.url ?? null,
-      author,
+      author: author || null,
       advisoryBot: isAdvisoryBot(author),
       kind: 'review',
       bodyExcerpt: excerpt(review.body),

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -1,0 +1,285 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildMergedPrFeedbackSweep,
+  type MergedPrInput,
+} from '../src/scripts/merged-pr-feedback-sweep.mts';
+
+const OPTIONS = {
+  trustedMarkerActors: ['kurone-kito'],
+  advisoryBotLogins: ['coderabbitai[bot]'],
+  iddAgentLogins: ['kurone-kito'],
+};
+
+function thread(
+  isResolved: boolean,
+  comments: { login: string; body: string; createdAt: string; url?: string }[],
+  path = 'src/x.mts',
+) {
+  return {
+    isResolved,
+    path,
+    comments: {
+      nodes: comments.map((c) => ({
+        body: c.body,
+        url: c.url ?? 'https://example/thread',
+        createdAt: c.createdAt,
+        author: { login: c.login },
+      })),
+    },
+  };
+}
+
+test('surfaces an unresolved reviewer thread with no disposition', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 1,
+      mergedAt: '2026-06-10T00:00:00Z',
+      mergeCommit: 'abc',
+      threads: [
+        thread(false, [
+          {
+            login: 'coderabbitai[bot]',
+            body: 'This loop can deadlock.',
+            createdAt: '2026-06-09T00:00:00Z',
+          },
+        ]),
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unresolvedThreads.length, 1);
+  assert.equal(result.prs[0].unresolvedThreads[0].author, 'coderabbitai[bot]');
+  assert.equal(result.prs[0].unresolvedThreads[0].path, 'src/x.mts');
+  assert.equal(result.prs[0].unresolvedThreads[0].dispositioned, false);
+  assert.equal(result.prs[0].unresolvedThreads[0].advisoryBot, true);
+  assert.equal(result.summary.unresolvedThreadCount, 1);
+});
+
+test('excludes a resolved thread', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 2,
+      threads: [
+        thread(true, [
+          {
+            login: 'coderabbitai[bot]',
+            body: 'nit',
+            createdAt: '2026-06-09T00:00:00Z',
+          },
+        ]),
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
+test('marks an unresolved thread dispositioned when the agent replied with a marker', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 3,
+      threads: [
+        thread(false, [
+          {
+            login: 'coderabbitai[bot]',
+            body: 'concern',
+            createdAt: '2026-06-09T00:00:00Z',
+          },
+          {
+            login: 'kurone-kito',
+            body: '**Rejected** — false positive.',
+            createdAt: '2026-06-09T01:00:00Z',
+          },
+        ]),
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs[0].unresolvedThreads[0].dispositioned, true);
+});
+
+test('excludes a thread the IDD agent itself opened', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 4,
+      threads: [
+        thread(false, [
+          {
+            login: 'kurone-kito',
+            body: 'self note',
+            createdAt: '2026-06-09T00:00:00Z',
+          },
+        ]),
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
+test('surfaces a non-IDD regular comment with no later disposition', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 5,
+      comments: [
+        {
+          body: 'Did you consider X?',
+          url: 'https://example/c',
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unaddressedComments.length, 1);
+  assert.equal(result.prs[0].unaddressedComments[0].kind, 'comment');
+  assert.equal(
+    result.prs[0].unaddressedComments[0].author,
+    'coderabbitai[bot]',
+  );
+});
+
+test('excludes a comment addressed by a later IDD disposition', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 6,
+      comments: [
+        {
+          body: 'Did you consider X?',
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+        {
+          body: '**Rejected** — covered.',
+          createdAt: '2026-06-09T02:00:00Z',
+          author: { login: 'kurone-kito' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
+test('a non-disposition IDD comment (e.g. a marker) does not address feedback', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 7,
+      comments: [
+        {
+          body: 'Did you consider X?',
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+        // a later IDD comment that is NOT a disposition (operational marker)
+        {
+          body: '<!-- review-watermark: kurone-kito cid head 2026 1 none -->\n\n_note_',
+          createdAt: '2026-06-09T03:00:00Z',
+          author: { login: 'kurone-kito' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unaddressedComments.length, 1);
+  assert.equal(
+    result.prs[0].unaddressedComments[0].author,
+    'coderabbitai[bot]',
+  );
+});
+
+test('excludes a trusted IDD operational marker comment from the feedback set', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 8,
+      comments: [
+        {
+          body: '<!-- claimed-by: kurone-kito cid supersedes: none 2026 branch: issue/1 -->\n\n_claim_',
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'kurone-kito' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
+test('surfaces an unaddressed CHANGES_REQUESTED review body', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 9,
+      reviews: [
+        {
+          body: 'please fix',
+          url: 'https://example/r',
+          state: 'CHANGES_REQUESTED',
+          submittedAt: '2026-06-09T00:00:00Z',
+          author: { login: 'a-human' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unaddressedComments[0].kind, 'review');
+  assert.equal(result.prs[0].unaddressedComments[0].author, 'a-human');
+  assert.equal(result.prs[0].unaddressedComments[0].advisoryBot, false);
+});
+
+test('a COMMENTED (non-CHANGES_REQUESTED) review body is not feedback', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 10,
+      reviews: [
+        {
+          body: 'overview',
+          state: 'COMMENTED',
+          submittedAt: '2026-06-09T00:00:00Z',
+          author: { login: 'copilot-pull-request-reviewer' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
+test('summary aggregates across PRs and skips clean PRs', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 11,
+      threads: [
+        thread(false, [
+          { login: 'h', body: 'x', createdAt: '2026-06-09T00:00:00Z' },
+        ]),
+      ],
+      comments: [
+        {
+          body: 'y',
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'h' },
+        },
+      ],
+    },
+    {
+      number: 12,
+      threads: [
+        thread(true, [
+          { login: 'h', body: 'z', createdAt: '2026-06-09T00:00:00Z' },
+        ]),
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.summary.prCount, 2);
+  assert.equal(result.summary.flaggedPrCount, 1);
+  assert.equal(result.summary.unresolvedThreadCount, 1);
+  assert.equal(result.summary.unaddressedCommentCount, 1);
+});

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -190,6 +190,39 @@ test('excludes a comment addressed by a later IDD disposition', () => {
   assert.equal(result.prs.length, 0);
 });
 
+test('a later thread-level IDD disposition addresses a top-level comment', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 15,
+      comments: [
+        {
+          body: 'Did you consider X?',
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+      // The disposition lives inside a (resolved) review thread, not as a
+      // top-level comment; it must still count as the "later disposition".
+      threads: [
+        thread(true, [
+          {
+            login: 'coderabbitai[bot]',
+            body: 'related concern',
+            createdAt: '2026-06-09T00:30:00Z',
+          },
+          {
+            login: 'kurone-kito',
+            body: '**Accepted** — covered in follow-up.',
+            createdAt: '2026-06-09T02:00:00Z',
+          },
+        ]),
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
 test('surfaces a non-IDD comment that opens with a disposition marker', () => {
   const prs: MergedPrInput[] = [
     {

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -326,6 +326,36 @@ test('surfaces an unaddressed CHANGES_REQUESTED review body', () => {
   assert.equal(result.prs[0].unaddressedComments[0].advisoryBot, false);
 });
 
+test('surfaces a comment from a missing/unknown author with author null', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 16,
+      comments: [
+        {
+          body: 'This still looks wrong.',
+          createdAt: '2026-06-09T00:00:00Z',
+          author: null,
+        },
+      ],
+      reviews: [
+        {
+          body: 'please fix',
+          state: 'CHANGES_REQUESTED',
+          submittedAt: '2026-06-09T00:00:00Z',
+          author: null,
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unaddressedComments.length, 2);
+  for (const finding of result.prs[0].unaddressedComments) {
+    assert.equal(finding.author, null);
+    assert.equal(finding.advisoryBot, false);
+  }
+});
+
 test('a COMMENTED (non-CHANGES_REQUESTED) review body is not feedback', () => {
   const prs: MergedPrInput[] = [
     {

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -223,6 +223,31 @@ test('a later thread-level IDD disposition addresses a top-level comment', () =>
   assert.equal(result.prs.length, 0);
 });
 
+test('prefers updatedAt when ordering an edited IDD disposition', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 17,
+      comments: [
+        {
+          body: 'concern',
+          createdAt: '2026-06-09T01:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+        {
+          // Created BEFORE the concern but edited AFTER it: the disposition
+          // must still count as the later disposition (updatedAt wins).
+          body: '**Rejected** — not applicable.',
+          createdAt: '2026-06-09T00:00:00Z',
+          updatedAt: '2026-06-09T02:00:00Z',
+          author: { login: 'kurone-kito' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
 test('surfaces a non-IDD comment that opens with a disposition marker', () => {
   const prs: MergedPrInput[] = [
     {

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -101,6 +101,30 @@ test('marks an unresolved thread dispositioned when the agent replied with a mar
   assert.equal(result.prs[0].unresolvedThreads[0].dispositioned, true);
 });
 
+test('marks an unresolved thread dispositioned on an IDD AMD reply', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 3,
+      threads: [
+        thread(false, [
+          {
+            login: 'coderabbitai[bot]',
+            body: 'concern',
+            createdAt: '2026-06-09T00:00:00Z',
+          },
+          {
+            login: 'kurone-kito',
+            body: '**Awaiting maintainer decision** — needs a call.',
+            createdAt: '2026-06-09T01:00:00Z',
+          },
+        ]),
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs[0].unresolvedThreads[0].dispositioned, true);
+});
+
 test('excludes a thread the IDD agent itself opened', () => {
   const prs: MergedPrInput[] = [
     {

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -211,6 +211,23 @@ test('excludes a trusted IDD operational marker comment from the feedback set', 
   assert.equal(result.prs.length, 0);
 });
 
+test('excludes an IDD bookkeeping marker even from CI automation', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 13,
+      comments: [
+        {
+          body: '<!-- idd-cleanup-evidence: applied applied:1 failed:0 -->\n\n_evidence_',
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'github-actions[bot]' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
 test('surfaces an unaddressed CHANGES_REQUESTED review body', () => {
   const prs: MergedPrInput[] = [
     {

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -166,6 +166,25 @@ test('excludes a comment addressed by a later IDD disposition', () => {
   assert.equal(result.prs.length, 0);
 });
 
+test('surfaces a non-IDD comment that opens with a disposition marker', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 14,
+      comments: [
+        {
+          body: '**Rejected** — I disagree with this approach; it breaks X.',
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'a-human' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unaddressedComments.length, 1);
+  assert.equal(result.prs[0].unaddressedComments[0].author, 'a-human');
+});
+
 test('a non-disposition IDD comment (e.g. a marker) does not address feedback', () => {
   const prs: MergedPrInput[] = [
     {


### PR DESCRIPTION
## Summary

A manually-invoked, read-only helper that detects unresolved / unaddressed
advisory feedback on merged PRs and prints JSON for an operator to hand to
the issue-authoring skill. The recurring counterpart of the one-time audit
#910 and the chosen recovery path from #909 (advisory-wait stays
Copilot-only).

## What it does

- Enumerates merged PRs (`--since` / `--days` / `--pr` / `--prs`) and, per
  PR, surfaces:
  - review threads with `isResolved == false` (excluding IDD-agent-originated
    threads; each carries a `dispositioned` flag), and
  - regular comments / `CHANGES_REQUESTED` review bodies from non-IDD-agent
    authors with **no later IDD-agent disposition** (Accepted / Rejected /
    Awaiting maintainer decision).
- Excludes trusted IDD operational markers and IDD disposition comments.
- Each finding carries an `advisoryBot` flag so the operator can prioritize
  human feedback over capricious advisory-bot noise.
- **Read-only**: reads via `gh` only — no minimize / post / create.

## Design

- Pure `buildMergedPrFeedbackSweep()` is the testable core (11 table-driven
  tests, no network); `main()` does the `gh` I/O.
- Reuses `hasFreshDisposition`, `isDispositionComment`,
  `operationalMarkerPrefix`, `resolveTrustedMarkerActors`,
  `resolveAdvisoryBotLogins`, `isKnownReviewBot` from `protocol-helpers`.
- bin `idd-merged-pr-feedback-sweep`; documented in
  `docs/idd-helper-scripts.md`. Cadence is manual (operator-invoked), per the
  #909 decision.

## Verification

`node --test` (973 pass, +11 new), `pnpm run build` (no diff), `tsc`,
`biome check`, `node scripts/audit-docs.mjs --check`, cspell, and
markdownlint all pass.

Closes #931
