### PR TITLE
fix(external-check-waiver): gate coverage to configured waivable checks

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -344,9 +344,11 @@ The adopted helper boundaries are intentionally narrow:
   unreplied comments, reviewer states, advisory state, CI, claim
   validation, and `waiverEvidence` (parsed external-check waiver comments
   classified as `valid`, `expired`, `wrongHead`, `wrongClaim`,
-  `unauthorized`, or `malformed`; checks covered by a valid waiver are
-  reported with `coveredByWaiver: true` and treated as passing by the CI
-  gate)
+  `unauthorized`, `malformed`, or `notConfigured` — the last for a valid
+  waiver naming a check the policy never declared waivable in
+  `ciGate.externalChecks.waivable`; only a `valid` waiver for a
+  configured-waivable check is reported with `coveredByWaiver: true` and
+  treated as passing by the CI gate)
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence

--- a/fixtures/pre-merge-readiness/ack-only-current.json
+++ b/fixtures/pre-merge-readiness/ack-only-current.json
@@ -329,7 +329,8 @@
       "wrongHead": [],
       "wrongClaim": [],
       "unauthorized": [],
-      "malformed": []
+      "malformed": [],
+      "notConfigured": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -263,7 +263,8 @@
       "wrongHead": [],
       "wrongClaim": [],
       "unauthorized": [],
-      "malformed": []
+      "malformed": [],
+      "notConfigured": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -267,7 +267,8 @@
       "wrongHead": [],
       "wrongClaim": [],
       "unauthorized": [],
-      "malformed": []
+      "malformed": [],
+      "notConfigured": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -291,7 +291,8 @@
       "wrongHead": [],
       "wrongClaim": [],
       "unauthorized": [],
-      "malformed": []
+      "malformed": [],
+      "notConfigured": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -291,7 +291,8 @@
       "wrongHead": [],
       "wrongClaim": [],
       "unauthorized": [],
-      "malformed": []
+      "malformed": [],
+      "notConfigured": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -291,7 +291,8 @@
       "wrongHead": [],
       "wrongClaim": [],
       "unauthorized": [],
-      "malformed": []
+      "malformed": [],
+      "notConfigured": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -277,7 +277,8 @@
       "wrongHead": [],
       "wrongClaim": [],
       "unauthorized": [],
-      "malformed": []
+      "malformed": [],
+      "notConfigured": []
     }
   }
 }

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -291,7 +291,8 @@
       "wrongHead": [],
       "wrongClaim": [],
       "unauthorized": [],
-      "malformed": []
+      "malformed": [],
+      "notConfigured": []
     }
   }
 }

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -170,6 +170,7 @@
     "wrongHead": [],
     "wrongClaim": [],
     "unauthorized": [],
-    "malformed": []
+    "malformed": [],
+    "notConfigured": []
   }
 }

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -344,9 +344,11 @@ The adopted helper boundaries are intentionally narrow:
   unreplied comments, reviewer states, advisory state, CI, claim
   validation, and `waiverEvidence` (parsed external-check waiver comments
   classified as `valid`, `expired`, `wrongHead`, `wrongClaim`,
-  `unauthorized`, or `malformed`; checks covered by a valid waiver are
-  reported with `coveredByWaiver: true` and treated as passing by the CI
-  gate)
+  `unauthorized`, `malformed`, or `notConfigured` — the last for a valid
+  waiver naming a check the policy never declared waivable in
+  `ciGate.externalChecks.waivable`; only a `valid` waiver for a
+  configured-waivable check is reported with `coveredByWaiver: true` and
+  treated as passing by the CI gate)
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -950,7 +950,8 @@
         "wrongHead",
         "wrongClaim",
         "unauthorized",
-        "malformed"
+        "malformed",
+        "notConfigured"
       ],
       "additionalProperties": false,
       "properties": {
@@ -1087,6 +1088,29 @@
                 "type": "string"
               },
               "bodyPreview": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "notConfigured": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "authorLogin",
+              "checkSelector",
+              "expiresAt"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "authorLogin": {
+                "type": "string"
+              },
+              "checkSelector": {
+                "type": "string"
+              },
+              "expiresAt": {
                 "type": "string"
               }
             }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -12,7 +12,10 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mjs';
