### PR TITLE
feat(idd): add an author-recorded effort hint as a soft selection tie-breaker

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -357,6 +357,10 @@ Validation expectations:
 - an autopilot-suitability footer at the end of the body (visible
   line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker;
   see [Autopilot-suitability score](#autopilot-suitability-score))
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Validation expectations:
 
@@ -378,6 +382,10 @@ Validation expectations:
 - one `<!-- <marker-prefix>-roadmap-id: <roadmap-id> -->` marker
 - an autopilot-suitability footer at the end of the body (visible
   line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Validation expectations:
 
@@ -400,6 +408,10 @@ Validation expectations:
 - optional dependency line or sequential roadmap marker when needed
 - an autopilot-suitability footer at the end of the body (visible
   line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Validation expectations:
 
@@ -511,6 +523,58 @@ score footer is next edited by the authoring flow, add one. No
 bulk backfill of the existing backlog is required. The claim-state
 precondition still applies — never add the footer to the body of an
 actively-claimed or open-PR issue; defer it to a follow-up instead.
+
+## Effort hint
+
+Authored issues may also carry an **effort hint** — an author-time
+`S | M | L` size estimate, recorded once while context is fresh, that
+Discover consumes as a **soft selection tie-breaker** so autopilot tends
+to clear small issues first and leave large ones for a fresh session.
+Effort is distinct from the autopilot-suitability score: suitability
+captures _autonomy_ (can an agent finish unattended), while effort
+captures _size_ (a fully-autonomous issue can still be large).
+
+| Hint | Meaning | Typical signals                                                                                     |
+| ---- | ------- | --------------------------------------------------------------------------------------------------- |
+| S    | Small   | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
+| M    | Medium  | A helper plus its callers, or one instruction surface with mirrors and tests                        |
+| L    | Large   | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+
+The hint is recorded as a **footer at the end of the issue body** — a
+visible line paired with a hidden, prefix-aware machine marker, beside
+the autopilot-suitability footer:
+
+```text
+---
+
+_Effort: S | M | L -- author-estimated size; a soft autopilot
+selection tie-breaker only._
+
+<!-- {marker-prefix}-effort: S|M|L -->
+```
+
+Binding rules:
+
+- **Authoritative value = the HTML marker**, read prefix-aware exactly
+  as `autopilot-suitability` is. `S | M | L` is upper-cased on parse.
+  The visible line is a human-readable mirror authoring keeps in sync;
+  discovery parses only the marker.
+- **Authoring marker, not operational marker.** Like
+  `autopilot-suitability`, it is body content and must never be added to
+  `OPERATIONAL_MARKERS` or subjected to F4 minimization.
+- **Soft tie-breaker, never a gate.** Effort only reorders candidates
+  **within** a single suitability-score band, after the score and
+  optional desync rules and **before** the lowest-issue-number tie-break.
+  It never skips, gates, crosses a score band, or bypasses the A4.5/A5
+  gates, and a large (`L`) issue stays fully claimable when it is the only
+  ready work.
+- **Fail-safe on absence.** A missing, non-`S|M|L`, or conflicting
+  marker means "no effort hint": selection behaves exactly as it does
+  today (a missing hint sorts as the neutral middle, as-if `M`).
+  Pre-existing issues with no effort footer keep flowing.
+
+Backfill is opportunistic and follows the same claim-state precondition
+as the suitability footer.
 
 ## Publication boundary
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -47,6 +47,7 @@ scripts/force-handoff.mjs linguist-generated=true
 scripts/external-check-waiver.mjs linguist-generated=true
 scripts/audit-pr-cleanup.mjs linguist-generated=true
 scripts/discover-shared-file-overlap.mjs linguist-generated=true
+scripts/effort.mjs linguist-generated=true
 idd-template/scripts/minimize-superseded-markers.mjs linguist-generated=true
 # Every bin/ shim is generated from src/bin/*.mts (whole directory).
 bin/**/*.mjs linguist-generated=true

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -529,13 +529,27 @@ convergence is preserved because the branch name derives from the issue,
 not selection order. With `off`, a single-entry band, or no applicable
 score, keep the deterministic **lowest issue number** pick.
 
+**Author-recorded effort hint (soft tie-breaker).** When candidates remain
+tied after the score and optional desync rules, prefer the **lower-effort**
+candidate **before** the lowest-issue-number tie-break, so autopilot tends to
+clear small issues first and leave large ones for a fresh session. Read the
+authored `<!-- idd-skill-effort: S|M|L -->` footer (or the
+`discover-roadmap-graph` node's `effort`): order `S` < `M` < `L`, and a
+missing or invalid hint is treated as the **neutral middle** (as-if `M`), so a
+band with no effort hints keeps the lowest-issue-number order exactly as
+before. This is a **soft** rule: it reorders **only within** a single score
+tie band, never skips, gates, or crosses a score band, and a large (`L`) issue
+stays fully claimable when it is the only ready work. The
+`discover-roadmap-graph` union already emits this order, so it is a cheap read;
+the pick still passes A4.5/A5 unchanged.
+
 **High-contention shared-file overlap (advisory).** Concurrent autopilot
 sessions tend to edit the same F-phase bundle instruction files
 (`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`, so a
 colliding pick costs a later merge-from-main conflict. As a **soft**
-tie-breaker layered after the score / lowest-number / desync rules, prefer a
-candidate whose `## Candidate files` do **not** overlap an actively-claimed or
-open-PR issue on one of those files; the optional
+tie-breaker layered after the score / desync / effort / lowest-number
+rules, prefer a candidate whose `## Candidate files` do **not** overlap an
+actively-claimed or open-PR issue on one of those files; the optional
 `discover-shared-file-overlap` helper (see
 [IDD helper scripts](../../docs/idd-helper-scripts.md)) reports each candidate's
 `overlapFlag` and a `recommendedOrder`. This is **never a hard gate** — overlap

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -148,7 +148,7 @@
     "glob": ".github/instructions/idd-*.instructions.md",
     "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
     "alwaysLoadedLimitBytes": 20000,
-    "phaseLimitBytes": 31400
+    "phaseLimitBytes": 32200
   },
   "bundleBudgets": [
     {
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 90321
+      "limitBytes": 92000
     },
     {
       "id": "bundle-resume",

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -156,6 +156,28 @@ rules.
   `status:blocked-by-human`, and a missing or out-of-range score is
   treated as having no score (evaluated normally, never skipped).
 
+### Effort hint
+
+Issues may also carry an author-time **effort hint** (`S | M | L`) that
+captures _size_, distinct from the suitability score's _autonomy_. Emit
+it as an optional end-of-body footer beside the suitability footer (a
+visible line plus a hidden, prefix-aware marker
+`<!-- {marker-prefix}-effort: S|M|L -->`). Discover consumes it as a
+**soft selection tie-breaker** so autopilot tends to clear small issues
+first and leave large ones for a fresh session. See the
+[Effort hint](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#effort-hint)
+section of the contract for the rubric, footer format, and binding
+rules.
+
+- `S` small · `M` medium · `L` large.
+- The hint only reorders candidates **within** one suitability-score
+  band (after the score and optional desync rules, before the
+  lowest-issue-number tie-break); it never skips, gates, crosses a score
+  band, or bypasses the A4.5/A5 gates, and a large issue stays claimable
+  when it is the only ready work.
+- A missing or invalid hint is **fail-safe**: selection behaves exactly
+  as today (a missing hint sorts as the neutral middle, as-if `M`).
+
 ## Specificity target
 
 Issue drafting should aim for a level of specificity where a
@@ -610,6 +632,10 @@ Required content:
 - an autopilot-suitability footer at the end of the body (visible line +
   `<!-- idd-skill-autopilot-suitability: N -->` marker; see
   [Autopilot-suitability score](#autopilot-suitability-score))
+- an optional effort footer next to it (visible line +
+  `<!-- idd-skill-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Optional content:
 
@@ -650,6 +676,10 @@ Required content:
 - one `<!-- idd-skill-roadmap-id: <roadmap-id> -->` marker
 - an autopilot-suitability footer at the end of the body (visible line +
   `<!-- idd-skill-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- idd-skill-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Recommended content inside `## Tracks`:
 
@@ -686,6 +716,10 @@ Required content:
 - `## Acceptance criteria`
 - an autopilot-suitability footer at the end of the body (visible line +
   `<!-- idd-skill-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- idd-skill-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Optional content:
 

--- a/fixtures/schemas/discover-roadmap-union.valid.json
+++ b/fixtures/schemas/discover-roadmap-union.valid.json
@@ -23,6 +23,7 @@
       "classification": "execution",
       "roadmapMarkerId": "",
       "autopilotSuitability": 5,
+      "effort": "S",
       "sourceRoots": [100],
       "activeClaim": {
         "present": true,
@@ -41,6 +42,7 @@
       "classification": "execution",
       "roadmapMarkerId": "",
       "autopilotSuitability": null,
+      "effort": null,
       "sourceRoots": [100, 200],
       "activeClaim": {
         "present": false,

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -549,13 +549,27 @@ convergence is preserved because the branch name derives from the issue,
 not selection order. With `off`, a single-entry band, or no applicable
 score, keep the deterministic **lowest issue number** pick.
 
+**Author-recorded effort hint (soft tie-breaker).** When candidates remain
+tied after the score and optional desync rules, prefer the **lower-effort**
+candidate **before** the lowest-issue-number tie-break, so autopilot tends to
+clear small issues first and leave large ones for a fresh session. Read the
+authored `<!-- {{PROJECT_MARKER_PREFIX}}-effort: S|M|L -->` footer (or the
+`discover-roadmap-graph` node's `effort`): order `S` < `M` < `L`, and a
+missing or invalid hint is treated as the **neutral middle** (as-if `M`), so a
+band with no effort hints keeps the lowest-issue-number order exactly as
+before. This is a **soft** rule: it reorders **only within** a single score
+tie band, never skips, gates, or crosses a score band, and a large (`L`) issue
+stays fully claimable when it is the only ready work. The
+`discover-roadmap-graph` union already emits this order, so it is a cheap read;
+the pick still passes A4.5/A5 unchanged.
+
 **High-contention shared-file overlap (advisory).** Concurrent autopilot
 sessions tend to edit the same F-phase bundle instruction files
 (`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`, so a
 colliding pick costs a later merge-from-main conflict. As a **soft**
-tie-breaker layered after the score / lowest-number / desync rules, prefer a
-candidate whose `## Candidate files` do **not** overlap an actively-claimed or
-open-PR issue on one of those files; the optional
+tie-breaker layered after the score / desync / effort / lowest-number
+rules, prefer a candidate whose `## Candidate files` do **not** overlap an
+actively-claimed or open-PR issue on one of those files; the optional
 `discover-shared-file-overlap` helper (see
 [IDD helper scripts](../../docs/idd-helper-scripts.md)) reports each candidate's
 `overlapFlag` and a `recommendedOrder`. This is **never a hard gate** — overlap

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -59,6 +59,7 @@
           "classification",
           "roadmapMarkerId",
           "autopilotSuitability",
+          "effort",
           "sourceRoots"
         ],
         "additionalProperties": false,
@@ -97,6 +98,15 @@
               3,
               4,
               5
+            ]
+          },
+          "effort": {
+            "description": "Authored effort hint (S | M | L) or null when no coherent marker is present. A soft A4 Step 2 selection tie-breaker only (after suitability/desync, before lowest issue number); fail-safe on absence, matching parseEffort at runtime.",
+            "enum": [
+              null,
+              "S",
+              "M",
+              "L"
             ]
           },
           "sourceRoots": {

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -205,18 +205,22 @@ export function filterOrphanIssues(issues, options = {}) {
   // discovery the low-score issues stay selectable, just ranked last.
   // Advisory throughout — the A4.5/A5 gates still run on any selected
   // candidate, and unscored issues are never routed out (fail-safe).
-  const orphansByNumber = [...orphans].sort(
+  const orphansByEffortThenNumber = [...orphans].sort(
     (left, right) =>
       effortOrdinal(left.effort) - effortOrdinal(right.effort) ||
       left.number - right.number,
   );
-  const { ranked, routedToHuman } = rankAndRouteBySuitability(orphansByNumber, {
-    floor:
-      options.autopilotSuitabilityFloor ?? DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
-    enabled: options.autopilotSuitabilityEnabled !== false,
-    routeBelowFloor: options.autopilot === true,
-    getScore: (orphan) => orphan.autopilotSuitability,
-  });
+  const { ranked, routedToHuman } = rankAndRouteBySuitability(
+    orphansByEffortThenNumber,
+    {
+      floor:
+        options.autopilotSuitabilityFloor ??
+        DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+      enabled: options.autopilotSuitabilityEnabled !== false,
+      routeBelowFloor: options.autopilot === true,
+      getScore: (orphan) => orphan.autopilotSuitability,
+    },
+  );
   const counts = {
     scanned: issues.length,
     orphans: ranked.length,

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -18,6 +18,7 @@ import {
   parseAutopilotSuitability,
   rankAndRouteBySuitability,
 } from './autopilot-suitability.mjs';
+import { effortOrdinal, parseEffort } from './effort.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 const BLOCKED_LABELS = new Set([
@@ -176,6 +177,12 @@ export function filterOrphanIssues(issues, options = {}) {
             ? options.markerPrefix
             : undefined,
         ),
+        effort: parseEffort(
+          issue.body,
+          typeof options.markerPrefix === 'string'
+            ? options.markerPrefix
+            : undefined,
+        ),
       });
       continue;
     }
@@ -190,14 +197,18 @@ export function filterOrphanIssues(issues, options = {}) {
     filtered[result.reason].push(entry);
   }
   // Rank the orphan candidate list by authored autopilot-suitability
-  // score. Pre-sort by issue number so equal scores resolve by lowest
-  // number (the Step 2 tie-break) rather than by API fetch order.
+  // score. Pre-sort by the soft effort tie-breaker (lower effort first,
+  // with a missing hint at the neutral middle) and then issue number, so
+  // the stable score sort below resolves equal scores by effort and then
+  // lowest number (the Step 2 tie-breaks) rather than by API fetch order.
   // Below-floor routing is opt-in (autopilot runs only): in attended
   // discovery the low-score issues stay selectable, just ranked last.
   // Advisory throughout — the A4.5/A5 gates still run on any selected
   // candidate, and unscored issues are never routed out (fail-safe).
   const orphansByNumber = [...orphans].sort(
-    (left, right) => left.number - right.number,
+    (left, right) =>
+      effortOrdinal(left.effort) - effortOrdinal(right.effort) ||
+      left.number - right.number,
   );
   const { ranked, routedToHuman } = rankAndRouteBySuitability(orphansByNumber, {
     floor:

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -13,6 +13,7 @@ import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mjs';
+import { effortOrdinal, parseEffort } from './effort.mjs';
 import { parseIsoDurationToMs } from './policy-helpers.mjs';
 import {
   isStaleAt,
@@ -161,6 +162,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
       classification: node.classification,
       roadmapMarkerId: node.roadmapMarkerId,
       autopilotSuitability: node.autopilotSuitability ?? null,
+      effort: node.effort ?? null,
       depth: node.depth,
     }))
     .sort(compareByNumber);
@@ -362,6 +364,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
       classification: classification.kind,
       roadmapMarkerId: classification.roadmapMarkerId,
       autopilotSuitability: parseAutopilotSuitability(issue.body, markerPrefix),
+      effort: parseEffort(issue.body, markerPrefix),
       depth,
     });
     recordProvenancePath(issue.number, path);
@@ -472,6 +475,7 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
         classification: 'execution',
         roadmapMarkerId: node.roadmapMarkerId,
         autopilotSuitability: node.autopilotSuitability,
+        effort: node.effort,
         sourceRoots: [graph.root.number],
       });
     }
@@ -577,9 +581,17 @@ function compareUnionLeaves(left, right, floor) {
   // Unscored or out-of-range leaves rank at the configured floor.
   const leftEffective = leftScored ? left.autopilotSuitability : floor;
   const rightEffective = rightScored ? right.autopilotSuitability : floor;
+  // Soft effort tie-breaker (after the suitability score, before the
+  // lowest-issue-number fallback): within one effective-score band prefer
+  // the lower-effort leaf (S < M < L). A missing/invalid hint resolves to
+  // the neutral middle ordinal via effortOrdinal, so a band with no effort
+  // hints stays ordered by issue number exactly as before. This never
+  // crosses a score band and never drops a leaf — a large issue is still
+  // selectable when it is the only ready work.
   return (
     rightEffective - leftEffective ||
     Number(rightScored) - Number(leftScored) ||
+    effortOrdinal(left.effort) - effortOrdinal(right.effort) ||
     left.number - right.number
   );
 }

--- a/scripts/effort.mjs
+++ b/scripts/effort.mjs
@@ -24,9 +24,9 @@ const DEFAULT_MARKER_PREFIX = 'idd-skill';
 export const EFFORT_HINTS = ['S', 'M', 'L'];
 // Ordinal used by the soft tie-breaker (lower = smaller = preferred). A
 // missing or invalid hint resolves to the **neutral** middle ordinal so an
-// unscored issue is neither preferred over nor de-preferred against an
-// equally-ranked `M` issue; this keeps a band with no effort hints ordered
-// exactly as today (by lowest issue number).
+// issue with no coherent effort hint is neither preferred over nor
+// de-preferred against an equally-ranked `M` issue; this keeps a band with no
+// effort hints ordered exactly as today (by lowest issue number).
 const EFFORT_ORDINALS = { S: 1, M: 2, L: 3 };
 export const NEUTRAL_EFFORT_ORDINAL = 2;
 /**
@@ -97,7 +97,7 @@ export function parseEffort(body, markerPrefix = DEFAULT_MARKER_PREFIX) {
  * The soft-tie-break ordinal for an effort hint: `S` → 1, `M` → 2,
  * `L` → 3, and any non-hint (null / invalid) → the neutral middle ordinal
  * (2). Lower sorts first, so the A4 Step 2 tie-breaker prefers smaller
- * issues while leaving unscored ones in the middle and never excluding any
+ * issues while leaving un-hinted ones in the middle and never excluding any
  * candidate.
  */
 export function effortOrdinal(value) {

--- a/scripts/effort.mjs
+++ b/scripts/effort.mjs
@@ -8,6 +8,7 @@
 // Consumed by:
 //
 // - scripts/discover-roadmap-graph.mjs (A2 node enumeration / union rank)
+// - scripts/discover-orphan-filter.mjs (A0-O orphan candidate ranking)
 //
 // The effort hint is the authored `S | M | L` size estimate defined in
 // skills/issue-authoring/references/contract.md. It is a **soft**
@@ -33,12 +34,16 @@ export const NEUTRAL_EFFORT_ORDINAL = 2;
  * marker.
  *
  * Returns `{ present, value, malformed }`:
- * - `present` is false only when no marker appears in the body.
+ * - `present` is true when a marker carrying a non-whitespace token after
+ *   `-effort:` appears. Like the suitability marker, the detection regex
+ *   requires that token (`[^\s>]+`), so a value-less `<!-- {prefix}-effort:
+ *   -->` does not match and reads as `present: false` rather than a present
+ *   malformed marker.
  * - `value` is the single coherent band (`S`, `M`, or `L`, upper-cased),
  *   or null (fail-safe = "no effort hint") when the marker is absent, not
  *   one of the bands, or repeated with disagreeing values.
- * - `malformed` is true when a marker is present but its value is not a
- *   single coherent band.
+ * - `malformed` is true when a detected marker's value is not a single
+ *   coherent band (e.g. `XL`, `2`, or conflicting duplicates).
  *
  * Mirrors `parseAutopilotSuitabilityMarker` so the regex and fail-safe
  * rules stay aligned between the two authored footers.

--- a/scripts/effort.mjs
+++ b/scripts/effort.mjs
@@ -1,0 +1,107 @@
+// idd-generated-from: src/scripts/effort.mts
+//
+// The scripts/effort.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Shared author-recorded effort-hint parsing for discovery selection.
+// Consumed by:
+//
+// - scripts/discover-roadmap-graph.mjs (A2 node enumeration / union rank)
+//
+// The effort hint is the authored `S | M | L` size estimate defined in
+// skills/issue-authoring/references/contract.md. It is a **soft**
+// selection tie-breaker only (A4 Step 2, after the suitability score and
+// optional desync, before the lowest-issue-number tie-break): it never
+// skips, gates, or reorders candidates across suitability score bands,
+// and a large issue stays fully claimable when it is the only ready work.
+// Like the suitability score it is fail-safe on absence — a missing or
+// invalid marker means "no effort hint" and selection behaves exactly as
+// it does today.
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+/** The authored effort bands, smallest to largest. */
+export const EFFORT_HINTS = ['S', 'M', 'L'];
+// Ordinal used by the soft tie-breaker (lower = smaller = preferred). A
+// missing or invalid hint resolves to the **neutral** middle ordinal so an
+// unscored issue is neither preferred over nor de-preferred against an
+// equally-ranked `M` issue; this keeps a band with no effort hints ordered
+// exactly as today (by lowest issue number).
+const EFFORT_ORDINALS = { S: 1, M: 2, L: 3 };
+export const NEUTRAL_EFFORT_ORDINAL = 2;
+/**
+ * Canonical parser for the authored `<!-- {prefix}-effort: S|M|L -->`
+ * marker.
+ *
+ * Returns `{ present, value, malformed }`:
+ * - `present` is false only when no marker appears in the body.
+ * - `value` is the single coherent band (`S`, `M`, or `L`, upper-cased),
+ *   or null (fail-safe = "no effort hint") when the marker is absent, not
+ *   one of the bands, or repeated with disagreeing values.
+ * - `malformed` is true when a marker is present but its value is not a
+ *   single coherent band.
+ *
+ * Mirrors `parseAutopilotSuitabilityMarker` so the regex and fail-safe
+ * rules stay aligned between the two authored footers.
+ */
+export function parseEffortMarker(body, markerPrefix = DEFAULT_MARKER_PREFIX) {
+  const prefix =
+    typeof markerPrefix === 'string' && markerPrefix.length > 0
+      ? markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-effort:\\s*([^\\s>]+)\\s*-->`,
+    'gi',
+  );
+  const text = String(body ?? '');
+  // Stream matches with regex.exec so an untrusted, marker-heavy body stays
+  // O(1) memory, and fail fast on the first invalid token or first value
+  // that conflicts with an earlier one.
+  let present = false;
+  let value = null;
+  let match = regex.exec(text);
+  while (match) {
+    present = true;
+    const normalized = match[1].toUpperCase();
+    // Fail-safe: any invalid token, or a value disagreeing with an earlier
+    // coherent one, yields no hint.
+    if (!isEffortHint(normalized) || (value !== null && normalized !== value)) {
+      return { present: true, value: null, malformed: true };
+    }
+    value = normalized;
+    match = regex.exec(text);
+  }
+  if (!present) {
+    return { present: false, value: null, malformed: false };
+  }
+  return { present: true, value, malformed: false };
+}
+/**
+ * Parse the authored effort hint from an issue body.
+ *
+ * Returns `S | M | L` when the body carries a single coherent
+ * `<!-- {prefix}-effort: … -->` marker, or null (fail-safe = "no effort
+ * hint") when the marker is absent, not one of the bands, or present more
+ * than once with disagreeing values. A null hint must never cause an issue
+ * to be skipped; the caller selects it the normal way. Thin value-only
+ * view over {@link parseEffortMarker}.
+ */
+export function parseEffort(body, markerPrefix = DEFAULT_MARKER_PREFIX) {
+  return parseEffortMarker(body, markerPrefix).value;
+}
+/**
+ * The soft-tie-break ordinal for an effort hint: `S` → 1, `M` → 2,
+ * `L` → 3, and any non-hint (null / invalid) → the neutral middle ordinal
+ * (2). Lower sorts first, so the A4 Step 2 tie-breaker prefers smaller
+ * issues while leaving unscored ones in the middle and never excluding any
+ * candidate.
+ */
+export function effortOrdinal(value) {
+  return isEffortHint(value) ? EFFORT_ORDINALS[value] : NEUTRAL_EFFORT_ORDINAL;
+}
+/** True when `value` is one of the authored effort bands `S | M | L`. */
+export function isEffortHint(value) {
+  return typeof value === 'string' && EFFORT_HINTS.includes(value);
+}
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -357,6 +357,10 @@ Validation expectations:
 - an autopilot-suitability footer at the end of the body (visible
   line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker;
   see [Autopilot-suitability score](#autopilot-suitability-score))
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Validation expectations:
 
@@ -378,6 +382,10 @@ Validation expectations:
 - one `<!-- <marker-prefix>-roadmap-id: <roadmap-id> -->` marker
 - an autopilot-suitability footer at the end of the body (visible
   line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Validation expectations:
 
@@ -400,6 +408,10 @@ Validation expectations:
 - optional dependency line or sequential roadmap marker when needed
 - an autopilot-suitability footer at the end of the body (visible
   line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Validation expectations:
 
@@ -511,6 +523,58 @@ score footer is next edited by the authoring flow, add one. No
 bulk backfill of the existing backlog is required. The claim-state
 precondition still applies — never add the footer to the body of an
 actively-claimed or open-PR issue; defer it to a follow-up instead.
+
+## Effort hint
+
+Authored issues may also carry an **effort hint** — an author-time
+`S | M | L` size estimate, recorded once while context is fresh, that
+Discover consumes as a **soft selection tie-breaker** so autopilot tends
+to clear small issues first and leave large ones for a fresh session.
+Effort is distinct from the autopilot-suitability score: suitability
+captures _autonomy_ (can an agent finish unattended), while effort
+captures _size_ (a fully-autonomous issue can still be large).
+
+| Hint | Meaning | Typical signals                                                                                     |
+| ---- | ------- | --------------------------------------------------------------------------------------------------- |
+| S    | Small   | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
+| M    | Medium  | A helper plus its callers, or one instruction surface with mirrors and tests                        |
+| L    | Large   | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+
+The hint is recorded as a **footer at the end of the issue body** — a
+visible line paired with a hidden, prefix-aware machine marker, beside
+the autopilot-suitability footer:
+
+```text
+---
+
+_Effort: S | M | L -- author-estimated size; a soft autopilot
+selection tie-breaker only._
+
+<!-- {marker-prefix}-effort: S|M|L -->
+```
+
+Binding rules:
+
+- **Authoritative value = the HTML marker**, read prefix-aware exactly
+  as `autopilot-suitability` is. `S | M | L` is upper-cased on parse.
+  The visible line is a human-readable mirror authoring keeps in sync;
+  discovery parses only the marker.
+- **Authoring marker, not operational marker.** Like
+  `autopilot-suitability`, it is body content and must never be added to
+  `OPERATIONAL_MARKERS` or subjected to F4 minimization.
+- **Soft tie-breaker, never a gate.** Effort only reorders candidates
+  **within** a single suitability-score band, after the score and
+  optional desync rules and **before** the lowest-issue-number tie-break.
+  It never skips, gates, crosses a score band, or bypasses the A4.5/A5
+  gates, and a large (`L`) issue stays fully claimable when it is the only
+  ready work.
+- **Fail-safe on absence.** A missing, non-`S|M|L`, or conflicting
+  marker means "no effort hint": selection behaves exactly as it does
+  today (a missing hint sorts as the neutral middle, as-if `M`).
+  Pre-existing issues with no effort footer keep flowing.
+
+Backfill is opportunistic and follows the same claim-state precondition
+as the suitability footer.
 
 ## Publication boundary
 

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -20,6 +20,7 @@ import {
   parseAutopilotSuitability,
   rankAndRouteBySuitability,
 } from './autopilot-suitability.mts';
+import { type EffortHint, effortOrdinal, parseEffort } from './effort.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 const BLOCKED_LABELS = new Set([
@@ -102,6 +103,7 @@ interface OrphanCandidate {
   reason: string;
   url: unknown;
   autopilotSuitability: number | null;
+  effort: EffortHint | null;
 }
 
 interface ParsedArgs {
@@ -297,6 +299,12 @@ export function filterOrphanIssues(
             ? options.markerPrefix
             : undefined,
         ),
+        effort: parseEffort(
+          issue.body,
+          typeof options.markerPrefix === 'string'
+            ? options.markerPrefix
+            : undefined,
+        ),
       });
       continue;
     }
@@ -313,14 +321,18 @@ export function filterOrphanIssues(
   }
 
   // Rank the orphan candidate list by authored autopilot-suitability
-  // score. Pre-sort by issue number so equal scores resolve by lowest
-  // number (the Step 2 tie-break) rather than by API fetch order.
+  // score. Pre-sort by the soft effort tie-breaker (lower effort first,
+  // with a missing hint at the neutral middle) and then issue number, so
+  // the stable score sort below resolves equal scores by effort and then
+  // lowest number (the Step 2 tie-breaks) rather than by API fetch order.
   // Below-floor routing is opt-in (autopilot runs only): in attended
   // discovery the low-score issues stay selectable, just ranked last.
   // Advisory throughout — the A4.5/A5 gates still run on any selected
   // candidate, and unscored issues are never routed out (fail-safe).
   const orphansByNumber = [...orphans].sort(
-    (left, right) => left.number - right.number,
+    (left, right) =>
+      effortOrdinal(left.effort) - effortOrdinal(right.effort) ||
+      left.number - right.number,
   );
   const { ranked, routedToHuman } = rankAndRouteBySuitability(orphansByNumber, {
     floor:

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -329,18 +329,22 @@ export function filterOrphanIssues(
   // discovery the low-score issues stay selectable, just ranked last.
   // Advisory throughout — the A4.5/A5 gates still run on any selected
   // candidate, and unscored issues are never routed out (fail-safe).
-  const orphansByNumber = [...orphans].sort(
+  const orphansByEffortThenNumber = [...orphans].sort(
     (left, right) =>
       effortOrdinal(left.effort) - effortOrdinal(right.effort) ||
       left.number - right.number,
   );
-  const { ranked, routedToHuman } = rankAndRouteBySuitability(orphansByNumber, {
-    floor:
-      options.autopilotSuitabilityFloor ?? DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
-    enabled: options.autopilotSuitabilityEnabled !== false,
-    routeBelowFloor: options.autopilot === true,
-    getScore: (orphan) => orphan.autopilotSuitability,
-  });
+  const { ranked, routedToHuman } = rankAndRouteBySuitability(
+    orphansByEffortThenNumber,
+    {
+      floor:
+        options.autopilotSuitabilityFloor ??
+        DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
+      enabled: options.autopilotSuitabilityEnabled !== false,
+      routeBelowFloor: options.autopilot === true,
+      getScore: (orphan) => orphan.autopilotSuitability,
+    },
+  );
 
   const counts = {
     scanned: issues.length,

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -15,6 +15,7 @@ import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mts';
+import { type EffortHint, effortOrdinal, parseEffort } from './effort.mts';
 import { parseIsoDurationToMs } from './policy-helpers.mts';
 import {
   isStaleAt,
@@ -107,6 +108,7 @@ export interface RoadmapGraphNode {
   classification: 'roadmap' | 'execution';
   roadmapMarkerId: string;
   autopilotSuitability: number | null;
+  effort: EffortHint | null;
   depth: number;
   /**
    * Active-claim annotation, present only under `--with-claim-state` and only
@@ -201,6 +203,7 @@ export interface RoadmapUnionLeaf {
   classification: 'execution';
   roadmapMarkerId: string;
   autopilotSuitability: number | null;
+  effort: EffortHint | null;
   /**
    * The set of open roadmap roots this leaf is reachable from, sorted
    * ascending. A leaf reachable from several sibling epics carries every
@@ -276,6 +279,7 @@ interface RoadmapNodeRecord {
   classification: 'roadmap' | 'execution';
   roadmapMarkerId: string;
   autopilotSuitability: number | null;
+  effort: EffortHint | null;
   depth: number;
 }
 
@@ -472,6 +476,7 @@ export async function enumerateRoadmapGraph(
       classification: node.classification,
       roadmapMarkerId: node.roadmapMarkerId,
       autopilotSuitability: node.autopilotSuitability ?? null,
+      effort: node.effort ?? null,
       depth: node.depth,
     }))
     .sort(compareByNumber);
@@ -689,6 +694,7 @@ export async function enumerateRoadmapGraph(
       classification: classification.kind,
       roadmapMarkerId: classification.roadmapMarkerId,
       autopilotSuitability: parseAutopilotSuitability(issue.body, markerPrefix),
+      effort: parseEffort(issue.body, markerPrefix),
       depth,
     });
     recordProvenancePath(issue.number, path);
@@ -815,6 +821,7 @@ export async function enumerateAllRoadmapsGraph(
         classification: 'execution',
         roadmapMarkerId: node.roadmapMarkerId,
         autopilotSuitability: node.autopilotSuitability,
+        effort: node.effort,
         sourceRoots: [graph.root.number],
       });
     }
@@ -934,9 +941,17 @@ function compareUnionLeaves(
   const rightEffective = rightScored
     ? (right.autopilotSuitability as number)
     : floor;
+  // Soft effort tie-breaker (after the suitability score, before the
+  // lowest-issue-number fallback): within one effective-score band prefer
+  // the lower-effort leaf (S < M < L). A missing/invalid hint resolves to
+  // the neutral middle ordinal via effortOrdinal, so a band with no effort
+  // hints stays ordered by issue number exactly as before. This never
+  // crosses a score band and never drops a leaf — a large issue is still
+  // selectable when it is the only ready work.
   return (
     rightEffective - leftEffective ||
     Number(rightScored) - Number(leftScored) ||
+    effortOrdinal(left.effort) - effortOrdinal(right.effort) ||
     left.number - right.number
   );
 }

--- a/src/scripts/effort.mts
+++ b/src/scripts/effort.mts
@@ -1,0 +1,138 @@
+// idd-generated-from: src/scripts/effort.mts
+//
+// The scripts/effort.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Shared author-recorded effort-hint parsing for discovery selection.
+// Consumed by:
+//
+// - scripts/discover-roadmap-graph.mjs (A2 node enumeration / union rank)
+//
+// The effort hint is the authored `S | M | L` size estimate defined in
+// skills/issue-authoring/references/contract.md. It is a **soft**
+// selection tie-breaker only (A4 Step 2, after the suitability score and
+// optional desync, before the lowest-issue-number tie-break): it never
+// skips, gates, or reorders candidates across suitability score bands,
+// and a large issue stays fully claimable when it is the only ready work.
+// Like the suitability score it is fail-safe on absence — a missing or
+// invalid marker means "no effort hint" and selection behaves exactly as
+// it does today.
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+
+/** The authored effort bands, smallest to largest. */
+export const EFFORT_HINTS = ['S', 'M', 'L'] as const;
+
+export type EffortHint = (typeof EFFORT_HINTS)[number];
+
+// Ordinal used by the soft tie-breaker (lower = smaller = preferred). A
+// missing or invalid hint resolves to the **neutral** middle ordinal so an
+// unscored issue is neither preferred over nor de-preferred against an
+// equally-ranked `M` issue; this keeps a band with no effort hints ordered
+// exactly as today (by lowest issue number).
+const EFFORT_ORDINALS: Record<EffortHint, number> = { S: 1, M: 2, L: 3 };
+export const NEUTRAL_EFFORT_ORDINAL = 2;
+
+/**
+ * Detection shape for the authored effort marker: whether a marker is
+ * present at all, its coherent `S | M | L` value or null, and whether the
+ * present marker is malformed.
+ */
+export interface EffortMarkerDetection {
+  present: boolean;
+  value: EffortHint | null;
+  malformed: boolean;
+}
+
+/**
+ * Canonical parser for the authored `<!-- {prefix}-effort: S|M|L -->`
+ * marker.
+ *
+ * Returns `{ present, value, malformed }`:
+ * - `present` is false only when no marker appears in the body.
+ * - `value` is the single coherent band (`S`, `M`, or `L`, upper-cased),
+ *   or null (fail-safe = "no effort hint") when the marker is absent, not
+ *   one of the bands, or repeated with disagreeing values.
+ * - `malformed` is true when a marker is present but its value is not a
+ *   single coherent band.
+ *
+ * Mirrors `parseAutopilotSuitabilityMarker` so the regex and fail-safe
+ * rules stay aligned between the two authored footers.
+ */
+export function parseEffortMarker(
+  body: unknown,
+  markerPrefix: string = DEFAULT_MARKER_PREFIX,
+): EffortMarkerDetection {
+  const prefix =
+    typeof markerPrefix === 'string' && markerPrefix.length > 0
+      ? markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-effort:\\s*([^\\s>]+)\\s*-->`,
+    'gi',
+  );
+  const text = String(body ?? '');
+  // Stream matches with regex.exec so an untrusted, marker-heavy body stays
+  // O(1) memory, and fail fast on the first invalid token or first value
+  // that conflicts with an earlier one.
+  let present = false;
+  let value: EffortHint | null = null;
+  let match = regex.exec(text);
+  while (match) {
+    present = true;
+    const normalized = match[1].toUpperCase();
+    // Fail-safe: any invalid token, or a value disagreeing with an earlier
+    // coherent one, yields no hint.
+    if (!isEffortHint(normalized) || (value !== null && normalized !== value)) {
+      return { present: true, value: null, malformed: true };
+    }
+    value = normalized;
+    match = regex.exec(text);
+  }
+  if (!present) {
+    return { present: false, value: null, malformed: false };
+  }
+  return { present: true, value, malformed: false };
+}
+
+/**
+ * Parse the authored effort hint from an issue body.
+ *
+ * Returns `S | M | L` when the body carries a single coherent
+ * `<!-- {prefix}-effort: … -->` marker, or null (fail-safe = "no effort
+ * hint") when the marker is absent, not one of the bands, or present more
+ * than once with disagreeing values. A null hint must never cause an issue
+ * to be skipped; the caller selects it the normal way. Thin value-only
+ * view over {@link parseEffortMarker}.
+ */
+export function parseEffort(
+  body: unknown,
+  markerPrefix: string = DEFAULT_MARKER_PREFIX,
+): EffortHint | null {
+  return parseEffortMarker(body, markerPrefix).value;
+}
+
+/**
+ * The soft-tie-break ordinal for an effort hint: `S` → 1, `M` → 2,
+ * `L` → 3, and any non-hint (null / invalid) → the neutral middle ordinal
+ * (2). Lower sorts first, so the A4 Step 2 tie-breaker prefers smaller
+ * issues while leaving unscored ones in the middle and never excluding any
+ * candidate.
+ */
+export function effortOrdinal(value: unknown): number {
+  return isEffortHint(value)
+    ? EFFORT_ORDINALS[value]
+    : NEUTRAL_EFFORT_ORDINAL;
+}
+
+/** True when `value` is one of the authored effort bands `S | M | L`. */
+export function isEffortHint(value: unknown): value is EffortHint {
+  return (
+    typeof value === 'string' && (EFFORT_HINTS as readonly string[]).includes(value)
+  );
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/scripts/effort.mts
+++ b/src/scripts/effort.mts
@@ -29,9 +29,9 @@ export type EffortHint = (typeof EFFORT_HINTS)[number];
 
 // Ordinal used by the soft tie-breaker (lower = smaller = preferred). A
 // missing or invalid hint resolves to the **neutral** middle ordinal so an
-// unscored issue is neither preferred over nor de-preferred against an
-// equally-ranked `M` issue; this keeps a band with no effort hints ordered
-// exactly as today (by lowest issue number).
+// issue with no coherent effort hint is neither preferred over nor
+// de-preferred against an equally-ranked `M` issue; this keeps a band with no
+// effort hints ordered exactly as today (by lowest issue number).
 const EFFORT_ORDINALS: Record<EffortHint, number> = { S: 1, M: 2, L: 3 };
 export const NEUTRAL_EFFORT_ORDINAL = 2;
 
@@ -122,7 +122,7 @@ export function parseEffort(
  * The soft-tie-break ordinal for an effort hint: `S` → 1, `M` → 2,
  * `L` → 3, and any non-hint (null / invalid) → the neutral middle ordinal
  * (2). Lower sorts first, so the A4 Step 2 tie-breaker prefers smaller
- * issues while leaving unscored ones in the middle and never excluding any
+ * issues while leaving un-hinted ones in the middle and never excluding any
  * candidate.
  */
 export function effortOrdinal(value: unknown): number {

--- a/src/scripts/effort.mts
+++ b/src/scripts/effort.mts
@@ -121,15 +121,14 @@ export function parseEffort(
  * candidate.
  */
 export function effortOrdinal(value: unknown): number {
-  return isEffortHint(value)
-    ? EFFORT_ORDINALS[value]
-    : NEUTRAL_EFFORT_ORDINAL;
+  return isEffortHint(value) ? EFFORT_ORDINALS[value] : NEUTRAL_EFFORT_ORDINAL;
 }
 
 /** True when `value` is one of the authored effort bands `S | M | L`. */
 export function isEffortHint(value: unknown): value is EffortHint {
   return (
-    typeof value === 'string' && (EFFORT_HINTS as readonly string[]).includes(value)
+    typeof value === 'string' &&
+    (EFFORT_HINTS as readonly string[]).includes(value)
   );
 }
 

--- a/src/scripts/effort.mts
+++ b/src/scripts/effort.mts
@@ -8,6 +8,7 @@
 // Consumed by:
 //
 // - scripts/discover-roadmap-graph.mjs (A2 node enumeration / union rank)
+// - scripts/discover-orphan-filter.mjs (A0-O orphan candidate ranking)
 //
 // The effort hint is the authored `S | M | L` size estimate defined in
 // skills/issue-authoring/references/contract.md. It is a **soft**
@@ -50,12 +51,16 @@ export interface EffortMarkerDetection {
  * marker.
  *
  * Returns `{ present, value, malformed }`:
- * - `present` is false only when no marker appears in the body.
+ * - `present` is true when a marker carrying a non-whitespace token after
+ *   `-effort:` appears. Like the suitability marker, the detection regex
+ *   requires that token (`[^\s>]+`), so a value-less `<!-- {prefix}-effort:
+ *   -->` does not match and reads as `present: false` rather than a present
+ *   malformed marker.
  * - `value` is the single coherent band (`S`, `M`, or `L`, upper-cased),
  *   or null (fail-safe = "no effort hint") when the marker is absent, not
  *   one of the bands, or repeated with disagreeing values.
- * - `malformed` is true when a marker is present but its value is not a
- *   single coherent band.
+ * - `malformed` is true when a detected marker's value is not a single
+ *   coherent band (e.g. `XL`, `2`, or conflicting duplicates).
  *
  * Mirrors `parseAutopilotSuitabilityMarker` so the regex and fail-safe
  * rules stay aligned between the two authored footers.

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -436,7 +436,12 @@ test('filterOrphanIssues applies the effort hint as a soft tie-breaker within a 
   // All four share score 4; effort orders the band: S (7, 20) before the
   // no-hint neutral (13) before L (4), with 7 < 20 broken by number.
   const issues = [
-    { number: 20, title: 'twenty', state: 'OPEN', body: `t\n${s(4)}\n${e('S')}` },
+    {
+      number: 20,
+      title: 'twenty',
+      state: 'OPEN',
+      body: `t\n${s(4)}\n${e('S')}`,
+    },
     { number: 7, title: 'seven', state: 'OPEN', body: `t\n${s(4)}\n${e('S')}` },
     { number: 13, title: 'thirteen', state: 'OPEN', body: `t\n${s(4)}` },
     { number: 4, title: 'four', state: 'OPEN', body: `t\n${s(4)}\n${e('L')}` },

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -430,6 +430,31 @@ test('filterOrphanIssues tie-breaks equal scores by lowest issue number', () => 
   );
 });
 
+test('filterOrphanIssues applies the effort hint as a soft tie-breaker within a score band', () => {
+  const s = (n: number) => `<!-- idd-skill-autopilot-suitability: ${n} -->`;
+  const e = (hint: string) => `<!-- idd-skill-effort: ${hint} -->`;
+  // All four share score 4; effort orders the band: S (7, 20) before the
+  // no-hint neutral (13) before L (4), with 7 < 20 broken by number.
+  const issues = [
+    { number: 20, title: 'twenty', state: 'OPEN', body: `t\n${s(4)}\n${e('S')}` },
+    { number: 7, title: 'seven', state: 'OPEN', body: `t\n${s(4)}\n${e('S')}` },
+    { number: 13, title: 'thirteen', state: 'OPEN', body: `t\n${s(4)}` },
+    { number: 4, title: 'four', state: 'OPEN', body: `t\n${s(4)}\n${e('L')}` },
+  ];
+  const result = filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+  });
+  assert.deepEqual(
+    result.orphans.map((o) => o.number),
+    [7, 20, 13, 4],
+  );
+  // The parsed hint is emitted per orphan for the cheap A4 Step 2 read.
+  assert.equal(result.orphans.find((o) => o.number === 7)?.effort, 'S');
+  assert.equal(result.orphans.find((o) => o.number === 13)?.effort, null);
+  assert.equal(result.orphans.find((o) => o.number === 4)?.effort, 'L');
+});
+
 test('filterOrphanIssues leaves orphans unrouted when suitability is disabled', () => {
   const m = (n: number) => `<!-- idd-skill-autopilot-suitability: ${n} -->`;
   const issues = [

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -896,7 +896,14 @@ function scoredEffortExecutionIssue(
 // One epic, four same-score leaves with mixed effort hints.
 //   900 (epic-effort) → 901 (3, L), 902 (3, S), 903 (3, no hint), 904 (3, S)
 const EFFORT_TIE_ISSUES = new Map<number, unknown>([
-  [900, roadmapIssue(900, '- [ ] #901\n- [ ] #902\n- [ ] #903\n- [ ] #904', 'epic-effort')],
+  [
+    900,
+    roadmapIssue(
+      900,
+      '- [ ] #901\n- [ ] #902\n- [ ] #903\n- [ ] #904',
+      'epic-effort',
+    ),
+  ],
   [901, scoredEffortExecutionIssue(901, 3, 'L')],
   [902, scoredEffortExecutionIssue(902, 3, 'S')],
   [903, scoredExecutionIssue(903, 3)],
@@ -906,7 +913,8 @@ const EFFORT_TIE_ISSUES = new Map<number, unknown>([
 test('all-roadmaps applies the effort hint as a soft tie-breaker within a score band', async () => {
   const report = await enumerateAllRoadmapsGraph({
     loadOpenRoadmapRoots: async () => [900],
-    loadIssue: async (issueNumber) => EFFORT_TIE_ISSUES.get(issueNumber) ?? null,
+    loadIssue: async (issueNumber) =>
+      EFFORT_TIE_ISSUES.get(issueNumber) ?? null,
   });
 
   // All four share suitability 3, so the effort hint orders the band: the two

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -880,6 +880,50 @@ test('all-roadmaps ranks unscored leaves at the configured floor', async () => {
   );
 });
 
+function scoredEffortExecutionIssue(
+  number: number,
+  score: number,
+  effort: string,
+  state = 'open',
+) {
+  return executionIssue(
+    number,
+    `task ${number}\n<!-- idd-skill-autopilot-suitability: ${score} -->\n<!-- idd-skill-effort: ${effort} -->`,
+    state,
+  );
+}
+
+// One epic, four same-score leaves with mixed effort hints.
+//   900 (epic-effort) → 901 (3, L), 902 (3, S), 903 (3, no hint), 904 (3, S)
+const EFFORT_TIE_ISSUES = new Map<number, unknown>([
+  [900, roadmapIssue(900, '- [ ] #901\n- [ ] #902\n- [ ] #903\n- [ ] #904', 'epic-effort')],
+  [901, scoredEffortExecutionIssue(901, 3, 'L')],
+  [902, scoredEffortExecutionIssue(902, 3, 'S')],
+  [903, scoredExecutionIssue(903, 3)],
+  [904, scoredEffortExecutionIssue(904, 3, 'S')],
+]);
+
+test('all-roadmaps applies the effort hint as a soft tie-breaker within a score band', async () => {
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [900],
+    loadIssue: async (issueNumber) => EFFORT_TIE_ISSUES.get(issueNumber) ?? null,
+  });
+
+  // All four share suitability 3, so the effort hint orders the band: the two
+  // `S` leaves first (lowest-number-tie-broken 902 < 904), then the no-hint
+  // neutral 903, then `L` 901. Effort never crosses a score band and never
+  // drops a leaf.
+  assert.deepEqual(
+    report.leaves.map((leaf) => leaf.number),
+    [902, 904, 903, 901],
+  );
+  // The parsed hint is emitted per leaf for the cheap A4 Step 2 read.
+  const byNumber = new Map(report.leaves.map((leaf) => [leaf.number, leaf]));
+  assert.equal(byNumber.get(902)?.effort, 'S');
+  assert.equal(byNumber.get(903)?.effort, null);
+  assert.equal(byNumber.get(901)?.effort, 'L');
+});
+
 test('all-roadmaps keeps scored work above an unscored leaf at the same effective score', async () => {
   const issues = new Map<number, unknown>([
     [900, roadmapIssue(900, '- [ ] #901\n- [ ] #902', 'epic-floor')],

--- a/tests/effort.test.mts
+++ b/tests/effort.test.mts
@@ -23,8 +23,9 @@ test('effortOrdinal orders S < M < L and resolves non-hints to the neutral middl
   assert.equal(effortOrdinal('S'), 1);
   assert.equal(effortOrdinal('M'), 2);
   assert.equal(effortOrdinal('L'), 3);
-  // A missing or invalid hint sorts as-if M, so an unscored issue is neither
-  // preferred over nor de-preferred against an equally-ranked M issue.
+  // A missing or invalid hint sorts as-if M, so an issue with no coherent
+  // effort hint is neither preferred over nor de-preferred against an
+  // equally-ranked M issue.
   assert.equal(effortOrdinal(null), NEUTRAL_EFFORT_ORDINAL);
   assert.equal(effortOrdinal('bogus'), NEUTRAL_EFFORT_ORDINAL);
   assert.equal(effortOrdinal(undefined), NEUTRAL_EFFORT_ORDINAL);

--- a/tests/effort.test.mts
+++ b/tests/effort.test.mts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  EFFORT_HINTS,
+  effortOrdinal,
+  isEffortHint,
+  NEUTRAL_EFFORT_ORDINAL,
+  parseEffort,
+  parseEffortMarker,
+} from '../src/scripts/effort.mts';
+
+test('isEffortHint accepts only the S | M | L bands', () => {
+  for (const hint of EFFORT_HINTS) {
+    assert.equal(isEffortHint(hint), true, `hint ${hint}`);
+  }
+  for (const value of ['s', 'XL', '', 'SM', 1, null, undefined, {}]) {
+    assert.equal(isEffortHint(value), false, `rejects ${String(value)}`);
+  }
+});
+
+test('effortOrdinal orders S < M < L and resolves non-hints to the neutral middle', () => {
+  assert.equal(effortOrdinal('S'), 1);
+  assert.equal(effortOrdinal('M'), 2);
+  assert.equal(effortOrdinal('L'), 3);
+  // A missing or invalid hint sorts as-if M, so an unscored issue is neither
+  // preferred over nor de-preferred against an equally-ranked M issue.
+  assert.equal(effortOrdinal(null), NEUTRAL_EFFORT_ORDINAL);
+  assert.equal(effortOrdinal('bogus'), NEUTRAL_EFFORT_ORDINAL);
+  assert.equal(effortOrdinal(undefined), NEUTRAL_EFFORT_ORDINAL);
+  assert.equal(NEUTRAL_EFFORT_ORDINAL, effortOrdinal('M'));
+});
+
+test('parseEffort reads a single coherent marker (case-insensitive)', () => {
+  assert.equal(parseEffort('intro\n\n<!-- idd-skill-effort: S -->'), 'S');
+  assert.equal(parseEffort('<!-- idd-skill-effort: M -->'), 'M');
+  // Lower-case is normalized to the canonical upper-case band.
+  assert.equal(parseEffort('<!-- idd-skill-effort: l -->'), 'L');
+});
+
+test('parseEffort is prefix-aware', () => {
+  assert.equal(parseEffort('<!-- acme-effort: L -->', 'acme'), 'L');
+  // The default prefix marker is not read under a custom prefix.
+  assert.equal(parseEffort('<!-- idd-skill-effort: L -->', 'acme'), null);
+});
+
+test('parseEffort fails safe on absent or invalid markers', () => {
+  assert.equal(parseEffort('no marker here'), null);
+  assert.equal(parseEffort('<!-- idd-skill-effort: XL -->'), null);
+  assert.equal(parseEffort('<!-- idd-skill-effort: 2 -->'), null);
+  assert.equal(parseEffort('<!-- idd-skill-effort:  -->'), null);
+  assert.equal(parseEffort(null), null);
+  assert.equal(parseEffort(undefined), null);
+});
+
+test('parseEffort returns null on conflicting duplicate markers', () => {
+  assert.equal(
+    parseEffort('<!-- idd-skill-effort: S -->\n<!-- idd-skill-effort: L -->'),
+    null,
+  );
+  // Agreeing duplicates keep the coherent value.
+  assert.equal(
+    parseEffort('<!-- idd-skill-effort: M -->\n<!-- idd-skill-effort: M -->'),
+    'M',
+  );
+});
+
+test('parseEffortMarker reports present/value/malformed per case', () => {
+  assert.deepEqual(parseEffortMarker('<!-- idd-skill-effort: S -->'), {
+    present: true,
+    value: 'S',
+    malformed: false,
+  });
+  assert.deepEqual(parseEffortMarker('no marker'), {
+    present: false,
+    value: null,
+    malformed: false,
+  });
+  assert.deepEqual(parseEffortMarker('<!-- idd-skill-effort: XL -->'), {
+    present: true,
+    value: null,
+    malformed: true,
+  });
+  assert.deepEqual(
+    parseEffortMarker(
+      '<!-- idd-skill-effort: S -->\n<!-- idd-skill-effort: L -->',
+    ),
+    { present: true, value: null, malformed: true },
+  );
+});
+
+test('parseEffort is the value-only view of the shared marker parser', () => {
+  for (const body of [
+    '<!-- idd-skill-effort: S -->',
+    '<!-- idd-skill-effort: bogus -->',
+    'nothing',
+  ]) {
+    assert.equal(parseEffort(body), parseEffortMarker(body).value);
+  }
+});

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -580,6 +580,7 @@ const discoverRoadmapUnionFixture = {
       classification: 'execution',
       roadmapMarkerId: '',
       autopilotSuitability: 5,
+      effort: 'S',
       sourceRoots: [100],
     },
     {
@@ -590,6 +591,7 @@ const discoverRoadmapUnionFixture = {
       classification: 'execution',
       roadmapMarkerId: '',
       autopilotSuitability: null,
+      effort: null,
       sourceRoots: [100, 200],
     },
   ],


### PR DESCRIPTION
## Summary

A4 Step 2 ranked autopilot candidates by **suitability score** then
**lowest issue number**, with no notion of issue **size**. A large
multi-review-round issue (e.g. a new helper family) could therefore be
selected late in a context-limited session and dominate or exhaust it,
where a fresh session would have been the right home. Suitability captures
*autonomy* (can an agent finish unattended), not *size* — a fully-autonomous
issue can still be large — so effort is a separate author-time judgment.

## Change

- **New marker + parser** (`src/scripts/effort.mts`): an `S | M | L` effort
  footer `<!-- {prefix}-effort: … -->`, parsed fail-safe (absent / invalid /
  conflicting → "no hint") and case-insensitively, mirroring
  `parseAutopilotSuitabilityMarker`. `effortOrdinal` maps `S<M<L` and resolves
  a non-hint to the **neutral middle** (as-if `M`).
- **Soft A4 Step 2 tie-breaker**: after the score and optional desync rules and
  **before** the lowest-issue-number fallback, prefer lower effort. It reorders
  **only within** one suitability-score band, never skips, gates, crosses a
  score band, or bypasses A4.5/A5, and a large (`L`) issue stays fully claimable
  when it is the only ready work. A band with no effort hints keeps today's
  lowest-number order (fail-safe). Documented in both `structure`-mode copies of
  `idd-discover.instructions.md`.
- **Cheap read in both discover helpers**: `discover-roadmap-graph` (single +
  `--all-roadmaps` union) and `discover-orphan-filter` both parse and **emit**
  `effort` per node/candidate and apply the same within-band effort tie-break in
  their ranking; the union schema + fixture gain the `effort` field.
- **Authoring contract**: the canonical bundle, its dogfood `.claude/skills/`
  copy, and `docs/issue-authoring-skill.md` document and emit the effort footer
  beside the suitability footer (rubric table, footer format, binding rules).

## Bundle-budget ratchet callout

Two budgets are raised for the A4 Step 2 documentation, both with small
headroom well under the ~10% ceiling:

- per-phase instruction budget `phaseLimitBytes` **31400 → 32200**
  (`idd-discover.instructions.md` grew with the new tie-breaker paragraph);
- `bundle-discovery` `limitBytes` **90321 → 92000**.

The A4 Step 2 content is shared, terminology-sensitive instruction prose, so
per the ratchet/margin convention the addition is kept small and the limits are
raised rather than trimming shared content.

## Tests

`tests/effort.test.mts` (parser / ordinal / fail-safe, 8 cases) plus
within-band effort tie-break tests in both `discover-roadmap-graph` and
`discover-orphan-filter`, and the union schema fixture. Full suite: 1171 tests
pass; `pnpm run lint:minimum` green.

Closes #1026
