### PR TITLE
docs: consolidate doc-consistency nits from merged-PR review

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -277,7 +277,7 @@ availability, or ordering constraint.
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
 - when authoring a **docs or operator-help child that documents
-  behavior implemented by sibling issues**, encode `Blocked by` those
+  behavior implemented by sibling issues**, encode `Blocked by #NNN` those
   implementation issues (or otherwise sequence the docs child to run
   after they merge) so the documentation is written against **shipped**
   behavior. Describing designed-but-unshipped behavior in the present

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -277,8 +277,8 @@ availability, or ordering constraint.
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
 - when authoring a **docs or operator-help child that documents
-  behavior implemented by sibling issues**, encode `Blocked by #NNN` those
-  implementation issues (or otherwise sequence the docs child to run
+  behavior implemented by sibling issues**, encode `Blocked by #NNN` for
+  those implementation issues (or otherwise sequence the docs child to run
   after they merge) so the documentation is written against **shipped**
   behavior. Describing designed-but-unshipped behavior in the present
   tense is a recurring advisory-review-thrash pattern; "describe shipped

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -110,7 +110,7 @@ re-review:
 gh pr edit {pr-number} --add-reviewer {reviewer-login}
 ```
 
-For an **advisory bot**, pass the bot's reviewer **slug** to this
+For an **advisory bot**, pass the bot's reviewer **login** to this
 add-reviewer command (the reliable trigger). The REST `requested_reviewers`
 endpoint called with a bot's **display name** silently no-ops and wastes a
 full advisory-wait cycle, so do not use that path to request a re-review.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1150,7 +1150,7 @@ wire it into the default F-phase merge gate.
 ## Optional: CI cost discipline on billed runners
 
 This is an **optional** appendix for adopters running on metered or private
-Actions runners. The core, cross-agent workflow does not require it.
+GitHub Actions runners. The core, cross-agent workflow does not require it.
 
 IDD's frequent **main-into-feature re-sync cadence** is the dominant driver of
 CI minutes — every sync re-runs the PR's checks. Uncached container builds and
@@ -1160,7 +1160,7 @@ per-PR multi-arch builds compound it. Levers to control the cost:
   the paths they cover actually change.
 - **Cache build layers** (image layer cache, dependency cache) so re-syncs
   reuse prior work instead of rebuilding from scratch.
-- **Keep multi-arch / publish jobs on integration-branch pushes only**, not on
+- **Keep multi-arch / publish jobs on integration branch pushes only**, not on
   every PR head, so per-PR cost stays low.
 - Remember that **re-sync cadence is the main cost lever**: the
   merge-from-`main` freshness model trades CI minutes for merge safety, so tune

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -339,7 +339,7 @@ Node.js helper path.
   wrapper scripts out of the target repository entirely.
 
 **Authoritative invocation surface per profile.** Under `vendored-node`, the
-canonical invocation is `node scripts/<name>.mjs`; the package-manager / `npx`
+canonical invocation is `node scripts/<name>.mjs`; the `package-manager` / `npx`
 `bin/` facade (the `idd-*` bin wrappers) is **redundant** in this profile and
 may be skipped — keeping it only adds a second surface to align with the
 instruction files for no portability gain. Under `package-manager` and

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -337,8 +337,8 @@ F2/F3 merge decision. The `review-activity-snapshot` helper builds the
 F-phase merge decision: the two can disagree in the window just before
 merge ("ci-pass-drift"), so reading CI/activity from the E-phase snapshot
 instead of the live pre-merge run risks merging on stale evidence. See
-[IDD helper script evaluation](idd-helper-scripts.md) for each helper's
-phase role.
+[IDD helper script evaluation](idd-helper-scripts.md#merge-gate-evidence)
+for each helper's phase role.
 
 ## Review Policy Profiles
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -481,7 +481,7 @@ availability, or ordering constraint.
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
 - when authoring a **docs or operator-help child that documents
-  behavior implemented by sibling issues**, encode `Blocked by` those
+  behavior implemented by sibling issues**, encode `Blocked by #NNN` those
   implementation issues (or otherwise sequence the docs child to run
   after they merge) so the documentation is written against **shipped**
   behavior. Describing designed-but-unshipped behavior in the present

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -481,8 +481,8 @@ availability, or ordering constraint.
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
 - when authoring a **docs or operator-help child that documents
-  behavior implemented by sibling issues**, encode `Blocked by #NNN` those
-  implementation issues (or otherwise sequence the docs child to run
+  behavior implemented by sibling issues**, encode `Blocked by #NNN` for
+  those implementation issues (or otherwise sequence the docs child to run
   after they merge) so the documentation is written against **shipped**
   behavior. Describing designed-but-unshipped behavior in the present
   tense is a recurring advisory-review-thrash pattern; "describe shipped

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -110,7 +110,7 @@ re-review:
 gh pr edit {pr-number} --add-reviewer {reviewer-login}
 ```
 
-For an **advisory bot**, pass the bot's reviewer **slug** to this
+For an **advisory bot**, pass the bot's reviewer **login** to this
 add-reviewer command (the reliable trigger). The REST `requested_reviewers`
 endpoint called with a bot's **display name** silently no-ops and wastes a
 full advisory-wait cycle, so do not use that path to request a re-review.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1150,7 +1150,7 @@ wire it into the default F-phase merge gate.
 ## Optional: CI cost discipline on billed runners
 
 This is an **optional** appendix for adopters running on metered or private
-Actions runners. The core, cross-agent workflow does not require it.
+GitHub Actions runners. The core, cross-agent workflow does not require it.
 
 IDD's frequent **main-into-feature re-sync cadence** is the dominant driver of
 CI minutes — every sync re-runs the PR's checks. Uncached container builds and
@@ -1160,7 +1160,7 @@ per-PR multi-arch builds compound it. Levers to control the cost:
   the paths they cover actually change.
 - **Cache build layers** (image layer cache, dependency cache) so re-syncs
   reuse prior work instead of rebuilding from scratch.
-- **Keep multi-arch / publish jobs on integration-branch pushes only**, not on
+- **Keep multi-arch / publish jobs on integration branch pushes only**, not on
   every PR head, so per-PR cost stays low.
 - Remember that **re-sync cadence is the main cost lever**: the
   merge-from-`main` freshness model trades CI minutes for merge safety, so tune

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -339,7 +339,7 @@ Node.js helper path.
   wrapper scripts out of the target repository entirely.
 
 **Authoritative invocation surface per profile.** Under `vendored-node`, the
-canonical invocation is `node scripts/<name>.mjs`; the package-manager / `npx`
+canonical invocation is `node scripts/<name>.mjs`; the `package-manager` / `npx`
 `bin/` facade (the `idd-*` bin wrappers) is **redundant** in this profile and
 may be skipped — keeping it only adds a second surface to align with the
 instruction files for no portability gain. Under `package-manager` and

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -311,8 +311,8 @@ F2/F3 merge decision. The `review-activity-snapshot` helper builds the
 F-phase merge decision: the two can disagree in the window just before
 merge ("ci-pass-drift"), so reading CI/activity from the E-phase snapshot
 instead of the live pre-merge run risks merging on stale evidence. See
-[IDD helper script evaluation](idd-helper-scripts.md) for each helper's
-phase role.
+[IDD helper script evaluation](idd-helper-scripts.md#merge-gate-evidence)
+for each helper's phase role.
 
 ## Review Policy Profiles
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -277,7 +277,7 @@ availability, or ordering constraint.
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
 - when authoring a **docs or operator-help child that documents
-  behavior implemented by sibling issues**, encode `Blocked by` those
+  behavior implemented by sibling issues**, encode `Blocked by #NNN` those
   implementation issues (or otherwise sequence the docs child to run
   after they merge) so the documentation is written against **shipped**
   behavior. Describing designed-but-unshipped behavior in the present

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -277,8 +277,8 @@ availability, or ordering constraint.
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
 - when authoring a **docs or operator-help child that documents
-  behavior implemented by sibling issues**, encode `Blocked by #NNN` those
-  implementation issues (or otherwise sequence the docs child to run
+  behavior implemented by sibling issues**, encode `Blocked by #NNN` for
+  those implementation issues (or otherwise sequence the docs child to run
   after they merge) so the documentation is written against **shipped**
   behavior. Describing designed-but-unshipped behavior in the present
   tense is a recurring advisory-review-thrash pattern; "describe shipped


### PR DESCRIPTION
## Summary

Bundles six independent, ≤1-line documentation-consistency nits that Copilot
flagged on merged PRs (#826, #827, #843, #845, #895) and left unresolved. Each
was re-verified as still present on current `main`. They are pure
terminology/link/formatting edits with no behavioral risk.

## Edits

- **idd-workflow.md** (PR #826): anchor the phase-role "IDD helper script
  evaluation" link to `idd-helper-scripts.md#merge-gate-evidence` (the bare file
  has no "IDD helper script evaluation" heading; `### Merge-gate evidence`
  is the section documenting each helper's phase role).
- **idd-review-fix.instructions.md** (PR #827): "reviewer **slug**" →
  "reviewer **login**", matching the `{reviewer-login}` placeholder in the
  adjacent `--add-reviewer` command.
- **customization.md** (PR #843): "Actions runners" → "GitHub Actions runners";
  "integration-branch pushes" → "integration branch pushes" (matches
  "integration branch" used elsewhere in the same doc).
- **idd-helper-scripts.md** (PR #845): code-format the bare `package-manager`
  profile name to match the other backticked profile identifiers.
- **contract.md** (PR #895): `Blocked by` → `Blocked by #NNN`, the canonical
  form used elsewhere in the file. No terminal period added (the bullet list
  uses none by convention).

## Propagation

Edits land on the `idd-template/` and `skills/` sources; `sync-docs --apply`
propagates the four exact-mode copies. Two surfaces are not exact-mode copies
and received the same edit directly: the structure-checked top-level
`docs/idd-workflow.md`, and the `## Dependency minimization` section of the
hand-edited canonical `docs/issue-authoring-skill.md` (kept byte-synced with
`contract.md` by `tests/issue-authoring-specificity.test.mts`).

## Excluded (not re-raised)

- PR #826 review-activity-snapshot phase-scope nit — already fixed by its own
  "Authoritative phase role" bullet.
- PR #895 "missing terminal punctuation" — false positive (the bullet list uses
  no terminal periods by convention).

## Verification

- `node scripts/sync-docs.mjs --check` and `node scripts/audit-docs.mjs --check`
  pass.
- `pnpm run lint` passes (full suite, markdownlint, cspell).

Closes #917
