### PR TITLE
feat(idd): add cross-roadmap autopilot discovery mode

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -175,6 +175,16 @@ Use GH CLI or GH MCP to find the roadmap among open issues. Identify it
 by the `roadmap` label (project field) or by recognizing it as an
 umbrella issue. If no roadmap issue exists, report and abort.
 
+**Autopilot cross-roadmap mode (optional, additive).** When several
+roadmaps run in parallel and the active autopilot-suitable work may live
+under **sibling** epics, do not commit to a single umbrella here. Instead,
+enumerate the open execution leaves across **all** open roadmap roots and
+rank them by autopilot-suitability (see A2), then carry the top-ranked
+candidate through the normal A3/A4/A4.5/A5 gates. This is additive: the
+single-root selection above stays the default, and orphan-first filtering
+still applies only to true orphans (cross-roadmap leaves carry
+`idd-skill-roadmap-id` markers, so they are not orphans).
+
 **Note**: Repo-wide or label-based issue queries are permitted only in
 **A0-T** (the scoped `idd-skill-roadmap-id` lookup needed to resolve the
 explicit target's `idd-skill-blocked-by` markers),
@@ -284,6 +294,19 @@ abort).
 Report every A2 execution candidate with its provenance path (e.g.,
 `#222 → #228 → #257`), open roadmap nodes encountered, and any
 unresolvable references before passing to A3.
+
+**Autopilot cross-roadmap union (optional, additive).** When A1 elected
+the cross-roadmap mode, enumerate from **each** open roadmap root and take
+the **union** of open execution leaves. De-duplicate a leaf reached from
+several roots (record every source root as provenance; never double-count
+it). Rank the union by autopilot-suitability **descending**, tie-broken by
+issue number **ascending**; treat a missing or out-of-range score as the
+configured floor, but never rank an unscored leaf above genuinely scored
+work at the same effective value. The `discover-roadmap-graph` helper's
+`--all-roadmaps` mode produces exactly this ranked union (see
+[IDD helper script evaluation](../../docs/idd-helper-scripts.md)). The
+score is an advisory ranking hint only — A3/A4/A4.5/A5 still run on the
+selected candidate.
 
 ## A3 — Filter to ready-to-start
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -182,8 +182,11 @@ enumerate the open execution leaves across **all** open roadmap roots and
 rank them by autopilot-suitability (see A2), then carry the top-ranked
 candidate through the normal A3/A4/A4.5/A5 gates. This is additive: the
 single-root selection above stays the default, and orphan-first filtering
