### PR TITLE
fix(idd-doctor): harden workshop back-link detection against false positives

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1333,7 +1333,18 @@ function stripIndentedCodeBlocksPreservingLines(content) {
       inBlock = false;
       continue;
     }
-    if (indented && (prevBlank || inBlock) && !looksLikeListItem) {
+    if (indented && inBlock) {
+      // Continuation of an open indented code block. Per CommonMark §4.4
+      // a list cannot start inside an open indented code block without an
+      // intervening blank line and dedent, so a list-marker-looking line
+      // here stays code and must be blanked too (it is not a list opener).
+      out.push('');
+      prevBlank = false;
+      continue;
+    }
+    if (indented && prevBlank && !looksLikeListItem) {
+      // Opener: an indented, non-list line after a blank line starts a
+      // new indented code block.
       out.push('');
       inBlock = true;
       prevBlank = false;
@@ -1362,7 +1373,29 @@ export function containsExampleRepoBackLink(readmeContent, repoSlug) {
     /!\[[^\]]*\]\(\s*<?[^()\s>]+>?(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g,
     '',
   );
-  const stripped = imagedStripped;
+  // Reference-style images (`![alt][id]`, collapsed `![id][]`, shortcut
+  // `![id]`) resolve their source through a separate `[id]: <url>`
+  // reference definition, so the definition is an image source, not a
+  // navigation link. Collect every label an image references, then drop
+  // the matching reference-definition lines before the URL scans below.
+  // A real reference *link* (`[text][id]`) keeps its definition and is
+  // still counted.
+  const imageLabels = new Set();
+  const imageRefPattern = /!\[([^\]]*)\](?:\[([^\]]*)\])?/g;
+  let imageMatch;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((imageMatch = imageRefPattern.exec(imagedStripped)) !== null) {
+    const explicit = imageMatch[2]?.trim() ?? '';
+    const shortcut = imageMatch[1]?.trim() ?? '';
+    const label = explicit.length > 0 ? explicit : shortcut;
+    if (label.length > 0) imageLabels.add(label.toLowerCase());
+  }
+  const stripped =
+    imageLabels.size === 0
+      ? imagedStripped
+      : imagedStripped.replace(/^ {0,3}\[([^\]]+)\]:.*$/gm, (full, label) =>
+          imageLabels.has(label.trim().toLowerCase()) ? '' : full,
+        );
   // Absolute http(s) URLs.
   const urlPattern = /https?:\/\/[^\s<>)\]"']+/gi;
   let match;

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1328,9 +1328,14 @@ function stripIndentedCodeBlocksPreservingLines(content) {
     // code) even when indented under a parent item.
     const looksLikeListItem = /^\s*(?:[-*+]\s|\d+[.)]\s)/.test(line);
     if (isBlank) {
+      // A blank line does not end an open indented code block: per
+      // CommonMark §4.4 a code block is one or more indented chunks
+      // separated by blank lines, so `inBlock` must survive the blank.
+      // The block only ends when a later non-indented, non-blank line
+      // appears (handled by the fall-through below). Leaving `inBlock`
+      // set keeps a post-blank indented list-marker line as code.
       out.push(line);
       prevBlank = true;
-      inBlock = false;
       continue;
     }
     if (indented && inBlock) {
@@ -1390,11 +1395,33 @@ export function containsExampleRepoBackLink(readmeContent, repoSlug) {
     const label = explicit.length > 0 ? explicit : shortcut;
     if (label.length > 0) imageLabels.add(label.toLowerCase());
   }
+  // A reference *link* (`[text][id]` full or `[id][]` collapsed; the
+  // leading `!` excludes images) shares the `[id]: <url>` definition with
+  // navigation, so a label used by a link must keep its definition even
+  // when an image also references it. Collect link labels and drop only
+  // definitions for labels referenced *exclusively* by images.
+  const linkLabels = new Set();
+  const refLinkPattern = /(?<!!)\[[^\]]*\]\[([^\]]*)\]/g;
+  let linkMatch;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((linkMatch = refLinkPattern.exec(imagedStripped)) !== null) {
+    const explicit = linkMatch[1]?.trim() ?? '';
+    // Collapsed form `[id][]` carries the label in the first bracket;
+    // recover it from the full match when the second bracket is empty.
+    const label =
+      explicit.length > 0
+        ? explicit
+        : (linkMatch[0].match(/^\[([^\]]*)\]\[\]$/)?.[1]?.trim() ?? '');
+    if (label.length > 0) linkLabels.add(label.toLowerCase());
+  }
+  const dropLabels = new Set(
+    [...imageLabels].filter((label) => !linkLabels.has(label)),
+  );
   const stripped =
