### PR TITLE
docs(forced-handoff): adopt marker new-claim-id in successor recovery

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -253,7 +253,9 @@ Determine `{branch-name}`:
   `issue/<number>-<slug>` where `<slug>` follows the deterministic title
   normalization algorithm from pre-check (e).
 
-Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
+Generate a fresh `{claim-id}` — **except in forced-handoff recovery**, where
+the successor adopts the marker's pre-recorded `new-claim-id` instead of
+minting one (see _Claim verification_ below). Determine `{prior-claim-id}`:
 
 - **Takeover of an active claim** (stale claim recovery) → the current
   active claim's `{claim-id}`
@@ -321,10 +323,15 @@ unless the operator has explicitly switched to normal discovery.
 Once verified, record this `{claim-id}` as your current claim token for
 the rest of the workflow.
 
-When the new claim came from forced-handoff recovery, cite the trusted
-forced-handoff evidence in the issue digest or resume report's
-`Authoritative by` field. Do not invent ad hoc `claimed-by` fields and
-do not reuse the displaced `{claim-id}`.
+When the new claim came from forced-handoff recovery, the verified
+`forced-handoff` marker has already set the active claim to its pre-recorded
+`new-claim-id` (Claim-state parsing rule 7). Adopt that `new-claim-id` as your
+own `{claim-id}` for the rest of the run — including the `--claim-id` passed to
+`pre-merge-readiness` at F2/F3 — instead of minting a fresh one; no separate
+`claimed-by supersedes: none` post is required for the transfer itself. Cite
+the trusted forced-handoff evidence in the issue digest or resume report's
+`Authoritative by` field. Do not invent ad hoc `claimed-by` fields, and do not
+reuse the displaced old `{claim-id}`.
 
 ### Hide displaced claim chain on takeover
 

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 85353
+      "limitBytes": 85927
     },
     {
       "id": "bundle-resume",

--- a/docs/idd-resume-detail.md
+++ b/docs/idd-resume-detail.md
@@ -37,9 +37,13 @@ forced-handoff if:
 has already updated the GitHub claim stream to a released or
 successor-ready state. If the displaced non-stale claim still remains
 active, stop and wait rather than inventing a local superseding claim.
-Once GitHub state reflects the handoff outcome, re-claim via
-`idd-claim.instructions.md` with a fresh `{claim-id}` and the branch named
-in the forced-handoff evidence.
+Once GitHub state reflects the handoff outcome, continue via
+`idd-claim.instructions.md` on the branch named in the forced-handoff evidence.
+The verified `forced-handoff` marker has already set the active claim to its
+pre-recorded `new-claim-id` (rule 7), so the successor **adopts that
+`new-claim-id`** as its own `{claim-id}` for the rest of the run — including the
+`--claim-id` passed to `pre-merge-readiness` at F2/F3 — rather than minting a
+fresh one. No separate `claimed-by` post is required for the transfer itself.
 
 **Displaced-session guard** — If the forced-handoff evidence names a
 `{claim-id}` that this current session had already verified before this
@@ -48,7 +52,8 @@ Do not push, comment, reply, resolve threads, request reviewers, or merge
 until a maintainer reassigns ownership.
 
 The successor must cite the forced-handoff evidence in its resume report or
-digest `Authoritative by`. It must not silently inherit the old `{claim-id}`.
+digest `Authoritative by`. It must not reuse the displaced old `{claim-id}`,
+which is distinct from the adopted `new-claim-id`.
 
 ## §W1 — PR exists (1 match), no worktree
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -253,7 +253,9 @@ Determine `{branch-name}`:
   `issue/<number>-<slug>` where `<slug>` follows the deterministic title
   normalization algorithm from pre-check (e).
 
-Generate a fresh `{claim-id}`. Determine `{prior-claim-id}`:
+Generate a fresh `{claim-id}` — **except in forced-handoff recovery**, where
+the successor adopts the marker's pre-recorded `new-claim-id` instead of
+minting one (see _Claim verification_ below). Determine `{prior-claim-id}`:
 
 - **Takeover of an active claim** (stale claim recovery) → the current
   active claim's `{claim-id}`
@@ -321,10 +323,15 @@ unless the operator has explicitly switched to normal discovery.
 Once verified, record this `{claim-id}` as your current claim token for
 the rest of the workflow.
 
-When the new claim came from forced-handoff recovery, cite the trusted
-forced-handoff evidence in the issue digest or resume report's
-`Authoritative by` field. Do not invent ad hoc `claimed-by` fields and
-do not reuse the displaced `{claim-id}`.
+When the new claim came from forced-handoff recovery, the verified
+`forced-handoff` marker has already set the active claim to its pre-recorded
+`new-claim-id` (Claim-state parsing rule 7). Adopt that `new-claim-id` as your
+own `{claim-id}` for the rest of the run — including the `--claim-id` passed to
+`pre-merge-readiness` at F2/F3 — instead of minting a fresh one; no separate
+`claimed-by supersedes: none` post is required for the transfer itself. Cite
+the trusted forced-handoff evidence in the issue digest or resume report's
+`Authoritative by` field. Do not invent ad hoc `claimed-by` fields, and do not
+reuse the displaced old `{claim-id}`.
 
 ### Hide displaced claim chain on takeover
 

--- a/idd-template/docs/idd-resume-detail.md
+++ b/idd-template/docs/idd-resume-detail.md
@@ -37,9 +37,13 @@ forced-handoff if:
 has already updated the GitHub claim stream to a released or
 successor-ready state. If the displaced non-stale claim still remains
 active, stop and wait rather than inventing a local superseding claim.
-Once GitHub state reflects the handoff outcome, re-claim via
-`idd-claim.instructions.md` with a fresh `{claim-id}` and the branch named
-in the forced-handoff evidence.
+Once GitHub state reflects the handoff outcome, continue via
+`idd-claim.instructions.md` on the branch named in the forced-handoff evidence.
+The verified `forced-handoff` marker has already set the active claim to its
+pre-recorded `new-claim-id` (rule 7), so the successor **adopts that
+`new-claim-id`** as its own `{claim-id}` for the rest of the run — including the
+`--claim-id` passed to `pre-merge-readiness` at F2/F3 — rather than minting a
+fresh one. No separate `claimed-by` post is required for the transfer itself.
 
 **Displaced-session guard** — If the forced-handoff evidence names a
 `{claim-id}` that this current session had already verified before this
@@ -48,7 +52,8 @@ Do not push, comment, reply, resolve threads, request reviewers, or merge
 until a maintainer reassigns ownership.
 
 The successor must cite the forced-handoff evidence in its resume report or
-digest `Authoritative by`. It must not silently inherit the old `{claim-id}`.
+digest `Authoritative by`. It must not reuse the displaced old `{claim-id}`,
+which is distinct from the adopted `new-claim-id`.
 
 ## §W1 — PR exists (1 match), no worktree
 


### PR DESCRIPTION
## Summary

Reconciles the forced-handoff successor `{claim-id}` recovery prose with the
existing rule-7 mechanism. A verified `forced-handoff` marker is parsed by
`applyClaimEvent`, and rule 7 of *Claim-state parsing* already transfers the
active claim to the marker's pre-recorded `new-claim-id`. The recovery prose
previously told the successor to re-claim "with a fresh `{claim-id}`", which a
successor that minted a new id could not match — so the F2/F3
`pre-merge-readiness --claim-id` check could falsely report `claimLost` at the
most safety-sensitive gate.

This change makes the recovery guidance in `idd-claim` (Claim execution / Claim
verification) and `idd-resume-detail` (§FH) state that the successor **adopts
the marker's `new-claim-id`** as its own `{claim-id}` for the rest of the run —
including the `--claim-id` passed to `pre-merge-readiness` — instead of minting
a fresh one. The displaced old `{claim-id}` must still not be reused.

## Changes

- `idd-template/.github/instructions/idd-claim.instructions.md` (source) + root
  mirror: qualify the "Generate a fresh `{claim-id}`" line and reword the
  forced-handoff *Claim verification* paragraph.
- `idd-template/docs/idd-resume-detail.md` (§FH, source) + root mirror: reword
  the *Re-claim rule* and clarify the old-vs-new id distinction.
- Root mirrors regenerated via `node scripts/sync-docs.mjs --apply`.

## Budget callout (manifest ratchet)

`audit/sync-manifest.json` `bundleBudgets[0].limitBytes` (`bundle-discovery`)
is raised **85353 → 85927** (+574 B) to fit the concise
`idd-claim.instructions.md` addition. Per the manifest ratchet rule, raising a
bundle limit requires an explicit PR-description callout — this is it. The new
limit equals the measured bundle total.

## Non-goals / safety

Documentation-only. No change to `applyClaimEvent`, the forced-handoff helpers,
or any `.mts` source. `pnpm run lint:minimum` passes (audit-docs parity +
budgets, typecheck, build, biome, tests, cspell, markdownlint).

Closes #977


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated forced-handoff recovery instructions to clarify claim ID adoption during verification and workflow continuation
  * Refined digest and resume report guidance to specify proper citation of forced-handoff evidence
  * Clarified that no separate claim supersession post is required for handoff transfers

* **Chores**
  * Updated bundle budget configuration limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->