### PR TITLE
docs(work): update B1 worktree-create to current WorkTrunk verb

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -91,13 +91,14 @@ cleanup before continuing.
 `wt switch --create` (the older `wt new` subcommand was removed):
 
 - macOS/Linux: `wt switch --create -b <base-branch> <branch-name>`
-- Windows: `git-wt switch --create -b <base-branch> <branch-name>` (fall
-  back to `wt switch --create …` if `git-wt` is unavailable)
+- Windows: `git-wt switch --create -b <base-branch> <branch-name>`, or the
+  same `wt switch --create -b <base-branch> <branch-name>` if `git-wt` is
+  unavailable
 
 `<base-branch>` is normally `main`. In a **non-interactive / automation**
 context, append `-x <noop>` (for example `-x true`): otherwise WorkTrunk
-tries to change the caller's directory, warns `Cannot change directory —
-shell requires restart`, and can hang; `-x` makes it create → run the
+tries to change the caller's directory, warns "Cannot change directory —
+shell requires restart", and can hang; `-x` makes it create → run the
 pre-start hook → exit cleanly. Describe the current verb rather than pinning
 a WorkTrunk version.
 

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -31,7 +31,8 @@ Before creating, check for local conflicts in this order:
    `main` — these include read-only inspection (`git worktree list`)
    and the HEAD-preserving branch/worktree commands used by Steps 2-3
    below and by Worktree creation
-   (`git branch -d <stale-branch>`, `git worktree add`, `wt new`).
+   (`git branch -d <stale-branch>`, `git worktree add`,
+   `wt switch --create`).
    What must not happen is the primary worktree's HEAD switching to
    the issue branch. See Anti-patterns below.
 
@@ -68,7 +69,7 @@ branch in the primary worktree:
 
 The primary worktree's HEAD MUST remain on `main` throughout B1. The
 implementation branch exists only inside the sibling worktree created
-by `git worktree add` (or WorkTrunk's `wt new`). If the primary
+by `git worktree add` (or WorkTrunk's `wt switch --create`). If the primary
 worktree ever leaves `main` during B1, stop immediately and follow the
 B1 self-check repair path below.
 
@@ -86,11 +87,19 @@ Example: repo `idd-skill`, branch `issue/123-add-foo` → worktree path
 but is not listed in `git worktree list`, stop and report for manual
 cleanup before continuing.
 
-**Step 2 — Create**: use **WorkTrunk** if available:
+**Step 2 — Create**: use **WorkTrunk** if available. The create verb is
+`wt switch --create` (the older `wt new` subcommand was removed):
 
-- macOS/Linux: `wt new <branch-name>`
-- Windows: `git-wt new <branch-name>` (fall back to
-  `wt new <branch-name>` if `git-wt` is unavailable)
+- macOS/Linux: `wt switch --create -b <base-branch> <branch-name>`
+- Windows: `git-wt switch --create -b <base-branch> <branch-name>` (fall
+  back to `wt switch --create …` if `git-wt` is unavailable)
+
+`<base-branch>` is normally `main`. In a **non-interactive / automation**
+context, append `-x <noop>` (for example `-x true`): otherwise WorkTrunk
+tries to change the caller's directory, warns `Cannot change directory —
+shell requires restart`, and can hang; `-x` makes it create → run the
+pre-start hook → exit cleanly. Describe the current verb rather than pinning
+a WorkTrunk version.
 
 If WorkTrunk is not available, choose the correct case:
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -91,13 +91,14 @@ cleanup before continuing.
 `wt switch --create` (the older `wt new` subcommand was removed):
 
 - macOS/Linux: `wt switch --create -b <base-branch> <branch-name>`
-- Windows: `git-wt switch --create -b <base-branch> <branch-name>` (fall
-  back to `wt switch --create …` if `git-wt` is unavailable)
+- Windows: `git-wt switch --create -b <base-branch> <branch-name>`, or the
+  same `wt switch --create -b <base-branch> <branch-name>` if `git-wt` is
+  unavailable
 
 `<base-branch>` is normally `main`. In a **non-interactive / automation**
 context, append `-x <noop>` (for example `-x true`): otherwise WorkTrunk
-tries to change the caller's directory, warns `Cannot change directory —
-shell requires restart`, and can hang; `-x` makes it create → run the
+tries to change the caller's directory, warns "Cannot change directory —
+shell requires restart", and can hang; `-x` makes it create → run the
 pre-start hook → exit cleanly. Describe the current verb rather than pinning
 a WorkTrunk version.
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -31,7 +31,8 @@ Before creating, check for local conflicts in this order:
    `main` — these include read-only inspection (`git worktree list`)
    and the HEAD-preserving branch/worktree commands used by Steps 2-3
    below and by Worktree creation
-   (`git branch -d <stale-branch>`, `git worktree add`, `wt new`).
+   (`git branch -d <stale-branch>`, `git worktree add`,
+   `wt switch --create`).
    What must not happen is the primary worktree's HEAD switching to
    the issue branch. See Anti-patterns below.
 
@@ -68,7 +69,7 @@ branch in the primary worktree:
 
 The primary worktree's HEAD MUST remain on `main` throughout B1. The
 implementation branch exists only inside the sibling worktree created
-by `git worktree add` (or WorkTrunk's `wt new`). If the primary
+by `git worktree add` (or WorkTrunk's `wt switch --create`). If the primary
 worktree ever leaves `main` during B1, stop immediately and follow the
 B1 self-check repair path below.
 
@@ -86,11 +87,19 @@ Example: repo `{{REPO_NAME}}`, branch `issue/123-add-foo` → worktree path
 but is not listed in `git worktree list`, stop and report for manual
 cleanup before continuing.
 
-**Step 2 — Create**: use **WorkTrunk** if available:
+**Step 2 — Create**: use **WorkTrunk** if available. The create verb is
+`wt switch --create` (the older `wt new` subcommand was removed):
 
-- macOS/Linux: `wt new <branch-name>`
-- Windows: `git-wt new <branch-name>` (fall back to
-  `wt new <branch-name>` if `git-wt` is unavailable)
+- macOS/Linux: `wt switch --create -b <base-branch> <branch-name>`
+- Windows: `git-wt switch --create -b <base-branch> <branch-name>` (fall
+  back to `wt switch --create …` if `git-wt` is unavailable)
+
+`<base-branch>` is normally `main`. In a **non-interactive / automation**
+context, append `-x <noop>` (for example `-x true`): otherwise WorkTrunk
+tries to change the caller's directory, warns `Cannot change directory —
+shell requires restart`, and can hang; `-x` makes it create → run the
+pre-start hook → exit cleanly. Describe the current verb rather than pinning
+a WorkTrunk version.
 
 If WorkTrunk is not available, choose the correct case:
 


### PR DESCRIPTION
## Summary

Update B1 worktree-create guidance to the current WorkTrunk verb — `wt new`
was removed (observed on v0.61.0); the create verb is now `wt switch --create`.

- B1 **Step 2 — Create** now prescribes
  `wt switch --create -b <base-branch> <branch-name>` and the
  `git-wt switch --create` Windows equivalent.
- The two inline `wt new` mentions — the HEAD-preserving-commands aside and the
  "created by … or WorkTrunk's …" fallback prose — are updated to
  `wt switch --create`.
- Documents the **automation-safe** `-x <noop>` form (e.g. `-x true`): a bare
  `wt switch --create` in a non-interactive context tries to change the
  caller's directory, warns "Cannot change directory — shell requires restart,"
  and can hang; `-x` makes it create → run the pre-start hook → exit cleanly.

The `git worktree add` fallback table and the F4 `wt remove` teardown are
unchanged. Guidance describes the current verb rather than pinning a WorkTrunk
version. First-hand confirmed against WorkTrunk v0.61 in the dogfooding
environment (both the removed-`new` failure and the `-x` clean-exit behavior).

## Source-of-truth

Edited the `idd-template/` source;
`.github/instructions/idd-work.instructions.md` was regenerated via
`node scripts/sync-docs.mjs --apply` (`concreted` mode — only the `{{REPO_NAME}}`
substitution differs). `pnpm run lint:minimum` passes (work-bundle size budget,
audit-docs parity, markdownlint, cspell).

Closes #987
