### PR TITLE
fix(idd): dedupe syncPairs targets and guard re-duplication

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -268,12 +268,6 @@
       "mode": "exact"
     },
     {
-      "id": "idd-merge-handoff-instructions",
-      "source": "idd-template/.github/instructions/idd-merge-handoff.instructions.md",
-      "target": ".github/instructions/idd-merge-handoff.instructions.md",
-      "mode": "exact"
-    },
-    {
       "id": "idd-overview-core-instructions",
       "source": "idd-template/.github/instructions/idd-overview-core.instructions.md",
       "target": ".github/instructions/idd-overview-core.instructions.md",
@@ -497,56 +491,6 @@
         "This bundle handles pre-approval issue drafting only.",
         "start the Discover -> Claim -> Work loop implicitly"
       ]
-    },
-    {
-      "id": "idd-overview-core-instructions",
-      "source": "idd-template/.github/instructions/idd-overview-core.instructions.md",
-      "target": ".github/instructions/idd-overview-core.instructions.md",
-      "mode": "concreted",
-      "replacements": [
-        {
-          "from": "| Name                    | Commands                         |",
-          "to": "| Name                    | Commands                                                                                                                                     |"
-        },
-        {
-          "from": "| ----------------------- | -------------------------------- |",
-          "to": "| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |"
-        },
-        {
-          "from": "| **fix-validate**        | `{{FIX_VALIDATE_COMMANDS}}`      |",
-          "to": "| **fix-validate**        | `npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"`                                       |"
-        },
-        {
-          "from": "| **pre-push-validate**   | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |",
-          "to": "| **pre-push-validate**   | `npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress`                                        |"
-        },
-        {
-          "from": "| **post-fix-validate**   | `{{POST_FIX_VALIDATE_COMMANDS}}` |",
-          "to": "| **post-fix-validate**   | `npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress` |"
-        },
-        {
-          "from": "| **install-deps**        | `{{INSTALL_DEPS_COMMAND}}`       |",
-          "to": "| **install-deps**        | `pnpm install --frozen-lockfile`                                                                                                             |"
-        },
-        {
-          "from": "| **issue-scope**         | `roadmap-first`                  |",
-          "to": "| **issue-scope**         | `roadmap-first`                                                                                                                              |"
-        },
-        {
-          "from": "| **orphan-first-policy** | `none`                           |",
-          "to": "| **orphan-first-policy** | `none`                                                                                                                                       |"
-        },
-        {
-          "from": "use `npx <tool>` if Node.js and `npx` are available",
-          "to": "use `npx <tool>` only when `npx` is available"
-        }
-      ]
-    },
-    {
-      "id": "idd-overview-appendix-instructions",
-      "source": "idd-template/.github/instructions/idd-overview-appendix.instructions.md",
-      "target": ".github/instructions/idd-overview-appendix.instructions.md",
-      "mode": "exact"
     },
     {
       "id": "claude-skills-issue-authoring-skill",

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -8,6 +8,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  collectDuplicateSyncPairTargets,
   collectInstructionSizeBudgetViolations,
   collectPolicyConfigDrift,
   collectRootMarkdownAllowlistViolations,
@@ -303,6 +304,7 @@ function resolveBlockFiles(block) {
   return files;
 }
 function checkSyncPairs(pairs) {
+  errors.push(...collectDuplicateSyncPairTargets(pairs));
   for (const pair of pairs) {
     if (pair.mode === 'contains') {
       checkContainsPair(pair);

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -421,3 +421,33 @@ export function collectInstructionSizeBudgetViolations(
   }
   return { errors, notices: [] };
 }
+/**
+ * Collect duplicate `syncPairs` target violations. Pure (no I/O) so it can be
+ * unit-tested and shared between the docs audit and sync-docs.
+ *
+ * `sync-docs` only applies the first occurrence of each target, so a second
+ * entry for the same target is silently skipped and becomes dead data: editing
+ * one copy of a divergent pair leaves the ignored copy stale and misleading.
+ * Flagging duplicates turns that latent authoring hazard into a hard failure.
+ */
+export function collectDuplicateSyncPairTargets(syncPairs) {
+  if (!Array.isArray(syncPairs)) {
+    return [];
+  }
+  const seen = new Set();
+  const violations = [];
+  for (const pair of syncPairs) {
+    const target = String(pair?.target ?? '');
+    if (!target) {
+      continue;
+    }
+    if (seen.has(target)) {
+      violations.push(
+        `syncPairs: duplicate target "${target}" (pair "${String(pair?.id ?? '')}"); each syncPairs target must appear exactly once — a duplicate is silently skipped and becomes dead data`,
+      );
+      continue;
+    }
+    seen.add(target);
+  }
+  return violations;
+}

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -437,13 +437,17 @@ export function collectDuplicateSyncPairTargets(syncPairs) {
   const seen = new Set();
   const violations = [];
   for (const pair of syncPairs) {
-    const target = String(pair?.target ?? '');
-    if (!target) {
+    const target = pair?.target;
+    // Only string targets participate: a missing or non-string target is an
+    // invalid entry, not a duplicate, and coercing it (e.g. an object to
+    // "[object Object]") would manufacture confusing false positives.
+    if (typeof target !== 'string' || target === '') {
       continue;
     }
     if (seen.has(target)) {
+      const id = typeof pair?.id === 'string' ? pair.id : '';
       violations.push(
-        `syncPairs: duplicate target "${target}" (pair "${String(pair?.id ?? '')}"); each syncPairs target must appear exactly once — a duplicate is silently skipped and becomes dead data`,
+        `syncPairs: duplicate target "${target}" (pair "${id}"); each syncPairs target must appear exactly once — a duplicate is silently skipped and becomes dead data`,
       );
       continue;
     }

--- a/scripts/sync-docs.mjs
+++ b/scripts/sync-docs.mjs
@@ -102,18 +102,19 @@ function processSyncPairs(pairs) {
   const seenTargets = new Set();
   for (const pair of pairs) {
     const { id, source, target, mode, replacements = [] } = pair;
+    // A duplicate target is dead data: only the first occurrence is applied,
+    // so a divergent second copy is silently ignored and misleads future
+    // maintainers. Enforce uniqueness across every pair (matching the docs
+    // audit's collectDuplicateSyncPairTargets, which checks all modes) so the
+    // error message's "each syncPairs target must appear exactly once" holds
+    // regardless of mode.
+    if (seenTargets.has(target)) {
+      throw new Error(
+        `sync-docs: duplicate target "${target}" in pair "${id}" — each syncPairs target must appear exactly once`,
+      );
+    }
+    seenTargets.add(target);
     if (mode === 'exact' || mode === 'concreted') {
-      if (seenTargets.has(target)) {
-        // A duplicate target is dead data: only the first occurrence is
-        // applied, so a divergent second copy is silently ignored and
-        // misleads future maintainers. Fail loudly instead of skipping so an
-        // accidental re-duplication cannot slip in (the docs audit enforces
-        // the same invariant via collectDuplicateSyncPairTargets).
-        throw new Error(
-          `sync-docs: duplicate target "${target}" in pair "${id}" — each syncPairs target must appear exactly once`,
-        );
-      }
-      seenTargets.add(target);
       const sourceText = readText(source);
       const generated = normalizeText(
         applyReplacements(sourceText, replacements),

--- a/scripts/sync-docs.mjs
+++ b/scripts/sync-docs.mjs
@@ -104,12 +104,14 @@ function processSyncPairs(pairs) {
     const { id, source, target, mode, replacements = [] } = pair;
     if (mode === 'exact' || mode === 'concreted') {
       if (seenTargets.has(target)) {
-        // Duplicate target — both entries produce the same content by design.
-        // Log so maintenance errors become visible rather than silent.
-        console.warn(
-          `sync-docs: duplicate target "${target}" in pair "${id}" — skipping second occurrence`,
+        // A duplicate target is dead data: only the first occurrence is
+        // applied, so a divergent second copy is silently ignored and
+        // misleads future maintainers. Fail loudly instead of skipping so an
+        // accidental re-duplication cannot slip in (the docs audit enforces
+        // the same invariant via collectDuplicateSyncPairTargets).
+        throw new Error(
+          `sync-docs: duplicate target "${target}" in pair "${id}" — each syncPairs target must appear exactly once`,
         );
-        continue;
       }
       seenTargets.add(target);
       const sourceText = readText(source);

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -14,6 +14,7 @@ import type {
   TypeSuppressionBudgetConfig,
 } from './consistency-helpers.mts';
 import {
+  collectDuplicateSyncPairTargets,
   collectInstructionSizeBudgetViolations,
   collectPolicyConfigDrift,
   collectRootMarkdownAllowlistViolations,
@@ -417,6 +418,7 @@ function resolveBlockFiles(block: GeneratedBlock): string[] {
 }
 
 function checkSyncPairs(pairs: SyncPair[]) {
+  errors.push(...collectDuplicateSyncPairTargets(pairs));
   for (const pair of pairs) {
     if (pair.mode === 'contains') {
       checkContainsPair(pair);

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -507,3 +507,38 @@ export function collectInstructionSizeBudgetViolations(
   }
   return { errors, notices: [] };
 }
+
+/**
+ * Collect duplicate `syncPairs` target violations. Pure (no I/O) so it can be
+ * unit-tested and shared between the docs audit and sync-docs.
+ *
+ * `sync-docs` only applies the first occurrence of each target, so a second
+ * entry for the same target is silently skipped and becomes dead data: editing
+ * one copy of a divergent pair leaves the ignored copy stale and misleading.
+ * Flagging duplicates turns that latent authoring hazard into a hard failure.
+ */
+export function collectDuplicateSyncPairTargets(
+  syncPairs: readonly { id?: unknown; target?: unknown }[] | null | undefined,
+): string[] {
+  if (!Array.isArray(syncPairs)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const violations: string[] = [];
+  for (const pair of syncPairs) {
+    const target = String(pair?.target ?? '');
+    if (!target) {
+      continue;
+    }
+    if (seen.has(target)) {
+      violations.push(
+        `syncPairs: duplicate target "${target}" (pair "${String(
+          pair?.id ?? '',
+        )}"); each syncPairs target must appear exactly once — a duplicate is silently skipped and becomes dead data`,
+      );
+      continue;
+    }
+    seen.add(target);
+  }
+  return violations;
+}

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -526,15 +526,17 @@ export function collectDuplicateSyncPairTargets(
   const seen = new Set<string>();
   const violations: string[] = [];
   for (const pair of syncPairs) {
-    const target = String(pair?.target ?? '');
-    if (!target) {
+    const target = pair?.target;
+    // Only string targets participate: a missing or non-string target is an
+    // invalid entry, not a duplicate, and coercing it (e.g. an object to
+    // "[object Object]") would manufacture confusing false positives.
+    if (typeof target !== 'string' || target === '') {
       continue;
     }
     if (seen.has(target)) {
+      const id = typeof pair?.id === 'string' ? pair.id : '';
       violations.push(
-        `syncPairs: duplicate target "${target}" (pair "${String(
-          pair?.id ?? '',
-        )}"); each syncPairs target must appear exactly once — a duplicate is silently skipped and becomes dead data`,
+        `syncPairs: duplicate target "${target}" (pair "${id}"); each syncPairs target must appear exactly once — a duplicate is silently skipped and becomes dead data`,
       );
       continue;
     }

--- a/src/scripts/sync-docs.mts
+++ b/src/scripts/sync-docs.mts
@@ -155,19 +155,20 @@ function processSyncPairs(pairs: SyncPair[]): void {
   for (const pair of pairs) {
     const { id, source, target, mode, replacements = [] } = pair;
 
-    if (mode === 'exact' || mode === 'concreted') {
-      if (seenTargets.has(target)) {
-        // A duplicate target is dead data: only the first occurrence is
-        // applied, so a divergent second copy is silently ignored and
-        // misleads future maintainers. Fail loudly instead of skipping so an
-        // accidental re-duplication cannot slip in (the docs audit enforces
-        // the same invariant via collectDuplicateSyncPairTargets).
-        throw new Error(
-          `sync-docs: duplicate target "${target}" in pair "${id}" — each syncPairs target must appear exactly once`,
-        );
-      }
-      seenTargets.add(target);
+    // A duplicate target is dead data: only the first occurrence is applied,
+    // so a divergent second copy is silently ignored and misleads future
+    // maintainers. Enforce uniqueness across every pair (matching the docs
+    // audit's collectDuplicateSyncPairTargets, which checks all modes) so the
+    // error message's "each syncPairs target must appear exactly once" holds
+    // regardless of mode.
+    if (seenTargets.has(target)) {
+      throw new Error(
+        `sync-docs: duplicate target "${target}" in pair "${id}" — each syncPairs target must appear exactly once`,
+      );
+    }
+    seenTargets.add(target);
 
+    if (mode === 'exact' || mode === 'concreted') {
       const sourceText = readText(source);
       const generated = normalizeText(
         applyReplacements(sourceText, replacements),

--- a/src/scripts/sync-docs.mts
+++ b/src/scripts/sync-docs.mts
@@ -157,12 +157,14 @@ function processSyncPairs(pairs: SyncPair[]): void {
 
     if (mode === 'exact' || mode === 'concreted') {
       if (seenTargets.has(target)) {
-        // Duplicate target — both entries produce the same content by design.
-        // Log so maintenance errors become visible rather than silent.
-        console.warn(
-          `sync-docs: duplicate target "${target}" in pair "${id}" — skipping second occurrence`,
+        // A duplicate target is dead data: only the first occurrence is
+        // applied, so a divergent second copy is silently ignored and
+        // misleads future maintainers. Fail loudly instead of skipping so an
+        // accidental re-duplication cannot slip in (the docs audit enforces
+        // the same invariant via collectDuplicateSyncPairTargets).
+        throw new Error(
+          `sync-docs: duplicate target "${target}" in pair "${id}" — each syncPairs target must appear exactly once`,
         );
-        continue;
       }
       seenTargets.add(target);
 

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -720,9 +720,17 @@ test('collectDuplicateSyncPairTargets flags repeated targets and ignores unique 
     ]),
     [],
   );
-  // Non-array / empty / missing targets are not violations.
+  // Non-array / empty / missing / non-string targets are not violations:
+  // invalid entries are ignored rather than coerced into a fake duplicate.
   assert.deepEqual(collectDuplicateSyncPairTargets(undefined), []);
   assert.deepEqual(collectDuplicateSyncPairTargets([{ id: 'a' }]), []);
+  assert.deepEqual(
+    collectDuplicateSyncPairTargets([
+      { id: 'a', target: {} },
+      { id: 'b', target: {} },
+    ]),
+    [],
+  );
 
   const dupes = collectDuplicateSyncPairTargets([
     { id: 'first', target: 'shared.md' },

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -5,6 +5,7 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  collectDuplicateSyncPairTargets,
   collectInstructionSizeBudgetViolations,
   collectPolicyConfigDrift,
   inspectHelperRuntimeConfig,
@@ -709,4 +710,36 @@ test('package.json version stays aligned with iddVersion in the shipped and temp
         `(${config.iddVersion}) in ${configPath}`,
     );
   }
+});
+
+test('collectDuplicateSyncPairTargets flags repeated targets and ignores unique ones', () => {
+  assert.deepEqual(
+    collectDuplicateSyncPairTargets([
+      { id: 'a', target: 'x.md' },
+      { id: 'b', target: 'y.md' },
+    ]),
+    [],
+  );
+  // Non-array / empty / missing targets are not violations.
+  assert.deepEqual(collectDuplicateSyncPairTargets(undefined), []);
+  assert.deepEqual(collectDuplicateSyncPairTargets([{ id: 'a' }]), []);
+
+  const dupes = collectDuplicateSyncPairTargets([
+    { id: 'first', target: 'shared.md' },
+    { id: 'other', target: 'unique.md' },
+    { id: 'second', target: 'shared.md' },
+  ]);
+  assert.equal(dupes.length, 1);
+  assert.match(dupes[0], /duplicate target "shared\.md"/);
+  assert.match(dupes[0], /pair "second"/);
+});
+
+test('audit/sync-manifest.json has no duplicate syncPairs targets', () => {
+  const manifest = JSON.parse(
+    readFileSync(
+      new URL('../audit/sync-manifest.json', import.meta.url),
+      'utf8',
+    ),
+  ) as { syncPairs?: { id?: string; target?: string }[] };
+  assert.deepEqual(collectDuplicateSyncPairTargets(manifest.syncPairs), []);
 });


### PR DESCRIPTION
## Summary

Dedupe the three duplicated `syncPairs` targets in
`audit/sync-manifest.json` and guard against re-duplication.

- **Dedupe**: remove the byte-identical second occurrence of
  `idd-overview-core-instructions`,
  `idd-overview-appendix-instructions`, and
  `idd-merge-handoff-instructions` (`syncPairs` 43 → 40). The pairs were
  verified identical and no other manifest section references them; the
  diff is limited to the removed entries (a round-trip identity guard
  kept the JSON formatting unchanged).
- **Guard (audit)**: new pure `collectDuplicateSyncPairTargets` helper in
  `consistency-helpers.mts`, called from `audit-docs` `checkSyncPairs`, so
  a re-introduced duplicate target fails `audit-docs --check` (already in
  `lint:minimum`).
- **Guard (generator)**: `sync-docs` now **throws** on a duplicate target
  instead of warn-and-skip — the silent-skip path is exactly the
  dead-data hazard the issue describes.
- **Test**: unit-test the helper (flags a duplicate, ignores unique /
  empty input) and assert the live manifest has no duplicate targets.

## Why

Only the first occurrence of a duplicated target is applied, so a second
copy is silently skipped. Editing one copy of a divergent pair leaves the
ignored copy stale and misleading (this bit the #989 work).

## Verification

- `node scripts/sync-docs.mjs --check`: no `duplicate target … skipping`
  line, all mirrored artifacts up to date (dedupe changes no output).
- `node scripts/audit-docs.mjs --check`: passes.
- A temporarily re-introduced duplicate fails **both**
  `audit-docs --check` and `sync-docs --check`.
- Full test suite (1118) and `build:check` pass; generated `.mjs`
  regenerated via `pnpm run build`.

Closes #1024
