### PR TITLE
feat(idd): add the resolve-review-thread write-side helper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -43,6 +43,7 @@ scripts/phase-id-resolver.mjs linguist-generated=true
 scripts/policy-helpers.mjs linguist-generated=true
 scripts/pre-merge-readiness.mjs linguist-generated=true
 scripts/protocol-helpers.mjs linguist-generated=true
+scripts/resolve-review-thread.mjs linguist-generated=true
 scripts/resume-claim-routing.mjs linguist-generated=true
 scripts/resume-route-selection.mjs linguist-generated=true
 scripts/review-activity-snapshot.mjs linguist-generated=true

--- a/bin/idd-resolve-review-thread.mjs
+++ b/bin/idd-resolve-review-thread.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-resolve-review-thread.mts
+//
+// The bin/idd-resolve-review-thread.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/resolve-review-thread.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -541,17 +541,25 @@ The adopted helper boundaries are intentionally narrow:
   --claim-id <id>` to post the reply and resolve the thread. Optional
   `--owner` / `--repo` / `--agent-id` / `--trusted-marker-logins`.
 - Maps `--comment-id` (the review comment's REST id) to its owning review
-  thread via the GraphQL `reviewThreads` `databaseId`, then in `--apply`
-  posts the reply (REST `pulls/.../comments/{id}/replies`) and resolves the
-  thread (GraphQL `resolveReviewThread`). Reply first, resolve second, so a
-  failed reply never resolves the thread without a disposition.
+  thread via the GraphQL `reviewThreads` `databaseId` (both the threads and
+  the nested comments connections are paginated to completion), then in
+  `--apply` posts the reply against the thread's **top-level** comment (REST
+  `pulls/.../comments/{root-id}/replies` — GitHub does not support replies to
+  replies, so a `--comment-id` naming a later reply still resolves the right
+  thread) and resolves the thread (GraphQL `resolveReviewThread`). Reply
+  first, resolve second, so a failed reply never resolves the thread without a
+  disposition.
 - **Dry-run** reports the resolved `threadId` and current `alreadyResolved`
   state without posting; a comment with no owning thread omits `threadId`
   and includes an `error` note.
 - **Fail-closed**: `--apply` requires `--body` and the
-  `--claim-issue` / `--claim-id` pair, and re-validates the active claim
-  (scoped to trusted marker authors, aborting on a targeting
-  `forced-handoff`) immediately before the reply.
+  `--claim-issue` / `--claim-id` pair, re-validates the active claim before
+  **each** of the reply and the resolve (scoped to trusted marker authors,
+  aborting on a targeting `forced-handoff`), and binds the mutation to the
+  claimed PR by requiring the active claim's branch to equal the PR's head
+  branch. GraphQL `errors` fail fast rather than masquerading as a missing
+  thread, and a partial apply (reply posted, resolve not confirmed) still
+  reports the posted `replyId`.
 - Stable contract: [`resolve-review-thread.schema.json`][resolve-review-thread-schema].
 - The written E13 reply-and-resolve rule in
   `idd-review-fix.instructions.md` stays authoritative; this helper is the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -103,6 +103,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   on a PR — emitting or posting the canonical E6 `**Rejected** — {bot} did
   not review HEAD …` marker-first, one comment per notice, idempotently and
   fail-closed (only classifier-recognized notices)
+- `scripts/resolve-review-thread.mjs` for the E13 write-side disposition:
+  post the reply to the review thread that owns a review comment **and**
+  resolve that thread in one invocation — dry-run by default, `--apply`
+  re-validates the active claim and posts the reply before resolving
+  (a failed reply never leaves a silently-resolved thread)
 
 **Operator Recovery Helpers:**
 
@@ -526,6 +531,31 @@ The adopted helper boundaries are intentionally narrow:
 - The written E6 non-review-notice rule in
   `idd-review-triage.instructions.md` stays authoritative; this helper is
   the helper-first convenience path with the manual `gh api` fallback
+  retained.
+
+### E13 reply-and-resolve (resolve-review-thread)
+
+- Command:
+  `node scripts/resolve-review-thread.mjs --pr <number> --comment-id <id>`
+  (dry-run); add `--body "<disposition>" --apply --claim-issue <n>
+  --claim-id <id>` to post the reply and resolve the thread. Optional
+  `--owner` / `--repo` / `--agent-id` / `--trusted-marker-logins`.
+- Maps `--comment-id` (the review comment's REST id) to its owning review
+  thread via the GraphQL `reviewThreads` `databaseId`, then in `--apply`
+  posts the reply (REST `pulls/.../comments/{id}/replies`) and resolves the
+  thread (GraphQL `resolveReviewThread`). Reply first, resolve second, so a
+  failed reply never resolves the thread without a disposition.
+- **Dry-run** reports the resolved `threadId` and current `alreadyResolved`
+  state without posting; a comment with no owning thread reports
+  `threadId: null` with an `error` note.
+- **Fail-closed**: `--apply` requires `--body` and the
+  `--claim-issue` / `--claim-id` pair, and re-validates the active claim
+  (scoped to trusted marker authors, aborting on a targeting
+  `forced-handoff`) immediately before the reply.
+- Stable contract: [`resolve-review-thread.schema.json`][resolve-review-thread-schema].
+- The written E13 reply-and-resolve rule in
+  `idd-review-fix.instructions.md` stays authoritative; this helper is the
+  helper-first convenience path with the manual REST + GraphQL fallback
   retained.
 
 ## Stable Helper Evidence Outputs
@@ -1138,3 +1168,4 @@ replace the written decision tables.
 [disposition-non-review-notices-schema]: https://kurone-kito.github.io/idd-skill/schemas/disposition-non-review-notices.schema.json
 [idd-merge-execute-schema]: https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json
 [pre-merge-readiness-schema]: https://kurone-kito.github.io/idd-skill/schemas/pre-merge-readiness.schema.json
+[resolve-review-thread-schema]: https://kurone-kito.github.io/idd-skill/schemas/resolve-review-thread.schema.json

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -541,8 +541,9 @@ The adopted helper boundaries are intentionally narrow:
   --claim-id <id>` to post the reply and resolve the thread. Optional
   `--owner` / `--repo` / `--agent-id` / `--trusted-marker-logins`.
 - Maps `--comment-id` (the review comment's REST id) to its owning review
-  thread via the GraphQL `reviewThreads` `databaseId` (both the threads and
-  the nested comments connections are paginated to completion), then in
+  thread by matching it against the `databaseId` of the comments inside each
+  GraphQL `reviewThreads` node (both the threads and the nested comments
+  connections are paginated to completion), then in
   `--apply` posts the reply against the thread's **top-level** comment (REST
   `pulls/.../comments/{root-id}/replies` — GitHub does not support replies to
   replies, so a `--comment-id` naming a later reply still resolves the right

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -546,8 +546,8 @@ The adopted helper boundaries are intentionally narrow:
   thread (GraphQL `resolveReviewThread`). Reply first, resolve second, so a
   failed reply never resolves the thread without a disposition.
 - **Dry-run** reports the resolved `threadId` and current `alreadyResolved`
-  state without posting; a comment with no owning thread reports
-  `threadId: null` with an `error` note.
+  state without posting; a comment with no owning thread omits `threadId`
+  and includes an `error` note.
 - **Fail-closed**: `--apply` requires `--body` and the
   `--claim-issue` / `--claim-id` pair, and re-validates the active claim
   (scoped to trusted marker authors, aborting on a targeting

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -541,17 +541,25 @@ The adopted helper boundaries are intentionally narrow:
   --claim-id <id>` to post the reply and resolve the thread. Optional
   `--owner` / `--repo` / `--agent-id` / `--trusted-marker-logins`.
 - Maps `--comment-id` (the review comment's REST id) to its owning review
-  thread via the GraphQL `reviewThreads` `databaseId`, then in `--apply`
-  posts the reply (REST `pulls/.../comments/{id}/replies`) and resolves the
-  thread (GraphQL `resolveReviewThread`). Reply first, resolve second, so a
-  failed reply never resolves the thread without a disposition.
+  thread via the GraphQL `reviewThreads` `databaseId` (both the threads and
+  the nested comments connections are paginated to completion), then in
+  `--apply` posts the reply against the thread's **top-level** comment (REST
+  `pulls/.../comments/{root-id}/replies` — GitHub does not support replies to
+  replies, so a `--comment-id` naming a later reply still resolves the right
+  thread) and resolves the thread (GraphQL `resolveReviewThread`). Reply
+  first, resolve second, so a failed reply never resolves the thread without a
+  disposition.
 - **Dry-run** reports the resolved `threadId` and current `alreadyResolved`
   state without posting; a comment with no owning thread omits `threadId`
   and includes an `error` note.
 - **Fail-closed**: `--apply` requires `--body` and the
-  `--claim-issue` / `--claim-id` pair, and re-validates the active claim
-  (scoped to trusted marker authors, aborting on a targeting
-  `forced-handoff`) immediately before the reply.
+  `--claim-issue` / `--claim-id` pair, re-validates the active claim before
+  **each** of the reply and the resolve (scoped to trusted marker authors,
+  aborting on a targeting `forced-handoff`), and binds the mutation to the
+  claimed PR by requiring the active claim's branch to equal the PR's head
+  branch. GraphQL `errors` fail fast rather than masquerading as a missing
+  thread, and a partial apply (reply posted, resolve not confirmed) still
+  reports the posted `replyId`.
 - Stable contract: [`resolve-review-thread.schema.json`][resolve-review-thread-schema].
 - The written E13 reply-and-resolve rule in
   `idd-review-fix.instructions.md` stays authoritative; this helper is the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -103,6 +103,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   on a PR — emitting or posting the canonical E6 `**Rejected** — {bot} did
   not review HEAD …` marker-first, one comment per notice, idempotently and
   fail-closed (only classifier-recognized notices)
+- `scripts/resolve-review-thread.mjs` for the E13 write-side disposition:
+  post the reply to the review thread that owns a review comment **and**
+  resolve that thread in one invocation — dry-run by default, `--apply`
+  re-validates the active claim and posts the reply before resolving
+  (a failed reply never leaves a silently-resolved thread)
 
 **Operator Recovery Helpers:**
 
@@ -526,6 +531,31 @@ The adopted helper boundaries are intentionally narrow:
 - The written E6 non-review-notice rule in
   `idd-review-triage.instructions.md` stays authoritative; this helper is
   the helper-first convenience path with the manual `gh api` fallback
+  retained.
+
+### E13 reply-and-resolve (resolve-review-thread)
+
+- Command:
+  `node scripts/resolve-review-thread.mjs --pr <number> --comment-id <id>`
+  (dry-run); add `--body "<disposition>" --apply --claim-issue <n>
+  --claim-id <id>` to post the reply and resolve the thread. Optional
+  `--owner` / `--repo` / `--agent-id` / `--trusted-marker-logins`.
+- Maps `--comment-id` (the review comment's REST id) to its owning review
+  thread via the GraphQL `reviewThreads` `databaseId`, then in `--apply`
+  posts the reply (REST `pulls/.../comments/{id}/replies`) and resolves the
+  thread (GraphQL `resolveReviewThread`). Reply first, resolve second, so a
+  failed reply never resolves the thread without a disposition.
+- **Dry-run** reports the resolved `threadId` and current `alreadyResolved`
+  state without posting; a comment with no owning thread reports
+  `threadId: null` with an `error` note.
+- **Fail-closed**: `--apply` requires `--body` and the
+  `--claim-issue` / `--claim-id` pair, and re-validates the active claim
+  (scoped to trusted marker authors, aborting on a targeting
+  `forced-handoff`) immediately before the reply.
+- Stable contract: [`resolve-review-thread.schema.json`][resolve-review-thread-schema].
+- The written E13 reply-and-resolve rule in
+  `idd-review-fix.instructions.md` stays authoritative; this helper is the
+  helper-first convenience path with the manual REST + GraphQL fallback
   retained.
 
 ## Stable Helper Evidence Outputs
@@ -1138,3 +1168,4 @@ replace the written decision tables.
 [disposition-non-review-notices-schema]: https://kurone-kito.github.io/idd-skill/schemas/disposition-non-review-notices.schema.json
 [idd-merge-execute-schema]: https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json
 [pre-merge-readiness-schema]: https://kurone-kito.github.io/idd-skill/schemas/pre-merge-readiness.schema.json
+[resolve-review-thread-schema]: https://kurone-kito.github.io/idd-skill/schemas/resolve-review-thread.schema.json

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -541,8 +541,9 @@ The adopted helper boundaries are intentionally narrow:
   --claim-id <id>` to post the reply and resolve the thread. Optional
   `--owner` / `--repo` / `--agent-id` / `--trusted-marker-logins`.
 - Maps `--comment-id` (the review comment's REST id) to its owning review
-  thread via the GraphQL `reviewThreads` `databaseId` (both the threads and
-  the nested comments connections are paginated to completion), then in
+  thread by matching it against the `databaseId` of the comments inside each
+  GraphQL `reviewThreads` node (both the threads and the nested comments
+  connections are paginated to completion), then in
   `--apply` posts the reply against the thread's **top-level** comment (REST
   `pulls/.../comments/{root-id}/replies` — GitHub does not support replies to
   replies, so a `--comment-id` naming a later reply still resolves the right

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -546,8 +546,8 @@ The adopted helper boundaries are intentionally narrow:
   thread (GraphQL `resolveReviewThread`). Reply first, resolve second, so a
   failed reply never resolves the thread without a disposition.
 - **Dry-run** reports the resolved `threadId` and current `alreadyResolved`
-  state without posting; a comment with no owning thread reports
-  `threadId: null` with an `error` note.
+  state without posting; a comment with no owning thread omits `threadId`
+  and includes an `error` note.
 - **Fail-closed**: `--apply` requires `--body` and the
   `--claim-issue` / `--claim-id` pair, and re-validates the active claim
   (scoped to trusted marker authors, aborting on a targeting

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "idd-merged-pr-feedback-sweep": "./bin/idd-merged-pr-feedback-sweep.mjs",
     "idd-phase-id-resolver": "./bin/idd-phase-id-resolver.mjs",
     "idd-pre-merge-readiness": "./bin/idd-pre-merge-readiness.mjs",
+    "idd-resolve-review-thread": "./bin/idd-resolve-review-thread.mjs",
     "idd-resume-claim-routing": "./bin/idd-resume-claim-routing.mjs",
     "idd-resume-route-selection": "./bin/idd-resume-route-selection.mjs",
     "idd-review-activity-snapshot": "./bin/idd-review-activity-snapshot.mjs",

--- a/schemas/resolve-review-thread.schema.json
+++ b/schemas/resolve-review-thread.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/resolve-review-thread.schema.json",
+  "title": "Resolve Review Thread Result",
+  "description": "Dry-run plan or apply result for the E13 reply-and-resolve write-side helper: post a reply to the thread that owns a review comment and resolve that thread in one invocation.",
+  "type": "object",
+  "required": ["mode", "prNumber", "commentId", "alreadyResolved"],
+  "additionalProperties": false,
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["dry-run", "apply"]
+    },
+    "prNumber": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "commentId": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "threadId": {
+      "description": "GraphQL node id of the resolved review thread; omitted when no thread owns the comment.",
+      "type": "string"
+    },
+    "alreadyResolved": {
+      "type": "boolean"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["applied", "failed"]
+    },
+    "replyId": {
+      "type": "integer"
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -288,6 +288,16 @@ const HELPER_COMMANDS = [
     contractPaths: ['schemas/pre-merge-readiness.schema.json'],
   },
   {
+    id: 'resolve-review-thread',
+    scriptName: 'idd:resolve-review-thread',
+    binName: 'idd-resolve-review-thread',
+    entryPath: 'scripts/resolve-review-thread.mjs',
+    vendoredCommand: 'node scripts/resolve-review-thread.mjs',
+    description:
+      'Post the E13 reply and resolve the owning review thread in one invocation (dry-run by default; --apply mutates).',
+    contractPaths: ['schemas/resolve-review-thread.schema.json'],
+  },
+  {
     id: 'resume-claim-routing',
     scriptName: 'idd:resume-claim-routing',
     binName: 'idd-resume-claim-routing',

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/resolve-review-thread.mts
+//
+// The scripts/resolve-review-thread.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Perform the common E13 review-thread disposition in one invocation: post the
+// reply comment to the thread that owns a review comment AND resolve that
+// thread. This is the write-side companion to the read-side review helpers
+// (`review-activity-snapshot`, `review-disposition-verify`). It follows the
+// write-side helper family conventions: dry-run by default, `--apply` mutates
+// and requires `--claim-issue` / `--claim-id` so the active claim is
+// revalidated immediately before the reply is posted (fail-closed). Reply
+// first, resolve second — a failed reply never leaves a silently-resolved
+// thread with no disposition.
+import { execFileSync } from 'node:child_process';
+import {
+  parseForcedHandoffComment,
+  resolveActiveClaim,
+} from './protocol-helpers.mjs';
+/**
+ * Find the review thread that owns the review comment whose REST database id is
+ * `commentId`. The GraphQL `PullRequestReviewComment.databaseId` equals the REST
+ * comment id, so the lookup is exact. Pure: takes already-fetched thread nodes
+ * and returns the owning thread's node id plus its current resolution state, or
+ * `null` when no thread contains that comment.
+ */
+export function findThreadForComment(threads, commentId) {
+  for (const thread of Array.isArray(threads) ? threads : []) {
+    for (const comment of thread.comments?.nodes ?? []) {
+      if (
+        comment.databaseId !== null &&
+        comment.databaseId !== undefined &&
+        Number(comment.databaseId) === Number(commentId)
+      ) {
+        return { threadId: thread.id, isResolved: Boolean(thread.isResolved) };
+      }
+    }
+  }
+  return null;
+}
+/**
+ * Orchestrate the apply-mode mutation with injected side effects so the
+ * reply→resolve sequencing is testable without the network. Revalidate the
+ * active claim first; a thrown claim check aborts before the reply is posted.
+ * Resolve only after the reply lands, so a failed reply never leaves a
+ * silently-resolved thread with no disposition.
+ */
+export function applyResolveReviewThread(deps) {
+  deps.assertClaim();
+  const reply = deps.postReply();
+  deps.resolveThread();
+  return { replyId: reply.id };
+}
+export function parseArgs(argv) {
+  const args = {
+    pr: null,
+    commentId: null,
+    body: '',
+    owner: '',
+    repo: '',
+    claimIssue: null,
+    claimId: '',
+    agentId: '',
+    trustedMarkerLogins: [],
+    apply: false,
+    help: false,
+  };
+  const splitList = (value) =>
+    value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const next = () => {
+      index += 1;
+      return argv[index] ?? '';
+    };
+    switch (flag) {
+      case '--pr':
+        args.pr = Number.parseInt(next(), 10);
+        break;
+      case '--comment-id':
+        args.commentId = Number.parseInt(next(), 10);
+        break;
+      case '--body':
+        args.body = next();
+        break;
+      case '--owner':
+        args.owner = next();
+        break;
+      case '--repo':
+        args.repo = next();
+        break;
+      case '--claim-issue':
+        args.claimIssue = Number.parseInt(next(), 10);
+        break;
+      case '--claim-id':
+        args.claimId = next();
+        break;
+      case '--agent-id':
+        args.agentId = next();
+        break;
+      case '--trusted-marker-logins':
+        args.trustedMarkerLogins = splitList(next());
+        break;
+      case '--apply':
+        args.apply = true;
+        break;
+      case '--help':
+      case '-h':
+        args.help = true;
+        break;
+      default:
+        break;
+    }
+  }
+  return args;
+}
+const USAGE = `usage: node scripts/resolve-review-thread.mjs --pr <number> --comment-id <id> [options]
+
+Post a reply to the review thread that owns <comment-id> and resolve that
+thread in one invocation (E13). Dry-run by default; --apply mutates.
+
+  --pr <number>                  PR number (required)
+  --comment-id <id>              review comment REST id whose thread to resolve (required)
+  --body <text>                  reply body (required with --apply)
+  --owner <owner>                repo owner (default: gh repo view)
+  --repo <repo>                  repo name (default: gh repo view)
+  --claim-issue <number>         issue carrying the active claim (required with --apply)
+  --claim-id <claim-id>          active claim id to re-validate (required with --apply)
+  --agent-id <agent-id>          current session agent id (optional, tightens the claim check)
+  --trusted-marker-logins a,b    logins whose claim markers are trusted
+                                 (default: your gh login)
+  --apply                        post the reply and resolve the thread (default: dry-run)
+  -h, --help                     show this help
+`;
+function ghText(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+function ghJson(args) {
+  return JSON.parse(execFileSync('gh', args, { encoding: 'utf8' }));
+}
+/**
+ * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
+ * one JSON array per page; `--jq '.[]'` flattens each page to one JSON value per
+ * line (NDJSON), which we parse line-by-line (mirrors the sibling helpers).
+ */
+function ghJsonPaginated(args) {
+  const out = execFileSync('gh', [...args, '--paginate', '--jq', '.[]'], {
+    encoding: 'utf8',
+  });
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .map((line) => JSON.parse(line));
+}
+function ghGraphql(query, variables) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === 'number') {
+      args.push('-F', `${key}=${value}`);
+      continue;
+    }
+    args.push('-f', `${key}=${value}`);
+  }
+  return JSON.parse(
+    execFileSync('gh', args, { encoding: 'utf8' }).trim() || '{}',
+  );
+}
+/**
+ * Fetch every review thread of a PR (paginated), each with its node id,
+ * resolution state, and member comment database ids — enough to map a REST
+ * comment id to its owning thread. Each thread's comments are read up to the
+ * first 100, which covers the disposition target (the thread's root or an early
+ * reply) in practice; a comment buried past 100 in one thread would not match.
+ */
+function fetchReviewThreads(owner, repo, prNumber) {
+  const nodes = [];
+  let cursor = null;
+  while (true) {
+    const payload = ghGraphql(
+      `query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewThreads(first: 100, after: $cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                isResolved
+                comments(first: 100) { nodes { databaseId } }
+              }
+            }
+          }
+        }
+      }`,
+      { owner, repo, number: prNumber, cursor },
+    );
+    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
+    nodes.push(...(reviewThreads?.nodes ?? []));
+    if (!reviewThreads?.pageInfo?.hasNextPage) {
+      break;
+    }
+    if (!reviewThreads.pageInfo.endCursor) {
+      throw new Error('review thread pagination payload is missing endCursor');
+    }
+    cursor = reviewThreads.pageInfo.endCursor;
+  }
+  return nodes;
+}
+/** Post a reply to the review thread that owns `commentId` (REST). */
+function postReply(owner, repo, pr, commentId, body) {
+  return ghJson([
+    'api',
+    '--method',
+    'POST',
+    `repos/${owner}/${repo}/pulls/${pr}/comments/${commentId}/replies`,
+    '-f',
+    `body=${body}`,
+  ]);
+}
+/** Resolve a review thread by its GraphQL node id, confirming the result. */
+function resolveThread(threadId) {
+  const payload = ghGraphql(
+    `mutation($threadId: ID!) {
+      resolveReviewThread(input: { threadId: $threadId }) {
+        thread { id isResolved }
+      }
+    }`,
+    { threadId },
+  );
+  if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
+    throw new Error(
+      `resolveReviewThread failed: ${payload.errors
+        .map((entry) => String(entry.message ?? ''))
+        .filter(Boolean)
+        .join('; ')
+        .slice(0, 200)}`,
+    );
+  }
+  if (payload?.data?.resolveReviewThread?.thread?.isResolved !== true) {
+    throw new Error(
+      'resolveReviewThread returned without confirming thread.isResolved',
+    );
+  }
+}
+/**
+ * Re-fetch the claim issue and decide whether `claimId` is still the active
+ * claim. Scoped to trusted marker authors via the shared `resolveActiveClaim`
+ * state machine, and fails closed on any `forced-handoff` marker that targets
+ * this claim. Aborting on a contested claim is always safe (the manual E13 path
+ * remains).
+ */
+function claimStillActive(
+  owner,
+  repo,
+  issue,
+  agentId,
+  claimId,
+  isTrustedAuthor,
+) {
+  const comments = ghJsonPaginated([
+    'api',
+    `repos/${owner}/${repo}/issues/${issue}/comments`,
+  ]);
+  for (const comment of comments) {
+    const forcedHandoff = parseForcedHandoffComment(
+      comment.body ?? '',
+      comment.created_at ?? '',
+    );
+    if (forcedHandoff && forcedHandoff.oldClaimId === claimId) {
+      return false;
+    }
+  }
+  const events = comments.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  }));
+  const active = resolveActiveClaim(events, isTrustedAuthor);
+  if (active?.claimId !== claimId) {
+    return false;
+  }
+  return agentId ? active.agentId === agentId : true;
+}
+function isMainModule(moduleUrl) {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return moduleUrl === `file://${entry}` || moduleUrl.endsWith(entry);
+}
+if (isMainModule(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2));
+  if (
+    args.help ||
+    !Number.isInteger(args.pr) ||
+    (args.pr ?? 0) <= 0 ||
+    !Number.isInteger(args.commentId) ||
+    (args.commentId ?? 0) <= 0
+  ) {
+    process.stdout.write(USAGE);
+    process.exit(args.help ? 0 : 1);
+  }
+  // Fail closed: --apply mutates PR state, so the active-claim revalidation and
+  // a reply body are mandatory. Missing inputs must abort before any read or
+  // write rather than silently bypassing the gate.
+  if (
+    args.apply &&
+    (!Number.isInteger(args.claimIssue) ||
+      (args.claimIssue ?? 0) <= 0 ||
+      !args.claimId ||
+      !args.body)
+  ) {
+    process.stderr.write(
+      '--apply requires --body and the --claim-issue / --claim-id pair for the mandatory claim revalidation\n',
+    );
+    process.exit(1);
+  }
+  const pr = args.pr;
+  const commentId = args.commentId;
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const match = findThreadForComment(
+    fetchReviewThreads(owner, repo, pr),
+    commentId,
+  );
+  const report = {
+    mode: args.apply ? 'apply' : 'dry-run',
+    prNumber: pr,
+    commentId,
+    ...(match ? { threadId: match.threadId } : {}),
+    alreadyResolved: match?.isResolved ?? false,
+  };
+  if (!match) {
+    report.error = `no review thread found for comment ${commentId} on PR #${pr}`;
+    if (args.apply) {
+      report.status = 'failed';
+    }
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    // A missing thread is informational in dry-run but a hard failure in apply.
+    process.exit(args.apply ? 1 : 0);
+  }
+  if (!args.apply) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(0);
+  }
+  // --apply: default the trusted claim authors to this gh login so the
+  // revalidation recognizes the session's own claim markers.
+  const viewerLogin = ghText(['api', 'user', '--jq', '.login']).toLowerCase();
+  const trustedAuthors = new Set(
+    (args.trustedMarkerLogins.length > 0
+      ? args.trustedMarkerLogins
+      : [viewerLogin]
+    ).map((login) => login.toLowerCase()),
+  );
+  const isTrustedAuthor = (login) =>
+    trustedAuthors.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+  try {
+    const result = applyResolveReviewThread({
+      assertClaim: () => {
+        if (
+          !claimStillActive(
+            owner,
+            repo,
+            args.claimIssue,
+            args.agentId,
+            args.claimId,
+            isTrustedAuthor,
+          )
+        ) {
+          throw new Error(
+            `claim revalidation failed: "${args.claimId}" is no longer the active claim on issue #${args.claimIssue}`,
+          );
+        }
+      },
+      postReply: () => postReply(owner, repo, pr, commentId, args.body),
+      resolveThread: () => resolveThread(match.threadId),
+    });
+    report.status = 'applied';
+    report.replyId = result.replyId;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(0);
+  } catch (error) {
+    report.status = 'failed';
+    report.error = error.message;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -43,13 +43,17 @@ export function findThreadForComment(threads, commentId) {
 /**
  * Orchestrate the apply-mode mutation with injected side effects so the
  * reply→resolve sequencing is testable without the network. Revalidate the
- * active claim first; a thrown claim check aborts before the reply is posted.
+ * active claim before **each** GitHub-side mutation (E13 requires a claim
+ * revalidation before every reply/resolve side effect): the first check aborts
+ * before the reply is posted, and the second aborts before the resolve if the
+ * claim was released or handed off in the window between the two mutations.
  * Resolve only after the reply lands, so a failed reply never leaves a
  * silently-resolved thread with no disposition.
  */
 export function applyResolveReviewThread(deps) {
   deps.assertClaim();
   const reply = deps.postReply();
+  deps.assertClaim();
   deps.resolveThread();
   return { replyId: reply.id };
 }
@@ -175,11 +179,29 @@ function ghGraphql(query, variables) {
   );
 }
 /**
+ * Throw when a GraphQL response carries top-level `errors`, so a bad
+ * PR/repo/auth or any server-side GraphQL failure fails fast with a clear
+ * message instead of being silently read as an empty result (which would
+ * masquerade as "no review thread found").
+ */
+export function assertNoGraphqlErrors(payload, context) {
+  const errors = payload?.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    throw new Error(
+      `${context} failed: ${errors
+        .map((entry) => String(entry.message ?? ''))
+        .filter(Boolean)
+        .join('; ')
+        .slice(0, 200)}`,
+    );
+  }
+}
+/**
  * Fetch every review thread of a PR (paginated), each with its node id,
  * resolution state, and member comment database ids — enough to map a REST
- * comment id to its owning thread. Each thread's comments are read up to the
- * first 100, which covers the disposition target (the thread's root or an early
- * reply) in practice; a comment buried past 100 in one thread would not match.
+ * comment id to its owning thread. Both the threads connection **and** each
+ * thread's nested comments connection are paginated to completion, so a target
+ * comment buried past the first 100 replies in a deep thread still resolves.
  */
 function fetchReviewThreads(owner, repo, prNumber) {
   const nodes = [];
@@ -194,7 +216,10 @@ function fetchReviewThreads(owner, repo, prNumber) {
               nodes {
                 id
                 isResolved
-                comments(first: 100) { nodes { databaseId } }
+                comments(first: 100) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes { databaseId }
+                }
               }
             }
           }
