### PR TITLE
feat(idd): carry non-review-notice dispositions across HEAD changes

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -90,6 +90,15 @@ unambiguous:
   can reopen the thread and add a new reply, which will re-surface it in
   the next E1 pass.
 - **Regular comments**: reply only; do not resolve.
+- **Persistent non-review notices**: a non-review notice (rate-limit /
+  usage-limit / review-limit) already dispositioned `**Rejected** — {bot}
+  did not review HEAD …` in a prior pass **carries that rejection forward**
+  across this push — do **not** re-post an identical rejection just because
+  the notice's `updatedAt` bumped or the bot re-posted the same summary. The
+  F2/F3 disposition-evidence gate honors the existing rejection while the bot
+  still has not reviewed any HEAD (see the E6 non-review-notice rule). Only a
+  notice the bot replaces with an actual completed review of the current HEAD
+  needs a fresh disposition.
 
 After E13 replies and resolutions are complete, upsert the PR live
 status digest before E14 if the next route is still review-fix or CI

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -241,7 +241,10 @@ ack / error, as defined in E4):
   re-request, no wait.** The notice item itself is **always rejected**,
   because it carries no advisory result — never record `**Accepted**` on
   the notice: `**Rejected** — {bot} did not review HEAD {sha}
-  ({reason}); this is not a completed review`. A separate _completed_
+  ({reason}); this is not a completed review`. Write `{bot}` as the bot's
+  **GitHub login** (e.g. `coderabbitai[bot]`, `chatgpt-codex-connector[bot]`)
+  so the carry-forward below can attribute the rejection to exactly that bot
+  when several advisory bots are configured. A separate _completed_
   review of the current HEAD, if one is present, is a **distinct**
   ReviewItems_snapshot item dispositioned `**Accepted**` under the
   completed-review rules above — accept that review, not the notice.
@@ -259,10 +262,13 @@ ack / error, as defined in E4):
   reviewed any HEAD. A review-fix push that bumps the notice's `updatedAt` (or a
   re-posted identical rate-limit / usage-limit summary) does **not** require a
   fresh identical rejection: the F2/F3 disposition-evidence gate carries the
-  existing rejection forward. Re-disposition **only** when the bot replaces the
-  notice with an actual completed review of the current HEAD — disposition that
-  review under the completed-review rules above (the carry-forward no longer
-  applies to a notice that became a real review).
+  existing rejection forward. The carry-forward is **scoped to the bot the
+  rejection names** (by GitHub login), so a rejection of one advisory bot's
+  notice never clears another bot's still-undispositioned notice. Re-disposition
+  **only** when the bot replaces the notice with an actual completed review of
+  the current HEAD — disposition that review under the completed-review rules
+  above (the carry-forward no longer applies to a notice that became a real
+  review).
 - **Do not auto-request a fresh review from triage** to "upgrade" a
   non-review notice. Triggering a new review is a separate concern:
   Copilot advisory state is owned solely by the advisory-wait protocol

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -252,6 +252,17 @@ ack / error, as defined in E4):
   review out of the next pass. This
   keeps the disposition vocabulary unchanged for the E7 verifier and the
   F2/F3 gates, and never leaves the item pending across snapshots.
+- **Carry the rejection forward across pushes — do not re-disposition an
+  unchanged notice.** Once a non-review notice carries its `**Rejected** —
+  {bot} did not review HEAD …` reply, that disposition **persists across later
+  HEAD changes** while the same notice persists and the bot still has not
+  reviewed any HEAD. A review-fix push that bumps the notice's `updatedAt` (or a
+  re-posted identical rate-limit / usage-limit summary) does **not** require a
+  fresh identical rejection: the F2/F3 disposition-evidence gate carries the
+  existing rejection forward. Re-disposition **only** when the bot replaces the
+  notice with an actual completed review of the current HEAD — disposition that
+  review under the completed-review rules above (the carry-forward no longer
+  applies to a notice that became a real review).
 - **Do not auto-request a fresh review from triage** to "upgrade" a
   non-review notice. Triggering a new review is a separate concern:
   Copilot advisory state is owned solely by the advisory-wait protocol

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -195,7 +195,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 96402
+      "limitBytes": 98300
     },
     {
       "id": "bundle-merge",

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -90,6 +90,15 @@ unambiguous:
   can reopen the thread and add a new reply, which will re-surface it in
   the next E1 pass.
 - **Regular comments**: reply only; do not resolve.
+- **Persistent non-review notices**: a non-review notice (rate-limit /
+  usage-limit / review-limit) already dispositioned `**Rejected** — {bot}
+  did not review HEAD …` in a prior pass **carries that rejection forward**
+  across this push — do **not** re-post an identical rejection just because
+  the notice's `updatedAt` bumped or the bot re-posted the same summary. The
+  F2/F3 disposition-evidence gate honors the existing rejection while the bot
+  still has not reviewed any HEAD (see the E6 non-review-notice rule). Only a
+  notice the bot replaces with an actual completed review of the current HEAD
+  needs a fresh disposition.
 
 After E13 replies and resolutions are complete, upsert the PR live
 status digest before E14 if the next route is still review-fix or CI

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -241,7 +241,10 @@ ack / error, as defined in E4):
   re-request, no wait.** The notice item itself is **always rejected**,
   because it carries no advisory result — never record `**Accepted**` on
   the notice: `**Rejected** — {bot} did not review HEAD {sha}
