### PR TITLE
docs(ci): codify a wake-up discipline for CI/advisory wait points

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -46,6 +46,11 @@ Enter the full protocol below **only** when `LAST_COPILOT_COMMIT != PR_HEAD_SHA`
 — the canonical path (or the shell fallback when the helper cannot be trusted)
 then handles the request, pending, stalled, restart, and cap cases.
 
+Keep the wait itself cheap per the
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): background or
+schedule a single wake at the **expected** completion rather than inserting
+interim polling turns, and batch all post-wait actions into one turn.
+
 ## 1. Canonical path (helper-first)
 
 When helper support is installed, use the profile-selected

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -147,3 +147,23 @@ for the same run before posting a hold.
 | Any required check is non-pass `cancelled` or `timed_out`                                  | Investigate cause. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. If infra-caused: apply `ciWait.rerunPolicy`; rerun or re-push only when the current rerun budget allows it, otherwise post a hold comment and stop.                                                                                                                                                                                                                                                               |
 | Any required check is running (`pending`/`requested`/`waiting`/`expected`/...)             | Continue waiting. After `ciWait.runningTimeout` — measured from the check's server `startedAt` (see the Polling algorithm) — elapses with no completion (default: 30 min), apply `ciWait.rerunPolicy`. If it resolves to rerun, rerun CI once and resume polling. If the same route recurs after that rerun, or if the policy is `hold`, post a hold comment and stop.                                                                                                                                                                    |
 | Required checks are not generated after `ciWait.generationTimeout`                         | Treat as running. Default: 10 min. If the corresponding workflow run does not exist at all when that window elapses, post a hold comment and escalate to a maintainer, then stop.                                                                                                                                                                                                                                                                                                                                                         |
+
+## Wake-up discipline
+
+The polling mechanics above are unchanged. This advisory, tool-agnostic note
+keeps the **wait itself cheap**: the dominant cost of a wait is each
+re-invocation's context re-read (worse once it crosses the prompt-cache TTL,
+as CI/e2e waits routinely do), not the idle time.
+
+- **No interim polling turns** — background the watch, or schedule one wake at
+  the **expected** completion interval; do not insert "is it done yet?" turns
+  or peek at an empty watch buffer between wakes.
+- **Batch post-wait actions** into a single turn once the wait resolves
+  (disposition, replies, marker, next gate together — not one round-trip each).
+- **Scope post-fix re-validation to the changed surface** when the change is
+  provably outside the full build/test suite, instead of re-running everything
+  (also avoids the context cost of large log outputs).
+
+This trims only the wasteful dimensions (context re-read, CI minutes); it does
+**not** reduce review rounds, which remain valuable and run in full. This same
+discipline applies to the advisory-wait and review-fix wait points.

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -239,6 +239,10 @@ keys preserve the distributed defaults. The outcome paths below are
 authoritative and override the shared helper's generic outcomes for this
 phase:
 
+Keep the wait cheap per the
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline) (no interim
+polling turns; batch post-wait actions into one turn).
+
 **While polling**: if new review threads or comments arrive during the
 CI wait, note them. After CI resolves (any outcome), return to E1 before
 proceeding to F — do not skip triage.

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -195,7 +195,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 92400
+      "limitBytes": 93685
     },
     {
       "id": "bundle-merge",
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 80782
+      "limitBytes": 82142
     }
   ],
   "syncPairs": [

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -46,6 +46,11 @@ Enter the full protocol below **only** when `LAST_COPILOT_COMMIT != PR_HEAD_SHA`
 — the canonical path (or the shell fallback when the helper cannot be trusted)
 then handles the request, pending, stalled, restart, and cap cases.
 
+Keep the wait itself cheap per the
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): background or
+schedule a single wake at the **expected** completion rather than inserting
+interim polling turns, and batch all post-wait actions into one turn.
+
 ## 1. Canonical path (helper-first)
 
 When helper support is installed, use the profile-selected

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -147,3 +147,23 @@ for the same run before posting a hold.
 | Any required check is non-pass `cancelled` or `timed_out`                                  | Investigate cause. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. If infra-caused: apply `ciWait.rerunPolicy`; rerun or re-push only when the current rerun budget allows it, otherwise post a hold comment and stop.                                                                                                                                                                                                                                                               |
 | Any required check is running (`pending`/`requested`/`waiting`/`expected`/...)             | Continue waiting. After `ciWait.runningTimeout` — measured from the check's server `startedAt` (see the Polling algorithm) — elapses with no completion (default: 30 min), apply `ciWait.rerunPolicy`. If it resolves to rerun, rerun CI once and resume polling. If the same route recurs after that rerun, or if the policy is `hold`, post a hold comment and stop.                                                                                                                                                                    |
 | Required checks are not generated after `ciWait.generationTimeout`                         | Treat as running. Default: 10 min. If the corresponding workflow run does not exist at all when that window elapses, post a hold comment and escalate to a maintainer, then stop.                                                                                                                                                                                                                                                                                                                                                         |
