### PR TITLE
fix(idd): install pnpm deps in B1 worktrees via install-deps

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -20,7 +20,7 @@
     "exampleRepository": "kurone-kito/vrc-event-calendar"
   },
   "commands": {
-    "install-deps": "true",
+    "install-deps": "pnpm install --frozen-lockfile",
     "fix-validate": "npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
     "pre-push-validate": "npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress",
     "post-fix-validate": "npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress"

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -253,7 +253,7 @@ enabled and default approval actors to
 | **fix-validate**        | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
 | **pre-push-validate**   | `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                        |
 | **post-fix-validate**   | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
-| **install-deps**        | `true`                                                                                                                                       |
+| **install-deps**        | `pnpm install --frozen-lockfile`                                                                                                             |
 | **issue-scope**         | `roadmap-first`                                                                                                                              |
 | **orphan-first-policy** | `none`                                                                                                                                       |
 

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -301,7 +301,7 @@
         },
         {
           "from": "| **install-deps**        | `{{INSTALL_DEPS_COMMAND}}`       |",
-          "to": "| **install-deps**        | `true`                                                                                                                                       |"
+          "to": "| **install-deps**        | `pnpm install --frozen-lockfile`                                                                                                             |"
         },
         {
           "from": "| **issue-scope**         | `roadmap-first`                  |",
@@ -526,7 +526,7 @@
         },
         {
           "from": "| **install-deps**        | `{{INSTALL_DEPS_COMMAND}}`       |",
-          "to": "| **install-deps**        | `true`                                                                                                                                       |"
+          "to": "| **install-deps**        | `pnpm install --frozen-lockfile`                                                                                                             |"
         },
         {
           "from": "| **issue-scope**         | `roadmap-first`                  |",


### PR DESCRIPTION
## Summary

Fresh B1 sibling worktrees had no `node_modules`, so this repo's standard
`pnpm run lint:minimum` failed until a manual `pnpm install` was run in
every new worktree (the WorkTrunk pre-start hook only symlinks `.env`,
and `commands.install-deps` was the `true` no-op).

This sets this repo's **live** `commands.install-deps` to
`pnpm install --frozen-lockfile` (idempotent via the pnpm
content-addressable store) and reconciles the surfaces that
`audit-docs --check` keeps consistent with it:

- `.github/idd/config.json` — `commands.install-deps`
- `.github/instructions/idd-overview-core.instructions.md` — generated
  Project-commands table row
- `audit/sync-manifest.json` — the `install-deps` concreted-replacement
  `to` value (both `syncPairs` occurrences)

## Out of scope (intentionally unchanged)

- `idd-template/.github/idd/config.json` and the template overview keep
  the `{{INSTALL_DEPS_COMMAND}}` placeholder — the adopter default is
  preserved and `check-pnpm-boundary` still forbids `pnpm` in the
  template.
- The `docs/customization.md` generic adopter-default table stays `true`.

## Verification

- A fresh worktree reproduced the bug (`node_modules` absent);
  `pnpm install --frozen-lockfile` fixes it idempotently (~2.7s).
- `pnpm run lint:minimum` passes end to end (audit-docs config/scope
  notice + sync check + tsc + build:check + biome + dprint + 1067 tests
  + cspell + markdownlint).

Closes #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgWE9Zk471naViV3AExSJ4