-still applies only to true orphans (cross-roadmap leaves carry
-`idd-skill-roadmap-id` markers, so they are not orphans).
+still applies only to true orphans (cross-roadmap leaves are reached via a
+parent roadmap's task list, and per A2 do **not** carry an
+`idd-skill-roadmap-id` marker themselves — that would make them roadmap
+nodes — so orphan-first, which targets issues with no roadmap linkage,
+does not exclude them).
 
 **Note**: Repo-wide or label-based issue queries are permitted only in
 **A0-T** (the scoped `idd-skill-roadmap-id` lookup needed to resolve the

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 86379
+      "limitBytes": 88100
     },
     {
       "id": "bundle-resume",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -148,7 +148,7 @@
     "glob": ".github/instructions/idd-*.instructions.md",
     "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
     "alwaysLoadedLimitBytes": 20000,
-    "phaseLimitBytes": 30000
+    "phaseLimitBytes": 30100
   },
   "bundleBudgets": [
     {

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -129,10 +129,15 @@ future inventory reviews do not need to re-infer their role from code.
 ### Discover Roadmap Graph Contract
 
 `scripts/discover-roadmap-graph.mjs` evaluates the recursive A1.5/A2
-roadmap graph for one selected roadmap issue.
+roadmap graph for one selected roadmap issue. It also offers an additive
+cross-roadmap autopilot discovery mode (`--all-roadmaps`) that unions the
+open execution leaves across every open roadmap root; the single-root
+default below is unchanged.
 
 - **Inputs**: `--issue <number>`, with optional `--owner <owner>`,
-  `--repo <repo>`, and `--policy <path>`.
+  `--repo <repo>`, and `--policy <path>`. `--issue` and `--all-roadmaps`
+  are mutually exclusive; exactly one mode must be selected. Passing both,
+  or neither, is an error.
 - **JSON output**:
   - `root`: `{ number: number, title: string, state: string,`
     `classification: "roadmap" | "execution", roadmapMarkerId: string }`
@@ -152,7 +157,37 @@ roadmap graph for one selected roadmap issue.
     `duplicateReferenceCount: number, cycleCount: number,`
     `inaccessibleReferenceCount: number, unresolvedReferenceCount: number,`
     `maxDepth: number }`
-- **Error conditions**: missing `--issue`, unknown flags, an unreadable
+- **Cross-roadmap autopilot mode (`--all-roadmaps`)**: discovers every
+  **open** roadmap root (an open issue carrying the `roadmap` label **or**
+  an `<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: ... -->` marker), runs the
+  single-root enumeration above from each root, and returns a **union** of
+  open execution leaves. The output shape differs from single-root mode:
+  - `mode`: `"all-roadmaps"`
+  - `roots`: `[{ number: number, title: string, state: string,`
+    `roadmapMarkerId: string }]` — every open roadmap root enumerated
+  - `leaves`: `[{ number: number, title: string, state: string,`
+    `labels: string[], classification: "execution",`
+    `roadmapMarkerId: string, autopilotSuitability: number | null,`
+    `sourceRoots: number[] }]` — the union of open execution leaves. Each
+    leaf records every roadmap root it is reachable from in `sourceRoots`
+    (provenance); a leaf shared by sibling epics appears **once** and is
+    never double-counted.
+  - `diagnostics`: same four buckets as single-root mode, deduped across
+    every per-root enumeration.
+  - `summary`: `{ rootCount: number, leafCount: number,`
+    `scoredLeafCount: number, sharedLeafCount: number,`
+    `duplicateReferenceCount: number, cycleCount: number,`
+    `inaccessibleReferenceCount: number, unresolvedReferenceCount: number }`
+  - **Ranking** (global-by-score): `leaves` is sorted by
+    `autopilotSuitability` **descending**, tie-broken by issue number
+    **ascending** (stable). A missing or out-of-range score is treated as
+    the configured suitability floor for ordering so unscored work is not
+    buried, but a coherently scored leaf never ranks below an unscored leaf
+    at the same effective value — scored work always sorts first at a tie.
+    The score is an advisory ranking hint only; it never replaces the
+    A4.5 suitability gate or the A5 claim safety checks.
+- **Error conditions**: missing `--issue` (and no `--all-roadmaps`),
+  combining `--issue` with `--all-roadmaps`, unknown flags, an unreadable
   root roadmap, or incomplete `subIssues` GraphQL data throw. Missing or
   inaccessible descendants are reported in `diagnostics` instead of
   crashing.

--- a/fixtures/schemas/discover-roadmap-union.invalid.json
+++ b/fixtures/schemas/discover-roadmap-union.invalid.json
@@ -1,0 +1,38 @@
+{
+  "mode": "single-root",
+  "roots": [
+    {
+      "number": 0,
+      "title": "bad root number",
+      "state": "OPEN",
+      "roadmapMarkerId": ""
+    }
+  ],
+  "leaves": [
+    {
+      "number": 101,
+      "title": "leaf missing sourceRoots",
+      "state": "OPEN",
+      "labels": [],
+      "classification": "execution",
+      "roadmapMarkerId": "",
+      "autopilotSuitability": 0
+    }
+  ],
+  "diagnostics": {
+    "duplicateReferences": [],
+    "cycles": [],
+    "inaccessibleReferences": [],
+    "unresolvedReferences": []
+  },
+  "summary": {
+    "rootCount": 1,
+    "leafCount": 1,
+    "scoredLeafCount": 0,
+    "sharedLeafCount": 0,
+    "duplicateReferenceCount": 0,
+    "cycleCount": 0,
+    "inaccessibleReferenceCount": 0,
+    "unresolvedReferenceCount": 0
+  }
+}

--- a/fixtures/schemas/discover-roadmap-union.invalid.json
+++ b/fixtures/schemas/discover-roadmap-union.invalid.json
@@ -16,7 +16,7 @@
       "labels": [],
       "classification": "execution",
       "roadmapMarkerId": "",
-      "autopilotSuitability": 0
+      "autopilotSuitability": 6
     }
   ],
   "diagnostics": {

--- a/fixtures/schemas/discover-roadmap-union.valid.json
+++ b/fixtures/schemas/discover-roadmap-union.valid.json
@@ -1,0 +1,55 @@
+{
+  "mode": "all-roadmaps",
+  "roots": [
+    {
+      "number": 100,
+      "title": "roadmap 100",
+      "state": "OPEN",
+      "roadmapMarkerId": "epic-alpha"
+    },
+    {
+      "number": 200,
+      "title": "roadmap 200",
+      "state": "OPEN",
+      "roadmapMarkerId": "epic-beta"
+    }
+  ],
+  "leaves": [
+    {
+      "number": 101,
+      "title": "scored leaf",
+      "state": "OPEN",
+      "labels": [],
+      "classification": "execution",
+      "roadmapMarkerId": "",
+      "autopilotSuitability": 5,
+      "sourceRoots": [100]
+    },
+    {
+      "number": 201,
+      "title": "shared unscored leaf",
+      "state": "OPEN",
+      "labels": ["enhancement"],
+      "classification": "execution",
+      "roadmapMarkerId": "",
+      "autopilotSuitability": null,
+      "sourceRoots": [100, 200]
+    }
+  ],
+  "diagnostics": {
+    "duplicateReferences": [],
+    "cycles": [],
+    "inaccessibleReferences": [],
+    "unresolvedReferences": []
+  },
+  "summary": {
+    "rootCount": 2,
+    "leafCount": 2,
+    "scoredLeafCount": 1,
+    "sharedLeafCount": 1,
+    "duplicateReferenceCount": 0,
+    "cycleCount": 0,
+    "inaccessibleReferenceCount": 0,
+    "unresolvedReferenceCount": 0
+  }
+}

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -185,8 +185,12 @@ enumerate the open execution leaves across **all** open roadmap roots and
 rank them by autopilot-suitability (see A2), then carry the top-ranked
 candidate through the normal A3/A4/A4.5/A5 gates. This is additive: the
 single-root selection above stays the default, and orphan-first filtering
-still applies only to true orphans (cross-roadmap leaves carry
-`{{PROJECT_MARKER_PREFIX}}-roadmap-id` markers, so they are not orphans).
+still applies only to true orphans (cross-roadmap leaves are referenced
+by a parent roadmap's task list, so roadmap traversal reaches them; per
+A2 they do **not** carry `{{PROJECT_MARKER_PREFIX}}-roadmap-id` markers
+themselves — a marker would make them roadmap nodes — so orphan-first
+filtering, which targets issues with no roadmap linkage at all, does not
+apply to them).
 
 **Note**: Repo-wide or label-based issue queries are permitted only in
 **A0-T** (the scoped `{{PROJECT_MARKER_PREFIX}}-roadmap-id` lookup

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -178,6 +178,16 @@ Use GH CLI or GH MCP to find the roadmap among open issues. Identify it
 by the `roadmap` label (project field) or by recognizing it as an
 umbrella issue. If no roadmap issue exists, report and abort.
 
+**Autopilot cross-roadmap mode (optional, additive).** When several
+roadmaps run in parallel and the active autopilot-suitable work may live
+under **sibling** epics, do not commit to a single umbrella here. Instead,
+enumerate the open execution leaves across **all** open roadmap roots and
+rank them by autopilot-suitability (see A2), then carry the top-ranked
+candidate through the normal A3/A4/A4.5/A5 gates. This is additive: the
+single-root selection above stays the default, and orphan-first filtering
+still applies only to true orphans (cross-roadmap leaves carry
+`{{PROJECT_MARKER_PREFIX}}-roadmap-id` markers, so they are not orphans).
+
 **Note**: Repo-wide or label-based issue queries are permitted only in
 **A0-T** (the scoped `{{PROJECT_MARKER_PREFIX}}-roadmap-id` lookup
 needed to resolve the explicit target's
@@ -302,6 +312,19 @@ abort).
 Report every A2 execution candidate with its provenance path (e.g.,
 `#222 → #228 → #257`), open roadmap nodes encountered, and any
 unresolvable references before passing to A3.
+
+**Autopilot cross-roadmap union (optional, additive).** When A1 elected
+the cross-roadmap mode, enumerate from **each** open roadmap root and take
+the **union** of open execution leaves. De-duplicate a leaf reached from
+several roots (record every source root as provenance; never double-count
+it). Rank the union by autopilot-suitability **descending**, tie-broken by
+issue number **ascending**; treat a missing or out-of-range score as the
+configured floor, but never rank an unscored leaf above genuinely scored
+work at the same effective value. The `discover-roadmap-graph` helper's
+`--all-roadmaps` mode produces exactly this ranked union (see
+[IDD helper script evaluation](../../docs/idd-helper-scripts.md)). The
+score is an advisory ranking hint only — A3/A4/A4.5/A5 still run on the
+selected candidate.
 
 ## A3 — Filter to ready-to-start
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -129,10 +129,15 @@ future inventory reviews do not need to re-infer their role from code.
 ### Discover Roadmap Graph Contract
 
 `scripts/discover-roadmap-graph.mjs` evaluates the recursive A1.5/A2
-roadmap graph for one selected roadmap issue.
+roadmap graph for one selected roadmap issue. It also offers an additive
+cross-roadmap autopilot discovery mode (`--all-roadmaps`) that unions the
+open execution leaves across every open roadmap root; the single-root
+default below is unchanged.
 
 - **Inputs**: `--issue <number>`, with optional `--owner <owner>`,
-  `--repo <repo>`, and `--policy <path>`.
+  `--repo <repo>`, and `--policy <path>`. `--issue` and `--all-roadmaps`
+  are mutually exclusive; exactly one mode must be selected. Passing both,
+  or neither, is an error.
 - **JSON output**:
   - `root`: `{ number: number, title: string, state: string,`
     `classification: "roadmap" | "execution", roadmapMarkerId: string }`
@@ -152,7 +157,37 @@ roadmap graph for one selected roadmap issue.
     `duplicateReferenceCount: number, cycleCount: number,`
     `inaccessibleReferenceCount: number, unresolvedReferenceCount: number,`
     `maxDepth: number }`
-- **Error conditions**: missing `--issue`, unknown flags, an unreadable
+- **Cross-roadmap autopilot mode (`--all-roadmaps`)**: discovers every
+  **open** roadmap root (an open issue carrying the `roadmap` label **or**
+  an `<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: ... -->` marker), runs the
+  single-root enumeration above from each root, and returns a **union** of
+  open execution leaves. The output shape differs from single-root mode:
+  - `mode`: `"all-roadmaps"`
+  - `roots`: `[{ number: number, title: string, state: string,`
+    `roadmapMarkerId: string }]` — every open roadmap root enumerated
+  - `leaves`: `[{ number: number, title: string, state: string,`
+    `labels: string[], classification: "execution",`
+    `roadmapMarkerId: string, autopilotSuitability: number | null,`
+    `sourceRoots: number[] }]` — the union of open execution leaves. Each
+    leaf records every roadmap root it is reachable from in `sourceRoots`
+    (provenance); a leaf shared by sibling epics appears **once** and is
+    never double-counted.
+  - `diagnostics`: same four buckets as single-root mode, deduped across
+    every per-root enumeration.
+  - `summary`: `{ rootCount: number, leafCount: number,`
+    `scoredLeafCount: number, sharedLeafCount: number,`
+    `duplicateReferenceCount: number, cycleCount: number,`
+    `inaccessibleReferenceCount: number, unresolvedReferenceCount: number }`
+  - **Ranking** (global-by-score): `leaves` is sorted by
+    `autopilotSuitability` **descending**, tie-broken by issue number
+    **ascending** (stable). A missing or out-of-range score is treated as
+    the configured suitability floor for ordering so unscored work is not
+    buried, but a coherently scored leaf never ranks below an unscored leaf
+    at the same effective value — scored work always sorts first at a tie.
+    The score is an advisory ranking hint only; it never replaces the
+    A4.5 suitability gate or the A5 claim safety checks.
+- **Error conditions**: missing `--issue` (and no `--all-roadmaps`),
+  combining `--issue` with `--all-roadmaps`, unknown flags, an unreadable
   root roadmap, or incomplete `subIssues` GraphQL data throw. Missing or
   inaccessible descendants are reported in `diagnostics` instead of
   crashing.

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -82,7 +82,6 @@
           "classification": {
             "type": "string",
             "enum": [
-              "roadmap",
               "execution"
             ]
           },
@@ -90,8 +89,15 @@
             "type": "string"
           },
           "autopilotSuitability": {
-            "description": "Authored autopilot-suitability score (1-5) or null when unscored. The in-repo validator supports neither union types nor `maximum`, so only the lower bound (1) is enforced here; the upper bound (5) is enforced by parseAutopilotSuitability at runtime.",
-            "minimum": 1
+            "description": "Authored autopilot-suitability score (1-5) or null when unscored. The `enum` enumerates every coherent value, so the full null | 1..5 contract (including the upper bound and rejection of non-numeric values) is enforced here, matching parseAutopilotSuitability at runtime.",
+            "enum": [
+              null,
+              1,
+              2,
+              3,
+              4,
+              5
+            ]
           },
           "sourceRoots": {
             "type": "array",

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -1,0 +1,300 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/discover-roadmap-union.schema.json",
+  "title": "Discover Roadmap Union",
+  "description": "Read-only cross-roadmap autopilot discovery union: open execution leaves across every open roadmap root, each tagged with its source roots and ranked by autopilot suitability.",
+  "type": "object",
+  "required": [
+    "mode",
+    "roots",
+    "leaves",
+    "diagnostics",
+    "summary"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": [
+        "all-roadmaps"
+      ]
+    },
+    "roots": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "number",
+          "title",
+          "state",
+          "roadmapMarkerId"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "number": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "title": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "roadmapMarkerId": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "leaves": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "number",
+          "title",
+          "state",
+          "labels",
+          "classification",
+          "roadmapMarkerId",
+          "autopilotSuitability",
+          "sourceRoots"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "number": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "title": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "roadmap",
+              "execution"
+            ]
+          },
+          "roadmapMarkerId": {
+            "type": "string"
+          },
+          "autopilotSuitability": {
+            "description": "Authored autopilot-suitability score (1-5) or null when unscored. The in-repo validator supports neither union types nor `maximum`, so only the lower bound (1) is enforced here; the upper bound (5) is enforced by parseAutopilotSuitability at runtime.",
+            "minimum": 1
+          },
+          "sourceRoots": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      }
+    },
+    "diagnostics": {
+      "type": "object",
+      "required": [
+        "duplicateReferences",
+        "cycles",
+        "inaccessibleReferences",
+        "unresolvedReferences"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "duplicateReferences": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "source",
+              "target",
+              "relationship",
+              "evidence",
+              "firstSeenFrom"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "source": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "target": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "relationship": {
+                "type": "string"
+              },
+              "evidence": {
+                "type": "string"
+              },
+              "firstSeenFrom": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          }
+        },
+        "cycles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "source",
+              "target",
+              "relationship",
+              "path"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "source": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "target": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "relationship": {
+                "type": "string"
+              },
+              "path": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            }
+          }
+        },
+        "inaccessibleReferences": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "source",
+              "target",
+              "relationship",
+              "evidence",
+              "reason"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "source": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "target": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "relationship": {
+                "type": "string"
+              },
+              "evidence": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "unresolvedReferences": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "source",
+              "target",
+              "relationship",
+              "evidence",
+              "reason"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "source": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "target": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "relationship": {
+                "type": "string"
+              },
+              "evidence": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "rootCount",
+        "leafCount",
+        "scoredLeafCount",
+        "sharedLeafCount",
+        "duplicateReferenceCount",
+        "cycleCount",
+        "inaccessibleReferenceCount",
+        "unresolvedReferenceCount"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "rootCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "leafCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "scoredLeafCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sharedLeafCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "duplicateReferenceCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cycleCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "inaccessibleReferenceCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unresolvedReferenceCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -779,7 +779,7 @@ function printHelp() {
   root (the union), each tagged with its sourceRoots and ranked by
   autopilotSuitability (descending, tie-broken by ascending issue number).
 
