### PR TITLE
fix(idd-doctor): detect indented code blocks nested inside list items in back-link scan

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1297,71 +1297,91 @@ function stripFencesPreservingLines(content) {
 // leading whitespace) stay as text — loose-list nested items can
 // otherwise be misread as code. We only blank lines that follow a
 // blank or already-blanked line and do not look like list items.
+/** Leading-indent width of a line in columns (space = 1, tab = 4). */
+function leadingIndentColumns(line) {
+  let columns = 0;
+  for (const ch of line) {
+    if (ch === ' ') {
+      columns += 1;
+    } else if (ch === '\t') {
+      columns += 4;
+    } else {
+      break;
+    }
+  }
+  return columns;
+}
 function stripIndentedCodeBlocksPreservingLines(content) {
   const lines = String(content).split(/\r?\n/);
   const out = [];
   let prevBlank = true;
   let inBlock = false;
-  // Whether a list is currently open at the top level. Under an open
-  // list, indented content is list continuation / nested-list items; with
-  // no list open, a top-level >=4-space indent is an indented code block,
-  // even when the line looks like a list marker (CommonMark: a list
-  // marker at >=4 spaces of indent is code, not a list).
-  let listOpen = false;
+  // The minimum indent (in columns) of the open indented code block, set
+  // at its opener. A line indented below this leaves the block.
+  let codeBaseIndent = 4;
+  // Content-indent column of the innermost open list, or `null` when no
+  // list is open. Under an open list, content indented up to
+  // `listContentIndent + 3` is list continuation / nested-list items,
+  // while content indented `>= listContentIndent + 4` is an indented code
+  // block nested inside the item (CommonMark allows code blocks within a
+  // list item). With no list open the threshold is the top-level 4
+  // columns, so a top-level `>=4`-column indent is still a code block even
+  // when it looks like a list marker.
+  let listContentIndent = null;
   for (const line of lines) {
-    const isBlank = /^\s*$/.test(line);
-    const indented = /^(?: {4}|\t)/.test(line);
-    // CommonMark §5.2: ordered-list markers may use either `.` or
-    // `)` after the digit. Both shapes count as list items (not
-    // code) even when indented under a parent item.
-    const looksLikeListItem = /^\s*(?:[-*+]\s|\d+[.)]\s)/.test(line);
-    if (isBlank) {
+    if (/^\s*$/.test(line)) {
       // A blank line ends neither an open indented code block nor an open
       // list: per CommonMark §4.4 a code block is one or more indented
       // chunks separated by blank lines, and loose lists are blank-line
-      // separated too. Both `inBlock` and `listOpen` survive the blank;
-      // the block/list only ends at a later non-indented, non-blank line.
+      // separated too. Both states survive the blank; they only end at a
+      // later non-indented, non-blank line (or a dedent).
       out.push(line);
       prevBlank = true;
       continue;
     }
-    if (indented) {
-      if (inBlock) {
-        // Continuation of an open indented code block (even across an
-        // internal blank line). A list cannot start inside it, so a
-        // list-marker-looking line here stays code and is blanked.
+    const indent = leadingIndentColumns(line);
+    // CommonMark §5.2: ordered-list markers may use either `.` or `)`
+    // after the digit. The match width is the list item's content column.
+    const listMarker = /^\s*(?:[-*+]|\d+[.)])\s+/.exec(line);
+    if (inBlock) {
+      if (indent >= codeBaseIndent) {
+        // Continuation of the open code block (even across blank lines).
+        // A list cannot start inside it, so a list-marker-looking line
+        // here stays code and is blanked.
         out.push('');
         prevBlank = false;
         continue;
       }
-      if (listOpen) {
-        // Indented content under an open list is list continuation or a
-        // nested list item, not a top-level code block: keep it.
-        out.push(line);
-        prevBlank = false;
-        continue;
-      }
-      if (prevBlank) {
-        // Opener: a top-level indented line after a blank with no open
-        // list starts an indented code block, even a list-marker-looking
-        // one (>=4 spaces of top-level indent is code, not a list).
-        out.push('');
-        inBlock = true;
-        prevBlank = false;
-        continue;
-      }
-      // Indented line lazily continuing a paragraph (code cannot
-      // interrupt a paragraph): keep it.
-      out.push(line);
+      // Indented below the code block base; it ends. Reprocess this line.
+      inBlock = false;
+    }
+    const codeThreshold = (listContentIndent ?? 0) + 4;
+    if (prevBlank && indent >= codeThreshold) {
+      // Indented code block opener — at the top level (no list) or nested
+      // inside the current list item. A list marker at this depth is code,
+      // not a list, so this branch precedes the list-marker handling.
+      out.push('');
+      inBlock = true;
+      codeBaseIndent = codeThreshold;
       prevBlank = false;
       continue;
     }
-    // Non-indented (<=3 spaces), non-blank line: it closes any open code
-    // block and resets the list context — a top-level list marker opens
-    // (or continues) a list; any other line closes it.
+    if (listMarker) {
+      // A list item (top-level or nested, but shallower than a nested code
+      // block per the threshold above). Its content column becomes the new
+      // innermost list-content indent.
+      out.push(line);
+      listContentIndent = listMarker[0].length;
+      prevBlank = false;
+      continue;
+    }
+    // A non-code, non-list line. If it is indented within the open list's
+    // content column it continues the list; otherwise it falls below that
+    // column and closes the list.
     out.push(line);
-    inBlock = false;
-    listOpen = looksLikeListItem;
+    if (listContentIndent === null || indent < listContentIndent) {
+      listContentIndent = null;
+    }
     prevBlank = false;
   }
   return out.join('\n');

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1387,8 +1387,15 @@ function stripIndentedCodeBlocksPreservingLines(content) {
       // A list item (top-level or nested, but shallower than a nested code
       // block per the threshold above). Close any deeper sibling levels,
       // then record this item's content column as the new innermost list.
+      // The content column is the full prefix width in columns (tab = 4),
+      // consistent with leadingIndentColumns, so a tab after the marker is
+      // not miscounted as a single column.
       out.push(line);
-      const contentColumn = indent + listMarker[2].length;
+      let prefixWidth = 0;
+      for (const ch of listMarker[0]) {
+        prefixWidth += ch === '\t' ? 4 : 1;
+      }
+      const contentColumn = prefixWidth;
       popDeeperThan(indent);
       listContentIndents.push(contentColumn);
       prevBlank = false;

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1383,9 +1383,11 @@ function stripIndentedCodeBlocksPreservingLines(content) {
       prevBlank = false;
       continue;
     }
-    if (listMarker) {
-      // A list item (top-level or nested, but shallower than a nested code
-      // block per the threshold above). Close any deeper sibling levels,
+    if (listMarker && indent < codeThreshold) {
+      // A list item (top-level or nested, but shallower than a code block
+      // per the threshold above — a marker at code depth that was not
+      // opened as a code block is paragraph continuation, handled below,
+      // and must not open a list level). Close any deeper sibling levels,
       // then record this item's content column as the new innermost list.
       // The content column is the full prefix width in columns (tab = 4),
       // consistent with leadingIndentColumns, so a tab after the marker is

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1291,12 +1291,14 @@ function stripFencesPreservingLines(content) {
   }
   return out.join('\n');
 }
-// CommonMark §4.4 indented code blocks: at least 4 leading spaces
-// (or one tab), preceded by a blank line. Indented lines that are
-// recognizable list items (`-`, `*`, `+`, or `\d+\.` after the
-// leading whitespace) stay as text — loose-list nested items can
-// otherwise be misread as code. We only blank lines that follow a
-// blank or already-blanked line and do not look like list items.
+// CommonMark §4.4 indented code blocks: content indented at least 4
+// columns beyond the enclosing context (the top level, or an open list
+// item's content column), preceded by a blank line. The stripper below
+// tracks open list levels by content column (supporting `-`/`*`/`+` and
+// ordered `\d+[.)]` markers), so list continuation and nested list items
+// are preserved, while a deeper indent — even a list-marker-looking line
+// — is treated as a nested indented code block and blanked. See
+// stripIndentedCodeBlocksPreservingLines.
 /** Leading-indent width of a line in columns (space = 1, tab = 4). */
 function leadingIndentColumns(line) {
   let columns = 0;

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1319,15 +1319,30 @@ function stripIndentedCodeBlocksPreservingLines(content) {
   // The minimum indent (in columns) of the open indented code block, set
   // at its opener. A line indented below this leaves the block.
   let codeBaseIndent = 4;
-  // Content-indent column of the innermost open list, or `null` when no
-  // list is open. Under an open list, content indented up to
-  // `listContentIndent + 3` is list continuation / nested-list items,
-  // while content indented `>= listContentIndent + 4` is an indented code
-  // block nested inside the item (CommonMark allows code blocks within a
-  // list item). With no list open the threshold is the top-level 4
-  // columns, so a top-level `>=4`-column indent is still a code block even
-  // when it looks like a list marker.
-  let listContentIndent = null;
+  // Content-indent columns of the currently open list levels, outermost
+  // first (a stack, so ending an inner list returns to the outer level
+  // instead of losing its context). Under the innermost open list, content
+  // indented up to `top + 3` is list continuation / nested-list items,
+  // while content indented `>= top + 4` is an indented code block nested
+  // inside the item (CommonMark allows code blocks within a list item).
+  // With no list open the threshold is the top-level 4 columns, so a
+  // top-level `>=4`-column indent is still a code block even when it looks
+  // like a list marker.
+  const listContentIndents = [];
+  const innermostListIndent = () =>
+    listContentIndents.length > 0
+      ? listContentIndents[listContentIndents.length - 1]
+      : null;
+  // Drop list levels whose content column is deeper than `indent`, so a
+  // dedent re-exposes the enclosing list (or no list).
+  const popDeeperThan = (indent) => {
+    while (
+      listContentIndents.length > 0 &&
+      indent < listContentIndents[listContentIndents.length - 1]
+    ) {
+      listContentIndents.pop();
+    }
+  };
   for (const line of lines) {
     if (/^\s*$/.test(line)) {
       // A blank line ends neither an open indented code block nor an open
@@ -1341,8 +1356,10 @@ function stripIndentedCodeBlocksPreservingLines(content) {
     }
     const indent = leadingIndentColumns(line);
     // CommonMark §5.2: ordered-list markers may use either `.` or `)`
-    // after the digit. The match width is the list item's content column.
-    const listMarker = /^\s*(?:[-*+]|\d+[.)])\s+/.exec(line);
+    // after the digit. Group 2 (marker + trailing spaces) measures the
+    // marker width in columns since it is ASCII; the content column is the
+    // leading-indent columns plus that width.
+    const listMarker = /^(\s*)((?:[-*+]|\d+[.)])\s+)/.exec(line);
     if (inBlock) {
       if (indent >= codeBaseIndent) {
         // Continuation of the open code block (even across blank lines).
@@ -1355,7 +1372,7 @@ function stripIndentedCodeBlocksPreservingLines(content) {
       // Indented below the code block base; it ends. Reprocess this line.
       inBlock = false;
     }
-    const codeThreshold = (listContentIndent ?? 0) + 4;
+    const codeThreshold = (innermostListIndent() ?? 0) + 4;
     if (prevBlank && indent >= codeThreshold) {
       // Indented code block opener — at the top level (no list) or nested
       // inside the current list item. A list marker at this depth is code,
@@ -1368,20 +1385,21 @@ function stripIndentedCodeBlocksPreservingLines(content) {
     }
     if (listMarker) {
       // A list item (top-level or nested, but shallower than a nested code
-      // block per the threshold above). Its content column becomes the new
-      // innermost list-content indent.
+      // block per the threshold above). Close any deeper sibling levels,
+      // then record this item's content column as the new innermost list.
       out.push(line);
-      listContentIndent = listMarker[0].length;
+      const contentColumn = indent + listMarker[2].length;
+      popDeeperThan(indent);
+      listContentIndents.push(contentColumn);
       prevBlank = false;
       continue;
     }
-    // A non-code, non-list line. If it is indented within the open list's
-    // content column it continues the list; otherwise it falls below that
-    // column and closes the list.
+    // A non-code, non-list line: close any list levels whose content
+    // column is deeper than this line's indent. A line that drops below
+    // every level closes the list entirely; a line still within an outer
+    // level keeps that level open.
     out.push(line);
-    if (listContentIndent === null || indent < listContentIndent) {
-      listContentIndent = null;
-    }
+    popDeeperThan(indent);
     prevBlank = false;
   }
   return out.join('\n');

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1358,10 +1358,11 @@ function stripIndentedCodeBlocksPreservingLines(content) {
     }
     const indent = leadingIndentColumns(line);
     // CommonMark §5.2: ordered-list markers may use either `.` or `)`
-    // after the digit. Group 2 (marker + trailing spaces) measures the
-    // marker width in columns since it is ASCII; the content column is the
-    // leading-indent columns plus that width.
-    const listMarker = /^(\s*)((?:[-*+]|\d+[.)])\s+)/.exec(line);
+    // after the digit. The match is the full marker prefix (leading
+    // whitespace + marker + trailing whitespace); its column width gives
+    // the list item's content column, computed tab-aware where the item
+    // is kept below.
+    const listMarker = /^\s*(?:[-*+]|\d+[.)])\s+/.exec(line);
     if (inBlock) {
       if (indent >= codeBaseIndent) {
         // Continuation of the open code block (even across blank lines).

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1497,12 +1497,14 @@ function stripFencesPreservingLines(content: string): string {
   return out.join('\n');
 }
 
-// CommonMark §4.4 indented code blocks: at least 4 leading spaces
-// (or one tab), preceded by a blank line. Indented lines that are
-// recognizable list items (`-`, `*`, `+`, or `\d+\.` after the
-// leading whitespace) stay as text — loose-list nested items can
-// otherwise be misread as code. We only blank lines that follow a
-// blank or already-blanked line and do not look like list items.
+// CommonMark §4.4 indented code blocks: content indented at least 4
+// columns beyond the enclosing context (the top level, or an open list
+// item's content column), preceded by a blank line. The stripper below
+// tracks open list levels by content column (supporting `-`/`*`/`+` and
+// ordered `\d+[.)]` markers), so list continuation and nested list items
+// are preserved, while a deeper indent — even a list-marker-looking line
+// — is treated as a nested indented code block and blanked. See
+// stripIndentedCodeBlocksPreservingLines.
 /** Leading-indent width of a line in columns (space = 1, tab = 4). */
 function leadingIndentColumns(line: string): number {
   let columns = 0;

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1593,9 +1593,11 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
       continue;
     }
 
-    if (listMarker) {
-      // A list item (top-level or nested, but shallower than a nested code
-      // block per the threshold above). Close any deeper sibling levels,
+    if (listMarker && indent < codeThreshold) {
+      // A list item (top-level or nested, but shallower than a code block
+      // per the threshold above — a marker at code depth that was not
+      // opened as a code block is paragraph continuation, handled below,
+      // and must not open a list level). Close any deeper sibling levels,
       // then record this item's content column as the new innermost list.
       // The content column is the full prefix width in columns (tab = 4),
       // consistent with leadingIndentColumns, so a tab after the marker is

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1565,10 +1565,11 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
     }
     const indent = leadingIndentColumns(line);
     // CommonMark §5.2: ordered-list markers may use either `.` or `)`
-    // after the digit. Group 2 (marker + trailing spaces) measures the
-    // marker width in columns since it is ASCII; the content column is the
-    // leading-indent columns plus that width.
-    const listMarker = /^(\s*)((?:[-*+]|\d+[.)])\s+)/.exec(line);
+    // after the digit. The match is the full marker prefix (leading
+    // whitespace + marker + trailing whitespace); its column width gives
+    // the list item's content column, computed tab-aware where the item
+    // is kept below.
+    const listMarker = /^\s*(?:[-*+]|\d+[.)])\s+/.exec(line);
 
     if (inBlock) {
       if (indent >= codeBaseIndent) {

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1526,15 +1526,30 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
   // The minimum indent (in columns) of the open indented code block, set
   // at its opener. A line indented below this leaves the block.
   let codeBaseIndent = 4;
-  // Content-indent column of the innermost open list, or `null` when no
-  // list is open. Under an open list, content indented up to
-  // `listContentIndent + 3` is list continuation / nested-list items,
-  // while content indented `>= listContentIndent + 4` is an indented code
-  // block nested inside the item (CommonMark allows code blocks within a
-  // list item). With no list open the threshold is the top-level 4
-  // columns, so a top-level `>=4`-column indent is still a code block even
-  // when it looks like a list marker.
-  let listContentIndent: number | null = null;
+  // Content-indent columns of the currently open list levels, outermost
+  // first (a stack, so ending an inner list returns to the outer level
+  // instead of losing its context). Under the innermost open list, content
+  // indented up to `top + 3` is list continuation / nested-list items,
+  // while content indented `>= top + 4` is an indented code block nested
+  // inside the item (CommonMark allows code blocks within a list item).
+  // With no list open the threshold is the top-level 4 columns, so a
+  // top-level `>=4`-column indent is still a code block even when it looks
+  // like a list marker.
+  const listContentIndents: number[] = [];
+  const innermostListIndent = () =>
+    listContentIndents.length > 0
+      ? listContentIndents[listContentIndents.length - 1]
+      : null;
+  // Drop list levels whose content column is deeper than `indent`, so a
+  // dedent re-exposes the enclosing list (or no list).
+  const popDeeperThan = (indent: number) => {
+    while (
+      listContentIndents.length > 0 &&
+      indent < listContentIndents[listContentIndents.length - 1]
+    ) {
+      listContentIndents.pop();
+    }
+  };
   for (const line of lines) {
     if (/^\s*$/.test(line)) {
       // A blank line ends neither an open indented code block nor an open
@@ -1548,8 +1563,10 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
     }
     const indent = leadingIndentColumns(line);
     // CommonMark §5.2: ordered-list markers may use either `.` or `)`
-    // after the digit. The match width is the list item's content column.
-    const listMarker = /^\s*(?:[-*+]|\d+[.)])\s+/.exec(line);
+    // after the digit. Group 2 (marker + trailing spaces) measures the
+    // marker width in columns since it is ASCII; the content column is the
+    // leading-indent columns plus that width.
+    const listMarker = /^(\s*)((?:[-*+]|\d+[.)])\s+)/.exec(line);
 
     if (inBlock) {
       if (indent >= codeBaseIndent) {
@@ -1564,7 +1581,7 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
       inBlock = false;
     }
 
-    const codeThreshold = (listContentIndent ?? 0) + 4;
+    const codeThreshold = (innermostListIndent() ?? 0) + 4;
     if (prevBlank && indent >= codeThreshold) {
       // Indented code block opener — at the top level (no list) or nested
       // inside the current list item. A list marker at this depth is code,
@@ -1578,21 +1595,22 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
 
     if (listMarker) {
       // A list item (top-level or nested, but shallower than a nested code
-      // block per the threshold above). Its content column becomes the new
-      // innermost list-content indent.
+      // block per the threshold above). Close any deeper sibling levels,
+      // then record this item's content column as the new innermost list.
       out.push(line);
-      listContentIndent = listMarker[0].length;
+      const contentColumn = indent + listMarker[2].length;
+      popDeeperThan(indent);
+      listContentIndents.push(contentColumn);
       prevBlank = false;
       continue;
     }
 
-    // A non-code, non-list line. If it is indented within the open list's
-    // content column it continues the list; otherwise it falls below that
-    // column and closes the list.
+    // A non-code, non-list line: close any list levels whose content
+    // column is deeper than this line's indent. A line that drops below
+    // every level closes the list entirely; a line still within an outer
+    // level keeps that level open.
     out.push(line);
-    if (listContentIndent === null || indent < listContentIndent) {
-      listContentIndent = null;
-    }
+    popDeeperThan(indent);
     prevBlank = false;
   }
   return out.join('\n');

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1503,71 +1503,96 @@ function stripFencesPreservingLines(content: string): string {
 // leading whitespace) stay as text — loose-list nested items can
 // otherwise be misread as code. We only blank lines that follow a
 // blank or already-blanked line and do not look like list items.
+/** Leading-indent width of a line in columns (space = 1, tab = 4). */
+function leadingIndentColumns(line: string): number {
+  let columns = 0;
+  for (const ch of line) {
+    if (ch === ' ') {
+      columns += 1;
+    } else if (ch === '\t') {
+      columns += 4;
+    } else {
+      break;
+    }
+  }
+  return columns;
+}
+
 function stripIndentedCodeBlocksPreservingLines(content: string): string {
   const lines = String(content).split(/\r?\n/);
   const out: string[] = [];
   let prevBlank = true;
   let inBlock = false;
-  // Whether a list is currently open at the top level. Under an open
-  // list, indented content is list continuation / nested-list items; with
-  // no list open, a top-level >=4-space indent is an indented code block,
-  // even when the line looks like a list marker (CommonMark: a list
-  // marker at >=4 spaces of indent is code, not a list).
-  let listOpen = false;
+  // The minimum indent (in columns) of the open indented code block, set
+  // at its opener. A line indented below this leaves the block.
+  let codeBaseIndent = 4;
+  // Content-indent column of the innermost open list, or `null` when no
+  // list is open. Under an open list, content indented up to
+  // `listContentIndent + 3` is list continuation / nested-list items,
+  // while content indented `>= listContentIndent + 4` is an indented code
+  // block nested inside the item (CommonMark allows code blocks within a
+  // list item). With no list open the threshold is the top-level 4
+  // columns, so a top-level `>=4`-column indent is still a code block even
+  // when it looks like a list marker.
+  let listContentIndent: number | null = null;
   for (const line of lines) {
-    const isBlank = /^\s*$/.test(line);
-    const indented = /^(?: {4}|\t)/.test(line);
-    // CommonMark §5.2: ordered-list markers may use either `.` or
-    // `)` after the digit. Both shapes count as list items (not
-    // code) even when indented under a parent item.
-    const looksLikeListItem = /^\s*(?:[-*+]\s|\d+[.)]\s)/.test(line);
-    if (isBlank) {
+    if (/^\s*$/.test(line)) {
       // A blank line ends neither an open indented code block nor an open
       // list: per CommonMark §4.4 a code block is one or more indented
       // chunks separated by blank lines, and loose lists are blank-line
-      // separated too. Both `inBlock` and `listOpen` survive the blank;
-      // the block/list only ends at a later non-indented, non-blank line.
+      // separated too. Both states survive the blank; they only end at a
+      // later non-indented, non-blank line (or a dedent).
       out.push(line);
       prevBlank = true;
       continue;
     }
-    if (indented) {
-      if (inBlock) {
-        // Continuation of an open indented code block (even across an
-        // internal blank line). A list cannot start inside it, so a
-        // list-marker-looking line here stays code and is blanked.
+    const indent = leadingIndentColumns(line);
+    // CommonMark §5.2: ordered-list markers may use either `.` or `)`
+    // after the digit. The match width is the list item's content column.
+    const listMarker = /^\s*(?:[-*+]|\d+[.)])\s+/.exec(line);
+
+    if (inBlock) {
+      if (indent >= codeBaseIndent) {
+        // Continuation of the open code block (even across blank lines).
+        // A list cannot start inside it, so a list-marker-looking line
+        // here stays code and is blanked.
         out.push('');
         prevBlank = false;
         continue;
       }
-      if (listOpen) {
-        // Indented content under an open list is list continuation or a
-        // nested list item, not a top-level code block: keep it.
-        out.push(line);
-        prevBlank = false;
-        continue;
-      }
-      if (prevBlank) {
-        // Opener: a top-level indented line after a blank with no open
-        // list starts an indented code block, even a list-marker-looking
-        // one (>=4 spaces of top-level indent is code, not a list).
-        out.push('');
-        inBlock = true;
-        prevBlank = false;
-        continue;
-      }
-      // Indented line lazily continuing a paragraph (code cannot
-      // interrupt a paragraph): keep it.
-      out.push(line);
+      // Indented below the code block base; it ends. Reprocess this line.
+      inBlock = false;
+    }
+
+    const codeThreshold = (listContentIndent ?? 0) + 4;
+    if (prevBlank && indent >= codeThreshold) {
+      // Indented code block opener — at the top level (no list) or nested
+      // inside the current list item. A list marker at this depth is code,
+      // not a list, so this branch precedes the list-marker handling.
+      out.push('');
+      inBlock = true;
+      codeBaseIndent = codeThreshold;
       prevBlank = false;
       continue;
     }
-    // Non-indented (<=3 spaces), non-blank line: it closes any open code
-    // block and resets the list context — a top-level list marker opens
-    // (or continues) a list; any other line closes it.
+
+    if (listMarker) {
+      // A list item (top-level or nested, but shallower than a nested code
+      // block per the threshold above). Its content column becomes the new
+      // innermost list-content indent.
+      out.push(line);
+      listContentIndent = listMarker[0].length;
+      prevBlank = false;
+      continue;
+    }
+
+    // A non-code, non-list line. If it is indented within the open list's
+    // content column it continues the list; otherwise it falls below that
+    // column and closes the list.
     out.push(line);
-    inBlock = false;
-    listOpen = looksLikeListItem;
+    if (listContentIndent === null || indent < listContentIndent) {
+      listContentIndent = null;
+    }
     prevBlank = false;
   }
   return out.join('\n');

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1597,8 +1597,15 @@ function stripIndentedCodeBlocksPreservingLines(content: string): string {
       // A list item (top-level or nested, but shallower than a nested code
       // block per the threshold above). Close any deeper sibling levels,
       // then record this item's content column as the new innermost list.
+      // The content column is the full prefix width in columns (tab = 4),
+      // consistent with leadingIndentColumns, so a tab after the marker is
+      // not miscounted as a single column.
       out.push(line);
-      const contentColumn = indent + listMarker[2].length;
+      let prefixWidth = 0;
+      for (const ch of listMarker[0]) {
+        prefixWidth += ch === '\t' ? 4 : 1;
+      }
+      const contentColumn = prefixWidth;
       popDeeperThan(indent);
       listContentIndents.push(contentColumn);
       prevBlank = false;

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1117,6 +1117,16 @@ test('containsExampleRepoBackLink still detects list-item paragraph back-links a
   assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
 });
 
+test('containsExampleRepoBackLink does not open a list for a deeply-indented mid-paragraph marker', () => {
+  // A `- ` marker indented >=4 columns mid-paragraph (no list open) is
+  // paragraph continuation, not a list item. It must not keep a list level
+  // open across the later blank and shield the following top-level indented
+  // code block from being blanked (which would reintroduce a false pass).
+  const md =
+    'text\n    - foo\n\n        [workshop](https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)\n';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), false);
+});
+
 test('containsExampleRepoBackLink keeps a back-link in an outer list item after an inner list ends', () => {
   // Multi-level lists: after the inner list and its paragraph dedent back
   // to the outer item, the back-link sits in a nested item of the still

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1117,6 +1117,17 @@ test('containsExampleRepoBackLink still detects list-item paragraph back-links a
   assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
 });
 
+test('containsExampleRepoBackLink keeps a back-link in an outer list item after an inner list ends', () => {
+  // Multi-level lists: after the inner list and its paragraph dedent back
+  // to the outer item, the back-link sits in a nested item of the still
+  // open outer list (content column 2), not a top-level code block, so it
+  // must still count. (Single-level list tracking would lose the outer
+  // context here and blank it.)
+  const md =
+    '- outer\n  - inner\n  text after inner\n\n    - [workshop](https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)\n';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
+});
+
 test('containsExampleRepoBackLink rejects URL whose host is not a GitHub host', () => {
   const md =
     '[trap](https://example.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)';

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1117,6 +1117,16 @@ test('containsExampleRepoBackLink still detects list-item paragraph back-links a
   assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
 });
 
+test('containsExampleRepoBackLink measures a tab after a list marker as columns', () => {
+  // `-\t` has content column 1 (`-`) + 4 (tab) = 5, so a 7-column-indented
+  // back-link is list content (< 5 + 4), not a nested code block. With the
+  // old character-length content column (2) the threshold would be 6 and
+  // the 7-column line would be mis-blanked as code.
+  const md =
+    '-\titem\n\n       [workshop](https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)\n';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
+});
+
 test('containsExampleRepoBackLink does not open a list for a deeply-indented mid-paragraph marker', () => {
   // A `- ` marker indented >=4 columns mid-paragraph (no list open) is
   // paragraph continuation, not a list item. It must not keep a list level

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1090,6 +1090,33 @@ test('containsExampleRepoBackLink treats a top-level indented list-marker line a
   assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), false);
 });
 
+test('containsExampleRepoBackLink ignores an indented code block nested inside a list item', () => {
+  // The list item content sits at column 2; a blank-separated line indented
+  // >= 6 columns (8 here) is an indented code block within the item
+  // (CommonMark), not list content, so a workshop URL there must not
+  // produce a false back-link pass.
+  const md =
+    '- item\n\n        [workshop](https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)\n';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), false);
+});
+
+test('containsExampleRepoBackLink keeps a real nested list item under a list (not code)', () => {
+  // Regression guard for the nested-code fix: a 4-column nested list item
+  // under a `- ` parent (content column 2) is within `2 + 4`, so it stays
+  // a list item and its back-link still counts.
+  const md =
+    '- parent\n\n    - [workshop](https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)\n';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
+});
+
+test('containsExampleRepoBackLink still detects list-item paragraph back-links after the nested-code fix', () => {
+  // A back-link in ordinary list-item paragraph text (indented to the
+  // content column, below the nested-code threshold) must still count.
+  const md =
+    '- See the [workshop](https://github.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)\n  for details.\n';
+  assert.equal(containsExampleRepoBackLink(md, 'kurone-kito/idd-skill'), true);
+});
+
 test('containsExampleRepoBackLink rejects URL whose host is not a GitHub host', () => {
   const md =
     '[trap](https://example.com/kurone-kito/idd-skill/blob/main/docs/workshop/README.md)';


### PR DESCRIPTION
## Summary

Follows up the Copilot review on PR #938 (#912): the back-link scan's
`stripIndentedCodeBlocksPreservingLines` preserved **every** indented line
under an open list, so a workshop URL inside an indented code block nested
in a list item still produced a false `containsExampleRepoBackLink` pass.

## Changes

- Track the innermost open list's **content-indent column** instead of a
  bare open/closed flag. A line indented `>= listContentIndent + 4` after a
  blank is an indented code block nested in the item (CommonMark) and is
  blanked; shallower indents stay list continuation / nested-list items.
  With no list open the threshold is the top-level 4 columns, so existing
  top-level code-block and nested-list behavior is unchanged.
- Add `leadingIndentColumns` (space = 1, tab = 4) and a `codeBaseIndent`
  so a nested code block ends when content dedents back to list level.
- `tests/idd-doctor.test.mts`: nested code block → `false`; real nested
  list item → `true`; list-item paragraph back-link → `true`.
- Regenerate `scripts/idd-doctor.mjs`.

## Verification

`pnpm run lint` (1030 tests, biome, dprint, cspell, markdownlint,
`audit-docs --check`) and `pnpm run build:check` pass.

Closes #945

Follows up #912 / PR #938; thematically adjacent to roadmap #892.