-    imageLabels.size === 0
+    dropLabels.size === 0
       ? imagedStripped
       : imagedStripped.replace(/^ {0,3}\[([^\]]+)\]:.*$/gm, (full, label) =>
-          imageLabels.has(label.trim().toLowerCase()) ? '' : full,
+          dropLabels.has(label.trim().toLowerCase()) ? '' : full,
         );
   // Absolute http(s) URLs.
   const urlPattern = /https?:\/\/[^\s<>)\]"']+/gi;

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1320,6 +1320,12 @@ function stripIndentedCodeBlocksPreservingLines(content) {
   const out = [];
   let prevBlank = true;
   let inBlock = false;
+  // Whether a list is currently open at the top level. Under an open
+  // list, indented content is list continuation / nested-list items; with
+  // no list open, a top-level >=4-space indent is an indented code block,
+  // even when the line looks like a list marker (CommonMark: a list
+  // marker at >=4 spaces of indent is code, not a list).
+  let listOpen = false;
   for (const line of lines) {
     const isBlank = /^\s*$/.test(line);
     const indented = /^(?: {4}|\t)/.test(line);
@@ -1328,35 +1334,52 @@ function stripIndentedCodeBlocksPreservingLines(content) {
     // code) even when indented under a parent item.
     const looksLikeListItem = /^\s*(?:[-*+]\s|\d+[.)]\s)/.test(line);
     if (isBlank) {
-      // A blank line does not end an open indented code block: per
-      // CommonMark §4.4 a code block is one or more indented chunks
-      // separated by blank lines, so `inBlock` must survive the blank.
-      // The block only ends when a later non-indented, non-blank line
-      // appears (handled by the fall-through below). Leaving `inBlock`
-      // set keeps a post-blank indented list-marker line as code.
+      // A blank line ends neither an open indented code block nor an open
+      // list: per CommonMark §4.4 a code block is one or more indented
+      // chunks separated by blank lines, and loose lists are blank-line
+      // separated too. Both `inBlock` and `listOpen` survive the blank;
+      // the block/list only ends at a later non-indented, non-blank line.
       out.push(line);
       prevBlank = true;
       continue;
     }
-    if (indented && inBlock) {
-      // Continuation of an open indented code block. Per CommonMark §4.4
-      // a list cannot start inside an open indented code block without an
-      // intervening blank line and dedent, so a list-marker-looking line
-      // here stays code and must be blanked too (it is not a list opener).
-      out.push('');
+    if (indented) {
+      if (inBlock) {
+        // Continuation of an open indented code block (even across an
+        // internal blank line). A list cannot start inside it, so a
+        // list-marker-looking line here stays code and is blanked.
+        out.push('');
+        prevBlank = false;
+        continue;
+      }
+      if (listOpen) {
+        // Indented content under an open list is list continuation or a
+        // nested list item, not a top-level code block: keep it.
+        out.push(line);
+        prevBlank = false;
+        continue;
+      }
+      if (prevBlank) {
+        // Opener: a top-level indented line after a blank with no open
+        // list starts an indented code block, even a list-marker-looking
+        // one (>=4 spaces of top-level indent is code, not a list).
+        out.push('');
+        inBlock = true;
+        prevBlank = false;
+        continue;
+      }
+      // Indented line lazily continuing a paragraph (code cannot
+      // interrupt a paragraph): keep it.
+      out.push(line);
       prevBlank = false;
       continue;
     }
-    if (indented && prevBlank && !looksLikeListItem) {
-      // Opener: an indented, non-list line after a blank line starts a
-      // new indented code block.
-      out.push('');
-      inBlock = true;
-      prevBlank = false;
-      continue;
-    }
+    // Non-indented (<=3 spaces), non-blank line: it closes any open code
+    // block and resets the list context — a top-level list marker opens
+    // (or continues) a list; any other line closes it.
     out.push(line);
     inBlock = false;
+    listOpen = looksLikeListItem;
     prevBlank = false;
   }
   return out.join('\n');
@@ -1395,11 +1418,23 @@ export function containsExampleRepoBackLink(readmeContent, repoSlug) {
     const label = explicit.length > 0 ? explicit : shortcut;
     if (label.length > 0) imageLabels.add(label.toLowerCase());
   }
-  // A reference *link* (`[text][id]` full or `[id][]` collapsed; the
-  // leading `!` excludes images) shares the `[id]: <url>` definition with
-  // navigation, so a label used by a link must keep its definition even
-  // when an image also references it. Collect link labels and drop only
-  // definitions for labels referenced *exclusively* by images.
+  // Labels that have a reference definition. A shortcut reference
+  // (`[id]`) only resolves to a link/image when such a definition exists,
+  // so the defined-label set scopes shortcut detection below and avoids
+  // treating ordinary bracketed prose as a reference.
+  const definedLabels = new Set();
+  const refDefPattern = /^ {0,3}\[([^\]]+)\]:.*$/gm;
+  let defMatch;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((defMatch = refDefPattern.exec(imagedStripped)) !== null) {
+    definedLabels.add(defMatch[1].trim().toLowerCase());
+  }
+  // A reference *link* (full `[text][id]`, collapsed `[id][]`, or shortcut
+  // `[id]`; the leading `!` excludes images) shares the `[id]: <url>`
+  // definition with navigation, so a label used by a link must keep its
+  // definition even when an image also references it. Collect link labels
+  // and drop only definitions for labels referenced *exclusively* by
+  // images.
   const linkLabels = new Set();
   const refLinkPattern = /(?<!!)\[[^\]]*\]\[([^\]]*)\]/g;
   let linkMatch;
