### PR TITLE
build(idd): add biome to the named validation command gates

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -21,9 +21,9 @@
   },
   "commands": {
     "install-deps": "pnpm install --frozen-lockfile",
-    "fix-validate": "npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
-    "pre-push-validate": "npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress",
-    "post-fix-validate": "npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress"
+    "fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
+    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress",
+    "post-fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress"
   },
   "helperRuntime": {
     "profile": "package-manager"

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -248,14 +248,14 @@ the recorded machine-readable policy. Absent values keep the gate
 enabled and default approval actors to
 `owners-and-maintainers-only`.
 
-| Name                    | Commands                                                                                                                                     |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| **fix-validate**        | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
-| **pre-push-validate**   | `npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                        |
-| **post-fix-validate**   | `npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
-| **install-deps**        | `pnpm install --frozen-lockfile`                                                                                                             |
-| **issue-scope**         | `roadmap-first`                                                                                                                              |
-| **orphan-first-policy** | `none`                                                                                                                                       |
+| Name                    | Commands                                                                                                                                                                |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **fix-validate**        | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
+| **pre-push-validate**   | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                                |
+| **post-fix-validate**   | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
+| **install-deps**        | `pnpm install --frozen-lockfile`                                                                                                                                        |
+| **issue-scope**         | `roadmap-first`                                                                                                                                                         |
+| **orphan-first-policy** | `none`                                                                                                                                                                  |
 
 Non-shell rows such as **issue-scope** and **orphan-first-policy** are
 workflow settings. Read them literally, not as commands.

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 88100
+      "limitBytes": 88223
     },
     {
       "id": "bundle-resume",
@@ -275,35 +275,35 @@
       "replacements": [
         {
           "from": "| Name                    | Commands                         |",
-          "to": "| Name                    | Commands                                                                                                                                     |"
+          "to": "| Name                    | Commands                                                                                                                                                                |"
         },
         {
           "from": "| ----------------------- | -------------------------------- |",
-          "to": "| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |"
+          "to": "| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |"
         },
         {
           "from": "| **fix-validate**        | `{{FIX_VALIDATE_COMMANDS}}`      |",
-          "to": "| **fix-validate**        | `npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"`                                       |"
+          "to": "| **fix-validate**        | `npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"`                                       |"
         },
         {
           "from": "| **pre-push-validate**   | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |",
-          "to": "| **pre-push-validate**   | `npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress`                                        |"
+          "to": "| **pre-push-validate**   | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress`                                                |"
         },
         {
           "from": "| **post-fix-validate**   | `{{POST_FIX_VALIDATE_COMMANDS}}` |",
-          "to": "| **post-fix-validate**   | `npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress` |"
+          "to": "| **post-fix-validate**   | `npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress` |"
         },
         {
           "from": "| **install-deps**        | `{{INSTALL_DEPS_COMMAND}}`       |",
-          "to": "| **install-deps**        | `pnpm install --frozen-lockfile`                                                                                                             |"
+          "to": "| **install-deps**        | `pnpm install --frozen-lockfile`                                                                                                                                        |"
         },
         {
           "from": "| **issue-scope**         | `roadmap-first`                  |",
-          "to": "| **issue-scope**         | `roadmap-first`                                                                                                                              |"
+          "to": "| **issue-scope**         | `roadmap-first`                                                                                                                                                         |"
         },
         {
           "from": "| **orphan-first-policy** | `none`                           |",
-          "to": "| **orphan-first-policy** | `none`                                                                                                                                       |"
+          "to": "| **orphan-first-policy** | `none`                                                                                                                                                                  |"
         },
         {
           "from": "use `npx <tool>` if Node.js and `npx` are available",


### PR DESCRIPTION
## Summary

The IDD named validation command sets — **`fix-validate`** (B3, before
each commit), **`pre-push-validate`** (D2, before push), and
**`post-fix-validate`** — were markdown-only (`dprint` + `markdownlint`
+ `cspell`) and did **not** run `biome`. CI's `pnpm-boundary` runs the
full `lint:minimum`, which **does** include `biome check`, so a biome
formatting slip in a `.mts` / `.json` / test file passed the prescribed
B3/D2 gates and only failed later in CI (observed on PR #1027 / #1008).

This change prepends the code-aware `biome` step to the three command
sets, mirroring the existing `dprint` fix-vs-check split:

- **`fix-validate`** / **`post-fix-validate`**: `npx biome check --write`
  (auto-fix, like `dprint fmt`)
- **`pre-push-validate`**: `npx biome check` (check-only, like `dprint check`)

Full markdown + `cspell` coverage and the fix-vs-check distinction are
preserved; `typecheck` / `node --test` / `build:check` are intentionally
left out of the commit-time path (the acceptance criteria require only
`biome`, and this keeps the high-contention bundle edit minimal).

## Approach

Chose **(a) inline extension** over **(b) pointing at `lint:fix` /
`lint:precommit`**: approach (b) would either add `cspell` to the lean
commit-time `fix-validate` (a behavior change #1031 did not ask for) or
drop `cspell` from `pre-push-validate` (`lint:precommit` omits it).
Inline keeps each command's existing coverage exactly and only adds
`biome`.

## Edit surface

The command strings live in synced places:

1. `.github/idd/config.json` `commands` (hand-maintained live policy).
2. `audit/sync-manifest.json` — the `idd-overview-core-instructions`
   syncPair `replacements` map the template's `{{FIX_VALIDATE_COMMANDS}}`
   placeholders to the concrete strings in the generated root mirror.
3. `.github/instructions/idd-overview-core.instructions.md` (root mirror)
   regenerated via `node scripts/sync-docs.mjs --apply` (not hand-edited).

The `idd-template/.github/instructions/...` table keeps its `{{…}}`
placeholders (unchanged). `docs/customization.md` /
`idd-template/docs/customization.md` are intentionally **not** changed:
their Project commands table is a generic portable example (note
`install-deps: true`, unlike this repo's `pnpm install --frozen-lockfile`),
and `biome` is repo-specific tooling. `package.json` is untouched.

## ⚠️ Budget ratchet callout (required)

The longer commands widen the Commands column of the root mirror's
Project commands table (140 → 167 chars across the 8 dprint-canonical
table rows), which grows the discovery instruction bundle past its
limit. Per the `sync-manifest.json` ratchet rule, this PR **raises**
`bundleBudgets` `bundle-discovery` `limitBytes` **88100 → 88223** (the
exact measured post-change total). The growth is a mechanical
consequence of the table re-pad, not new prose.

## Verification

`pnpm run lint:minimum` passes locally (audit-docs `--check`, typecheck,
`build:check`, `biome check`, `dprint check`, `node --test` — 1134 tests,
`cspell`, `markdownlint`); CI `pnpm-boundary` will confirm.

## Possible follow-up (non-blocking)

No regression test currently asserts the live config's validation
commands contain `biome`, so a future edit could silently drop it again
(the #1031 class of bug). A small assertion in the consistency / doctor
suite could lock it in.

Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)
