### PR TITLE
perf(idd): narrow --all-roadmaps root discovery with server-side search

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -42,6 +42,7 @@ words:
   - pyproject
   - tsfile
   - undispositioned
+  - unioned
   - unpushed
   - unreplied
   - unrouted

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -49,27 +49,6 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   }
 }
 `;
-const OPEN_ISSUES_QUERY = `
-query($owner:String!, $repo:String!, $after:String) {
-  repository(owner:$owner, name:$repo) {
-    issues(states:OPEN, first:100, after:$after) {
-      nodes {
-        number
-        body
-        labels(first:100) {
-          nodes {
-            name
-          }
-        }
-      }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-    }
-  }
-}
-`;
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
   const hasIssue = Number.isInteger(args.issue) && args.issue > 0;
@@ -1232,48 +1211,124 @@ function buildSubIssueLoader(owner, repo) {
     return [...new Set(numbers)];
   };
 }
-function buildOpenRoadmapRootsLoader(owner, repo, markerPrefix) {
+/**
+ * Live open-roadmap-roots loader (#1017): search-narrowed root discovery.
+ *
+ * Replaces the previous full open-issue scan (which fetched every open
+ * issue's `body` plus up to 100 labels just to detect a root) with two
+ * cheap server-side searches whose union is the SAME open-root set:
+ *
+ *   1. Label roots — `gh search issues --label roadmap --state open` returns
+ *      every open issue carrying the `roadmap` label. These are roots by
+ *      label with NO body inspection needed; the old scan's
+ *      `labels.has('roadmap')` branch is reproduced exactly (the GitHub
+ *      search `--label` qualifier is a case-insensitive exact-name match, as
+ *      is the `normalizeLabels`-backed `Set.has('roadmap')` it replaces).
+ *   2. Marker-only roots — `gh search issues --match body "<...>roadmap-id"
+ *      --state open` narrows to open issues whose body text contains the
+ *      `idd-skill-roadmap-id`-style marker token, then RE-CONFIRMS each
+ *      candidate with the same `extractRoadmapMarkerId(body, prefix)` regex
+ *      the old scan used (the search already returns the body, so no extra
+ *      per-issue fetch is made). Only confirmed markers are kept, so a
+ *      non-marker text hit on the token never inflates the root set.
+ *
+ * The two candidate sets are unioned and deduped by number. The output is
+ * the identical `number[]` (deduped, ascending) the previous scan returned,
+ * so the downstream union/provenance/ranking is byte-stable.
+ *
+ * Boundary (documented parity note): the marker search uses GitHub's
+ * full-text body index. The label search is exact and complete on its own,
+ * so every LABELED root is always found regardless of the marker index. A
+ * marker-ONLY root (no `roadmap` label, marker only in the body) is found
+ * when the body-text index surfaces the broad `roadmap-id` token, which the
+ * `re`-confirm step then verifies — this is the only path that depends on
+ * the search index rather than an exact qualifier. The IDD authoring path
+ * applies the `roadmap` label to roadmap roots, so in practice marker-only
+ * roots are covered by the label search; the marker search is the additive
+ * safety net for unlabeled markers.
+ */
+export function buildOpenRoadmapRootsLoader(
+  owner,
+  repo,
+  markerPrefix,
+  searchIssues = buildSearchIssuesRunner(),
+) {
   const prefix = normalizeMarkerPrefix(markerPrefix);
   return async () => {
-    const numbers = [];
-    let after = '';
-    while (true) {
-      const variables = { owner, repo };
-      if (after) {
-        variables.after = after;
+    const numbers = new Set();
+    // 1. Label roots: roadmap-labeled open issues are roots by label.
+    for (const issue of searchIssues({
+      owner,
+      repo,
+      label: 'roadmap',
+      fields: ['number'],
+    })) {
+      const issueNumber = normalizeSearchIssueNumber(issue);
+      if (issueNumber !== null) {
+        numbers.add(issueNumber);
       }
-      const result = runGraphqlQuery(OPEN_ISSUES_QUERY, variables);
-      const connection = result?.data?.repository?.issues;
-      if (
-        !connection ||
-        !Array.isArray(connection.nodes) ||
-        !connection.pageInfo
-      ) {
-        throw new Error('open issues connection missing');
-      }
-      for (const node of connection.nodes) {
-        const issue = node;
-        const issueNumber = Number.parseInt(String(issue?.number ?? ''), 10);
-        if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
-          continue;
-        }
-        const labels = normalizeLabels(issue?.labels?.nodes);
-        const hasRoadmapMarker = Boolean(
-          extractRoadmapMarkerId(issue?.body, prefix),
-        );
-        if (labels.has('roadmap') || hasRoadmapMarker) {
-          numbers.push(issueNumber);
-        }
-      }
-      if (!connection.pageInfo.hasNextPage) {
-        break;
-      }
-      if (!connection.pageInfo.endCursor) {
-        throw new Error('open issues pagination cursor missing');
-      }
-      after = String(connection.pageInfo.endCursor);
     }
-    return [...new Set(numbers)];
+    // 2. Marker-only roots: narrow to open issues whose body carries the
+    //    marker token, then re-confirm with the exact regex on the body the
+    //    search already returned (no extra per-issue body fetch).
+    for (const issue of searchIssues({
+      owner,
+      repo,
+      matchBody: `${prefix}-roadmap-id`,
+      fields: ['number', 'body'],
+    })) {
+      const issueNumber = normalizeSearchIssueNumber(issue);
+      if (issueNumber === null) {
+        continue;
+      }
+      const body = issue?.body;
+      if (extractRoadmapMarkerId(body, prefix)) {
+        numbers.add(issueNumber);
+      }
+    }
+    return [...numbers];
+  };
+}
+/** Coerce a `gh search issues` JSON entry's number to a positive integer. */
+function normalizeSearchIssueNumber(issue) {
+  const issueNumber = Number.parseInt(String(issue?.number ?? ''), 10);
+  return Number.isInteger(issueNumber) && issueNumber > 0 ? issueNumber : null;
+}
+/**
+ * Build the live `gh search issues` runner used by the open-roadmap-roots
+ * loader. Each call issues one read-only server-side search; the search API
+ * caps a single query at 1000 results, so the limit is pinned at that cap.
+ * Pull requests are excluded by default (`--include-prs` is never passed),
+ * matching the old scan which only ever saw issues from the issues
+ * connection.
+ */
+function buildSearchIssuesRunner() {
+  // GitHub's search API returns at most 1000 results for a single query.
+  const SEARCH_RESULT_CAP = 1000;
+  return ({ owner, repo, label, matchBody, fields }) => {
+    const args = [
+      'search',
+      'issues',
+      '--repo',
+      `${owner}/${repo}`,
+      '--state',
+      'open',
+      '--limit',
+      String(SEARCH_RESULT_CAP),
+      '--json',
+      fields.join(','),
+    ];
+    if (label) {
+      args.push('--label', label);
+    }
+    if (matchBody) {
+      // Restrict the free-text query to the body field, then pass the token
+      // as the positional search query.
+      args.push('--match', 'body', matchBody);
+    }
+    const raw = runGh(args).trim();
+    const parsed = raw && raw !== 'null' ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
   };
 }
 function runGraphqlQuery(query, variables) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -21,6 +21,10 @@ import {
 } from './protocol-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// GitHub's search API returns at most 1000 results for a single query. The
+// open-roadmap-roots loader pins each search at this cap and warns when a
+// single search returns the full cap (a possible silent truncation).
+const GH_SEARCH_RESULT_CAP = 1000;
 // Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
 // the default baked into protocol-helpers' `isStaleAt`, so when the configured
 // stale age equals this default the shared `isStaleAt` path is
@@ -1232,9 +1236,20 @@ function buildSubIssueLoader(owner, repo) {
  *      per-issue fetch is made). Only confirmed markers are kept, so a
  *      non-marker text hit on the token never inflates the root set.
  *
- * The two candidate sets are unioned and deduped by number. The output is
- * the identical `number[]` (deduped, ascending) the previous scan returned,
- * so the downstream union/provenance/ranking is byte-stable.
+ * The two candidate sets are unioned and deduped by number, then sorted
+ * ascending. The output is the identical `number[]` (deduped, ascending) the
+ * previous scan returned, so the downstream union/provenance/ranking is
+ * byte-stable.
+ *
+ * Result-cap boundary: `gh search` is hard-capped at
+ * {@link GH_SEARCH_RESULT_CAP} results per query. When a single label or
+ * body-marker search returns the full cap it may have been truncated, so a
+ * repo with >= {@link GH_SEARCH_RESULT_CAP} hits could silently yield an
+ * incomplete root set. The loader emits a NON-FATAL one-line WARNING to stderr
+ * in that case (see {@link warnOnSearchResultCap}) rather than aborting — the
+ * body-marker search can legitimately match many re-confirmed-and-dropped
+ * prose mentions, so a hard error would over-abort. The JSON report itself
+ * goes to stdout, so the stderr warning never corrupts it.
  *
  * Boundary (documented parity note): the marker search uses GitHub's
  * full-text body index. The label search is exact and complete on its own,
@@ -1257,12 +1272,14 @@ export function buildOpenRoadmapRootsLoader(
   return async () => {
     const numbers = new Set();
     // 1. Label roots: roadmap-labeled open issues are roots by label.
-    for (const issue of searchIssues({
+    const labelResults = searchIssues({
       owner,
       repo,
       label: 'roadmap',
       fields: ['number'],
-    })) {
+    });
+    warnOnSearchResultCap(labelResults, 'label');
+    for (const issue of labelResults) {
       const issueNumber = normalizeSearchIssueNumber(issue);
       if (issueNumber !== null) {
         numbers.add(issueNumber);
@@ -1271,12 +1288,14 @@ export function buildOpenRoadmapRootsLoader(
     // 2. Marker-only roots: narrow to open issues whose body carries the
     //    marker token, then re-confirm with the exact regex on the body the
     //    search already returned (no extra per-issue body fetch).
-    for (const issue of searchIssues({
+    const markerResults = searchIssues({
       owner,
       repo,
       matchBody: `${prefix}-roadmap-id`,
       fields: ['number', 'body'],
-    })) {
+    });
+    warnOnSearchResultCap(markerResults, 'body-marker');
+    for (const issue of markerResults) {
       const issueNumber = normalizeSearchIssueNumber(issue);
       if (issueNumber === null) {
         continue;
@@ -1286,8 +1305,28 @@ export function buildOpenRoadmapRootsLoader(
         numbers.add(issueNumber);
       }
     }
-    return [...numbers];
+    // Ascending, deduped — matches the documented `number[]` contract.
+    return [...numbers].sort((left, right) => left - right);
   };
+}
+/**
+ * GitHub's search API caps a single query at 1000 results
+ * ({@link GH_SEARCH_RESULT_CAP}). When a root search returns the full cap it
+ * may have been truncated, so a repo with >= 1000 label or marker-token hits
+ * could silently yield an incomplete root set.
+ *
+ * This is NON-FATAL: the body-marker search can legitimately match many prose
+ * mentions that are re-confirmed and dropped, so a hard error would over-abort.
+ * Instead emit one clear WARNING line to STDERR (the JSON report goes to
+ * stdout, so stderr keeps the report stream clean) and continue. Exported for
+ * the focused loader test that asserts the warning fires.
+ */
+export function warnOnSearchResultCap(results, searchKind) {
+  if (Array.isArray(results) && results.length >= GH_SEARCH_RESULT_CAP) {
+    process.stderr.write(
+      `discover-roadmap-graph: --all-roadmaps root search hit the ${GH_SEARCH_RESULT_CAP}-result cap (${searchKind}); root discovery may be incomplete on this scale.\n`,
+    );
+  }
 }
 /** Coerce a `gh search issues` JSON entry's number to a positive integer. */
 function normalizeSearchIssueNumber(issue) {
@@ -1297,14 +1336,13 @@ function normalizeSearchIssueNumber(issue) {
 /**
  * Build the live `gh search issues` runner used by the open-roadmap-roots
  * loader. Each call issues one read-only server-side search; the search API
- * caps a single query at 1000 results, so the limit is pinned at that cap.
+ * caps a single query at {@link GH_SEARCH_RESULT_CAP} results, so the limit is
+ * pinned at that cap (the loader warns when a search returns the full cap).
  * Pull requests are excluded by default (`--include-prs` is never passed),
  * matching the old scan which only ever saw issues from the issues
  * connection.
  */
 function buildSearchIssuesRunner() {
-  // GitHub's search API returns at most 1000 results for a single query.
-  const SEARCH_RESULT_CAP = 1000;
   return ({ owner, repo, label, matchBody, fields }) => {
     const args = [
       'search',
@@ -1314,7 +1352,7 @@ function buildSearchIssuesRunner() {
       '--state',
       'open',
       '--limit',
-      String(SEARCH_RESULT_CAP),
+      String(GH_SEARCH_RESULT_CAP),
       '--json',
       fields.join(','),
     ];

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -51,27 +51,6 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   }
 }
 `;