-  ({reason}); this is not a completed review`. A separate _completed_
+  ({reason}); this is not a completed review`. Write `{bot}` as the bot's
+  **GitHub login** (e.g. `coderabbitai[bot]`, `chatgpt-codex-connector[bot]`)
+  so the carry-forward below can attribute the rejection to exactly that bot
+  when several advisory bots are configured. A separate _completed_
   review of the current HEAD, if one is present, is a **distinct**
   ReviewItems_snapshot item dispositioned `**Accepted**` under the
   completed-review rules above — accept that review, not the notice.
@@ -259,10 +262,13 @@ ack / error, as defined in E4):
   reviewed any HEAD. A review-fix push that bumps the notice's `updatedAt` (or a
   re-posted identical rate-limit / usage-limit summary) does **not** require a
   fresh identical rejection: the F2/F3 disposition-evidence gate carries the
-  existing rejection forward. Re-disposition **only** when the bot replaces the
-  notice with an actual completed review of the current HEAD — disposition that
-  review under the completed-review rules above (the carry-forward no longer
-  applies to a notice that became a real review).
+  existing rejection forward. The carry-forward is **scoped to the bot the
+  rejection names** (by GitHub login), so a rejection of one advisory bot's
+  notice never clears another bot's still-undispositioned notice. Re-disposition
+  **only** when the bot replaces the notice with an actual completed review of
+  the current HEAD — disposition that review under the completed-review rules
+  above (the carry-forward no longer applies to a notice that became a real
+  review).
 - **Do not auto-request a fresh review from triage** to "upgrade" a
   non-review notice. Triggering a new review is a separate concern:
   Copilot advisory state is owned solely by the advisory-wait protocol

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -252,6 +252,17 @@ ack / error, as defined in E4):
   review out of the next pass. This
   keeps the disposition vocabulary unchanged for the E7 verifier and the
   F2/F3 gates, and never leaves the item pending across snapshots.
+- **Carry the rejection forward across pushes — do not re-disposition an
+  unchanged notice.** Once a non-review notice carries its `**Rejected** —
+  {bot} did not review HEAD …` reply, that disposition **persists across later
+  HEAD changes** while the same notice persists and the bot still has not
+  reviewed any HEAD. A review-fix push that bumps the notice's `updatedAt` (or a
+  re-posted identical rate-limit / usage-limit summary) does **not** require a
+  fresh identical rejection: the F2/F3 disposition-evidence gate carries the
+  existing rejection forward. Re-disposition **only** when the bot replaces the
+  notice with an actual completed review of the current HEAD — disposition that
+  review under the completed-review rules above (the carry-forward no longer
+  applies to a notice that became a real review).
 - **Do not auto-request a fresh review from triage** to "upgrade" a
   non-review notice. Triggering a new review is a separate concern:
   Copilot advisory state is owned solely by the advisory-wait protocol

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1337,6 +1337,52 @@ export function isIddDispositionComment(comment) {
   const author = comment.author?.login ?? '';
   return isDispositionComment(comment) && !isKnownReviewBot(author);
 }
