### PR TITLE
docs(idd): require watermark after merge-gate CI completes

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -120,7 +120,8 @@ returns the workflow to E1 instead of merging over it.
   - The current latest CI pass `completedAt` for HEAD differs from
     `{latest-ci-completed-at}` in the watermark (a new CI run completed
     after E1's snapshot; if watermark value is `none`, any current CI
-    pass triggers re-evaluation).
+    pass triggers re-evaluation). A late label-triggered job enabled after
+    the watermark commonly causes this; sequence it before E1, not a fault.
 
   Structural ack-only carve-out: when the only trigger above is newer
   activity or count growth, and the helper evidence proves it consists

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -120,8 +120,8 @@ returns the workflow to E1 instead of merging over it.
   - The current latest CI pass `completedAt` for HEAD differs from
     `{latest-ci-completed-at}` in the watermark (a new CI run completed
     after E1's snapshot; if watermark value is `none`, any current CI
-    pass triggers re-evaluation). A late label-triggered job enabled after
-    the watermark commonly causes this; sequence it before E1, not a fault.
+    pass triggers re-evaluation). A late label-triggered job after the
+    watermark commonly causes this; sequence it before E1; this is not a fault.
 
   Structural ack-only carve-out: when the only trigger above is newer
   activity or count growth, and the helper evidence proves it consists

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -108,6 +108,15 @@ ambiguous). Example Japanese note:
 
 Use server-reported timestamps, not the local wall clock.
 
+**CI-completion precondition.** Post the `review-watermark` only **after**
+every CI run that will count toward the merge gate has completed — including
+any opt-in / label-triggered job enabled at the quiescent pre-merge point.
+Operationally: enable the late job, await its completion, **then** take the
+Step 1 snapshot and post the watermark. A merge-gate-counting run
+completing _after_ the watermark advances HEAD's latest CI time and forces a
+wasted E1↔F2 round-trip (F2's `ci-pass-drift` return-to-E1) even though no new
+review activity occurred.
+
 Note: the comment body begins with an HTML comment token. Some GitHub
 client tools (e.g., `gh issue comment`, `gh api -f body=`) silently
 reject bodies that consist entirely of HTML comments; this format

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -120,7 +120,8 @@ returns the workflow to E1 instead of merging over it.
   - The current latest CI pass `completedAt` for HEAD differs from
     `{latest-ci-completed-at}` in the watermark (a new CI run completed
     after E1's snapshot; if watermark value is `none`, any current CI
-    pass triggers re-evaluation).
+    pass triggers re-evaluation). A late label-triggered job enabled after
+    the watermark commonly causes this; sequence it before E1, not a fault.
 
   Structural ack-only carve-out: when the only trigger above is newer
   activity or count growth, and the helper evidence proves it consists

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -120,8 +120,8 @@ returns the workflow to E1 instead of merging over it.
   - The current latest CI pass `completedAt` for HEAD differs from
     `{latest-ci-completed-at}` in the watermark (a new CI run completed
     after E1's snapshot; if watermark value is `none`, any current CI
-    pass triggers re-evaluation). A late label-triggered job enabled after
-    the watermark commonly causes this; sequence it before E1, not a fault.
+    pass triggers re-evaluation). A late label-triggered job after the
+    watermark commonly causes this; sequence it before E1; this is not a fault.
 
   Structural ack-only carve-out: when the only trigger above is newer
   activity or count growth, and the helper evidence proves it consists

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -108,6 +108,15 @@ ambiguous). Example Japanese note:
 
 Use server-reported timestamps, not the local wall clock.
 
+**CI-completion precondition.** Post the `review-watermark` only **after**
+every CI run that will count toward the merge gate has completed — including
+any opt-in / label-triggered job enabled at the quiescent pre-merge point.
+Operationally: enable the late job, await its completion, **then** take the
+Step 1 snapshot and post the watermark. A merge-gate-counting run
+completing _after_ the watermark advances HEAD's latest CI time and forces a
+wasted E1↔F2 round-trip (F2's `ci-pass-drift` return-to-E1) even though no new
+review activity occurred.
+
 Note: the comment body begins with an HTML comment token. Some GitHub
 client tools (e.g., `gh issue comment`, `gh api -f body=`) silently
 reject bodies that consist entirely of HTML comments; this format


### PR DESCRIPTION
## Summary

States an explicit ordering precondition so a late merge-gate CI job no longer forces a wasted review-snapshot cycle.

- **E1** (`idd-review-snapshot.instructions.md`): a new **CI-completion precondition** — post the `review-watermark` only after every CI run that counts toward the merge gate has completed, including any opt-in / label-triggered job enabled at the quiescent pre-merge point. Operationally: enable the late job → await completion → then snapshot + watermark.
- **F2** (`idd-pre-merge.instructions.md`): the CI-drift bullet now notes that a late label-triggered job enabled after the watermark is the common cause of the `ci-pass-drift` return-to-E1, and to sequence it before E1 rather than treat it as a fault.

## Notes

- Doc-only; the `diffReviewSnapshot` exact-match comparison behavior is unchanged (that exact-match is correct).
- Edited the `idd-template/` sources; root mirrors regenerated via `node scripts/sync-docs.mjs --apply`.
- The F2 note is intentionally terse: the `bundle-merge` instruction budget is nearly full, so the operational detail lives in the E1 precondition and F2 carries a one-line pointer.
- `pnpm run lint:minimum` passes (bundle budgets, `audit-docs --check`, markdownlint, cspell).

Closes #988