### PR TITLE
docs(idd): require disposition markers to be body-first, one per item

### DIFF
--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -214,9 +214,12 @@ Use these prefixes so that disposition is always unambiguous:
 - CODEOWNER / required reviewer exception:
   `**Awaiting maintainer decision** — {reasoning}`
 
-Two requirements make the F2/F3 gate recognize each marker — it reads
-`isDispositionComment` as "the body **starts with** the marker" and pairs
-dispositions to advisory comments **1:1 by count**:
+Two requirements make the F2/F3 disposition-evidence gate recognize an
+`**Accepted**` / `**Rejected**` disposition — it reads `isDispositionComment`
+as "the body **starts with** that marker" and pairs such dispositions to
+advisory comments **1:1 by count** (the `**Awaiting maintainer decision**`
+marker is a separate PATH A thread signal, not part of this predicate or
+count pairing):
 
 - The marker must be the **first bytes of the comment body** — no heading,
   block quote, or preamble before it, or the gate counts zero dispositions for

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -214,6 +214,18 @@ Use these prefixes so that disposition is always unambiguous:
 - CODEOWNER / required reviewer exception:
   `**Awaiting maintainer decision** — {reasoning}`
 
+Two requirements make the F2/F3 gate recognize each marker — it reads
+`isDispositionComment` as "the body **starts with** the marker" and pairs
+dispositions to advisory comments **1:1 by count**:
+
+- The marker must be the **first bytes of the comment body** — no heading,
+  block quote, or preamble before it, or the gate counts zero dispositions for
+  that comment.
+- Post **one disposition reply per advisory item**. Do **not** combine several
+  markers into one comment: the 1:1 count pairing clears only one item per
+  comment, so a combined reply leaves the rest flagged
+  `missing-disposition-evidence`.
+
 PATH B — Advisory items (completed review of the current HEAD):
 
 - Reply immediately with a decision marker, even when no code change is

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -214,9 +214,12 @@ Use these prefixes so that disposition is always unambiguous:
 - CODEOWNER / required reviewer exception:
   `**Awaiting maintainer decision** — {reasoning}`
 
-Two requirements make the F2/F3 gate recognize each marker — it reads
-`isDispositionComment` as "the body **starts with** the marker" and pairs
-dispositions to advisory comments **1:1 by count**:
+Two requirements make the F2/F3 disposition-evidence gate recognize an
+`**Accepted**` / `**Rejected**` disposition — it reads `isDispositionComment`
+as "the body **starts with** that marker" and pairs such dispositions to
+advisory comments **1:1 by count** (the `**Awaiting maintainer decision**`
+marker is a separate PATH A thread signal, not part of this predicate or
+count pairing):
 
 - The marker must be the **first bytes of the comment body** — no heading,
   block quote, or preamble before it, or the gate counts zero dispositions for

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -214,6 +214,18 @@ Use these prefixes so that disposition is always unambiguous:
 - CODEOWNER / required reviewer exception:
   `**Awaiting maintainer decision** — {reasoning}`
 
+Two requirements make the F2/F3 gate recognize each marker — it reads
+`isDispositionComment` as "the body **starts with** the marker" and pairs
+dispositions to advisory comments **1:1 by count**:
+
+- The marker must be the **first bytes of the comment body** — no heading,
+  block quote, or preamble before it, or the gate counts zero dispositions for
+  that comment.
+- Post **one disposition reply per advisory item**. Do **not** combine several
+  markers into one comment: the 1:1 count pairing clears only one item per
+  comment, so a combined reply leaves the rest flagged
+  `missing-disposition-evidence`.
+
 PATH B — Advisory items (completed review of the current HEAD):
 
 - Reply immediately with a decision marker, even when no code change is


### PR DESCRIPTION
## Summary

The F2/F3 disposition-evidence gate recognizes an IDD disposition only when the
comment body **starts with** `**Accepted**` / `**Rejected**`
(`isDispositionComment` = `body.trimEnd().startsWith(...)`) and pairs
dispositions to advisory comments **1:1 by count**. E6 of
`idd-review-triage.instructions.md` showed the prefix formats but never stated
these two load-bearing requirements, so combining dispositions — the natural,
efficient-looking move for PR-level advisory comments — silently fails the gate.

**Observed harm (PR #1035):** an agent posted one combined comment that began
with a `### IDD review triage — disposition` heading and listed two `**Rejected**`
lines. Because the body did not start with a marker, the gate counted zero
dispositions and returned `missing-disposition-evidence` (`blockingCount: 2`),
costing a wasted F2 cycle.

## Change

Add a tight clarification to the E6 "Use these prefixes" area stating both
requirements, with the gate rationale:

- the marker must be the **first bytes of the comment body** (no heading, block
  quote, or preamble before it);
- post **one disposition reply per advisory item** — do not combine markers,
  since pairing is 1:1 by count.

Mirrored into `idd-template/` (`sync-docs --apply` leaves no drift). No
`bundle-review` budget bump is needed — the ~10% headroom from #1037 absorbs the
addition (9.4% headroom remains).

## Tests

`pnpm run lint:minimum` passes (`audit-docs --check`, bundle budgets,
markdownlint, cspell, build:check).

Closes #1038
