### PR TITLE
fix(stalled-session-quiet-check): committer-date evidence and drop dead flag

### DIFF
--- a/.github/instructions/idd-resume-stall.instructions.md
+++ b/.github/instructions/idd-resume-stall.instructions.md
@@ -72,7 +72,7 @@ stable fields `quiet_window_met`, `quiet_window_ms`, `window_start`,
 `now`, `latest_activity`, `latest_activity_type`, `reason`, and
 `evidence` (`activity_count_in_window`, `blocking_activities`,
 `has_heartbeat_in_window`, `has_ci_running`,
-`has_pr_head_movement`, `has_branch_tip_movement`).
+`has_branch_tip_movement`).
 
 The helper gathers evidence only. It never decides trusted-marker
 validity, stale-age, advisory state, forced-handoff routing, or takeover

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -853,7 +853,7 @@ Interpretation rules:
   `latest_activity_type`, `reason`, and `evidence`
   (`activity_count_in_window`, `blocking_activities`,
   `has_heartbeat_in_window`, `has_ci_running`,
-  `has_pr_head_movement`, `has_branch_tip_movement`)
+  `has_branch_tip_movement`)
 - `ci-running` activities always break the quiet window regardless
   of their timestamp; all other types are checked against
   `window_start = now - quiet_window_ms`

--- a/docs/stalled-session-quiet-check.md
+++ b/docs/stalled-session-quiet-check.md
@@ -185,8 +185,10 @@ The helper throws an error if:
   (`new Date()`), **not** a server timestamp; pass `--now <ISO8601>` to
   pin it to a server-derived time when exact server-relative evaluation
   matters
-- Branch-tip movement uses the head commit's **committer** date (server-set
-  on push), not the client-settable author date
+- Branch-tip movement uses the head commit's **committer** date, which is
+  refreshed on (re)create / rebase / cherry-pick / amend, rather than the
+  author date, which preserves the original (possibly very old) authorship
+  time. (Both are Git commit-object fields, not server timestamps.)
 - Normalizes timestamps to ISO8601 UTC with a `Z` suffix
 - Treats `ci-running` as blocking even if its timestamp would otherwise
   fall outside the window

--- a/docs/stalled-session-quiet-check.md
+++ b/docs/stalled-session-quiet-check.md
@@ -90,7 +90,6 @@ Resume/S2 treats these fields as the stable contract:
 - `evidence.blocking_activities`
 - `evidence.has_heartbeat_in_window`
 - `evidence.has_ci_running`
-- `evidence.has_pr_head_movement`
 - `evidence.has_branch_tip_movement`
 
 The CLI also includes `repository`, `pr`, and `policy` envelopes for
@@ -138,7 +137,6 @@ The CLI returns JSON shaped like:
     ],
     "has_heartbeat_in_window": false,
     "has_ci_running": false,
-    "has_pr_head_movement": false,
     "has_branch_tip_movement": false
   }
 }
@@ -182,7 +180,13 @@ The helper throws an error if:
 
 ## Timestamp handling
 
-- Uses GitHub server timestamps from API responses
+- Activity timestamps come from GitHub API responses (server time)
+- The `now` reference defaults to the executor's local clock
+  (`new Date()`), **not** a server timestamp; pass `--now <ISO8601>` to
+  pin it to a server-derived time when exact server-relative evaluation
+  matters
+- Branch-tip movement uses the head commit's **committer** date (server-set
+  on push), not the client-settable author date
 - Normalizes timestamps to ISO8601 UTC with a `Z` suffix
 - Treats `ci-running` as blocking even if its timestamp would otherwise
   fall outside the window

--- a/idd-template/.github/instructions/idd-resume-stall.instructions.md
+++ b/idd-template/.github/instructions/idd-resume-stall.instructions.md
@@ -72,7 +72,7 @@ stable fields `quiet_window_met`, `quiet_window_ms`, `window_start`,
 `now`, `latest_activity`, `latest_activity_type`, `reason`, and
 `evidence` (`activity_count_in_window`, `blocking_activities`,
 `has_heartbeat_in_window`, `has_ci_running`,
-`has_pr_head_movement`, `has_branch_tip_movement`).
+`has_branch_tip_movement`).
 
 The helper gathers evidence only. It never decides trusted-marker
 validity, stale-age, advisory state, forced-handoff routing, or takeover

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -853,7 +853,7 @@ Interpretation rules:
   `latest_activity_type`, `reason`, and `evidence`
   (`activity_count_in_window`, `blocking_activities`,
   `has_heartbeat_in_window`, `has_ci_running`,
-  `has_pr_head_movement`, `has_branch_tip_movement`)
+  `has_branch_tip_movement`)
 - `ci-running` activities always break the quiet window regardless
   of their timestamp; all other types are checked against
   `window_start = now - quiet_window_ms`