@@ -1413,6 +1448,17 @@ export function containsExampleRepoBackLink(readmeContent, repoSlug) {
         ? explicit
         : (linkMatch[0].match(/^\[([^\]]*)\]\[\]$/)?.[1]?.trim() ?? '');
     if (label.length > 0) linkLabels.add(label.toLowerCase());
+  }
+  // Shortcut reference links: a bare `[id]` not preceded by `]`/`!` (which
+  // would be a full-reference tail or an image) and not followed by
+  // `(`/`[`/`:` (inline link, full/collapsed reference, or definition).
+  // Only count it when `id` is actually defined.
+  const shortcutPattern = /(?<![\]!])\[([^\]]+)\](?![([:])/g;
+  let shortcutMatch;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((shortcutMatch = shortcutPattern.exec(imagedStripped)) !== null) {
+    const label = shortcutMatch[1].trim().toLowerCase();
+    if (label.length > 0 && definedLabels.has(label)) linkLabels.add(label);
   }
   const dropLabels = new Set(
     [...imageLabels].filter((label) => !linkLabels.has(label)),

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1536,6 +1536,12 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
   const out: string[] = [];
   let prevBlank = true;
   let inBlock = false;
+  // Whether a list is currently open at the top level. Under an open
+  // list, indented content is list continuation / nested-list items; with
+  // no list open, a top-level >=4-space indent is an indented code block,
+  // even when the line looks like a list marker (CommonMark: a list
+  // marker at >=4 spaces of indent is code, not a list).
+  let listOpen = false;
   for (const line of lines) {
     const isBlank = /^\s*$/.test(line);
     const indented = /^(?: {4}|\t)/.test(line);
@@ -1544,35 +1550,52 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
     // code) even when indented under a parent item.
     const looksLikeListItem = /^\s*(?:[-*+]\s|\d+[.)]\s)/.test(line);
     if (isBlank) {
-      // A blank line does not end an open indented code block: per
-      // CommonMark §4.4 a code block is one or more indented chunks
-      // separated by blank lines, so `inBlock` must survive the blank.
-      // The block only ends when a later non-indented, non-blank line
-      // appears (handled by the fall-through below). Leaving `inBlock`
-      // set keeps a post-blank indented list-marker line as code.
+      // A blank line ends neither an open indented code block nor an open
+      // list: per CommonMark §4.4 a code block is one or more indented
+      // chunks separated by blank lines, and loose lists are blank-line
+      // separated too. Both `inBlock` and `listOpen` survive the blank;
+      // the block/list only ends at a later non-indented, non-blank line.
       out.push(line);
       prevBlank = true;
       continue;
     }
-    if (indented && inBlock) {
-      // Continuation of an open indented code block. Per CommonMark §4.4
-      // a list cannot start inside an open indented code block without an
-      // intervening blank line and dedent, so a list-marker-looking line
-      // here stays code and must be blanked too (it is not a list opener).
-      out.push('');
+    if (indented) {
+      if (inBlock) {
+        // Continuation of an open indented code block (even across an
+        // internal blank line). A list cannot start inside it, so a
+        // list-marker-looking line here stays code and is blanked.
+        out.push('');
+        prevBlank = false;
+        continue;
+      }
+      if (listOpen) {
+        // Indented content under an open list is list continuation or a
+        // nested list item, not a top-level code block: keep it.
+        out.push(line);
+        prevBlank = false;
+        continue;
+      }
+      if (prevBlank) {
+        // Opener: a top-level indented line after a blank with no open
+        // list starts an indented code block, even a list-marker-looking
+        // one (>=4 spaces of top-level indent is code, not a list).
+        out.push('');
+        inBlock = true;
+        prevBlank = false;
+        continue;
+      }
+      // Indented line lazily continuing a paragraph (code cannot
+      // interrupt a paragraph): keep it.
+      out.push(line);
       prevBlank = false;
       continue;
     }
-    if (indented && prevBlank && !looksLikeListItem) {
-      // Opener: an indented, non-list line after a blank line starts a
-      // new indented code block.
-      out.push('');
-      inBlock = true;
-      prevBlank = false;
-      continue;
-    }
+    // Non-indented (<=3 spaces), non-blank line: it closes any open code
+    // block and resets the list context — a top-level list marker opens
+    // (or continues) a list; any other line closes it.
     out.push(line);
     inBlock = false;
+    listOpen = looksLikeListItem;
     prevBlank = false;
   }
   return out.join('\n');
@@ -1615,11 +1638,23 @@ export function containsExampleRepoBackLink(
     const label = explicit.length > 0 ? explicit : shortcut;
     if (label.length > 0) imageLabels.add(label.toLowerCase());
   }
-  // A reference *link* (`[text][id]` full or `[id][]` collapsed; the
-  // leading `!` excludes images) shares the `[id]: <url>` definition with
-  // navigation, so a label used by a link must keep its definition even
-  // when an image also references it. Collect link labels and drop only
-  // definitions for labels referenced *exclusively* by images.
+  // Labels that have a reference definition. A shortcut reference
+  // (`[id]`) only resolves to a link/image when such a definition exists,
+  // so the defined-label set scopes shortcut detection below and avoids
+  // treating ordinary bracketed prose as a reference.
+  const definedLabels = new Set<string>();
+  const refDefPattern = /^ {0,3}\[([^\]]+)\]:.*$/gm;
+  let defMatch: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((defMatch = refDefPattern.exec(imagedStripped)) !== null) {
+    definedLabels.add(defMatch[1].trim().toLowerCase());
+  }
+  // A reference *link* (full `[text][id]`, collapsed `[id][]`, or shortcut
+  // `[id]`; the leading `!` excludes images) shares the `[id]: <url>`
+  // definition with navigation, so a label used by a link must keep its
+  // definition even when an image also references it. Collect link labels
+  // and drop only definitions for labels referenced *exclusively* by
+  // images.
   const linkLabels = new Set<string>();
   const refLinkPattern = /(?<!!)\[[^\]]*\]\[([^\]]*)\]/g;
   let linkMatch: RegExpExecArray | null;