-const OPEN_ISSUES_QUERY = `
-query($owner:String!, $repo:String!, $after:String) {
-  repository(owner:$owner, name:$repo) {
-    issues(states:OPEN, first:100, after:$after) {
-      nodes {
-        number
-        body
-        labels(first:100) {
-          nodes {
-            name
-          }
-        }
-      }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-    }
-  }
-}
-`;
 
 type InaccessibleIssueSentinel = typeof INACCESSIBLE_ISSUE_SENTINEL;
 
@@ -1707,71 +1686,146 @@ function buildSubIssueLoader(owner: string, repo: string) {
   };
 }
 
-function buildOpenRoadmapRootsLoader(
+/**
+ * Live open-roadmap-roots loader (#1017): search-narrowed root discovery.
+ *
+ * Replaces the previous full open-issue scan (which fetched every open
+ * issue's `body` plus up to 100 labels just to detect a root) with two
+ * cheap server-side searches whose union is the SAME open-root set:
+ *
+ *   1. Label roots — `gh search issues --label roadmap --state open` returns
+ *      every open issue carrying the `roadmap` label. These are roots by
+ *      label with NO body inspection needed; the old scan's
+ *      `labels.has('roadmap')` branch is reproduced exactly (the GitHub
+ *      search `--label` qualifier is a case-insensitive exact-name match, as
+ *      is the `normalizeLabels`-backed `Set.has('roadmap')` it replaces).
+ *   2. Marker-only roots — `gh search issues --match body "<...>roadmap-id"
+ *      --state open` narrows to open issues whose body text contains the
+ *      `idd-skill-roadmap-id`-style marker token, then RE-CONFIRMS each
+ *      candidate with the same `extractRoadmapMarkerId(body, prefix)` regex
+ *      the old scan used (the search already returns the body, so no extra
+ *      per-issue fetch is made). Only confirmed markers are kept, so a
+ *      non-marker text hit on the token never inflates the root set.
+ *
+ * The two candidate sets are unioned and deduped by number. The output is
+ * the identical `number[]` (deduped, ascending) the previous scan returned,
+ * so the downstream union/provenance/ranking is byte-stable.
+ *
+ * Boundary (documented parity note): the marker search uses GitHub's
+ * full-text body index. The label search is exact and complete on its own,
+ * so every LABELED root is always found regardless of the marker index. A
+ * marker-ONLY root (no `roadmap` label, marker only in the body) is found
+ * when the body-text index surfaces the broad `roadmap-id` token, which the
+ * `re`-confirm step then verifies — this is the only path that depends on
+ * the search index rather than an exact qualifier. The IDD authoring path
+ * applies the `roadmap` label to roadmap roots, so in practice marker-only
+ * roots are covered by the label search; the marker search is the additive
+ * safety net for unlabeled markers.
+ */
+export function buildOpenRoadmapRootsLoader(
   owner: string,
   repo: string,
   markerPrefix: unknown,
+  searchIssues: SearchIssuesFn = buildSearchIssuesRunner(),
 ) {
   const prefix = normalizeMarkerPrefix(markerPrefix);
   return async () => {
-    const numbers: number[] = [];
-    let after = '';
+    const numbers = new Set<number>();
 
-    while (true) {
-      const variables: Record<string, string | number> = { owner, repo };
-      if (after) {
-        variables.after = after;
+    // 1. Label roots: roadmap-labeled open issues are roots by label.
+    for (const issue of searchIssues({
+      owner,
+      repo,
+      label: 'roadmap',
+      fields: ['number'],
+    })) {
+      const issueNumber = normalizeSearchIssueNumber(issue);
+      if (issueNumber !== null) {
+        numbers.add(issueNumber);
       }
-      const result = runGraphqlQuery(OPEN_ISSUES_QUERY, variables) as {
-        data?: {
-          repository?: {
-            issues?: {
-              nodes?: unknown;
-              pageInfo?: { hasNextPage?: unknown; endCursor?: unknown };
-            };
-          };
-        };
-      };
-      const connection = result?.data?.repository?.issues;
-      if (
-        !connection ||
-        !Array.isArray(connection.nodes) ||
-        !connection.pageInfo
-      ) {
-        throw new Error('open issues connection missing');
-      }
-
-      for (const node of connection.nodes) {
-        const issue = node as {
-          number?: unknown;
-          body?: unknown;
-          labels?: { nodes?: unknown };
-        } | null;
-        const issueNumber = Number.parseInt(String(issue?.number ?? ''), 10);
-        if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
-          continue;
-        }
-        const labels = normalizeLabels(
-          (issue?.labels as { nodes?: unknown } | undefined)?.nodes,
-        );
-        const hasRoadmapMarker = Boolean(
-          extractRoadmapMarkerId(issue?.body, prefix),
-        );
-        if (labels.has('roadmap') || hasRoadmapMarker) {
-          numbers.push(issueNumber);
-        }
-      }
-
-      if (!connection.pageInfo.hasNextPage) {
-        break;
-      }
-      if (!connection.pageInfo.endCursor) {
-        throw new Error('open issues pagination cursor missing');
-      }
-      after = String(connection.pageInfo.endCursor);
     }
 
-    return [...new Set(numbers)];
+    // 2. Marker-only roots: narrow to open issues whose body carries the
+    //    marker token, then re-confirm with the exact regex on the body the
+    //    search already returned (no extra per-issue body fetch).
+    for (const issue of searchIssues({
+      owner,
+      repo,
+      matchBody: `${prefix}-roadmap-id`,
+      fields: ['number', 'body'],
+    })) {
+      const issueNumber = normalizeSearchIssueNumber(issue);
+      if (issueNumber === null) {
+        continue;
+      }
+      const body = (issue as { body?: unknown } | null)?.body;
+      if (extractRoadmapMarkerId(body, prefix)) {
+        numbers.add(issueNumber);
+      }
+    }
+
+    return [...numbers];
+  };
+}
+
+/** One `gh search issues` query, narrowed to a candidate root set. */
+export interface SearchIssuesQuery {
+  owner: string;
+  repo: string;
+  /** Exact `--label` qualifier (open issues carrying this label). */
+  label?: string;
+  /** Free-text token restricted to the issue body (`--match body`). */
+  matchBody?: string;
+  /** Requested `--json` fields. */
+  fields: string[];
+}
+
+export type SearchIssuesFn = (query: SearchIssuesQuery) => unknown[];
+
+/** Coerce a `gh search issues` JSON entry's number to a positive integer. */
+function normalizeSearchIssueNumber(issue: unknown): number | null {
+  const issueNumber = Number.parseInt(
+    String((issue as { number?: unknown } | null)?.number ?? ''),
+    10,
+  );
+  return Number.isInteger(issueNumber) && issueNumber > 0 ? issueNumber : null;
+}
+
+/**
+ * Build the live `gh search issues` runner used by the open-roadmap-roots
+ * loader. Each call issues one read-only server-side search; the search API
+ * caps a single query at 1000 results, so the limit is pinned at that cap.
+ * Pull requests are excluded by default (`--include-prs` is never passed),
+ * matching the old scan which only ever saw issues from the issues
+ * connection.
+ */
+function buildSearchIssuesRunner(): SearchIssuesFn {
+  // GitHub's search API returns at most 1000 results for a single query.
+  const SEARCH_RESULT_CAP = 1000;
+  return ({ owner, repo, label, matchBody, fields }) => {
+    const args = [
+      'search',
+      'issues',
+      '--repo',
+      `${owner}/${repo}`,
+      '--state',
+      'open',
+      '--limit',
+      String(SEARCH_RESULT_CAP),
+      '--json',
+      fields.join(','),
+    ];
+    if (label) {
+      args.push('--label', label);
+    }
+    if (matchBody) {
+      // Restrict the free-text query to the body field, then pass the token
+      // as the positional search query.
+      args.push('--match', 'body', matchBody);
+    }
+    const raw = runGh(args).trim();
+    const parsed = raw && raw !== 'null' ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
   };
 }
 

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -23,6 +23,10 @@ import {
 } from './protocol-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// GitHub's search API returns at most 1000 results for a single query. The
+// open-roadmap-roots loader pins each search at this cap and warns when a
+// single search returns the full cap (a possible silent truncation).
+const GH_SEARCH_RESULT_CAP = 1000;
 // Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
 // the default baked into protocol-helpers' `isStaleAt`, so when the configured
 // stale age equals this default the shared `isStaleAt` path is
@@ -1707,9 +1711,20 @@ function buildSubIssueLoader(owner: string, repo: string) {
  *      per-issue fetch is made). Only confirmed markers are kept, so a
  *      non-marker text hit on the token never inflates the root set.
  *
- * The two candidate sets are unioned and deduped by number. The output is
- * the identical `number[]` (deduped, ascending) the previous scan returned,
- * so the downstream union/provenance/ranking is byte-stable.
+ * The two candidate sets are unioned and deduped by number, then sorted
+ * ascending. The output is the identical `number[]` (deduped, ascending) the
+ * previous scan returned, so the downstream union/provenance/ranking is
+ * byte-stable.
+ *
+ * Result-cap boundary: `gh search` is hard-capped at
+ * {@link GH_SEARCH_RESULT_CAP} results per query. When a single label or
+ * body-marker search returns the full cap it may have been truncated, so a
+ * repo with >= {@link GH_SEARCH_RESULT_CAP} hits could silently yield an
+ * incomplete root set. The loader emits a NON-FATAL one-line WARNING to stderr
+ * in that case (see {@link warnOnSearchResultCap}) rather than aborting — the
+ * body-marker search can legitimately match many re-confirmed-and-dropped
+ * prose mentions, so a hard error would over-abort. The JSON report itself
+ * goes to stdout, so the stderr warning never corrupts it.
  *
  * Boundary (documented parity note): the marker search uses GitHub's
  * full-text body index. The label search is exact and complete on its own,
@@ -1733,12 +1748,14 @@ export function buildOpenRoadmapRootsLoader(
     const numbers = new Set<number>();
 
     // 1. Label roots: roadmap-labeled open issues are roots by label.
-    for (const issue of searchIssues({
+    const labelResults = searchIssues({
       owner,
       repo,
       label: 'roadmap',
       fields: ['number'],
-    })) {
+    });
+    warnOnSearchResultCap(labelResults, 'label');
+    for (const issue of labelResults) {
       const issueNumber = normalizeSearchIssueNumber(issue);
       if (issueNumber !== null) {
         numbers.add(issueNumber);
@@ -1748,12 +1765,14 @@ export function buildOpenRoadmapRootsLoader(
     // 2. Marker-only roots: narrow to open issues whose body carries the
     //    marker token, then re-confirm with the exact regex on the body the
     //    search already returned (no extra per-issue body fetch).
-    for (const issue of searchIssues({
+    const markerResults = searchIssues({
       owner,
       repo,
       matchBody: `${prefix}-roadmap-id`,
       fields: ['number', 'body'],
-    })) {
+    });
+    warnOnSearchResultCap(markerResults, 'body-marker');
+    for (const issue of markerResults) {
       const issueNumber = normalizeSearchIssueNumber(issue);
       if (issueNumber === null) {
         continue;
@@ -1764,8 +1783,32 @@ export function buildOpenRoadmapRootsLoader(
       }
     }
 
-    return [...numbers];
+    // Ascending, deduped — matches the documented `number[]` contract.
+    return [...numbers].sort((left, right) => left - right);
   };
+}
+
+/**
+ * GitHub's search API caps a single query at 1000 results
+ * ({@link GH_SEARCH_RESULT_CAP}). When a root search returns the full cap it
+ * may have been truncated, so a repo with >= 1000 label or marker-token hits
+ * could silently yield an incomplete root set.
+ *
+ * This is NON-FATAL: the body-marker search can legitimately match many prose
+ * mentions that are re-confirmed and dropped, so a hard error would over-abort.
+ * Instead emit one clear WARNING line to STDERR (the JSON report goes to
+ * stdout, so stderr keeps the report stream clean) and continue. Exported for
+ * the focused loader test that asserts the warning fires.
+ */
+export function warnOnSearchResultCap(
+  results: unknown[],
+  searchKind: 'label' | 'body-marker',
+): void {
+  if (Array.isArray(results) && results.length >= GH_SEARCH_RESULT_CAP) {
+    process.stderr.write(
+      `discover-roadmap-graph: --all-roadmaps root search hit the ${GH_SEARCH_RESULT_CAP}-result cap (${searchKind}); root discovery may be incomplete on this scale.\n`,
+    );
+  }
 }
 
 /** One `gh search issues` query, narrowed to a candidate root set. */
@@ -1794,14 +1837,13 @@ function normalizeSearchIssueNumber(issue: unknown): number | null {
 /**
  * Build the live `gh search issues` runner used by the open-roadmap-roots
  * loader. Each call issues one read-only server-side search; the search API
- * caps a single query at 1000 results, so the limit is pinned at that cap.
+ * caps a single query at {@link GH_SEARCH_RESULT_CAP} results, so the limit is
+ * pinned at that cap (the loader warns when a search returns the full cap).
  * Pull requests are excluded by default (`--include-prs` is never passed),
  * matching the old scan which only ever saw issues from the issues
  * connection.
  */
 function buildSearchIssuesRunner(): SearchIssuesFn {
-  // GitHub's search API returns at most 1000 results for a single query.
-  const SEARCH_RESULT_CAP = 1000;
   return ({ owner, repo, label, matchBody, fields }) => {
     const args = [
       'search',
@@ -1811,7 +1853,7 @@ function buildSearchIssuesRunner(): SearchIssuesFn {
       '--state',
       'open',
       '--limit',
-      String(SEARCH_RESULT_CAP),
+      String(GH_SEARCH_RESULT_CAP),
       '--json',
       fields.join(','),
     ];

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -7,6 +7,7 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  buildOpenRoadmapRootsLoader,
   buildTrustedAuthorPredicate,
   classifyIssue,
   enumerateAllRoadmapsGraph,
@@ -15,6 +16,7 @@ import {
   extractRoadmapMarkerId,
   extractTaskListReferences,
   parseClaimStaleAgeMs,
+  type SearchIssuesQuery,
 } from '../src/scripts/discover-roadmap-graph.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
@@ -1025,6 +1027,92 @@ process.exit(1);
         },
       ),
     /missing required --issue/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Search-narrowed open-roadmap-root discovery (#1017).
+//
+// The live loader narrows root discovery to two cheap server-side searches
+// (a `--label roadmap` search and a body-marker `--match body` search) and
+// re-confirms marker candidates against the body the search already returned,
+// instead of fetching every open issue's body. These tests inject a stubbed
+// `searchIssues` runner at that seam to pin: both root kinds are discovered,
+// a non-marker body hit is dropped, and no full open-issue scan happens.
+// ---------------------------------------------------------------------------
+
+test('open-roadmap-roots loader unions label roots and re-confirmed marker roots', async () => {
+  const queries: SearchIssuesQuery[] = [];
+  const searchIssues = (query: SearchIssuesQuery) => {
+    queries.push(query);
+    if (query.label === 'roadmap') {
+      // Labeled roots: roots by label, no body needed for detection.
+      return [{ number: 701 }, { number: 702 }];
+    }
+    if (query.matchBody) {
+      // Body-marker candidates: 703 carries a real marker (kept on
+      // re-confirm); 704 is a non-marker token hit (dropped); 701 also
+      // surfaces here and must dedupe against the label root.
+      return [
+        { number: 703, body: '<!-- idd-skill-roadmap-id: marker-only -->' },
+        { number: 704, body: 'mentions roadmap-id in prose but no marker' },
+        { number: 701, body: '<!-- idd-skill-roadmap-id: also-labeled -->' },
+      ];
+    }
+    return [];
+  };
+
+  const loadRoots = buildOpenRoadmapRootsLoader(
+    'kurone-kito',
+    'idd-skill',
+    'idd-skill',
+    searchIssues,
+  );
+  const roots = await loadRoots();
+
+  // 701 + 702 (label roots) ∪ 703 (re-confirmed marker root); 704 dropped
+  // because its body carries no marker, 701 deduped across both searches.
+  assert.deepEqual(
+    [...roots].sort((a, b) => a - b),
+    [701, 702, 703],
+  );
+
+  // Exactly two server-side searches: one exact `--label roadmap` (no body
+  // requested) and one body-marker `--match body` carrying the prefixed
+  // marker token. No full open-issue body scan is performed.
+  assert.equal(queries.length, 2);
+  const labelQuery = queries.find((query) => query.label === 'roadmap');
+  assert.deepEqual(labelQuery?.fields, ['number']);
+  assert.equal(labelQuery?.matchBody, undefined);
+  const markerQuery = queries.find((query) => query.matchBody);
+  assert.equal(markerQuery?.matchBody, 'idd-skill-roadmap-id');
+  assert.deepEqual(markerQuery?.fields, ['number', 'body']);
+  assert.equal(markerQuery?.label, undefined);
+});
+
+test('open-roadmap-roots loader honors a custom marker prefix in the body search', async () => {
+  const queries: SearchIssuesQuery[] = [];
+  const searchIssues = (query: SearchIssuesQuery) => {
+    queries.push(query);
+    if (query.matchBody) {
+      return [{ number: 810, body: '<!-- acme-roadmap-id: scoped -->' }];
+    }
+    return [];
+  };
+
+  const roots = await buildOpenRoadmapRootsLoader(
+    'kurone-kito',
+    'idd-skill',
+    'acme',
+    searchIssues,
+  )();
+
+  // The custom prefix flows into both the search token and the re-confirm
+  // regex, so the `acme-` marker is discovered.
+  assert.deepEqual(roots, [810]);
+  assert.equal(
+    queries.find((query) => query.matchBody)?.matchBody,
+    'acme-roadmap-id',
   );
 });
 

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -17,7 +17,24 @@ import {
   extractTaskListReferences,
   parseClaimStaleAgeMs,
   type SearchIssuesQuery,
+  warnOnSearchResultCap,
 } from '../src/scripts/discover-roadmap-graph.mts';
+
+/** Run `body` with `process.stderr.write` captured; return the joined output. */
+function captureStderr(body: () => void): string {
+  const original = process.stderr.write.bind(process.stderr);
+  const chunks: string[] = [];
+  process.stderr.write = ((chunk: unknown) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    body();
+  } finally {
+    process.stderr.write = original;
+  }
+  return chunks.join('');
+}
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
@@ -1046,8 +1063,10 @@ test('open-roadmap-roots loader unions label roots and re-confirmed marker roots
   const searchIssues = (query: SearchIssuesQuery) => {
     queries.push(query);
     if (query.label === 'roadmap') {
-      // Labeled roots: roots by label, no body needed for detection.
-      return [{ number: 701 }, { number: 702 }];
+      // Labeled roots returned out of insertion order on purpose: 702 before
+      // 701 so the loader cannot rely on search/Set order for its ascending
+      // contract.
+      return [{ number: 702 }, { number: 701 }];
     }
     if (query.matchBody) {
       // Body-marker candidates: 703 carries a real marker (kept on
@@ -1072,10 +1091,10 @@ test('open-roadmap-roots loader unions label roots and re-confirmed marker roots
 
   // 701 + 702 (label roots) ∪ 703 (re-confirmed marker root); 704 dropped
   // because its body carries no marker, 701 deduped across both searches.
-  assert.deepEqual(
-    [...roots].sort((a, b) => a - b),
-    [701, 702, 703],
-  );
+  // The loader's documented contract is deduped + ASCENDING, so the raw
+  // return must already be sorted even though the stub yielded 702 before 701
+  // and surfaced 703 only via the marker search (no caller-side sort here).
+  assert.deepEqual(roots, [701, 702, 703]);
 
   // Exactly two server-side searches: one exact `--label roadmap` (no body
   // requested) and one body-marker `--match body` carrying the prefixed
@@ -1114,6 +1133,25 @@ test('open-roadmap-roots loader honors a custom marker prefix in the body search
     queries.find((query) => query.matchBody)?.matchBody,
     'acme-roadmap-id',
   );
+});
+
+test('open-roadmap-roots loader warns on the 1000-result search cap', () => {
+  // Below the cap: no warning is emitted (the common case stays silent).
+  const belowCap = captureStderr(() => {
+    warnOnSearchResultCap(new Array(999).fill({ number: 1 }), 'label');
+  });
+  assert.equal(belowCap, '');
+
+  // At the cap: a single NON-FATAL warning line goes to stderr (the JSON
+  // report goes to stdout, so this never corrupts the report stream), naming
+  // which search saturated so root discovery is no longer silently truncated.
+  const atCap = captureStderr(() => {
+    warnOnSearchResultCap(new Array(1000).fill({ number: 1 }), 'body-marker');
+  });
+  assert.match(atCap, /hit the 1000-result cap \(body-marker\)/u);
+  assert.match(atCap, /root discovery may be incomplete/u);
+  // Exactly one warning line.
+  assert.equal(atCap.trimEnd().split('\n').length, 1);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Optimizes `discover-roadmap-graph --all-roadmaps` root discovery so it no
longer paginates every open issue and fetches each full `body` (+ labels) just
to detect a roadmap root. Replaces the full scan with two cheap server-side
searches whose union is the same open-root set.

## What changed

- `src/scripts/discover-roadmap-graph.mts` (source): `buildOpenRoadmapRootsLoader`
  now runs:
  - a `label:roadmap` search (exact label match — complete for labeled roots,
    no body fetch);
  - a `--match-body "<prefix>-roadmap-id"` search, re-confirmed with the same
    `extractRoadmapMarkerId` regex on the body the search already returned (no
    extra per-issue body fetch).
  Their union (deduped) is fed to the unchanged downstream pipeline. The now-dead
  `OPEN_ISSUES_QUERY` full-scan is removed. `buildOpenRoadmapRootsLoader` gains
  an injectable `searchIssues` seam (default = live runner) for tests.
- `tests/discover-roadmap-graph.test.mts`: existing `--all-roadmaps`
  union/provenance/ranking tests pass unchanged (they inject the roots loader
  above this seam); adds tests for the narrowed path (label root + re-confirmed
  marker root unioned; prose-token hits dropped; non-root bodies never fetched;
  custom marker prefix flows into both the search token and the regex).

## Output parity & boundary

The `--all-roadmaps` contract (union, provenance, ranking, diagnostics) is
unchanged. Labeled roadmap roots — the IDD authoring norm (A1 identifies the
roadmap by its `roadmap` label) — are always found by the exact label search.
The marker search is an **additive, index-backed safety net** for roots that
carry only the `idd-skill-roadmap-id` body marker without the label; this is
documented in the loader JSDoc. Eliminating that index dependency entirely would
require scanning every body again, which is exactly the cost this issue asks to
remove, so the search approach (the issue's preferred option) is taken with the
boundary made explicit rather than silent.

## Verification

`pnpm run lint:minimum` passes (typecheck, build:check, node --test, biome,
cspell, markdownlint).

Closes #1017


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Roadmap discovery now uses faster search-based lookups to find open roadmap items.
  - Results from label matches and body markers are combined, deduped, and sorted consistently.

- **Bug Fixes**
  - Improved handling for large search result sets by showing a warning when results may be incomplete.
  - Better support for custom roadmap marker prefixes during discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->