### PR TITLE
docs(idd): refresh review-watermark after E6/E7 dispositions

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -133,6 +133,13 @@ returns the workflow to E1 instead of merging over it.
   rule in `idd-review-triage.instructions.md` applies: do not return to
   E1 for that activity alone. The agent still confirms the semantic
   residual, and every other trigger and gate is unaffected.
+
+  A current-claim agent's own post-watermark disposition replies are
+  expected convergence activity, not reviewer input; the E6/E7 watermark
+  refresh (`idd-review-triage.instructions.md`) re-covers them so this
+  check passes on the refreshed watermark. If they still trip a
+  return-to-E1, refresh the watermark rather than treating them as new
+  reviewer activity.
 - **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
   already available from the review-currency check above. Apply the
   advisory-wait protocol (`idd-advisory-wait.instructions.md`):

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -135,11 +135,12 @@ returns the workflow to E1 instead of merging over it.
   residual, and every other trigger and gate is unaffected.
 
   A current-claim agent's own post-watermark disposition replies are
-  expected convergence activity, not reviewer input; the E-phase
-  branch-sync watermark refresh (`idd-review-triage.instructions.md`,
-  on the direct-to-F-phase route) re-covers them so this check passes on
-  the refreshed watermark. If they still trip a return-to-E1, refresh the
-  watermark rather than treating them as new reviewer activity.
+  expected convergence activity, not reviewer input; the watermark refresh
+  on the E-phase branch-sync `clean` / `behind-no-conflict`
+  (direct-to-F-phase) route (`idd-review-triage.instructions.md`)
+  re-covers them so this check passes on the refreshed watermark. If a
+  return-to-E1 is triggered solely by those disposition replies, refresh
+  the watermark rather than treating them as new reviewer activity.
 - **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
   already available from the review-currency check above. Apply the
   advisory-wait protocol (`idd-advisory-wait.instructions.md`):

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -135,11 +135,11 @@ returns the workflow to E1 instead of merging over it.
   residual, and every other trigger and gate is unaffected.
 
   A current-claim agent's own post-watermark disposition replies are