@@ -1633,6 +1668,17 @@ export function containsExampleRepoBackLink(
         ? explicit
         : (linkMatch[0].match(/^\[([^\]]*)\]\[\]$/)?.[1]?.trim() ?? '');
     if (label.length > 0) linkLabels.add(label.toLowerCase());
+  }
+  // Shortcut reference links: a bare `[id]` not preceded by `]`/`!` (which
+  // would be a full-reference tail or an image) and not followed by
+  // `(`/`[`/`:` (inline link, full/collapsed reference, or definition).
+  // Only count it when `id` is actually defined.
+  const shortcutPattern = /(?<![\]!])\[([^\]]+)\](?![([:])/g;
+  let shortcutMatch: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((shortcutMatch = shortcutPattern.exec(imagedStripped)) !== null) {
+    const label = shortcutMatch[1].trim().toLowerCase();
+    if (label.length > 0 && definedLabels.has(label)) linkLabels.add(label);
   }
   const dropLabels = new Set(
     [...imageLabels].filter((label) => !linkLabels.has(label)),

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1544,9 +1544,14 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
     // code) even when indented under a parent item.
     const looksLikeListItem = /^\s*(?:[-*+]\s|\d+[.)]\s)/.test(line);
     if (isBlank) {
+      // A blank line does not end an open indented code block: per
+      // CommonMark §4.4 a code block is one or more indented chunks
+      // separated by blank lines, so `inBlock` must survive the blank.
+      // The block only ends when a later non-indented, non-blank line
+      // appears (handled by the fall-through below). Leaving `inBlock`
+      // set keeps a post-blank indented list-marker line as code.
       out.push(line);
       prevBlank = true;
-      inBlock = false;
       continue;
     }
     if (indented && inBlock) {
@@ -1610,13 +1615,35 @@ export function containsExampleRepoBackLink(
     const label = explicit.length > 0 ? explicit : shortcut;
     if (label.length > 0) imageLabels.add(label.toLowerCase());
   }
+  // A reference *link* (`[text][id]` full or `[id][]` collapsed; the
+  // leading `!` excludes images) shares the `[id]: <url>` definition with
+  // navigation, so a label used by a link must keep its definition even
+  // when an image also references it. Collect link labels and drop only
+  // definitions for labels referenced *exclusively* by images.
+  const linkLabels = new Set<string>();
+  const refLinkPattern = /(?<!!)\[[^\]]*\]\[([^\]]*)\]/g;
+  let linkMatch: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((linkMatch = refLinkPattern.exec(imagedStripped)) !== null) {
+    const explicit = linkMatch[1]?.trim() ?? '';
+    // Collapsed form `[id][]` carries the label in the first bracket;
+    // recover it from the full match when the second bracket is empty.
+    const label =
+      explicit.length > 0
+        ? explicit
+        : (linkMatch[0].match(/^\[([^\]]*)\]\[\]$/)?.[1]?.trim() ?? '');
+    if (label.length > 0) linkLabels.add(label.toLowerCase());
+  }
+  const dropLabels = new Set(
+    [...imageLabels].filter((label) => !linkLabels.has(label)),
+  );
   const stripped =
