### PR TITLE
feat(idd): add a helper that auto-dispositions advisory non-review notices

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,6 +27,7 @@ scripts/discover-readiness-check.mjs linguist-generated=true
 scripts/discover-roadmap-graph.mjs linguist-generated=true
 scripts/discover-shared-file-overlap.mjs linguist-generated=true
 scripts/discover-viability-gate.mjs linguist-generated=true
+scripts/disposition-non-review-notices.mjs linguist-generated=true
 scripts/effort.mjs linguist-generated=true
 scripts/emit-marker.mjs linguist-generated=true
 scripts/external-check-waiver.mjs linguist-generated=true

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -252,6 +252,12 @@ ack / error, as defined in E4):
   prove that no review exists — if a separate _completed_ review of the
   current HEAD is also present, disposition that review under the
   completed-review rules above.)
+- **Helper-first (optional).** When helper runtime is enabled, the
+  `disposition-non-review-notices` helper (see
+  `docs/idd-helper-scripts.md`) detects these notices and emits (dry-run)
+  or posts (`--apply`) the canonical disposition below — marker-first, one
+  per notice, idempotently and fail-closed. The written rule here stays
+  authoritative; the manual `gh api` path is the fallback.
 - **Disposition it deterministically in the current pass — no
   re-request, no wait.** The notice item itself is **always rejected**,
   because it carries no advisory result — never record `**Accepted**` on

--- a/bin/idd-disposition-non-review-notices.mjs
+++ b/bin/idd-disposition-non-review-notices.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-disposition-non-review-notices.mts
+//
+// The bin/idd-disposition-non-review-notices.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/disposition-non-review-notices.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -98,6 +98,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   `trustCollaboratorMarkers` config field)
 - `scripts/review-disposition-verify.mjs` for read-only E7 disposition
   marker presence verification across PATH A and PATH B items
+- `scripts/disposition-non-review-notices.mjs` for dry-run/apply
+  dispositioning of advisory non-review notices (rate-limit / usage-limit)
+  on a PR — emitting or posting the canonical E6 `**Rejected** — {bot} did
+  not review HEAD …` marker-first, one comment per notice, idempotently and
+  fail-closed (only classifier-recognized notices)
 
 **Operator Recovery Helpers:**
 
@@ -496,6 +501,32 @@ The adopted helper boundaries are intentionally narrow:
 - written E7 rules in `idd-review-triage.instructions.md` remain
   authoritative; this helper only reduces command-copy variance when
   confirming marker presence before triage exits
+
+### Non-review-notice disposition (E6 helper-first)
+
+- Command:
+  `node scripts/disposition-non-review-notices.mjs --pr <number>`
+  (dry-run); add `--apply --claim-issue <n> --claim-id <id>` to post.
+  Pass `--advisory-bot-logins` / `--trusted-marker-logins` to override the
+  defaults.
+- Detects advisory-bot regular comments that the single-sourced
+  `isAdvisoryNonReviewNotice` classifier (`protocol-helpers`) recognizes
+  (rate-limit / usage-limit), and emits / posts the canonical
+  `**Rejected** — {bot-login} did not review HEAD {sha} ({reason}); this
+  is not a completed review` — marker-first, one comment per notice,
+  naming the bot login so the carry-forward attributes it author-scoped.
+- **Idempotent**: per advisory bot, existing trusted
+  `isNonReviewNoticeDisposition` comments naming that bot already cover
+  that many of its notices, so a re-run posts nothing new.
+- **Fail-closed**: only classifier-recognized notices are dispositioned;
+  real reviews and review threads are never touched. `--apply`
+  re-validates the active claim and retries once on a transient post
+  failure.
+- Stable contract: [`disposition-non-review-notices.schema.json`][disposition-non-review-notices-schema].
+- The written E6 non-review-notice rule in
+  `idd-review-triage.instructions.md` stays authoritative; this helper is
+  the helper-first convenience path with the manual `gh api` fallback
+  retained.
 
 ## Stable Helper Evidence Outputs
 
@@ -1104,5 +1135,6 @@ pre-merge readiness or later claim-state inspection. They should not
 replace the written decision tables.
 
 [advisory-wait-state-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-wait-state.schema.json
+[disposition-non-review-notices-schema]: https://kurone-kito.github.io/idd-skill/schemas/disposition-non-review-notices.schema.json
 [idd-merge-execute-schema]: https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json
 [pre-merge-readiness-schema]: https://kurone-kito.github.io/idd-skill/schemas/pre-merge-readiness.schema.json

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -252,6 +252,12 @@ ack / error, as defined in E4):
   prove that no review exists — if a separate _completed_ review of the
   current HEAD is also present, disposition that review under the
   completed-review rules above.)
+- **Helper-first (optional).** When helper runtime is enabled, the
+  `disposition-non-review-notices` helper (see
+  `docs/idd-helper-scripts.md`) detects these notices and emits (dry-run)
+  or posts (`--apply`) the canonical disposition below — marker-first, one
+  per notice, idempotently and fail-closed. The written rule here stays
+  authoritative; the manual `gh api` path is the fallback.
 - **Disposition it deterministically in the current pass — no
   re-request, no wait.** The notice item itself is **always rejected**,
   because it carries no advisory result — never record `**Accepted**` on

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -98,6 +98,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   `trustCollaboratorMarkers` config field)
 - `scripts/review-disposition-verify.mjs` for read-only E7 disposition
   marker presence verification across PATH A and PATH B items
+- `scripts/disposition-non-review-notices.mjs` for dry-run/apply
+  dispositioning of advisory non-review notices (rate-limit / usage-limit)
+  on a PR — emitting or posting the canonical E6 `**Rejected** — {bot} did
+  not review HEAD …` marker-first, one comment per notice, idempotently and
+  fail-closed (only classifier-recognized notices)
 
 **Operator Recovery Helpers:**
 
@@ -496,6 +501,32 @@ The adopted helper boundaries are intentionally narrow:
 - written E7 rules in `idd-review-triage.instructions.md` remain
   authoritative; this helper only reduces command-copy variance when
   confirming marker presence before triage exits
+
+### Non-review-notice disposition (E6 helper-first)
+
+- Command:
+  `node scripts/disposition-non-review-notices.mjs --pr <number>`
+  (dry-run); add `--apply --claim-issue <n> --claim-id <id>` to post.
+  Pass `--advisory-bot-logins` / `--trusted-marker-logins` to override the
+  defaults.
+- Detects advisory-bot regular comments that the single-sourced
+  `isAdvisoryNonReviewNotice` classifier (`protocol-helpers`) recognizes
+  (rate-limit / usage-limit), and emits / posts the canonical
+  `**Rejected** — {bot-login} did not review HEAD {sha} ({reason}); this
+  is not a completed review` — marker-first, one comment per notice,
+  naming the bot login so the carry-forward attributes it author-scoped.
+- **Idempotent**: per advisory bot, existing trusted
+  `isNonReviewNoticeDisposition` comments naming that bot already cover
+  that many of its notices, so a re-run posts nothing new.
+- **Fail-closed**: only classifier-recognized notices are dispositioned;
+  real reviews and review threads are never touched. `--apply`
+  re-validates the active claim and retries once on a transient post
+  failure.
+- Stable contract: [`disposition-non-review-notices.schema.json`][disposition-non-review-notices-schema].
+- The written E6 non-review-notice rule in
+  `idd-review-triage.instructions.md` stays authoritative; this helper is
+  the helper-first convenience path with the manual `gh api` fallback
+  retained.
 
 ## Stable Helper Evidence Outputs
 
