### PR TITLE
refactor(idd-doctor): reuse the shared autopilot-suitability parser

### DIFF
--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -18,16 +18,22 @@
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 export const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
 /**
- * Parse the authored autopilot-suitability score from an issue body.
+ * Canonical parser for the authored
+ * `<!-- {prefix}-autopilot-suitability: N -->` marker.
  *
- * Returns an integer 1-5 when the body carries a single coherent
- * `<!-- {prefix}-autopilot-suitability: N -->` marker. Returns null
- * (fail-safe = "no score") when the marker is absent, non-integer,
- * out of the 1-5 range, or present more than once with disagreeing
- * values. A null score must never cause an issue to be skipped; the
- * caller evaluates it the normal way.
+ * Returns `{ present, value, malformed }`:
+ * - `present` is false only when no marker appears in the body.
+ * - `value` is the single coherent integer 1-5, or null (fail-safe =
+ *   "no score") when the marker is absent, non-integer, out of the 1-5
+ *   range, or repeated with disagreeing values.
+ * - `malformed` is true when a marker is present but its value is not a
+ *   single coherent 1-5 score.
+ *
+ * `parseAutopilotSuitability` and `idd-doctor` both parse the marker
+ * through this one implementation so the regex and fail-safe rules never
+ * drift between the discovery rankers and the doctor consistency check.
  */
