### PR TITLE
fix(idd): align the budget ratchet text and give bundles ~10% headroom

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -161,7 +161,7 @@
         ".github/instructions/idd-suitability.instructions.md",
         ".github/instructions/idd-claim.instructions.md"
       ],
-      "limitBytes": 92000
+      "limitBytes": 100400
     },
     {
       "id": "bundle-resume",
@@ -171,7 +171,7 @@
         ".github/instructions/idd-overview-appendix.instructions.md",
         ".github/instructions/idd-resume.instructions.md"
       ],
-      "limitBytes": 46000
+      "limitBytes": 43300
     },
     {
       "id": "bundle-work",
@@ -181,7 +181,7 @@
         ".github/instructions/idd-overview-appendix.instructions.md",
         ".github/instructions/idd-work.instructions.md"
       ],
-      "limitBytes": 34900
+      "limitBytes": 37400
     },
     {
       "id": "bundle-review",
@@ -195,7 +195,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 98300
+      "limitBytes": 108200
     },
     {
       "id": "bundle-merge",
@@ -209,7 +209,7 @@
         ".github/instructions/idd-advisory-wait.instructions.md",
         ".github/instructions/idd-ci.instructions.md"
       ],
-      "limitBytes": 87138
+      "limitBytes": 95900
     }
   ],
   "syncPairs": [
@@ -545,7 +545,7 @@
   },
   "typeSuppressionBudgets": {
     "id": "type-suppression-budgets",
-    "description": "Ratchet rule (mirrors bundleBudgets): raising a limit requires an explicit callout in the PR description; lowering is always allowed. The ts-ignore directive is forbidden outright; ts-expect-error is the only allowed escape and must carry a same-line reason. Limits record the measured current counts, not aspirations.",
+    "description": "Ratchet rule: raising a limit requires an explicit callout in the PR description; lowering is always allowed. The ts-ignore directive is forbidden outright; ts-expect-error is the only allowed escape and must carry a same-line reason. These ts-suppression limits (ts-expect-error / explicit-any) record the measured current counts, not aspirations. The separate bundleBudgets instead carry a small headroom (at most roughly 10% over the measured total, never an exact fit) so a concurrent budget bump does not collide; see audit/README.md and docs/policy-constants.md.",
     "globs": [
       "src/**/*.mts",
       "tests/**/*.mts"


### PR DESCRIPTION
## Summary

`audit/sync-manifest.json`'s only in-file ratchet description
(`typeSuppressionBudgets.description`, the text an agent reads while editing
budgets) said the limits **"mirror bundleBudgets"** and **"record the measured
current counts, not aspirations"** — i.e. exact fit. Since #1006, the documented
convention is the opposite: `audit/README.md` and `docs/policy-constants.md` say
bundle budgets carry **"at most roughly 10% headroom"** to stop concurrent
re-bump collisions. That contradiction made the margin convention dead-letter,
leaving the committed budgets near exact-fit (bundle-merge 0%, bundle-review
0.0%) — exactly what collided on PRs #1033/#1034/#1035.

## Change

- **Reword the manifest ratchet description** so it no longer claims the
  ts-suppression limits mirror `bundleBudgets`, nor describes the bundles as
  exact-fit: the ts-suppression limits (ts-expect-error / explicit-any) stay
  exact (0), while `bundleBudgets` carry the small ~10% headroom, pointing to
  `audit/README.md` / `docs/policy-constants.md`. The raise-needs-a-callout
  ratchet is preserved. README and policy-constants already state the margin
  convention, so the three sources now agree (no edit needed there).
- **Bring every bundle budget to ~10% headroom** over its measured total (no
  longer exact-fit). No runtime behavior change — the `total > limitBytes` audit
  check is unchanged; the limits just gain consistent slack.

## Bundle-budget ratchet callout

| Bundle | measured total | old limit (headroom) | new limit (headroom) |
| --- | --- | --- | --- |
| bundle-discovery | 91253 | 92000 (0.8%) | **100400 (10.0%)** |
| bundle-resume | 39357 | 46000 (16.9%) | **43300 (10.0%)** ↓ |
| bundle-work | 33981 | 34900 (2.7%) | **37400 (10.1%)** |
| bundle-review | 98294 | 98300 (0.0%) | **108200 (10.1%)** |
| bundle-merge | 87138 | 87138 (0.0%) | **95900 (10.1%)** |

Four budgets are **raised** to the conventional ~10% headroom (this callout is
the ratchet requirement). `bundle-resume` was already at 16.9% — above the "at
most roughly 10%" ceiling — so it is **lowered** to ~10% (lowering needs no
callout) to make the convention uniformly true; 10% (3.9 KB) is still far above
the exact-fit danger zone that caused the real collisions.

## Tests

`pnpm run lint:minimum` passes (`audit-docs --check` with the new limits,
bundle-budget check, markdownlint, cspell, build:check). No `idd-template/`
mirror exists for `sync-manifest.json` (root-only), and `docs/policy-constants.md`
is unchanged, so no mirror sync is required.

Closes #1037