-import { resolveCollaboratorMarkerTrust } from './policy-helpers.mjs';
+import {
+  normalizePolicyConfig,
+  resolveCollaboratorMarkerTrust,
+} from './policy-helpers.mjs';
 import {
   buildPreMergeReadinessSummary,
   deriveIddAgentLogins,
@@ -163,6 +166,7 @@ const advisoryWaitPolicy = readAdvisoryWaitPolicy();
 const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
 const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
 const forcedHandoffPermissionCache = new Map();
+const waivableCheckSelectors = readWaivableCheckSelectors();
 const summary = buildPreMergeReadinessSummary(
   {
     prHeadSha,
@@ -196,6 +200,7 @@ const summary = buildPreMergeReadinessSummary(
     settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
     pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
     capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
+    waivableCheckSelectors,
     forcedHandoffEnabled,
     expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
     isAuthorizedForcedHandoff: (forcedBy) =>
@@ -691,6 +696,21 @@ function readCollaboratorTrustEnabled() {
     // Fall through to env-var fallback.
   }
   return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
+}
+// Configured waivable external-check selectors (`ciGate.externalChecks.
+// waivable`). The F2 gate only lets a valid waiver fold a check into
+// `requiredChecksPassing` when that check sits on this surface; an absent or
+// unreadable config yields an empty list (nothing waivable).
+function readWaivableCheckSelectors() {
+  try {
+    return [
+      ...normalizePolicyConfig(
+        JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+      ).ciGate.externalChecks.waivable,
+    ];
+  } catch {
+    return [];
+  }
 }
 function loadIddConfig() {
   try {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -452,15 +452,35 @@ export function renderReviewBaselineMarker(payload) {
     `_${agentId}: critique baseline — IDD automation marker. Do not edit._`,
   ].join('\n');
 }
-function matchCheckSelectorLocal(name, selector) {
+function matchCheckSelectorLocal(name, selector, matchMode) {
   const n = String(name ?? '').trim();
   const s = String(selector ?? '').trim();
   if (!n || !s) return false;
-  if (s.includes('*')) {
+  // An explicit matchMode wins; otherwise infer glob from a `*` in the
+  // selector (the legacy behavior every existing two-argument caller relies
+  // on, e.g. waiver-selector vs check-name coverage matching).
+  const useGlob =
+    matchMode === undefined ? s.includes('*') : matchMode === 'glob';
+  if (useGlob) {
     const source = s.replace(/[|\\{}()[\]^$+?.]/g, '\\$&').replace(/\*/g, '.*');
     return new RegExp(`^${source}$`).test(n);
   }
   return n === s;
+}
+/**
+ * True when `target` matches any configured waivable selector, honoring each
+ * selector's own `matchMode`. Mirrors the creation-path gate in
+ * `planExternalCheckWaiver` so the consumption and creation paths agree on
+ * which checks a waiver may cover.
+ */
+function matchesConfiguredWaivableSelector(target, waivableSelectors) {
+  return waivableSelectors.some((sel) =>
+    matchCheckSelectorLocal(
+      target,
+      sel?.selector,
+      sel?.matchMode === 'glob' ? 'glob' : 'exact',
+    ),
+  );
 }
 export function summarizeExternalCheckWaivers(
   comments,
@@ -469,6 +489,7 @@ export function summarizeExternalCheckWaivers(
     activeClaimId = '',
     trustedMarkerLogins = [],
     now = '',
+    waivableSelectors = null,
   } = {},
 ) {
   const trustedSet = new Set(normalizeTrustedMarkerLogins(trustedMarkerLogins));
@@ -481,6 +502,7 @@ export function summarizeExternalCheckWaivers(
   const wrongClaim = [];
   const unauthorized = [];
   const malformed = [];
+  const notConfigured = [];
   for (const comment of comments ?? []) {
     const body = String(comment?.body ?? '');
     // Prefilter on a marker-start, case-insensitive match aligned with
@@ -531,6 +553,24 @@ export function summarizeExternalCheckWaivers(
       });
       continue;
     }
+    // When the policy declares its waivable surface, a valid waiver still only
+    // counts when its selector names a configured-waivable check; otherwise it
+    // is reported but never folds a check in. A null/undefined list disables
+    // the gate (legacy callers), an empty list waives nothing.
+    if (
+      Array.isArray(waivableSelectors) &&
+      !matchesConfiguredWaivableSelector(
+        parsed.checkSelector,
+        waivableSelectors,
+      )
+    ) {
+      notConfigured.push({
+        authorLogin,
+        checkSelector: parsed.checkSelector,
+        expiresAt: parsed.expiresAt,
+      });
+      continue;
+    }
     valid.push({
       authorLogin,
       checkSelector: parsed.checkSelector,
@@ -538,7 +578,15 @@ export function summarizeExternalCheckWaivers(
       expiresAt: parsed.expiresAt,
     });
   }
-  return { valid, expired, wrongHead, wrongClaim, unauthorized, malformed };
+  return {
+    valid,
+    expired,
+    wrongHead,
+    wrongClaim,
+    unauthorized,
+    malformed,
+    notConfigured,
+  };
 }
 export function parseExternalCheckWaiverComment(body, createdAt) {
   const match = body
@@ -2395,7 +2443,7 @@ export function summarizeRequiredChecks(
   checks = [],
   branchRules = [],
   branchProtection = {},
-  { waivers = null } = {},
+  { waivers = null, waivableSelectors = null } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(
     branchRules,
@@ -2415,7 +2463,14 @@ export function summarizeRequiredChecks(
     const state = String(check.state ?? '').toUpperCase();
     const coveredByWaiver =
       !SUCCESS_STATES.has(state) &&
-      validWaivers.some((w) => matchCheckSelectorLocal(name, w.checkSelector));
+      validWaivers.some((w) =>
+        matchCheckSelectorLocal(name, w.checkSelector),
+      ) &&
+      // The check must also sit on the policy's waivable surface. A
+      // null/undefined list keeps the legacy behavior with no gate; an empty
+      // configured list covers nothing.
+      (!Array.isArray(waivableSelectors) ||
+        matchesConfiguredWaivableSelector(name, waivableSelectors));
     return {
       name,
       state,
@@ -3179,14 +3234,17 @@ export function buildPreMergeReadinessSummary(
     expectedClaimId: options.expectedClaimId,
     expectedAgentId: options.expectedAgentId,
   });
+  const waivableCheckSelectors = options.waivableCheckSelectors ?? null;
   const waiverEvidence = summarizeExternalCheckWaivers(comments, {
     prHeadSha,
     activeClaimId: claim.activeClaim?.claimId ?? options.activeClaimId ?? '',
     trustedMarkerLogins,
     now,
+    waivableSelectors: waivableCheckSelectors,
   });
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
     waivers: waiverEvidence,
+    waivableSelectors: waivableCheckSelectors,
   });
   const dispositionEvidence = options.includeDispositionEvidence
     ? summarizeDispositionEvidenceForGate(

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -468,18 +468,42 @@ function matchCheckSelectorLocal(name, selector, matchMode) {
   return n === s;
 }
 /**
- * True when `target` matches any configured waivable selector, honoring each
- * selector's own `matchMode`. Mirrors the creation-path gate in
- * `planExternalCheckWaiver` so the consumption and creation paths agree on
- * which checks a waiver may cover.
+ * True when a concrete check `name` matches any configured waivable selector,
+ * honoring each selector's own `matchMode`. Used to gate whether a present
+ * check sits on the policy's waivable surface.
  */
-function matchesConfiguredWaivableSelector(target, waivableSelectors) {
+function isCheckNameConfiguredWaivable(name, waivableSelectors) {
   return waivableSelectors.some((sel) =>
     matchCheckSelectorLocal(
-      target,
+      name,
       sel?.selector,
       sel?.matchMode === 'glob' ? 'glob' : 'exact',
     ),
+  );
+}
+/**
+ * True when a waiver's `checkSelector` can name a check that the policy
+ * declared waivable. Unlike a concrete check name, a waiver selector may
+ * itself be a glob, so this tests both directions: the waiver selector
+ * against each configured pattern, and each configured selector against the
+ * waiver pattern (glob inferred from `*`). Either direction means the two
+ * selectors can resolve to a common check — e.g. a glob waiver `Code*`
+ * overlaps an exact waivable `CodeRabbit`. This mirrors the creation-path
+ * gate in `planExternalCheckWaiver`, which validates glob waivers against the
+ * actual matched checks, so a legitimately created waiver is not wrongly
+ * bucketed as `notConfigured` at consumption.
+ */
+function waiverSelectorOverlapsConfiguredWaivable(
+  waiverSelector,
+  waivableSelectors,
+) {
+  return waivableSelectors.some(
+    (sel) =>
+      matchCheckSelectorLocal(
+        waiverSelector,
+        sel?.selector,
+        sel?.matchMode === 'glob' ? 'glob' : 'exact',
+      ) || matchCheckSelectorLocal(sel?.selector, waiverSelector),
   );
 }
 export function summarizeExternalCheckWaivers(
@@ -554,12 +578,14 @@ export function summarizeExternalCheckWaivers(
       continue;
     }
     // When the policy declares its waivable surface, a valid waiver still only
-    // counts when its selector names a configured-waivable check; otherwise it
-    // is reported but never folds a check in. A null/undefined list disables
-    // the gate (legacy callers), an empty list waives nothing.
+    // counts when its selector can name a configured-waivable check; otherwise
+    // it is reported but never folds a check in. The overlap test treats the
+    // waiver selector as a possible glob so a `Code*` waiver still matches an
+    // exact `CodeRabbit` surface. A null/undefined list disables the gate
+    // (legacy callers), an empty list waives nothing.
     if (
       Array.isArray(waivableSelectors) &&
-      !matchesConfiguredWaivableSelector(
+      !waiverSelectorOverlapsConfiguredWaivable(
         parsed.checkSelector,
         waivableSelectors,
       )
@@ -2470,7 +2496,7 @@ export function summarizeRequiredChecks(
       // null/undefined list keeps the legacy behavior with no gate; an empty
       // configured list covers nothing.
       (!Array.isArray(waivableSelectors) ||
-        matchesConfiguredWaivableSelector(name, waivableSelectors));
+        isCheckNameConfiguredWaivable(name, waivableSelectors));
     return {
       name,
       state,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -15,7 +15,10 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mts';
-import { resolveCollaboratorMarkerTrust } from './policy-helpers.mts';
+import {
+  normalizePolicyConfig,
+  resolveCollaboratorMarkerTrust,
+} from './policy-helpers.mts';
 import type { TrustedMarkerActorResolution } from './protocol-helpers.mts';
 import {
   buildPreMergeReadinessSummary,
@@ -331,6 +334,7 @@ const advisoryWaitPolicy = readAdvisoryWaitPolicy();
 const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
 const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
 const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
+const waivableCheckSelectors = readWaivableCheckSelectors();
 
 const summary = buildPreMergeReadinessSummary(
   {
@@ -365,6 +369,7 @@ const summary = buildPreMergeReadinessSummary(
     settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
     pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
     capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
+    waivableCheckSelectors,
     forcedHandoffEnabled,
     expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
     isAuthorizedForcedHandoff: (forcedBy) =>
@@ -948,6 +953,25 @@ function readCollaboratorTrustEnabled(): boolean {
     // Fall through to env-var fallback.
   }
   return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
+}
+
+// Configured waivable external-check selectors (`ciGate.externalChecks.
+// waivable`). The F2 gate only lets a valid waiver fold a check into
+// `requiredChecksPassing` when that check sits on this surface; an absent or
+// unreadable config yields an empty list (nothing waivable).
+function readWaivableCheckSelectors(): {
+  selector?: unknown;
+  matchMode?: unknown;
+}[] {
+  try {
+    return [
+      ...normalizePolicyConfig(
+        JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+      ).ciGate.externalChecks.waivable,
+    ];
+  } catch {
+    return [];
+  }
 }
 
 function loadIddConfig(): {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1012,21 +1012,46 @@ function matchCheckSelectorLocal(
 }
 
 /**
- * True when `target` matches any configured waivable selector, honoring each
- * selector's own `matchMode`. Mirrors the creation-path gate in
- * `planExternalCheckWaiver` so the consumption and creation paths agree on
- * which checks a waiver may cover.
+ * True when a concrete check `name` matches any configured waivable selector,
+ * honoring each selector's own `matchMode`. Used to gate whether a present
+ * check sits on the policy's waivable surface.
  */
-function matchesConfiguredWaivableSelector(
-  target: unknown,
+function isCheckNameConfiguredWaivable(
+  name: unknown,
   waivableSelectors: { selector?: unknown; matchMode?: unknown }[],
 ): boolean {
   return waivableSelectors.some((sel) =>
     matchCheckSelectorLocal(
-      target,
+      name,
       sel?.selector,
       sel?.matchMode === 'glob' ? 'glob' : 'exact',
     ),
+  );
+}
+
+/**
+ * True when a waiver's `checkSelector` can name a check that the policy
+ * declared waivable. Unlike a concrete check name, a waiver selector may
+ * itself be a glob, so this tests both directions: the waiver selector
+ * against each configured pattern, and each configured selector against the
+ * waiver pattern (glob inferred from `*`). Either direction means the two
+ * selectors can resolve to a common check — e.g. a glob waiver `Code*`
+ * overlaps an exact waivable `CodeRabbit`. This mirrors the creation-path
+ * gate in `planExternalCheckWaiver`, which validates glob waivers against the
+ * actual matched checks, so a legitimately created waiver is not wrongly
+ * bucketed as `notConfigured` at consumption.
+ */
+function waiverSelectorOverlapsConfiguredWaivable(
+  waiverSelector: unknown,
+  waivableSelectors: { selector?: unknown; matchMode?: unknown }[],
+): boolean {
+  return waivableSelectors.some(
+    (sel) =>
+      matchCheckSelectorLocal(
+        waiverSelector,
+        sel?.selector,
+        sel?.matchMode === 'glob' ? 'glob' : 'exact',
+      ) || matchCheckSelectorLocal(sel?.selector, waiverSelector),
   );
 }
 
@@ -1117,12 +1142,14 @@ export function summarizeExternalCheckWaivers(
     }
 
     // When the policy declares its waivable surface, a valid waiver still only
-    // counts when its selector names a configured-waivable check; otherwise it
-    // is reported but never folds a check in. A null/undefined list disables
-    // the gate (legacy callers), an empty list waives nothing.
+    // counts when its selector can name a configured-waivable check; otherwise
+    // it is reported but never folds a check in. The overlap test treats the
+    // waiver selector as a possible glob so a `Code*` waiver still matches an
+    // exact `CodeRabbit` surface. A null/undefined list disables the gate
+    // (legacy callers), an empty list waives nothing.
     if (
       Array.isArray(waivableSelectors) &&
-      !matchesConfiguredWaivableSelector(
+      !waiverSelectorOverlapsConfiguredWaivable(
         parsed.checkSelector,
         waivableSelectors,
       )
@@ -3383,7 +3410,7 @@ export function summarizeRequiredChecks(
       // null/undefined list keeps the legacy behavior with no gate; an empty
       // configured list covers nothing.
       (!Array.isArray(waivableSelectors) ||
-        matchesConfiguredWaivableSelector(name, waivableSelectors));
+        isCheckNameConfiguredWaivable(name, waivableSelectors));
     return {
       name,
       state,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -335,6 +335,16 @@ export interface ExternalCheckWaiverEvidence {
     expiresAt: string;
   }[];
   malformed: { authorLogin: string; bodyPreview: string }[];
+  /**
+   * Waivers that passed every validity check but name a check the policy
+   * never declared waivable (`ciGate.externalChecks.waivable`); they are
+   * excluded from `valid` and never fold a check into `requiredChecksPassing`.
+   */
+  notConfigured: {
+    authorLogin: string;
+    checkSelector: string;
+    expiresAt: string;
+  }[];
 }
 
 /** Classification outcome for a single review thread at the gate. */
@@ -981,15 +991,43 @@ export function renderReviewBaselineMarker(payload: {
   ].join('\n');
 }
 
-function matchCheckSelectorLocal(name: unknown, selector: unknown): boolean {
+function matchCheckSelectorLocal(
+  name: unknown,
+  selector: unknown,
+  matchMode?: 'exact' | 'glob',
+): boolean {
   const n = String(name ?? '').trim();
   const s = String(selector ?? '').trim();
   if (!n || !s) return false;
-  if (s.includes('*')) {
+  // An explicit matchMode wins; otherwise infer glob from a `*` in the
+  // selector (the legacy behavior every existing two-argument caller relies
+  // on, e.g. waiver-selector vs check-name coverage matching).
+  const useGlob =
+    matchMode === undefined ? s.includes('*') : matchMode === 'glob';
+  if (useGlob) {
     const source = s.replace(/[|\\{}()[\]^$+?.]/g, '\\$&').replace(/\*/g, '.*');
     return new RegExp(`^${source}$`).test(n);
   }
   return n === s;
+}
+
+/**
+ * True when `target` matches any configured waivable selector, honoring each
+ * selector's own `matchMode`. Mirrors the creation-path gate in
+ * `planExternalCheckWaiver` so the consumption and creation paths agree on
+ * which checks a waiver may cover.
+ */
+function matchesConfiguredWaivableSelector(
+  target: unknown,
+  waivableSelectors: { selector?: unknown; matchMode?: unknown }[],
+): boolean {
+  return waivableSelectors.some((sel) =>
+    matchCheckSelectorLocal(
+      target,
+      sel?.selector,
+      sel?.matchMode === 'glob' ? 'glob' : 'exact',
+    ),
+  );
 }
 
 export function summarizeExternalCheckWaivers(
@@ -999,11 +1037,13 @@ export function summarizeExternalCheckWaivers(
     activeClaimId = '',
     trustedMarkerLogins = [],
     now = '',
+    waivableSelectors = null,
   }: {
     prHeadSha?: string;
     activeClaimId?: unknown;
     trustedMarkerLogins?: unknown[];
     now?: string;
+    waivableSelectors?: { selector?: unknown; matchMode?: unknown }[] | null;
   } = {},
 ): ExternalCheckWaiverEvidence {
   const trustedSet = new Set(normalizeTrustedMarkerLogins(trustedMarkerLogins));
@@ -1017,6 +1057,7 @@ export function summarizeExternalCheckWaivers(
   const wrongClaim: ExternalCheckWaiverEvidence['wrongClaim'] = [];
   const unauthorized: ExternalCheckWaiverEvidence['unauthorized'] = [];
   const malformed: ExternalCheckWaiverEvidence['malformed'] = [];
+  const notConfigured: ExternalCheckWaiverEvidence['notConfigured'] = [];
 
   for (const comment of comments ?? []) {
     const body = String(comment?.body ?? '');
@@ -1075,6 +1116,25 @@ export function summarizeExternalCheckWaivers(
       continue;
     }
 
+    // When the policy declares its waivable surface, a valid waiver still only
+    // counts when its selector names a configured-waivable check; otherwise it
+    // is reported but never folds a check in. A null/undefined list disables
+    // the gate (legacy callers), an empty list waives nothing.
+    if (
+      Array.isArray(waivableSelectors) &&
+      !matchesConfiguredWaivableSelector(
+        parsed.checkSelector,
+        waivableSelectors,
+      )
+    ) {
+      notConfigured.push({
+        authorLogin,
+        checkSelector: parsed.checkSelector,
+        expiresAt: parsed.expiresAt,
+      });
+      continue;
+    }
+
     valid.push({
       authorLogin,
       checkSelector: parsed.checkSelector,
@@ -1083,7 +1143,15 @@ export function summarizeExternalCheckWaivers(
     });
   }
 
-  return { valid, expired, wrongHead, wrongClaim, unauthorized, malformed };
+  return {
+    valid,
+    expired,
+    wrongHead,
+    wrongClaim,
+    unauthorized,
+    malformed,
+    notConfigured,
+  };
 }
 
 export function parseExternalCheckWaiverComment(
@@ -3283,8 +3351,10 @@ export function summarizeRequiredChecks(
   branchProtection: BranchProtectionLike = {},
   {
     waivers = null,
+    waivableSelectors = null,
   }: {
     waivers?: { valid?: { checkSelector?: unknown }[] | null } | null;
+    waivableSelectors?: { selector?: unknown; matchMode?: unknown }[] | null;
   } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(
@@ -3306,7 +3376,14 @@ export function summarizeRequiredChecks(
     const state = String(check.state ?? '').toUpperCase();
     const coveredByWaiver =
       !SUCCESS_STATES.has(state) &&
-      validWaivers.some((w) => matchCheckSelectorLocal(name, w.checkSelector));
+      validWaivers.some((w) =>
+        matchCheckSelectorLocal(name, w.checkSelector),
+      ) &&
+      // The check must also sit on the policy's waivable surface. A
+      // null/undefined list keeps the legacy behavior with no gate; an empty
+      // configured list covers nothing.
+      (!Array.isArray(waivableSelectors) ||
+        matchesConfiguredWaivableSelector(name, waivableSelectors));
     return {
       name,
       state,
@@ -4102,6 +4179,9 @@ export function buildPreMergeReadinessSummary(
     settledWindowMinutes?: number;
     pollIntervalMinutes?: number;
     capExhaustedRoute?: string;
+    waivableCheckSelectors?:
+      | { selector?: unknown; matchMode?: unknown }[]
+      | null;
   } = {},
 ) {
   const now = String(options.now ?? '');
@@ -4219,14 +4299,17 @@ export function buildPreMergeReadinessSummary(
     expectedClaimId: options.expectedClaimId,
     expectedAgentId: options.expectedAgentId,
   });
+  const waivableCheckSelectors = options.waivableCheckSelectors ?? null;
   const waiverEvidence = summarizeExternalCheckWaivers(comments, {
     prHeadSha,
     activeClaimId: claim.activeClaim?.claimId ?? options.activeClaimId ?? '',
     trustedMarkerLogins,
     now,
+    waivableSelectors: waivableCheckSelectors,
   });
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
     waivers: waiverEvidence,
+    waivableSelectors: waivableCheckSelectors,
   });
 
   const dispositionEvidence = options.includeDispositionEvidence

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2799,6 +2799,67 @@ test('summarizeRequiredChecks: an empty waivable list covers nothing', () => {
   assert.notEqual(result.status, 'success');
 });
 
+test('summarizeExternalCheckWaivers: a glob waiver selector overlaps an exact waivable surface', () => {
+  const head = 'f'.repeat(40);
+  // A glob waiver "Code*" against an exact waivable "CodeRabbit" must stay
+  // valid: planExternalCheckWaiver creates such globs, so misbucketing them as
+  // notConfigured would silently drop a legitimate waiver.
+  const body = makeWaiverComment({
+    claimId: 'claim-123',
+    headSha: head,
+    checkSelector: 'Code*',
+  });
+  const result = summarizeExternalCheckWaivers(
+    [
+      {
+        body,
+        author: { login: 'kurone-kito' },
+        createdAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    {
+      prHeadSha: head,
+      activeClaimId: 'claim-123',
+      trustedMarkerLogins: ['kurone-kito'],
+      now: '2026-05-17T00:00:00Z',
+      waivableSelectors: [{ selector: 'CodeRabbit', matchMode: 'exact' }],
+    },
+  );
+  assert.equal(result.valid.length, 1);
+  assert.equal(result.valid[0].checkSelector, 'Code*');
+  assert.equal(result.notConfigured.length, 0);
+});
+
+test('summarizeRequiredChecks: a glob waiver folds in an exact-configured-waivable check', () => {
+  const waivers = {
+    valid: [
+      {
+        authorLogin: 'kurone-kito',
+        checkSelector: 'Code*',
+        reason: 'rate-limit',
+        expiresAt: '2099-01-01T00:00:00Z',
+      },
+    ],
+    expired: [],
+    wrongHead: [],
+    wrongClaim: [],
+    unauthorized: [],
+    malformed: [],
+    notConfigured: [],
+  };
+  const result = summarizeRequiredChecks(
+    [{ name: 'CodeRabbit', state: 'FAILURE', completedAt: '' }],
+    [],
+    { required_status_checks: { contexts: ['CodeRabbit'] } },
+    {
+      waivers,
+      waivableSelectors: [{ selector: 'CodeRabbit', matchMode: 'exact' }],
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, true);
+  assert.equal(result.status, 'success');
+});
+
 test('buildPreMergeReadinessSummary: waiverEvidence always present and validates against schema', () => {
   const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
   const summary = buildPreMergeReadinessSummary(fixture.input, fixture.options);

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2212,6 +2212,7 @@ test('summarizeExternalCheckWaivers: empty comments returns all-empty evidence',
     wrongClaim: [],
     unauthorized: [],
     malformed: [],
+    notConfigured: [],
   });
 });
 
@@ -2553,6 +2554,7 @@ test('summarizeExternalCheckWaivers: non-waiver comments are skipped without err
     wrongClaim: [],
     unauthorized: [],
     malformed: [],
+    notConfigured: [],
   });
 });
 
@@ -2592,6 +2594,211 @@ test('summarizeRequiredChecks: waiver with glob selector covers matching failing
   );
 });
 
+test('summarizeExternalCheckWaivers: validity-passing waiver for a non-waivable check goes to notConfigured', () => {
+  const head = 'e'.repeat(40);
+  // The waiver names "CodeRabbit" but the policy only declares "deploy/prod"
+  // waivable, so it is reported but must not count as valid.
+  const body = makeWaiverComment({ claimId: 'claim-123', headSha: head });
+  const result = summarizeExternalCheckWaivers(
+    [
+      {
+        body,
+        author: { login: 'kurone-kito' },
+        createdAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    {
+      prHeadSha: head,
+      activeClaimId: 'claim-123',
+      trustedMarkerLogins: ['kurone-kito'],
+      now: '2026-05-17T00:00:00Z',
+      waivableSelectors: [{ selector: 'deploy/prod', matchMode: 'exact' }],
+    },
+  );
+  assert.equal(result.valid.length, 0);
+  assert.equal(result.notConfigured.length, 1);
+  assert.equal(result.notConfigured[0].checkSelector, 'CodeRabbit');
+  assert.equal(result.notConfigured[0].authorLogin, 'kurone-kito');
+});
+
+test('summarizeExternalCheckWaivers: waiver naming a configured-waivable check stays valid', () => {
+  const head = 'e'.repeat(40);
+  const body = makeWaiverComment({ claimId: 'claim-123', headSha: head });
+  const result = summarizeExternalCheckWaivers(
+    [
+      {
+        body,
+        author: { login: 'kurone-kito' },
+        createdAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    {
+      prHeadSha: head,
+      activeClaimId: 'claim-123',
+      trustedMarkerLogins: ['kurone-kito'],
+      now: '2026-05-17T00:00:00Z',
+      waivableSelectors: [{ selector: 'CodeRabbit', matchMode: 'exact' }],
+    },
+  );
+  assert.equal(result.valid.length, 1);
+  assert.equal(result.notConfigured.length, 0);
+});
+
+test('summarizeExternalCheckWaivers: a glob waivable selector admits a matching waiver', () => {
+  const head = 'e'.repeat(40);
+  const body = makeWaiverComment({ claimId: 'claim-123', headSha: head });
+  const result = summarizeExternalCheckWaivers(
+    [
+      {
+        body,
+        author: { login: 'kurone-kito' },
+        createdAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    {
+      prHeadSha: head,
+      activeClaimId: 'claim-123',
+      trustedMarkerLogins: ['kurone-kito'],
+      now: '2026-05-17T00:00:00Z',
+      waivableSelectors: [{ selector: 'Code*', matchMode: 'glob' }],
+    },
+  );
+  assert.equal(result.valid.length, 1);
+  assert.equal(result.notConfigured.length, 0);
+});
+
+test('summarizeExternalCheckWaivers: omitting waivableSelectors keeps the legacy no-gate path', () => {
+  const head = 'e'.repeat(40);
+  const body = makeWaiverComment({ claimId: 'claim-123', headSha: head });
+  const result = summarizeExternalCheckWaivers(
+    [
+      {
+        body,
+        author: { login: 'kurone-kito' },
+        createdAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    {
+      prHeadSha: head,
+      activeClaimId: 'claim-123',
+      trustedMarkerLogins: ['kurone-kito'],
+      now: '2026-05-17T00:00:00Z',
+    },
+  );
+  assert.equal(result.valid.length, 1);
+  assert.equal(result.notConfigured.length, 0);
+});
+
+test('summarizeExternalCheckWaivers: an empty waivable list waives nothing', () => {
+  const head = 'e'.repeat(40);
+  const body = makeWaiverComment({ claimId: 'claim-123', headSha: head });
+  const result = summarizeExternalCheckWaivers(
+    [
+      {
+        body,
+        author: { login: 'kurone-kito' },
+        createdAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    {
+      prHeadSha: head,
+      activeClaimId: 'claim-123',
+      trustedMarkerLogins: ['kurone-kito'],
+      now: '2026-05-17T00:00:00Z',
+      waivableSelectors: [],
+    },
+  );
+  assert.equal(result.valid.length, 0);
+  assert.equal(result.notConfigured.length, 1);
+});
+
+test('summarizeRequiredChecks: a configured-waivable check still folds in', () => {
+  const waivers = {
+    valid: [
+      {
+        authorLogin: 'kurone-kito',
+        checkSelector: 'CodeRabbit',
+        reason: 'rate-limit',
+        expiresAt: '2099-01-01T00:00:00Z',
+      },
+    ],
+    expired: [],
+    wrongHead: [],
+    wrongClaim: [],
+    unauthorized: [],
+    malformed: [],
+    notConfigured: [],
+  };
+  const result = summarizeRequiredChecks(
+    [{ name: 'CodeRabbit', state: 'FAILURE', completedAt: '' }],
+    [],
+    { required_status_checks: { contexts: ['CodeRabbit'] } },
+    {
+      waivers,
+      waivableSelectors: [{ selector: 'CodeRabbit', matchMode: 'exact' }],
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, true);
+  assert.equal(result.status, 'success');
+});
+
+test('summarizeRequiredChecks: a waived but non-waivable check is not covered', () => {
+  const waivers = {
+    valid: [
+      {
+        authorLogin: 'kurone-kito',
+        checkSelector: 'CodeRabbit',
+        reason: 'rate-limit',
+        expiresAt: '2099-01-01T00:00:00Z',
+      },
+    ],
+    expired: [],
+    wrongHead: [],
+    wrongClaim: [],
+    unauthorized: [],
+    malformed: [],
+    notConfigured: [],
+  };
+  const result = summarizeRequiredChecks(
+    [{ name: 'CodeRabbit', state: 'FAILURE', completedAt: '' }],
+    [],
+    { required_status_checks: { contexts: ['CodeRabbit'] } },
+    {
+      waivers,
+      waivableSelectors: [{ selector: 'deploy/prod', matchMode: 'exact' }],
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.notEqual(result.status, 'success');
+});
+
+test('summarizeRequiredChecks: an empty waivable list covers nothing', () => {
+  const waivers = {
+    valid: [
+      {
+        authorLogin: 'kurone-kito',
+        checkSelector: 'CodeRabbit',
+        reason: 'rate-limit',
+        expiresAt: '2099-01-01T00:00:00Z',
+      },
+    ],
+    expired: [],
+    wrongHead: [],
+    wrongClaim: [],
+    unauthorized: [],
+    malformed: [],
+    notConfigured: [],
+  };
+  const result = summarizeRequiredChecks(
+    [{ name: 'CodeRabbit', state: 'FAILURE', completedAt: '' }],
+    [],
+    { required_status_checks: { contexts: ['CodeRabbit'] } },
+    { waivers, waivableSelectors: [] },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.notEqual(result.status, 'success');
+});
+
 test('buildPreMergeReadinessSummary: waiverEvidence always present and validates against schema', () => {
   const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
   const summary = buildPreMergeReadinessSummary(fixture.input, fixture.options);
@@ -2606,6 +2813,7 @@ test('buildPreMergeReadinessSummary: waiverEvidence always present and validates
   assert.ok(Array.isArray(waiverEvidence.wrongClaim));
   assert.ok(Array.isArray(waiverEvidence.unauthorized));
   assert.ok(Array.isArray(waiverEvidence.malformed));
+  assert.ok(Array.isArray(waiverEvidence.notConfigured));
   assert.deepEqual(validate(summary, readinessSchema), []);
 });
 

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -772,6 +772,7 @@ const preMergeReadinessFixture = {
     wrongClaim: [],
     unauthorized: [],
     malformed: [],
+    notConfigured: [],
   },
   trustedMarkerActors: ['copilot-cli'],
   trustedMarkerActorsSource: 'config',


### PR DESCRIPTION
## Summary

External-check waivers folded any matching check into `requiredChecksPassing`
regardless of whether the policy declared it waivable. This threads the
configured `ciGate.externalChecks.waivable` selectors into the pre-merge
readiness path so a valid waiver only covers a **configured-waivable** check.

- `summarizeExternalCheckWaivers` buckets a validity-passing waiver whose
  `checkSelector` is not configured-waivable into a new `notConfigured`
  evidence bucket instead of `valid`.
- `summarizeRequiredChecks` sets `coveredByWaiver` only when the check is both
  waived and configured-waivable.
- `buildPreMergeReadinessSummary` + `pre-merge-readiness` thread the policy's
  waivable selectors; the pre-merge-readiness schema, fixtures, and helper doc
  gain the `notConfigured` bucket.

## Rationale

Mirrors the creation-path gate in `planExternalCheckWaiver`
(`external-check-waiver.mts`), which already matches checks against
`ciGate.externalChecks.waivable` using each selector's `matchMode`. The
consumption path previously ignored that config, so a waiver could cover any
matching check. An import cycle (`external-check-waiver` already imports
`protocol-helpers`) prevents reusing `matchCheckSelector` inside
`protocol-helpers.mts`, so the local `matchCheckSelectorLocal` gained an
optional explicit `matchMode` (omitted ⇒ legacy `*`-inference, unchanged for
existing callers).

## Compatibility

The `waivableSelectors` option defaults to absent (legacy, no gate), so
existing callers and tests are unaffected. F2 always threads the policy value
(an empty configured list waives nothing — fail-safe). This repository keeps
external-check waivers disabled, so there is no live behavior change here.

## Tests

`tests/pre-merge-readiness.test.mts`: a non-waivable waiver lands in
`notConfigured`; a configured-waivable waiver (exact and glob) stays `valid`;
omitting the option keeps the legacy path; an empty list waives nothing;
`summarizeRequiredChecks` coverage is gated on configured-waivable. Full
`pnpm run lint` (lint:minimum) and `pnpm run build:check` pass.

Closes #973


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified waiver evidence classification semantics, explicitly enumerating all waiver statuses.

* **New Features**
  * Added support for configured waivable external-check selectors, ensuring only waivers for policy-configured checks are treated as passing.
  * Introduced `notConfigured` waiver evidence status for waivers targeting non-waivable checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->