### PR TITLE
fix(phase-id-resolver): resolve documented Resume phase, casing, and separators

### DIFF
--- a/scripts/phase-id-resolver.mjs
+++ b/scripts/phase-id-resolver.mjs
@@ -50,6 +50,7 @@ const DEFAULT_CANONICAL_PHASE_IDS = [
   'F3',
   'F4',
   'F5',
+  'Resume',
 ];
 const DEFAULT_LEGACY_ALIASES = {
   A0_O: ['A0-O', 'A0O'],
@@ -85,8 +86,12 @@ export function createPhaseIdResolver({
     if (canonicalByKey.has(normalized)) {
       continue;
     }
-    canonicalByKey.set(normalized, normalized);
-    canonicalOrder.push(normalized);
+    // Store the configured spelling as the canonical value and order (only
+    // the normalized form is the lookup key), so a mixed-case canonical ID
+    // such as `Resume` is emitted as `Resume`, not `RESUME`.
+    const spelling = String(candidate).trim();
+    canonicalByKey.set(normalized, spelling);
+    canonicalOrder.push(spelling);
   }
   for (const [canonical, aliases] of Object.entries(legacyAliases ?? {})) {
     const normalizedCanonical = normalizePhaseIdToken(canonical, {
@@ -160,8 +165,23 @@ export function createPhaseIdResolver({
       const aliasCanonical = aliasToCanonical.get(aliasInputKey);
       if (aliasCanonical) {
         return {
-          canonicalPhaseId: aliasCanonical,
+          canonicalPhaseId:
+            canonicalByKey.get(aliasCanonical) ?? aliasCanonical,
           matchedBy: 'legacy-alias',
+          normalizedInput,
+        };
+      }
+      // Separator-normalized fallback: `A4---5`, `A4/5`, and `A4 5` all
+      // normalize to `A4_5` via normalizePhaseIdToken, but normalizeAliasToken
+      // keeps the raw separators so the lookups above miss them. Resolve such
+      // inputs against the canonical map by their fully-normalized form.
+      if (
+        isCanonicalToken(normalizedInput) &&
+        canonicalByKey.has(normalizedInput)
+      ) {
+        return {
+          canonicalPhaseId: canonicalByKey.get(normalizedInput),
+          matchedBy: 'canonical',
           normalizedInput,
         };
       }

--- a/src/scripts/phase-id-resolver.mts
+++ b/src/scripts/phase-id-resolver.mts
@@ -51,6 +51,7 @@ const DEFAULT_CANONICAL_PHASE_IDS = [
   'F3',
   'F4',
   'F5',
+  'Resume',
 ];
 
 const DEFAULT_LEGACY_ALIASES: Record<string, string[]> = {
@@ -111,8 +112,12 @@ export function createPhaseIdResolver({
     if (canonicalByKey.has(normalized)) {
       continue;
     }
-    canonicalByKey.set(normalized, normalized);
-    canonicalOrder.push(normalized);
+    // Store the configured spelling as the canonical value and order (only
+    // the normalized form is the lookup key), so a mixed-case canonical ID
+    // such as `Resume` is emitted as `Resume`, not `RESUME`.
+    const spelling = String(candidate).trim();
+    canonicalByKey.set(normalized, spelling);
+    canonicalOrder.push(spelling);
   }
 
   for (const [canonical, aliases] of Object.entries(legacyAliases ?? {})) {
@@ -192,8 +197,24 @@ export function createPhaseIdResolver({
       const aliasCanonical = aliasToCanonical.get(aliasInputKey);
       if (aliasCanonical) {
         return {
-          canonicalPhaseId: aliasCanonical,
+          canonicalPhaseId:
+            canonicalByKey.get(aliasCanonical) ?? aliasCanonical,
           matchedBy: 'legacy-alias',
+          normalizedInput,
+        };
+      }
+
+      // Separator-normalized fallback: `A4---5`, `A4/5`, and `A4 5` all
+      // normalize to `A4_5` via normalizePhaseIdToken, but normalizeAliasToken
+      // keeps the raw separators so the lookups above miss them. Resolve such
+      // inputs against the canonical map by their fully-normalized form.
+      if (
+        isCanonicalToken(normalizedInput) &&
+        canonicalByKey.has(normalizedInput)
+      ) {
+        return {
+          canonicalPhaseId: canonicalByKey.get(normalizedInput) as string,
+          matchedBy: 'canonical',
           normalizedInput,
         };
       }

--- a/tests/phase-id-resolver.test.mts
+++ b/tests/phase-id-resolver.test.mts
@@ -143,6 +143,33 @@ test('phase-graph edges remain valid under normalized phase IDs', () => {
   }
 });
 
+test('resolves the documented Resume phase, preserving its configured casing', () => {
+  assert.equal(resolvePhaseId('Resume').canonicalPhaseId, 'Resume');
+  assert.equal(resolvePhaseId('resume').canonicalPhaseId, 'Resume');
+  assert.equal(resolvePhaseId('RESUME').canonicalPhaseId, 'Resume');
+});
+
+test('emits a configured mixed-case canonical id with its original casing', () => {
+  const resolution = resolvePhaseId('handoff', {
+    canonicalPhaseIds: ['Handoff'],
+    legacyAliases: {},
+  });
+  assert.equal(resolution.canonicalPhaseId, 'Handoff');
+});
+
+test('resolves separator-normalized canonical forms to the canonical id', () => {
+  for (const input of ['A4---5', 'A4/5', 'A4 5', 'A4:5']) {
+    assert.equal(
+      resolvePhaseId(input).canonicalPhaseId,
+      'A4_5',
+      `${input} should resolve to A4_5`,
+    );
+  }
+  // the dotted/hyphenated legacy aliases keep resolving as before
+  assert.equal(resolvePhaseId('A4.5').canonicalPhaseId, 'A4_5');
+  assert.equal(resolvePhaseId('A4.5').matchedBy, 'legacy-alias');
+});
+
 function readJson(relativePath: string): unknown {
   return JSON.parse(readFileSync(join(REPO_ROOT, relativePath), 'utf8'));
 }


### PR DESCRIPTION
## Summary

Three coupled fixes to `phase-id-resolver` from unresolved review feedback
(legacy PR #420):

- **`Resume` is now a canonical phase.** It is documented in
  `schemas/phase-graph.json` and `docs/reference.md` but was missing from
  the resolver's default canonical IDs, so `resolvePhaseId('Resume')` threw
  `unknown_phase_id`.
- **Mixed-case canonical IDs keep their configured casing.** The canonical
  map stored the uppercased form as the value, so `Resume` was emitted as
  `RESUME`. It now stores the configured spelling (key stays normalized).
- **Separator-normalized forms resolve.** `A4---5`, `A4/5`, and `A4 5` all
  normalize to `A4_5` but `normalizeAliasToken` keeps the raw separators, so
  only the `.`/`-` legacy aliases resolved before. Added a canonical
  fallback on the fully-normalized input (placed after the legacy-alias
  lookup so `A4.5`/`A4-5` keep their `legacy-alias` match).

## Verification

`pnpm run build`, `pnpm run lint` (lint:minimum), and `build:check` pass;
14/14 phase-id-resolver tests green (3 new: Resume casing, configured
mixed-case casing, separator forms).

Closes #925