### PR TITLE
docs(merge): harden F3 gate with a copy-paste-safe SHA check + checklist

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -129,8 +129,9 @@ Before any mutating action in F3, apply the
      (`{f2-head-SHA}`);
    - review-currency route is `proceed`;
    - `F3_UNRESOLVED_ACTIONABLE_COUNT` is `0`;
-   - advisory `f3Outcome` is `SATISFIED` (with `LAST_COPILOT_COMMIT` equal
-     to the current head, or `copilotPending` is `false`);
+   - advisory `f3Outcome` is `SATISFIED` (the authoritative advisory gate —
+     do not add stricter sub-conditions; e.g. a pending-window `SATISFIED`
+     can keep `copilotPending` true and `LAST_COPILOT_COMMIT` off the head);
    - all required CI checks pass for the current head;
    - claim ownership still uses your `{claim-id}`.
 
@@ -144,7 +145,7 @@ Before any mutating action in F3, apply the
    ```sh
    if [ "$PR_HEAD_SHA_F3" != "$F2_HEAD_SHA" ]; then
      echo "F3 abort: head moved ${F2_HEAD_SHA} -> ${PR_HEAD_SHA_F3}" >&2
-     exit 1  # do not merge — return to F1/E1 per the freshness rules above
+     exit 1  # do not merge — return to E1 per the freshness rules above
    fi
    ```
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -138,11 +138,12 @@ Before any mutating action in F3, apply the
    For the head-SHA field, use this **copy-paste-safe, fail-closed** check
    — both operands fully quoted, no glob, abort on mismatch — rather than
    re-deriving the comparison ad hoc (a stray glob or an unquoted operand
-   can silently mis-gate the most safety-sensitive step). `F2_HEAD_SHA` is
-   the carried `{f2-head-SHA}`; `PR_HEAD_SHA_F3` is the head re-fetched in
-   step 3:
+   can silently mis-gate the most safety-sensitive step). Set `F2_HEAD_SHA`
+   from the carried `{f2-head-SHA}` so the snippet is self-contained;
+   `PR_HEAD_SHA_F3` is the head re-fetched in step 3:
 
    ```sh
+   F2_HEAD_SHA="{f2-head-SHA}"   # the head recorded in the F2 snapshot
    if [ "$PR_HEAD_SHA_F3" != "$F2_HEAD_SHA" ]; then
      echo "F3 abort: head moved ${F2_HEAD_SHA} -> ${PR_HEAD_SHA_F3}" >&2
      exit 1  # do not merge — return to E1 per the freshness rules above

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -119,7 +119,37 @@ Before any mutating action in F3, apply the
 
 4. Merge the PR using a **merge commit**, binding to the validated SHA
    to prevent a race where a new push lands after the F3 freshness check
-   but before the merge executes:
+   but before the merge executes.
+
+   **Gate checklist** — confirm every field before merging; all must hold,
+   and any unmet or unknown field is a NO-GO (fail closed — stop, do not
+   merge):
+
+   - current HEAD SHA **equals** the carried F2-snapshot head
+     (`{f2-head-SHA}`);
+   - review-currency route is `proceed`;
+   - `F3_UNRESOLVED_ACTIONABLE_COUNT` is `0`;
+   - advisory `f3Outcome` is `SATISFIED` (with `LAST_COPILOT_COMMIT` equal
+     to the current head, or `copilotPending` is `false`);
+   - all required CI checks pass for the current head;
+   - claim ownership still uses your `{claim-id}`.
+
+   For the head-SHA field, use this **copy-paste-safe, fail-closed** check
+   — both operands fully quoted, no glob, abort on mismatch — rather than
+   re-deriving the comparison ad hoc (a stray glob or an unquoted operand
+   can silently mis-gate the most safety-sensitive step). `F2_HEAD_SHA` is
+   the carried `{f2-head-SHA}`; `PR_HEAD_SHA_F3` is the head re-fetched in
+   step 3:
+
+   ```sh
+   if [ "$PR_HEAD_SHA_F3" != "$F2_HEAD_SHA" ]; then
+     echo "F3 abort: head moved ${F2_HEAD_SHA} -> ${PR_HEAD_SHA_F3}" >&2
+     exit 1  # do not merge — return to F1/E1 per the freshness rules above
+   fi
+   ```
+
+   Then merge, binding `--match-head-commit` to the **freshly validated**
+   `${PR_HEAD_SHA_F3}` (never a stale, hardcoded, or unbound SHA):
 
    ```sh
    gh pr merge {pr-number} --merge --match-head-commit "${PR_HEAD_SHA_F3}"

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 83570
+      "limitBytes": 83681
     }
   ],
   "syncPairs": [

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 82142
+      "limitBytes": 83477
     }
   ],
   "syncPairs": [

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 83477
+      "limitBytes": 83570
     }
   ],
   "syncPairs": [

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -129,8 +129,9 @@ Before any mutating action in F3, apply the
      (`{f2-head-SHA}`);
    - review-currency route is `proceed`;
    - `F3_UNRESOLVED_ACTIONABLE_COUNT` is `0`;
-   - advisory `f3Outcome` is `SATISFIED` (with `LAST_COPILOT_COMMIT` equal
-     to the current head, or `copilotPending` is `false`);
+   - advisory `f3Outcome` is `SATISFIED` (the authoritative advisory gate —
+     do not add stricter sub-conditions; e.g. a pending-window `SATISFIED`
+     can keep `copilotPending` true and `LAST_COPILOT_COMMIT` off the head);
    - all required CI checks pass for the current head;
    - claim ownership still uses your `{claim-id}`.
 
@@ -144,7 +145,7 @@ Before any mutating action in F3, apply the
    ```sh
    if [ "$PR_HEAD_SHA_F3" != "$F2_HEAD_SHA" ]; then
      echo "F3 abort: head moved ${F2_HEAD_SHA} -> ${PR_HEAD_SHA_F3}" >&2
-     exit 1  # do not merge — return to F1/E1 per the freshness rules above
+     exit 1  # do not merge — return to E1 per the freshness rules above
    fi
    ```
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -138,11 +138,12 @@ Before any mutating action in F3, apply the
    For the head-SHA field, use this **copy-paste-safe, fail-closed** check
    — both operands fully quoted, no glob, abort on mismatch — rather than
    re-deriving the comparison ad hoc (a stray glob or an unquoted operand
-   can silently mis-gate the most safety-sensitive step). `F2_HEAD_SHA` is
-   the carried `{f2-head-SHA}`; `PR_HEAD_SHA_F3` is the head re-fetched in
-   step 3:
+   can silently mis-gate the most safety-sensitive step). Set `F2_HEAD_SHA`
+   from the carried `{f2-head-SHA}` so the snippet is self-contained;
+   `PR_HEAD_SHA_F3` is the head re-fetched in step 3:
 
    ```sh
+   F2_HEAD_SHA="{f2-head-SHA}"   # the head recorded in the F2 snapshot
    if [ "$PR_HEAD_SHA_F3" != "$F2_HEAD_SHA" ]; then
      echo "F3 abort: head moved ${F2_HEAD_SHA} -> ${PR_HEAD_SHA_F3}" >&2
      exit 1  # do not merge — return to E1 per the freshness rules above

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -119,7 +119,37 @@ Before any mutating action in F3, apply the
 
 4. Merge the PR using a **merge commit**, binding to the validated SHA
    to prevent a race where a new push lands after the F3 freshness check
-   but before the merge executes:
+   but before the merge executes.
+
+   **Gate checklist** — confirm every field before merging; all must hold,
+   and any unmet or unknown field is a NO-GO (fail closed — stop, do not
+   merge):
+
+   - current HEAD SHA **equals** the carried F2-snapshot head
+     (`{f2-head-SHA}`);
+   - review-currency route is `proceed`;
+   - `F3_UNRESOLVED_ACTIONABLE_COUNT` is `0`;
+   - advisory `f3Outcome` is `SATISFIED` (with `LAST_COPILOT_COMMIT` equal
+     to the current head, or `copilotPending` is `false`);
+   - all required CI checks pass for the current head;
+   - claim ownership still uses your `{claim-id}`.
+
+   For the head-SHA field, use this **copy-paste-safe, fail-closed** check
+   — both operands fully quoted, no glob, abort on mismatch — rather than
+   re-deriving the comparison ad hoc (a stray glob or an unquoted operand
+   can silently mis-gate the most safety-sensitive step). `F2_HEAD_SHA` is
+   the carried `{f2-head-SHA}`; `PR_HEAD_SHA_F3` is the head re-fetched in
+   step 3:
+
+   ```sh
+   if [ "$PR_HEAD_SHA_F3" != "$F2_HEAD_SHA" ]; then
+     echo "F3 abort: head moved ${F2_HEAD_SHA} -> ${PR_HEAD_SHA_F3}" >&2
+     exit 1  # do not merge — return to F1/E1 per the freshness rules above
+   fi
+   ```
+
+   Then merge, binding `--match-head-commit` to the **freshly validated**
+   `${PR_HEAD_SHA_F3}` (never a stale, hardcoded, or unbound SHA):
 
    ```sh
    gh pr merge {pr-number} --merge --match-head-commit "${PR_HEAD_SHA_F3}"


