### PR TITLE
fix(authoring-label-guard): match the authoring label case-insensitively and trimmed

### DIFF
--- a/scripts/authoring-label-guard.mjs
+++ b/scripts/authoring-label-guard.mjs
@@ -103,5 +103,10 @@ function isMatchingLabeledEvent(event, labelName) {
   }
   const eventLabel =
     typeof event.label === 'string' ? event.label : event.label?.name;
-  return eventLabel === labelName;
+  if (typeof eventLabel !== 'string') {
+    return false;
+  }
+  // Match case-insensitively and trimmed so a label differing only in case
+  // or surrounding whitespace (e.g. " Status:Authoring ") still registers.
+  return eventLabel.trim().toLowerCase() === labelName.trim().toLowerCase();
 }

--- a/src/scripts/authoring-label-guard.mts
+++ b/src/scripts/authoring-label-guard.mts
@@ -144,5 +144,10 @@ function isMatchingLabeledEvent(event: LabelEvent, labelName: string): boolean {
     typeof event.label === 'string'
       ? event.label
       : (event.label as { name?: unknown } | null | undefined)?.name;
-  return eventLabel === labelName;
+  if (typeof eventLabel !== 'string') {
+    return false;
+  }
+  // Match case-insensitively and trimmed so a label differing only in case
+  // or surrounding whitespace (e.g. " Status:Authoring ") still registers.
+  return eventLabel.trim().toLowerCase() === labelName.trim().toLowerCase();
 }

--- a/tests/authoring-label-guard.test.mts
+++ b/tests/authoring-label-guard.test.mts
@@ -50,6 +50,23 @@ test('findLatestLabeledAt matches the label case-insensitively and trimmed', () 
   assert.equal(latest, '2026-05-15T11:00:00Z');
 });
 
+test('findLatestLabeledAt normalizes the configured labelName too', () => {
+  // labelName side carries mixed case + whitespace; the event label is the
+  // canonical form. Both sides must be normalized for this to match.
+  const latest = findLatestLabeledAt(
+    [
+      {
+        event: 'labeled',
+        label: { name: 'status:authoring' },
+        created_at: '2026-05-15T12:00:00Z',
+      },
+    ],
+    '  Status:AUTHORING  ',
+  );
+
+  assert.equal(latest, '2026-05-15T12:00:00Z');
+});
+
 test('findLatestLabeledAt still ignores a genuinely different label', () => {
   const latest = findLatestLabeledAt(
     [

--- a/tests/authoring-label-guard.test.mts
+++ b/tests/authoring-label-guard.test.mts
@@ -30,6 +30,41 @@ test('findLatestLabeledAt only accepts explicit labeled events', () => {
   assert.equal(latest, '2026-05-15T07:00:00Z');
 });
 
+test('findLatestLabeledAt matches the label case-insensitively and trimmed', () => {
+  const latest = findLatestLabeledAt(
+    [
+      {
+        event: 'labeled',
+        label: { name: ' Status:Authoring ' },
+        created_at: '2026-05-15T10:00:00Z',
+      },
+      {
+        event: 'labeled',
+        label: 'STATUS:AUTHORING',
+        created_at: '2026-05-15T11:00:00Z',
+      },
+    ],
+    'status:authoring',
+  );
+
+  assert.equal(latest, '2026-05-15T11:00:00Z');
+});
+
+test('findLatestLabeledAt still ignores a genuinely different label', () => {
+  const latest = findLatestLabeledAt(
+    [
+      {
+        event: 'labeled',
+        label: { name: 'status:blocked-by-human' },
+        created_at: '2026-05-15T10:00:00Z',
+      },
+    ],
+    'status:authoring',
+  );
+
+  assert.equal(latest, '');
+});
+
 test('buildAuthoringLabelWarning treats implicit events as timestamp unavailable', () => {
   const warning = buildAuthoringLabelWarning({
     issueNumber: 536,


### PR DESCRIPTION
Part of roadmap #892 (Harden IDD evidence helpers — robustness behaviors a v0.3.0 downstream re-applied).

## Problem

`isMatchingLabeledEvent` in `src/scripts/authoring-label-guard.mts` compared the timeline event's label to the configured authoring label name with a strict `===`, so a label differing only in **case** or surrounding **whitespace** (`"Status:Authoring"`, `" status:authoring "`) was not recognized as the authoring-guard label — the Discover authoring guard and its stale-authoring warning silently missed it.

## Change

- Match `eventLabel` and `labelName` after trimming and lower-casing both (case-insensitive, trimmed), guarding a non-string event label.

## Tests

`tests/authoring-label-guard.test.mts` gains a `findLatestLabeledAt` case/whitespace-variant match case (string and `{name}` forms) and a still-non-matching different-label case.

## Verification

`pnpm run typecheck`, `biome check`, `pnpm run build:check`, full `node --test tests/*.test.mts` (1048 tests), `audit-docs`/`dprint`/`markdownlint`/`cspell` all pass.

Closes #961