-    imageLabels.size === 0
+    dropLabels.size === 0
       ? imagedStripped
       : imagedStripped.replace(
           /^ {0,3}\[([^\]]+)\]:.*$/gm,
           (full, label: string) =>
-            imageLabels.has(label.trim().toLowerCase()) ? '' : full,
+            dropLabels.has(label.trim().toLowerCase()) ? '' : full,
         );
   // Absolute http(s) URLs.
   const urlPattern = /https?:\/\/[^\s<>)\]"']+/gi;

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1549,7 +1549,18 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
       inBlock = false;
       continue;
     }
-    if (indented && (prevBlank || inBlock) && !looksLikeListItem) {
+    if (indented && inBlock) {
+      // Continuation of an open indented code block. Per CommonMark §4.4
+      // a list cannot start inside an open indented code block without an
+      // intervening blank line and dedent, so a list-marker-looking line
+      // here stays code and must be blanked too (it is not a list opener).
+      out.push('');
+      prevBlank = false;
+      continue;
+    }
+    if (indented && prevBlank && !looksLikeListItem) {
+      // Opener: an indented, non-list line after a blank line starts a
+      // new indented code block.
       out.push('');
       inBlock = true;
       prevBlank = false;
@@ -1582,7 +1593,31 @@ export function containsExampleRepoBackLink(
     /!\[[^\]]*\]\(\s*<?[^()\s>]+>?(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g,
     '',
   );
-  const stripped = imagedStripped;
+  // Reference-style images (`![alt][id]`, collapsed `![id][]`, shortcut
+  // `![id]`) resolve their source through a separate `[id]: <url>`
+  // reference definition, so the definition is an image source, not a
+  // navigation link. Collect every label an image references, then drop
+  // the matching reference-definition lines before the URL scans below.
+  // A real reference *link* (`[text][id]`) keeps its definition and is
+  // still counted.
+  const imageLabels = new Set<string>();
+  const imageRefPattern = /!\[([^\]]*)\](?:\[([^\]]*)\])?/g;
+  let imageMatch: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex-exec iteration idiom
+  while ((imageMatch = imageRefPattern.exec(imagedStripped)) !== null) {
+    const explicit = imageMatch[2]?.trim() ?? '';
+    const shortcut = imageMatch[1]?.trim() ?? '';
+    const label = explicit.length > 0 ? explicit : shortcut;
+    if (label.length > 0) imageLabels.add(label.toLowerCase());
+  }
+  const stripped =
+    imageLabels.size === 0
+      ? imagedStripped
+      : imagedStripped.replace(
+          /^ {0,3}\[([^\]]+)\]:.*$/gm,
+          (full, label: string) =>
+            imageLabels.has(label.trim().toLowerCase()) ? '' : full,
+        );
   // Absolute http(s) URLs.
   const urlPattern = /https?:\/\/[^\s<>)\]"']+/gi;
   let match: RegExpExecArray | null;

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1072,6 +1072,24 @@ test('containsExampleRepoBackLink keeps a shared image/link reference definition
   assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
 });
 