+// #1018 non-review-notice carry-forward classifiers.
+//
+// An advisory **non-review notice** — an advisory bot reporting it did not
+// review the current HEAD (rate-limit / usage-quota exhaustion / review-limit) —
+// carries no review result and is always dispositioned `**Rejected** — {bot} did
+// not review HEAD …` per the E6 non-review-notice rule. The gate uses the two
+// tight, fail-closed predicates below to let such a disposition carry forward
+// across HEAD changes (see `summarizeDispositionEvidenceForGate`), so a Codex
+// `updatedAt` bump or a re-posted CodeRabbit rate-limit summary does not re-flag
+// `missing-disposition-evidence` for a notice the agent already rejected.
+//
+// Both intentionally **under-match**: an unrecognized notice merely keeps the
+// existing per-push re-disposition churn (safe), while a false positive could
+// carry a stale disposition onto a real review (a false merge). Only
+// machine-generated, bot-specific signals match, and the notice predicate is
+// evaluated solely on advisory-bot-authored comments at the gate, so a human
+// reviewer comment is never reclassified as a notice.
+const ADVISORY_NON_REVIEW_NOTICE_PATTERNS = [
+  // CodeRabbit rate-limit notice: the machine-generated marker (distinct from
+  // the `summarize by coderabbit.ai` review marker) and its warning heading.
+  /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
+  /^[>\s]*#{1,6}\s*Review limit reached\b/im,
+  // Codex usage / quota exhaustion for code reviews.
+  /\bCodex usage limits for code reviews\b/i,
+  /\breached your Codex usage limits\b/i,
+];
+export function isAdvisoryNonReviewNotice(body) {
+  const text = String(body ?? '');
+  if (!text) {
+    return false;
+  }
+  return ADVISORY_NON_REVIEW_NOTICE_PATTERNS.some((pattern) =>
+    pattern.test(text),
+  );
+}
+// A trusted IDD disposition of a non-review notice: the canonical
+// `**Rejected** — {bot} did not review HEAD {sha} ({reason}); this is not a
+// completed review` reply. Requires the `**Rejected**` prefix (a notice is
+// always rejected, never accepted) and the `did not review HEAD` phrase that
+// names the notice, so an ordinary rejection of reviewer feedback is excluded.
+export function isNonReviewNoticeDisposition(comment) {
+  const body = (comment.body ?? '').trimStart();
+  return (
+    body.startsWith('**Rejected**') && /\bdid not review HEAD\b/i.test(body)
+  );
+}
 export function classifyCiChecks(checks) {
   const normalized = checks.map((check) => ({
     name: check.name,
@@ -2220,6 +2266,47 @@ export function summarizeDispositionEvidenceForGate(
         ) === null
       );
     });
+  const dispositionComments = normalizedComments.filter(
+    (comment) =>
+      iddAgentLogins.has(comment.authorLogin) &&
+      isDispositionComment({ body: comment.body }),
+  );
+  // #1018 non-review-notice carry-forward (fail-closed). A persistent advisory
+  // non-review notice already dispositioned `**Rejected** — {bot} did not review
+  // HEAD …` keeps that disposition across HEAD changes while the bot still has
+  // not reviewed any HEAD: a Codex `updatedAt` bump or a re-posted CodeRabbit
+  // rate-limit summary must not re-flag `missing-disposition-evidence` for a
+  // notice the agent already rejected. Carry forward `min(K, N)` of the `K`
+  // trusted IDD notice-dispositions and `N` outstanding advisory-bot non-review
+  // notices: the matched notices leave the outstanding set and the matched
+  // notice-dispositions leave the general disposition pool, so a notice
+  // disposition never also clears an unrelated regular comment and the notice's
+  // bumped activity can never strand its disposition. The carry-forward guard
+  // re-checks the current notice body, so a notice the bot later replaces with a
+  // real review no longer matches and still needs a fresh disposition. Any
+  // unmatched notice or disposition falls through to the unchanged 1:1 pairing.
+  const noticeDispositions = dispositionComments.filter((comment) =>
+    isNonReviewNoticeDisposition({ body: comment.body }),
+  );
+  const outstandingNotices = outstandingComments.filter(
+    (comment) =>
+      isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
+      isAdvisoryNonReviewNotice(comment.body),
+  );
+  const carryForwardCount = Math.min(
+    noticeDispositions.length,
+    outstandingNotices.length,
+  );
+  const carriedNoticeIndexes = new Set(
+    outstandingNotices
+      .slice(0, carryForwardCount)
+      .map((comment) => comment.sortedIndex),
+  );
+  const consumedNoticeDispositionIndexes = new Set(
+    noticeDispositions
+      .slice(0, carryForwardCount)
+      .map((comment) => comment.sortedIndex),
+  );
   // Count-based 1:1 pairing for the trailing-marker rule: a single later IDD
   // disposition marker addresses at most ONE earlier regular comment, so one
   // trailing marker cannot clear several distinct comments that each still
@@ -2227,11 +2314,9 @@ export function summarizeDispositionEvidenceForGate(
   // Walk the outstanding comments oldest-first and greedily consume the
   // earliest disposition marker strictly newer than each (markers that are not
   // newer than the current comment cannot address it or any later comment).
-  const dispositionTimes = normalizedComments
+  const dispositionTimes = dispositionComments
     .filter(
-      (comment) =>
-        iddAgentLogins.has(comment.authorLogin) &&
-        isDispositionComment({ body: comment.body }),
+      (comment) => !consumedNoticeDispositionIndexes.has(comment.sortedIndex),
     )
     .map((comment) => comment.activityAt)
     .filter(isValidIsoTimestamp)
@@ -2239,6 +2324,9 @@ export function summarizeDispositionEvidenceForGate(
   let markerCursor = 0;
   const missing = [];
   for (const comment of outstandingComments) {
+    if (carriedNoticeIndexes.has(comment.sortedIndex)) {
+      continue;
+    }
     while (
       markerCursor < dispositionTimes.length &&
       compareIsoTimestamps(

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1383,6 +1383,29 @@ export function isNonReviewNoticeDisposition(comment) {
     body.startsWith('**Rejected**') && /\bdid not review HEAD\b/i.test(body)
   );
 }
+// The stable identity token of an advisory bot, used to attribute a non-review
+// notice disposition to the bot it rejected. The `[bot]` suffix GitHub appends
+// is dropped so the token matches whether a login is stored as `coderabbitai`
+// or `coderabbitai[bot]`.
+function advisoryBotIdentityToken(login) {
+  return String(login ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/\[bot\]$/, '');
+}
+// True when a non-review-notice disposition body names the given advisory bot's
+// GitHub login, so the gate can attribute a carry-forward to exactly one bot
+// even when several advisory bots are configured. Fail-closed: an empty token or
+// a disposition that does not contain the login carries nothing forward.
+function dispositionNamesAdvisoryBot(dispositionBody, noticeAuthorLogin) {
+  const token = advisoryBotIdentityToken(noticeAuthorLogin);
+  if (!token) {
+    return false;
+  }
+  return String(dispositionBody ?? '')
+    .toLowerCase()
+    .includes(token);
+}
 export function classifyCiChecks(checks) {
   const normalized = checks.map((check) => ({
     name: check.name,
@@ -2271,20 +2294,27 @@ export function summarizeDispositionEvidenceForGate(
       iddAgentLogins.has(comment.authorLogin) &&
       isDispositionComment({ body: comment.body }),
   );
-  // #1018 non-review-notice carry-forward (fail-closed). A persistent advisory
-  // non-review notice already dispositioned `**Rejected** — {bot} did not review
-  // HEAD …` keeps that disposition across HEAD changes while the bot still has
-  // not reviewed any HEAD: a Codex `updatedAt` bump or a re-posted CodeRabbit
-  // rate-limit summary must not re-flag `missing-disposition-evidence` for a
-  // notice the agent already rejected. Carry forward `min(K, N)` of the `K`
-  // trusted IDD notice-dispositions and `N` outstanding advisory-bot non-review
-  // notices: the matched notices leave the outstanding set and the matched
-  // notice-dispositions leave the general disposition pool, so a notice
+  // #1018 non-review-notice carry-forward (fail-closed, author-scoped). A
+  // persistent advisory non-review notice already dispositioned `**Rejected** —
+  // {bot-login} did not review HEAD …` keeps that disposition across HEAD changes
+  // while the bot still has not reviewed any HEAD: a Codex `updatedAt` bump or a
+  // re-posted CodeRabbit rate-limit summary must not re-flag
+  // `missing-disposition-evidence` for a notice the agent already rejected.
+  //
+  // Each carry-forward is matched strictly WITHIN one advisory-bot identity: a
+  // notice carries forward only against a notice-disposition whose body names
+  // that same bot's GitHub login. This repository can configure several advisory
+  // bots at once (CodeRabbit + a Codex connector), so a count/order-only pairing
+  // could credit bot A's disposition to bot B's still-undispositioned notice and
+  // suppress a real blocker. An unattributable disposition (one that names no
+  // configured bot login) carries nothing forward — the original re-disposition
+  // churn, which is safe. Matched notices leave the outstanding set and the
+  // matched notice-dispositions leave the general disposition pool, so a notice
   // disposition never also clears an unrelated regular comment and the notice's
-  // bumped activity can never strand its disposition. The carry-forward guard
-  // re-checks the current notice body, so a notice the bot later replaces with a
-  // real review no longer matches and still needs a fresh disposition. Any
-  // unmatched notice or disposition falls through to the unchanged 1:1 pairing.
+  // bumped activity can never strand its disposition. The guard re-checks the
+  // current notice body, so a notice the bot later replaces with a real review no
+  // longer matches and still needs a fresh disposition. Any unmatched notice or
+  // disposition falls through to the unchanged 1:1 pairing.
   const noticeDispositions = dispositionComments.filter((comment) =>
     isNonReviewNoticeDisposition({ body: comment.body }),
   );
@@ -2293,20 +2323,32 @@ export function summarizeDispositionEvidenceForGate(
       isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
       isAdvisoryNonReviewNotice(comment.body),
   );
-  const carryForwardCount = Math.min(
-    noticeDispositions.length,
-    outstandingNotices.length,
-  );
-  const carriedNoticeIndexes = new Set(
-    outstandingNotices
-      .slice(0, carryForwardCount)
-      .map((comment) => comment.sortedIndex),
-  );
-  const consumedNoticeDispositionIndexes = new Set(
-    noticeDispositions
-      .slice(0, carryForwardCount)
-      .map((comment) => comment.sortedIndex),
-  );
+  const carriedNoticeIndexes = new Set();
+  const consumedNoticeDispositionIndexes = new Set();
+  const noticesByAuthor = new Map();
+  for (const notice of outstandingNotices) {
+    const list = noticesByAuthor.get(notice.authorLogin) ?? [];
+    list.push(notice);
+    noticesByAuthor.set(notice.authorLogin, list);
+  }
+  // Sort the bot logins so disposition consumption is deterministic when a single
+  // disposition body could name more than one configured bot (it is consumed by
+  // the lexicographically-first matching author only).
+  for (const authorLogin of [...noticesByAuthor.keys()].sort()) {
+    const notices = noticesByAuthor.get(authorLogin) ?? [];
+    const matchingDispositions = noticeDispositions.filter(
+      (disposition) =>
+        !consumedNoticeDispositionIndexes.has(disposition.sortedIndex) &&
+        dispositionNamesAdvisoryBot(disposition.body, authorLogin),
+    );
+    const carry = Math.min(notices.length, matchingDispositions.length);
+    for (let index = 0; index < carry; index += 1) {
+      carriedNoticeIndexes.add(notices[index].sortedIndex);
+      consumedNoticeDispositionIndexes.add(
+        matchingDispositions[index].sortedIndex,
+      );
+    }
+  }
   // Count-based 1:1 pairing for the trailing-marker rule: a single later IDD
   // disposition marker addresses at most ONE earlier regular comment, so one
   // trailing marker cannot clear several distinct comments that each still

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2096,6 +2096,57 @@ export function isIddDispositionComment(comment: CommentLike): boolean {
   return isDispositionComment(comment) && !isKnownReviewBot(author);
 }
 
+// #1018 non-review-notice carry-forward classifiers.
+//
+// An advisory **non-review notice** — an advisory bot reporting it did not
+// review the current HEAD (rate-limit / usage-quota exhaustion / review-limit) —
+// carries no review result and is always dispositioned `**Rejected** — {bot} did
+// not review HEAD …` per the E6 non-review-notice rule. The gate uses the two
+// tight, fail-closed predicates below to let such a disposition carry forward
+// across HEAD changes (see `summarizeDispositionEvidenceForGate`), so a Codex
+// `updatedAt` bump or a re-posted CodeRabbit rate-limit summary does not re-flag
+// `missing-disposition-evidence` for a notice the agent already rejected.
+//
+// Both intentionally **under-match**: an unrecognized notice merely keeps the
+// existing per-push re-disposition churn (safe), while a false positive could
+// carry a stale disposition onto a real review (a false merge). Only
+// machine-generated, bot-specific signals match, and the notice predicate is
+// evaluated solely on advisory-bot-authored comments at the gate, so a human
+// reviewer comment is never reclassified as a notice.
+const ADVISORY_NON_REVIEW_NOTICE_PATTERNS: RegExp[] = [
+  // CodeRabbit rate-limit notice: the machine-generated marker (distinct from
+  // the `summarize by coderabbit.ai` review marker) and its warning heading.
+  /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
+  /^[>\s]*#{1,6}\s*Review limit reached\b/im,
+  // Codex usage / quota exhaustion for code reviews.
+  /\bCodex usage limits for code reviews\b/i,
+  /\breached your Codex usage limits\b/i,
+];
+
+export function isAdvisoryNonReviewNotice(body: unknown): boolean {
+  const text = String(body ?? '');
+  if (!text) {
+    return false;
+  }
+  return ADVISORY_NON_REVIEW_NOTICE_PATTERNS.some((pattern) =>
+    pattern.test(text),
+  );
+}
+
+// A trusted IDD disposition of a non-review notice: the canonical
+// `**Rejected** — {bot} did not review HEAD {sha} ({reason}); this is not a
+// completed review` reply. Requires the `**Rejected**` prefix (a notice is
+// always rejected, never accepted) and the `did not review HEAD` phrase that
+// names the notice, so an ordinary rejection of reviewer feedback is excluded.
+export function isNonReviewNoticeDisposition(comment: {
+  body?: string | null;
+}): boolean {
+  const body = (comment.body ?? '').trimStart();
+  return (
+    body.startsWith('**Rejected**') && /\bdid not review HEAD\b/i.test(body)
+  );
+}
+
 export function classifyCiChecks(checks: CheckLike[]) {
   const normalized = checks.map((check) => ({
     name: check.name,
@@ -3128,6 +3179,49 @@ export function summarizeDispositionEvidenceForGate(
       );
     });
 
+  const dispositionComments = normalizedComments.filter(
+    (comment) =>
+      iddAgentLogins.has(comment.authorLogin) &&
+      isDispositionComment({ body: comment.body }),
+  );
+
+  // #1018 non-review-notice carry-forward (fail-closed). A persistent advisory
+  // non-review notice already dispositioned `**Rejected** — {bot} did not review
+  // HEAD …` keeps that disposition across HEAD changes while the bot still has
+  // not reviewed any HEAD: a Codex `updatedAt` bump or a re-posted CodeRabbit
+  // rate-limit summary must not re-flag `missing-disposition-evidence` for a
+  // notice the agent already rejected. Carry forward `min(K, N)` of the `K`
+  // trusted IDD notice-dispositions and `N` outstanding advisory-bot non-review
+  // notices: the matched notices leave the outstanding set and the matched
+  // notice-dispositions leave the general disposition pool, so a notice
+  // disposition never also clears an unrelated regular comment and the notice's
+  // bumped activity can never strand its disposition. The carry-forward guard
+  // re-checks the current notice body, so a notice the bot later replaces with a
+  // real review no longer matches and still needs a fresh disposition. Any
+  // unmatched notice or disposition falls through to the unchanged 1:1 pairing.
+  const noticeDispositions = dispositionComments.filter((comment) =>
+    isNonReviewNoticeDisposition({ body: comment.body }),
+  );
+  const outstandingNotices = outstandingComments.filter(
+    (comment) =>
+      isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
+      isAdvisoryNonReviewNotice(comment.body),
+  );
+  const carryForwardCount = Math.min(
+    noticeDispositions.length,
+    outstandingNotices.length,
+  );
+  const carriedNoticeIndexes = new Set(
+    outstandingNotices
+      .slice(0, carryForwardCount)
+      .map((comment) => comment.sortedIndex),
+  );
+  const consumedNoticeDispositionIndexes = new Set(
+    noticeDispositions
+      .slice(0, carryForwardCount)
+      .map((comment) => comment.sortedIndex),
+  );
+
   // Count-based 1:1 pairing for the trailing-marker rule: a single later IDD
   // disposition marker addresses at most ONE earlier regular comment, so one
   // trailing marker cannot clear several distinct comments that each still
@@ -3135,11 +3229,9 @@ export function summarizeDispositionEvidenceForGate(
   // Walk the outstanding comments oldest-first and greedily consume the
   // earliest disposition marker strictly newer than each (markers that are not
   // newer than the current comment cannot address it or any later comment).
-  const dispositionTimes = normalizedComments
+  const dispositionTimes = dispositionComments
     .filter(
-      (comment) =>
-        iddAgentLogins.has(comment.authorLogin) &&
-        isDispositionComment({ body: comment.body }),
+      (comment) => !consumedNoticeDispositionIndexes.has(comment.sortedIndex),
     )
     .map((comment) => comment.activityAt)
     .filter(isValidIsoTimestamp)
@@ -3148,6 +3240,9 @@ export function summarizeDispositionEvidenceForGate(
   let markerCursor = 0;
   const missing: typeof outstandingComments = [];
   for (const comment of outstandingComments) {
+    if (carriedNoticeIndexes.has(comment.sortedIndex)) {
+      continue;
+    }
     while (
       markerCursor < dispositionTimes.length &&
       compareIsoTimestamps(

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2147,6 +2147,34 @@ export function isNonReviewNoticeDisposition(comment: {
   );
 }
 
+// The stable identity token of an advisory bot, used to attribute a non-review
+// notice disposition to the bot it rejected. The `[bot]` suffix GitHub appends
+// is dropped so the token matches whether a login is stored as `coderabbitai`
+// or `coderabbitai[bot]`.
+function advisoryBotIdentityToken(login: unknown): string {
+  return String(login ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/\[bot\]$/, '');
+}
+
+// True when a non-review-notice disposition body names the given advisory bot's
+// GitHub login, so the gate can attribute a carry-forward to exactly one bot
+// even when several advisory bots are configured. Fail-closed: an empty token or
+// a disposition that does not contain the login carries nothing forward.
+function dispositionNamesAdvisoryBot(
+  dispositionBody: unknown,
+  noticeAuthorLogin: string,
+): boolean {
+  const token = advisoryBotIdentityToken(noticeAuthorLogin);
+  if (!token) {
+    return false;
+  }
+  return String(dispositionBody ?? '')
+    .toLowerCase()
+    .includes(token);
+}
+
 export function classifyCiChecks(checks: CheckLike[]) {
   const normalized = checks.map((check) => ({
     name: check.name,
@@ -3185,20 +3213,27 @@ export function summarizeDispositionEvidenceForGate(
       isDispositionComment({ body: comment.body }),
   );
 
-  // #1018 non-review-notice carry-forward (fail-closed). A persistent advisory
-  // non-review notice already dispositioned `**Rejected** — {bot} did not review
-  // HEAD …` keeps that disposition across HEAD changes while the bot still has
-  // not reviewed any HEAD: a Codex `updatedAt` bump or a re-posted CodeRabbit
-  // rate-limit summary must not re-flag `missing-disposition-evidence` for a
-  // notice the agent already rejected. Carry forward `min(K, N)` of the `K`
-  // trusted IDD notice-dispositions and `N` outstanding advisory-bot non-review
-  // notices: the matched notices leave the outstanding set and the matched
-  // notice-dispositions leave the general disposition pool, so a notice
+  // #1018 non-review-notice carry-forward (fail-closed, author-scoped). A
+  // persistent advisory non-review notice already dispositioned `**Rejected** —
+  // {bot-login} did not review HEAD …` keeps that disposition across HEAD changes
+  // while the bot still has not reviewed any HEAD: a Codex `updatedAt` bump or a
+  // re-posted CodeRabbit rate-limit summary must not re-flag
+  // `missing-disposition-evidence` for a notice the agent already rejected.
+  //
+  // Each carry-forward is matched strictly WITHIN one advisory-bot identity: a
+  // notice carries forward only against a notice-disposition whose body names
+  // that same bot's GitHub login. This repository can configure several advisory
+  // bots at once (CodeRabbit + a Codex connector), so a count/order-only pairing
+  // could credit bot A's disposition to bot B's still-undispositioned notice and
+  // suppress a real blocker. An unattributable disposition (one that names no
+  // configured bot login) carries nothing forward — the original re-disposition
+  // churn, which is safe. Matched notices leave the outstanding set and the
+  // matched notice-dispositions leave the general disposition pool, so a notice
   // disposition never also clears an unrelated regular comment and the notice's
-  // bumped activity can never strand its disposition. The carry-forward guard
-  // re-checks the current notice body, so a notice the bot later replaces with a
-  // real review no longer matches and still needs a fresh disposition. Any
-  // unmatched notice or disposition falls through to the unchanged 1:1 pairing.
+  // bumped activity can never strand its disposition. The guard re-checks the
+  // current notice body, so a notice the bot later replaces with a real review no
+  // longer matches and still needs a fresh disposition. Any unmatched notice or
+  // disposition falls through to the unchanged 1:1 pairing.
   const noticeDispositions = dispositionComments.filter((comment) =>
     isNonReviewNoticeDisposition({ body: comment.body }),
   );
@@ -3207,20 +3242,32 @@ export function summarizeDispositionEvidenceForGate(
       isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
       isAdvisoryNonReviewNotice(comment.body),
   );
-  const carryForwardCount = Math.min(
-    noticeDispositions.length,
-    outstandingNotices.length,
-  );
-  const carriedNoticeIndexes = new Set(
-    outstandingNotices
-      .slice(0, carryForwardCount)
-      .map((comment) => comment.sortedIndex),
-  );
-  const consumedNoticeDispositionIndexes = new Set(
-    noticeDispositions
-      .slice(0, carryForwardCount)
-      .map((comment) => comment.sortedIndex),
-  );
+  const carriedNoticeIndexes = new Set<number>();
+  const consumedNoticeDispositionIndexes = new Set<number>();
+  const noticesByAuthor = new Map<string, typeof outstandingNotices>();
+  for (const notice of outstandingNotices) {
+    const list = noticesByAuthor.get(notice.authorLogin) ?? [];
+    list.push(notice);
+    noticesByAuthor.set(notice.authorLogin, list);
+  }
+  // Sort the bot logins so disposition consumption is deterministic when a single
+  // disposition body could name more than one configured bot (it is consumed by
+  // the lexicographically-first matching author only).
+  for (const authorLogin of [...noticesByAuthor.keys()].sort()) {
+    const notices = noticesByAuthor.get(authorLogin) ?? [];
+    const matchingDispositions = noticeDispositions.filter(
+      (disposition) =>
+        !consumedNoticeDispositionIndexes.has(disposition.sortedIndex) &&
+        dispositionNamesAdvisoryBot(disposition.body, authorLogin),
+    );
+    const carry = Math.min(notices.length, matchingDispositions.length);
+    for (let index = 0; index < carry; index += 1) {
+      carriedNoticeIndexes.add(notices[index].sortedIndex);
+      consumedNoticeDispositionIndexes.add(
+        matchingDispositions[index].sortedIndex,
+      );
+    }
+  }
 
   // Count-based 1:1 pairing for the trailing-marker rule: a single later IDD
   // disposition marker addresses at most ONE earlier regular comment, so one

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -9,6 +9,8 @@ import {
   deriveIddAgentLogins,
   findLastCopilotReviewCommit,
   indexLatestGatingReviewsByAuthor,
+  isAdvisoryNonReviewNotice,
+  isNonReviewNoticeDisposition,
   resolveCodeownersForFiles,
   resolveRulesetDetailPath,
   selectCodeownersText,
@@ -2085,6 +2087,186 @@ test('disposition evidence accepts edited IDD disposition comments as fresh repl
 
   assert.equal(summary.route, 'proceed');
   assert.equal(summary.blockingCount, 0);
+});
+
+// #1018 — a persistent advisory non-review notice already dispositioned
+// `**Rejected** — {bot} did not review HEAD …` carries that disposition forward
+// across HEAD changes, so a Codex `updatedAt` bump does not re-flag it.
+test('disposition evidence carries a persistent non-review notice forward across a bumped updatedAt', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          // The push re-triggered Codex, which re-stamped the same notice; its
+          // updatedAt now post-dates the disposition below.
+          updatedAt: '2026-05-12T03:00:00Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T00:00:30Z',
+          body: '**Rejected** — chatgpt-codex-connector did not review HEAD abc1234 (usage limits); this is not a completed review',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.blockingCount, 0);
+  assert.equal(summary.missingRegularCommentCount, 0);
+});
+
+// A re-posted CodeRabbit rate-limit summary (new createdAt, after the push) is
+// carried forward by the existing non-review-notice disposition that predates it.
+test('disposition evidence carries a re-posted CodeRabbit rate-limit notice forward', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:30Z',
+          body: '**Rejected** — CodeRabbit did not review HEAD abc1234 (review limit reached); this is not a completed review',
+          author: { login: 'idd-bot' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T03:00:00Z',
+          body: '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> [!WARNING]\n> ## Review limit reached\n>\n> `@kurone-kito`, we could not start this review because the limit was reached.',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+    },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.blockingCount, 0);
+});
+
+// No regression: when the bot later replaces the notice with a real review of
+// the current HEAD, the carry-forward does not fire and a fresh disposition is
+// still required.
+test('disposition evidence still requires a fresh disposition when a notice becomes a real review', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:30Z',
+          body: '**Rejected** — chatgpt-codex-connector did not review HEAD abc1234 (usage limits); this is not a completed review',
+          author: { login: 'idd-bot' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T03:00:00Z',
+          body: 'I found a potential off-by-one in `foo.mts` at line 42 — the loop bound should be `<=` to include the final element.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingRegularCommentCount, 1);
+});
+
+// No regression: an undispositioned non-review notice still blocks even when its
+// updatedAt is bumped (the carry-forward requires a matching disposition).
+test('disposition evidence still blocks an undispositioned non-review notice', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T03:00:00Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingRegularCommentCount, 1);
+});
+
+test('isAdvisoryNonReviewNotice matches only machine-generated non-review notices', () => {
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'You have reached your Codex usage limits for code reviews.',
+    ),
+    true,
+  );
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> ## Review limit reached',
+    ),
+    true,
+  );
+  // A real CodeRabbit review summary must NOT be classified as a notice.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n\n## Walkthrough\n\nThe change adds a carry-forward carve-out.',
+    ),
+    false,
+  );
+  // An ordinary reviewer comment that merely mentions usage limits must not match.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'This rate limit handling looks off — please cap the retries.',
+    ),
+    false,
+  );
+  assert.equal(isAdvisoryNonReviewNotice(''), false);
+  assert.equal(isAdvisoryNonReviewNotice(null), false);
+});
+
+test('isNonReviewNoticeDisposition matches only a rejected non-review-notice reply', () => {
+  assert.equal(
+    isNonReviewNoticeDisposition({
+      body: '**Rejected** — CodeRabbit did not review HEAD abc1234 (review limit reached); this is not a completed review',
+    }),
+    true,
+  );
+  // An ordinary rejection of reviewer feedback is not a non-review-notice reply.
+  assert.equal(
+    isNonReviewNoticeDisposition({
+      body: '**Rejected** — verified: the flagged path is already covered by a test',
+    }),
+    false,
+  );
+  // An acceptance is never a non-review-notice disposition.
+  assert.equal(
+    isNonReviewNoticeDisposition({
+      body: '**Accepted** — the bot did not review HEAD, noting for context',
+    }),
+    false,
+  );
+  assert.equal(isNonReviewNoticeDisposition({ body: null }), false);
 });
 
 test('deriveIddAgentLogins keeps prior trusted operational actors but not generic maintainer comments', () => {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2134,7 +2134,7 @@ test('disposition evidence carries a re-posted CodeRabbit rate-limit notice forw
         {
           id: 1,
           createdAt: '2026-05-12T00:00:30Z',
-          body: '**Rejected** — CodeRabbit did not review HEAD abc1234 (review limit reached); this is not a completed review',
+          body: '**Rejected** — coderabbitai[bot] (CodeRabbit) did not review HEAD abc1234 (review limit reached); this is not a completed review',
           author: { login: 'idd-bot' },
         },
         {
@@ -2210,6 +2210,49 @@ test('disposition evidence still blocks an undispositioned non-review notice', (
     },
   );
 
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingRegularCommentCount, 1);
+});
+
+// No regression (multi-bot): a disposition naming one advisory bot must NOT
+// carry forward another bot's still-undispositioned notice. The repo can
+// configure several advisory bots at once, so an order/count-only pairing would
+// let a Codex rejection suppress a real CodeRabbit missing-disposition blocker.
+test('disposition evidence does not carry one bot disposition onto another bot notice', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          // CodeRabbit rate-limit notice — never dispositioned.
+          body: '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> ## Review limit reached',
+          author: { login: 'coderabbitai[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T00:00:01Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 3,
+          createdAt: '2026-05-12T00:00:30Z',
+          // Names only the Codex connector — must not carry the CodeRabbit notice.
+          body: '**Rejected** — chatgpt-codex-connector did not review HEAD abc1234 (usage limits); this is not a completed review',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]', 'chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  // The Codex notice carries forward on its own disposition; the undispositioned
+  // CodeRabbit notice still blocks (one missing regular comment).
   assert.equal(summary.route, 'return-to-e1');
   assert.equal(summary.missingRegularCommentCount, 1);
 });


### PR DESCRIPTION
## Summary

The F2/F3 disposition-evidence merge gate
(`summarizeDispositionEvidenceForGate`) re-flagged a **persistent advisory
non-review notice** as `missing-disposition-evidence` after every review-fix
push, forcing the agent to re-post an essentially identical `**Rejected**`
reply for the new HEAD even though the bot still had not reviewed anything.
Two distinct mechanisms cause it (both empirically reproduced against the
built gate):

- **Codex** (non-CodeRabbit): the notice is matched by effective activity
  (`updatedAt`-preferring); a push re-trigger bumps the notice's `updatedAt`
  past its disposition, so the 1:1 pairing can no longer find a newer marker.
- **CodeRabbit**: a re-posted rate-limit summary has a new `createdAt` the
  old disposition no longer covers.

Observed on PR #1011 (issue #1005): a CodeRabbit rate-limit notice
dispositioned once had to be re-dispositioned after each push — pure churn.

## Change

Add a **fail-closed carry-forward carve-out** to
`summarizeDispositionEvidenceForGate`: an outstanding advisory-bot comment
that still matches a tight, machine-generated **non-review-notice** pattern
carries its trusted `**Rejected** — {bot} did not review HEAD …` disposition
forward while the bot remains non-reviewing. Matched notice / disposition
pairs leave **both** the outstanding set and the general disposition pool, so
a notice disposition never double-clears an unrelated regular comment and the
notice's bumped activity can never strand its disposition. Anything unmatched
falls through to the unchanged 1:1 timestamp pairing.

Two tight predicates back it, both deliberately under-matching (an
unrecognized notice merely keeps the old churn — safe; a false positive could
carry a stale disposition onto a real review — a false merge, so only
bot-specific machine-generated signals match, evaluated **only** on
advisory-bot-authored comments):

- `isAdvisoryNonReviewNotice` — CodeRabbit `rate limited by coderabbit.ai`
  marker / `## Review limit reached`; Codex `Codex usage limits for code
  reviews`.
- `isNonReviewNoticeDisposition` — `**Rejected**` + the canonical
  `did not review HEAD` phrase.

A notice the bot later **replaces with a real review** no longer matches the
notice pattern and still requires a fresh disposition (no regression). The
gate output shape is unchanged, so no schema change was needed.

E6 (`idd-review-triage`) and the E13 review-fix flow document the
carry-forward so agents stop re-posting identical non-review-notice
rejections on every push.

## Bundle-budget ratchet callout

`bundle-review` `limitBytes` is raised **96402 → 98300**. The E6 and E13
carry-forward documentation are shared, terminology-sensitive instruction
content in the `bundle-review` path; per the ratchet/margin convention the
addition is kept small and the limit is raised (rather than trimming shared
prose) with a small headroom well under the ~10% ceiling.

## Tests

`tests/pre-merge-readiness.test.mts` adds both paths: carry-forward on a
bumped Codex notice and a re-posted CodeRabbit rate-limit summary;
no-regression when a notice is superseded by a real review and when a notice
is undispositioned; plus classifier unit coverage (a real
`summarize by coderabbit.ai` review must NOT match). Full suite: 1160 tests
pass; `pnpm run lint:minimum` green.

Closes #1018
