### PR TITLE
fix(discover): fail closed on gh lookup errors instead of misclassifying exit codes

### DIFF
--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -12,6 +12,7 @@ import {
   buildAuthoringLabelWarning,
   resolveAuthoringGuardPolicy,
 } from './authoring-label-guard.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
 
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
@@ -441,12 +442,19 @@ function buildIssueLoader(owner, repo) {
       '.',
     ];
     try {
-      const result = runGh(args, { allowStatuses: [404] }).trim();
+      const result = runGh(args).trim();
       if (!result || result === 'null') {
         return null;
       }
       return JSON.parse(result);
     } catch (error) {
+      // `gh` exits 1 for every HTTP error, so derive the real status from
+      // its output. Fail closed: a genuine 404 maps to issue_not_found,
+      // a visibility 403/410/451 maps to issue_inaccessible, and auth /
+      // rate-limit / network / unknown failures propagate to abort.
+      if (deriveGhHttpStatus(error) === 404) {
+        return null;
+      }
       if (isInaccessibleIssueLookupError(error)) {
         return INACCESSIBLE_ISSUE_SENTINEL;
       }
@@ -504,8 +512,7 @@ function loadPolicy(policyPath) {
     return {};
   }
 }
-function runGh(args, options = {}) {
-  const { allowStatuses = [] } = options;
+function runGh(args) {
   try {
     return execFileSync('gh', args, {
       encoding: 'utf8',
@@ -514,34 +521,37 @@ function runGh(args, options = {}) {
   } catch (error) {
     const rawStatus = error?.status;
     const status = typeof rawStatus === 'number' ? rawStatus : null;
-    if (status !== null && allowStatuses.includes(status)) {
-      return '';
-    }
     const stderr = String(error?.stderr ?? '').trim();
+    const stdout = String(error?.stdout ?? '').trim();
     const prefix = `gh ${args.join(' ')}`;
+    // Preserve stderr and stdout on the wrapped error so deriveGhHttpStatus
+    // can recover the real HTTP status; the process exit status is always
+    // 1 and is kept only for diagnostics.
     const wrapped = new Error(
       stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`,
     );
     wrapped.status = status;
     wrapped.stderr = stderr;
+    wrapped.stdout = stdout;
     throw wrapped;
   }
 }
 function isInaccessibleIssue(value) {
   return value?.__iddLookupStatus === 'inaccessible';
 }
-function isInaccessibleIssueLookupError(error) {
-  if (!error) {
+export function isInaccessibleIssueLookupError(error) {
+  const status = deriveGhHttpStatus(error);
+  // Only a true 403/410/451 can be an inaccessible-issue downgrade.
+  if (status === null || !INACCESSIBLE_HTTP_STATUSES.has(status)) {
     return false;
   }
-  const rawStatus = error.status;
-  const status = typeof rawStatus === 'number' ? rawStatus : null;
-  if (status !== null && INACCESSIBLE_HTTP_STATUSES.has(status)) {
-    return true;
-  }
+  // Among those, downgrade only on visibility / integration-permission
+  // wording. A 403 secondary-rate-limit (or an auth failure that somehow
+  // surfaces as 403) must abort instead of being downgraded, so the regex
+  // deliberately excludes generic "forbidden" / "requires authentication".
   const candidate = error;
   const stderr = String(candidate.stderr ?? candidate.message ?? '');
-  return /resource not accessible|forbidden|requires authentication|visibility/i.test(
+  return /resource not accessible|not accessible by integration|visibility/i.test(
     stderr,
   );
 }

--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -7,6 +7,7 @@
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
 
 const CRITERIA = [
   {
@@ -295,10 +296,25 @@ function escapeCsv(value) {
 }
 function buildIssueLoader(owner, repo) {
   return async function loadIssue(issueNumber) {
-    const data = ghJson(
-      ['api', `repos/${owner}/${repo}/issues/${issueNumber}`, '--jq', '.'],
-      { allowStatuses: [1] },
-    );
+    let data;
+    try {
+      data = ghJson([
+        'api',
+        `repos/${owner}/${repo}/issues/${issueNumber}`,
+        '--jq',
+        '.',
+      ]);
+    } catch (error) {
+      // Fail closed: only a genuine 404 means the issue is absent. Auth,
+      // rate-limit, network, and unknown failures (status null) must
+      // propagate so discovery aborts instead of marking the issue
+      // not-found. `gh` exits 1 for every HTTP error, so derive the real
+      // status from its output rather than the process exit code.
+      if (deriveGhHttpStatus(error) === 404) {
+        return null;
+      }
+      throw error;
+    }
     if (!data) {
       return null;
     }
@@ -310,22 +326,14 @@ function buildIssueLoader(owner, repo) {
     };
   };
 }
-function ghText(args, options = {}) {
-  const { allowStatuses = [] } = options;
-  try {
-    return execFileSync('gh', args, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-  } catch (error) {
-    if (allowStatuses.includes(error.status)) {
-      return '';
-    }
-    throw error;
-  }
+function ghText(args) {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
 }
-function ghJson(args, options = {}) {
-  const text = ghText(args, options);
+function ghJson(args) {
+  const text = ghText(args);
   if (!text) {
     return null;
   }

--- a/scripts/gh-http-status.mjs
+++ b/scripts/gh-http-status.mjs
@@ -1,0 +1,48 @@
+// Shared HTTP-status derivation for failed `gh api` invocations.
+//
+// `gh` exits with process code 1 for 401, 403, and 404 alike, so the
+// child-process exit status is useless for HTTP classification. The real
+// status appears in gh's stderr as `(HTTP NNN)`, or in a JSON error body's
+// `"status"` field. Discovery helpers use this to fail closed on auth /
+// rate-limit / network failures instead of misreading them as a genuine
+// 404. Consumed by:
+//
+// - scripts/discover-viability-gate.mjs (A4 viability gate)
+// - scripts/discover-readiness-check.mjs (A3 readiness check)
+/**
+ * Derive the real HTTP status code from a failed `gh` invocation error.
+ *
+ * Inspects the error's `stderr`, `stdout`, and `message` text for either
+ * gh's `(HTTP NNN)` suffix or a JSON error body carrying a `"status"`
+ * field. Returns the numeric status, or null when no status can be
+ * determined — callers must fail closed on null (treat it as a tool
+ * failure, not a genuine 404).
+ */
+export function deriveGhHttpStatus(error) {
+  const text = ghErrorText(error);
+  if (!text) {
+    return null;
+  }
+  // Primary signal: gh prints the real status as `(HTTP NNN)` on stderr.
+  const httpMatch = text.match(/\(HTTP (\d{3})\)/);
+  if (httpMatch) {
+    return Number.parseInt(httpMatch[1], 10);
+  }
+  // Fallback: a JSON error body may carry a "status" field, as a string
+  // (e.g. {"message":"Not Found","status":"404"}) or a number.
+  const jsonMatch = text.match(/"status"\s*:\s*"?(\d{3})"?/);
+  if (jsonMatch) {
+    return Number.parseInt(jsonMatch[1], 10);
+  }
+  return null;
+}
+function ghErrorText(error) {
+  if (!error || typeof error !== 'object') {
+    return '';
+  }
+  const candidate = error;
+  return [candidate.stderr, candidate.stdout, candidate.message]
+    .map((value) => (value == null ? '' : String(value)))
+    .filter((value) => value.length > 0)
+    .join('\n');
+}

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -14,6 +14,7 @@ import {
   buildAuthoringLabelWarning,
   resolveAuthoringGuardPolicy,
 } from './authoring-label-guard.mts';
+import { deriveGhHttpStatus } from './gh-http-status.mts';
 
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
@@ -582,12 +583,19 @@ function buildIssueLoader(owner: string, repo: string) {
       '.',
     ];
     try {
-      const result = runGh(args, { allowStatuses: [404] }).trim();
+      const result = runGh(args).trim();
       if (!result || result === 'null') {
         return null;
       }
       return JSON.parse(result);
     } catch (error) {
+      // `gh` exits 1 for every HTTP error, so derive the real status from
+      // its output. Fail closed: a genuine 404 maps to issue_not_found,
+      // a visibility 403/410/451 maps to issue_inaccessible, and auth /
+      // rate-limit / network / unknown failures propagate to abort.
+      if (deriveGhHttpStatus(error) === 404) {
+        return null;
+      }
       if (isInaccessibleIssueLookupError(error)) {
         return INACCESSIBLE_ISSUE_SENTINEL;
       }
@@ -653,12 +661,7 @@ function loadPolicy(policyPath: string): unknown {
   }
 }
 
-function runGh(
-  args: string[],
-  options: { allowStatuses?: number[] } = {},
-): string {
-  const { allowStatuses = [] } = options;
-
+function runGh(args: string[]): string {
   try {
     return execFileSync('gh', args, {
       encoding: 'utf8',
@@ -667,18 +670,22 @@ function runGh(
   } catch (error) {
     const rawStatus = (error as { status?: unknown } | null)?.status;
     const status = typeof rawStatus === 'number' ? rawStatus : null;
-    if (status !== null && allowStatuses.includes(status)) {
-      return '';
-    }
     const stderr = String(
       (error as { stderr?: unknown } | null)?.stderr ?? '',
     ).trim();
+    const stdout = String(
+      (error as { stdout?: unknown } | null)?.stdout ?? '',
+    ).trim();
     const prefix = `gh ${args.join(' ')}`;
+    // Preserve stderr and stdout on the wrapped error so deriveGhHttpStatus
+    // can recover the real HTTP status; the process exit status is always
+    // 1 and is kept only for diagnostics.
     const wrapped = new Error(
       stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`,
-    ) as Error & { status?: number | null; stderr?: string };
+    ) as Error & { status?: number | null; stderr?: string; stdout?: string };
     wrapped.status = status;
     wrapped.stderr = stderr;
+    wrapped.stdout = stdout;
     throw wrapped;
   }
 }
@@ -692,18 +699,19 @@ function isInaccessibleIssue(
   );
 }
 
-function isInaccessibleIssueLookupError(error: unknown): boolean {
-  if (!error) {
+export function isInaccessibleIssueLookupError(error: unknown): boolean {
+  const status = deriveGhHttpStatus(error);
+  // Only a true 403/410/451 can be an inaccessible-issue downgrade.
+  if (status === null || !INACCESSIBLE_HTTP_STATUSES.has(status)) {
     return false;
   }
-  const rawStatus = (error as { status?: unknown }).status;
-  const status = typeof rawStatus === 'number' ? rawStatus : null;
-  if (status !== null && INACCESSIBLE_HTTP_STATUSES.has(status)) {
-    return true;
-  }
+  // Among those, downgrade only on visibility / integration-permission
+  // wording. A 403 secondary-rate-limit (or an auth failure that somehow
+  // surfaces as 403) must abort instead of being downgraded, so the regex
+  // deliberately excludes generic "forbidden" / "requires authentication".
   const candidate = error as { stderr?: unknown; message?: unknown };
   const stderr = String(candidate.stderr ?? candidate.message ?? '');
-  return /resource not accessible|forbidden|requires authentication|visibility/i.test(
+  return /resource not accessible|not accessible by integration|visibility/i.test(
     stderr,
   );
 }

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -8,6 +8,7 @@
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { deriveGhHttpStatus } from './gh-http-status.mts';
 
 interface NormalizedIssue {
   number: number;
@@ -406,10 +407,25 @@ function buildIssueLoader(
   return async function loadIssue(
     issueNumber: number,
   ): Promise<IssueLike | null> {
-    const data = ghJson(
-      ['api', `repos/${owner}/${repo}/issues/${issueNumber}`, '--jq', '.'],
-      { allowStatuses: [1] },
-    ) as IssueLike | null;
+    let data: IssueLike | null;
+    try {
+      data = ghJson([
+        'api',
+        `repos/${owner}/${repo}/issues/${issueNumber}`,
+        '--jq',
+        '.',
+      ]) as IssueLike | null;
+    } catch (error) {
+      // Fail closed: only a genuine 404 means the issue is absent. Auth,
+      // rate-limit, network, and unknown failures (status null) must
+      // propagate so discovery aborts instead of marking the issue
+      // not-found. `gh` exits 1 for every HTTP error, so derive the real
+      // status from its output rather than the process exit code.
+      if (deriveGhHttpStatus(error) === 404) {
+        return null;
+      }
+      throw error;
+    }
     if (!data) {
       return null;
     }
@@ -422,31 +438,15 @@ function buildIssueLoader(
   };
 }
 
-function ghText(
-  args: string[],
-  options: { allowStatuses?: number[] } = {},
-): string {
-  const { allowStatuses = [] } = options;
-  try {
-    return execFileSync('gh', args, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-  } catch (error) {
-    if (
-      allowStatuses.includes((error as { status?: number }).status as number)
-    ) {
-      return '';
-    }
-    throw error;
-  }
+function ghText(args: string[]): string {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
 }
 
-function ghJson(
-  args: string[],
-  options: { allowStatuses?: number[] } = {},
-): unknown {
-  const text = ghText(args, options);
+function ghJson(args: string[]): unknown {
+  const text = ghText(args);
   if (!text) {
     return null;
   }

--- a/src/scripts/gh-http-status.mts
+++ b/src/scripts/gh-http-status.mts
@@ -1,0 +1,54 @@
+// Shared HTTP-status derivation for failed `gh api` invocations.
+//
+// `gh` exits with process code 1 for 401, 403, and 404 alike, so the
+// child-process exit status is useless for HTTP classification. The real
+// status appears in gh's stderr as `(HTTP NNN)`, or in a JSON error body's
+// `"status"` field. Discovery helpers use this to fail closed on auth /
+// rate-limit / network failures instead of misreading them as a genuine
+// 404. Consumed by:
+//
+// - scripts/discover-viability-gate.mjs (A4 viability gate)
+// - scripts/discover-readiness-check.mjs (A3 readiness check)
+
+/**
+ * Derive the real HTTP status code from a failed `gh` invocation error.
+ *
+ * Inspects the error's `stderr`, `stdout`, and `message` text for either
+ * gh's `(HTTP NNN)` suffix or a JSON error body carrying a `"status"`
+ * field. Returns the numeric status, or null when no status can be
+ * determined — callers must fail closed on null (treat it as a tool
+ * failure, not a genuine 404).
+ */
+export function deriveGhHttpStatus(error: unknown): number | null {
+  const text = ghErrorText(error);
+  if (!text) {
+    return null;
+  }
+  // Primary signal: gh prints the real status as `(HTTP NNN)` on stderr.
+  const httpMatch = text.match(/\(HTTP (\d{3})\)/);
+  if (httpMatch) {
+    return Number.parseInt(httpMatch[1], 10);
+  }
+  // Fallback: a JSON error body may carry a "status" field, as a string
+  // (e.g. {"message":"Not Found","status":"404"}) or a number.
+  const jsonMatch = text.match(/"status"\s*:\s*"?(\d{3})"?/);
+  if (jsonMatch) {
+    return Number.parseInt(jsonMatch[1], 10);
+  }
+  return null;
+}
+
+function ghErrorText(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return '';
+  }
+  const candidate = error as {
+    stderr?: unknown;
+    stdout?: unknown;
+    message?: unknown;
+  };
+  return [candidate.stderr, candidate.stdout, candidate.message]
+    .map((value) => (value == null ? '' : String(value)))
+    .filter((value) => value.length > 0)
+    .join('\n');
+}

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -6,7 +6,16 @@ import {
   extractBlockedByIssueNumbers,
   extractBlockedByRoadmapMarkers,
   extractDependencyIssueNumbers,
+  isInaccessibleIssueLookupError,
 } from '../src/scripts/discover-readiness-check.mts';
+
+// Shape of a wrapped runGh failure: process exit code 1 with the true
+// HTTP status carried in stderr.
+const ghError = (stderr: string) =>
+  Object.assign(new Error(`gh api ... failed: ${stderr}`), {
+    status: 1,
+    stderr,
+  });
 
 test('extractors parse blocked-by references, roadmap markers, and dependencies', () => {
   const body = `
@@ -259,5 +268,46 @@ test('bubbles non-recoverable loader failures', async () => {
       findRoadmapsByMarker: async () => [],
     }),
     /network timeout/,
+  );
+});
+
+test('isInaccessibleIssueLookupError downgrades only visibility 403/410/451', () => {
+  // Visibility / integration-permission 403, 410, 451 -> inaccessible
+  assert.equal(
+    isInaccessibleIssueLookupError(
+      ghError('Resource not accessible by integration (HTTP 403)'),
+    ),
+    true,
+  );
+  assert.equal(
+    isInaccessibleIssueLookupError(
+      ghError('Repository access blocked due to visibility (HTTP 451)'),
+    ),
+    true,
+  );
+});
+
+test('isInaccessibleIssueLookupError fails closed on auth, rate-limit, and 404', () => {
+  // 403 secondary-rate-limit must abort, not downgrade.
+  assert.equal(
+    isInaccessibleIssueLookupError(
+      ghError('You have exceeded a secondary rate limit (HTTP 403)'),
+    ),
+    false,
+  );
+  // 401 auth failure must abort.
+  assert.equal(
+    isInaccessibleIssueLookupError(ghError('Bad credentials (HTTP 401)')),
+    false,
+  );
+  // A genuine 404 is handled as not-found upstream, never inaccessible.
+  assert.equal(
+    isInaccessibleIssueLookupError(ghError('Not Found (HTTP 404)')),
+    false,
+  );
+  // No derivable status -> fail closed (not inaccessible -> abort upstream).
+  assert.equal(
+    isInaccessibleIssueLookupError(ghError('connect ETIMEDOUT')),
+    false,
   );
 });

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -281,6 +281,12 @@ test('isInaccessibleIssueLookupError downgrades only visibility 403/410/451', ()
   );
   assert.equal(
     isInaccessibleIssueLookupError(
+      ghError('Resource not accessible by integration (HTTP 410)'),
+    ),
+    true,
+  );
+  assert.equal(
+    isInaccessibleIssueLookupError(
       ghError('Repository access blocked due to visibility (HTTP 451)'),
     ),
     true,

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -130,6 +130,19 @@ test('fails autonomous completion when external coordination is required', () =>
   assert.ok(result.failedCriteria.includes('autonomous_completion'));
 });
 
+test('evaluateDiscoverViability fails closed when a lookup aborts', async () => {
+  // A non-404 gh failure (auth / rate-limit / network) propagates out of
+  // loadIssue instead of being swallowed into a silent issue_not_found.
+  await assert.rejects(
+    evaluateDiscoverViability([900], {
+      loadIssue: async () => {
+        throw new Error('gh api ... failed: Bad credentials (HTTP 401)');
+      },
+    }),
+    /Bad credentials/,
+  );
+});
+
 test('evaluateDiscoverViability groups viable and discarded candidates', async () => {
   const issues = new Map([
     [

--- a/tests/gh-http-status.test.mts
+++ b/tests/gh-http-status.test.mts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { deriveGhHttpStatus } from '../src/scripts/gh-http-status.mts';
+
+// Shape of a real execFileSync('gh', ...) failure: process exit code 1
+// regardless of the HTTP status, with the true status in stderr/stdout.
+const ghError = (parts: {
+  stderr?: string;
+  stdout?: string;
+  message?: string;
+}) =>
+  Object.assign(new Error(parts.message ?? 'Command failed'), {
+    status: 1,
+    ...parts,
+  });
+
+test('derives the HTTP status from gh stderr (HTTP NNN)', () => {
+  assert.equal(
+    deriveGhHttpStatus(ghError({ stderr: 'gh: Not Found (HTTP 404)' })),
+    404,
+  );
+  assert.equal(
+    deriveGhHttpStatus(
+      ghError({ stderr: 'gh: API rate limit exceeded (HTTP 403)' }),
+    ),
+    403,
+  );
+  assert.equal(
+    deriveGhHttpStatus(ghError({ stderr: 'gh: Bad credentials (HTTP 401)' })),
+    401,
+  );
+});
+
+test('falls back to a JSON error body "status" field', () => {
+  assert.equal(
+    deriveGhHttpStatus(
+      ghError({ stdout: '{"message":"Not Found","status":"404"}' }),
+    ),
+    404,
+  );
+  // numeric status value, surfaced via the wrapped error message
+  assert.equal(
+    deriveGhHttpStatus(ghError({ message: 'failed: {"status":410}' })),
+    410,
+  );
+});
+
+test('prefers the (HTTP NNN) signal over the JSON body', () => {
+  assert.equal(
+    deriveGhHttpStatus(
+      ghError({
+        stderr: 'gh: Gone (HTTP 410)',
+        stdout: '{"status":"403"}',
+      }),
+    ),
+    410,
+  );
+});
+
+test('returns null when no status can be determined (fail closed)', () => {
+  assert.equal(
+    deriveGhHttpStatus(ghError({ stderr: 'connect ETIMEDOUT 140.82.0.0:443' })),
+    null,
+  );
+  assert.equal(deriveGhHttpStatus(ghError({})), null);
+  assert.equal(deriveGhHttpStatus(null), null);
+  assert.equal(deriveGhHttpStatus(undefined), null);
+  assert.equal(deriveGhHttpStatus('a bare string'), null);
+});


### PR DESCRIPTION
Part of roadmap #910 (resolve unresolved merged-PR review feedback — legacy era). Addresses comments left unresolved on PRs #436 (viability) and #410 / #419 (readiness).

## Problem

`gh api` exits with process code **1** for 401, 403, and 404 alike, so two discovery loaders that read `error.status` as if it were an HTTP status misclassified every failure — in **opposite** dangerous directions:

- **viability-gate failed OPEN**: `allowStatuses: [1]` swallowed *every* gh failure (auth, rate-limit, network, real 404) into a silent `issue_not_found`.
- **readiness-check failed CLOSED on the wrong cases**: its stderr regex downgraded rate-limit 403s and auth 401s to `issue_inaccessible`, while a genuine 404 aborted.

## Changes

- **New shared helper** `src/scripts/gh-http-status.mts` — `deriveGhHttpStatus(error)` recovers the real status from gh's `(HTTP NNN)` stderr suffix, falling back to a JSON `"status"` field; returns `null` when undeterminable so callers fail closed.
- **viability-gate**: drop the blanket `allowStatuses: [1]`; return `null` only on a genuine 404 and rethrow every other failure so the run aborts.
- **readiness-check**: map a genuine 404 to `issue_not_found`; classify `issue_inaccessible` only on a true 403/410/451 carrying visibility / integration-permission wording (excluding generic "forbidden" / "requires authentication"); rethrow auth and rate-limit 403s so they abort. Preserve `stdout` on the wrapped error for status recovery.
- Regenerate both committed `.mjs` via `pnpm run build`.

The new module is picked up automatically by the vendored-node helper import-closure (drift guard test stays green).

## Tests

New `tests/gh-http-status.test.mts` covers status derivation (HTTP-suffix and JSON-body forms, fail-closed null). Readiness tests cover `isInaccessibleIssueLookupError`: 403/451-visibility → inaccessible; 403-rate-limit / 401 / 404 / no-status → not inaccessible (abort). Viability gains a fail-closed abort-propagation test. Existing abort-propagation tests stay green (987 tests pass).

Closes #921