### PR TITLE
feat(pre-merge): surface ack-only-post-disposition override signal

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -263,6 +263,16 @@ returns the workflow to E1 instead of merging over it.
   `dispositionEvidence` shape only; do not substitute E7 verifier fields
   (`passed`, `items[]`) here.
 
+  Deterministic override (advisory-only): if `dispositionEvidence.route`
+  is `return-to-e1` but `dispositionEvidence.soleCauseAckOnlyPostDisposition`
+  is `true` — every blocking item is an `ackOnlyPostDisposition` resolved
+  thread, with no missing regular comments — autopilot **may** treat this
+  gate as satisfied and proceed on the current HEAD SHA, mirroring the
+  review-currency ack-only carve-out. The override applies to that signal
+  **only**; any other `return-to-e1` cause (a missing regular comment, or
+  any thread whose `ackOnlyPostDisposition` is `false`) keeps the backstop
+  and routes to E1/E4 unchanged.
+
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the PR live status digest after the blocking evidence is recorded and
 before stopping or returning. Set `Phase` to the failing F2 check,

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -406,6 +406,20 @@ the semantic residual — confirming the ack raises no new actionable
 finding — and the evidence never weakens the disposition-evidence or
 unreplied-comment gates, which remain the backstop.
 
+**Disposition-evidence parity (advisory-only)**: the same post-disposition
+advisory-bot ack can also re-block the `dispositionEvidence` backstop on an
+already-resolved thread (`route: return-to-e1`,
+`reason: missing-fresh-disposition`). The backstop default is unchanged, but
+`pre-merge-readiness` now surfaces a deterministic signal: each such thread
+carries `ackOnlyPostDisposition: true`, and the top-level
+`dispositionEvidence.soleCauseAckOnlyPostDisposition` is `true` only when
+**every** blocking item is one of those threads (no missing regular comments,
+no non-ack thread). When that signal is `true`, autopilot may deterministically
+override the `return-to-e1` and proceed on the current HEAD SHA (see
+`idd-pre-merge.instructions.md` F2). The signal never changes `route`, and any
+non-ack blocking cause makes it `false`, so the backstop still holds for every
+other case.
+
 ## Review item classes
 
 During E-phase review triage, classify each ReviewItems_snapshot item

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -263,6 +263,16 @@ returns the workflow to E1 instead of merging over it.
   `dispositionEvidence` shape only; do not substitute E7 verifier fields
   (`passed`, `items[]`) here.
 
+  Deterministic override (advisory-only): if `dispositionEvidence.route`
+  is `return-to-e1` but `dispositionEvidence.soleCauseAckOnlyPostDisposition`
+  is `true` — every blocking item is an `ackOnlyPostDisposition` resolved
+  thread, with no missing regular comments — autopilot **may** treat this
+  gate as satisfied and proceed on the current HEAD SHA, mirroring the
+  review-currency ack-only carve-out. The override applies to that signal
+  **only**; any other `return-to-e1` cause (a missing regular comment, or
+  any thread whose `ackOnlyPostDisposition` is `false`) keeps the backstop
+  and routes to E1/E4 unchanged.
+
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the PR live status digest after the blocking evidence is recorded and
 before stopping or returning. Set `Phase` to the failing F2 check,

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -406,6 +406,20 @@ the semantic residual — confirming the ack raises no new actionable
 finding — and the evidence never weakens the disposition-evidence or
 unreplied-comment gates, which remain the backstop.
 
+**Disposition-evidence parity (advisory-only)**: the same post-disposition
+advisory-bot ack can also re-block the `dispositionEvidence` backstop on an
+already-resolved thread (`route: return-to-e1`,
+`reason: missing-fresh-disposition`). The backstop default is unchanged, but
+`pre-merge-readiness` now surfaces a deterministic signal: each such thread
+carries `ackOnlyPostDisposition: true`, and the top-level
+`dispositionEvidence.soleCauseAckOnlyPostDisposition` is `true` only when
+**every** blocking item is one of those threads (no missing regular comments,
+no non-ack thread). When that signal is `true`, autopilot may deterministically
+override the `return-to-e1` and proceed on the current HEAD SHA (see
+`idd-pre-merge.instructions.md` F2). The signal never changes `route`, and any
+non-ack blocking cause makes it `false`, so the backstop still holds for every
+other case.
+
 ## Review item classes
 
 During E-phase review triage, classify each ReviewItems_snapshot item

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -849,6 +849,7 @@
         "blockingCount",
         "missingRegularCommentCount",
         "missingThreadCount",
