### PR TITLE
docs(idd): document F4/F5 as the safe session-exit boundary

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -184,9 +184,9 @@ Before any mutating action in F3, apply the
    - Known review-bot regular PR comments may be minimized only after
      the PR is merged and the comment shows a completed-review or
      stale-notification signal: a CodeRabbit no-action summary, a
-     review-trigger summary with a matching later IDD disposition, or a
-     CodeRabbit summary whose review threads are all resolved with fresh
-     IDD dispositions.
+     review-trigger acknowledgement with a matching later IDD disposition,
+     or a CodeRabbit summary whose review threads are all resolved with
+     fresh IDD dispositions.
    - Bot review parent bodies without associated review threads are
      skipped by default, including Copilot error review bodies, unless a
      future policy explicitly narrows a safe cleanup class for them.

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -182,12 +182,11 @@ Before any mutating action in F3, apply the
      parent has been accepted or rejected, replied to as required, and
      resolved.
    - Known review-bot regular PR comments may be minimized only after
-     the PR is merged and the comment has a clear completed-review or
-     stale-notification signal, such as a CodeRabbit no-action summary
-     or a CodeRabbit summary / review-trigger acknowledgement with a
-     matching later IDD disposition. CodeRabbit summaries may also be
-     minimized when all CodeRabbit review threads are resolved and have
-     fresh IDD dispositions.
+     the PR is merged and the comment shows a completed-review or
+     stale-notification signal: a CodeRabbit no-action summary, a
+     review-trigger summary with a matching later IDD disposition, or a
+     CodeRabbit summary whose review threads are all resolved with fresh
+     IDD dispositions.
    - Bot review parent bodies without associated review threads are
      skipped by default, including Copilot error review bodies, unless a
      future policy explicitly narrows a safe cleanup class for them.
@@ -266,7 +265,7 @@ Before any mutating action in F3, apply the
 
 ## F5 — Loop
 
-Return to `idd-discover.instructions.md` and pick the next issue. Prefer
-re-entering Discover in a fresh short-lived session rather than looping
-in-process — see the autopilot operating model in
-[`docs/idd-workflow.md`](../../docs/idd-workflow.md).
+Return to `idd-discover.instructions.md` and pick the next issue. F4-complete /
+F5 is the **safe session-exit boundary**: under context pressure, exit here for
+a fresh Discover session rather than looping in-process — see the autopilot
+operating model in [`docs/idd-workflow.md`](../../docs/idd-workflow.md).

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -182,10 +182,11 @@ Before any mutating action in F3, apply the
      parent has been accepted or rejected, replied to as required, and
      resolved.
    - Known review-bot regular PR comments may be minimized only after