+
+## Wake-up discipline
+
+The polling mechanics above are unchanged. This advisory, tool-agnostic note
+keeps the **wait itself cheap**: the dominant cost of a wait is each
+re-invocation's context re-read (worse once it crosses the prompt-cache TTL,
+as CI/e2e waits routinely do), not the idle time.
+
+- **No interim polling turns** — background the watch, or schedule one wake at
+  the **expected** completion interval; do not insert "is it done yet?" turns
+  or peek at an empty watch buffer between wakes.
+- **Batch post-wait actions** into a single turn once the wait resolves
+  (disposition, replies, marker, next gate together — not one round-trip each).
+- **Scope post-fix re-validation to the changed surface** when the change is
+  provably outside the full build/test suite, instead of re-running everything
+  (also avoids the context cost of large log outputs).
+
+This trims only the wasteful dimensions (context re-read, CI minutes); it does
+**not** reduce review rounds, which remain valuable and run in full. This same
+discipline applies to the advisory-wait and review-fix wait points.

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -239,6 +239,10 @@ keys preserve the distributed defaults. The outcome paths below are
 authoritative and override the shared helper's generic outcomes for this
 phase:
 
+Keep the wait cheap per the
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline) (no interim
+polling turns; batch post-wait actions into one turn).
+
 **While polling**: if new review threads or comments arrive during the
 CI wait, note them. After CI resolves (any outcome), return to E1 before
 proceeding to F — do not skip triage.


### PR DESCRIPTION
## Summary

The wait points documented only polling **mechanics**, not a strategic wake-up
**discipline**: interim "is it done yet?" turns and no-op peeks at an empty
watch buffer are pure context-re-read waste that multiplies with each review
round.

- New **Wake-up discipline** section in `idd-ci.instructions.md` (the shared
  polling helper): (a) **no interim polling turns** — background the watch or
  schedule one wake at the **expected** completion; (b) **batch post-wait
  actions** into a single turn; (c) **scope post-fix re-validation to the
  changed surface** when provably outside the full suite.
- Cross-referenced from the **advisory-wait** and **review-fix** wait points
  (single shared note, not duplicated three times).
- **Review rounds are explicitly preserved** (not reduced); poll-interval /
  timeout mechanics are unchanged. Advisory and tool-agnostic.

## Bundle-budget ratchet callout

The shared note + two cross-references grow two bundles that include
`idd-ci.instructions.md`, so `audit/sync-manifest.json` raises
`bundle-merge.limitBytes` **80782 → 82142** and `bundle-review.limitBytes`
**92400 → 93685** (measured current sizes; the manifest ratchet rule requires
this explicit callout).

## Source-of-truth

All three files are `exact`-mode mirrors; edited the `idd-template/` sources and
regenerated the root mirrors via `node scripts/sync-docs.mjs --apply` (verified
byte-identical). `pnpm run lint:minimum` passes (audit-docs parity, bundle
budgets, typecheck, build:check, biome, tests, dprint, cspell, markdownlint).

Closes #992