### PR DESCRIPTION
## Summary

F3 left the GO/NO-GO decision + bound merge to a hand-built shell block, so a
mis-assembled comparison — e.g. a **glob inside `[ … ]`** that only "passes" by
`||`/`&&` precedence luck — could mis-gate the single most safety-sensitive step
or fail to bind `--match-head-commit` to the validated SHA (re-introducing the
post-validation push race that flag exists to prevent).

Harden F3 step 4 (`idd-merge.instructions.md`), doc-only, semantics unchanged:

- **Gate checklist** enumerating each required field + value (HEAD SHA unchanged
  vs F2; review-currency route `proceed`; `F3_UNRESOLVED_ACTIONABLE_COUNT` = 0;
  advisory `f3Outcome == SATISFIED`; CI passing; claim ownership), fail-closed on
  any unmet/unknown field.
- A **copy-paste-safe SHA equality snippet** — self-contained (sets
  `F2_HEAD_SHA` from the carried `{f2-head-SHA}`), both operands fully quoted,
  glob-free, aborts on mismatch.
- Reiterates binding `--match-head-commit` to the **freshly validated** head.

## Bundle-budget ratchet callout

This PR raises `bundle-merge.limitBytes` from **82202** (the value on `main`) to
a measured **83741**, absorbing both this PR's F3 additions and the concurrent
#991 (PR #1003) growth that was synced in from `main` via `git merge origin/main`.
(Per the manifest ratchet rule, raising a limit requires this explicit callout.)

## Source-of-truth

`idd-merge.instructions.md` is an `exact`-mode mirror; edited the `idd-template/`
source and regenerated the root mirror via `node scripts/sync-docs.mjs --apply`
(verified byte-identical). `pnpm run lint:minimum` passes (audit-docs parity,
bundle budgets, typecheck, build:check, biome, tests, dprint, cspell,
markdownlint).

Closes #993
