### PR TITLE
fix(merge-gate): recognize resolved AMD-rejection and out-of-snapshot threads

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1187,6 +1187,14 @@ export function hasFreshDisposition(thread, options = {}) {
       ? options.isDispositionAuthor
       : (login) => !isKnownReviewBot(login);
   const comments = thread.comments?.nodes ?? [];
+  // A resolved thread may be terminally dispositioned with the documented
+  // `**Rejection confirmed by maintainer**` marker instead of a fresh
+  // `**Rejected**` re-post; recognize it as a disposition ONLY when the thread
+  // is resolved (an unresolved thread still needs an explicit disposition).
+  const threadResolved = Boolean(thread.isResolved);
+  const isDisposition = (comment) =>
+    isDispositionComment(comment) ||
+    (threadResolved && isRejectionConfirmedDisposition(comment));
   const latestFeedbackAt = maxIsoTimestamp(
     comments
       .filter((comment) => {
@@ -1194,8 +1202,7 @@ export function hasFreshDisposition(thread, options = {}) {
           .trim()
           .toLowerCase();
         return !(
-          isDispositionComment(comment) &&
-          dispositionAuthorPredicate(authorLogin)
+          isDisposition(comment) && dispositionAuthorPredicate(authorLogin)
         );
       })
       .map((comment) => effectiveThreadCommentActivityAt(comment))
@@ -1205,11 +1212,7 @@ export function hasFreshDisposition(thread, options = {}) {
     const authorLogin = String(comment.author?.login ?? '')
       .trim()
       .toLowerCase();
-    if (
-      !(
-        isDispositionComment(comment) && dispositionAuthorPredicate(authorLogin)
-      )
-    ) {
+    if (!(isDisposition(comment) && dispositionAuthorPredicate(authorLogin))) {
       return false;
     }
     const dispositionActivityAt = effectiveThreadCommentActivityAt(comment);
@@ -1225,6 +1228,18 @@ export function hasFreshDisposition(thread, options = {}) {
 export function isDispositionComment(comment) {
   const body = (comment.body ?? '').trimEnd();
   return body.startsWith('**Accepted**') || body.startsWith('**Rejected**');
+}
+// Terminal AMD-rejection marker. When a maintainer agrees with a rejection the
+// agent replies `**Rejection confirmed by maintainer** — {summary}` and resolves
+// the thread, with no separate `**Rejected**` re-post (per
+// idd-review-triage.instructions.md). Mirrors the regex in
+// review-disposition-verify so the F2/F3 gate recognizes the same marker.
+const REJECTION_CONFIRMED_BY_MAINTAINER_RE =
+  /^\*\*Rejection confirmed by maintainer\*\*\s+—/;
+export function isRejectionConfirmedDisposition(comment) {
+  return REJECTION_CONFIRMED_BY_MAINTAINER_RE.test(
+    (comment.body ?? '').trimStart(),
+  );
 }
 export function isIddDispositionComment(comment) {
   const author = comment.author?.login ?? '';
@@ -2026,6 +2041,12 @@ export function summarizeDispositionEvidenceForGate(
   const iddAgentLogins = new Set(
     normalizeTrustedMarkerLogins(options.iddAgentLogins ?? []),
   );
+  // The review-snapshot boundary (the active watermark's
+  // max-activity-updatedAt). A resolved thread whose newest external feedback
+  // predates it was settled before the snapshot and is out of E7 scope.
+  const snapshotBoundaryAt = isValidIsoTimestamp(options.snapshotBoundaryAt)
+    ? String(options.snapshotBoundaryAt)
+    : null;
   const advisoryBotLogins = new Set(
     normalizeTrustedMarkerLogins(options.advisoryBotLogins ?? []),
   );
@@ -2140,6 +2161,35 @@ export function summarizeDispositionEvidenceForGate(
         })
       ) {
         return null;
+      }
+      // E1 only snapshots UNRESOLVED non-awaiting threads, and E7 only requires
+      // dispositions for snapshot items. A thread that is already resolved and
+      // whose newest external feedback predates the review-snapshot boundary was
+      // settled out-of-band (or resolved by the reviewer) and must not block; a
+      // resolved thread with external feedback newer than the boundary (e.g.
+      // freshly reopened) still requires a disposition.
+      if (thread.isResolved && snapshotBoundaryAt) {
+        const newestFeedbackAt = maxIsoTimestamp(
+          commentsInThread
+            .filter((comment) => {
+              const authorLogin = String(comment.author?.login ?? '')
+                .trim()
+                .toLowerCase();
+              return (
+                authorLogin &&
+                !iddAgentLogins.has(authorLogin) &&
+                authorLogin !== prAuthorLogin
+              );
+            })
+            .map((comment) => effectiveThreadCommentActivityAt(comment))
+            .filter(isValidIsoTimestamp),
+        );
+        if (
+          !newestFeedbackAt ||
+          compareIsoTimestamps(newestFeedbackAt, snapshotBoundaryAt) <= 0
+        ) {
+          return null;
+        }
       }
       return {
         id: String(thread.id ?? '') || `thread-${index + 1}`,
@@ -3087,6 +3137,7 @@ export function buildPreMergeReadinessSummary(
           advisoryBotLogins,
           trustedMarkerLogins,
           prAuthorLogin,
+          snapshotBoundaryAt: watermark?.maxActivityUpdatedAt ?? null,
         },
       )
     : null;

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1901,6 +1901,14 @@ export function hasFreshDisposition(
       ? options.isDispositionAuthor
       : (login: string) => !isKnownReviewBot(login);
   const comments = thread.comments?.nodes ?? [];
+  // A resolved thread may be terminally dispositioned with the documented
+  // `**Rejection confirmed by maintainer**` marker instead of a fresh
+  // `**Rejected**` re-post; recognize it as a disposition ONLY when the thread
+  // is resolved (an unresolved thread still needs an explicit disposition).
+  const threadResolved = Boolean(thread.isResolved);
+  const isDisposition = (comment: { body?: string | null }): boolean =>
+    isDispositionComment(comment) ||
+    (threadResolved && isRejectionConfirmedDisposition(comment));
   const latestFeedbackAt = maxIsoTimestamp(
     comments
       .filter((comment) => {
@@ -1908,8 +1916,7 @@ export function hasFreshDisposition(
           .trim()
           .toLowerCase();
         return !(
-          isDispositionComment(comment) &&
-          dispositionAuthorPredicate(authorLogin)
+          isDisposition(comment) && dispositionAuthorPredicate(authorLogin)
         );
       })
       .map((comment) => effectiveThreadCommentActivityAt(comment))
@@ -1920,11 +1927,7 @@ export function hasFreshDisposition(
     const authorLogin = String(comment.author?.login ?? '')
       .trim()
       .toLowerCase();
-    if (
-      !(
-        isDispositionComment(comment) && dispositionAuthorPredicate(authorLogin)
-      )
-    ) {
+    if (!(isDisposition(comment) && dispositionAuthorPredicate(authorLogin))) {
       return false;
     }
     const dispositionActivityAt = effectiveThreadCommentActivityAt(comment);
@@ -1943,6 +1946,22 @@ export function isDispositionComment(comment: {
 }): boolean {
   const body = (comment.body ?? '').trimEnd();
   return body.startsWith('**Accepted**') || body.startsWith('**Rejected**');
+}
+
+// Terminal AMD-rejection marker. When a maintainer agrees with a rejection the
+// agent replies `**Rejection confirmed by maintainer** — {summary}` and resolves
+// the thread, with no separate `**Rejected**` re-post (per
+// idd-review-triage.instructions.md). Mirrors the regex in
+// review-disposition-verify so the F2/F3 gate recognizes the same marker.
+const REJECTION_CONFIRMED_BY_MAINTAINER_RE =
+  /^\*\*Rejection confirmed by maintainer\*\*\s+—/;
+
+export function isRejectionConfirmedDisposition(comment: {
+  body?: string | null;
+}): boolean {
+  return REJECTION_CONFIRMED_BY_MAINTAINER_RE.test(
+    (comment.body ?? '').trimStart(),
+  );
 }
 
 export function isIddDispositionComment(comment: CommentLike): boolean {
@@ -2885,11 +2904,18 @@ export function summarizeDispositionEvidenceForGate(
     advisoryBotLogins?: unknown[] | null;
     trustedMarkerLogins?: unknown[] | null;
     prAuthorLogin?: string | null;
+    snapshotBoundaryAt?: string | null;
   } = {},
 ): DispositionEvidenceSummary {
   const iddAgentLogins = new Set(
     normalizeTrustedMarkerLogins(options.iddAgentLogins ?? []),
   );
+  // The review-snapshot boundary (the active watermark's
+  // max-activity-updatedAt). A resolved thread whose newest external feedback
+  // predates it was settled before the snapshot and is out of E7 scope.
+  const snapshotBoundaryAt = isValidIsoTimestamp(options.snapshotBoundaryAt)
+    ? String(options.snapshotBoundaryAt)
+    : null;
   const advisoryBotLogins = new Set(
     normalizeTrustedMarkerLogins(options.advisoryBotLogins ?? []),
   );
@@ -3008,6 +3034,35 @@ export function summarizeDispositionEvidenceForGate(
         })
       ) {
         return null;
+      }
+      // E1 only snapshots UNRESOLVED non-awaiting threads, and E7 only requires
+      // dispositions for snapshot items. A thread that is already resolved and
+      // whose newest external feedback predates the review-snapshot boundary was
+      // settled out-of-band (or resolved by the reviewer) and must not block; a
+      // resolved thread with external feedback newer than the boundary (e.g.
+      // freshly reopened) still requires a disposition.
+      if (thread.isResolved && snapshotBoundaryAt) {
+        const newestFeedbackAt = maxIsoTimestamp(
+          commentsInThread
+            .filter((comment) => {
+              const authorLogin = String(comment.author?.login ?? '')
+                .trim()
+                .toLowerCase();
+              return (
+                authorLogin &&
+                !iddAgentLogins.has(authorLogin) &&
+                authorLogin !== prAuthorLogin
+              );
+            })
+            .map((comment) => effectiveThreadCommentActivityAt(comment))
+            .filter(isValidIsoTimestamp),
+        );
+        if (
+          !newestFeedbackAt ||
+          compareIsoTimestamps(newestFeedbackAt, snapshotBoundaryAt) <= 0
+        ) {
+          return null;
+        }
       }
       return {
         id: String(thread.id ?? '') || `thread-${index + 1}`,
@@ -4121,6 +4176,7 @@ export function buildPreMergeReadinessSummary(
           advisoryBotLogins,
           trustedMarkerLogins,
           prAuthorLogin,
+          snapshotBoundaryAt: watermark?.maxActivityUpdatedAt ?? null,
         },
       )
     : null;

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1526,6 +1526,131 @@ test('disposition evidence rejects reviewer-authored Accepted marker in threads'
   assert.equal(summary.missingThreads[0].reason, 'missing-fresh-disposition');
 });
 
+test('disposition evidence accepts a resolved Rejection-confirmed-by-maintainer marker', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-amd',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'this is wrong',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:05:00Z',
+                body: '**Rejection confirmed by maintainer** — out of scope; tracked separately.',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'] },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.missingThreadCount, 0);
+});
+
+test('disposition evidence rejects a Rejection-confirmed marker on an unresolved thread', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-amd-open',
+          isResolved: false,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'this is wrong',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:05:00Z',
+                body: '**Rejection confirmed by maintainer** — out of scope.',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'] },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(
+    summary.missingThreads[0].reason,
+    'unresolved-without-fresh-disposition',
+  );
+});
+
+test('disposition evidence skips a resolved out-of-snapshot thread before the boundary', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-old',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'old feedback resolved out of band',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'], snapshotBoundaryAt: '2026-05-12T01:00:00Z' },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.missingThreadCount, 0);
+});
+
+test('disposition evidence still blocks a resolved thread reopened after the boundary', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-reopened',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T02:00:00Z',
+                body: 'new feedback after the snapshot',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'], snapshotBoundaryAt: '2026-05-12T01:00:00Z' },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingThreads[0].reason, 'missing-fresh-disposition');
+});
+
 test('disposition evidence accepts edited IDD disposition comments as fresh replies', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {


### PR DESCRIPTION
Closes #924 (items 1–2). Part of roadmap #910.

## Problem

Two F2/F3 **disposition-evidence** merge-gate gaps caused spurious `return-to-e1` loops in live IDD autopilot runs:

1. The gate (`hasFreshDisposition` / `summarizeDispositionEvidenceForGate`) only recognized `**Accepted**` / `**Rejected**`. A correctly-completed AMD-rejection thread closed with the documented `**Rejection confirmed by maintainer**` marker (no separate `**Rejected**` re-post, per `idd-review-triage.instructions.md`) reported `missing-fresh-disposition`.
2. A thread resolved out-of-band — or resolved by the reviewer — **before** the review snapshot was flagged `missing-fresh-disposition`, even though E1 only snapshots *unresolved* non-awaiting threads and E7 only requires dispositions for snapshot items.

## Change (`src/scripts/protocol-helpers.mts`)

- **Item 1** — `hasFreshDisposition` now treats `**Rejection confirmed by maintainer**` as a disposition **only when the thread is resolved** (an unresolved thread still needs an explicit disposition), via a new `isRejectionConfirmedDisposition` recognizer that mirrors the regex in `review-disposition-verify`.
- **Item 2** — `summarizeDispositionEvidenceForGate` accepts a `snapshotBoundaryAt` option (wired to the active watermark's `maxActivityUpdatedAt`) and skips a **resolved** thread whose newest external feedback predates the boundary; a thread reopened with feedback newer than the boundary still blocks. With no watermark the prior (conservative) behavior is preserved.
- Generated `scripts/protocol-helpers.mjs` regenerated via `pnpm run build`.

## Split to follow-up #951

Items 3 (IDD-scope the **non-gate** `hasFreshDisposition` callers’ loose default) and 4 (per-item / count-based trailing-marker pairing) are split out — they touch non-gate callers and a larger matching design, distinct from this gate fix and better reviewed on their own. The gate caller already passes an explicit IDD-scoped predicate and is unaffected.

## Testing

- 4 new gate tests in `tests/pre-merge-readiness.test.mts`: resolved AMD-rejection accepted; AMD marker rejected on an unresolved thread; resolved out-of-snapshot thread skipped before the boundary; resolved thread reopened after the boundary still blocks.
- `pnpm run lint:minimum` green (1011 tests), `pnpm run build:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)