### PR TITLE
fix(idd-doctor): exclude score 1 from the blocked-by-human floor contradiction check

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -120,6 +120,7 @@ export function evaluateAutopilotSuitabilityConsistency(issues, options = {}) {
       );
     } else if (
       marker.value !== null &&
+      marker.value > 1 &&
       marker.value >= floor &&
       blockedByHuman
     ) {

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -208,6 +208,7 @@ export function evaluateAutopilotSuitabilityConsistency(
       );
     } else if (
       marker.value !== null &&
+      marker.value > 1 &&
       marker.value >= floor &&
       blockedByHuman
     ) {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -131,6 +131,42 @@ test('autopilot-suitability consistency: honors a custom floor and marker prefix
   assert.match(warnings[0], /issue #14 is scored 4 \(>= floor 4\)/);
 });
 
+test('autopilot-suitability consistency: floor 1 treats score-1 + blocked-by-human as agreement', () => {
+  const issues = [
+    // floor 1: score 1 with blocked-by-human AGREES — the score and label
+    // both mark the issue human-only, so there is no contradiction.
+    {
+      number: 21,
+      body: `human-only\n${ap(1)}`,
+      labels: ['status:blocked-by-human'],
+    },
+    // floor 1: score 1 without the label still warns via the first branch.
+    { number: 22, body: `task\n${ap(1)}`, labels: [] },
+    // floor 1: score 2 with blocked-by-human still warns (>= floor 1).
+    {
+      number: 23,
+      body: `task\n${ap(2)}`,
+      labels: ['status:blocked-by-human'],
+    },
+  ];
+  const { warnings } = evaluateAutopilotSuitabilityConsistency(issues, {
+    floor: 1,
+  });
+  assert.equal(warnings.length, 2);
+  assert.ok(
+    !warnings.some((w) => /issue #21/.test(w)),
+    'score-1 + blocked-by-human must not warn at floor 1',
+  );
+  assert.match(
+    warnings.find((w) => /issue #22/.test(w)) ?? '',
+    /issue #22 is scored 1 .* missing the status:blocked-by-human label/,
+  );
+  assert.match(
+    warnings.find((w) => /issue #23/.test(w)) ?? '',
+    /issue #23 is scored 2 \(>= floor 1\) but carries status:blocked-by-human/,
+  );
+});
+
 test('findPlaceholders returns template tokens', () => {
   const placeholders = findPlaceholders(`
   keep {{REPO_NAME}}


### PR DESCRIPTION
## Summary

`evaluateAutopilotSuitabilityConsistency` in `src/scripts/idd-doctor.mts`
warned when `autopilotSuitability.floor` is `1` and a score-1 issue carried
`status:blocked-by-human` — even though a score-1 issue is contractually
*required* to carry that label, so the score and label actually **agree**.

This adds `marker.value > 1` to the second (`>= floor` + `blocked-by-human`)
branch so score-1 issues are governed solely by the first (missing-label)
branch. Behavior:

- `floor: 1`, score 1, `blocked-by-human` → **no** warning (they agree).
- `floor: 1`, score ≥ 2, `blocked-by-human` → still warns (`>= floor 1`).
- score 1 without the label → still warns via the first branch.
- floor-3 / floor-4 behavior is unchanged.

## Changes

- `src/scripts/idd-doctor.mts`: exclude score 1 from the `>= floor`
  contradiction branch.
- `tests/idd-doctor.test.mts`: add `floor: 1` coverage for all three cases.
- `scripts/idd-doctor.mjs`: regenerated via `pnpm run build`.

## Verification

`pnpm run lint` (963 tests, biome, dprint, cspell, markdownlint,
`audit-docs --check`) and `pnpm run build:check` pass.

Closes #913

Part of roadmap #910.