+test('containsExampleRepoBackLink keeps a definition shared by an image and a shortcut link', () => {
+  // `shared` is used by a reference image and a *shortcut* reference link
+  // (`[shared]`). The shortcut link still counts, so the definition must
+  // not be dropped.
+  const md =
+    '![badge][shared] — see [shared] for details.\n\n[shared]: https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
+});
+
+test('containsExampleRepoBackLink treats a top-level indented list-marker line as code', () => {
+  // With no list open, a >=4-space indented `- ...` line after a blank is
+  // an indented code block (CommonMark), not a list item, so a workshop
+  // URL there must not produce a false back-link pass.
+  const md =
+    'paragraph\n\n    - [workshop](https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)\n';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), false);
+});
+
 test('containsExampleRepoBackLink rejects URL whose host is not a GitHub host', () => {
   const md =
     '[trap](https://example.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)';

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1054,6 +1054,24 @@ test('containsExampleRepoBackLink keeps counting a real reference-style link', (
   assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
 });
 
+test('containsExampleRepoBackLink keeps a code block open across an internal blank line', () => {
+  // CommonMark §4.4: an indented code block survives a blank line between
+  // indented chunks. The post-blank `- [workshop](...)` line is still
+  // code, so it must not produce a false back-link pass.
+  const md =
+    'paragraph\n\n    code line\n\n    - [workshop](https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)\n';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), false);
+});
+
+test('containsExampleRepoBackLink keeps a shared image/link reference definition', () => {
+  // The label `shared` is used by both a reference image and a real
+  // reference link, so its definition must NOT be dropped — the link
+  // still counts as a navigation back-link.
+  const md =
+    '![badge][shared] and [the workshop][shared].\n\n[shared]: https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
+});
+
 test('containsExampleRepoBackLink rejects URL whose host is not a GitHub host', () => {
   const md =
     '[trap](https://example.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)';

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1014,6 +1014,46 @@ test('containsExampleRepoBackLink preserves links inside blank-separated nested 
   assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
 });
 
+test('containsExampleRepoBackLink ignores a list-marker line inside an open indented code block', () => {
+  // The indented `- [workshop](...)` line is a continuation of the open
+  // indented code block started by `code line`, not a list item: per
+  // CommonMark a list cannot start inside an open indented code block
+  // without an intervening blank line. It must not produce a false pass.
+  const md =
+    'paragraph\n\n    code line\n    - [workshop](https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)\n';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), false);
+});
+
+test('containsExampleRepoBackLink ignores reference-style image destinations (absolute and root-relative)', () => {
+  const absolute =
+    '![badge][b]\n\n[b]: https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md';
+  const rootRelative =
+    '![badge][b]\n\n[b]: /kurone-kito/idd-skill/blob/main/docs/workshop/README.md';
+  // Shortcut form `![b]` resolves to the same `[b]:` definition.
+  const shortcut =
+    '![b]\n\n[b]: https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md';
+  assert.equal(
+    containsExampleRepoBackLink(absolute, 'kurone-kito/idd-skill'),
+    false,
+  );
+  assert.equal(
+    containsExampleRepoBackLink(rootRelative, 'kurone-kito/idd-skill'),
+    false,
+  );
+  assert.equal(
+    containsExampleRepoBackLink(shortcut, 'kurone-kito/idd-skill'),
+    false,
+  );
+});
+
+test('containsExampleRepoBackLink keeps counting a real reference-style link', () => {
+  // A reference *link* (no leading `!`) is navigation, so its definition
+  // is still scanned even though a reference *image* would be excluded.
+  const md =
+    'See the [workshop guide][w].\n\n[w]: https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
+});
+
 test('containsExampleRepoBackLink rejects URL whose host is not a GitHub host', () => {
   const md =
     '[trap](https://example.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)';


### PR DESCRIPTION
## Summary

Two unresolved review findings (PR #742: Codex P2 + Copilot) on the
`--require-github` workshop back-link gate each produced a **false pass**
on current `main`. Both are fixed in `src/scripts/idd-doctor.mts`.

### 1. List-marker line inside an open indented code block

`stripIndentedCodeBlocksPreservingLines` applied the list-item exemption
even on the `inBlock` continuation case, so a line like
`    - [link](workshop-url)` continuing an open indented code block was
kept as a list item. Per CommonMark §4.4 a list cannot start inside an
open indented code block without an intervening blank line, so the
continuation now stays code and is blanked. The blank-separated-list and
not-blank-separated nested-list cases still resolve to a real list.

### 2. Reference-style image destinations scanned as links

`containsExampleRepoBackLink` masked only inline images, so a
reference-style image (`![alt][id]` + `[id]: <url>`) had its source
definition scanned by both the absolute-URL and root-relative ref-def
scans. Image-referenced labels (full `![alt][id]`, collapsed `![id][]`,
shortcut `![id]`) are now collected and their reference-definition lines
dropped before the URL scans. A real reference *link* (`[text][id]`)
keeps its definition and still counts.

## Changes

- `src/scripts/idd-doctor.mts`: both fixes above.
- `tests/idd-doctor.test.mts`: false-pass guards (code-block list-marker,
  reference-style image absolute + root-relative + shortcut) and
  regression guards (real reference link still counts).
- `scripts/idd-doctor.mjs`: regenerated via `pnpm run build`.

## Verification

`pnpm run lint` (966 tests, biome, dprint, cspell, markdownlint,
`audit-docs --check`) and `pnpm run build:check` pass.

Closes #912

Part of roadmap #910.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown code block parsing to correctly preserve blank lines within indented code blocks.
  * Enhanced back-link detection to distinguish image references from actual navigational links in documentation.

* **Tests**
  * Added comprehensive test coverage for Markdown parsing edge cases and reference-style link/image handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->