### PR TITLE
fix(merge-gate): IDD-scope non-gate disposition callers and pair markers 1:1

### DIFF
--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -142,24 +142,41 @@ if (args.apply) {
 }
 computeReportSummary(report);
 writeReport(report, args.format);
+// Build an IDD-scoped disposition-author predicate from the resolved
+// trusted-marker actors (the accounts the IDD agent posts dispositions under).
+// The non-gate `hasFreshDisposition` callers must use this so a human
+// reviewer's `**Accepted**`/`**Rejected**` is not mistaken for a completed IDD
+// disposition.
+function makeIddDispositionAuthorPredicate(iddLogins) {
+  const set = new Set(iddLogins);
+  return (login) =>
+    set.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+}
 async function buildReport(owner, repo, prNumber, options = {}) {
   const pr = fetchPullRequest(owner, repo, prNumber, options);
   const comments = fetchIssueComments(owner, repo, prNumber, options);
   const reviews = fetchReviews(owner, repo, prNumber, options);
   const threads = fetchReviewThreads(owner, repo, prNumber, options);
-  const threadIndex = indexThreadsByReview(threads);
-  const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
   const configuredTrust = configuredTrustedMarkerActorSources();
+  const iddAgentLogins = normalizeTrustedMarkerLogins([
+    currentViewerLogin(),
+    ...configuredTrust.actors,
+  ]);
+  const threadIndex = indexThreadsByReview(threads, {
+    isDispositionAuthor: makeIddDispositionAuthorPredicate(iddAgentLogins),
+  });
+  const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
   const report = {
     repository: `${owner}/${repo}`,
     pr: prNumber,
     prUrl: pr.url,
     merged: pr.merged,
     mode: 'dry-run',
-    trustedMarkerActors: normalizeTrustedMarkerLogins([
-      currentViewerLogin(),
-      ...configuredTrust.actors,
-    ]),
+    trustedMarkerActors: iddAgentLogins,
     trustedMarkerActorsSources: [
       ...(currentViewerLogin() ? ['viewer'] : []),
       ...configuredTrust.sources,
@@ -239,7 +256,11 @@ function evaluateRegularBotComment(comment, comments, threads, pr, report) {
   if (!isKnownReviewBot(author)) {
     return;
   }
-  const classification = classifyRegularBotComment(comment, comments, threads);
+  const classification = classifyRegularBotComment(comment, comments, threads, {
+    isDispositionAuthor: makeIddDispositionAuthorPredicate(
+      report.trustedMarkerActors,
+    ),
+  });
   const subject = subjectFromNode(
     comment,
     'IssueComment',
@@ -438,7 +459,13 @@ function evaluateReviewComment(
     );
     return;
   }
-  if (!hasFreshDisposition(thread)) {
+  if (
+    !hasFreshDisposition(thread, {
+      isDispositionAuthor: makeIddDispositionAuthorPredicate(
+        report.trustedMarkerActors,
+      ),
+    })
+  ) {
     addSkipped(
       report,
       { ...subject, threadId: thread.id },

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -799,7 +799,9 @@ export function classifyRegularBotComment(
       };
     }
     if (
-      hasExplicitDispositionAfter(comment, comments) ||
+      hasExplicitDispositionAfter(comment, comments, {
+        isDispositionAuthor: options.isDispositionAuthor,
+      }) ||
       hasCompletedBotThreadDispositions(threads, isCodeRabbitLogin, {
         isDispositionAuthor: options.isDispositionAuthor,
       })
@@ -817,7 +819,9 @@ export function classifyRegularBotComment(
   ) {
     if (
       /\b(Review triggered|Sure! I'll review|I'll review)\b/i.test(body) &&
-      hasExplicitDispositionAfter(comment, comments)
+      hasExplicitDispositionAfter(comment, comments, {
+        isDispositionAuthor: options.isDispositionAuthor,
+      })
     ) {
       return {
         classifier: 'OUTDATED',
@@ -2031,6 +2035,14 @@ export function summarizeRegularCommentsForGate(comments, options = {}) {
           },
           classificationComments,
           threads,
+          {
+            isDispositionAuthor: (login) =>
+              iddAgentLogins.has(
+                String(login ?? '')
+                  .trim()
+                  .toLowerCase(),
+              ),
+          },
         ) === null
       );
     })
@@ -2120,6 +2132,14 @@ export function summarizeDispositionEvidenceForGate(
           },
           classificationComments,
           threads,
+          {
+            isDispositionAuthor: (login) =>
+              iddAgentLogins.has(
+                String(login ?? '')
+                  .trim()
+                  .toLowerCase(),
+              ),
+          },
         ) === null
       );
     });
@@ -3718,11 +3738,20 @@ export function classifyResumeRoutingCase(input, options = {}) {
     reason: `non-owned claim is stale at >= ${staleHours}h with quiet-window evidence >= ${stallMinutes}m`,
   };
 }
-function hasExplicitDispositionAfter(targetComment, comments) {
+function hasExplicitDispositionAfter(targetComment, comments, options = {}) {
+  // Default accepts any non-bot human; an IDD-scoped predicate (when supplied)
+  // restricts the disposition author so a reviewer-authored marker does not
+  // count as a completed IDD disposition.
+  const isDispositionAuthor =
+    typeof options.isDispositionAuthor === 'function'
+      ? options.isDispositionAuthor
+      : (login) => !isKnownReviewBot(login);
   const targetTime = Date.parse(targetComment.createdAt ?? '');
   return comments.some((comment) => {
-    const author = comment.author?.login ?? '';
-    if (isKnownReviewBot(author) || !isDispositionComment(comment)) {
+    const author = String(comment.author?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!isDispositionAuthor(author) || !isDispositionComment(comment)) {
       return false;
     }
     if (!/\bCodeRabbit\b/i.test(comment.body ?? '')) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -773,7 +773,12 @@ export function isCodeRabbitLogin(login) {
   const normalized = login.toLowerCase();
   return normalized === 'coderabbitai' || normalized === 'coderabbitai[bot]';
 }
-export function classifyRegularBotComment(comment, comments, threads) {
+export function classifyRegularBotComment(
+  comment,
+  comments,
+  threads,
+  options = {},
+) {
   const author = comment.author?.login ?? '';
   if (!isCodeRabbitLogin(author)) {
     return null;
@@ -795,7 +800,9 @@ export function classifyRegularBotComment(comment, comments, threads) {
     }
     if (
       hasExplicitDispositionAfter(comment, comments) ||
-      hasCompletedBotThreadDispositions(threads, isCodeRabbitLogin)
+      hasCompletedBotThreadDispositions(threads, isCodeRabbitLogin, {
+        isDispositionAuthor: options.isDispositionAuthor,
+      })
     ) {
       return {
         classifier: 'RESOLVED',
@@ -851,7 +858,7 @@ export function indexLatestGatingReviewsByAuthor(reviews) {
   }
   return index;
 }
-export function indexThreadsByReview(threads) {
+export function indexThreadsByReview(threads, options = {}) {
   const index = new Map();
   for (const thread of threads) {
     const reviewIds = new Set(
@@ -871,7 +878,11 @@ export function indexThreadsByReview(threads) {
       if (!thread.isResolved) {
         current.unresolved += 1;
       }
-      if (!hasFreshDisposition(thread)) {
+      if (
+        !hasFreshDisposition(thread, {
+          isDispositionAuthor: options.isDispositionAuthor,
+        })
+      ) {
         current.missingDisposition += 1;
       }
       if (thread.comments?.pageInfo?.hasNextPage) {
@@ -2086,7 +2097,7 @@ export function summarizeDispositionEvidenceForGate(
     body: comment.body,
     createdAt: comment.createdAt,
   }));
-  const missingRegularComments = normalizedComments
+  const outstandingComments = normalizedComments
     .filter(
       (comment) =>
         !isOperationalOrDigestCommentForGate(
@@ -2111,22 +2122,47 @@ export function summarizeDispositionEvidenceForGate(
           threads,
         ) === null
       );
-    })
-    .filter((comment) => {
-      return !normalizedComments.some((reply) => {
-        return (
-          iddAgentLogins.has(reply.authorLogin) &&
-          isDispositionComment({ body: reply.body }) &&
-          compareIsoTimestamps(reply.activityAt, comment.activityAt) > 0
-        );
-      });
-    })
-    .map((comment) => ({
-      id: comment.id || `comment-${comment.sortedIndex + 1}`,
-      authorLogin: comment.authorLogin || 'unknown',
-      createdAt: comment.createdAt,
-      bodyPreview: buildBodyPreview(comment.body),
-    }));
+    });
+  // Count-based 1:1 pairing for the trailing-marker rule: a single later IDD
+  // disposition marker addresses at most ONE earlier regular comment, so one
+  // trailing marker cannot clear several distinct comments that each still
+  // lack a disposition.
+  // Walk the outstanding comments oldest-first and greedily consume the
+  // earliest disposition marker strictly newer than each (markers that are not
+  // newer than the current comment cannot address it or any later comment).
+  const dispositionTimes = normalizedComments
+    .filter(
+      (comment) =>
+        iddAgentLogins.has(comment.authorLogin) &&
+        isDispositionComment({ body: comment.body }),
+    )
+    .map((comment) => comment.activityAt)
+    .filter(isValidIsoTimestamp)
+    .sort((left, right) => Date.parse(left) - Date.parse(right));
+  let markerCursor = 0;
+  const missing = [];
+  for (const comment of outstandingComments) {
+    while (
+      markerCursor < dispositionTimes.length &&
+      compareIsoTimestamps(
+        dispositionTimes[markerCursor],
+        comment.activityAt,
+      ) <= 0
+    ) {
+      markerCursor += 1;
+    }
+    if (markerCursor < dispositionTimes.length) {
+      markerCursor += 1;
+    } else {
+      missing.push(comment);
+    }
+  }
+  const missingRegularComments = missing.map((comment) => ({
+    id: comment.id || `comment-${comment.sortedIndex + 1}`,
+    authorLogin: comment.authorLogin || 'unknown',
+    createdAt: comment.createdAt,
+    bodyPreview: buildBodyPreview(comment.body),
+  }));
   const missingThreads = (threads ?? [])
     .map((thread, index) => {
       const commentsInThread = thread.comments?.nodes ?? [];
@@ -4059,7 +4095,11 @@ function effectiveThreadCommentActivityAt(comment) {
   }
   return '';
 }
-function hasCompletedBotThreadDispositions(threads, loginPredicate) {
+function hasCompletedBotThreadDispositions(
+  threads,
+  loginPredicate,
+  options = {},
+) {
   const botThreads = threads.filter((thread) => {
     return (thread.comments?.nodes ?? []).some((comment) => {
       return (
@@ -4074,7 +4114,9 @@ function hasCompletedBotThreadDispositions(threads, loginPredicate) {
       return (
         thread.isResolved &&
         !thread.comments?.pageInfo?.hasNextPage &&
-        hasFreshDisposition(thread)
+        hasFreshDisposition(thread, {
+          isDispositionAuthor: options.isDispositionAuthor,
+        })
       );
     })
   );

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -312,6 +312,23 @@ if (args.apply) {
 computeReportSummary(report);
 writeReport(report, args.format);
 
+// Build an IDD-scoped disposition-author predicate from the resolved
+// trusted-marker actors (the accounts the IDD agent posts dispositions under).
+// The non-gate `hasFreshDisposition` callers must use this so a human
+// reviewer's `**Accepted**`/`**Rejected**` is not mistaken for a completed IDD
+// disposition.
+function makeIddDispositionAuthorPredicate(
+  iddLogins: string[],
+): (login: string) => boolean {
+  const set = new Set(iddLogins);
+  return (login) =>
+    set.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+}
+
 async function buildReport(
   owner: string,
   repo: string,
@@ -322,20 +339,24 @@ async function buildReport(
   const comments = fetchIssueComments(owner, repo, prNumber, options);
   const reviews = fetchReviews(owner, repo, prNumber, options);
   const threads = fetchReviewThreads(owner, repo, prNumber, options);
-  const threadIndex = indexThreadsByReview(threads);
-  const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
 
   const configuredTrust = configuredTrustedMarkerActorSources();
+  const iddAgentLogins = normalizeTrustedMarkerLogins([
+    currentViewerLogin(),
+    ...configuredTrust.actors,
+  ]);
+  const threadIndex = indexThreadsByReview(threads, {
+    isDispositionAuthor: makeIddDispositionAuthorPredicate(iddAgentLogins),
+  });
+  const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
+
   const report: CleanupAuditReport = {
     repository: `${owner}/${repo}`,
     pr: prNumber,
     prUrl: pr.url,
     merged: pr.merged,
     mode: 'dry-run',
-    trustedMarkerActors: normalizeTrustedMarkerLogins([
-      currentViewerLogin(),
-      ...configuredTrust.actors,
-    ]),
+    trustedMarkerActors: iddAgentLogins,
     trustedMarkerActorsSources: [
       ...(currentViewerLogin() ? ['viewer'] : []),
       ...configuredTrust.sources,
@@ -443,7 +464,11 @@ function evaluateRegularBotComment(
     return;
   }
 
-  const classification = classifyRegularBotComment(comment, comments, threads);
+  const classification = classifyRegularBotComment(comment, comments, threads, {
+    isDispositionAuthor: makeIddDispositionAuthorPredicate(
+      report.trustedMarkerActors,
+    ),
+  });
   const subject = subjectFromNode(
     comment,
     'IssueComment',
@@ -678,7 +703,13 @@ function evaluateReviewComment(
     return;
   }
 
-  if (!hasFreshDisposition(thread)) {
+  if (
+    !hasFreshDisposition(thread, {
+      isDispositionAuthor: makeIddDispositionAuthorPredicate(
+        report.trustedMarkerActors,
+      ),
+    })
+  ) {
     addSkipped(
       report,
       { ...subject, threadId: thread.id },

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1416,7 +1416,9 @@ export function classifyRegularBotComment(
       };
     }
     if (
-      hasExplicitDispositionAfter(comment, comments) ||
+      hasExplicitDispositionAfter(comment, comments, {
+        isDispositionAuthor: options.isDispositionAuthor,
+      }) ||
       hasCompletedBotThreadDispositions(threads, isCodeRabbitLogin, {
         isDispositionAuthor: options.isDispositionAuthor,
       })
@@ -1435,7 +1437,9 @@ export function classifyRegularBotComment(
   ) {
     if (
       /\b(Review triggered|Sure! I'll review|I'll review)\b/i.test(body) &&
-      hasExplicitDispositionAfter(comment, comments)
+      hasExplicitDispositionAfter(comment, comments, {
+        isDispositionAuthor: options.isDispositionAuthor,
+      })
     ) {
       return {
         classifier: 'OUTDATED',
@@ -2888,6 +2892,14 @@ export function summarizeRegularCommentsForGate(
           },
           classificationComments,
           threads,
+          {
+            isDispositionAuthor: (login) =>
+              iddAgentLogins.has(
+                String(login ?? '')
+                  .trim()
+                  .toLowerCase(),
+              ),
+          },
         ) === null
       );
     })
@@ -2991,6 +3003,14 @@ export function summarizeDispositionEvidenceForGate(
           },
           classificationComments,
           threads,
+          {
+            isDispositionAuthor: (login) =>
+              iddAgentLogins.has(
+                String(login ?? '')
+                  .trim()
+                  .toLowerCase(),
+              ),
+          },
         ) === null
       );
     });
@@ -4861,11 +4881,21 @@ export function classifyResumeRoutingCase(
 function hasExplicitDispositionAfter(
   targetComment: CommentLike,
   comments: CommentLike[],
+  options: { isDispositionAuthor?: (login: string) => boolean } = {},
 ): boolean {
+  // Default accepts any non-bot human; an IDD-scoped predicate (when supplied)
+  // restricts the disposition author so a reviewer-authored marker does not
+  // count as a completed IDD disposition.
+  const isDispositionAuthor =
+    typeof options.isDispositionAuthor === 'function'
+      ? options.isDispositionAuthor
+      : (login: string) => !isKnownReviewBot(login);
   const targetTime = Date.parse(targetComment.createdAt ?? '');
   return comments.some((comment) => {
-    const author = comment.author?.login ?? '';
-    if (isKnownReviewBot(author) || !isDispositionComment(comment)) {
+    const author = String(comment.author?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!isDispositionAuthor(author) || !isDispositionComment(comment)) {
       return false;
     }
     if (!/\bCodeRabbit\b/i.test(comment.body ?? '')) {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1391,6 +1391,7 @@ export function classifyRegularBotComment(
   comment: CommentLike,
   comments: CommentLike[],
   threads: ThreadLike[],
+  options: { isDispositionAuthor?: (login: string) => boolean } = {},
 ): CommentClassification | null {
   const author = comment.author?.login ?? '';
   if (!isCodeRabbitLogin(author)) {
@@ -1416,7 +1417,9 @@ export function classifyRegularBotComment(
     }
     if (
       hasExplicitDispositionAfter(comment, comments) ||
-      hasCompletedBotThreadDispositions(threads, isCodeRabbitLogin)
+      hasCompletedBotThreadDispositions(threads, isCodeRabbitLogin, {
+        isDispositionAuthor: options.isDispositionAuthor,
+      })
     ) {
       return {
         classifier: 'RESOLVED',
@@ -1479,7 +1482,10 @@ export function indexLatestGatingReviewsByAuthor(reviews: ReviewLike[]) {
   return index;
 }
 
-export function indexThreadsByReview(threads: ThreadLike[]) {
+export function indexThreadsByReview(
+  threads: ThreadLike[],
+  options: { isDispositionAuthor?: (login: string) => boolean } = {},
+) {
   const index = new Map<
     string,
     {
@@ -1510,7 +1516,11 @@ export function indexThreadsByReview(threads: ThreadLike[]) {
       if (!thread.isResolved) {
         current.unresolved += 1;
       }
-      if (!hasFreshDisposition(thread)) {
+      if (
+        !hasFreshDisposition(thread, {
+          isDispositionAuthor: options.isDispositionAuthor,
+        })
+      ) {
         current.missingDisposition += 1;
       }
       if (thread.comments?.pageInfo?.hasNextPage) {
@@ -2958,7 +2968,7 @@ export function summarizeDispositionEvidenceForGate(
     createdAt: comment.createdAt,
   }));
 
-  const missingRegularComments = normalizedComments
+  const outstandingComments = normalizedComments
     .filter(
       (comment) =>
         !isOperationalOrDigestCommentForGate(
@@ -2983,22 +2993,50 @@ export function summarizeDispositionEvidenceForGate(
           threads,
         ) === null
       );
-    })
-    .filter((comment) => {
-      return !normalizedComments.some((reply) => {
-        return (
-          iddAgentLogins.has(reply.authorLogin) &&
-          isDispositionComment({ body: reply.body }) &&
-          compareIsoTimestamps(reply.activityAt, comment.activityAt) > 0
-        );
-      });
-    })
-    .map((comment) => ({
-      id: comment.id || `comment-${comment.sortedIndex + 1}`,
-      authorLogin: comment.authorLogin || 'unknown',
-      createdAt: comment.createdAt,
-      bodyPreview: buildBodyPreview(comment.body),
-    }));
+    });
+
+  // Count-based 1:1 pairing for the trailing-marker rule: a single later IDD
+  // disposition marker addresses at most ONE earlier regular comment, so one
+  // trailing marker cannot clear several distinct comments that each still
+  // lack a disposition.
+  // Walk the outstanding comments oldest-first and greedily consume the
+  // earliest disposition marker strictly newer than each (markers that are not
+  // newer than the current comment cannot address it or any later comment).
+  const dispositionTimes = normalizedComments
+    .filter(
+      (comment) =>
+        iddAgentLogins.has(comment.authorLogin) &&
+        isDispositionComment({ body: comment.body }),
+    )
+    .map((comment) => comment.activityAt)
+    .filter(isValidIsoTimestamp)
+    .sort((left, right) => Date.parse(left) - Date.parse(right));
+
+  let markerCursor = 0;
+  const missing: typeof outstandingComments = [];
+  for (const comment of outstandingComments) {
+    while (
+      markerCursor < dispositionTimes.length &&
+      compareIsoTimestamps(
+        dispositionTimes[markerCursor],
+        comment.activityAt,
+      ) <= 0
+    ) {
+      markerCursor += 1;
+    }
+    if (markerCursor < dispositionTimes.length) {
+      markerCursor += 1;
+    } else {
+      missing.push(comment);
+    }
+  }
+
+  const missingRegularComments = missing.map((comment) => ({
+    id: comment.id || `comment-${comment.sortedIndex + 1}`,
+    authorLogin: comment.authorLogin || 'unknown',
+    createdAt: comment.createdAt,
+    bodyPreview: buildBodyPreview(comment.body),
+  }));
 
   const missingThreads = (threads ?? [])
     .map((thread, index) => {
@@ -5264,6 +5302,7 @@ function effectiveThreadCommentActivityAt(
 function hasCompletedBotThreadDispositions(
   threads: ThreadLike[],
   loginPredicate: (login: string) => boolean,
+  options: { isDispositionAuthor?: (login: string) => boolean } = {},
 ): boolean {
   const botThreads = threads.filter((thread) => {
     return (thread.comments?.nodes ?? []).some((comment) => {
@@ -5280,7 +5319,9 @@ function hasCompletedBotThreadDispositions(
       return (
         thread.isResolved &&
         !thread.comments?.pageInfo?.hasNextPage &&
-        hasFreshDisposition(thread)
+        hasFreshDisposition(thread, {
+          isDispositionAuthor: options.isDispositionAuthor,
+        })
       );
     })
   );

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1458,6 +1458,52 @@ test('disposition evidence treats PATH A and PATH B as complete when both have m
   assert.equal(summary.missingThreadCount, 0);
 });
 
+test('disposition evidence IDD-scopes advisory-bot resolution at the gate', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n\nWalkthrough.',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+      threads: [
+        {
+          id: 'BT-1',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'coderabbitai[bot]' },
+                createdAt: '2026-05-12T00:00:01Z',
+                body: 'consider renaming this',
+              },
+              // Resolved only by a reviewer-authored marker — not an IDD agent.
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:02Z',
+                body: '**Accepted** — done',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+    },
+  );
+
+  // The CodeRabbit summary is "resolved" only by a reviewer-authored marker,
+  // which the IDD-scoped gate must not accept, so the summary is still flagged.
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingRegularCommentCount, 1);
+});
+
 test('disposition evidence pairs trailing markers 1:1 across regular comments', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1458,6 +1458,77 @@ test('disposition evidence treats PATH A and PATH B as complete when both have m
   assert.equal(summary.missingThreadCount, 0);
 });
 
+test('disposition evidence pairs trailing markers 1:1 across regular comments', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: 'first concern',
+          author: { login: 'reviewer-a' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T00:00:01Z',
+          body: 'second concern',
+          author: { login: 'reviewer-b' },
+        },
+        // A single trailing disposition can address only ONE of the two.
+        {
+          id: 3,
+          createdAt: '2026-05-12T00:00:02Z',
+          body: '**Accepted** — addressed',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    { iddAgentLogins: ['idd-bot'] },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingRegularCommentCount, 1);
+});
+
+test('disposition evidence clears two regular comments when each has its own marker', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: 'first concern',
+          author: { login: 'reviewer-a' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T00:00:01Z',
+          body: 'second concern',
+          author: { login: 'reviewer-b' },
+        },
+        {
+          id: 3,
+          createdAt: '2026-05-12T00:00:02Z',
+          body: '**Accepted** — first addressed',
+          author: { login: 'idd-bot' },
+        },
+        {
+          id: 4,
+          createdAt: '2026-05-12T00:00:03Z',
+          body: '**Rejected** — second declined',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    { iddAgentLogins: ['idd-bot'] },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.missingRegularCommentCount, 0);
+});
+
 test('disposition evidence blocks unresolved threads without fresh disposition markers', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {

--- a/tests/review-snapshot.test.mts
+++ b/tests/review-snapshot.test.mts
@@ -140,6 +140,35 @@ test('classifyRegularBotComment honors an IDD-scoped disposition-author predicat
   );
 });
 
+test('classifyRegularBotComment IDD-scopes the explicit-disposition path', () => {
+  const summary: CommentLike = {
+    author: { login: 'coderabbitai[bot]' },
+    body: '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n\nWalkthrough of the change.',
+    createdAt: '2026-05-12T00:00:00Z',
+  };
+  // A later top-level disposition mentioning CodeRabbit, authored by a human
+  // reviewer rather than an IDD agent.
+  const reviewerDisposition: CommentLike = {
+    author: { login: 'reviewer-a' },
+    body: '**Accepted** — CodeRabbit summary acknowledged',
+    createdAt: '2026-05-12T00:01:00Z',
+  };
+  const comments = [summary, reviewerDisposition];
+
+  // Loose default accepts the reviewer-authored disposition.
+  assert.equal(
+    classifyRegularBotComment(summary, comments, [])?.classifier,
+    'RESOLVED',
+  );
+  // IDD-scoped predicate rejects it (no completed IDD disposition).
+  assert.equal(
+    classifyRegularBotComment(summary, comments, [], {
+      isDispositionAuthor: (login) => login === 'idd-bot',
+    }),
+    null,
+  );
+});
+
 test('tracks latest gating reviews and truncated threads', () => {
   const gatingIndex = indexLatestGatingReviewsByAuthor(
     latestGatingReview.reviews,

--- a/tests/review-snapshot.test.mts
+++ b/tests/review-snapshot.test.mts
@@ -59,6 +59,87 @@ test('indexes review threads by review id', () => {
   assert.equal(requestedThreads.get('REVIEW-2')?.missingDisposition, 1);
 });
 
+test('indexThreadsByReview honors an IDD-scoped disposition-author predicate', () => {
+  const threads: ThreadLike[] = [
+    {
+      id: 'T-1',
+      isResolved: true,
+      comments: {
+        pageInfo: { hasNextPage: false },
+        nodes: [
+          {
+            author: { login: 'reviewer-a' },
+            body: 'please fix',
+            createdAt: '2026-05-12T00:00:00Z',
+            pullRequestReview: { id: 'REVIEW-9' },
+          },
+          {
+            author: { login: 'reviewer-a' },
+            body: '**Accepted** — looks fine',
+            createdAt: '2026-05-12T00:00:01Z',
+            pullRequestReview: { id: 'REVIEW-9' },
+          },
+        ],
+      },
+    },
+  ];
+
+  // Loose default accepts any non-bot human's marker as a disposition.
+  assert.equal(
+    indexThreadsByReview(threads).get('REVIEW-9')?.missingDisposition,
+    0,
+  );
+  // IDD-scoped predicate rejects the reviewer-authored marker, so the thread
+  // is missing a disposition.
+  const scoped = indexThreadsByReview(threads, {
+    isDispositionAuthor: (login) => login === 'idd-bot',
+  });
+  assert.equal(scoped.get('REVIEW-9')?.missingDisposition, 1);
+});
+
+test('classifyRegularBotComment honors an IDD-scoped disposition-author predicate', () => {
+  const summary: CommentLike = {
+    author: { login: 'coderabbitai[bot]' },
+    body: '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n\nWalkthrough of the change.',
+    createdAt: '2026-05-12T00:00:00Z',
+  };
+  const threads: ThreadLike[] = [
+    {
+      id: 'BT-1',
+      isResolved: true,
+      comments: {
+        pageInfo: { hasNextPage: false },
+        nodes: [
+          {
+            author: { login: 'coderabbitai[bot]' },
+            body: 'consider renaming this',
+            createdAt: '2026-05-12T00:00:01Z',
+          },
+          {
+            author: { login: 'reviewer-a' },
+            body: '**Accepted** — done',
+            createdAt: '2026-05-12T00:00:02Z',
+          },
+        ],
+      },
+    },
+  ];
+
+  // Loose default treats the reviewer-authored marker as a completed
+  // disposition, so the bot summary classifies as RESOLVED.
+  assert.equal(
+    classifyRegularBotComment(summary, [summary], threads)?.classifier,
+    'RESOLVED',
+  );
+  // IDD-scoped predicate rejects it, so there is no completed disposition.
+  assert.equal(
+    classifyRegularBotComment(summary, [summary], threads, {
+      isDispositionAuthor: (login) => login === 'idd-bot',
+    }),
+    null,
+  );
+});
+
 test('tracks latest gating reviews and truncated threads', () => {
   const gatingIndex = indexLatestGatingReviewsByAuthor(
     latestGatingReview.reviews,


### PR DESCRIPTION
Closes #951. Completes the items split from #924 (items 3–4). Part of roadmap #910.

## Problem

Two residual disposition-evidence gaps from #924:

3. **Loose default in non-gate `hasFreshDisposition` callers.** The default disposition-author predicate is `login => !isKnownReviewBot(login)` — it accepts any human, so a *reviewer*-authored `**Accepted**`/`**Rejected**` could be mistaken for a completed IDD disposition. The F2/F3 gate already passes an explicit IDD-scoped predicate and is safe, but three non-gate callers in the `audit-pr-cleanup` minimizer path relied on the loose default.
4. **One trailing marker cleared every earlier comment.** In `summarizeDispositionEvidenceForGate`, a regular comment dropped from `missingRegularComments` if *any* later IDD disposition existed — so a single trailing marker could clear several distinct comments that each still lacked a disposition.

## Change

- **Item 3** — `indexThreadsByReview`, `classifyRegularBotComment`, and `hasCompletedBotThreadDispositions` (`src/scripts/protocol-helpers.mts`) take an optional `isDispositionAuthor` predicate (defaulting to the existing loose behavior, so the gate's own calls are unchanged). `audit-pr-cleanup` builds an IDD-scoped predicate from its resolved trusted-marker actors and passes it at all three `hasFreshDisposition`-bearing sites (`indexThreadsByReview`, `classifyRegularBotComment`, and the direct minimizer call).
- **Item 4** — `summarizeDispositionEvidenceForGate` now does count-based **1:1 pairing**: walk outstanding comments oldest-first and greedily consume the earliest disposition marker strictly newer than each, so each comment needs its own later marker.
- Generated `scripts/*.mjs` regenerated via `pnpm run build`.

## Testing

- `tests/review-snapshot.test.mts`: `indexThreadsByReview` and `classifyRegularBotComment` reject a reviewer-authored marker under an IDD predicate but accept it under the loose default.
- `tests/pre-merge-readiness.test.mts`: one trailing marker leaves a second comment outstanding (`missingRegularCommentCount == 1`); two markers clear two comments. Existing PATH A/B (2 comments + 2 markers) stays green.
- `pnpm run lint:minimum` green (1031 tests), `pnpm run build:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)