@@ -202,7 +227,25 @@ function fetchReviewThreads(owner, repo, prNumber) {
       }`,
       { owner, repo, number: prNumber, cursor },
     );
+    assertNoGraphqlErrors(payload, 'review thread lookup');
     const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
+    for (const thread of reviewThreads?.nodes ?? []) {
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        if (!thread.id || !thread.comments.pageInfo.endCursor) {
+          throw new Error(
+            'review thread comment pagination payload is missing id or endCursor',
+          );
+        }
+        thread.comments.nodes = [
+          ...(thread.comments.nodes ?? []),
+          ...fetchThreadCommentIds(
+            thread.id,
+            thread.comments.pageInfo.endCursor,
+          ),
+        ];
+        thread.comments.pageInfo.hasNextPage = false;
+      }
+    }
     nodes.push(...(reviewThreads?.nodes ?? []));
     if (!reviewThreads?.pageInfo?.hasNextPage) {
       break;
@@ -211,6 +254,40 @@ function fetchReviewThreads(owner, repo, prNumber) {
       throw new Error('review thread pagination payload is missing endCursor');
     }
     cursor = reviewThreads.pageInfo.endCursor;
+  }
+  return nodes;
+}
+/**
+ * Page the remaining comment-id nodes of one review thread, starting after
+ * `afterCursor`, until the connection is exhausted. Mirrors the sibling
+ * snapshot helper's nested-comment pagination.
+ */
+function fetchThreadCommentIds(threadId, afterCursor) {
+  const nodes = [];
+  let cursor = afterCursor;
+  while (cursor) {
+    const payload = ghGraphql(
+      `query($id: ID!, $cursor: String) {
+        node(id: $id) {
+          ... on PullRequestReviewThread {
+            comments(first: 100, after: $cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes { databaseId }
+            }
+          }
+        }
+      }`,
+      { id: threadId, cursor },
+    );
+    assertNoGraphqlErrors(payload, 'review thread comment pagination');
+    const comments = payload?.data?.node?.comments;
+    nodes.push(...(comments?.nodes ?? []));
+    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
+      throw new Error('thread comment pagination payload is missing endCursor');
+    }
+    cursor = comments?.pageInfo?.hasNextPage
+      ? comments.pageInfo.endCursor
+      : null;
   }
   return nodes;
 }
@@ -235,15 +312,7 @@ function resolveThread(threadId) {
     }`,
     { threadId },
   );
