### PR TITLE
feat(idd): distinguish computing from terminal unknown mergeability

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -47,6 +47,15 @@ This check is read-only — F1 does not rebase, merge, or push.
   in `idd-review-triage.instructions.md`. Before returning, update the PR
   live status digest with `Phase: F1 sync-required`, the branch state in
   `Open blockers`, and `Next action: E-phase branch-sync`.
+- **`computing`** (`syncRecommendation` is `recheck`): `mergeable` is
+  `UNKNOWN` / null because GitHub computes mergeability asynchronously and
+  has not settled yet (common right after E1 posts its watermark/baseline) —
+  a **transient** state, not a terminal one. Do **not** hold. Re-poll the
+  branch state after a short wait (the helper is a single read; the wait
+  belongs to this caller), up to a small fixed attempt budget (distributed
+  default: 3 attempts, a few seconds apart), then route by the first settled
+  result. Only if it is **still** `computing` (or `unknown`) after the budget
+  is exhausted, fall through to the terminal hold below.
 - **`dirty`** (`mergeStateStatus` is `DIRTY`) or **`unknown`**: hold; post
   a PR comment documenting the branch state and stop. Do not proceed to F2
   without confirmed clean branch-state evidence. A maintainer must clear

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -362,6 +362,13 @@ Route based on `branchState` from the helper (or `mergeable` /
   policy requires an up-to-date head: → **sync path** below.
 - **`content-conflict`** (`mergeable` is `CONFLICTING`): → **sync path**
   below.
+- **`computing`** (`syncRecommendation` is `recheck`): `mergeable` is
+  `UNKNOWN` / null because GitHub computes mergeability asynchronously and
+  has not settled — a **transient** state. Do **not** hold. Re-poll after a
+  short wait, up to a small fixed attempt budget (distributed default: 3
+  attempts, a few seconds apart), then route by the first settled result.
+  Only a state that is **still** `computing` / `unknown` after the budget
+  falls through to the hold below.
 - **`dirty`** (`mergeStateStatus` is `DIRTY`) or **`unknown`**: hold; post
   a PR comment documenting the state and stop. Do not proceed to F-phase
   without confirmed branch-state evidence.

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -195,7 +195,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 94650
+      "limitBytes": 95600
     },
     {
       "id": "bundle-merge",
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 84250
+      "limitBytes": 85500
     }
   ],
   "syncPairs": [

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -771,9 +771,12 @@ Interpretation rules:
   ```
 
 - `branchState` values: `clean`, `behind-no-conflict`, `content-conflict`,
-  `dirty`, `force-push-exception`, `unknown`
+  `dirty`, `force-push-exception`, `computing`, `unknown` (`computing` is the
+  transient still-computing mergeability that callers re-poll; `unknown` stays
+  terminal)
 - `syncRecommendation` values: `none`, `merge-main`, `policy-required-update`,
-  `force-push-exception`, `hold-unknown`
+  `force-push-exception`, `recheck`, `hold-unknown` (`recheck` pairs with
+  `computing`)
 - Stable fields consumed by D/E/F routing: `branchState`,
   `syncRecommendation`, `published`, `readOnly`, `worktreeUnchanged`
 - Read-only boundary: the helper never runs `git merge`, `git rebase`, or

--- a/fixtures/branch-conflict-state/computing.json
+++ b/fixtures/branch-conflict-state/computing.json
@@ -1,0 +1,20 @@
+{
+  "prData": {
+    "number": 104,
+    "headRefOid": "1111111111111111111111111111111111111111",
+    "baseRefOid": "2222222222222222222222222222222222222222",
+    "headRefName": "feature/computing",
+    "baseRefName": "main",
+    "mergeable": "UNKNOWN",
+    "mergeStateStatus": "UNKNOWN",
+    "headRepository": {
+      "id": "R_test",
+      "name": "test-repo"
+    }
+  },
+  "expected": {
+    "branchState": "computing",
+    "syncRecommendation": "recheck",
+    "mergeableSource": "none"
+  }
+}

--- a/fixtures/branch-conflict-state/unknown.json
+++ b/fixtures/branch-conflict-state/unknown.json
@@ -1,12 +1,12 @@
 {
   "prData": {
-    "number": 104,
-    "headRefOid": "1111111111111111111111111111111111111111",
-    "baseRefOid": "2222222222222222222222222222222222222222",
-    "headRefName": "feature/unknown",
+    "number": 105,
+    "headRefOid": "3333333333333333333333333333333333333333",
+    "baseRefOid": "4444444444444444444444444444444444444444",
+    "headRefName": "feature/unrecognized",
     "baseRefName": "main",
-    "mergeable": "UNKNOWN",
-    "mergeStateStatus": "UNKNOWN",
+    "mergeable": "UNRECOGNIZED",
+    "mergeStateStatus": "UNRECOGNIZED",
     "headRepository": {
       "id": "R_test",
       "name": "test-repo"

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -47,6 +47,15 @@ This check is read-only — F1 does not rebase, merge, or push.
   in `idd-review-triage.instructions.md`. Before returning, update the PR
   live status digest with `Phase: F1 sync-required`, the branch state in
   `Open blockers`, and `Next action: E-phase branch-sync`.
+- **`computing`** (`syncRecommendation` is `recheck`): `mergeable` is
+  `UNKNOWN` / null because GitHub computes mergeability asynchronously and
+  has not settled yet (common right after E1 posts its watermark/baseline) —
+  a **transient** state, not a terminal one. Do **not** hold. Re-poll the
+  branch state after a short wait (the helper is a single read; the wait
+  belongs to this caller), up to a small fixed attempt budget (distributed
+  default: 3 attempts, a few seconds apart), then route by the first settled
+  result. Only if it is **still** `computing` (or `unknown`) after the budget
+  is exhausted, fall through to the terminal hold below.
 - **`dirty`** (`mergeStateStatus` is `DIRTY`) or **`unknown`**: hold; post
   a PR comment documenting the branch state and stop. Do not proceed to F2
   without confirmed clean branch-state evidence. A maintainer must clear

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -362,6 +362,13 @@ Route based on `branchState` from the helper (or `mergeable` /
   policy requires an up-to-date head: → **sync path** below.
 - **`content-conflict`** (`mergeable` is `CONFLICTING`): → **sync path**
   below.
+- **`computing`** (`syncRecommendation` is `recheck`): `mergeable` is
+  `UNKNOWN` / null because GitHub computes mergeability asynchronously and
+  has not settled — a **transient** state. Do **not** hold. Re-poll after a
+  short wait, up to a small fixed attempt budget (distributed default: 3
+  attempts, a few seconds apart), then route by the first settled result.
+  Only a state that is **still** `computing` / `unknown` after the budget
+  falls through to the hold below.
 - **`dirty`** (`mergeStateStatus` is `DIRTY`) or **`unknown`**: hold; post
   a PR comment documenting the state and stop. Do not proceed to F-phase
   without confirmed branch-state evidence.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -771,9 +771,12 @@ Interpretation rules:
   ```
 
 - `branchState` values: `clean`, `behind-no-conflict`, `content-conflict`,
-  `dirty`, `force-push-exception`, `unknown`
+  `dirty`, `force-push-exception`, `computing`, `unknown` (`computing` is the
+  transient still-computing mergeability that callers re-poll; `unknown` stays
+  terminal)
 - `syncRecommendation` values: `none`, `merge-main`, `policy-required-update`,
-  `force-push-exception`, `hold-unknown`
+  `force-push-exception`, `recheck`, `hold-unknown` (`recheck` pairs with
+  `computing`)
 - Stable fields consumed by D/E/F routing: `branchState`,
   `syncRecommendation`, `published`, `readOnly`, `worktreeUnchanged`
 - Read-only boundary: the helper never runs `git merge`, `git rebase`, or

--- a/schemas/branch-conflict-state.schema.json
+++ b/schemas/branch-conflict-state.schema.json
@@ -51,6 +51,7 @@
         "content-conflict",
         "dirty",
         "force-push-exception",
+        "computing",
         "unknown"
       ]
     },