-export function parseAutopilotSuitability(
+export function parseAutopilotSuitabilityMarker(
   body,
   markerPrefix = DEFAULT_MARKER_PREFIX,
 ) {
@@ -39,29 +45,36 @@ export function parseAutopilotSuitability(
     `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
     'gi',
   );
-  const text = String(body ?? '');
-  const values = new Set();
-  let sawInvalid = false;
-  let match = regex.exec(text);
-  while (match) {
-    const raw = match[1];
-    if (/^\d+$/.test(raw)) {
-      const value = Number.parseInt(raw, 10);
-      if (value >= 1 && value <= 5) {
-        values.add(value);
-      } else {
-        sawInvalid = true;
-      }
-    } else {
-      sawInvalid = true;
-    }
-    match = regex.exec(text);
+  const raws = [...String(body ?? '').matchAll(regex)].map((match) => match[1]);
+  if (raws.length === 0) {
+    return { present: false, value: null, malformed: false };
   }
+  const values = raws.map((raw) =>
+    /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN,
+  );
+  const distinct = new Set(values);
   // Fail-safe: any invalid token, or conflicting values, yields no score.
-  if (sawInvalid || values.size !== 1) {
-    return null;
+  if (!values.every(isAutopilotSuitabilityScore) || distinct.size !== 1) {
+    return { present: true, value: null, malformed: true };
   }
-  return [...values][0];
+  return { present: true, value: [...distinct][0], malformed: false };
+}
+/**
+ * Parse the authored autopilot-suitability score from an issue body.
+ *
+ * Returns an integer 1-5 when the body carries a single coherent
+ * `<!-- {prefix}-autopilot-suitability: N -->` marker. Returns null
+ * (fail-safe = "no score") when the marker is absent, non-integer,
+ * out of the 1-5 range, or present more than once with disagreeing
+ * values. A null score must never cause an issue to be skipped; the
+ * caller evaluates it the normal way. Thin value-only view over
+ * {@link parseAutopilotSuitabilityMarker}.
+ */
+export function parseAutopilotSuitability(
+  body,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+) {
+  return parseAutopilotSuitabilityMarker(body, markerPrefix).value;
 }
 /**
  * Normalize a configured floor to an integer 1-5, falling back to the

--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -45,19 +45,32 @@ export function parseAutopilotSuitabilityMarker(
     `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
     'gi',
   );
-  const raws = [...String(body ?? '').matchAll(regex)].map((match) => match[1]);
-  if (raws.length === 0) {
+  const text = String(body ?? '');
+  // Stream matches with regex.exec so an untrusted, marker-heavy body
+  // stays O(1) memory (no per-match arrays), and fail fast on the first
+  // invalid token or first value that conflicts with an earlier one.
+  let present = false;
+  let value = null;
+  let match = regex.exec(text);
+  while (match) {
+    present = true;
+    const raw = match[1];
+    const parsed = /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN;
+    // Fail-safe: any invalid token, or a value disagreeing with an
+    // earlier coherent one, yields no score.
+    if (
+      !isAutopilotSuitabilityScore(parsed) ||
+      (value !== null && parsed !== value)
+    ) {
+      return { present: true, value: null, malformed: true };
+    }
+    value = parsed;
+    match = regex.exec(text);
+  }
+  if (!present) {
     return { present: false, value: null, malformed: false };
   }
-  const values = raws.map((raw) =>
-    /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN,
-  );
-  const distinct = new Set(values);
-  // Fail-safe: any invalid token, or conflicting values, yields no score.
-  if (!values.every(isAutopilotSuitabilityScore) || distinct.size !== 1) {
-    return { present: true, value: null, malformed: true };
-  }
-  return { present: true, value: [...distinct][0], malformed: false };
+  return { present: true, value, malformed: false };
 }
 /**
  * Parse the authored autopilot-suitability score from an issue body.

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -9,8 +9,8 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  isAutopilotSuitabilityScore,
   normalizeAutopilotSuitabilityFloor,
+  parseAutopilotSuitabilityMarker,
 } from './autopilot-suitability.mjs';
 import {
   inspectHelperRuntimeConfig,
@@ -103,7 +103,7 @@ export function evaluateAutopilotSuitabilityConsistency(issues, options = {}) {
       ),
     );
     const blockedByHuman = labelNames.has('status:blocked-by-human');
-    const marker = detectAutopilotSuitabilityMarker(issue?.body, prefix);
+    const marker = parseAutopilotSuitabilityMarker(issue?.body, prefix);
     if (!marker.present) {
       continue;
     }
@@ -130,24 +130,6 @@ export function evaluateAutopilotSuitabilityConsistency(issues, options = {}) {
     }
   }
   return { warnings };
-}
-function detectAutopilotSuitabilityMarker(body, prefix) {
-  const regex = new RegExp(
-    `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
-    'gi',
-  );
-  const raws = [...String(body ?? '').matchAll(regex)].map((match) => match[1]);
-  if (raws.length === 0) {
-    return { present: false, value: null, malformed: false };
-  }
-  const values = raws.map((raw) =>
-    /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN,
-  );
-  const distinct = new Set(values);
-  if (!values.every(isAutopilotSuitabilityScore) || distinct.size !== 1) {
-    return { present: true, value: null, malformed: true };
-  }
-  return { present: true, value: [...distinct][0], malformed: false };
 }
 function checkAutopilotSuitabilityConsistency(root, options, report) {
   const requireGithub = options.requireGithub === true;

--- a/src/scripts/autopilot-suitability.mts
+++ b/src/scripts/autopilot-suitability.mts
@@ -65,19 +65,32 @@ export function parseAutopilotSuitabilityMarker(
     `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
     'gi',
   );
-  const raws = [...String(body ?? '').matchAll(regex)].map((match) => match[1]);
-  if (raws.length === 0) {
+  const text = String(body ?? '');
+  // Stream matches with regex.exec so an untrusted, marker-heavy body
+  // stays O(1) memory (no per-match arrays), and fail fast on the first
+  // invalid token or first value that conflicts with an earlier one.
+  let present = false;
+  let value: number | null = null;
+  let match = regex.exec(text);
+  while (match) {
+    present = true;
+    const raw = match[1];
+    const parsed = /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN;
+    // Fail-safe: any invalid token, or a value disagreeing with an
+    // earlier coherent one, yields no score.
+    if (
+      !isAutopilotSuitabilityScore(parsed) ||
+      (value !== null && parsed !== value)
+    ) {
+      return { present: true, value: null, malformed: true };
+    }
+    value = parsed;
+    match = regex.exec(text);
+  }
+  if (!present) {
     return { present: false, value: null, malformed: false };
   }
-  const values = raws.map((raw) =>
-    /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN,
-  );
-  const distinct = new Set(values);
-  // Fail-safe: any invalid token, or conflicting values, yields no score.
-  if (!values.every(isAutopilotSuitabilityScore) || distinct.size !== 1) {
-    return { present: true, value: null, malformed: true };
-  }
-  return { present: true, value: [...distinct][0], malformed: false };
+  return { present: true, value, malformed: false };
 }
 
 /**

--- a/src/scripts/autopilot-suitability.mts
+++ b/src/scripts/autopilot-suitability.mts
@@ -27,19 +27,36 @@ interface RankOptions<T> {
 }
 
 /**
- * Parse the authored autopilot-suitability score from an issue body.
- *
- * Returns an integer 1-5 when the body carries a single coherent
- * `<!-- {prefix}-autopilot-suitability: N -->` marker. Returns null
- * (fail-safe = "no score") when the marker is absent, non-integer,
- * out of the 1-5 range, or present more than once with disagreeing
- * values. A null score must never cause an issue to be skipped; the
- * caller evaluates it the normal way.
+ * Detection shape for the authored autopilot-suitability marker:
+ * whether a marker is present at all, its coherent integer value (1-5)
+ * or null, and whether the present marker is malformed.
  */
-export function parseAutopilotSuitability(
+export interface AutopilotSuitabilityMarkerDetection {
+  present: boolean;
+  value: number | null;
+  malformed: boolean;
+}
+
+/**
+ * Canonical parser for the authored
+ * `<!-- {prefix}-autopilot-suitability: N -->` marker.
+ *
+ * Returns `{ present, value, malformed }`:
+ * - `present` is false only when no marker appears in the body.
+ * - `value` is the single coherent integer 1-5, or null (fail-safe =
+ *   "no score") when the marker is absent, non-integer, out of the 1-5
+ *   range, or repeated with disagreeing values.
+ * - `malformed` is true when a marker is present but its value is not a
+ *   single coherent 1-5 score.
+ *
+ * `parseAutopilotSuitability` and `idd-doctor` both parse the marker
+ * through this one implementation so the regex and fail-safe rules never
+ * drift between the discovery rankers and the doctor consistency check.
+ */
+export function parseAutopilotSuitabilityMarker(
   body: unknown,
   markerPrefix: string = DEFAULT_MARKER_PREFIX,
-): number | null {
+): AutopilotSuitabilityMarkerDetection {
   const prefix =
     typeof markerPrefix === 'string' && markerPrefix.length > 0
       ? markerPrefix
@@ -48,29 +65,37 @@ export function parseAutopilotSuitability(
     `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
     'gi',
   );
-  const text = String(body ?? '');
-  const values = new Set<number>();
-  let sawInvalid = false;
-  let match = regex.exec(text);
-  while (match) {
-    const raw = match[1];
-    if (/^\d+$/.test(raw)) {
-      const value = Number.parseInt(raw, 10);
-      if (value >= 1 && value <= 5) {
-        values.add(value);
-      } else {
-        sawInvalid = true;
-      }
-    } else {
-      sawInvalid = true;
-    }
-    match = regex.exec(text);
+  const raws = [...String(body ?? '').matchAll(regex)].map((match) => match[1]);
+  if (raws.length === 0) {
+    return { present: false, value: null, malformed: false };
   }
+  const values = raws.map((raw) =>
+    /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN,
+  );
+  const distinct = new Set(values);
   // Fail-safe: any invalid token, or conflicting values, yields no score.
-  if (sawInvalid || values.size !== 1) {
-    return null;
+  if (!values.every(isAutopilotSuitabilityScore) || distinct.size !== 1) {
+    return { present: true, value: null, malformed: true };
   }
-  return [...values][0];
+  return { present: true, value: [...distinct][0], malformed: false };
+}
+
+/**
+ * Parse the authored autopilot-suitability score from an issue body.
+ *
+ * Returns an integer 1-5 when the body carries a single coherent
+ * `<!-- {prefix}-autopilot-suitability: N -->` marker. Returns null
+ * (fail-safe = "no score") when the marker is absent, non-integer,
+ * out of the 1-5 range, or present more than once with disagreeing
+ * values. A null score must never cause an issue to be skipped; the
+ * caller evaluates it the normal way. Thin value-only view over
+ * {@link parseAutopilotSuitabilityMarker}.
+ */
+export function parseAutopilotSuitability(
+  body: unknown,
+  markerPrefix: string = DEFAULT_MARKER_PREFIX,
+): number | null {
+  return parseAutopilotSuitabilityMarker(body, markerPrefix).value;
 }
 
 /**

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -10,8 +10,8 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  isAutopilotSuitabilityScore,
   normalizeAutopilotSuitabilityFloor,
+  parseAutopilotSuitabilityMarker,
 } from './autopilot-suitability.mts';
 import {
   inspectHelperRuntimeConfig,
@@ -81,12 +81,6 @@ interface SuitabilityIssueInput {
   number?: unknown;
   body?: unknown;
   labels?: unknown;
-}
-
-interface SuitabilityMarkerDetection {
-  present: boolean;
-  value: number | null;
-  malformed: boolean;
 }
 
 type CommandResult =
@@ -191,7 +185,7 @@ export function evaluateAutopilotSuitabilityConsistency(
       ),
     );
     const blockedByHuman = labelNames.has('status:blocked-by-human');
-    const marker = detectAutopilotSuitabilityMarker(issue?.body, prefix);
+    const marker = parseAutopilotSuitabilityMarker(issue?.body, prefix);
     if (!marker.present) {
       continue;
     }
@@ -218,28 +212,6 @@ export function evaluateAutopilotSuitabilityConsistency(
     }
   }
   return { warnings };
-}
-
-function detectAutopilotSuitabilityMarker(
-  body: unknown,
-  prefix: string,
-): SuitabilityMarkerDetection {
-  const regex = new RegExp(
-    `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
-    'gi',
-  );
-  const raws = [...String(body ?? '').matchAll(regex)].map((match) => match[1]);
-  if (raws.length === 0) {
-    return { present: false, value: null, malformed: false };
-  }
-  const values = raws.map((raw) =>
-    /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : Number.NaN,
-  );
-  const distinct = new Set(values);
-  if (!values.every(isAutopilotSuitabilityScore) || distinct.size !== 1) {
-    return { present: true, value: null, malformed: true };
-  }
-  return { present: true, value: [...distinct][0], malformed: false };
 }
 
 function checkAutopilotSuitabilityConsistency(

--- a/tests/autopilot-suitability.test.mts
+++ b/tests/autopilot-suitability.test.mts
@@ -6,6 +6,7 @@ import {
   isAutopilotSuitabilityScore,
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
+  parseAutopilotSuitabilityMarker,
   rankAndRouteBySuitability,
 } from '../src/scripts/autopilot-suitability.mts';
 
@@ -79,6 +80,85 @@ test('parseAutopilotSuitability returns null on conflicting duplicate markers', 
   assert.equal(parseAutopilotSuitability(`${marker(4)}\n${marker(2)}`), null);
   // identical duplicates collapse to the single value
   assert.equal(parseAutopilotSuitability(`${marker(4)}\n${marker(4)}`), 4);
+});
+
+test('parseAutopilotSuitabilityMarker reports present/value/malformed per case', () => {
+  // absent — no marker in the body at all
+  assert.deepEqual(parseAutopilotSuitabilityMarker('no marker here'), {
+    present: false,
+    value: null,
+    malformed: false,
+  });
+  // present and coherent
+  assert.deepEqual(parseAutopilotSuitabilityMarker(`body\n\n${marker(3)}`), {
+    present: true,
+    value: 3,
+    malformed: false,
+  });
+  // present but malformed: out of range, non-integer, non-numeric
+  for (const bad of [marker(0), marker(6), marker('3.5'), marker('high')]) {
+    assert.deepEqual(
+      parseAutopilotSuitabilityMarker(bad),
+      { present: true, value: null, malformed: true },
+      `malformed: ${bad}`,
+    );
+  }
+  // present but conflicting duplicates -> malformed
+  assert.deepEqual(
+    parseAutopilotSuitabilityMarker(`${marker(4)}\n${marker(2)}`),
+    {
+      present: true,
+      value: null,
+      malformed: true,
+    },
+  );
+  // identical duplicates collapse to a single coherent value
+  assert.deepEqual(
+    parseAutopilotSuitabilityMarker(`${marker(4)}\n${marker(4)}`),
+    {
+      present: true,
+      value: 4,
+      malformed: false,
+    },
+  );
+});
+
+test('parseAutopilotSuitabilityMarker is prefix-aware', () => {
+  assert.deepEqual(
+    parseAutopilotSuitabilityMarker(marker(4, 'my-org'), 'my-org'),
+    {
+      present: true,
+      value: 4,
+      malformed: false,
+    },
+  );
+  // wrong prefix -> not present
+  assert.deepEqual(
+    parseAutopilotSuitabilityMarker(marker(4, 'my-org'), 'idd-skill'),
+    { present: false, value: null, malformed: false },
+  );
+});
+
+test('parseAutopilotSuitability is the value-only view of the shared marker parser', () => {
+  const bodies = [
+    'no marker here',
+    '',
+    `body\n\n${marker(1)}`,
+    marker(5),
+    marker(0),
+    marker(6),
+    marker('high'),
+    marker('3.5'),
+    `${marker(4)}\n${marker(2)}`,
+    `${marker(4)}\n${marker(4)}`,
+  ];
+  for (const body of bodies) {
+    assert.equal(
+      parseAutopilotSuitability(body),
+      parseAutopilotSuitabilityMarker(body).value,
+      `value equivalence: ${JSON.stringify(body)}`,
+    );
+  }
 });
 
 test('normalizeAutopilotSuitabilityFloor clamps to default for bad input', () => {


### PR DESCRIPTION
Part of roadmap #910 (resolve unresolved merged-PR review feedback). Addresses the PR #767 Copilot comment left unresolved at merge: `idd-doctor`'s `detectAutopilotSuitabilityMarker` duplicated the marker parsing already implemented by `parseAutopilotSuitability`.

## Changes

- `src/scripts/autopilot-suitability.mts`: add and export `parseAutopilotSuitabilityMarker(body, prefix)` returning `{ present, value, malformed }` as the canonical marker parser (canonical regex + fail-safe). `parseAutopilotSuitability` now delegates to its `.value`.
- `src/scripts/idd-doctor.mts`: import and call the shared parser; drop the private `detectAutopilotSuitabilityMarker`, its now-unused `SuitabilityMarkerDetection` type, and the `isAutopilotSuitabilityScore` import. (`escapeRegex` stays — still used by the worktree-hardening token check.)
- Regenerate both committed `.mjs` via `pnpm run build`.

The two implementations were byte-identical (same regex, same `gi` flags, same fail-safe), so this removes a real drift risk with no behavior change.

## Tests

`tests/autopilot-suitability.test.mts` gains equivalence coverage for `parseAutopilotSuitabilityMarker` across present / absent / malformed / out-of-range / conflicting markers, plus a value-only-view check that `parseAutopilotSuitability` equals `parseAutopilotSuitabilityMarker(...).value`. Existing `tests/idd-doctor.test.mts` and `tests/autopilot-suitability.test.mts` stay green (977 tests pass).

## Verification

`pnpm run typecheck`, `biome check`, `pnpm run build:check`, full `node --test tests/*.test.mts` (977 tests), `dprint`/`markdownlint`/`cspell` all pass.

Closes #914