-  if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
-    throw new Error(
-      `resolveReviewThread failed: ${payload.errors
-        .map((entry) => String(entry.message ?? ''))
-        .filter(Boolean)
-        .join('; ')
-        .slice(0, 200)}`,
-    );
-  }
+  assertNoGraphqlErrors(payload, 'resolveReviewThread');
   if (payload?.data?.resolveReviewThread?.thread?.isResolved !== true) {
     throw new Error(
       'resolveReviewThread returned without confirming thread.isResolved',

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -28,13 +28,25 @@ import {
  */
 export function findThreadForComment(threads, commentId) {
   for (const thread of Array.isArray(threads) ? threads : []) {
-    for (const comment of thread.comments?.nodes ?? []) {
+    const nodes = thread.comments?.nodes ?? [];
+    for (const comment of nodes) {
       if (
         comment.databaseId !== null &&
         comment.databaseId !== undefined &&
         Number(comment.databaseId) === Number(commentId)
       ) {
-        return { threadId: thread.id, isResolved: Boolean(thread.isResolved) };
+        // The top-level review comment is the first node in the thread's
+        // comments connection; the reply must target it, even when the request
+        // named a later reply in the thread.
+        const rootDatabaseId = nodes[0]?.databaseId;
+        return {
+          threadId: thread.id,
+          isResolved: Boolean(thread.isResolved),
+          rootCommentId:
+            rootDatabaseId !== null && rootDatabaseId !== undefined
+              ? Number(rootDatabaseId)
+              : null,
+        };
       }
     }
   }
@@ -320,13 +332,15 @@ function resolveThread(threadId) {
   }
 }
 /**
- * Re-fetch the claim issue and decide whether `claimId` is still the active
- * claim. Scoped to trusted marker authors via the shared `resolveActiveClaim`
- * state machine, and fails closed on any `forced-handoff` marker that targets
- * this claim. Aborting on a contested claim is always safe (the manual E13 path
- * remains).
+ * Re-fetch the claim issue and return the active claim **owned by this session**
+ * (its `claimId`, and `agentId` when supplied, match), or `null` when the claim
+ * was lost. Scoped to trusted marker authors via the shared `resolveActiveClaim`
+ * state machine, and fails closed (returns `null`) on any `forced-handoff`
+ * marker that targets this claim. Aborting on a contested claim is always safe
+ * (the manual E13 path remains). The returned `branch` lets the caller bind the
+ * mutation to the PR whose head is that branch.
  */
-function claimStillActive(
+function activeOwnedClaim(
   owner,
   repo,
   issue,
@@ -344,7 +358,7 @@ function claimStillActive(
       comment.created_at ?? '',
     );
     if (forcedHandoff && forcedHandoff.oldClaimId === claimId) {
-      return false;
+      return null;
     }
   }
   const events = comments.map((comment) => ({
@@ -354,9 +368,12 @@ function claimStillActive(
   }));
   const active = resolveActiveClaim(events, isTrustedAuthor);
   if (active?.claimId !== claimId) {
-    return false;
+    return null;
   }
-  return agentId ? active.agentId === agentId : true;
+  if (agentId && active.agentId !== agentId) {
+    return null;
+  }
+  return active;
 }
 function isMainModule(moduleUrl) {
   const entry = process.argv[1];
@@ -423,6 +440,24 @@ if (isMainModule(import.meta.url)) {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     process.exit(0);
   }
+  // The reply targets the thread's top-level review comment, so a thread with
+  // no exposed comment id cannot be replied to — fail closed before mutating.
+  const rootCommentId = match.rootCommentId;
+  if (rootCommentId === null) {
+    report.status = 'failed';
+    report.error = `review thread ${match.threadId} exposes no top-level comment id to reply to`;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(1);
+  }
+  // Bind the mutation to the claimed PR: the active claim's branch must be the
+  // PR's head branch, so a valid claim on the issue cannot be used to reply to
+  // and resolve a thread on some other PR passed as --pr.
+  const prHeadRef = ghText([
+    'api',
+    `repos/${owner}/${repo}/pulls/${pr}`,
+    '--jq',
+    '.head.ref',
+  ]);
   // --apply: default the trusted claim authors to this gh login so the
   // revalidation recognizes the session's own claim markers.
   const viewerLogin = ghText(['api', 'user', '--jq', '.login']).toLowerCase();
@@ -438,25 +473,37 @@ if (isMainModule(import.meta.url)) {
         .trim()
         .toLowerCase(),
     );
+  // Retain the posted reply id across a later failure so a partial apply (reply
+  // posted, resolve not confirmed) reports the reply id instead of looking like
+  // nothing was posted — that distinguishes "retry the resolve" from "re-post".
+  let postedReplyId;
   try {
     const result = applyResolveReviewThread({
       assertClaim: () => {
-        if (
-          !claimStillActive(
-            owner,
-            repo,
-            args.claimIssue,
-            args.agentId,
-            args.claimId,
-            isTrustedAuthor,
-          )
-        ) {
+        const active = activeOwnedClaim(
+          owner,
+          repo,
+          args.claimIssue,
+          args.agentId,
+          args.claimId,
+          isTrustedAuthor,
+        );
+        if (!active) {
           throw new Error(
             `claim revalidation failed: "${args.claimId}" is no longer the active claim on issue #${args.claimIssue}`,
           );
         }
+        if (active.branch !== prHeadRef) {
+          throw new Error(
+            `claim/PR mismatch: active claim branch "${active.branch}" does not match PR #${pr} head branch "${prHeadRef}"`,
+          );
+        }
       },
-      postReply: () => postReply(owner, repo, pr, commentId, args.body),
+      postReply: () => {
+        const posted = postReply(owner, repo, pr, rootCommentId, args.body);
+        postedReplyId = posted.id;
+        return posted;
+      },
       resolveThread: () => resolveThread(match.threadId),
     });
     report.status = 'applied';
@@ -465,6 +512,9 @@ if (isMainModule(import.meta.url)) {
     process.exit(0);
   } catch (error) {
     report.status = 'failed';
+    if (postedReplyId !== undefined) {
+      report.replyId = postedReplyId;
+    }
     report.error = error.message;
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     process.exit(1);

--- a/src/bin/idd-resolve-review-thread.mts
+++ b/src/bin/idd-resolve-review-thread.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-resolve-review-thread.mts
+//
+// The bin/idd-resolve-review-thread.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/resolve-review-thread.mjs');

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -360,6 +360,16 @@ const HELPER_COMMANDS: HelperCommand[] = [
     contractPaths: ['schemas/pre-merge-readiness.schema.json'],
   },
   {
+    id: 'resolve-review-thread',
+    scriptName: 'idd:resolve-review-thread',
+    binName: 'idd-resolve-review-thread',
+    entryPath: 'scripts/resolve-review-thread.mjs',
+    vendoredCommand: 'node scripts/resolve-review-thread.mjs',
+    description:
+      'Post the E13 reply and resolve the owning review thread in one invocation (dry-run by default; --apply mutates).',
+    contractPaths: ['schemas/resolve-review-thread.schema.json'],
+  },
+  {
     id: 'resume-claim-routing',
     scriptName: 'idd:resume-claim-routing',
     binName: 'idd-resume-claim-routing',

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -22,11 +22,17 @@ import {
   resolveActiveClaim,
 } from './protocol-helpers.mts';
 
+/** A comment-id page within a review thread's `comments` connection. */
+interface ThreadCommentsConnection {
+  pageInfo?: { hasNextPage?: boolean; endCursor?: string | null } | null;
+  nodes?: { databaseId?: number | null }[] | null;
+}
+
 /** A review thread node from the GraphQL `reviewThreads` connection. */
 export interface ReviewThreadNode {
   id: string;
   isResolved: boolean;
-  comments?: { nodes?: { databaseId?: number | null }[] | null } | null;
+  comments?: ThreadCommentsConnection | null;
 }
 
 /** The thread that owns the requested review comment. */
@@ -76,7 +82,10 @@ export function findThreadForComment(
 /**
  * Orchestrate the apply-mode mutation with injected side effects so the
  * reply→resolve sequencing is testable without the network. Revalidate the
- * active claim first; a thrown claim check aborts before the reply is posted.
+ * active claim before **each** GitHub-side mutation (E13 requires a claim
+ * revalidation before every reply/resolve side effect): the first check aborts
+ * before the reply is posted, and the second aborts before the resolve if the
+ * claim was released or handed off in the window between the two mutations.
  * Resolve only after the reply lands, so a failed reply never leaves a
  * silently-resolved thread with no disposition.
  */
@@ -87,6 +96,7 @@ export function applyResolveReviewThread(deps: {
 }): { replyId: number } {
   deps.assertClaim();
   const reply = deps.postReply();
+  deps.assertClaim();
   deps.resolveThread();
   return { replyId: reply.id };
 }
@@ -244,11 +254,31 @@ interface ReviewThreadsConnectionPayload {
 }
 
 /**
+ * Throw when a GraphQL response carries top-level `errors`, so a bad
+ * PR/repo/auth or any server-side GraphQL failure fails fast with a clear
+ * message instead of being silently read as an empty result (which would
+ * masquerade as "no review thread found").
+ */
+export function assertNoGraphqlErrors(payload: unknown, context: string): void {
+  const errors = (payload as { errors?: { message?: unknown }[] } | null)
+    ?.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    throw new Error(
+      `${context} failed: ${errors
+        .map((entry) => String(entry.message ?? ''))
+        .filter(Boolean)
+        .join('; ')
+        .slice(0, 200)}`,
+    );
+  }
+}
+
+/**
  * Fetch every review thread of a PR (paginated), each with its node id,
  * resolution state, and member comment database ids — enough to map a REST
- * comment id to its owning thread. Each thread's comments are read up to the
- * first 100, which covers the disposition target (the thread's root or an early
- * reply) in practice; a comment buried past 100 in one thread would not match.
+ * comment id to its owning thread. Both the threads connection **and** each
+ * thread's nested comments connection are paginated to completion, so a target
+ * comment buried past the first 100 replies in a deep thread still resolves.
  */
 function fetchReviewThreads(
   owner: string,
@@ -267,23 +297,46 @@ function fetchReviewThreads(
               nodes {
                 id
                 isResolved
-                comments(first: 100) { nodes { databaseId } }
+                comments(first: 100) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes { databaseId }
+                }
               }
             }
           }
         }
       }`,
       { owner, repo, number: prNumber, cursor },
-    ) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            reviewThreads?: ReviewThreadsConnectionPayload | null;
+    );
+    assertNoGraphqlErrors(payload, 'review thread lookup');
+    const reviewThreads = (
+      payload as {
+        data?: {
+          repository?: {
+            pullRequest?: {
+              reviewThreads?: ReviewThreadsConnectionPayload | null;
+            } | null;
           } | null;
         } | null;
-      } | null;
-    };
-    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
+      }
+    )?.data?.repository?.pullRequest?.reviewThreads;
+    for (const thread of reviewThreads?.nodes ?? []) {
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        if (!thread.id || !thread.comments.pageInfo.endCursor) {
+          throw new Error(
+            'review thread comment pagination payload is missing id or endCursor',
+          );
+        }
+        thread.comments.nodes = [
+          ...(thread.comments.nodes ?? []),
+          ...fetchThreadCommentIds(
+            thread.id,
+            thread.comments.pageInfo.endCursor,
+          ),
+        ];
+        thread.comments.pageInfo.hasNextPage = false;
+      }
+    }
     nodes.push(...(reviewThreads?.nodes ?? []));
     if (!reviewThreads?.pageInfo?.hasNextPage) {
       break;
@@ -292,6 +345,48 @@ function fetchReviewThreads(
       throw new Error('review thread pagination payload is missing endCursor');
     }
     cursor = reviewThreads.pageInfo.endCursor;
+  }
+  return nodes;
+}
+
+/**
+ * Page the remaining comment-id nodes of one review thread, starting after
+ * `afterCursor`, until the connection is exhausted. Mirrors the sibling
+ * snapshot helper's nested-comment pagination.
+ */
+function fetchThreadCommentIds(
+  threadId: string,
+  afterCursor: string,
+): { databaseId?: number | null }[] {
+  const nodes: { databaseId?: number | null }[] = [];
+  let cursor: string | null | undefined = afterCursor;
+  while (cursor) {
+    const payload = ghGraphql(
+      `query($id: ID!, $cursor: String) {
+        node(id: $id) {
+          ... on PullRequestReviewThread {
+            comments(first: 100, after: $cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes { databaseId }
+            }
+          }
+        }
+      }`,
+      { id: threadId, cursor },
+    );
+    assertNoGraphqlErrors(payload, 'review thread comment pagination');
+    const comments = (
+      payload as {
+        data?: { node?: { comments?: ThreadCommentsConnection | null } | null };
+      }
+    )?.data?.node?.comments;
+    nodes.push(...(comments?.nodes ?? []));
+    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
+      throw new Error('thread comment pagination payload is missing endCursor');
+    }
+    cursor = comments?.pageInfo?.hasNextPage
+      ? comments.pageInfo.endCursor
+      : null;
   }
   return nodes;
 }
@@ -324,18 +419,9 @@ function resolveThread(threadId: string): void {
     }`,
     { threadId },
   ) as {
-    errors?: { message?: unknown }[];
     data?: { resolveReviewThread?: { thread?: { isResolved?: unknown } } };
   };
-  if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
-    throw new Error(
-      `resolveReviewThread failed: ${payload.errors
-        .map((entry) => String(entry.message ?? ''))
-        .filter(Boolean)
-        .join('; ')
-        .slice(0, 200)}`,
-    );
-  }
+  assertNoGraphqlErrors(payload, 'resolveReviewThread');
   if (payload?.data?.resolveReviewThread?.thread?.isResolved !== true) {
     throw new Error(
       'resolveReviewThread returned without confirming thread.isResolved',

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -1,0 +1,504 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/resolve-review-thread.mts
+//
+// The scripts/resolve-review-thread.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Perform the common E13 review-thread disposition in one invocation: post the
+// reply comment to the thread that owns a review comment AND resolve that
+// thread. This is the write-side companion to the read-side review helpers
+// (`review-activity-snapshot`, `review-disposition-verify`). It follows the
+// write-side helper family conventions: dry-run by default, `--apply` mutates
+// and requires `--claim-issue` / `--claim-id` so the active claim is
+// revalidated immediately before the reply is posted (fail-closed). Reply
+// first, resolve second — a failed reply never leaves a silently-resolved
+// thread with no disposition.
+
+import { execFileSync } from 'node:child_process';
+
+import {
+  parseForcedHandoffComment,
+  resolveActiveClaim,
+} from './protocol-helpers.mts';
+
+/** A review thread node from the GraphQL `reviewThreads` connection. */
+export interface ReviewThreadNode {
+  id: string;
+  isResolved: boolean;
+  comments?: { nodes?: { databaseId?: number | null }[] | null } | null;
+}
+
+/** The thread that owns the requested review comment. */
+export interface ThreadMatch {
+  threadId: string;
+  isResolved: boolean;
+}
+
+/** The CLI output envelope for both `dry-run` and `--apply` modes. */
+export interface ResolveReviewThreadReport {
+  mode: 'dry-run' | 'apply';
+  prNumber: number;
+  commentId: number;
+  /** Omitted when no review thread owns the comment. */
+  threadId?: string;
+  alreadyResolved: boolean;
+  status?: 'applied' | 'failed';
+  replyId?: number;
+  error?: string;
+}
+
+/**
+ * Find the review thread that owns the review comment whose REST database id is
+ * `commentId`. The GraphQL `PullRequestReviewComment.databaseId` equals the REST
+ * comment id, so the lookup is exact. Pure: takes already-fetched thread nodes
+ * and returns the owning thread's node id plus its current resolution state, or
+ * `null` when no thread contains that comment.
+ */
+export function findThreadForComment(
+  threads: ReviewThreadNode[],
+  commentId: number,
+): ThreadMatch | null {
+  for (const thread of Array.isArray(threads) ? threads : []) {
+    for (const comment of thread.comments?.nodes ?? []) {
+      if (
+        comment.databaseId !== null &&
+        comment.databaseId !== undefined &&
+        Number(comment.databaseId) === Number(commentId)
+      ) {
+        return { threadId: thread.id, isResolved: Boolean(thread.isResolved) };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Orchestrate the apply-mode mutation with injected side effects so the
+ * reply→resolve sequencing is testable without the network. Revalidate the
+ * active claim first; a thrown claim check aborts before the reply is posted.
+ * Resolve only after the reply lands, so a failed reply never leaves a
+ * silently-resolved thread with no disposition.
+ */
+export function applyResolveReviewThread(deps: {
+  assertClaim: () => void;
+  postReply: () => { id: number };
+  resolveThread: () => void;
+}): { replyId: number } {
+  deps.assertClaim();
+  const reply = deps.postReply();
+  deps.resolveThread();
+  return { replyId: reply.id };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+interface CliArgs {
+  pr: number | null;
+  commentId: number | null;
+  body: string;
+  owner: string;
+  repo: string;
+  claimIssue: number | null;
+  claimId: string;
+  agentId: string;
+  trustedMarkerLogins: string[];
+  apply: boolean;
+  help: boolean;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    pr: null,
+    commentId: null,
+    body: '',
+    owner: '',
+    repo: '',
+    claimIssue: null,
+    claimId: '',
+    agentId: '',
+    trustedMarkerLogins: [],
+    apply: false,
+    help: false,
+  };
+  const splitList = (value: string): string[] =>
+    value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const next = (): string => {
+      index += 1;
+      return argv[index] ?? '';
+    };
+    switch (flag) {
+      case '--pr':
+        args.pr = Number.parseInt(next(), 10);
+        break;
+      case '--comment-id':
+        args.commentId = Number.parseInt(next(), 10);
+        break;
+      case '--body':
+        args.body = next();
+        break;
+      case '--owner':
+        args.owner = next();
+        break;
+      case '--repo':
+        args.repo = next();
+        break;
+      case '--claim-issue':
+        args.claimIssue = Number.parseInt(next(), 10);
+        break;
+      case '--claim-id':
+        args.claimId = next();
+        break;
+      case '--agent-id':
+        args.agentId = next();
+        break;
+      case '--trusted-marker-logins':
+        args.trustedMarkerLogins = splitList(next());
+        break;
+      case '--apply':
+        args.apply = true;
+        break;
+      case '--help':
+      case '-h':
+        args.help = true;
+        break;
+      default:
+        break;
+    }
+  }
+  return args;
+}
+
+const USAGE = `usage: node scripts/resolve-review-thread.mjs --pr <number> --comment-id <id> [options]
+
+Post a reply to the review thread that owns <comment-id> and resolve that
+thread in one invocation (E13). Dry-run by default; --apply mutates.
+
+  --pr <number>                  PR number (required)
+  --comment-id <id>              review comment REST id whose thread to resolve (required)
+  --body <text>                  reply body (required with --apply)
+  --owner <owner>                repo owner (default: gh repo view)
+  --repo <repo>                  repo name (default: gh repo view)
+  --claim-issue <number>         issue carrying the active claim (required with --apply)
+  --claim-id <claim-id>          active claim id to re-validate (required with --apply)
+  --agent-id <agent-id>          current session agent id (optional, tightens the claim check)
+  --trusted-marker-logins a,b    logins whose claim markers are trusted
+                                 (default: your gh login)
+  --apply                        post the reply and resolve the thread (default: dry-run)
+  -h, --help                     show this help
+`;
+
+function ghText(args: string[]): string {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+
+function ghJson(args: string[]): unknown {
+  return JSON.parse(execFileSync('gh', args, { encoding: 'utf8' }));
+}
+
+/**
+ * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
+ * one JSON array per page; `--jq '.[]'` flattens each page to one JSON value per
+ * line (NDJSON), which we parse line-by-line (mirrors the sibling helpers).
+ */
+function ghJsonPaginated(args: string[]): unknown[] {
+  const out = execFileSync('gh', [...args, '--paginate', '--jq', '.[]'], {
+    encoding: 'utf8',
+  });
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function ghGraphql(
+  query: string,
+  variables: Record<string, string | number | null | undefined>,
+): unknown {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === 'number') {
+      args.push('-F', `${key}=${value}`);
+      continue;
+    }
+    args.push('-f', `${key}=${value}`);
+  }
+  return JSON.parse(
+    execFileSync('gh', args, { encoding: 'utf8' }).trim() || '{}',
+  );
+}
+
+interface ReviewThreadsConnectionPayload {
+  pageInfo?: { hasNextPage?: boolean; endCursor?: string | null } | null;
+  nodes?: ReviewThreadNode[] | null;
+}
+
+/**
+ * Fetch every review thread of a PR (paginated), each with its node id,
+ * resolution state, and member comment database ids — enough to map a REST
+ * comment id to its owning thread. Each thread's comments are read up to the
+ * first 100, which covers the disposition target (the thread's root or an early
+ * reply) in practice; a comment buried past 100 in one thread would not match.
+ */
+function fetchReviewThreads(
+  owner: string,
+  repo: string,
+  prNumber: number,
+): ReviewThreadNode[] {
+  const nodes: ReviewThreadNode[] = [];
+  let cursor: string | null | undefined = null;
+  while (true) {
+    const payload = ghGraphql(
+      `query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewThreads(first: 100, after: $cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                isResolved
+                comments(first: 100) { nodes { databaseId } }
+              }
+            }
+          }
+        }
+      }`,
+      { owner, repo, number: prNumber, cursor },
+    ) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviewThreads?: ReviewThreadsConnectionPayload | null;
+          } | null;
+        } | null;
+      } | null;
+    };
+    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
+    nodes.push(...(reviewThreads?.nodes ?? []));
+    if (!reviewThreads?.pageInfo?.hasNextPage) {
+      break;
+    }
+    if (!reviewThreads.pageInfo.endCursor) {
+      throw new Error('review thread pagination payload is missing endCursor');
+    }
+    cursor = reviewThreads.pageInfo.endCursor;
+  }
+  return nodes;
+}
+
+/** Post a reply to the review thread that owns `commentId` (REST). */
+function postReply(
+  owner: string,
+  repo: string,
+  pr: number,
+  commentId: number,
+  body: string,
+): { id: number } {
+  return ghJson([
+    'api',
+    '--method',
+    'POST',
+    `repos/${owner}/${repo}/pulls/${pr}/comments/${commentId}/replies`,
+    '-f',
+    `body=${body}`,
+  ]) as { id: number };
+}
+
+/** Resolve a review thread by its GraphQL node id, confirming the result. */
+function resolveThread(threadId: string): void {
+  const payload = ghGraphql(
+    `mutation($threadId: ID!) {
+      resolveReviewThread(input: { threadId: $threadId }) {
+        thread { id isResolved }
+      }
+    }`,
+    { threadId },
+  ) as {
+    errors?: { message?: unknown }[];
+    data?: { resolveReviewThread?: { thread?: { isResolved?: unknown } } };
+  };
+  if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
+    throw new Error(
+      `resolveReviewThread failed: ${payload.errors
+        .map((entry) => String(entry.message ?? ''))
+        .filter(Boolean)
+        .join('; ')
+        .slice(0, 200)}`,
+    );
+  }
+  if (payload?.data?.resolveReviewThread?.thread?.isResolved !== true) {
+    throw new Error(
+      'resolveReviewThread returned without confirming thread.isResolved',
+    );
+  }
+}
+
+/**
+ * Re-fetch the claim issue and decide whether `claimId` is still the active
+ * claim. Scoped to trusted marker authors via the shared `resolveActiveClaim`
+ * state machine, and fails closed on any `forced-handoff` marker that targets
+ * this claim. Aborting on a contested claim is always safe (the manual E13 path
+ * remains).
+ */
+function claimStillActive(
+  owner: string,
+  repo: string,
+  issue: number,
+  agentId: string,
+  claimId: string,
+  isTrustedAuthor: (login: string) => boolean,
+): boolean {
+  const comments = ghJsonPaginated([
+    'api',
+    `repos/${owner}/${repo}/issues/${issue}/comments`,
+  ]) as { body?: string; created_at?: string; user?: { login?: string } }[];
+  for (const comment of comments) {
+    const forcedHandoff = parseForcedHandoffComment(
+      comment.body ?? '',
+      comment.created_at ?? '',
+    );
+    if (forcedHandoff && forcedHandoff.oldClaimId === claimId) {
+      return false;
+    }
+  }
+  const events = comments.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  }));
+  const active = resolveActiveClaim(events, isTrustedAuthor);
+  if (active?.claimId !== claimId) {
+    return false;
+  }
+  return agentId ? active.agentId === agentId : true;
+}
+
+function isMainModule(moduleUrl: string): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return moduleUrl === `file://${entry}` || moduleUrl.endsWith(entry);
+}
+
+if (isMainModule(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2));
+  if (
+    args.help ||
+    !Number.isInteger(args.pr) ||
+    (args.pr ?? 0) <= 0 ||
+    !Number.isInteger(args.commentId) ||
+    (args.commentId ?? 0) <= 0
+  ) {
+    process.stdout.write(USAGE);
+    process.exit(args.help ? 0 : 1);
+  }
+  // Fail closed: --apply mutates PR state, so the active-claim revalidation and
+  // a reply body are mandatory. Missing inputs must abort before any read or
+  // write rather than silently bypassing the gate.
+  if (
+    args.apply &&
+    (!Number.isInteger(args.claimIssue) ||
+      (args.claimIssue ?? 0) <= 0 ||
+      !args.claimId ||
+      !args.body)
+  ) {
+    process.stderr.write(
+      '--apply requires --body and the --claim-issue / --claim-id pair for the mandatory claim revalidation\n',
+    );
+    process.exit(1);
+  }
+  const pr = args.pr as number;
+  const commentId = args.commentId as number;
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+
+  const match = findThreadForComment(
+    fetchReviewThreads(owner, repo, pr),
+    commentId,
+  );
+
+  const report: ResolveReviewThreadReport = {
+    mode: args.apply ? 'apply' : 'dry-run',
+    prNumber: pr,
+    commentId,
+    ...(match ? { threadId: match.threadId } : {}),
+    alreadyResolved: match?.isResolved ?? false,
+  };
+
+  if (!match) {
+    report.error = `no review thread found for comment ${commentId} on PR #${pr}`;
+    if (args.apply) {
+      report.status = 'failed';
+    }
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    // A missing thread is informational in dry-run but a hard failure in apply.
+    process.exit(args.apply ? 1 : 0);
+  }
+
+  if (!args.apply) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(0);
+  }
+
+  // --apply: default the trusted claim authors to this gh login so the
+  // revalidation recognizes the session's own claim markers.
+  const viewerLogin = ghText(['api', 'user', '--jq', '.login']).toLowerCase();
+  const trustedAuthors = new Set(
+    (args.trustedMarkerLogins.length > 0
+      ? args.trustedMarkerLogins
+      : [viewerLogin]
+    ).map((login) => login.toLowerCase()),
+  );
+  const isTrustedAuthor = (login: string): boolean =>
+    trustedAuthors.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+
+  try {
+    const result = applyResolveReviewThread({
+      assertClaim: () => {
+        if (
+          !claimStillActive(
+            owner,
+            repo,
+            args.claimIssue as number,
+            args.agentId,
+            args.claimId,
+            isTrustedAuthor,
+          )
+        ) {
+          throw new Error(
+            `claim revalidation failed: "${args.claimId}" is no longer the active claim on issue #${args.claimIssue}`,
+          );
+        }
+      },
+      postReply: () => postReply(owner, repo, pr, commentId, args.body),
+      resolveThread: () => resolveThread(match.threadId),
+    });
+    report.status = 'applied';
+    report.replyId = result.replyId;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(0);
+  } catch (error) {
+    report.status = 'failed';
+    report.error = (error as Error).message;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(1);
+  }
+}

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -18,6 +18,7 @@
 import { execFileSync } from 'node:child_process';
 
 import {
+  type ParsedClaimMarker,
   parseForcedHandoffComment,
   resolveActiveClaim,
 } from './protocol-helpers.mts';