@@ -61,6 +62,7 @@
         "merge-main",
         "policy-required-update",
         "force-push-exception",
+        "recheck",
         "hold-unknown"
       ]
     },

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -188,11 +188,11 @@ function deriveBranchState({
   }
   if (mergeableNorm === 'UNKNOWN' || !mergeableNorm) {
     notes.push(
-      `Mergeable status is ${mergeable ?? 'null'}; unable to classify definitively.`,
+      `Mergeable status is ${mergeable ?? 'null'}; GitHub computes mergeability asynchronously, so this is most likely still computing. Re-poll before treating it as terminal.`,
     );
     return {
-      branchState: 'unknown',
-      syncRecommendation: 'hold-unknown',
+      branchState: 'computing',
+      syncRecommendation: 'recheck',
       conflictFiles: [],
       mergeableSource: 'none',
     };

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -90,6 +90,12 @@ export function selectResumeRoute(input) {
         reasonParts,
       );
     }
+    if (state.branchState === 'computing') {
+      // Mergeability is still computing (transient `UNKNOWN`); resume into F1,
+      // whose bounded re-poll resolves it instead of stopping on a
+      // self-resolving state.
+      return result('F1', 'pr-ci-success-branch-computing', state, reasonParts);
+    }
     if (state.branchState === 'behind-no-conflict') {
       return result(
         'F1',
@@ -316,6 +322,10 @@ export function classifyBranchState(mergeState) {
   if (mergeStateStatus === 'CLEAN') return 'clean';
   if (mergeStateStatus === 'BEHIND') return 'behind-no-conflict';
   if (mergeable === 'MERGEABLE') return 'clean';
+  // GitHub computes `mergeable` asynchronously: an explicit `UNKNOWN` means the
+  // result is still computing (transient), not a terminal classification
+  // failure. Keep `unknown` for genuinely missing/unrecognized state.
+  if (mergeable === 'UNKNOWN') return 'computing';
   return 'unknown';
 }
 export function countLatestChangesRequestedByReviewer(reviews) {

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -313,7 +313,8 @@ function countUnrepliedRegularComments(comments, viewerLogin) {
   return count;
 }
 export function classifyBranchState(mergeState) {
-  const mergeable = String(mergeState?.mergeable ?? '').toUpperCase();
+  const rawMergeable = mergeState?.mergeable;
+  const mergeable = String(rawMergeable ?? '').toUpperCase();
   const mergeStateStatus = String(
     mergeState?.mergeStateStatus ?? '',
   ).toUpperCase();
@@ -322,10 +323,12 @@ export function classifyBranchState(mergeState) {
   if (mergeStateStatus === 'CLEAN') return 'clean';
   if (mergeStateStatus === 'BEHIND') return 'behind-no-conflict';
   if (mergeable === 'MERGEABLE') return 'clean';
-  // GitHub computes `mergeable` asynchronously: an explicit `UNKNOWN` means the
-  // result is still computing (transient), not a terminal classification
-  // failure. Keep `unknown` for genuinely missing/unrecognized state.
-  if (mergeable === 'UNKNOWN') return 'computing';
+  // GitHub computes `mergeable` asynchronously: an explicit `UNKNOWN` — or an
+  // explicit `null` mergeable on a present payload — means the result is still
+  // computing (transient), not a terminal classification failure. A genuinely
+  // missing/unparseable payload (no `mergeable` field at all, i.e. `undefined`)
+  // stays terminal `unknown`.
+  if (mergeable === 'UNKNOWN' || rawMergeable === null) return 'computing';
   return 'unknown';
 }
 export function countLatestChangesRequestedByReviewer(reviews) {

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -264,11 +264,11 @@ function deriveBranchState({
 
   if (mergeableNorm === 'UNKNOWN' || !mergeableNorm) {
     notes.push(
-      `Mergeable status is ${mergeable ?? 'null'}; unable to classify definitively.`,
+      `Mergeable status is ${mergeable ?? 'null'}; GitHub computes mergeability asynchronously, so this is most likely still computing. Re-poll before treating it as terminal.`,
     );
     return {
-      branchState: 'unknown',
-      syncRecommendation: 'hold-unknown',
+      branchState: 'computing',
+      syncRecommendation: 'recheck',
       conflictFiles: [],
       mergeableSource: 'none',
     };

--- a/src/scripts/resume-route-selection.mts
+++ b/src/scripts/resume-route-selection.mts
@@ -188,6 +188,12 @@ export function selectResumeRoute(input: ResumeRouteInput) {
         reasonParts,
       );
     }
+    if (state.branchState === 'computing') {
+      // Mergeability is still computing (transient `UNKNOWN`); resume into F1,
+      // whose bounded re-poll resolves it instead of stopping on a
+      // self-resolving state.
+      return result('F1', 'pr-ci-success-branch-computing', state, reasonParts);
+    }
     if (state.branchState === 'behind-no-conflict') {
       return result(
         'F1',
@@ -460,6 +466,10 @@ export function classifyBranchState(
   if (mergeStateStatus === 'CLEAN') return 'clean';
   if (mergeStateStatus === 'BEHIND') return 'behind-no-conflict';
   if (mergeable === 'MERGEABLE') return 'clean';
+  // GitHub computes `mergeable` asynchronously: an explicit `UNKNOWN` means the
+  // result is still computing (transient), not a terminal classification
+  // failure. Keep `unknown` for genuinely missing/unrecognized state.
+  if (mergeable === 'UNKNOWN') return 'computing';
   return 'unknown';
 }
 

--- a/src/scripts/resume-route-selection.mts
+++ b/src/scripts/resume-route-selection.mts
@@ -457,7 +457,8 @@ function countUnrepliedRegularComments(
 export function classifyBranchState(
   mergeState: MergeStatePayload | null | undefined,
 ): string {
-  const mergeable = String(mergeState?.mergeable ?? '').toUpperCase();
+  const rawMergeable = mergeState?.mergeable;
+  const mergeable = String(rawMergeable ?? '').toUpperCase();
   const mergeStateStatus = String(
     mergeState?.mergeStateStatus ?? '',
   ).toUpperCase();
@@ -466,10 +467,12 @@ export function classifyBranchState(
   if (mergeStateStatus === 'CLEAN') return 'clean';
   if (mergeStateStatus === 'BEHIND') return 'behind-no-conflict';
   if (mergeable === 'MERGEABLE') return 'clean';
-  // GitHub computes `mergeable` asynchronously: an explicit `UNKNOWN` means the
-  // result is still computing (transient), not a terminal classification
-  // failure. Keep `unknown` for genuinely missing/unrecognized state.
-  if (mergeable === 'UNKNOWN') return 'computing';
+  // GitHub computes `mergeable` asynchronously: an explicit `UNKNOWN` — or an
+  // explicit `null` mergeable on a present payload — means the result is still
+  // computing (transient), not a terminal classification failure. A genuinely
+  // missing/unparseable payload (no `mergeable` field at all, i.e. `undefined`)
+  // stays terminal `unknown`.
+  if (mergeable === 'UNKNOWN' || rawMergeable === null) return 'computing';
   return 'unknown';
 }
 

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -93,7 +93,18 @@ test('classifyBranchConflictState: DIRTY returns dirty state', async () => {
   );
 });
 
-test('classifyBranchConflictState: UNKNOWN returns unknown state', async () => {
+test('classifyBranchConflictState: UNKNOWN returns transient computing state', async () => {
+  const fixture = loadFixture('computing');
+  const result = await classifyBranchConflictState(fixture.prData.number, {
+    owner: 'test-owner',
+    repo: 'test-repo',
+    _testPrData: fixture.prData,
+  });
+  assert.equal(result.branchState, 'computing');
+  assert.equal(result.syncRecommendation, 'recheck');
+});
+
+test('classifyBranchConflictState: unrecognized mergeable returns terminal unknown', async () => {
   const fixture = loadFixture('unknown');
   const result = await classifyBranchConflictState(fixture.prData.number, {
     owner: 'test-owner',

--- a/tests/resume-route-selection.test.mts
+++ b/tests/resume-route-selection.test.mts
@@ -146,6 +146,19 @@ test('routes stop when PR exists, CI succeeded, no pending reviews, and branch s
   assert.equal(result.reason, 'pr-ci-success-branch-dirty-or-unknown');
 });
 
+test('routes F1 when PR exists, CI succeeded, no pending reviews, and branch state is computing', () => {
+  const result = selectResumeRoute({
+    prExists: true,
+    requiredChecksGenerated: true,
+    ciSuccess: true,
+    reviewExists: false,
+    reviewPending: false,
+    branchState: 'computing',
+  });
+  assert.equal(result.route, 'F1');
+  assert.equal(result.reason, 'pr-ci-success-branch-computing');
+});
+
 test('routes F2 when PR exists, CI succeeded, no pending reviews, and branchState is not provided (defaults to clean)', () => {
   const result = selectResumeRoute({
     prExists: true,
@@ -221,9 +234,16 @@ test('classifyBranchState returns clean for BLOCKED MERGEABLE (non-git-conflict 
 test('classifyBranchState returns unknown for null/missing state', () => {
   assert.equal(classifyBranchState(null), 'unknown');
   assert.equal(classifyBranchState({}), 'unknown');
+});
+
+test('classifyBranchState returns computing for transient UNKNOWN mergeable', () => {
   assert.equal(
     classifyBranchState({ mergeable: 'UNKNOWN', mergeStateStatus: '' }),
-    'unknown',
+    'computing',
+  );
+  assert.equal(
+    classifyBranchState({ mergeable: 'UNKNOWN', mergeStateStatus: 'UNKNOWN' }),
+    'computing',
   );
 });
 

--- a/tests/resume-route-selection.test.mts
+++ b/tests/resume-route-selection.test.mts
@@ -231,18 +231,27 @@ test('classifyBranchState returns clean for BLOCKED MERGEABLE (non-git-conflict 
   );
 });
 
-test('classifyBranchState returns unknown for null/missing state', () => {
+test('classifyBranchState returns unknown for genuinely missing state', () => {
+  // No payload, or a payload with no `mergeable` field at all (undefined):
+  // genuinely missing/unparseable, so it stays terminal `unknown`.
   assert.equal(classifyBranchState(null), 'unknown');
   assert.equal(classifyBranchState({}), 'unknown');
+  assert.equal(classifyBranchState({ mergeStateStatus: 'UNKNOWN' }), 'unknown');
 });
 
-test('classifyBranchState returns computing for transient UNKNOWN mergeable', () => {
+test('classifyBranchState returns computing for transient UNKNOWN/null mergeable', () => {
   assert.equal(
     classifyBranchState({ mergeable: 'UNKNOWN', mergeStateStatus: '' }),
     'computing',
   );
   assert.equal(
     classifyBranchState({ mergeable: 'UNKNOWN', mergeStateStatus: 'UNKNOWN' }),
+    'computing',
+  );
+  // An explicit `null` mergeable on a present payload is GitHub still
+  // computing, not a missing payload, so it is transient `computing`.
+  assert.equal(
+    classifyBranchState({ mergeable: null, mergeStateStatus: 'UNKNOWN' }),
     'computing',
   );
 });


### PR DESCRIPTION
## Summary

`branch-conflict-state` mapped a GitHub `mergeable: UNKNOWN` / null read
directly to a terminal `unknown` / `hold-unknown`. Because GitHub computes
mergeability **asynchronously**, that value is transiently `UNKNOWN` right
after a mutation (F1 is reached just after E1 posts its watermark/baseline)
and resolves within seconds — so F1 posted a maintainer hold and **stopped on
a self-resolving state**.

This distinguishes a **transient** still-computing mergeability from a
**terminal** unknown:

- **`branch-conflict-state`** classifies `mergeable` UNKNOWN/null as a new
  `computing` / `recheck` state; `unknown` / `hold-unknown` is retained for
  genuinely unclassifiable input (missing SHA, merge-tree probe failure,
  unrecognized value). The helper stays a single-read classifier — the
  bounded wait belongs to the caller, matching the advisory-wait pattern.
- **`resume-route-selection`** classifies transient `UNKNOWN` as `computing`
  and resumes into F1 (bounded re-poll) instead of stopping; null/missing
  state stays `unknown`.
- **F1** (`idd-pre-merge`) and the shared E-phase branch-sync taxonomy
  (`idd-review-triage`) route `computing` to a bounded re-poll (default 3
  attempts, a few seconds apart) and treat only a **persistently**
  `computing` / `unknown` state after the budget as the terminal hold.

Net effect: transient `UNKNOWN` self-resolves; persistent `UNKNOWN` ends in
the same hold as before — no regression.

Schema enum, the `idd-helper-scripts` enum list, fixtures (renamed
`unknown` → `computing`; added a terminal-`unknown` fallback fixture), and
tests are updated consistently. Generated artifacts (`pnpm run build`) and the
root instruction mirror (`node scripts/sync-docs.mjs --apply`) are regenerated.
The other issue-listed sites (`helper-runtime-manifest`,
`schema-validation.test`, `flag-name-matrix.test`) do not enumerate these enum
values, so they need no change; `schema-type-reconciliation` passes unchanged
(`branchState` is typed `string`).

## ⚠️ Bundle-budget callout (bundleBudgets ratchet)

The `computing` routing text raises two limits in `audit/sync-manifest.json`:

- `bundle-review`: 94650 → **95600** (measured 95015)
- `bundle-merge`: 84250 → **85500** (measured 84882)

Each keeps a small margin over the measured size (rather than an exact-fit
bump) to avoid an immediate wall for concurrent sessions, per the
documented bump-with-margin convention. The added instruction content is the
load-bearing `computing` re-poll routing, so raising the limit is preferred
over trimming shared, terminology-sensitive content.

## Verification

`pnpm run lint:minimum` passes: typecheck, `build:check`, biome, 1070 tests
(incl. new `computing` classification + routing tests), schema-validation,
`audit-docs --check` (sync parity + bundle budgets), cspell, markdownlint.

Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new “computing” branch state when mergeability is still being determined.
  * Review and resume flows now re-check this state briefly before falling back to a hold action.

* **Bug Fixes**
  * Improved handling of uncertain mergeability results so transient states are no longer treated as terminal too early.
  * CI-success resume routing now continues correctly when branch status is still computing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->