### PR TITLE
feat(idd): add opt-in --with-claim-state to discover-roadmap-graph

### DIFF
--- a/fixtures/schemas/discover-roadmap-union.valid.json
+++ b/fixtures/schemas/discover-roadmap-union.valid.json
@@ -23,7 +23,15 @@
       "classification": "execution",
       "roadmapMarkerId": "",
       "autopilotSuitability": 5,
-      "sourceRoots": [100]
+      "sourceRoots": [100],
+      "activeClaim": {
+        "present": true,
+        "stale": false,
+        "claimId": "claim-20260625T000000Z-101",
+        "agentId": "github-copilot-cli",
+        "ownedByCurrentSession": false
+      },
+      "claimEligible": false
     },
     {
       "number": 201,
@@ -33,7 +41,9 @@
       "classification": "execution",
       "roadmapMarkerId": "",
       "autopilotSuitability": null,
-      "sourceRoots": [100, 200]
+      "sourceRoots": [100, 200],
+      "activeClaim": null,
+      "claimEligible": true
     }
   ],
   "diagnostics": {

--- a/fixtures/schemas/discover-roadmap-union.valid.json
+++ b/fixtures/schemas/discover-roadmap-union.valid.json
@@ -42,7 +42,12 @@
       "roadmapMarkerId": "",
       "autopilotSuitability": null,
       "sourceRoots": [100, 200],
-      "activeClaim": null,
+      "activeClaim": {
+        "present": false,
+        "stale": false,
+        "claimId": null,
+        "agentId": null
+      },
       "claimEligible": true
     }
   ],

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -107,7 +107,8 @@
             }
           },
           "activeClaim": {
-            "description": "Active-claim annotation, present only under --with-claim-state, where it is always an object (Design O): present:false (with claimId:null, agentId:null) means no trusted claim is present, present:true means one exists (possibly stale). The object is constrained by `required` + `properties` + `additionalProperties: false`; the runtime contract is { present, stale, claimId, agentId, ownedByCurrentSession? }. ownedByCurrentSession is intentionally absent from `required`: it is emitted only with --current-claim-id.",
+            "description": "Active-claim annotation, present only under --with-claim-state, where it is always an object (Design O): present:false (with claimId:null, agentId:null) means no trusted claim is present, present:true means one exists (possibly stale). The object is constrained by `type: object` + `required` + `properties` + `additionalProperties: false`; the runtime contract is { present, stale, claimId, agentId, ownedByCurrentSession? }. ownedByCurrentSession is intentionally absent from `required`: it is emitted only with --current-claim-id.",
+            "type": "object",
             "required": [
               "present",
               "stale",

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -107,7 +107,7 @@
             }
           },
           "activeClaim": {
-            "description": "Active-claim annotation, present only under --with-claim-state. Either null (no present trusted claim) or an object describing the resolved active claim. The in-repo validator has no union `type` / `oneOf` support, so the object case is constrained by `properties` + `additionalProperties: false` (applied only when the value is an object) while `null` passes the type-free check; the runtime contract is null | { present, stale, claimId, agentId, ownedByCurrentSession? }.",
+            "description": "Active-claim annotation, present only under --with-claim-state, where it is always an object (Design O): present:false (with claimId:null, agentId:null) means no trusted claim is present, present:true means one exists (possibly stale). The object is constrained by `properties` + `additionalProperties: false`; the runtime contract is { present, stale, claimId, agentId, ownedByCurrentSession? }.",
             "additionalProperties": false,
             "properties": {
               "present": {
@@ -117,10 +117,10 @@
                 "type": "boolean"
               },
               "claimId": {
-                "description": "Active claim id (string), or null when no claim is present. The in-repo validator cannot express the `string | null` union, so no `type` is declared here; the runtime contract is string | null."
+                "description": "Active claim id (string) when present:true, or null when present:false. The in-repo validator cannot express the `string | null` union, so no `type` is declared here; the runtime contract is string | null."
               },
               "agentId": {
-                "description": "Active claim agent id (string), or null when no claim is present. The in-repo validator cannot express the `string | null` union, so no `type` is declared here; the runtime contract is string | null."
+                "description": "Active claim agent id (string) when present:true, or null when present:false. The in-repo validator cannot express the `string | null` union, so no `type` is declared here; the runtime contract is string | null."
               },
               "ownedByCurrentSession": {
                 "description": "Present only when --current-claim-id is supplied: true when the active claim's claimId equals it.",

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -107,7 +107,13 @@
             }
           },
           "activeClaim": {
-            "description": "Active-claim annotation, present only under --with-claim-state, where it is always an object (Design O): present:false (with claimId:null, agentId:null) means no trusted claim is present, present:true means one exists (possibly stale). The object is constrained by `properties` + `additionalProperties: false`; the runtime contract is { present, stale, claimId, agentId, ownedByCurrentSession? }.",
+            "description": "Active-claim annotation, present only under --with-claim-state, where it is always an object (Design O): present:false (with claimId:null, agentId:null) means no trusted claim is present, present:true means one exists (possibly stale). The object is constrained by `required` + `properties` + `additionalProperties: false`; the runtime contract is { present, stale, claimId, agentId, ownedByCurrentSession? }. ownedByCurrentSession is intentionally absent from `required`: it is emitted only with --current-claim-id.",
+            "required": [
+              "present",
+              "stale",
+              "claimId",
+              "agentId"
+            ],
             "additionalProperties": false,
             "properties": {
               "present": {

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -105,6 +105,32 @@
               "type": "integer",
               "minimum": 1
             }
+          },
+          "activeClaim": {
+            "description": "Active-claim annotation, present only under --with-claim-state. Either null (no present trusted claim) or an object describing the resolved active claim. The in-repo validator has no union `type` / `oneOf` support, so the object case is constrained by `properties` + `additionalProperties: false` (applied only when the value is an object) while `null` passes the type-free check; the runtime contract is null | { present, stale, claimId, agentId, ownedByCurrentSession? }.",
+            "additionalProperties": false,
+            "properties": {
+              "present": {
+                "type": "boolean"
+              },
+              "stale": {
+                "type": "boolean"
+              },
+              "claimId": {
+                "description": "Active claim id (string), or null when no claim is present. The in-repo validator cannot express the `string | null` union, so no `type` is declared here; the runtime contract is string | null."
+              },
+              "agentId": {
+                "description": "Active claim agent id (string), or null when no claim is present. The in-repo validator cannot express the `string | null` union, so no `type` is declared here; the runtime contract is string | null."
+              },
+              "ownedByCurrentSession": {
+                "description": "Present only when --current-claim-id is supplied: true when the active claim's claimId equals it.",
+                "type": "boolean"
+              }
+            }
+          },
+          "claimEligible": {
+            "description": "Derived eligibility, present only under --with-claim-state: true when no present, non-stale, trusted-actor claim blocks this leaf.",
+            "type": "boolean"
           }
         }
       }

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -13,6 +13,7 @@ import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mjs';
+import { parseIsoDurationToMs } from './policy-helpers.mjs';
 import { isStaleAt, resolveActiveClaim } from './protocol-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