@@ -39,6 +40,13 @@ export interface ReviewThreadNode {
 export interface ThreadMatch {
   threadId: string;
   isResolved: boolean;
+  /**
+   * REST database id of the thread's **top-level** review comment. The reply is
+   * posted against this id (not the requested `--comment-id`), because GitHub's
+   * create-reply endpoint requires a top-level review comment — replies to
+   * replies are unsupported. `null` when the thread exposes no comment id.
+   */
+  rootCommentId: number | null;
 }
 
 /** The CLI output envelope for both `dry-run` and `--apply` modes. */
@@ -66,13 +74,25 @@ export function findThreadForComment(
   commentId: number,
 ): ThreadMatch | null {
   for (const thread of Array.isArray(threads) ? threads : []) {
-    for (const comment of thread.comments?.nodes ?? []) {
+    const nodes = thread.comments?.nodes ?? [];
+    for (const comment of nodes) {
       if (
         comment.databaseId !== null &&
         comment.databaseId !== undefined &&
         Number(comment.databaseId) === Number(commentId)
       ) {
-        return { threadId: thread.id, isResolved: Boolean(thread.isResolved) };
+        // The top-level review comment is the first node in the thread's
+        // comments connection; the reply must target it, even when the request
+        // named a later reply in the thread.
+        const rootDatabaseId = nodes[0]?.databaseId;
+        return {
+          threadId: thread.id,
+          isResolved: Boolean(thread.isResolved),
+          rootCommentId:
+            rootDatabaseId !== null && rootDatabaseId !== undefined
+              ? Number(rootDatabaseId)
+              : null,
+        };
       }
     }
   }
@@ -430,20 +450,22 @@ function resolveThread(threadId: string): void {
 }
 
 /**
- * Re-fetch the claim issue and decide whether `claimId` is still the active
- * claim. Scoped to trusted marker authors via the shared `resolveActiveClaim`
- * state machine, and fails closed on any `forced-handoff` marker that targets
- * this claim. Aborting on a contested claim is always safe (the manual E13 path
- * remains).
+ * Re-fetch the claim issue and return the active claim **owned by this session**
+ * (its `claimId`, and `agentId` when supplied, match), or `null` when the claim
+ * was lost. Scoped to trusted marker authors via the shared `resolveActiveClaim`
+ * state machine, and fails closed (returns `null`) on any `forced-handoff`
+ * marker that targets this claim. Aborting on a contested claim is always safe
+ * (the manual E13 path remains). The returned `branch` lets the caller bind the
+ * mutation to the PR whose head is that branch.
  */
-function claimStillActive(
+function activeOwnedClaim(
   owner: string,
   repo: string,
   issue: number,
   agentId: string,
   claimId: string,
   isTrustedAuthor: (login: string) => boolean,
-): boolean {
+): ParsedClaimMarker | null {
   const comments = ghJsonPaginated([
     'api',
     `repos/${owner}/${repo}/issues/${issue}/comments`,
@@ -454,7 +476,7 @@ function claimStillActive(
       comment.created_at ?? '',
     );
     if (forcedHandoff && forcedHandoff.oldClaimId === claimId) {
-      return false;
+      return null;
     }
   }
   const events = comments.map((comment) => ({
@@ -464,9 +486,12 @@ function claimStillActive(
   }));
   const active = resolveActiveClaim(events, isTrustedAuthor);
   if (active?.claimId !== claimId) {
-    return false;
+    return null;
   }
-  return agentId ? active.agentId === agentId : true;
+  if (agentId && active.agentId !== agentId) {
+    return null;
+  }
+  return active;
 }
 
 function isMainModule(moduleUrl: string): boolean {
@@ -540,6 +565,26 @@ if (isMainModule(import.meta.url)) {
     process.exit(0);
   }
 
+  // The reply targets the thread's top-level review comment, so a thread with
+  // no exposed comment id cannot be replied to — fail closed before mutating.
+  const rootCommentId = match.rootCommentId;
+  if (rootCommentId === null) {
+    report.status = 'failed';
+    report.error = `review thread ${match.threadId} exposes no top-level comment id to reply to`;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(1);
+  }
+
+  // Bind the mutation to the claimed PR: the active claim's branch must be the
+  // PR's head branch, so a valid claim on the issue cannot be used to reply to
+  // and resolve a thread on some other PR passed as --pr.
+  const prHeadRef = ghText([
+    'api',
+    `repos/${owner}/${repo}/pulls/${pr}`,
+    '--jq',
+    '.head.ref',
+  ]);
+
   // --apply: default the trusted claim authors to this gh login so the
   // revalidation recognizes the session's own claim markers.
   const viewerLogin = ghText(['api', 'user', '--jq', '.login']).toLowerCase();
@@ -556,25 +601,37 @@ if (isMainModule(import.meta.url)) {
         .toLowerCase(),
     );
 
+  // Retain the posted reply id across a later failure so a partial apply (reply
+  // posted, resolve not confirmed) reports the reply id instead of looking like
+  // nothing was posted — that distinguishes "retry the resolve" from "re-post".
+  let postedReplyId: number | undefined;
   try {
     const result = applyResolveReviewThread({
       assertClaim: () => {
-        if (
-          !claimStillActive(
-            owner,
-            repo,
-            args.claimIssue as number,
-            args.agentId,
-            args.claimId,
-            isTrustedAuthor,
-          )
-        ) {
+        const active = activeOwnedClaim(
+          owner,
+          repo,
+          args.claimIssue as number,
+          args.agentId,
+          args.claimId,
+          isTrustedAuthor,
+        );
+        if (!active) {
           throw new Error(
             `claim revalidation failed: "${args.claimId}" is no longer the active claim on issue #${args.claimIssue}`,
           );
         }
+        if (active.branch !== prHeadRef) {
+          throw new Error(
+            `claim/PR mismatch: active claim branch "${active.branch}" does not match PR #${pr} head branch "${prHeadRef}"`,
+          );
+        }
       },
-      postReply: () => postReply(owner, repo, pr, commentId, args.body),
+      postReply: () => {
+        const posted = postReply(owner, repo, pr, rootCommentId, args.body);
+        postedReplyId = posted.id;
+        return posted;
+      },
       resolveThread: () => resolveThread(match.threadId),
     });
     report.status = 'applied';
@@ -583,6 +640,9 @@ if (isMainModule(import.meta.url)) {
     process.exit(0);
   } catch (error) {
     report.status = 'failed';
+    if (postedReplyId !== undefined) {
+      report.replyId = postedReplyId;
+    }
     report.error = (error as Error).message;
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     process.exit(1);

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  applyResolveReviewThread,
+  findThreadForComment,
+  parseArgs,
+  type ResolveReviewThreadReport,
+  type ReviewThreadNode,
+} from '../src/scripts/resolve-review-thread.mts';
+import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
+
+const resultSchema = loadJson('schemas/resolve-review-thread.schema.json');
+
+function thread(
+  id: string,
+  isResolved: boolean,
+  commentDatabaseIds: number[],
+): ReviewThreadNode {
+  return {
+    id,
+    isResolved,
+    comments: {
+      nodes: commentDatabaseIds.map((databaseId) => ({ databaseId })),
+    },
+  };
+}
+
+test('parseArgs reads the call shape and defaults to dry-run', () => {
+  const args = parseArgs([
+    '--pr',
+    '42',
+    '--comment-id',
+    '1001',
+    '--body',
+    '**Accepted** — fixed in abc1234',
+  ]);
+  assert.equal(args.pr, 42);
+  assert.equal(args.commentId, 1001);
+  assert.equal(args.body, '**Accepted** — fixed in abc1234');
+  assert.equal(args.apply, false);
+});
+
+test('parseArgs reads the apply-mode claim inputs', () => {
+  const args = parseArgs([
+    '--pr',
+    '42',
+    '--comment-id',
+    '1001',
+    '--body',
+    'x',
+    '--apply',
+    '--claim-issue',
+    '7',
+    '--claim-id',
+    'deadbeef',
+    '--trusted-marker-logins',
+    'kurone-kito, second-user',
+  ]);
+  assert.equal(args.apply, true);
+  assert.equal(args.claimIssue, 7);
+  assert.equal(args.claimId, 'deadbeef');
+  assert.deepEqual(args.trustedMarkerLogins, ['kurone-kito', 'second-user']);
+});
+
+test('findThreadForComment maps a REST comment id to its owning thread', () => {
+  const threads = [
+    thread('thread-a', false, [900, 901]),
+    thread('thread-b', true, [1001, 1002]),
+  ];
+  const match = findThreadForComment(threads, 1002);
+  assert.deepEqual(match, { threadId: 'thread-b', isResolved: true });
+});
+
+test('findThreadForComment returns null when no thread owns the comment', () => {
+  const threads = [thread('thread-a', false, [900])];
+  assert.equal(findThreadForComment(threads, 999), null);
+});
+
+test('findThreadForComment ignores missing databaseId nodes safely', () => {
+  const threads: ReviewThreadNode[] = [
+    {
+      id: 'thread-a',
+      isResolved: false,
+      comments: { nodes: [{ databaseId: null }] },
+    },
+    { id: 'thread-b', isResolved: false, comments: { nodes: null } },
+    thread('thread-c', false, [1001]),
+  ];
+  assert.deepEqual(findThreadForComment(threads, 1001), {
+    threadId: 'thread-c',
+    isResolved: false,
+  });
+});
+
+test('applyResolveReviewThread revalidates the claim before posting, then resolves after the reply', () => {
+  const calls: string[] = [];
+  const result = applyResolveReviewThread({
+    assertClaim: () => {
+      calls.push('claim');
+    },
+    postReply: () => {
+      calls.push('reply');
+      return { id: 555 };
+    },
+    resolveThread: () => {
+      calls.push('resolve');
+    },
+  });
+  assert.deepEqual(calls, ['claim', 'reply', 'resolve']);
+  assert.equal(result.replyId, 555);
+});
+
+test('applyResolveReviewThread aborts before any mutation when the claim check throws', () => {
+  const calls: string[] = [];
+  assert.throws(
+    () =>
+      applyResolveReviewThread({
+        assertClaim: () => {
+          throw new Error('claim lost');
+        },
+        postReply: () => {
+          calls.push('reply');
+          return { id: 1 };
+        },
+        resolveThread: () => {
+          calls.push('resolve');
+        },
+      }),
+    /claim lost/,
+  );
+  assert.deepEqual(calls, []);
+});
+
+test('applyResolveReviewThread does not resolve the thread when the reply fails', () => {
+  const calls: string[] = [];
+  assert.throws(
+    () =>
+      applyResolveReviewThread({
+        assertClaim: () => {
+          calls.push('claim');
+        },
+        postReply: () => {
+          throw new Error('reply failed');
+        },
+        resolveThread: () => {
+          calls.push('resolve');
+        },
+      }),
+    /reply failed/,
+  );
+  assert.deepEqual(calls, ['claim']);
+});
+
+test('the dry-run and apply output envelopes validate against the schema', () => {
+  const dryRun: ResolveReviewThreadReport = {
+    mode: 'dry-run',
+    prNumber: 7,
+    commentId: 1001,
+    threadId: 'thread-b',
+    alreadyResolved: false,
+  };
+  assert.equal(validate(dryRun, resultSchema).length, 0, 'dry-run output');
+
+  const notFound: ResolveReviewThreadReport = {
+    mode: 'dry-run',
+    prNumber: 7,
+    commentId: 999,
+    alreadyResolved: false,
+    error: 'no review thread found for comment 999 on PR #7',
+  };
+  assert.equal(validate(notFound, resultSchema).length, 0, 'not-found output');
+
+  const apply: ResolveReviewThreadReport = {
+    mode: 'apply',
+    prNumber: 7,
+    commentId: 1001,
+    threadId: 'thread-b',
+    alreadyResolved: false,
+    status: 'applied',
+    replyId: 4242,
+  };
+  assert.equal(validate(apply, resultSchema).length, 0, 'apply output');
+});

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 
 import {
   applyResolveReviewThread,
+  assertNoGraphqlErrors,
   findThreadForComment,
   parseArgs,
   type ResolveReviewThreadReport,
@@ -93,7 +94,29 @@ test('findThreadForComment ignores missing databaseId nodes safely', () => {
   });
 });
 
-test('applyResolveReviewThread revalidates the claim before posting, then resolves after the reply', () => {
+test('assertNoGraphqlErrors throws on a response carrying errors', () => {
+  assert.throws(
+    () =>
+      assertNoGraphqlErrors(
+        { errors: [{ message: 'Could not resolve to a Repository' }] },
+        'review thread lookup',
+      ),
+    /review thread lookup failed: Could not resolve to a Repository/,
+  );
+});
+
+test('assertNoGraphqlErrors passes a clean response so a real not-found is not masked', () => {
+  assert.doesNotThrow(() =>
+    assertNoGraphqlErrors(
+      {
+        data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+      },
+      'review thread lookup',
+    ),
+  );
+});
+
+test('applyResolveReviewThread revalidates the claim before each mutation (reply then resolve)', () => {
   const calls: string[] = [];
   const result = applyResolveReviewThread({
     assertClaim: () => {
@@ -107,8 +130,34 @@ test('applyResolveReviewThread revalidates the claim before posting, then resolv
       calls.push('resolve');
     },
   });
-  assert.deepEqual(calls, ['claim', 'reply', 'resolve']);
+  assert.deepEqual(calls, ['claim', 'reply', 'claim', 'resolve']);
   assert.equal(result.replyId, 555);
+});
+
+test('applyResolveReviewThread does not resolve when the second claim check fails after the reply', () => {
+  const calls: string[] = [];
+  let claimChecks = 0;
+  assert.throws(
+    () =>
+      applyResolveReviewThread({
+        assertClaim: () => {
+          claimChecks += 1;
+          calls.push('claim');
+          if (claimChecks === 2) {
+            throw new Error('claim handed off mid-flight');
+          }
+        },
+        postReply: () => {
+          calls.push('reply');
+          return { id: 1 };
+        },
+        resolveThread: () => {
+          calls.push('resolve');
+        },
+      }),
+    /claim handed off mid-flight/,
+  );
+  assert.deepEqual(calls, ['claim', 'reply', 'claim']);
 });
 
 test('applyResolveReviewThread aborts before any mutation when the claim check throws', () => {

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -64,13 +64,29 @@ test('parseArgs reads the apply-mode claim inputs', () => {
   assert.deepEqual(args.trustedMarkerLogins, ['kurone-kito', 'second-user']);
 });
 
-test('findThreadForComment maps a REST comment id to its owning thread', () => {
+test('findThreadForComment maps a REST comment id to its owning thread and root comment', () => {
   const threads = [
     thread('thread-a', false, [900, 901]),
     thread('thread-b', true, [1001, 1002]),
   ];
   const match = findThreadForComment(threads, 1002);
-  assert.deepEqual(match, { threadId: 'thread-b', isResolved: true });
+  assert.deepEqual(match, {
+    threadId: 'thread-b',
+    isResolved: true,
+    rootCommentId: 1001,
+  });
+});
+
+test('findThreadForComment returns the top-level comment id when a later reply matches', () => {
+  // The reply must target the thread's first (top-level) comment, since GitHub
+  // does not support replies to replies; matching a later reply still resolves
+  // to the root comment id.
+  const threads = [thread('thread-x', false, [500, 777])];
+  assert.deepEqual(findThreadForComment(threads, 777), {
+    threadId: 'thread-x',
+    isResolved: false,
+    rootCommentId: 500,
+  });
 });
 
 test('findThreadForComment returns null when no thread owns the comment', () => {
@@ -91,6 +107,7 @@ test('findThreadForComment ignores missing databaseId nodes safely', () => {
   assert.deepEqual(findThreadForComment(threads, 1001), {
     threadId: 'thread-c',
     isResolved: false,
+    rootCommentId: 1001,
   });
 });
 
@@ -179,6 +196,33 @@ test('applyResolveReviewThread aborts before any mutation when the claim check t
     /claim lost/,
   );
   assert.deepEqual(calls, []);
+});
+
+test('applyResolveReviewThread posts the reply before a resolve failure surfaces (id observable for the partial-failure report)', () => {
+  const calls: string[] = [];
+  let observedReplyId: number | undefined;
+  assert.throws(
+    () =>
+      applyResolveReviewThread({
+        assertClaim: () => {
+          calls.push('claim');
+        },
+        postReply: () => {
+          calls.push('reply');
+          observedReplyId = 999;
+          return { id: 999 };
+        },
+        resolveThread: () => {
+          calls.push('resolve');
+          throw new Error('resolve failed');
+        },
+      }),
+    /resolve failed/,
+  );
+  assert.deepEqual(calls, ['claim', 'reply', 'claim', 'resolve']);
+  // The reply id is observable before the resolve throws, so the CLI can retain
+  // it in the failed report instead of looking like nothing was posted.
+  assert.equal(observedReplyId, 999);
 });
 
 test('applyResolveReviewThread does not resolve the thread when the reply fails', () => {

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -14,6 +14,7 @@ import type {
   ParsedClaimMarker,
   ParsedForcedHandoffMarker,
 } from '../src/scripts/protocol-helpers.mts';
+import type { ResolveReviewThreadReport } from '../src/scripts/resolve-review-thread.mts';
 import type { StalledSessionQuietCheckReport } from '../src/scripts/stalled-session-quiet-check.mts';
 import {
   checkSchemaKeywords,
@@ -957,6 +958,27 @@ const dispositionNonReviewNoticesFixture = {
   ],
 } satisfies DispositionReport;
 
+const resolveReviewThreadKeys = [
+  'mode',
+  'prNumber',
+  'commentId',
+  'threadId',
+  'alreadyResolved',
+  'status',
+  'replyId',
+  'error',
+] as const satisfies readonly (keyof ResolveReviewThreadReport)[];
+
+const resolveReviewThreadFixture = {
+  mode: 'apply',
+  prNumber: 7,
+  commentId: 1001,
+  threadId: 'thread-node-id',
+  alreadyResolved: false,
+  status: 'applied',
+  replyId: 4242,
+} satisfies ResolveReviewThreadReport;
+
 const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
   {
     schemaFile: 'disposition-non-review-notices.schema.json',
@@ -964,6 +986,13 @@ const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
     owningModule: 'src/scripts/disposition-non-review-notices.mts',
     keys: dispositionNonReviewNoticesKeys,
     fixture: dispositionNonReviewNoticesFixture,
+  },
+  {
+    schemaFile: 'resolve-review-thread.schema.json',
+    exportedType: 'ResolveReviewThreadReport',
+    owningModule: 'src/scripts/resolve-review-thread.mts',
+    keys: resolveReviewThreadKeys,
+    fixture: resolveReviewThreadFixture,
   },
   {
     schemaFile: 'advisory-wait-state.schema.json',


### PR DESCRIPTION
## Summary

Adds the `resolve-review-thread` write-side helper. E13 review-thread
disposition was a hand-built REST reply **plus** a separate GraphQL
`resolveReviewThread` mutation — two manual calls per thread, every review
round. The read-side review helpers removed the read half; this adds the write
half.

`resolve-review-thread --pr <n> --comment-id <id> --body "<disposition>"` posts
the reply to the review thread that owns `--comment-id` and resolves that thread
in one invocation. It follows the write-side helper family conventions:

- **Dry-run by default**; `--apply` mutates and requires `--claim-issue` /
  `--claim-id` so the active claim is re-validated immediately before the reply.
- **Reply first, resolve second** — a failed reply never leaves a
  silently-resolved thread with no disposition.
- Maps `--comment-id` (REST id) to its owning thread via the GraphQL
  `reviewThreads` `databaseId`; reply uses REST
  `pulls/.../comments/{id}/replies`, resolution uses GraphQL
  `resolveReviewThread`.

Follows the established helper layout exactly (sibling: `review-activity-snapshot`
/ `disposition-non-review-notices`): `.mts` source + `bin` wrapper, a stable
schema (mapped in the schema-type reconciliation table), a test covering arg
parsing, comment→thread mapping, and the reply+resolve sequencing with injected
deps, manifest registration, and `idd-helper-scripts` docs (edited in the
`idd-template` source, root mirror regenerated). Generated `.mjs` artifacts are
rebuilt and committed.

The written E13 reply-and-resolve rule in `idd-review-fix.instructions.md` stays
authoritative; this helper is the helper-first convenience path with the manual
REST + GraphQL fallback retained.

## Verification

`pnpm run lint:minimum` passes (typecheck, build:check, biome, dprint,
node --test with the 9 new tests, cspell, markdownlint).

## Follow-up

- #1051 wires the E13 review-disposition instructions to reference this helper.

Closes #1048


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new helper command to reply to a review comment’s thread and resolve it in one step.
  * Supports dry-run by default, with an apply mode that performs the action for real.
  * Adds a new CLI entry point and includes the command in available helper listings.

* **Documentation**
  * Updated helper documentation with usage details, output behavior, and the new result contract.

* **Bug Fixes**
  * Added safeguards so the thread is only resolved after a successful reply, and failures stop the process cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->