### PR TITLE
fix(idd-doctor): resolve the Project commands table from whichever overview file carries it

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -515,21 +515,36 @@ export function evaluateMarkerPrefixConsistency(
   }
   return { prefix: allPrefixes[0] };
 }
-function checkProjectCommands(root, report) {
-  const path = join(
-    root,
-    '.github/instructions/idd-overview-core.instructions.md',
-  );
-  let text = '';
-  try {
-    text = readFileSync(path, 'utf8');
-  } catch {
+// The Project commands table normally lives in idd-overview-core, but a
+// router/core split can keep it in idd-overview instead. Resolve whichever
+// candidate carries a non-empty table rather than hardcoding one file.
+const PROJECT_COMMANDS_CANDIDATE_FILES = [
+  '.github/instructions/idd-overview-core.instructions.md',
+  '.github/instructions/idd-overview.instructions.md',
+];
+export function checkProjectCommands(root, report) {
+  let commands = null;
+  let usedPath = '';
+  for (const rel of PROJECT_COMMANDS_CANDIDATE_FILES) {
+    let text;
+    try {
+      text = readFileSync(join(root, rel), 'utf8');
+    } catch {
+      continue;
+    }
+    const parsed = parseProjectCommandRows(text);
+    if (parsed.size > 0) {
+      commands = parsed;
+      usedPath = rel;
+      break;
+    }
+  }
+  if (!commands) {
     report.errors.push(
-      'cannot read .github/instructions/idd-overview-core.instructions.md',
+      `cannot find a Project commands table in any of: ${PROJECT_COMMANDS_CANDIDATE_FILES.join(', ')}`,
     );
     return null;
   }
-  const commands = parseProjectCommandRows(text);
   const requiredRows = [
     'fix-validate',
     'pre-push-validate',
@@ -539,7 +554,7 @@ function checkProjectCommands(root, report) {
   const missingRows = requiredRows.filter((row) => !commands.has(row));
   if (missingRows.length > 0) {
     report.errors.push(
-      `project commands table is missing rows: ${missingRows.join(', ')}`,
+      `project commands table (${usedPath}) is missing rows: ${missingRows.join(', ')}`,
     );
     return null;
   }

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -631,25 +631,41 @@ export function evaluateMarkerPrefixConsistency(
   return { prefix: allPrefixes[0] };
 }
 
-function checkProjectCommands(
+// The Project commands table normally lives in idd-overview-core, but a
+// router/core split can keep it in idd-overview instead. Resolve whichever
+// candidate carries a non-empty table rather than hardcoding one file.
+const PROJECT_COMMANDS_CANDIDATE_FILES = [
+  '.github/instructions/idd-overview-core.instructions.md',
+  '.github/instructions/idd-overview.instructions.md',
+];
+
+export function checkProjectCommands(
   root: string,
   report: DoctorReport,
 ): Map<string, string> | null {
-  const path = join(
-    root,
-    '.github/instructions/idd-overview-core.instructions.md',
-  );
-  let text = '';
-  try {
-    text = readFileSync(path, 'utf8');
-  } catch {
+  let commands: Map<string, string> | null = null;
+  let usedPath = '';
+  for (const rel of PROJECT_COMMANDS_CANDIDATE_FILES) {
+    let text: string;
+    try {
+      text = readFileSync(join(root, rel), 'utf8');
+    } catch {
+      continue;
+    }
+    const parsed = parseProjectCommandRows(text);
+    if (parsed.size > 0) {
+      commands = parsed;
+      usedPath = rel;
+      break;
+    }
+  }
+  if (!commands) {
     report.errors.push(
-      'cannot read .github/instructions/idd-overview-core.instructions.md',
+      `cannot find a Project commands table in any of: ${PROJECT_COMMANDS_CANDIDATE_FILES.join(', ')}`,
     );
     return null;
   }
 
-  const commands = parseProjectCommandRows(text);
   const requiredRows = [
     'fix-validate',
     'pre-push-validate',
@@ -659,7 +675,7 @@ function checkProjectCommands(
   const missingRows = requiredRows.filter((row) => !commands.has(row));
   if (missingRows.length > 0) {
     report.errors.push(
-      `project commands table is missing rows: ${missingRows.join(', ')}`,
+      `project commands table (${usedPath}) is missing rows: ${missingRows.join(', ')}`,
     );
     return null;
   }

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 
 import {
   backLinkPatternFor,
+  checkProjectCommands,
   classifyBacklog,
   classifyPrimaryHead,
   classifyWorktreeHeadFinding,
@@ -1365,4 +1366,81 @@ test('decodeGithubReadmeBase64 rejects literal jq-null and non-multiple-of-4 len
   // Base64 strings are always a multiple of 4 chars (with padding).
   assert.equal(decodeGithubReadmeBase64('abc'), null);
   assert.equal(decodeGithubReadmeBase64('abcde'), null);
+});
+
+// Minimal Project commands table (parseProjectCommandRows reads
+// `| **name** | `cmd` |` rows). At least one non-`true` value avoids the
+// all-no-op warning path.
+const PROJECT_COMMANDS_TABLE = [
+  '| Name | Commands |',
+  '| --- | --- |',
+  '| **fix-validate** | `npx dprint fmt` |',
+  '| **pre-push-validate** | `npx dprint check` |',
+  '| **post-fix-validate** | `npx dprint fmt` |',
+  '| **install-deps** | `true` |',
+  '',
+].join('\n');
+
+function makeOverviewFixture(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-pc-'));
+  mkdirSync(join(dir, '.github/instructions'), { recursive: true });
+  for (const [name, text] of Object.entries(files)) {
+    writeFileSync(join(dir, '.github/instructions', name), text);
+  }
+  return dir;
+}
+
+const emptyReport = (root: string) => ({
+  root,
+  errors: [] as string[],
+  warnings: [] as string[],
+  passes: [] as string[],
+});
+
+test('checkProjectCommands reads the table from idd-overview-core', () => {
+  const dir = makeOverviewFixture({
+    'idd-overview-core.instructions.md': PROJECT_COMMANDS_TABLE,
+  });
+  try {
+    const report = emptyReport(dir);
+    const commands = checkProjectCommands(dir, report);
+    assert.ok(commands instanceof Map);
+    assert.equal(commands?.get('fix-validate'), 'npx dprint fmt');
+    assert.deepEqual(report.errors, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkProjectCommands falls back to idd-overview on a router/core split', () => {
+  // core is a router with no commands table; the table lives in idd-overview.
+  const dir = makeOverviewFixture({
+    'idd-overview-core.instructions.md':
+      '# Router\n\nNo commands table here.\n',
+    'idd-overview.instructions.md': PROJECT_COMMANDS_TABLE,
+  });
+  try {
+    const report = emptyReport(dir);
+    const commands = checkProjectCommands(dir, report);
+    assert.ok(commands instanceof Map);
+    assert.equal(commands?.get('install-deps'), 'true');
+    assert.deepEqual(report.errors, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkProjectCommands errors when no overview file carries the table', () => {
+  const dir = makeOverviewFixture({
+    'idd-overview-core.instructions.md': '# Router\n\nNo table.\n',
+  });
+  try {
+    const report = emptyReport(dir);
+    const commands = checkProjectCommands(dir, report);
+    assert.equal(commands, null);
+    assert.equal(report.errors.length, 1);
+    assert.match(report.errors[0], /cannot find a Project commands table/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Part of roadmap #892 (Harden IDD evidence helpers — robustness behaviors a v0.3.0 downstream re-applied).

## Problem

`checkProjectCommands` hardcoded `.github/instructions/idd-overview-core.instructions.md` as the source of the Project commands table. A downstream that keeps that table in an `idd-overview` router file (a router/core split) makes `idd-doctor` red **independent of `--strict`**, because the hardcoded path doesn't carry the table.

## Change

- Resolve the table from whichever of `idd-overview-core` / `idd-overview` carries a **non-empty** table (`parseProjectCommandRows(...).size > 0`), trying `idd-overview-core` first (this repo's layout) then `idd-overview`, and only error when neither does. The missing-rows error now names the file that was actually used.
- Export `checkProjectCommands` so it can be unit-tested.

## Tests

`tests/idd-doctor.test.mts` adds temp-fixture cases for the `idd-overview-core` layout, the router/core split (`idd-overview-core` is a router with no table, `idd-overview` carries it), and the no-table-anywhere error.

## Verification

`pnpm run typecheck`, `biome check`, `pnpm run build:check`, full `node --test tests/*.test.mts` (1054 tests), and `audit-docs`/`dprint`/`markdownlint`/`cspell` all pass.

Closes #963