-Output schema (JSON mode):
+Output schema (JSON mode) — --issue single-root report:
   {
     "root": { "number": 638, "title": "...", "state": "OPEN", "classification": "roadmap", "roadmapMarkerId": "..." },
     "nodes": [{ "number": 638, "title": "...", "state": "OPEN", "labels": ["roadmap"], "classification": "roadmap", "roadmapMarkerId": "...", "autopilotSuitability": null, "depth": 0 }],
@@ -804,6 +804,30 @@ Output schema (JSON mode):
       "inaccessibleReferenceCount": 0,
       "unresolvedReferenceCount": 0,
       "maxDepth": 1
+    }
+  }
+
+Output schema (JSON mode) — --all-roadmaps union report (a different
+top-level shape from the single-root report above):
+  {
+    "mode": "all-roadmaps",
+    "roots": [{ "number": 638, "title": "...", "state": "OPEN", "roadmapMarkerId": "..." }],
+    "leaves": [{ "number": 640, "title": "...", "state": "OPEN", "labels": ["..."], "classification": "execution", "roadmapMarkerId": "", "autopilotSuitability": null, "sourceRoots": [638] }],
+    "diagnostics": {
+      "duplicateReferences": [],
+      "cycles": [],
+      "inaccessibleReferences": [],
+      "unresolvedReferences": []
+    },
+    "summary": {
+      "rootCount": 1,
+      "leafCount": 1,
+      "scoredLeafCount": 0,
+      "sharedLeafCount": 0,
+      "duplicateReferenceCount": 0,
+      "cycleCount": 0,
+      "inaccessibleReferenceCount": 0,
+      "unresolvedReferenceCount": 0
     }
   }
 `);

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -9,8 +9,8 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
   isAutopilotSuitabilityScore,
+  normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mjs';
 
@@ -82,6 +82,7 @@ if (isMainModule(import.meta.url)) {
   const report = args.allRoadmaps
     ? await enumerateAllRoadmapsGraph({
         markerPrefix: policy.markerPrefix,
+        floor: policy.autopilotSuitability?.floor,
         owner,
         repo,
         loadIssue: buildIssueLoader(owner, repo),
@@ -392,6 +393,10 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
  */
 export async function enumerateAllRoadmapsGraph(options = {}) {
   const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  // Resolve the configured suitability floor (normalized to an integer
+  // 1-5, falling back to the default when unset) once, then rank unscored
+  // leaves at that configured floor.
+  const floor = normalizeAutopilotSuitabilityFloor(options.floor);
   const loadOpenRoadmapRoots = options.loadOpenRoadmapRoots;
   if (typeof loadOpenRoadmapRoots !== 'function') {
     throw new Error(
@@ -441,7 +446,9 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
         title: node.title,
         state: node.state,
         labels: node.labels,
-        classification: node.classification,
+        // Only execution candidates reach this branch (filtered by
+        // executionSet above), so the classification is always 'execution'.
+        classification: 'execution',
         roadmapMarkerId: node.roadmapMarkerId,
         autopilotSuitability: node.autopilotSuitability,
         sourceRoots: [graph.root.number],
@@ -476,7 +483,7 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
       ...leaf,
       sourceRoots: [...leaf.sourceRoots].sort((left, right) => left - right),
     }))
-    .sort(compareUnionLeaves);
+    .sort((left, right) => compareUnionLeaves(left, right, floor));
   const scoredLeafCount = leaves.filter((leaf) =>
     isAutopilotSuitabilityScore(leaf.autopilotSuitability),
   ).length;
@@ -516,24 +523,24 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
  *
  * Sort key, in order:
  *   1. effective suitability DESCENDING — a coherent 1-5 score uses its
- *      own value; a missing/out-of-range score uses the floor so unscored
- *      pre-existing work is not buried below the floor;
+ *      own value; a missing/out-of-range score uses the configured floor
+ *      so unscored pre-existing work is not buried below the floor;
  *   2. scored-before-unscored at a tie — a leaf with a coherent score
  *      never ranks below an unscored leaf at the same effective value, so
- *      "missing is treated as the floor" never lets unscored work jump
- *      ahead of genuinely scored work;
+ *      "missing is treated as the configured floor" never lets unscored
+ *      work jump ahead of genuinely scored work;
  *   3. issue number ASCENDING — a stable, repository-deterministic
  *      tie-break that keeps the order from thrashing between epics.
+ *
+ * `floor` is the configured `autopilotSuitability.floor` (already
+ * normalized to an integer 1-5). The comparator stays a total order.
  */
-function compareUnionLeaves(left, right) {
+function compareUnionLeaves(left, right, floor) {
   const leftScored = isAutopilotSuitabilityScore(left.autopilotSuitability);
   const rightScored = isAutopilotSuitabilityScore(right.autopilotSuitability);
-  const leftEffective = leftScored
-    ? left.autopilotSuitability
-    : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
-  const rightEffective = rightScored
-    ? right.autopilotSuitability
-    : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  // Unscored or out-of-range leaves rank at the configured floor.
+  const leftEffective = leftScored ? left.autopilotSuitability : floor;
+  const rightEffective = rightScored ? right.autopilotSuitability : floor;
   return (
     rightEffective - leftEffective ||
     Number(rightScored) - Number(leftScored) ||

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -8,7 +8,11 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseAutopilotSuitability } from './autopilot-suitability.mjs';
+import {
+  DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+  isAutopilotSuitabilityScore,
+  parseAutopilotSuitability,
+} from './autopilot-suitability.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
@@ -34,10 +38,40 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   }
 }
 `;
+const OPEN_ISSUES_QUERY = `
+query($owner:String!, $repo:String!, $after:String) {
+  repository(owner:$owner, name:$repo) {
+    issues(states:OPEN, first:100, after:$after) {
+      nodes {
+        number
+        body
+        labels(first:100) {
+          nodes {
+            name
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+`;
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
-  if (!Number.isInteger(args.issue) || args.issue <= 0) {
-    throw new Error('missing required --issue <number>');
+  const hasIssue = Number.isInteger(args.issue) && args.issue > 0;
+  // --issue and --all-roadmaps are mutually exclusive: exactly one route
+  // must be selected. The single-root --issue contract (required when
+  // --all-roadmaps is absent) is preserved.
+  if (args.allRoadmaps && hasIssue) {
+    throw new Error('--all-roadmaps cannot be combined with --issue');
+  }
+  if (!args.allRoadmaps && !hasIssue) {
+    throw new Error(
+      'missing required --issue <number> (or pass --all-roadmaps)',
+    );
   }
   const owner =
     args.owner ||
@@ -45,14 +79,27 @@ if (isMainModule(import.meta.url)) {
   const repo =
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
   const policy = loadPolicy(args.policy);
-  const graph = await enumerateRoadmapGraph(args.issue, {
-    markerPrefix: policy.markerPrefix,
-    owner,
-    repo,
-    loadIssue: buildIssueLoader(owner, repo),
-    loadSubIssues: buildSubIssueLoader(owner, repo),
-  });
-  process.stdout.write(`${JSON.stringify(graph, null, 2)}\n`);
+  const report = args.allRoadmaps
+    ? await enumerateAllRoadmapsGraph({
+        markerPrefix: policy.markerPrefix,
+        owner,
+        repo,
+        loadIssue: buildIssueLoader(owner, repo),
+        loadSubIssues: buildSubIssueLoader(owner, repo),
+        loadOpenRoadmapRoots: buildOpenRoadmapRootsLoader(
+          owner,
+          repo,
+          policy.markerPrefix,
+        ),
+      })
+    : await enumerateRoadmapGraph(args.issue, {
+        markerPrefix: policy.markerPrefix,
+        owner,
+        repo,
+        loadIssue: buildIssueLoader(owner, repo),
+        loadSubIssues: buildSubIssueLoader(owner, repo),
+      });
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
 }
 export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
@@ -320,6 +367,204 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
     });
   }
 }
