### PR TITLE
docs: surface merged-pr-feedback-sweep in workflow and issue-authoring

### DIFF
--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -380,6 +380,13 @@ what the agent can verify independently.
 
 ## Handling duplicates and non-ready outcomes
 
+One source of follow-up issue candidates is the read-only
+`merged-pr-feedback-sweep` helper's JSON output — the unresolved review
+threads and undispositioned advisory feedback it detects on merged PRs.
+Treat each entry as a candidate only: re-verify it against current `main`
+with the reuse-first tree below before drafting, because the feedback may
+already be addressed.
+
 Before publishing an issue, apply a reuse-first decision tree:
 
 1. Is an existing open issue a better fit? If yes, extend it instead of

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -41,6 +41,7 @@ words:
   - pytest
   - pyproject
   - tsfile
+  - undispositioned
   - unpushed
   - unreplied
   - unrouted

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -423,6 +423,10 @@ This source repository currently ships the following optional helper scripts:
   dry-run and claim-checked upsert)
 - `scripts/audit-pr-cleanup.mjs` (post-merge cleanup audit and optional
   apply mode)
+- `scripts/merged-pr-feedback-sweep.mjs` (read-only, manually-invoked
+  post-merge sweep that scans merged PRs for unresolved review threads
+  and undispositioned advisory feedback, handing JSON to the
+  issue-authoring skill)
 
 Shell / `gh` / `jq` snippets in
 `.github/instructions/*.instructions.md` remain the canonical portable

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -398,6 +398,10 @@ following optional helper scripts:
   dry-run and claim-checked upsert)
 - `scripts/audit-pr-cleanup.mjs` (post-merge cleanup audit and optional
   apply mode)
+- `scripts/merged-pr-feedback-sweep.mjs` (read-only, manually-invoked
+  post-merge sweep that scans merged PRs for unresolved review threads
+  and undispositioned advisory feedback, handing JSON to the
+  issue-authoring skill)
 
 Shell / `gh` / `jq` snippets in
 `.github/instructions/*.instructions.md` remain the canonical portable

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -380,6 +380,13 @@ what the agent can verify independently.
 
 ## Handling duplicates and non-ready outcomes
 
+One source of follow-up issue candidates is the read-only
+`merged-pr-feedback-sweep` helper's JSON output — the unresolved review
+threads and undispositioned advisory feedback it detects on merged PRs.
+Treat each entry as a candidate only: re-verify it against current `main`
+with the reuse-first tree below before drafting, because the feedback may
+already be addressed.
+
 Before publishing an issue, apply a reuse-first decision tree:
 
 1. Is an existing open issue a better fit? If yes, extend it instead of


### PR DESCRIPTION
## Summary

Surfaces the read-only `merged-pr-feedback-sweep` helper in the two operator-facing entry points where its discoverability was below parity with comparable helpers.

- **`docs/idd-workflow.md` + `idd-template/docs/idd-workflow.md`**: add a `merged-pr-feedback-sweep.mjs` bullet to the "Optional helper scripts" list, at parity with the adjacent `audit-pr-cleanup` entry. This pair is `structure`-mode in `audit/sync-manifest.json`, so both hand-maintained files were edited consistently.
- **`skills/issue-authoring/references/draft-patterns.md`**: note that the sweep's JSON output is one source of follow-up candidates, re-verified against `main` before drafting — closing the previously one-directional helper → skill link. The `.claude/skills/issue-authoring/` exact mirror was regenerated via `node scripts/sync-docs.mjs --apply`.
- **`.cspell.config.yml`**: add `undispositioned` for the new prose, consistent with the existing `un*` domain coinages.

Out of scope (per the issue): `README*` are untouched and `docs/idd-helper-scripts.md` is not re-categorized. The sweep stays operator-on-demand — no `.github/instructions/*` automation wiring.

## Verification

- `node scripts/sync-docs.mjs --check` — all mirrored artifacts in sync
- `node scripts/audit-docs.mjs --check` — passed
- `pnpm run lint:minimum` — 1061 tests pass; dprint / markdownlint / cspell clean

Closes #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxZgFApAQkV8aGmw19FAr3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation and draft pattern guidance to include information about identifying follow-up issue candidates from merged pull request feedback.
  * Documented a new optional helper script for scanning merged PRs to find unresolved review threads and advisory feedback.

* **Chores**
  * Updated spelling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->