@@ -1104,5 +1135,6 @@ pre-merge readiness or later claim-state inspection. They should not
 replace the written decision tables.
 
 [advisory-wait-state-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-wait-state.schema.json
+[disposition-non-review-notices-schema]: https://kurone-kito.github.io/idd-skill/schemas/disposition-non-review-notices.schema.json
 [idd-merge-execute-schema]: https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json
 [pre-merge-readiness-schema]: https://kurone-kito.github.io/idd-skill/schemas/pre-merge-readiness.schema.json

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "idd-discover-roadmap-graph": "./bin/idd-discover-roadmap-graph.mjs",
     "idd-discover-shared-file-overlap": "./bin/idd-discover-shared-file-overlap.mjs",
     "idd-discover-viability-gate": "./bin/idd-discover-viability-gate.mjs",
+    "idd-disposition-non-review-notices": "./bin/idd-disposition-non-review-notices.mjs",
     "idd-doctor": "./bin/idd-doctor.mjs",
     "idd-emit-marker": "./bin/idd-emit-marker.mjs",
     "idd-external-check-waiver": "./bin/idd-external-check-waiver.mjs",

--- a/schemas/disposition-non-review-notices.schema.json
+++ b/schemas/disposition-non-review-notices.schema.json
@@ -15,7 +15,8 @@
       "minimum": 1
     },
     "headSha": {
-      "type": "string"
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
     },
     "planned": {
       "type": "array",

--- a/schemas/disposition-non-review-notices.schema.json
+++ b/schemas/disposition-non-review-notices.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/disposition-non-review-notices.schema.json",
+  "title": "Non-Review-Notice Disposition Plan",
+  "description": "Dry-run plan or apply result for auto-dispositioning advisory non-review notices on a PR (E6 PATH B).",
+  "type": "object",
+  "required": ["mode", "prNumber", "headSha", "skipped"],
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["dry-run", "apply"]
+    },
+    "prNumber": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "headSha": {
+      "type": "string"
+    },
+    "planned": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["noticeId", "botLogin", "reason", "body"],
+        "additionalProperties": false,
+        "properties": {
+          "noticeId": { "type": "integer" },
+          "botLogin": { "type": "string" },
+          "reason": { "type": "string" },
+          "body": { "type": "string", "pattern": "^\\*\\*Rejected\\*\\*" }
+        }
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["applied", "failed"]
+    },
+    "applied": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["noticeId", "commentId"],
+        "additionalProperties": false,
+        "properties": {
+          "noticeId": { "type": "integer" },
+          "commentId": { "type": "integer" }
+        }
+      }
+    },
+    "failed": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["noticeId", "error"],
+        "additionalProperties": false,
+        "properties": {
+          "noticeId": { "type": "integer" },
+          "error": { "type": "string" }
+        }
+      }
+    },
+    "skipped": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["noticeId", "botLogin", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "noticeId": { "type": "integer" },
+          "botLogin": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -17,18 +17,32 @@
 // only classifier-recognized notices are dispositioned; real reviews and review
 // threads are never touched.
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import {
   dispositionNamesAdvisoryBot,
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
   normalizeTrustedMarkerLogins,
+  parseForcedHandoffComment,
   resolveActiveClaim,
+  resolveAdvisoryBotLogins,
 } from './protocol-helpers.mjs';
 
 const DEFAULT_ADVISORY_BOT_LOGINS = [
   'coderabbitai[bot]',
   'chatgpt-codex-connector[bot]',
 ];
+// CodeRabbit posts a completed review as a regular issue comment carrying this
+// marker (see `classifyRegularBotComment`), not a PR review. A bot that has one
+// has "reviewed" the PR, so its non-review notice must not be rejected.
+const CODERABBIT_SUMMARY_MARKER =
+  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
+/** True for a CodeRabbit completed-review summary comment. */
+export function isCodeRabbitCompletedSummary(body) {
+  return String(body ?? '')
+    .trimStart()
+    .startsWith(CODERABBIT_SUMMARY_MARKER);
+}
 /**
  * Derive the short `({reason})` clause for a non-review notice from its body.
  * Tightly tied to the categories `isAdvisoryNonReviewNotice` recognizes; falls
@@ -71,12 +85,13 @@ export function buildDispositionPlan(input, options = {}) {
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
   );
-  // Advisory bots that already have a completed review of the current HEAD (a
-  // distinct, non-notice review). Per the E6 "re-validate just before posting"
-  // rule, their notice must not be rejected: the gate accepts that review, and
-  // a later-timestamped `did not review HEAD` rejection could filter it out.
-  const botsWithCompletedHeadReview = new Set(
-    normalizeTrustedMarkerLogins(options.botsWithCompletedHeadReview ?? []),
+  // Advisory bots that already have a completed review (a distinct, non-notice
+  // PR review of the current HEAD, or a CodeRabbit completed-summary comment).
+  // Per the E6 "re-validate just before posting" rule, their notice must not be
+  // rejected: the gate accepts that review, and a later-timestamped `did not
+  // review HEAD` rejection could filter it out.
+  const botsWithCompletedReview = new Set(
+    normalizeTrustedMarkerLogins(options.botsWithCompletedReview ?? []),
   );
   const headSha = String(input.headSha ?? '');
   const comments = (Array.isArray(input.comments) ? input.comments : [])
@@ -126,9 +141,9 @@ export function buildDispositionPlan(input, options = {}) {
     ) {
       continue;
     }
-    if (botsWithCompletedHeadReview.has(comment.login)) {
-      // The bot has a completed review of the current HEAD; accept that review
-      // separately and leave the notice un-rejected (E6 race re-validation).
+    if (botsWithCompletedReview.has(comment.login)) {
+      // The bot has a completed review; accept that review separately and leave
+      // the notice un-rejected (E6 race re-validation).
       skipped.push({
         noticeId: comment.id,
         botLogin: comment.login,
@@ -264,28 +279,47 @@ disposition, one marker-first comment per notice. Idempotent and fail-closed.
   --agent-id <agent-id>          current session agent id
   --trusted-marker-logins a,b    logins whose existing dispositions count
                                  (default: your gh login, so re-runs are idempotent)
-  --advisory-bot-logins a,b      advisory bot logins (default: coderabbit + codex)
+  --advisory-bot-logins a,b      advisory bot logins (default: flag > IDD_ADVISORY_BOT_LOGINS
+                                 > .github/idd/config.json > coderabbit + codex)
   --apply                        post the dispositions (default: dry-run)
   -h, --help                     show this help
 `;
+function loadIddConfig() {
+  try {
+    return JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    return null;
+  }
+}
 /**
- * Resolve the active claim id on an issue using the shared
- * `resolveActiveClaim` state machine, scoped to trusted marker authors. This
- * reuses the canonical claim parsing/validation (superseding, release,
- * forced-handoff) and — crucially — ignores claim markers posted by untrusted
- * authors, so a copied/forged `claimed-by` marker cannot satisfy revalidation.
+ * Re-fetch the claim issue and decide whether the supplied claim id is still the
+ * active claim. Scoped to trusted marker authors via the shared
+ * `resolveActiveClaim` state machine (so a copied/forged `claimed-by` marker
+ * from an untrusted author cannot satisfy the gate), and fails closed on any
+ * `forced-handoff` marker that targets this claim — regardless of the marker's
+ * author, since an authorizing maintainer is typically not in the trusted set.
+ * Aborting on a contested claim is always safe (the manual E6 path remains).
  */
-function resolveActiveClaimId(owner, repo, issue, isTrustedAuthor) {
+function claimStillActive(owner, repo, issue, claimId, isTrustedAuthor) {
   const comments = ghJsonPaginated([
     'api',
     `repos/${owner}/${repo}/issues/${issue}/comments`,
   ]);
+  for (const comment of comments) {
+    const forcedHandoff = parseForcedHandoffComment(
+      comment.body ?? '',
+      comment.created_at ?? '',
+    );
+    if (forcedHandoff && forcedHandoff.oldClaimId === claimId) {
+      return false;
+    }
+  }
   const events = comments.map((comment) => ({
     body: comment.body ?? '',
     createdAt: comment.created_at ?? '',
     author: { login: comment.user?.login ?? '' },
   }));
-  return resolveActiveClaim(events, isTrustedAuthor)?.claimId ?? null;
+  return resolveActiveClaim(events, isTrustedAuthor)?.claimId === claimId;
 }
 function postDisposition(owner, repo, pr, body) {
   // A disposition body is plain text starting with `**Rejected**` (not an
@@ -340,18 +374,29 @@ if (isMainModule(import.meta.url)) {
     args.trustedMarkerLogins.length > 0
       ? args.trustedMarkerLogins
       : [viewerLogin];
+  // Resolve advisory bot logins from flag > env > config (the same sources the
+  // sibling helpers use), falling back to the CodeRabbit/Codex defaults so a
+  // repo that configures custom advisory bots is not silently omitted.
+  const resolvedAdvisoryBotLogins = resolveAdvisoryBotLogins({
+    flagValue: args.advisoryBotLogins,
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+    config: loadIddConfig(),
+  }).logins;
   const advisoryBotLogins =
-    args.advisoryBotLogins.length > 0 ? args.advisoryBotLogins : undefined;
-  const headSha = ghText([
-    'api',
-    `repos/${owner}/${repo}/pulls/${pr}`,
-    '--jq',
-    '.head.sha',
-  ]);
-  // Build a plan from a fresh read of the PR's comments and reviews. Called once
-  // for dry-run and again immediately before --apply posts, so a disposition (or
-  // a completed review) another session raced in is reflected just-in-time.
+    resolvedAdvisoryBotLogins.length > 0
+      ? resolvedAdvisoryBotLogins
+      : DEFAULT_ADVISORY_BOT_LOGINS;
+  // Build a plan from a fresh read of the PR's HEAD, comments, and reviews.
+  // Called once for dry-run and again immediately before --apply posts, so a
+  // HEAD advance, a disposition, or a completed review another session raced in
+  // is reflected just-in-time (the apply path never reuses the dry-run snapshot).
   const planNow = () => {
+    const headSha = ghText([
+      'api',
+      `repos/${owner}/${repo}/pulls/${pr}`,
+      '--jq',
+      '.head.sha',
+    ]);
     const rawComments = ghJsonPaginated([
       'api',
       `repos/${owner}/${repo}/issues/${pr}/comments`,
@@ -366,24 +411,30 @@ if (isMainModule(import.meta.url)) {
       'api',
       `repos/${owner}/${repo}/pulls/${pr}/reviews`,
     ]);
-    // A bot that posted a real (non-notice) review of the current HEAD has
-    // "reviewed HEAD" — its notice must not be rejected (see buildDispositionPlan).
-    const botsWithCompletedHeadReview = Array.from(
+    // Bots with a completed review the gate will accept: a real (non-notice) PR
+    // review of the current HEAD, OR a CodeRabbit completed-summary comment
+    // (CodeRabbit reviews land as regular issue comments, not PR reviews). Their
+    // notice must not be rejected (see buildDispositionPlan).
+    const botsWithCompletedReview = Array.from(
       new Set(
-        reviews
-          .filter(
-            (review) =>
-              review.commit_id === headSha &&
-              COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
-              !isAdvisoryNonReviewNotice(review.body ?? ''),
-          )
-          .map((review) => review.user?.login ?? '')
-          .filter(Boolean),
+        [
+          ...reviews
+            .filter(
+              (review) =>
+                review.commit_id === headSha &&
+                COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
+                !isAdvisoryNonReviewNotice(review.body ?? ''),
+            )
+            .map((review) => review.user?.login ?? ''),
+          ...comments
+            .filter((comment) => isCodeRabbitCompletedSummary(comment.body))
+            .map((comment) => comment.login),
+        ].filter(Boolean),
       ),
     );
     return buildDispositionPlan(
       { headSha, comments },
-      { advisoryBotLogins, trustedMarkerLogins, botsWithCompletedHeadReview },
+      { advisoryBotLogins, trustedMarkerLogins, botsWithCompletedReview },
     );
   };
   if (!args.apply) {
@@ -392,25 +443,25 @@ if (isMainModule(import.meta.url)) {
     );
     process.exit(0);
   }
-  // --apply: re-validate the active claim immediately before posting, scoped to
-  // trusted marker authors so a forged claim marker cannot satisfy the gate.
+  // --apply: revalidate the active claim immediately before EACH post, scoped to
+  // trusted marker authors and failing closed on a forced handoff. Re-checking
+  // per post means a claim released, superseded, or handed off mid-loop stops
+  // the remaining writes instead of posting under a lost claim.
+  const claimIssue = args.claimIssue;
   const trustedAuthors = new Set(
     trustedMarkerLogins.map((login) => login.toLowerCase()),
   );
-  const activeClaimId = resolveActiveClaimId(
-    owner,
-    repo,
-    args.claimIssue,
-    (login) =>
-      trustedAuthors.has(
-        String(login ?? '')
-          .trim()
-          .toLowerCase(),
-      ),
-  );
-  if (activeClaimId !== args.claimId) {
+  const isTrustedAuthor = (login) =>
+    trustedAuthors.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+  const revalidateClaim = () =>
+    claimStillActive(owner, repo, claimIssue, args.claimId, isTrustedAuthor);
+  if (!revalidateClaim()) {
     process.stderr.write(
-      `claim revalidation failed: active claim is "${activeClaimId ?? 'none'}", expected "${args.claimId}"\n`,
+      `claim revalidation failed: "${args.claimId}" is no longer the active claim on issue #${claimIssue}\n`,
     );
     process.exit(1);
   }
@@ -420,7 +471,18 @@ if (isMainModule(import.meta.url)) {
   const plan = planNow();
   const applied = [];
   const failed = [];
+  let claimLost = false;
   for (const item of plan.planned) {
+    if (!revalidateClaim()) {
+      // Claim lost mid-loop: stop writing and surface the remaining notices as
+      // failed rather than posting them under a claim we no longer hold.
+      claimLost = true;
+      failed.push({
+        noticeId: item.noticeId,
+        error: 'claim revalidation failed before post',
+      });
+      break;
+    }
     let posted = null;
     for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
       try {
@@ -440,7 +502,7 @@ if (isMainModule(import.meta.url)) {
   }
   const status = failed.length > 0 ? 'failed' : 'applied';
   process.stdout.write(
-    `${JSON.stringify({ mode: 'apply', prNumber: pr, headSha, status, applied, failed, skipped: plan.skipped }, null, 2)}\n`,
+    `${JSON.stringify({ mode: 'apply', prNumber: pr, headSha: plan.headSha, status, applied, failed, skipped: plan.skipped }, null, 2)}\n`,
   );
-  process.exit(failed.length > 0 ? 1 : 0);
+  process.exit(claimLost || failed.length > 0 ? 1 : 0);
 }

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -90,8 +90,20 @@ export function buildDispositionPlan(input, options = {}) {
       createdAt: String(comment.createdAt ?? ''),
     }))
     .sort((left, right) => {
-      const delta = Date.parse(left.createdAt) - Date.parse(right.createdAt);
-      return Number.isNaN(delta) ? 0 : delta;
+      // Oldest-first, with a deterministic tie-breaker so the oldest-first
+      // pairing is stable: comments with equal (or invalid) timestamps fall back
+      // to the monotonic comment id, and an invalid timestamp sorts last.
+      const leftTime = Date.parse(left.createdAt);
+      const rightTime = Date.parse(right.createdAt);
+      const leftValid = !Number.isNaN(leftTime);
+      const rightValid = !Number.isNaN(rightTime);
+      if (leftValid && rightValid && leftTime !== rightTime) {
+        return leftTime - rightTime;
+      }
+      if (leftValid !== rightValid) {
+        return leftValid ? -1 : 1;
+      }
+      return left.id - right.id;
     });
   // Trusted IDD non-review-notice dispositions, grouped per advisory bot
   // identity they name (so each bot's existing dispositions only cover its own
@@ -476,15 +488,19 @@ if (isMainModule(import.meta.url)) {
   // current notice instead of an earlier notice with an identical body.
   const knownViewerCommentIds = viewerCommentIds(owner, repo, pr, viewerLogin);
   let claimLost = false;
-  for (const item of plan.planned) {
+  for (let index = 0; index < plan.planned.length; index += 1) {
+    const item = plan.planned[index];
     if (!revalidateClaim()) {
-      // Claim lost mid-loop: stop writing and surface the remaining notices as
-      // failed rather than posting them under a claim we no longer hold.
+      // Claim lost mid-loop: stop writing and surface the current AND all
+      // remaining notices as failed rather than posting them under a claim we no
+      // longer hold, so the apply report names every notice left un-dispositioned.
       claimLost = true;
-      failed.push({
-        noticeId: item.noticeId,
-        error: 'claim revalidation failed before post',
-      });
+      for (const remaining of plan.planned.slice(index)) {
+        failed.push({
+          noticeId: remaining.noticeId,
+          error: 'claim revalidation failed before post',
+        });
+      }
       break;
     }
     let posted = null;

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -19,6 +19,7 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import {
+  advisoryBotIdentityToken,
   dispositionNamesAdvisoryBot,
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
@@ -77,22 +78,41 @@ export function buildDispositionBody(botLogin, headSha, reason) {
  * gate would not credit and never double-posts on a re-run.
  */
 export function buildDispositionPlan(input, options = {}) {
-  const advisoryBotLogins = new Set(
+  // Key all advisory-bot comparisons by the suffix-insensitive identity token
+  // (`coderabbitai[bot]` and `coderabbitai` collapse to one identity, matching
+  // `dispositionNamesAdvisoryBot`), so a notice/review/disposition authored
+  // under either variant counts against the same bot.
+  const advisoryBotIdentities = new Set(
     normalizeTrustedMarkerLogins(
       options.advisoryBotLogins ?? DEFAULT_ADVISORY_BOT_LOGINS,
-    ),
+    ).map(advisoryBotIdentityToken),
   );
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
   );
-  // Advisory bots that already have a completed review (a distinct, non-notice
-  // PR review of the current HEAD, or a CodeRabbit completed-summary comment).
-  // Per the E6 "re-validate just before posting" rule, their notice must not be
-  // rejected: the gate accepts that review, and a later-timestamped `did not
-  // review HEAD` rejection could filter it out.
-  const botsWithCompletedReview = new Set(
-    normalizeTrustedMarkerLogins(options.botsWithCompletedReview ?? []),
-  );
+  // Per advisory bot identity, the most recent time it produced a completed
+  // review (a non-notice PR review, or a CodeRabbit summary comment). A notice
+  // is left un-rejected only when a completed review landed AT OR AFTER it (the
+  // notice is then stale); an OLDER review does not cover a newer notice. This
+  // honours the E6 "re-validate just before posting" rule without skipping a
+  // current notice merely because the bot reviewed an earlier HEAD.
+  const completedReviewAtByBot = new Map();
+  for (const [login, value] of Object.entries(
+    options.completedReviewAtByBot ?? {},
+  )) {
+    const at = Date.parse(String(value ?? ''));
+    if (Number.isNaN(at)) {
+      continue;
+    }
+    const token = advisoryBotIdentityToken(login);
+    completedReviewAtByBot.set(
+      token,
+      Math.max(
+        completedReviewAtByBot.get(token) ?? Number.NEGATIVE_INFINITY,
+        at,
+      ),
+    );
+  }
   const headSha = String(input.headSha ?? '');
   const comments = (Array.isArray(input.comments) ? input.comments : [])
     .map((comment) => ({
@@ -107,8 +127,9 @@ export function buildDispositionPlan(input, options = {}) {
       const delta = Date.parse(left.createdAt) - Date.parse(right.createdAt);
       return Number.isNaN(delta) ? 0 : delta;
     });
-  // Trusted IDD non-review-notice dispositions, grouped per advisory bot login
-  // they name (so each bot's existing dispositions only cover its own notices).
+  // Trusted IDD non-review-notice dispositions, grouped per advisory bot
+  // identity they name (so each bot's existing dispositions only cover its own
+  // notices).
   const dispositionCountByBot = new Map();
   for (const comment of comments) {
     if (
@@ -121,11 +142,11 @@ export function buildDispositionPlan(input, options = {}) {
     // consumes a notice disposition at most once, so a combined marker naming
     // several bots must not be credited as covering one notice per bot (that
     // would let the helper skip notices the gate still blocks on).
-    for (const botLogin of advisoryBotLogins) {
-      if (dispositionNamesAdvisoryBot(comment.body, botLogin)) {
+    for (const identity of advisoryBotIdentities) {
+      if (dispositionNamesAdvisoryBot(comment.body, identity)) {
         dispositionCountByBot.set(
-          botLogin,
-          (dispositionCountByBot.get(botLogin) ?? 0) + 1,
+          identity,
+          (dispositionCountByBot.get(identity) ?? 0) + 1,
         );
         break;
       }
@@ -135,15 +156,22 @@ export function buildDispositionPlan(input, options = {}) {
   const skipped = [];
   const coveredByBot = new Map();
   for (const comment of comments) {
+    const identity = advisoryBotIdentityToken(comment.login);
     if (
-      !advisoryBotLogins.has(comment.login) ||
+      !advisoryBotIdentities.has(identity) ||
       !isAdvisoryNonReviewNotice(comment.body)
     ) {
       continue;
     }
-    if (botsWithCompletedReview.has(comment.login)) {
-      // The bot has a completed review; accept that review separately and leave
-      // the notice un-rejected (E6 race re-validation).
+    const reviewAt = completedReviewAtByBot.get(identity);
+    const noticeAt = Date.parse(comment.createdAt);
+    if (
+      reviewAt !== undefined &&
+      !Number.isNaN(noticeAt) &&
+      reviewAt >= noticeAt
+    ) {
+      // A completed review landed at or after this notice, so the notice is
+      // stale; accept that review separately and leave the notice un-rejected.
       skipped.push({
         noticeId: comment.id,
         botLogin: comment.login,
@@ -151,11 +179,11 @@ export function buildDispositionPlan(input, options = {}) {
       });
       continue;
     }
-    const alreadyCovered = coveredByBot.get(comment.login) ?? 0;
-    if (alreadyCovered < (dispositionCountByBot.get(comment.login) ?? 0)) {
+    const alreadyCovered = coveredByBot.get(identity) ?? 0;
+    if (alreadyCovered < (dispositionCountByBot.get(identity) ?? 0)) {
       // An existing trusted disposition naming this bot already covers a notice;
       // attribute it (oldest-first) and skip this one as idempotent.
-      coveredByBot.set(comment.login, alreadyCovered + 1);
+      coveredByBot.set(identity, alreadyCovered + 1);
       skipped.push({
         noticeId: comment.id,
         botLogin: comment.login,
@@ -334,6 +362,29 @@ function postDisposition(owner, repo, pr, body) {
     `body=${body}`,
   ]);
 }
+/**
+ * Find an already-posted disposition with this exact body authored by `viewer`.
+ * Used after a failed create to detect a comment that landed server-side even
+ * though `gh` exited nonzero (lost response), so a retry never double-posts a
+ * marker the F2/F3 1:1 pairing would consume twice. The body is unique per
+ * notice (bot + head SHA + reason), so an exact match is reliable.
+ */
+function findPostedDisposition(owner, repo, pr, body, viewerLogin) {
+  const comments = ghJsonPaginated([
+    'api',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+  ]);
+  for (let index = comments.length - 1; index >= 0; index -= 1) {
+    const comment = comments[index];
+    if (
+      (comment.user?.login ?? '').trim().toLowerCase() === viewerLogin &&
+      (comment.body ?? '') === body
+    ) {
+      return { id: comment.id };
+    }
+  }
+  return null;
+}
 const COMPLETED_REVIEW_STATES = new Set([
   'APPROVED',
   'CHANGES_REQUESTED',
@@ -411,30 +462,41 @@ if (isMainModule(import.meta.url)) {
       'api',
       `repos/${owner}/${repo}/pulls/${pr}/reviews`,
     ]);
-    // Bots with a completed review the gate will accept: a real (non-notice) PR
-    // review of the current HEAD, OR a CodeRabbit completed-summary comment
-    // (CodeRabbit reviews land as regular issue comments, not PR reviews). Their
-    // notice must not be rejected (see buildDispositionPlan).
-    const botsWithCompletedReview = Array.from(
-      new Set(
-        [
-          ...reviews
-            .filter(
-              (review) =>
-                review.commit_id === headSha &&
-                COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
-                !isAdvisoryNonReviewNotice(review.body ?? ''),
-            )
-            .map((review) => review.user?.login ?? ''),
-          ...comments
-            .filter((comment) => isCodeRabbitCompletedSummary(comment.body))
-            .map((comment) => comment.login),
-        ].filter(Boolean),
-      ),
-    );
+    // The latest time each bot produced a completed review the gate accepts: a
+    // real (non-notice) PR review, or a CodeRabbit completed-summary comment
+    // (CodeRabbit reviews land as regular issue comments, not PR reviews).
+    // buildDispositionPlan compares these timestamps against each notice, so a
+    // review only suppresses a notice it is at-or-newer than (a stale review of
+    // an older HEAD does not cover a fresh notice).
+    const completedReviewAtByBot = {};
+    const recordCompletedReview = (login, at) => {
+      const key = login.trim().toLowerCase();
+      if (!key || !at) {
+        return;
+      }
+      if (!completedReviewAtByBot[key] || completedReviewAtByBot[key] < at) {
+        completedReviewAtByBot[key] = at;
+      }
+    };
+    for (const review of reviews) {
+      if (
+        COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
+        !isAdvisoryNonReviewNotice(review.body ?? '')
+      ) {
+        recordCompletedReview(
+          review.user?.login ?? '',
+          review.submitted_at ?? '',
+        );
+      }
+    }
+    for (const comment of comments) {
+      if (isCodeRabbitCompletedSummary(comment.body)) {
+        recordCompletedReview(comment.login, comment.createdAt);
+      }
+    }
     return buildDispositionPlan(
       { headSha, comments },
-      { advisoryBotLogins, trustedMarkerLogins, botsWithCompletedReview },
+      { advisoryBotLogins, trustedMarkerLogins, completedReviewAtByBot },
     );
   };
   if (!args.apply) {
@@ -484,20 +546,24 @@ if (isMainModule(import.meta.url)) {
       break;
     }
     let posted = null;
+    let lastError = null;
     for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
       try {
         posted = postDisposition(owner, repo, pr, item.body);
       } catch (error) {
-        if (attempt === 1) {
-          failed.push({
-            noticeId: item.noticeId,
-            error: error.message,
-          });
-        }
+        lastError = error;
+        // The create may have landed server-side despite the nonzero exit;
+        // re-read before any retry so we never double-post the same marker.
+        posted = findPostedDisposition(owner, repo, pr, item.body, viewerLogin);
       }
     }
     if (posted) {
       applied.push({ noticeId: item.noticeId, commentId: posted.id });
+    } else {
+      failed.push({
+        noticeId: item.noticeId,
+        error: lastError?.message ?? 'unknown error',
+      });
     }
   }
   const status = failed.length > 0 ? 'failed' : 'applied';

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -22,6 +22,7 @@ import {
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
   normalizeTrustedMarkerLogins,
+  resolveActiveClaim,
 } from './protocol-helpers.mjs';
 
 const DEFAULT_ADVISORY_BOT_LOGINS = [
@@ -50,7 +51,7 @@ export function noticeReason(body) {
  * the current head SHA.
  */
 export function buildDispositionBody(botLogin, headSha, reason) {
-  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review.`;
+  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review`;
 }
 /**
  * Plan the dispositions for a PR's regular comments. Pure: takes the fetched
@@ -69,6 +70,13 @@ export function buildDispositionPlan(input, options = {}) {
   );
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
+  );
+  // Advisory bots that already have a completed review of the current HEAD (a
+  // distinct, non-notice review). Per the E6 "re-validate just before posting"
+  // rule, their notice must not be rejected: the gate accepts that review, and
+  // a later-timestamped `did not review HEAD` rejection could filter it out.
+  const botsWithCompletedHeadReview = new Set(
+    normalizeTrustedMarkerLogins(options.botsWithCompletedHeadReview ?? []),
   );
   const headSha = String(input.headSha ?? '');
   const comments = (Array.isArray(input.comments) ? input.comments : [])
@@ -94,12 +102,17 @@ export function buildDispositionPlan(input, options = {}) {
     ) {
       continue;
     }
+    // Count a disposition toward at most ONE bot it names. The F2/F3 gate
+    // consumes a notice disposition at most once, so a combined marker naming
+    // several bots must not be credited as covering one notice per bot (that
+    // would let the helper skip notices the gate still blocks on).
     for (const botLogin of advisoryBotLogins) {
       if (dispositionNamesAdvisoryBot(comment.body, botLogin)) {
         dispositionCountByBot.set(
           botLogin,
           (dispositionCountByBot.get(botLogin) ?? 0) + 1,
         );
+        break;
       }
     }
   }
@@ -111,6 +124,16 @@ export function buildDispositionPlan(input, options = {}) {
       !advisoryBotLogins.has(comment.login) ||
       !isAdvisoryNonReviewNotice(comment.body)
     ) {
+      continue;
+    }
+    if (botsWithCompletedHeadReview.has(comment.login)) {
+      // The bot has a completed review of the current HEAD; accept that review
+      // separately and leave the notice un-rejected (E6 race re-validation).
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'completed-review-present',
+      });
       continue;
     }
     const alreadyCovered = coveredByBot.get(comment.login) ?? 0;
@@ -203,6 +226,23 @@ function ghText(args) {
 function ghJson(args) {
   return JSON.parse(execFileSync('gh', args, { encoding: 'utf8' }));
 }
+/**
+ * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
+ * one JSON array per page, so a >1-page response is not a single JSON document;
+ * `--jq '.[]'` flattens each page to one JSON value per line (NDJSON), which we
+ * parse line-by-line. (`--slurp` would be simpler but needs gh >= 2.48.0; Ubuntu
+ * 24.04 LTS ships gh 2.45.0, so the repo standardizes on `--jq '.[]'`.)
+ */
+function ghJsonPaginated(args) {
+  const out = execFileSync('gh', [...args, '--paginate', '--jq', '.[]'], {
+    encoding: 'utf8',
+  });
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .map((line) => JSON.parse(line));
+}
 function isMainModule(moduleUrl) {
   const entry = process.argv[1];
   if (!entry) {
@@ -219,36 +259,33 @@ disposition, one marker-first comment per notice. Idempotent and fail-closed.
   --pr <number>                  PR number (required)
   --owner <owner>                repo owner (default: gh repo view)
   --repo <repo>                  repo name (default: gh repo view)
-  --claim-issue <number>         issue carrying the active claim (for --apply)
-  --claim-id <claim-id>          active claim id to re-validate before --apply
+  --claim-issue <number>         issue carrying the active claim (required with --apply)
+  --claim-id <claim-id>          active claim id to re-validate (required with --apply)
   --agent-id <agent-id>          current session agent id
   --trusted-marker-logins a,b    logins whose existing dispositions count
+                                 (default: your gh login, so re-runs are idempotent)
   --advisory-bot-logins a,b      advisory bot logins (default: coderabbit + codex)
   --apply                        post the dispositions (default: dry-run)
   -h, --help                     show this help
 `;
-function resolveActiveClaimId(owner, repo, issue) {
-  const comments = ghJson([
+/**
+ * Resolve the active claim id on an issue using the shared
+ * `resolveActiveClaim` state machine, scoped to trusted marker authors. This
+ * reuses the canonical claim parsing/validation (superseding, release,
+ * forced-handoff) and — crucially — ignores claim markers posted by untrusted
+ * authors, so a copied/forged `claimed-by` marker cannot satisfy revalidation.
+ */
+function resolveActiveClaimId(owner, repo, issue, isTrustedAuthor) {
+  const comments = ghJsonPaginated([
     'api',
     `repos/${owner}/${repo}/issues/${issue}/comments`,
-    '--paginate',
   ]);
-  let activeClaimId = null;
-  for (const comment of comments) {
-    const body = String(comment.body ?? '');
-    const claimed = body.match(
-      /<!--\s*claimed-by:\s*\S+\s+(\S+)\s+supersedes:/,
-    );
-    if (claimed) {
-      activeClaimId = claimed[1];
-      continue;
-    }
-    const unclaimed = body.match(/<!--\s*unclaimed-by:\s*\S+\s+(\S+)\s/);
-    if (unclaimed && unclaimed[1] === activeClaimId) {
-      activeClaimId = null;
-    }
-  }
-  return activeClaimId;
+  const events = comments.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  }));
+  return resolveActiveClaim(events, isTrustedAuthor)?.claimId ?? null;
 }
 function postDisposition(owner, repo, pr, body) {
   // A disposition body is plain text starting with `**Rejected**` (not an
@@ -263,11 +300,30 @@ function postDisposition(owner, repo, pr, body) {
     `body=${body}`,
   ]);
 }
+const COMPLETED_REVIEW_STATES = new Set([
+  'APPROVED',
+  'CHANGES_REQUESTED',
+  'COMMENTED',
+]);
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
   if (args.help || !Number.isInteger(args.pr) || (args.pr ?? 0) <= 0) {
     process.stdout.write(USAGE);
     process.exit(args.help ? 0 : 1);
+  }
+  // Fail closed: --apply mutates PR state, so the active-claim revalidation is
+  // mandatory. Missing/invalid claim inputs must abort before any read or write
+  // rather than silently bypassing the gate.
+  if (
+    args.apply &&
+    (!Number.isInteger(args.claimIssue) ||
+      (args.claimIssue ?? 0) <= 0 ||
+      !args.claimId)
+  ) {
+    process.stderr.write(
+      '--apply requires --claim-issue and --claim-id for the mandatory claim revalidation\n',
+    );
+    process.exit(1);
   }
   const pr = args.pr;
   const owner =
@@ -275,47 +331,93 @@ if (isMainModule(import.meta.url)) {
     ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
   const repo =
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  // Default the trusted disposition authors to this gh login. Existing
+  // dispositions only count toward idempotency when their author is trusted, so
+  // without this default a re-run would not recognize its own prior posts and
+  // would double-post. The same trusted set scopes claim revalidation below.
+  const viewerLogin = ghText(['api', 'user', '--jq', '.login']).toLowerCase();
+  const trustedMarkerLogins =
+    args.trustedMarkerLogins.length > 0
+      ? args.trustedMarkerLogins
+      : [viewerLogin];
+  const advisoryBotLogins =
+    args.advisoryBotLogins.length > 0 ? args.advisoryBotLogins : undefined;
   const headSha = ghText([
     'api',
     `repos/${owner}/${repo}/pulls/${pr}`,
     '--jq',
     '.head.sha',
   ]);
-  const rawComments = ghJson([
-    'api',
-    `repos/${owner}/${repo}/issues/${pr}/comments`,
-    '--paginate',
-  ]);
-  const comments = rawComments.map((comment) => ({
-    id: comment.id,
-    login: comment.user?.login ?? '',
-    body: comment.body ?? '',
-    createdAt: comment.created_at ?? '',
-  }));
-  const plan = buildDispositionPlan(
-    { headSha, comments },
-    {
-      advisoryBotLogins:
-        args.advisoryBotLogins.length > 0 ? args.advisoryBotLogins : undefined,
-      trustedMarkerLogins: args.trustedMarkerLogins,
-    },
-  );
+  // Build a plan from a fresh read of the PR's comments and reviews. Called once
+  // for dry-run and again immediately before --apply posts, so a disposition (or
+  // a completed review) another session raced in is reflected just-in-time.
+  const planNow = () => {
+    const rawComments = ghJsonPaginated([
+      'api',
+      `repos/${owner}/${repo}/issues/${pr}/comments`,
+    ]);
+    const comments = rawComments.map((comment) => ({
+      id: comment.id,
+      login: comment.user?.login ?? '',
+      body: comment.body ?? '',
+      createdAt: comment.created_at ?? '',
+    }));
+    const reviews = ghJsonPaginated([
+      'api',
+      `repos/${owner}/${repo}/pulls/${pr}/reviews`,
+    ]);
+    // A bot that posted a real (non-notice) review of the current HEAD has
+    // "reviewed HEAD" — its notice must not be rejected (see buildDispositionPlan).
+    const botsWithCompletedHeadReview = Array.from(
+      new Set(
+        reviews
+          .filter(
+            (review) =>
+              review.commit_id === headSha &&
+              COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
+              !isAdvisoryNonReviewNotice(review.body ?? ''),
+          )
+          .map((review) => review.user?.login ?? '')
+          .filter(Boolean),
+      ),
+    );
+    return buildDispositionPlan(
+      { headSha, comments },
+      { advisoryBotLogins, trustedMarkerLogins, botsWithCompletedHeadReview },
+    );
+  };
   if (!args.apply) {
     process.stdout.write(
-      `${JSON.stringify({ mode: 'dry-run', prNumber: pr, ...plan }, null, 2)}\n`,
+      `${JSON.stringify({ mode: 'dry-run', prNumber: pr, ...planNow() }, null, 2)}\n`,
     );
     process.exit(0);
   }
-  // --apply: re-validate the active claim immediately before posting.
-  if (Number.isInteger(args.claimIssue) && args.claimId) {
-    const activeClaimId = resolveActiveClaimId(owner, repo, args.claimIssue);
-    if (activeClaimId !== args.claimId) {
-      process.stderr.write(
-        `claim revalidation failed: active claim is "${activeClaimId ?? 'none'}", expected "${args.claimId}"\n`,
-      );
-      process.exit(1);
-    }
+  // --apply: re-validate the active claim immediately before posting, scoped to
+  // trusted marker authors so a forged claim marker cannot satisfy the gate.
+  const trustedAuthors = new Set(
+    trustedMarkerLogins.map((login) => login.toLowerCase()),
+  );
+  const activeClaimId = resolveActiveClaimId(
+    owner,
+    repo,
+    args.claimIssue,
+    (login) =>
+      trustedAuthors.has(
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      ),
+  );
+  if (activeClaimId !== args.claimId) {
+    process.stderr.write(
+      `claim revalidation failed: active claim is "${activeClaimId ?? 'none'}", expected "${args.claimId}"\n`,
+    );
+    process.exit(1);
   }
+  // Re-plan from a fresh read AFTER claim revalidation, so the post loop never
+  // re-posts a disposition (or rejects a notice whose bot just reviewed HEAD)
+  // that raced in since the dry-run.
+  const plan = planNow();
   const applied = [];
   const failed = [];
   for (const item of plan.planned) {

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -33,17 +33,6 @@ const DEFAULT_ADVISORY_BOT_LOGINS = [
   'coderabbitai[bot]',
   'chatgpt-codex-connector[bot]',
 ];
-// CodeRabbit posts a completed review as a regular issue comment carrying this
-// marker (see `classifyRegularBotComment`), not a PR review. A bot that has one
-// has "reviewed" the PR, so its non-review notice must not be rejected.
-const CODERABBIT_SUMMARY_MARKER =
-  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
-/** True for a CodeRabbit completed-review summary comment. */
-export function isCodeRabbitCompletedSummary(body) {
-  return String(body ?? '')
-    .trimStart()
-    .startsWith(CODERABBIT_SUMMARY_MARKER);
-}
 /**
  * Derive the short `({reason})` clause for a non-review notice from its body.
  * Tightly tied to the categories `isAdvisoryNonReviewNotice` recognizes; falls
@@ -80,8 +69,8 @@ export function buildDispositionBody(botLogin, headSha, reason) {
 export function buildDispositionPlan(input, options = {}) {
   // Key all advisory-bot comparisons by the suffix-insensitive identity token
   // (`coderabbitai[bot]` and `coderabbitai` collapse to one identity, matching
-  // `dispositionNamesAdvisoryBot`), so a notice/review/disposition authored
-  // under either variant counts against the same bot.
+  // `dispositionNamesAdvisoryBot`), so a notice/disposition authored under
+  // either variant counts against the same bot.
   const advisoryBotIdentities = new Set(
     normalizeTrustedMarkerLogins(
       options.advisoryBotLogins ?? DEFAULT_ADVISORY_BOT_LOGINS,
@@ -90,29 +79,6 @@ export function buildDispositionPlan(input, options = {}) {
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
   );
-  // Per advisory bot identity, the most recent time it produced a completed
-  // review (a non-notice PR review, or a CodeRabbit summary comment). A notice
-  // is left un-rejected only when a completed review landed AT OR AFTER it (the
-  // notice is then stale); an OLDER review does not cover a newer notice. This
-  // honours the E6 "re-validate just before posting" rule without skipping a
-  // current notice merely because the bot reviewed an earlier HEAD.
-  const completedReviewAtByBot = new Map();
-  for (const [login, value] of Object.entries(
-    options.completedReviewAtByBot ?? {},
-  )) {
-    const at = Date.parse(String(value ?? ''));
-    if (Number.isNaN(at)) {
-      continue;
-    }
-    const token = advisoryBotIdentityToken(login);
-    completedReviewAtByBot.set(
-      token,
-      Math.max(
-        completedReviewAtByBot.get(token) ?? Number.NEGATIVE_INFINITY,
-        at,
-      ),
-    );
-  }
   const headSha = String(input.headSha ?? '');
   const comments = (Array.isArray(input.comments) ? input.comments : [])
     .map((comment) => ({
@@ -152,6 +118,13 @@ export function buildDispositionPlan(input, options = {}) {
       }
     }
   }
+  // Every persistent advisory non-review notice needs its own `**Rejected**`
+  // disposition, EVEN when the bot also has a completed review of the current
+  // HEAD: `summarizeDispositionEvidenceForGate` keeps the notice in its
+  // outstanding set until a notice-disposition naming that bot carries it, and
+  // that disposition is consumed only by the notice (never clears the separate
+  // completed review). So the helper always plans an undispositioned notice;
+  // the completed review is accepted as its own item by the E6 flow.
   const planned = [];
   const skipped = [];
   const coveredByBot = new Map();
@@ -161,22 +134,6 @@ export function buildDispositionPlan(input, options = {}) {
       !advisoryBotIdentities.has(identity) ||
       !isAdvisoryNonReviewNotice(comment.body)
     ) {
-      continue;
-    }
-    const reviewAt = completedReviewAtByBot.get(identity);
-    const noticeAt = Date.parse(comment.createdAt);
-    if (
-      reviewAt !== undefined &&
-      !Number.isNaN(noticeAt) &&
-      reviewAt >= noticeAt
-    ) {
-      // A completed review landed at or after this notice, so the notice is
-      // stale; accept that review separately and leave the notice un-rejected.
-      skipped.push({
-        noticeId: comment.id,
-        botLogin: comment.login,
-        reason: 'completed-review-present',
-      });
       continue;
     }
     const alreadyCovered = coveredByBot.get(identity) ?? 0;
@@ -362,14 +319,36 @@ function postDisposition(owner, repo, pr, body) {
     `body=${body}`,
   ]);
 }
+/** Ids of all comments on the PR authored by `viewerLogin`. */
+function viewerCommentIds(owner, repo, pr, viewerLogin) {
+  const comments = ghJsonPaginated([
+    'api',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+  ]);
+  const ids = new Set();
+  for (const comment of comments) {
+    if ((comment.user?.login ?? '').trim().toLowerCase() === viewerLogin) {
+      ids.add(comment.id);
+    }
+  }
+  return ids;
+}
 /**
- * Find an already-posted disposition with this exact body authored by `viewer`.
- * Used after a failed create to detect a comment that landed server-side even
- * though `gh` exited nonzero (lost response), so a retry never double-posts a
- * marker the F2/F3 1:1 pairing would consume twice. The body is unique per
- * notice (bot + head SHA + reason), so an exact match is reliable.
+ * After a failed create, find a viewer-authored comment with this exact body
+ * whose id is NOT in `knownIds` — i.e., one created since posting began. Two
+ * notices from the same bot on the same HEAD share an identical canonical body,
+ * so keying recovery on a NEW comment id (not body uniqueness) is what stops the
+ * helper from mistaking an earlier notice's marker for a failed create, which
+ * would under-count the markers the F2/F3 1:1 pairing needs.
  */
-function findPostedDisposition(owner, repo, pr, body, viewerLogin) {
+function recoverPostedDisposition(
+  owner,
+  repo,
+  pr,
+  body,
+  viewerLogin,
+  knownIds,
+) {
   const comments = ghJsonPaginated([
     'api',
     `repos/${owner}/${repo}/issues/${pr}/comments`,
@@ -377,6 +356,7 @@ function findPostedDisposition(owner, repo, pr, body, viewerLogin) {
   for (let index = comments.length - 1; index >= 0; index -= 1) {
     const comment = comments[index];
     if (
+      !knownIds.has(comment.id) &&
       (comment.user?.login ?? '').trim().toLowerCase() === viewerLogin &&
       (comment.body ?? '') === body
     ) {
@@ -385,11 +365,6 @@ function findPostedDisposition(owner, repo, pr, body, viewerLogin) {
   }
   return null;
 }
-const COMPLETED_REVIEW_STATES = new Set([
-  'APPROVED',
-  'CHANGES_REQUESTED',
-  'COMMENTED',
-]);
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
   if (args.help || !Number.isInteger(args.pr) || (args.pr ?? 0) <= 0) {
@@ -437,10 +412,10 @@ if (isMainModule(import.meta.url)) {
     resolvedAdvisoryBotLogins.length > 0
       ? resolvedAdvisoryBotLogins
       : DEFAULT_ADVISORY_BOT_LOGINS;
-  // Build a plan from a fresh read of the PR's HEAD, comments, and reviews.
-  // Called once for dry-run and again immediately before --apply posts, so a
-  // HEAD advance, a disposition, or a completed review another session raced in
-  // is reflected just-in-time (the apply path never reuses the dry-run snapshot).
+  // Build a plan from a fresh read of the PR's HEAD and comments. Called once
+  // for dry-run and again immediately before --apply posts, so a HEAD advance or
+  // a disposition another session raced in is reflected just-in-time (the apply
+  // path never reuses the dry-run snapshot).
   const planNow = () => {
     const headSha = ghText([
       'api',
@@ -458,45 +433,9 @@ if (isMainModule(import.meta.url)) {
       body: comment.body ?? '',
       createdAt: comment.created_at ?? '',
     }));
-    const reviews = ghJsonPaginated([
-      'api',
-      `repos/${owner}/${repo}/pulls/${pr}/reviews`,
-    ]);
-    // The latest time each bot produced a completed review the gate accepts: a
-    // real (non-notice) PR review, or a CodeRabbit completed-summary comment
-    // (CodeRabbit reviews land as regular issue comments, not PR reviews).
-    // buildDispositionPlan compares these timestamps against each notice, so a
-    // review only suppresses a notice it is at-or-newer than (a stale review of
-    // an older HEAD does not cover a fresh notice).
-    const completedReviewAtByBot = {};
-    const recordCompletedReview = (login, at) => {
-      const key = login.trim().toLowerCase();
-      if (!key || !at) {
-        return;
-      }
-      if (!completedReviewAtByBot[key] || completedReviewAtByBot[key] < at) {
-        completedReviewAtByBot[key] = at;
-      }
-    };
-    for (const review of reviews) {
-      if (
-        COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
-        !isAdvisoryNonReviewNotice(review.body ?? '')
-      ) {
-        recordCompletedReview(
-          review.user?.login ?? '',
-          review.submitted_at ?? '',
-        );
-      }
-    }
-    for (const comment of comments) {
-      if (isCodeRabbitCompletedSummary(comment.body)) {
-        recordCompletedReview(comment.login, comment.createdAt);
-      }
-    }
     return buildDispositionPlan(
       { headSha, comments },
-      { advisoryBotLogins, trustedMarkerLogins, completedReviewAtByBot },
+      { advisoryBotLogins, trustedMarkerLogins },
     );
   };
   if (!args.apply) {
@@ -528,11 +467,14 @@ if (isMainModule(import.meta.url)) {
     process.exit(1);
   }
   // Re-plan from a fresh read AFTER claim revalidation, so the post loop never
-  // re-posts a disposition (or rejects a notice whose bot just reviewed HEAD)
-  // that raced in since the dry-run.
+  // re-posts a disposition that raced in since the dry-run.
   const plan = planNow();
   const applied = [];
   const failed = [];
+  // Track every viewer-authored comment id we know about (pre-existing plus the
+  // ones we post), so a post-failure recovery attributes a NEW comment to the
+  // current notice instead of an earlier notice with an identical body.
+  const knownViewerCommentIds = viewerCommentIds(owner, repo, pr, viewerLogin);
   let claimLost = false;
   for (const item of plan.planned) {
     if (!revalidateClaim()) {
@@ -553,11 +495,19 @@ if (isMainModule(import.meta.url)) {
       } catch (error) {
         lastError = error;
         // The create may have landed server-side despite the nonzero exit;
-        // re-read before any retry so we never double-post the same marker.
-        posted = findPostedDisposition(owner, repo, pr, item.body, viewerLogin);
+        // re-read (by NEW comment id) before any retry so we never double-post.
+        posted = recoverPostedDisposition(
+          owner,
+          repo,
+          pr,
+          item.body,
+          viewerLogin,
+          knownViewerCommentIds,
+        );
       }
     }
     if (posted) {
+      knownViewerCommentIds.add(posted.id);
       applied.push({ noticeId: item.noticeId, commentId: posted.id });
     } else {
       failed.push({

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/disposition-non-review-notices.mts
+//
+// The scripts/disposition-non-review-notices.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Auto-disposition advisory non-review notices on a PR (E6 PATH B). Every
+// autopilot PR draws advisory-bot rate-limit / usage-limit notices that are
+// dispositioned deterministically as `**Rejected** — {bot} did not review HEAD
+// {sha} ({reason}); this is not a completed review` — marker-first (#1038), one
+// per notice (the F2/F3 gate pairs 1:1 by count), naming the bot's login so the
+// #1018 author-scoped carry-forward attributes it. This helper detects those
+// notices with the single-sourced `isAdvisoryNonReviewNotice` classifier and
+// emits (dry-run) or posts (`--apply`) the canonical disposition, skipping
+// notices already dispositioned so a re-run is idempotent. It is fail-closed:
+// only classifier-recognized notices are dispositioned; real reviews and review
+// threads are never touched.
+import { execFileSync } from 'node:child_process';
+import {
+  dispositionNamesAdvisoryBot,
+  isAdvisoryNonReviewNotice,
+  isNonReviewNoticeDisposition,
+  normalizeTrustedMarkerLogins,
+} from './protocol-helpers.mjs';
+
+const DEFAULT_ADVISORY_BOT_LOGINS = [
+  'coderabbitai[bot]',
+  'chatgpt-codex-connector[bot]',
+];
+/**
+ * Derive the short `({reason})` clause for a non-review notice from its body.
+ * Tightly tied to the categories `isAdvisoryNonReviewNotice` recognizes; falls
+ * back to a generic label so an unrecognized-but-classified notice still gets a
+ * coherent disposition.
+ */
+export function noticeReason(body) {
+  const text = String(body ?? '');
+  if (/rate limited by coderabbit\.ai|Review limit reached/i.test(text)) {
+    return 'review limit reached / rate limited';
+  }
+  if (/Codex usage limits/i.test(text)) {
+    return 'Codex usage limits for code reviews reached';
+  }
+  return 'advisory non-review notice';
+}
+/**
+ * Build the canonical E6 non-review-notice disposition body: marker-first,
+ * naming the bot's GitHub login (for the #1018 author-scoped carry-forward) and
+ * the current head SHA.
+ */
+export function buildDispositionBody(botLogin, headSha, reason) {
+  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review.`;
+}
+/**
+ * Plan the dispositions for a PR's regular comments. Pure: takes the fetched
+ * comments and returns which advisory non-review notices need a disposition and
+ * which already have one. Per advisory bot, the count of trusted IDD non-review
+ * notice dispositions naming that bot covers that many of its notices
+ * (oldest-first); the remainder are planned. This mirrors the gate's
+ * author-scoped 1:1 carry-forward, so the helper never posts a disposition the
+ * gate would not credit and never double-posts on a re-run.
+ */
+export function buildDispositionPlan(input, options = {}) {
+  const advisoryBotLogins = new Set(
+    normalizeTrustedMarkerLogins(
+      options.advisoryBotLogins ?? DEFAULT_ADVISORY_BOT_LOGINS,
+    ),
+  );
+  const trustedMarkerLogins = new Set(
+    normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
+  );
+  const headSha = String(input.headSha ?? '');
+  const comments = (Array.isArray(input.comments) ? input.comments : [])
+    .map((comment) => ({
+      id: comment.id,
+      login: String(comment.login ?? '')
+        .trim()
+        .toLowerCase(),
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? ''),
+    }))
+    .sort((left, right) => {
+      const delta = Date.parse(left.createdAt) - Date.parse(right.createdAt);
+      return Number.isNaN(delta) ? 0 : delta;
+    });
+  // Trusted IDD non-review-notice dispositions, grouped per advisory bot login
+  // they name (so each bot's existing dispositions only cover its own notices).
+  const dispositionCountByBot = new Map();
+  for (const comment of comments) {
+    if (
+      !trustedMarkerLogins.has(comment.login) ||
+      !isNonReviewNoticeDisposition({ body: comment.body })
+    ) {
+      continue;
+    }
+    for (const botLogin of advisoryBotLogins) {
+      if (dispositionNamesAdvisoryBot(comment.body, botLogin)) {
+        dispositionCountByBot.set(
+          botLogin,
+          (dispositionCountByBot.get(botLogin) ?? 0) + 1,
+        );
+      }
+    }
+  }
+  const planned = [];
+  const skipped = [];
+  const coveredByBot = new Map();
+  for (const comment of comments) {
+    if (
+      !advisoryBotLogins.has(comment.login) ||
+      !isAdvisoryNonReviewNotice(comment.body)
+    ) {
+      continue;
+    }
+    const alreadyCovered = coveredByBot.get(comment.login) ?? 0;
+    if (alreadyCovered < (dispositionCountByBot.get(comment.login) ?? 0)) {
+      // An existing trusted disposition naming this bot already covers a notice;
+      // attribute it (oldest-first) and skip this one as idempotent.
+      coveredByBot.set(comment.login, alreadyCovered + 1);
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'already-dispositioned',
+      });
+      continue;
+    }
+    const reason = noticeReason(comment.body);
+    planned.push({
+      noticeId: comment.id,
+      botLogin: comment.login,
+      reason,
+      body: buildDispositionBody(comment.login, headSha, reason),
+    });
+  }
+  return { headSha, planned, skipped };
+}
+function parseArgs(argv) {
+  const args = {
+    pr: null,
+    owner: '',
+    repo: '',
+    claimIssue: null,
+    claimId: '',
+    agentId: '',
+    trustedMarkerLogins: [],
+    advisoryBotLogins: [],
+    apply: false,
+    help: false,
+  };
+  const splitList = (value) =>
+    value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const next = () => {
+      index += 1;
+      return argv[index] ?? '';
+    };
+    switch (flag) {
+      case '--pr':
+        args.pr = Number.parseInt(next(), 10);
+        break;
+      case '--owner':
+        args.owner = next();
+        break;
+      case '--repo':
+        args.repo = next();
+        break;
+      case '--claim-issue':
+        args.claimIssue = Number.parseInt(next(), 10);
+        break;
+      case '--claim-id':
+        args.claimId = next();
+        break;
+      case '--agent-id':
+        args.agentId = next();
+        break;
+      case '--trusted-marker-logins':
+        args.trustedMarkerLogins = splitList(next());
+        break;
+      case '--advisory-bot-logins':
+        args.advisoryBotLogins = splitList(next());
+        break;
+      case '--apply':
+        args.apply = true;
+        break;
+      case '--help':
+      case '-h':
+        args.help = true;
+        break;
+      default:
+        break;
+    }
+  }
+  return args;
+}
+function ghText(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+function ghJson(args) {
+  return JSON.parse(execFileSync('gh', args, { encoding: 'utf8' }));
+}
+function isMainModule(moduleUrl) {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return moduleUrl === `file://${entry}` || moduleUrl.endsWith(entry);
+}
+const USAGE = `usage: node scripts/disposition-non-review-notices.mjs --pr <number> [options]
+
+Detect advisory non-review notices on a PR and emit (default) or post
+(--apply) the canonical E6 \`**Rejected** — {bot} did not review HEAD …\`
+disposition, one marker-first comment per notice. Idempotent and fail-closed.
+
+  --pr <number>                  PR number (required)
+  --owner <owner>                repo owner (default: gh repo view)
+  --repo <repo>                  repo name (default: gh repo view)
+  --claim-issue <number>         issue carrying the active claim (for --apply)
+  --claim-id <claim-id>          active claim id to re-validate before --apply
+  --agent-id <agent-id>          current session agent id
+  --trusted-marker-logins a,b    logins whose existing dispositions count
+  --advisory-bot-logins a,b      advisory bot logins (default: coderabbit + codex)
+  --apply                        post the dispositions (default: dry-run)
+  -h, --help                     show this help
+`;
+function resolveActiveClaimId(owner, repo, issue) {
+  const comments = ghJson([
+    'api',
+    `repos/${owner}/${repo}/issues/${issue}/comments`,
+    '--paginate',
+  ]);
+  let activeClaimId = null;
+  for (const comment of comments) {
+    const body = String(comment.body ?? '');
+    const claimed = body.match(
+      /<!--\s*claimed-by:\s*\S+\s+(\S+)\s+supersedes:/,
+    );
+    if (claimed) {
+      activeClaimId = claimed[1];
+      continue;
+    }
+    const unclaimed = body.match(/<!--\s*unclaimed-by:\s*\S+\s+(\S+)\s/);
+    if (unclaimed && unclaimed[1] === activeClaimId) {
+      activeClaimId = null;
+    }
+  }
+  return activeClaimId;
+}
+function postDisposition(owner, repo, pr, body) {
+  // A disposition body is plain text starting with `**Rejected**` (not an
+  // HTML-comment-first marker), so the `-f body=` field path posts it
+  // reliably; gh sends `{"body": <value>}` to the comments API.
+  return ghJson([
+    'api',
+    '--method',
+    'POST',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+    '-f',
+    `body=${body}`,
+  ]);
+}
+if (isMainModule(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !Number.isInteger(args.pr) || (args.pr ?? 0) <= 0) {
+    process.stdout.write(USAGE);
+    process.exit(args.help ? 0 : 1);
+  }
+  const pr = args.pr;
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const headSha = ghText([
+    'api',
+    `repos/${owner}/${repo}/pulls/${pr}`,
+    '--jq',
+    '.head.sha',
+  ]);
+  const rawComments = ghJson([
+    'api',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+    '--paginate',
+  ]);
+  const comments = rawComments.map((comment) => ({
+    id: comment.id,
+    login: comment.user?.login ?? '',
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+  }));
+  const plan = buildDispositionPlan(
+    { headSha, comments },
+    {
+      advisoryBotLogins:
+        args.advisoryBotLogins.length > 0 ? args.advisoryBotLogins : undefined,
+      trustedMarkerLogins: args.trustedMarkerLogins,
+    },
+  );
+  if (!args.apply) {
+    process.stdout.write(
+      `${JSON.stringify({ mode: 'dry-run', prNumber: pr, ...plan }, null, 2)}\n`,
+    );
+    process.exit(0);
+  }
+  // --apply: re-validate the active claim immediately before posting.
+  if (Number.isInteger(args.claimIssue) && args.claimId) {
+    const activeClaimId = resolveActiveClaimId(owner, repo, args.claimIssue);
+    if (activeClaimId !== args.claimId) {
+      process.stderr.write(
+        `claim revalidation failed: active claim is "${activeClaimId ?? 'none'}", expected "${args.claimId}"\n`,
+      );
+      process.exit(1);
+    }
+  }
+  const applied = [];
+  const failed = [];
+  for (const item of plan.planned) {
+    let posted = null;
+    for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
+      try {
+        posted = postDisposition(owner, repo, pr, item.body);
+      } catch (error) {
+        if (attempt === 1) {
+          failed.push({
+            noticeId: item.noticeId,
+            error: error.message,
+          });
+        }
+      }
+    }
+    if (posted) {
+      applied.push({ noticeId: item.noticeId, commentId: posted.id });
+    }
+  }
+  const status = failed.length > 0 ? 'failed' : 'applied';
+  process.stdout.write(
+    `${JSON.stringify({ mode: 'apply', prNumber: pr, headSha, status, applied, failed, skipped: plan.skipped }, null, 2)}\n`,
+  );
+  process.exit(failed.length > 0 ? 1 : 0);
+}

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -195,6 +195,7 @@ const HELPER_COMMANDS = [
     vendoredCommand: 'node scripts/disposition-non-review-notices.mjs',
     description:
       'Detect advisory non-review notices on a PR and emit or post their canonical E6 dispositions.',
+    contractPaths: ['schemas/disposition-non-review-notices.schema.json'],
   },
   {
     id: 'doctor',

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -188,6 +188,15 @@ const HELPER_COMMANDS = [
       'Collect read-only A4 viability filtering evidence for candidate issues.',
   },
   {
+    id: 'disposition-non-review-notices',
+    scriptName: 'idd:disposition-non-review-notices',
+    binName: 'idd-disposition-non-review-notices',
+    entryPath: 'scripts/disposition-non-review-notices.mjs',
+    vendoredCommand: 'node scripts/disposition-non-review-notices.mjs',
+    description:
+      'Detect advisory non-review notices on a PR and emit or post their canonical E6 dispositions.',
+  },
+  {
     id: 'doctor',
     scriptName: 'idd:doctor',
     binName: 'idd-doctor',

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1387,7 +1387,7 @@ export function isNonReviewNoticeDisposition(comment) {
 // notice disposition to the bot it rejected. The `[bot]` suffix GitHub appends
 // is dropped so the token matches whether a login is stored as `coderabbitai`
 // or `coderabbitai[bot]`.
-function advisoryBotIdentityToken(login) {
+export function advisoryBotIdentityToken(login) {
   return String(login ?? '')
     .trim()
     .toLowerCase()
@@ -1397,7 +1397,10 @@ function advisoryBotIdentityToken(login) {
 // GitHub login, so the gate can attribute a carry-forward to exactly one bot
 // even when several advisory bots are configured. Fail-closed: an empty token or
 // a disposition that does not contain the login carries nothing forward.
-function dispositionNamesAdvisoryBot(dispositionBody, noticeAuthorLogin) {
+export function dispositionNamesAdvisoryBot(
+  dispositionBody,
+  noticeAuthorLogin,
+) {
   const token = advisoryBotIdentityToken(noticeAuthorLogin);
   if (!token) {
     return false;

--- a/src/bin/idd-disposition-non-review-notices.mts
+++ b/src/bin/idd-disposition-non-review-notices.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-disposition-non-review-notices.mts
+//
+// The bin/idd-disposition-non-review-notices.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/disposition-non-review-notices.mjs');

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -24,6 +24,7 @@ import {
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
   normalizeTrustedMarkerLogins,
+  resolveActiveClaim,
 } from './protocol-helpers.mts';
 
 const DEFAULT_ADVISORY_BOT_LOGINS = [
@@ -106,7 +107,7 @@ export function buildDispositionBody(
   headSha: string,
   reason: string,
 ): string {
-  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review.`;
+  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review`;
 }
 
 /**
@@ -123,6 +124,7 @@ export function buildDispositionPlan(
   options: {
     advisoryBotLogins?: unknown[] | null;
     trustedMarkerLogins?: unknown[] | null;
+    botsWithCompletedHeadReview?: unknown[] | null;
   } = {},
 ): DispositionPlan {
   const advisoryBotLogins = new Set(
@@ -132,6 +134,13 @@ export function buildDispositionPlan(
   );
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
+  );
+  // Advisory bots that already have a completed review of the current HEAD (a
+  // distinct, non-notice review). Per the E6 "re-validate just before posting"
+  // rule, their notice must not be rejected: the gate accepts that review, and
+  // a later-timestamped `did not review HEAD` rejection could filter it out.
+  const botsWithCompletedHeadReview = new Set(
+    normalizeTrustedMarkerLogins(options.botsWithCompletedHeadReview ?? []),
   );
   const headSha = String(input.headSha ?? '');
 
@@ -159,12 +168,17 @@ export function buildDispositionPlan(
     ) {
       continue;
     }
+    // Count a disposition toward at most ONE bot it names. The F2/F3 gate
+    // consumes a notice disposition at most once, so a combined marker naming
+    // several bots must not be credited as covering one notice per bot (that
+    // would let the helper skip notices the gate still blocks on).
     for (const botLogin of advisoryBotLogins) {
       if (dispositionNamesAdvisoryBot(comment.body, botLogin)) {
         dispositionCountByBot.set(
           botLogin,
           (dispositionCountByBot.get(botLogin) ?? 0) + 1,
         );
+        break;
       }
     }
   }
@@ -177,6 +191,16 @@ export function buildDispositionPlan(
       !advisoryBotLogins.has(comment.login) ||
       !isAdvisoryNonReviewNotice(comment.body)
     ) {
+      continue;
+    }
+    if (botsWithCompletedHeadReview.has(comment.login)) {
+      // The bot has a completed review of the current HEAD; accept that review
+      // separately and leave the notice un-rejected (E6 race re-validation).
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'completed-review-present',
+      });
       continue;
     }
     const alreadyCovered = coveredByBot.get(comment.login) ?? 0;
@@ -290,6 +314,24 @@ function ghJson(args: string[]): unknown {
   return JSON.parse(execFileSync('gh', args, { encoding: 'utf8' }));
 }
 
+/**
+ * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
+ * one JSON array per page, so a >1-page response is not a single JSON document;
+ * `--jq '.[]'` flattens each page to one JSON value per line (NDJSON), which we
+ * parse line-by-line. (`--slurp` would be simpler but needs gh >= 2.48.0; Ubuntu
+ * 24.04 LTS ships gh 2.45.0, so the repo standardizes on `--jq '.[]'`.)
+ */
+function ghJsonPaginated(args: string[]): unknown[] {
+  const out = execFileSync('gh', [...args, '--paginate', '--jq', '.[]'], {
+    encoding: 'utf8',
+  });
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .map((line) => JSON.parse(line) as unknown);
+}
+
 function isMainModule(moduleUrl: string): boolean {
   const entry = process.argv[1];
   if (!entry) {
@@ -307,41 +349,39 @@ disposition, one marker-first comment per notice. Idempotent and fail-closed.
   --pr <number>                  PR number (required)
   --owner <owner>                repo owner (default: gh repo view)
   --repo <repo>                  repo name (default: gh repo view)
-  --claim-issue <number>         issue carrying the active claim (for --apply)
-  --claim-id <claim-id>          active claim id to re-validate before --apply
+  --claim-issue <number>         issue carrying the active claim (required with --apply)
+  --claim-id <claim-id>          active claim id to re-validate (required with --apply)
   --agent-id <agent-id>          current session agent id
   --trusted-marker-logins a,b    logins whose existing dispositions count
+                                 (default: your gh login, so re-runs are idempotent)
   --advisory-bot-logins a,b      advisory bot logins (default: coderabbit + codex)
   --apply                        post the dispositions (default: dry-run)
   -h, --help                     show this help
 `;
 
+/**
+ * Resolve the active claim id on an issue using the shared
+ * `resolveActiveClaim` state machine, scoped to trusted marker authors. This
+ * reuses the canonical claim parsing/validation (superseding, release,
+ * forced-handoff) and — crucially — ignores claim markers posted by untrusted
+ * authors, so a copied/forged `claimed-by` marker cannot satisfy revalidation.
+ */
 function resolveActiveClaimId(
   owner: string,
   repo: string,
   issue: number,
+  isTrustedAuthor: (login: string) => boolean,
 ): string | null {
-  const comments = ghJson([
+  const comments = ghJsonPaginated([
     'api',
     `repos/${owner}/${repo}/issues/${issue}/comments`,
-    '--paginate',
-  ]) as { body?: string }[];
-  let activeClaimId: string | null = null;
-  for (const comment of comments) {
-    const body = String(comment.body ?? '');
-    const claimed = body.match(
-      /<!--\s*claimed-by:\s*\S+\s+(\S+)\s+supersedes:/,
-    );
-    if (claimed) {
-      activeClaimId = claimed[1];
-      continue;
-    }
-    const unclaimed = body.match(/<!--\s*unclaimed-by:\s*\S+\s+(\S+)\s/);
-    if (unclaimed && unclaimed[1] === activeClaimId) {
-      activeClaimId = null;
-    }
-  }
-  return activeClaimId;
+  ]) as { body?: string; created_at?: string; user?: { login?: string } }[];
+  const events = comments.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  }));
+  return resolveActiveClaim(events, isTrustedAuthor)?.claimId ?? null;
 }
 
 function postDisposition(
@@ -363,11 +403,31 @@ function postDisposition(
   ]) as { id: number };
 }
 
+const COMPLETED_REVIEW_STATES = new Set([
+  'APPROVED',
+  'CHANGES_REQUESTED',
+  'COMMENTED',
+]);
+
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
   if (args.help || !Number.isInteger(args.pr) || (args.pr ?? 0) <= 0) {
     process.stdout.write(USAGE);
     process.exit(args.help ? 0 : 1);
+  }
+  // Fail closed: --apply mutates PR state, so the active-claim revalidation is
+  // mandatory. Missing/invalid claim inputs must abort before any read or write
+  // rather than silently bypassing the gate.
+  if (
+    args.apply &&
+    (!Number.isInteger(args.claimIssue) ||
+      (args.claimIssue ?? 0) <= 0 ||
+      !args.claimId)
+  ) {
+    process.stderr.write(
+      '--apply requires --claim-issue and --claim-id for the mandatory claim revalidation\n',
+    );
+    process.exit(1);
   }
   const pr = args.pr as number;
   const owner =
@@ -376,60 +436,108 @@ if (isMainModule(import.meta.url)) {
   const repo =
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
 
+  // Default the trusted disposition authors to this gh login. Existing
+  // dispositions only count toward idempotency when their author is trusted, so
+  // without this default a re-run would not recognize its own prior posts and
+  // would double-post. The same trusted set scopes claim revalidation below.
+  const viewerLogin = ghText(['api', 'user', '--jq', '.login']).toLowerCase();
+  const trustedMarkerLogins =
+    args.trustedMarkerLogins.length > 0
+      ? args.trustedMarkerLogins
+      : [viewerLogin];
+  const advisoryBotLogins =
+    args.advisoryBotLogins.length > 0 ? args.advisoryBotLogins : undefined;
+
   const headSha = ghText([
     'api',
     `repos/${owner}/${repo}/pulls/${pr}`,
     '--jq',
     '.head.sha',
   ]);
-  const rawComments = ghJson([
-    'api',
-    `repos/${owner}/${repo}/issues/${pr}/comments`,
-    '--paginate',
-  ]) as {
-    id: number;
-    user?: { login?: string };
-    body?: string;
-    created_at?: string;
-  }[];
-  const comments: NoticeComment[] = rawComments.map((comment) => ({
-    id: comment.id,
-    login: comment.user?.login ?? '',
-    body: comment.body ?? '',
-    createdAt: comment.created_at ?? '',
-  }));
 
-  const plan = buildDispositionPlan(
-    { headSha, comments },
-    {
-      advisoryBotLogins:
-        args.advisoryBotLogins.length > 0 ? args.advisoryBotLogins : undefined,
-      trustedMarkerLogins: args.trustedMarkerLogins,
-    },
-  );
+  // Build a plan from a fresh read of the PR's comments and reviews. Called once
+  // for dry-run and again immediately before --apply posts, so a disposition (or
+  // a completed review) another session raced in is reflected just-in-time.
+  const planNow = (): DispositionPlan => {
+    const rawComments = ghJsonPaginated([
+      'api',
+      `repos/${owner}/${repo}/issues/${pr}/comments`,
+    ]) as {
+      id: number;
+      user?: { login?: string };
+      body?: string;
+      created_at?: string;
+    }[];
+    const comments: NoticeComment[] = rawComments.map((comment) => ({
+      id: comment.id,
+      login: comment.user?.login ?? '',
+      body: comment.body ?? '',
+      createdAt: comment.created_at ?? '',
+    }));
+    const reviews = ghJsonPaginated([
+      'api',
+      `repos/${owner}/${repo}/pulls/${pr}/reviews`,
+    ]) as {
+      user?: { login?: string };
+      body?: string;
+      commit_id?: string;
+      state?: string;
+    }[];
+    // A bot that posted a real (non-notice) review of the current HEAD has
+    // "reviewed HEAD" — its notice must not be rejected (see buildDispositionPlan).
+    const botsWithCompletedHeadReview = Array.from(
+      new Set(
+        reviews
+          .filter(
+            (review) =>
+              review.commit_id === headSha &&
+              COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
+              !isAdvisoryNonReviewNotice(review.body ?? ''),
+          )
+          .map((review) => review.user?.login ?? '')
+          .filter(Boolean),
+      ),
+    );
+    return buildDispositionPlan(
+      { headSha, comments },
+      { advisoryBotLogins, trustedMarkerLogins, botsWithCompletedHeadReview },
+    );
+  };
 
   if (!args.apply) {
     process.stdout.write(
-      `${JSON.stringify({ mode: 'dry-run', prNumber: pr, ...plan }, null, 2)}\n`,
+      `${JSON.stringify({ mode: 'dry-run', prNumber: pr, ...planNow() }, null, 2)}\n`,
     );
     process.exit(0);
   }
 
-  // --apply: re-validate the active claim immediately before posting.
-  if (Number.isInteger(args.claimIssue) && args.claimId) {
-    const activeClaimId = resolveActiveClaimId(
-      owner,
-      repo,
-      args.claimIssue as number,
+  // --apply: re-validate the active claim immediately before posting, scoped to
+  // trusted marker authors so a forged claim marker cannot satisfy the gate.
+  const trustedAuthors = new Set(
+    trustedMarkerLogins.map((login) => login.toLowerCase()),
+  );
+  const activeClaimId = resolveActiveClaimId(
+    owner,
+    repo,
+    args.claimIssue as number,
+    (login) =>
+      trustedAuthors.has(
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      ),
+  );
+  if (activeClaimId !== args.claimId) {
+    process.stderr.write(
+      `claim revalidation failed: active claim is "${activeClaimId ?? 'none'}", expected "${args.claimId}"\n`,
     );
-    if (activeClaimId !== args.claimId) {
-      process.stderr.write(
-        `claim revalidation failed: active claim is "${activeClaimId ?? 'none'}", expected "${args.claimId}"\n`,
-      );
-      process.exit(1);
-    }
+    process.exit(1);
   }
 
+  // Re-plan from a fresh read AFTER claim revalidation, so the post loop never
+  // re-posts a disposition (or rejects a notice whose bot just reviewed HEAD)
+  // that raced in since the dry-run.
+  const plan = planNow();
   const applied: { noticeId: string | number; commentId: number }[] = [];
   const failed: { noticeId: string | number; error: string }[] = [];
   for (const item of plan.planned) {

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -154,8 +154,20 @@ export function buildDispositionPlan(
       createdAt: String(comment.createdAt ?? ''),
     }))
     .sort((left, right) => {
-      const delta = Date.parse(left.createdAt) - Date.parse(right.createdAt);
-      return Number.isNaN(delta) ? 0 : delta;
+      // Oldest-first, with a deterministic tie-breaker so the oldest-first
+      // pairing is stable: comments with equal (or invalid) timestamps fall back
+      // to the monotonic comment id, and an invalid timestamp sorts last.
+      const leftTime = Date.parse(left.createdAt);
+      const rightTime = Date.parse(right.createdAt);
+      const leftValid = !Number.isNaN(leftTime);
+      const rightValid = !Number.isNaN(rightTime);
+      if (leftValid && rightValid && leftTime !== rightTime) {
+        return leftTime - rightTime;
+      }
+      if (leftValid !== rightValid) {
+        return leftValid ? -1 : 1;
+      }
+      return left.id - right.id;
     });
 
   // Trusted IDD non-review-notice dispositions, grouped per advisory bot
@@ -600,15 +612,19 @@ if (isMainModule(import.meta.url)) {
   // current notice instead of an earlier notice with an identical body.
   const knownViewerCommentIds = viewerCommentIds(owner, repo, pr, viewerLogin);
   let claimLost = false;
-  for (const item of plan.planned) {
+  for (let index = 0; index < plan.planned.length; index += 1) {
+    const item = plan.planned[index];
     if (!revalidateClaim()) {
-      // Claim lost mid-loop: stop writing and surface the remaining notices as
-      // failed rather than posting them under a claim we no longer hold.
+      // Claim lost mid-loop: stop writing and surface the current AND all
+      // remaining notices as failed rather than posting them under a claim we no
+      // longer hold, so the apply report names every notice left un-dispositioned.
       claimLost = true;
-      failed.push({
-        noticeId: item.noticeId,
-        error: 'claim revalidation failed before post',
-      });
+      for (const remaining of plan.planned.slice(index)) {
+        failed.push({
+          noticeId: remaining.noticeId,
+          error: 'claim revalidation failed before post',
+        });
+      }
       break;
     }
     let posted: { id: number } | null = null;

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -21,6 +21,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
 import {
+  advisoryBotIdentityToken,
   dispositionNamesAdvisoryBot,
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
@@ -49,21 +50,21 @@ export function isCodeRabbitCompletedSummary(body: unknown): boolean {
 }
 
 export interface NoticeComment {
-  id: string | number;
+  id: number;
   login: string;
   body: string;
   createdAt: string;
 }
 
 export interface PlannedDisposition {
-  noticeId: string | number;
+  noticeId: number;
   botLogin: string;
   reason: string;
   body: string;
 }
 
 export interface SkippedNotice {
-  noticeId: string | number;
+  noticeId: number;
   botLogin: string;
   reason: string;
 }
@@ -75,12 +76,12 @@ export interface DispositionPlan {
 }
 
 export interface AppliedDisposition {
-  noticeId: string | number;
+  noticeId: number;
   commentId: number;
 }
 
 export interface FailedDisposition {
-  noticeId: string | number;
+  noticeId: number;
   error: string;
 }
 
@@ -140,25 +141,44 @@ export function buildDispositionPlan(
   options: {
     advisoryBotLogins?: unknown[] | null;
     trustedMarkerLogins?: unknown[] | null;
-    botsWithCompletedReview?: unknown[] | null;
+    completedReviewAtByBot?: Record<string, unknown> | null;
   } = {},
 ): DispositionPlan {
-  const advisoryBotLogins = new Set(
+  // Key all advisory-bot comparisons by the suffix-insensitive identity token
+  // (`coderabbitai[bot]` and `coderabbitai` collapse to one identity, matching
+  // `dispositionNamesAdvisoryBot`), so a notice/review/disposition authored
+  // under either variant counts against the same bot.
+  const advisoryBotIdentities = new Set(
     normalizeTrustedMarkerLogins(
       options.advisoryBotLogins ?? DEFAULT_ADVISORY_BOT_LOGINS,
-    ),
+    ).map(advisoryBotIdentityToken),
   );
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
   );
-  // Advisory bots that already have a completed review (a distinct, non-notice
-  // PR review of the current HEAD, or a CodeRabbit completed-summary comment).
-  // Per the E6 "re-validate just before posting" rule, their notice must not be
-  // rejected: the gate accepts that review, and a later-timestamped `did not
-  // review HEAD` rejection could filter it out.
-  const botsWithCompletedReview = new Set(
-    normalizeTrustedMarkerLogins(options.botsWithCompletedReview ?? []),
-  );
+  // Per advisory bot identity, the most recent time it produced a completed
+  // review (a non-notice PR review, or a CodeRabbit summary comment). A notice
+  // is left un-rejected only when a completed review landed AT OR AFTER it (the
+  // notice is then stale); an OLDER review does not cover a newer notice. This
+  // honours the E6 "re-validate just before posting" rule without skipping a
+  // current notice merely because the bot reviewed an earlier HEAD.
+  const completedReviewAtByBot = new Map<string, number>();
+  for (const [login, value] of Object.entries(
+    options.completedReviewAtByBot ?? {},
+  )) {
+    const at = Date.parse(String(value ?? ''));
+    if (Number.isNaN(at)) {
+      continue;
+    }
+    const token = advisoryBotIdentityToken(login);
+    completedReviewAtByBot.set(
+      token,
+      Math.max(
+        completedReviewAtByBot.get(token) ?? Number.NEGATIVE_INFINITY,
+        at,
+      ),
+    );
+  }
   const headSha = String(input.headSha ?? '');
 
   const comments = (Array.isArray(input.comments) ? input.comments : [])
@@ -175,8 +195,9 @@ export function buildDispositionPlan(
       return Number.isNaN(delta) ? 0 : delta;
     });
 
-  // Trusted IDD non-review-notice dispositions, grouped per advisory bot login
-  // they name (so each bot's existing dispositions only cover its own notices).
+  // Trusted IDD non-review-notice dispositions, grouped per advisory bot
+  // identity they name (so each bot's existing dispositions only cover its own
+  // notices).
   const dispositionCountByBot = new Map<string, number>();
   for (const comment of comments) {
     if (
@@ -189,11 +210,11 @@ export function buildDispositionPlan(
     // consumes a notice disposition at most once, so a combined marker naming
     // several bots must not be credited as covering one notice per bot (that
     // would let the helper skip notices the gate still blocks on).
-    for (const botLogin of advisoryBotLogins) {
-      if (dispositionNamesAdvisoryBot(comment.body, botLogin)) {
+    for (const identity of advisoryBotIdentities) {
+      if (dispositionNamesAdvisoryBot(comment.body, identity)) {
         dispositionCountByBot.set(
-          botLogin,
-          (dispositionCountByBot.get(botLogin) ?? 0) + 1,
+          identity,
+          (dispositionCountByBot.get(identity) ?? 0) + 1,
         );
         break;
       }
@@ -204,15 +225,22 @@ export function buildDispositionPlan(
   const skipped: SkippedNotice[] = [];
   const coveredByBot = new Map<string, number>();
   for (const comment of comments) {
+    const identity = advisoryBotIdentityToken(comment.login);
     if (
-      !advisoryBotLogins.has(comment.login) ||
+      !advisoryBotIdentities.has(identity) ||
       !isAdvisoryNonReviewNotice(comment.body)
     ) {
       continue;
     }
-    if (botsWithCompletedReview.has(comment.login)) {
-      // The bot has a completed review; accept that review separately and leave
-      // the notice un-rejected (E6 race re-validation).
+    const reviewAt = completedReviewAtByBot.get(identity);
+    const noticeAt = Date.parse(comment.createdAt);
+    if (
+      reviewAt !== undefined &&
+      !Number.isNaN(noticeAt) &&
+      reviewAt >= noticeAt
+    ) {
+      // A completed review landed at or after this notice, so the notice is
+      // stale; accept that review separately and leave the notice un-rejected.
       skipped.push({
         noticeId: comment.id,
         botLogin: comment.login,
@@ -220,11 +248,11 @@ export function buildDispositionPlan(
       });
       continue;
     }
-    const alreadyCovered = coveredByBot.get(comment.login) ?? 0;
-    if (alreadyCovered < (dispositionCountByBot.get(comment.login) ?? 0)) {
+    const alreadyCovered = coveredByBot.get(identity) ?? 0;
+    if (alreadyCovered < (dispositionCountByBot.get(identity) ?? 0)) {
       // An existing trusted disposition naming this bot already covers a notice;
       // attribute it (oldest-first) and skip this one as idempotent.
-      coveredByBot.set(comment.login, alreadyCovered + 1);
+      coveredByBot.set(identity, alreadyCovered + 1);
       skipped.push({
         noticeId: comment.id,
         botLogin: comment.login,
@@ -443,6 +471,36 @@ function postDisposition(
   ]) as { id: number };
 }
 
+/**
+ * Find an already-posted disposition with this exact body authored by `viewer`.
+ * Used after a failed create to detect a comment that landed server-side even
+ * though `gh` exited nonzero (lost response), so a retry never double-posts a
+ * marker the F2/F3 1:1 pairing would consume twice. The body is unique per
+ * notice (bot + head SHA + reason), so an exact match is reliable.
+ */
+function findPostedDisposition(
+  owner: string,
+  repo: string,
+  pr: number,
+  body: string,
+  viewerLogin: string,
+): { id: number } | null {
+  const comments = ghJsonPaginated([
+    'api',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+  ]) as { id: number; user?: { login?: string }; body?: string }[];
+  for (let index = comments.length - 1; index >= 0; index -= 1) {
+    const comment = comments[index];
+    if (
+      (comment.user?.login ?? '').trim().toLowerCase() === viewerLogin &&
+      (comment.body ?? '') === body
+    ) {
+      return { id: comment.id };
+    }
+  }
+  return null;
+}
+
 const COMPLETED_REVIEW_STATES = new Set([
   'APPROVED',
   'CHANGES_REQUESTED',
@@ -530,33 +588,44 @@ if (isMainModule(import.meta.url)) {
     ]) as {
       user?: { login?: string };
       body?: string;
-      commit_id?: string;
       state?: string;
+      submitted_at?: string;
     }[];
-    // Bots with a completed review the gate will accept: a real (non-notice) PR
-    // review of the current HEAD, OR a CodeRabbit completed-summary comment
-    // (CodeRabbit reviews land as regular issue comments, not PR reviews). Their
-    // notice must not be rejected (see buildDispositionPlan).
-    const botsWithCompletedReview = Array.from(
-      new Set(
-        [
-          ...reviews
-            .filter(
-              (review) =>
-                review.commit_id === headSha &&
-                COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
-                !isAdvisoryNonReviewNotice(review.body ?? ''),
-            )
-            .map((review) => review.user?.login ?? ''),
-          ...comments
-            .filter((comment) => isCodeRabbitCompletedSummary(comment.body))
-            .map((comment) => comment.login),
-        ].filter(Boolean),
-      ),
-    );
+    // The latest time each bot produced a completed review the gate accepts: a
+    // real (non-notice) PR review, or a CodeRabbit completed-summary comment
+    // (CodeRabbit reviews land as regular issue comments, not PR reviews).
+    // buildDispositionPlan compares these timestamps against each notice, so a
+    // review only suppresses a notice it is at-or-newer than (a stale review of
+    // an older HEAD does not cover a fresh notice).
+    const completedReviewAtByBot: Record<string, string> = {};
+    const recordCompletedReview = (login: string, at: string): void => {
+      const key = login.trim().toLowerCase();
+      if (!key || !at) {
+        return;
+      }
+      if (!completedReviewAtByBot[key] || completedReviewAtByBot[key] < at) {
+        completedReviewAtByBot[key] = at;
+      }
+    };
+    for (const review of reviews) {
+      if (
+        COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
+        !isAdvisoryNonReviewNotice(review.body ?? '')
+      ) {
+        recordCompletedReview(
+          review.user?.login ?? '',
+          review.submitted_at ?? '',
+        );
+      }
+    }
+    for (const comment of comments) {
+      if (isCodeRabbitCompletedSummary(comment.body)) {
+        recordCompletedReview(comment.login, comment.createdAt);
+      }
+    }
     return buildDispositionPlan(
       { headSha, comments },
-      { advisoryBotLogins, trustedMarkerLogins, botsWithCompletedReview },
+      { advisoryBotLogins, trustedMarkerLogins, completedReviewAtByBot },
     );
   };
 
@@ -595,8 +664,8 @@ if (isMainModule(import.meta.url)) {
   // re-posts a disposition (or rejects a notice whose bot just reviewed HEAD)
   // that raced in since the dry-run.
   const plan = planNow();
-  const applied: { noticeId: string | number; commentId: number }[] = [];
-  const failed: { noticeId: string | number; error: string }[] = [];
+  const applied: AppliedDisposition[] = [];
+  const failed: FailedDisposition[] = [];
   let claimLost = false;
   for (const item of plan.planned) {
     if (!revalidateClaim()) {
@@ -610,20 +679,24 @@ if (isMainModule(import.meta.url)) {
       break;
     }
     let posted: { id: number } | null = null;
+    let lastError: Error | null = null;
     for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
       try {
         posted = postDisposition(owner, repo, pr, item.body);
       } catch (error) {
-        if (attempt === 1) {
-          failed.push({
-            noticeId: item.noticeId,
-            error: (error as Error).message,
-          });
-        }
+        lastError = error as Error;
+        // The create may have landed server-side despite the nonzero exit;
+        // re-read before any retry so we never double-post the same marker.
+        posted = findPostedDisposition(owner, repo, pr, item.body, viewerLogin);
       }
     }
     if (posted) {
       applied.push({ noticeId: item.noticeId, commentId: posted.id });
+    } else {
+      failed.push({
+        noticeId: item.noticeId,
+        error: lastError?.message ?? 'unknown error',
+      });
     }
   }
 

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -1,0 +1,459 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/disposition-non-review-notices.mts
+//
+// The scripts/disposition-non-review-notices.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Auto-disposition advisory non-review notices on a PR (E6 PATH B). Every
+// autopilot PR draws advisory-bot rate-limit / usage-limit notices that are
+// dispositioned deterministically as `**Rejected** — {bot} did not review HEAD
+// {sha} ({reason}); this is not a completed review` — marker-first (#1038), one
+// per notice (the F2/F3 gate pairs 1:1 by count), naming the bot's login so the
+// #1018 author-scoped carry-forward attributes it. This helper detects those
+// notices with the single-sourced `isAdvisoryNonReviewNotice` classifier and
+// emits (dry-run) or posts (`--apply`) the canonical disposition, skipping
+// notices already dispositioned so a re-run is idempotent. It is fail-closed:
+// only classifier-recognized notices are dispositioned; real reviews and review
+// threads are never touched.
+
+import { execFileSync } from 'node:child_process';
+
+import {
+  dispositionNamesAdvisoryBot,
+  isAdvisoryNonReviewNotice,
+  isNonReviewNoticeDisposition,
+  normalizeTrustedMarkerLogins,
+} from './protocol-helpers.mts';
+
+const DEFAULT_ADVISORY_BOT_LOGINS = [
+  'coderabbitai[bot]',
+  'chatgpt-codex-connector[bot]',
+];
+
+export interface NoticeComment {
+  id: string | number;
+  login: string;
+  body: string;
+  createdAt: string;
+}
+
+export interface PlannedDisposition {
+  noticeId: string | number;
+  botLogin: string;
+  reason: string;
+  body: string;
+}
+
+export interface SkippedNotice {
+  noticeId: string | number;
+  botLogin: string;
+  reason: string;
+}
+
+export interface DispositionPlan {
+  headSha: string;
+  planned: PlannedDisposition[];
+  skipped: SkippedNotice[];
+}
+
+export interface AppliedDisposition {
+  noticeId: string | number;
+  commentId: number;
+}
+
+export interface FailedDisposition {
+  noticeId: string | number;
+  error: string;
+}
+
+/** The CLI output envelope for both `dry-run` and `--apply` modes. */
+export interface DispositionReport {
+  mode: 'dry-run' | 'apply';
+  prNumber: number;
+  headSha: string;
+  planned?: PlannedDisposition[];
+  status?: 'applied' | 'failed';
+  applied?: AppliedDisposition[];
+  failed?: FailedDisposition[];
+  skipped: SkippedNotice[];
+}
+
+/**
+ * Derive the short `({reason})` clause for a non-review notice from its body.
+ * Tightly tied to the categories `isAdvisoryNonReviewNotice` recognizes; falls
+ * back to a generic label so an unrecognized-but-classified notice still gets a
+ * coherent disposition.
+ */
+export function noticeReason(body: unknown): string {
+  const text = String(body ?? '');
+  if (/rate limited by coderabbit\.ai|Review limit reached/i.test(text)) {
+    return 'review limit reached / rate limited';
+  }
+  if (/Codex usage limits/i.test(text)) {
+    return 'Codex usage limits for code reviews reached';
+  }
+  return 'advisory non-review notice';
+}
+
+/**
+ * Build the canonical E6 non-review-notice disposition body: marker-first,
+ * naming the bot's GitHub login (for the #1018 author-scoped carry-forward) and
+ * the current head SHA.
+ */
+export function buildDispositionBody(
+  botLogin: string,
+  headSha: string,
+  reason: string,
+): string {
+  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review.`;
+}
+
+/**
+ * Plan the dispositions for a PR's regular comments. Pure: takes the fetched
+ * comments and returns which advisory non-review notices need a disposition and
+ * which already have one. Per advisory bot, the count of trusted IDD non-review
+ * notice dispositions naming that bot covers that many of its notices
+ * (oldest-first); the remainder are planned. This mirrors the gate's
+ * author-scoped 1:1 carry-forward, so the helper never posts a disposition the
+ * gate would not credit and never double-posts on a re-run.
+ */
+export function buildDispositionPlan(
+  input: { headSha: string; comments: NoticeComment[] },
+  options: {
+    advisoryBotLogins?: unknown[] | null;
+    trustedMarkerLogins?: unknown[] | null;
+  } = {},
+): DispositionPlan {
+  const advisoryBotLogins = new Set(
+    normalizeTrustedMarkerLogins(
+      options.advisoryBotLogins ?? DEFAULT_ADVISORY_BOT_LOGINS,
+    ),
+  );
+  const trustedMarkerLogins = new Set(
+    normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
+  );
+  const headSha = String(input.headSha ?? '');
+
+  const comments = (Array.isArray(input.comments) ? input.comments : [])
+    .map((comment) => ({
+      id: comment.id,
+      login: String(comment.login ?? '')
+        .trim()
+        .toLowerCase(),
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? ''),
+    }))
+    .sort((left, right) => {
+      const delta = Date.parse(left.createdAt) - Date.parse(right.createdAt);
+      return Number.isNaN(delta) ? 0 : delta;
+    });
+
+  // Trusted IDD non-review-notice dispositions, grouped per advisory bot login
+  // they name (so each bot's existing dispositions only cover its own notices).
+  const dispositionCountByBot = new Map<string, number>();
+  for (const comment of comments) {
+    if (
+      !trustedMarkerLogins.has(comment.login) ||
+      !isNonReviewNoticeDisposition({ body: comment.body })
+    ) {
+      continue;
+    }
+    for (const botLogin of advisoryBotLogins) {
+      if (dispositionNamesAdvisoryBot(comment.body, botLogin)) {
+        dispositionCountByBot.set(
+          botLogin,
+          (dispositionCountByBot.get(botLogin) ?? 0) + 1,
+        );
+      }
+    }
+  }
+
+  const planned: PlannedDisposition[] = [];
+  const skipped: SkippedNotice[] = [];
+  const coveredByBot = new Map<string, number>();
+  for (const comment of comments) {
+    if (
+      !advisoryBotLogins.has(comment.login) ||
+      !isAdvisoryNonReviewNotice(comment.body)
+    ) {
+      continue;
+    }
+    const alreadyCovered = coveredByBot.get(comment.login) ?? 0;
+    if (alreadyCovered < (dispositionCountByBot.get(comment.login) ?? 0)) {
+      // An existing trusted disposition naming this bot already covers a notice;
+      // attribute it (oldest-first) and skip this one as idempotent.
+      coveredByBot.set(comment.login, alreadyCovered + 1);
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'already-dispositioned',
+      });
+      continue;
+    }
+    const reason = noticeReason(comment.body);
+    planned.push({
+      noticeId: comment.id,
+      botLogin: comment.login,
+      reason,
+      body: buildDispositionBody(comment.login, headSha, reason),
+    });
+  }
+
+  return { headSha, planned, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+interface CliArgs {
+  pr: number | null;
+  owner: string;
+  repo: string;
+  claimIssue: number | null;
+  claimId: string;
+  agentId: string;
+  trustedMarkerLogins: string[];
+  advisoryBotLogins: string[];
+  apply: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    pr: null,
+    owner: '',
+    repo: '',
+    claimIssue: null,
+    claimId: '',
+    agentId: '',
+    trustedMarkerLogins: [],
+    advisoryBotLogins: [],
+    apply: false,
+    help: false,
+  };
+  const splitList = (value: string): string[] =>
+    value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const next = (): string => {
+      index += 1;
+      return argv[index] ?? '';
+    };
+    switch (flag) {
+      case '--pr':
+        args.pr = Number.parseInt(next(), 10);
+        break;
+      case '--owner':
+        args.owner = next();
+        break;
+      case '--repo':
+        args.repo = next();
+        break;
+      case '--claim-issue':
+        args.claimIssue = Number.parseInt(next(), 10);
+        break;
+      case '--claim-id':
+        args.claimId = next();
+        break;
+      case '--agent-id':
+        args.agentId = next();
+        break;
+      case '--trusted-marker-logins':
+        args.trustedMarkerLogins = splitList(next());
+        break;
+      case '--advisory-bot-logins':
+        args.advisoryBotLogins = splitList(next());
+        break;
+      case '--apply':
+        args.apply = true;
+        break;
+      case '--help':
+      case '-h':
+        args.help = true;
+        break;
+      default:
+        break;
+    }
+  }
+  return args;
+}
+
+function ghText(args: string[]): string {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+
+function ghJson(args: string[]): unknown {
+  return JSON.parse(execFileSync('gh', args, { encoding: 'utf8' }));
+}
+
+function isMainModule(moduleUrl: string): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return moduleUrl === `file://${entry}` || moduleUrl.endsWith(entry);
+}
+
+const USAGE = `usage: node scripts/disposition-non-review-notices.mjs --pr <number> [options]
+
+Detect advisory non-review notices on a PR and emit (default) or post
+(--apply) the canonical E6 \`**Rejected** — {bot} did not review HEAD …\`
+disposition, one marker-first comment per notice. Idempotent and fail-closed.
+
+  --pr <number>                  PR number (required)
+  --owner <owner>                repo owner (default: gh repo view)
+  --repo <repo>                  repo name (default: gh repo view)
+  --claim-issue <number>         issue carrying the active claim (for --apply)
+  --claim-id <claim-id>          active claim id to re-validate before --apply
+  --agent-id <agent-id>          current session agent id
+  --trusted-marker-logins a,b    logins whose existing dispositions count
+  --advisory-bot-logins a,b      advisory bot logins (default: coderabbit + codex)
+  --apply                        post the dispositions (default: dry-run)
+  -h, --help                     show this help
+`;
+
+function resolveActiveClaimId(
+  owner: string,
+  repo: string,
+  issue: number,
+): string | null {
+  const comments = ghJson([
+    'api',
+    `repos/${owner}/${repo}/issues/${issue}/comments`,
+    '--paginate',
+  ]) as { body?: string }[];
+  let activeClaimId: string | null = null;
+  for (const comment of comments) {
+    const body = String(comment.body ?? '');
+    const claimed = body.match(
+      /<!--\s*claimed-by:\s*\S+\s+(\S+)\s+supersedes:/,
+    );
+    if (claimed) {
+      activeClaimId = claimed[1];
+      continue;
+    }
+    const unclaimed = body.match(/<!--\s*unclaimed-by:\s*\S+\s+(\S+)\s/);
+    if (unclaimed && unclaimed[1] === activeClaimId) {
+      activeClaimId = null;
+    }
+  }
+  return activeClaimId;
+}
+
+function postDisposition(
+  owner: string,
+  repo: string,
+  pr: number,
+  body: string,
+): { id: number } {
+  // A disposition body is plain text starting with `**Rejected**` (not an
+  // HTML-comment-first marker), so the `-f body=` field path posts it
+  // reliably; gh sends `{"body": <value>}` to the comments API.
+  return ghJson([
+    'api',
+    '--method',
+    'POST',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+    '-f',
+    `body=${body}`,
+  ]) as { id: number };
+}
+
+if (isMainModule(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !Number.isInteger(args.pr) || (args.pr ?? 0) <= 0) {
+    process.stdout.write(USAGE);
+    process.exit(args.help ? 0 : 1);
+  }
+  const pr = args.pr as number;
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+
+  const headSha = ghText([
+    'api',
+    `repos/${owner}/${repo}/pulls/${pr}`,
+    '--jq',
+    '.head.sha',
+  ]);
+  const rawComments = ghJson([
+    'api',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+    '--paginate',
+  ]) as {
+    id: number;
+    user?: { login?: string };
+    body?: string;
+    created_at?: string;
+  }[];
+  const comments: NoticeComment[] = rawComments.map((comment) => ({
+    id: comment.id,
+    login: comment.user?.login ?? '',
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+  }));
+
+  const plan = buildDispositionPlan(
+    { headSha, comments },
+    {
+      advisoryBotLogins:
+        args.advisoryBotLogins.length > 0 ? args.advisoryBotLogins : undefined,
+      trustedMarkerLogins: args.trustedMarkerLogins,
+    },
+  );
+
+  if (!args.apply) {
+    process.stdout.write(
+      `${JSON.stringify({ mode: 'dry-run', prNumber: pr, ...plan }, null, 2)}\n`,
+    );
+    process.exit(0);
+  }
+
+  // --apply: re-validate the active claim immediately before posting.
+  if (Number.isInteger(args.claimIssue) && args.claimId) {
+    const activeClaimId = resolveActiveClaimId(
+      owner,
+      repo,
+      args.claimIssue as number,
+    );
+    if (activeClaimId !== args.claimId) {
+      process.stderr.write(
+        `claim revalidation failed: active claim is "${activeClaimId ?? 'none'}", expected "${args.claimId}"\n`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const applied: { noticeId: string | number; commentId: number }[] = [];
+  const failed: { noticeId: string | number; error: string }[] = [];
+  for (const item of plan.planned) {
+    let posted: { id: number } | null = null;
+    for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
+      try {
+        posted = postDisposition(owner, repo, pr, item.body);
+      } catch (error) {
+        if (attempt === 1) {
+          failed.push({
+            noticeId: item.noticeId,
+            error: (error as Error).message,
+          });
+        }
+      }
+    }
+    if (posted) {
+      applied.push({ noticeId: item.noticeId, commentId: posted.id });
+    }
+  }
+
+  const status = failed.length > 0 ? 'failed' : 'applied';
+  process.stdout.write(
+    `${JSON.stringify({ mode: 'apply', prNumber: pr, headSha, status, applied, failed, skipped: plan.skipped }, null, 2)}\n`,
+  );
+  process.exit(failed.length > 0 ? 1 : 0);
+}

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -18,19 +18,35 @@
 // threads are never touched.
 
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 import {
   dispositionNamesAdvisoryBot,
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
   normalizeTrustedMarkerLogins,
+  parseForcedHandoffComment,
   resolveActiveClaim,
+  resolveAdvisoryBotLogins,
 } from './protocol-helpers.mts';
 
 const DEFAULT_ADVISORY_BOT_LOGINS = [
   'coderabbitai[bot]',
   'chatgpt-codex-connector[bot]',
 ];
+
+// CodeRabbit posts a completed review as a regular issue comment carrying this
+// marker (see `classifyRegularBotComment`), not a PR review. A bot that has one
+// has "reviewed" the PR, so its non-review notice must not be rejected.
+const CODERABBIT_SUMMARY_MARKER =
+  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
+
+/** True for a CodeRabbit completed-review summary comment. */
+export function isCodeRabbitCompletedSummary(body: unknown): boolean {
+  return String(body ?? '')
+    .trimStart()
+    .startsWith(CODERABBIT_SUMMARY_MARKER);
+}
 
 export interface NoticeComment {
   id: string | number;
@@ -124,7 +140,7 @@ export function buildDispositionPlan(
   options: {
     advisoryBotLogins?: unknown[] | null;
     trustedMarkerLogins?: unknown[] | null;
-    botsWithCompletedHeadReview?: unknown[] | null;
+    botsWithCompletedReview?: unknown[] | null;
   } = {},
 ): DispositionPlan {
   const advisoryBotLogins = new Set(
@@ -135,12 +151,13 @@ export function buildDispositionPlan(
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
   );
-  // Advisory bots that already have a completed review of the current HEAD (a
-  // distinct, non-notice review). Per the E6 "re-validate just before posting"
-  // rule, their notice must not be rejected: the gate accepts that review, and
-  // a later-timestamped `did not review HEAD` rejection could filter it out.
-  const botsWithCompletedHeadReview = new Set(
-    normalizeTrustedMarkerLogins(options.botsWithCompletedHeadReview ?? []),
+  // Advisory bots that already have a completed review (a distinct, non-notice
+  // PR review of the current HEAD, or a CodeRabbit completed-summary comment).
+  // Per the E6 "re-validate just before posting" rule, their notice must not be
+  // rejected: the gate accepts that review, and a later-timestamped `did not
+  // review HEAD` rejection could filter it out.
+  const botsWithCompletedReview = new Set(
+    normalizeTrustedMarkerLogins(options.botsWithCompletedReview ?? []),
   );
   const headSha = String(input.headSha ?? '');
 
@@ -193,9 +210,9 @@ export function buildDispositionPlan(
     ) {
       continue;
     }
-    if (botsWithCompletedHeadReview.has(comment.login)) {
-      // The bot has a completed review of the current HEAD; accept that review
-      // separately and leave the notice un-rejected (E6 race re-validation).
+    if (botsWithCompletedReview.has(comment.login)) {
+      // The bot has a completed review; accept that review separately and leave
+      // the notice un-rejected (E6 race re-validation).
       skipped.push({
         noticeId: comment.id,
         botLogin: comment.login,
@@ -354,34 +371,57 @@ disposition, one marker-first comment per notice. Idempotent and fail-closed.
   --agent-id <agent-id>          current session agent id
   --trusted-marker-logins a,b    logins whose existing dispositions count
                                  (default: your gh login, so re-runs are idempotent)
-  --advisory-bot-logins a,b      advisory bot logins (default: coderabbit + codex)
+  --advisory-bot-logins a,b      advisory bot logins (default: flag > IDD_ADVISORY_BOT_LOGINS
+                                 > .github/idd/config.json > coderabbit + codex)
   --apply                        post the dispositions (default: dry-run)
   -h, --help                     show this help
 `;
 
+function loadIddConfig(): { advisoryBotLogins?: unknown } | null {
+  try {
+    return JSON.parse(readFileSync('.github/idd/config.json', 'utf8')) as {
+      advisoryBotLogins?: unknown;
+    };
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Resolve the active claim id on an issue using the shared
- * `resolveActiveClaim` state machine, scoped to trusted marker authors. This
- * reuses the canonical claim parsing/validation (superseding, release,
- * forced-handoff) and — crucially — ignores claim markers posted by untrusted
- * authors, so a copied/forged `claimed-by` marker cannot satisfy revalidation.
+ * Re-fetch the claim issue and decide whether the supplied claim id is still the
+ * active claim. Scoped to trusted marker authors via the shared
+ * `resolveActiveClaim` state machine (so a copied/forged `claimed-by` marker
+ * from an untrusted author cannot satisfy the gate), and fails closed on any
+ * `forced-handoff` marker that targets this claim — regardless of the marker's
+ * author, since an authorizing maintainer is typically not in the trusted set.
+ * Aborting on a contested claim is always safe (the manual E6 path remains).
  */
-function resolveActiveClaimId(
+function claimStillActive(
   owner: string,
   repo: string,
   issue: number,
+  claimId: string,
   isTrustedAuthor: (login: string) => boolean,
-): string | null {
+): boolean {
   const comments = ghJsonPaginated([
     'api',
     `repos/${owner}/${repo}/issues/${issue}/comments`,
   ]) as { body?: string; created_at?: string; user?: { login?: string } }[];
+  for (const comment of comments) {
+    const forcedHandoff = parseForcedHandoffComment(
+      comment.body ?? '',
+      comment.created_at ?? '',
+    );
+    if (forcedHandoff && forcedHandoff.oldClaimId === claimId) {
+      return false;
+    }
+  }
   const events = comments.map((comment) => ({
     body: comment.body ?? '',
     createdAt: comment.created_at ?? '',
     author: { login: comment.user?.login ?? '' },
   }));
-  return resolveActiveClaim(events, isTrustedAuthor)?.claimId ?? null;
+  return resolveActiveClaim(events, isTrustedAuthor)?.claimId === claimId;
 }
 
 function postDisposition(
@@ -445,20 +485,30 @@ if (isMainModule(import.meta.url)) {
     args.trustedMarkerLogins.length > 0
       ? args.trustedMarkerLogins
       : [viewerLogin];
+  // Resolve advisory bot logins from flag > env > config (the same sources the
+  // sibling helpers use), falling back to the CodeRabbit/Codex defaults so a
+  // repo that configures custom advisory bots is not silently omitted.
+  const resolvedAdvisoryBotLogins = resolveAdvisoryBotLogins({
+    flagValue: args.advisoryBotLogins,
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+    config: loadIddConfig(),
+  }).logins;
   const advisoryBotLogins =
-    args.advisoryBotLogins.length > 0 ? args.advisoryBotLogins : undefined;
+    resolvedAdvisoryBotLogins.length > 0
+      ? resolvedAdvisoryBotLogins
+      : DEFAULT_ADVISORY_BOT_LOGINS;
 
-  const headSha = ghText([
-    'api',
-    `repos/${owner}/${repo}/pulls/${pr}`,
-    '--jq',
-    '.head.sha',
-  ]);
-
-  // Build a plan from a fresh read of the PR's comments and reviews. Called once
-  // for dry-run and again immediately before --apply posts, so a disposition (or
-  // a completed review) another session raced in is reflected just-in-time.
+  // Build a plan from a fresh read of the PR's HEAD, comments, and reviews.
+  // Called once for dry-run and again immediately before --apply posts, so a
+  // HEAD advance, a disposition, or a completed review another session raced in
+  // is reflected just-in-time (the apply path never reuses the dry-run snapshot).
   const planNow = (): DispositionPlan => {
+    const headSha = ghText([
+      'api',
+      `repos/${owner}/${repo}/pulls/${pr}`,
+      '--jq',
+      '.head.sha',
+    ]);
     const rawComments = ghJsonPaginated([
       'api',
       `repos/${owner}/${repo}/issues/${pr}/comments`,
@@ -483,24 +533,30 @@ if (isMainModule(import.meta.url)) {
       commit_id?: string;
       state?: string;
     }[];
-    // A bot that posted a real (non-notice) review of the current HEAD has
-    // "reviewed HEAD" — its notice must not be rejected (see buildDispositionPlan).
-    const botsWithCompletedHeadReview = Array.from(
+    // Bots with a completed review the gate will accept: a real (non-notice) PR
+    // review of the current HEAD, OR a CodeRabbit completed-summary comment
+    // (CodeRabbit reviews land as regular issue comments, not PR reviews). Their
+    // notice must not be rejected (see buildDispositionPlan).
+    const botsWithCompletedReview = Array.from(
       new Set(
-        reviews
-          .filter(
-            (review) =>
-              review.commit_id === headSha &&
-              COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
-              !isAdvisoryNonReviewNotice(review.body ?? ''),
-          )
-          .map((review) => review.user?.login ?? '')
-          .filter(Boolean),
+        [
+          ...reviews
+            .filter(
+              (review) =>
+                review.commit_id === headSha &&
+                COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
+                !isAdvisoryNonReviewNotice(review.body ?? ''),
+            )
+            .map((review) => review.user?.login ?? ''),
+          ...comments
+            .filter((comment) => isCodeRabbitCompletedSummary(comment.body))
+            .map((comment) => comment.login),
+        ].filter(Boolean),
       ),
     );
     return buildDispositionPlan(
       { headSha, comments },
-      { advisoryBotLogins, trustedMarkerLogins, botsWithCompletedHeadReview },
+      { advisoryBotLogins, trustedMarkerLogins, botsWithCompletedReview },
     );
   };
 
@@ -511,25 +567,26 @@ if (isMainModule(import.meta.url)) {
     process.exit(0);
   }
 
-  // --apply: re-validate the active claim immediately before posting, scoped to
-  // trusted marker authors so a forged claim marker cannot satisfy the gate.
+  // --apply: revalidate the active claim immediately before EACH post, scoped to
+  // trusted marker authors and failing closed on a forced handoff. Re-checking
+  // per post means a claim released, superseded, or handed off mid-loop stops
+  // the remaining writes instead of posting under a lost claim.
+  const claimIssue = args.claimIssue as number;
   const trustedAuthors = new Set(
     trustedMarkerLogins.map((login) => login.toLowerCase()),
   );
-  const activeClaimId = resolveActiveClaimId(
-    owner,
-    repo,
-    args.claimIssue as number,
-    (login) =>
-      trustedAuthors.has(
-        String(login ?? '')
-          .trim()
-          .toLowerCase(),
-      ),
-  );
-  if (activeClaimId !== args.claimId) {
+  const isTrustedAuthor = (login: string): boolean =>
+    trustedAuthors.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+  const revalidateClaim = (): boolean =>
+    claimStillActive(owner, repo, claimIssue, args.claimId, isTrustedAuthor);
+
+  if (!revalidateClaim()) {
     process.stderr.write(
-      `claim revalidation failed: active claim is "${activeClaimId ?? 'none'}", expected "${args.claimId}"\n`,
+      `claim revalidation failed: "${args.claimId}" is no longer the active claim on issue #${claimIssue}\n`,
     );
     process.exit(1);
   }
@@ -540,7 +597,18 @@ if (isMainModule(import.meta.url)) {
   const plan = planNow();
   const applied: { noticeId: string | number; commentId: number }[] = [];
   const failed: { noticeId: string | number; error: string }[] = [];
+  let claimLost = false;
   for (const item of plan.planned) {
+    if (!revalidateClaim()) {
+      // Claim lost mid-loop: stop writing and surface the remaining notices as
+      // failed rather than posting them under a claim we no longer hold.
+      claimLost = true;
+      failed.push({
+        noticeId: item.noticeId,
+        error: 'claim revalidation failed before post',
+      });
+      break;
+    }
     let posted: { id: number } | null = null;
     for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
       try {
@@ -561,7 +629,7 @@ if (isMainModule(import.meta.url)) {
 
   const status = failed.length > 0 ? 'failed' : 'applied';
   process.stdout.write(
-    `${JSON.stringify({ mode: 'apply', prNumber: pr, headSha, status, applied, failed, skipped: plan.skipped }, null, 2)}\n`,
+    `${JSON.stringify({ mode: 'apply', prNumber: pr, headSha: plan.headSha, status, applied, failed, skipped: plan.skipped }, null, 2)}\n`,
   );
-  process.exit(failed.length > 0 ? 1 : 0);
+  process.exit(claimLost || failed.length > 0 ? 1 : 0);
 }

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -36,19 +36,6 @@ const DEFAULT_ADVISORY_BOT_LOGINS = [
   'chatgpt-codex-connector[bot]',
 ];
 
-// CodeRabbit posts a completed review as a regular issue comment carrying this
-// marker (see `classifyRegularBotComment`), not a PR review. A bot that has one
-// has "reviewed" the PR, so its non-review notice must not be rejected.
-const CODERABBIT_SUMMARY_MARKER =
-  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
-
-/** True for a CodeRabbit completed-review summary comment. */
-export function isCodeRabbitCompletedSummary(body: unknown): boolean {
-  return String(body ?? '')
-    .trimStart()
-    .startsWith(CODERABBIT_SUMMARY_MARKER);
-}
-
 export interface NoticeComment {
   id: number;
   login: string;
@@ -141,13 +128,12 @@ export function buildDispositionPlan(
   options: {
     advisoryBotLogins?: unknown[] | null;
     trustedMarkerLogins?: unknown[] | null;
-    completedReviewAtByBot?: Record<string, unknown> | null;
   } = {},
 ): DispositionPlan {
   // Key all advisory-bot comparisons by the suffix-insensitive identity token
   // (`coderabbitai[bot]` and `coderabbitai` collapse to one identity, matching
-  // `dispositionNamesAdvisoryBot`), so a notice/review/disposition authored
-  // under either variant counts against the same bot.
+  // `dispositionNamesAdvisoryBot`), so a notice/disposition authored under
+  // either variant counts against the same bot.
   const advisoryBotIdentities = new Set(
     normalizeTrustedMarkerLogins(
       options.advisoryBotLogins ?? DEFAULT_ADVISORY_BOT_LOGINS,
@@ -156,29 +142,6 @@ export function buildDispositionPlan(
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
   );
-  // Per advisory bot identity, the most recent time it produced a completed
-  // review (a non-notice PR review, or a CodeRabbit summary comment). A notice
-  // is left un-rejected only when a completed review landed AT OR AFTER it (the
-  // notice is then stale); an OLDER review does not cover a newer notice. This
-  // honours the E6 "re-validate just before posting" rule without skipping a
-  // current notice merely because the bot reviewed an earlier HEAD.
-  const completedReviewAtByBot = new Map<string, number>();
-  for (const [login, value] of Object.entries(
-    options.completedReviewAtByBot ?? {},
-  )) {
-    const at = Date.parse(String(value ?? ''));
-    if (Number.isNaN(at)) {
-      continue;
-    }
-    const token = advisoryBotIdentityToken(login);
-    completedReviewAtByBot.set(
-      token,
-      Math.max(
-        completedReviewAtByBot.get(token) ?? Number.NEGATIVE_INFINITY,
-        at,
-      ),
-    );
-  }
   const headSha = String(input.headSha ?? '');
 
   const comments = (Array.isArray(input.comments) ? input.comments : [])
@@ -221,6 +184,13 @@ export function buildDispositionPlan(
     }
   }
 
+  // Every persistent advisory non-review notice needs its own `**Rejected**`
+  // disposition, EVEN when the bot also has a completed review of the current
+  // HEAD: `summarizeDispositionEvidenceForGate` keeps the notice in its
+  // outstanding set until a notice-disposition naming that bot carries it, and
+  // that disposition is consumed only by the notice (never clears the separate
+  // completed review). So the helper always plans an undispositioned notice;
+  // the completed review is accepted as its own item by the E6 flow.
   const planned: PlannedDisposition[] = [];
   const skipped: SkippedNotice[] = [];
   const coveredByBot = new Map<string, number>();
@@ -230,22 +200,6 @@ export function buildDispositionPlan(
       !advisoryBotIdentities.has(identity) ||
       !isAdvisoryNonReviewNotice(comment.body)
     ) {
-      continue;
-    }
-    const reviewAt = completedReviewAtByBot.get(identity);
-    const noticeAt = Date.parse(comment.createdAt);
-    if (
-      reviewAt !== undefined &&
-      !Number.isNaN(noticeAt) &&
-      reviewAt >= noticeAt
-    ) {
-      // A completed review landed at or after this notice, so the notice is
-      // stale; accept that review separately and leave the notice un-rejected.
-      skipped.push({
-        noticeId: comment.id,
-        botLogin: comment.login,
-        reason: 'completed-review-present',
-      });
       continue;
     }
     const alreadyCovered = coveredByBot.get(identity) ?? 0;
@@ -471,19 +425,41 @@ function postDisposition(
   ]) as { id: number };
 }
 
+/** Ids of all comments on the PR authored by `viewerLogin`. */
+function viewerCommentIds(
+  owner: string,
+  repo: string,
+  pr: number,
+  viewerLogin: string,
+): Set<number> {
+  const comments = ghJsonPaginated([
+    'api',
+    `repos/${owner}/${repo}/issues/${pr}/comments`,
+  ]) as { id: number; user?: { login?: string } }[];
+  const ids = new Set<number>();
+  for (const comment of comments) {
+    if ((comment.user?.login ?? '').trim().toLowerCase() === viewerLogin) {
+      ids.add(comment.id);
+    }
+  }
+  return ids;
+}
+
 /**
- * Find an already-posted disposition with this exact body authored by `viewer`.
- * Used after a failed create to detect a comment that landed server-side even
- * though `gh` exited nonzero (lost response), so a retry never double-posts a
- * marker the F2/F3 1:1 pairing would consume twice. The body is unique per
- * notice (bot + head SHA + reason), so an exact match is reliable.
+ * After a failed create, find a viewer-authored comment with this exact body
+ * whose id is NOT in `knownIds` — i.e., one created since posting began. Two
+ * notices from the same bot on the same HEAD share an identical canonical body,
+ * so keying recovery on a NEW comment id (not body uniqueness) is what stops the
+ * helper from mistaking an earlier notice's marker for a failed create, which
+ * would under-count the markers the F2/F3 1:1 pairing needs.
  */
-function findPostedDisposition(
+function recoverPostedDisposition(
   owner: string,
   repo: string,
   pr: number,
   body: string,
   viewerLogin: string,
+  knownIds: Set<number>,
 ): { id: number } | null {
   const comments = ghJsonPaginated([
     'api',
@@ -492,6 +468,7 @@ function findPostedDisposition(
   for (let index = comments.length - 1; index >= 0; index -= 1) {
     const comment = comments[index];
     if (
+      !knownIds.has(comment.id) &&
       (comment.user?.login ?? '').trim().toLowerCase() === viewerLogin &&
       (comment.body ?? '') === body
     ) {
@@ -500,12 +477,6 @@ function findPostedDisposition(
   }
   return null;
 }
-
-const COMPLETED_REVIEW_STATES = new Set([
-  'APPROVED',
-  'CHANGES_REQUESTED',
-  'COMMENTED',
-]);
 
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
@@ -556,10 +527,10 @@ if (isMainModule(import.meta.url)) {
       ? resolvedAdvisoryBotLogins
       : DEFAULT_ADVISORY_BOT_LOGINS;
 
-  // Build a plan from a fresh read of the PR's HEAD, comments, and reviews.
-  // Called once for dry-run and again immediately before --apply posts, so a
-  // HEAD advance, a disposition, or a completed review another session raced in
-  // is reflected just-in-time (the apply path never reuses the dry-run snapshot).
+  // Build a plan from a fresh read of the PR's HEAD and comments. Called once
+  // for dry-run and again immediately before --apply posts, so a HEAD advance or
+  // a disposition another session raced in is reflected just-in-time (the apply
+  // path never reuses the dry-run snapshot).
   const planNow = (): DispositionPlan => {
     const headSha = ghText([
       'api',
@@ -582,50 +553,9 @@ if (isMainModule(import.meta.url)) {
       body: comment.body ?? '',
       createdAt: comment.created_at ?? '',
     }));
-    const reviews = ghJsonPaginated([
-      'api',
-      `repos/${owner}/${repo}/pulls/${pr}/reviews`,
-    ]) as {
-      user?: { login?: string };
-      body?: string;
-      state?: string;
-      submitted_at?: string;
-    }[];
-    // The latest time each bot produced a completed review the gate accepts: a
-    // real (non-notice) PR review, or a CodeRabbit completed-summary comment
-    // (CodeRabbit reviews land as regular issue comments, not PR reviews).
-    // buildDispositionPlan compares these timestamps against each notice, so a
-    // review only suppresses a notice it is at-or-newer than (a stale review of
-    // an older HEAD does not cover a fresh notice).
-    const completedReviewAtByBot: Record<string, string> = {};
-    const recordCompletedReview = (login: string, at: string): void => {
-      const key = login.trim().toLowerCase();
-      if (!key || !at) {
-        return;
-      }
-      if (!completedReviewAtByBot[key] || completedReviewAtByBot[key] < at) {
-        completedReviewAtByBot[key] = at;
-      }
-    };
-    for (const review of reviews) {
-      if (
-        COMPLETED_REVIEW_STATES.has(String(review.state ?? '')) &&
-        !isAdvisoryNonReviewNotice(review.body ?? '')
-      ) {
-        recordCompletedReview(
-          review.user?.login ?? '',
-          review.submitted_at ?? '',
-        );
-      }
-    }
-    for (const comment of comments) {
-      if (isCodeRabbitCompletedSummary(comment.body)) {
-        recordCompletedReview(comment.login, comment.createdAt);
-      }
-    }
     return buildDispositionPlan(
       { headSha, comments },
-      { advisoryBotLogins, trustedMarkerLogins, completedReviewAtByBot },
+      { advisoryBotLogins, trustedMarkerLogins },
     );
   };
 
@@ -661,11 +591,14 @@ if (isMainModule(import.meta.url)) {
   }
 
   // Re-plan from a fresh read AFTER claim revalidation, so the post loop never
-  // re-posts a disposition (or rejects a notice whose bot just reviewed HEAD)
-  // that raced in since the dry-run.
+  // re-posts a disposition that raced in since the dry-run.
   const plan = planNow();
   const applied: AppliedDisposition[] = [];
   const failed: FailedDisposition[] = [];
+  // Track every viewer-authored comment id we know about (pre-existing plus the
+  // ones we post), so a post-failure recovery attributes a NEW comment to the
+  // current notice instead of an earlier notice with an identical body.
+  const knownViewerCommentIds = viewerCommentIds(owner, repo, pr, viewerLogin);
   let claimLost = false;
   for (const item of plan.planned) {
     if (!revalidateClaim()) {
@@ -686,11 +619,19 @@ if (isMainModule(import.meta.url)) {
       } catch (error) {
         lastError = error as Error;
         // The create may have landed server-side despite the nonzero exit;
-        // re-read before any retry so we never double-post the same marker.
-        posted = findPostedDisposition(owner, repo, pr, item.body, viewerLogin);
+        // re-read (by NEW comment id) before any retry so we never double-post.
+        posted = recoverPostedDisposition(
+          owner,
+          repo,
+          pr,
+          item.body,
+          viewerLogin,
+          knownViewerCommentIds,
+        );
       }
     }
     if (posted) {
+      knownViewerCommentIds.add(posted.id);
       applied.push({ noticeId: item.noticeId, commentId: posted.id });
     } else {
       failed.push({

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -267,6 +267,7 @@ const HELPER_COMMANDS: HelperCommand[] = [
     vendoredCommand: 'node scripts/disposition-non-review-notices.mjs',
     description:
       'Detect advisory non-review notices on a PR and emit or post their canonical E6 dispositions.',
+    contractPaths: ['schemas/disposition-non-review-notices.schema.json'],
   },
   {
     id: 'doctor',

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -260,6 +260,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
       'Collect read-only A4 viability filtering evidence for candidate issues.',
   },
   {
+    id: 'disposition-non-review-notices',
+    scriptName: 'idd:disposition-non-review-notices',
+    binName: 'idd-disposition-non-review-notices',
+    entryPath: 'scripts/disposition-non-review-notices.mjs',
+    vendoredCommand: 'node scripts/disposition-non-review-notices.mjs',
+    description:
+      'Detect advisory non-review notices on a PR and emit or post their canonical E6 dispositions.',
+  },
+  {
     id: 'doctor',
     scriptName: 'idd:doctor',
     binName: 'idd-doctor',

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2151,7 +2151,7 @@ export function isNonReviewNoticeDisposition(comment: {
 // notice disposition to the bot it rejected. The `[bot]` suffix GitHub appends
 // is dropped so the token matches whether a login is stored as `coderabbitai`
 // or `coderabbitai[bot]`.
-function advisoryBotIdentityToken(login: unknown): string {
+export function advisoryBotIdentityToken(login: unknown): string {
   return String(login ?? '')
     .trim()
     .toLowerCase()
@@ -2162,7 +2162,7 @@ function advisoryBotIdentityToken(login: unknown): string {
 // GitHub login, so the gate can attribute a carry-forward to exactly one bot
 // even when several advisory bots are configured. Fail-closed: an empty token or
 // a disposition that does not contain the login carries nothing forward.
-function dispositionNamesAdvisoryBot(
+export function dispositionNamesAdvisoryBot(
   dispositionBody: unknown,
   noticeAuthorLogin: string,
 ): boolean {

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -191,22 +191,23 @@ test('buildDispositionPlan only considers configured advisory bots', () => {
   assert.equal(plan.planned.length, 0);
 });
 
-test('buildDispositionPlan skips a notice when its bot has a completed HEAD review', () => {
+test('buildDispositionPlan skips a notice when its bot reviewed at/after it', () => {
   const plan = buildDispositionPlan(
     {
       headSha: 'abc1234',
       comments: [
-        notice(1, CODEX, CODEX_NOTICE),
-        notice(2, CODERABBIT, CODERABBIT_NOTICE),
+        notice(1, CODEX, CODEX_NOTICE, '2026-05-12T00:00:01Z'),
+        notice(2, CODERABBIT, CODERABBIT_NOTICE, '2026-05-12T00:00:02Z'),
       ],
     },
     {
       trustedMarkerLogins: ['kurone-kito'],
-      botsWithCompletedReview: [CODEX],
+      // Codex completed a review AFTER its notice; CodeRabbit has none.
+      completedReviewAtByBot: { [CODEX]: '2026-05-12T00:00:05Z' },
     },
   );
-  // Codex has a completed review of HEAD, so its notice is left un-rejected
-  // (the gate accepts that review); CodeRabbit's notice is still planned.
+  // Codex's notice is stale (review is newer), so it is left un-rejected;
+  // CodeRabbit's notice is still planned.
   assert.deepEqual(
     plan.planned.map((entry) => entry.botLogin),
     [CODERABBIT],
@@ -220,6 +221,41 @@ test('buildDispositionPlan skips a notice when its bot has a completed HEAD revi
   );
 });
 
+test('buildDispositionPlan still plans a notice newer than a stale review (Codex #4)', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(1, CODERABBIT, CODERABBIT_NOTICE, '2026-05-12T09:00:00Z'),
+      ],
+    },
+    {
+      trustedMarkerLogins: ['kurone-kito'],
+      // An OLD summary (earlier HEAD) must not cover a fresh rate-limit notice.
+      completedReviewAtByBot: { [CODERABBIT]: '2026-05-12T08:00:00Z' },
+    },
+  );
+  assert.equal(plan.planned.length, 1);
+  assert.equal(plan.skipped.length, 0);
+});
+
+test('buildDispositionPlan keys advisory bots by suffix-insensitive identity', () => {
+  // The notice is authored as `coderabbitai` (no [bot]); the configured advisory
+  // login is `coderabbitai[bot]`. They must resolve to the same identity.
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [notice(1, 'coderabbitai', CODERABBIT_NOTICE)],
+    },
+    {
+      advisoryBotLogins: [CODERABBIT],
+      trustedMarkerLogins: ['kurone-kito'],
+    },
+  );
+  assert.equal(plan.planned.length, 1);
+  assert.equal(plan.planned[0].botLogin, 'coderabbitai');
+});
+
 test('isCodeRabbitCompletedSummary recognizes a CodeRabbit summary, not a notice', () => {
   assert.equal(
     isCodeRabbitCompletedSummary(`${CODERABBIT_SUMMARY}\n## Walkthrough`),
@@ -229,17 +265,19 @@ test('isCodeRabbitCompletedSummary recognizes a CodeRabbit summary, not a notice
   assert.equal(isCodeRabbitCompletedSummary('a human comment'), false);
 });
 
-test('buildDispositionPlan skips a CodeRabbit notice when a summary review is present', () => {
-  // The CLI feeds CodeRabbit's summary comment into botsWithCompletedReview; the
-  // plan then leaves CodeRabbit's rate-limit notice un-rejected.
+test('buildDispositionPlan skips a CodeRabbit notice superseded by a later summary', () => {
+  // The CLI records CodeRabbit's summary timestamp; a summary at/after the notice
+  // leaves CodeRabbit's rate-limit notice un-rejected.
   const plan = buildDispositionPlan(
     {
       headSha: 'abc1234',
-      comments: [notice(1, CODERABBIT, CODERABBIT_NOTICE)],
+      comments: [
+        notice(1, CODERABBIT, CODERABBIT_NOTICE, '2026-05-12T00:00:01Z'),
+      ],
     },
     {
       trustedMarkerLogins: ['kurone-kito'],
-      botsWithCompletedReview: [CODERABBIT],
+      completedReviewAtByBot: { [CODERABBIT]: '2026-05-12T00:00:09Z' },
     },
   );
   assert.equal(plan.planned.length, 0);

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -229,6 +229,35 @@ test('buildDispositionPlan keys advisory bots by suffix-insensitive identity', (
   assert.equal(plan.planned[0].botLogin, 'coderabbitai');
 });
 
+test('buildDispositionPlan breaks oldest-first ties deterministically by id', () => {
+  // Two same-bot notices share a timestamp; the lower-id one is covered first.
+  const ts = '2026-05-12T00:00:00Z';
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(2, CODEX, CODEX_NOTICE, ts),
+        notice(1, CODEX, CODEX_NOTICE, ts),
+        notice(
+          3,
+          'kurone-kito',
+          '**Rejected** — chatgpt-codex-connector[bot] did not review HEAD abc1234 (usage); this is not a completed review',
+          ts,
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.deepEqual(
+    plan.skipped.map((entry) => entry.noticeId),
+    [1],
+  );
+  assert.deepEqual(
+    plan.planned.map((entry) => entry.noticeId),
+    [2],
+  );
+});
+
 test('a combined disposition naming several bots covers only one notice', () => {
   const plan = buildDispositionPlan(
     {

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -4,7 +4,6 @@ import { test } from 'node:test';
 import {
   buildDispositionBody,
   buildDispositionPlan,
-  isCodeRabbitCompletedSummary,
   type NoticeComment,
   noticeReason,
 } from '../src/scripts/disposition-non-review-notices.mts';
@@ -20,8 +19,6 @@ const CODEX_NOTICE =
   'You have reached your Codex usage limits for code reviews.';
 const CODERABBIT_NOTICE =
   '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n> ## Review limit reached';
-const CODERABBIT_SUMMARY =
-  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
 // A full 40-char head SHA for the cases that validate against the schema, which
 // now constrains `headSha` to `^[0-9a-f]{40}$`.
 const HEAD_SHA = '0123456789abcdef0123456789abcdef01234567';
@@ -191,51 +188,27 @@ test('buildDispositionPlan only considers configured advisory bots', () => {
   assert.equal(plan.planned.length, 0);
 });
 
-test('buildDispositionPlan skips a notice when its bot reviewed at/after it', () => {
+test('buildDispositionPlan plans a notice even when the bot also reviewed', () => {
+  // A persistent rate-limit notice stays in the gate's outstanding set until a
+  // disposition naming the bot carries it, even when the bot has a separate
+  // completed review. The helper always plans the undispositioned notice.
   const plan = buildDispositionPlan(
     {
       headSha: 'abc1234',
       comments: [
-        notice(1, CODEX, CODEX_NOTICE, '2026-05-12T00:00:01Z'),
-        notice(2, CODERABBIT, CODERABBIT_NOTICE, '2026-05-12T00:00:02Z'),
+        notice(1, CODERABBIT, CODERABBIT_NOTICE),
+        // A separate CodeRabbit summary review (handled by the agent, not here).
+        notice(
+          2,
+          CODERABBIT,
+          '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n## Walkthrough',
+        ),
       ],
     },
-    {
-      trustedMarkerLogins: ['kurone-kito'],
-      // Codex completed a review AFTER its notice; CodeRabbit has none.
-      completedReviewAtByBot: { [CODEX]: '2026-05-12T00:00:05Z' },
-    },
-  );
-  // Codex's notice is stale (review is newer), so it is left un-rejected;
-  // CodeRabbit's notice is still planned.
-  assert.deepEqual(
-    plan.planned.map((entry) => entry.botLogin),
-    [CODERABBIT],
-  );
-  assert.deepEqual(
-    plan.skipped.map((entry) => ({
-      botLogin: entry.botLogin,
-      reason: entry.reason,
-    })),
-    [{ botLogin: CODEX, reason: 'completed-review-present' }],
-  );
-});
-
-test('buildDispositionPlan still plans a notice newer than a stale review (Codex #4)', () => {
-  const plan = buildDispositionPlan(
-    {
-      headSha: 'abc1234',
-      comments: [
-        notice(1, CODERABBIT, CODERABBIT_NOTICE, '2026-05-12T09:00:00Z'),
-      ],
-    },
-    {
-      trustedMarkerLogins: ['kurone-kito'],
-      // An OLD summary (earlier HEAD) must not cover a fresh rate-limit notice.
-      completedReviewAtByBot: { [CODERABBIT]: '2026-05-12T08:00:00Z' },
-    },
+    { trustedMarkerLogins: ['kurone-kito'] },
   );
   assert.equal(plan.planned.length, 1);
+  assert.equal(plan.planned[0].botLogin, CODERABBIT);
   assert.equal(plan.skipped.length, 0);
 });
 
@@ -254,37 +227,6 @@ test('buildDispositionPlan keys advisory bots by suffix-insensitive identity', (
   );
   assert.equal(plan.planned.length, 1);
   assert.equal(plan.planned[0].botLogin, 'coderabbitai');
-});
-
-test('isCodeRabbitCompletedSummary recognizes a CodeRabbit summary, not a notice', () => {
-  assert.equal(
-    isCodeRabbitCompletedSummary(`${CODERABBIT_SUMMARY}\n## Walkthrough`),
-    true,
-  );
-  assert.equal(isCodeRabbitCompletedSummary(CODERABBIT_NOTICE), false);
-  assert.equal(isCodeRabbitCompletedSummary('a human comment'), false);
-});
-
-test('buildDispositionPlan skips a CodeRabbit notice superseded by a later summary', () => {
-  // The CLI records CodeRabbit's summary timestamp; a summary at/after the notice
-  // leaves CodeRabbit's rate-limit notice un-rejected.
-  const plan = buildDispositionPlan(
-    {
-      headSha: 'abc1234',
-      comments: [
-        notice(1, CODERABBIT, CODERABBIT_NOTICE, '2026-05-12T00:00:01Z'),
-      ],
-    },
-    {
-      trustedMarkerLogins: ['kurone-kito'],
-      completedReviewAtByBot: { [CODERABBIT]: '2026-05-12T00:00:09Z' },
-    },
-  );
-  assert.equal(plan.planned.length, 0);
-  assert.deepEqual(
-    plan.skipped.map((entry) => entry.reason),
-    ['completed-review-present'],
-  );
 });
 
 test('a combined disposition naming several bots covers only one notice', () => {
@@ -321,7 +263,7 @@ test('the dry-run and apply output envelopes validate against the schema', () =>
     { trustedMarkerLogins: ['kurone-kito'] },
   );
   const dryRun = { mode: 'dry-run', prNumber: 7, ...plan };
-  assert.equal(validate(planSchema, dryRun).length, 0, 'dry-run output');
+  assert.equal(validate(dryRun, planSchema).length, 0, 'dry-run output');
 
   const apply = {
     mode: 'apply',
@@ -335,5 +277,5 @@ test('the dry-run and apply output envelopes validate against the schema', () =>
     failed: [],
     skipped: plan.skipped,
   };
-  assert.equal(validate(planSchema, apply).length, 0, 'apply output');
+  assert.equal(validate(apply, planSchema).length, 0, 'apply output');
 });

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -19,6 +19,9 @@ const CODEX_NOTICE =
   'You have reached your Codex usage limits for code reviews.';
 const CODERABBIT_NOTICE =
   '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n> ## Review limit reached';
+// A full 40-char head SHA for the cases that validate against the schema, which
+// now constrains `headSha` to `^[0-9a-f]{40}$`.
+const HEAD_SHA = '0123456789abcdef0123456789abcdef01234567';
 
 function notice(
   id: number,
@@ -37,9 +40,10 @@ test('buildDispositionBody is marker-first and names the bot login + head sha', 
   );
   assert.ok(body.startsWith('**Rejected**'), 'marker must be first bytes');
   assert.match(body, /coderabbitai\[bot\] did not review HEAD abc1234/);
+  // Canonical E6 text ends at "completed review" with no trailing punctuation.
   assert.match(
     body,
-    /\(review limit reached\); this is not a completed review\.$/,
+    /\(review limit reached\); this is not a completed review$/,
   );
 });
 
@@ -184,10 +188,61 @@ test('buildDispositionPlan only considers configured advisory bots', () => {
   assert.equal(plan.planned.length, 0);
 });
 
-test('the dry-run and apply output envelopes validate against the schema', () => {
+test('buildDispositionPlan skips a notice when its bot has a completed HEAD review', () => {
   const plan = buildDispositionPlan(
     {
       headSha: 'abc1234',
+      comments: [
+        notice(1, CODEX, CODEX_NOTICE),
+        notice(2, CODERABBIT, CODERABBIT_NOTICE),
+      ],
+    },
+    {
+      trustedMarkerLogins: ['kurone-kito'],
+      botsWithCompletedHeadReview: [CODEX],
+    },
+  );
+  // Codex has a completed review of HEAD, so its notice is left un-rejected
+  // (the gate accepts that review); CodeRabbit's notice is still planned.
+  assert.deepEqual(
+    plan.planned.map((entry) => entry.botLogin),
+    [CODERABBIT],
+  );
+  assert.deepEqual(
+    plan.skipped.map((entry) => ({
+      botLogin: entry.botLogin,
+      reason: entry.reason,
+    })),
+    [{ botLogin: CODEX, reason: 'completed-review-present' }],
+  );
+});
+
+test('a combined disposition naming several bots covers only one notice', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(1, CODEX, CODEX_NOTICE),
+        notice(2, CODERABBIT, CODERABBIT_NOTICE),
+        // One trusted disposition that (improperly) names BOTH bots: the F2/F3
+        // gate consumes it once, so it must cover one notice, not one per bot.
+        notice(
+          3,
+          'kurone-kito',
+          '**Rejected** — chatgpt-codex-connector[bot] and coderabbitai[bot] did not review HEAD abc1234 (usage); this is not a completed review',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.skipped.length, 1);
+  assert.equal(plan.planned.length, 1);
+});
+
+test('the dry-run and apply output envelopes validate against the schema', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: HEAD_SHA,
       comments: [
         notice(1, CODEX, CODEX_NOTICE),
         notice(2, CODERABBIT, CODERABBIT_NOTICE),

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import {
   buildDispositionBody,
   buildDispositionPlan,
+  isCodeRabbitCompletedSummary,
   type NoticeComment,
   noticeReason,
 } from '../src/scripts/disposition-non-review-notices.mts';
@@ -19,6 +20,8 @@ const CODEX_NOTICE =
   'You have reached your Codex usage limits for code reviews.';
 const CODERABBIT_NOTICE =
   '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n> ## Review limit reached';
+const CODERABBIT_SUMMARY =
+  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
 // A full 40-char head SHA for the cases that validate against the schema, which
 // now constrains `headSha` to `^[0-9a-f]{40}$`.
 const HEAD_SHA = '0123456789abcdef0123456789abcdef01234567';
@@ -199,7 +202,7 @@ test('buildDispositionPlan skips a notice when its bot has a completed HEAD revi
     },
     {
       trustedMarkerLogins: ['kurone-kito'],
-      botsWithCompletedHeadReview: [CODEX],
+      botsWithCompletedReview: [CODEX],
     },
   );
   // Codex has a completed review of HEAD, so its notice is left un-rejected
@@ -214,6 +217,35 @@ test('buildDispositionPlan skips a notice when its bot has a completed HEAD revi
       reason: entry.reason,
     })),
     [{ botLogin: CODEX, reason: 'completed-review-present' }],
+  );
+});
+
+test('isCodeRabbitCompletedSummary recognizes a CodeRabbit summary, not a notice', () => {
+  assert.equal(
+    isCodeRabbitCompletedSummary(`${CODERABBIT_SUMMARY}\n## Walkthrough`),
+    true,
+  );
+  assert.equal(isCodeRabbitCompletedSummary(CODERABBIT_NOTICE), false);
+  assert.equal(isCodeRabbitCompletedSummary('a human comment'), false);
+});
+
+test('buildDispositionPlan skips a CodeRabbit notice when a summary review is present', () => {
+  // The CLI feeds CodeRabbit's summary comment into botsWithCompletedReview; the
+  // plan then leaves CodeRabbit's rate-limit notice un-rejected.
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [notice(1, CODERABBIT, CODERABBIT_NOTICE)],
+    },
+    {
+      trustedMarkerLogins: ['kurone-kito'],
+      botsWithCompletedReview: [CODERABBIT],
+    },
+  );
+  assert.equal(plan.planned.length, 0);
+  assert.deepEqual(
+    plan.skipped.map((entry) => entry.reason),
+    ['completed-review-present'],
   );
 });
 

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildDispositionBody,
+  buildDispositionPlan,
+  type NoticeComment,
+  noticeReason,
+} from '../src/scripts/disposition-non-review-notices.mts';
+import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
+
+const planSchema = loadJson(
+  'schemas/disposition-non-review-notices.schema.json',
+);
+
+const CODEX = 'chatgpt-codex-connector[bot]';
+const CODERABBIT = 'coderabbitai[bot]';
+const CODEX_NOTICE =
+  'You have reached your Codex usage limits for code reviews.';
+const CODERABBIT_NOTICE =
+  '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n> ## Review limit reached';
+
+function notice(
+  id: number,
+  login: string,
+  body: string,
+  createdAt = `2026-05-12T00:00:0${id}Z`,
+): NoticeComment {
+  return { id, login, body, createdAt };
+}
+
+test('buildDispositionBody is marker-first and names the bot login + head sha', () => {
+  const body = buildDispositionBody(
+    CODERABBIT,
+    'abc1234',
+    'review limit reached',
+  );
+  assert.ok(body.startsWith('**Rejected**'), 'marker must be first bytes');
+  assert.match(body, /coderabbitai\[bot\] did not review HEAD abc1234/);
+  assert.match(
+    body,
+    /\(review limit reached\); this is not a completed review\.$/,
+  );
+});
+
+test('noticeReason derives the category-specific reason', () => {
+  assert.equal(
+    noticeReason(CODERABBIT_NOTICE),
+    'review limit reached / rate limited',
+  );
+  assert.equal(
+    noticeReason(CODEX_NOTICE),
+    'Codex usage limits for code reviews reached',
+  );
+  assert.equal(noticeReason('something else'), 'advisory non-review notice');
+});
+
+test('buildDispositionPlan plans one disposition per undispositioned notice', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(1, CODEX, CODEX_NOTICE),
+        notice(2, CODERABBIT, CODERABBIT_NOTICE),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 2);
+  assert.deepEqual(
+    plan.planned.map((entry) => entry.botLogin).sort(),
+    [CODERABBIT, CODEX].sort(),
+  );
+  assert.equal(plan.skipped.length, 0);
+  for (const entry of plan.planned) {
+    assert.ok(entry.body.startsWith('**Rejected**'));
+    assert.match(entry.body, /did not review HEAD abc1234/);
+  }
+});
+
+test('buildDispositionPlan is idempotent: a notice already dispositioned for its bot is skipped', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(1, CODEX, CODEX_NOTICE),
+        notice(2, CODERABBIT, CODERABBIT_NOTICE),
+        // A trusted IDD disposition that names the Codex connector.
+        notice(
+          3,
+          'kurone-kito',
+          '**Rejected** — chatgpt-codex-connector[bot] did not review HEAD abc1234 (usage); this is not a completed review',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  // Codex covered (skipped); CodeRabbit still needs one (planned).
+  assert.deepEqual(
+    plan.planned.map((entry) => entry.botLogin),
+    [CODERABBIT],
+  );
+  assert.deepEqual(
+    plan.skipped.map((entry) => entry.botLogin),
+    [CODEX],
+  );
+});
+
+test('buildDispositionPlan attributes a disposition only to the bot it names (author-scoped)', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(1, CODERABBIT, CODERABBIT_NOTICE),
+        // A Codex-only disposition must NOT cover the CodeRabbit notice.
+        notice(
+          2,
+          'kurone-kito',
+          '**Rejected** — chatgpt-codex-connector[bot] did not review HEAD abc1234 (usage); this is not a completed review',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.deepEqual(
+    plan.planned.map((entry) => entry.botLogin),
+    [CODERABBIT],
+  );
+  assert.equal(plan.skipped.length, 0);
+});
+
+test('buildDispositionPlan pairs by count: N notices, K dispositions -> N-K planned', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(1, CODEX, CODEX_NOTICE),
+        notice(2, CODEX, CODEX_NOTICE),
+        notice(
+          3,
+          'kurone-kito',
+          '**Rejected** — chatgpt-codex-connector[bot] did not review HEAD abc1234 (usage); this is not a completed review',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 1);
+  assert.equal(plan.skipped.length, 1);
+});
+
+test('buildDispositionPlan is fail-closed: real reviews and non-bot comments are never dispositioned', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        // A real Codex review (not a notice) must not be dispositioned.
+        notice(1, CODEX, 'I found an off-by-one in foo.mts at line 42.'),
+        // A real CodeRabbit summarize review (not a rate-limit notice).
+        notice(
+          2,
+          CODERABBIT,
+          '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n## Walkthrough',
+        ),
+        // A human comment that merely mentions usage limits.
+        notice(3, 'reviewer-a', 'please cap the Codex usage limits in config'),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 0);
+  assert.equal(plan.skipped.length, 0);
+});
+
+test('buildDispositionPlan only considers configured advisory bots', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [notice(1, CODEX, CODEX_NOTICE)],
+    },
+    { advisoryBotLogins: [CODERABBIT], trustedMarkerLogins: ['kurone-kito'] },
+  );
+  // Codex is not in the configured advisory-bot set here, so nothing is planned.
+  assert.equal(plan.planned.length, 0);
+});
+
+test('the dry-run and apply output envelopes validate against the schema', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(1, CODEX, CODEX_NOTICE),
+        notice(2, CODERABBIT, CODERABBIT_NOTICE),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  const dryRun = { mode: 'dry-run', prNumber: 7, ...plan };
+  assert.equal(validate(planSchema, dryRun).length, 0, 'dry-run output');
+
+  const apply = {
+    mode: 'apply',
+    prNumber: 7,
+    headSha: plan.headSha,
+    status: 'applied',
+    applied: plan.planned.map((entry, index) => ({
+      noticeId: entry.noticeId,
+      commentId: 1000 + index,
+    })),
+    failed: [],
+    skipped: plan.skipped,
+  };
+  assert.equal(validate(planSchema, apply).length, 0, 'apply output');
+});

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -943,7 +943,7 @@ const dispositionNonReviewNoticesKeys = [
 const dispositionNonReviewNoticesFixture = {
   mode: 'apply',
   prNumber: 7,
-  headSha: 'abc1234',
+  headSha: '0123456789abcdef0123456789abcdef01234567',
   planned: [],
   status: 'applied',
   applied: [{ noticeId: 1, commentId: 1000 }],

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import type { AdvisoryWaitStateReport } from '../src/scripts/advisory-wait-state.mts';
 import type { BranchConflictResult } from '../src/scripts/branch-conflict-state.mts';
 import type { RoadmapGraphUnionReport } from '../src/scripts/discover-roadmap-graph.mts';
+import type { DispositionReport } from '../src/scripts/disposition-non-review-notices.mts';
 import type { IddMergeExecuteVerdict } from '../src/scripts/idd-merge-execute.mts';
 import type { PreMergeReadinessReport } from '../src/scripts/pre-merge-readiness.mts';
 import type {
@@ -928,7 +929,42 @@ const stalledSessionQuietCheckFixture = {
 // The reconciliation table (single source of truth).
 // ---------------------------------------------------------------------------
 
+const dispositionNonReviewNoticesKeys = [
+  'mode',
+  'prNumber',
+  'headSha',
+  'planned',
+  'status',
+  'applied',
+  'failed',
+  'skipped',
+] as const satisfies readonly (keyof DispositionReport)[];
+
+const dispositionNonReviewNoticesFixture = {
+  mode: 'apply',
+  prNumber: 7,
+  headSha: 'abc1234',
+  planned: [],
+  status: 'applied',
+  applied: [{ noticeId: 1, commentId: 1000 }],
+  failed: [],
+  skipped: [
+    {
+      noticeId: 2,
+      botLogin: 'coderabbitai[bot]',
+      reason: 'already-dispositioned',
+    },
+  ],
+} satisfies DispositionReport;
+
 const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
+  {
+    schemaFile: 'disposition-non-review-notices.schema.json',
+    exportedType: 'DispositionReport',
+    owningModule: 'src/scripts/disposition-non-review-notices.mts',
+    keys: dispositionNonReviewNoticesKeys,
+    fixture: dispositionNonReviewNoticesFixture,
+  },
   {
     schemaFile: 'advisory-wait-state.schema.json',
     exportedType: 'AdvisoryWaitStateReport',


### PR DESCRIPTION
## Summary

Every autopilot PR draws advisory-bot **non-review notices** (CodeRabbit
rate-limit, Codex usage-limit). Per E6 each is dispositioned deterministically
as `**Rejected** — {bot} did not review HEAD {sha} ({reason}); this is not a
completed review` — marker-first (#1038), one per notice (the F2/F3 gate pairs
1:1 by count), naming the bot login so the #1018 author-scoped carry-forward
attributes it. Hand-assembling that for every notice on every PR was the single
most-repeated write of a multi-PR session.

## Change

`scripts/disposition-non-review-notices.mjs` (dry-run by default, `--apply` to
post):

- **Detect** advisory-bot non-review notices with the single-sourced
  `isAdvisoryNonReviewNotice` classifier (exports `dispositionNamesAdvisoryBot`
  / `advisoryBotIdentityToken` from `protocol-helpers` so the helper reuses the
  #1018 matching rather than duplicating the patterns).
- **`buildDispositionPlan`** is pure and unit-tested: per advisory bot, existing
  trusted `isNonReviewNoticeDisposition` comments naming that bot cover that many
  of its notices (idempotent re-runs); the remainder are planned with the
  canonical body. **Fail-closed** — only classifier-recognized notices are
  planned; real reviews and review threads are never touched.
- **`--apply`** re-validates the active claim before posting and retries once on
  a transient post failure, then prints a stable report.

Registered in the helper-scripts doc, `HELPER_COMMANDS`, `package.json` `bin`,
and `.gitattributes` (canonical sorted positions — the #1032 order +
completeness guard passes); referenced as the E6 helper-first path with the
manual `gh api` fallback retained. A stable schema +
`schema-type-reconciliation` entry pin the output contract.

No `bundle-review` budget bump is needed — the ~10% headroom from #1037 absorbs
the E6 reference (8.7% headroom remains).

## Tests

`tests/disposition-non-review-notices.test.mts` covers detection, generation
(login/sha/reason, marker-first), idempotency, author-scoped attribution,
count-based pairing, the fail-closed boundary (a real review is never planned),
and schema validation of both output envelopes. `pnpm run lint:minimum` passes
(`build:check`, schema reconciliation, 1190 tests, audit-docs, markdownlint,
cspell).

Closes #1045


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new helper workflow and command-line tool to automatically disposition advisory E6 non-review notices, supporting both dry-run and apply modes with an explicit plan output and schema validation.
  * Disposition comments are generated in a consistent marker-first format with canonical “Rejected” messaging.
* **Bug Fixes**
  * Improved fail-closed behavior, stronger idempotency (won’t repost already-covered notices), and safer claim verification before posting.
* **Documentation**
  * Updated helper inventories and E6 triage guidance with the new helper-first instructions and exact command/contract details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->