### PR TITLE
fix(idd): stop audit-pr-cleanup --apply reporting a false incomplete

### DIFF
--- a/scripts/audit-pr-cleanup-summary.mjs
+++ b/scripts/audit-pr-cleanup-summary.mjs
@@ -37,17 +37,20 @@ export function computeReportSummary(report) {
       report.status = 'failed';
       return;
     }
-    if (
-      report.applied.length > 0 &&
-      report.candidates.length === report.applied.length
-    ) {
-      report.status = 'applied';
-      return;
-    }
-    if (report.applied.length > 0) {
+    // A candidate that ended up minimized is done — whether this run minimized
+    // it (`applied`) or it was already / cascade-minimized (an
+    // already-minimized skip; minimizing a parent collapses its child threads,
+    // so a single apply converges more comments than it counts into `applied`).
+    // The only genuine unfinished work is a permission-blocked remainder
+    // (`viewer-cannot-minimize`); a real per-call failure is already handled
+    // above. So `incomplete` is reserved for that remainder, and a converged
+    // run reports `applied` (work done) or `clean` (nothing left). This stops a
+    // converged multi-candidate apply from spuriously reporting `incomplete`
+    // and drawing a false cleanup-failure comment on a merged PR (#1039).
+    if (viewerCannotMinimize > 0) {
       report.status = 'incomplete';
       return;
     }
-    report.status = report.candidates.length === 0 ? 'clean' : 'incomplete';
+    report.status = report.applied.length > 0 ? 'applied' : 'clean';
   }
 }

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -707,9 +707,18 @@ async function revalidateCandidate(owner, repo, prNumber, candidate, report) {
       current.classifier === candidate.classifier
     );
   });
+  // Carry the FRESH state of the candidate (not the stale scan row) so the
+  // summary classifies it correctly: a candidate that was minimized between the
+  // scan and this apply — typically a cascade when its parent was minimized
+  // earlier in the same run — now has `isMinimized: true` and is counted as an
+  // already-minimized (converged) skip, while a candidate that became
+  // permission-blocked keeps `viewerCanMinimize: false` and is counted as a
+  // genuine remainder. Without this, a cascade-minimized child kept the stale
+  // `isMinimized: false`, so the run looked `incomplete` even though it
+  // converged (#1039).
   addSkipped(
     report,
-    candidate,
+    skipped ?? candidate,
     `pre-minimize revalidation failed: ${skipped?.skipReason ?? 'candidate is no longer eligible'}`,
   );
   return null;

--- a/src/scripts/audit-pr-cleanup-summary.mts
+++ b/src/scripts/audit-pr-cleanup-summary.mts
@@ -57,17 +57,20 @@ export function computeReportSummary(report: CleanupReport): void {
       report.status = 'failed';
       return;
     }
-    if (
-      report.applied.length > 0 &&
-      report.candidates.length === report.applied.length
-    ) {
-      report.status = 'applied';
-      return;
-    }
-    if (report.applied.length > 0) {
+    // A candidate that ended up minimized is done — whether this run minimized
+    // it (`applied`) or it was already / cascade-minimized (an
+    // already-minimized skip; minimizing a parent collapses its child threads,
+    // so a single apply converges more comments than it counts into `applied`).
+    // The only genuine unfinished work is a permission-blocked remainder
+    // (`viewer-cannot-minimize`); a real per-call failure is already handled
+    // above. So `incomplete` is reserved for that remainder, and a converged
+    // run reports `applied` (work done) or `clean` (nothing left). This stops a
+    // converged multi-candidate apply from spuriously reporting `incomplete`
+    // and drawing a false cleanup-failure comment on a merged PR (#1039).
+    if (viewerCannotMinimize > 0) {
       report.status = 'incomplete';
       return;
     }
-    report.status = report.candidates.length === 0 ? 'clean' : 'incomplete';
+    report.status = report.applied.length > 0 ? 'applied' : 'clean';
   }
 }

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -1047,9 +1047,18 @@ async function revalidateCandidate(
       current.classifier === candidate.classifier
     );
   });
+  // Carry the FRESH state of the candidate (not the stale scan row) so the
+  // summary classifies it correctly: a candidate that was minimized between the
+  // scan and this apply — typically a cascade when its parent was minimized
+  // earlier in the same run — now has `isMinimized: true` and is counted as an
+  // already-minimized (converged) skip, while a candidate that became
+  // permission-blocked keeps `viewerCanMinimize: false` and is counted as a
+  // genuine remainder. Without this, a cascade-minimized child kept the stale
+  // `isMinimized: false`, so the run looked `incomplete` even though it
+  // converged (#1039).
   addSkipped(
     report,
-    candidate,
+    skipped ?? candidate,
     `pre-minimize revalidation failed: ${skipped?.skipReason ?? 'candidate is no longer eligible'}`,
   );
   return null;

--- a/tests/audit-pr-cleanup-summary.test.mts
+++ b/tests/audit-pr-cleanup-summary.test.mts
@@ -50,7 +50,10 @@ test('computeReportSummary reflects apply results after mutations', () => {
   });
 
   computeReportSummary(report);