--- a/schemas/stalled-session-quiet-check.schema.json
+++ b/schemas/stalled-session-quiet-check.schema.json
@@ -134,7 +134,6 @@
         "blocking_activities",
         "has_heartbeat_in_window",
         "has_ci_running",
-        "has_pr_head_movement",
         "has_branch_tip_movement"
       ],
       "properties": {
@@ -176,10 +175,6 @@
         "has_ci_running": {
           "type": "boolean",
           "description": "Whether running or queued CI was observed"
-        },
-        "has_pr_head_movement": {
-          "type": "boolean",
-          "description": "Whether PR head movement was observed in the quiet window"
         },
         "has_branch_tip_movement": {
           "type": "boolean",

--- a/scripts/stalled-session-quiet-check.mjs
+++ b/scripts/stalled-session-quiet-check.mjs
@@ -73,7 +73,6 @@ export function evaluateQuietWindow(input) {
       blocking_activities: blocking,
       has_heartbeat_in_window: blocking.some((a) => a.type === 'heartbeat'),
       has_ci_running: blocking.some((a) => a.type === 'ci-running'),
-      has_pr_head_movement: blocking.some((a) => a.type === 'pr-head-movement'),
       has_branch_tip_movement: blocking.some(
         (a) => a.type === 'branch-tip-movement',
       ),
@@ -174,12 +173,16 @@ function collectActivities({ repository, pr, now, claimCreatedAt }) {
   ]);
   const headSha = prData.head_sha;
   if (headSha) {
-    // Fetch head commit timestamp for branch-tip-movement
+    // Fetch head commit timestamp for branch-tip-movement. Use the
+    // committer date (server-set on push/rebase/cherry-pick), not the
+    // author date — the author date is client-settable and arbitrarily
+    // old, so a recent push of an older-authored commit would otherwise
+    // look stale and falsely satisfy the quiet window.
     const headCommit = ghJson([
       'api',
       `repos/${repository}/commits/${headSha}`,
       '--jq',
-      '{commit_timestamp: .commit.author.date}',
+      '{commit_timestamp: .commit.committer.date}',
     ]);
     if (headCommit.commit_timestamp) {
       activities.push({

--- a/scripts/stalled-session-quiet-check.mjs
+++ b/scripts/stalled-session-quiet-check.mjs
@@ -173,11 +173,14 @@ function collectActivities({ repository, pr, now, claimCreatedAt }) {
   ]);
   const headSha = prData.head_sha;
   if (headSha) {
-    // Fetch head commit timestamp for branch-tip-movement. Use the
-    // committer date (server-set on push/rebase/cherry-pick), not the
-    // author date — the author date is client-settable and arbitrarily
-    // old, so a recent push of an older-authored commit would otherwise
-    // look stale and falsely satisfy the quiet window.
+    // Fetch head commit timestamp for branch-tip-movement. Prefer the
+    // committer date over the author date: the committer date is refreshed
+    // whenever the commit is (re)created — including rebase, cherry-pick,
+    // and amend — so it tracks when the commit was last placed on the
+    // branch, whereas the author date preserves the original authorship
+    // time and can be arbitrarily old. A recent push of an older-authored
+    // commit would otherwise look stale and falsely satisfy the quiet
+    // window. (Both are Git commit-object fields, not server timestamps.)
     const headCommit = ghJson([
       'api',
       `repos/${repository}/commits/${headSha}`,

--- a/src/scripts/stalled-session-quiet-check.mts
+++ b/src/scripts/stalled-session-quiet-check.mts
@@ -262,11 +262,14 @@ function collectActivities({
 
   const headSha = prData.head_sha;
   if (headSha) {
-    // Fetch head commit timestamp for branch-tip-movement. Use the
-    // committer date (server-set on push/rebase/cherry-pick), not the
-    // author date — the author date is client-settable and arbitrarily
-    // old, so a recent push of an older-authored commit would otherwise
-    // look stale and falsely satisfy the quiet window.
+    // Fetch head commit timestamp for branch-tip-movement. Prefer the
+    // committer date over the author date: the committer date is refreshed
+    // whenever the commit is (re)created — including rebase, cherry-pick,
+    // and amend — so it tracks when the commit was last placed on the
+    // branch, whereas the author date preserves the original authorship
+    // time and can be arbitrarily old. A recent push of an older-authored
+    // commit would otherwise look stale and falsely satisfy the quiet
+    // window. (Both are Git commit-object fields, not server timestamps.)
     const headCommit = ghJson([
       'api',
       `repos/${repository}/commits/${headSha}`,

--- a/src/scripts/stalled-session-quiet-check.mts
+++ b/src/scripts/stalled-session-quiet-check.mts
@@ -35,7 +35,6 @@ interface QuietWindowResult {
     blocking_activities: Activity[];
     has_heartbeat_in_window: boolean;
     has_ci_running: boolean;
-    has_pr_head_movement: boolean;
     has_branch_tip_movement: boolean;
   };
 }
@@ -136,7 +135,6 @@ export function evaluateQuietWindow(input: unknown): QuietWindowResult {
       blocking_activities: blocking,
       has_heartbeat_in_window: blocking.some((a) => a.type === 'heartbeat'),
       has_ci_running: blocking.some((a) => a.type === 'ci-running'),
-      has_pr_head_movement: blocking.some((a) => a.type === 'pr-head-movement'),
       has_branch_tip_movement: blocking.some(
         (a) => a.type === 'branch-tip-movement',
       ),
@@ -264,12 +262,16 @@ function collectActivities({
 
   const headSha = prData.head_sha;
   if (headSha) {
-    // Fetch head commit timestamp for branch-tip-movement
+    // Fetch head commit timestamp for branch-tip-movement. Use the
+    // committer date (server-set on push/rebase/cherry-pick), not the
+    // author date — the author date is client-settable and arbitrarily
+    // old, so a recent push of an older-authored commit would otherwise
+    // look stale and falsely satisfy the quiet window.
     const headCommit = ghJson([
       'api',
       `repos/${repository}/commits/${headSha}`,
       '--jq',
-      '{commit_timestamp: .commit.author.date}',
+      '{commit_timestamp: .commit.committer.date}',
     ]) as { commit_timestamp?: unknown };
     if (headCommit.commit_timestamp) {
       activities.push({

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -806,7 +806,6 @@ const stalledSessionQuietCheckFixture = {
     ],
     has_heartbeat_in_window: false,
     has_ci_running: false,
-    has_pr_head_movement: false,
     has_branch_tip_movement: false,
   },
 } satisfies StalledSessionQuietCheckReport;

--- a/tests/stalled-session-quiet-check.test.mts
+++ b/tests/stalled-session-quiet-check.test.mts
@@ -24,7 +24,6 @@ describe('stalled-session-quiet-check', () => {
         blocking_activities: [],
         has_heartbeat_in_window: false,
         has_ci_running: false,
-        has_pr_head_movement: false,
         has_branch_tip_movement: false,
       },
     });
@@ -65,7 +64,6 @@ describe('stalled-session-quiet-check', () => {
     assert.strictEqual(result.evidence.activity_count_in_window, 2);
     assert.strictEqual(result.evidence.has_heartbeat_in_window, true);
     assert.strictEqual(result.evidence.has_branch_tip_movement, true);
-    assert.strictEqual(result.evidence.has_pr_head_movement, false);
   });
 
   it('always treats ci-running as blocking even without a timestamp', () => {


### PR DESCRIPTION
## Summary

Two robustness fixes to the stalled-session quiet-window helper, from
unresolved review feedback (legacy PRs #437/#441):

- **branch-tip-movement now uses the head commit's committer date** instead
  of the author date. The author date is client-settable and arbitrarily
  old, so a recent push/rebase of an older-authored commit looked stale and
  falsely satisfied the quiet window (a stalled-session false negative).
- **Removed the dead `has_pr_head_movement` evidence flag.** It was never
  emitted (permanently `false`) and is redundant with
  `has_branch_tip_movement`, which accurately captures head movement for a
  PR. Removed from the type, schema (required + property), docs,
  instructions, and tests.
- Clarified in `docs/stalled-session-quiet-check.md` that `--now` defaults
  to the local clock, not a server timestamp.

## Verification

`pnpm run build`, `sync-docs --apply`, `validate-schemas`, `pnpm run lint`
(lint:minimum), and `build:check` pass; 50/50 stalled + schema-reconciliation
tests green.

Note: the committer-date change lives in the CLI data-collection path
(`collectActivities` → `ghJson`, which spawns `gh`) and is not unit-tested
(no subprocess-mock harness) — it is a verified 1-token jq-path change. The
`has_pr_head_movement` removal is covered by the schema-reconciliation and
stalled-session tests.

Closes #918