### PR TITLE
fix(idd-doctor): make parsePrimaryWorktreePath CRLF/null-robust

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -184,7 +184,14 @@ function checkAutopilotSuitabilityConsistency(root, options, report) {
   }
 }
 export function parsePrimaryWorktreePath(porcelain) {
-  const lines = porcelain.split('\n');
+  if (typeof porcelain !== 'string') {
+    return null;
+  }
+  // Split on CRLF or LF so a CRLF porcelain line parses (a `\r` is not
+  // matched by `.` and `$` does not anchor before a trailing `\r`); this
+  // matches the `/\r?\n/` splitting used by the sibling helpers in this
+  // file.
+  const lines = porcelain.split(/\r?\n/);
   for (const line of lines) {
     const match = line.match(/^worktree (.+)$/);
     if (match) {

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -274,8 +274,15 @@ function checkAutopilotSuitabilityConsistency(
   }
 }
 
-export function parsePrimaryWorktreePath(porcelain: string): string | null {
-  const lines = porcelain.split('\n');
+export function parsePrimaryWorktreePath(porcelain: unknown): string | null {
+  if (typeof porcelain !== 'string') {
+    return null;
+  }
+  // Split on CRLF or LF so a CRLF porcelain line parses (a `\r` is not
+  // matched by `.` and `$` does not anchor before a trailing `\r`); this
+  // matches the `/\r?\n/` splitting used by the sibling helpers in this
+  // file.
+  const lines = porcelain.split(/\r?\n/);
   for (const line of lines) {
     const match = line.match(/^worktree (.+)$/);
     if (match) {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -332,6 +332,23 @@ test('parsePrimaryWorktreePath returns null when input has no worktree line', ()
   assert.equal(parsePrimaryWorktreePath('HEAD abc\nbranch main\n'), null);
 });
 
+test('parsePrimaryWorktreePath parses CRLF-delimited porcelain output', () => {
+  const porcelain = [
+    'worktree C:\\repo\\idd-skill',
+    'HEAD ec72ee60dea3b9eeeb6ca0d7717daa46b98dcc13',
+    'branch refs/heads/main',
+    '',
+  ].join('\r\n');
+
+  assert.equal(parsePrimaryWorktreePath(porcelain), 'C:\\repo\\idd-skill');
+});
+
+test('parsePrimaryWorktreePath returns null for null / undefined / non-string input', () => {
+  assert.equal(parsePrimaryWorktreePath(null), null);
+  assert.equal(parsePrimaryWorktreePath(undefined), null);
+  assert.equal(parsePrimaryWorktreePath(42), null);
+});
+
 test('classifyPrimaryHead flags issue/* branches as B1 violations', () => {
   assert.deepEqual(classifyPrimaryHead('issue/123-foo'), {
     isB1Violation: true,


### PR DESCRIPTION
## Summary

`parsePrimaryWorktreePath` in `src/scripts/idd-doctor.mts` split
`git worktree list --porcelain` output on `\n` only and assumed a string
input (a robustness gap a v0.3.0 downstream re-applied; #892).

- A CRLF porcelain line (`worktree C:\path\r`) failed the
  `/^worktree (.+)$/` match (`.` does not match `\r`, `$` does not anchor
  before a trailing `\r`) and returned `null`.
- A `null`/`undefined`/non-string input threw on `.split`.

## Changes

- Guard a non-string input (return `null`).
- Split on `/\r?\n/`, matching the CRLF-tolerant splitting already used by
  the sibling helpers in this file.
- `tests/idd-doctor.test.mts`: cover the CRLF and null/undefined/non-string
  cases.

## Verification

`pnpm run lint` (1048 tests, biome, dprint, cspell, markdownlint,
`audit-docs --check`) and `pnpm run build:check` pass.

Closes #960

Part of roadmap #892.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of Git integration to correctly handle both Unix and Windows line endings.
  * Added input validation to handle edge cases gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->