### PR TITLE
docs(workflow): document one-issue-per-session autopilot operating model

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -266,4 +266,7 @@ Before any mutating action in F3, apply the
 
 ## F5 — Loop
 
-Return to `idd-discover.instructions.md` and pick the next issue.
+Return to `idd-discover.instructions.md` and pick the next issue. Prefer
+re-entering Discover in a fresh short-lived session rather than looping
+in-process — see the autopilot operating model in
+[`docs/idd-workflow.md`](../../docs/idd-workflow.md).

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 80600
+      "limitBytes": 80665
     }
   ],
   "syncPairs": [

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -221,8 +221,8 @@ and issue/PR status — lives in the forge (GitHub), not in the agent's
 context, so the loop does not need to be carried in one long-lived process:
 a thin external runner or scheduler (or a dynamic-paced loop primitive)
 re-enters Discover for the next unclaimed issue in a fresh session. This
-composes with the external-scheduler model already described in
-[positioning](positioning.md) — IDD ships no daemon.
+composes with IDD's existing model — it ships no daemon and relies on an
+external scheduler to drive the loop.
 
 Treat the **context window as a first-class, exhaustible resource**,
 alongside wall-clock time and token budget. A single session that runs

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -212,6 +212,34 @@ stale-claim takeover, or ordinary clean continuation. This keeps crash
 and stall handling separate without requiring the stalled session to
 publish a final self-report.
 
+## Autopilot operating model
+
+The execution loop is **one issue = one short-lived session**: drive a
+single Discover → Claim → Work → PR → Review → Merge → F4 cleanup cycle to
+completion, then let the session end. All durable loop state — claims, PRs,
+and issue/PR status — lives in the forge (GitHub), not in the agent's
+context, so the loop does not need to be carried in one long-lived process:
+a thin external runner or scheduler (or a dynamic-paced loop primitive)
+re-enters Discover for the next unclaimed issue in a fresh session. This
+composes with the external-scheduler model already described in
+[positioning](positioning.md) — IDD ships no daemon.
+
+Treat the **context window as a first-class, exhaustible resource**,
+alongside wall-clock time and token budget. A single session that runs
+F5 → Discover → … → F5 in-process accumulates every issue's tool output,
+diffs, CI logs, and review threads, so each later issue pays a steadily
+larger context-re-read cost — a direct cause of mid-run context exhaustion.
+The monolithic single-session loop is therefore the **anti-pattern**;
+prefer short sessions that exit at the F4/F5 boundary and let the runner
+start the next one.
+
+Short sessions need cheap ramp-up, which the "facts live in docs and
+helpers, not in session memory" design already supports: a fresh session
+reconstructs what it needs from the instruction files, `.github/idd/`
+config, and forge state. This guidance is **advisory** — a recommended
+practice with its rationale, not a hard requirement — and
+**runner-agnostic**, since this repository ships no runner.
+
 ## Live Status Digests
 
 Use the live status digest contract in

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -266,4 +266,7 @@ Before any mutating action in F3, apply the
 
 ## F5 — Loop
 
-Return to `idd-discover.instructions.md` and pick the next issue.
+Return to `idd-discover.instructions.md` and pick the next issue. Prefer
+re-entering Discover in a fresh short-lived session rather than looping
+in-process — see the autopilot operating model in
+[`docs/idd-workflow.md`](../../docs/idd-workflow.md).

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -190,6 +190,34 @@ stale-claim takeover, or ordinary clean continuation. This keeps crash
 and stall handling separate without requiring the stalled session to
 publish a final self-report.
 
+## Autopilot operating model
+
+The execution loop is **one issue = one short-lived session**: drive a
+single Discover → Claim → Work → PR → Review → Merge → F4 cleanup cycle to
+completion, then let the session end. All durable loop state — claims, PRs,
+and issue/PR status — lives in the forge (GitHub), not in the agent's
+context, so the loop does not need to be carried in one long-lived process:
+a thin external runner or scheduler (or a dynamic-paced loop primitive)
+re-enters Discover for the next unclaimed issue in a fresh session. This
+composes with the external-scheduler model already described in
+[positioning](positioning.md) — IDD ships no daemon.
+
+Treat the **context window as a first-class, exhaustible resource**,
+alongside wall-clock time and token budget. A single session that runs
+F5 → Discover → … → F5 in-process accumulates every issue's tool output,
+diffs, CI logs, and review threads, so each later issue pays a steadily
+larger context-re-read cost — a direct cause of mid-run context exhaustion.
+The monolithic single-session loop is therefore the **anti-pattern**;
+prefer short sessions that exit at the F4/F5 boundary and let the runner
+start the next one.
+
+Short sessions need cheap ramp-up, which the "facts live in docs and
+helpers, not in session memory" design already supports: a fresh session
+reconstructs what it needs from the instruction files, `.github/idd/`
+config, and forge state. This guidance is **advisory** — a recommended
+practice with its rationale, not a hard requirement — and
+**runner-agnostic**, since this repository ships no runner.
+
 ## Live Status Digests
 
 Use the live status digest contract in

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -199,8 +199,8 @@ and issue/PR status — lives in the forge (GitHub), not in the agent's
 context, so the loop does not need to be carried in one long-lived process:
 a thin external runner or scheduler (or a dynamic-paced loop primitive)
 re-enters Discover for the next unclaimed issue in a fresh session. This
-composes with the external-scheduler model already described in
-[positioning](positioning.md) — IDD ships no daemon.
+composes with IDD's existing model — it ships no daemon and relies on an
+external scheduler to drive the loop.
 
 Treat the **context window as a first-class, exhaustible resource**,
 alongside wall-clock time and token budget. A single session that runs


### PR DESCRIPTION
## Summary

F5 was neutral about session scope, so running F5 → Discover → … → F5 in one
long-lived session accumulates unbounded context (every issue's tool output,
diffs, CI logs, review threads) — a direct cause of mid-run context exhaustion.
Document the recommended **one-issue-per-session** autopilot operating model.

- New **Autopilot operating model** section in `docs/idd-workflow.md`: durable
  loop state (claims, PRs, status) lives in the forge, so a thin external
  runner can drive a fresh short-lived session per Discover→Merge→cleanup
  cycle. Frames the **context window as a first-class exhaustible resource**
  (alongside wall-clock and token budget) and names the monolithic
  single-session loop as the **anti-pattern**. Runner-agnostic and advisory.
- `idd-merge.instructions.md` **F5** gains a short cross-reference to the
  section.

## Bundle-budget ratchet callout

The F5 cross-reference grows the merge bundle, so `audit/sync-manifest.json`
raises `bundle-merge.limitBytes` **80600 → 80782** (measured current size; the
manifest ratchet rule requires this explicit callout). The value also absorbs
the concurrent `idd-pre-merge.instructions.md` growth merged from `main` (PR
#1000 / #988) while this branch was open — `main` was merged in (not rebased)
and the limit reconciled to the post-merge measured total.

## Source-of-truth

`docs/idd-workflow.md` is a `structure`-mode pair, so both the `idd-template/`
source and the root copy were hand-edited with the identical section (verified
byte-identical). `idd-merge.instructions.md` is `exact` mode; its root mirror
was regenerated via `node scripts/sync-docs.mjs --apply`. `pnpm run lint:minimum`
passes (audit-docs parity, bundle budgets, typecheck, build:check, biome, tests,
dprint, cspell, markdownlint).

Closes #990
