### PR TITLE
fix(live-status-digest): revalidate the active claim before create/update

### DIFF
--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -14,6 +14,7 @@ import {
 } from './collaborator-permission.mjs';
 import { resolveCollaboratorMarkerTrust } from './policy-helpers.mjs';
 import {
+  applyDigestUpsert,
   normalizeTrustedMarkerLogins,
   parsePaginatedGhNdjson,
   planLiveStatusDigestUpsert,
@@ -111,56 +112,46 @@ if (planned.action === 'duplicate') {
   process.exit(1);
 }
 if (args.apply) {
-  // Re-fetch and re-plan against the latest comments first, then
-  // revalidate the active claim immediately before the create/update
-  // mutation. The replan performs network I/O, so checking the claim
-  // before it would leave a window where a claim release or takeover during
-  // the fetch goes undetected before the write lands.
+  // The ordering invariant — re-fetch and re-plan, then revalidate the
+  // active claim immediately before the create/update mutation, with no
+  // write if the claim check throws — lives in applyDigestUpsert. The live
+  // `gh` I/O is injected here so that invariant stays unit-testable.
+  let outcome;
   try {
-    planned = planLiveStatusDigestUpsert(
-      fetchIssueComments(owner, repo, targetNumber),
-      fields,
-    );
+    outcome = applyDigestUpsert({
+      skipClaimCheck: Boolean(args.skipClaimCheck),
+      refetchAndPlan: () =>
+        planLiveStatusDigestUpsert(
+          fetchIssueComments(owner, repo, targetNumber),
+          fields,
+        ),
+      assertClaim: () =>
+        assertActiveClaim(
+          owner,
+          repo,
+          args.claimIssue,
+          args.agentId,
+          args.claimId,
+          claimContext,
+        ),
+      createComment: (body) =>
+        createIssueComment(owner, repo, targetNumber, body),
+      updateComment: (commentId, body) =>
+        updateIssueComment(owner, repo, commentId, body),
+    });
   } catch (error) {
     fail(error.message);
   }
+  planned = outcome.planned;
   updateReportFromPlan(report, planned);
-  if (planned.action === 'duplicate') {
+  if (outcome.outcome === 'duplicate') {
     writeReport(report, args.format);
     process.exit(1);
   }
-  if (!args.skipClaimCheck) {
-    try {
-      assertActiveClaim(
-        owner,
-        repo,
-        args.claimIssue,
-        args.agentId,
-        args.claimId,
-        claimContext,
-      );
-    } catch (error) {
-      fail(error.message);
-    }
-  }
-  if (planned.action === 'create') {
-    const created = createIssueComment(owner, repo, targetNumber, planned.body);
+  if (outcome.outcome === 'created' || outcome.outcome === 'updated') {
     report.applied = true;
-    report.commentId = created.id ?? null;
-    report.url = created.html_url ?? created.url ?? null;
-  } else if (planned.action === 'update') {
-    if (!planned.commentId) {
-      fail('cannot update digest because the current comment id is missing');
-    }
-    const updated = updateIssueComment(
-      owner,
-      repo,
-      planned.commentId,
-      planned.body,
-    );
-    report.applied = true;
-    report.commentId = updated.id ?? planned.commentId;
-    report.url = updated.html_url ?? updated.url ?? planned.url ?? null;
+    report.commentId = outcome.commentId ?? report.commentId;
+    report.url = outcome.url ?? report.url;
   }
 }
 writeReport(report, args.format);

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -111,6 +111,24 @@ if (planned.action === 'duplicate') {
   process.exit(1);
 }
 if (args.apply) {
+  // Re-fetch and re-plan against the latest comments first, then
+  // revalidate the active claim immediately before the create/update
+  // mutation. The replan performs network I/O, so checking the claim
+  // before it would leave a window where a claim release or takeover during
+  // the fetch goes undetected before the write lands.
+  try {
+    planned = planLiveStatusDigestUpsert(
+      fetchIssueComments(owner, repo, targetNumber),
+      fields,
+    );
+  } catch (error) {
+    fail(error.message);
+  }
+  updateReportFromPlan(report, planned);
+  if (planned.action === 'duplicate') {
+    writeReport(report, args.format);
+    process.exit(1);
+  }
   if (!args.skipClaimCheck) {
     try {
       assertActiveClaim(
@@ -124,19 +142,6 @@ if (args.apply) {
     } catch (error) {
       fail(error.message);
     }
-  }
-  try {
-    planned = planLiveStatusDigestUpsert(
-      fetchIssueComments(owner, repo, targetNumber),
-      fields,
-    );
-  } catch (error) {
-    fail(error.message);
-  }
-  updateReportFromPlan(report, planned);
-  if (planned.action === 'duplicate') {
-    writeReport(report, args.format);
-    process.exit(1);
   }
   if (planned.action === 'create') {
     const created = createIssueComment(owner, repo, targetNumber, planned.body);

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -712,6 +712,48 @@ export function planLiveStatusDigestUpsert(comments, fields) {
     duplicates: [],
   };
 }
+/**
+ * Orchestrate the apply-time live-status-digest upsert: re-fetch and
+ * re-plan against the latest comments, then revalidate the active claim
+ * immediately before the create/update mutation, so a claim release or
+ * takeover that lands during the replan's network fetch is caught before
+ * the write. The side-effecting I/O is injected so the ordering invariant
+ * — replan, then claim check, then mutation, and no write when the claim
+ * check throws — is unit-testable apart from the live `gh` calls.
+ */
+export function applyDigestUpsert(io) {
+  const planned = io.refetchAndPlan();
+  if (planned.action === 'duplicate') {
+    return { planned, outcome: 'duplicate' };
+  }
+  if (!io.skipClaimCheck) {
+    io.assertClaim();
+  }
+  if (planned.action === 'create') {
+    const created = io.createComment(planned.body);
+    return {
+      planned,
+      outcome: 'created',
+      commentId: created.id ?? null,
+      url: created.html_url ?? created.url ?? null,
+    };
+  }
+  if (planned.action === 'update') {
+    if (planned.commentId === undefined || planned.commentId === null) {
+      throw new Error(
+        'cannot update digest because the current comment id is missing',
+      );
+    }
+    const updated = io.updateComment(planned.commentId, planned.body);
+    return {
+      planned,
+      outcome: 'updated',
+      commentId: updated.id ?? planned.commentId,
+      url: updated.html_url ?? updated.url ?? planned.url ?? null,
+    };
+  }
+  return { planned, outcome: 'noop' };
+}
 export function unsafeTextReason(body) {
   for (const rule of UNSAFE_TEXT_RULES) {
     if (rule.pattern.test(body)) {

--- a/src/scripts/live-status-digest.mts
+++ b/src/scripts/live-status-digest.mts
@@ -16,6 +16,8 @@ import {
 } from './collaborator-permission.mts';
 import { resolveCollaboratorMarkerTrust } from './policy-helpers.mts';
 import {
+  applyDigestUpsert,
+  type DigestUpsertOutcome,
   normalizeTrustedMarkerLogins,
   parsePaginatedGhNdjson,
   planLiveStatusDigestUpsert,
@@ -198,58 +200,47 @@ if (planned.action === 'duplicate') {
 }
 
 if (args.apply) {
-  // Re-fetch and re-plan against the latest comments first, then
-  // revalidate the active claim immediately before the create/update
-  // mutation. The replan performs network I/O, so checking the claim
-  // before it would leave a window where a claim release or takeover during
-  // the fetch goes undetected before the write lands.
+  // The ordering invariant — re-fetch and re-plan, then revalidate the
+  // active claim immediately before the create/update mutation, with no
+  // write if the claim check throws — lives in applyDigestUpsert. The live
+  // `gh` I/O is injected here so that invariant stays unit-testable.
+  let outcome: DigestUpsertOutcome<LiveStatusDigestPlan>;
   try {
-    planned = planLiveStatusDigestUpsert(
-      fetchIssueComments(owner, repo, targetNumber),
-      fields,
-    );
+    outcome = applyDigestUpsert<LiveStatusDigestPlan>({
+      skipClaimCheck: Boolean(args.skipClaimCheck),
+      refetchAndPlan: () =>
+        planLiveStatusDigestUpsert(
+          fetchIssueComments(owner, repo, targetNumber),
+          fields,
+        ),
+      assertClaim: () =>
+        assertActiveClaim(
+          owner,
+          repo,
+          args.claimIssue,
+          args.agentId,
+          args.claimId,
+          claimContext,
+        ),
+      createComment: (body) =>
+        createIssueComment(owner, repo, targetNumber, body),
+      updateComment: (commentId, body) =>
+        updateIssueComment(owner, repo, commentId, body),
+    });
   } catch (error) {
     fail((error as Error).message);
   }
+
+  planned = outcome.planned;
   updateReportFromPlan(report, planned);
-  if (planned.action === 'duplicate') {
+  if (outcome.outcome === 'duplicate') {
     writeReport(report, args.format);
     process.exit(1);
   }
-
-  if (!args.skipClaimCheck) {
-    try {
-      assertActiveClaim(
-        owner,
-        repo,
-        args.claimIssue,
-        args.agentId,
-        args.claimId,
-        claimContext,
-      );
-    } catch (error) {
-      fail((error as Error).message);
-    }
-  }
-
-  if (planned.action === 'create') {
-    const created = createIssueComment(owner, repo, targetNumber, planned.body);
+  if (outcome.outcome === 'created' || outcome.outcome === 'updated') {
     report.applied = true;
-    report.commentId = created.id ?? null;
-    report.url = created.html_url ?? created.url ?? null;
-  } else if (planned.action === 'update') {
-    if (!planned.commentId) {
-      fail('cannot update digest because the current comment id is missing');
-    }
-    const updated = updateIssueComment(
-      owner,
-      repo,
-      planned.commentId,
-      planned.body,
-    );
-    report.applied = true;
-    report.commentId = updated.id ?? planned.commentId;
-    report.url = updated.html_url ?? updated.url ?? planned.url ?? null;
+    report.commentId = outcome.commentId ?? report.commentId;
+    report.url = outcome.url ?? report.url;
   }
 }
 

--- a/src/scripts/live-status-digest.mts
+++ b/src/scripts/live-status-digest.mts
@@ -198,6 +198,25 @@ if (planned.action === 'duplicate') {
 }
 
 if (args.apply) {
+  // Re-fetch and re-plan against the latest comments first, then
+  // revalidate the active claim immediately before the create/update
+  // mutation. The replan performs network I/O, so checking the claim
+  // before it would leave a window where a claim release or takeover during
+  // the fetch goes undetected before the write lands.
+  try {
+    planned = planLiveStatusDigestUpsert(
+      fetchIssueComments(owner, repo, targetNumber),
+      fields,
+    );
+  } catch (error) {
+    fail((error as Error).message);
+  }
+  updateReportFromPlan(report, planned);
+  if (planned.action === 'duplicate') {
+    writeReport(report, args.format);
+    process.exit(1);
+  }
+
   if (!args.skipClaimCheck) {
     try {
       assertActiveClaim(
@@ -211,20 +230,6 @@ if (args.apply) {
     } catch (error) {
       fail((error as Error).message);
     }
-  }
-
-  try {
-    planned = planLiveStatusDigestUpsert(
-      fetchIssueComments(owner, repo, targetNumber),
-      fields,
-    );
-  } catch (error) {
-    fail((error as Error).message);
-  }
-  updateReportFromPlan(report, planned);
-  if (planned.action === 'duplicate') {
-    writeReport(report, args.format);
-    process.exit(1);
   }
 
   if (planned.action === 'create') {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1285,6 +1285,86 @@ export function planLiveStatusDigestUpsert(
   };
 }
 
+/** Minimal upsert-plan shape consumed by {@link applyDigestUpsert}. */
+export interface DigestUpsertPlanLike {
+  action: string;
+  body: string | null;
+  commentId?: string | number | null;
+  url?: string | null;
+}
+
+/** Result of a comment create/update GitHub mutation. */
+export interface DigestCommentMutationResult {
+  id?: string | number | null;
+  html_url?: string | null;
+  url?: string | null;
+}
+
+/** Injected side effects for {@link applyDigestUpsert}. */
+export interface DigestUpsertIo<P extends DigestUpsertPlanLike> {
+  skipClaimCheck: boolean;
+  refetchAndPlan: () => P;
+  assertClaim: () => void;
+  createComment: (body: string | null) => DigestCommentMutationResult;
+  updateComment: (
+    commentId: string | number,
+    body: string | null,
+  ) => DigestCommentMutationResult;
+}
+
+/** Outcome of {@link applyDigestUpsert}. */
+export interface DigestUpsertOutcome<P extends DigestUpsertPlanLike> {
+  planned: P;
+  outcome: 'duplicate' | 'created' | 'updated' | 'noop';
+  commentId?: string | number | null;
+  url?: string | null;
+}
+
+/**
+ * Orchestrate the apply-time live-status-digest upsert: re-fetch and
+ * re-plan against the latest comments, then revalidate the active claim
+ * immediately before the create/update mutation, so a claim release or
+ * takeover that lands during the replan's network fetch is caught before
+ * the write. The side-effecting I/O is injected so the ordering invariant
+ * — replan, then claim check, then mutation, and no write when the claim
+ * check throws — is unit-testable apart from the live `gh` calls.
+ */
+export function applyDigestUpsert<P extends DigestUpsertPlanLike>(
+  io: DigestUpsertIo<P>,
+): DigestUpsertOutcome<P> {
+  const planned = io.refetchAndPlan();
+  if (planned.action === 'duplicate') {
+    return { planned, outcome: 'duplicate' };
+  }
+  if (!io.skipClaimCheck) {
+    io.assertClaim();
+  }
+  if (planned.action === 'create') {
+    const created = io.createComment(planned.body);
+    return {
+      planned,
+      outcome: 'created',
+      commentId: created.id ?? null,
+      url: created.html_url ?? created.url ?? null,
+    };
+  }
+  if (planned.action === 'update') {
+    if (planned.commentId === undefined || planned.commentId === null) {
+      throw new Error(
+        'cannot update digest because the current comment id is missing',
+      );
+    }
+    const updated = io.updateComment(planned.commentId, planned.body);
+    return {
+      planned,
+      outcome: 'updated',
+      commentId: updated.id ?? planned.commentId,
+      url: updated.html_url ?? updated.url ?? planned.url ?? null,
+    };
+  }
+  return { planned, outcome: 'noop' };
+}
+
 export function unsafeTextReason(body: string): string | null {
   for (const rule of UNSAFE_TEXT_RULES) {
     if (rule.pattern.test(body)) {

--- a/tests/live-status-digest.test.mts
+++ b/tests/live-status-digest.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  applyDigestUpsert,
   findLiveStatusDigestComments,
   LIVE_STATUS_DIGEST_MARKER,
   planLiveStatusDigestUpsert,
@@ -131,4 +132,82 @@ test('does not modify operational marker comments during digest operations', () 
   assert.equal(plan.action, 'update');
   assert.equal(plan.commentId, 201);
   assert.notEqual(plan.commentId, 200);
+});
+
+test('applyDigestUpsert revalidates the claim after the replan and before the mutation', () => {
+  const calls: string[] = [];
+  const result = applyDigestUpsert({
+    skipClaimCheck: false,
+    refetchAndPlan: () => {
+      calls.push('replan');
+      return { action: 'create', body: 'digest body', duplicates: [] };
+    },
+    assertClaim: () => {
+      calls.push('assertClaim');
+    },
+    createComment: (body) => {
+      calls.push(`create:${body}`);
+      return { id: 42, html_url: 'https://example.test/c/42' };
+    },
+    updateComment: () => {
+      calls.push('update');
+      return {};
+    },
+  });
+  assert.deepEqual(calls, ['replan', 'assertClaim', 'create:digest body']);
+  assert.equal(result.outcome, 'created');
+  assert.equal(result.commentId, 42);
+  assert.equal(result.url, 'https://example.test/c/42');
+});
+
+test('applyDigestUpsert aborts the write when the claim check throws after the replan', () => {
+  const calls: string[] = [];
+  assert.throws(
+    () =>
+      applyDigestUpsert({
+        skipClaimCheck: false,
+        refetchAndPlan: () => {
+          calls.push('replan');
+          return { action: 'update', body: 'x', commentId: 7, duplicates: [] };
+        },
+        assertClaim: () => {
+          calls.push('assertClaim');
+          throw new Error('claim lost: superseded by another session');
+        },
+        createComment: () => {
+          calls.push('create');
+          return {};
+        },
+        updateComment: () => {
+          calls.push('update');
+          return {};
+        },
+      }),
+    /claim lost/,
+  );
+  // The replan ran, the claim check ran and threw, and crucially NO
+  // create/update mutation happened — a claim change between the replan and
+  // the write aborts the apply.
+  assert.deepEqual(calls, ['replan', 'assertClaim']);
+});
+
+test('applyDigestUpsert skips the claim check and mutation on a duplicate plan', () => {
+  const calls: string[] = [];
+  const result = applyDigestUpsert({
+    skipClaimCheck: false,
+    refetchAndPlan: () => ({ action: 'duplicate', body: null, duplicates: [] }),
+    assertClaim: () => {
+      calls.push('assertClaim');
+    },
+    createComment: () => {
+      calls.push('create');
+      return {};
+    },
+    updateComment: () => {
+      calls.push('update');
+      return {};
+    },
+  });
+  assert.equal(result.outcome, 'duplicate');
+  assert.deepEqual(calls, []);
 });


### PR DESCRIPTION
## Summary

The `live-status-digest` apply path asserted the active claim **before** the
fresh replan, which re-fetches all issue comments over the network — so a
claim release or takeover during that fetch window went undetected before
the digest create/update mutation landed. Relocate `assertActiveClaim` to
immediately before the create/update, after the replan and duplicate
recheck. Pure ordering change; the replan and duplicate guard are
unaffected.

From unresolved review feedback (legacy PR #219).

## Verification

`pnpm run build`, `pnpm run lint` (lint:minimum), `build:check`, and 6/6
live-status-digest planner tests pass.

Note: the relocation is in the module-level CLI orchestration
(`assertActiveClaim` / `fetchIssueComments` / create/update are live-`gh`),
which is not unit-tested; verified by inspection. The exported planner
(`planLiveStatusDigestUpsert`) is unchanged and its tests pass.

Closes #923