### PR TITLE
feat(idd): ship idd-merge-execute helper for the F3 gate + merge

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -121,6 +121,20 @@ Before any mutating action in F3, apply the
    to prevent a race where a new push lands after the F3 freshness check
    but before the merge executes.
 
+   **Preferred path (helper runtime enabled)**: run the F3 merge helper
+   documented in
+   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#merge-execution-f3).
+   First run it in dry-run (no `--apply`) and confirm `ready: true` with
+   an empty `blockers[]`; the helper wraps the read-only
+   `pre-merge-readiness` gate and adds no new authority. Then re-run with
+   `--apply`: when `ready`, it re-fetches the head SHA and re-validates
+   the claim immediately before merging, fails closed (no merge) on head
+   drift or lost claim, and runs the merge commit bound to the validated
+   head (never squash/rebase). The gate checklist and decision table
+   below stay canonical: if the helper is unavailable, its output is
+   invalid, or its evidence conflicts with live GitHub state, discard it
+   and use the manual gate + merge steps in this section.
+
    **Gate checklist** — confirm every field before merging; all must hold,
    and any unmet or unknown field is a NO-GO (fail closed — stop, do not
    merge):

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 85500
+      "limitBytes": 86200
     }
   ],
   "syncPairs": [

--- a/bin/idd-merge-execute.mjs
+++ b/bin/idd-merge-execute.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-merge-execute.mts
+//
+// The bin/idd-merge-execute.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/idd-merge-execute.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -767,9 +767,11 @@ Interpretation rules:
   `comparisonRoute == "proceed"`, `threads.actionableCount == 0`,
   advisory `f3Outcome == "SATISFIED"`, CI all-passing (the F2/F3
   no-required-checks fallback included), required/CODEOWNER reviews
-  satisfied, claim ownership matches, and
-  `dispositionEvidence.route == "proceed"`. Each failing gate is listed
-  in `blockers[]` as `{ gate, detail }`.
+  satisfied, claim ownership matches, and disposition evidence both
+  routes proceed and is unblocked (`dispositionEvidence.route ==
+  "proceed"` **and** `dispositionEvidence.blockingCount == 0`; `route`
+  alone is not sufficient). Each failing gate is listed in `blockers[]`
+  as `{ gate, detail }`.
 - Dry-run (default) is read-only: it prints `ready`, `blockers`, and
   `mergeCommand` (a `gh pr merge <pr> --merge --match-head-commit
   <validated-head>` bound to the freshly fetched head) and never merges.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -61,6 +61,9 @@ In the idd-skill source repository, the following optional helpers were adopted:
   and rerun-budget decisions
 - `scripts/pre-merge-readiness.mjs` for read-only F2/F3 readiness
   evidence collection
+- `scripts/idd-merge-execute.mjs` for the F3 merge gate: a dry-run
+  verdict by default and, with `--apply`, the bound merge execution; it
+  wraps `pre-merge-readiness` and adds no new decision authority
 - `scripts/live-status-digest.mjs` for issue or PR live status digest
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
@@ -394,6 +397,18 @@ The adopted helper boundaries are intentionally narrow:
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence
+
+- `idd-merge-execute.mjs` defaults to dry-run and stays read-only in
+  that mode: it reuses `pre-merge-readiness` to evaluate the F3 gates and
+  prints `{ ready, blockers, mergeCommand }` without merging
+- apply mode (`--apply`) is the only mutating path: when `ready` it
+  re-fetches the head SHA and re-validates the claim immediately before
+  merging, fails closed (no merge) on head drift or lost claim, and runs
+  a merge commit bound to the validated head — never squash or rebase
+- it adds no new decision authority (`decisionAuthority: instructions`):
+  it does not replace the written F3 gate checklist or decision table,
+  and on any helper failure or evidence conflict the agent falls back to
+  the manual F3 steps
 
 - `live-status-digest.mjs` defaults to dry-run, supports issue and PR
   targets, and mutates only with explicit `--apply`
@@ -735,6 +750,42 @@ Interpretation rules:
   live GitHub state, discard helper output and use the portable manual
   fetch path.
 
+### Merge execution (F3)
+
+- Preferred F3 path when helper runtime is enabled: dry-run first to
+  inspect the verdict, then `--apply` to execute the bound merge.
+- Command: `node scripts/idd-merge-execute.mjs --pr <pr-number>
+  --claim-issue <issue-number> --claim-id <claim-id>` plus the same
+  optional flags as `pre-merge-readiness` (`--agent-id`, `--owner`,
+  `--repo`, `--trusted-marker-logins`, `--advisory-bot-logins`); add
+  `--apply` to merge.
+- Stable contract:
+  [`idd-merge-execute.schema.json`][idd-merge-execute-schema]
+- It WRAPS the read-only `pre-merge-readiness` collector and adds no new
+  decision authority (`decisionAuthority: instructions`). `ready` is
+  `true` only when every F3 gate holds: review-currency
+  `comparisonRoute == "proceed"`, `threads.actionableCount == 0`,
+  advisory `f3Outcome == "SATISFIED"`, CI all-passing (the F2/F3
+  no-required-checks fallback included), required/CODEOWNER reviews
+  satisfied, claim ownership matches, and
+  `dispositionEvidence.route == "proceed"`. Each failing gate is listed
+  in `blockers[]` as `{ gate, detail }`.
+- Dry-run (default) is read-only: it prints `ready`, `blockers`, and
+  `mergeCommand` (a `gh pr merge <pr> --merge --match-head-commit
+  <validated-head>` bound to the freshly fetched head) and never merges.
+  It exits non-zero when not ready.
+- `--apply` is the only mutating path. If not `ready` it exits non-zero
+  without merging. If `ready` it re-fetches the head SHA and re-validates
+  the claim immediately before merging and **fails closed** (exit
+  non-zero, no merge, clear message) on any head drift or lost claim.
+  Otherwise it runs the merge commit bound to the validated head and
+  reports the result. It never squash- or rebase-merges.
+- Fail closed: if helper execution fails, output is invalid JSON,
+  required fields are missing, or helper evidence conflicts with live
+  GitHub state, discard helper output and run the manual F3 gate +
+  merge steps in `idd-merge.instructions.md`. The written F3 decision
+  table and gate checklist remain canonical.
+
 ### E7 disposition verification
 
 - Preferred command when helper runtime is enabled:
@@ -999,4 +1050,5 @@ pre-merge readiness or later claim-state inspection. They should not
 replace the written decision tables.
 
 [advisory-wait-state-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-wait-state.schema.json
+[idd-merge-execute-schema]: https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json
 [pre-merge-readiness-schema]: https://kurone-kito.github.io/idd-skill/schemas/pre-merge-readiness.schema.json

--- a/fixtures/schemas/idd-merge-execute.invalid.json
+++ b/fixtures/schemas/idd-merge-execute.invalid.json
@@ -3,7 +3,7 @@
   "decisionAuthority": "instructions",
   "mode": "dry-run",
   "prNumber": 994,
-  "prHeadSha": "0123456789abcdef0123456789abcdef01234567",
+  "prHeadSha": "",
   "ready": true,
   "blockers": [],
   "merged": false,

--- a/fixtures/schemas/idd-merge-execute.invalid.json
+++ b/fixtures/schemas/idd-merge-execute.invalid.json
@@ -1,0 +1,11 @@
+{
+  "protocolVersion": "1",
+  "decisionAuthority": "instructions",
+  "mode": "dry-run",
+  "prNumber": 994,
+  "prHeadSha": "0123456789abcdef0123456789abcdef01234567",
+  "ready": true,
+  "blockers": [],
+  "merged": false,
+  "mergeResult": ""
+}

--- a/fixtures/schemas/idd-merge-execute.valid.json
+++ b/fixtures/schemas/idd-merge-execute.valid.json
@@ -1,0 +1,17 @@
+{
+  "protocolVersion": "1",
+  "decisionAuthority": "instructions",
+  "mode": "dry-run",
+  "prNumber": 994,
+  "prHeadSha": "0123456789abcdef0123456789abcdef01234567",
+  "ready": false,
+  "blockers": [
+    {
+      "gate": "advisory-wait",
+      "detail": "f3Outcome is \"WAIT\" (expected \"SATISFIED\")"
+    }
+  ],
+  "mergeCommand": "gh pr merge 994 --merge --match-head-commit 0123456789abcdef0123456789abcdef01234567",
+  "merged": false,
+  "mergeResult": ""
+}

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -121,6 +121,20 @@ Before any mutating action in F3, apply the
    to prevent a race where a new push lands after the F3 freshness check
    but before the merge executes.
 
+   **Preferred path (helper runtime enabled)**: run the F3 merge helper
+   documented in
+   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#merge-execution-f3).
+   First run it in dry-run (no `--apply`) and confirm `ready: true` with
+   an empty `blockers[]`; the helper wraps the read-only
+   `pre-merge-readiness` gate and adds no new authority. Then re-run with
+   `--apply`: when `ready`, it re-fetches the head SHA and re-validates
+   the claim immediately before merging, fails closed (no merge) on head
+   drift or lost claim, and runs the merge commit bound to the validated
+   head (never squash/rebase). The gate checklist and decision table
+   below stay canonical: if the helper is unavailable, its output is
+   invalid, or its evidence conflicts with live GitHub state, discard it
+   and use the manual gate + merge steps in this section.
+
    **Gate checklist** — confirm every field before merging; all must hold,
    and any unmet or unknown field is a NO-GO (fail closed — stop, do not
    merge):

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -767,9 +767,11 @@ Interpretation rules:
   `comparisonRoute == "proceed"`, `threads.actionableCount == 0`,
   advisory `f3Outcome == "SATISFIED"`, CI all-passing (the F2/F3
   no-required-checks fallback included), required/CODEOWNER reviews
-  satisfied, claim ownership matches, and
-  `dispositionEvidence.route == "proceed"`. Each failing gate is listed
-  in `blockers[]` as `{ gate, detail }`.
+  satisfied, claim ownership matches, and disposition evidence both
+  routes proceed and is unblocked (`dispositionEvidence.route ==
+  "proceed"` **and** `dispositionEvidence.blockingCount == 0`; `route`
+  alone is not sufficient). Each failing gate is listed in `blockers[]`
+  as `{ gate, detail }`.
 - Dry-run (default) is read-only: it prints `ready`, `blockers`, and
   `mergeCommand` (a `gh pr merge <pr> --merge --match-head-commit
   <validated-head>` bound to the freshly fetched head) and never merges.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -61,6 +61,9 @@ In the idd-skill source repository, the following optional helpers were adopted:
   and rerun-budget decisions
 - `scripts/pre-merge-readiness.mjs` for read-only F2/F3 readiness
   evidence collection
+- `scripts/idd-merge-execute.mjs` for the F3 merge gate: a dry-run
+  verdict by default and, with `--apply`, the bound merge execution; it
+  wraps `pre-merge-readiness` and adds no new decision authority
 - `scripts/live-status-digest.mjs` for issue or PR live status digest
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
@@ -394,6 +397,18 @@ The adopted helper boundaries are intentionally narrow:
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence
+
+- `idd-merge-execute.mjs` defaults to dry-run and stays read-only in
+  that mode: it reuses `pre-merge-readiness` to evaluate the F3 gates and
+  prints `{ ready, blockers, mergeCommand }` without merging
+- apply mode (`--apply`) is the only mutating path: when `ready` it
+  re-fetches the head SHA and re-validates the claim immediately before
+  merging, fails closed (no merge) on head drift or lost claim, and runs
+  a merge commit bound to the validated head — never squash or rebase
+- it adds no new decision authority (`decisionAuthority: instructions`):
+  it does not replace the written F3 gate checklist or decision table,
+  and on any helper failure or evidence conflict the agent falls back to
+  the manual F3 steps
 
 - `live-status-digest.mjs` defaults to dry-run, supports issue and PR
   targets, and mutates only with explicit `--apply`
@@ -735,6 +750,42 @@ Interpretation rules:
   live GitHub state, discard helper output and use the portable manual
   fetch path.
 
+### Merge execution (F3)
+
+- Preferred F3 path when helper runtime is enabled: dry-run first to
+  inspect the verdict, then `--apply` to execute the bound merge.
+- Command: `node scripts/idd-merge-execute.mjs --pr <pr-number>
+  --claim-issue <issue-number> --claim-id <claim-id>` plus the same
+  optional flags as `pre-merge-readiness` (`--agent-id`, `--owner`,
+  `--repo`, `--trusted-marker-logins`, `--advisory-bot-logins`); add
+  `--apply` to merge.
+- Stable contract:
+  [`idd-merge-execute.schema.json`][idd-merge-execute-schema]
+- It WRAPS the read-only `pre-merge-readiness` collector and adds no new
+  decision authority (`decisionAuthority: instructions`). `ready` is
+  `true` only when every F3 gate holds: review-currency
+  `comparisonRoute == "proceed"`, `threads.actionableCount == 0`,
+  advisory `f3Outcome == "SATISFIED"`, CI all-passing (the F2/F3
+  no-required-checks fallback included), required/CODEOWNER reviews
+  satisfied, claim ownership matches, and
+  `dispositionEvidence.route == "proceed"`. Each failing gate is listed
+  in `blockers[]` as `{ gate, detail }`.
+- Dry-run (default) is read-only: it prints `ready`, `blockers`, and
+  `mergeCommand` (a `gh pr merge <pr> --merge --match-head-commit
+  <validated-head>` bound to the freshly fetched head) and never merges.
+  It exits non-zero when not ready.
+- `--apply` is the only mutating path. If not `ready` it exits non-zero
+  without merging. If `ready` it re-fetches the head SHA and re-validates
+  the claim immediately before merging and **fails closed** (exit
+  non-zero, no merge, clear message) on any head drift or lost claim.
+  Otherwise it runs the merge commit bound to the validated head and
+  reports the result. It never squash- or rebase-merges.
+- Fail closed: if helper execution fails, output is invalid JSON,
+  required fields are missing, or helper evidence conflicts with live
+  GitHub state, discard helper output and run the manual F3 gate +
+  merge steps in `idd-merge.instructions.md`. The written F3 decision
+  table and gate checklist remain canonical.
+
 ### E7 disposition verification
 
 - Preferred command when helper runtime is enabled:
@@ -999,4 +1050,5 @@ pre-merge readiness or later claim-state inspection. They should not
 replace the written decision tables.
 
 [advisory-wait-state-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-wait-state.schema.json
+[idd-merge-execute-schema]: https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json
 [pre-merge-readiness-schema]: https://kurone-kito.github.io/idd-skill/schemas/pre-merge-readiness.schema.json

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "idd-forced-handoff-marker": "./bin/idd-forced-handoff-marker.mjs",
     "idd-helper-bundle-manifest": "./bin/idd-helper-bundle-manifest.mjs",
     "idd-live-status-digest": "./bin/idd-live-status-digest.mjs",
+    "idd-merge-execute": "./bin/idd-merge-execute.mjs",
     "idd-merged-pr-feedback-sweep": "./bin/idd-merged-pr-feedback-sweep.mjs",
     "idd-phase-id-resolver": "./bin/idd-phase-id-resolver.mjs",
     "idd-pre-merge-readiness": "./bin/idd-pre-merge-readiness.mjs",

--- a/schemas/idd-merge-execute.schema.json
+++ b/schemas/idd-merge-execute.schema.json
@@ -35,7 +35,7 @@
     },
     "prHeadSha": {
       "type": "string",
-      "pattern": "^$|^[0-9a-f]{40}$"
+      "pattern": "^[0-9a-f]{40}$"
     },
     "ready": {
       "type": "boolean"

--- a/schemas/idd-merge-execute.schema.json
+++ b/schemas/idd-merge-execute.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json",
+  "title": "IDD Merge Execute",
+  "description": "F3 merge-gate verdict and (under --apply) execution result for a PR head.",
+  "type": "object",
+  "required": [
+    "protocolVersion",
+    "decisionAuthority",
+    "mode",
+    "prNumber",
+    "prHeadSha",
+    "ready",
+    "blockers",
+    "mergeCommand",
+    "merged",
+    "mergeResult"
+  ],
+  "properties": {
+    "protocolVersion": {
+      "type": "string",
+      "pattern": "^1$"
+    },
+    "decisionAuthority": {
+      "type": "string",
+      "enum": ["instructions"]
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["dry-run", "apply"]
+    },
+    "prNumber": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "prHeadSha": {
+      "type": "string",
+      "pattern": "^$|^[0-9a-f]{40}$"
+    },
+    "ready": {
+      "type": "boolean"
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["gate", "detail"],
+        "properties": {
+          "gate": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "mergeCommand": {
+      "type": "string"
+    },
+    "merged": {
+      "type": "boolean"
+    },
+    "mergeResult": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -61,6 +61,7 @@ const EXTRA_RUNTIME_FILES = new Map([
       'schemas/advisory-wait-state.schema.json',
       'schemas/claim-marker.schema.json',
       'schemas/forced-handoff-marker.schema.json',
+      'schemas/idd-merge-execute.schema.json',
       'schemas/live-status-digest.schema.json',
       'schemas/phase-graph.json',
       'schemas/phase-graph.schema.json',
@@ -72,6 +73,8 @@ const EXTRA_RUNTIME_FILES = new Map([
       'fixtures/schemas/claim-marker.valid.json',
       'fixtures/schemas/forced-handoff-marker.invalid.json',
       'fixtures/schemas/forced-handoff-marker.valid.json',
+      'fixtures/schemas/idd-merge-execute.invalid.json',
+      'fixtures/schemas/idd-merge-execute.valid.json',
       'fixtures/schemas/live-status-digest.invalid.json',
       'fixtures/schemas/live-status-digest.valid.json',
       'fixtures/schemas/phase-graph.invalid.json',
@@ -182,6 +185,16 @@ const HELPER_COMMANDS = [
     vendoredCommand: 'node scripts/pre-merge-readiness.mjs',
     description: 'Collect read-only F2/F3 merge-gate evidence.',
     contractPaths: ['schemas/pre-merge-readiness.schema.json'],
+  },
+  {
+    id: 'merge-execute',
+    scriptName: 'idd:merge-execute',
+    binName: 'idd-merge-execute',
+    entryPath: 'scripts/idd-merge-execute.mjs',
+    vendoredCommand: 'node scripts/idd-merge-execute.mjs',
+    description:
+      'Evaluate the F3 merge gate (dry-run) and execute the bound merge with --apply.',
+    contractPaths: ['schemas/idd-merge-execute.schema.json'],
   },
   {
     id: 'live-status-digest',

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -176,7 +176,13 @@ export function runMergeExecute(argv, deps = defaultDeps) {
   // Scope the printed command to the same repo the merge would run against so
   // it matches what `--apply` executes (current-directory repo when unset).
   const repoScope = args.repoRef ? `-R ${args.repoRef} ` : '';
-  const mergeCommand = `gh ${repoScope}pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
+  // Suppress the copy-pasteable command when the head is invalid (the
+  // head-sha gate fired): binding --match-head-commit to a non-SHA would
+  // emit a malformed, unsafe command despite the helper failing closed.
+  const hasHeadShaBlocker = blockers.some((b) => b.gate === 'head-sha');
+  const mergeCommand = hasHeadShaBlocker
+    ? ''
+    : `gh ${repoScope}pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
   const verdict = {
     protocolVersion: '1',
     decisionAuthority: 'instructions',

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -70,10 +70,17 @@ export function evaluateMergeGates(report) {
     });
   }
   const dispositionEvidence = asRecord(report.dispositionEvidence);
-  if (String(dispositionEvidence.route ?? '') !== 'proceed') {
+  // The written F2/F3 gate requires BOTH `route === 'proceed'` AND
+  // `blockingCount === 0`. Fail closed on a non-zero or non-numeric
+  // blockingCount so a missing/garbled count is treated as a blocker.
+  const dispositionRoute = String(dispositionEvidence.route ?? '');
+  const dispositionBlockingCount = Number(
+    dispositionEvidence.blockingCount ?? -1,
+  );
+  if (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0) {
     blockers.push({
       gate: 'disposition-evidence',
-      detail: `dispositionEvidence.route is "${String(dispositionEvidence.route ?? 'missing')}" (expected "proceed"): blockingCount=${Number(dispositionEvidence.blockingCount ?? -1)}`,
+      detail: `dispositionEvidence.route is "${dispositionRoute || 'missing'}" (expected "proceed"), blockingCount=${dispositionBlockingCount} (expected 0)`,
     });
   }
   return blockers;

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -279,9 +279,19 @@ function parseArgs(argv) {
   if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
     parsed.prNumber = null;
   }
-  // Scope to `<owner>/<repo>` only when BOTH are provided; a single flag is
-  // treated as not-set so the merge stays on the current-directory repo
-  // rather than constructing a half-formed repo reference.
+  // Fail closed on exactly one of `--owner` / `--repo`: the collector
+  // (`pre-merge-readiness`) fills the missing half from the
+  // current-directory repo, so a single flag would validate one repoRef
+  // while the head re-fetch and merge run against the current-directory
+  // repo — an unsafe split under `--apply`. Require both or neither.
+  if ((owner === '') !== (repo === '')) {
+    throw new Error(
+      'idd-merge-execute: --owner and --repo must be provided together or not at all',
+    );
+  }
+  // Both provided → scope to `<owner>/<repo>`. Neither → null, so the
+  // collector, the head re-fetch, and the merge all default to the
+  // current-directory repo (consistent).
   parsed.repoRef = owner && repo ? `${owner}/${repo}` : null;
   return parsed;
 }

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-merge-execute.mts
+//
+// The scripts/idd-merge-execute.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Thin F3 merge-gate evaluator + executor. It WRAPS the read-only
+// pre-merge-readiness collector (reuses its gate logic verbatim) and
+// introduces NO new decision authority: `decisionAuthority` stays
+// `instructions`. In the default dry-run it only collects evidence and
+// reports the bound merge command; the ONLY mutation anywhere is the
+// `gh pr merge` issued under `--apply` once every F3 gate holds and the
+// head + claim re-validate immediately before the merge.
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { collectPreMergeReadiness } from './pre-merge-readiness.mjs';
+/**
+ * Evaluate every F3 gate against `report` (the pre-merge-readiness
+ * summary). A gate failure is collected as a blocker; `ready` is true
+ * only when no blocker is collected. The conditions mirror the written
+ * F3 gate checklist exactly — this helper adds no stricter sub-condition.
+ */
+export function evaluateMergeGates(report) {
+  const blockers = [];
+  const reviewCurrency = asRecord(report.reviewCurrency);
+  const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
+  if (comparisonRoute !== 'proceed') {
+    blockers.push({
+      gate: 'review-currency',
+      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${String(reviewCurrency.comparisonReason ?? 'unknown')}`,
+    });
+  }
+  const threads = asRecord(report.threads);
+  const actionableCount = Number(threads.actionableCount ?? -1);
+  if (actionableCount !== 0) {
+    blockers.push({
+      gate: 'unresolved-threads',
+      detail: `actionableCount is ${actionableCount} (expected 0)`,
+    });
+  }
+  const advisoryWait = asRecord(report.advisoryWait);
+  const f3Outcome = String(advisoryWait.f3Outcome ?? '');
+  if (f3Outcome !== 'SATISFIED') {
+    blockers.push({
+      gate: 'advisory-wait',
+      detail: `f3Outcome is "${f3Outcome}" (expected "SATISFIED")`,
+    });
+  }
+  const ci = asRecord(report.ci);
+  if (!isCiAllPassing(ci)) {
+    blockers.push({
+      gate: 'ci',
+      detail: `CI is not all-passing (status="${String(ci.status ?? '')}", noRequiredChecksConfigured=${Boolean(ci.noRequiredChecksConfigured)}, presentRunConclusion="${String(ci.presentRunConclusion ?? '')}")`,
+    });
+  }
+  const reviewerStates = asRecord(report.reviewerStates);
+  if (!isReviewSatisfied(reviewerStates)) {
+    const selfApproval = asRecord(reviewerStates.codeownerSelfApproval);
+    blockers.push({
+      gate: 'required-reviews',
+      detail: `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(reviewerStates.requiredApprovalsSatisfied)}, codeownerApprovalSatisfied=${Boolean(reviewerStates.codeownerApprovalSatisfied)}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`,
+    });
+  }
+  const claim = asRecord(report.claim);
+  if (!claim.matchesExpectedClaim) {
+    blockers.push({
+      gate: 'claim-ownership',
+      detail: `claim ownership does not match (reason="${String(claim.reason ?? 'unknown')}")`,
+    });
+  }
+  const dispositionEvidence = asRecord(report.dispositionEvidence);
+  if (String(dispositionEvidence.route ?? '') !== 'proceed') {
+    blockers.push({
+      gate: 'disposition-evidence',
+      detail: `dispositionEvidence.route is "${String(dispositionEvidence.route ?? 'missing')}" (expected "proceed"): blockingCount=${Number(dispositionEvidence.blockingCount ?? -1)}`,
+    });
+  }
+  return blockers;
+}
+// CI all-passing mirrors the F2/F3 rule: required checks pass, OR (no
+// required checks are configured AND every present run concludes passing).
+// `status === 'success'` already implies required checks passed; the
+// no-required-checks branch must not satisfy CI vacuously, so it requires
+// `presentRunConclusion === 'all-passing'`.
+function isCiAllPassing(ci) {
+  if (ci.requiredChecksPassing === true || ci.status === 'success') {
+    return true;
+  }
+  return (
+    ci.noRequiredChecksConfigured === true &&
+    String(ci.presentRunConclusion ?? '') === 'all-passing'
+  );
+}
+// Required + CODEOWNER reviews are satisfied when the approval-count gate
+// passes and the CODEOWNER gate either passes outright or the self-approval
+// diagnostic is `clear` (a satisfiable bypass topology).
+function isReviewSatisfied(reviewerStates) {
+  if (reviewerStates.requiredApprovalsSatisfied !== true) {
+    return false;
+  }
+  if (reviewerStates.codeownerApprovalSatisfied === true) {
+    return true;
+  }
+  const selfApproval = asRecord(reviewerStates.codeownerSelfApproval);
+  return String(selfApproval.status ?? '') === 'clear';
+}
+function asRecord(value) {
+  return value && typeof value === 'object' ? value : {};
+}
+const defaultDeps = {
+  collect: (passthrough) => collectPreMergeReadiness(passthrough),
+  fetchHeadSha: (prNumber) =>
+    ghText([
+      'pr',
+      'view',
+      String(prNumber),
+      '--json',
+      'headRefOid',
+      '--jq',
+      '.headRefOid',
+    ]),
+  mergePr: (prNumber, headSha) =>
+    ghText([
+      'pr',
+      'merge',
+      String(prNumber),
+      // Always a merge commit — never squash/rebase. Bind to the head.
+      '--merge',
+      '--match-head-commit',
+      headSha,
+    ]),
+};
+/**
+ * Build the F3 verdict and, under `--apply`, execute the merge. The
+ * dry-run path performs NO mutation. The apply path fails closed: if the
+ * gate is not ready it exits without merging; if it is ready it RE-FETCHES
+ * the head SHA and RE-VALIDATES the claim immediately before merging, and
+ * refuses to merge (clear message) on any head drift or lost claim.
+ */
+export function runMergeExecute(argv, deps = defaultDeps) {
+  const args = parseArgs(argv);
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const report = deps.collect(args.passthrough);
+  const prHeadSha = String(report.prHeadSha ?? '');
+  const blockers = evaluateMergeGates(report);
+  const ready = blockers.length === 0;
+  const mergeCommand = `gh pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
+  const verdict = {
+    protocolVersion: '1',
+    decisionAuthority: 'instructions',
+    mode: args.apply ? 'apply' : 'dry-run',
+    prNumber: args.prNumber,
+    prHeadSha,
+    ready,
+    blockers,
+    mergeCommand,
+    merged: false,
+    mergeResult: '',
+  };
+  if (!args.apply) {
+    // Dry-run: read-only. Never merge.
+    return { verdict, exitCode: ready ? 0 : 1 };
+  }
+  if (!ready) {
+    // Apply but not ready: fail closed, do not merge.
+    verdict.mergeResult =
+      'not-ready: gate blockers present; no merge attempted';
+    return { verdict, exitCode: 1 };
+  }
+  // Ready under --apply: re-fetch the head and re-validate the claim
+  // immediately before merging, then fail closed on any drift.
+  const liveHeadSha = deps.fetchHeadSha(args.prNumber);
+  if (liveHeadSha !== prHeadSha) {
+    verdict.mergeResult = `head drift: validated ${prHeadSha} but live head is ${liveHeadSha}; no merge`;
+    return { verdict, exitCode: 1 };
+  }
+  const revalidated = deps.collect(args.passthrough);
+  if (String(revalidated.prHeadSha ?? '') !== prHeadSha) {
+    verdict.mergeResult = `head drift on re-validation: ${String(revalidated.prHeadSha ?? '')} != ${prHeadSha}; no merge`;
+    return { verdict, exitCode: 1 };
+  }
+  const revalidatedClaim = asRecord(revalidated.claim);
+  if (!revalidatedClaim.matchesExpectedClaim) {
+    verdict.mergeResult = `claim lost on re-validation (reason="${String(revalidatedClaim.reason ?? 'unknown')}"); no merge`;
+    return { verdict, exitCode: 1 };
+  }
+  const revalidatedBlockers = evaluateMergeGates(revalidated);
+  if (revalidatedBlockers.length > 0) {
+    verdict.blockers = revalidatedBlockers;
+    verdict.ready = false;
+    verdict.mergeResult =
+      're-validation found new blockers immediately before merge; no merge';
+    return { verdict, exitCode: 1 };
+  }
+  // Always a merge commit — never squash/rebase. Bind to the validated head.
+  const mergeOutput = deps.mergePr(args.prNumber, prHeadSha);
+  verdict.merged = true;
+  verdict.mergeResult = mergeOutput || 'merge command completed';
+  return { verdict, exitCode: 0 };
+}
+function parseArgs(argv) {
+  const parsed = {
+    prNumber: null,
+    passthrough: [],
+    apply: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--apply') {
+      parsed.apply = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+    if (token === '--pr') {
+      const value = argv[index + 1];
+      parsed.prNumber = Number.parseInt(value ?? '', 10);
+      parsed.passthrough.push(token, value ?? '');
+      index += 1;
+      continue;
+    }
+    // Every other flag (and its value, if it takes one) is forwarded
+    // verbatim to the pre-merge-readiness collector so the two CLIs accept
+    // an identical flag surface without re-declaring it here.
+    if (token.startsWith('--')) {
+      const value = argv[index + 1];
+      if (value !== undefined && !value.startsWith('--')) {
+        parsed.passthrough.push(token, value);
+        index += 1;
+      } else {
+        parsed.passthrough.push(token);
+      }
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
+    parsed.prNumber = null;
+  }
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/idd-merge-execute.mjs --pr <number> --claim-issue <number> [--claim-id <claim-id>] [--agent-id <agent-id>] [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <bot1,bot2>] [--apply]
+
+  Default (no --apply): dry-run. Evaluates every F3 merge gate via the
+  read-only pre-merge-readiness collector and prints { ready, blockers,
+  mergeCommand } without merging. Exit 0 when ready, 1 otherwise.
+
+  --apply: when ready, re-fetch the head SHA and re-validate the claim
+  immediately before merging, then run a merge commit bound to the
+  validated head. Fails closed (exit 1, no merge) on head drift or lost
+  claim. Never squash/rebase merges. The merge is the only mutation.
+`);
+}
+function ghText(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+// CLI: print the verdict as JSON and exit with the gate/merge status.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { verdict, exitCode } = runMergeExecute(process.argv.slice(2));
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  process.exit(exitCode);
+}

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -23,6 +23,16 @@ import { collectPreMergeReadiness } from './pre-merge-readiness.mjs';
  */
 export function evaluateMergeGates(report) {
   const blockers = [];
+  // Fail closed on a missing/invalid head: `prHeadSha` binds
+  // `--match-head-commit`, so a non-40-hex value must never yield a
+  // "ready" verdict with an unsafe merge binding.
+  const prHeadSha = String(report.prHeadSha ?? '');
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    blockers.push({
+      gate: 'head-sha',
+      detail: `prHeadSha "${prHeadSha}" is not a 40-hex commit SHA; cannot bind a safe merge`,
+    });
+  }
   const reviewCurrency = asRecord(report.reviewCurrency);
   const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
   if (comparisonRoute !== 'proceed') {

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -63,7 +63,7 @@ export function evaluateMergeGates(report) {
     });
   }
   const claim = asRecord(report.claim);
-  if (!claim.matchesExpectedClaim) {
+  if (claim.matchesExpectedClaim !== true) {
     blockers.push({
       gate: 'claim-ownership',
       detail: `claim ownership does not match (reason="${String(claim.reason ?? 'unknown')}")`,
@@ -108,28 +108,37 @@ function isReviewSatisfied(reviewerStates) {
 function asRecord(value) {
   return value && typeof value === 'object' ? value : {};
 }
+// Prepend `-R <repoRef>` to a `gh` argument array only when a repo scope is
+// set; otherwise pass the args verbatim (current-directory repo).
+function scopedGhArgs(repoRef, args) {
+  return repoRef ? ['-R', repoRef, ...args] : args;
+}
 const defaultDeps = {
   collect: (passthrough) => collectPreMergeReadiness(passthrough),
-  fetchHeadSha: (prNumber) =>
-    ghText([
-      'pr',
-      'view',
-      String(prNumber),
-      '--json',
-      'headRefOid',
-      '--jq',
-      '.headRefOid',
-    ]),
-  mergePr: (prNumber, headSha) =>
-    ghText([
-      'pr',
-      'merge',
-      String(prNumber),
-      // Always a merge commit — never squash/rebase. Bind to the head.
-      '--merge',
-      '--match-head-commit',
-      headSha,
-    ]),
+  fetchHeadSha: (prNumber, repoRef) =>
+    ghText(
+      scopedGhArgs(repoRef, [
+        'pr',
+        'view',
+        String(prNumber),
+        '--json',
+        'headRefOid',
+        '--jq',
+        '.headRefOid',
+      ]),
+    ),
+  mergePr: (prNumber, headSha, repoRef) =>
+    ghText(
+      scopedGhArgs(repoRef, [
+        'pr',
+        'merge',
+        String(prNumber),
+        // Always a merge commit — never squash/rebase. Bind to the head.
+        '--merge',
+        '--match-head-commit',
+        headSha,
+      ]),
+    ),
 };
 /**
  * Build the F3 verdict and, under `--apply`, execute the merge. The
@@ -147,7 +156,10 @@ export function runMergeExecute(argv, deps = defaultDeps) {
   const prHeadSha = String(report.prHeadSha ?? '');
   const blockers = evaluateMergeGates(report);
   const ready = blockers.length === 0;
-  const mergeCommand = `gh pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
+  // Scope the printed command to the same repo the merge would run against so
+  // it matches what `--apply` executes (current-directory repo when unset).
+  const repoScope = args.repoRef ? `-R ${args.repoRef} ` : '';
+  const mergeCommand = `gh ${repoScope}pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
   const verdict = {
     protocolVersion: '1',
     decisionAuthority: 'instructions',
@@ -172,7 +184,7 @@ export function runMergeExecute(argv, deps = defaultDeps) {
   }
   // Ready under --apply: re-fetch the head and re-validate the claim
   // immediately before merging, then fail closed on any drift.
-  const liveHeadSha = deps.fetchHeadSha(args.prNumber);
+  const liveHeadSha = deps.fetchHeadSha(args.prNumber, args.repoRef);
   if (liveHeadSha !== prHeadSha) {
     verdict.mergeResult = `head drift: validated ${prHeadSha} but live head is ${liveHeadSha}; no merge`;
     return { verdict, exitCode: 1 };
@@ -183,7 +195,7 @@ export function runMergeExecute(argv, deps = defaultDeps) {
     return { verdict, exitCode: 1 };
   }
   const revalidatedClaim = asRecord(revalidated.claim);
-  if (!revalidatedClaim.matchesExpectedClaim) {
+  if (revalidatedClaim.matchesExpectedClaim !== true) {
     verdict.mergeResult = `claim lost on re-validation (reason="${String(revalidatedClaim.reason ?? 'unknown')}"); no merge`;
     return { verdict, exitCode: 1 };
   }
@@ -196,7 +208,7 @@ export function runMergeExecute(argv, deps = defaultDeps) {
     return { verdict, exitCode: 1 };
   }
   // Always a merge commit — never squash/rebase. Bind to the validated head.
-  const mergeOutput = deps.mergePr(args.prNumber, prHeadSha);
+  const mergeOutput = deps.mergePr(args.prNumber, prHeadSha, args.repoRef);
   verdict.merged = true;
   verdict.mergeResult = mergeOutput || 'merge command completed';
   return { verdict, exitCode: 0 };
@@ -206,7 +218,13 @@ function parseArgs(argv) {
     prNumber: null,
     passthrough: [],
     apply: false,
+    repoRef: null,
   };
+  // Captured locally so `repoRef` is set only when BOTH are present; these
+  // are ALSO forwarded to the collector via passthrough (we do not stop
+  // forwarding them — the collector still scopes its own gh/API calls).
+  let owner = '';
+  let repo = '';
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === '--apply') {
@@ -220,6 +238,18 @@ function parseArgs(argv) {
     if (token === '--pr') {
       const value = argv[index + 1];
       parsed.prNumber = Number.parseInt(value ?? '', 10);
+      parsed.passthrough.push(token, value ?? '');
+      index += 1;
+      continue;
+    }
+    if (token === '--owner' || token === '--repo') {
+      const value = argv[index + 1];
+      if (token === '--owner') {
+        owner = value ?? '';
+      } else {
+        repo = value ?? '';
+      }
+      // Keep forwarding to the collector so it still validates this repo.
       parsed.passthrough.push(token, value ?? '');
       index += 1;
       continue;
@@ -242,6 +272,10 @@ function parseArgs(argv) {
   if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
     parsed.prNumber = null;
   }
+  // Scope to `<owner>/<repo>` only when BOTH are provided; a single flag is
+  // treated as not-set so the merge stays on the current-directory repo
+  // rather than constructing a half-formed repo reference.
+  parsed.repoRef = owner && repo ? `${owner}/${repo}` : null;
   return parsed;
 }
 function printHelp() {

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -297,7 +297,13 @@ function parseArgs(argv) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/idd-merge-execute.mjs --pr <number> --claim-issue <number> [--claim-id <claim-id>] [--agent-id <agent-id>] [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <bot1,bot2>] [--apply]
+  node scripts/idd-merge-execute.mjs --pr <number> --claim-issue <number> [--claim-id <claim-id>] [--agent-id <agent-id>] [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <bot1,bot2>] [--idd-agent-logins <login1,login2>] [--now <ISO8601>] [--apply]
+
+  Every flag except --apply is forwarded verbatim to the read-only
+  pre-merge-readiness collector, so the full collector flag surface is
+  accepted here — including --idd-agent-logins, --now, and the deprecated
+  --expected-claim-id / --expected-agent-id aliases. --owner and --repo
+  must be passed together or not at all.
 
   Default (no --apply): dry-run. Evaluates every F3 merge gate via the
   read-only pre-merge-readiness collector and prints { ready, blockers,

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -6,6 +6,7 @@
 // generated .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { readAdvisoryWaitPolicy } from './advisory-wait-policy.mjs';
 import {
   isAuthorizedForcedHandoffActor,
@@ -28,207 +29,219 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mjs';
-
-const args = parseArgs(process.argv.slice(2));
-if (!args.prNumber) {
-  throw new Error('missing required --pr <number> argument');
-}
-if (!args.claimIssueNumber) {
-  throw new Error('missing required --claim-issue <number> argument');
-}
-const owner =
-  args.owner ||
-  ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-const repo =
-  args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-const repoRef = `${owner}/${repo}`;
-const viewerLogin = safeGhText(['api', 'user', '--jq', '.login']).toLowerCase();
-const viewerAppSlug = safeGhText([
-  'api',
-  'app',
-  '--jq',
-  '.slug // .app_slug // empty',
-]).toLowerCase();
-const iddConfig = loadIddConfig();
-const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
-  resolveTrustedMarkerActors({
-    flagValue: args.trustedMarkerLogins,
-    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
-    config: iddConfig,
-  });
-const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
-  resolveAdvisoryBotLogins({
-    flagValue: args.advisoryBotLogins,
-    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
-    config: iddConfig,
-  });
-const pr = ghJson([
-  'pr',
-  'view',
-  String(args.prNumber),
-  '-R',
-  repoRef,
-  '--json',
-  'headRefOid,baseRefName,url,author,reviewDecision',
-  '--jq',
-  '.',
-]);
-const prHeadSha = String(pr.headRefOid ?? '');
-const baseRefName = String(pr.baseRefName ?? '');
-const prUrl = String(pr.url ?? '');
-const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
-const reviewDecision = String(pr.reviewDecision ?? '');
-const encodedBaseRefName = encodeURIComponent(baseRefName);
-const checks = ghJson(
-  [
+/**
+ * Fetch live GitHub state for the PR + claim issue and build the
+ * read-only pre-merge readiness report. Shared by this CLI and the
+ * `idd-merge-execute` helper so the F2/F3 gate logic is collected from
+ * exactly one place (no duplicated gh plumbing or gate evaluation).
+ */
+export function collectPreMergeReadiness(argv) {
+  const args = parseArgs(argv);
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  if (!args.claimIssueNumber) {
+    throw new Error('missing required --claim-issue <number> argument');
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const viewerLogin = safeGhText([
+    'api',
+    'user',
+    '--jq',
+    '.login',
+  ]).toLowerCase();
+  const viewerAppSlug = safeGhText([
+    'api',
+    'app',
+    '--jq',
+    '.slug // .app_slug // empty',
+  ]).toLowerCase();
+  const iddConfig = loadIddConfig();
+  const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: iddConfig,
+    });
+  const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
+    resolveAdvisoryBotLogins({
+      flagValue: args.advisoryBotLogins,
+      envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+      config: iddConfig,
+    });
+  const pr = ghJson([
     'pr',
-    'checks',
+    'view',
     String(args.prNumber),
     '-R',
     repoRef,
     '--json',
-    'name,state,completedAt',
+    'headRefOid,baseRefName,url,author,reviewDecision',
     '--jq',
     '.',
-  ],
-  { allowStatuses: [1, 8] },
-);
-const branchRules = ghApiJson(
-  `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
-  true,
-  [],
-  { allowHttpStatuses: [404] },
-);
-const branchRulesets = fetchBranchRulesets(owner, repo, branchRules);
-const branchProtection = ghApiJson(
-  `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
-  false,
-  [],
-  { allowHttpStatuses: [404] },
-);
-const reviews = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-  true,
-);
-const requestedReviewers = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
-  false,
-);
-const timelineEvents = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
-  true,
-  ['-H', 'Accept: application/vnd.github+json'],
-);
-const comments = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-  true,
-);
-const claimComments = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
-  true,
-);
-const threads = fetchReviewThreads(owner, repo, args.prNumber);
-const changedFiles = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/files`,
-  true,
-)
-  .map((file) => String(file.filename ?? ''))
-  .filter(Boolean);
-const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
-const eligibleCodeownerUserLogins = resolveEligibleCodeownerUserLogins(
-  owner,
-  repo,
-  resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
-);
-const viewerTeamSlugs = resolveViewerClassicBypassTeamSlugs(
-  owner,
-  viewerLogin,
-  branchProtection,
-);
-const collaboratorTrustEnabled = readCollaboratorTrustEnabled();
-const trustedMarkerLogins = normalizeTrustedMarkerLogins([
-  viewerLogin,
-  ...configuredTrustedActors,
-  ...(collaboratorTrustEnabled
-    ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
-        ...comments,
-        ...claimComments,
-      ])
-    : []),
-]);
-const iddAgentLogins = deriveIddAgentLogins({
-  viewerLogin,
-  iddAgentLogins: splitCsv(args.iddAgentLogins),
-  trustedMarkerLogins,
-  operationalComments: [...comments, ...claimComments],
-});
-const advisoryWaitPolicy = readAdvisoryWaitPolicy();
-const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
-const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
-const forcedHandoffPermissionCache = new Map();
-const waivableCheckSelectors = readWaivableCheckSelectors();
-const summary = buildPreMergeReadinessSummary(
-  {
-    prHeadSha,
-    comments: comments.map(normalizeComment),
-    reviews: reviews.map(normalizeReview),
-    threads: threads.map(normalizeThread),
-    checks,
-    branchRules,
-    branchRulesets,
-    branchProtection,
-    requestedReviewers: requestedReviewers.users ?? [],
-    timelineEvents,
-    claimEvents: claimComments.map(normalizeClaimComment),
-    changedFiles,
-    codeownersText,
-    eligibleCodeownerUserLogins,
-    reviewDecision,
-  },
-  {
-    now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
-    trustedMarkerLogins,
-    iddAgentLogins,
-    advisoryBotLogins,
-    advisoryBotLoginsSource,
-    prAuthorLogin,
-    expectedClaimId: args.expectedClaimId,
-    expectedAgentId: args.expectedAgentId,
-    includeDispositionEvidence: true,
-    requestCap: advisoryWaitPolicy.requestCap,
-    pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
-    settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
-    pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
-    capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
-    waivableCheckSelectors,
-    forcedHandoffEnabled,
-    expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
-    isAuthorizedForcedHandoff: (forcedBy) =>
-      isAuthorizedForcedHandoffActor(
-        owner,
-        repo,
-        forcedBy,
-        forcedHandoffAuthorityPolicy,
-        forcedHandoffPermissionCache,
-      ),
+  ]);
+  const prHeadSha = String(pr.headRefOid ?? '');
+  const baseRefName = String(pr.baseRefName ?? '');
+  const prUrl = String(pr.url ?? '');
+  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
+  const reviewDecision = String(pr.reviewDecision ?? '');
+  const encodedBaseRefName = encodeURIComponent(baseRefName);
+  const checks = ghJson(
+    [
+      'pr',
+      'checks',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'name,state,completedAt',
+      '--jq',
+      '.',
+    ],
+    { allowStatuses: [1, 8] },
+  );
+  const branchRules = ghApiJson(
+    `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
+    true,
+    [],
+    { allowHttpStatuses: [404] },
+  );
+  const branchRulesets = fetchBranchRulesets(owner, repo, branchRules);
+  const branchProtection = ghApiJson(
+    `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
+    false,
+    [],
+    { allowHttpStatuses: [404] },
+  );
+  const reviews = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
+    true,
+  );
+  const requestedReviewers = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
+    false,
+  );
+  const timelineEvents = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
+    true,
+    ['-H', 'Accept: application/vnd.github+json'],
+  );
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    true,
+  );
+  const claimComments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
+    true,
+  );
+  const threads = fetchReviewThreads(owner, repo, args.prNumber);
+  const changedFiles = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/files`,
+    true,
+  )
+    .map((file) => String(file.filename ?? ''))
+    .filter(Boolean);
+  const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
+  const eligibleCodeownerUserLogins = resolveEligibleCodeownerUserLogins(
+    owner,
+    repo,
+    resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
+  );
+  const viewerTeamSlugs = resolveViewerClassicBypassTeamSlugs(
+    owner,
     viewerLogin,
-    viewerTeamSlugs,
-    viewerAppSlug,
-    configuredTrustedActors,
-    collaboratorTrustEnabled,
-  },
-);
-process.stdout.write(
-  `${JSON.stringify(
+    branchProtection,
+  );
+  const collaboratorTrustEnabled = readCollaboratorTrustEnabled();
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins([
+    viewerLogin,
+    ...configuredTrustedActors,
+    ...(collaboratorTrustEnabled
+      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
+          ...comments,
+          ...claimComments,
+        ])
+      : []),
+  ]);
+  const iddAgentLogins = deriveIddAgentLogins({
+    viewerLogin,
+    iddAgentLogins: splitCsv(args.iddAgentLogins),
+    trustedMarkerLogins,
+    operationalComments: [...comments, ...claimComments],
+  });
+  const advisoryWaitPolicy = readAdvisoryWaitPolicy();
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  const forcedHandoffPermissionCache = new Map();
+  const waivableCheckSelectors = readWaivableCheckSelectors();
+  const summary = buildPreMergeReadinessSummary(
     {
-      ...summary,
-      trustedMarkerActors: configuredTrustedActors,
-      trustedMarkerActorsSource,
+      prHeadSha,
+      comments: comments.map(normalizeComment),
+      reviews: reviews.map(normalizeReview),
+      threads: threads.map(normalizeThread),
+      checks,
+      branchRules,
+      branchRulesets,
+      branchProtection,
+      requestedReviewers: requestedReviewers.users ?? [],
+      timelineEvents,
+      claimEvents: claimComments.map(normalizeClaimComment),
+      changedFiles,
+      codeownersText,
+      eligibleCodeownerUserLogins,
+      reviewDecision,
     },
-    null,
-    2,
-  )}\n`,
-);
+    {
+      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      trustedMarkerLogins,
+      iddAgentLogins,
+      advisoryBotLogins,
+      advisoryBotLoginsSource,
+      prAuthorLogin,
+      expectedClaimId: args.expectedClaimId,
+      expectedAgentId: args.expectedAgentId,
+      includeDispositionEvidence: true,
+      requestCap: advisoryWaitPolicy.requestCap,
+      pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
+      settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
+      pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
+      capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
+      waivableCheckSelectors,
+      forcedHandoffEnabled,
+      expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
+      isAuthorizedForcedHandoff: (forcedBy) =>
+        isAuthorizedForcedHandoffActor(
+          owner,
+          repo,
+          forcedBy,
+          forcedHandoffAuthorityPolicy,
+          forcedHandoffPermissionCache,
+        ),
+      viewerLogin,
+      viewerTeamSlugs,
+      viewerAppSlug,
+      configuredTrustedActors,
+      collaboratorTrustEnabled,
+    },
+  );
+  return {
+    ...summary,
+    trustedMarkerActors: configuredTrustedActors,
+    trustedMarkerActorsSource,
+  };
+}
+// CLI: emit the readiness report as JSON when invoked directly.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.stdout.write(
+    `${JSON.stringify(collectPreMergeReadiness(process.argv.slice(2)), null, 2)}\n`,
+  );
+}
 function warnDeprecatedFlag(deprecated, canonical) {
   process.stderr.write(
     `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -357,6 +357,16 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       'fixtures/schemas/pre-merge-readiness.invalid.json',
       false,
     ],
+    [
+      'schemas/idd-merge-execute.schema.json',
+      'fixtures/schemas/idd-merge-execute.valid.json',
+      true,
+    ],
+    [
+      'schemas/idd-merge-execute.schema.json',
+      'fixtures/schemas/idd-merge-execute.invalid.json',
+      false,
+    ],
     ['schemas/policy.schema.json', 'fixtures/schemas/policy.valid.json', true],
     [
       'schemas/policy.schema.json',

--- a/src/bin/idd-merge-execute.mts
+++ b/src/bin/idd-merge-execute.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-merge-execute.mts
+//
+// The bin/idd-merge-execute.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/idd-merge-execute.mjs');

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -132,6 +132,7 @@ const EXTRA_RUNTIME_FILES = new Map<string, string[]>([
       'schemas/advisory-wait-state.schema.json',
       'schemas/claim-marker.schema.json',
       'schemas/forced-handoff-marker.schema.json',
+      'schemas/idd-merge-execute.schema.json',
       'schemas/live-status-digest.schema.json',
       'schemas/phase-graph.json',
       'schemas/phase-graph.schema.json',
@@ -143,6 +144,8 @@ const EXTRA_RUNTIME_FILES = new Map<string, string[]>([
       'fixtures/schemas/claim-marker.valid.json',
       'fixtures/schemas/forced-handoff-marker.invalid.json',
       'fixtures/schemas/forced-handoff-marker.valid.json',
+      'fixtures/schemas/idd-merge-execute.invalid.json',
+      'fixtures/schemas/idd-merge-execute.valid.json',
       'fixtures/schemas/live-status-digest.invalid.json',
       'fixtures/schemas/live-status-digest.valid.json',
       'fixtures/schemas/phase-graph.invalid.json',
@@ -254,6 +257,16 @@ const HELPER_COMMANDS: HelperCommand[] = [
     vendoredCommand: 'node scripts/pre-merge-readiness.mjs',
     description: 'Collect read-only F2/F3 merge-gate evidence.',
     contractPaths: ['schemas/pre-merge-readiness.schema.json'],
+  },
+  {
+    id: 'merge-execute',
+    scriptName: 'idd:merge-execute',
+    binName: 'idd-merge-execute',
+    entryPath: 'scripts/idd-merge-execute.mjs',
+    vendoredCommand: 'node scripts/idd-merge-execute.mjs',
+    description:
+      'Evaluate the F3 merge gate (dry-run) and execute the bound merge with --apply.',
+    contractPaths: ['schemas/idd-merge-execute.schema.json'],
   },
   {
     id: 'live-status-digest',

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -420,7 +420,13 @@ function parseArgs(argv: string[]): IddMergeExecuteArgs {
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/idd-merge-execute.mjs --pr <number> --claim-issue <number> [--claim-id <claim-id>] [--agent-id <agent-id>] [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <bot1,bot2>] [--apply]
+  node scripts/idd-merge-execute.mjs --pr <number> --claim-issue <number> [--claim-id <claim-id>] [--agent-id <agent-id>] [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <bot1,bot2>] [--idd-agent-logins <login1,login2>] [--now <ISO8601>] [--apply]
+
+  Every flag except --apply is forwarded verbatim to the read-only
+  pre-merge-readiness collector, so the full collector flag surface is
+  accepted here — including --idd-agent-logins, --now, and the deprecated
+  --expected-claim-id / --expected-agent-id aliases. --owner and --repo
+  must be passed together or not at all.
 
   Default (no --apply): dry-run. Evaluates every F3 merge gate via the
   read-only pre-merge-readiness collector and prints { ready, blockers,

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -134,14 +134,19 @@ export function evaluateMergeGates(
   }
 
   const dispositionEvidence = asRecord(report.dispositionEvidence);
-  if (String(dispositionEvidence.route ?? '') !== 'proceed') {
+  // The written F2/F3 gate requires BOTH `route === 'proceed'` AND
+  // `blockingCount === 0`. Fail closed on a non-zero or non-numeric
+  // blockingCount so a missing/garbled count is treated as a blocker.
+  const dispositionRoute = String(dispositionEvidence.route ?? '');
+  const dispositionBlockingCount = Number(
+    dispositionEvidence.blockingCount ?? -1,
+  );
+  if (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0) {
     blockers.push({
       gate: 'disposition-evidence',
-      detail: `dispositionEvidence.route is "${String(
-        dispositionEvidence.route ?? 'missing',
-      )}" (expected "proceed"): blockingCount=${Number(
-        dispositionEvidence.blockingCount ?? -1,
-      )}`,
+      detail: `dispositionEvidence.route is "${
+        dispositionRoute || 'missing'
+      }" (expected "proceed"), blockingCount=${dispositionBlockingCount} (expected 0)`,
     });
   }
 

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -47,6 +47,15 @@ interface IddMergeExecuteArgs {
   prNumber: number | null;
   passthrough: string[];
   apply: boolean;
+  /**
+   * `<owner>/<repo>` repo scope, set only when BOTH `--owner` and `--repo`
+   * are provided. The head re-fetch, the merge, and the emitted
+   * `mergeCommand` are all scoped to this repo so the helper never validates
+   * one repo (via the collector's `--owner/--repo`) while operating on a
+   * different current-directory repo. `null` keeps current-directory `gh`
+   * behavior.
+   */
+  repoRef: string | null;
 }
 
 /**
@@ -115,7 +124,7 @@ export function evaluateMergeGates(
   }
 
   const claim = asRecord(report.claim);
-  if (!claim.matchesExpectedClaim) {
+  if (claim.matchesExpectedClaim !== true) {
     blockers.push({
       gate: 'claim-ownership',
       detail: `claim ownership does not match (reason="${String(
@@ -182,35 +191,55 @@ function asRecord(value: unknown): Record<string, unknown> {
 export interface MergeExecuteDeps {
   /** Collect the read-only pre-merge readiness report from live state. */
   collect: (passthrough: string[]) => Record<string, unknown>;
-  /** Re-fetch the current PR head SHA immediately before merging. */
-  fetchHeadSha: (prNumber: number) => string;
-  /** Execute the bound merge commit and return gh's stdout. */
-  mergePr: (prNumber: number, headSha: string) => string;
+  /**
+   * Re-fetch the current PR head SHA immediately before merging, scoped to
+   * `repoRef` (`<owner>/<repo>`) when set, else the current-directory repo.
+   */
+  fetchHeadSha: (prNumber: number, repoRef: string | null) => string;
+  /**
+   * Execute the bound merge commit and return gh's stdout, scoped to
+   * `repoRef` (`<owner>/<repo>`) when set, else the current-directory repo.
+   */
+  mergePr: (
+    prNumber: number,
+    headSha: string,
+    repoRef: string | null,
+  ) => string;
+}
+
+// Prepend `-R <repoRef>` to a `gh` argument array only when a repo scope is
+// set; otherwise pass the args verbatim (current-directory repo).
+function scopedGhArgs(repoRef: string | null, args: string[]): string[] {
+  return repoRef ? ['-R', repoRef, ...args] : args;
 }
 
 const defaultDeps: MergeExecuteDeps = {
   collect: (passthrough) =>
     collectPreMergeReadiness(passthrough) as Record<string, unknown>,
-  fetchHeadSha: (prNumber) =>
-    ghText([
-      'pr',
-      'view',
-      String(prNumber),
-      '--json',
-      'headRefOid',
-      '--jq',
-      '.headRefOid',
-    ]),
-  mergePr: (prNumber, headSha) =>
-    ghText([
-      'pr',
-      'merge',
-      String(prNumber),
-      // Always a merge commit — never squash/rebase. Bind to the head.
-      '--merge',
-      '--match-head-commit',
-      headSha,
-    ]),
+  fetchHeadSha: (prNumber, repoRef) =>
+    ghText(
+      scopedGhArgs(repoRef, [
+        'pr',
+        'view',
+        String(prNumber),
+        '--json',
+        'headRefOid',
+        '--jq',
+        '.headRefOid',
+      ]),
+    ),
+  mergePr: (prNumber, headSha, repoRef) =>
+    ghText(
+      scopedGhArgs(repoRef, [
+        'pr',
+        'merge',
+        String(prNumber),
+        // Always a merge commit — never squash/rebase. Bind to the head.
+        '--merge',
+        '--match-head-commit',
+        headSha,
+      ]),
+    ),
 };
 
 /**
@@ -236,7 +265,10 @@ export function runMergeExecute(
   const prHeadSha = String(report.prHeadSha ?? '');
   const blockers = evaluateMergeGates(report);
   const ready = blockers.length === 0;
-  const mergeCommand = `gh pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
+  // Scope the printed command to the same repo the merge would run against so
+  // it matches what `--apply` executes (current-directory repo when unset).
+  const repoScope = args.repoRef ? `-R ${args.repoRef} ` : '';
+  const mergeCommand = `gh ${repoScope}pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
 
   const verdict: IddMergeExecuteVerdict = {
     protocolVersion: '1',
@@ -265,7 +297,7 @@ export function runMergeExecute(
 
   // Ready under --apply: re-fetch the head and re-validate the claim
   // immediately before merging, then fail closed on any drift.
-  const liveHeadSha = deps.fetchHeadSha(args.prNumber);
+  const liveHeadSha = deps.fetchHeadSha(args.prNumber, args.repoRef);
   if (liveHeadSha !== prHeadSha) {
     verdict.mergeResult = `head drift: validated ${prHeadSha} but live head is ${liveHeadSha}; no merge`;
     return { verdict, exitCode: 1 };
@@ -279,7 +311,7 @@ export function runMergeExecute(
     return { verdict, exitCode: 1 };
   }
   const revalidatedClaim = asRecord(revalidated.claim);
-  if (!revalidatedClaim.matchesExpectedClaim) {
+  if (revalidatedClaim.matchesExpectedClaim !== true) {
     verdict.mergeResult = `claim lost on re-validation (reason="${String(
       revalidatedClaim.reason ?? 'unknown',
     )}"); no merge`;
@@ -295,7 +327,7 @@ export function runMergeExecute(
   }
 
   // Always a merge commit — never squash/rebase. Bind to the validated head.
-  const mergeOutput = deps.mergePr(args.prNumber, prHeadSha);
+  const mergeOutput = deps.mergePr(args.prNumber, prHeadSha, args.repoRef);
   verdict.merged = true;
   verdict.mergeResult = mergeOutput || 'merge command completed';
   return { verdict, exitCode: 0 };
@@ -306,7 +338,13 @@ function parseArgs(argv: string[]): IddMergeExecuteArgs {
     prNumber: null,
     passthrough: [],
     apply: false,
+    repoRef: null,
   };
+  // Captured locally so `repoRef` is set only when BOTH are present; these
+  // are ALSO forwarded to the collector via passthrough (we do not stop
+  // forwarding them — the collector still scopes its own gh/API calls).
+  let owner = '';
+  let repo = '';
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -321,6 +359,18 @@ function parseArgs(argv: string[]): IddMergeExecuteArgs {
     if (token === '--pr') {
       const value = argv[index + 1];
       parsed.prNumber = Number.parseInt(value ?? '', 10);
+      parsed.passthrough.push(token, value ?? '');
+      index += 1;
+      continue;
+    }
+    if (token === '--owner' || token === '--repo') {
+      const value = argv[index + 1];
+      if (token === '--owner') {
+        owner = value ?? '';
+      } else {
+        repo = value ?? '';
+      }
+      // Keep forwarding to the collector so it still validates this repo.
       parsed.passthrough.push(token, value ?? '');
       index += 1;
       continue;
@@ -344,6 +394,11 @@ function parseArgs(argv: string[]): IddMergeExecuteArgs {
   if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
     parsed.prNumber = null;
   }
+
+  // Scope to `<owner>/<repo>` only when BOTH are provided; a single flag is
+  // treated as not-set so the merge stays on the current-directory repo
+  // rather than constructing a half-formed repo reference.
+  parsed.repoRef = owner && repo ? `${owner}/${repo}` : null;
 
   return parsed;
 }

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -284,7 +284,13 @@ export function runMergeExecute(
   // Scope the printed command to the same repo the merge would run against so
   // it matches what `--apply` executes (current-directory repo when unset).
   const repoScope = args.repoRef ? `-R ${args.repoRef} ` : '';
-  const mergeCommand = `gh ${repoScope}pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
+  // Suppress the copy-pasteable command when the head is invalid (the
+  // head-sha gate fired): binding --match-head-commit to a non-SHA would
+  // emit a malformed, unsafe command despite the helper failing closed.
+  const hasHeadShaBlocker = blockers.some((b) => b.gate === 'head-sha');
+  const mergeCommand = hasHeadShaBlocker
+    ? ''
+    : `gh ${repoScope}pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
 
   const verdict: IddMergeExecuteVerdict = {
     protocolVersion: '1',

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-merge-execute.mts
+//
+// The scripts/idd-merge-execute.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Thin F3 merge-gate evaluator + executor. It WRAPS the read-only
+// pre-merge-readiness collector (reuses its gate logic verbatim) and
+// introduces NO new decision authority: `decisionAuthority` stays
+// `instructions`. In the default dry-run it only collects evidence and
+// reports the bound merge command; the ONLY mutation anywhere is the
+// `gh pr merge` issued under `--apply` once every F3 gate holds and the
+// head + claim re-validate immediately before the merge.
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { collectPreMergeReadiness } from './pre-merge-readiness.mts';
+
+/** One failing F3 gate, keyed by the gate name plus a human detail. */
+export interface MergeBlocker {
+  gate: string;
+  detail: string;
+}
+
+/**
+ * JSON verdict document printed by the `idd-merge-execute` CLI. The
+ * helper is evidence + execution convenience only, so `decisionAuthority`
+ * stays `instructions` (consistent with pre-merge-readiness).
+ */
+export interface IddMergeExecuteVerdict {
+  protocolVersion: '1';
+  decisionAuthority: 'instructions';
+  mode: 'dry-run' | 'apply';
+  prNumber: number;
+  prHeadSha: string;
+  ready: boolean;
+  blockers: MergeBlocker[];
+  mergeCommand: string;
+  merged: boolean;
+  mergeResult: string;
+}
+
+/** Parsed CLI arguments mirroring pre-merge-readiness, plus `--apply`. */
+interface IddMergeExecuteArgs {
+  prNumber: number | null;
+  passthrough: string[];
+  apply: boolean;
+}
+
+/**
+ * Evaluate every F3 gate against `report` (the pre-merge-readiness
+ * summary). A gate failure is collected as a blocker; `ready` is true
+ * only when no blocker is collected. The conditions mirror the written
+ * F3 gate checklist exactly — this helper adds no stricter sub-condition.
+ */
+export function evaluateMergeGates(
+  report: Record<string, unknown>,
+): MergeBlocker[] {
+  const blockers: MergeBlocker[] = [];
+
+  const reviewCurrency = asRecord(report.reviewCurrency);
+  const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
+  if (comparisonRoute !== 'proceed') {
+    blockers.push({
+      gate: 'review-currency',
+      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${String(
+        reviewCurrency.comparisonReason ?? 'unknown',
+      )}`,
+    });
+  }
+
+  const threads = asRecord(report.threads);
+  const actionableCount = Number(threads.actionableCount ?? -1);
+  if (actionableCount !== 0) {
+    blockers.push({
+      gate: 'unresolved-threads',
+      detail: `actionableCount is ${actionableCount} (expected 0)`,
+    });
+  }
+
+  const advisoryWait = asRecord(report.advisoryWait);
+  const f3Outcome = String(advisoryWait.f3Outcome ?? '');
+  if (f3Outcome !== 'SATISFIED') {
+    blockers.push({
+      gate: 'advisory-wait',
+      detail: `f3Outcome is "${f3Outcome}" (expected "SATISFIED")`,
+    });
+  }
+
+  const ci = asRecord(report.ci);
+  if (!isCiAllPassing(ci)) {
+    blockers.push({
+      gate: 'ci',
+      detail: `CI is not all-passing (status="${String(
+        ci.status ?? '',
+      )}", noRequiredChecksConfigured=${Boolean(
+        ci.noRequiredChecksConfigured,
+      )}, presentRunConclusion="${String(ci.presentRunConclusion ?? '')}")`,
+    });
+  }
+
+  const reviewerStates = asRecord(report.reviewerStates);
+  if (!isReviewSatisfied(reviewerStates)) {
+    const selfApproval = asRecord(reviewerStates.codeownerSelfApproval);
+    blockers.push({
+      gate: 'required-reviews',
+      detail: `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(
+        reviewerStates.requiredApprovalsSatisfied,
+      )}, codeownerApprovalSatisfied=${Boolean(
+        reviewerStates.codeownerApprovalSatisfied,
+      )}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`,
+    });
+  }
+
+  const claim = asRecord(report.claim);
+  if (!claim.matchesExpectedClaim) {
+    blockers.push({
+      gate: 'claim-ownership',
+      detail: `claim ownership does not match (reason="${String(
+        claim.reason ?? 'unknown',
+      )}")`,
+    });
+  }
+
+  const dispositionEvidence = asRecord(report.dispositionEvidence);
+  if (String(dispositionEvidence.route ?? '') !== 'proceed') {
+    blockers.push({
+      gate: 'disposition-evidence',
+      detail: `dispositionEvidence.route is "${String(
+        dispositionEvidence.route ?? 'missing',
+      )}" (expected "proceed"): blockingCount=${Number(
+        dispositionEvidence.blockingCount ?? -1,
+      )}`,
+    });
+  }
+
+  return blockers;
+}
+
+// CI all-passing mirrors the F2/F3 rule: required checks pass, OR (no
+// required checks are configured AND every present run concludes passing).
+// `status === 'success'` already implies required checks passed; the
+// no-required-checks branch must not satisfy CI vacuously, so it requires
+// `presentRunConclusion === 'all-passing'`.
+function isCiAllPassing(ci: Record<string, unknown>): boolean {
+  if (ci.requiredChecksPassing === true || ci.status === 'success') {
+    return true;
+  }
+  return (
+    ci.noRequiredChecksConfigured === true &&
+    String(ci.presentRunConclusion ?? '') === 'all-passing'
+  );
+}
+
+// Required + CODEOWNER reviews are satisfied when the approval-count gate
+// passes and the CODEOWNER gate either passes outright or the self-approval
+// diagnostic is `clear` (a satisfiable bypass topology).
+function isReviewSatisfied(reviewerStates: Record<string, unknown>): boolean {
+  if (reviewerStates.requiredApprovalsSatisfied !== true) {
+    return false;
+  }
+  if (reviewerStates.codeownerApprovalSatisfied === true) {
+    return true;
+  }
+  const selfApproval = asRecord(reviewerStates.codeownerSelfApproval);
+  return String(selfApproval.status ?? '') === 'clear';
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Injectable side-effecting dependencies. Tests substitute these to drive
+ * the dry-run / apply / fail-closed paths without faking the full live
+ * GitHub state; production uses the real readiness collector and `gh`.
+ */
+export interface MergeExecuteDeps {
+  /** Collect the read-only pre-merge readiness report from live state. */
+  collect: (passthrough: string[]) => Record<string, unknown>;
+  /** Re-fetch the current PR head SHA immediately before merging. */
+  fetchHeadSha: (prNumber: number) => string;
+  /** Execute the bound merge commit and return gh's stdout. */
+  mergePr: (prNumber: number, headSha: string) => string;
+}
+
+const defaultDeps: MergeExecuteDeps = {
+  collect: (passthrough) =>
+    collectPreMergeReadiness(passthrough) as Record<string, unknown>,
+  fetchHeadSha: (prNumber) =>
+    ghText([
+      'pr',
+      'view',
+      String(prNumber),
+      '--json',
+      'headRefOid',
+      '--jq',
+      '.headRefOid',
+    ]),
+  mergePr: (prNumber, headSha) =>
+    ghText([
+      'pr',
+      'merge',
+      String(prNumber),
+      // Always a merge commit — never squash/rebase. Bind to the head.
+      '--merge',
+      '--match-head-commit',
+      headSha,
+    ]),
+};
+
+/**
+ * Build the F3 verdict and, under `--apply`, execute the merge. The
+ * dry-run path performs NO mutation. The apply path fails closed: if the
+ * gate is not ready it exits without merging; if it is ready it RE-FETCHES
+ * the head SHA and RE-VALIDATES the claim immediately before merging, and
+ * refuses to merge (clear message) on any head drift or lost claim.
+ */
+export function runMergeExecute(
+  argv: string[],
+  deps: MergeExecuteDeps = defaultDeps,
+): {
+  verdict: IddMergeExecuteVerdict;
+  exitCode: number;
+} {
+  const args = parseArgs(argv);
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+
+  const report = deps.collect(args.passthrough);
+  const prHeadSha = String(report.prHeadSha ?? '');
+  const blockers = evaluateMergeGates(report);
+  const ready = blockers.length === 0;
+  const mergeCommand = `gh pr merge ${args.prNumber} --merge --match-head-commit ${prHeadSha}`;
+
+  const verdict: IddMergeExecuteVerdict = {
+    protocolVersion: '1',
+    decisionAuthority: 'instructions',
+    mode: args.apply ? 'apply' : 'dry-run',
+    prNumber: args.prNumber,
+    prHeadSha,
+    ready,
+    blockers,
+    mergeCommand,
+    merged: false,
+    mergeResult: '',
+  };
+
+  if (!args.apply) {
+    // Dry-run: read-only. Never merge.
+    return { verdict, exitCode: ready ? 0 : 1 };
+  }
+
+  if (!ready) {
+    // Apply but not ready: fail closed, do not merge.
+    verdict.mergeResult =
+      'not-ready: gate blockers present; no merge attempted';
+    return { verdict, exitCode: 1 };
+  }
+
+  // Ready under --apply: re-fetch the head and re-validate the claim
+  // immediately before merging, then fail closed on any drift.
+  const liveHeadSha = deps.fetchHeadSha(args.prNumber);
+  if (liveHeadSha !== prHeadSha) {
+    verdict.mergeResult = `head drift: validated ${prHeadSha} but live head is ${liveHeadSha}; no merge`;
+    return { verdict, exitCode: 1 };
+  }
+
+  const revalidated = deps.collect(args.passthrough);
+  if (String(revalidated.prHeadSha ?? '') !== prHeadSha) {
+    verdict.mergeResult = `head drift on re-validation: ${String(
+      revalidated.prHeadSha ?? '',
+    )} != ${prHeadSha}; no merge`;
+    return { verdict, exitCode: 1 };
+  }
+  const revalidatedClaim = asRecord(revalidated.claim);
+  if (!revalidatedClaim.matchesExpectedClaim) {
+    verdict.mergeResult = `claim lost on re-validation (reason="${String(
+      revalidatedClaim.reason ?? 'unknown',
+    )}"); no merge`;
+    return { verdict, exitCode: 1 };
+  }
+  const revalidatedBlockers = evaluateMergeGates(revalidated);
+  if (revalidatedBlockers.length > 0) {
+    verdict.blockers = revalidatedBlockers;
+    verdict.ready = false;
+    verdict.mergeResult =
+      're-validation found new blockers immediately before merge; no merge';
+    return { verdict, exitCode: 1 };
+  }
+
+  // Always a merge commit — never squash/rebase. Bind to the validated head.
+  const mergeOutput = deps.mergePr(args.prNumber, prHeadSha);
+  verdict.merged = true;
+  verdict.mergeResult = mergeOutput || 'merge command completed';
+  return { verdict, exitCode: 0 };
+}
+
+function parseArgs(argv: string[]): IddMergeExecuteArgs {
+  const parsed: IddMergeExecuteArgs = {
+    prNumber: null,
+    passthrough: [],
+    apply: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--apply') {
+      parsed.apply = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+    if (token === '--pr') {
+      const value = argv[index + 1];
+      parsed.prNumber = Number.parseInt(value ?? '', 10);
+      parsed.passthrough.push(token, value ?? '');
+      index += 1;
+      continue;
+    }
+    // Every other flag (and its value, if it takes one) is forwarded
+    // verbatim to the pre-merge-readiness collector so the two CLIs accept
+    // an identical flag surface without re-declaring it here.
+    if (token.startsWith('--')) {
+      const value = argv[index + 1];
+      if (value !== undefined && !value.startsWith('--')) {
+        parsed.passthrough.push(token, value);
+        index += 1;
+      } else {
+        parsed.passthrough.push(token);
+      }
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+
+  if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
+    parsed.prNumber = null;
+  }
+
+  return parsed;
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/idd-merge-execute.mjs --pr <number> --claim-issue <number> [--claim-id <claim-id>] [--agent-id <agent-id>] [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <bot1,bot2>] [--apply]
+
+  Default (no --apply): dry-run. Evaluates every F3 merge gate via the
+  read-only pre-merge-readiness collector and prints { ready, blockers,
+  mergeCommand } without merging. Exit 0 when ready, 1 otherwise.
+
+  --apply: when ready, re-fetch the head SHA and re-validate the claim
+  immediately before merging, then run a merge commit bound to the
+  validated head. Fails closed (exit 1, no merge) on head drift or lost
+  claim. Never squash/rebase merges. The merge is the only mutation.
+`);
+}
+
+function ghText(args: string[]): string {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+
+// CLI: print the verdict as JSON and exit with the gate/merge status.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { verdict, exitCode } = runMergeExecute(process.argv.slice(2));
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  process.exit(exitCode);
+}

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -400,9 +400,19 @@ function parseArgs(argv: string[]): IddMergeExecuteArgs {
     parsed.prNumber = null;
   }
 
-  // Scope to `<owner>/<repo>` only when BOTH are provided; a single flag is
-  // treated as not-set so the merge stays on the current-directory repo
-  // rather than constructing a half-formed repo reference.
+  // Fail closed on exactly one of `--owner` / `--repo`: the collector
+  // (`pre-merge-readiness`) fills the missing half from the
+  // current-directory repo, so a single flag would validate one repoRef
+  // while the head re-fetch and merge run against the current-directory
+  // repo — an unsafe split under `--apply`. Require both or neither.
+  if ((owner === '') !== (repo === '')) {
+    throw new Error(
+      'idd-merge-execute: --owner and --repo must be provided together or not at all',
+    );
+  }
+  // Both provided → scope to `<owner>/<repo>`. Neither → null, so the
+  // collector, the head re-fetch, and the merge all default to the
+  // current-directory repo (consistent).
   parsed.repoRef = owner && repo ? `${owner}/${repo}` : null;
 
   return parsed;

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -69,6 +69,17 @@ export function evaluateMergeGates(
 ): MergeBlocker[] {
   const blockers: MergeBlocker[] = [];
 
+  // Fail closed on a missing/invalid head: `prHeadSha` binds
+  // `--match-head-commit`, so a non-40-hex value must never yield a
+  // "ready" verdict with an unsafe merge binding.
+  const prHeadSha = String(report.prHeadSha ?? '');
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    blockers.push({
+      gate: 'head-sha',
+      detail: `prHeadSha "${prHeadSha}" is not a 40-hex commit SHA; cannot bind a safe merge`,
+    });
+  }
+
   const reviewCurrency = asRecord(report.reviewCurrency);
   const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
   if (comparisonRoute !== 'proceed') {

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -7,6 +7,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 import { readAdvisoryWaitPolicy } from './advisory-wait-policy.mts';
 import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
@@ -186,219 +187,235 @@ export type PreMergeReadinessReport = ReturnType<
   trustedMarkerActorsSource: TrustedMarkerActorResolution['source'];
 };
 
-const args = parseArgs(process.argv.slice(2));
-if (!args.prNumber) {
-  throw new Error('missing required --pr <number> argument');
-}
-if (!args.claimIssueNumber) {
-  throw new Error('missing required --claim-issue <number> argument');
-}
+/**
+ * Fetch live GitHub state for the PR + claim issue and build the
+ * read-only pre-merge readiness report. Shared by this CLI and the
+ * `idd-merge-execute` helper so the F2/F3 gate logic is collected from
+ * exactly one place (no duplicated gh plumbing or gate evaluation).
+ */
+export function collectPreMergeReadiness(
+  argv: string[],
+): PreMergeReadinessReport {
+  const args = parseArgs(argv);
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  if (!args.claimIssueNumber) {
+    throw new Error('missing required --claim-issue <number> argument');
+  }
 
-const owner =
-  args.owner ||
-  ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-const repo =
-  args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-const repoRef = `${owner}/${repo}`;
-const viewerLogin = safeGhText(['api', 'user', '--jq', '.login']).toLowerCase();
-const viewerAppSlug = safeGhText([
-  'api',
-  'app',
-  '--jq',
-  '.slug // .app_slug // empty',
-]).toLowerCase();
-const iddConfig = loadIddConfig();
-const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
-  resolveTrustedMarkerActors({
-    flagValue: args.trustedMarkerLogins,
-    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
-    config: iddConfig,
-  });
-const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
-  resolveAdvisoryBotLogins({
-    flagValue: args.advisoryBotLogins,
-    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
-    config: iddConfig,
-  });
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const viewerLogin = safeGhText([
+    'api',
+    'user',
+    '--jq',
+    '.login',
+  ]).toLowerCase();
+  const viewerAppSlug = safeGhText([
+    'api',
+    'app',
+    '--jq',
+    '.slug // .app_slug // empty',
+  ]).toLowerCase();
+  const iddConfig = loadIddConfig();
+  const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: iddConfig,
+    });
+  const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
+    resolveAdvisoryBotLogins({
+      flagValue: args.advisoryBotLogins,
+      envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+      config: iddConfig,
+    });
 
-const pr = ghJson([
-  'pr',
-  'view',
-  String(args.prNumber),
-  '-R',
-  repoRef,
-  '--json',
-  'headRefOid,baseRefName,url,author,reviewDecision',
-  '--jq',
-  '.',
-]) as {
-  headRefOid?: unknown;
-  baseRefName?: unknown;
-  url?: unknown;
-  author?: { login?: unknown } | null;
-  reviewDecision?: unknown;
-};
-const prHeadSha = String(pr.headRefOid ?? '');
-const baseRefName = String(pr.baseRefName ?? '');
-const prUrl = String(pr.url ?? '');
-const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
-const reviewDecision = String(pr.reviewDecision ?? '');
-const encodedBaseRefName = encodeURIComponent(baseRefName);
-
-const checks = ghJson(
-  [
+  const pr = ghJson([
     'pr',
-    'checks',
+    'view',
     String(args.prNumber),
     '-R',
     repoRef,
     '--json',
-    'name,state,completedAt',
+    'headRefOid,baseRefName,url,author,reviewDecision',
     '--jq',
     '.',
-  ],
-  { allowStatuses: [1, 8] },
-) as CheckPayload[];
-const branchRules = ghApiJson(
-  `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
-  true,
-  [],
-  { allowHttpStatuses: [404] },
-) as BranchRulePayload[];
-const branchRulesets = fetchBranchRulesets(owner, repo, branchRules);
-const branchProtection = ghApiJson(
-  `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
-  false,
-  [],
-  { allowHttpStatuses: [404] },
-) as BranchProtectionPayload;
-const reviews = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-  true,
-) as ReviewPayload[];
-const requestedReviewers = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
-  false,
-) as { users?: GhAuthorPayload[] | null };
-const timelineEvents = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
-  true,
-  ['-H', 'Accept: application/vnd.github+json'],
-) as TimelineEventPayload[];
-const comments = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-  true,
-) as IssueCommentPayload[];
-const claimComments = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
-  true,
-) as IssueCommentPayload[];
-const threads = fetchReviewThreads(owner, repo, args.prNumber);
-const changedFiles = (
-  ghApiJson(`repos/${owner}/${repo}/pulls/${args.prNumber}/files`, true) as {
-    filename?: unknown;
-  }[]
-)
-  .map((file) => String(file.filename ?? ''))
-  .filter(Boolean);
-const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
-const eligibleCodeownerUserLogins = resolveEligibleCodeownerUserLogins(
-  owner,
-  repo,
-  resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
-);
-const viewerTeamSlugs = resolveViewerClassicBypassTeamSlugs(
-  owner,
-  viewerLogin,
-  branchProtection,
-);
+  ]) as {
+    headRefOid?: unknown;
+    baseRefName?: unknown;
+    url?: unknown;
+    author?: { login?: unknown } | null;
+    reviewDecision?: unknown;
+  };
+  const prHeadSha = String(pr.headRefOid ?? '');
+  const baseRefName = String(pr.baseRefName ?? '');
+  const prUrl = String(pr.url ?? '');
+  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
+  const reviewDecision = String(pr.reviewDecision ?? '');
+  const encodedBaseRefName = encodeURIComponent(baseRefName);
 
-const collaboratorTrustEnabled = readCollaboratorTrustEnabled();
-const trustedMarkerLogins = normalizeTrustedMarkerLogins([
-  viewerLogin,
-  ...configuredTrustedActors,
-  ...(collaboratorTrustEnabled
-    ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
-        ...comments,
-        ...claimComments,
-      ])
-    : []),
-]);
-const iddAgentLogins = deriveIddAgentLogins({
-  viewerLogin,
-  iddAgentLogins: splitCsv(args.iddAgentLogins),
-  trustedMarkerLogins,
-  operationalComments: [...comments, ...claimComments],
-});
-const advisoryWaitPolicy = readAdvisoryWaitPolicy();
-const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
-const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
-const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
-const waivableCheckSelectors = readWaivableCheckSelectors();
-
-const summary = buildPreMergeReadinessSummary(
-  {
-    prHeadSha,
-    comments: comments.map(normalizeComment),
-    reviews: reviews.map(normalizeReview),
-    threads: threads.map(normalizeThread),
-    checks,
-    branchRules,
-    branchRulesets,
-    branchProtection,
-    requestedReviewers: requestedReviewers.users ?? [],
-    timelineEvents,
-    claimEvents: claimComments.map(normalizeClaimComment),
-    changedFiles,
-    codeownersText,
-    eligibleCodeownerUserLogins,
-    reviewDecision,
-  },
-  {
-    now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
-    trustedMarkerLogins,
-    iddAgentLogins,
-    advisoryBotLogins,
-    advisoryBotLoginsSource,
-    prAuthorLogin,
-    expectedClaimId: args.expectedClaimId,
-    expectedAgentId: args.expectedAgentId,
-    includeDispositionEvidence: true,
-    requestCap: advisoryWaitPolicy.requestCap,
-    pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
-    settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
-    pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
-    capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
-    waivableCheckSelectors,
-    forcedHandoffEnabled,
-    expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
-    isAuthorizedForcedHandoff: (forcedBy) =>
-      isAuthorizedForcedHandoffActor(
-        owner,
-        repo,
-        forcedBy,
-        forcedHandoffAuthorityPolicy,
-        forcedHandoffPermissionCache,
-      ),
+  const checks = ghJson(
+    [
+      'pr',
+      'checks',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'name,state,completedAt',
+      '--jq',
+      '.',
+    ],
+    { allowStatuses: [1, 8] },
+  ) as CheckPayload[];
+  const branchRules = ghApiJson(
+    `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
+    true,
+    [],
+    { allowHttpStatuses: [404] },
+  ) as BranchRulePayload[];
+  const branchRulesets = fetchBranchRulesets(owner, repo, branchRules);
+  const branchProtection = ghApiJson(
+    `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
+    false,
+    [],
+    { allowHttpStatuses: [404] },
+  ) as BranchProtectionPayload;
+  const reviews = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
+    true,
+  ) as ReviewPayload[];
+  const requestedReviewers = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
+    false,
+  ) as { users?: GhAuthorPayload[] | null };
+  const timelineEvents = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
+    true,
+    ['-H', 'Accept: application/vnd.github+json'],
+  ) as TimelineEventPayload[];
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    true,
+  ) as IssueCommentPayload[];
+  const claimComments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
+    true,
+  ) as IssueCommentPayload[];
+  const threads = fetchReviewThreads(owner, repo, args.prNumber);
+  const changedFiles = (
+    ghApiJson(`repos/${owner}/${repo}/pulls/${args.prNumber}/files`, true) as {
+      filename?: unknown;
+    }[]
+  )
+    .map((file) => String(file.filename ?? ''))
+    .filter(Boolean);
+  const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
+  const eligibleCodeownerUserLogins = resolveEligibleCodeownerUserLogins(
+    owner,
+    repo,
+    resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
+  );
+  const viewerTeamSlugs = resolveViewerClassicBypassTeamSlugs(
+    owner,
     viewerLogin,
-    viewerTeamSlugs,
-    viewerAppSlug,
-    configuredTrustedActors,
-    collaboratorTrustEnabled,
-  },
-);
+    branchProtection,
+  );
 
-process.stdout.write(
-  `${JSON.stringify(
+  const collaboratorTrustEnabled = readCollaboratorTrustEnabled();
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins([
+    viewerLogin,
+    ...configuredTrustedActors,
+    ...(collaboratorTrustEnabled
+      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
+          ...comments,
+          ...claimComments,
+        ])
+      : []),
+  ]);
+  const iddAgentLogins = deriveIddAgentLogins({
+    viewerLogin,
+    iddAgentLogins: splitCsv(args.iddAgentLogins),
+    trustedMarkerLogins,
+    operationalComments: [...comments, ...claimComments],
+  });
+  const advisoryWaitPolicy = readAdvisoryWaitPolicy();
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
+  const waivableCheckSelectors = readWaivableCheckSelectors();
+
+  const summary = buildPreMergeReadinessSummary(
     {
-      ...summary,
-      trustedMarkerActors: configuredTrustedActors,
-      trustedMarkerActorsSource,
+      prHeadSha,
+      comments: comments.map(normalizeComment),
+      reviews: reviews.map(normalizeReview),
+      threads: threads.map(normalizeThread),
+      checks,
+      branchRules,
+      branchRulesets,
+      branchProtection,
+      requestedReviewers: requestedReviewers.users ?? [],
+      timelineEvents,
+      claimEvents: claimComments.map(normalizeClaimComment),
+      changedFiles,
+      codeownersText,
+      eligibleCodeownerUserLogins,
+      reviewDecision,
     },
-    null,
-    2,
-  )}\n`,
-);
+    {
+      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      trustedMarkerLogins,
+      iddAgentLogins,
+      advisoryBotLogins,
+      advisoryBotLoginsSource,
+      prAuthorLogin,
+      expectedClaimId: args.expectedClaimId,
+      expectedAgentId: args.expectedAgentId,
+      includeDispositionEvidence: true,
+      requestCap: advisoryWaitPolicy.requestCap,
+      pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
+      settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
+      pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
+      capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
+      waivableCheckSelectors,
+      forcedHandoffEnabled,
+      expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
+      isAuthorizedForcedHandoff: (forcedBy) =>
+        isAuthorizedForcedHandoffActor(
+          owner,
+          repo,
+          forcedBy,
+          forcedHandoffAuthorityPolicy,
+          forcedHandoffPermissionCache,
+        ),
+      viewerLogin,
+      viewerTeamSlugs,
+      viewerAppSlug,
+      configuredTrustedActors,
+      collaboratorTrustEnabled,
+    },
+  );
+
+  return {
+    ...summary,
+    trustedMarkerActors: configuredTrustedActors,
+    trustedMarkerActorsSource,
+  } as PreMergeReadinessReport;
+}
+
+// CLI: emit the readiness report as JSON when invoked directly.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.stdout.write(
+    `${JSON.stringify(collectPreMergeReadiness(process.argv.slice(2)), null, 2)}\n`,
+  );
+}
 
 function warnDeprecatedFlag(deprecated: string, canonical: string): void {
   process.stderr.write(

--- a/src/scripts/validate-schemas.mts
+++ b/src/scripts/validate-schemas.mts
@@ -410,6 +410,16 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       'fixtures/schemas/pre-merge-readiness.invalid.json',
       false,
     ],
+    [
+      'schemas/idd-merge-execute.schema.json',
+      'fixtures/schemas/idd-merge-execute.valid.json',
+      true,
+    ],
+    [
+      'schemas/idd-merge-execute.schema.json',
+      'fixtures/schemas/idd-merge-execute.invalid.json',
+      false,
+    ],
     ['schemas/policy.schema.json', 'fixtures/schemas/policy.valid.json', true],
     [
       'schemas/policy.schema.json',

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -86,6 +86,17 @@ test('a missing or invalid prHeadSha fails closed as a head-sha blocker', () => 
   }
 });
 
+test('mergeCommand is suppressed when the head-sha gate fires', () => {
+  const report = readyReport();
+  report.prHeadSha = 'not-a-sha';
+  const { deps } = depsFor(report);
+  const { verdict, exitCode } = runMergeExecute(BASE_ARGS, deps);
+  assert.equal(verdict.ready, false);
+  // No copy-pasteable command when the head cannot bind --match-head-commit.
+  assert.equal(verdict.mergeCommand, '');
+  assert.equal(exitCode, 1);
+});
+
 test('dry-run on a ready report reports ready with the bound merge command', () => {
   const { deps, calls } = depsFor(readyReport());
   const { verdict, exitCode } = runMergeExecute(BASE_ARGS, deps);

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -261,6 +261,20 @@ test('without --owner/--repo no -R scope is added (current-directory repo)', () 
   assert.deepEqual(calls.mergeRepoRefs, [null]);
 });
 
+test('exactly one of --owner/--repo fails closed (require both or neither)', () => {
+  const { deps } = depsFor(readyReport());
+  // The collector fills the missing half from the current-directory repo,
+  // so a single flag would validate one repo but merge another.
+  assert.throws(
+    () => runMergeExecute([...BASE_ARGS, '--owner', 'acme', '--apply'], deps),
+    /must be provided together or not at all/,
+  );
+  assert.throws(
+    () => runMergeExecute([...BASE_ARGS, '--repo', 'widget', '--apply'], deps),
+    /must be provided together or not at all/,
+  );
+});
+
 test('--apply on a blocked gate fails closed without merging', () => {
   const report = readyReport();
   report.advisoryWait = { f3Outcome: 'WAIT' };

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -39,13 +39,28 @@ function readyReport(): Record<string, unknown> {
 function depsFor(
   report: Record<string, unknown>,
   overrides: Partial<MergeExecuteDeps> = {},
-): { deps: MergeExecuteDeps; calls: { merged: string[] } } {
-  const calls = { merged: [] as string[] };
+): {
+  deps: MergeExecuteDeps;
+  calls: {
+    merged: string[];
+    fetchRepoRefs: (string | null)[];
+    mergeRepoRefs: (string | null)[];
+  };
+} {
+  const calls = {
+    merged: [] as string[],
+    fetchRepoRefs: [] as (string | null)[],
+    mergeRepoRefs: [] as (string | null)[],
+  };
   const deps: MergeExecuteDeps = {
     collect: () => report,
-    fetchHeadSha: () => String(report.prHeadSha ?? ''),
-    mergePr: (prNumber, headSha) => {
+    fetchHeadSha: (_prNumber, repoRef) => {
+      calls.fetchRepoRefs.push(repoRef);
+      return String(report.prHeadSha ?? '');
+    },
+    mergePr: (prNumber, headSha, repoRef) => {
       calls.merged.push(`${prNumber}:${headSha}`);
+      calls.mergeRepoRefs.push(repoRef);
       return 'Merged PR.';
     },
     ...overrides,
@@ -197,6 +212,37 @@ test('--apply merges a ready PR bound to the validated head', () => {
   assert.equal(verdict.merged, true);
   assert.deepEqual(calls.merged, [`994:${HEAD}`]);
   assert.equal(exitCode, 0);
+});
+
+test('--owner/--repo scope the head re-fetch, merge, and mergeCommand to that repoRef', () => {
+  const { deps, calls } = depsFor(readyReport());
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--owner', 'acme', '--repo', 'widget', '--apply'],
+    deps,
+  );
+
+  assert.equal(verdict.merged, true);
+  assert.equal(exitCode, 0);
+  // The emitted command is scoped to the same repo.
+  assert.equal(
+    verdict.mergeCommand,
+    `gh -R acme/widget pr merge 994 --merge --match-head-commit ${HEAD}`,
+  );
+  // Both the head re-fetch and the merge gh calls are scoped to repoRef.
+  assert.deepEqual(calls.fetchRepoRefs, ['acme/widget']);
+  assert.deepEqual(calls.mergeRepoRefs, ['acme/widget']);
+});
+
+test('without --owner/--repo no -R scope is added (current-directory repo)', () => {
+  const { deps, calls } = depsFor(readyReport());
+  const { verdict } = runMergeExecute([...BASE_ARGS, '--apply'], deps);
+
+  assert.equal(
+    verdict.mergeCommand,
+    `gh pr merge 994 --merge --match-head-commit ${HEAD}`,
+  );
+  assert.deepEqual(calls.fetchRepoRefs, [null]);
+  assert.deepEqual(calls.mergeRepoRefs, [null]);
 });
 
 test('--apply on a blocked gate fails closed without merging', () => {

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -74,6 +74,18 @@ test('evaluateMergeGates returns no blockers for a fully ready report', () => {
   assert.deepEqual(evaluateMergeGates(readyReport()), []);
 });
 
+test('a missing or invalid prHeadSha fails closed as a head-sha blocker', () => {
+  for (const bad of ['', 'not-a-sha', 'ABCDEF', `${HEAD}extra`]) {
+    const report = readyReport();
+    report.prHeadSha = bad;
+    const blockers = evaluateMergeGates(report);
+    assert.ok(
+      blockers.some((b) => b.gate === 'head-sha'),
+      `expected a head-sha blocker for prHeadSha=${JSON.stringify(bad)}`,
+    );
+  }
+});
+
 test('dry-run on a ready report reports ready with the bound merge command', () => {
   const { deps, calls } = depsFor(readyReport());
   const { verdict, exitCode } = runMergeExecute(BASE_ARGS, deps);

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  evaluateMergeGates,
+  type MergeExecuteDeps,
+  runMergeExecute,
+} from '../src/scripts/idd-merge-execute.mts';
+
+const HEAD = '1111111111111111111111111111111111111111';
+const DRIFTED = '2222222222222222222222222222222222222222';
+
+// A pre-merge-readiness report whose every F3 gate is satisfied. Each
+// test mutates a shallow copy to flip exactly one gate.
+function readyReport(): Record<string, unknown> {
+  return {
+    prHeadSha: HEAD,
+    reviewCurrency: { comparisonRoute: 'proceed', comparisonReason: 'match' },
+    threads: { actionableCount: 0 },
+    advisoryWait: { f3Outcome: 'SATISFIED' },
+    ci: {
+      status: 'success',
+      requiredChecksPassing: true,
+      noRequiredChecksConfigured: false,
+      presentRunConclusion: 'all-passing',
+    },
+    reviewerStates: {
+      requiredApprovalsSatisfied: true,
+      codeownerApprovalSatisfied: true,
+      codeownerSelfApproval: { status: 'not_applicable' },
+    },
+    claim: { matchesExpectedClaim: true, reason: 'match' },
+    dispositionEvidence: { route: 'proceed', blockingCount: 0 },
+  };
+}
+
+// Build injectable deps from a fixed report; record merge attempts so a
+// test can assert merge did or did not happen.
+function depsFor(
+  report: Record<string, unknown>,
+  overrides: Partial<MergeExecuteDeps> = {},
+): { deps: MergeExecuteDeps; calls: { merged: string[] } } {
+  const calls = { merged: [] as string[] };
+  const deps: MergeExecuteDeps = {
+    collect: () => report,
+    fetchHeadSha: () => String(report.prHeadSha ?? ''),
+    mergePr: (prNumber, headSha) => {
+      calls.merged.push(`${prNumber}:${headSha}`);
+      return 'Merged PR.';
+    },
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+const BASE_ARGS = ['--pr', '994', '--claim-issue', '309', '--claim-id', 'c-1'];
+
+test('evaluateMergeGates returns no blockers for a fully ready report', () => {
+  assert.deepEqual(evaluateMergeGates(readyReport()), []);
+});
+
+test('dry-run on a ready report reports ready with the bound merge command', () => {
+  const { deps, calls } = depsFor(readyReport());
+  const { verdict, exitCode } = runMergeExecute(BASE_ARGS, deps);
+
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.blockers, []);
+  assert.equal(verdict.mode, 'dry-run');
+  assert.equal(verdict.decisionAuthority, 'instructions');
+  assert.equal(
+    verdict.mergeCommand,
+    `gh pr merge 994 --merge --match-head-commit ${HEAD}`,
+  );
+  // Dry-run NEVER merges.
+  assert.equal(verdict.merged, false);
+  assert.deepEqual(calls.merged, []);
+  assert.equal(exitCode, 0);
+});
+
+test('a failing gate becomes a blocker and blocks readiness', () => {
+  const report = readyReport();
+  report.advisoryWait = { f3Outcome: 'WAIT' };
+  const { deps } = depsFor(report);
+  const { verdict, exitCode } = runMergeExecute(BASE_ARGS, deps);
+
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.blockers.length, 1);
+  assert.equal(verdict.blockers[0]?.gate, 'advisory-wait');
+  assert.match(verdict.blockers[0]?.detail ?? '', /WAIT/);
+  assert.equal(exitCode, 1);
+});
+
+test('every F3 gate maps to its own blocker', () => {
+  const cases: [string, (r: Record<string, unknown>) => void][] = [
+    [
+      'review-currency',
+      (r) => {
+        r.reviewCurrency = {
+          comparisonRoute: 'return-to-e1',
+          comparisonReason: 'newer-activity',
+        };
+      },
+    ],
+    ['unresolved-threads', (r) => (r.threads = { actionableCount: 2 })],
+    ['advisory-wait', (r) => (r.advisoryWait = { f3Outcome: 'HOLD' })],
+    [
+      'ci',
+      (r) =>
+        (r.ci = {
+          status: 'pending',
+          requiredChecksPassing: false,
+          noRequiredChecksConfigured: false,
+          presentRunConclusion: 'pending',
+        }),
+    ],
+    [
+      'required-reviews',
+      (r) =>
+        (r.reviewerStates = {
+          requiredApprovalsSatisfied: false,
+          codeownerApprovalSatisfied: true,
+          codeownerSelfApproval: { status: 'not_applicable' },
+        }),
+    ],
+    [
+      'claim-ownership',
+      (r) =>
+        (r.claim = {
+          matchesExpectedClaim: false,
+          reason: 'claim-id-mismatch',
+        }),
+    ],
+    [
+      'disposition-evidence',
+      (r) =>
+        (r.dispositionEvidence = {
+          route: 'return-to-e1',
+          blockingCount: 1,
+        }),
+    ],
+  ];
+
+  for (const [gate, mutate] of cases) {
+    const report = readyReport();
+    mutate(report);
+    const blockers = evaluateMergeGates(report);
+    assert.deepEqual(
+      blockers.map((b) => b.gate),
+      [gate],
+      `expected sole blocker ${gate}`,
+    );
+  }
+});
+
+test('CI all-passing accepts the no-required-checks fallback', () => {
+  const report = readyReport();
+  report.ci = {
+    status: 'unknown',
+    requiredChecksPassing: false,
+    noRequiredChecksConfigured: true,
+    presentRunConclusion: 'all-passing',
+  };
+  assert.deepEqual(evaluateMergeGates(report), []);
+
+  // ...but a vacuous "no checks at all" must NOT satisfy CI.
+  report.ci = {
+    status: 'unknown',
+    requiredChecksPassing: false,
+    noRequiredChecksConfigured: true,
+    presentRunConclusion: 'none',
+  };
+  assert.deepEqual(
+    evaluateMergeGates(report).map((b) => b.gate),
+    ['ci'],
+  );
+});
+
+test('required-reviews clears on a clear codeowner self-approval bypass', () => {
+  const report = readyReport();
+  report.reviewerStates = {
+    requiredApprovalsSatisfied: true,
+    codeownerApprovalSatisfied: false,
+    codeownerSelfApproval: { status: 'clear' },
+  };
+  assert.deepEqual(evaluateMergeGates(report), []);
+});
+
+test('--apply merges a ready PR bound to the validated head', () => {
+  const { deps, calls } = depsFor(readyReport());
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
+
+  assert.equal(verdict.mode, 'apply');
+  assert.equal(verdict.ready, true);
+  assert.equal(verdict.merged, true);
+  assert.deepEqual(calls.merged, [`994:${HEAD}`]);
+  assert.equal(exitCode, 0);
+});
+
+test('--apply on a blocked gate fails closed without merging', () => {
+  const report = readyReport();
+  report.advisoryWait = { f3Outcome: 'WAIT' };
+  const { deps, calls } = depsFor(report);
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
+
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.merged, false);
+  assert.deepEqual(calls.merged, []);
+  assert.match(verdict.mergeResult, /not-ready/);
+  assert.equal(exitCode, 1);
+});
+
+test('--apply fails closed when the head drifts before merge', () => {
+  // Live head re-fetch returns a different SHA than the validated head.
+  const { deps, calls } = depsFor(readyReport(), {
+    fetchHeadSha: () => DRIFTED,
+  });
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
+
+  assert.equal(verdict.merged, false);
+  assert.deepEqual(calls.merged, []);
+  assert.match(verdict.mergeResult, /head drift/);
+  assert.equal(exitCode, 1);
+});
+
+test('--apply fails closed when re-validation finds head drift', () => {
+  // Head re-fetch agrees, but the re-validation collect reports a moved head.
+  let collectCount = 0;
+  const { deps, calls } = depsFor(readyReport(), {
+    collect: () => {
+      collectCount += 1;
+      const report = readyReport();
+      if (collectCount >= 2) {
+        report.prHeadSha = DRIFTED;
+      }
+      return report;
+    },
+  });
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
+
+  assert.equal(verdict.merged, false);
+  assert.deepEqual(calls.merged, []);
+  assert.match(verdict.mergeResult, /head drift on re-validation/);
+  assert.equal(exitCode, 1);
+});
+
+test('--apply fails closed when the claim is lost on re-validation', () => {
+  let collectCount = 0;
+  const { deps, calls } = depsFor(readyReport(), {
+    collect: () => {
+      collectCount += 1;
+      const report = readyReport();
+      if (collectCount >= 2) {
+        report.claim = { matchesExpectedClaim: false, reason: 'claim-lost' };
+      }
+      return report;
+    },
+  });
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
+
+  assert.equal(verdict.merged, false);
+  assert.deepEqual(calls.merged, []);
+  assert.match(verdict.mergeResult, /claim lost on re-validation/);
+  assert.equal(exitCode, 1);
+});
+
+test('--apply fails closed when a new blocker appears at re-validation', () => {
+  let collectCount = 0;
+  const { deps, calls } = depsFor(readyReport(), {
+    collect: () => {
+      collectCount += 1;
+      const report = readyReport();
+      if (collectCount >= 2) {
+        report.threads = { actionableCount: 1 };
+      }
+      return report;
+    },
+  });
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
+
+  assert.equal(verdict.merged, false);
+  assert.deepEqual(calls.merged, []);
+  assert.equal(verdict.ready, false);
+  assert.match(verdict.mergeResult, /new blockers/);
+  assert.equal(exitCode, 1);
+});
+
+test('missing --pr is rejected', () => {
+  assert.throws(
+    () =>
+      runMergeExecute(['--claim-issue', '309'], depsFor(readyReport()).deps),
+    /missing required --pr/,
+  );
+});

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -167,6 +167,22 @@ test('every F3 gate maps to its own blocker', () => {
   }
 });
 
+test('disposition-evidence blocks when route is proceed but blockingCount is non-zero', () => {
+  const report = readyReport();
+  report.dispositionEvidence = { route: 'proceed', blockingCount: 1 };
+  const blockers = evaluateMergeGates(report);
+  assert.deepEqual(
+    blockers.map((b) => b.gate),
+    ['disposition-evidence'],
+  );
+  assert.match(blockers[0]?.detail ?? '', /blockingCount=1/);
+
+  const { deps } = depsFor(report);
+  const { verdict, exitCode } = runMergeExecute(BASE_ARGS, deps);
+  assert.equal(verdict.ready, false);
+  assert.equal(exitCode, 1);
+});
+
 test('CI all-passing accepts the no-required-checks fallback', () => {
   const report = readyReport();
   report.ci = {

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import type { AdvisoryWaitStateReport } from '../src/scripts/advisory-wait-state.mts';
 import type { BranchConflictResult } from '../src/scripts/branch-conflict-state.mts';
 import type { RoadmapGraphUnionReport } from '../src/scripts/discover-roadmap-graph.mts';
+import type { IddMergeExecuteVerdict } from '../src/scripts/idd-merge-execute.mts';
 import type { PreMergeReadinessReport } from '../src/scripts/pre-merge-readiness.mts';
 import type {
   LiveStatusDigestFields,
@@ -295,6 +296,19 @@ export const discoverRoadmapUnionKeys = [
   'summary',
 ] as const satisfies readonly (keyof RoadmapGraphUnionReport)[];
 
+export const iddMergeExecuteKeys = [
+  'protocolVersion',
+  'decisionAuthority',
+  'mode',
+  'prNumber',
+  'prHeadSha',
+  'ready',
+  'blockers',
+  'mergeCommand',
+  'merged',
+  'mergeResult',
+] as const satisfies readonly (keyof IddMergeExecuteVerdict)[];
+
 export const forcedHandoffMarkerKeys = [
   'oldAgentId',
   'oldClaimId',
@@ -444,6 +458,10 @@ const exhaustivenessWitnesses: {
     ParsedForcedHandoffMarker,
     (typeof forcedHandoffMarkerKeys)[number]
   >;
+  iddMergeExecute: CoversAllKeysOf<
+    IddMergeExecuteVerdict,
+    (typeof iddMergeExecuteKeys)[number]
+  >;
   liveStatusDigest: CoversAllKeysOf<
     LiveStatusDigestFields,
     (typeof liveStatusDigestKeys)[number]
@@ -466,6 +484,7 @@ const exhaustivenessWitnesses: {
   claimMarker: true,
   discoverRoadmapUnion: true,
   forcedHandoffMarker: true,
+  iddMergeExecute: true,
   liveStatusDigest: true,
   phaseGraph: true,
   policyConfig: true,
@@ -605,6 +624,25 @@ const forcedHandoffMarkerFixture = {
   contextScope: 'issue-plus-pr',
   createdAt: '2026-05-12T11:00:05Z',
 } satisfies ParsedForcedHandoffMarker;
+
+const iddMergeExecuteFixture = {
+  protocolVersion: '1',
+  decisionAuthority: 'instructions',
+  mode: 'dry-run',
+  prNumber: 994,
+  prHeadSha: '0123456789abcdef0123456789abcdef01234567',
+  ready: false,
+  blockers: [
+    {
+      gate: 'advisory-wait',
+      detail: 'f3Outcome is "WAIT" (expected "SATISFIED")',
+    },
+  ],
+  mergeCommand:
+    'gh pr merge 994 --merge --match-head-commit 0123456789abcdef0123456789abcdef01234567',
+  merged: false,
+  mergeResult: '',
+} satisfies IddMergeExecuteVerdict;
 
 const liveStatusDigestFixture = {
   phase: 'E1',
@@ -924,6 +962,13 @@ const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
     owningModule: 'src/scripts/protocol-helpers.mts',
     keys: forcedHandoffMarkerKeys,
     fixture: forcedHandoffMarkerFixture,
+  },
+  {
+    schemaFile: 'idd-merge-execute.schema.json',
+    exportedType: 'IddMergeExecuteVerdict',
+    owningModule: 'src/scripts/idd-merge-execute.mts',
+    keys: iddMergeExecuteKeys,
+    fixture: iddMergeExecuteFixture,
   },
   {
     schemaFile: 'live-status-digest.schema.json',

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -64,6 +64,27 @@ test('pre-merge-readiness schema publishes metadata fields', () => {
   );
 });
 
+test('idd-merge-execute schema uses only allowed keywords', () => {
+  const schema = loadJson('schemas/idd-merge-execute.schema.json');
+  assert.deepEqual(checkSchemaKeywords(schema), []);
+});
+
+test('idd-merge-execute schema publishes metadata fields', () => {
+  const schema = loadJson(
+    'schemas/idd-merge-execute.schema.json',
+  ) as JsonRecord;
+  assert.equal(schema.$schema, 'https://json-schema.org/draft/2020-12/schema');
+  assert.equal(
+    schema.$id,
+    'https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json',
+  );
+  assert.equal(schema.title, 'IDD Merge Execute');
+  assert.equal(
+    schema.description,
+    'F3 merge-gate verdict and (under --apply) execution result for a PR head.',
+  );
+});
+
 test('policy schema uses only allowed keywords', () => {
   const schema = loadJson('schemas/policy.schema.json');
   assert.deepEqual(checkSchemaKeywords(schema), []);
@@ -183,6 +204,24 @@ test('advisory-wait-state invalid fixture fails validation', () => {
   const { ok } = validateFixture(
     'schemas/advisory-wait-state.schema.json',
     'fixtures/schemas/advisory-wait-state.invalid.json',
+    false,
+  );
+  assert.ok(ok, 'Expected invalid fixture to fail schema validation');
+});
+
+test('idd-merge-execute valid fixture passes validation', () => {
+  const { ok, errors } = validateFixture(
+    'schemas/idd-merge-execute.schema.json',
+    'fixtures/schemas/idd-merge-execute.valid.json',
+    true,
+  );
+  assert.ok(ok, errors.join('\n'));
+});
+
+test('idd-merge-execute invalid fixture fails validation', () => {
+  const { ok } = validateFixture(
+    'schemas/idd-merge-execute.schema.json',
+    'fixtures/schemas/idd-merge-execute.invalid.json',
     false,
   );
   assert.ok(ok, 'Expected invalid fixture to fail schema validation');


### PR DESCRIPTION
## Summary

`pre-merge-readiness` is the authoritative, read-only source of F3 merge
evidence, but it emits no merge command and has no apply mode — so F3's
GO/NO-GO **decision** plus the bound `gh pr merge` were re-assembled by
hand on every merge (one of which carried the shell-comparison bug
hardened in #993).

This ships a thin **`idd-merge-execute`** helper that wraps
`pre-merge-readiness`, re-runs the full F3 gate against live state, and
optionally executes the bound merge — without becoming a new decision
authority (`decisionAuthority: "instructions"`).

- **Refactor** `pre-merge-readiness` to export `collectPreMergeReadiness`
  (CLI output unchanged, gated on direct invocation) so the gate logic is
  reused, not duplicated.
- **Dry-run (default):** emits `{ ready, blockers, mergeCommand }` with
  `mergeCommand` bound to the freshly fetched head. `ready` requires every
  F3 gate: review currency `proceed`, unresolved actionable threads `0`,
  advisory `f3Outcome == SATISFIED`, CI all-passing (vacuous green
  blocks), required/CODEOWNER reviews satisfied (deadlock blocks), claim
  ownership, and disposition evidence `proceed`.
- **`--apply`:** re-fetches the head and re-validates the claim immediately
  before merging; **fails closed** (no merge) on head drift, lost claim,
  or any new blocker; then runs `gh pr merge --merge --match-head-commit
  <validated-head>` as the sole mutation (merge commit only).
- Stable `schemas/idd-merge-execute.schema.json` + fixtures + 13 tests
  (including every fail-closed path), wired into the schema↔type
  reconciliation and validation harness.
- F3 in `idd-merge.instructions.md` now prefers the helper while keeping
  the written decision table / gate checklist and the manual fallback
  (both `exact`-mode copies). No safety guidance removed.

## Verification

`pnpm run lint:minimum` passes (audit-docs --check, build:check, tsc,
biome, dprint, 1110 tests, cspell, markdownlint). The
`pre-merge-readiness` refactor is behavior-preserving (its 118 tests pass;
CLI JSON byte-identical). This PR is itself merged via the existing manual
F3 path; the helper is now available for subsequent merges.

Raises `bundle-merge` limitBytes 85500 → 86200 for the F3 rewrite.

Closes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgWE9Zk471naViV3AExSJ4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an F3 merge-execution helper with **dry-run** verdict output and an optional **apply** mode to perform merges.
  * Updated merge guidance to prefer the helper when available, with a safe fallback to the manual gate if helper evidence can’t be trusted.
  * Introduced a new merge-execution schema plus validation fixtures.

* **Bug Fixes**
  * Apply mode now re-checks the live PR state immediately before merging and **fails closed** on drift, lost claim, or newly failing gates.
  * Ensures merges occur as a merge commit bound to the validated head (no squash/rebase).

* **Tests**
  * Expanded schema validation, schema/type reconciliation, and merge-helper behavior tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->