-     the PR is merged and the comment shows a completed-review or
-     stale-notification signal: a CodeRabbit no-action summary, a
-     review-trigger acknowledgement with a matching later IDD disposition,
-     or a CodeRabbit summary whose review threads are all resolved with
+     the PR is merged and the comment has a clear completed-review or
+     stale-notification signal, such as a CodeRabbit no-action summary
+     or a CodeRabbit summary / review-trigger acknowledgement with a
+     matching later IDD disposition. CodeRabbit summaries may also be
+     minimized when all CodeRabbit review threads are resolved and have
      fresh IDD dispositions.
    - Bot review parent bodies without associated review threads are
      skipped by default, including Copilot error review bodies, unless a

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 82142
+      "limitBytes": 82202
     }
   ],
   "syncPairs": [

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -233,6 +233,15 @@ The monolithic single-session loop is therefore the **anti-pattern**;
 prefer short sessions that exit at the F4/F5 boundary and let the runner
 start the next one.
 
+F4-complete / F5 is therefore the recommended **safe session-exit boundary**.
+When context pressure hits mid-issue, a session can die mid-flight and leave a
+partially-progressed issue (claimed, branch pushed, PR open, or mid-review) for
+a later session to untangle. Finishing the current issue to the F4/F5 boundary
+and exiting there converts that uncontrolled failure into a controlled handoff —
+durable claim and PR state plus the existing resume phase let a fresh session
+pick up cleanly at Discover, rather than starting another issue and risking a
+mid-loop death.
+
 Short sessions need cheap ramp-up, which the "facts live in docs and
 helpers, not in session memory" design already supports: a fresh session
 reconstructs what it needs from the instruction files, `.github/idd/`

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -184,9 +184,9 @@ Before any mutating action in F3, apply the
    - Known review-bot regular PR comments may be minimized only after
      the PR is merged and the comment shows a completed-review or
      stale-notification signal: a CodeRabbit no-action summary, a
-     review-trigger summary with a matching later IDD disposition, or a
-     CodeRabbit summary whose review threads are all resolved with fresh
-     IDD dispositions.
+     review-trigger acknowledgement with a matching later IDD disposition,
+     or a CodeRabbit summary whose review threads are all resolved with
+     fresh IDD dispositions.
    - Bot review parent bodies without associated review threads are
      skipped by default, including Copilot error review bodies, unless a
      future policy explicitly narrows a safe cleanup class for them.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -182,12 +182,11 @@ Before any mutating action in F3, apply the
      parent has been accepted or rejected, replied to as required, and
      resolved.
    - Known review-bot regular PR comments may be minimized only after
-     the PR is merged and the comment has a clear completed-review or
-     stale-notification signal, such as a CodeRabbit no-action summary
-     or a CodeRabbit summary / review-trigger acknowledgement with a
-     matching later IDD disposition. CodeRabbit summaries may also be
-     minimized when all CodeRabbit review threads are resolved and have
-     fresh IDD dispositions.
+     the PR is merged and the comment shows a completed-review or
+     stale-notification signal: a CodeRabbit no-action summary, a
+     review-trigger summary with a matching later IDD disposition, or a
+     CodeRabbit summary whose review threads are all resolved with fresh
+     IDD dispositions.
    - Bot review parent bodies without associated review threads are
      skipped by default, including Copilot error review bodies, unless a
      future policy explicitly narrows a safe cleanup class for them.
@@ -266,7 +265,7 @@ Before any mutating action in F3, apply the
 
 ## F5 — Loop
 
-Return to `idd-discover.instructions.md` and pick the next issue. Prefer
-re-entering Discover in a fresh short-lived session rather than looping
-in-process — see the autopilot operating model in
-[`docs/idd-workflow.md`](../../docs/idd-workflow.md).
+Return to `idd-discover.instructions.md` and pick the next issue. F4-complete /
+F5 is the **safe session-exit boundary**: under context pressure, exit here for
+a fresh Discover session rather than looping in-process — see the autopilot
+operating model in [`docs/idd-workflow.md`](../../docs/idd-workflow.md).

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -182,10 +182,11 @@ Before any mutating action in F3, apply the
      parent has been accepted or rejected, replied to as required, and
      resolved.
    - Known review-bot regular PR comments may be minimized only after
-     the PR is merged and the comment shows a completed-review or
-     stale-notification signal: a CodeRabbit no-action summary, a
-     review-trigger acknowledgement with a matching later IDD disposition,
-     or a CodeRabbit summary whose review threads are all resolved with
+     the PR is merged and the comment has a clear completed-review or
+     stale-notification signal, such as a CodeRabbit no-action summary
+     or a CodeRabbit summary / review-trigger acknowledgement with a
+     matching later IDD disposition. CodeRabbit summaries may also be
+     minimized when all CodeRabbit review threads are resolved and have
      fresh IDD dispositions.
    - Bot review parent bodies without associated review threads are
      skipped by default, including Copilot error review bodies, unless a

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -211,6 +211,15 @@ The monolithic single-session loop is therefore the **anti-pattern**;
 prefer short sessions that exit at the F4/F5 boundary and let the runner
 start the next one.
 
+F4-complete / F5 is therefore the recommended **safe session-exit boundary**.
+When context pressure hits mid-issue, a session can die mid-flight and leave a
+partially-progressed issue (claimed, branch pushed, PR open, or mid-review) for
+a later session to untangle. Finishing the current issue to the F4/F5 boundary
+and exiting there converts that uncontrolled failure into a controlled handoff —
+durable claim and PR state plus the existing resume phase let a fresh session
+pick up cleanly at Discover, rather than starting another issue and risking a
+mid-loop death.
+
 Short sessions need cheap ramp-up, which the "facts live in docs and
 helpers, not in session memory" design already supports: a fresh session
 reconstructs what it needs from the instruction files, `.github/idd/`


### PR DESCRIPTION
## Summary

Documents F4-complete / F5 as the recommended **safe session-exit boundary**, as a minimal complement to the one-issue-per-session operating model added by #990 (merged first while this was in progress).

- **F5** (`idd-merge.instructions.md`): the F5 note now names the **safe session-exit boundary** explicitly and adds the *under context pressure* trigger (building on #990's existing pointer to the operating model).
- **Workflow doc** (`docs/idd-workflow.md`, both structure-mode copies): adds one paragraph to #990's `## Autopilot operating model` section covering the **failure-mode / controlled-handoff** angle that section lacked — a mid-issue death leaves a partially-progressed issue (claimed, branch pushed, PR open, or mid-review) to untangle, so finishing to the F4/F5 boundary and exiting there converts an uncontrolled failure into a controlled handoff backed by durable forge state and the existing resume phase.

## Coordination with #990

Per the issue, this is the companion context-guard to #990; it **cross-references rather than duplicates** the operating-model rationale. The new workflow paragraph adds only the crash-resilience/controlled-handoff framing, not a restatement of #990's content.

## Notes

- Advisory and tool-agnostic; no change to the F4 cleanup steps themselves.
- Edited the `idd-template/` sources; the `idd-merge` mirror is regenerated by `node scripts/sync-docs.mjs --apply`, and the workflow doc is hand-edited in both `structure`-mode copies.
- To keep the near-full `bundle-merge` budget satisfied (limit 80782, now 21 free), the verbose "Known review-bot regular PR comments" F4 cleanup bullet was tightened (meaning-preserving; the no-action-summary standalone class is unchanged).
- `pnpm run lint:minimum` passes (bundle budgets, `audit-docs --check`, markdownlint, cspell).

Closes #991