-  assert.equal(report.status, 'incomplete');
+  // No applied work yet and no genuine remainder (the lone skip is neither
+  // permission-blocked nor a failure), so the run is converged-clean rather
+  // than the pre-#1039 `incomplete` that compared candidates to applied.
+  assert.equal(report.status, 'clean');
   assert.equal(report.summary?.applied, 0);
 
   report.applied.push({ subjectId: 'candidate-1' });
@@ -141,11 +144,16 @@ test('computeReportSummary emits failed when apply is attempted but all candidat
   assert.equal(report.summary?.applied, 0);
 });
 
-test('computeReportSummary emits incomplete when apply is partial', () => {
+test('computeReportSummary keeps incomplete when a permission-blocked remainder stays after apply', () => {
+  // A genuine partial: one candidate minimized, but another comment cannot be
+  // minimized by the viewer. That permission-blocked remainder is the only
+  // thing `incomplete` is reserved for after a successful (failure-free) apply.
   const report = createReport({
     mode: 'apply',
-    candidates: [{ subjectId: 'candidate-1' }, { subjectId: 'candidate-2' }],
-    skipped: [],
+    candidates: [{ subjectId: 'candidate-1' }],
+    skipped: [
+      { subjectId: 'skip-1', isMinimized: false, viewerCanMinimize: false },
+    ],
     applied: [{ subjectId: 'candidate-1' }],
     failed: [],
   });
@@ -154,7 +162,37 @@ test('computeReportSummary emits incomplete when apply is partial', () => {
 
   assert.equal(report.status, 'incomplete');
   assert.equal(report.summary?.applied, 1);
+  assert.equal(report.summary?.['viewer-cannot-minimize'], 1);
   assert.equal(report.summary?.failed, 0);
+});
+
+test('computeReportSummary converges to applied when remaining candidates were cascade-minimized', () => {
+  // Minimizing a parent comment collapses its child review threads, so a single
+  // apply minimizes candidate-1 explicitly while candidate-2/3 cascade into
+  // already-minimized skips. With no permission-blocked remainder and no
+  // failure the run has converged and must report `applied`, not the spurious
+  // `incomplete` that drew a false cleanup-failure comment on merged PRs (#1039).
+  const report = createReport({
+    mode: 'apply',
+    candidates: [
+      { subjectId: 'candidate-1' },
+      { subjectId: 'candidate-2' },
+      { subjectId: 'candidate-3' },
+    ],
+    skipped: [
+      { subjectId: 'candidate-2', isMinimized: true, viewerCanMinimize: true },
+      { subjectId: 'candidate-3', isMinimized: true, viewerCanMinimize: true },
+    ],
+    applied: [{ subjectId: 'candidate-1' }],
+    failed: [],
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.status, 'applied');
+  assert.equal(report.summary?.applied, 1);
+  assert.equal(report.summary?.['already-minimized'], 2);
+  assert.equal(report.summary?.['viewer-cannot-minimize'], 0);
 });
 
 test('computeReportSummary emits failed when apply has both applied and failed candidates', () => {


### PR DESCRIPTION
## Summary

F4 merged-PR cleanup (`audit-pr-cleanup --apply`) reported `status=incomplete`
on a multi-candidate PR even when a **single apply converged** (an immediate
re-run reached `clean`), so an unattended autopilot session posted a **false
cleanup-failure** comment on a successfully merged PR. Observed repeatedly this
session (e.g. `applied=3, skipped=10, failed=0` → `incomplete`).

**Root cause.** Minimizing a parent comment collapses its child review threads,
so one apply minimizes more comments than it counts into `applied`. The
cascade-minimized children leave the candidate list and land in `skipped` via
pre-minimize revalidation, and the status derivation compared `candidates` to
`applied` (`applied < candidates` → `incomplete`) even though the run converged.

## Change (helper-only)

- `revalidateCandidate` records the **fresh** state of a candidate that left the
  candidate list, so a cascade-minimized child is counted as an
  already-minimized (converged) skip instead of keeping its stale
  `isMinimized: false` — making the `already-minimized` tally accurate and
  internally consistent across passes.
- The apply-mode status derivation reserves `incomplete` for a **genuine
  remainder** — a permission-blocked `viewer-cannot-minimize` skip (real
  per-call failures already route to `failed`). A converged run reports
  `applied` (work done) or `clean` (nothing left), so a successfully-cleaned PR
  no longer draws a false cleanup-failure comment.

The apply now converges in one pass, so no `re-apply-to-converge` state remains
and the `idd-merge.instructions.md` F4 routing (`applied`→evidence,
`incomplete`/`failed`→cleanup-failure) is unchanged.

## Tests

`tests/audit-pr-cleanup-summary.test.mts` adds the cascade-convergence path
(`applied < candidates` with already-minimized skips → `applied`) and asserts a
permission-blocked remainder still reports `incomplete`; the two pre-existing
tests that encoded the old `candidates`-vs-`applied` model are updated to the
corrected semantics. `pnpm run lint:minimum` passes (`build:check` confirms the
`scripts/audit-pr-cleanup*.mjs` regenerate from the `.mts` sources); 1177 tests
pass.

Closes #1039
