### PR TITLE
fix(idd-doctor): trim worktreeGuard.branchPatterns on read

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -804,10 +804,11 @@ export function readWorktreeGuardBranchPatterns(root) {
     ) {
       // Return trimmed patterns: a configured entry with surrounding
       // whitespace (e.g. `"issue/* "`) otherwise passes validation but
-      // never matches a real branch, silently covering nothing.
-      return patterns
-        .map((pattern) => pattern.trim())
-        .filter((pattern) => pattern.length > 0);
+      // never matches a real branch, silently covering nothing. The
+      // validation above stays fail-closed — any empty/whitespace-only or
+      // non-string entry invalidates the whole list and falls back to the
+      // defaults — so every surviving entry is non-empty after trim.
+      return patterns.map((pattern) => pattern.trim());
     }
   } catch {
     // fall through to defaults

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -802,7 +802,12 @@ export function readWorktreeGuardBranchPatterns(root) {
       patterns.length > 0 &&
       patterns.every((p) => typeof p === 'string' && p.trim().length > 0)
     ) {
-      return patterns;
+      // Return trimmed patterns: a configured entry with surrounding
+      // whitespace (e.g. `"issue/* "`) otherwise passes validation but
+      // never matches a real branch, silently covering nothing.
+      return patterns
+        .map((pattern) => pattern.trim())
+        .filter((pattern) => pattern.length > 0);
     }
   } catch {
     // fall through to defaults

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -950,10 +950,11 @@ export function readWorktreeGuardBranchPatterns(root: string): string[] {
     ) {
       // Return trimmed patterns: a configured entry with surrounding
       // whitespace (e.g. `"issue/* "`) otherwise passes validation but
-      // never matches a real branch, silently covering nothing.
-      return (patterns as string[])
-        .map((pattern) => pattern.trim())
-        .filter((pattern) => pattern.length > 0);
+      // never matches a real branch, silently covering nothing. The
+      // validation above stays fail-closed — any empty/whitespace-only or
+      // non-string entry invalidates the whole list and falls back to the
+      // defaults — so every surviving entry is non-empty after trim.
+      return (patterns as string[]).map((pattern) => pattern.trim());
     }
   } catch {
     // fall through to defaults

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -948,7 +948,12 @@ export function readWorktreeGuardBranchPatterns(root: string): string[] {
       patterns.length > 0 &&
       patterns.every((p) => typeof p === 'string' && p.trim().length > 0)
     ) {
-      return patterns;
+      // Return trimmed patterns: a configured entry with surrounding
+      // whitespace (e.g. `"issue/* "`) otherwise passes validation but
+      // never matches a real branch, silently covering nothing.
+      return (patterns as string[])
+        .map((pattern) => pattern.trim())
+        .filter((pattern) => pattern.length > 0);
     }
   } catch {
     // fall through to defaults

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -481,8 +481,24 @@ test('readWorktreeGuardBranchPatterns trims configured patterns and falls back w
       'issue/*',
       'release/*',
     ]);
-    // Whitespace-only entries are invalid -> fall back to defaults.
+    // Fail-closed: a single empty/whitespace-only entry invalidates the
+    // whole list and falls back to defaults (no partial honoring of a
+    // malformed config).
+    writeConfig({
+      worktreeGuard: { branchPatterns: ['issue/* ', ''] },
+    });
+    assert.deepEqual(
+      readWorktreeGuardBranchPatterns(dir),
+      DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
+    );
+    // Whitespace-only entries -> fall back to defaults.
     writeConfig({ worktreeGuard: { branchPatterns: ['  ', ''] } });
+    assert.deepEqual(
+      readWorktreeGuardBranchPatterns(dir),
+      DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
+    );
+    // A non-string entry is malformed -> fall back to defaults.
+    writeConfig({ worktreeGuard: { branchPatterns: ['issue/*', 42] } });
     assert.deepEqual(
       readWorktreeGuardBranchPatterns(dir),
       DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -461,6 +461,43 @@ test('readWorktreeGuardEnabled returns false when config is missing or invalid',
   }
 });
 
+test('readWorktreeGuardBranchPatterns trims configured patterns and falls back when invalid', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-'));
+  try {
+    const writeConfig = (obj: unknown) => {
+      mkdirSync(join(dir, '.github/idd'), { recursive: true });
+      writeFileSync(join(dir, '.github/idd/config.json'), JSON.stringify(obj));
+    };
+    // Missing config -> defaults.
+    assert.deepEqual(
+      readWorktreeGuardBranchPatterns(dir),
+      DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
+    );
+    // Surrounding whitespace is trimmed so the pattern matches real branches.
+    writeConfig({
+      worktreeGuard: { branchPatterns: ['  issue/* ', 'release/*\t'] },
+    });
+    assert.deepEqual(readWorktreeGuardBranchPatterns(dir), [
+      'issue/*',
+      'release/*',
+    ]);
+    // Whitespace-only entries are invalid -> fall back to defaults.
+    writeConfig({ worktreeGuard: { branchPatterns: ['  ', ''] } });
+    assert.deepEqual(
+      readWorktreeGuardBranchPatterns(dir),
+      DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
+    );
+    // Non-array -> defaults.
+    writeConfig({ worktreeGuard: { branchPatterns: 'issue/*' } });
+    assert.deepEqual(
+      readWorktreeGuardBranchPatterns(dir),
+      DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 const HARDENED_WORK =
   '## B1\n\n### Anti-patterns\n\ntext\n\n### B1 self-check\n\ntext\n';
 const HARDENED_CORE =


### PR DESCRIPTION
## Summary

`readWorktreeGuardBranchPatterns` in `src/scripts/idd-doctor.mts` validated
each configured pattern with `p.trim().length > 0` but returned the raw,
**untrimmed** array (a robustness gap a v0.3.0 downstream re-applied; #892).
A pattern with surrounding whitespace (e.g. `"issue/* "`) passed validation
yet never matched a real branch, so the guard silently covered nothing for
that entry.

## Changes

- Trim each returned pattern.
- Keep the existing **fail-closed** validation unchanged: any
  empty/whitespace-only or non-string entry invalidates the whole list and
  falls back to `DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS` (no partial
  honoring of a malformed config — consistent with the pre-existing
  `["", "issue/*"] → default` test). Every surviving entry is therefore
  non-empty after trim, so no separate "drop empty entries" step is needed.
- `tests/idd-doctor.test.mts`: cover the trim behavior plus the
  fail-closed empty-entry, whitespace-only, non-string, and non-array
  cases.

## Verification

`pnpm run lint` (1049 tests, biome, dprint, cspell, markdownlint,
`audit-docs --check`) and `pnpm run build:check` pass.

Closes #962

Part of roadmap #892.
