### PR TITLE
fix(audit-docs): skip instruction size-budget check when no diff base resolves

### DIFF
--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -518,15 +518,15 @@ function docsSyncCommandByPackageManager(packageManager) {
 }
 function checkInstructionSizeBudgets(config) {
   // The scope/skip decision and budget evaluation live in the pure helper
-  // so they can be unit-tested; the audit pipeline only supplies the
-  // changed-file set and a lazy reader for the globbed instruction files.
+  // so they can be unit-tested; the audit pipeline supplies the changed
+  // file set, a glob lister, and a reader. The helper reads only changed
+  // files, so unchanged instruction files are never loaded from disk.
   const result = collectInstructionSizeBudgetViolations(
     config,
     changedFiles,
     () =>
-      globFiles(
-        config?.glob ?? '.github/instructions/idd-*.instructions.md',
-      ).map((file) => ({ path: file, text: readText(file) })),
+      globFiles(config?.glob ?? '.github/instructions/idd-*.instructions.md'),
+    readText,
   );
   errors.push(...result.errors);
   notices.push(...result.notices);

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -8,6 +8,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  collectInstructionSizeBudgetViolations,
   collectPolicyConfigDrift,
   collectRootMarkdownAllowlistViolations,
   collectTypeSuppressionViolations,
@@ -516,33 +517,19 @@ function docsSyncCommandByPackageManager(packageManager) {
   }
 }
 function checkInstructionSizeBudgets(config) {
-  if (!config) {
-    return;
-  }
-  const id = config.id ?? 'instruction-size-budgets';
-  const files = globFiles(
-    config.glob ?? '.github/instructions/idd-*.instructions.md',
+  // The scope/skip decision and budget evaluation live in the pure helper
+  // so they can be unit-tested; the audit pipeline only supplies the
+  // changed-file set and a lazy reader for the globbed instruction files.
+  const result = collectInstructionSizeBudgetViolations(
+    config,
+    changedFiles,
+    () =>
+      globFiles(
+        config?.glob ?? '.github/instructions/idd-*.instructions.md',
+      ).map((file) => ({ path: file, text: readText(file) })),
   );
-  const alwaysLoadedPattern =
-    config.alwaysLoadedPattern ?? 'applyTo:\\s*"\\*\\*"';
-  const alwaysLoadedRegex = new RegExp(alwaysLoadedPattern, 'm');
-  const alwaysLoadedLimitBytes = config.alwaysLoadedLimitBytes ?? 20_000;
-  const phaseLimitBytes = config.phaseLimitBytes ?? 30_000;
-  const candidates =
-    changedFiles === null
-      ? files
-      : files.filter((file) => changedFiles.has(file));
-  for (const file of candidates) {
-    const text = readText(file);
-    const bytes = Buffer.byteLength(text, 'utf8');
-    const alwaysLoaded = alwaysLoadedRegex.test(text);
-    const limit = alwaysLoaded ? alwaysLoadedLimitBytes : phaseLimitBytes;
-    if (bytes > limit) {
-      errors.push(
-        `${id}: ${file} is ${bytes} bytes (limit ${limit}; ${alwaysLoaded ? 'always-loaded' : 'phase'})`,
-      );
-    }
-  }
+  errors.push(...result.errors);
+  notices.push(...result.notices);
 }
 function checkBundleBudgets(budgets) {
   for (const budget of budgets) {

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -366,20 +366,26 @@ function regexCanStartAfter(lastCodeChar, lastWord) {
   return !/[\w$)\]'"`/]/.test(lastCodeChar);
 }
 /**
- * Collect instruction size-budget violations. Pure (no I/O) so it can be
- * unit-tested; the audit pipeline feeds it the globbed file text.
+ * Collect instruction size-budget violations. Pure (no direct I/O) so it
+ * can be unit-tested; the audit pipeline supplies a path lister and a file
+ * reader.
  *
  * Scope rule (mirrors checkPairedChange): the budget is scoped to the
  * files changed against the git comparison base. When `changedFiles` is
  * `null` (no resolvable base — e.g. a CI clone without `origin/main`) the
  * check is skipped with a notice rather than auditing every instruction
  * file, which would let an unrelated PR fail on a file it never touched.
- * `loadFiles` is a thunk so no files are read on the skip path.
+ *
+ * `listFiles` is only invoked when a base resolves, and `readFile` is
+ * invoked only for files in `changedFiles`, so unchanged files are never
+ * read (the audit reads from disk, so reading every match would be wasted
+ * I/O on large repos).
  */
 export function collectInstructionSizeBudgetViolations(
   config,
   changedFiles,
-  loadFiles,
+  listFiles,
+  readFile,
 ) {
   if (!config) {
     return { errors: [], notices: [] };
@@ -399,17 +405,17 @@ export function collectInstructionSizeBudgetViolations(
   const alwaysLoadedLimitBytes = config.alwaysLoadedLimitBytes ?? 20_000;
   const phaseLimitBytes = config.phaseLimitBytes ?? 30_000;
   const errors = [];
-  for (const file of loadFiles()) {
-    if (!changedFiles.has(file.path)) {
+  for (const path of listFiles()) {
+    if (!changedFiles.has(path)) {
       continue;
     }
-    const text = String(file.text ?? '');
+    const text = String(readFile(path) ?? '');
     const bytes = Buffer.byteLength(text, 'utf8');
     const alwaysLoaded = alwaysLoadedRegex.test(text);
     const limit = alwaysLoaded ? alwaysLoadedLimitBytes : phaseLimitBytes;
     if (bytes > limit) {
       errors.push(
-        `${id}: ${file.path} is ${bytes} bytes (limit ${limit}; ${alwaysLoaded ? 'always-loaded' : 'phase'})`,
+        `${id}: ${path} is ${bytes} bytes (limit ${limit}; ${alwaysLoaded ? 'always-loaded' : 'phase'})`,
       );
     }
   }

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -365,3 +365,53 @@ function regexCanStartAfter(lastCodeChar, lastWord) {
   }
   return !/[\w$)\]'"`/]/.test(lastCodeChar);
 }
+/**
+ * Collect instruction size-budget violations. Pure (no I/O) so it can be
+ * unit-tested; the audit pipeline feeds it the globbed file text.
+ *
+ * Scope rule (mirrors checkPairedChange): the budget is scoped to the
+ * files changed against the git comparison base. When `changedFiles` is
+ * `null` (no resolvable base — e.g. a CI clone without `origin/main`) the
+ * check is skipped with a notice rather than auditing every instruction
+ * file, which would let an unrelated PR fail on a file it never touched.
+ * `loadFiles` is a thunk so no files are read on the skip path.
+ */
+export function collectInstructionSizeBudgetViolations(
+  config,
+  changedFiles,
+  loadFiles,
+) {
+  if (!config) {
+    return { errors: [], notices: [] };
+  }
+  const id = config.id ?? 'instruction-size-budgets';
+  if (changedFiles === null) {
+    return {
+      errors: [],
+      notices: [
+        `${id}: skipped instruction size budget check because no git comparison base was available`,
+      ],
+    };
+  }
+  const alwaysLoadedPattern =
+    config.alwaysLoadedPattern ?? 'applyTo:\\s*"\\*\\*"';
+  const alwaysLoadedRegex = new RegExp(alwaysLoadedPattern, 'm');
+  const alwaysLoadedLimitBytes = config.alwaysLoadedLimitBytes ?? 20_000;
+  const phaseLimitBytes = config.phaseLimitBytes ?? 30_000;
+  const errors = [];
+  for (const file of loadFiles()) {
+    if (!changedFiles.has(file.path)) {
+      continue;
+    }
+    const text = String(file.text ?? '');
+    const bytes = Buffer.byteLength(text, 'utf8');
+    const alwaysLoaded = alwaysLoadedRegex.test(text);
+    const limit = alwaysLoaded ? alwaysLoadedLimitBytes : phaseLimitBytes;
+    if (bytes > limit) {
+      errors.push(
+        `${id}: ${file.path} is ${bytes} bytes (limit ${limit}; ${alwaysLoaded ? 'always-loaded' : 'phase'})`,
+      );
+    }
+  }
+  return { errors, notices: [] };
+}

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -9,10 +9,12 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type {
+  InstructionSizeBudgetConfig,
   RootMarkdownAllowlistConfig,
   TypeSuppressionBudgetConfig,
 } from './consistency-helpers.mts';
 import {
+  collectInstructionSizeBudgetViolations,
   collectPolicyConfigDrift,
   collectRootMarkdownAllowlistViolations,
   collectTypeSuppressionViolations,
@@ -63,14 +65,6 @@ interface SyncPair {
   requiredPatterns?: string[];
 }
 
-interface InstructionSizeBudgets {
-  id?: string;
-  glob?: string;
-  alwaysLoadedPattern?: string;
-  alwaysLoadedLimitBytes?: number;
-  phaseLimitBytes?: number;
-}
-
 interface BundleBudget {
   id?: string;
   files?: string[];
@@ -90,7 +84,7 @@ interface AuditManifest {
   generatedBlocks?: GeneratedBlock[];
   shellFileLists?: ShellFileList[];
   syncPairs?: SyncPair[];
-  instructionSizeBudgets?: InstructionSizeBudgets | null;
+  instructionSizeBudgets?: InstructionSizeBudgetConfig | null;
   bundleBudgets?: BundleBudget[];
   forbiddenPatterns?: ForbiddenPattern[];
   rootMarkdownAllowlist?: RootMarkdownAllowlistConfig | null;
@@ -663,38 +657,22 @@ function docsSyncCommandByPackageManager(packageManager: unknown): string {
   }
 }
 
-function checkInstructionSizeBudgets(config: InstructionSizeBudgets | null) {
-  if (!config) {
-    return;
-  }
-
-  const id = config.id ?? 'instruction-size-budgets';
-  const files = globFiles(
-    config.glob ?? '.github/instructions/idd-*.instructions.md',
+function checkInstructionSizeBudgets(
+  config: InstructionSizeBudgetConfig | null,
+) {
+  // The scope/skip decision and budget evaluation live in the pure helper
+  // so they can be unit-tested; the audit pipeline only supplies the
+  // changed-file set and a lazy reader for the globbed instruction files.
+  const result = collectInstructionSizeBudgetViolations(
+    config,
+    changedFiles,
+    () =>
+      globFiles(
+        config?.glob ?? '.github/instructions/idd-*.instructions.md',
+      ).map((file) => ({ path: file, text: readText(file) })),
   );
-  const alwaysLoadedPattern =
-    config.alwaysLoadedPattern ?? 'applyTo:\\s*"\\*\\*"';
-  const alwaysLoadedRegex = new RegExp(alwaysLoadedPattern, 'm');
-  const alwaysLoadedLimitBytes = config.alwaysLoadedLimitBytes ?? 20_000;
-  const phaseLimitBytes = config.phaseLimitBytes ?? 30_000;
-  const candidates =
-    changedFiles === null
-      ? files
-      : files.filter((file) => changedFiles.has(file));
-
-  for (const file of candidates) {
-    const text = readText(file);
-    const bytes = Buffer.byteLength(text, 'utf8');
-    const alwaysLoaded = alwaysLoadedRegex.test(text);
-    const limit = alwaysLoaded ? alwaysLoadedLimitBytes : phaseLimitBytes;
-    if (bytes > limit) {
-      errors.push(
-        `${id}: ${file} is ${bytes} bytes (limit ${limit}; ${
-          alwaysLoaded ? 'always-loaded' : 'phase'
-        })`,
-      );
-    }
-  }
+  errors.push(...result.errors);
+  notices.push(...result.notices);
 }
 
 function checkBundleBudgets(budgets: BundleBudget[]) {

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -661,15 +661,15 @@ function checkInstructionSizeBudgets(
   config: InstructionSizeBudgetConfig | null,
 ) {
   // The scope/skip decision and budget evaluation live in the pure helper
-  // so they can be unit-tested; the audit pipeline only supplies the
-  // changed-file set and a lazy reader for the globbed instruction files.
+  // so they can be unit-tested; the audit pipeline supplies the changed
+  // file set, a glob lister, and a reader. The helper reads only changed
+  // files, so unchanged instruction files are never loaded from disk.
   const result = collectInstructionSizeBudgetViolations(
     config,
     changedFiles,
     () =>
-      globFiles(
-        config?.glob ?? '.github/instructions/idd-*.instructions.md',
-      ).map((file) => ({ path: file, text: readText(file) })),
+      globFiles(config?.glob ?? '.github/instructions/idd-*.instructions.md'),
+    readText,
   );
   errors.push(...result.errors);
   notices.push(...result.notices);

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -436,3 +436,74 @@ function regexCanStartAfter(lastCodeChar: string, lastWord: string): boolean {
   }
   return !/[\w$)\]'"`/]/.test(lastCodeChar);
 }
+
+/** Manifest config for the instruction size-budget audit. */
+export interface InstructionSizeBudgetConfig {
+  id?: string;
+  glob?: string;
+  alwaysLoadedPattern?: string;
+  alwaysLoadedLimitBytes?: number;
+  phaseLimitBytes?: number;
+}
+
+/** One globbed instruction file: repo-relative path plus its full text. */
+export interface InstructionSizeFileInput {
+  path: string;
+  text: string;
+}
+
+/**
+ * Collect instruction size-budget violations. Pure (no I/O) so it can be
+ * unit-tested; the audit pipeline feeds it the globbed file text.
+ *
+ * Scope rule (mirrors checkPairedChange): the budget is scoped to the
+ * files changed against the git comparison base. When `changedFiles` is
+ * `null` (no resolvable base — e.g. a CI clone without `origin/main`) the
+ * check is skipped with a notice rather than auditing every instruction
+ * file, which would let an unrelated PR fail on a file it never touched.
+ * `loadFiles` is a thunk so no files are read on the skip path.
+ */
+export function collectInstructionSizeBudgetViolations(
+  config: InstructionSizeBudgetConfig | null | undefined,
+  changedFiles: ReadonlySet<string> | null,
+  loadFiles: () => readonly InstructionSizeFileInput[],
+): { errors: string[]; notices: string[] } {
+  if (!config) {
+    return { errors: [], notices: [] };
+  }
+
+  const id = config.id ?? 'instruction-size-budgets';
+  if (changedFiles === null) {
+    return {
+      errors: [],
+      notices: [
+        `${id}: skipped instruction size budget check because no git comparison base was available`,
+      ],
+    };
+  }
+
+  const alwaysLoadedPattern =
+    config.alwaysLoadedPattern ?? 'applyTo:\\s*"\\*\\*"';
+  const alwaysLoadedRegex = new RegExp(alwaysLoadedPattern, 'm');
+  const alwaysLoadedLimitBytes = config.alwaysLoadedLimitBytes ?? 20_000;
+  const phaseLimitBytes = config.phaseLimitBytes ?? 30_000;
+
+  const errors: string[] = [];
+  for (const file of loadFiles()) {
+    if (!changedFiles.has(file.path)) {
+      continue;
+    }
+    const text = String(file.text ?? '');
+    const bytes = Buffer.byteLength(text, 'utf8');
+    const alwaysLoaded = alwaysLoadedRegex.test(text);
+    const limit = alwaysLoaded ? alwaysLoadedLimitBytes : phaseLimitBytes;
+    if (bytes > limit) {
+      errors.push(
+        `${id}: ${file.path} is ${bytes} bytes (limit ${limit}; ${
+          alwaysLoaded ? 'always-loaded' : 'phase'
+        })`,
+      );
+    }
+  }
+  return { errors, notices: [] };
+}

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -446,27 +446,27 @@ export interface InstructionSizeBudgetConfig {
   phaseLimitBytes?: number;
 }
 
-/** One globbed instruction file: repo-relative path plus its full text. */
-export interface InstructionSizeFileInput {
-  path: string;
-  text: string;
-}
-
 /**
- * Collect instruction size-budget violations. Pure (no I/O) so it can be
- * unit-tested; the audit pipeline feeds it the globbed file text.
+ * Collect instruction size-budget violations. Pure (no direct I/O) so it
+ * can be unit-tested; the audit pipeline supplies a path lister and a file
+ * reader.
  *
  * Scope rule (mirrors checkPairedChange): the budget is scoped to the
  * files changed against the git comparison base. When `changedFiles` is
  * `null` (no resolvable base — e.g. a CI clone without `origin/main`) the
  * check is skipped with a notice rather than auditing every instruction
  * file, which would let an unrelated PR fail on a file it never touched.
- * `loadFiles` is a thunk so no files are read on the skip path.
+ *
+ * `listFiles` is only invoked when a base resolves, and `readFile` is
+ * invoked only for files in `changedFiles`, so unchanged files are never
+ * read (the audit reads from disk, so reading every match would be wasted
+ * I/O on large repos).
  */
 export function collectInstructionSizeBudgetViolations(
   config: InstructionSizeBudgetConfig | null | undefined,
   changedFiles: ReadonlySet<string> | null,
-  loadFiles: () => readonly InstructionSizeFileInput[],
+  listFiles: () => readonly string[],
+  readFile: (path: string) => string,
 ): { errors: string[]; notices: string[] } {
   if (!config) {
     return { errors: [], notices: [] };
@@ -489,17 +489,17 @@ export function collectInstructionSizeBudgetViolations(
   const phaseLimitBytes = config.phaseLimitBytes ?? 30_000;
 
   const errors: string[] = [];
-  for (const file of loadFiles()) {
-    if (!changedFiles.has(file.path)) {
+  for (const path of listFiles()) {
+    if (!changedFiles.has(path)) {
       continue;
     }
-    const text = String(file.text ?? '');
+    const text = String(readFile(path) ?? '');
     const bytes = Buffer.byteLength(text, 'utf8');
     const alwaysLoaded = alwaysLoadedRegex.test(text);
     const limit = alwaysLoaded ? alwaysLoadedLimitBytes : phaseLimitBytes;
     if (bytes > limit) {
       errors.push(
-        `${id}: ${file.path} is ${bytes} bytes (limit ${limit}; ${
+        `${id}: ${path} is ${bytes} bytes (limit ${limit}; ${
           alwaysLoaded ? 'always-loaded' : 'phase'
         })`,
       );

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -5,6 +5,7 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  collectInstructionSizeBudgetViolations,
   collectPolicyConfigDrift,
   inspectHelperRuntimeConfig,
   normalizePolicyConfig,
@@ -37,6 +38,63 @@ test('placeholder scenarios detect clean and dirty post-onboarding fixtures', ()
     '.github/idd/config.json: {{PROJECT_MARKER_PREFIX}}, {{TRUSTED_MARKER_ACTOR}}',
     'README.md: {{REPO_NAME}}',
   ]);
+});
+
+test('instruction size budget skips with a notice when no git comparison base resolves', () => {
+  let loaded = false;
+  const result = collectInstructionSizeBudgetViolations(
+    { id: 'instruction-size-budgets', phaseLimitBytes: 1 },
+    null,
+    () => {
+      loaded = true;
+      return [{ path: 'idd-x.instructions.md', text: 'x'.repeat(10_000) }];
+    },
+  );
+  assert.equal(loaded, false, 'must not read files on the null-base skip path');
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.notices, [
+    'instruction-size-budgets: skipped instruction size budget check because no git comparison base was available',
+  ]);
+});
+
+test('instruction size budget audits only changed files and honors both limits', () => {
+  const files = [
+    // phase file over the phase limit AND changed -> error.
+    { path: 'idd-phase.instructions.md', text: 'p'.repeat(120) },
+    // always-loaded file over the always-loaded limit AND changed -> error.
+    {
+      path: 'idd-core.instructions.md',
+      text: `---\napplyTo: "**"\n---\n${'c'.repeat(120)}`,
+    },
+    // over budget but NOT in the changed set -> ignored.
+    { path: 'idd-untouched.instructions.md', text: 'u'.repeat(10_000) },
+  ];
+  const result = collectInstructionSizeBudgetViolations(
+    {
+      id: 'instruction-size-budgets',
+      alwaysLoadedLimitBytes: 50,
+      phaseLimitBytes: 100,
+    },
+    new Set(['idd-phase.instructions.md', 'idd-core.instructions.md']),
+    () => files,
+  );
+  assert.deepEqual(result.notices, []);
+  assert.equal(result.errors.length, 2);
+  assert.match(
+    result.errors[0],
+    /idd-phase\.instructions\.md is 120 bytes .*phase/,
+  );
+  assert.match(
+    result.errors[1],
+    /idd-core\.instructions\.md is \d+ bytes .*always-loaded/,
+  );
+});
+
+test('instruction size budget returns nothing for absent config', () => {
+  const result = collectInstructionSizeBudgetViolations(null, new Set(), () => {
+    throw new Error('must not load files when config is absent');
+  });
+  assert.deepEqual(result, { errors: [], notices: [] });
 });
 
 test('config drift scenarios detect mismatches between config and overview defaults', () => {

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -41,34 +41,32 @@ test('placeholder scenarios detect clean and dirty post-onboarding fixtures', ()
 });
 
 test('instruction size budget skips with a notice when no git comparison base resolves', () => {
-  let loaded = false;
+  let listed = false;
   const result = collectInstructionSizeBudgetViolations(
     { id: 'instruction-size-budgets', phaseLimitBytes: 1 },
     null,
     () => {
-      loaded = true;
-      return [{ path: 'idd-x.instructions.md', text: 'x'.repeat(10_000) }];
+      listed = true;
+      return ['idd-x.instructions.md'];
+    },
+    () => {
+      throw new Error('must not read files on the null-base skip path');
     },
   );
-  assert.equal(loaded, false, 'must not read files on the null-base skip path');
+  assert.equal(listed, false, 'must not list files on the null-base skip path');
   assert.deepEqual(result.errors, []);
   assert.deepEqual(result.notices, [
     'instruction-size-budgets: skipped instruction size budget check because no git comparison base was available',
   ]);
 });
 
-test('instruction size budget audits only changed files and honors both limits', () => {
-  const files = [
-    // phase file over the phase limit AND changed -> error.
-    { path: 'idd-phase.instructions.md', text: 'p'.repeat(120) },
-    // always-loaded file over the always-loaded limit AND changed -> error.
-    {
-      path: 'idd-core.instructions.md',
-      text: `---\napplyTo: "**"\n---\n${'c'.repeat(120)}`,
-    },
-    // over budget but NOT in the changed set -> ignored.
-    { path: 'idd-untouched.instructions.md', text: 'u'.repeat(10_000) },
-  ];
+test('instruction size budget reads and audits only changed files, honoring both limits', () => {
+  const texts: Record<string, string> = {
+    'idd-phase.instructions.md': 'p'.repeat(120),
+    'idd-core.instructions.md': `---\napplyTo: "**"\n---\n${'c'.repeat(120)}`,
+    'idd-untouched.instructions.md': 'u'.repeat(10_000),
+  };
+  const readPaths: string[] = [];
   const result = collectInstructionSizeBudgetViolations(
     {
       id: 'instruction-size-budgets',
@@ -76,24 +74,42 @@ test('instruction size budget audits only changed files and honors both limits',
       phaseLimitBytes: 100,
     },
     new Set(['idd-phase.instructions.md', 'idd-core.instructions.md']),
-    () => files,
+    () => Object.keys(texts),
+    (path) => {
+      readPaths.push(path);
+      return texts[path];
+    },
   );
+  // The unchanged file is never read (no wasted disk I/O on large repos).
+  assert.deepEqual(readPaths.sort(), [
+    'idd-core.instructions.md',
+    'idd-phase.instructions.md',
+  ]);
   assert.deepEqual(result.notices, []);
   assert.equal(result.errors.length, 2);
-  assert.match(
-    result.errors[0],
-    /idd-phase\.instructions\.md is 120 bytes .*phase/,
+  assert.ok(
+    result.errors.some((e) =>
+      /idd-phase\.instructions\.md is 120 bytes .*phase/.test(e),
+    ),
   );
-  assert.match(
-    result.errors[1],
-    /idd-core\.instructions\.md is \d+ bytes .*always-loaded/,
+  assert.ok(
+    result.errors.some((e) =>
+      /idd-core\.instructions\.md is \d+ bytes .*always-loaded/.test(e),
+    ),
   );
 });
 
 test('instruction size budget returns nothing for absent config', () => {
-  const result = collectInstructionSizeBudgetViolations(null, new Set(), () => {
-    throw new Error('must not load files when config is absent');
-  });
+  const result = collectInstructionSizeBudgetViolations(
+    null,
+    new Set(),
+    () => {
+      throw new Error('must not list files when config is absent');
+    },
+    () => {
+      throw new Error('must not read files when config is absent');
+    },
+  );
   assert.deepEqual(result, { errors: [], notices: [] });
 });
 


### PR DESCRIPTION
## Summary

`checkInstructionSizeBudgets` in `src/scripts/audit-docs.mts` fell back to
auditing **all** instruction files when no git comparison base resolved
(`changedFiles === null ? files : ...`), unlike `checkPairedChange` in the
same file, which **skips with a notice**. The inconsistency (left
unresolved on PR #284) could fail a PR on an over-budget file it never
touched — e.g. a CI clone without `origin/main`.

The concrete harm the original reviewers cited is dormant (the cited file
is now well under budget), but the scope inconsistency remains.

## Changes

- Move the scope/skip decision and budget evaluation into a pure,
  unit-testable `collectInstructionSizeBudgetViolations` helper in
  `src/scripts/consistency-helpers.mts` (matching the existing `collect*`
  helpers). With no resolvable base it now skips with a notice (mirroring
  `checkPairedChange`) instead of the full-file fallback.
- `audit-docs.mts` supplies the changed-file set and a **lazy** file
  reader, so no instruction files are read on the skip path.
- Add focused tests in `tests/consistency.test.mts` for the null-base
  skip (asserting files are not read) and the changed-files budget path
  (both always-loaded and phase limits, and ignoring unchanged files).
- Regenerate the `scripts/*.mjs` copies.

## Verification

`pnpm run lint` (993 tests, biome, dprint, cspell, markdownlint,
`audit-docs --check`) and `pnpm run build:check` pass.

Closes #922

Part of roadmap #910.