-  expected convergence activity, not reviewer input; the E6/E7 watermark
-  refresh (`idd-review-triage.instructions.md`) re-covers them so this
-  check passes on the refreshed watermark. If they still trip a
-  return-to-E1, refresh the watermark rather than treating them as new
-  reviewer activity.
+  expected convergence activity, not reviewer input; the E-phase
+  branch-sync watermark refresh (`idd-review-triage.instructions.md`,
+  on the direct-to-F-phase route) re-covers them so this check passes on
+  the refreshed watermark. If they still trip a return-to-E1, refresh the
+  watermark rather than treating them as new reviewer activity.
 - **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
   already available from the review-currency check above. Apply the
   advisory-wait protocol (`idd-advisory-wait.instructions.md`):

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -356,8 +356,8 @@ Route based on `branchState` from the helper (or `mergeable` /
   current-claim agent absorbing its own deterministic dispositions, not
   new reviewer activity; without the refresh F2's review-currency treats
   them as newer activity and returns to E1 for an avoidable cycle. Do
-  **not** refresh on the sync path or a hold below — both re-snapshot at
-  E1 anyway.
+  **not** refresh on the sync path (it re-snapshots at E1 after merging
+  `main`) or on a hold (it stops without proceeding to F-phase).
 - **`behind-no-conflict`** when branch protection or recorded repository
   policy requires an up-to-date head: → **sync path** below.
 - **`content-conflict`** (`mergeable` is `CONFLICTING`): → **sync path**

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -317,6 +317,20 @@ ReviewItems_snapshot is empty and the next step is F2, defer the digest
 update unless you intentionally
 return to E1 afterward.
 
+**Refresh the watermark to cover your own dispositions.** If E6 posted any
+disposition replies (any `**Accepted**` / `**Rejected**` reply, on
+reviewer feedback, advisory items, or bot non-review notices), those are
+regular agent-authored comments that
+advance the activity universe past the E1 `review-watermark`. They are the
+current-claim agent absorbing its own deterministic dispositions, not new
+reviewer activity. Before routing to F-phase, re-post the `review-watermark`
+(same `{head-SHA}`, recomputing `{max-activity-updatedAt}` /
+`{total-item-count}` / `{latest-ci-completed-at}` over the current snapshot)
+so it covers them. Skip the refresh only when E6 posted no disposition
+replies (the E1 watermark already covers the snapshot). Without it, F2's
+review-currency sees the agent's own dispositions as newer activity and
+returns to E1 for an avoidable extra cycle.
+
 ## E8 — Accepted PATH A count check
 
 If the Accepted PATH A count is zero → proceed to the

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -317,20 +317,6 @@ ReviewItems_snapshot is empty and the next step is F2, defer the digest
 update unless you intentionally
 return to E1 afterward.
 
-**Refresh the watermark to cover your own dispositions.** If E6 posted any
-disposition replies (any `**Accepted**` / `**Rejected**` reply, on
-reviewer feedback, advisory items, or bot non-review notices), those are
-regular agent-authored comments that
-advance the activity universe past the E1 `review-watermark`. They are the
-current-claim agent absorbing its own deterministic dispositions, not new
-reviewer activity. Before routing to F-phase, re-post the `review-watermark`
-(same `{head-SHA}`, recomputing `{max-activity-updatedAt}` /
-`{total-item-count}` / `{latest-ci-completed-at}` over the current snapshot)
-so it covers them. Skip the refresh only when E6 posted no disposition
-replies (the E1 watermark already covers the snapshot). Without it, F2's
-review-currency sees the agent's own dispositions as newer activity and
-returns to E1 for an avoidable extra cycle.
-
 ## E8 — Accepted PATH A count check
 
 If the Accepted PATH A count is zero → proceed to the
@@ -359,7 +345,19 @@ Route based on `branchState` from the helper (or `mergeable` /
 
 - **`clean`** or **`behind-no-conflict`** when branch protection does not
   require an up-to-date head: proceed to
-  `idd-pre-merge.instructions.md` (F1).
+  `idd-pre-merge.instructions.md` (F1). **First, only if E6 posted
+  disposition replies** (any `**Accepted**` / `**Rejected**` reply on
+  reviewer feedback, advisory items, or bot non-review notices), refresh
+  the `review-watermark` so it covers them: re-post it for the same
+  `{head-SHA}`, recomputing `{max-activity-updatedAt}` /
+  `{total-item-count}` / `{latest-ci-completed-at}` over the current
+  snapshot, following the E1 Step 2 rules (CI-completion precondition;
+  hide superseded same-claim watermarks). Those replies are the
+  current-claim agent absorbing its own deterministic dispositions, not
+  new reviewer activity; without the refresh F2's review-currency treats
+  them as newer activity and returns to E1 for an avoidable cycle. Do
+  **not** refresh on the sync path or a hold below — both re-snapshot at
+  E1 anyway.
 - **`behind-no-conflict`** when branch protection or recorded repository
   policy requires an up-to-date head: → **sync path** below.
 - **`content-conflict`** (`mergeable` is `CONFLICTING`): → **sync path**

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -195,7 +195,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 93685
+      "limitBytes": 94650
     },
     {
       "id": "bundle-merge",
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 83741
+      "limitBytes": 84250
     }
   ],
   "syncPairs": [

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -133,6 +133,13 @@ returns the workflow to E1 instead of merging over it.
   rule in `idd-review-triage.instructions.md` applies: do not return to
   E1 for that activity alone. The agent still confirms the semantic
   residual, and every other trigger and gate is unaffected.
+
+  A current-claim agent's own post-watermark disposition replies are
+  expected convergence activity, not reviewer input; the E6/E7 watermark
+  refresh (`idd-review-triage.instructions.md`) re-covers them so this
+  check passes on the refreshed watermark. If they still trip a
+  return-to-E1, refresh the watermark rather than treating them as new
+  reviewer activity.
 - **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
   already available from the review-currency check above. Apply the
   advisory-wait protocol (`idd-advisory-wait.instructions.md`):

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -135,11 +135,12 @@ returns the workflow to E1 instead of merging over it.
   residual, and every other trigger and gate is unaffected.
 
   A current-claim agent's own post-watermark disposition replies are
-  expected convergence activity, not reviewer input; the E-phase
-  branch-sync watermark refresh (`idd-review-triage.instructions.md`,
-  on the direct-to-F-phase route) re-covers them so this check passes on
-  the refreshed watermark. If they still trip a return-to-E1, refresh the
-  watermark rather than treating them as new reviewer activity.
+  expected convergence activity, not reviewer input; the watermark refresh
+  on the E-phase branch-sync `clean` / `behind-no-conflict`
+  (direct-to-F-phase) route (`idd-review-triage.instructions.md`)
+  re-covers them so this check passes on the refreshed watermark. If a
+  return-to-E1 is triggered solely by those disposition replies, refresh
+  the watermark rather than treating them as new reviewer activity.
 - **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
   already available from the review-currency check above. Apply the
   advisory-wait protocol (`idd-advisory-wait.instructions.md`):

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -135,11 +135,11 @@ returns the workflow to E1 instead of merging over it.
   residual, and every other trigger and gate is unaffected.
 
   A current-claim agent's own post-watermark disposition replies are
-  expected convergence activity, not reviewer input; the E6/E7 watermark
-  refresh (`idd-review-triage.instructions.md`) re-covers them so this
-  check passes on the refreshed watermark. If they still trip a
-  return-to-E1, refresh the watermark rather than treating them as new
-  reviewer activity.
+  expected convergence activity, not reviewer input; the E-phase
+  branch-sync watermark refresh (`idd-review-triage.instructions.md`,
+  on the direct-to-F-phase route) re-covers them so this check passes on
+  the refreshed watermark. If they still trip a return-to-E1, refresh the
+  watermark rather than treating them as new reviewer activity.
 - **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
   already available from the review-currency check above. Apply the
   advisory-wait protocol (`idd-advisory-wait.instructions.md`):

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -356,8 +356,8 @@ Route based on `branchState` from the helper (or `mergeable` /
   current-claim agent absorbing its own deterministic dispositions, not
   new reviewer activity; without the refresh F2's review-currency treats
   them as newer activity and returns to E1 for an avoidable cycle. Do
-  **not** refresh on the sync path or a hold below — both re-snapshot at
-  E1 anyway.
+  **not** refresh on the sync path (it re-snapshots at E1 after merging
+  `main`) or on a hold (it stops without proceeding to F-phase).
 - **`behind-no-conflict`** when branch protection or recorded repository
   policy requires an up-to-date head: → **sync path** below.
 - **`content-conflict`** (`mergeable` is `CONFLICTING`): → **sync path**

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -317,6 +317,20 @@ ReviewItems_snapshot is empty and the next step is F2, defer the digest
 update unless you intentionally
 return to E1 afterward.
 
+**Refresh the watermark to cover your own dispositions.** If E6 posted any
+disposition replies (any `**Accepted**` / `**Rejected**` reply, on
+reviewer feedback, advisory items, or bot non-review notices), those are
+regular agent-authored comments that
+advance the activity universe past the E1 `review-watermark`. They are the
+current-claim agent absorbing its own deterministic dispositions, not new
+reviewer activity. Before routing to F-phase, re-post the `review-watermark`
+(same `{head-SHA}`, recomputing `{max-activity-updatedAt}` /
+`{total-item-count}` / `{latest-ci-completed-at}` over the current snapshot)
+so it covers them. Skip the refresh only when E6 posted no disposition
+replies (the E1 watermark already covers the snapshot). Without it, F2's
+review-currency sees the agent's own dispositions as newer activity and
+returns to E1 for an avoidable extra cycle.
+
 ## E8 — Accepted PATH A count check
 
 If the Accepted PATH A count is zero → proceed to the

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -317,20 +317,6 @@ ReviewItems_snapshot is empty and the next step is F2, defer the digest
 update unless you intentionally
 return to E1 afterward.
 
-**Refresh the watermark to cover your own dispositions.** If E6 posted any
-disposition replies (any `**Accepted**` / `**Rejected**` reply, on
-reviewer feedback, advisory items, or bot non-review notices), those are
-regular agent-authored comments that
-advance the activity universe past the E1 `review-watermark`. They are the
-current-claim agent absorbing its own deterministic dispositions, not new
-reviewer activity. Before routing to F-phase, re-post the `review-watermark`
-(same `{head-SHA}`, recomputing `{max-activity-updatedAt}` /
-`{total-item-count}` / `{latest-ci-completed-at}` over the current snapshot)
-so it covers them. Skip the refresh only when E6 posted no disposition
-replies (the E1 watermark already covers the snapshot). Without it, F2's
-review-currency sees the agent's own dispositions as newer activity and
-returns to E1 for an avoidable extra cycle.
-
 ## E8 — Accepted PATH A count check
 
 If the Accepted PATH A count is zero → proceed to the
@@ -359,7 +345,19 @@ Route based on `branchState` from the helper (or `mergeable` /
 
 - **`clean`** or **`behind-no-conflict`** when branch protection does not
   require an up-to-date head: proceed to
-  `idd-pre-merge.instructions.md` (F1).
+  `idd-pre-merge.instructions.md` (F1). **First, only if E6 posted
+  disposition replies** (any `**Accepted**` / `**Rejected**` reply on
+  reviewer feedback, advisory items, or bot non-review notices), refresh
+  the `review-watermark` so it covers them: re-post it for the same
+  `{head-SHA}`, recomputing `{max-activity-updatedAt}` /
+  `{total-item-count}` / `{latest-ci-completed-at}` over the current
+  snapshot, following the E1 Step 2 rules (CI-completion precondition;
+  hide superseded same-claim watermarks). Those replies are the
+  current-claim agent absorbing its own deterministic dispositions, not
+  new reviewer activity; without the refresh F2's review-currency treats
+  them as newer activity and returns to E1 for an avoidable cycle. Do
+  **not** refresh on the sync path or a hold below — both re-snapshot at
+  E1 anyway.
 - **`behind-no-conflict`** when branch protection or recorded repository
   policy requires an up-to-date head: → **sync path** below.
 - **`content-conflict`** (`mergeable` is `CONFLICTING`): → **sync path**


### PR DESCRIPTION
## Summary

Eliminates an avoidable extra E1↔F2 cycle that occurred on every issue: an IDD agent's own E6 disposition replies (`**Accepted**` / `**Rejected**`) are regular agent-authored comments that advance the activity universe past the E1 `review-watermark`, so F2's review-currency saw them as `newer-activity` and returned to E1.

- **idd-review-triage.instructions.md** (after E7, before E8): a new step to **re-post the `review-watermark`** covering the agent's own dispositions (same `{head-SHA}`, recomputed snapshot fields) before routing to F-phase — skipped when E6 posted no disposition replies.
- **idd-pre-merge.instructions.md** (Review currency): a note that current-claim agent-own post-watermark disposition replies are expected convergence cleared by that refresh — distinct from the bot-only ack-only carve-out, and not a reviewer-driven return-to-E1.

## Notes

- No change to the early E1 Step 2 watermark post or to the advisory-bot ack-only carve-out semantics.
- Edited the `idd-template/` sources; `exact` mirrors regenerated via `node scripts/sync-docs.mjs --apply`.
- **Bundle-budget ratchet callout**: raised `bundle-review` 93685 → 94650 (margin ~119) and `bundle-merge` 83741 → 84250 (margin ~139) in `audit/sync-manifest.json` to fit the additions, with a small margin rather than an exact fit (per the bump-with-margin convention proposed in #1006).
- `pnpm run lint:minimum` passes (bundle budgets, `audit-docs --check`, markdownlint, cspell).

Closes #1005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified review-currency handling so post-watermark disposition replies are treated as expected convergence activity, reducing unnecessary returns to earlier review steps.
  * Added guidance to refresh the review watermark only in the specific branch-sync case where disposition replies were posted, helping prevent stale-state loops.

* **Chores**
  * Adjusted bundle size limits in the audit manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->