+        "soleCauseAckOnlyPostDisposition",
         "missingRegularComments",
         "missingThreads"
       ],
@@ -879,6 +880,9 @@
         "missingThreadCount": {
           "type": "integer",
           "minimum": 0
+        },
+        "soleCauseAckOnlyPostDisposition": {
+          "type": "boolean"
         },
         "missingRegularComments": {
           "type": "array",
@@ -918,7 +922,8 @@
             "required": [
               "id",
               "isResolved",
-              "reason"
+              "reason",
+              "ackOnlyPostDisposition"
             ],
             "additionalProperties": false,
             "properties": {
@@ -936,6 +941,9 @@
                   "missing-fresh-disposition",
                   "unresolved-without-fresh-disposition"
                 ]
+              },
+              "ackOnlyPostDisposition": {
+                "type": "boolean"
               }
             }
           }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2260,6 +2260,69 @@ export function summarizeDispositionEvidenceForGate(
     createdAt: comment.createdAt,
     bodyPreview: buildBodyPreview(comment.body),
   }));
+  // #978 advisory-only diagnostic: a blocking resolved thread is
+  // "ack-only-post-disposition" when a thread-local IDD disposition exists and
+  // EVERY external comment newer than the snapshot boundary (the activity that
+  // makes the thread block) is an advisory-bot, non-disposition reply posted
+  // after that disposition — i.e. a post-disposition courtesy ack. Reuses the
+  // review-currency carve-out's recognition shape (advisory-bot predicate driven
+  // by `advisoryBotLogins`, no hard-coded logins; post-disposition ack). Fails
+  // closed (false) without a snapshot boundary, without a thread-local
+  // disposition, or for unresolved threads, and never changes the gate route.
+  const isThreadAckOnlyPostDisposition = (thread) => {
+    if (!thread.isResolved || !snapshotBoundaryAt) {
+      return false;
+    }
+    const nodes = thread.comments?.nodes ?? [];
+    const threadDispositionAt = maxIsoTimestamp(
+      nodes
+        .filter(
+          (comment) =>
+            iddAgentLogins.has(
+              String(comment.author?.login ?? '')
+                .trim()
+                .toLowerCase(),
+            ) && isDispositionComment({ body: String(comment.body ?? '') }),
+        )
+        .map((comment) => comment.createdAt)
+        .filter(isValidIsoTimestamp),
+    );
+    if (!threadDispositionAt) {
+      return false;
+    }
+    const boundaryBlockingFeedback = nodes.filter((comment) => {
+      const authorLogin = String(comment.author?.login ?? '')
+        .trim()
+        .toLowerCase();
+      if (
+        !authorLogin ||
+        iddAgentLogins.has(authorLogin) ||
+        authorLogin === prAuthorLogin
+      ) {
+        return false;
+      }
+      const activityAt = effectiveThreadCommentActivityAt(comment);
+      return (
+        isValidIsoTimestamp(activityAt) &&
+        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0
+      );
+    });
+    if (boundaryBlockingFeedback.length === 0) {
+      return false;
+    }
+    return boundaryBlockingFeedback.every((comment) => {
+      const activityAt = effectiveThreadCommentActivityAt(comment);
+      return (
+        advisoryBotLogins.has(
+          String(comment.author?.login ?? '')
+            .trim()
+            .toLowerCase(),
+        ) &&
+        !isDispositionComment({ body: String(comment.body ?? '') }) &&
+        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
+      );
+    });
+  };
   const missingThreads = (threads ?? [])
     .map((thread, index) => {
       const commentsInThread = thread.comments?.nodes ?? [];
@@ -2281,6 +2344,7 @@ export function summarizeDispositionEvidenceForGate(
           id: String(thread.id ?? '') || `thread-${index + 1}`,
           isResolved: Boolean(thread.isResolved),
           reason: 'incomplete-thread-comments',
+          ackOnlyPostDisposition: false,
         };
       }
       if (
@@ -2330,16 +2394,27 @@ export function summarizeDispositionEvidenceForGate(
         reason: thread.isResolved
           ? 'missing-fresh-disposition'
           : 'unresolved-without-fresh-disposition',
+        ackOnlyPostDisposition: isThreadAckOnlyPostDisposition(thread),
       };
     })
     .filter(Boolean);
   const blockingCount = missingRegularComments.length + missingThreads.length;
