### PR TITLE
docs(discover): warn discover-roadmap-graph is long-running

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -273,6 +273,14 @@ authorizes an alternate scope for the current run:
   unresolvable with the reason, skip that branch, and continue with the
   rest of the traversal. This is not an enumeration failure.
 
+**Helper read timing.** The `discover-roadmap-graph` helper (see
+[IDD helper script evaluation](../../docs/idd-helper-scripts.md)) is
+long-running on large graphs — it emits the whole graph in one final stdout
+write after many API calls. Redirect stdout to a file and wait for process
+exit before parsing; a zero-byte or mid-run read is **"still running," not** an
+A2 enumeration failure (only the genuine infrastructure/tool failures above
+abort).
+
 Report every A2 execution candidate with its provenance path (e.g.,
 `#222 → #228 → #257`), open roadmap nodes encountered, and any
 unresolvable references before passing to A3.

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 85927
+      "limitBytes": 86379
     },
     {
       "id": "bundle-resume",

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -160,6 +160,13 @@ roadmap graph for one selected roadmap issue.
   bodies and GitHub sub-issue relationships, but it must not claim
   issues, edit roadmap bodies, close roadmap nodes, or decide readiness
   by itself.
+- **Runtime / read timing**: the helper is **long-running** on large
+  roadmaps — it issues many sequential API calls and emits the whole graph
+  in a single final stdout write, with no progress line or completion
+  sentinel. Redirect stdout to a file and wait for process exit before
+  parsing; a zero-byte or partial read from a still-running (or
+  just-finished) helper means **"still running," not** an A2 enumeration
+  failure.
 
 ### Discover Viability Gate Contract
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -291,6 +291,14 @@ authorizes an alternate scope for the current run:
   unresolvable with the reason, skip that branch, and continue with the
   rest of the traversal. This is not an enumeration failure.
 
+**Helper read timing.** The `discover-roadmap-graph` helper (see
+[IDD helper script evaluation](../../docs/idd-helper-scripts.md)) is
+long-running on large graphs — it emits the whole graph in one final stdout
+write after many API calls. Redirect stdout to a file and wait for process
+exit before parsing; a zero-byte or mid-run read is **"still running," not** an
+A2 enumeration failure (only the genuine infrastructure/tool failures above
+abort).
+
 Report every A2 execution candidate with its provenance path (e.g.,
 `#222 → #228 → #257`), open roadmap nodes encountered, and any
 unresolvable references before passing to A3.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -160,6 +160,13 @@ roadmap graph for one selected roadmap issue.
   bodies and GitHub sub-issue relationships, but it must not claim
   issues, edit roadmap bodies, close roadmap nodes, or decide readiness
   by itself.
+- **Runtime / read timing**: the helper is **long-running** on large
+  roadmaps — it issues many sequential API calls and emits the whole graph
+  in a single final stdout write, with no progress line or completion
+  sentinel. Redirect stdout to a file and wait for process exit before
+  parsing; a zero-byte or partial read from a still-running (or
+  just-finished) helper means **"still running," not** an A2 enumeration
+  failure.
 
 ### Discover Viability Gate Contract
 


### PR DESCRIPTION
## Summary

Document that the `discover-roadmap-graph` helper is long-running so a consumer
does not misread a zero-byte / mid-run read as an A2 enumeration failure (which
the prose says to abort on).

- **A2** (`idd-discover.instructions.md`): a concise *Helper read timing* note
  under the existing A2 heading (no new heading, so the `structure`-mode parity
  holds) — the helper is long-running on large graphs (one final stdout write
  after many API calls); redirect stdout to a file and wait for process exit
  before parsing; a zero-byte / mid-run read is "still running," **not** an A2
  enumeration failure. The genuine infrastructure/tool failures above still
  abort.
- **Discover Roadmap Graph Contract** (`docs/idd-helper-scripts.md`): a
  *Runtime / read timing* bullet carrying the same guidance.

Doc-only — no helper/code change. A stderr heartbeat / `done` sentinel in the
helper itself is recorded as **out of scope** (possible future follow-up).

## Bundle-budget ratchet callout

The note grows the discovery bundle from 85927 to a measured **86379** bytes,
so `audit/sync-manifest.json` raises `bundle-discovery.limitBytes`
**85927 → 86379**. Per the manifest ratchet rule, raising a limit requires an
explicit PR callout (this section); the new value records the measured current
size, not an aspiration.

## Source-of-truth

Edited the `idd-template/` sources. `docs/idd-helper-scripts.md` was regenerated
via `node scripts/sync-docs.mjs --apply` (`exact` mode).
`idd-discover.instructions.md` is a `structure`-mode pair, so sync does **not**
auto-copy it; its root mirror was hand-edited to match, and
`node scripts/audit-docs.mjs --check` confirms heading parity.
`pnpm run lint:minimum` passes (audit-docs, discovery-bundle budget, typecheck,
build:check, biome, tests, dprint, cspell, markdownlint).

Closes #982
