### PR TITLE
fix(discover-viability-gate): close scope/csv/main-module gaps

### DIFF
--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -5,6 +5,8 @@
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const CRITERIA = [
   {
@@ -131,16 +133,20 @@ export function evaluateA4Viability(issue) {
 }
 export function evaluateLimitedScope(issue) {
   const corpus = `${issue.title}\n${issue.body}`;
-  if (NARROW_SCOPE_PATTERN.test(corpus)) {
-    return {
-      pass: true,
-      evidence: 'Narrow-scope signal detected.',
-    };
-  }
+  // Test the broad-scope signal first: a broad/A4-fail cue must fail the
+  // gate even when a narrow cue is also present (e.g. "single module change
+  // that redesigns a public interface"). Returning narrow-pass first would
+  // let that wording bypass the gate.
   if (BROAD_SCOPE_PATTERN.test(corpus)) {
     return {
       pass: false,
       evidence: 'Broad or cross-cutting scope signal detected.',
+    };
+  }
+  if (NARROW_SCOPE_PATTERN.test(corpus)) {
+    return {
+      pass: true,
+      evidence: 'Narrow-scope signal detected.',
     };
   }
   return {
@@ -268,20 +274,24 @@ function countDiscardedCriteria(discarded) {
   }
   return counts;
 }
-function renderCsv(summary) {
+export function renderCsv(summary) {
   const lines = ['kind,number,title,criteria'];
   for (const item of summary.viable) {
-    lines.push(`viable,${item.number},${escapeCsv(item.title)},""`);
+    lines.push(`viable,${item.number},${escapeCsv(item.title)},`);
   }
   for (const item of summary.discarded) {
     lines.push(
-      `discarded,${item.number},${escapeCsv(item.title)},"${escapeCsv((item.failedCriteria ?? []).join('|'))}"`,
+      `discarded,${item.number},${escapeCsv(item.title)},${escapeCsv((item.failedCriteria ?? []).join('|'))}`,
     );
   }
   return `${lines.join('\n')}\n`;
 }
 function escapeCsv(value) {
-  return String(value ?? '').replaceAll('"', '""');
+  const text = String(value ?? '');
+  if (!/[",\n]/.test(text)) {
+    return text;
+  }
+  return `"${text.replaceAll('"', '""')}"`;
 }
 function buildIssueLoader(owner, repo) {
   return async function loadIssue(issueNumber) {
@@ -322,12 +332,10 @@ function ghJson(args, options = {}) {
   return JSON.parse(text);
 }
 function isMainModule(metaUrl) {
-  if (!process.argv[1]) {
+  if (!metaUrl || !process.argv[1]) {
     return false;
   }
-  try {
-    return metaUrl === new URL(`file://${process.argv[1]}`).href;
-  } catch {
-    return false;
-  }
+  // Compare filesystem paths instead of building a file:// URL from
+  // argv[1], which mis-parses Windows drive-letter paths.
+  return fileURLToPath(metaUrl) === resolve(process.argv[1]);
 }

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -6,6 +6,8 @@
 // generated .mjs. See docs/typescript-sources.md.
 
 import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 interface NormalizedIssue {
   number: number;
@@ -209,16 +211,20 @@ export function evaluateA4Viability(issue: unknown): {
 
 export function evaluateLimitedScope(issue: NormalizedIssue): EvalResult {
   const corpus = `${issue.title}\n${issue.body}`;
-  if (NARROW_SCOPE_PATTERN.test(corpus)) {
-    return {
-      pass: true,
-      evidence: 'Narrow-scope signal detected.',
-    };
-  }
+  // Test the broad-scope signal first: a broad/A4-fail cue must fail the
+  // gate even when a narrow cue is also present (e.g. "single module change
+  // that redesigns a public interface"). Returning narrow-pass first would
+  // let that wording bypass the gate.
   if (BROAD_SCOPE_PATTERN.test(corpus)) {
     return {
       pass: false,
       evidence: 'Broad or cross-cutting scope signal detected.',
+    };
+  }
+  if (NARROW_SCOPE_PATTERN.test(corpus)) {
+    return {
+      pass: true,
+      evidence: 'Narrow-scope signal detected.',
     };
   }
   return {
@@ -370,23 +376,27 @@ function countDiscardedCriteria(
   return counts;
 }
 
-function renderCsv(summary: ViabilitySummary): string {
+export function renderCsv(summary: ViabilitySummary): string {
   const lines = ['kind,number,title,criteria'];
   for (const item of summary.viable) {
-    lines.push(`viable,${item.number},${escapeCsv(item.title)},""`);
+    lines.push(`viable,${item.number},${escapeCsv(item.title)},`);
   }
   for (const item of summary.discarded) {
     lines.push(
-      `discarded,${item.number},${escapeCsv(item.title)},"${escapeCsv(
+      `discarded,${item.number},${escapeCsv(item.title)},${escapeCsv(
         (item.failedCriteria ?? []).join('|'),
-      )}"`,
+      )}`,
     );
   }
   return `${lines.join('\n')}\n`;
 }
 
 function escapeCsv(value: unknown): string {
-  return String(value ?? '').replaceAll('"', '""');
+  const text = String(value ?? '');
+  if (!/[",\n]/.test(text)) {
+    return text;
+  }
+  return `"${text.replaceAll('"', '""')}"`;
 }
 
 function buildIssueLoader(
@@ -444,12 +454,10 @@ function ghJson(
 }
 
 function isMainModule(metaUrl: string): boolean {
-  if (!process.argv[1]) {
+  if (!metaUrl || !process.argv[1]) {
     return false;
   }
-  try {
-    return metaUrl === new URL(`file://${process.argv[1]}`).href;
-  } catch {
-    return false;
-  }
+  // Compare filesystem paths instead of building a file:// URL from
+  // argv[1], which mis-parses Windows drive-letter paths.
+  return fileURLToPath(metaUrl) === resolve(process.argv[1]);
 }

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -4,7 +4,40 @@ import { test } from 'node:test';
 import {
   evaluateA4Viability,
   evaluateDiscoverViability,
+  renderCsv,
 } from '../src/scripts/discover-viability-gate.mts';
+
+// Minimal RFC 4180 single-row field splitter: respects quoted fields so a
+// comma inside a quoted title does not start a new column.
+function parseCsvRow(row: string): string[] {
+  const fields: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  for (let index = 0; index < row.length; index += 1) {
+    const char = row[index];
+    if (inQuotes) {
+      if (char === '"') {
+        if (row[index + 1] === '"') {
+          field += '"';
+          index += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += char;
+      }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === ',') {
+      fields.push(field);
+      field = '';
+    } else {
+      field += char;
+    }
+  }
+  fields.push(field);
+  return fields;
+}
 
 test('passes viability for narrow scope with objective verification and no external coordination', () => {
   const result = evaluateA4Viability({
@@ -31,6 +64,46 @@ test('fails limited scope for broad cross-cutting work', () => {
 
   assert.equal(result.passed, false);
   assert.ok(result.failedCriteria.includes('limited_scope'));
+});
+
+test('fails limited scope when a broad cue accompanies a narrow cue', () => {
+  const result = evaluateA4Viability({
+    number: 5,
+    title: 'single module change that redesigns a public interface',
+    body: 'Targeted edit, but it redesigns a public interface. Tests included.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('limited_scope'));
+});
+
+test('renderCsv quotes titles containing commas and quotes', () => {
+  const csv = renderCsv({
+    viable: [{ number: 10, title: 'fix parser, escape "quotes" too' }],
+    discarded: [
+      {
+        number: 11,
+        title: 'redesign, broadly',
+        failedCriteria: ['limited_scope'],
+      },
+    ],
+    summary: {
+      total: 2,
+      viableCount: 1,
+      discardedCount: 1,
+      discardedByCriterion: { limited_scope: 1 },
+    },
+  });
+
+  const rows = csv.trimEnd().split('\n');
+  assert.equal(rows[0], 'kind,number,title,criteria');
+  assert.equal(rows[1], 'viable,10,"fix parser, escape ""quotes"" too",');
+  assert.equal(rows[2], 'discarded,11,"redesign, broadly",limited_scope');
+  // Each data row keeps exactly four fields when parsed as RFC 4180 CSV.
+  for (const row of rows.slice(1)) {
+    assert.equal(parseCsvRow(row).length, 4);
+  }
 });
 
 test('fails clear verification when only subjective checks are present', () => {


### PR DESCRIPTION
Part of roadmap #910 (resolve unresolved merged-PR review feedback — legacy era). Carries into the A4 viability gate three robustness fixes that the sibling readiness/orphan helpers already have, but that PR #436's unresolved review comments never applied here.

## Changes (`src/scripts/discover-viability-gate.mts`, generated `.mjs` regenerated via `pnpm run build`)

- **Broad-scope precedence** — `evaluateLimitedScope` now tests `BROAD_SCOPE_PATTERN` first and returns `pass: false` before the narrow-scope check. Wording that carries both a narrow cue and a broad/A4-fail cue (e.g. "single module change that redesigns a public interface") now fails `limited_scope` instead of bypassing the gate.
- **CSV title quoting** — `escapeCsv` adopts the readiness helper's self-wrapping form (wrap only when the value contains `"`, `,`, or newline; double inner quotes), and `renderCsv` relies on it. A title containing a comma/quote no longer breaks CSV columns.
- **Windows-safe main-module detection** — `isMainModule` compares `fileURLToPath(metaUrl)` with `resolve(process.argv[1])` instead of building a `file://` URL from `argv[1]`, which mis-parses Windows drive-letter paths.

## Tests

`tests/discover-viability-gate.test.mts` adds a narrow+broad-cue precedence case and a `renderCsv` comma/quote case (with a small RFC 4180 row splitter asserting the rows stay parseable).

## Verification

`pnpm run typecheck`, `biome check`, `pnpm run build:check`, and the full `node --test tests/*.test.mts` suite (964 tests) pass; `dprint`/`markdownlint`/`cspell` clean.

Closes #920