### PR TITLE
fix(resume-claim-routing): baseline competing-claim search on the original claim

### DIFF
--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -333,7 +333,16 @@ function findSameSecondContenders(events, activeClaim) {
     .sort();
 }
 function findLaterCompetingClaim(events, activeClaim) {
-  const activeSecond = toSecond(activeClaim.createdAt);
+  // Baseline on the active claim's ORIGINAL event time, not
+  // activeClaim.createdAt: applyClaimEvent refreshes the latter to the most
+  // recent heartbeat, which would hide a competing claim posted between the
+  // original claim and that heartbeat.
+  const originalClaim = events
+    .map((event) => parseClaimComment(event.body, event.createdAt))
+    .find((claim) => Boolean(claim) && claim?.claimId === activeClaim.claimId);
+  const activeSecond = toSecond(
+    originalClaim?.createdAt ?? activeClaim.createdAt,
+  );
   if (activeSecond === null) {
     return null;
   }

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -336,13 +336,20 @@ function findLaterCompetingClaim(events, activeClaim) {
   // Baseline on the active claim's ORIGINAL event time, not
   // activeClaim.createdAt: applyClaimEvent refreshes the latter to the most
   // recent heartbeat, which would hide a competing claim posted between the
-  // original claim and that heartbeat.
-  const originalClaim = events
+  // original claim and that heartbeat. Take the earliest matching claim
+  // event by timestamp rather than array position, since `events` is not
+  // guaranteed to be sorted oldest-first.
+  const originalCreatedAt = events
     .map((event) => parseClaimComment(event.body, event.createdAt))
-    .find((claim) => Boolean(claim) && claim?.claimId === activeClaim.claimId);
-  const activeSecond = toSecond(
-    originalClaim?.createdAt ?? activeClaim.createdAt,
-  );
+    .filter((claim) => Boolean(claim) && claim?.claimId === activeClaim.claimId)
+    .reduce(
+      (earliest, claim) =>
+        earliest === null || compareIso(claim.createdAt, earliest) < 0
+          ? claim.createdAt
+          : earliest,
+      null,
+    );
+  const activeSecond = toSecond(originalCreatedAt ?? activeClaim.createdAt);
   if (activeSecond === null) {
     return null;
   }

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -487,7 +487,19 @@ function findLaterCompetingClaim(
   events: NormalizedClaimEvent[],
   activeClaim: ParsedClaimMarker,
 ) {
-  const activeSecond = toSecond(activeClaim.createdAt);
+  // Baseline on the active claim's ORIGINAL event time, not
+  // activeClaim.createdAt: applyClaimEvent refreshes the latter to the most
+  // recent heartbeat, which would hide a competing claim posted between the
+  // original claim and that heartbeat.
+  const originalClaim = events
+    .map((event) => parseClaimComment(event.body, event.createdAt))
+    .find(
+      (claim): claim is ParsedClaimMarker =>
+        Boolean(claim) && claim?.claimId === activeClaim.claimId,
+    );
+  const activeSecond = toSecond(
+    originalClaim?.createdAt ?? activeClaim.createdAt,
+  );
   if (activeSecond === null) {
     return null;
   }

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -490,16 +490,23 @@ function findLaterCompetingClaim(
   // Baseline on the active claim's ORIGINAL event time, not
   // activeClaim.createdAt: applyClaimEvent refreshes the latter to the most
   // recent heartbeat, which would hide a competing claim posted between the
-  // original claim and that heartbeat.
-  const originalClaim = events
+  // original claim and that heartbeat. Take the earliest matching claim
+  // event by timestamp rather than array position, since `events` is not
+  // guaranteed to be sorted oldest-first.
+  const originalCreatedAt = events
     .map((event) => parseClaimComment(event.body, event.createdAt))
-    .find(
+    .filter(
       (claim): claim is ParsedClaimMarker =>
         Boolean(claim) && claim?.claimId === activeClaim.claimId,
+    )
+    .reduce<string | null>(
+      (earliest, claim) =>
+        earliest === null || compareIso(claim.createdAt, earliest) < 0
+          ? claim.createdAt
+          : earliest,
+      null,
     );
-  const activeSecond = toSecond(
-    originalClaim?.createdAt ?? activeClaim.createdAt,
-  );
+  const activeSecond = toSecond(originalCreatedAt ?? activeClaim.createdAt);
   if (activeSecond === null) {
     return null;
   }

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -447,3 +447,39 @@ test('legacy matching release remains valid after unrelated later unclaim', () =
   assert.equal(result.reason, 'legacy-released');
   assert.equal(result.active_claim, null);
 });
+
+test('detects a later competing claim that precedes a heartbeat of the active claim', () => {
+  // claim-race (10:05) is posted after the original claim (10:00) but before
+  // a heartbeat of the active claim (10:10). The heartbeat refreshes the
+  // active claim's createdAt; baselining the competitor search on that
+  // refreshed time would hide the race, so the search baselines on the
+  // original claim event instead.
+  const result = evaluateResumeClaimRouting(
+    {
+      claimId: 'claim-owned',
+      now: '2026-05-12T11:00:00Z',
+      events: [
+        {
+          createdAt: '2026-05-12T10:00:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-owned supersedes: none 2026-05-12T10:00:00Z branch: issue/11-task -->',
+        },
+        {
+          createdAt: '2026-05-12T10:05:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: other claim-race supersedes: none 2026-05-12T10:05:00Z branch: issue/11-task -->',
+        },
+        {
+          createdAt: '2026-05-12T10:10:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-owned supersedes: none 2026-05-12T10:10:00Z branch: issue/11-task -->',
+        },
+      ],
+    },
+    { isTrustedAuthor: trusted(['maintainer']) },
+  );
+
+  assert.equal(result.state, 'disputed');
+  assert.equal(result.reason, 'later-competing-claim');
+  assert.equal(result.evidence.later_competing_claim?.claim_id, 'claim-race');
+});

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -483,3 +483,36 @@ test('detects a later competing claim that precedes a heartbeat of the active cl
   assert.equal(result.reason, 'later-competing-claim');
   assert.equal(result.evidence.later_competing_claim?.claim_id, 'claim-race');
 });
+
+test('baselines the competing-claim search by timestamp regardless of event order', () => {
+  // The events array is not oldest-first (the heartbeat appears before the
+  // original claim). The original-claim baseline must be chosen by
+  // timestamp, not array position, so the race is still detected.
+  const result = evaluateResumeClaimRouting(
+    {
+      claimId: 'claim-owned',
+      now: '2026-05-12T11:00:00Z',
+      events: [
+        {
+          createdAt: '2026-05-12T10:10:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-owned supersedes: none 2026-05-12T10:10:00Z branch: issue/12-task -->',
+        },
+        {
+          createdAt: '2026-05-12T10:05:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: other claim-race supersedes: none 2026-05-12T10:05:00Z branch: issue/12-task -->',
+        },
+        {
+          createdAt: '2026-05-12T10:00:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-owned supersedes: none 2026-05-12T10:00:00Z branch: issue/12-task -->',
+        },
+      ],
+    },
+    { isTrustedAuthor: trusted(['maintainer']) },
+  );
+
+  assert.equal(result.state, 'disputed');
+  assert.equal(result.evidence.later_competing_claim?.claim_id, 'claim-race');
+});


### PR DESCRIPTION
## Summary

Fixes the claim-race-detection half of #926: `findLaterCompetingClaim`
baselined the competitor search on `activeClaim.createdAt`, but
`applyClaimEvent` refreshes that to the most recent heartbeat. A competing
claim posted **between** the original claim and a heartbeat was therefore
missed — the session reported `already_owned` and silently proceeded over a
disputed claim. It now baselines on the active claim's **original** event
time.

The second half of #926 — requiring PR-scoped (`issue-plus-pr`)
forced-handoff evidence for PR-backed claims — is **split to #955**, because
it needs a precise "is this claim PR-backed" detection (a connected/closing
PR, not a bare cross-reference) plus a GitHub-context fetch the CLI does not
yet do; bundling untested live-`gh` detection here would muddy this focused
fix.

## Verification

`pnpm run build`, `pnpm run lint` (lint:minimum), `build:check`, and 18/18
resume-claim-routing tests pass (1 new: a later competing claim that
precedes a heartbeat is detected as `disputed`).

Closes #926