### PR TITLE
docs(pr-submit): add D1 post-rebase detached-HEAD guard

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -27,6 +27,31 @@ them and continue the rebase. After completing the rebase, if any files
 were manually edited during conflict resolution, run **fix-validate**
 before proceeding.
 
+### Post-rebase verification
+
+In a sibling-worktree setup, a rebase can leave HEAD **detached at the
+upstream tip without replaying the local commit**: the branch ref is
+preserved, but HEAD is moved off it. After the rebase completes and before
+D2, verify both:
+
+1. `git branch --show-current` is **non-empty** — HEAD is on the claimed
+   branch, not detached.
+2. The expected local commit is present in `main..HEAD` (for example,
+   `git log --oneline main..HEAD` lists it).
+
+If HEAD is detached (current branch empty), **auto-recover once**: re-attach
+to the claimed branch with `git checkout {branch-name}` (the local commit is
+preserved on the branch ref), re-run the D1 rebase, then re-verify both
+checks. The re-rebase re-signs through the configured commit-signing path —
+do not pin a key. If recovery still fails (HEAD still detached or the
+expected commit absent), post a hold note documenting the branch state and
+stop; do not push.
+
+This is the same divergence the shared
+[claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate)
+catches at the next mutation (current branch ≠ claimed branch); detecting it
+here turns a confusing later failure into an immediate, recoverable signal.
+
 ## D2 — Verify claim, lint, test, push
 
 1. Re-read the issue to confirm the claim is still yours: the **active

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -27,6 +27,31 @@ them and continue the rebase. After completing the rebase, if any files
 were manually edited during conflict resolution, run **fix-validate**
 before proceeding.
 
+### Post-rebase verification
+
+In a sibling-worktree setup, a rebase can leave HEAD **detached at the
+upstream tip without replaying the local commit**: the branch ref is
+preserved, but HEAD is moved off it. After the rebase completes and before
+D2, verify both:
+
+1. `git branch --show-current` is **non-empty** — HEAD is on the claimed
+   branch, not detached.
+2. The expected local commit is present in `main..HEAD` (for example,
+   `git log --oneline main..HEAD` lists it).
+
+If HEAD is detached (current branch empty), **auto-recover once**: re-attach
+to the claimed branch with `git checkout {branch-name}` (the local commit is
+preserved on the branch ref), re-run the D1 rebase, then re-verify both
+checks. The re-rebase re-signs through the configured commit-signing path —
+do not pin a key. If recovery still fails (HEAD still detached or the
+expected commit absent), post a hold note documenting the branch state and
+stop; do not push.
+
+This is the same divergence the shared
+[claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate)
+catches at the next mutation (current branch ≠ claimed branch); detecting it
+here turns a confusing later failure into an immediate, recoverable signal.
+
 ## D2 — Verify claim, lint, test, push
 
 1. Re-read the issue to confirm the claim is still yours: the **active


### PR DESCRIPTION
## Summary

Adds a concise D1 post-rebase detached-HEAD guard with bounded auto-recovery to
`idd-pr-submit.instructions.md`.

## Background

D1 rebases the branch onto `main` before the first push with no post-rebase
verification. In a sibling-worktree setup (`worktreeGuard.enabled: true` here),
a rebase can leave HEAD **detached at the upstream tip without replaying the
local commit** — the branch ref is preserved, but HEAD is moved off it. The
shared claim-revalidation gate only catches this at the **next mutation**, with
a confusing "branch differs" failure and **no recovery path**, stalling an
unattended run.

## Change

A new D1 *Post-rebase verification* subsection (source +
synced root mirror) that:

- asserts `git branch --show-current` is non-empty **and** the expected commit
  is present in `main..HEAD`, after the rebase and before the D2 push;
- auto-recovers **once** on a detached HEAD (`git checkout {branch-name}` to
  re-attach — the commit is preserved on the branch ref — then re-run the D1
  rebase and re-verify; the re-rebase re-signs through the configured signing
  path, no pinned key);
- posts a hold note and stops if recovery still fails (no push);
- stays tool-agnostic (plain git) and **references** the existing
  claim-revalidation gate rather than restating it.

No change to the "rebase only before the first push; later sync merges `main`"
contract. Root mirror regenerated via `node scripts/sync-docs.mjs --apply`;
`pnpm run lint:minimum` passes (instruction-size budget, markdownlint, cspell,
audit-docs parity).

Closes #979
