### PR TITLE
build(idd): compare build:check against HEAD

### DIFF
--- a/docs/typescript-sources.md
+++ b/docs/typescript-sources.md
@@ -48,11 +48,11 @@ adopter repositories that vendor the bundle.
 
 ## Build and verification
 
-| Command                | Purpose                                                          |
-| ---------------------- | ---------------------------------------------------------------- |
-| `pnpm run typecheck`   | `tsc --noEmit` over `src/**/*.mts` + `tests/**/*.mts` (`strict`) |
-| `pnpm run build`       | Emit the generated `.mjs` (tsc) and normalize them with Biome    |
-| `pnpm run build:check` | `build` then `git diff --exit-code` — fails when the tree drifts |
+| Command                | Purpose                                                                         |
+| ---------------------- | ------------------------------------------------------------------------------- |
+| `pnpm run typecheck`   | `tsc --noEmit` over `src/**/*.mts` + `tests/**/*.mts` (`strict`)                |
+| `pnpm run build`       | Emit the generated `.mjs` (tsc) and normalize them with Biome                   |
+| `pnpm run build:check` | `build` then `git diff HEAD --exit-code` — fails when the committed tree drifts |
 
 `pnpm run lint:minimum` runs `typecheck` and `build:check`, so a forgotten
 rebuild or a hand-edited generated file fails the installed CI lane. The

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lint:precommit": "biome check && dprint check \"**/*.md\" && markdownlint-cli2 \"**/*.md\"",
     "typecheck": "tsc -p tsconfig.json",
     "build": "node scripts/build-ts.mjs",
-    "build:check": "pnpm run build && git diff --exit-code -- scripts bin",
+    "build:check": "pnpm run build && git diff HEAD --exit-code -- scripts bin",
     "test": "pnpm run test:scripts",
     "test:scripts": "node --test tests/*.test.mts",
     "docs:sync": "node scripts/sync-docs.mjs --apply",


### PR DESCRIPTION
## Summary

Make `build:check` stage-agnostic by comparing the rebuilt tree against
`HEAD` instead of the index.

- `package.json` `build:check`: `git diff --exit-code -- scripts bin` →
  `git diff HEAD --exit-code -- scripts bin`
- `docs/typescript-sources.md`: one-line note updated to the
  `HEAD`-relative comparison.

## Why

`git diff --exit-code` compared the working tree against the **index**, so
a freshly regenerated `scripts/*.mjs` / `bin/*.mjs` surfaced as a
confusing `lint:minimum` failure until it was `git add`-ed (seen on
#989 / #994 / #1007). It also could miss a **committed-but-stale**
artifact when the wrong `.mjs` was already staged. `git diff HEAD`
compares the post-rebuild tree to the committed `HEAD`, so regenerated
artifacts no longer fail spuriously and stale committed artifacts are
detected as drift.

## Verification

- Clean tree: `pnpm run build:check` passes (regenerated-but-unstaged
  artifacts no longer fail).
- Drift: temporarily editing a `.mts` source makes `build:check` exit
  non-zero (committed-stale detection preserved).
- `pnpm run pre-push-validate` passes (dprint, markdownlint, cspell).

Repo-local tooling only; not part of the `idd-template/` mirror.

Closes #1023
