### PR TITLE
feat(idd): flag high-contention shared-file overlap in A4 Step 2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -46,6 +46,7 @@ scripts/forced-handoff-marker.mjs linguist-generated=true
 scripts/force-handoff.mjs linguist-generated=true
 scripts/external-check-waiver.mjs linguist-generated=true
 scripts/audit-pr-cleanup.mjs linguist-generated=true
+scripts/discover-shared-file-overlap.mjs linguist-generated=true
 idd-template/scripts/minimize-superseded-markers.mjs linguist-generated=true
 # Every bin/ shim is generated from src/bin/*.mts (whole directory).
 bin/**/*.mjs linguist-generated=true

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -529,6 +529,20 @@ convergence is preserved because the branch name derives from the issue,
 not selection order. With `off`, a single-entry band, or no applicable
 score, keep the deterministic **lowest issue number** pick.
 
+**High-contention shared-file overlap (advisory).** Concurrent autopilot
+sessions tend to edit the same F-phase bundle instruction files
+(`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`, so a
+colliding pick costs a later merge-from-main conflict. As a **soft**
+tie-breaker layered after the score / lowest-number / desync rules, prefer a
+candidate whose `## Candidate files` do **not** overlap an actively-claimed or
+open-PR issue on one of those files; the optional
+`discover-shared-file-overlap` helper (see
+[IDD helper scripts](../../docs/idd-helper-scripts.md)) reports each candidate's
+`overlapFlag` and a `recommendedOrder`. This is **never a hard gate** — overlap
+never overrides the score or crosses a score band, and a colliding candidate
+stays claimable when it is the only ready work. See the
+[high-contention shared-file convention](../../docs/policy-constants.md#high-contention-shared-files).
+
 After picking, proceed to **A4.5** (`idd-suitability.instructions.md`).
 
 ## A4.5 — Pre-Claim Issue-Suitability Triage

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,5 +1,6 @@
 ignores:
   - .github/CODE_OF_CONDUCT*
   - fixtures/issue-comments/*.md
+  - fixtures/shared-file-overlap/*.md
   - node_modules/**/*.md
   - .pnpm-config/**/*.md

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -148,7 +148,7 @@
     "glob": ".github/instructions/idd-*.instructions.md",
     "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
     "alwaysLoadedLimitBytes": 20000,
-    "phaseLimitBytes": 30100
+    "phaseLimitBytes": 31400
   },
   "bundleBudgets": [
     {
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 88100
+      "limitBytes": 89400
     },
     {
       "id": "bundle-resume",

--- a/bin/idd-discover-shared-file-overlap.mjs
+++ b/bin/idd-discover-shared-file-overlap.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-discover-shared-file-overlap.mts
+//
+// The bin/idd-discover-shared-file-overlap.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/discover-shared-file-overlap.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -276,7 +276,9 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
     `reason: "claim" | "pr", files: string[] }], overlapFlag: boolean }]`
   - `recommendedOrder`: `number[]` — candidate numbers after the soft
     tie-breaker (score desc, then non-overlapping first within a score band,
-    then issue number). Advisory only; never a hard gate.
+    then issue number). It does **not** apply `discover.selectionDesync`; the
+    agent layers the overlap nudge after its own desync pick. Advisory only;
+    never a hard gate.
   - `summary`: `{ candidateCount: number, flaggedCount: number,`
     `activeIssueCount: number }`
 - **Behavior boundary**: evidence-only and heuristic. `## Candidate files` are

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -256,13 +256,13 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
   claim comments of issues that have a remote `issue/<n>-*` branch, resolved
   with the shared claim-state rules and the configured claim stale age) is
   **gated behind `--check-overlap`** because it adds GitHub API cost; without it
-  each candidate's high-contention files are still reported. **Coverage**:
-  open-PR overlap is repo-wide; active-claim overlap covers every issue that has
-  a remote `issue/<n>-*` branch (every IDD claim creates one once pushed), so a
-  non-stale claim held by another session is detected even when it is outside
-  the unclaimed candidate set being ranked. It is bounded by the number of
-  active issue branches, not a repo-wide comment scan; a claim whose branch is
-  not yet pushed is picked up once it appears remotely.
+  each candidate's high-contention files are still reported. **Coverage**
+  (best-effort, no repo-wide comment scan): open-PR overlap scans open PRs
+  (bounded by the `gh pr list` page cap); active-claim overlap covers every
+  issue that has a remote `issue/<n>-*` branch (every IDD claim creates one once
+  pushed, paginated to the end), so a non-stale claim held by another session is
+  detected even when it is outside the unclaimed candidate set being ranked. A
+  claim whose branch is not yet pushed is picked up once it appears remotely.
 - **High-contention set**: the union of the named bundles' member files plus
   `audit/sync-manifest.json`. Instruction files are keyed by their repo-wide
   unique basename so a source path, mirror path, or bare citation all match.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -255,7 +255,11 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
   `--check-overlap`. The cross-issue active-set discovery (open PRs plus
   claimed-candidate comment scans, resolved with the shared claim-state rules)
   is **gated behind `--check-overlap`** because it adds GitHub API cost; without
-  it each candidate's high-contention files are still reported.
+  it each candidate's high-contention files are still reported. **Coverage**:
+  open-PR overlap is repo-wide, but active-claim overlap is scanned only within
+  the candidate set (no repo-wide comment scan), so a non-stale claim on a
+  non-candidate issue with no open PR is not detected — acceptable for an
+  advisory tie-breaker, since a claimed candidate becomes active next run.
 - **High-contention set**: the union of the named bundles' member files plus
   `audit/sync-manifest.json`. Instruction files are keyed by their repo-wide
   unique basename so a source path, mirror path, or bare citation all match.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -22,6 +22,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   across limited scope, clear verification, and autonomous completion
   criteria (referenced in
   [kurone-kito/idd-skill#505](https://github.com/kurone-kito/idd-skill/issues/505))
+- `scripts/discover-shared-file-overlap.mjs` for read-only A4 Step 2
+  high-contention shared-file overlap evidence: it flags candidate issues
+  whose `## Candidate files` collide with actively-claimed / open-PR work on
+  the F-phase bundle instruction files (referenced in
+  [kurone-kito/idd-skill#1019](https://github.com/kurone-kito/idd-skill/issues/1019))
 - `scripts/suitability-triage.mjs` for A4.5 seven-check suitability
   evaluation (referenced in
   [kurone-kito/idd-skill#392](https://github.com/kurone-kito/idd-skill/issues/392))
@@ -233,6 +238,44 @@ one or more issues.
     "summary": { "total": 2, "viableCount": 1, "discardedCount": 1, "discardedByCriterion": { "limited_scope": 1, "autonomous_completion": 1 } }
   }
   ```
+
+### Discover Shared File Overlap Contract
+
+`scripts/discover-shared-file-overlap.mjs` is the read-only file-contention
+companion to the `discover-roadmap-graph` `--with-claim-state` claim-eligibility
+annotation. For a set of candidate issues it reports the high-contention shared
+files each would touch (parsed from its `## Candidate files` section) and
+whether any overlap an actively-claimed or open-PR issue, and it emits the soft
+A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
+
+- **Inputs**: `--candidate <number>` (repeatable) or `--candidates <n1,n2>`,
+  with optional `--owner <owner>`, `--repo <repo>`, `--policy <path>`,
+  `--manifest <path>` (default `audit/sync-manifest.json`), `--bundles
+  <id1,id2>` (default `bundle-review,bundle-merge`), `--now <ISO8601>`, and
+  `--check-overlap`. The cross-issue active-set discovery (open PRs plus
+  claimed-candidate comment scans, resolved with the shared claim-state rules)
+  is **gated behind `--check-overlap`** because it adds GitHub API cost; without
+  it each candidate's high-contention files are still reported.
+- **High-contention set**: the union of the named bundles' member files plus
+  `audit/sync-manifest.json`. Instruction files are keyed by their repo-wide
+  unique basename so a source path, mirror path, or bare citation all match.
+- **JSON output**:
+  - `repository`: `{ owner: string, repo: string }`
+  - `checkedOverlap`: `boolean`
+  - `highContentionFiles`: `string[]` (sorted)
+  - `candidates`: `[{ number: number, score: number | null,`
+    `effectiveScore: number, candidateFiles: string[],`
+    `highContentionTouched: string[], overlaps: [{ number: number,`
+    `reason: "claim" | "pr", files: string[] }], overlapFlag: boolean }]`
+  - `recommendedOrder`: `number[]` — candidate numbers after the soft
+    tie-breaker (score desc, then non-overlapping first within a score band,
+    then issue number). Advisory only; never a hard gate.
+  - `summary`: `{ candidateCount: number, flaggedCount: number,`
+    `activeIssueCount: number }`
+- **Behavior boundary**: evidence-only and heuristic. `## Candidate files` are
+  advisory cues, not an exhaustive manifest, so the overlap signal must stay a
+  soft A4 Step 2 tie-breaker — never a claim gate. The written discover
+  instructions remain authoritative.
 
 The exported template remains portable without a `scripts/` directory.
 Adopters can copy the helper separately when they want the same

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -252,14 +252,17 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
   with optional `--owner <owner>`, `--repo <repo>`, `--policy <path>`,
   `--manifest <path>` (default `audit/sync-manifest.json`), `--bundles
   <id1,id2>` (default `bundle-review,bundle-merge`), `--now <ISO8601>`, and
-  `--check-overlap`. The cross-issue active-set discovery (open PRs plus
-  claimed-candidate comment scans, resolved with the shared claim-state rules)
-  is **gated behind `--check-overlap`** because it adds GitHub API cost; without
-  it each candidate's high-contention files are still reported. **Coverage**:
-  open-PR overlap is repo-wide, but active-claim overlap is scanned only within
-  the candidate set (no repo-wide comment scan), so a non-stale claim on a
-  non-candidate issue with no open PR is not detected — acceptable for an
-  advisory tie-breaker, since a claimed candidate becomes active next run.
+  `--check-overlap`. The cross-issue active-set discovery (open PRs plus the
+  claim comments of issues that have a remote `issue/<n>-*` branch, resolved
+  with the shared claim-state rules and the configured claim stale age) is
+  **gated behind `--check-overlap`** because it adds GitHub API cost; without it
+  each candidate's high-contention files are still reported. **Coverage**:
+  open-PR overlap is repo-wide; active-claim overlap covers every issue that has
+  a remote `issue/<n>-*` branch (every IDD claim creates one once pushed), so a
+  non-stale claim held by another session is detected even when it is outside
+  the unclaimed candidate set being ranked. It is bounded by the number of
+  active issue branches, not a repo-wide comment scan; a claim whose branch is
+  not yet pushed is picked up once it appears remotely.
 - **High-contention set**: the union of the named bundles' member files plus
   `audit/sync-manifest.json`. Instruction files are keyed by their repo-wide
   unique basename so a source path, mirror path, or bare citation all match.

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -297,6 +297,38 @@ rather than bumping to an exact fit** — an exact-fit bump leaves the next
 concurrent session with zero free bytes, forcing an immediate rebase and
 re-bump.
 
+### High-contention shared files
+
+A small set of files concentrates concurrent autopilot edits and therefore
+conflicts most often: the **F-phase bundle instruction files** (the
+`bundle-review` and `bundle-merge` members — `idd-overview-core`,
+`idd-overview-appendix`, `idd-review-snapshot`, `idd-review-triage`,
+`idd-review-fix`, `idd-advisory-wait`, `idd-ci`, `idd-pre-merge`,
+`idd-merge-handoff`, `idd-merge`) and the single-line entries in
+`audit/sync-manifest.json`. When a change touches one of these:
+
+- **Expect a merge-from-main conflict** and keep the addition small and
+  localized so the conflict stays a trivial keep-both. Bump any affected
+  bundle budget with the margin convention above.
+- **Discover de-prioritizes overlap** softly: A4 Step 2 prefers a candidate
+  whose `## Candidate files` do not collide with actively-claimed / open-PR
+  work on these files (the `discover-shared-file-overlap` helper reports the
+  signal). It is advisory, never a claim gate.
+
+**Deterministic-ordering lever.** An **append-mostly shared file** — one that
+several independent issues mutate at the same anchor (a generated-file
+classification registry, a size-budget JSON, a barrel / export or registry
+list, and, in adopter repos, i18n message catalogs) — conflicts precisely
+because both sides append at the same insertion point, even though each PR
+passes its own CI in isolation. Where feasible, keep such files
+**deterministically ordered** (sorted keys / one entry per line) and guard
+that order where it can be guarded, so independent additions land in different
+positions and merge cleanly far more often. The conflict on such a file is
+almost always two independent additions, so resolve the sync by **keeping
+both**. Apply this to clearly append-mostly surfaces such as
+`audit/sync-manifest.json` helper / budget entries and any export / registry
+list; file a follow-up where a reorder is non-trivial.
+
 ## Changing A Default
 
 For now, this page records the defaults; it does not centralize them.

--- a/fixtures/shared-file-overlap/candidate-isolated.md
+++ b/fixtures/shared-file-overlap/candidate-isolated.md
@@ -1,0 +1,8 @@
+## Proposed change
+
+A self-contained helper that touches no shared bundle file.
+
+## Candidate files
+
+- `src/scripts/discover-shared-file-overlap.mts` (+ `src/bin/`) — **source**
+- `tests/discover-shared-file-overlap.test.mts`; `fixtures/**`

--- a/fixtures/shared-file-overlap/candidate-merge.md
+++ b/fixtures/shared-file-overlap/candidate-merge.md
@@ -1,0 +1,12 @@
+## Background
+
+Some merge-path instruction tweak.
+
+## Candidate files
+
+- `idd-template/.github/instructions/idd-merge.instructions.md` (F5) —
+  **source**; root mirror regenerated
+- `idd-template/.github/instructions/idd-advisory-wait.instructions.md` —
+  **source**
+- generated/mirrored root copies (do not hand-edit):
+  `.github/instructions/idd-merge.instructions.md`

--- a/fixtures/shared-file-overlap/candidate-review.md
+++ b/fixtures/shared-file-overlap/candidate-review.md
@@ -1,0 +1,13 @@
+## Proposed change
+
+Touch a review-bundle file plus a helper source.
+
+## Candidate files
+
+- `idd-template/.github/instructions/idd-advisory-wait.instructions.md` —
+  **source**
+- `src/scripts/review-activity-snapshot.mts` — **source**; `tests/*.test.mts`
+
+## Notes
+
+Unrelated trailing section.

--- a/fixtures/shared-file-overlap/no-candidate-section.md
+++ b/fixtures/shared-file-overlap/no-candidate-section.md
@@ -1,0 +1,11 @@
+## Background
+
+An issue that never lists a candidate-files section.
+
+## Proposed change
+
+Do the thing.
+
+## Acceptance criteria
+
+- It works.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -549,6 +549,20 @@ convergence is preserved because the branch name derives from the issue,
 not selection order. With `off`, a single-entry band, or no applicable
 score, keep the deterministic **lowest issue number** pick.
 
+**High-contention shared-file overlap (advisory).** Concurrent autopilot
+sessions tend to edit the same F-phase bundle instruction files
+(`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`, so a
+colliding pick costs a later merge-from-main conflict. As a **soft**
+tie-breaker layered after the score / lowest-number / desync rules, prefer a
+candidate whose `## Candidate files` do **not** overlap an actively-claimed or
+open-PR issue on one of those files; the optional
+`discover-shared-file-overlap` helper (see
+[IDD helper scripts](../../docs/idd-helper-scripts.md)) reports each candidate's
+`overlapFlag` and a `recommendedOrder`. This is **never a hard gate** — overlap
+never overrides the score or crosses a score band, and a colliding candidate
+stays claimable when it is the only ready work. See the
+[high-contention shared-file convention](../../docs/policy-constants.md#high-contention-shared-files).
+
 After picking, continue to **A4.5** (`idd-suitability.instructions.md`).
 
 ## A4.5 — Pre-Claim Issue-Suitability Triage

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -276,7 +276,9 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
     `reason: "claim" | "pr", files: string[] }], overlapFlag: boolean }]`
   - `recommendedOrder`: `number[]` — candidate numbers after the soft
     tie-breaker (score desc, then non-overlapping first within a score band,
-    then issue number). Advisory only; never a hard gate.
+    then issue number). It does **not** apply `discover.selectionDesync`; the
+    agent layers the overlap nudge after its own desync pick. Advisory only;
+    never a hard gate.
   - `summary`: `{ candidateCount: number, flaggedCount: number,`
     `activeIssueCount: number }`
 - **Behavior boundary**: evidence-only and heuristic. `## Candidate files` are

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -256,13 +256,13 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
   claim comments of issues that have a remote `issue/<n>-*` branch, resolved
   with the shared claim-state rules and the configured claim stale age) is
   **gated behind `--check-overlap`** because it adds GitHub API cost; without it
-  each candidate's high-contention files are still reported. **Coverage**:
-  open-PR overlap is repo-wide; active-claim overlap covers every issue that has
-  a remote `issue/<n>-*` branch (every IDD claim creates one once pushed), so a
-  non-stale claim held by another session is detected even when it is outside
-  the unclaimed candidate set being ranked. It is bounded by the number of
-  active issue branches, not a repo-wide comment scan; a claim whose branch is
-  not yet pushed is picked up once it appears remotely.
+  each candidate's high-contention files are still reported. **Coverage**
+  (best-effort, no repo-wide comment scan): open-PR overlap scans open PRs
+  (bounded by the `gh pr list` page cap); active-claim overlap covers every
+  issue that has a remote `issue/<n>-*` branch (every IDD claim creates one once
+  pushed, paginated to the end), so a non-stale claim held by another session is
+  detected even when it is outside the unclaimed candidate set being ranked. A
+  claim whose branch is not yet pushed is picked up once it appears remotely.
 - **High-contention set**: the union of the named bundles' member files plus
   `audit/sync-manifest.json`. Instruction files are keyed by their repo-wide
   unique basename so a source path, mirror path, or bare citation all match.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -255,7 +255,11 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
   `--check-overlap`. The cross-issue active-set discovery (open PRs plus
   claimed-candidate comment scans, resolved with the shared claim-state rules)
   is **gated behind `--check-overlap`** because it adds GitHub API cost; without
-  it each candidate's high-contention files are still reported.
+  it each candidate's high-contention files are still reported. **Coverage**:
+  open-PR overlap is repo-wide, but active-claim overlap is scanned only within
+  the candidate set (no repo-wide comment scan), so a non-stale claim on a
+  non-candidate issue with no open PR is not detected — acceptable for an
+  advisory tie-breaker, since a claimed candidate becomes active next run.
 - **High-contention set**: the union of the named bundles' member files plus
   `audit/sync-manifest.json`. Instruction files are keyed by their repo-wide
   unique basename so a source path, mirror path, or bare citation all match.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -22,6 +22,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   across limited scope, clear verification, and autonomous completion
   criteria (referenced in
   [kurone-kito/idd-skill#505](https://github.com/kurone-kito/idd-skill/issues/505))
+- `scripts/discover-shared-file-overlap.mjs` for read-only A4 Step 2
+  high-contention shared-file overlap evidence: it flags candidate issues
+  whose `## Candidate files` collide with actively-claimed / open-PR work on
+  the F-phase bundle instruction files (referenced in
+  [kurone-kito/idd-skill#1019](https://github.com/kurone-kito/idd-skill/issues/1019))
 - `scripts/suitability-triage.mjs` for A4.5 seven-check suitability
   evaluation (referenced in
   [kurone-kito/idd-skill#392](https://github.com/kurone-kito/idd-skill/issues/392))
@@ -233,6 +238,44 @@ one or more issues.
     "summary": { "total": 2, "viableCount": 1, "discardedCount": 1, "discardedByCriterion": { "limited_scope": 1, "autonomous_completion": 1 } }
   }
   ```
+
+### Discover Shared File Overlap Contract
+
+`scripts/discover-shared-file-overlap.mjs` is the read-only file-contention
+companion to the `discover-roadmap-graph` `--with-claim-state` claim-eligibility
+annotation. For a set of candidate issues it reports the high-contention shared
+files each would touch (parsed from its `## Candidate files` section) and
+whether any overlap an actively-claimed or open-PR issue, and it emits the soft
+A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
+
+- **Inputs**: `--candidate <number>` (repeatable) or `--candidates <n1,n2>`,
+  with optional `--owner <owner>`, `--repo <repo>`, `--policy <path>`,
+  `--manifest <path>` (default `audit/sync-manifest.json`), `--bundles
+  <id1,id2>` (default `bundle-review,bundle-merge`), `--now <ISO8601>`, and
+  `--check-overlap`. The cross-issue active-set discovery (open PRs plus
+  claimed-candidate comment scans, resolved with the shared claim-state rules)
+  is **gated behind `--check-overlap`** because it adds GitHub API cost; without
+  it each candidate's high-contention files are still reported.
+- **High-contention set**: the union of the named bundles' member files plus
+  `audit/sync-manifest.json`. Instruction files are keyed by their repo-wide
+  unique basename so a source path, mirror path, or bare citation all match.
+- **JSON output**:
+  - `repository`: `{ owner: string, repo: string }`
+  - `checkedOverlap`: `boolean`
+  - `highContentionFiles`: `string[]` (sorted)
+  - `candidates`: `[{ number: number, score: number | null,`
+    `effectiveScore: number, candidateFiles: string[],`
+    `highContentionTouched: string[], overlaps: [{ number: number,`
+    `reason: "claim" | "pr", files: string[] }], overlapFlag: boolean }]`
+  - `recommendedOrder`: `number[]` — candidate numbers after the soft
+    tie-breaker (score desc, then non-overlapping first within a score band,
+    then issue number). Advisory only; never a hard gate.
+  - `summary`: `{ candidateCount: number, flaggedCount: number,`
+    `activeIssueCount: number }`
+- **Behavior boundary**: evidence-only and heuristic. `## Candidate files` are
+  advisory cues, not an exhaustive manifest, so the overlap signal must stay a
+  soft A4 Step 2 tie-breaker — never a claim gate. The written discover
+  instructions remain authoritative.
 
 The exported template remains portable without a `scripts/` directory.
 Adopters can copy the helper separately when they want the same

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -252,14 +252,17 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
   with optional `--owner <owner>`, `--repo <repo>`, `--policy <path>`,
   `--manifest <path>` (default `audit/sync-manifest.json`), `--bundles
   <id1,id2>` (default `bundle-review,bundle-merge`), `--now <ISO8601>`, and
-  `--check-overlap`. The cross-issue active-set discovery (open PRs plus
-  claimed-candidate comment scans, resolved with the shared claim-state rules)
-  is **gated behind `--check-overlap`** because it adds GitHub API cost; without
-  it each candidate's high-contention files are still reported. **Coverage**:
-  open-PR overlap is repo-wide, but active-claim overlap is scanned only within
-  the candidate set (no repo-wide comment scan), so a non-stale claim on a
-  non-candidate issue with no open PR is not detected — acceptable for an
-  advisory tie-breaker, since a claimed candidate becomes active next run.
+  `--check-overlap`. The cross-issue active-set discovery (open PRs plus the
+  claim comments of issues that have a remote `issue/<n>-*` branch, resolved
+  with the shared claim-state rules and the configured claim stale age) is
+  **gated behind `--check-overlap`** because it adds GitHub API cost; without it
+  each candidate's high-contention files are still reported. **Coverage**:
+  open-PR overlap is repo-wide; active-claim overlap covers every issue that has
+  a remote `issue/<n>-*` branch (every IDD claim creates one once pushed), so a
+  non-stale claim held by another session is detected even when it is outside
+  the unclaimed candidate set being ranked. It is bounded by the number of
+  active issue branches, not a repo-wide comment scan; a claim whose branch is
+  not yet pushed is picked up once it appears remotely.
 - **High-contention set**: the union of the named bundles' member files plus
   `audit/sync-manifest.json`. Instruction files are keyed by their repo-wide
   unique basename so a source path, mirror path, or bare citation all match.

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -297,6 +297,38 @@ rather than bumping to an exact fit** — an exact-fit bump leaves the next
 concurrent session with zero free bytes, forcing an immediate rebase and
 re-bump.
 
+### High-contention shared files
+
+A small set of files concentrates concurrent autopilot edits and therefore
+conflicts most often: the **F-phase bundle instruction files** (the
+`bundle-review` and `bundle-merge` members — `idd-overview-core`,
+`idd-overview-appendix`, `idd-review-snapshot`, `idd-review-triage`,
+`idd-review-fix`, `idd-advisory-wait`, `idd-ci`, `idd-pre-merge`,
+`idd-merge-handoff`, `idd-merge`) and the single-line entries in
+`audit/sync-manifest.json`. When a change touches one of these:
+
+- **Expect a merge-from-main conflict** and keep the addition small and
+  localized so the conflict stays a trivial keep-both. Bump any affected
+  bundle budget with the margin convention above.
+- **Discover de-prioritizes overlap** softly: A4 Step 2 prefers a candidate
+  whose `## Candidate files` do not collide with actively-claimed / open-PR
+  work on these files (the `discover-shared-file-overlap` helper reports the
+  signal). It is advisory, never a claim gate.
+
+**Deterministic-ordering lever.** An **append-mostly shared file** — one that
+several independent issues mutate at the same anchor (a generated-file
+classification registry, a size-budget JSON, a barrel / export or registry
+list, and, in adopter repos, i18n message catalogs) — conflicts precisely
+because both sides append at the same insertion point, even though each PR
+passes its own CI in isolation. Where feasible, keep such files
+**deterministically ordered** (sorted keys / one entry per line) and guard
+that order where it can be guarded, so independent additions land in different
+positions and merge cleanly far more often. The conflict on such a file is
+almost always two independent additions, so resolve the sync by **keeping
+both**. Apply this to clearly append-mostly surfaces such as
+`audit/sync-manifest.json` helper / budget entries and any export / registry
+list; file a follow-up where a reorder is non-trivial.
+
 ## Changing A Default
 
 For now, this page records the defaults; it does not centralize them.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "idd-discover-readiness-check": "./bin/idd-discover-readiness-check.mjs",
     "idd-discover-orphan-filter": "./bin/idd-discover-orphan-filter.mjs",
     "idd-discover-viability-gate": "./bin/idd-discover-viability-gate.mjs",
+    "idd-discover-shared-file-overlap": "./bin/idd-discover-shared-file-overlap.mjs",
     "idd-doctor": "./bin/idd-doctor.mjs",
     "idd-emit-marker": "./bin/idd-emit-marker.mjs",
     "idd-external-check-waiver": "./bin/idd-external-check-waiver.mjs",

--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -323,10 +323,14 @@ function runCli() {
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }
 /**
- * Discover the concurrently-active set: every issue closed by an open PR, plus
- * candidate issues that already carry a non-stale claim. Claim scanning is
- * bounded to the candidate set (no repo-wide comment scan); this fetch cost is
- * what the `--check-overlap` flag gates.
+ * Discover the concurrently-active set: every issue closed by an open PR
+ * (repo-wide), plus candidate issues that already carry a non-stale claim.
+ * Claim scanning is intentionally bounded to the candidate set (no repo-wide
+ * comment scan) — that fetch cost is what `--check-overlap` gates — so a
+ * non-stale claim on a non-candidate issue with no open PR is not detected.
+ * This bounded coverage is acceptable because the overlap signal is an advisory
+ * A4 Step 2 tie-breaker, and a claimed candidate becomes active for the next
+ * discovery run. Open-PR coverage stays repo-wide.
  */
 function discoverActiveIssues(options) {
   const { repoRef, candidateNumbers, trustedActors, now } = options;
@@ -363,22 +367,21 @@ function discoverActiveIssues(options) {
   return [...active.values()].sort((left, right) => left.number - right.number);
 }
 function fetchIssue(repoRef, number) {
-  try {
-    const body = ghText([
-      'issue',
-      'view',
-      String(number),
-      '--repo',
-      repoRef,
-      '--json',
-      'body',
-      '--jq',
-      '.body',
-    ]);
-    return { body };
-  } catch {
-    return { body: '' };
-  }
+  // Fail closed: let a fetch failure surface rather than returning an empty
+  // body, which would silently suppress this issue's candidate files and emit
+  // a false "no overlap" result.
+  const body = ghText([
+    'issue',
+    'view',
+    String(number),
+    '--repo',
+    repoRef,
+    '--json',
+    'body',
+    '--jq',
+    '.body',
+  ]);
+  return { body };
 }
 /**
  * Map a REST issue-comment payload to the `CommentLike` shape
@@ -460,8 +463,13 @@ function loadManifest(manifestPath) {
   );
   try {
     return JSON.parse(readFileSync(targetPath, 'utf8'));
-  } catch {
-    return { bundleBudgets: [] };
+  } catch (error) {
+    // Fail closed: an empty manifest would yield an empty high-contention set,
+    // making every candidate look non-overlapping. Surface the load failure.
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `failed to load sync manifest at ${targetPath}: ${message}`,
+    );
   }
 }
 function loadPolicy(policyPath) {
@@ -587,6 +595,13 @@ first within a score band, then issue number). Evidence-only: never a hard gate.
 
 Without --check-overlap no active-set discovery runs (no extra GitHub API
 cost); each candidate's high-contention files are still reported.
+
+--check-overlap coverage: open-PR overlap is repo-wide (every issue closed by
+an open PR), but active-claim overlap is scanned only within the candidate set
+to avoid a repo-wide comment scan — a non-stale claim on a non-candidate issue
+with no open PR is not detected. The signal is an advisory A4 Step 2 hint, so
+this bounded coverage is acceptable; a claimed candidate becomes active for the
+next discovery run.
 `);
 }
 function ghJson(args) {

--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -298,6 +298,9 @@ function runCli() {
   const highContentionFiles = resolveHighContentionFiles({
     manifest,
     bundleIds: args.bundles ?? DEFAULT_BUNDLE_IDS,
+    // Track the manifest actually in use so a custom --manifest is the file
+    // reported (and matched) as high-contention, not the hard-coded default.
+    extraFiles: [args.manifest],
   });
   const candidates = args.candidates.map((number) => {
     const issue = fetchIssue(repoRef, number);

--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -1,0 +1,622 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/discover-shared-file-overlap.mts
+//
+// The scripts/discover-shared-file-overlap.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+//
+// Read-only discovery-time evidence helper (#1019): for a set of candidate
+// issues, report the high-contention shared files each would touch (parsed
+// from its `## Candidate files` section) and whether any of those files
+// overlap an actively-claimed or open-PR issue's candidate files. It also
+// emits a soft de-prioritization order for A4 Step 2. It is the
+// file-contention companion to the #1008 `--with-claim-state` claim-eligibility
+// annotation. Evidence-only: it claims nothing and mutates no state.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  isStaleAt,
+  resolveActiveClaim,
+  resolveTrustedMarkerActors,
+} from './protocol-helpers.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
+/** F-phase bundles whose member instruction files concentrate concurrent edits. */
+const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
+/** Append-mostly shared surfaces that are not bundle members. */
+const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
+const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
+if (isCliExecution()) {
+  runCli();
+}
+/**
+ * Normalize a candidate-file path to its contention key. Strips surrounding
+ * backticks and a leading `./`, and collapses a `idd-template/<x>` source onto
+ * its generated `<x>` mirror so the two count as one contention surface. An
+ * instruction file is keyed by its basename (`idd-merge.instructions.md`):
+ * those basenames are unique repo-wide and issues cite them in several forms
+ * (full source path, mirror path, or bare), so basename keying makes every
+ * form compare equal.
+ */
+export function normalizeContentionPath(raw) {
+  let value = String(raw ?? '').trim();
+  value = value.replace(/^`+/, '').replace(/`+$/, '').trim();
+  value = value.replace(/^\.\//, '');
+  value = value.replace(/^idd-template\//, '');
+  const instruction = value.match(/(?:^|\/)([^/]+\.instructions\.md)$/);
+  if (instruction) {
+    return instruction[1];
+  }
+  return value;
+}
+/**
+ * Parse the `## Candidate files` section of an issue body into a
+ * de-duplicated, normalized path list. The section is advisory, so parsing is
+ * lenient: it extracts every backtick-quoted path in the section — including
+ * the continuation lines of a multi-line bullet — plus the leading path-like
+ * token of any bullet that has no backticks at all. Returns `[]` when the
+ * section is absent.
+ */
+export function parseCandidateFiles(body) {
+  const text = typeof body === 'string' ? body : '';
+  const lines = text.split(/\r?\n/);
+  let start = -1;
+  let end = lines.length;
+  for (let index = 0; index < lines.length; index += 1) {
+    const heading = lines[index].match(/^\s{0,3}(#{1,6})\s+(.*)$/);
+    if (!heading) {
+      continue;
+    }
+    const title = heading[2].replace(/[*_`]/g, '').trim().toLowerCase();
+    if (start === -1) {
+      if (/^candidate files\b/.test(title)) {
+        start = index + 1;
+      }
+      continue;
+    }
+    end = index;
+    break;
+  }
+  if (start === -1) {
+    return [];
+  }
+  const section = lines.slice(start, end);
+  const sectionText = section.join('\n');
+  const files = [];
+  // Every backtick-quoted path in the section, regardless of line wrapping.
+  for (const match of sectionText.matchAll(/`([^`]+)`/g)) {
+    const normalized = normalizeContentionPath(match[1]);
+    if (looksLikePath(normalized)) {
+      files.push(normalized);
+    }
+  }
+  // Bullets that quote no path fall back to a strict leading-token scan.
+  for (const line of section) {
+    const item = line.match(/^\s*(?:[-*+]|\d+[.)])\s+(.*)$/);
+    if (!item || /`[^`]+`/.test(item[1])) {
+      continue;
+    }
+    const token = extractStandaloneToken(item[1]);
+    if (token) {
+      files.push(token);
+    }
+  }
+  return [...new Set(files)];
+}
+/** Extract a strict leading path token from a bullet that quotes no path. */
+function extractStandaloneToken(itemBody) {
+  let text = itemBody.trim();
+  text = text.split(/\s+(?:—|–|--)\s+/)[0];
+  text = text.split(/\s+\(/)[0];
+  const leading = text.split(/[\s,;]+/)[0] ?? '';
+  const normalized = normalizeContentionPath(leading);
+  return looksLikeStandalonePath(normalized) ? normalized : null;
+}
+/** A backtick-quoted token only needs a separator or extension. */
+function looksLikePath(value) {
+  return value.length > 0 && !/\s/.test(value) && /[/.]/.test(value);
+}
+/**
+ * An unquoted bullet token must look unambiguously like a file path: a final
+ * extension, a glob, or a trailing directory slash. This rejects prose such
+ * as "generated/mirrored" that merely contains a slash.
+ */
+function looksLikeStandalonePath(value) {
+  if (value.length === 0 || /\s/.test(value)) {
+    return false;
+  }
+  return (
+    /\.[a-z0-9]+$/i.test(value) || value.includes('*') || value.endsWith('/')
+  );
+}
+/**
+ * Resolve the high-contention shared-file set from the sync manifest: the
+ * union of the named bundles' member files plus any extra append-mostly
+ * surfaces. Paths are normalized so a source and its mirror collapse together.
+ */
+export function resolveHighContentionFiles(options) {
+  const bundleIds = new Set(options.bundleIds ?? DEFAULT_BUNDLE_IDS);
+  const extraFiles = options.extraFiles ?? DEFAULT_EXTRA_FILES;
+  const result = new Set();
+  const bundles = options.manifest?.bundleBudgets;
+  if (Array.isArray(bundles)) {
+    for (const bundle of bundles) {
+      const entry = bundle;
+      if (!entry || !bundleIds.has(String(entry.id))) {
+        continue;
+      }
+      if (Array.isArray(entry.files)) {
+        for (const file of entry.files) {
+          result.add(normalizeContentionPath(file));
+        }
+      }
+    }
+  }
+  for (const file of extraFiles) {
+    result.add(normalizeContentionPath(file));
+  }
+  return result;
+}
+/**
+ * Compute per-candidate high-contention overlap evidence against the active
+ * set, plus a soft de-prioritization order for A4 Step 2.
+ */
+export function analyzeSharedFileOverlap(input) {
+  const floor = input.floor ?? DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  const highContention = new Set(input.highContentionFiles);
+  const activeTouched = input.activeIssues.map((active) => ({
+    number: active.number,
+    reason: active.reason,
+    files: intersect(active.candidateFiles, highContention),
+  }));
+  const candidates = input.candidates.map((candidate) => {
+    const score = typeof candidate.score === 'number' ? candidate.score : null;
+    const highContentionTouched = intersect(
+      candidate.candidateFiles,
+      highContention,
+    );
+    const touchedSet = new Set(highContentionTouched);
+    const overlaps = [];
+    for (const active of activeTouched) {
+      if (active.number === candidate.number) {
+        continue;
+      }
+      const shared = active.files.filter((file) => touchedSet.has(file));
+      if (shared.length > 0) {
+        overlaps.push({
+          number: active.number,
+          reason: active.reason,
+          files: shared.slice().sort(),
+        });
+      }
+    }
+    overlaps.sort((left, right) => left.number - right.number);
+    return {
+      number: candidate.number,
+      score,
+      effectiveScore: score ?? floor,
+      candidateFiles: candidate.candidateFiles,
+      highContentionTouched,
+      overlaps,
+      overlapFlag: overlaps.length > 0,
+    };
+  });
+  const preSorted = candidates
+    .slice()
+    .sort(
+      (left, right) =>
+        right.effectiveScore - left.effectiveScore ||
+        left.number - right.number,
+    );
+  const recommendedOrder = applyOverlapTieBreaker(preSorted).map(
+    (candidate) => candidate.number,
+  );
+  return {
+    candidates,
+    recommendedOrder,
+    summary: {
+      candidateCount: candidates.length,
+      flaggedCount: candidates.filter((candidate) => candidate.overlapFlag)
+        .length,
+      activeIssueCount: input.activeIssues.length,
+    },
+  };
+}
+/**
+ * Soft de-prioritization tie-breaker for A4 Step 2. The input must already be
+ * ordered by the existing rules (suitability score descending, then issue
+ * number ascending / desync). Within each equal-`effectiveScore` band this
+ * stably moves overlap-flagged candidates after the non-overlapping ones; it
+ * never crosses a score band and never drops a candidate, so a colliding
+ * candidate that is the only ready work keeps its position.
+ */
+export function applyOverlapTieBreaker(ranked) {
+  const out = [];
+  for (let index = 0; index < ranked.length; ) {
+    let end = index;
+    while (
+      end < ranked.length &&
+      ranked[end].effectiveScore === ranked[index].effectiveScore
+    ) {
+      end += 1;
+    }
+    const band = ranked.slice(index, end);
+    for (const candidate of band) {
+      if (!candidate.overlapFlag) {
+        out.push(candidate);
+      }
+    }
+    for (const candidate of band) {
+      if (candidate.overlapFlag) {
+        out.push(candidate);
+      }
+    }
+    index = end;
+  }
+  return out;
+}
+function intersect(files, highContention) {
+  const seen = new Set();
+  const result = [];
+  for (const file of files) {
+    if (highContention.has(file) && !seen.has(file)) {
+      seen.add(file);
+      result.push(file);
+    }
+  }
+  return result.sort();
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.candidates.length === 0) {
+    throw new Error('at least one --candidate <number> is required');
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const policy = loadPolicy(args.policy);
+  const now = args.now || new Date().toISOString();
+  const manifest = loadManifest(args.manifest);
+  const highContentionFiles = resolveHighContentionFiles({
+    manifest,
+    bundleIds: args.bundles ?? DEFAULT_BUNDLE_IDS,
+  });
+  const candidates = args.candidates.map((number) => {
+    const issue = fetchIssue(repoRef, number);
+    return {
+      number,
+      score: parseSuitabilityScore(issue.body, policy.markerPrefix),
+      candidateFiles: parseCandidateFiles(issue.body),
+    };
+  });
+  let activeIssues = [];
+  if (args.checkOverlap) {
+    activeIssues = discoverActiveIssues({
+      repoRef,
+      candidateNumbers: args.candidates,
+      trustedActors: policy.trustedMarkerActors,
+      now,
+    });
+  }
+  const analysis = analyzeSharedFileOverlap({
+    candidates,
+    activeIssues,
+    highContentionFiles,
+    floor: policy.autopilotSuitabilityFloor,
+  });
+  const output = {
+    repository: { owner, repo },
+    checkedOverlap: args.checkOverlap,
+    highContentionFiles: [...highContentionFiles].sort(),
+    ...analysis,
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+/**
+ * Discover the concurrently-active set: every issue closed by an open PR, plus
+ * candidate issues that already carry a non-stale claim. Claim scanning is
+ * bounded to the candidate set (no repo-wide comment scan); this fetch cost is
+ * what the `--check-overlap` flag gates.
+ */
+function discoverActiveIssues(options) {
+  const { repoRef, candidateNumbers, trustedActors, now } = options;
+  const active = new Map();
+  // Active-by-PR: every issue closed by an open PR.
+  for (const number of fetchOpenPrLinkedIssues(repoRef)) {
+    if (!active.has(number)) {
+      const body = fetchIssue(repoRef, number).body;
+      active.set(number, {
+        number,
+        reason: 'pr',
+        candidateFiles: parseCandidateFiles(body),
+      });
+    }
+  }
+  // Active-by-claim: candidate issues that already carry a non-stale claim.
+  const isTrusted = (login) =>
+    trustedActors.some((actor) => actor.toLowerCase() === login.toLowerCase());
+  for (const number of candidateNumbers) {
+    if (active.has(number)) {
+      continue;
+    }
+    const comments = fetchIssueComments(repoRef, number);
+    const claim = resolveActiveClaim(comments, isTrusted);
+    if (claim && !isStaleAt(claim.createdAt, now)) {
+      const body = fetchIssue(repoRef, number).body;
+      active.set(number, {
+        number,
+        reason: 'claim',
+        candidateFiles: parseCandidateFiles(body),
+      });
+    }
+  }
+  return [...active.values()].sort((left, right) => left.number - right.number);
+}
+function fetchIssue(repoRef, number) {
+  try {
+    const body = ghText([
+      'issue',
+      'view',
+      String(number),
+      '--repo',
+      repoRef,
+      '--json',
+      'body',
+      '--jq',
+      '.body',
+    ]);
+    return { body };
+  } catch {
+    return { body: '' };
+  }
+}
+/**
+ * Map a REST issue-comment payload to the `CommentLike` shape
+ * `resolveActiveClaim` consumes. `resolveActiveClaim` reads the author from
+ * `author.login`, but the REST comments API returns it under `user.login`, so
+ * the login must be mapped across here (matching `discover-roadmap-graph`'s
+ * comment loader). Emitting `user` would leave the author empty and silently
+ * disable claim detection.
+ */
+export function toClaimComment(raw) {
+  const entry = raw;
+  return {
+    body: String(entry.body ?? ''),
+    createdAt: String(entry.created_at ?? ''),
+    author: { login: String(entry.user?.login ?? '') },
+  };
+}
+function fetchIssueComments(repoRef, number) {
+  const comments = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const rawPage = ghJson([
+      'api',
+      `repos/${repoRef}/issues/${number}/comments?per_page=${pageSize}&page=${page}`,
+    ]);
+    for (const raw of rawPage) {
+      comments.push(toClaimComment(raw));
+    }
+    if (rawPage.length < pageSize) {
+      break;
+    }
+  }
+  return comments;
+}
+function fetchOpenPrLinkedIssues(repoRef) {
+  const numbers = new Set();
+  const prs = ghJson([
+    'pr',
+    'list',
+    '--repo',
+    repoRef,
+    '--state',
+    'open',
+    '--limit',
+    '200',
+    '--json',
+    'closingIssuesReferences',
+  ]);
+  for (const pr of prs) {
+    const refs = pr.closingIssuesReferences;
+    if (Array.isArray(refs)) {
+      for (const ref of refs) {
+        const value = Number.parseInt(String(ref.number ?? ''), 10);
+        if (Number.isInteger(value) && value > 0) {
+          numbers.add(value);
+        }
+      }
+    }
+  }
+  return [...numbers];
+}
+function parseSuitabilityScore(body, markerPrefix) {
+  const text = typeof body === 'string' ? body : '';
+  const match = text.match(
+    new RegExp(
+      `<!--\\s*${escapeRegex(markerPrefix)}-autopilot-suitability:\\s*([0-9]+)\\s*-->`,
+    ),
+  );
+  if (!match) {
+    return null;
+  }
+  const value = Number.parseInt(match[1], 10);
+  return value >= 1 && value <= 5 ? value : null;
+}
+function loadManifest(manifestPath) {
+  const targetPath = resolve(
+    process.cwd(),
+    manifestPath || DEFAULT_MANIFEST_PATH,
+  );
+  try {
+    return JSON.parse(readFileSync(targetPath, 'utf8'));
+  } catch {
+    return { bundleBudgets: [] };
+  }
+}
+function loadPolicy(policyPath) {
+  const targetPath = policyPath
+    ? resolve(process.cwd(), policyPath)
+    : resolve(process.cwd(), '.github/idd/config.json');
+  let config = null;
+  try {
+    config = JSON.parse(readFileSync(targetPath, 'utf8'));
+  } catch {
+    config = null;
+  }
+  const markerPrefix =
+    typeof config?.markerPrefix === 'string' && config.markerPrefix.length > 0
+      ? config.markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  const trusted = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config,
+  });
+  const floorValue = config?.autopilotSuitability?.floor;
+  const autopilotSuitabilityFloor =
+    typeof floorValue === 'number' && floorValue >= 1 && floorValue <= 5
+      ? floorValue
+      : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  return {
+    markerPrefix,
+    trustedMarkerActors: trusted.actors,
+    autopilotSuitabilityFloor,
+  };
+}
+function parseArgs(argv) {
+  const parsed = {
+    candidates: [],
+    owner: '',
+    repo: '',
+    policy: '',
+    manifest: DEFAULT_MANIFEST_PATH,
+    bundles: null,
+    checkOverlap: false,
+    now: '',
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === '--candidate') {
+      parsed.candidates.push(parsePositiveInt(value, '--candidate'));
+      index += 1;
+      continue;
+    }
+    if (token === '--candidates') {
+      for (const part of String(value ?? '').split(',')) {
+        const trimmed = part.trim();
+        if (trimmed) {
+          parsed.candidates.push(parsePositiveInt(trimmed, '--candidates'));
+        }
+      }
+      index += 1;
+      continue;
+    }
+    if (token === '--owner') {
+      parsed.owner = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--repo') {
+      parsed.repo = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--policy') {
+      parsed.policy = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--manifest') {
+      parsed.manifest = value ?? DEFAULT_MANIFEST_PATH;
+      index += 1;
+      continue;
+    }
+    if (token === '--bundles') {
+      parsed.bundles = String(value ?? '')
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (token === '--check-overlap') {
+      parsed.checkOverlap = true;
+      continue;
+    }
+    if (token === '--now') {
+      parsed.now = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  return parsed;
+}
+function parsePositiveInt(value, flag) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`invalid ${flag} value: ${value ?? ''}`);
+  }
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/discover-shared-file-overlap.mjs --candidate <number> [--candidate <number> ...] [--candidates <n1,n2>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--check-overlap] [--now <ISO8601>]
+
+Reports, per candidate, the high-contention shared files it would touch (from
+its '## Candidate files' section) and — with --check-overlap — whether any
+overlap an actively-claimed or open-PR issue. recommendedOrder applies the soft
+A4 Step 2 de-prioritization tie-breaker (score desc, then non-overlapping
+first within a score band, then issue number). Evidence-only: never a hard gate.
+
+Without --check-overlap no active-set discovery runs (no extra GitHub API
+cost); each candidate's high-contention files are still reported.
+`);
+}
+function ghJson(args) {
+  const parsed = JSON.parse(runGh(args).trim() || '[]');
+  return Array.isArray(parsed) ? parsed : [];
+}
+function ghText(args) {
+  return runGh(args).trim();
+}
+function runGh(args) {
+  try {
+    return execFileSync('gh', args, {
+      encoding: 'utf8',
+      timeout: 30_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const stderr = String(error?.stderr ?? '').trim();
+    if (stderr) {
+      throw new Error(`gh command failed: ${stderr}`);
+    }
+    throw error;
+  }
+}
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+function isCliExecution() {
+  return Boolean(
+    process.argv[1] &&
+      fileURLToPath(import.meta.url) === resolve(process.argv[1]),
+  );
+}

--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -16,6 +16,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseAutopilotSuitability } from './autopilot-suitability.mjs';
 import { parseIsoDurationToMs } from './policy-helpers.mjs';
 import {
   resolveActiveClaim,
@@ -302,7 +303,7 @@ function runCli() {
     const issue = fetchIssue(repoRef, number);
     return {
       number,
-      score: parseSuitabilityScore(issue.body, policy.markerPrefix),
+      score: parseAutopilotSuitability(issue.body, policy.markerPrefix),
       candidateFiles: parseCandidateFiles(issue.body),
     };
   });
@@ -334,14 +335,16 @@ function runCli() {
  * Discover the concurrently-active set: every issue closed by an open PR
  * (repo-wide), plus candidate issues that already carry a non-stale claim.
  * Active-by-claim covers every issue with a remote `issue/<n>-*` branch (every
- * IDD claim creates one once pushed), resolved via the shared claim-state rules
- * — not just the candidate set — so a claim held by another session is detected
- * even though it is outside the unclaimed candidates being ranked. A claim whose
- * branch is not yet pushed is picked up once it appears remotely. Active-by-PR
- * is a best-effort scan of open PRs (bounded by the PR-list page cap). Both
- * stay bounded — no repo-wide comment scan — which is the fetch cost
- * `--check-overlap` gates; the overlap signal is an advisory A4 Step 2
- * tie-breaker, so best-effort coverage is acceptable.
+ * IDD claim creates one once pushed), resolved with the standard `claimed-by`
+ * claim-state rules — not just the candidate set — so a claim held by another
+ * session is detected even though it is outside the unclaimed candidates being
+ * ranked. A claim whose branch is not yet pushed is picked up once it appears
+ * remotely. Active-by-PR is a best-effort scan of open PRs (bounded by the
+ * PR-list page cap). Both stay bounded — no repo-wide comment scan — which is
+ * the fetch cost `--check-overlap` gates; the overlap signal is an advisory A4
+ * Step 2 tie-breaker, so best-effort coverage is acceptable. Edge cases the
+ * advisory signal does not specially resolve: legacy claim-id-less markers and
+ * forced-handoff-successor adoption (the default `resolveActiveClaim` path).
  */
 function discoverActiveIssues(options) {
   const { repoRef, trustedActors, staleAgeMs, now } = options;
@@ -490,19 +493,6 @@ function fetchOpenPrLinkedIssues(repoRef) {
   }
   return [...numbers];
 }
-function parseSuitabilityScore(body, markerPrefix) {
-  const text = typeof body === 'string' ? body : '';
-  const match = text.match(
-    new RegExp(
-      `<!--\\s*${escapeRegex(markerPrefix)}-autopilot-suitability:\\s*([0-9]+)\\s*-->`,
-    ),
-  );
-  if (!match) {
-    return null;
-  }
-  const value = Number.parseInt(match[1], 10);
-  return value >= 1 && value <= 5 ? value : null;
-}
 function loadManifest(manifestPath) {
   const targetPath = resolve(
     process.cwd(),
@@ -520,13 +510,21 @@ function loadManifest(manifestPath) {
   }
 }
 function loadPolicy(policyPath) {
-  const targetPath = policyPath
+  const explicit = policyPath.length > 0;
+  const targetPath = explicit
     ? resolve(process.cwd(), policyPath)
     : resolve(process.cwd(), '.github/idd/config.json');
   let config = null;
   try {
     config = JSON.parse(readFileSync(targetPath, 'utf8'));
-  } catch {
+  } catch (error) {
+    // Fail closed on an explicit --policy that cannot be loaded: silently
+    // using defaults would drop custom trusted actors / claim timing and let
+    // active claims disappear. An absent default config still falls back.
+    if (explicit) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`failed to load policy at ${targetPath}: ${message}`);
+    }
     config = null;
   }
   const markerPrefix =
@@ -645,7 +643,9 @@ Reports, per candidate, the high-contention shared files it would touch (from
 its '## Candidate files' section) and — with --check-overlap — whether any
 overlap an actively-claimed or open-PR issue. recommendedOrder applies the soft
 A4 Step 2 de-prioritization tie-breaker (score desc, then non-overlapping
-first within a score band, then issue number). Evidence-only: never a hard gate.
+first within a score band, then issue number); it does NOT apply
+discover.selectionDesync — the agent layers the overlap nudge after its own
+desync pick. Evidence-only: never a hard gate.
 
 Without --check-overlap no active-set discovery runs (no extra GitHub API
 cost); each candidate's high-contention files are still reported.
@@ -680,9 +680,6 @@ function runGh(args) {
     }
     throw error;
   }
-}
-function escapeRegex(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 function isCliExecution() {
   return Boolean(

--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -16,8 +16,8 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseIsoDurationToMs } from './policy-helpers.mjs';
 import {
-  isStaleAt,
   resolveActiveClaim,
   resolveTrustedMarkerActors,
 } from './protocol-helpers.mjs';
@@ -29,6 +29,7 @@ const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
 /** Append-mostly shared surfaces that are not bundle members. */
 const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
 const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 if (isCliExecution()) {
   runCli();
 }
@@ -166,6 +167,10 @@ export function resolveHighContentionFiles(options) {
  */
 export function analyzeSharedFileOverlap(input) {
   const floor = input.floor ?? DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  // When the autopilot-suitability kill switch is off (A4 Step 2 ignores the
+  // score and selects by lowest issue number), equalize every effectiveScore so
+  // the recommended order is driven by overlap then issue number, not score.
+  const suitabilityEnabled = input.suitabilityEnabled !== false;
   const highContention = new Set(input.highContentionFiles);
   const activeTouched = input.activeIssues.map((active) => ({
     number: active.number,
@@ -197,7 +202,7 @@ export function analyzeSharedFileOverlap(input) {
     return {
       number: candidate.number,
       score,
-      effectiveScore: score ?? floor,
+      effectiveScore: suitabilityEnabled ? (score ?? floor) : 0,
       candidateFiles: candidate.candidateFiles,
       highContentionTouched,
       overlaps,
@@ -303,8 +308,8 @@ function runCli() {
   if (args.checkOverlap) {
     activeIssues = discoverActiveIssues({
       repoRef,
-      candidateNumbers: args.candidates,
       trustedActors: policy.trustedMarkerActors,
+      staleAgeMs: policy.claimStaleAgeMs,
       now,
     });
   }
@@ -313,6 +318,7 @@ function runCli() {
     activeIssues,
     highContentionFiles,
     floor: policy.autopilotSuitabilityFloor,
+    suitabilityEnabled: policy.autopilotSuitabilityEnabled,
   });
   const output = {
     repository: { owner, repo },
@@ -333,9 +339,9 @@ function runCli() {
  * discovery run. Open-PR coverage stays repo-wide.
  */
 function discoverActiveIssues(options) {
-  const { repoRef, candidateNumbers, trustedActors, now } = options;
+  const { repoRef, trustedActors, staleAgeMs, now } = options;
   const active = new Map();
-  // Active-by-PR: every issue closed by an open PR.
+  // Active-by-PR: every issue closed by an open PR (repo-wide).
   for (const number of fetchOpenPrLinkedIssues(repoRef)) {
     if (!active.has(number)) {
       const body = fetchIssue(repoRef, number).body;
@@ -346,16 +352,29 @@ function discoverActiveIssues(options) {
       });
     }
   }
-  // Active-by-claim: candidate issues that already carry a non-stale claim.
+  // Active-by-claim: scan the issues that have a *remote* `issue/<n>-*` branch
+  // — every IDD claim creates one, published once its branch is pushed — so a
+  // non-stale claim held by another session is detected even though it is
+  // outside the (unclaimed) candidate set the ranking operates on. Bounded by
+  // the number of active issue branches, not a repo-wide comment scan; a claim
+  // whose branch is not yet pushed is picked up once it appears remotely. The
+  // configured claim stale age drives both the supersession check inside
+  // resolveActiveClaim and the non-stale filter here.
   const isTrusted = (login) =>
     trustedActors.some((actor) => actor.toLowerCase() === login.toLowerCase());
-  for (const number of candidateNumbers) {
+  const isStale = (activeCreatedAt, nextCreatedAt) =>
+    new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >=
+    staleAgeMs;
+  for (const number of fetchActiveClaimBranchNumbers(repoRef)) {
     if (active.has(number)) {
       continue;
     }
     const comments = fetchIssueComments(repoRef, number);
-    const claim = resolveActiveClaim(comments, isTrusted);
-    if (claim && !isStaleAt(claim.createdAt, now)) {
+    const claim = resolveActiveClaim(comments, {
+      isTrustedAuthor: isTrusted,
+      isStale,
+    });
+    if (claim && !isStale(claim.createdAt, now)) {
       const body = fetchIssue(repoRef, number).body;
       active.set(number, {
         number,
@@ -365,6 +384,22 @@ function discoverActiveIssues(options) {
     }
   }
   return [...active.values()].sort((left, right) => left.number - right.number);
+}
+/** Issue numbers that currently have an `issue/<n>-*` branch on the remote. */
+function fetchActiveClaimBranchNumbers(repoRef) {
+  const refs = ghJson([
+    'api',
+    `repos/${repoRef}/git/matching-refs/heads/issue/`,
+  ]);
+  const numbers = new Set();
+  for (const ref of refs) {
+    const name = String(ref.ref ?? '');
+    const match = name.match(/^refs\/heads\/issue\/(\d+)-/);
+    if (match) {
+      numbers.add(Number.parseInt(match[1], 10));
+    }
+  }
+  return [...numbers];
 }
 function fetchIssue(repoRef, number) {
   // Fail closed: let a fetch failure surface rather than returning an empty
@@ -495,10 +530,17 @@ function loadPolicy(policyPath) {
     typeof floorValue === 'number' && floorValue >= 1 && floorValue <= 5
       ? floorValue
       : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  const autopilotSuitabilityEnabled =
+    config?.autopilotSuitability?.enabled !== false;
+  const claimStaleAgeMs =
+    parseIsoDurationToMs(config?.claimTiming?.staleAge) ??
+    DEFAULT_CLAIM_STALE_AGE_MS;
   return {
     markerPrefix,
     trustedMarkerActors: trusted.actors,
     autopilotSuitabilityFloor,
+    autopilotSuitabilityEnabled,
+    claimStaleAgeMs,
   };
 }
 function parseArgs(argv) {
@@ -597,11 +639,13 @@ Without --check-overlap no active-set discovery runs (no extra GitHub API
 cost); each candidate's high-contention files are still reported.
 
 --check-overlap coverage: open-PR overlap is repo-wide (every issue closed by
-an open PR), but active-claim overlap is scanned only within the candidate set
-to avoid a repo-wide comment scan — a non-stale claim on a non-candidate issue
-with no open PR is not detected. The signal is an advisory A4 Step 2 hint, so
-this bounded coverage is acceptable; a claimed candidate becomes active for the
-next discovery run.
+an open PR). Active-claim overlap scans the issues that have a remote
+issue/<n>-* branch (every IDD claim creates one once pushed), resolving each
+with the configured claim stale age, so a non-stale claim held by another
+session is detected even when it is outside the unclaimed candidate set being
+ranked. It is bounded by the number of active issue branches, not a repo-wide
+comment scan; a claim whose branch is not yet pushed is picked up once it
+appears remotely.
 `);
 }
 function ghJson(args) {

--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -30,6 +30,8 @@ const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
 const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
 const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
 const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+/** Upper bound on the best-effort open-PR scan (a `gh pr list --limit`). */
+const OPEN_PR_SCAN_LIMIT = 500;
 if (isCliExecution()) {
   runCli();
 }
@@ -331,17 +333,21 @@ function runCli() {
 /**
  * Discover the concurrently-active set: every issue closed by an open PR
  * (repo-wide), plus candidate issues that already carry a non-stale claim.
- * Claim scanning is intentionally bounded to the candidate set (no repo-wide
- * comment scan) — that fetch cost is what `--check-overlap` gates — so a
- * non-stale claim on a non-candidate issue with no open PR is not detected.
- * This bounded coverage is acceptable because the overlap signal is an advisory
- * A4 Step 2 tie-breaker, and a claimed candidate becomes active for the next
- * discovery run. Open-PR coverage stays repo-wide.
+ * Active-by-claim covers every issue with a remote `issue/<n>-*` branch (every
+ * IDD claim creates one once pushed), resolved via the shared claim-state rules
+ * — not just the candidate set — so a claim held by another session is detected
+ * even though it is outside the unclaimed candidates being ranked. A claim whose
+ * branch is not yet pushed is picked up once it appears remotely. Active-by-PR
+ * is a best-effort scan of open PRs (bounded by the PR-list page cap). Both
+ * stay bounded — no repo-wide comment scan — which is the fetch cost
+ * `--check-overlap` gates; the overlap signal is an advisory A4 Step 2
+ * tie-breaker, so best-effort coverage is acceptable.
  */
 function discoverActiveIssues(options) {
   const { repoRef, trustedActors, staleAgeMs, now } = options;
   const active = new Map();
-  // Active-by-PR: every issue closed by an open PR (repo-wide).
+  // Active-by-PR: issues closed by an open PR (best-effort across open PRs,
+  // bounded by the PR-list page cap).
   for (const number of fetchOpenPrLinkedIssues(repoRef)) {
     if (!active.has(number)) {
       const body = fetchIssue(repoRef, number).body;
@@ -387,14 +393,18 @@ function discoverActiveIssues(options) {
 }
 /** Issue numbers that currently have an `issue/<n>-*` branch on the remote. */
 function fetchActiveClaimBranchNumbers(repoRef) {
-  const refs = ghJson([
-    'api',
-    `repos/${repoRef}/git/matching-refs/heads/issue/`,
-  ]);
   const numbers = new Set();
-  for (const ref of refs) {
-    const name = String(ref.ref ?? '');
-    const match = name.match(/^refs\/heads\/issue\/(\d+)-/);
+  // `--paginate` follows the Link headers to the end, so a repo with many
+  // issue branches does not silently drop branches past the first page.
+  const output = ghText([
+    'api',
+    '--paginate',
+    `repos/${repoRef}/git/matching-refs/heads/issue/`,
+    '--jq',
+    '.[].ref',
+  ]);
+  for (const line of output.split('\n')) {
+    const match = line.match(/^refs\/heads\/issue\/(\d+)-/);
     if (match) {
       numbers.add(Number.parseInt(match[1], 10));
     }
@@ -453,6 +463,8 @@ function fetchIssueComments(repoRef, number) {
 }
 function fetchOpenPrLinkedIssues(repoRef) {
   const numbers = new Set();
+  // Best-effort: `gh pr list` caps at --limit, so a repo with more open PRs
+  // than the cap drops the overflow. Acceptable for an advisory signal.
   const prs = ghJson([
     'pr',
     'list',
@@ -461,7 +473,7 @@ function fetchOpenPrLinkedIssues(repoRef) {
     '--state',
     'open',
     '--limit',
-    '200',
+    String(OPEN_PR_SCAN_LIMIT),
     '--json',
     'closingIssuesReferences',
   ]);
@@ -638,14 +650,13 @@ first within a score band, then issue number). Evidence-only: never a hard gate.
 Without --check-overlap no active-set discovery runs (no extra GitHub API
 cost); each candidate's high-contention files are still reported.
 
---check-overlap coverage: open-PR overlap is repo-wide (every issue closed by
-an open PR). Active-claim overlap scans the issues that have a remote
-issue/<n>-* branch (every IDD claim creates one once pushed), resolving each
-with the configured claim stale age, so a non-stale claim held by another
-session is detected even when it is outside the unclaimed candidate set being
-ranked. It is bounded by the number of active issue branches, not a repo-wide
-comment scan; a claim whose branch is not yet pushed is picked up once it
-appears remotely.
+--check-overlap coverage (best-effort, no repo-wide comment scan): open-PR
+overlap scans open PRs (bounded by the gh pr list page cap). Active-claim
+overlap scans the issues that have a remote issue/<n>-* branch (every IDD claim
+creates one once pushed), paginated to the end and resolved with the configured
+claim stale age, so a non-stale claim held by another session is detected even
+when it is outside the unclaimed candidate set being ranked. A claim whose
+branch is not yet pushed is picked up once it appears remotely.
 `);
 }
 function ghJson(args) {

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -168,6 +168,15 @@ const HELPER_COMMANDS = [
       'Collect read-only A4 viability filtering evidence for candidate issues.',
   },
   {
+    id: 'discover-shared-file-overlap',
+    scriptName: 'idd:discover-shared-file-overlap',
+    binName: 'idd-discover-shared-file-overlap',
+    entryPath: 'scripts/discover-shared-file-overlap.mjs',
+    vendoredCommand: 'node scripts/discover-shared-file-overlap.mjs',
+    description:
+      'Flag high-contention shared-file overlap between candidate issues and actively-claimed / open-PR work.',
+  },
+  {
     id: 'advisory-wait-state',
     scriptName: 'idd:advisory-wait-state',
     binName: 'idd-advisory-wait-state',

--- a/src/bin/idd-discover-shared-file-overlap.mts
+++ b/src/bin/idd-discover-shared-file-overlap.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-discover-shared-file-overlap.mts
+//
+// The bin/idd-discover-shared-file-overlap.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/discover-shared-file-overlap.mjs');

--- a/src/scripts/discover-shared-file-overlap.mts
+++ b/src/scripts/discover-shared-file-overlap.mts
@@ -433,10 +433,14 @@ function runCli(): void {
 }
 
 /**
- * Discover the concurrently-active set: every issue closed by an open PR, plus
- * candidate issues that already carry a non-stale claim. Claim scanning is
- * bounded to the candidate set (no repo-wide comment scan); this fetch cost is
- * what the `--check-overlap` flag gates.
+ * Discover the concurrently-active set: every issue closed by an open PR
+ * (repo-wide), plus candidate issues that already carry a non-stale claim.
+ * Claim scanning is intentionally bounded to the candidate set (no repo-wide
+ * comment scan) — that fetch cost is what `--check-overlap` gates — so a
+ * non-stale claim on a non-candidate issue with no open PR is not detected.
+ * This bounded coverage is acceptable because the overlap signal is an advisory
+ * A4 Step 2 tie-breaker, and a claimed candidate becomes active for the next
+ * discovery run. Open-PR coverage stays repo-wide.
  */
 function discoverActiveIssues(options: {
   repoRef: string;
@@ -486,22 +490,21 @@ interface FetchedIssue {
 }
 
 function fetchIssue(repoRef: string, number: number): FetchedIssue {
-  try {
-    const body = ghText([
-      'issue',
-      'view',
-      String(number),
-      '--repo',
-      repoRef,
-      '--json',
-      'body',
-      '--jq',
-      '.body',
-    ]);
-    return { body };
-  } catch {
-    return { body: '' };
-  }
+  // Fail closed: let a fetch failure surface rather than returning an empty
+  // body, which would silently suppress this issue's candidate files and emit
+  // a false "no overlap" result.
+  const body = ghText([
+    'issue',
+    'view',
+    String(number),
+    '--repo',
+    repoRef,
+    '--json',
+    'body',
+    '--jq',
+    '.body',
+  ]);
+  return { body };
 }
 
 /**
@@ -606,8 +609,13 @@ function loadManifest(manifestPath: string): unknown {
   );
   try {
     return JSON.parse(readFileSync(targetPath, 'utf8'));
-  } catch {
-    return { bundleBudgets: [] };
+  } catch (error) {
+    // Fail closed: an empty manifest would yield an empty high-contention set,
+    // making every candidate look non-overlapping. Surface the load failure.
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `failed to load sync manifest at ${targetPath}: ${message}`,
+    );
   }
 }
 
@@ -745,6 +753,13 @@ first within a score band, then issue number). Evidence-only: never a hard gate.
 
 Without --check-overlap no active-set discovery runs (no extra GitHub API
 cost); each candidate's high-contention files are still reported.
+
+--check-overlap coverage: open-PR overlap is repo-wide (every issue closed by
+an open PR), but active-claim overlap is scanned only within the candidate set
+to avoid a repo-wide comment scan — a non-stale claim on a non-candidate issue
+with no open PR is not detected. The signal is an advisory A4 Step 2 hint, so
+this bounded coverage is acceptable; a claimed candidate becomes active for the
+next discovery run.
 `);
 }
 

--- a/src/scripts/discover-shared-file-overlap.mts
+++ b/src/scripts/discover-shared-file-overlap.mts
@@ -18,8 +18,8 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { parseIsoDurationToMs } from './policy-helpers.mts';
 import {
-  isStaleAt,
   resolveActiveClaim,
   resolveTrustedMarkerActors,
 } from './protocol-helpers.mts';
@@ -31,6 +31,7 @@ const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
 /** Append-mostly shared surfaces that are not bundle members. */
 const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
 const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 
 if (isCliExecution()) {
   runCli();
@@ -231,6 +232,7 @@ export function analyzeSharedFileOverlap(input: {
   activeIssues: ActiveIssueInput[];
   highContentionFiles: Iterable<string>;
   floor?: number;
+  suitabilityEnabled?: boolean;
 }): {
   candidates: OverlapCandidateResult[];
   recommendedOrder: number[];
@@ -241,6 +243,10 @@ export function analyzeSharedFileOverlap(input: {
   };
 } {
   const floor = input.floor ?? DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  // When the autopilot-suitability kill switch is off (A4 Step 2 ignores the
+  // score and selects by lowest issue number), equalize every effectiveScore so
+  // the recommended order is driven by overlap then issue number, not score.
+  const suitabilityEnabled = input.suitabilityEnabled !== false;
   const highContention = new Set(input.highContentionFiles);
 
   const activeTouched = input.activeIssues.map((active) => ({
@@ -276,7 +282,7 @@ export function analyzeSharedFileOverlap(input: {
       return {
         number: candidate.number,
         score,
-        effectiveScore: score ?? floor,
+        effectiveScore: suitabilityEnabled ? (score ?? floor) : 0,
         candidateFiles: candidate.candidateFiles,
         highContentionTouched,
         overlaps,
@@ -410,8 +416,8 @@ function runCli(): void {
   if (args.checkOverlap) {
     activeIssues = discoverActiveIssues({
       repoRef,
-      candidateNumbers: args.candidates,
       trustedActors: policy.trustedMarkerActors,
+      staleAgeMs: policy.claimStaleAgeMs,
       now,
     });
   }
@@ -421,6 +427,7 @@ function runCli(): void {
     activeIssues,
     highContentionFiles,
     floor: policy.autopilotSuitabilityFloor,
+    suitabilityEnabled: policy.autopilotSuitabilityEnabled,
   });
 
   const output = {
@@ -444,14 +451,14 @@ function runCli(): void {
  */
 function discoverActiveIssues(options: {
   repoRef: string;
-  candidateNumbers: number[];
   trustedActors: string[];
+  staleAgeMs: number;
   now: string;
 }): ActiveIssueInput[] {
-  const { repoRef, candidateNumbers, trustedActors, now } = options;
+  const { repoRef, trustedActors, staleAgeMs, now } = options;
   const active = new Map<number, ActiveIssueInput>();
 
-  // Active-by-PR: every issue closed by an open PR.
+  // Active-by-PR: every issue closed by an open PR (repo-wide).
   for (const number of fetchOpenPrLinkedIssues(repoRef)) {
     if (!active.has(number)) {
       const body = fetchIssue(repoRef, number).body;
@@ -463,16 +470,29 @@ function discoverActiveIssues(options: {
     }
   }
 
-  // Active-by-claim: candidate issues that already carry a non-stale claim.
+  // Active-by-claim: scan the issues that have a *remote* `issue/<n>-*` branch
+  // — every IDD claim creates one, published once its branch is pushed — so a
+  // non-stale claim held by another session is detected even though it is
+  // outside the (unclaimed) candidate set the ranking operates on. Bounded by
+  // the number of active issue branches, not a repo-wide comment scan; a claim
+  // whose branch is not yet pushed is picked up once it appears remotely. The
+  // configured claim stale age drives both the supersession check inside
+  // resolveActiveClaim and the non-stale filter here.
   const isTrusted = (login: string) =>
     trustedActors.some((actor) => actor.toLowerCase() === login.toLowerCase());
-  for (const number of candidateNumbers) {
+  const isStale = (activeCreatedAt: string, nextCreatedAt: string): boolean =>
+    new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >=
+    staleAgeMs;
+  for (const number of fetchActiveClaimBranchNumbers(repoRef)) {
     if (active.has(number)) {
       continue;
     }
     const comments = fetchIssueComments(repoRef, number);
-    const claim = resolveActiveClaim(comments, isTrusted);
-    if (claim && !isStaleAt(claim.createdAt, now)) {
+    const claim = resolveActiveClaim(comments, {
+      isTrustedAuthor: isTrusted,
+      isStale,
+    });
+    if (claim && !isStale(claim.createdAt, now)) {
       const body = fetchIssue(repoRef, number).body;
       active.set(number, {
         number,
@@ -483,6 +503,23 @@ function discoverActiveIssues(options: {
   }
 
   return [...active.values()].sort((left, right) => left.number - right.number);
+}
+
+/** Issue numbers that currently have an `issue/<n>-*` branch on the remote. */
+function fetchActiveClaimBranchNumbers(repoRef: string): number[] {
+  const refs = ghJson([
+    'api',
+    `repos/${repoRef}/git/matching-refs/heads/issue/`,
+  ]);
+  const numbers = new Set<number>();
+  for (const ref of refs) {
+    const name = String((ref as { ref?: unknown }).ref ?? '');
+    const match = name.match(/^refs\/heads\/issue\/(\d+)-/);
+    if (match) {
+      numbers.add(Number.parseInt(match[1], 10));
+    }
+  }
+  return [...numbers];
 }
 
 interface FetchedIssue {
@@ -623,6 +660,8 @@ function loadPolicy(policyPath: string): {
   markerPrefix: string;
   trustedMarkerActors: string[];
   autopilotSuitabilityFloor: number;
+  autopilotSuitabilityEnabled: boolean;
+  claimStaleAgeMs: number;
 } {
   const targetPath = policyPath
     ? resolve(process.cwd(), policyPath)
@@ -630,7 +669,8 @@ function loadPolicy(policyPath: string): {
   let config: {
     markerPrefix?: unknown;
     trustedMarkerActors?: unknown;
-    autopilotSuitability?: { floor?: unknown } | null;
+    autopilotSuitability?: { floor?: unknown; enabled?: unknown } | null;
+    claimTiming?: { staleAge?: unknown } | null;
   } | null = null;
   try {
     config = JSON.parse(readFileSync(targetPath, 'utf8'));
@@ -650,10 +690,17 @@ function loadPolicy(policyPath: string): {
     typeof floorValue === 'number' && floorValue >= 1 && floorValue <= 5
       ? floorValue
       : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  const autopilotSuitabilityEnabled =
+    config?.autopilotSuitability?.enabled !== false;
+  const claimStaleAgeMs =
+    parseIsoDurationToMs(config?.claimTiming?.staleAge) ??
+    DEFAULT_CLAIM_STALE_AGE_MS;
   return {
     markerPrefix,
     trustedMarkerActors: trusted.actors,
     autopilotSuitabilityFloor,
+    autopilotSuitabilityEnabled,
+    claimStaleAgeMs,
   };
 }
 
@@ -755,11 +802,13 @@ Without --check-overlap no active-set discovery runs (no extra GitHub API
 cost); each candidate's high-contention files are still reported.
 
 --check-overlap coverage: open-PR overlap is repo-wide (every issue closed by
-an open PR), but active-claim overlap is scanned only within the candidate set
-to avoid a repo-wide comment scan — a non-stale claim on a non-candidate issue
-with no open PR is not detected. The signal is an advisory A4 Step 2 hint, so
-this bounded coverage is acceptable; a claimed candidate becomes active for the
-next discovery run.
+an open PR). Active-claim overlap scans the issues that have a remote
+issue/<n>-* branch (every IDD claim creates one once pushed), resolving each
+with the configured claim stale age, so a non-stale claim held by another
+session is detected even when it is outside the unclaimed candidate set being
+ranked. It is bounded by the number of active issue branches, not a repo-wide
+comment scan; a claim whose branch is not yet pushed is picked up once it
+appears remotely.
 `);
 }
 

--- a/src/scripts/discover-shared-file-overlap.mts
+++ b/src/scripts/discover-shared-file-overlap.mts
@@ -1,0 +1,787 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/discover-shared-file-overlap.mts
+//
+// The scripts/discover-shared-file-overlap.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+//
+// Read-only discovery-time evidence helper (#1019): for a set of candidate
+// issues, report the high-contention shared files each would touch (parsed
+// from its `## Candidate files` section) and whether any of those files
+// overlap an actively-claimed or open-PR issue's candidate files. It also
+// emits a soft de-prioritization order for A4 Step 2. It is the
+// file-contention companion to the #1008 `--with-claim-state` claim-eligibility
+// annotation. Evidence-only: it claims nothing and mutates no state.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  isStaleAt,
+  resolveActiveClaim,
+  resolveTrustedMarkerActors,
+} from './protocol-helpers.mts';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
+/** F-phase bundles whose member instruction files concentrate concurrent edits. */
+const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
+/** Append-mostly shared surfaces that are not bundle members. */
+const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
+const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
+
+if (isCliExecution()) {
+  runCli();
+}
+
+// ---------------------------------------------------------------------------
+// Pure core (exported for tests)
+// ---------------------------------------------------------------------------
+
+/** One evaluated candidate issue and its overlap evidence. */
+export interface OverlapCandidateResult {
+  number: number;
+  score: number | null;
+  effectiveScore: number;
+  candidateFiles: string[];
+  highContentionTouched: string[];
+  overlaps: OverlapHit[];
+  overlapFlag: boolean;
+}
+
+/** One actively-claimed / open-PR issue that shares a high-contention file. */
+export interface OverlapHit {
+  number: number;
+  reason: 'claim' | 'pr';
+  files: string[];
+}
+
+/** Candidate issue fed to {@link analyzeSharedFileOverlap}. */
+export interface OverlapCandidateInput {
+  number: number;
+  score?: number | null;
+  candidateFiles: string[];
+}
+
+/** Concurrently-active issue (claimed or with an open PR) used for overlap. */
+export interface ActiveIssueInput {
+  number: number;
+  reason: 'claim' | 'pr';
+  candidateFiles: string[];
+}
+
+/** A candidate the soft tie-breaker can reorder. */
+export interface RankableCandidate {
+  number: number;
+  effectiveScore: number;
+  overlapFlag: boolean;
+}
+
+/**
+ * Normalize a candidate-file path to its contention key. Strips surrounding
+ * backticks and a leading `./`, and collapses a `idd-template/<x>` source onto
+ * its generated `<x>` mirror so the two count as one contention surface. An
+ * instruction file is keyed by its basename (`idd-merge.instructions.md`):
+ * those basenames are unique repo-wide and issues cite them in several forms
+ * (full source path, mirror path, or bare), so basename keying makes every
+ * form compare equal.
+ */
+export function normalizeContentionPath(raw: unknown): string {
+  let value = String(raw ?? '').trim();
+  value = value.replace(/^`+/, '').replace(/`+$/, '').trim();
+  value = value.replace(/^\.\//, '');
+  value = value.replace(/^idd-template\//, '');
+  const instruction = value.match(/(?:^|\/)([^/]+\.instructions\.md)$/);
+  if (instruction) {
+    return instruction[1];
+  }
+  return value;
+}
+
+/**
+ * Parse the `## Candidate files` section of an issue body into a
+ * de-duplicated, normalized path list. The section is advisory, so parsing is
+ * lenient: it extracts every backtick-quoted path in the section — including
+ * the continuation lines of a multi-line bullet — plus the leading path-like
+ * token of any bullet that has no backticks at all. Returns `[]` when the
+ * section is absent.
+ */
+export function parseCandidateFiles(body: unknown): string[] {
+  const text = typeof body === 'string' ? body : '';
+  const lines = text.split(/\r?\n/);
+  let start = -1;
+  let end = lines.length;
+  for (let index = 0; index < lines.length; index += 1) {
+    const heading = lines[index].match(/^\s{0,3}(#{1,6})\s+(.*)$/);
+    if (!heading) {
+      continue;
+    }
+    const title = heading[2].replace(/[*_`]/g, '').trim().toLowerCase();
+    if (start === -1) {
+      if (/^candidate files\b/.test(title)) {
+        start = index + 1;
+      }
+      continue;
+    }
+    end = index;
+    break;
+  }
+  if (start === -1) {
+    return [];
+  }
+
+  const section = lines.slice(start, end);
+  const sectionText = section.join('\n');
+  const files: string[] = [];
+
+  // Every backtick-quoted path in the section, regardless of line wrapping.
+  for (const match of sectionText.matchAll(/`([^`]+)`/g)) {
+    const normalized = normalizeContentionPath(match[1]);
+    if (looksLikePath(normalized)) {
+      files.push(normalized);
+    }
+  }
+
+  // Bullets that quote no path fall back to a strict leading-token scan.
+  for (const line of section) {
+    const item = line.match(/^\s*(?:[-*+]|\d+[.)])\s+(.*)$/);
+    if (!item || /`[^`]+`/.test(item[1])) {
+      continue;
+    }
+    const token = extractStandaloneToken(item[1]);
+    if (token) {
+      files.push(token);
+    }
+  }
+
+  return [...new Set(files)];
+}
+
+/** Extract a strict leading path token from a bullet that quotes no path. */
+function extractStandaloneToken(itemBody: string): string | null {
+  let text = itemBody.trim();
+  text = text.split(/\s+(?:—|–|--)\s+/)[0];
+  text = text.split(/\s+\(/)[0];
+  const leading = text.split(/[\s,;]+/)[0] ?? '';
+  const normalized = normalizeContentionPath(leading);
+  return looksLikeStandalonePath(normalized) ? normalized : null;
+}
+
+/** A backtick-quoted token only needs a separator or extension. */
+function looksLikePath(value: string): boolean {
+  return value.length > 0 && !/\s/.test(value) && /[/.]/.test(value);
+}
+
+/**
+ * An unquoted bullet token must look unambiguously like a file path: a final
+ * extension, a glob, or a trailing directory slash. This rejects prose such
+ * as "generated/mirrored" that merely contains a slash.
+ */
+function looksLikeStandalonePath(value: string): boolean {
+  if (value.length === 0 || /\s/.test(value)) {
+    return false;
+  }
+  return (
+    /\.[a-z0-9]+$/i.test(value) || value.includes('*') || value.endsWith('/')
+  );
+}
+
+/**
+ * Resolve the high-contention shared-file set from the sync manifest: the
+ * union of the named bundles' member files plus any extra append-mostly
+ * surfaces. Paths are normalized so a source and its mirror collapse together.
+ */
+export function resolveHighContentionFiles(options: {
+  manifest: unknown;
+  bundleIds?: string[];
+  extraFiles?: string[];
+}): Set<string> {
+  const bundleIds = new Set(options.bundleIds ?? DEFAULT_BUNDLE_IDS);
+  const extraFiles = options.extraFiles ?? DEFAULT_EXTRA_FILES;
+  const result = new Set<string>();
+  const bundles = (options.manifest as { bundleBudgets?: unknown } | null)
+    ?.bundleBudgets;
+  if (Array.isArray(bundles)) {
+    for (const bundle of bundles) {
+      const entry = bundle as { id?: unknown; files?: unknown } | null;
+      if (!entry || !bundleIds.has(String(entry.id))) {
+        continue;
+      }
+      if (Array.isArray(entry.files)) {
+        for (const file of entry.files) {
+          result.add(normalizeContentionPath(file));
+        }
+      }
+    }
+  }
+  for (const file of extraFiles) {
+    result.add(normalizeContentionPath(file));
+  }
+  return result;
+}
+
+/**
+ * Compute per-candidate high-contention overlap evidence against the active
+ * set, plus a soft de-prioritization order for A4 Step 2.
+ */
+export function analyzeSharedFileOverlap(input: {
+  candidates: OverlapCandidateInput[];
+  activeIssues: ActiveIssueInput[];
+  highContentionFiles: Iterable<string>;
+  floor?: number;
+}): {
+  candidates: OverlapCandidateResult[];
+  recommendedOrder: number[];
+  summary: {
+    candidateCount: number;
+    flaggedCount: number;
+    activeIssueCount: number;
+  };
+} {
+  const floor = input.floor ?? DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  const highContention = new Set(input.highContentionFiles);
+
+  const activeTouched = input.activeIssues.map((active) => ({
+    number: active.number,
+    reason: active.reason,
+    files: intersect(active.candidateFiles, highContention),
+  }));
+
+  const candidates: OverlapCandidateResult[] = input.candidates.map(
+    (candidate) => {
+      const score =
+        typeof candidate.score === 'number' ? candidate.score : null;
+      const highContentionTouched = intersect(
+        candidate.candidateFiles,
+        highContention,
+      );
+      const touchedSet = new Set(highContentionTouched);
+      const overlaps: OverlapHit[] = [];
+      for (const active of activeTouched) {
+        if (active.number === candidate.number) {
+          continue;
+        }
+        const shared = active.files.filter((file) => touchedSet.has(file));
+        if (shared.length > 0) {
+          overlaps.push({
+            number: active.number,
+            reason: active.reason,
+            files: shared.slice().sort(),
+          });
+        }
+      }
+      overlaps.sort((left, right) => left.number - right.number);
+      return {
+        number: candidate.number,
+        score,
+        effectiveScore: score ?? floor,
+        candidateFiles: candidate.candidateFiles,
+        highContentionTouched,
+        overlaps,
+        overlapFlag: overlaps.length > 0,
+      };
+    },
+  );
+
+  const preSorted = candidates
+    .slice()
+    .sort(
+      (left, right) =>
+        right.effectiveScore - left.effectiveScore ||
+        left.number - right.number,
+    );
+  const recommendedOrder = applyOverlapTieBreaker(preSorted).map(
+    (candidate) => candidate.number,
+  );
+
+  return {
+    candidates,
+    recommendedOrder,
+    summary: {
+      candidateCount: candidates.length,
+      flaggedCount: candidates.filter((candidate) => candidate.overlapFlag)
+        .length,
+      activeIssueCount: input.activeIssues.length,
+    },
+  };
+}
+
+/**
+ * Soft de-prioritization tie-breaker for A4 Step 2. The input must already be
+ * ordered by the existing rules (suitability score descending, then issue
+ * number ascending / desync). Within each equal-`effectiveScore` band this
+ * stably moves overlap-flagged candidates after the non-overlapping ones; it
+ * never crosses a score band and never drops a candidate, so a colliding
+ * candidate that is the only ready work keeps its position.
+ */
+export function applyOverlapTieBreaker<T extends RankableCandidate>(
+  ranked: T[],
+): T[] {
+  const out: T[] = [];
+  for (let index = 0; index < ranked.length; ) {
+    let end = index;
+    while (
+      end < ranked.length &&
+      ranked[end].effectiveScore === ranked[index].effectiveScore
+    ) {
+      end += 1;
+    }
+    const band = ranked.slice(index, end);
+    for (const candidate of band) {
+      if (!candidate.overlapFlag) {
+        out.push(candidate);
+      }
+    }
+    for (const candidate of band) {
+      if (candidate.overlapFlag) {
+        out.push(candidate);
+      }
+    }
+    index = end;
+  }
+  return out;
+}
+
+function intersect(files: string[], highContention: Set<string>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const file of files) {
+    if (highContention.has(file) && !seen.has(file)) {
+      seen.add(file);
+      result.push(file);
+    }
+  }
+  return result.sort();
+}
+
+// ---------------------------------------------------------------------------
+// CLI glue (not unit-tested; the pure core above is)
+// ---------------------------------------------------------------------------
+
+interface ParsedArgs {
+  candidates: number[];
+  owner: string;
+  repo: string;
+  policy: string;
+  manifest: string;
+  bundles: string[] | null;
+  checkOverlap: boolean;
+  now: string;
+  help: boolean;
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.candidates.length === 0) {
+    throw new Error('at least one --candidate <number> is required');
+  }
+
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const policy = loadPolicy(args.policy);
+  const now = args.now || new Date().toISOString();
+
+  const manifest = loadManifest(args.manifest);
+  const highContentionFiles = resolveHighContentionFiles({
+    manifest,
+    bundleIds: args.bundles ?? DEFAULT_BUNDLE_IDS,
+  });
+
+  const candidates: OverlapCandidateInput[] = args.candidates.map((number) => {
+    const issue = fetchIssue(repoRef, number);
+    return {
+      number,
+      score: parseSuitabilityScore(issue.body, policy.markerPrefix),
+      candidateFiles: parseCandidateFiles(issue.body),
+    };
+  });
+
+  let activeIssues: ActiveIssueInput[] = [];
+  if (args.checkOverlap) {
+    activeIssues = discoverActiveIssues({
+      repoRef,
+      candidateNumbers: args.candidates,
+      trustedActors: policy.trustedMarkerActors,
+      now,
+    });
+  }
+
+  const analysis = analyzeSharedFileOverlap({
+    candidates,
+    activeIssues,
+    highContentionFiles,
+    floor: policy.autopilotSuitabilityFloor,
+  });
+
+  const output = {
+    repository: { owner, repo },
+    checkedOverlap: args.checkOverlap,
+    highContentionFiles: [...highContentionFiles].sort(),
+    ...analysis,
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+/**
+ * Discover the concurrently-active set: every issue closed by an open PR, plus
+ * candidate issues that already carry a non-stale claim. Claim scanning is
+ * bounded to the candidate set (no repo-wide comment scan); this fetch cost is
+ * what the `--check-overlap` flag gates.
+ */
+function discoverActiveIssues(options: {
+  repoRef: string;
+  candidateNumbers: number[];
+  trustedActors: string[];
+  now: string;
+}): ActiveIssueInput[] {
+  const { repoRef, candidateNumbers, trustedActors, now } = options;
+  const active = new Map<number, ActiveIssueInput>();
+
+  // Active-by-PR: every issue closed by an open PR.
+  for (const number of fetchOpenPrLinkedIssues(repoRef)) {
+    if (!active.has(number)) {
+      const body = fetchIssue(repoRef, number).body;
+      active.set(number, {
+        number,
+        reason: 'pr',
+        candidateFiles: parseCandidateFiles(body),
+      });
+    }
+  }
+
+  // Active-by-claim: candidate issues that already carry a non-stale claim.
+  const isTrusted = (login: string) =>
+    trustedActors.some((actor) => actor.toLowerCase() === login.toLowerCase());
+  for (const number of candidateNumbers) {
+    if (active.has(number)) {
+      continue;
+    }
+    const comments = fetchIssueComments(repoRef, number);
+    const claim = resolveActiveClaim(comments, isTrusted);
+    if (claim && !isStaleAt(claim.createdAt, now)) {
+      const body = fetchIssue(repoRef, number).body;
+      active.set(number, {
+        number,
+        reason: 'claim',
+        candidateFiles: parseCandidateFiles(body),
+      });
+    }
+  }
+
+  return [...active.values()].sort((left, right) => left.number - right.number);
+}
+
+interface FetchedIssue {
+  body: string;
+}
+
+function fetchIssue(repoRef: string, number: number): FetchedIssue {
+  try {
+    const body = ghText([
+      'issue',
+      'view',
+      String(number),
+      '--repo',
+      repoRef,
+      '--json',
+      'body',
+      '--jq',
+      '.body',
+    ]);
+    return { body };
+  } catch {
+    return { body: '' };
+  }
+}
+
+/**
+ * Map a REST issue-comment payload to the `CommentLike` shape
+ * `resolveActiveClaim` consumes. `resolveActiveClaim` reads the author from
+ * `author.login`, but the REST comments API returns it under `user.login`, so
+ * the login must be mapped across here (matching `discover-roadmap-graph`'s
+ * comment loader). Emitting `user` would leave the author empty and silently
+ * disable claim detection.
+ */
+export function toClaimComment(raw: unknown): {
+  body: string;
+  createdAt: string;
+  author: { login: string };
+} {
+  const entry = raw as {
+    body?: unknown;
+    created_at?: unknown;
+    user?: { login?: unknown } | null;
+  };
+  return {
+    body: String(entry.body ?? ''),
+    createdAt: String(entry.created_at ?? ''),
+    author: { login: String(entry.user?.login ?? '') },
+  };
+}
+
+function fetchIssueComments(
+  repoRef: string,
+  number: number,
+): { body: string; createdAt: string; author: { login: string } }[] {
+  const comments: ReturnType<typeof toClaimComment>[] = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const rawPage = ghJson([
+      'api',
+      `repos/${repoRef}/issues/${number}/comments?per_page=${pageSize}&page=${page}`,
+    ]);
+    for (const raw of rawPage) {
+      comments.push(toClaimComment(raw));
+    }
+    if (rawPage.length < pageSize) {
+      break;
+    }
+  }
+  return comments;
+}
+
+function fetchOpenPrLinkedIssues(repoRef: string): number[] {
+  const numbers = new Set<number>();
+  const prs = ghJson([
+    'pr',
+    'list',
+    '--repo',
+    repoRef,
+    '--state',
+    'open',
+    '--limit',
+    '200',
+    '--json',
+    'closingIssuesReferences',
+  ]);
+  for (const pr of prs) {
+    const refs = (pr as { closingIssuesReferences?: unknown })
+      .closingIssuesReferences;
+    if (Array.isArray(refs)) {
+      for (const ref of refs) {
+        const value = Number.parseInt(
+          String((ref as { number?: unknown }).number ?? ''),
+          10,
+        );
+        if (Number.isInteger(value) && value > 0) {
+          numbers.add(value);
+        }
+      }
+    }
+  }
+  return [...numbers];
+}
+
+function parseSuitabilityScore(
+  body: unknown,
+  markerPrefix: string,
+): number | null {
+  const text = typeof body === 'string' ? body : '';
+  const match = text.match(
+    new RegExp(
+      `<!--\\s*${escapeRegex(markerPrefix)}-autopilot-suitability:\\s*([0-9]+)\\s*-->`,
+    ),
+  );
+  if (!match) {
+    return null;
+  }
+  const value = Number.parseInt(match[1], 10);
+  return value >= 1 && value <= 5 ? value : null;
+}
+
+function loadManifest(manifestPath: string): unknown {
+  const targetPath = resolve(
+    process.cwd(),
+    manifestPath || DEFAULT_MANIFEST_PATH,
+  );
+  try {
+    return JSON.parse(readFileSync(targetPath, 'utf8'));
+  } catch {
+    return { bundleBudgets: [] };
+  }
+}
+
+function loadPolicy(policyPath: string): {
+  markerPrefix: string;
+  trustedMarkerActors: string[];
+  autopilotSuitabilityFloor: number;
+} {
+  const targetPath = policyPath
+    ? resolve(process.cwd(), policyPath)
+    : resolve(process.cwd(), '.github/idd/config.json');
+  let config: {
+    markerPrefix?: unknown;
+    trustedMarkerActors?: unknown;
+    autopilotSuitability?: { floor?: unknown } | null;
+  } | null = null;
+  try {
+    config = JSON.parse(readFileSync(targetPath, 'utf8'));
+  } catch {
+    config = null;
+  }
+  const markerPrefix =
+    typeof config?.markerPrefix === 'string' && config.markerPrefix.length > 0
+      ? config.markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  const trusted = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config,
+  });
+  const floorValue = config?.autopilotSuitability?.floor;
+  const autopilotSuitabilityFloor =
+    typeof floorValue === 'number' && floorValue >= 1 && floorValue <= 5
+      ? floorValue
+      : DEFAULT_AUTOPILOT_SUITABILITY_FLOOR;
+  return {
+    markerPrefix,
+    trustedMarkerActors: trusted.actors,
+    autopilotSuitabilityFloor,
+  };
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    candidates: [],
+    owner: '',
+    repo: '',
+    policy: '',
+    manifest: DEFAULT_MANIFEST_PATH,
+    bundles: null,
+    checkOverlap: false,
+    now: '',
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === '--candidate') {
+      parsed.candidates.push(parsePositiveInt(value, '--candidate'));
+      index += 1;
+      continue;
+    }
+    if (token === '--candidates') {
+      for (const part of String(value ?? '').split(',')) {
+        const trimmed = part.trim();
+        if (trimmed) {
+          parsed.candidates.push(parsePositiveInt(trimmed, '--candidates'));
+        }
+      }
+      index += 1;
+      continue;
+    }
+    if (token === '--owner') {
+      parsed.owner = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--repo') {
+      parsed.repo = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--policy') {
+      parsed.policy = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--manifest') {
+      parsed.manifest = value ?? DEFAULT_MANIFEST_PATH;
+      index += 1;
+      continue;
+    }
+    if (token === '--bundles') {
+      parsed.bundles = String(value ?? '')
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (token === '--check-overlap') {
+      parsed.checkOverlap = true;
+      continue;
+    }
+    if (token === '--now') {
+      parsed.now = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  return parsed;
+}
+
+function parsePositiveInt(value: string | undefined, flag: string): number {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`invalid ${flag} value: ${value ?? ''}`);
+  }
+  return parsed;
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/discover-shared-file-overlap.mjs --candidate <number> [--candidate <number> ...] [--candidates <n1,n2>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--check-overlap] [--now <ISO8601>]
+
+Reports, per candidate, the high-contention shared files it would touch (from
+its '## Candidate files' section) and — with --check-overlap — whether any
+overlap an actively-claimed or open-PR issue. recommendedOrder applies the soft
+A4 Step 2 de-prioritization tie-breaker (score desc, then non-overlapping
+first within a score band, then issue number). Evidence-only: never a hard gate.
+
+Without --check-overlap no active-set discovery runs (no extra GitHub API
+cost); each candidate's high-contention files are still reported.
+`);
+}
+
+function ghJson(args: string[]): unknown[] {
+  const parsed = JSON.parse(runGh(args).trim() || '[]');
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+function ghText(args: string[]): string {
+  return runGh(args).trim();
+}
+
+function runGh(args: string[]): string {
+  try {
+    return execFileSync('gh', args, {
+      encoding: 'utf8',
+      timeout: 30_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const stderr = String(
+      (error as { stderr?: unknown } | null)?.stderr ?? '',
+    ).trim();
+    if (stderr) {
+      throw new Error(`gh command failed: ${stderr}`);
+    }
+    throw error;
+  }
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isCliExecution(): boolean {
+  return Boolean(
+    process.argv[1] &&
+      fileURLToPath(import.meta.url) === resolve(process.argv[1]),
+  );
+}

--- a/src/scripts/discover-shared-file-overlap.mts
+++ b/src/scripts/discover-shared-file-overlap.mts
@@ -404,6 +404,9 @@ function runCli(): void {
   const highContentionFiles = resolveHighContentionFiles({
     manifest,
     bundleIds: args.bundles ?? DEFAULT_BUNDLE_IDS,
+    // Track the manifest actually in use so a custom --manifest is the file
+    // reported (and matched) as high-contention, not the hard-coded default.
+    extraFiles: [args.manifest],
   });
 
   const candidates: OverlapCandidateInput[] = args.candidates.map((number) => {

--- a/src/scripts/discover-shared-file-overlap.mts
+++ b/src/scripts/discover-shared-file-overlap.mts
@@ -18,6 +18,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { parseAutopilotSuitability } from './autopilot-suitability.mts';
 import { parseIsoDurationToMs } from './policy-helpers.mts';
 import {
   resolveActiveClaim,
@@ -409,7 +410,7 @@ function runCli(): void {
     const issue = fetchIssue(repoRef, number);
     return {
       number,
-      score: parseSuitabilityScore(issue.body, policy.markerPrefix),
+      score: parseAutopilotSuitability(issue.body, policy.markerPrefix),
       candidateFiles: parseCandidateFiles(issue.body),
     };
   });
@@ -445,14 +446,16 @@ function runCli(): void {
  * Discover the concurrently-active set: every issue closed by an open PR
  * (repo-wide), plus candidate issues that already carry a non-stale claim.
  * Active-by-claim covers every issue with a remote `issue/<n>-*` branch (every
- * IDD claim creates one once pushed), resolved via the shared claim-state rules
- * — not just the candidate set — so a claim held by another session is detected
- * even though it is outside the unclaimed candidates being ranked. A claim whose
- * branch is not yet pushed is picked up once it appears remotely. Active-by-PR
- * is a best-effort scan of open PRs (bounded by the PR-list page cap). Both
- * stay bounded — no repo-wide comment scan — which is the fetch cost
- * `--check-overlap` gates; the overlap signal is an advisory A4 Step 2
- * tie-breaker, so best-effort coverage is acceptable.
+ * IDD claim creates one once pushed), resolved with the standard `claimed-by`
+ * claim-state rules — not just the candidate set — so a claim held by another
+ * session is detected even though it is outside the unclaimed candidates being
+ * ranked. A claim whose branch is not yet pushed is picked up once it appears
+ * remotely. Active-by-PR is a best-effort scan of open PRs (bounded by the
+ * PR-list page cap). Both stay bounded — no repo-wide comment scan — which is
+ * the fetch cost `--check-overlap` gates; the overlap signal is an advisory A4
+ * Step 2 tie-breaker, so best-effort coverage is acceptable. Edge cases the
+ * advisory signal does not specially resolve: legacy claim-id-less markers and
+ * forced-handoff-successor adoption (the default `resolveActiveClaim` path).
  */
 function discoverActiveIssues(options: {
   repoRef: string;
@@ -634,23 +637,6 @@ function fetchOpenPrLinkedIssues(repoRef: string): number[] {
   return [...numbers];
 }
 
-function parseSuitabilityScore(
-  body: unknown,
-  markerPrefix: string,
-): number | null {
-  const text = typeof body === 'string' ? body : '';
-  const match = text.match(
-    new RegExp(
-      `<!--\\s*${escapeRegex(markerPrefix)}-autopilot-suitability:\\s*([0-9]+)\\s*-->`,
-    ),
-  );
-  if (!match) {
-    return null;
-  }
-  const value = Number.parseInt(match[1], 10);
-  return value >= 1 && value <= 5 ? value : null;
-}
-
 function loadManifest(manifestPath: string): unknown {
   const targetPath = resolve(
     process.cwd(),
@@ -675,7 +661,8 @@ function loadPolicy(policyPath: string): {
   autopilotSuitabilityEnabled: boolean;
   claimStaleAgeMs: number;
 } {
-  const targetPath = policyPath
+  const explicit = policyPath.length > 0;
+  const targetPath = explicit
     ? resolve(process.cwd(), policyPath)
     : resolve(process.cwd(), '.github/idd/config.json');
   let config: {
@@ -686,7 +673,14 @@ function loadPolicy(policyPath: string): {
   } | null = null;
   try {
     config = JSON.parse(readFileSync(targetPath, 'utf8'));
-  } catch {
+  } catch (error) {
+    // Fail closed on an explicit --policy that cannot be loaded: silently
+    // using defaults would drop custom trusted actors / claim timing and let
+    // active claims disappear. An absent default config still falls back.
+    if (explicit) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`failed to load policy at ${targetPath}: ${message}`);
+    }
     config = null;
   }
   const markerPrefix =
@@ -808,7 +802,9 @@ Reports, per candidate, the high-contention shared files it would touch (from
 its '## Candidate files' section) and — with --check-overlap — whether any
 overlap an actively-claimed or open-PR issue. recommendedOrder applies the soft
 A4 Step 2 de-prioritization tie-breaker (score desc, then non-overlapping
-first within a score band, then issue number). Evidence-only: never a hard gate.
+first within a score band, then issue number); it does NOT apply
+discover.selectionDesync — the agent layers the overlap nudge after its own
+desync pick. Evidence-only: never a hard gate.
 
 Without --check-overlap no active-set discovery runs (no extra GitHub API
 cost); each candidate's high-contention files are still reported.
@@ -848,10 +844,6 @@ function runGh(args: string[]): string {
     }
     throw error;
   }
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function isCliExecution(): boolean {

--- a/src/scripts/discover-shared-file-overlap.mts
+++ b/src/scripts/discover-shared-file-overlap.mts
@@ -32,6 +32,8 @@ const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
 const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
 const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
 const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+/** Upper bound on the best-effort open-PR scan (a `gh pr list --limit`). */
+const OPEN_PR_SCAN_LIMIT = 500;
 
 if (isCliExecution()) {
   runCli();
@@ -442,12 +444,15 @@ function runCli(): void {
 /**
  * Discover the concurrently-active set: every issue closed by an open PR
  * (repo-wide), plus candidate issues that already carry a non-stale claim.
- * Claim scanning is intentionally bounded to the candidate set (no repo-wide
- * comment scan) — that fetch cost is what `--check-overlap` gates — so a
- * non-stale claim on a non-candidate issue with no open PR is not detected.
- * This bounded coverage is acceptable because the overlap signal is an advisory
- * A4 Step 2 tie-breaker, and a claimed candidate becomes active for the next
- * discovery run. Open-PR coverage stays repo-wide.
+ * Active-by-claim covers every issue with a remote `issue/<n>-*` branch (every
+ * IDD claim creates one once pushed), resolved via the shared claim-state rules
+ * — not just the candidate set — so a claim held by another session is detected
+ * even though it is outside the unclaimed candidates being ranked. A claim whose
+ * branch is not yet pushed is picked up once it appears remotely. Active-by-PR
+ * is a best-effort scan of open PRs (bounded by the PR-list page cap). Both
+ * stay bounded — no repo-wide comment scan — which is the fetch cost
+ * `--check-overlap` gates; the overlap signal is an advisory A4 Step 2
+ * tie-breaker, so best-effort coverage is acceptable.
  */
 function discoverActiveIssues(options: {
   repoRef: string;
@@ -458,7 +463,8 @@ function discoverActiveIssues(options: {
   const { repoRef, trustedActors, staleAgeMs, now } = options;
   const active = new Map<number, ActiveIssueInput>();
 
-  // Active-by-PR: every issue closed by an open PR (repo-wide).
+  // Active-by-PR: issues closed by an open PR (best-effort across open PRs,
+  // bounded by the PR-list page cap).
   for (const number of fetchOpenPrLinkedIssues(repoRef)) {
     if (!active.has(number)) {
       const body = fetchIssue(repoRef, number).body;
@@ -507,14 +513,18 @@ function discoverActiveIssues(options: {
 
 /** Issue numbers that currently have an `issue/<n>-*` branch on the remote. */
 function fetchActiveClaimBranchNumbers(repoRef: string): number[] {
-  const refs = ghJson([
-    'api',
-    `repos/${repoRef}/git/matching-refs/heads/issue/`,
-  ]);
   const numbers = new Set<number>();
-  for (const ref of refs) {
-    const name = String((ref as { ref?: unknown }).ref ?? '');
-    const match = name.match(/^refs\/heads\/issue\/(\d+)-/);
+  // `--paginate` follows the Link headers to the end, so a repo with many
+  // issue branches does not silently drop branches past the first page.
+  const output = ghText([
+    'api',
+    '--paginate',
+    `repos/${repoRef}/git/matching-refs/heads/issue/`,
+    '--jq',
+    '.[].ref',
+  ]);
+  for (const line of output.split('\n')) {
+    const match = line.match(/^refs\/heads\/issue\/(\d+)-/);
     if (match) {
       numbers.add(Number.parseInt(match[1], 10));
     }
@@ -592,6 +602,8 @@ function fetchIssueComments(
 
 function fetchOpenPrLinkedIssues(repoRef: string): number[] {
   const numbers = new Set<number>();
+  // Best-effort: `gh pr list` caps at --limit, so a repo with more open PRs
+  // than the cap drops the overflow. Acceptable for an advisory signal.
   const prs = ghJson([
     'pr',
     'list',
@@ -600,7 +612,7 @@ function fetchOpenPrLinkedIssues(repoRef: string): number[] {
     '--state',
     'open',
     '--limit',
-    '200',
+    String(OPEN_PR_SCAN_LIMIT),
     '--json',
     'closingIssuesReferences',
   ]);
@@ -801,14 +813,13 @@ first within a score band, then issue number). Evidence-only: never a hard gate.
 Without --check-overlap no active-set discovery runs (no extra GitHub API
 cost); each candidate's high-contention files are still reported.
 
---check-overlap coverage: open-PR overlap is repo-wide (every issue closed by
-an open PR). Active-claim overlap scans the issues that have a remote
-issue/<n>-* branch (every IDD claim creates one once pushed), resolving each
-with the configured claim stale age, so a non-stale claim held by another
-session is detected even when it is outside the unclaimed candidate set being
-ranked. It is bounded by the number of active issue branches, not a repo-wide
-comment scan; a claim whose branch is not yet pushed is picked up once it
-appears remotely.
+--check-overlap coverage (best-effort, no repo-wide comment scan): open-PR
+overlap scans open PRs (bounded by the gh pr list page cap). Active-claim
+overlap scans the issues that have a remote issue/<n>-* branch (every IDD claim
+creates one once pushed), paginated to the end and resolved with the configured
+claim stale age, so a non-stale claim held by another session is detected even
+when it is outside the unclaimed candidate set being ranked. A claim whose
+branch is not yet pushed is picked up once it appears remotely.
 `);
 }
 

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -240,6 +240,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
       'Collect read-only A4 viability filtering evidence for candidate issues.',
   },
   {
+    id: 'discover-shared-file-overlap',
+    scriptName: 'idd:discover-shared-file-overlap',
+    binName: 'idd-discover-shared-file-overlap',
+    entryPath: 'scripts/discover-shared-file-overlap.mjs',
+    vendoredCommand: 'node scripts/discover-shared-file-overlap.mjs',
+    description:
+      'Flag high-contention shared-file overlap between candidate issues and actively-claimed / open-PR work.',
+  },
+  {
     id: 'advisory-wait-state',
     scriptName: 'idd:advisory-wait-state',
     binName: 'idd-advisory-wait-state',

--- a/tests/discover-shared-file-overlap.test.mts
+++ b/tests/discover-shared-file-overlap.test.mts
@@ -340,3 +340,39 @@ test('analyzeSharedFileOverlap treats a missing score as the floor for ordering'
     3,
   );
 });
+
+test('analyzeSharedFileOverlap ignores the score when the suitability kill switch is off', () => {
+  const input = {
+    candidates: [
+      { number: 30, score: 3, candidateFiles: [] },
+      { number: 31, score: 5, candidateFiles: [] },
+    ],
+    activeIssues: [],
+    highContentionFiles: HIGH_CONTENTION,
+  };
+  // Enabled (default): score 5 ranks ahead of the lower-numbered score 3.
+  assert.deepEqual(analyzeSharedFileOverlap(input).recommendedOrder, [31, 30]);
+  // Disabled: scores are equalized, so the lower issue number wins (A4 Step 2
+  // falls back to lowest-number selection).
+  const disabled = analyzeSharedFileOverlap({
+    ...input,
+    suitabilityEnabled: false,
+  });
+  assert.deepEqual(disabled.recommendedOrder, [30, 31]);
+  assert.equal(disabled.candidates[0].effectiveScore, 0);
+});
+
+test('the suitability kill switch still de-prioritizes overlap before issue number', () => {
+  // Disabled scores → one band; within it, the colliding low number is moved
+  // after the clean higher number.
+  const result = analyzeSharedFileOverlap({
+    candidates: [
+      { number: 18, score: 5, candidateFiles: [MERGE_FILE] },
+      { number: 19, score: 3, candidateFiles: ['src/scripts/isolated.mts'] },
+    ],
+    activeIssues: [{ number: 991, reason: 'pr', candidateFiles: [MERGE_FILE] }],
+    highContentionFiles: HIGH_CONTENTION,
+    suitabilityEnabled: false,
+  });
+  assert.deepEqual(result.recommendedOrder, [19, 18]);
+});

--- a/tests/discover-shared-file-overlap.test.mts
+++ b/tests/discover-shared-file-overlap.test.mts
@@ -1,0 +1,342 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+import {
+  type ActiveIssueInput,
+  analyzeSharedFileOverlap,
+  applyOverlapTieBreaker,
+  normalizeContentionPath,
+  type OverlapCandidateInput,
+  parseCandidateFiles,
+  type RankableCandidate,
+  resolveHighContentionFiles,
+  toClaimComment,
+} from '../src/scripts/discover-shared-file-overlap.mts';
+import { resolveActiveClaim } from '../src/scripts/protocol-helpers.mts';
+
+// Instruction files are keyed by their (repo-wide unique) basename so that
+// the source path, the mirror path, and a bare citation all compare equal.
+const MERGE_FILE = 'idd-merge.instructions.md';
+const ADVISORY_FILE = 'idd-advisory-wait.instructions.md';
+const REVIEW_FIX_FILE = 'idd-review-fix.instructions.md';
+const MANIFEST_FILE = 'audit/sync-manifest.json';
+
+function readFixture(name: string): string {
+  return readFileSync(
+    new URL(`../fixtures/shared-file-overlap/${name}`, import.meta.url),
+    'utf8',
+  );
+}
+
+function loadRealManifest(): unknown {
+  return JSON.parse(
+    readFileSync(
+      new URL('../audit/sync-manifest.json', import.meta.url),
+      'utf8',
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// normalizeContentionPath
+// ---------------------------------------------------------------------------
+
+test('normalizeContentionPath strips backticks, leading ./, and idd-template/', () => {
+  assert.equal(
+    normalizeContentionPath('`audit/sync-manifest.json`'),
+    MANIFEST_FILE,
+  );
+  assert.equal(normalizeContentionPath('./scripts/foo.mjs'), 'scripts/foo.mjs');
+  assert.equal(
+    normalizeContentionPath(
+      'idd-template/.github/instructions/idd-merge.instructions.md',
+    ),
+    MERGE_FILE,
+  );
+});
+
+test('normalizeContentionPath collapses a source and its mirror onto one key', () => {
+  const source = normalizeContentionPath(
+    'idd-template/.github/instructions/idd-merge.instructions.md',
+  );
+  const mirror = normalizeContentionPath(
+    '.github/instructions/idd-merge.instructions.md',
+  );
+  assert.equal(source, mirror);
+});
+
+// ---------------------------------------------------------------------------
+// parseCandidateFiles
+// ---------------------------------------------------------------------------
+
+test('parseCandidateFiles extracts and normalizes every backtick path, de-duping the mirror', () => {
+  const files = parseCandidateFiles(readFixture('candidate-merge.md'));
+  assert.deepEqual(files, [MERGE_FILE, ADVISORY_FILE]);
+});
+
+test('parseCandidateFiles keeps non-high-contention helper and glob tokens', () => {
+  const files = parseCandidateFiles(readFixture('candidate-review.md'));
+  assert.deepEqual(files, [
+    ADVISORY_FILE,
+    'src/scripts/review-activity-snapshot.mts',
+    'tests/*.test.mts',
+  ]);
+});
+
+test('parseCandidateFiles returns [] when no candidate-files section exists', () => {
+  assert.deepEqual(
+    parseCandidateFiles(readFixture('no-candidate-section.md')),
+    [],
+  );
+});
+
+test('parseCandidateFiles stops at the next heading and ignores non-list prose', () => {
+  const body = [
+    '## Candidate files',
+    '',
+    '- `scripts/a.mjs`',
+    '',
+    '## Notes',
+    '',
+    '- `scripts/should-not-count.mjs`',
+  ].join('\n');
+  assert.deepEqual(parseCandidateFiles(body), ['scripts/a.mjs']);
+});
+
+// ---------------------------------------------------------------------------
+// resolveHighContentionFiles
+// ---------------------------------------------------------------------------
+
+test('resolveHighContentionFiles unions the named bundles plus extra surfaces', () => {
+  const manifest = {
+    bundleBudgets: [
+      { id: 'bundle-review', files: ['a.md', 'shared.md'] },
+      { id: 'bundle-merge', files: ['shared.md', 'b.md'] },
+      { id: 'bundle-discovery', files: ['c.md'] },
+    ],
+  };
+  const resolved = resolveHighContentionFiles({ manifest });
+  assert.deepEqual([...resolved].sort(), [
+    'a.md',
+    MANIFEST_FILE,
+    'b.md',
+    'shared.md',
+  ]);
+  assert.equal(resolved.has('c.md'), false);
+});
+
+test('resolveHighContentionFiles over the real manifest yields the issue-named files', () => {
+  const resolved = resolveHighContentionFiles({ manifest: loadRealManifest() });
+  for (const file of [
+    'idd-overview-core.instructions.md',
+    'idd-overview-appendix.instructions.md',
+    'idd-review-snapshot.instructions.md',
+    'idd-review-triage.instructions.md',
+    REVIEW_FIX_FILE,
+    ADVISORY_FILE,
+    'idd-ci.instructions.md',
+    'idd-pre-merge.instructions.md',
+    'idd-merge-handoff.instructions.md',
+    MERGE_FILE,
+    MANIFEST_FILE,
+  ]) {
+    assert.equal(resolved.has(file), true, `expected high-contention: ${file}`);
+  }
+  // A discovery-bundle-only file must not be flagged high-contention.
+  assert.equal(resolved.has('idd-suitability.instructions.md'), false);
+});
+
+// ---------------------------------------------------------------------------
+// analyzeSharedFileOverlap
+// ---------------------------------------------------------------------------
+
+const HIGH_CONTENTION = [MERGE_FILE, ADVISORY_FILE, REVIEW_FIX_FILE];
+
+test('analyzeSharedFileOverlap flags a candidate that shares a high-contention file with active work', () => {
+  const candidates: OverlapCandidateInput[] = [
+    {
+      number: 1019,
+      score: 3,
+      candidateFiles: [ADVISORY_FILE, 'src/scripts/x.mts'],
+    },
+  ];
+  const activeIssues: ActiveIssueInput[] = [
+    { number: 991, reason: 'pr', candidateFiles: [ADVISORY_FILE, MERGE_FILE] },
+  ];
+  const result = analyzeSharedFileOverlap({
+    candidates,
+    activeIssues,
+    highContentionFiles: HIGH_CONTENTION,
+  });
+  const candidate = result.candidates[0];
+  assert.deepEqual(candidate.highContentionTouched, [ADVISORY_FILE]);
+  assert.equal(candidate.overlapFlag, true);
+  assert.deepEqual(candidate.overlaps, [
+    { number: 991, reason: 'pr', files: [ADVISORY_FILE] },
+  ]);
+  assert.equal(result.summary.flaggedCount, 1);
+});
+
+test('analyzeSharedFileOverlap does not flag a candidate with no shared high-contention file', () => {
+  const candidates: OverlapCandidateInput[] = [
+    { number: 2000, score: 3, candidateFiles: ['src/scripts/only-helper.mts'] },
+  ];
+  const activeIssues: ActiveIssueInput[] = [
+    { number: 991, reason: 'claim', candidateFiles: [MERGE_FILE] },
+  ];
+  const result = analyzeSharedFileOverlap({
+    candidates,
+    activeIssues,
+    highContentionFiles: HIGH_CONTENTION,
+  });
+  assert.deepEqual(result.candidates[0].highContentionTouched, []);
+  assert.equal(result.candidates[0].overlapFlag, false);
+  assert.deepEqual(result.candidates[0].overlaps, []);
+  assert.equal(result.summary.flaggedCount, 0);
+});
+
+test('analyzeSharedFileOverlap never reports a candidate overlapping itself', () => {
+  const candidates: OverlapCandidateInput[] = [
+    { number: 1019, score: 3, candidateFiles: [MERGE_FILE] },
+  ];
+  const activeIssues: ActiveIssueInput[] = [
+    { number: 1019, reason: 'claim', candidateFiles: [MERGE_FILE] },
+  ];
+  const result = analyzeSharedFileOverlap({
+    candidates,
+    activeIssues,
+    highContentionFiles: HIGH_CONTENTION,
+  });
+  assert.equal(result.candidates[0].overlapFlag, false);
+});
+
+test('analyzeSharedFileOverlap parses fixtures: merge and review collide on advisory-wait', () => {
+  const merge = {
+    number: 991,
+    score: 3,
+    candidateFiles: parseCandidateFiles(readFixture('candidate-merge.md')),
+  };
+  const review = {
+    number: 1019,
+    score: 3,
+    candidateFiles: parseCandidateFiles(readFixture('candidate-review.md')),
+  };
+  const isolated = {
+    number: 2000,
+    score: 3,
+    candidateFiles: parseCandidateFiles(readFixture('candidate-isolated.md')),
+  };
+  const result = analyzeSharedFileOverlap({
+    candidates: [review, isolated],
+    activeIssues: [{ ...merge, reason: 'pr' as const }],
+    highContentionFiles: resolveHighContentionFiles({
+      manifest: loadRealManifest(),
+    }),
+  });
+  const reviewResult = result.candidates.find((c) => c.number === 1019);
+  const isolatedResult = result.candidates.find((c) => c.number === 2000);
+  assert.equal(reviewResult?.overlapFlag, true);
+  assert.deepEqual(reviewResult?.overlaps, [
+    { number: 991, reason: 'pr', files: [ADVISORY_FILE] },
+  ]);
+  assert.equal(isolatedResult?.overlapFlag, false);
+});
+
+// ---------------------------------------------------------------------------
+// toClaimComment — REST `user.login` must reach the `author.login` field that
+// resolveActiveClaim reads (regression guard for the active-by-claim path)
+// ---------------------------------------------------------------------------
+
+test('toClaimComment maps REST user.login into the author field resolveActiveClaim reads', () => {
+  const rest = {
+    body: '<!-- claimed-by: agent-x claim-abc supersedes: none 2026-06-25T00:00:00Z branch: issue/1-x -->',
+    created_at: '2026-06-25T00:00:00Z',
+    user: { login: 'kurone-kito' },
+  };
+  const mapped = toClaimComment(rest);
+  assert.equal(mapped.author.login, 'kurone-kito');
+
+  // A trusted author yields the claim; an empty/untrusted author yields none —
+  // mapping the login to `user` instead of `author` would break the former.
+  const trusted = resolveActiveClaim(
+    [mapped],
+    (login) => login === 'kurone-kito',
+  );
+  assert.equal(trusted?.claimId, 'claim-abc');
+  assert.equal(
+    resolveActiveClaim([mapped], (login) => login === 'someone-else'),
+    null,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// applyOverlapTieBreaker / recommendedOrder
+// ---------------------------------------------------------------------------
+
+test('applyOverlapTieBreaker moves overlapping candidates after non-overlapping ones within a score band', () => {
+  const ranked: RankableCandidate[] = [
+    { number: 10, effectiveScore: 3, overlapFlag: true },
+    { number: 11, effectiveScore: 3, overlapFlag: false },
+    { number: 12, effectiveScore: 3, overlapFlag: true },
+    { number: 13, effectiveScore: 3, overlapFlag: false },
+  ];
+  assert.deepEqual(
+    applyOverlapTieBreaker(ranked).map((candidate) => candidate.number),
+    [11, 13, 10, 12],
+  );
+});
+
+test('applyOverlapTieBreaker never reorders across score bands', () => {
+  const ranked: RankableCandidate[] = [
+    { number: 10, effectiveScore: 4, overlapFlag: true },
+    { number: 11, effectiveScore: 3, overlapFlag: false },
+  ];
+  // The colliding score-4 candidate stays ahead of the clean score-3 one.
+  assert.deepEqual(
+    applyOverlapTieBreaker(ranked).map((candidate) => candidate.number),
+    [10, 11],
+  );
+});
+
+test('recommendedOrder de-prioritizes a colliding candidate within its score band', () => {
+  const result = analyzeSharedFileOverlap({
+    candidates: [
+      { number: 18, score: 3, candidateFiles: [MERGE_FILE] },
+      { number: 19, score: 3, candidateFiles: ['src/scripts/isolated.mts'] },
+    ],
+    activeIssues: [{ number: 991, reason: 'pr', candidateFiles: [MERGE_FILE] }],
+    highContentionFiles: HIGH_CONTENTION,
+  });
+  // #18 collides; the lowest-number rule alone would pick #18 first, but the
+  // soft overlap tie-breaker puts the clean #19 ahead within the score band.
+  assert.deepEqual(result.recommendedOrder, [19, 18]);
+});
+
+test('recommendedOrder keeps a colliding candidate when it is the only ready work', () => {
+  const result = analyzeSharedFileOverlap({
+    candidates: [{ number: 18, score: 3, candidateFiles: [MERGE_FILE] }],
+    activeIssues: [{ number: 991, reason: 'pr', candidateFiles: [MERGE_FILE] }],
+    highContentionFiles: HIGH_CONTENTION,
+  });
+  assert.deepEqual(result.recommendedOrder, [18]);
+  assert.equal(result.candidates[0].overlapFlag, true);
+});
+
+test('analyzeSharedFileOverlap treats a missing score as the floor for ordering', () => {
+  const result = analyzeSharedFileOverlap({
+    candidates: [
+      { number: 30, score: null, candidateFiles: [] },
+      { number: 31, score: 4, candidateFiles: [] },
+    ],
+    activeIssues: [],
+    highContentionFiles: HIGH_CONTENTION,
+    floor: 3,
+  });
+  // score 4 outranks the unscored (floor 3) candidate.
+  assert.deepEqual(result.recommendedOrder, [31, 30]);
+  assert.equal(
+    result.candidates.find((c) => c.number === 30)?.effectiveScore,
+    3,
+  );
+});


### PR DESCRIPTION
## Summary

Implements the high-contention shared-file overlap signal from #1019.

A new read-only **`discover-shared-file-overlap`** helper, for a set of
candidate issues:

- parses each issue's `## Candidate files` section (multi-line bullets and
  the source/mirror/bare forms all collapse via instruction-basename keying);
- resolves the **high-contention set** data-driven from the F-phase bundles
  (`bundle-review` + `bundle-merge`) in `audit/sync-manifest.json` plus the
  manifest itself — exactly the files #1019 names;
- reports each candidate's `highContentionTouched` and, **behind
  `--check-overlap`** (the GitHub-API cost is gated), whether it overlaps an
  actively-claimed or open-PR issue, using the shared `resolveActiveClaim`
  claim-state rules;
- emits a `recommendedOrder` applying the **soft A4 Step 2 tie-breaker**
  (score desc → non-overlapping first within a score band → issue number).

`idd-discover.instructions.md` A4 Step 2 documents the signal as a soft
de-prioritization tie-breaker after score / lowest-number / desync — **never a
hard gate** (a colliding candidate stays claimable when it is the only ready
work). `docs/policy-constants.md` adds the high-contention shared-file
convention plus the **deterministic-ordering keep-both lever** for
append-mostly files.

## Budget bump (raise callout)

Per the bump-with-margin convention this PR raises two limits in
`audit/sync-manifest.json` for the grown `idd-discover` guidance, with margin:

- `instructionSizeBudgets.phaseLimitBytes`: **30100 → 31400**
- `bundle-discovery` `limitBytes`: **88100 → 89400**

## Append-mostly audit (addendum)

Audited the repo's clearly append-mostly inventory surfaces (`package.json`
`bin`, `.gitattributes` `scripts/*.mjs`, `HELPER_COMMANDS`,
`audit/sync-manifest.json` `syncPairs`): none is deterministically ordered.
Reordering all in-place is large, conflict-prone, and needs an order guard, so
it is filed as follow-up **#1032** (the convention note documents the lever).

## Verification

- `pnpm run lint:minimum` passes (audit-docs, typecheck, build:check, biome,
  dprint, 1152 tests, workshop integrity, cspell, markdownlint).
- New `tests/discover-shared-file-overlap.test.mts` (18 cases) + fixtures cover
  parsing, the high-contention resolution, overlapping vs non-overlapping
  candidate sets, the soft-tie-breaker ordering, and the REST `user.login` →
  `author.login` claim-comment mapping (active-by-claim regression guard).

Closes #1019.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new evidence-only overlap-check helper and CLI to identify when proposed work touches shared, high-conflict files.
  * Updated IDD discover Step 2 tie-breaking with an advisory preference to deprioritize candidates that overlap with actively-claimed or open-PR high-contention instruction files (without blocking claims).
* **Documentation**
  * Expanded guidance on high-contention shared files and documented the helper’s inputs, JSON output, and soft tie-breaker behavior.
* **Bug Fixes**
  * Improved consistency of candidate-file parsing, overlap detection, and within-band recommended ordering across mirrored/source paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->