### PR TITLE
docs(issue-authoring): require the suitability footer in draft schemas

### DIFF
--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -590,6 +590,9 @@ Required content:
 - `## Background` or `## Goal`
 - `## Proposed change`
 - `## Acceptance criteria`
+- an autopilot-suitability footer at the end of the body (visible line +
+  `<!-- idd-skill-autopilot-suitability: N -->` marker; see
+  [Autopilot-suitability score](#autopilot-suitability-score))
 
 Optional content:
 
@@ -612,6 +615,8 @@ Validation expectations:
 - when the repository uses `orphan-first-policy: maintainer-approved`,
   the draft includes a post-publication maintainer approval step after
   the final title, body, and generated plan are stable
+- exactly one autopilot-suitability footer with an integer 1-5 marker; a
+  score of `1` also carries `status:blocked-by-human`
 
 ### Roadmap issue schema
 
@@ -626,6 +631,8 @@ Required content:
 - `## Tracks`
 - `## Success criteria`
 - one `<!-- idd-skill-roadmap-id: <roadmap-id> -->` marker
+- an autopilot-suitability footer at the end of the body (visible line +
+  `<!-- idd-skill-autopilot-suitability: N -->` marker)
 
 Recommended content inside `## Tracks`:
 
@@ -646,6 +653,8 @@ Validation expectations:
   instead of normal execution leaves
 - the roadmap can survive multi-session handoffs without relying on
   private session memory
+- exactly one autopilot-suitability footer with an integer 1-5 marker; a
+  score of `1` also carries `status:blocked-by-human`
 
 ### Sub-issue schema
 
@@ -658,6 +667,8 @@ Required content:
 - `## Background`
 - `## Proposed change`
 - `## Acceptance criteria`
+- an autopilot-suitability footer at the end of the body (visible line +
+  `<!-- idd-skill-autopilot-suitability: N -->` marker)
 
 Optional content:
 
@@ -674,6 +685,8 @@ Validation expectations:
 - any dependency marker is resolvable, intentionally chosen, and
   justified
 - the issue can be claimed independently without absorbing sibling work
+- exactly one autopilot-suitability footer with an integer 1-5 marker; a
+  score of `1` also carries `status:blocked-by-human`
 
 ## Validation checklist for drafted output
 


### PR DESCRIPTION
## Summary

Brings the draft schemas in `docs/issue-authoring-skill.md` in line with the
active contract. A Codex P2 review comment on PR #765 (left unresolved at merge)
noted that the autopilot-suitability footer requirement was not reflected in the
schemas an author actually follows. Re-verified on current `main`:
`skills/issue-authoring/references/contract.md` "Required draft content" lists
the footer for all three issue types, but the canonical
`docs/issue-authoring-skill.md` "Draft schemas" "Required content" and
"Validation expectations" lists still omitted it — so an author following the
schema checklists could produce a valid-looking draft with no marker.

## Change

In `docs/issue-authoring-skill.md` only (hand-edited canonical; not generated —
it is a `contains`-check reference against `contract.md`):

- Add the autopilot-suitability footer bullet to the orphan, roadmap, and
  sub-issue "Required content" lists, mirroring `contract.md` (the orphan entry
  keeps the in-doc link to the "Autopilot-suitability score" section).
- Add the matching "exactly one autopilot-suitability footer (integer 1-5; a
  `1` also carries `status:blocked-by-human`)" line to each "Validation
  expectations" list.

The two normative schema surfaces now agree.

## Verification

- `node scripts/audit-docs.mjs --check` passes (the `contains` reference check
  is unaffected).
- `pnpm run lint` passes (markdownlint, cspell, full suite).

Closes #915
