### PR TITLE
docs(advisory-wait): add a LAST_COPILOT_COMMIT == HEAD fast path

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -30,6 +30,22 @@ merge-readiness gate — not this advisory-wait window. See
 merge-gate requirement that forbids a bare CI-green merge without a fresh
 covering snapshot.
 
+## Fast path — common case
+
+In the overwhelmingly common case the advisory bot reviews the current HEAD
+within a couple of minutes, so the gate reduces to one check: poll
+`LAST_COPILOT_COMMIT` (the `commit_id` of the latest Copilot review); as soon
+as it equals the current `PR_HEAD_SHA` the gate is **SATISFIED** — skip the
+AW2-AW5 marker / recovery / cap machinery and take the caller's `SATISFIED`
+action (E14 → E15, F2 → CI check, F3 → merge). This is the common-case outcome
+of **both** the helper-first canonical path (`outcome` / `f3Outcome` =
+`SATISFIED`) and the shell fallback (AW3 decision table, row one), and changes
+neither.
+
+Enter the full protocol below **only** when `LAST_COPILOT_COMMIT != PR_HEAD_SHA`
+— the canonical path (or the shell fallback when the helper cannot be trusted)
+then handles the request, pending, stalled, restart, and cap cases.
+
 ## 1. Canonical path (helper-first)
 
 When helper support is installed, use the profile-selected

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -30,6 +30,22 @@ merge-readiness gate — not this advisory-wait window. See
 merge-gate requirement that forbids a bare CI-green merge without a fresh
 covering snapshot.
 
+## Fast path — common case
+
+In the overwhelmingly common case the advisory bot reviews the current HEAD
+within a couple of minutes, so the gate reduces to one check: poll
+`LAST_COPILOT_COMMIT` (the `commit_id` of the latest Copilot review); as soon
+as it equals the current `PR_HEAD_SHA` the gate is **SATISFIED** — skip the
+AW2-AW5 marker / recovery / cap machinery and take the caller's `SATISFIED`
+action (E14 → E15, F2 → CI check, F3 → merge). This is the common-case outcome
+of **both** the helper-first canonical path (`outcome` / `f3Outcome` =
+`SATISFIED`) and the shell fallback (AW3 decision table, row one), and changes
+neither.
+
+Enter the full protocol below **only** when `LAST_COPILOT_COMMIT != PR_HEAD_SHA`
+— the canonical path (or the shell fallback when the helper cannot be trusted)
+then handles the request, pending, stalled, restart, and cap cases.
+
 ## 1. Canonical path (helper-first)
 
 When helper support is installed, use the profile-selected


### PR DESCRIPTION
## Summary

Leads `idd-advisory-wait.instructions.md` with a concise **Fast path — common case** block so an agent on the happy path resolves the advisory-wait gate in one check, instead of re-reading the full marker / recovery / cap machinery on every PR and post-fix push.

- Poll `LAST_COPILOT_COMMIT`; as soon as it equals the current `PR_HEAD_SHA`, the gate is **SATISFIED** — skip the AW2-AW5 machinery and take the caller's `SATISFIED` action (E14 → E15, F2 → CI check, F3 → merge).
- The block summarizes the common-case outcome of **both** the helper-first canonical path and the shell fallback (AW3 row one), and changes neither.
- Fall-through condition is explicit: enter the full protocol only when `LAST_COPILOT_COMMIT != PR_HEAD_SHA`.

## Notes

- Ordering / surfacing change only; the full AW1-AW5 protocol stays intact below as the fallback, and no satisfied / recovery / cap semantics change.
- Edited the `idd-template/` source; root mirror regenerated via `node scripts/sync-docs.mjs --apply`. The block is kept tight to stay within the review and merge instruction bundle budgets.
- `pnpm run lint:minimum` passes (bundle/instruction-size budgets, `audit-docs --check`, markdownlint, cspell).

Closes #983