### PR TITLE
docs(issue-authoring): add codebase-fidelity pre-publish guards

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -262,6 +262,23 @@ choice does not by itself make an otherwise autonomous issue non-ready.
 The ready issue should still carry its own objective verification even
 when a human will look at the result afterward.
 
+## Codebase-fidelity validation
+
+Before publishing a `ready` issue, run a short pre-publication check that
+the spec stays faithful to the existing codebase. Treat this as a routing
+aid, not a rigid wording linter: A4.5 suitability triage is structural and
+does not read the codebase, so a spec that contradicts established
+semantics can still pass that gate and only surface the mismatch in
+advisory review, costing extra review-fix round-trips.
+
+Ask these checks:
+
+1. When an issue reuses an existing identifier or field name, confirm the
+   specified value matches that name's established semantics in the
+   codebase — do not overload a name with a new shape or source.
+2. Flag values that are mutable at runtime — specify a live read at the
+   point of use rather than a one-time capture at construction.
+
 ## Dependency minimization
 
 Encode a dependency edge only when it reflects a true correctness,

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -92,6 +92,16 @@ Before you publish a `ready` issue, confirm:
 - dependency markers represent true start blockers rather than grouping
   related work
 
+## Codebase-fidelity quick check
+
+Before you publish a `ready` issue, confirm:
+
+- when the issue reuses an existing identifier or field name, the
+  specified value matches that name's established semantics in the
+  codebase — it does not overload a name with a new shape or source
+- values that are mutable at runtime are flagged to specify a live read
+  at the point of use rather than a one-time capture at construction
+
 ## Example orphan issue
 
 - `## Background` or `## Goal`

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -311,6 +311,23 @@ choice does not by itself make an otherwise autonomous issue non-ready.
 The ready issue should still carry its own objective verification even
 when a human will look at the result afterward.
 
+## Codebase-fidelity validation
+
+Before publishing a `ready` issue, run a short pre-publication check that
+the spec stays faithful to the existing codebase. Treat this as a routing
+aid, not a rigid wording linter: A4.5 suitability triage is structural and
+does not read the codebase, so a spec that contradicts established
+semantics can still pass that gate and only surface the mismatch in
+advisory review, costing extra review-fix round-trips.
+
+Ask these checks:
+
+1. When an issue reuses an existing identifier or field name, confirm the
+   specified value matches that name's established semantics in the
+   codebase — do not overload a name with a new shape or source.
+2. Flag values that are mutable at runtime — specify a live read at the
+   point of use rather than a one-time capture at construction.
+
 ## Alignment with A4.5 Suitability Gate
 
 The IDD discover phase uses an A4.5 pre-claim suitability gate that

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -262,6 +262,23 @@ choice does not by itself make an otherwise autonomous issue non-ready.
 The ready issue should still carry its own objective verification even
 when a human will look at the result afterward.
 
+## Codebase-fidelity validation
+
+Before publishing a `ready` issue, run a short pre-publication check that
+the spec stays faithful to the existing codebase. Treat this as a routing
+aid, not a rigid wording linter: A4.5 suitability triage is structural and
+does not read the codebase, so a spec that contradicts established
+semantics can still pass that gate and only surface the mismatch in
+advisory review, costing extra review-fix round-trips.
+
+Ask these checks:
+
+1. When an issue reuses an existing identifier or field name, confirm the
+   specified value matches that name's established semantics in the
+   codebase — do not overload a name with a new shape or source.
+2. Flag values that are mutable at runtime — specify a live read at the
+   point of use rather than a one-time capture at construction.
+
 ## Dependency minimization
 
 Encode a dependency edge only when it reflects a true correctness,

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -92,6 +92,16 @@ Before you publish a `ready` issue, confirm:
 - dependency markers represent true start blockers rather than grouping
   related work
 
+## Codebase-fidelity quick check
+
+Before you publish a `ready` issue, confirm:
+
+- when the issue reuses an existing identifier or field name, the
+  specified value matches that name's established semantics in the
+  codebase — it does not overload a name with a new shape or source
+- values that are mutable at runtime are flagged to specify a live read
+  at the point of use rather than a one-time capture at construction
+
 ## Example orphan issue
 
 - `## Background` or `## Goal`


### PR DESCRIPTION
## Summary

Adds a **Codebase-fidelity validation** pre-publish check group to the issue-authoring checklist so spec-vs-codebase mismatches are caught before publish instead of in advisory review.

Two guards, phrased as a routing aid (not a rigid wording linter), consistent with the existing *Hidden human-dependency validation* tone:

1. When an issue reuses an existing identifier or field name, confirm the specified value matches that name's established semantics in the codebase — do not overload a name with a new shape or source.
2. Flag values that are mutable at runtime — specify a live read at the point of use rather than a one-time capture at construction.

## Changes

- `docs/issue-authoring-skill.md` (canonical) — new `## Codebase-fidelity validation` section after `## Hidden human-dependency validation`.
- `skills/issue-authoring/references/contract.md` — mirrored section in the bundle pre-publish checklist.
- `skills/issue-authoring/references/draft-patterns.md` — condensed `## Codebase-fidelity quick check`, matching the established quick-check mirror pattern.
- `.claude/skills/issue-authoring/references/*.md` — regenerated byte-identical via `node scripts/sync-docs.mjs --apply`.

## Rationale

A4.5 suitability triage is structural and does not read the codebase, so these two mismatch classes (reused identifier with different semantics; runtime-mutable value captured once) previously surfaced only in advisory review, costing extra review-fix round-trips.

## Verification

- `pnpm run lint:minimum` passes (audit-docs `--check`, typecheck, build, biome, dprint, 1067 tests, workshop integrity, cspell, markdownlint).

Closes #980