+/**
+ * Cross-roadmap autopilot discovery (additive `--all-roadmaps` mode).
+ *
+ * Discovers every OPEN roadmap root (an open issue carrying the
+ * `roadmap` label OR an `<!-- {markerPrefix}-roadmap-id: ... -->`
+ * marker), runs the existing single-root {@link enumerateRoadmapGraph}
+ * from each root, and returns the UNION of open execution leaves. A leaf
+ * reachable from several sibling roots is recorded once, carrying every
+ * `sourceRoots` it is reachable from (provenance), so it is never
+ * double-counted.
+ *
+ * Ranking (global-by-score): the union is sorted by `autopilotSuitability`
+ * DESCENDING, tie-broken by issue number ASCENDING (stable). Missing or
+ * out-of-range suitability is treated as the configured floor for
+ * ordering, but a leaf with no coherent score never ranks above a scored
+ * leaf at the same effective value — scored work always sorts first at a
+ * tie. See {@link compareUnionLeaves}.
+ *
+ * The helper stays READ-ONLY / evidence-only: it reads issue bodies and
+ * GitHub sub-issue relationships and never claims, mutates, or writes to
+ * GitHub. The single-root report shape is unchanged; this union shape is
+ * only produced in `--all-roadmaps` mode.
+ */
+export async function enumerateAllRoadmapsGraph(options = {}) {
+  const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  const loadOpenRoadmapRoots = options.loadOpenRoadmapRoots;
+  if (typeof loadOpenRoadmapRoots !== 'function') {
+    throw new Error(
+      'enumerateAllRoadmapsGraph requires loadOpenRoadmapRoots()',
+    );
+  }
+  const rootNumbers = normalizeOpenRoadmapRootNumbers(
+    await loadOpenRoadmapRoots(),
+  );
+  const roots = [];
+  const leafRecords = new Map();
+  // Diagnostics accumulate across every per-root enumeration, deduped on
+  // the same identity keys the single-root report uses so a reference
+  // shared by sibling roots is reported once.
+  const duplicateReferences = new Map();
+  const cycles = new Map();
+  const inaccessibleReferences = new Map();
+  const unresolvedReferences = new Map();
+  for (const rootNumber of rootNumbers) {
+    const graph = await enumerateRoadmapGraph(rootNumber, {
+      markerPrefix,
+      owner: options.owner,
+      repo: options.repo,
+      loadIssue: options.loadIssue,
+      loadSubIssues: options.loadSubIssues,
+    });
+    roots.push({
+      number: graph.root.number,
+      title: graph.root.title,
+      state: graph.root.state,
+      roadmapMarkerId: graph.root.roadmapMarkerId,
+    });
+    const executionSet = new Set(graph.executionCandidates);
+    for (const node of graph.nodes) {
+      if (!executionSet.has(node.number)) {
+        continue;
+      }
+      const existing = leafRecords.get(node.number);
+      if (existing) {
+        if (!existing.sourceRoots.includes(graph.root.number)) {
+          existing.sourceRoots.push(graph.root.number);
+        }
+        continue;
+      }
+      leafRecords.set(node.number, {
+        number: node.number,
+        title: node.title,
+        state: node.state,
+        labels: node.labels,
+        classification: node.classification,
+        roadmapMarkerId: node.roadmapMarkerId,
+        autopilotSuitability: node.autopilotSuitability,
+        sourceRoots: [graph.root.number],
+      });
+    }
+    mergeDiagnostic(
+      duplicateReferences,
+      graph.diagnostics.duplicateReferences,
+      (entry) =>
+        `${entry.source}:${entry.target}:${entry.relationship}:${entry.evidence}`,
+    );
+    mergeDiagnostic(
+      cycles,
+      graph.diagnostics.cycles,
+      (entry) => `${entry.source}:${entry.target}:${entry.path.join('>')}`,
+    );
+    mergeDiagnostic(
+      inaccessibleReferences,
+      graph.diagnostics.inaccessibleReferences,
+      (entry) =>
+        `${entry.source}:${entry.target}:${entry.relationship}:${entry.reason}`,
+    );
+    mergeDiagnostic(
+      unresolvedReferences,
+      graph.diagnostics.unresolvedReferences,
+      (entry) =>
+        `${entry.source}:${entry.target}:${entry.relationship}:${entry.reason}`,
+    );
+  }
+  const leaves = [...leafRecords.values()]
+    .map((leaf) => ({
+      ...leaf,
+      sourceRoots: [...leaf.sourceRoots].sort((left, right) => left - right),
+    }))
+    .sort(compareUnionLeaves);
+  const scoredLeafCount = leaves.filter((leaf) =>
+    isAutopilotSuitabilityScore(leaf.autopilotSuitability),
+  ).length;
+  const sharedLeafCount = leaves.filter(
+    (leaf) => leaf.sourceRoots.length > 1,
+  ).length;
+  return {
+    mode: 'all-roadmaps',
+    roots: roots.sort(compareByNumber),
+    leaves,
+    diagnostics: {
+      duplicateReferences: [...duplicateReferences.values()].sort(
+        compareDiagnostics,
+      ),
+      cycles: [...cycles.values()].sort(compareCycles),
+      inaccessibleReferences: [...inaccessibleReferences.values()].sort(
+        compareDiagnostics,
+      ),
+      unresolvedReferences: [...unresolvedReferences.values()].sort(
+        compareDiagnostics,
+      ),
+    },
+    summary: {
+      rootCount: roots.length,
+      leafCount: leaves.length,
+      scoredLeafCount,
+      sharedLeafCount,
+      duplicateReferenceCount: duplicateReferences.size,
+      cycleCount: cycles.size,
+      inaccessibleReferenceCount: inaccessibleReferences.size,
+      unresolvedReferenceCount: unresolvedReferences.size,
+    },
+  };
+}
+/**
+ * Global-by-score comparator for the cross-roadmap union.
+ *
+ * Sort key, in order:
+ *   1. effective suitability DESCENDING — a coherent 1-5 score uses its
+ *      own value; a missing/out-of-range score uses the floor so unscored
+ *      pre-existing work is not buried below the floor;
+ *   2. scored-before-unscored at a tie — a leaf with a coherent score
+ *      never ranks below an unscored leaf at the same effective value, so
+ *      "missing is treated as the floor" never lets unscored work jump
+ *      ahead of genuinely scored work;
+ *   3. issue number ASCENDING — a stable, repository-deterministic
+ *      tie-break that keeps the order from thrashing between epics.
+ */
+function compareUnionLeaves(left, right) {
+  const leftScored = isAutopilotSuitabilityScore(left.autopilotSuitability);
+  const rightScored = isAutopilotSuitabilityScore(right.autopilotSuitability);
+  const leftEffective = leftScored
+    ? left.autopilotSuitability
+    : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  const rightEffective = rightScored
+    ? right.autopilotSuitability
+    : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  return (
+    rightEffective - leftEffective ||
+    Number(rightScored) - Number(leftScored) ||
+    left.number - right.number
+  );
+}
+function mergeDiagnostic(store, entries, keyOf) {
+  for (const entry of entries) {
+    const key = keyOf(entry);
+    if (!store.has(key)) {
+      store.set(key, entry);
+    }
+  }
+}
+function normalizeOpenRoadmapRootNumbers(roots) {
+  if (!Array.isArray(roots)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      roots
+        .map((entry) => {
+          if (typeof entry === 'number') {
+            return entry;
+          }
+          return Number.parseInt(String(entry?.number ?? entry), 10);
+        })
+        .filter((value) => Number.isInteger(value) && value > 0),
+    ),
+  ].sort((left, right) => left - right);
+}
 export function extractRoadmapMarkerId(
   body,
   markerPrefix = DEFAULT_MARKER_PREFIX,
@@ -476,6 +721,7 @@ function normalizeSubIssueNumbers(subIssues) {
 function parseArgs(argv) {
   const parsed = {
     issue: 0,
+    allRoadmaps: false,
     owner: '',
     repo: '',
     policy: '',
@@ -487,6 +733,10 @@ function parseArgs(argv) {
     if (token === '--issue') {
       parsed.issue = Number.parseInt(String(value ?? ''), 10);
       index += 1;
+      continue;
+    }
+    if (token === '--all-roadmaps') {
+      parsed.allRoadmaps = true;
       continue;
     }
     if (token === '--owner') {
@@ -515,6 +765,12 @@ function parseArgs(argv) {
 function printHelp() {
   process.stdout.write(`Usage:
   node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>]
+  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>]
+
+  --issue and --all-roadmaps are mutually exclusive; exactly one is required.
+  --all-roadmaps enumerates open execution leaves across every open roadmap
+  root (the union), each tagged with its sourceRoots and ranked by
+  autopilotSuitability (descending, tie-broken by ascending issue number).
 
 Output schema (JSON mode):
   {
@@ -655,6 +911,50 @@ function buildSubIssueLoader(owner, repo) {
         throw new Error(
           `subIssues pagination cursor missing for issue #${issueNumber}`,
         );
+      }
+      after = String(connection.pageInfo.endCursor);
+    }
+    return [...new Set(numbers)];
+  };
+}
+function buildOpenRoadmapRootsLoader(owner, repo, markerPrefix) {
+  const prefix = normalizeMarkerPrefix(markerPrefix);
+  return async () => {
+    const numbers = [];
+    let after = '';
+    while (true) {
+      const variables = { owner, repo };
+      if (after) {
+        variables.after = after;
+      }
+      const result = runGraphqlQuery(OPEN_ISSUES_QUERY, variables);
+      const connection = result?.data?.repository?.issues;
+      if (
+        !connection ||
+        !Array.isArray(connection.nodes) ||
+        !connection.pageInfo
+      ) {
+        throw new Error('open issues connection missing');
+      }
+      for (const node of connection.nodes) {
+        const issue = node;
+        const issueNumber = Number.parseInt(String(issue?.number ?? ''), 10);
+        if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+          continue;
+        }
+        const labels = normalizeLabels(issue?.labels?.nodes);
+        const hasRoadmapMarker = Boolean(
+          extractRoadmapMarkerId(issue?.body, prefix),
+        );
+        if (labels.has('roadmap') || hasRoadmapMarker) {
+          numbers.push(issueNumber);
+        }
+      }
+      if (!connection.pageInfo.hasNextPage) {
+        break;
+      }
+      if (!connection.pageInfo.endCursor) {
+        throw new Error('open issues pagination cursor missing');
       }
       after = String(connection.pageInfo.endCursor);
     }

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -10,7 +10,11 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { parseAutopilotSuitability } from './autopilot-suitability.mts';
+import {
+  DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+  isAutopilotSuitabilityScore,
+  parseAutopilotSuitability,
+} from './autopilot-suitability.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
@@ -31,6 +35,27 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
           hasNextPage
           endCursor
         }
+      }
+    }
+  }
+}
+`;
+const OPEN_ISSUES_QUERY = `
+query($owner:String!, $repo:String!, $after:String) {
+  repository(owner:$owner, name:$repo) {
+    issues(states:OPEN, first:100, after:$after) {
+      nodes {
+        number
+        body
+        labels(first:100) {
+          nodes {
+            name
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
       }
     }
   }
@@ -135,6 +160,60 @@ export interface RoadmapGraphReport {
   };
 }
 
+/** One ranked open execution leaf in the cross-roadmap union report. */
+export interface RoadmapUnionLeaf {
+  number: number;
+  title: string;
+  state: string;
+  labels: string[];
+  classification: 'roadmap' | 'execution';
+  roadmapMarkerId: string;
+  autopilotSuitability: number | null;
+  /**
+   * The set of open roadmap roots this leaf is reachable from, sorted
+   * ascending. A leaf reachable from several sibling epics carries every
+   * source root here and is never double-counted in the union.
+   */
+  sourceRoots: number[];
+}
+
+/** One discovered open roadmap root the union enumeration started from. */
+export interface RoadmapUnionRoot {
+  number: number;
+  title: string;
+  state: string;
+  roadmapMarkerId: string;
+}
+
+/**
+ * Cross-roadmap union report returned by `enumerateAllRoadmapsGraph`.
+ *
+ * Additive `--all-roadmaps` mode: the single-root `RoadmapGraphReport`
+ * shape (returned by `enumerateRoadmapGraph`) is unchanged. This report
+ * is only produced when `--all-roadmaps` is passed.
+ */
+export interface RoadmapGraphUnionReport {
+  mode: 'all-roadmaps';
+  roots: RoadmapUnionRoot[];
+  leaves: RoadmapUnionLeaf[];
+  diagnostics: {
+    duplicateReferences: RoadmapDuplicateReferenceDiagnostic[];
+    cycles: RoadmapCycleDiagnostic[];
+    inaccessibleReferences: RoadmapReferenceDiagnostic[];
+    unresolvedReferences: RoadmapReferenceDiagnostic[];
+  };
+  summary: {
+    rootCount: number;
+    leafCount: number;
+    scoredLeafCount: number;
+    sharedLeafCount: number;
+    duplicateReferenceCount: number;
+    cycleCount: number;
+    inaccessibleReferenceCount: number;
+    unresolvedReferenceCount: number;
+  };
+}
+
 interface NormalizedIssue {
   number: number;
   title: string;
@@ -163,8 +242,20 @@ interface EnumerateRoadmapGraphOptions {
   loadSubIssues?: (issueNumber: number) => unknown;
 }
 
+interface EnumerateAllRoadmapsGraphOptions
+  extends EnumerateRoadmapGraphOptions {
+  /**
+   * Discover every open roadmap root. Each entry is an open issue
+   * carrying the `roadmap` label or an
+   * `<!-- {markerPrefix}-roadmap-id: ... -->` marker. The union mode
+   * runs the existing single-root enumeration from each returned root.
+   */
+  loadOpenRoadmapRoots?: () => unknown;
+}
+
 interface ParsedArgs {
   issue: number;
+  allRoadmaps: boolean;
   owner: string;
   repo: string;
   policy: string;
@@ -175,8 +266,17 @@ type CachedIssue = NormalizedIssue | InaccessibleIssueSentinel | null;
 
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
-  if (!Number.isInteger(args.issue) || args.issue <= 0) {
-    throw new Error('missing required --issue <number>');
+  const hasIssue = Number.isInteger(args.issue) && args.issue > 0;
+  // --issue and --all-roadmaps are mutually exclusive: exactly one route
+  // must be selected. The single-root --issue contract (required when
+  // --all-roadmaps is absent) is preserved.
+  if (args.allRoadmaps && hasIssue) {
+    throw new Error('--all-roadmaps cannot be combined with --issue');
+  }
+  if (!args.allRoadmaps && !hasIssue) {
+    throw new Error(
+      'missing required --issue <number> (or pass --all-roadmaps)',
+    );
   }
 
   const owner =
@@ -186,15 +286,28 @@ if (isMainModule(import.meta.url)) {
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
   const policy = loadPolicy(args.policy) as { markerPrefix?: unknown };
 
-  const graph = await enumerateRoadmapGraph(args.issue, {
-    markerPrefix: policy.markerPrefix,
-    owner,
-    repo,
-    loadIssue: buildIssueLoader(owner, repo),
-    loadSubIssues: buildSubIssueLoader(owner, repo),
-  });
+  const report = args.allRoadmaps
+    ? await enumerateAllRoadmapsGraph({
+        markerPrefix: policy.markerPrefix,
+        owner,
+        repo,
+        loadIssue: buildIssueLoader(owner, repo),
+        loadSubIssues: buildSubIssueLoader(owner, repo),
+        loadOpenRoadmapRoots: buildOpenRoadmapRootsLoader(
+          owner,
+          repo,
+          policy.markerPrefix,
+        ),
+      })
+    : await enumerateRoadmapGraph(args.issue, {
+        markerPrefix: policy.markerPrefix,
+        owner,
+        repo,
+        loadIssue: buildIssueLoader(owner, repo),
+        loadSubIssues: buildSubIssueLoader(owner, repo),
+      });
 
-  process.stdout.write(`${JSON.stringify(graph, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
 }
 
 export async function enumerateRoadmapGraph(
@@ -491,6 +604,232 @@ export async function enumerateRoadmapGraph(
   }
 }
 
+/**
+ * Cross-roadmap autopilot discovery (additive `--all-roadmaps` mode).
+ *
+ * Discovers every OPEN roadmap root (an open issue carrying the
+ * `roadmap` label OR an `<!-- {markerPrefix}-roadmap-id: ... -->`
+ * marker), runs the existing single-root {@link enumerateRoadmapGraph}
+ * from each root, and returns the UNION of open execution leaves. A leaf
+ * reachable from several sibling roots is recorded once, carrying every
+ * `sourceRoots` it is reachable from (provenance), so it is never
+ * double-counted.
+ *
+ * Ranking (global-by-score): the union is sorted by `autopilotSuitability`
+ * DESCENDING, tie-broken by issue number ASCENDING (stable). Missing or
+ * out-of-range suitability is treated as the configured floor for
+ * ordering, but a leaf with no coherent score never ranks above a scored
+ * leaf at the same effective value — scored work always sorts first at a
+ * tie. See {@link compareUnionLeaves}.
+ *
+ * The helper stays READ-ONLY / evidence-only: it reads issue bodies and
+ * GitHub sub-issue relationships and never claims, mutates, or writes to
+ * GitHub. The single-root report shape is unchanged; this union shape is
+ * only produced in `--all-roadmaps` mode.
+ */
+export async function enumerateAllRoadmapsGraph(
+  options: EnumerateAllRoadmapsGraphOptions = {},
+): Promise<RoadmapGraphUnionReport> {
+  const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  const loadOpenRoadmapRoots = options.loadOpenRoadmapRoots;
+  if (typeof loadOpenRoadmapRoots !== 'function') {
+    throw new Error(
+      'enumerateAllRoadmapsGraph requires loadOpenRoadmapRoots()',
+    );
+  }
+
+  const rootNumbers = normalizeOpenRoadmapRootNumbers(
+    await loadOpenRoadmapRoots(),
+  );
+
+  const roots: RoadmapUnionRoot[] = [];
+  const leafRecords = new Map<number, RoadmapUnionLeaf>();
+  // Diagnostics accumulate across every per-root enumeration, deduped on
+  // the same identity keys the single-root report uses so a reference
+  // shared by sibling roots is reported once.
+  const duplicateReferences = new Map<
+    string,
+    RoadmapDuplicateReferenceDiagnostic
+  >();
+  const cycles = new Map<string, RoadmapCycleDiagnostic>();
+  const inaccessibleReferences = new Map<string, RoadmapReferenceDiagnostic>();
+  const unresolvedReferences = new Map<string, RoadmapReferenceDiagnostic>();
+
+  for (const rootNumber of rootNumbers) {
+    const graph = await enumerateRoadmapGraph(rootNumber, {
+      markerPrefix,
+      owner: options.owner,
+      repo: options.repo,
+      loadIssue: options.loadIssue,
+      loadSubIssues: options.loadSubIssues,
+    });
+
+    roots.push({
+      number: graph.root.number,
+      title: graph.root.title,
+      state: graph.root.state,
+      roadmapMarkerId: graph.root.roadmapMarkerId,
+    });
+
+    const executionSet = new Set(graph.executionCandidates);
+    for (const node of graph.nodes) {
+      if (!executionSet.has(node.number)) {
+        continue;
+      }
+      const existing = leafRecords.get(node.number);
+      if (existing) {
+        if (!existing.sourceRoots.includes(graph.root.number)) {
+          existing.sourceRoots.push(graph.root.number);
+        }
+        continue;
+      }
+      leafRecords.set(node.number, {
+        number: node.number,
+        title: node.title,
+        state: node.state,
+        labels: node.labels,
+        classification: node.classification,
+        roadmapMarkerId: node.roadmapMarkerId,
+        autopilotSuitability: node.autopilotSuitability,
+        sourceRoots: [graph.root.number],
+      });
+    }
+
+    mergeDiagnostic(
+      duplicateReferences,
+      graph.diagnostics.duplicateReferences,
+      (entry) =>
+        `${entry.source}:${entry.target}:${entry.relationship}:${entry.evidence}`,
+    );
+    mergeDiagnostic(
+      cycles,
+      graph.diagnostics.cycles,
+      (entry) => `${entry.source}:${entry.target}:${entry.path.join('>')}`,
+    );
+    mergeDiagnostic(
+      inaccessibleReferences,
+      graph.diagnostics.inaccessibleReferences,
+      (entry) =>
+        `${entry.source}:${entry.target}:${entry.relationship}:${entry.reason}`,
+    );
+    mergeDiagnostic(
+      unresolvedReferences,
+      graph.diagnostics.unresolvedReferences,
+      (entry) =>
+        `${entry.source}:${entry.target}:${entry.relationship}:${entry.reason}`,
+    );
+  }
+
+  const leaves = [...leafRecords.values()]
+    .map((leaf) => ({
+      ...leaf,
+      sourceRoots: [...leaf.sourceRoots].sort((left, right) => left - right),
+    }))
+    .sort(compareUnionLeaves);
+
+  const scoredLeafCount = leaves.filter((leaf) =>
+    isAutopilotSuitabilityScore(leaf.autopilotSuitability),
+  ).length;
+  const sharedLeafCount = leaves.filter(
+    (leaf) => leaf.sourceRoots.length > 1,
+  ).length;
+
+  return {
+    mode: 'all-roadmaps',
+    roots: roots.sort(compareByNumber),
+    leaves,
+    diagnostics: {
+      duplicateReferences: [...duplicateReferences.values()].sort(
+        compareDiagnostics,
+      ),
+      cycles: [...cycles.values()].sort(compareCycles),
+      inaccessibleReferences: [...inaccessibleReferences.values()].sort(
+        compareDiagnostics,
+      ),
+      unresolvedReferences: [...unresolvedReferences.values()].sort(
+        compareDiagnostics,
+      ),
+    },
+    summary: {
+      rootCount: roots.length,
+      leafCount: leaves.length,
+      scoredLeafCount,
+      sharedLeafCount,
+      duplicateReferenceCount: duplicateReferences.size,
+      cycleCount: cycles.size,
+      inaccessibleReferenceCount: inaccessibleReferences.size,
+      unresolvedReferenceCount: unresolvedReferences.size,
+    },
+  };
+}
+
+/**
+ * Global-by-score comparator for the cross-roadmap union.
+ *
+ * Sort key, in order:
+ *   1. effective suitability DESCENDING — a coherent 1-5 score uses its
+ *      own value; a missing/out-of-range score uses the floor so unscored
+ *      pre-existing work is not buried below the floor;
+ *   2. scored-before-unscored at a tie — a leaf with a coherent score
+ *      never ranks below an unscored leaf at the same effective value, so
+ *      "missing is treated as the floor" never lets unscored work jump
+ *      ahead of genuinely scored work;
+ *   3. issue number ASCENDING — a stable, repository-deterministic
+ *      tie-break that keeps the order from thrashing between epics.
+ */
+function compareUnionLeaves(
+  left: RoadmapUnionLeaf,
+  right: RoadmapUnionLeaf,
+): number {
+  const leftScored = isAutopilotSuitabilityScore(left.autopilotSuitability);
+  const rightScored = isAutopilotSuitabilityScore(right.autopilotSuitability);
+  const leftEffective = leftScored
+    ? (left.autopilotSuitability as number)
+    : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  const rightEffective = rightScored
+    ? (right.autopilotSuitability as number)
+    : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  return (
+    rightEffective - leftEffective ||
+    Number(rightScored) - Number(leftScored) ||
+    left.number - right.number
+  );
+}
+
+function mergeDiagnostic<T>(
+  store: Map<string, T>,
+  entries: T[],
+  keyOf: (entry: T) => string,
+) {
+  for (const entry of entries) {
+    const key = keyOf(entry);
+    if (!store.has(key)) {
+      store.set(key, entry);
+    }
+  }
+}
+
+function normalizeOpenRoadmapRootNumbers(roots: unknown): number[] {
+  if (!Array.isArray(roots)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      roots
+        .map((entry) => {
+          if (typeof entry === 'number') {
+            return entry;
+          }
+          return Number.parseInt(
+            String((entry as { number?: unknown } | null)?.number ?? entry),
+            10,
+          );
+        })
+        .filter((value) => Number.isInteger(value) && value > 0),
+    ),
+  ].sort((left, right) => left - right);
+}
+
 export function extractRoadmapMarkerId(
   body: unknown,
   markerPrefix: string = DEFAULT_MARKER_PREFIX,
@@ -676,6 +1015,7 @@ function normalizeSubIssueNumbers(subIssues: unknown): number[] {
 function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = {
     issue: 0,
+    allRoadmaps: false,
     owner: '',
     repo: '',
     policy: '',
@@ -688,6 +1028,10 @@ function parseArgs(argv: string[]): ParsedArgs {
     if (token === '--issue') {
       parsed.issue = Number.parseInt(String(value ?? ''), 10);
       index += 1;
+      continue;
+    }
+    if (token === '--all-roadmaps') {
+      parsed.allRoadmaps = true;
       continue;
     }
     if (token === '--owner') {
@@ -718,6 +1062,12 @@ function parseArgs(argv: string[]): ParsedArgs {
 function printHelp() {
   process.stdout.write(`Usage:
   node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>]
+  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>]
+
+  --issue and --all-roadmaps are mutually exclusive; exactly one is required.
+  --all-roadmaps enumerates open execution leaves across every open roadmap
+  root (the union), each tagged with its sourceRoots and ranked by
+  autopilotSuitability (descending, tie-broken by ascending issue number).
 
 Output schema (JSON mode):
   {
@@ -890,6 +1240,74 @@ function buildSubIssueLoader(owner: string, repo: string) {
         throw new Error(
           `subIssues pagination cursor missing for issue #${issueNumber}`,
         );
+      }
+      after = String(connection.pageInfo.endCursor);
+    }
+
+    return [...new Set(numbers)];
+  };
+}
+
+function buildOpenRoadmapRootsLoader(
+  owner: string,
+  repo: string,
+  markerPrefix: unknown,
+) {
+  const prefix = normalizeMarkerPrefix(markerPrefix);
+  return async () => {
+    const numbers: number[] = [];
+    let after = '';
+
+    while (true) {
+      const variables: Record<string, string | number> = { owner, repo };
+      if (after) {
+        variables.after = after;
+      }
+      const result = runGraphqlQuery(OPEN_ISSUES_QUERY, variables) as {
+        data?: {
+          repository?: {
+            issues?: {
+              nodes?: unknown;
+              pageInfo?: { hasNextPage?: unknown; endCursor?: unknown };
+            };
+          };
+        };
+      };
+      const connection = result?.data?.repository?.issues;
+      if (
+        !connection ||
+        !Array.isArray(connection.nodes) ||
+        !connection.pageInfo
+      ) {
+        throw new Error('open issues connection missing');
+      }
+
+      for (const node of connection.nodes) {
+        const issue = node as {
+          number?: unknown;
+          body?: unknown;
+          labels?: { nodes?: unknown };
+        } | null;
+        const issueNumber = Number.parseInt(String(issue?.number ?? ''), 10);
+        if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+          continue;
+        }
+        const labels = normalizeLabels(
+          (issue?.labels as { nodes?: unknown } | undefined)?.nodes,
+        );
+        const hasRoadmapMarker = Boolean(
+          extractRoadmapMarkerId(issue?.body, prefix),
+        );
+        if (labels.has('roadmap') || hasRoadmapMarker) {
+          numbers.push(issueNumber);
+        }
+      }
+
+      if (!connection.pageInfo.hasNextPage) {
+        break;
+      }
+      if (!connection.pageInfo.endCursor) {
+        throw new Error('open issues pagination cursor missing');
       }
       after = String(connection.pageInfo.endCursor);
     }

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -11,8 +11,8 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
   isAutopilotSuitabilityScore,
+  normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mts';
 
@@ -166,7 +166,9 @@ export interface RoadmapUnionLeaf {
   title: string;
   state: string;
   labels: string[];
-  classification: 'roadmap' | 'execution';
+  // Union leaves come only from execution candidates, so the
+  // classification is always the literal 'execution'.
+  classification: 'execution';
   roadmapMarkerId: string;
   autopilotSuitability: number | null;
   /**
@@ -251,6 +253,13 @@ interface EnumerateAllRoadmapsGraphOptions
    * runs the existing single-root enumeration from each returned root.
    */
   loadOpenRoadmapRoots?: () => unknown;
+  /**
+   * Configured autopilot-suitability floor (`autopilotSuitability.floor`
+   * from policy). Unscored or out-of-range leaves rank at this floor in
+   * the union ordering. Normalized to an integer 1-5, falling back to the
+   * default autopilot-suitability floor when unset or invalid.
+   */
+  floor?: unknown;
 }
 
 interface ParsedArgs {
@@ -284,11 +293,15 @@ if (isMainModule(import.meta.url)) {
     ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
   const repo =
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const policy = loadPolicy(args.policy) as { markerPrefix?: unknown };
+  const policy = loadPolicy(args.policy) as {
+    markerPrefix?: unknown;
+    autopilotSuitability?: { floor?: unknown };
+  };
 
   const report = args.allRoadmaps
     ? await enumerateAllRoadmapsGraph({
         markerPrefix: policy.markerPrefix,
+        floor: policy.autopilotSuitability?.floor,
         owner,
         repo,
         loadIssue: buildIssueLoader(owner, repo),
@@ -631,6 +644,10 @@ export async function enumerateAllRoadmapsGraph(
   options: EnumerateAllRoadmapsGraphOptions = {},
 ): Promise<RoadmapGraphUnionReport> {
   const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  // Resolve the configured suitability floor (normalized to an integer
+  // 1-5, falling back to the default when unset) once, then rank unscored
+  // leaves at that configured floor.
+  const floor = normalizeAutopilotSuitabilityFloor(options.floor);
   const loadOpenRoadmapRoots = options.loadOpenRoadmapRoots;
   if (typeof loadOpenRoadmapRoots !== 'function') {
     throw new Error(
@@ -688,7 +705,9 @@ export async function enumerateAllRoadmapsGraph(
         title: node.title,
         state: node.state,
         labels: node.labels,
-        classification: node.classification,
+        // Only execution candidates reach this branch (filtered by
+        // executionSet above), so the classification is always 'execution'.
+        classification: 'execution',
         roadmapMarkerId: node.roadmapMarkerId,
         autopilotSuitability: node.autopilotSuitability,
         sourceRoots: [graph.root.number],
@@ -725,7 +744,7 @@ export async function enumerateAllRoadmapsGraph(
       ...leaf,
       sourceRoots: [...leaf.sourceRoots].sort((left, right) => left - right),
     }))
-    .sort(compareUnionLeaves);
+    .sort((left, right) => compareUnionLeaves(left, right, floor));
 
   const scoredLeafCount = leaves.filter((leaf) =>
     isAutopilotSuitabilityScore(leaf.autopilotSuitability),
@@ -768,27 +787,32 @@ export async function enumerateAllRoadmapsGraph(
  *
  * Sort key, in order:
  *   1. effective suitability DESCENDING — a coherent 1-5 score uses its
- *      own value; a missing/out-of-range score uses the floor so unscored
- *      pre-existing work is not buried below the floor;
+ *      own value; a missing/out-of-range score uses the configured floor
+ *      so unscored pre-existing work is not buried below the floor;
  *   2. scored-before-unscored at a tie — a leaf with a coherent score
  *      never ranks below an unscored leaf at the same effective value, so
- *      "missing is treated as the floor" never lets unscored work jump
- *      ahead of genuinely scored work;
+ *      "missing is treated as the configured floor" never lets unscored
+ *      work jump ahead of genuinely scored work;
  *   3. issue number ASCENDING — a stable, repository-deterministic
  *      tie-break that keeps the order from thrashing between epics.
+ *
+ * `floor` is the configured `autopilotSuitability.floor` (already
+ * normalized to an integer 1-5). The comparator stays a total order.
  */
 function compareUnionLeaves(
   left: RoadmapUnionLeaf,
   right: RoadmapUnionLeaf,
+  floor: number,
 ): number {
   const leftScored = isAutopilotSuitabilityScore(left.autopilotSuitability);
   const rightScored = isAutopilotSuitabilityScore(right.autopilotSuitability);
+  // Unscored or out-of-range leaves rank at the configured floor.
   const leftEffective = leftScored
     ? (left.autopilotSuitability as number)
-    : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+    : floor;
   const rightEffective = rightScored
     ? (right.autopilotSuitability as number)
-    : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+    : floor;
   return (
     rightEffective - leftEffective ||
     Number(rightScored) - Number(leftScored) ||

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1093,7 +1093,7 @@ function printHelp() {
   root (the union), each tagged with its sourceRoots and ranked by
   autopilotSuitability (descending, tie-broken by ascending issue number).
 
-Output schema (JSON mode):
+Output schema (JSON mode) — --issue single-root report:
   {
     "root": { "number": 638, "title": "...", "state": "OPEN", "classification": "roadmap", "roadmapMarkerId": "..." },
     "nodes": [{ "number": 638, "title": "...", "state": "OPEN", "labels": ["roadmap"], "classification": "roadmap", "roadmapMarkerId": "...", "autopilotSuitability": null, "depth": 0 }],
@@ -1118,6 +1118,30 @@ Output schema (JSON mode):
       "inaccessibleReferenceCount": 0,
       "unresolvedReferenceCount": 0,
       "maxDepth": 1
+    }
+  }
+
+Output schema (JSON mode) — --all-roadmaps union report (a different
+top-level shape from the single-root report above):
+  {
+    "mode": "all-roadmaps",
+    "roots": [{ "number": 638, "title": "...", "state": "OPEN", "roadmapMarkerId": "..." }],
+    "leaves": [{ "number": 640, "title": "...", "state": "OPEN", "labels": ["..."], "classification": "execution", "roadmapMarkerId": "", "autopilotSuitability": null, "sourceRoots": [638] }],
+    "diagnostics": {
+      "duplicateReferences": [],
+      "cycles": [],
+      "inaccessibleReferences": [],
+      "unresolvedReferences": []
+    },
+    "summary": {
+      "rootCount": 1,
+      "leafCount": 1,
+      "scoredLeafCount": 0,
+      "sharedLeafCount": 0,
+      "duplicateReferenceCount": 0,
+      "cycleCount": 0,
+      "inaccessibleReferenceCount": 0,
+      "unresolvedReferenceCount": 0
     }
   }
 `);

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -841,6 +841,24 @@ test('all-roadmaps ranks the union by suitability descending, tie-broken by issu
   );
 });
 
+test('all-roadmaps ranks unscored leaves at the configured floor', async () => {
+  // With the configured floor at 1, an unscored leaf ranks at effective 1
+  // — now BELOW 702 (score 2), reversing the default-floor (3) ordering
+  // where 804 sorted above 702. This pins that the comparator honors the
+  // configured floor, not the hard-coded default.
+  const report = await enumerateAllRoadmapsGraph({
+    floor: 1,
+    loadOpenRoadmapRoots: async () => [700, 800],
+    loadIssue: async (issueNumber) => loadSiblingEpicIssue(issueNumber),
+  });
+
+  // 701 (5) > 803 (4) > 702 (2) > 804 (unscored, configured floor 1).
+  assert.deepEqual(
+    report.leaves.map((leaf) => leaf.number),
+    [701, 803, 702, 804],
+  );
+});
+
 test('all-roadmaps keeps scored work above an unscored leaf at the same effective score', async () => {
   const issues = new Map<number, unknown>([
     [900, roadmapIssue(900, '- [ ] #901\n- [ ] #902', 'epic-floor')],

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   classifyIssue,
+  enumerateAllRoadmapsGraph,
   enumerateRoadmapGraph,
   extractKeywordReferences,
   extractRoadmapMarkerId,
@@ -759,4 +760,250 @@ test('nodes carry the authored autopilot-suitability score (null when unscored)'
   const byNumber = new Map(graph.nodes.map((node) => [node.number, node]));
   assert.equal(byNumber.get(501)?.autopilotSuitability, 5);
   assert.equal(byNumber.get(502)?.autopilotSuitability, null);
+});
+
+function scoredExecutionIssue(number: number, score: number, state = 'open') {
+  return executionIssue(
+    number,
+    `task ${number}\n<!-- idd-skill-autopilot-suitability: ${score} -->`,
+    state,
+  );
+}
+
+// Two sibling epics, one shared leaf, mixed suitability scores.
+//
+//   700 (epic-alpha) → 701 (score 5), 702 (score 2)
+//   800 (epic-beta)  → 702 (shared),  803 (score 4), 804 (no score)
+const SIBLING_EPIC_ISSUES = new Map<number, unknown>([
+  [700, roadmapIssue(700, '- [ ] #701\n- [ ] #702', 'epic-alpha')],
+  [800, roadmapIssue(800, '- [ ] #702\n- [ ] #803\n- [ ] #804', 'epic-beta')],
+  [701, scoredExecutionIssue(701, 5)],
+  [702, scoredExecutionIssue(702, 2)],
+  [803, scoredExecutionIssue(803, 4)],
+  [804, executionIssue(804, 'task 804 with no score')],
+]);
+
+function loadSiblingEpicIssue(issueNumber: number) {
+  return SIBLING_EPIC_ISSUES.get(issueNumber) ?? null;
+}
+
+test('all-roadmaps unions open execution leaves across every open roadmap root', async () => {
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [700, 800],
+    loadIssue: async (issueNumber) => loadSiblingEpicIssue(issueNumber),
+  });
+
+  assert.equal(report.mode, 'all-roadmaps');
+  assert.deepEqual(
+    report.roots.map((root) => root.number),
+    [700, 800],
+  );
+  // Union of leaves under both epics, deduped (702 counted once).
+  assert.deepEqual(
+    [...report.leaves].map((leaf) => leaf.number).sort((a, b) => a - b),
+    [701, 702, 803, 804],
+  );
+  assert.equal(report.summary.rootCount, 2);
+  assert.equal(report.summary.leafCount, 4);
+});
+
+test('all-roadmaps records source-root provenance and never double-counts shared leaves', async () => {
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [700, 800],
+    loadIssue: async (issueNumber) => loadSiblingEpicIssue(issueNumber),
+  });
+
+  const byNumber = new Map(report.leaves.map((leaf) => [leaf.number, leaf]));
+  // 702 is reachable from both epics: one leaf entry, two source roots.
+  assert.deepEqual(byNumber.get(702)?.sourceRoots, [700, 800]);
+  assert.deepEqual(byNumber.get(701)?.sourceRoots, [700]);
+  assert.deepEqual(byNumber.get(803)?.sourceRoots, [800]);
+  assert.deepEqual(byNumber.get(804)?.sourceRoots, [800]);
+  // The shared leaf appears exactly once in the union.
+  assert.equal(report.leaves.filter((leaf) => leaf.number === 702).length, 1);
+  assert.equal(report.summary.sharedLeafCount, 1);
+  assert.equal(report.summary.scoredLeafCount, 3);
+});
+
+test('all-roadmaps ranks the union by suitability descending, tie-broken by issue number', async () => {
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [700, 800],
+    loadIssue: async (issueNumber) => loadSiblingEpicIssue(issueNumber),
+  });
+
+  // 701 (5) > 803 (4) > [702 (2) and 804 (unscored-floor 3)].
+  // 804 is unscored: it uses the floor (3) as its effective score, so it
+  // sorts above 702 (score 2), but a coherently scored leaf at the floor
+  // would still outrank it.
+  assert.deepEqual(
+    report.leaves.map((leaf) => leaf.number),
+    [701, 803, 804, 702],
+  );
+});
+
+test('all-roadmaps keeps scored work above an unscored leaf at the same effective score', async () => {
+  const issues = new Map<number, unknown>([
+    [900, roadmapIssue(900, '- [ ] #901\n- [ ] #902', 'epic-floor')],
+    // 901 carries a coherent floor-value score; 902 is unscored and thus
+    // treated as the floor for ordering — scored work must sort first.
+    [901, scoredExecutionIssue(901, 3)],
+    [902, executionIssue(902, 'unscored leaf')],
+  ]);
+
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [900],
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(
+    report.leaves.map((leaf) => leaf.number),
+    [901, 902],
+  );
+});
+
+test('all-roadmaps tie-breaks equal scores by ascending issue number', async () => {
+  const issues = new Map<number, unknown>([
+    [1000, roadmapIssue(1000, '- [ ] #1003\n- [ ] #1001', 'epic-ties')],
+    [1003, scoredExecutionIssue(1003, 4)],
+    [1001, scoredExecutionIssue(1001, 4)],
+  ]);
+
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [1000],
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(
+    report.leaves.map((leaf) => leaf.number),
+    [1001, 1003],
+  );
+});
+
+test('all-roadmaps returns an empty union when no open roadmap roots exist', async () => {
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [],
+    loadIssue: async () => null,
+  });
+
+  assert.deepEqual(report.roots, []);
+  assert.deepEqual(report.leaves, []);
+  assert.equal(report.summary.rootCount, 0);
+  assert.equal(report.summary.leafCount, 0);
+});
+
+test('single-root --issue output is unchanged by the all-roadmaps addition', async () => {
+  const issues = new Map([
+    [100, roadmapIssue(100, '- [ ] #101\n- [ ] #102', 'root-roadmap')],
+    [101, executionIssue(101, 'alpha')],
+    [102, executionIssue(102, 'beta')],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(100, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  // The single-root report carries no union-only fields (mode / leaves /
+  // sourceRoots): its top-level shape is byte-stable with the contract.
+  const graphRecord = graph as unknown as Record<string, unknown>;
+  assert.equal(graphRecord.mode, undefined);
+  assert.equal(graphRecord.leaves, undefined);
+  assert.equal(graphRecord.roots, undefined);
+  for (const node of graph.nodes) {
+    assert.equal(
+      Object.hasOwn(node as unknown as Record<string, unknown>, 'sourceRoots'),
+      false,
+    );
+  }
+  assert.deepEqual(graph.executionCandidates, [101, 102]);
+});
+
+test('all-roadmaps requires the open-roadmap-roots loader', async () => {
+  await assert.rejects(
+    () =>
+      enumerateAllRoadmapsGraph({
+        loadIssue: async () => null,
+      }),
+    /requires loadOpenRoadmapRoots/,
+  );
+});
+
+test('CLI rejects combining --issue with --all-roadmaps', () => {
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-discover-roadmap-graph-mutex-'),
+  );
+  const ghPath = join(tempRoot, 'gh');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "repo" && args[1] === "view") {
+  const jq = args[args.indexOf("--jq") + 1];
+  process.stdout.write(jq === ".owner.login" ? "kurone-kito\\n" : "idd-skill\\n");
+  process.exit(0);
+}
+process.stderr.write("unexpected gh invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+
+  assert.throws(
+    () =>
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/discover-roadmap-graph.mjs'),
+          '--issue',
+          '700',
+          '--all-roadmaps',
+        ],
+        {
+          cwd: REPO_ROOT,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${tempRoot}:${process.env.PATH ?? ''}`,
+          },
+        },
+      ),
+    /--all-roadmaps cannot be combined with --issue/,
+  );
+});
+
+test('CLI requires --issue when --all-roadmaps is absent', () => {
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-discover-roadmap-graph-no-args-'),
+  );
+  const ghPath = join(tempRoot, 'gh');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "repo" && args[1] === "view") {
+  const jq = args[args.indexOf("--jq") + 1];
+  process.stdout.write(jq === ".owner.login" ? "kurone-kito\\n" : "idd-skill\\n");
+  process.exit(0);
+}
+process.stderr.write("unexpected gh invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+
+  assert.throws(
+    () =>
+      execFileSync(
+        process.execPath,
+        [join(REPO_ROOT, 'scripts/discover-roadmap-graph.mjs')],
+        {
+          cwd: REPO_ROOT,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${tempRoot}:${process.env.PATH ?? ''}`,
+          },
+        },
+      ),
+    /missing required --issue/,
+  );
 });

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import type { AdvisoryWaitStateReport } from '../src/scripts/advisory-wait-state.mts';
 import type { BranchConflictResult } from '../src/scripts/branch-conflict-state.mts';
+import type { RoadmapGraphUnionReport } from '../src/scripts/discover-roadmap-graph.mts';
 import type { PreMergeReadinessReport } from '../src/scripts/pre-merge-readiness.mts';
 import type {
   LiveStatusDigestFields,
@@ -286,6 +287,14 @@ export const claimMarkerKeys = [
   'createdAt',
 ] as const satisfies readonly (keyof ParsedClaimMarker)[];
 
+export const discoverRoadmapUnionKeys = [
+  'mode',
+  'roots',
+  'leaves',
+  'diagnostics',
+  'summary',
+] as const satisfies readonly (keyof RoadmapGraphUnionReport)[];
+
 export const forcedHandoffMarkerKeys = [
   'oldAgentId',
   'oldClaimId',
@@ -427,6 +436,10 @@ const exhaustivenessWitnesses: {
     ParsedClaimMarker,
     (typeof claimMarkerKeys)[number]
   >;
+  discoverRoadmapUnion: CoversAllKeysOf<
+    RoadmapGraphUnionReport,
+    (typeof discoverRoadmapUnionKeys)[number]
+  >;
   forcedHandoffMarker: CoversAllKeysOf<
     ParsedForcedHandoffMarker,
     (typeof forcedHandoffMarkerKeys)[number]
@@ -451,6 +464,7 @@ const exhaustivenessWitnesses: {
   advisoryWaitState: true,
   branchConflictState: true,
   claimMarker: true,
+  discoverRoadmapUnion: true,
   forcedHandoffMarker: true,
   liveStatusDigest: true,
   phaseGraph: true,
@@ -521,6 +535,62 @@ const claimMarkerFixture = {
   branch: 'issue/874-reconcile-schemas-json-exported',
   createdAt: '2026-06-11T00:00:00Z',
 } satisfies ParsedClaimMarker;
+
+const discoverRoadmapUnionFixture = {
+  mode: 'all-roadmaps',
+  roots: [
+    {
+      number: 100,
+      title: 'roadmap 100',
+      state: 'OPEN',
+      roadmapMarkerId: 'epic-alpha',
+    },
+    {
+      number: 200,
+      title: 'roadmap 200',
+      state: 'OPEN',
+      roadmapMarkerId: 'epic-beta',
+    },
+  ],
+  leaves: [
+    {
+      number: 101,
+      title: 'scored leaf',
+      state: 'OPEN',
+      labels: [],
+      classification: 'execution',
+      roadmapMarkerId: '',
+      autopilotSuitability: 5,
+      sourceRoots: [100],
+    },
+    {
+      number: 201,
+      title: 'shared unscored leaf',
+      state: 'OPEN',
+      labels: ['enhancement'],
+      classification: 'execution',
+      roadmapMarkerId: '',
+      autopilotSuitability: null,
+      sourceRoots: [100, 200],
+    },
+  ],
+  diagnostics: {
+    duplicateReferences: [],
+    cycles: [],
+    inaccessibleReferences: [],
+    unresolvedReferences: [],
+  },
+  summary: {
+    rootCount: 2,
+    leafCount: 2,
+    scoredLeafCount: 1,
+    sharedLeafCount: 1,
+    duplicateReferenceCount: 0,
+    cycleCount: 0,
+    inaccessibleReferenceCount: 0,
+    unresolvedReferenceCount: 0,
+  },
+} satisfies RoadmapGraphUnionReport;
 
 const forcedHandoffMarkerFixture = {
   oldAgentId: 'github-copilot-cli-old',
@@ -840,6 +910,13 @@ const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
     owningModule: 'src/scripts/protocol-helpers.mts',
     keys: claimMarkerKeys,
     fixture: claimMarkerFixture,
+  },
+  {
+    schemaFile: 'discover-roadmap-union.schema.json',
+    exportedType: 'RoadmapGraphUnionReport',
+    owningModule: 'src/scripts/discover-roadmap-graph.mts',
+    keys: discoverRoadmapUnionKeys,
+    fixture: discoverRoadmapUnionFixture,
   },
   {
     schemaFile: 'forced-handoff-marker.schema.json',

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -1616,3 +1616,38 @@ test('branch-conflict-state invalid fixture fails validation', () => {
   );
   assert.ok(ok, 'Expected invalid fixture to fail schema validation');
 });
+
+test('discover-roadmap-union schema uses only allowed keywords', () => {
+  const schema = loadJson('schemas/discover-roadmap-union.schema.json');
+  assert.deepEqual(checkSchemaKeywords(schema), []);
+});
+
+test('discover-roadmap-union schema publishes metadata fields', () => {
+  const schema = loadJson(
+    'schemas/discover-roadmap-union.schema.json',
+  ) as JsonRecord;
+  assert.equal(schema.$schema, 'https://json-schema.org/draft/2020-12/schema');
+  assert.equal(
+    schema.$id,
+    'https://kurone-kito.github.io/idd-skill/schemas/discover-roadmap-union.schema.json',
+  );
+  assert.equal(schema.title, 'Discover Roadmap Union');
+});
+
+test('discover-roadmap-union valid fixture passes validation', () => {
+  const { ok, errors } = validateFixture(
+    'schemas/discover-roadmap-union.schema.json',
+    'fixtures/schemas/discover-roadmap-union.valid.json',
+    true,
+  );
+  assert.ok(ok, errors.join('\n'));
+});
+
+test('discover-roadmap-union invalid fixture fails validation', () => {
+  const { ok } = validateFixture(
+    'schemas/discover-roadmap-union.schema.json',
+    'fixtures/schemas/discover-roadmap-union.invalid.json',
+    false,
+  );
+  assert.ok(ok, 'Expected invalid fixture to fail schema validation');
+});


### PR DESCRIPTION
## Summary

Discover's A1/A2 commit to a single umbrella roadmap, so when several
top-level epics run in parallel the autopilot-suitable execution leaves
under **sibling** epics were unreachable: the orphan fallback did not fire
(the roadmap path returned candidates, just blocked/unscored ones), and the
per-node autopilot-suitability score was never ranked across epics.

This adds an **additive** cross-roadmap autopilot discovery mode.

### Helper (`src/scripts/discover-roadmap-graph.mts`, .mts source of truth)

- New `--all-roadmaps` flag (mutually exclusive with `--issue`): discovers
  every open roadmap root (`roadmap` label or `idd-skill-roadmap-id` marker),
  runs the existing single-root enumeration from each, and returns a
  **union** of open execution leaves.
- Each union leaf carries `sourceRoots: number[]` provenance; a leaf reached
  from multiple roots appears once with all its roots (no double-counting).
- Ranking: autopilot-suitability **descending**, issue number **ascending**
  tie-break; missing/out-of-range score treated as the floor but a scored
  leaf never ranks below an unscored one at the same effective value.
- The single-root `--issue` path and output shape are unchanged; the helper
  stays read-only / evidence-only.

### Docs & schema

- A1/A2 cross-roadmap autopilot selection guidance in both `structure`-mode
  `idd-discover.instructions.md` copies (same headings) and the Discover
  Roadmap Graph contract in `idd-helper-scripts.md` (`exact` mode).
- New stable `schemas/discover-roadmap-union.schema.json` with valid/invalid
  fixtures, wired into the schema↔type reconciliation and validation tests.
- New helper tests for union, provenance, ranking/tie-break, dedup, and
  single-root invariance.

## Verification

`pnpm run lint:minimum` passes (audit-docs --check, build:check, bundle
budgets, tsc, biome, dprint, 1085 tests, cspell, markdownlint). Generated
`.mjs`/mirrors regenerated via `sync-docs --apply` + `pnpm run build`.

Closes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgWE9Zk471naViV3AExSJ4
