### PR TITLE
fix(branch-name): treat non-string titles as empty and fall back to task

### DIFF
--- a/scripts/branch-name.mjs
+++ b/scripts/branch-name.mjs
@@ -45,9 +45,14 @@ if (isCliExecution()) {
  *    and a `-` exists before char 40, trim back to that `-`, else keep
  *    the hard 40-char cut — then strip any trailing `-`;
  * 6. if empty, fall back to `task`.
+ *
+ * The algorithm is defined over an issue *title string*. Non-string
+ * inputs (including `null`/`undefined`) are out of that domain and are
+ * treated as empty, so they fall back to `task` rather than producing a
+ * coerced slug such as `object-object` or `123`.
  */
 export function computeBranchSlug(title) {
-  const normalized = String(title ?? '')
+  const normalized = (typeof title === 'string' ? title : '')
     .toLowerCase()
     .replace(/[^a-z0-9]/g, '-');
   const tokens = normalized

--- a/src/scripts/branch-name.mts
+++ b/src/scripts/branch-name.mts
@@ -49,9 +49,14 @@ if (isCliExecution()) {
  *    and a `-` exists before char 40, trim back to that `-`, else keep
  *    the hard 40-char cut — then strip any trailing `-`;
  * 6. if empty, fall back to `task`.
+ *
+ * The algorithm is defined over an issue *title string*. Non-string
+ * inputs (including `null`/`undefined`) are out of that domain and are
+ * treated as empty, so they fall back to `task` rather than producing a
+ * coerced slug such as `object-object` or `123`.
  */
 export function computeBranchSlug(title: unknown): string {
-  const normalized = String(title ?? '')
+  const normalized = (typeof title === 'string' ? title : '')
     .toLowerCase()
     .replace(/[^a-z0-9]/g, '-');
   const tokens = normalized

--- a/tests/branch-name.test.mts
+++ b/tests/branch-name.test.mts
@@ -106,5 +106,13 @@ test('computeBranchName composes issue/<number>-<slug>', () => {
 test('handles nullish and non-string titles defensively', () => {
   assert.equal(computeBranchSlug(null), 'task');
   assert.equal(computeBranchSlug(undefined), 'task');
+  // non-string inputs are out of the documented (title-string) domain and
+  // fall back to `task` rather than producing coerced slugs like
+  // `123` / `object-object`
+  assert.equal(computeBranchSlug(123), 'task');
+  assert.equal(computeBranchSlug({}), 'task');
+  assert.equal(computeBranchSlug([1, 2]), 'task');
+  assert.equal(computeBranchSlug(true), 'task');
   assert.equal(computeBranchName(8, null), 'issue/8-task');
+  assert.equal(computeBranchName(9, 123), 'issue/9-task');
 });


### PR DESCRIPTION
## Summary

`computeBranchSlug` coerced any non-nullish value with `String(...)`, so a
number/object title produced surprising slugs like `123` / `object-object`.
The slug algorithm is defined over an issue *title string*, so non-string
inputs are now treated as empty and fall back to `task` (matching the
nullish cases). Tests cover number/object/array/boolean inputs.

## Verification

`pnpm run build`, `pnpm run lint` (lint:minimum, full suite), and
`pnpm run build:check` pass; 11/11 branch-name tests green.

Closes #911