+  // #978: the sole blocking cause is post-disposition advisory-bot ack-only
+  // activity. True only when something blocks AND every blocking item is an
+  // ack-only-post-disposition resolved thread (no missing regular comments, no
+  // non-ack thread). The guard implies missingThreads is non-empty, so `.every`
+  // is never vacuously true.
+  const soleCauseAckOnlyPostDisposition =
+    blockingCount > 0 &&
+    missingRegularComments.length === 0 &&
+    missingThreads.every((entry) => entry.ackOnlyPostDisposition === true);
   return {
     route: blockingCount > 0 ? 'return-to-e1' : 'proceed',
     reason: blockingCount > 0 ? 'missing-disposition-evidence' : 'complete',
     blockingCount,
     missingRegularCommentCount: missingRegularComments.length,
     missingThreadCount: missingThreads.length,
+    soleCauseAckOnlyPostDisposition,
     missingRegularComments,
     missingThreads,
   };

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2274,6 +2274,12 @@ export function summarizeDispositionEvidenceForGate(
       return false;
     }
     const nodes = thread.comments?.nodes ?? [];
+    // Recognize the same dispositions `hasFreshDisposition` accepts on a
+    // resolved thread (the gate that already decided this thread blocks): a
+    // `**Accepted**`/`**Rejected**` marker OR the terminal
+    // `**Rejection confirmed by maintainer**` marker, anchored by effective
+    // activity (`updatedAt`-preferring) so an edited disposition is dated
+    // consistently. The thread is already known resolved here.
     const threadDispositionAt = maxIsoTimestamp(
       nodes
         .filter(
@@ -2282,9 +2288,13 @@ export function summarizeDispositionEvidenceForGate(
               String(comment.author?.login ?? '')
                 .trim()
                 .toLowerCase(),
-            ) && isDispositionComment({ body: String(comment.body ?? '') }),
+            ) &&
+            (isDispositionComment({ body: String(comment.body ?? '') }) ||
+              isRejectionConfirmedDisposition({
+                body: String(comment.body ?? ''),
+              })),
         )
-        .map((comment) => comment.createdAt)
+        .map((comment) => effectiveThreadCommentActivityAt(comment))
         .filter(isValidIsoTimestamp),
     );
     if (!threadDispositionAt) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2262,13 +2262,13 @@ export function summarizeDispositionEvidenceForGate(
   }));
   // #978 advisory-only diagnostic: a blocking resolved thread is
   // "ack-only-post-disposition" when a thread-local IDD disposition exists and
