### PR TITLE
docs(idd): de-hardcode bundle limits, document bump-with-margin

### DIFF
--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -261,14 +261,41 @@ CI enforces two layers of instruction file size limits via `audit/sync-manifest.
 
 ### Bundle limits
 
-| Bundle ID          | Files included                                                                                   | Limit        |
-| ------------------ | ------------------------------------------------------------------------------------------------ | ------------ |
-| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 80,000 bytes |
-| `bundle-resume`    | `idd-overview-core` + `idd-overview-appendix` + `idd-resume`                                     | 46,000 bytes |
+`audit/sync-manifest.json` `bundleBudgets` is the single authoritative source
+for each bundle's byte limit (`limitBytes`). The table below lists the current
+bundles and their phase-path composition but deliberately does not duplicate
+the volatile byte values, so this page cannot silently re-drift from the
+manifest. Read the live limits with
+`jq '.bundleBudgets' audit/sync-manifest.json`.
+
+| Bundle ID          | Files included (phase path)                                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim`                                                |
+| `bundle-resume`    | `idd-overview-core` + `idd-overview-appendix` + `idd-resume`                                                                                    |
+| `bundle-work`      | `idd-overview-core` + `idd-overview-appendix` + `idd-work`                                                                                      |
+| `bundle-review`    | `idd-overview-core` + `idd-overview-appendix` + `idd-review-snapshot` + `idd-review-triage` + `idd-review-fix` + `idd-advisory-wait` + `idd-ci` |
+| `bundle-merge`     | `idd-overview-core` + `idd-overview-appendix` + `idd-pre-merge` + `idd-merge-handoff` + `idd-merge` + `idd-advisory-wait` + `idd-ci`            |
 
 Bundle checks run unconditionally (not filtered by changed files) and
-measure the combined byte length of all listed files. Adjust limits in
-`audit/sync-manifest.json` when deliberate growth is accepted.
+measure the combined byte length of all listed files.
+
+### Bundle-budget growth
+
+`bundleBudgets` follows a **ratchet** (documented in full under "Bundle
+Budgets" in `audit/README.md`, and mirrored by the `typeSuppressionBudgets`
+rule): **raising** any `limitBytes` value requires an explicit callout in the
+pull request description justifying the growth; **lowering** a limit after an
+instruction diet needs no callout.
+
+When a legitimate addition pushes a bundle over its current limit, **prefer
+raising the limit (with the PR-description callout) over trimming shared,
+terminology-sensitive instruction content**: trimming such content churns text
+that multiple phases depend on and tends to draw repeated advisory
+terminology-drift review comments. When you do raise a limit, **leave a small
+margin (roughly 10% headroom, the convention recorded in `audit/README.md`)
+rather than bumping to an exact fit** — an exact-fit bump leaves the next
+concurrent session with zero free bytes, forcing an immediate rebase and
+re-bump.
 
 ## Changing A Default
 

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -261,14 +261,41 @@ CI enforces two layers of instruction file size limits via `audit/sync-manifest.
 
 ### Bundle limits
 
-| Bundle ID          | Files included                                                                                   | Limit        |
-| ------------------ | ------------------------------------------------------------------------------------------------ | ------------ |
-| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 80,000 bytes |
-| `bundle-resume`    | `idd-overview-core` + `idd-overview-appendix` + `idd-resume`                                     | 46,000 bytes |
+`audit/sync-manifest.json` `bundleBudgets` is the single authoritative source
+for each bundle's byte limit (`limitBytes`). The table below lists the current
+bundles and their phase-path composition but deliberately does not duplicate
+the volatile byte values, so this page cannot silently re-drift from the
+manifest. Read the live limits with
+`jq '.bundleBudgets' audit/sync-manifest.json`.
+
+| Bundle ID          | Files included (phase path)                                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim`                                                |
+| `bundle-resume`    | `idd-overview-core` + `idd-overview-appendix` + `idd-resume`                                                                                    |
+| `bundle-work`      | `idd-overview-core` + `idd-overview-appendix` + `idd-work`                                                                                      |
+| `bundle-review`    | `idd-overview-core` + `idd-overview-appendix` + `idd-review-snapshot` + `idd-review-triage` + `idd-review-fix` + `idd-advisory-wait` + `idd-ci` |
+| `bundle-merge`     | `idd-overview-core` + `idd-overview-appendix` + `idd-pre-merge` + `idd-merge-handoff` + `idd-merge` + `idd-advisory-wait` + `idd-ci`            |
 
 Bundle checks run unconditionally (not filtered by changed files) and
-measure the combined byte length of all listed files. Adjust limits in
-`audit/sync-manifest.json` when deliberate growth is accepted.
+measure the combined byte length of all listed files.
+
+### Bundle-budget growth
+
+`bundleBudgets` follows a **ratchet** (documented in full under "Bundle
+Budgets" in `audit/README.md`, and mirrored by the `typeSuppressionBudgets`
+rule): **raising** any `limitBytes` value requires an explicit callout in the
+pull request description justifying the growth; **lowering** a limit after an
+instruction diet needs no callout.
+
+When a legitimate addition pushes a bundle over its current limit, **prefer
+raising the limit (with the PR-description callout) over trimming shared,
+terminology-sensitive instruction content**: trimming such content churns text
+that multiple phases depend on and tends to draw repeated advisory
+terminology-drift review comments. When you do raise a limit, **leave a small
+margin (roughly 10% headroom, the convention recorded in `audit/README.md`)
+rather than bumping to an exact fit** — an exact-fit bump leaves the next
+concurrent session with zero free bytes, forcing an immediate rebase and
+re-bump.
 
 ## Changing A Default
 


### PR DESCRIPTION
## Summary

Reconcile the stale and incomplete "Bundle limits" table in
`docs/policy-constants.md` and surface the bundle-budget bump convention.

- The table listed only `bundle-discovery` (a stale `80,000`, vs
  `audit/sync-manifest.json`'s `86379`) and `bundle-resume`, omitting
  `bundle-work`, `bundle-review`, and `bundle-merge`. It now lists all
  five current bundles by phase-path composition and points to
  `audit/sync-manifest.json` `bundleBudgets` as the single authoritative
  source for the byte limits — de-hardcoding the volatile values so the
  page cannot silently re-drift from the manifest.
- Adds a **Bundle-budget growth** note documenting the `bundleBudgets`
  ratchet (raising a limit requires a PR-description callout; lowering is
  always allowed), and the conventions to prefer raising a limit over
  trimming shared, terminology-sensitive instruction content and to leave
  a small margin (~10% headroom, per `audit/README.md`) rather than an
  exact-fit bump, which reduces concurrent-session wall-hits and rebase
  churn.

Edited the `idd-template/docs/policy-constants.md` source and regenerated
the `exact` mirror `docs/policy-constants.md` via
`node scripts/sync-docs.mjs --apply`.

## Verification

`pnpm run lint:minimum` passes: audit-docs `--check` (sync parity + bundle
budgets), typecheck, build:check, biome, dprint, 1067 tests, cspell, and
markdownlint all clean.

## Notes

No bundle-budget impact — this PR de-hardcodes the table and does not raise
any `limitBytes`, so no ratchet callout is required. The per-file limits
table (20,000 / 30,000) already matched the manifest and is unchanged.

Follow-up (out of scope for this issue): `README.md` / `README.ja.md`
"Footprint and sizing guidance" still carries a separately-stale
`bundle-discovery` value (`75,300`); this issue scoped the fix to
`docs/policy-constants.md`.

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)
