### PR TITLE
docs(idd): add a mutation/write-side helper critique lens to C-phase

### DIFF
--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -132,9 +132,9 @@ Codex CLI / Gemini CLI), see
 
 When the diff under critique implements a helper that **mutates GitHub
 state, mutates git state, or performs a merge** (read-only helpers are out
-of scope), also apply this lens — each check below repeatedly passed a
-clean general critique yet was caught one finding per round by later
-review:
+of scope), also apply this lens — each check below targets a gap class that
+a clean general critique repeatedly missed and that later review then
+surfaced one finding per round:
 
 - **Fail-closed inputs**: guards use strict checks (`=== true`, explicit
   pattern/enum validation) so a non-boolean, empty, missing, or malformed

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -128,6 +128,27 @@ assessment. For the per-agent invocation table (Copilot / Claude Code /
 Codex CLI / Gemini CLI), see
 [`docs/idd-workflow.md` → Critique pass invocation](../../docs/idd-workflow.md#critique-pass-invocation).
 
+### Mutation / write-side helper lens
+
+When the diff under critique implements a helper that **mutates GitHub
+state, mutates git state, or performs a merge** (read-only helpers are out
+of scope), also apply this lens — each check below repeatedly passed a
+clean general critique yet was caught one finding per round by later
+review:
+
+- **Fail-closed inputs**: guards use strict checks (`=== true`, explicit
+  pattern/enum validation) so a non-boolean, empty, missing, or malformed
+  value blocks the mutation rather than passing it.
+- **Validate/execute scope parity**: the repo, identity, and HEAD the gate
+  validates are the same ones the mutation runs against — no split between
+  a read-side collector's scope and the executed `gh` / git command; reject
+  ambiguous partial scoping.
+- **Unsafe-output suppression**: a not-ready or invalid verdict never emits
+  a copy-pasteable command bound to an unvalidated value.
+- **Schema strictness parity**: output schemas match the values the helper
+  actually produces and mirror sibling-helper strictness (SHA patterns,
+  enums), so the published contract is no looser than the runtime.
+
 ## Template sync
 
 This repository is the canonical source of the IDD template distributed

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 88223
+      "limitBytes": 89364
     },
     {
       "id": "bundle-resume",
@@ -195,7 +195,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 95600
+      "limitBytes": 96372
     },
     {
       "id": "bundle-merge",
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 86200
+      "limitBytes": 87108
     }
   ],
   "syncPairs": [

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 90291
+      "limitBytes": 90321
     },
     {
       "id": "bundle-resume",
@@ -195,7 +195,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 96372
+      "limitBytes": 96402
     },
     {
       "id": "bundle-merge",
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 87108
+      "limitBytes": 87138
     }
   ],
   "syncPairs": [

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -132,9 +132,9 @@ Codex CLI / Gemini CLI), see
 
 When the diff under critique implements a helper that **mutates GitHub
 state, mutates git state, or performs a merge** (read-only helpers are out
-of scope), also apply this lens — each check below repeatedly passed a
-clean general critique yet was caught one finding per round by later
-review:
+of scope), also apply this lens — each check below targets a gap class that
+a clean general critique repeatedly missed and that later review then
+surfaced one finding per round:
 
 - **Fail-closed inputs**: guards use strict checks (`=== true`, explicit
   pattern/enum validation) so a non-boolean, empty, missing, or malformed

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -128,6 +128,27 @@ assessment. For the per-agent invocation table (Copilot / Claude Code /
 Codex CLI / Gemini CLI), see
 [`docs/idd-workflow.md` → Critique pass invocation](../../docs/idd-workflow.md#critique-pass-invocation).
 
+### Mutation / write-side helper lens
+
+When the diff under critique implements a helper that **mutates GitHub
+state, mutates git state, or performs a merge** (read-only helpers are out
+of scope), also apply this lens — each check below repeatedly passed a
+clean general critique yet was caught one finding per round by later
+review:
+
+- **Fail-closed inputs**: guards use strict checks (`=== true`, explicit
+  pattern/enum validation) so a non-boolean, empty, missing, or malformed
+  value blocks the mutation rather than passing it.
+- **Validate/execute scope parity**: the repo, identity, and HEAD the gate
+  validates are the same ones the mutation runs against — no split between
+  a read-side collector's scope and the executed `gh` / git command; reject
+  ambiguous partial scoping.
+- **Unsafe-output suppression**: a not-ready or invalid verdict never emits
+  a copy-pasteable command bound to an unvalidated value.
+- **Schema strictness parity**: output schemas match the values the helper
+  actually produces and mirror sibling-helper strictness (SHA patterns,
+  enums), so the published contract is no looser than the runtime.
+
 ## Template sync
 
 This repository is the canonical source of the IDD template distributed


### PR DESCRIPTION
## Summary

The C-phase self-review critique (C1) and the E2 critique are the agent's
pre-submission defense. For ordinary diffs they work well, but for
**write-side / mutation helpers** (helpers that execute `gh` mutations,
git operations, or a merge) an independent critique can report "no
actionable defects" while the advisory reviewer then surfaces a
recognizable **class** of safety gaps one finding per round — e.g. PR
#1020 (issue #994, the `idd-merge-execute` helper) took seven rounds for
seven findings that all belonged to one class.

This adds a scoped, additive **mutation / write-side helper lens** to the
shared `## Critique pass` guidance in
`idd-overview-appendix.instructions.md`. Because C1 (`idd-work`) and E2
(`idd-review-snapshot`) already reference that section for the per-agent
critique mechanism, both inherit the lens without extra cross-references.
The lens applies **only** to helpers that mutate GitHub/git/merge state
(read-only helpers are out of scope) and covers four checks:

- **Fail-closed inputs** — strict checks (`=== true`, explicit
  pattern/enum validation) so non-boolean/empty/missing/malformed values
  block the mutation.
- **Validate/execute scope parity** — the repo/identity/HEAD the gate
  validates is the one the mutation runs against; reject ambiguous partial
  scoping.
- **Unsafe-output suppression** — a not-ready/invalid verdict never emits a
  copy-pasteable command bound to an unvalidated value.
- **Schema strictness parity** — output schemas match produced values and
  mirror sibling-helper strictness (SHA patterns, enums).

Phrased generally (no #994-specific wording); non-mutation critique
behavior is unchanged. The `idd-template/` source and the `exact`-mode root
mirror are updated together and regenerated via `sync-docs --apply`.

## ⚠️ Budget ratchet callout (required)

`idd-overview-appendix.instructions.md` is a member of five instruction
bundles. The lens grows three of them past their limits, so this PR
**raises** the measured totals per the `sync-manifest.json` ratchet rule.

This branch also merged current `main` (which now includes PR #1033 /
#1019, itself a bundle-discovery raise to 89400). The values below are the
final measured totals **after** that merge and the lens reword:

- `bundle-discovery` 89400 → **90321**
- `bundle-review` 95600 → **96402**
- `bundle-merge` 86200 → **87138**

(`bundle-resume` and `bundle-work` keep headroom; not changed.)

## Verification

`pnpm run lint:minimum` passes (audit-docs `--check` with the new budgets,
bundle budgets, 1154 tests, markdownlint, cspell); root↔template mirror
parity confirmed.

Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