-  // EVERY external comment newer than the snapshot boundary (the activity that
-  // makes the thread block) is an advisory-bot, non-disposition reply posted
-  // after that disposition — i.e. a post-disposition courtesy ack. Reuses the
-  // review-currency carve-out's recognition shape (advisory-bot predicate driven
-  // by `advisoryBotLogins`, no hard-coded logins; post-disposition ack). Fails
-  // closed (false) without a snapshot boundary, without a thread-local
-  // disposition, or for unresolved threads, and never changes the gate route.
+  // EVERY external comment newer than BOTH the snapshot boundary (so it re-blocks
+  // the gate) AND the disposition is an advisory-bot, non-disposition courtesy
+  // ack. Reuses the review-currency carve-out's recognition shape (advisory-bot
+  // predicate driven by `advisoryBotLogins`, no hard-coded logins;
+  // post-disposition ack). Fails closed (false) without a snapshot boundary,
+  // without a thread-local disposition, or for unresolved threads, and never
+  // changes the gate route.
   const isThreadAckOnlyPostDisposition = (thread) => {
     if (!thread.isResolved || !snapshotBoundaryAt) {
       return false;
@@ -2300,7 +2300,12 @@ export function summarizeDispositionEvidenceForGate(
     if (!threadDispositionAt) {
       return false;
     }
-    const boundaryBlockingFeedback = nodes.filter((comment) => {
+    // The blocking activity is external feedback newer than BOTH the snapshot
+    // boundary (so it actually re-blocks the gate) AND the thread disposition
+    // (so already-dispositioned feedback predating the ack does not disqualify
+    // the signal). When the disposition lands after the boundary, the
+    // post-disposition bound is what isolates the genuine ack.
+    const postDispositionBlockingFeedback = nodes.filter((comment) => {
       const authorLogin = String(comment.author?.login ?? '')
         .trim()
         .toLowerCase();
@@ -2314,24 +2319,26 @@ export function summarizeDispositionEvidenceForGate(
       const activityAt = effectiveThreadCommentActivityAt(comment);
       return (
         isValidIsoTimestamp(activityAt) &&
-        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0
+        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0 &&
+        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
       );
     });
-    if (boundaryBlockingFeedback.length === 0) {
+    if (postDispositionBlockingFeedback.length === 0) {
       return false;
     }
-    return boundaryBlockingFeedback.every((comment) => {
-      const activityAt = effectiveThreadCommentActivityAt(comment);
-      return (
+    // Each remaining item must be a pure advisory-bot courtesy ack: an
+    // advisory-bot author whose body is neither a `**Accepted**`/`**Rejected**`
+    // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
+    return postDispositionBlockingFeedback.every(
+      (comment) =>
         advisoryBotLogins.has(
           String(comment.author?.login ?? '')
             .trim()
             .toLowerCase(),
         ) &&
         !isDispositionComment({ body: String(comment.body ?? '') }) &&
-        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
-      );
-    });
+        !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
+    );
   };
   const missingThreads = (threads ?? [])
     .map((thread, index) => {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -389,13 +389,28 @@ export interface DispositionEvidenceSummary {
   blockingCount: number;
   missingRegularCommentCount: number;
   missingThreadCount: number;
+  // Advisory-only (#978): true when there is at least one blocking item and
+  // every blocking item is an ack-only-post-disposition resolved thread (no
+  // missing regular comments, no non-ack thread). Lets autopilot deterministically
+  // override a `return-to-e1` whose sole cause is post-disposition advisory-bot
+  // acks. Never changes `route`; never relaxes the backstop for any other cause.
+  soleCauseAckOnlyPostDisposition: boolean;
   missingRegularComments: {
     id: string;
     authorLogin: string;
     createdAt: string;
     bodyPreview: string;
   }[];
-  missingThreads: { id: string; isResolved: boolean; reason: string }[];
+  // `ackOnlyPostDisposition` is advisory-only: true when this blocking resolved
+  // thread blocks solely because of post-disposition advisory-bot ack-only
+  // activity newer than the snapshot boundary. It never changes the entry's
+  // `reason` or the summary `route`.
+  missingThreads: {
+    id: string;
+    isResolved: boolean;
+    reason: string;
+    ackOnlyPostDisposition: boolean;
+  }[];
 }
 
 /** Advisory-wait marker counts split by marker-author trust. */
@@ -3156,6 +3171,70 @@ export function summarizeDispositionEvidenceForGate(
     bodyPreview: buildBodyPreview(comment.body),
   }));
 
+  // #978 advisory-only diagnostic: a blocking resolved thread is
+  // "ack-only-post-disposition" when a thread-local IDD disposition exists and
+  // EVERY external comment newer than the snapshot boundary (the activity that
+  // makes the thread block) is an advisory-bot, non-disposition reply posted
+  // after that disposition — i.e. a post-disposition courtesy ack. Reuses the
+  // review-currency carve-out's recognition shape (advisory-bot predicate driven
+  // by `advisoryBotLogins`, no hard-coded logins; post-disposition ack). Fails
+  // closed (false) without a snapshot boundary, without a thread-local
+  // disposition, or for unresolved threads, and never changes the gate route.
+  const isThreadAckOnlyPostDisposition = (thread: ThreadLike): boolean => {
+    if (!thread.isResolved || !snapshotBoundaryAt) {
+      return false;
+    }
+    const nodes = thread.comments?.nodes ?? [];
+    const threadDispositionAt = maxIsoTimestamp(
+      nodes
+        .filter(
+          (comment) =>
+            iddAgentLogins.has(
+              String(comment.author?.login ?? '')
+                .trim()
+                .toLowerCase(),
+            ) && isDispositionComment({ body: String(comment.body ?? '') }),
+        )
+        .map((comment) => comment.createdAt)
+        .filter(isValidIsoTimestamp),
+    );
+    if (!threadDispositionAt) {
+      return false;
+    }
+    const boundaryBlockingFeedback = nodes.filter((comment) => {
+      const authorLogin = String(comment.author?.login ?? '')
+        .trim()
+        .toLowerCase();
+      if (
+        !authorLogin ||
+        iddAgentLogins.has(authorLogin) ||
+        authorLogin === prAuthorLogin
+      ) {
+        return false;
+      }
+      const activityAt = effectiveThreadCommentActivityAt(comment);
+      return (
+        isValidIsoTimestamp(activityAt) &&
+        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0
+      );
+    });
+    if (boundaryBlockingFeedback.length === 0) {
+      return false;
+    }
+    return boundaryBlockingFeedback.every((comment) => {
+      const activityAt = effectiveThreadCommentActivityAt(comment);
+      return (
+        advisoryBotLogins.has(
+          String(comment.author?.login ?? '')
+            .trim()
+            .toLowerCase(),
+        ) &&
+        !isDispositionComment({ body: String(comment.body ?? '') }) &&
+        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
+      );
+    });
+  };
+
   const missingThreads = (threads ?? [])
     .map((thread, index) => {
       const commentsInThread = thread.comments?.nodes ?? [];
@@ -3177,6 +3256,7 @@ export function summarizeDispositionEvidenceForGate(
           id: String(thread.id ?? '') || `thread-${index + 1}`,
           isResolved: Boolean(thread.isResolved),
           reason: 'incomplete-thread-comments',
+          ackOnlyPostDisposition: false,
         };
       }
       if (
@@ -3226,17 +3306,28 @@ export function summarizeDispositionEvidenceForGate(
         reason: thread.isResolved
           ? 'missing-fresh-disposition'
           : 'unresolved-without-fresh-disposition',
+        ackOnlyPostDisposition: isThreadAckOnlyPostDisposition(thread),
       };
     })
     .filter(Boolean) as DispositionEvidenceSummary['missingThreads'];
 
   const blockingCount = missingRegularComments.length + missingThreads.length;
+  // #978: the sole blocking cause is post-disposition advisory-bot ack-only
+  // activity. True only when something blocks AND every blocking item is an
+  // ack-only-post-disposition resolved thread (no missing regular comments, no
+  // non-ack thread). The guard implies missingThreads is non-empty, so `.every`
+  // is never vacuously true.
+  const soleCauseAckOnlyPostDisposition =
+    blockingCount > 0 &&
+    missingRegularComments.length === 0 &&
+    missingThreads.every((entry) => entry.ackOnlyPostDisposition === true);
   return {
     route: blockingCount > 0 ? 'return-to-e1' : 'proceed',
     reason: blockingCount > 0 ? 'missing-disposition-evidence' : 'complete',
     blockingCount,
     missingRegularCommentCount: missingRegularComments.length,
     missingThreadCount: missingThreads.length,
+    soleCauseAckOnlyPostDisposition,
     missingRegularComments,
     missingThreads,
   };

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -3173,13 +3173,13 @@ export function summarizeDispositionEvidenceForGate(
 
   // #978 advisory-only diagnostic: a blocking resolved thread is
   // "ack-only-post-disposition" when a thread-local IDD disposition exists and
-  // EVERY external comment newer than the snapshot boundary (the activity that
-  // makes the thread block) is an advisory-bot, non-disposition reply posted
-  // after that disposition — i.e. a post-disposition courtesy ack. Reuses the
-  // review-currency carve-out's recognition shape (advisory-bot predicate driven
-  // by `advisoryBotLogins`, no hard-coded logins; post-disposition ack). Fails
-  // closed (false) without a snapshot boundary, without a thread-local
-  // disposition, or for unresolved threads, and never changes the gate route.
+  // EVERY external comment newer than BOTH the snapshot boundary (so it re-blocks
+  // the gate) AND the disposition is an advisory-bot, non-disposition courtesy
+  // ack. Reuses the review-currency carve-out's recognition shape (advisory-bot
+  // predicate driven by `advisoryBotLogins`, no hard-coded logins;
+  // post-disposition ack). Fails closed (false) without a snapshot boundary,
+  // without a thread-local disposition, or for unresolved threads, and never
+  // changes the gate route.
   const isThreadAckOnlyPostDisposition = (thread: ThreadLike): boolean => {
     if (!thread.isResolved || !snapshotBoundaryAt) {
       return false;
@@ -3211,7 +3211,12 @@ export function summarizeDispositionEvidenceForGate(
     if (!threadDispositionAt) {
       return false;
     }
-    const boundaryBlockingFeedback = nodes.filter((comment) => {
+    // The blocking activity is external feedback newer than BOTH the snapshot
+    // boundary (so it actually re-blocks the gate) AND the thread disposition
+    // (so already-dispositioned feedback predating the ack does not disqualify
+    // the signal). When the disposition lands after the boundary, the
+    // post-disposition bound is what isolates the genuine ack.
+    const postDispositionBlockingFeedback = nodes.filter((comment) => {
       const authorLogin = String(comment.author?.login ?? '')
         .trim()
         .toLowerCase();
@@ -3225,24 +3230,26 @@ export function summarizeDispositionEvidenceForGate(
       const activityAt = effectiveThreadCommentActivityAt(comment);
       return (
         isValidIsoTimestamp(activityAt) &&
-        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0
+        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0 &&
+        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
       );
     });
-    if (boundaryBlockingFeedback.length === 0) {
+    if (postDispositionBlockingFeedback.length === 0) {
       return false;
     }
-    return boundaryBlockingFeedback.every((comment) => {
-      const activityAt = effectiveThreadCommentActivityAt(comment);
-      return (
+    // Each remaining item must be a pure advisory-bot courtesy ack: an
+    // advisory-bot author whose body is neither a `**Accepted**`/`**Rejected**`
+    // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
+    return postDispositionBlockingFeedback.every(
+      (comment) =>
         advisoryBotLogins.has(
           String(comment.author?.login ?? '')
             .trim()
             .toLowerCase(),
         ) &&
         !isDispositionComment({ body: String(comment.body ?? '') }) &&
-        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
-      );
-    });
+        !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
+    );
   };
 
   const missingThreads = (threads ?? [])

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -3185,6 +3185,12 @@ export function summarizeDispositionEvidenceForGate(
       return false;
     }
     const nodes = thread.comments?.nodes ?? [];
+    // Recognize the same dispositions `hasFreshDisposition` accepts on a
+    // resolved thread (the gate that already decided this thread blocks): a
+    // `**Accepted**`/`**Rejected**` marker OR the terminal
+    // `**Rejection confirmed by maintainer**` marker, anchored by effective
+    // activity (`updatedAt`-preferring) so an edited disposition is dated
+    // consistently. The thread is already known resolved here.
     const threadDispositionAt = maxIsoTimestamp(
       nodes
         .filter(
@@ -3193,9 +3199,13 @@ export function summarizeDispositionEvidenceForGate(
               String(comment.author?.login ?? '')
                 .trim()
                 .toLowerCase(),
-            ) && isDispositionComment({ body: String(comment.body ?? '') }),
+            ) &&
+            (isDispositionComment({ body: String(comment.body ?? '') }) ||
+              isRejectionConfirmedDisposition({
+                body: String(comment.body ?? ''),
+              })),
         )
-        .map((comment) => comment.createdAt)
+        .map((comment) => effectiveThreadCommentActivityAt(comment))
         .filter(isValidIsoTimestamp),
     );
     if (!threadDispositionAt) {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1768,6 +1768,153 @@ test('disposition evidence still blocks a resolved thread reopened after the bou
   assert.equal(summary.missingThreads[0].reason, 'missing-fresh-disposition');
 });
 
+test('disposition evidence flags an ack-only-post-disposition resolved thread without changing the route (#978)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-ack',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'please reconsider this',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:30:00Z',
+                body: '**Rejected** — verified: not applicable here',
+              },
+              {
+                author: { login: 'coderabbitai[bot]' },
+                createdAt: '2026-05-12T02:00:00Z',
+                body: 'Thanks for confirming.',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
+  );
+
+  // The backstop verdict is unchanged: the thread still blocks.
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.blockingCount, 1);
+  assert.equal(summary.missingThreads[0].reason, 'missing-fresh-disposition');
+  // The advisory-only diagnostic recognizes the post-disposition bot ack.
+  assert.equal(summary.missingThreads[0].ackOnlyPostDisposition, true);
+  assert.equal(summary.soleCauseAckOnlyPostDisposition, true);
+});
+
+test('disposition evidence does not flag a resolved thread with substantive post-disposition feedback (#978)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-substantive',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'please reconsider this',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:30:00Z',
+                body: '**Rejected** — verified: not applicable here',
+              },
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T02:00:00Z',
+                body: 'No, this is still wrong — please fix it.',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingThreads[0].ackOnlyPostDisposition, false);
+  assert.equal(summary.soleCauseAckOnlyPostDisposition, false);
+});
+
+test('disposition evidence reports sole-cause false when a regular comment also blocks (#978)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 99,
+          createdAt: '2026-05-12T03:00:00Z',
+          body: 'a separate unanswered reviewer note',
+          author: { login: 'reviewer-b' },
+        },
+      ],
+      threads: [
+        {
+          id: 'thread-ack',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'please reconsider this',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:30:00Z',
+                body: '**Rejected** — verified: not applicable here',
+              },
+              {
+                author: { login: 'coderabbitai[bot]' },
+                createdAt: '2026-05-12T02:00:00Z',
+                body: 'Thanks for confirming.',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.ok(summary.blockingCount >= 2);
+  // The ack-only thread is still individually flagged ...
+  const ackThread = summary.missingThreads.find(
+    (entry) => entry.id === 'thread-ack',
+  );
+  assert.equal(ackThread?.ackOnlyPostDisposition, true);
+  // ... but a regular comment is a separate, non-ack blocking cause.
+  assert.equal(summary.missingRegularCommentCount, 1);
+  assert.equal(summary.soleCauseAckOnlyPostDisposition, false);
+});
+
 test('disposition evidence accepts edited IDD disposition comments as fresh replies', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1962,6 +1962,104 @@ test('disposition evidence flags an ack-only thread dispositioned via a rejectio
   assert.equal(summary.soleCauseAckOnlyPostDisposition, true);
 });
 
+test('disposition evidence flags ack-only when the disposition lands after the snapshot boundary (#978)', () => {
+  // The reviewer comment is post-boundary but pre-disposition (it was
+  // dispositioned), so only the later advisory-bot ack is genuinely
+  // post-disposition. The signal must isolate post-disposition activity and
+  // still flag this as ack-only.
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-late-disposition',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T01:30:00Z',
+                body: 'please reconsider this',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T02:00:00Z',
+                body: '**Rejected** — verified: not applicable here',
+              },
+              {
+                author: { login: 'coderabbitai[bot]' },
+                createdAt: '2026-05-12T03:00:00Z',
+                body: 'Thanks for confirming.',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingThreads[0].ackOnlyPostDisposition, true);
+  assert.equal(summary.soleCauseAckOnlyPostDisposition, true);
+});
+
+test('disposition evidence does not flag a thread with a post-disposition human reply (#978)', () => {
+  // A bot ack AND a later human comment both post-date the disposition. The
+  // human reply is genuine post-disposition feedback, so the post-disposition
+  // set is not advisory-bot-ack-only and the thread stays unflagged.
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-late-human',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'please reconsider this',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:30:00Z',
+                body: '**Rejected** — verified: not applicable here',
+              },
+              {
+                author: { login: 'coderabbitai[bot]' },
+                createdAt: '2026-05-12T02:00:00Z',
+                body: 'Thanks for confirming.',
+              },
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T02:30:00Z',
+                body: 'Actually, please reopen — still a problem.',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingThreads[0].ackOnlyPostDisposition, false);
+  assert.equal(summary.soleCauseAckOnlyPostDisposition, false);
+});
+
 test('disposition evidence accepts edited IDD disposition comments as fresh replies', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1915,6 +1915,53 @@ test('disposition evidence reports sole-cause false when a regular comment also 
   assert.equal(summary.soleCauseAckOnlyPostDisposition, false);
 });
 
+test('disposition evidence flags an ack-only thread dispositioned via a rejection-confirmed marker (#978)', () => {
+  // The thread-local disposition uses the terminal
+  // `**Rejection confirmed by maintainer**` marker (recognized by
+  // hasFreshDisposition on resolved threads), so the ack-only signal must
+  // recognize it too — otherwise this genuine ack-only case goes unflagged.
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-rejection-confirmed',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'please reconsider this',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:30:00Z',
+                body: '**Rejection confirmed by maintainer** — agreed, no change needed',
+              },
+              {
+                author: { login: 'coderabbitai[bot]' },
+                createdAt: '2026-05-12T02:00:00Z',
+                body: 'Thanks for confirming.',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingThreads[0].ackOnlyPostDisposition, true);
+  assert.equal(summary.soleCauseAckOnlyPostDisposition, true);
+});
+
 test('disposition evidence accepts edited IDD disposition comments as fresh replies', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {


### PR DESCRIPTION
## Summary

Adds a deterministic, **advisory-only** diagnostic to the F2/F3
`dispositionEvidence` output so autopilot can recognize and override **only**
the narrow case where an already-resolved review thread blocks the merge gate
solely because a configured advisory bot posted a post-disposition courtesy
ack. The gate verdict (`route`) is unchanged for every adopter and the backstop
is not weakened.

## Background

`dispositionEvidence` is the authoritative merge-gate backstop, and by design
the ack-only carve-out applies only to `reviewCurrency`. When an already-resolved
thread receives a post-disposition ack from a configured advisory bot,
`hasFreshDisposition` goes false and the resolved-thread carve-out does not
exclude the ack from `newestFeedbackAt`, so the gate returns `return-to-e1`. An
unattended autopilot run that re-disposition-marks can be re-acked and loop. Per
the maintainer decision the backstop default must not change — instead surface a
deterministic diagnostic.

## Changes

- `src/scripts/protocol-helpers.mts` (`summarizeDispositionEvidenceForGate`):
  per-thread `ackOnlyPostDisposition` flag on blocking resolved threads whose
  sole post-boundary external activity is advisory-bot ack-only post-disposition,
  plus a top-level `soleCauseAckOnlyPostDisposition` (true only when **every**
  blocking item is such a thread — no missing regular comments, no non-ack
  thread). `route` / `reason` / `blockingCount` unchanged. Advisory-bot
  recognition via `advisoryBotLogins` (no hard-coded logins).
- `schemas/pre-merge-readiness.schema.json`: describe both new fields.
- `idd-pre-merge.instructions.md` (F2) and `idd-review-triage.instructions.md`
  (ack-only convergence), mirrored sources + root: document the deterministic
  override and state it does **not** weaken the backstop for non-ack causes.
- `tests/pre-merge-readiness.test.mts`: (a) flagged + route still
  `return-to-e1` + sole-cause true; (b) substantive post-disposition comment →
  unflagged, blocks normally; (c) mixed blocking → sole-cause false.
- Regenerated committed `scripts/protocol-helpers.mjs`.

## Safety

Advisory-only signal — never changes `route`; any non-ack blocking cause keeps
the backstop. The new field is report content only (not added to
`OPERATIONAL_MARKERS`, not F4-minimized). `pnpm run lint:minimum` passes
(typecheck, `build:check`, biome, `node --test`, cspell, markdownlint).

Closes #978


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pre-merge and review-triage instructions to document an advisory-only acknowledgement override for the disposition-evidence backstop.
* **New Features**
  * Enhanced disposition-evidence diagnostics with `ackOnlyPostDisposition` and `soleCauseAckOnlyPostDisposition` to detect when blocking is driven only by post-disposition advisory acknowledgements.
  * When the sole blocking cause matches this advisory-only condition, workflows may proceed from the current HEAD; otherwise existing routing remains unchanged.
* **Tests**
  * Added coverage for advisory-only acknowledgement scenarios (including post-boundary and rejection marker cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->