@@ -658,8 +659,10 @@ export async function annotateLeafClaimState(issueNumber, claimState) {
       isClaimStaleByAge(activeCreatedAt, nextCreatedAt, claimState.staleAgeMs),
   });
   if (!active) {
-    // No present trusted claim → eligible. `ownedByCurrentSession` is omitted
-    // because there is no claim id to compare against.
+    // No present trusted claim → eligible. When `--current-claim-id` is
+    // supplied, `ownedByCurrentSession` is still emitted (as `false`) because
+    // there is no claim id to match it; it is omitted only when no
+    // `--current-claim-id` was passed.
     return {
       activeClaim: {
         present: false,
@@ -751,9 +754,12 @@ function buildClaimStateResolution(owner, repo, policy, currentClaimId) {
     DEFAULT_CLAIM_STALE_AGE_MS;
   return {
     loadComments: buildCommentLoader(owner, repo),
-    // When no trusted actors are configured, every author is distrusted so no
-    // claim resolves — fail closed (a leaf reads as eligible) rather than
-    // honoring an unverifiable claim marker.
+    // When `trustedMarkerActors` is empty no author is trusted, so no claim
+    // resolves and every leaf reads as `claimEligible: true`. This is a soft,
+    // availability-preferring default for the advisory discovery hint (it does
+    // NOT fail closed on eligibility): an unverifiable claim marker is simply
+    // not honored. The authoritative A5 claim gate (idd-claim.instructions.md)
+    // remains the real protection against acting on a contested claim.
     isTrustedAuthor: (login) =>
       trustedActors.has(
         String(login ?? '')
@@ -793,27 +799,17 @@ function buildCommentLoader(owner, repo) {
  * Parse an ISO8601 duration (`P[nD]T[nH][nM][nS]`) to ms; `null` on garbage OR
  * a non-positive total. A `PT0S` (or any zero/empty-component) duration is
  * rejected so the caller falls back to `DEFAULT_CLAIM_STALE_AGE_MS` instead of
- * configuring a 0ms stale age that would mark every claim immediately stale —
- * matching `parseIsoDurationToMs` in policy-helpers, which likewise returns
- * `null` for a non-positive duration.
+ * configuring a 0ms stale age that would mark every claim immediately stale.
+ *
+ * Thin wrapper over the shared `parseIsoDurationToMs` from policy-helpers
+ * (the single source of truth for ISO-8601 duration parsing, with its own
+ * tests). It already returns `null` for both garbage and a non-positive total,
+ * which is exactly the behavior required here. The unknown input is coerced to
+ * a trimmed string first so non-string/nullish values resolve to `null`
+ * (the shared parser accepts only strings).
  */
 export function parseClaimStaleAgeMs(value) {
-  const text = String(value ?? '').trim();
-  if (!text) {
-    return null;
-  }
-  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i.exec(
-    text,
-  );
-  if (!match) {
-    return null;
-  }
-  const days = Number.parseInt(match[1] ?? '0', 10);
-  const hours = Number.parseInt(match[2] ?? '0', 10);
-  const minutes = Number.parseInt(match[3] ?? '0', 10);
-  const seconds = Number.parseInt(match[4] ?? '0', 10);
-  const totalMs = (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
-  return totalMs > 0 ? totalMs : null;
+  return parseIsoDurationToMs(String(value ?? '').trim());
 }
 export function extractRoadmapMarkerId(
   body,
@@ -1011,8 +1007,14 @@ function parseArgs(argv) {
       continue;
     }
     if (token === '--current-claim-id') {
-      parsed.currentClaimId = value ?? '';
-      index += 1;
+      // Only consume the next token as the id when it exists and is not itself
+      // a flag, so `--current-claim-id --with-claim-state` does not swallow the
+      // following flag as the id. A missing/flag value leaves currentClaimId
+      // empty and the next flag is left for its own iteration.
+      if (value !== undefined && !value.startsWith('--')) {
+        parsed.currentClaimId = value;
+        index += 1;
+      }
       continue;
     }
     if (token === '--help' || token === '-h') {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -626,10 +626,12 @@ function normalizeOpenRoadmapRootNumbers(roots) {
  * Fetches the leaf issue's comments via the injected `loadComments` loader,
  * resolves the ACTIVE claim with the SHARED `resolveActiveClaim` from
  * protocol-helpers (trusted-author gated, stale-age aware), then derives
- * present/stale/eligibility. A leaf is eligible when there is NO present,
- * non-stale, trusted-actor claim. The shared `parseClaimComment` /
- * `resolveActiveClaim` parsing is reused read-only and never re-implemented
- * here.
+ * present/stale/eligibility. `activeClaim` is ALWAYS returned as an object
+ * (Design O): `present: false` (with `claimId: null`, `agentId: null`) when no
+ * trusted claim is present, `present: true` otherwise. A leaf is eligible when
+ * there is NO present, non-stale, trusted-actor claim. The shared
+ * `parseClaimComment` / `resolveActiveClaim` parsing is reused read-only and
+ * never re-implemented here.
  */
 export async function annotateLeafClaimState(issueNumber, claimState) {
   const comments = normalizeClaimComments(
@@ -775,8 +777,15 @@ function buildCommentLoader(owner, repo) {
     return comments;
   };
 }
-/** Parse an ISO8601 duration (`P[nD]T[nH][nM][nS]`) to ms; null on garbage. */
-function parseClaimStaleAgeMs(value) {
+/**
+ * Parse an ISO8601 duration (`P[nD]T[nH][nM][nS]`) to ms; `null` on garbage OR
+ * a non-positive total. A `PT0S` (or any zero/empty-component) duration is
+ * rejected so the caller falls back to `DEFAULT_CLAIM_STALE_AGE_MS` instead of
+ * configuring a 0ms stale age that would mark every claim immediately stale —
+ * matching `parseIsoDurationToMs` in policy-helpers, which likewise returns
+ * `null` for a non-positive duration.
+ */
+export function parseClaimStaleAgeMs(value) {
   const text = String(value ?? '').trim();
   if (!text) {
     return null;
@@ -791,7 +800,8 @@ function parseClaimStaleAgeMs(value) {
   const hours = Number.parseInt(match[2] ?? '0', 10);
   const minutes = Number.parseInt(match[3] ?? '0', 10);
   const seconds = Number.parseInt(match[4] ?? '0', 10);
-  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
+  const totalMs = (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
+  return totalMs > 0 ? totalMs : null;
 }
 export function extractRoadmapMarkerId(
   body,
@@ -1014,8 +1024,9 @@ function printHelp() {
   --with-claim-state (opt-in) annotates each OPEN execution leaf with active-
   claim eligibility: it fetches that issue's comments and resolves the active
   claim using the configured trustedMarkerActors and claimTiming.staleAge
-  (default PT24H). Each annotated leaf gains:
-    "activeClaim": { "present": bool, "stale": bool, "claimId": str|null, "agentId": str|null } | null
+  (default PT24H). Each annotated leaf gains (activeClaim is always an object):
+    "activeClaim": { "present": bool, "stale": bool, "claimId": str|null, "agentId": str|null }
+                   (present:false with claimId/agentId null = no trusted claim)
     "claimEligible": bool   (eligible = no present, non-stale, trusted claim)
   Absent the flag, NO comment API calls are made and no claim fields are
   emitted (the output shape is byte-stable).

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -14,7 +14,11 @@ import {
   parseAutopilotSuitability,
 } from './autopilot-suitability.mjs';
 import { parseIsoDurationToMs } from './policy-helpers.mjs';
-import { isStaleAt, resolveActiveClaim } from './protocol-helpers.mjs';
+import {
+  isStaleAt,
+  resolveActiveClaim,
+  resolveTrustedMarkerActors,
+} from './protocol-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
@@ -737,39 +741,47 @@ function isClaimStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs) {
  * never wired in the default path.
  */
 function buildClaimStateResolution(owner, repo, policy, currentClaimId) {
-  const trustedActors = new Set(
-    (Array.isArray(policy.trustedMarkerActors)
-      ? policy.trustedMarkerActors
-      : []
-    )
-      .map((value) =>
-        String(value ?? '')
-          .trim()
-          .toLowerCase(),
-      )
-      .filter(Boolean),
-  );
   const staleAgeMs =
     parseClaimStaleAgeMs(policy.claimTiming?.staleAge) ??
     DEFAULT_CLAIM_STALE_AGE_MS;
   return {
     loadComments: buildCommentLoader(owner, repo),
-    // When `trustedMarkerActors` is empty no author is trusted, so no claim
-    // resolves and every leaf reads as `claimEligible: true`. This is a soft,
-    // availability-preferring default for the advisory discovery hint (it does
-    // NOT fail closed on eligibility): an unverifiable claim marker is simply
-    // not honored. The authoritative A5 claim gate (idd-claim.instructions.md)
-    // remains the real protection against acting on a contested claim.
-    isTrustedAuthor: (login) =>
-      trustedActors.has(
-        String(login ?? '')
-          .trim()
-          .toLowerCase(),
-      ),
+    isTrustedAuthor: buildTrustedAuthorPredicate(policy),
     staleAgeMs,
     nowIso: new Date().toISOString(),
     currentClaimId: String(currentClaimId ?? '').trim(),
   };
+}
+/**
+ * Build the case-insensitive trusted-marker-author predicate for the
+ * `--with-claim-state` annotation.
+ *
+ * Trusted actors are resolved through the shared
+ * {@link resolveTrustedMarkerActors} helper so this CLI honors the
+ * `IDD_TRUSTED_MARKER_ACTORS` env override exactly like every other evidence
+ * helper, not just the `trustedMarkerActors` array declared in policy. The
+ * resolved actors are already trimmed, lowercased, and deduped, so the
+ * predicate only needs to normalize the incoming login the same way.
+ *
+ * When the resolved set is empty no author is trusted, so no claim resolves
+ * and every leaf reads as `claimEligible: true`. This is a soft,
+ * availability-preferring default for the advisory discovery hint (it does
+ * NOT fail closed on eligibility): an unverifiable claim marker is simply not
+ * honored. The authoritative A5 claim gate (idd-claim.instructions.md) remains
+ * the real protection against acting on a contested claim.
+ */
+export function buildTrustedAuthorPredicate(policy) {
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: policy,
+  });
+  const trustedActors = new Set(actors);
+  return (login) =>
+    trustedActors.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
 }
 /** Live per-issue comment loader (the sole new GitHub API surface). */
 function buildCommentLoader(owner, repo) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -13,8 +13,14 @@ import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mjs';
+import { isStaleAt, resolveActiveClaim } from './protocol-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
+// the default baked into protocol-helpers' `isStaleAt`, so when the configured
+// stale age equals this default the shared `isStaleAt` path is
+// reused verbatim instead of re-deriving the 24h math here.
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
 });
@@ -79,6 +85,14 @@ if (isMainModule(import.meta.url)) {
   const repo =
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
   const policy = loadPolicy(args.policy);
+  // The claim-state annotation is strictly opt-in: only when --with-claim-state
+  // is passed do we build the comment loader (the sole new GitHub API surface)
+  // and resolve the trusted-actor / stale-age policy. The default path leaves
+  // `claimState` undefined, so no extra fetch is made and the output is
+  // byte-stable.
+  const claimState = args.withClaimState
+    ? buildClaimStateResolution(owner, repo, policy, args.currentClaimId)
+    : undefined;
   const report = args.allRoadmaps
     ? await enumerateAllRoadmapsGraph({
         markerPrefix: policy.markerPrefix,
@@ -92,6 +106,7 @@ if (isMainModule(import.meta.url)) {
           repo,
           policy.markerPrefix,
         ),
+        claimState,
       })
     : await enumerateRoadmapGraph(args.issue, {
         markerPrefix: policy.markerPrefix,
@@ -99,6 +114,7 @@ if (isMainModule(import.meta.url)) {
         repo,
         loadIssue: buildIssueLoader(owner, repo),
         loadSubIssues: buildSubIssueLoader(owner, repo),
+        claimState,
       });
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
 }
@@ -176,6 +192,23 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   const rootNode = nodeRecords.get(rootIssue.number);
   if (!rootNode) {
     throw new Error(`root issue #${rootIssueNumber} was not recorded`);
+  }
+  // Opt-in (#1008): annotate each open execution-leaf node with active-claim
+  // eligibility. Gated on `options.claimState` so the default path makes no
+  // extra GitHub API call and the output shape stays byte-stable.
+  if (options.claimState) {
+    const executionCandidateSet = new Set(executionCandidates);
+    for (const node of nodes) {
+      if (!executionCandidateSet.has(node.number)) {
+        continue;
+      }
+      const annotated = await annotateLeafClaimState(
+        node.number,
+        options.claimState,
+      );
+      node.activeClaim = annotated.activeClaim;
+      node.claimEligible = annotated.claimEligible;
+    }
   }
   return {
     root: {
@@ -484,6 +517,21 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
       sourceRoots: [...leaf.sourceRoots].sort((left, right) => left - right),
     }))
     .sort((left, right) => compareUnionLeaves(left, right, floor));
+  // Opt-in (#1008): annotate the deduped union leaves once each. The per-root
+  // enumerations above intentionally run without `claimState`, so each issue's
+  // comments are fetched at most once here regardless of how many roots reach
+  // it. Gated on `options.claimState`, so the default path adds no extra
+  // GitHub API call and the union output shape stays byte-stable.
+  if (options.claimState) {
+    for (const leaf of leaves) {
+      const annotated = await annotateLeafClaimState(
+        leaf.number,
+        options.claimState,
+      );
+      leaf.activeClaim = annotated.activeClaim;
+      leaf.claimEligible = annotated.claimEligible;
+    }
+  }
   const scoredLeafCount = leaves.filter((leaf) =>
     isAutopilotSuitabilityScore(leaf.autopilotSuitability),
   ).length;
@@ -571,6 +619,179 @@ function normalizeOpenRoadmapRootNumbers(roots) {
         .filter((value) => Number.isInteger(value) && value > 0),
     ),
   ].sort((left, right) => left - right);
+}
+/**
+ * Resolve one execution leaf's active-claim eligibility (#1008).
+ *
+ * Fetches the leaf issue's comments via the injected `loadComments` loader,
+ * resolves the ACTIVE claim with the SHARED `resolveActiveClaim` from
+ * protocol-helpers (trusted-author gated, stale-age aware), then derives
+ * present/stale/eligibility. A leaf is eligible when there is NO present,
+ * non-stale, trusted-actor claim. The shared `parseClaimComment` /
+ * `resolveActiveClaim` parsing is reused read-only and never re-implemented
+ * here.
+ */
+export async function annotateLeafClaimState(issueNumber, claimState) {
+  const comments = normalizeClaimComments(
+    await claimState.loadComments(issueNumber),
+  );
+  const active = resolveActiveClaim(comments, {
+    isTrustedAuthor: claimState.isTrustedAuthor,
+    // The 24h math is not re-derived: when the configured stale age equals the
+    // PT24H default, the shared `isStaleAt` is reused as-is;
+    // otherwise the same comparison is applied with the configured age.
+    isStale: (activeCreatedAt, nextCreatedAt) =>
+      isClaimStaleByAge(activeCreatedAt, nextCreatedAt, claimState.staleAgeMs),
+  });
+  if (!active) {
+    // No present trusted claim → eligible. `ownedByCurrentSession` is omitted
+    // because there is no claim id to compare against.
+    return {
+      activeClaim: {
+        present: false,
+        stale: false,
+        claimId: null,
+        agentId: null,
+        ...(claimState.currentClaimId ? { ownedByCurrentSession: false } : {}),
+      },
+      claimEligible: true,
+    };
+  }
+  // Staleness of the present claim is measured against "now": a claim whose
+  // createdAt is older than the configured stale age is a stale (takeover-
+  // eligible) claim, mirroring resume-claim-routing's active-claim staleness.
+  const stale = isClaimStaleByAge(
+    active.createdAt,
+    claimState.nowIso,
+    claimState.staleAgeMs,
+  );
+  const annotation = {
+    present: true,
+    stale,
+    claimId: active.claimId,
+    agentId: active.agentId,
+  };
+  if (claimState.currentClaimId) {
+    annotation.ownedByCurrentSession =
+      active.claimId === claimState.currentClaimId;
+  }
+  // Eligible only when there is no present, NON-stale, trusted claim. A stale
+  // claim is takeover-eligible, so it does not block.
+  return { activeClaim: annotation, claimEligible: stale };
+}
+/** Coerce a loaded comment payload into the `resolveActiveClaim` event shape. */
+function normalizeClaimComments(raw) {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.map((entry) => {
+    const comment = entry ?? {};
+    return {
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? comment.created_at ?? ''),
+      author: {
+        login: String(comment.author?.login ?? comment.user?.login ?? ''),
+      },
+    };
+  });
+}
+/**
+ * Claim staleness by configured age. When the configured age equals the PT24H
+ * policy default, the shared `isStaleAt` is reused verbatim
+ * (the 24h math lives there, not here); otherwise the same millisecond
+ * comparison is applied with the configured age. Mirrors
+ * resume-claim-routing's `isStaleByAge`.
+ */
+function isClaimStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs) {
+  if (staleAgeMs === DEFAULT_CLAIM_STALE_AGE_MS) {
+    return isStaleAt(activeCreatedAt, nextCreatedAt);
+  }
+  const start = Date.parse(activeCreatedAt ?? '');
+  const end = Date.parse(nextCreatedAt ?? '');
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    return false;
+  }
+  return end - start >= staleAgeMs;
+}
+/**
+ * Build the CLI-side claim-state resolution: the live comment loader plus the
+ * resolved trusted-actor predicate, configured stale age, and "now". Only
+ * invoked when `--with-claim-state` is passed, so the live comment fetch is
+ * never wired in the default path.
+ */
+function buildClaimStateResolution(owner, repo, policy, currentClaimId) {
+  const trustedActors = new Set(
+    (Array.isArray(policy.trustedMarkerActors)
+      ? policy.trustedMarkerActors
+      : []
+    )
+      .map((value) =>
+        String(value ?? '')
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+  const staleAgeMs =
+    parseClaimStaleAgeMs(policy.claimTiming?.staleAge) ??
+    DEFAULT_CLAIM_STALE_AGE_MS;
+  return {
+    loadComments: buildCommentLoader(owner, repo),
+    // When no trusted actors are configured, every author is distrusted so no
+    // claim resolves — fail closed (a leaf reads as eligible) rather than
+    // honoring an unverifiable claim marker.
+    isTrustedAuthor: (login) =>
+      trustedActors.has(
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      ),
+    staleAgeMs,
+    nowIso: new Date().toISOString(),
+    currentClaimId: String(currentClaimId ?? '').trim(),
+  };
+}
+/** Live per-issue comment loader (the sole new GitHub API surface). */
+function buildCommentLoader(owner, repo) {
+  return (issueNumber) => {
+    const comments = [];
+    const pageSize = 100;
+    for (let page = 1; ; page += 1) {
+      const raw = runGh([
+        'api',
+        `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+        '--jq',
+        '.',
+      ]).trim();
+      const pageItems = raw && raw !== 'null' ? JSON.parse(raw) : [];
+      if (!Array.isArray(pageItems) || pageItems.length === 0) {
+        break;
+      }
+      comments.push(...pageItems);
+      if (pageItems.length < pageSize) {
+        break;
+      }
+    }
+    return comments;
+  };
+}
+/** Parse an ISO8601 duration (`P[nD]T[nH][nM][nS]`) to ms; null on garbage. */
+function parseClaimStaleAgeMs(value) {
+  const text = String(value ?? '').trim();
+  if (!text) {
+    return null;
+  }
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i.exec(
+    text,
+  );
+  if (!match) {
+    return null;
+  }
+  const days = Number.parseInt(match[1] ?? '0', 10);
+  const hours = Number.parseInt(match[2] ?? '0', 10);
+  const minutes = Number.parseInt(match[3] ?? '0', 10);
+  const seconds = Number.parseInt(match[4] ?? '0', 10);
+  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
 }
 export function extractRoadmapMarkerId(
   body,
@@ -732,6 +953,8 @@ function parseArgs(argv) {
     owner: '',
     repo: '',
     policy: '',
+    withClaimState: false,
+    currentClaimId: '',
     help: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -761,6 +984,15 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (token === '--with-claim-state') {
+      parsed.withClaimState = true;
+      continue;
+    }
+    if (token === '--current-claim-id') {
+      parsed.currentClaimId = value ?? '';
+      index += 1;
+      continue;
+    }
     if (token === '--help' || token === '-h') {
       printHelp();
       process.exit(0);
@@ -771,13 +1003,24 @@ function parseArgs(argv) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>]
-  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>]
+  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--current-claim-id <id>]
+  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--current-claim-id <id>]
 
   --issue and --all-roadmaps are mutually exclusive; exactly one is required.
   --all-roadmaps enumerates open execution leaves across every open roadmap
   root (the union), each tagged with its sourceRoots and ranked by
   autopilotSuitability (descending, tie-broken by ascending issue number).
+
+  --with-claim-state (opt-in) annotates each OPEN execution leaf with active-
+  claim eligibility: it fetches that issue's comments and resolves the active
+  claim using the configured trustedMarkerActors and claimTiming.staleAge
+  (default PT24H). Each annotated leaf gains:
+    "activeClaim": { "present": bool, "stale": bool, "claimId": str|null, "agentId": str|null } | null
+    "claimEligible": bool   (eligible = no present, non-stale, trusted claim)
+  Absent the flag, NO comment API calls are made and no claim fields are
+  emitted (the output shape is byte-stable).
+  --current-claim-id <id> additionally sets "ownedByCurrentSession": bool on
+  each activeClaim (true when the active claim's claimId equals <id>).
 
 Output schema (JSON mode) — --issue single-root report:
   {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -632,6 +632,18 @@ function normalizeOpenRoadmapRootNumbers(roots) {
  * there is NO present, non-stale, trusted-actor claim. The shared
  * `parseClaimComment` / `resolveActiveClaim` parsing is reused read-only and
  * never re-implemented here.
+ *
+ * Intentional limitation: this annotation resolves only NEW-format
+ * `claimed-by` markers via the shared `resolveActiveClaim`. It deliberately
+ * does NOT factor in legacy claim-id-less markers nor forced-handoff
+ * transfers, both of which the authoritative resume/claim path handles
+ * (resume-claim-routing's `resolveLegacyClaimState` and forced-handoff
+ * authorization). Replicating that here would require duplicating that
+ * machinery plus per-candidate permission API calls, which is out of scope
+ * for this read-only discovery hint. `claimEligible` is therefore a
+ * best-effort SOFT signal only; the authoritative A5 claim gate
+ * (`idd-claim.instructions.md`), which DOES account for legacy markers and
+ * forced handoffs, remains the real protection.
  */
 export async function annotateLeafClaimState(issueNumber, claimState) {
   const comments = normalizeClaimComments(
@@ -1032,6 +1044,10 @@ function printHelp() {
   emitted (the output shape is byte-stable).
   --current-claim-id <id> additionally sets "ownedByCurrentSession": bool on
   each activeClaim (true when the active claim's claimId equals <id>).
+  NOTE: claimEligible is a best-effort SOFT discovery hint. It resolves only
+  new-format claimed-by markers and intentionally does NOT account for legacy
+  claim-id-less markers or forced-handoff transfers; the authoritative A5
+  claim gate (idd-claim.instructions.md) remains the real protection.
 
 Output schema (JSON mode) — --issue single-root report:
   {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -16,7 +16,11 @@ import {
   parseAutopilotSuitability,
 } from './autopilot-suitability.mts';
 import { parseIsoDurationToMs } from './policy-helpers.mts';
-import { isStaleAt, resolveActiveClaim } from './protocol-helpers.mts';
+import {
+  isStaleAt,
+  resolveActiveClaim,
+  resolveTrustedMarkerActors,
+} from './protocol-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
@@ -304,7 +308,10 @@ interface RoadmapNodeRecord {
  */
 interface ClaimStateResolution {
   loadComments: (issueNumber: number) => unknown;
-  /** Trusted-actor predicate (configured `trustedMarkerActors`). */
+  /**
+   * Trusted-actor predicate, resolved from `IDD_TRUSTED_MARKER_ACTORS` then
+   * the configured `trustedMarkerActors`.
+   */
   isTrustedAuthor: (login: string) => boolean;
   /** Configured `claimTiming.staleAge` in ms (defaults to PT24H). */
   staleAgeMs: number;
@@ -1137,39 +1144,50 @@ function buildClaimStateResolution(
   },
   currentClaimId: string,
 ): ClaimStateResolution {
-  const trustedActors = new Set(
-    (Array.isArray(policy.trustedMarkerActors)
-      ? policy.trustedMarkerActors
-      : []
-    )
-      .map((value) =>
-        String(value ?? '')
-          .trim()
-          .toLowerCase(),
-      )
-      .filter(Boolean),
-  );
   const staleAgeMs =
     parseClaimStaleAgeMs(policy.claimTiming?.staleAge) ??
     DEFAULT_CLAIM_STALE_AGE_MS;
   return {
     loadComments: buildCommentLoader(owner, repo),
-    // When `trustedMarkerActors` is empty no author is trusted, so no claim
-    // resolves and every leaf reads as `claimEligible: true`. This is a soft,
-    // availability-preferring default for the advisory discovery hint (it does
-    // NOT fail closed on eligibility): an unverifiable claim marker is simply
-    // not honored. The authoritative A5 claim gate (idd-claim.instructions.md)
-    // remains the real protection against acting on a contested claim.
-    isTrustedAuthor: (login) =>
-      trustedActors.has(
-        String(login ?? '')
-          .trim()
-          .toLowerCase(),
-      ),
+    isTrustedAuthor: buildTrustedAuthorPredicate(policy),
     staleAgeMs,
     nowIso: new Date().toISOString(),
     currentClaimId: String(currentClaimId ?? '').trim(),
   };
+}
+
+/**
+ * Build the case-insensitive trusted-marker-author predicate for the
+ * `--with-claim-state` annotation.
+ *
+ * Trusted actors are resolved through the shared
+ * {@link resolveTrustedMarkerActors} helper so this CLI honors the
+ * `IDD_TRUSTED_MARKER_ACTORS` env override exactly like every other evidence
+ * helper, not just the `trustedMarkerActors` array declared in policy. The
+ * resolved actors are already trimmed, lowercased, and deduped, so the
+ * predicate only needs to normalize the incoming login the same way.
+ *
+ * When the resolved set is empty no author is trusted, so no claim resolves
+ * and every leaf reads as `claimEligible: true`. This is a soft,
+ * availability-preferring default for the advisory discovery hint (it does
+ * NOT fail closed on eligibility): an unverifiable claim marker is simply not
+ * honored. The authoritative A5 claim gate (idd-claim.instructions.md) remains
+ * the real protection against acting on a contested claim.
+ */
+export function buildTrustedAuthorPredicate(policy: {
+  trustedMarkerActors?: unknown;
+}): (login: string) => boolean {
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: policy,
+  });
+  const trustedActors = new Set(actors);
+  return (login) =>
+    trustedActors.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
 }
 
 /** Live per-issue comment loader (the sole new GitHub API surface). */

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -91,11 +91,14 @@ export interface RoadmapIssueClassification {
 /**
  * Active-claim eligibility annotation for one discovery execution leaf.
  *
- * Only emitted under the opt-in `--with-claim-state` flag. `null` means no
- * trusted claim is present at all; an object describes the resolved active
- * claim and whether it is stale (older than the configured `claimTiming.staleAge`
- * relative to now). `ownedByCurrentSession` is present only when the caller
- * passed `--current-claim-id`.
+ * Under the opt-in `--with-claim-state` flag every annotated open execution
+ * leaf carries this object (Design O). `present: false` (with `claimId: null`,
+ * `agentId: null`) means no trusted claim is present at all; `present: true`
+ * means a trusted claim exists, with `stale` reporting whether it is older
+ * than the configured `claimTiming.staleAge` relative to now (a stale claim is
+ * takeover-eligible). The whole annotation is absent (key omitted) on the
+ * default flag-absent path. `ownedByCurrentSession` is present only when the
+ * caller passed `--current-claim-id`.
  */
 export interface LeafActiveClaim {
   present: boolean;
@@ -117,11 +120,12 @@ export interface RoadmapGraphNode {
   depth: number;
   /**
    * Active-claim annotation, present only under `--with-claim-state` and only
-   * on open execution-leaf nodes. `null` means no trusted claim is present.
-   * Absent on every node in the default (flag-absent) path so the byte-stable
-   * output shape is unchanged.
+   * on open execution-leaf nodes, where it is always an object (Design O):
+   * `present: false` means no trusted claim is present, `present: true` means
+   * one exists (possibly stale). Absent on every node in the default
+   * (flag-absent) path so the byte-stable output shape is unchanged.
    */
-  activeClaim?: LeafActiveClaim | null;
+  activeClaim?: LeafActiveClaim;
   /**
    * Derived eligibility: `true` when no present, non-stale, trusted-actor
    * claim blocks this leaf. Present only under `--with-claim-state` on open
@@ -214,11 +218,13 @@ export interface RoadmapUnionLeaf {
    */
   sourceRoots: number[];
   /**
-   * Active-claim annotation, present only under `--with-claim-state`. `null`
-   * means no trusted claim is present. Absent on every leaf in the default
-   * (flag-absent) path so the byte-stable output shape is unchanged.
+   * Active-claim annotation, present only under `--with-claim-state`, where it
+   * is always an object (Design O): `present: false` means no trusted claim is
+   * present, `present: true` means one exists (possibly stale). Absent on
+   * every leaf in the default (flag-absent) path so the byte-stable output
+   * shape is unchanged.
    */
-  activeClaim?: LeafActiveClaim | null;
+  activeClaim?: LeafActiveClaim;
   /**
    * Derived eligibility: `true` when no present, non-stale, trusted-actor
    * claim blocks this leaf. Present only under `--with-claim-state`.
@@ -978,7 +984,7 @@ function normalizeOpenRoadmapRootNumbers(roots: unknown): number[] {
 
 /** One leaf's resolved claim annotation (`--with-claim-state` output). */
 interface LeafClaimAnnotation {
-  activeClaim: LeafActiveClaim | null;
+  activeClaim: LeafActiveClaim;
   claimEligible: boolean;
 }
 
@@ -988,10 +994,12 @@ interface LeafClaimAnnotation {
  * Fetches the leaf issue's comments via the injected `loadComments` loader,
  * resolves the ACTIVE claim with the SHARED `resolveActiveClaim` from
  * protocol-helpers (trusted-author gated, stale-age aware), then derives
- * present/stale/eligibility. A leaf is eligible when there is NO present,
- * non-stale, trusted-actor claim. The shared `parseClaimComment` /
- * `resolveActiveClaim` parsing is reused read-only and never re-implemented
- * here.
+ * present/stale/eligibility. `activeClaim` is ALWAYS returned as an object
+ * (Design O): `present: false` (with `claimId: null`, `agentId: null`) when no
+ * trusted claim is present, `present: true` otherwise. A leaf is eligible when
+ * there is NO present, non-stale, trusted-actor claim. The shared
+ * `parseClaimComment` / `resolveActiveClaim` parsing is reused read-only and
+ * never re-implemented here.
  */
 export async function annotateLeafClaimState(
   issueNumber: number,
@@ -1169,8 +1177,15 @@ function buildCommentLoader(owner: string, repo: string) {
   };
 }
 
-/** Parse an ISO8601 duration (`P[nD]T[nH][nM][nS]`) to ms; null on garbage. */
-function parseClaimStaleAgeMs(value: unknown): number | null {
+/**
+ * Parse an ISO8601 duration (`P[nD]T[nH][nM][nS]`) to ms; `null` on garbage OR
+ * a non-positive total. A `PT0S` (or any zero/empty-component) duration is
+ * rejected so the caller falls back to `DEFAULT_CLAIM_STALE_AGE_MS` instead of
+ * configuring a 0ms stale age that would mark every claim immediately stale —
+ * matching `parseIsoDurationToMs` in policy-helpers, which likewise returns
+ * `null` for a non-positive duration.
+ */
+export function parseClaimStaleAgeMs(value: unknown): number | null {
   const text = String(value ?? '').trim();
   if (!text) {
     return null;
@@ -1185,7 +1200,8 @@ function parseClaimStaleAgeMs(value: unknown): number | null {
   const hours = Number.parseInt(match[2] ?? '0', 10);
   const minutes = Number.parseInt(match[3] ?? '0', 10);
   const seconds = Number.parseInt(match[4] ?? '0', 10);
-  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
+  const totalMs = (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
+  return totalMs > 0 ? totalMs : null;
 }
 
 export function extractRoadmapMarkerId(
@@ -1441,8 +1457,9 @@ function printHelp() {
   --with-claim-state (opt-in) annotates each OPEN execution leaf with active-
   claim eligibility: it fetches that issue's comments and resolves the active
   claim using the configured trustedMarkerActors and claimTiming.staleAge
-  (default PT24H). Each annotated leaf gains:
-    "activeClaim": { "present": bool, "stale": bool, "claimId": str|null, "agentId": str|null } | null
+  (default PT24H). Each annotated leaf gains (activeClaim is always an object):
+    "activeClaim": { "present": bool, "stale": bool, "claimId": str|null, "agentId": str|null }
+                   (present:false with claimId/agentId null = no trusted claim)
     "claimEligible": bool   (eligible = no present, non-stale, trusted claim)
   Absent the flag, NO comment API calls are made and no claim fields are
   emitted (the output shape is byte-stable).

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -15,6 +15,7 @@ import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mts';
+import { parseIsoDurationToMs } from './policy-helpers.mts';
 import { isStaleAt, resolveActiveClaim } from './protocol-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
@@ -97,8 +98,10 @@ export interface RoadmapIssueClassification {
  * means a trusted claim exists, with `stale` reporting whether it is older
  * than the configured `claimTiming.staleAge` relative to now (a stale claim is
  * takeover-eligible). The whole annotation is absent (key omitted) on the
- * default flag-absent path. `ownedByCurrentSession` is present only when the
- * caller passed `--current-claim-id`.
+ * default flag-absent path. `ownedByCurrentSession` is present whenever the
+ * caller passed `--current-claim-id` (`true` when the active claim's `claimId`
+ * equals it, `false` otherwise — including the no-claim `present: false` case),
+ * and absent only when `--current-claim-id` was not supplied.
  */
 export interface LeafActiveClaim {
   present: boolean;
@@ -1030,8 +1033,10 @@ export async function annotateLeafClaimState(
   });
 
   if (!active) {
-    // No present trusted claim → eligible. `ownedByCurrentSession` is omitted
-    // because there is no claim id to compare against.
+    // No present trusted claim → eligible. When `--current-claim-id` is
+    // supplied, `ownedByCurrentSession` is still emitted (as `false`) because
+    // there is no claim id to match it; it is omitted only when no
+    // `--current-claim-id` was passed.
     return {
       activeClaim: {
         present: false,
@@ -1149,9 +1154,12 @@ function buildClaimStateResolution(
     DEFAULT_CLAIM_STALE_AGE_MS;
   return {
     loadComments: buildCommentLoader(owner, repo),
-    // When no trusted actors are configured, every author is distrusted so no
-    // claim resolves — fail closed (a leaf reads as eligible) rather than
-    // honoring an unverifiable claim marker.
+    // When `trustedMarkerActors` is empty no author is trusted, so no claim
+    // resolves and every leaf reads as `claimEligible: true`. This is a soft,
+    // availability-preferring default for the advisory discovery hint (it does
+    // NOT fail closed on eligibility): an unverifiable claim marker is simply
+    // not honored. The authoritative A5 claim gate (idd-claim.instructions.md)
+    // remains the real protection against acting on a contested claim.
     isTrustedAuthor: (login) =>
       trustedActors.has(
         String(login ?? '')
@@ -1193,27 +1201,17 @@ function buildCommentLoader(owner: string, repo: string) {
  * Parse an ISO8601 duration (`P[nD]T[nH][nM][nS]`) to ms; `null` on garbage OR
  * a non-positive total. A `PT0S` (or any zero/empty-component) duration is
  * rejected so the caller falls back to `DEFAULT_CLAIM_STALE_AGE_MS` instead of
- * configuring a 0ms stale age that would mark every claim immediately stale —
- * matching `parseIsoDurationToMs` in policy-helpers, which likewise returns
- * `null` for a non-positive duration.
+ * configuring a 0ms stale age that would mark every claim immediately stale.
+ *
+ * Thin wrapper over the shared `parseIsoDurationToMs` from policy-helpers
+ * (the single source of truth for ISO-8601 duration parsing, with its own
+ * tests). It already returns `null` for both garbage and a non-positive total,
+ * which is exactly the behavior required here. The unknown input is coerced to
+ * a trimmed string first so non-string/nullish values resolve to `null`
+ * (the shared parser accepts only strings).
  */
 export function parseClaimStaleAgeMs(value: unknown): number | null {
-  const text = String(value ?? '').trim();
-  if (!text) {
-    return null;
-  }
-  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i.exec(
-    text,
-  );
-  if (!match) {
-    return null;
-  }
-  const days = Number.parseInt(match[1] ?? '0', 10);
-  const hours = Number.parseInt(match[2] ?? '0', 10);
-  const minutes = Number.parseInt(match[3] ?? '0', 10);
-  const seconds = Number.parseInt(match[4] ?? '0', 10);
-  const totalMs = (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
-  return totalMs > 0 ? totalMs : null;
+  return parseIsoDurationToMs(String(value ?? '').trim());
 }
 
 export function extractRoadmapMarkerId(
@@ -1442,8 +1440,14 @@ function parseArgs(argv: string[]): ParsedArgs {
       continue;
     }
     if (token === '--current-claim-id') {
-      parsed.currentClaimId = value ?? '';
-      index += 1;
+      // Only consume the next token as the id when it exists and is not itself
+      // a flag, so `--current-claim-id --with-claim-state` does not swallow the
+      // following flag as the id. A missing/flag value leaves currentClaimId
+      // empty and the next flag is left for its own iteration.
+      if (value !== undefined && !value.startsWith('--')) {
+        parsed.currentClaimId = value;
+        index += 1;
+      }
       continue;
     }
     if (token === '--help' || token === '-h') {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -15,8 +15,14 @@ import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mts';
+import { isStaleAt, resolveActiveClaim } from './protocol-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
+// the default baked into protocol-helpers' `isStaleAt`, so when the configured
+// stale age equals this default the shared `isStaleAt` path is
+// reused verbatim instead of re-deriving the 24h math here.
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
 });
@@ -82,6 +88,23 @@ export interface RoadmapIssueClassification {
   roadmapMarkerId: string;
 }
 
+/**
+ * Active-claim eligibility annotation for one discovery execution leaf.
+ *
+ * Only emitted under the opt-in `--with-claim-state` flag. `null` means no
+ * trusted claim is present at all; an object describes the resolved active
+ * claim and whether it is stale (older than the configured `claimTiming.staleAge`
+ * relative to now). `ownedByCurrentSession` is present only when the caller
+ * passed `--current-claim-id`.
+ */
+export interface LeafActiveClaim {
+  present: boolean;
+  stale: boolean;
+  claimId: string | null;
+  agentId: string | null;
+  ownedByCurrentSession?: boolean;
+}
+
 /** One node of the enumerated roadmap graph in report form. */
 export interface RoadmapGraphNode {
   number: number;
@@ -92,6 +115,19 @@ export interface RoadmapGraphNode {
   roadmapMarkerId: string;
   autopilotSuitability: number | null;
   depth: number;
+  /**
+   * Active-claim annotation, present only under `--with-claim-state` and only
+   * on open execution-leaf nodes. `null` means no trusted claim is present.
+   * Absent on every node in the default (flag-absent) path so the byte-stable
+   * output shape is unchanged.
+   */
+  activeClaim?: LeafActiveClaim | null;
+  /**
+   * Derived eligibility: `true` when no present, non-stale, trusted-actor
+   * claim blocks this leaf. Present only under `--with-claim-state` on open
+   * execution-leaf nodes.
+   */
+  claimEligible?: boolean;
 }
 
 /** Provenance path from the root roadmap to one discovered node. */
@@ -177,6 +213,17 @@ export interface RoadmapUnionLeaf {
    * source root here and is never double-counted in the union.
    */
   sourceRoots: number[];
+  /**
+   * Active-claim annotation, present only under `--with-claim-state`. `null`
+   * means no trusted claim is present. Absent on every leaf in the default
+   * (flag-absent) path so the byte-stable output shape is unchanged.
+   */
+  activeClaim?: LeafActiveClaim | null;
+  /**
+   * Derived eligibility: `true` when no present, non-stale, trusted-actor
+   * claim blocks this leaf. Present only under `--with-claim-state`.
+   */
+  claimEligible?: boolean;
 }
 
 /** One discovered open roadmap root the union enumeration started from. */
@@ -236,7 +283,33 @@ interface RoadmapNodeRecord {
   depth: number;
 }
 
-interface EnumerateRoadmapGraphOptions {
+/**
+ * Opt-in active-claim annotation inputs (the `--with-claim-state` surface).
+ *
+ * The whole feature is gated on {@link ClaimStateOptions.claimState} being
+ * present: when it is absent the helper makes NO extra GitHub API calls and
+ * emits no claim fields, so the default output shape stays byte-stable. When
+ * present, each open execution leaf is annotated with active-claim eligibility
+ * using `loadComments` (an injected per-issue comment loader, mirroring the
+ * existing `loadIssue`/`loadSubIssues` injection so tests stay network-free).
+ */
+interface ClaimStateResolution {
+  loadComments: (issueNumber: number) => unknown;
+  /** Trusted-actor predicate (configured `trustedMarkerActors`). */
+  isTrustedAuthor: (login: string) => boolean;
+  /** Configured `claimTiming.staleAge` in ms (defaults to PT24H). */
+  staleAgeMs: number;
+  /** Resolution "now" (ISO8601); defaults to the wall clock. */
+  nowIso: string;
+  /** `--current-claim-id`, or '' when not supplied. */
+  currentClaimId: string;
+}
+
+interface ClaimStateOptions {
+  claimState?: ClaimStateResolution;
+}
+
+interface EnumerateRoadmapGraphOptions extends ClaimStateOptions {
   markerPrefix?: unknown;
   owner?: string;
   repo?: string;
@@ -268,6 +341,8 @@ interface ParsedArgs {
   owner: string;
   repo: string;
   policy: string;
+  withClaimState: boolean;
+  currentClaimId: string;
   help: boolean;
 }
 
@@ -296,7 +371,18 @@ if (isMainModule(import.meta.url)) {
   const policy = loadPolicy(args.policy) as {
     markerPrefix?: unknown;
     autopilotSuitability?: { floor?: unknown };
+    claimTiming?: { staleAge?: unknown };
+    trustedMarkerActors?: unknown;
   };
+
+  // The claim-state annotation is strictly opt-in: only when --with-claim-state
+  // is passed do we build the comment loader (the sole new GitHub API surface)
+  // and resolve the trusted-actor / stale-age policy. The default path leaves
+  // `claimState` undefined, so no extra fetch is made and the output is
+  // byte-stable.
+  const claimState = args.withClaimState
+    ? buildClaimStateResolution(owner, repo, policy, args.currentClaimId)
+    : undefined;
 
   const report = args.allRoadmaps
     ? await enumerateAllRoadmapsGraph({
@@ -311,6 +397,7 @@ if (isMainModule(import.meta.url)) {
           repo,
           policy.markerPrefix,
         ),
+        claimState,
       })
     : await enumerateRoadmapGraph(args.issue, {
         markerPrefix: policy.markerPrefix,
@@ -318,6 +405,7 @@ if (isMainModule(import.meta.url)) {
         repo,
         loadIssue: buildIssueLoader(owner, repo),
         loadSubIssues: buildSubIssueLoader(owner, repo),
+        claimState,
       });
 
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
@@ -404,6 +492,24 @@ export async function enumerateRoadmapGraph(
   const rootNode = nodeRecords.get(rootIssue.number);
   if (!rootNode) {
     throw new Error(`root issue #${rootIssueNumber} was not recorded`);
+  }
+
+  // Opt-in (#1008): annotate each open execution-leaf node with active-claim
+  // eligibility. Gated on `options.claimState` so the default path makes no
+  // extra GitHub API call and the output shape stays byte-stable.
+  if (options.claimState) {
+    const executionCandidateSet = new Set(executionCandidates);
+    for (const node of nodes) {
+      if (!executionCandidateSet.has(node.number)) {
+        continue;
+      }
+      const annotated = await annotateLeafClaimState(
+        node.number,
+        options.claimState,
+      );
+      (node as RoadmapGraphNode).activeClaim = annotated.activeClaim;
+      (node as RoadmapGraphNode).claimEligible = annotated.claimEligible;
+    }
   }
 
   return {
@@ -746,6 +852,22 @@ export async function enumerateAllRoadmapsGraph(
     }))
     .sort((left, right) => compareUnionLeaves(left, right, floor));
 
+  // Opt-in (#1008): annotate the deduped union leaves once each. The per-root
+  // enumerations above intentionally run without `claimState`, so each issue's
+  // comments are fetched at most once here regardless of how many roots reach
+  // it. Gated on `options.claimState`, so the default path adds no extra
+  // GitHub API call and the union output shape stays byte-stable.
+  if (options.claimState) {
+    for (const leaf of leaves) {
+      const annotated = await annotateLeafClaimState(
+        leaf.number,
+        options.claimState,
+      );
+      leaf.activeClaim = annotated.activeClaim;
+      leaf.claimEligible = annotated.claimEligible;
+    }
+  }
+
   const scoredLeafCount = leaves.filter((leaf) =>
     isAutopilotSuitabilityScore(leaf.autopilotSuitability),
   ).length;
@@ -852,6 +974,218 @@ function normalizeOpenRoadmapRootNumbers(roots: unknown): number[] {
         .filter((value) => Number.isInteger(value) && value > 0),
     ),
   ].sort((left, right) => left - right);
+}
+
+/** One leaf's resolved claim annotation (`--with-claim-state` output). */
+interface LeafClaimAnnotation {
+  activeClaim: LeafActiveClaim | null;
+  claimEligible: boolean;
+}
+
+/**
+ * Resolve one execution leaf's active-claim eligibility (#1008).
+ *
+ * Fetches the leaf issue's comments via the injected `loadComments` loader,
+ * resolves the ACTIVE claim with the SHARED `resolveActiveClaim` from
+ * protocol-helpers (trusted-author gated, stale-age aware), then derives
+ * present/stale/eligibility. A leaf is eligible when there is NO present,
+ * non-stale, trusted-actor claim. The shared `parseClaimComment` /
+ * `resolveActiveClaim` parsing is reused read-only and never re-implemented
+ * here.
+ */
+export async function annotateLeafClaimState(
+  issueNumber: number,
+  claimState: ClaimStateResolution,
+): Promise<LeafClaimAnnotation> {
+  const comments = normalizeClaimComments(
+    await claimState.loadComments(issueNumber),
+  );
+  const active = resolveActiveClaim(comments, {
+    isTrustedAuthor: claimState.isTrustedAuthor,
+    // The 24h math is not re-derived: when the configured stale age equals the
+    // PT24H default, the shared `isStaleAt` is reused as-is;
+    // otherwise the same comparison is applied with the configured age.
+    isStale: (activeCreatedAt, nextCreatedAt) =>
+      isClaimStaleByAge(activeCreatedAt, nextCreatedAt, claimState.staleAgeMs),
+  });
+
+  if (!active) {
+    // No present trusted claim → eligible. `ownedByCurrentSession` is omitted
+    // because there is no claim id to compare against.
+    return {
+      activeClaim: {
+        present: false,
+        stale: false,
+        claimId: null,
+        agentId: null,
+        ...(claimState.currentClaimId ? { ownedByCurrentSession: false } : {}),
+      },
+      claimEligible: true,
+    };
+  }
+
+  // Staleness of the present claim is measured against "now": a claim whose
+  // createdAt is older than the configured stale age is a stale (takeover-
+  // eligible) claim, mirroring resume-claim-routing's active-claim staleness.
+  const stale = isClaimStaleByAge(
+    active.createdAt,
+    claimState.nowIso,
+    claimState.staleAgeMs,
+  );
+
+  const annotation: LeafActiveClaim = {
+    present: true,
+    stale,
+    claimId: active.claimId,
+    agentId: active.agentId,
+  };
+  if (claimState.currentClaimId) {
+    annotation.ownedByCurrentSession =
+      active.claimId === claimState.currentClaimId;
+  }
+
+  // Eligible only when there is no present, NON-stale, trusted claim. A stale
+  // claim is takeover-eligible, so it does not block.
+  return { activeClaim: annotation, claimEligible: stale };
+}
+
+/** Coerce a loaded comment payload into the `resolveActiveClaim` event shape. */
+function normalizeClaimComments(
+  raw: unknown,
+): { body: string; createdAt: string; author: { login: string } }[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.map((entry) => {
+    const comment = (entry ?? {}) as {
+      body?: unknown;
+      createdAt?: unknown;
+      created_at?: unknown;
+      author?: { login?: unknown } | null;
+      user?: { login?: unknown } | null;
+    };
+    return {
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? comment.created_at ?? ''),
+      author: {
+        login: String(comment.author?.login ?? comment.user?.login ?? ''),
+      },
+    };
+  });
+}
+
+/**
+ * Claim staleness by configured age. When the configured age equals the PT24H
+ * policy default, the shared `isStaleAt` is reused verbatim
+ * (the 24h math lives there, not here); otherwise the same millisecond
+ * comparison is applied with the configured age. Mirrors
+ * resume-claim-routing's `isStaleByAge`.
+ */
+function isClaimStaleByAge(
+  activeCreatedAt: string,
+  nextCreatedAt: string,
+  staleAgeMs: number,
+): boolean {
+  if (staleAgeMs === DEFAULT_CLAIM_STALE_AGE_MS) {
+    return isStaleAt(activeCreatedAt, nextCreatedAt);
+  }
+  const start = Date.parse(activeCreatedAt ?? '');
+  const end = Date.parse(nextCreatedAt ?? '');
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    return false;
+  }
+  return end - start >= staleAgeMs;
+}
+
+/**
+ * Build the CLI-side claim-state resolution: the live comment loader plus the
+ * resolved trusted-actor predicate, configured stale age, and "now". Only
+ * invoked when `--with-claim-state` is passed, so the live comment fetch is
+ * never wired in the default path.
+ */
+function buildClaimStateResolution(
+  owner: string,
+  repo: string,
+  policy: {
+    claimTiming?: { staleAge?: unknown };
+    trustedMarkerActors?: unknown;
+  },
+  currentClaimId: string,
+): ClaimStateResolution {
+  const trustedActors = new Set(
+    (Array.isArray(policy.trustedMarkerActors)
+      ? policy.trustedMarkerActors
+      : []
+    )
+      .map((value) =>
+        String(value ?? '')
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+  const staleAgeMs =
+    parseClaimStaleAgeMs(policy.claimTiming?.staleAge) ??
+    DEFAULT_CLAIM_STALE_AGE_MS;
+  return {
+    loadComments: buildCommentLoader(owner, repo),
+    // When no trusted actors are configured, every author is distrusted so no
+    // claim resolves — fail closed (a leaf reads as eligible) rather than
+    // honoring an unverifiable claim marker.
+    isTrustedAuthor: (login) =>
+      trustedActors.has(
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      ),
+    staleAgeMs,
+    nowIso: new Date().toISOString(),
+    currentClaimId: String(currentClaimId ?? '').trim(),
+  };
+}
+
+/** Live per-issue comment loader (the sole new GitHub API surface). */
+function buildCommentLoader(owner: string, repo: string) {
+  return (issueNumber: number) => {
+    const comments: unknown[] = [];
+    const pageSize = 100;
+    for (let page = 1; ; page += 1) {
+      const raw = runGh([
+        'api',
+        `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+        '--jq',
+        '.',
+      ]).trim();
+      const pageItems = raw && raw !== 'null' ? JSON.parse(raw) : [];
+      if (!Array.isArray(pageItems) || pageItems.length === 0) {
+        break;
+      }
+      comments.push(...pageItems);
+      if (pageItems.length < pageSize) {
+        break;
+      }
+    }
+    return comments;
+  };
+}
+
+/** Parse an ISO8601 duration (`P[nD]T[nH][nM][nS]`) to ms; null on garbage. */
+function parseClaimStaleAgeMs(value: unknown): number | null {
+  const text = String(value ?? '').trim();
+  if (!text) {
+    return null;
+  }
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i.exec(
+    text,
+  );
+  if (!match) {
+    return null;
+  }
+  const days = Number.parseInt(match[1] ?? '0', 10);
+  const hours = Number.parseInt(match[2] ?? '0', 10);
+  const minutes = Number.parseInt(match[3] ?? '0', 10);
+  const seconds = Number.parseInt(match[4] ?? '0', 10);
+  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
 }
 
 export function extractRoadmapMarkerId(
@@ -1043,6 +1377,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     owner: '',
     repo: '',
     policy: '',
+    withClaimState: false,
+    currentClaimId: '',
     help: false,
   };
 
@@ -1073,6 +1409,15 @@ function parseArgs(argv: string[]): ParsedArgs {
       index += 1;
       continue;
     }
+    if (token === '--with-claim-state') {
+      parsed.withClaimState = true;
+      continue;
+    }
+    if (token === '--current-claim-id') {
+      parsed.currentClaimId = value ?? '';
+      index += 1;
+      continue;
+    }
     if (token === '--help' || token === '-h') {
       printHelp();
       process.exit(0);
@@ -1085,13 +1430,24 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>]
-  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>]
+  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--current-claim-id <id>]
+  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--current-claim-id <id>]
 
   --issue and --all-roadmaps are mutually exclusive; exactly one is required.
   --all-roadmaps enumerates open execution leaves across every open roadmap
   root (the union), each tagged with its sourceRoots and ranked by
   autopilotSuitability (descending, tie-broken by ascending issue number).
+
+  --with-claim-state (opt-in) annotates each OPEN execution leaf with active-
+  claim eligibility: it fetches that issue's comments and resolves the active
+  claim using the configured trustedMarkerActors and claimTiming.staleAge
+  (default PT24H). Each annotated leaf gains:
+    "activeClaim": { "present": bool, "stale": bool, "claimId": str|null, "agentId": str|null } | null
+    "claimEligible": bool   (eligible = no present, non-stale, trusted claim)
+  Absent the flag, NO comment API calls are made and no claim fields are
+  emitted (the output shape is byte-stable).
+  --current-claim-id <id> additionally sets "ownedByCurrentSession": bool on
+  each activeClaim (true when the active claim's claimId equals <id>).
 
 Output schema (JSON mode) — --issue single-root report:
   {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1000,6 +1000,18 @@ interface LeafClaimAnnotation {
  * there is NO present, non-stale, trusted-actor claim. The shared
  * `parseClaimComment` / `resolveActiveClaim` parsing is reused read-only and
  * never re-implemented here.
+ *
+ * Intentional limitation: this annotation resolves only NEW-format
+ * `claimed-by` markers via the shared `resolveActiveClaim`. It deliberately
+ * does NOT factor in legacy claim-id-less markers nor forced-handoff
+ * transfers, both of which the authoritative resume/claim path handles
+ * (resume-claim-routing's `resolveLegacyClaimState` and forced-handoff
+ * authorization). Replicating that here would require duplicating that
+ * machinery plus per-candidate permission API calls, which is out of scope
+ * for this read-only discovery hint. `claimEligible` is therefore a
+ * best-effort SOFT signal only; the authoritative A5 claim gate
+ * (`idd-claim.instructions.md`), which DOES account for legacy markers and
+ * forced handoffs, remains the real protection.
  */
 export async function annotateLeafClaimState(
   issueNumber: number,
@@ -1465,6 +1477,10 @@ function printHelp() {
   emitted (the output shape is byte-stable).
   --current-claim-id <id> additionally sets "ownedByCurrentSession": bool on
   each activeClaim (true when the active claim's claimId equals <id>).
+  NOTE: claimEligible is a best-effort SOFT discovery hint. It resolves only
+  new-format claimed-by markers and intentionally does NOT account for legacy
+  claim-id-less markers or forced-handoff transfers; the authoritative A5
+  claim gate (idd-claim.instructions.md) remains the real protection.
 
 Output schema (JSON mode) — --issue single-root report:
   {

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -1025,3 +1025,278 @@ process.exit(1);
     /missing required --issue/,
   );
 });
+
+// ---------------------------------------------------------------------------
+// --with-claim-state annotation (#1008).
+// ---------------------------------------------------------------------------
+
+const CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+const CLAIM_NOW = '2026-06-25T12:00:00Z';
+
+// A claim posted recently relative to CLAIM_NOW is non-stale; one posted
+// well over the 24h stale age earlier is stale.
+const FRESH_CLAIM_AT = '2026-06-25T06:00:00Z';
+const STALE_CLAIM_AT = '2026-06-20T06:00:00Z';
+
+function claimComment(
+  agentId: string,
+  claimId: string,
+  createdAt: string,
+  { author = 'kurone-kito', branch = 'issue/700-task' } = {},
+) {
+  return {
+    body: `<!-- claimed-by: ${agentId} ${claimId} supersedes: none ${createdAt} branch: ${branch} -->`,
+    createdAt,
+    author: { login: author },
+  };
+}
+
+function buildClaimState(
+  commentsByIssue: Map<number, unknown[]>,
+  {
+    currentClaimId = '',
+    trustedActors = ['kurone-kito'],
+    staleAgeMs = CLAIM_STALE_AGE_MS,
+  }: {
+    currentClaimId?: string;
+    trustedActors?: string[];
+    staleAgeMs?: number;
+  } = {},
+) {
+  const trusted = new Set(trustedActors.map((value) => value.toLowerCase()));
+  const seen: number[] = [];
+  return {
+    seen,
+    resolution: {
+      loadComments: (issueNumber: number) => {
+        seen.push(issueNumber);
+        return commentsByIssue.get(issueNumber) ?? [];
+      },
+      isTrustedAuthor: (login: string) =>
+        trusted.has(String(login ?? '').toLowerCase()),
+      staleAgeMs,
+      nowIso: CLAIM_NOW,
+      currentClaimId,
+    },
+  };
+}
+
+// One epic (700) → two open execution leaves (701, 702).
+function claimGraphIssues() {
+  return new Map<number, unknown>([
+    [700, roadmapIssue(700, '- [ ] #701\n- [ ] #702', 'epic-claim')],
+    [701, executionIssue(701, 'leaf 701')],
+    [702, executionIssue(702, 'leaf 702')],
+  ]);
+}
+
+test('without --with-claim-state, leaves carry no claim fields and fetch no comments', async () => {
+  const issues = claimGraphIssues();
+  const commentsByIssue = new Map<number, unknown[]>([
+    [701, [claimComment('agent-a', 'claim-701', FRESH_CLAIM_AT)]],
+  ]);
+  const { seen } = buildClaimState(commentsByIssue);
+
+  const graph = await enumerateRoadmapGraph(700, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    // claimState intentionally omitted (default path).
+  });
+
+  // No claim fields are present on any node.
+  for (const node of graph.nodes) {
+    const record = node as unknown as Record<string, unknown>;
+    assert.equal(Object.hasOwn(record, 'activeClaim'), false);
+    assert.equal(Object.hasOwn(record, 'claimEligible'), false);
+  }
+  // No comment fetch happened — the loader was never invoked.
+  assert.deepEqual(seen, []);
+});
+
+test('--all-roadmaps without claim state leaves the union shape byte-stable', async () => {
+  const issues = claimGraphIssues();
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [700],
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  for (const leaf of report.leaves) {
+    const record = leaf as unknown as Record<string, unknown>;
+    assert.equal(Object.hasOwn(record, 'activeClaim'), false);
+    assert.equal(Object.hasOwn(record, 'claimEligible'), false);
+  }
+});
+
+test('a present non-stale claim marks the leaf claimEligible:false', async () => {
+  const issues = claimGraphIssues();
+  const commentsByIssue = new Map<number, unknown[]>([
+    [701, [claimComment('agent-a', 'claim-701', FRESH_CLAIM_AT)]],
+  ]);
+  const { resolution, seen } = buildClaimState(commentsByIssue);
+
+  const graph = await enumerateRoadmapGraph(700, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    claimState: resolution,
+  });
+
+  const byNumber = new Map(graph.nodes.map((node) => [node.number, node]));
+  const leaf701 = byNumber.get(701);
+  assert.deepEqual(leaf701?.activeClaim, {
+    present: true,
+    stale: false,
+    claimId: 'claim-701',
+    agentId: 'agent-a',
+  });
+  assert.equal(leaf701?.claimEligible, false);
+  // Only the open execution leaves are probed (not the roadmap root 700).
+  assert.deepEqual(
+    [...seen].sort((a, b) => a - b),
+    [701, 702],
+  );
+});
+
+test('a stale claim is takeover-eligible: present:true, stale:true, claimEligible:true', async () => {
+  const issues = claimGraphIssues();
+  const commentsByIssue = new Map<number, unknown[]>([
+    [701, [claimComment('agent-a', 'claim-701', STALE_CLAIM_AT)]],
+  ]);
+  const { resolution } = buildClaimState(commentsByIssue);
+
+  const graph = await enumerateRoadmapGraph(700, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    claimState: resolution,
+  });
+
+  const byNumber = new Map(graph.nodes.map((node) => [node.number, node]));
+  const leaf701 = byNumber.get(701);
+  assert.deepEqual(leaf701?.activeClaim, {
+    present: true,
+    stale: true,
+    claimId: 'claim-701',
+    agentId: 'agent-a',
+  });
+  assert.equal(leaf701?.claimEligible, true);
+});
+
+test('an unclaimed leaf is eligible: present:false, claimEligible:true', async () => {
+  const issues = claimGraphIssues();
+  // 702 has no comments at all.
+  const commentsByIssue = new Map<number, unknown[]>([
+    [701, [claimComment('agent-a', 'claim-701', FRESH_CLAIM_AT)]],
+  ]);
+  const { resolution } = buildClaimState(commentsByIssue);
+
+  const graph = await enumerateRoadmapGraph(700, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    claimState: resolution,
+  });
+
+  const byNumber = new Map(graph.nodes.map((node) => [node.number, node]));
+  const leaf702 = byNumber.get(702);
+  assert.deepEqual(leaf702?.activeClaim, {
+    present: false,
+    stale: false,
+    claimId: null,
+    agentId: null,
+  });
+  assert.equal(leaf702?.claimEligible, true);
+});
+
+test('an untrusted-author claim does not block the leaf', async () => {
+  const issues = claimGraphIssues();
+  const commentsByIssue = new Map<number, unknown[]>([
+    [
+      701,
+      [
+        claimComment('agent-a', 'claim-701', FRESH_CLAIM_AT, {
+          author: 'random-drive-by',
+        }),
+      ],
+    ],
+  ]);
+  // Only kurone-kito is trusted, so the marker is ignored → no present claim.
+  const { resolution } = buildClaimState(commentsByIssue);
+
+  const graph = await enumerateRoadmapGraph(700, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    claimState: resolution,
+  });
+
+  const byNumber = new Map(graph.nodes.map((node) => [node.number, node]));
+  const leaf701 = byNumber.get(701);
+  assert.equal(leaf701?.activeClaim?.present, false);
+  assert.equal(leaf701?.claimEligible, true);
+});
+
+test('--current-claim-id sets ownedByCurrentSession on the matching claim', async () => {
+  const issues = claimGraphIssues();
+  const commentsByIssue = new Map<number, unknown[]>([
+    [701, [claimComment('agent-a', 'claim-701', FRESH_CLAIM_AT)]],
+    [702, [claimComment('agent-b', 'claim-702', FRESH_CLAIM_AT)]],
+  ]);
+  const { resolution } = buildClaimState(commentsByIssue, {
+    currentClaimId: 'claim-701',
+  });
+
+  const graph = await enumerateRoadmapGraph(700, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    claimState: resolution,
+  });
+
+  const byNumber = new Map(graph.nodes.map((node) => [node.number, node]));
+  // Matching claim id → owned by the current session.
+  assert.equal(byNumber.get(701)?.activeClaim?.ownedByCurrentSession, true);
+  // Non-matching claim id → not owned, but the flag is still emitted.
+  assert.equal(byNumber.get(702)?.activeClaim?.ownedByCurrentSession, false);
+});
+
+test('--current-claim-id emits ownedByCurrentSession:false on an unclaimed leaf', async () => {
+  const issues = claimGraphIssues();
+  const { resolution } = buildClaimState(new Map(), {
+    currentClaimId: 'claim-701',
+  });
+
+  const graph = await enumerateRoadmapGraph(700, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    claimState: resolution,
+  });
+
+  const byNumber = new Map(graph.nodes.map((node) => [node.number, node]));
+  assert.deepEqual(byNumber.get(701)?.activeClaim, {
+    present: false,
+    stale: false,
+    claimId: null,
+    agentId: null,
+    ownedByCurrentSession: false,
+  });
+});
+
+test('--all-roadmaps annotates union leaves and fetches each issue once', async () => {
+  // Two epics share leaf 702; with claim state it must be fetched once.
+  const issues = new Map<number, unknown>([
+    [700, roadmapIssue(700, '- [ ] #701\n- [ ] #702', 'epic-alpha')],
+    [800, roadmapIssue(800, '- [ ] #702\n- [ ] #803', 'epic-beta')],
+    [701, executionIssue(701, 'leaf 701')],
+    [702, executionIssue(702, 'shared leaf 702')],
+    [803, executionIssue(803, 'leaf 803')],
+  ]);
+  const commentsByIssue = new Map<number, unknown[]>([
+    [702, [claimComment('agent-a', 'claim-702', FRESH_CLAIM_AT)]],
+  ]);
+  const { resolution, seen } = buildClaimState(commentsByIssue);
+
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [700, 800],
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    claimState: resolution,
+  });
+
+  const byNumber = new Map(report.leaves.map((leaf) => [leaf.number, leaf]));
+  // Shared, claimed leaf 702: present non-stale claim → not eligible.
+  assert.equal(byNumber.get(702)?.activeClaim?.present, true);
+  assert.equal(byNumber.get(702)?.claimEligible, false);
+  // Unclaimed leaves are eligible.
+  assert.equal(byNumber.get(701)?.claimEligible, true);
+  assert.equal(byNumber.get(803)?.claimEligible, true);
+  // The shared leaf 702 is fetched exactly once even though two roots reach it.
+  assert.equal(seen.filter((issueNumber) => issueNumber === 702).length, 1);
+});

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -1329,8 +1329,7 @@ test('a PT0S staleAge falls back to the default 24h window, not 0ms', async () =
   // stale. Mirror that fallback here and confirm the fresh claim stays
   // non-stale (eligible:false), as the default 24h behavior demands.
   for (const staleAge of ['PT0S', 'PT0H0M0S', 'garbage', '']) {
-    const staleAgeMs =
-      parseClaimStaleAgeMs(staleAge) ?? CLAIM_STALE_AGE_MS;
+    const staleAgeMs = parseClaimStaleAgeMs(staleAge) ?? CLAIM_STALE_AGE_MS;
     assert.equal(
       staleAgeMs,
       CLAIM_STALE_AGE_MS,
@@ -1343,9 +1342,9 @@ test('a PT0S staleAge falls back to the default 24h window, not 0ms', async () =
       claimState: resolution,
     });
 
-    const leaf701 = new Map(
-      graph.nodes.map((node) => [node.number, node]),
-    ).get(701);
+    const leaf701 = new Map(graph.nodes.map((node) => [node.number, node])).get(
+      701,
+    );
     // The fresh claim is present and non-stale → it still blocks the leaf,
     // rather than being wrongly treated as stale by a 0ms window.
     assert.deepEqual(

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -13,6 +13,7 @@ import {
   extractKeywordReferences,
   extractRoadmapMarkerId,
   extractTaskListReferences,
+  parseClaimStaleAgeMs,
 } from '../src/scripts/discover-roadmap-graph.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
@@ -1299,4 +1300,59 @@ test('--all-roadmaps annotates union leaves and fetches each issue once', async 
   assert.equal(byNumber.get(803)?.claimEligible, true);
   // The shared leaf 702 is fetched exactly once even though two roots reach it.
   assert.equal(seen.filter((issueNumber) => issueNumber === 702).length, 1);
+});
+
+test('parseClaimStaleAgeMs rejects non-positive and garbage durations', () => {
+  // A non-positive stale age would configure a 0ms window that marks every
+  // claim immediately stale; reject it so callers fall back to the default.
+  assert.equal(parseClaimStaleAgeMs('PT0S'), null);
+  assert.equal(parseClaimStaleAgeMs('PT0H0M0S'), null);
+  assert.equal(parseClaimStaleAgeMs('P0D'), null);
+  assert.equal(parseClaimStaleAgeMs('PT'), null);
+  assert.equal(parseClaimStaleAgeMs('P'), null);
+  assert.equal(parseClaimStaleAgeMs(''), null);
+  assert.equal(parseClaimStaleAgeMs('garbage'), null);
+  assert.equal(parseClaimStaleAgeMs(undefined), null);
+  // A coherent positive duration still parses.
+  assert.equal(parseClaimStaleAgeMs('PT24H'), CLAIM_STALE_AGE_MS);
+  assert.equal(parseClaimStaleAgeMs('PT1S'), 1000);
+});
+
+test('a PT0S staleAge falls back to the default 24h window, not 0ms', async () => {
+  const issues = claimGraphIssues();
+  const commentsByIssue = new Map<number, unknown[]>([
+    [701, [claimComment('agent-a', 'claim-701', FRESH_CLAIM_AT)]],
+  ]);
+  // The CLI resolves the configured staleAge via parseClaimStaleAgeMs and
+  // falls back to the default when it returns null. A PT0S policy must NOT
+  // configure a 0ms window — a literal 0ms would mark even the fresh claim
+  // stale. Mirror that fallback here and confirm the fresh claim stays
+  // non-stale (eligible:false), as the default 24h behavior demands.
+  for (const staleAge of ['PT0S', 'PT0H0M0S', 'garbage', '']) {
+    const staleAgeMs =
+      parseClaimStaleAgeMs(staleAge) ?? CLAIM_STALE_AGE_MS;
+    assert.equal(
+      staleAgeMs,
+      CLAIM_STALE_AGE_MS,
+      `non-positive/garbage staleAge ${JSON.stringify(staleAge)} should fall back to the default`,
+    );
+
+    const { resolution } = buildClaimState(commentsByIssue, { staleAgeMs });
+    const graph = await enumerateRoadmapGraph(700, {
+      loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+      claimState: resolution,
+    });
+
+    const leaf701 = new Map(
+      graph.nodes.map((node) => [node.number, node]),
+    ).get(701);
+    // The fresh claim is present and non-stale → it still blocks the leaf,
+    // rather than being wrongly treated as stale by a 0ms window.
+    assert.deepEqual(
+      leaf701?.activeClaim,
+      { present: true, stale: false, claimId: 'claim-701', agentId: 'agent-a' },
+      `staleAge ${JSON.stringify(staleAge)} should not mark a fresh claim stale`,
+    );
+    assert.equal(leaf701?.claimEligible, false);
+  }
 });

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -7,6 +7,7 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  buildTrustedAuthorPredicate,
   classifyIssue,
   enumerateAllRoadmapsGraph,
   enumerateRoadmapGraph,
@@ -1226,6 +1227,49 @@ test('an untrusted-author claim does not block the leaf', async () => {
   const leaf701 = byNumber.get(701);
   assert.equal(leaf701?.activeClaim?.present, false);
   assert.equal(leaf701?.claimEligible, true);
+});
+
+test('IDD_TRUSTED_MARKER_ACTORS env override honors an actor absent from policy', async () => {
+  // `env-trusted-bot` is NOT in policy `trustedMarkerActors`, so a claim it
+  // authors is only honored when the env override is consulted.
+  const previous = process.env.IDD_TRUSTED_MARKER_ACTORS;
+  process.env.IDD_TRUSTED_MARKER_ACTORS = 'env-trusted-bot';
+  try {
+    const issues = claimGraphIssues();
+    const commentsByIssue = new Map<number, unknown[]>([
+      [
+        701,
+        [
+          claimComment('agent-a', 'claim-701', FRESH_CLAIM_AT, {
+            author: 'env-trusted-bot',
+          }),
+        ],
+      ],
+    ]);
+    // Build the resolution through the real, env-aware trusted-actor
+    // predicate (config trusts only `kurone-kito`).
+    const { resolution } = buildClaimState(commentsByIssue);
+    resolution.isTrustedAuthor = buildTrustedAuthorPredicate({
+      trustedMarkerActors: ['kurone-kito'],
+    });
+
+    const graph = await enumerateRoadmapGraph(700, {
+      loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+      claimState: resolution,
+    });
+
+    const byNumber = new Map(graph.nodes.map((node) => [node.number, node]));
+    const leaf701 = byNumber.get(701);
+    // The env-trusted author's fresh claim is now honored.
+    assert.equal(leaf701?.activeClaim?.present, true);
+    assert.equal(leaf701?.claimEligible, false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.IDD_TRUSTED_MARKER_ACTORS;
+    } else {
+      process.env.IDD_TRUSTED_MARKER_ACTORS = previous;
+    }
+  }
 });
 
 test('--current-claim-id sets ownedByCurrentSession on the matching claim', async () => {

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -1690,3 +1690,24 @@ test('discover-roadmap-union invalid fixture fails validation', () => {
   );
   assert.ok(ok, 'Expected invalid fixture to fail schema validation');
 });
+
+test('discover-roadmap-union schema rejects a non-object activeClaim', () => {
+  const schema = loadJson('schemas/discover-roadmap-union.schema.json');
+  // Under Design O activeClaim is always an object; the schema now declares
+  // `type: object`, so a scalar, string, array, or null must be rejected.
+  for (const activeClaim of [42, 'claimed', [], null]) {
+    const instance = JSON.parse(
+      JSON.stringify(
+        loadJson('fixtures/schemas/discover-roadmap-union.valid.json'),
+      ),
+    );
+    instance.leaves[0].activeClaim = activeClaim;
+    const errors = validate(instance, schema);
+    assert.ok(
+      errors.some((error) =>
+        error.includes('$.leaves[0].activeClaim: expected type "object"'),
+      ),
+      `activeClaim ${JSON.stringify(activeClaim)} should be rejected: ${errors.join('\n')}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Adds an opt-in `--with-claim-state` flag to the `discover-roadmap-graph`
helper so each open execution-leaf discovery candidate is annotated with
active-claim eligibility. Under concurrent autopilot sessions, A4 Step 1.5
(active-claim pre-scan) otherwise forces a manual per-candidate claim read
every discovery round; this surfaces that state as evidence so autopilot can
skip already-claimed candidates without a separate manual pass.

## What changed

- `src/scripts/discover-roadmap-graph.mts` (source): new `--with-claim-state`
  and optional `--current-claim-id <id>` flags. When set, each open
  execution-leaf candidate (both single-root `--issue` and `--all-roadmaps`
  union modes) is annotated with
  `activeClaim: { present, stale, claimId, agentId, ownedByCurrentSession? }` — always an object under the flag (Design O); `present:false` represents the unclaimed case
  and a derived `claimEligible` boolean (eligible = no present, non-stale,
  trusted-actor claim — a stale claim is takeover-eligible).
- Reuses the shared `resolveActiveClaim` / `isStaleAt` claim parsing from
  `protocol-helpers` **read-only** (that high-contention shared file is not
  edited) and the configured `trustedMarkerActors` / `claimTiming.staleAge`.
- `schemas/discover-roadmap-union.schema.json` + `fixtures/**`: optional
  additive `activeClaim` / `claimEligible` fields.
- `tests/discover-roadmap-graph.test.mts`: covers claimed (non-stale →
  ineligible), stale-claim (takeover-eligible), unclaimed, untrusted-author,
  `--current-claim-id` ownership, and the union fetch-once-per-issue path.
- Generated `scripts/discover-roadmap-graph.mjs` regenerated via
  `pnpm run build`.

## Design notes

- **Default path is byte-stable**: absent the flag, no comment API call is made
  and no claim fields are emitted, so existing output and per-candidate API
  cost are unchanged.
- Under Design O `activeClaim` is always an object when emitted, declared
  `type: object` in the schema (`present:false` represents the unclaimed case).

## Verification

`pnpm run lint:minimum` passes (typecheck, build:check, 1125 tests,
schema-validation, cspell, markdownlint).

## Follow-up (out of scope)

- Mirror the annotation into `discover-orphan-filter` for orphan candidates.
- Document consuming the signal in `idd-discover.instructions.md` (the Markdown
  discover instructions remain authoritative; this PR ships only the read-only
  evidence helper).

Closes #1008


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional claim-state details to roadmap output, including whether a leaf has an active claim and whether it remains eligible for takeover.
  * Introduced a new command-line option to include this claim-state information in generated reports.

* **Bug Fixes**
  * Improved handling of stale, unclaimed, and trusted claims so eligibility is reported more accurately.
  * Added support for showing whether the current session owns the active claim.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
