### PR TITLE
fix(resume-claim-routing): require PR-scoped forced-handoff evidence for PR-backed claims

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3530,7 +3530,7 @@ function normalizeForcedHandoffReason(value) {
   }
   return trimmed;
 }
-function normalizeLinkedPrReference(value) {
+export function normalizeLinkedPrReference(value) {
   const token = String(value ?? '').trim();
   if (!token) {
     return '';

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -202,11 +202,12 @@ function runCli() {
   const permissionCache = new Map();
   // A forced handoff that displaces a PR-backed claim must carry
   // issue-plus-pr evidence naming that PR; detect the open linked PR(s)
-  // so the gate below can enforce it (fail-safe to no enforcement).
-  const expectedLinkedPrReferences = fetchOpenLinkedPrReferences(
-    repository,
-    args.issue,
-  );
+  // so the gate below can enforce it (fail-safe to no enforcement). Skip
+  // the lookup entirely when forced-handoff mode is off — the gate never
+  // honors a handoff then, so the PR context would go unused.
+  const expectedLinkedPrReferences = forcedHandoffEnabled
+    ? fetchOpenLinkedPrReferences(repository, args.issue)
+    : new Set();
   const result = evaluateResumeClaimRouting(
     {
       events: comments.map((comment) => ({
@@ -712,7 +713,9 @@ function fetchOpenLinkedPrReferences(repository, issueNumber) {
   const query =
     'query($owner:String!,$repo:String!,$number:Int!){' +
     'repository(owner:$owner,name:$repo){issue(number:$number){' +
-    'timelineItems(first:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT])' +
+    // `last` so the most recent connect/disconnect events win: an issue
+    // with many such events must not have newer DISCONNECTED_EVENTs missed.
+    'timelineItems(last:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT])' +
     '{nodes{__typename ' +
     '... on ConnectedEvent{subject{__typename ... on PullRequest{number state}}} ' +
     '... on DisconnectedEvent{subject{__typename ... on PullRequest{number}}}' +

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -12,6 +12,7 @@ import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
 import {
   isStaleAt,
+  normalizeLinkedPrReference,
   parseClaimComment,
   resolveActiveClaim,
 } from './protocol-helpers.mjs';
@@ -23,6 +24,37 @@ const LEGACY_RELEASE_PATTERN =
   /^<!--\s*unclaimed-by:\s+(\S+)\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i;
 if (isCliExecution()) {
   runCli();
+}
+/**
+ * Build the `isForcedHandoffEnabled` gate used by the resume CLI.
+ *
+ * Mirrors `summarizeClaimValidation`'s gate so a forced handoff that
+ * displaces a **PR-backed** claim is honored only with `issue-plus-pr`
+ * evidence naming that PR:
+ *
+ * - forced-handoff mode disabled → never honor;
+ * - no open linked PR backs the claim (`expectedLinkedPrReferences`
+ *   empty, including the fail-safe lookup-error case) → honor an
+ *   `issue-only` handoff as before;
+ * - an open linked PR backs the claim → require `contextScope` of
+ *   `issue-plus-pr` whose `linkedPr` matches one of the expected PRs.
+ */
+export function buildForcedHandoffEnabledGate(options) {
+  const { forcedHandoffEnabled, expectedLinkedPrReferences } = options;
+  return (forcedHandoff) => {
+    if (!forcedHandoffEnabled) {
+      return false;
+    }
+    if (expectedLinkedPrReferences.size === 0) {
+      return true;
+    }
+    if (forcedHandoff.contextScope !== 'issue-plus-pr') {
+      return false;
+    }
+    return expectedLinkedPrReferences.has(
+      normalizeLinkedPrReference(forcedHandoff.linkedPr),
+    );
+  };
 }
 export function evaluateResumeClaimRouting(input, options = {}) {
   const nowIso =
@@ -168,6 +200,13 @@ function runCli() {
   const forcedHandoffEnabled = policy.forcedHandoff.mode === 'human-gated';
   const forcedHandoffAuthorityPolicy = policy.forcedHandoff.authorityPolicy;
   const permissionCache = new Map();
+  // A forced handoff that displaces a PR-backed claim must carry
+  // issue-plus-pr evidence naming that PR; detect the open linked PR(s)
+  // so the gate below can enforce it (fail-safe to no enforcement).
+  const expectedLinkedPrReferences = fetchOpenLinkedPrReferences(
+    repository,
+    args.issue,
+  );
   const result = evaluateResumeClaimRouting(
     {
       events: comments.map((comment) => ({
@@ -186,7 +225,10 @@ function runCli() {
             .trim()
             .toLowerCase(),
         ),
-      isForcedHandoffEnabled: () => forcedHandoffEnabled,
+      isForcedHandoffEnabled: buildForcedHandoffEnabledGate({
+        forcedHandoffEnabled,
+        expectedLinkedPrReferences,
+      }),
       isAuthorizedForcedHandoff: (forcedBy) =>
         isAuthorizedForcedHandoffActor(
           owner,
@@ -651,6 +693,78 @@ function toSecond(iso) {
 function normalizeToken(value) {
   const token = String(value ?? '').trim();
   return token.length > 0 ? token : '';
+}
+/**
+ * Resolve the set of open pull requests that back this issue's claim, as
+ * normalized PR references. Uses a precise signal — a PR connected to the
+ * issue via `CONNECTED_EVENT` (reconciled against later
+ * `DISCONNECTED_EVENT`s) that is currently `OPEN` — rather than a bare
+ * cross-reference/mention, so an unrelated open PR merely mentioning the
+ * issue does not falsely block a legitimate `issue-only` forced handoff.
+ * Fails safe to an empty set (no enforcement) on any lookup error.
+ */
+function fetchOpenLinkedPrReferences(repository, issueNumber) {
+  const references = new Set();
+  const [owner, repo] = repository.split('/');
+  if (!owner || !repo || !Number.isInteger(issueNumber)) {
+    return references;
+  }
+  const query =
+    'query($owner:String!,$repo:String!,$number:Int!){' +
+    'repository(owner:$owner,name:$repo){issue(number:$number){' +
+    'timelineItems(first:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT])' +
+    '{nodes{__typename ' +
+    '... on ConnectedEvent{subject{__typename ... on PullRequest{number state}}} ' +
+    '... on DisconnectedEvent{subject{__typename ... on PullRequest{number}}}' +
+    '}}}}}';
+  let data;
+  try {
+    data = ghJson([
+      'api',
+      'graphql',
+      '-f',
+      `query=${query}`,
+      '-f',
+      `owner=${owner}`,
+      '-f',
+      `repo=${repo}`,
+      '-F',
+      `number=${issueNumber}`,
+    ]);
+  } catch {
+    return references;
+  }
+  const nodes = data?.data?.repository?.issue?.timelineItems?.nodes;
+  if (!Array.isArray(nodes)) {
+    return references;
+  }
+  // The last connect/disconnect event per PR wins (timeline is chronological).
+  const connected = new Map();
+  const states = new Map();
+  for (const node of nodes) {
+    const record = node;
+    const subject = record?.subject;
+    if (subject?.__typename !== 'PullRequest') {
+      continue;
+    }
+    const number =
+      typeof subject.number === 'number' ? subject.number : Number.NaN;
+    if (!Number.isInteger(number)) {
+      continue;
+    }
+    if (record?.__typename === 'ConnectedEvent') {
+      connected.set(number, true);
+      states.set(number, String(subject.state ?? ''));
+    } else if (record?.__typename === 'DisconnectedEvent') {
+      connected.set(number, false);
+    }
+  }
+  for (const [number, isConnected] of connected) {
+    if (isConnected && states.get(number) === 'OPEN') {
+      references.add(normalizeLinkedPrReference(number));
+    }
+  }
+  return references;
 }
 function ghJson(args) {
   return JSON.parse(runGh(args).trim() || '[]');

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4634,7 +4634,7 @@ function normalizeForcedHandoffReason(value: unknown): string {
   return trimmed;
 }
 
-function normalizeLinkedPrReference(value: unknown): string {
+export function normalizeLinkedPrReference(value: unknown): string {
   const token = String(value ?? '').trim();
   if (!token) {
     return '';

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -307,11 +307,12 @@ function runCli(): void {
   const permissionCache: CollaboratorPermissionCache = new Map();
   // A forced handoff that displaces a PR-backed claim must carry
   // issue-plus-pr evidence naming that PR; detect the open linked PR(s)
-  // so the gate below can enforce it (fail-safe to no enforcement).
-  const expectedLinkedPrReferences = fetchOpenLinkedPrReferences(
-    repository,
-    args.issue,
-  );
+  // so the gate below can enforce it (fail-safe to no enforcement). Skip
+  // the lookup entirely when forced-handoff mode is off — the gate never
+  // honors a handoff then, so the PR context would go unused.
+  const expectedLinkedPrReferences = forcedHandoffEnabled
+    ? fetchOpenLinkedPrReferences(repository, args.issue)
+    : new Set<string>();
 
   const result = evaluateResumeClaimRouting(
     {
@@ -924,7 +925,9 @@ function fetchOpenLinkedPrReferences(
   const query =
     'query($owner:String!,$repo:String!,$number:Int!){' +
     'repository(owner:$owner,name:$repo){issue(number:$number){' +
-    'timelineItems(first:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT])' +
+    // `last` so the most recent connect/disconnect events win: an issue
+    // with many such events must not have newer DISCONNECTED_EVENTs missed.
+    'timelineItems(last:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT])' +
     '{nodes{__typename ' +
     '... on ConnectedEvent{subject{__typename ... on PullRequest{number state}}} ' +
     '... on DisconnectedEvent{subject{__typename ... on PullRequest{number}}}' +

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -18,6 +18,7 @@ import type {
 } from './protocol-helpers.mts';
 import {
   isStaleAt,
+  normalizeLinkedPrReference,
   parseClaimComment,
   resolveActiveClaim,
 } from './protocol-helpers.mts';
@@ -108,6 +109,41 @@ const LEGACY_RELEASE_PATTERN =
 
 if (isCliExecution()) {
   runCli();
+}
+
+/**
+ * Build the `isForcedHandoffEnabled` gate used by the resume CLI.
+ *
+ * Mirrors `summarizeClaimValidation`'s gate so a forced handoff that
+ * displaces a **PR-backed** claim is honored only with `issue-plus-pr`
+ * evidence naming that PR:
+ *
+ * - forced-handoff mode disabled → never honor;
+ * - no open linked PR backs the claim (`expectedLinkedPrReferences`
+ *   empty, including the fail-safe lookup-error case) → honor an
+ *   `issue-only` handoff as before;
+ * - an open linked PR backs the claim → require `contextScope` of
+ *   `issue-plus-pr` whose `linkedPr` matches one of the expected PRs.
+ */
+export function buildForcedHandoffEnabledGate(options: {
+  forcedHandoffEnabled: boolean;
+  expectedLinkedPrReferences: Set<string>;
+}): (forcedHandoff: ParsedForcedHandoffMarker) => boolean {
+  const { forcedHandoffEnabled, expectedLinkedPrReferences } = options;
+  return (forcedHandoff: ParsedForcedHandoffMarker) => {
+    if (!forcedHandoffEnabled) {
+      return false;
+    }
+    if (expectedLinkedPrReferences.size === 0) {
+      return true;
+    }
+    if (forcedHandoff.contextScope !== 'issue-plus-pr') {
+      return false;
+    }
+    return expectedLinkedPrReferences.has(
+      normalizeLinkedPrReference(forcedHandoff.linkedPr),
+    );
+  };
 }
 
 export function evaluateResumeClaimRouting(
@@ -269,6 +305,13 @@ function runCli(): void {
   const forcedHandoffEnabled = policy.forcedHandoff.mode === 'human-gated';
   const forcedHandoffAuthorityPolicy = policy.forcedHandoff.authorityPolicy;
   const permissionCache: CollaboratorPermissionCache = new Map();
+  // A forced handoff that displaces a PR-backed claim must carry
+  // issue-plus-pr evidence naming that PR; detect the open linked PR(s)
+  // so the gate below can enforce it (fail-safe to no enforcement).
+  const expectedLinkedPrReferences = fetchOpenLinkedPrReferences(
+    repository,
+    args.issue,
+  );
 
   const result = evaluateResumeClaimRouting(
     {
@@ -288,7 +331,10 @@ function runCli(): void {
             .trim()
             .toLowerCase(),
         ),
-      isForcedHandoffEnabled: () => forcedHandoffEnabled,
+      isForcedHandoffEnabled: buildForcedHandoffEnabledGate({
+        forcedHandoffEnabled,
+        expectedLinkedPrReferences,
+      }),
       isAuthorizedForcedHandoff: (forcedBy) =>
         isAuthorizedForcedHandoffActor(
           owner,
@@ -855,6 +901,91 @@ function toSecond(iso: string | null | undefined): number | null {
 function normalizeToken(value: unknown): string {
   const token = String(value ?? '').trim();
   return token.length > 0 ? token : '';
+}
+
+/**
+ * Resolve the set of open pull requests that back this issue's claim, as
+ * normalized PR references. Uses a precise signal — a PR connected to the
+ * issue via `CONNECTED_EVENT` (reconciled against later
+ * `DISCONNECTED_EVENT`s) that is currently `OPEN` — rather than a bare
+ * cross-reference/mention, so an unrelated open PR merely mentioning the
+ * issue does not falsely block a legitimate `issue-only` forced handoff.
+ * Fails safe to an empty set (no enforcement) on any lookup error.
+ */
+function fetchOpenLinkedPrReferences(
+  repository: string,
+  issueNumber: number | null,
+): Set<string> {
+  const references = new Set<string>();
+  const [owner, repo] = repository.split('/');
+  if (!owner || !repo || !Number.isInteger(issueNumber)) {
+    return references;
+  }
+  const query =
+    'query($owner:String!,$repo:String!,$number:Int!){' +
+    'repository(owner:$owner,name:$repo){issue(number:$number){' +
+    'timelineItems(first:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT])' +
+    '{nodes{__typename ' +
+    '... on ConnectedEvent{subject{__typename ... on PullRequest{number state}}} ' +
+    '... on DisconnectedEvent{subject{__typename ... on PullRequest{number}}}' +
+    '}}}}}';
+  let data: unknown;
+  try {
+    data = ghJson([
+      'api',
+      'graphql',
+      '-f',
+      `query=${query}`,
+      '-f',
+      `owner=${owner}`,
+      '-f',
+      `repo=${repo}`,
+      '-F',
+      `number=${issueNumber}`,
+    ]);
+  } catch {
+    return references;
+  }
+  const nodes = (
+    data as {
+      data?: {
+        repository?: { issue?: { timelineItems?: { nodes?: unknown } } };
+      };
+    } | null
+  )?.data?.repository?.issue?.timelineItems?.nodes;
+  if (!Array.isArray(nodes)) {
+    return references;
+  }
+  // The last connect/disconnect event per PR wins (timeline is chronological).
+  const connected = new Map<number, boolean>();
+  const states = new Map<number, string>();
+  for (const node of nodes) {
+    const record = node as {
+      __typename?: unknown;
+      subject?: { __typename?: unknown; number?: unknown; state?: unknown };
+    } | null;
+    const subject = record?.subject;
+    if (subject?.__typename !== 'PullRequest') {
+      continue;
+    }
+    const number =
+      typeof subject.number === 'number' ? subject.number : Number.NaN;
+    if (!Number.isInteger(number)) {
+      continue;
+    }
+    if (record?.__typename === 'ConnectedEvent') {
+      connected.set(number, true);
+      states.set(number, String(subject.state ?? ''));
+    } else if (record?.__typename === 'DisconnectedEvent') {
+      connected.set(number, false);
+    }
+  }
+  for (const [number, isConnected] of connected) {
+    if (isConnected && states.get(number) === 'OPEN') {
+      references.add(normalizeLinkedPrReference(number));
+    }
+  }
+  return references;
 }
 
 function ghJson(args: string[]): unknown {

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { evaluateResumeClaimRouting } from '../src/scripts/resume-claim-routing.mts';
+import {
+  buildForcedHandoffEnabledGate,
+  evaluateResumeClaimRouting,
+} from '../src/scripts/resume-claim-routing.mts';
 
 function trusted(logins: string[]) {
   const set = new Set(logins);
@@ -515,4 +518,111 @@ test('baselines the competing-claim search by timestamp regardless of event orde
 
   assert.equal(result.state, 'disputed');
   assert.equal(result.evidence.later_competing_claim?.claim_id, 'claim-race');
+});
+
+// Forced-handoff events whose marker scope/linkedPr can be varied to test
+// the buildForcedHandoffEnabledGate behavior end-to-end.
+function forcedHandoffEvents(scope: {
+  contextScope: string;
+  linkedPr?: string;
+}) {
+  const payload = {
+    oldAgentId: 'copilot',
+    oldClaimId: 'claim-old',
+    newAgentId: 'copilot',
+    newClaimId: 'claim-new',
+    branch: 'issue/11-task',
+    forcedBy: 'maintainer',
+    reason: 'handoff',
+    timestamp: '2026-05-12T10:01:00Z',
+    ...scope,
+  };
+  return [
+    {
+      createdAt: '2026-05-12T10:00:00Z',
+      author: { login: 'maintainer' },
+      body: '<!-- claimed-by: copilot claim-old supersedes: none 2026-05-12T10:00:00Z branch: issue/11-task -->',
+    },
+    {
+      createdAt: '2026-05-12T10:01:00Z',
+      author: { login: 'maintainer' },
+      body: `<!-- forced-handoff: ${JSON.stringify(payload)} -->\n\n_maintainer: forced handoff — IDD automation marker. Do not edit._`,
+    },
+  ];
+}
+
+const route = (
+  events: ReturnType<typeof forcedHandoffEvents>,
+  gate: ReturnType<typeof buildForcedHandoffEnabledGate>,
+) =>
+  evaluateResumeClaimRouting(
+    { claimId: 'claim-new', now: '2026-05-12T11:00:00Z', events },
+    {
+      isTrustedAuthor: trusted(['maintainer']),
+      isForcedHandoffEnabled: gate,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'maintainer',
+    },
+  );
+
+test('gate blocks an issue-only forced handoff that displaces a PR-backed claim', () => {
+  const gate = buildForcedHandoffEnabledGate({
+    forcedHandoffEnabled: true,
+    expectedLinkedPrReferences: new Set(['77']),
+  });
+  const result = route(
+    forcedHandoffEvents({ contextScope: 'issue-only' }),
+    gate,
+  );
+  // Handoff not honored: the original claim stays active, successor rejected.
+  assert.equal(result.active_claim?.claim_id, 'claim-old');
+});
+
+test('gate honors an issue-plus-pr forced handoff naming the backing PR', () => {
+  const gate = buildForcedHandoffEnabledGate({
+    forcedHandoffEnabled: true,
+    expectedLinkedPrReferences: new Set(['77']),
+  });
+  const result = route(
+    forcedHandoffEvents({ contextScope: 'issue-plus-pr', linkedPr: '77' }),
+    gate,
+  );
+  assert.equal(result.state, 'already_owned');
+  assert.equal(result.active_claim?.claim_id, 'claim-new');
+});
+
+test('gate rejects an issue-plus-pr handoff naming a different PR', () => {
+  const gate = buildForcedHandoffEnabledGate({
+    forcedHandoffEnabled: true,
+    expectedLinkedPrReferences: new Set(['77']),
+  });
+  const result = route(
+    forcedHandoffEvents({ contextScope: 'issue-plus-pr', linkedPr: '88' }),
+    gate,
+  );
+  assert.equal(result.active_claim?.claim_id, 'claim-old');
+});
+
+test('gate honors an issue-only handoff when no open linked PR backs the claim', () => {
+  const gate = buildForcedHandoffEnabledGate({
+    forcedHandoffEnabled: true,
+    expectedLinkedPrReferences: new Set(),
+  });
+  const result = route(
+    forcedHandoffEvents({ contextScope: 'issue-only' }),
+    gate,
+  );
+  assert.equal(result.state, 'already_owned');
+  assert.equal(result.active_claim?.claim_id, 'claim-new');
+});
+
+test('gate never honors a forced handoff when forced-handoff mode is disabled', () => {
+  const gate = buildForcedHandoffEnabledGate({
+    forcedHandoffEnabled: false,
+    expectedLinkedPrReferences: new Set(),
+  });
+  const result = route(
+    forcedHandoffEvents({ contextScope: 'issue-plus-pr', linkedPr: '77' }),
+    gate,
+  );
+  assert.equal(result.active_claim?.claim_id, 'claim-old');
 });


### PR DESCRIPTION
Part of roadmap #910 (split out of #926).

## Problem

The resume CLI wired `isForcedHandoffEnabled: () => forcedHandoffEnabled`, ignoring the forced-handoff marker's `contextScope`/`linkedPr` and fetching no PR context. So a forced handoff that displaces a **PR-backed** claim was honored even with only `issue-only` evidence — whereas `summarizeClaimValidation` already gates such handoffs on `issue-plus-pr` + the named PR.

## Changes (`src/scripts/resume-claim-routing.mts`)

- **`buildForcedHandoffEnabledGate`** (exported, pure): mirrors `summarizeClaimValidation`'s gate — forced-handoff mode off → never honor; no open linked PR backs the claim (empty set, including the fail-safe lookup-error case) → honor an `issue-only` handoff as before; an open linked PR backs the claim → require `contextScope === 'issue-plus-pr'` whose `linkedPr` matches one of the expected PRs.
- **`fetchOpenLinkedPrReferences`**: detects the issue's open linked PR(s) via a precise signal — a PR connected via `CONNECTED_EVENT` (reconciled against later `DISCONNECTED_EVENT`s) that is currently `OPEN` — **not** a bare cross-reference/mention, so an unrelated open PR merely mentioning the issue does not falsely block a legitimate `issue-only` handoff. Fails safe to no enforcement on any lookup error.
- Wire the gate into the CLI; export `normalizeLinkedPrReference` from `protocol-helpers` for reuse.
- Regenerate both committed `.mjs` via `pnpm run build`.

## Tests

`tests/resume-claim-routing.test.mts` exercises the gate through `evaluateResumeClaimRouting`'s injected `isForcedHandoffEnabled` callback: against a PR-backed claim, an `issue-only` handoff is **not** honored and an `issue-plus-pr` one naming the PR **is** (and a mismatched PR is not); plus the no-linked-PR honor path and the mode-disabled path. Existing routing tests stay green (1040 tests pass).

## Note

The feature branch merges `origin/main` (a clean, non-overlapping merge) so the committed `.mjs` stays consistent with the latest `protocol-helpers` regeneration; `build:check` is clean.

Closes #955