### PR TITLE
fix(external-check-waiver): match the waiver marker prefilter case-insensitively (marker-start)

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -483,7 +483,10 @@ export function summarizeExternalCheckWaivers(
   const malformed = [];
   for (const comment of comments ?? []) {
     const body = String(comment?.body ?? '');
-    if (!body.includes('idd-external-check-waiver')) continue;
+    // Prefilter on a marker-start, case-insensitive match aligned with
+    // parseExternalCheckWaiverComment's anchor — a case-sensitive substring
+    // skipped odd-cased markers and misclassified prose mentions as malformed.
+    if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) continue;
     const authorLogin = String(
       comment?.author?.login ?? comment?.user?.login ?? '',
     )

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1020,7 +1020,10 @@ export function summarizeExternalCheckWaivers(
 
   for (const comment of comments ?? []) {
     const body = String(comment?.body ?? '');
-    if (!body.includes('idd-external-check-waiver')) continue;
+    // Prefilter on a marker-start, case-insensitive match aligned with
+    // parseExternalCheckWaiverComment's anchor — a case-sensitive substring
+    // skipped odd-cased markers and misclassified prose mentions as malformed.
+    if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) continue;
 
     const authorLogin = String(
       comment?.author?.login ?? comment?.user?.login ?? '',

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2234,6 +2234,53 @@ test('summarizeExternalCheckWaivers: valid waiver is placed in valid bucket', ()
   assert.equal(result.valid[0].authorLogin, 'kurone-kito');
 });
 
+test('summarizeExternalCheckWaivers: an odd-cased marker is still recognized', () => {
+  const head = 'b'.repeat(40);
+  // Uppercase the marker token only; parseExternalCheckWaiverComment is
+  // case-insensitive, so the prefilter must not skip it.
+  const body = makeWaiverComment({
+    claimId: 'claim-123',
+    headSha: head,
+  }).replace(
+    '<!-- idd-external-check-waiver:',
+    '<!-- IDD-EXTERNAL-CHECK-WAIVER:',
+  );
+  const result = summarizeExternalCheckWaivers(
+    [
+      {
+        body,
+        author: { login: 'kurone-kito' },
+        createdAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    {
+      prHeadSha: head,
+      activeClaimId: 'claim-123',
+      trustedMarkerLogins: ['kurone-kito'],
+      now: '2026-05-17T00:00:00Z',
+    },
+  );
+  assert.equal(result.valid.length, 1);
+  assert.equal(result.malformed.length, 0);
+});
+
+test('summarizeExternalCheckWaivers: a prose mention of the marker name is ignored', () => {
+  const comment = {
+    body: 'We should document the idd-external-check-waiver flow for maintainers.',
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: 'b'.repeat(40),
+    activeClaimId: 'claim-123',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T00:00:00Z',
+  });
+  // Not a marker at the start of the body — must not be counted as malformed.
+  assert.equal(result.malformed.length, 0);
+  assert.equal(result.valid.length, 0);
+});
+
 test('summarizeExternalCheckWaivers: expired waiver goes to expired bucket', () => {
   const head = 'c'.repeat(40);
   const body = makeWaiverComment({


### PR DESCRIPTION
Part of roadmap #892 (Harden IDD evidence helpers). One of the two residual sub-items of the "External-check-waiver F2 consumption gates" gap (the core gating is already implemented; the `notConfigured`/waivable-only-coverage residual is split out separately as a larger, design-touching change).

## Problem

`summarizeExternalCheckWaivers` (`src/scripts/protocol-helpers.mts`) prefiltered comments with a **case-sensitive substring** (`body.includes('idd-external-check-waiver')`). The real parser (`parseExternalCheckWaiverComment`) is already case-insensitive (`/.../i`) and marker-start-anchored, but the prefilter ran first:

- an **odd-cased** marker (`<!-- IDD-EXTERNAL-CHECK-WAIVER: … -->`) failed the `includes` and was skipped before it could parse → a real waiver missed;
- a **prose mention** of the marker name passed the substring prefilter and was then recorded as `malformed`.

## Change

- Prefilter on a marker-start, case-insensitive match aligned with the parser's anchor: `/^<!--\s*idd-external-check-waiver:/i.test(body)`.

## Tests

`tests/pre-merge-readiness.test.mts` (where `summarizeExternalCheckWaivers` is already tested) gains an odd-cased-marker case (now in the `valid` bucket) and a prose-mention case (now ignored, not `malformed`). _(The issue suggested `tests/external-check-waiver.test.mts`, but the function's tests live in `pre-merge-readiness.test.mts`.)_

## Verification

`pnpm run typecheck`, `biome check`, `pnpm run build:check`, full `node --test tests/*.test.mts` (1046 tests), and `audit-docs`/`dprint`/`markdownlint`/`cspell` all pass.

Closes #970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external-check-waiver comment detection accuracy by reducing false positives from unrelated text mentions.

* **Tests**
  * Added tests verifying case-insensitive marker recognition and proper handling of prose mentions without proper formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->