### PR TITLE
docs(idd): skip D1 no-op rebase when branch is current with main

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -9,8 +9,22 @@ Before the D1 rebase and D2 push, apply the
 
 ## D1 — Sync main before first push
 
-If the branch has not been pushed yet, rebase it onto `main`. This is
-the routine pre-publication history cleanup step.
+If the branch has not been pushed yet, sync it onto `main` before the
+first push — the routine pre-publication history cleanup step. First run
+`git fetch origin main`, then check whether the branch is **already
+current** with `origin/main`: if `git merge-base HEAD origin/main` equals
+`origin/main` (behind-count 0), the branch already contains every commit
+on `main`, so the rebase would be a pure no-op. **Skip the rebase entirely
+and proceed to D2** — D1's pre-publication synchronization goal is already
+met. In a sibling-worktree setup a no-op `git rebase origin/main` can still
+detach HEAD at the upstream tip without replaying the local commit, and
+re-running that no-op rebase re-detaches every time, so the bounded
+recovery below cannot converge for the no-op case; skipping it is the clean
+exit.
+
+Otherwise the branch **is** behind `main`: rebase it onto `main`
+(`git rebase origin/main`), then apply the post-rebase verification and
+bounded recovery below.
 
 After the first D-phase push, do not reuse D1 as the normal
 synchronization path. Later branch updates should return through the

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -4,7 +4,7 @@ Read this file after the self-review loop passes. It covers
 pre-publication main sync, claim verification, tests, pushing, PR
 creation, and waiting for CI.
 
-Before the D1 rebase and D2 push, apply the
+Before the D1 sync and D2 push, apply the
 [shared claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 ## D1 — Sync main before first push
@@ -22,7 +22,7 @@ re-running that no-op rebase re-detaches every time, so the bounded
 recovery below cannot converge for the no-op case; skipping it is the clean
 exit.
 
-Otherwise the branch **is** behind `main`: rebase it onto `main`
+Otherwise the branch **is** behind `origin/main`: rebase it onto `main`
 (`git rebase origin/main`), then apply the post-rebase verification and
 bounded recovery below.
 

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -9,8 +9,22 @@ Before the D1 rebase and D2 push, apply the
 
 ## D1 — Sync main before first push
 
-If the branch has not been pushed yet, rebase it onto `main`. This is
-the routine pre-publication history cleanup step.
+If the branch has not been pushed yet, sync it onto `main` before the
+first push — the routine pre-publication history cleanup step. First run
+`git fetch origin main`, then check whether the branch is **already
+current** with `origin/main`: if `git merge-base HEAD origin/main` equals
+`origin/main` (behind-count 0), the branch already contains every commit
+on `main`, so the rebase would be a pure no-op. **Skip the rebase entirely
+and proceed to D2** — D1's pre-publication synchronization goal is already
+met. In a sibling-worktree setup a no-op `git rebase origin/main` can still
+detach HEAD at the upstream tip without replaying the local commit, and
+re-running that no-op rebase re-detaches every time, so the bounded
+recovery below cannot converge for the no-op case; skipping it is the clean
+exit.
+
+Otherwise the branch **is** behind `main`: rebase it onto `main`
+(`git rebase origin/main`), then apply the post-rebase verification and
+bounded recovery below.
 
 After the first D-phase push, do not reuse D1 as the normal
 synchronization path. Later branch updates should return through the

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -4,7 +4,7 @@ Read this file after the self-review loop passes. It covers
 pre-publication main sync, claim verification, tests, pushing, PR
 creation, and waiting for CI.
 
-Before the D1 rebase and D2 push, apply the
+Before the D1 sync and D2 push, apply the
 [shared claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 ## D1 — Sync main before first push
@@ -22,7 +22,7 @@ re-running that no-op rebase re-detaches every time, so the bounded
 recovery below cannot converge for the no-op case; skipping it is the clean
 exit.
 
-Otherwise the branch **is** behind `main`: rebase it onto `main`
+Otherwise the branch **is** behind `origin/main`: rebase it onto `main`
 (`git rebase origin/main`), then apply the post-rebase verification and
 bounded recovery below.
 


### PR DESCRIPTION
## Summary

Add a pre-rebase behind-count check to D1
(`idd-pr-submit.instructions.md`) so the pre-push rebase is skipped when
the feature branch is already current with `main`.

- When `main` has not advanced since the branch was created, the D1
  rebase is a pure no-op — but in a sibling-worktree setup a no-op
  `git rebase origin/main` can still detach HEAD at the upstream tip
  without replaying the local commit. Re-running a no-op rebase
  re-detaches every time, so the bounded #979 post-rebase recovery cannot
  converge for that case.
- D1 now runs `git fetch origin main`, and when
  `git merge-base HEAD origin/main` equals `origin/main` (behind-count 0)
  it **skips the rebase and proceeds to D2** — the synchronization goal is
  already met. When the branch **is** behind `main`, the rebase still runs
  with the existing post-rebase verification and bounded recovery (#979).
- The rebase-only-before-first-push / merge-`main`-later contract and the
  tool-agnostic (plain git) guidance are unchanged.

Edited the `idd-template/` source and regenerated the `exact` root mirror
via `node scripts/sync-docs.mjs --apply`.

## Verification

`pnpm run lint:minimum` passes: `audit-docs --check` (instruction-size +
bundle budgets + sync parity), 1067 tests, cspell, markdownlint — all
clean. `idd-pr-submit.instructions.md` is a phase file (30,000-byte
per-file limit) and is not part of any phase bundle, so the concise
addition has no bundle-budget impact.

This PR also dogfooded the new logic: D1 for this very branch detected
behind-count 0 and skipped the rebase, publishing without a HEAD detach.

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
