### PR TITLE
feat(idd): add post-idd-marker write-side helper that POSTs markers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,6 +41,7 @@ scripts/merged-pr-feedback-sweep.mjs linguist-generated=true
 scripts/minimize-superseded-markers.mjs linguist-generated=true
 scripts/phase-id-resolver.mjs linguist-generated=true
 scripts/policy-helpers.mjs linguist-generated=true
+scripts/post-idd-marker.mjs linguist-generated=true
 scripts/pre-merge-readiness.mjs linguist-generated=true
 scripts/protocol-helpers.mjs linguist-generated=true
 scripts/resume-claim-routing.mjs linguist-generated=true

--- a/bin/idd-post-idd-marker.mjs
+++ b/bin/idd-post-idd-marker.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-post-idd-marker.mts
+//
+// The bin/idd-post-idd-marker.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/post-idd-marker.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -731,7 +731,8 @@ Interpretation rules:
 
 - Source repo / vendored-node command:
   `node scripts/post-idd-marker.mjs --type <type> --target <issue|pr> <number> <fields...>`
-  (dry-run prints the body); add `--apply` to POST it.
+  (dry-run prints a JSON envelope whose `body` field is the marker); add
+  `--apply` to POST it.
 - Package-manager / ephemeral-npx command: use the profile-selected
   `idd:post-idd-marker` command from the helper runtime manifest wiring above
 - Write-side companion to `emit-marker`: it renders the canonical body for

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -42,6 +42,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   `review-watermark` / `review-baseline` marker bodies (emit-only, no
   network write; referenced in
   [kurone-kito/idd-skill#900](https://github.com/kurone-kito/idd-skill/issues/900))
+- `scripts/post-idd-marker.mjs` for rendering and POSTing any operational
+  marker (`claim` / `unclaim` / `watermark` / `baseline` / `advisory` /
+  `advisory-recovery`) via the reliable JSON path that HTML-comment-first
+  bodies require (referenced in
+  [kurone-kito/idd-skill#1047](https://github.com/kurone-kito/idd-skill/issues/1047))
 - `scripts/resume-claim-routing.mjs` for Resume Step 1 claim-state
   evaluation and takeover routing (referenced in
   [kurone-kito/idd-skill#394](https://github.com/kurone-kito/idd-skill/issues/394))
@@ -722,6 +727,37 @@ Interpretation rules:
   `idd-review-snapshot` (watermark/baseline) stay canonical; the render
   functions live in `protocol-helpers` with byte-shape tests
 
+### Post operational markers (write-side)
+
+- Source repo / vendored-node command:
+  `node scripts/post-idd-marker.mjs --type <type> --target <issue|pr> <number> <fields...>`
+  (dry-run prints the body); add `--apply` to POST it.
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd:post-idd-marker` command from the helper runtime manifest wiring above
+- Write-side companion to `emit-marker`: it renders the canonical body for
+  each operational marker `<type>` (`claim`, `unclaim`, `watermark`,
+  `baseline`, `advisory`, `advisory-recovery`) by reusing the single-sourced
+  `protocol-helpers` renderers, then POSTs it as a JSON document
+  (`{"body": …}`) via `gh api --method POST .../comments --input -`. The JSON
+  path is mandatory because `gh issue comment` / `gh api -f body=` silently
+  reject the HTML-comment-first claim-family bodies.
+- The `claim` / `unclaim` / `watermark` / `baseline` bodies are
+  HTML-comment-first with a visible "Do not edit" note; `advisory` /
+  `advisory-recovery` are the **plain-text** `advisory-wait:` /
+  `advisory-wait-recovery:` forms (no visible note) so the AW2 / shell-fallback
+  recognizers still match.
+- Fields per type: `claim` takes `--agent-id --claim-id --supersedes
+  --timestamp --branch`; `unclaim` takes `--agent-id --claim-id --timestamp`;
+  `watermark` takes `--agent-id --claim-id --head-sha --max-activity-at
+  --total-item-count --ci-completed-at`; `baseline` takes `--agent-id
+  --claim-id --sha`; `advisory` / `advisory-recovery` take `--agent-id
+  --head-sha --timestamp`.
+- **No claim/state gating** (the `emit-marker` philosophy): this is a
+  single-marker render+POST primitive, so the calling phase must run its
+  claim-revalidation gate before `--apply`, exactly as the manual POST path it
+  replaces already requires.
+- Stable contract: [`post-idd-marker.schema.json`][post-idd-marker-schema].
+
 ### Resume claim and route evidence
 
 - Claim routing command:
@@ -1137,4 +1173,5 @@ replace the written decision tables.
 [advisory-wait-state-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-wait-state.schema.json
 [disposition-non-review-notices-schema]: https://kurone-kito.github.io/idd-skill/schemas/disposition-non-review-notices.schema.json
 [idd-merge-execute-schema]: https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json
+[post-idd-marker-schema]: https://kurone-kito.github.io/idd-skill/schemas/post-idd-marker.schema.json
 [pre-merge-readiness-schema]: https://kurone-kito.github.io/idd-skill/schemas/pre-merge-readiness.schema.json

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -731,7 +731,8 @@ Interpretation rules:
 
 - Source repo / vendored-node command:
   `node scripts/post-idd-marker.mjs --type <type> --target <issue|pr> <number> <fields...>`
-  (dry-run prints the body); add `--apply` to POST it.
+  (dry-run prints a JSON envelope whose `body` field is the marker); add
+  `--apply` to POST it.
 - Package-manager / ephemeral-npx command: use the profile-selected
   `idd:post-idd-marker` command from the helper runtime manifest wiring above
 - Write-side companion to `emit-marker`: it renders the canonical body for

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -42,6 +42,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   `review-watermark` / `review-baseline` marker bodies (emit-only, no
   network write; referenced in
   [kurone-kito/idd-skill#900](https://github.com/kurone-kito/idd-skill/issues/900))
+- `scripts/post-idd-marker.mjs` for rendering and POSTing any operational
+  marker (`claim` / `unclaim` / `watermark` / `baseline` / `advisory` /
+  `advisory-recovery`) via the reliable JSON path that HTML-comment-first
+  bodies require (referenced in
+  [kurone-kito/idd-skill#1047](https://github.com/kurone-kito/idd-skill/issues/1047))
 - `scripts/resume-claim-routing.mjs` for Resume Step 1 claim-state
   evaluation and takeover routing (referenced in
   [kurone-kito/idd-skill#394](https://github.com/kurone-kito/idd-skill/issues/394))
@@ -722,6 +727,37 @@ Interpretation rules:
   `idd-review-snapshot` (watermark/baseline) stay canonical; the render
   functions live in `protocol-helpers` with byte-shape tests
 
+### Post operational markers (write-side)
+
+- Source repo / vendored-node command:
+  `node scripts/post-idd-marker.mjs --type <type> --target <issue|pr> <number> <fields...>`
+  (dry-run prints the body); add `--apply` to POST it.
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd:post-idd-marker` command from the helper runtime manifest wiring above
+- Write-side companion to `emit-marker`: it renders the canonical body for
+  each operational marker `<type>` (`claim`, `unclaim`, `watermark`,
+  `baseline`, `advisory`, `advisory-recovery`) by reusing the single-sourced
+  `protocol-helpers` renderers, then POSTs it as a JSON document
+  (`{"body": …}`) via `gh api --method POST .../comments --input -`. The JSON
+  path is mandatory because `gh issue comment` / `gh api -f body=` silently
+  reject the HTML-comment-first claim-family bodies.
+- The `claim` / `unclaim` / `watermark` / `baseline` bodies are
+  HTML-comment-first with a visible "Do not edit" note; `advisory` /
+  `advisory-recovery` are the **plain-text** `advisory-wait:` /
+  `advisory-wait-recovery:` forms (no visible note) so the AW2 / shell-fallback
+  recognizers still match.
+- Fields per type: `claim` takes `--agent-id --claim-id --supersedes
+  --timestamp --branch`; `unclaim` takes `--agent-id --claim-id --timestamp`;
+  `watermark` takes `--agent-id --claim-id --head-sha --max-activity-at
+  --total-item-count --ci-completed-at`; `baseline` takes `--agent-id
+  --claim-id --sha`; `advisory` / `advisory-recovery` take `--agent-id
+  --head-sha --timestamp`.
+- **No claim/state gating** (the `emit-marker` philosophy): this is a
+  single-marker render+POST primitive, so the calling phase must run its
+  claim-revalidation gate before `--apply`, exactly as the manual POST path it
+  replaces already requires.
+- Stable contract: [`post-idd-marker.schema.json`][post-idd-marker-schema].
+
 ### Resume claim and route evidence
 
 - Claim routing command:
@@ -1137,4 +1173,5 @@ replace the written decision tables.
 [advisory-wait-state-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-wait-state.schema.json
 [disposition-non-review-notices-schema]: https://kurone-kito.github.io/idd-skill/schemas/disposition-non-review-notices.schema.json
 [idd-merge-execute-schema]: https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json
+[post-idd-marker-schema]: https://kurone-kito.github.io/idd-skill/schemas/post-idd-marker.schema.json
 [pre-merge-readiness-schema]: https://kurone-kito.github.io/idd-skill/schemas/pre-merge-readiness.schema.json

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "idd-merge-execute": "./bin/idd-merge-execute.mjs",
     "idd-merged-pr-feedback-sweep": "./bin/idd-merged-pr-feedback-sweep.mjs",
     "idd-phase-id-resolver": "./bin/idd-phase-id-resolver.mjs",
+    "idd-post-idd-marker": "./bin/idd-post-idd-marker.mjs",
     "idd-pre-merge-readiness": "./bin/idd-pre-merge-readiness.mjs",
     "idd-resume-claim-routing": "./bin/idd-resume-claim-routing.mjs",
     "idd-resume-route-selection": "./bin/idd-resume-route-selection.mjs",

--- a/schemas/post-idd-marker.schema.json
+++ b/schemas/post-idd-marker.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/post-idd-marker.schema.json",
+  "title": "Post IDD Marker Result",
+  "description": "Dry-run body preview or apply result for POSTing a canonical IDD operational marker comment to an issue or PR.",
+  "type": "object",
+  "required": ["mode", "type", "target", "number"],
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["dry-run", "apply"]
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "claim",
+        "unclaim",
+        "watermark",
+        "baseline",
+        "advisory",
+        "advisory-recovery"
+      ]
+    },
+    "target": {
+      "type": "string",
+      "enum": ["issue", "pr"]
+    },
+    "number": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "body": {
+      "type": "string"
+    },
+    "commentId": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "url": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -279,6 +279,16 @@ const HELPER_COMMANDS = [
     description: 'Resolve canonical phase IDs with legacy alias compatibility.',
   },
   {
+    id: 'post-idd-marker',
+    scriptName: 'idd:post-idd-marker',
+    binName: 'idd-post-idd-marker',
+    entryPath: 'scripts/post-idd-marker.mjs',
+    vendoredCommand: 'node scripts/post-idd-marker.mjs',
+    description:
+      'Render and POST a canonical IDD operational marker (claim / unclaim / watermark / baseline / advisory / advisory-recovery) via the reliable JSON path.',
+    contractPaths: ['schemas/post-idd-marker.schema.json'],
+  },
+  {
     id: 'pre-merge-readiness',
     scriptName: 'idd:pre-merge-readiness',
     binName: 'idd-pre-merge-readiness',

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/post-idd-marker.mts
+//
+// The scripts/post-idd-marker.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
+// Write-side companion to emit-marker (#1047). IDD operational markers are
+// HTML-comment-first, so an agent must POST them as a JSON body — the
+// `gh issue comment` / `gh api -f body=` paths silently reject HTML-only
+// bodies. This helper renders the canonical body for each operational marker
+// type (reusing the single-sourced protocol-helpers renderers so formats are
+// not duplicated) and POSTs it via the reliable JSON path.
+//
+// It is a single-marker render+POST primitive with NO claim/state gating, by
+// design (the emit-marker philosophy). The calling phase runs its
+// claim-revalidation gate immediately before invoking `--apply`, exactly as the
+// manual POST path it replaces already requires.
+import { execFileSync } from 'node:child_process';
+import {
+  renderAdvisoryWaitMarker,
+  renderAdvisoryWaitRecoveryMarker,
+  renderClaimedByMarker,
+  renderReviewBaselineMarker,
+  renderReviewWatermarkMarker,
+  renderUnclaimedByMarker,
+} from './protocol-helpers.mjs';
+export const MARKER_TYPES = [
+  'claim',
+  'unclaim',
+  'watermark',
+  'baseline',
+  'advisory',
+  'advisory-recovery',
+];
+export const TARGET_KINDS = ['issue', 'pr'];
+/**
+ * Build the canonical ready-to-post body for one operational marker type.
+ * Pure and network-free: it dispatches to the single-sourced protocol-helpers
+ * renderer for `type`, so the body stays byte-identical to what emit-marker and
+ * the written marker formats produce. Throws on an unknown type or an invalid
+ * field set (the renderer's own validation).
+ */
+export function buildMarkerBody(type, fields) {
+  switch (type) {
+    case 'claim':
+      return renderClaimedByMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        supersedes: fields.supersedes,
+        timestamp: fields.timestamp,
+        branch: fields.branch,
+      });
+    case 'unclaim':
+      return renderUnclaimedByMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        timestamp: fields.timestamp,
+      });
+    case 'watermark':
+      return renderReviewWatermarkMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        headSha: fields['head-sha'],
+        maxActivityAt: fields['max-activity-at'],
+        totalItemCount: fields['total-item-count'],
+        ciCompletedAt: fields['ci-completed-at'],
+      });
+    case 'baseline':
+      return renderReviewBaselineMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        sha: fields.sha,
+      });
+    case 'advisory':
+      return renderAdvisoryWaitMarker({
+        agentId: fields['agent-id'],
+        headSha: fields['head-sha'],
+        timestamp: fields.timestamp,
+      });
+    case 'advisory-recovery':
+      return renderAdvisoryWaitRecoveryMarker({
+        agentId: fields['agent-id'],
+        headSha: fields['head-sha'],
+        timestamp: fields.timestamp,
+      });
+    default:
+      throw new Error(
+        `--type is required and must be one of: ${MARKER_TYPES.join(', ')}`,
+      );
+  }
+}
+export function parseArgs(argv) {
+  const args = {
+    type: '',
+    target: '',
+    number: null,
+    apply: false,
+    owner: '',
+    repo: '',
+    help: false,
+    fields: {},
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help' || token === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (token === '--apply') {
+      args.apply = true;
+      continue;
+    }
+    if (!token.startsWith('--')) {
+      // The sole positional argument is the issue/PR number.
+      if (args.number !== null) {
+        throw new Error(`unexpected positional argument: ${token}`);
+      }
+      const parsed = Number.parseInt(token, 10);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`invalid issue/PR number: ${token}`);
+      }
+      args.number = parsed;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`missing value for argument: ${token}`);
+    }
+    index += 1;
+    if (token === '--type') {
+      args.type = value;
+    } else if (token === '--target') {
+      args.target = value;
+    } else if (token === '--owner') {
+      args.owner = value;
+    } else if (token === '--repo') {
+      args.repo = value;
+    } else {
+      // Any other --flag is a renderer field, stored under its kebab name.
+      args.fields[token.slice(2)] = value;
+    }
+  }
+  return args;
+}
+const USAGE = `usage: node scripts/post-idd-marker.mjs --type <type> --target <issue|pr> <number> [field flags...] [--apply]
+
+Render the canonical HTML-comment-first body for an IDD operational marker
+(advisory markers are plain-text per the AW3 protocol) and POST it via the
+reliable JSON path. Default mode is dry-run (prints the body); --apply posts it.
+This helper performs no claim/state gating — the calling phase must run its
+claim-revalidation gate before --apply, as the manual POST path it replaces does.
+
+  --type <type>        one of: ${MARKER_TYPES.join(', ')}
+  --target <issue|pr>  the comment target kind (both use the issues comments API)
+  <number>             issue or PR number (positional, required)
+  --apply              POST the marker (default: dry-run, print the body)
+  --owner <owner>      repo owner (default: gh repo view)
+  --repo <repo>        repo name (default: gh repo view)
+  -h, --help           show this help
+
+Per-type field flags:
+  claim              --agent-id --claim-id --supersedes --timestamp --branch
+  unclaim            --agent-id --claim-id --timestamp
+  watermark          --agent-id --claim-id --head-sha --max-activity-at --total-item-count --ci-completed-at
+  baseline           --agent-id --claim-id --sha
+  advisory           --agent-id --head-sha --timestamp
+  advisory-recovery  --agent-id --head-sha --timestamp
+`;
+function ghText(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+/**
+ * POST the marker body as a JSON document (`{"body": …}`) read from stdin via
+ * `gh api --input -`. The JSON path is mandatory because HTML-comment-first
+ * bodies are silently dropped by `gh issue comment` / `gh api -f body=`.
+ *
+ * Both `--target issue` and `--target pr` POST to the same
+ * `repos/{owner}/{repo}/issues/{number}/comments` endpoint (a PR is an issue
+ * for the comments API); `target` is descriptive-only and never changes routing.
+ */
+function postMarker(owner, repo, number, body) {
+  const out = execFileSync(
+    'gh',
+    [
+      'api',
+      '--method',
+      'POST',
+      `repos/${owner}/${repo}/issues/${number}/comments`,
+      '--input',
+      '-',
+    ],
+    { input: JSON.stringify({ body }), encoding: 'utf8' },
+  );
+  return JSON.parse(out);
+}
+function isMainModule(moduleUrl) {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return moduleUrl === `file://${entry}` || moduleUrl.endsWith(entry);
+}
+if (isMainModule(import.meta.url)) {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+    throw error;
+  }
+  if (args.help) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+  if (!MARKER_TYPES.includes(args.type)) {
+    process.stderr.write(
+      `--type is required and must be one of: ${MARKER_TYPES.join(', ')}\n`,
+    );
+    process.exit(1);
+  }
+  if (!TARGET_KINDS.includes(args.target)) {
+    process.stderr.write(
+      `--target is required and must be one of: ${TARGET_KINDS.join(', ')}\n`,
+    );
+    process.exit(1);
+  }
+  if (args.number === null) {
+    process.stderr.write('a positional issue/PR <number> is required\n');
+    process.exit(1);
+  }
+  let body;
+  try {
+    body = buildMarkerBody(args.type, args.fields);
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+    throw error;
+  }
+  const number = args.number;
+  if (!args.apply) {
+    const result = {
+      mode: 'dry-run',
+      type: args.type,
+      target: args.target,
+      number,
+      body,
+    };
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.exit(0);
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const posted = postMarker(owner, repo, number, body);
+  const result = {
+    mode: 'apply',
+    type: args.type,
+    target: args.target,
+    number,
+    commentId: posted.id,
+    url: posted.html_url,
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  process.exit(0);
+}

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -17,6 +17,8 @@
 // claim-revalidation gate immediately before invoking `--apply`, exactly as the
 // manual POST path it replaces already requires.
 import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   renderAdvisoryWaitMarker,
   renderAdvisoryWaitRecoveryMarker,
@@ -112,12 +114,19 @@ export function parseArgs(argv) {
       continue;
     }
     if (!token.startsWith('--')) {
-      // The sole positional argument is the issue/PR number.
+      // The sole positional argument is the issue/PR number. Match the whole
+      // token as a positive integer BEFORE converting: Number.parseInt would
+      // silently accept a suffixed typo like `1047abc` / `1047-draft` as 1047
+      // and, with --apply, post the marker to the wrong target. Fail closed.
       if (args.number !== null) {
         throw new Error(`unexpected positional argument: ${token}`);
       }
       const parsed = Number.parseInt(token, 10);
-      if (!Number.isInteger(parsed) || parsed <= 0) {
+      if (
+        !/^\d+$/.test(token) ||
+        !Number.isSafeInteger(parsed) ||
+        parsed <= 0
+      ) {
         throw new Error(`invalid issue/PR number: ${token}`);
       }
       args.number = parsed;
@@ -199,7 +208,11 @@ function isMainModule(moduleUrl) {
   if (!entry) {
     return false;
   }
-  return moduleUrl === `file://${entry}` || moduleUrl.endsWith(entry);
+  // Compare decoded filesystem paths (matching the emit-marker / manifest entry
+  // guards). A raw `file://${entry}` string compare fails when the install path
+  // contains spaces: import.meta.url percent-encodes them while process.argv[1]
+  // does not, so the CLI body would silently never run.
+  return fileURLToPath(moduleUrl) === resolve(entry);
 }
 if (isMainModule(import.meta.url)) {
   let args;

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -156,14 +156,15 @@ const USAGE = `usage: node scripts/post-idd-marker.mjs --type <type> --target <i
 
 Render the canonical HTML-comment-first body for an IDD operational marker
 (advisory markers are plain-text per the AW3 protocol) and POST it via the
-reliable JSON path. Default mode is dry-run (prints the body); --apply posts it.
-This helper performs no claim/state gating — the calling phase must run its
-claim-revalidation gate before --apply, as the manual POST path it replaces does.
+reliable JSON path. Default mode is dry-run, which prints a JSON envelope whose
+\`body\` field is the marker; --apply POSTs it and prints the created comment
+id/URL. This helper performs no claim/state gating — the calling phase must run
+its claim-revalidation gate before --apply, as the manual POST path it replaces.
 
   --type <type>        one of: ${MARKER_TYPES.join(', ')}
   --target <issue|pr>  the comment target kind (both use the issues comments API)
   <number>             issue or PR number (positional, required)
-  --apply              POST the marker (default: dry-run, print the body)
+  --apply              POST the marker (default: dry-run prints it in a JSON envelope)
   --owner <owner>      repo owner (default: gh repo view)
   --repo <repo>        repo name (default: gh repo view)
   -h, --help           show this help

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -452,6 +452,47 @@ export function renderReviewBaselineMarker(payload) {
     `_${agentId}: critique baseline — IDD automation marker. Do not edit._`,
   ].join('\n');
 }
+// --- Write-side companion renderers (#1047) ---
+//
+// The post-idd-marker helper POSTs the same operational markers an agent emits
+// per cycle, so it needs a renderer for every type it can post. claim /
+// watermark / baseline already have renderers above; these three cover the
+// remaining post-idd-marker types so the body formats stay single-sourced.
+export function renderUnclaimedByMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !claimId || !timestamp) {
+    throw new Error('invalid unclaimed-by marker payload');
+  }
+  return [
+    `<!-- unclaimed-by: ${agentId} ${claimId} ${timestamp} -->`,
+    '',
+    `_${agentId}: issue claim released — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+// advisory-wait / advisory-wait-recovery are PLAIN-TEXT markers (no visible
+// note): the AW2 / shell-fallback recognizers anchor on `-->$` / `\s*$`, so a
+// trailing visible note would break them. They carry the PR HEAD SHA (not a
+// claim id) per the AW3 protocol.
+export function renderAdvisoryWaitMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-wait marker payload');
+  }
+  return `advisory-wait: ${agentId} ${headSha} ${timestamp}`;
+}
+export function renderAdvisoryWaitRecoveryMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-wait-recovery marker payload');
+  }
+  return `advisory-wait-recovery: ${agentId} ${headSha} ${timestamp}`;
+}
 function matchCheckSelectorLocal(name, selector, matchMode) {
   const n = String(name ?? '').trim();
   const s = String(selector ?? '').trim();

--- a/src/bin/idd-post-idd-marker.mts
+++ b/src/bin/idd-post-idd-marker.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-post-idd-marker.mts
+//
+// The bin/idd-post-idd-marker.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/post-idd-marker.mjs');

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -351,6 +351,16 @@ const HELPER_COMMANDS: HelperCommand[] = [
     description: 'Resolve canonical phase IDs with legacy alias compatibility.',
   },
   {
+    id: 'post-idd-marker',
+    scriptName: 'idd:post-idd-marker',
+    binName: 'idd-post-idd-marker',
+    entryPath: 'scripts/post-idd-marker.mjs',
+    vendoredCommand: 'node scripts/post-idd-marker.mjs',
+    description:
+      'Render and POST a canonical IDD operational marker (claim / unclaim / watermark / baseline / advisory / advisory-recovery) via the reliable JSON path.',
+    contractPaths: ['schemas/post-idd-marker.schema.json'],
+  },
+  {
     id: 'pre-merge-readiness',
     scriptName: 'idd:pre-merge-readiness',
     binName: 'idd-pre-merge-readiness',

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -18,6 +18,8 @@
 // manual POST path it replaces already requires.
 
 import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   renderAdvisoryWaitMarker,
@@ -153,12 +155,19 @@ export function parseArgs(argv: string[]): CliArgs {
       continue;
     }
     if (!token.startsWith('--')) {
-      // The sole positional argument is the issue/PR number.
+      // The sole positional argument is the issue/PR number. Match the whole
+      // token as a positive integer BEFORE converting: Number.parseInt would
+      // silently accept a suffixed typo like `1047abc` / `1047-draft` as 1047
+      // and, with --apply, post the marker to the wrong target. Fail closed.
       if (args.number !== null) {
         throw new Error(`unexpected positional argument: ${token}`);
       }
       const parsed = Number.parseInt(token, 10);
-      if (!Number.isInteger(parsed) || parsed <= 0) {
+      if (
+        !/^\d+$/.test(token) ||
+        !Number.isSafeInteger(parsed) ||
+        parsed <= 0
+      ) {
         throw new Error(`invalid issue/PR number: ${token}`);
       }
       args.number = parsed;
@@ -249,7 +258,11 @@ function isMainModule(moduleUrl: string): boolean {
   if (!entry) {
     return false;
   }
-  return moduleUrl === `file://${entry}` || moduleUrl.endsWith(entry);
+  // Compare decoded filesystem paths (matching the emit-marker / manifest entry
+  // guards). A raw `file://${entry}` string compare fails when the install path
+  // contains spaces: import.meta.url percent-encodes them while process.argv[1]
+  // does not, so the CLI body would silently never run.
+  return fileURLToPath(moduleUrl) === resolve(entry);
 }
 
 if (isMainModule(import.meta.url)) {

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -198,14 +198,15 @@ const USAGE = `usage: node scripts/post-idd-marker.mjs --type <type> --target <i
 
 Render the canonical HTML-comment-first body for an IDD operational marker
 (advisory markers are plain-text per the AW3 protocol) and POST it via the
-reliable JSON path. Default mode is dry-run (prints the body); --apply posts it.
-This helper performs no claim/state gating — the calling phase must run its
-claim-revalidation gate before --apply, as the manual POST path it replaces does.
+reliable JSON path. Default mode is dry-run, which prints a JSON envelope whose
+\`body\` field is the marker; --apply POSTs it and prints the created comment
+id/URL. This helper performs no claim/state gating — the calling phase must run
+its claim-revalidation gate before --apply, as the manual POST path it replaces.
 
   --type <type>        one of: ${MARKER_TYPES.join(', ')}
   --target <issue|pr>  the comment target kind (both use the issues comments API)
   <number>             issue or PR number (positional, required)
-  --apply              POST the marker (default: dry-run, print the body)
+  --apply              POST the marker (default: dry-run prints it in a JSON envelope)
   --owner <owner>      repo owner (default: gh repo view)
   --repo <repo>        repo name (default: gh repo view)
   -h, --help           show this help

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/post-idd-marker.mts
+//
+// The scripts/post-idd-marker.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
+// Write-side companion to emit-marker (#1047). IDD operational markers are
+// HTML-comment-first, so an agent must POST them as a JSON body — the
+// `gh issue comment` / `gh api -f body=` paths silently reject HTML-only
+// bodies. This helper renders the canonical body for each operational marker
+// type (reusing the single-sourced protocol-helpers renderers so formats are
+// not duplicated) and POSTs it via the reliable JSON path.
+//
+// It is a single-marker render+POST primitive with NO claim/state gating, by
+// design (the emit-marker philosophy). The calling phase runs its
+// claim-revalidation gate immediately before invoking `--apply`, exactly as the
+// manual POST path it replaces already requires.
+
+import { execFileSync } from 'node:child_process';
+
+import {
+  renderAdvisoryWaitMarker,
+  renderAdvisoryWaitRecoveryMarker,
+  renderClaimedByMarker,
+  renderReviewBaselineMarker,
+  renderReviewWatermarkMarker,
+  renderUnclaimedByMarker,
+} from './protocol-helpers.mts';
+
+export const MARKER_TYPES = [
+  'claim',
+  'unclaim',
+  'watermark',
+  'baseline',
+  'advisory',
+  'advisory-recovery',
+] as const;
+
+export type MarkerType = (typeof MARKER_TYPES)[number];
+
+export const TARGET_KINDS = ['issue', 'pr'] as const;
+export type TargetKind = (typeof TARGET_KINDS)[number];
+
+/** Raw `--flag value` field map, keyed by the CLI flag name (kebab-case). */
+export type MarkerFields = Record<string, string>;
+
+/** CLI output envelope for both dry-run and `--apply` modes. */
+export interface PostIddMarkerResult {
+  mode: 'dry-run' | 'apply';
+  type: MarkerType;
+  target: TargetKind;
+  number: number;
+  /** Present in dry-run: the byte-exact body that would be POSTed. */
+  body?: string;
+  /** Present in `--apply`: the created comment id. */
+  commentId?: number;
+  /** Present in `--apply`: the created comment URL. */
+  url?: string;
+}
+
+/**
+ * Build the canonical ready-to-post body for one operational marker type.
+ * Pure and network-free: it dispatches to the single-sourced protocol-helpers
+ * renderer for `type`, so the body stays byte-identical to what emit-marker and
+ * the written marker formats produce. Throws on an unknown type or an invalid
+ * field set (the renderer's own validation).
+ */
+export function buildMarkerBody(type: string, fields: MarkerFields): string {
+  switch (type) {
+    case 'claim':
+      return renderClaimedByMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        supersedes: fields.supersedes,
+        timestamp: fields.timestamp,
+        branch: fields.branch,
+      });
+    case 'unclaim':
+      return renderUnclaimedByMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        timestamp: fields.timestamp,
+      });
+    case 'watermark':
+      return renderReviewWatermarkMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        headSha: fields['head-sha'],
+        maxActivityAt: fields['max-activity-at'],
+        totalItemCount: fields['total-item-count'],
+        ciCompletedAt: fields['ci-completed-at'],
+      });
+    case 'baseline':
+      return renderReviewBaselineMarker({
+        agentId: fields['agent-id'],
+        claimId: fields['claim-id'],
+        sha: fields.sha,
+      });
+    case 'advisory':
+      return renderAdvisoryWaitMarker({
+        agentId: fields['agent-id'],
+        headSha: fields['head-sha'],
+        timestamp: fields.timestamp,
+      });
+    case 'advisory-recovery':
+      return renderAdvisoryWaitRecoveryMarker({
+        agentId: fields['agent-id'],
+        headSha: fields['head-sha'],
+        timestamp: fields.timestamp,
+      });
+    default:
+      throw new Error(
+        `--type is required and must be one of: ${MARKER_TYPES.join(', ')}`,
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface CliArgs {
+  type: string;
+  target: string;
+  number: number | null;
+  apply: boolean;
+  owner: string;
+  repo: string;
+  help: boolean;
+  fields: MarkerFields;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    type: '',
+    target: '',
+    number: null,
+    apply: false,
+    owner: '',
+    repo: '',
+    help: false,
+    fields: {},
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help' || token === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (token === '--apply') {
+      args.apply = true;
+      continue;
+    }
+    if (!token.startsWith('--')) {
+      // The sole positional argument is the issue/PR number.
+      if (args.number !== null) {
+        throw new Error(`unexpected positional argument: ${token}`);
+      }
+      const parsed = Number.parseInt(token, 10);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`invalid issue/PR number: ${token}`);
+      }
+      args.number = parsed;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`missing value for argument: ${token}`);
+    }
+    index += 1;
+    if (token === '--type') {
+      args.type = value;
+    } else if (token === '--target') {
+      args.target = value;
+    } else if (token === '--owner') {
+      args.owner = value;
+    } else if (token === '--repo') {
+      args.repo = value;
+    } else {
+      // Any other --flag is a renderer field, stored under its kebab name.
+      args.fields[token.slice(2)] = value;
+    }
+  }
+  return args;
+}
+
+const USAGE = `usage: node scripts/post-idd-marker.mjs --type <type> --target <issue|pr> <number> [field flags...] [--apply]
+
+Render the canonical HTML-comment-first body for an IDD operational marker
+(advisory markers are plain-text per the AW3 protocol) and POST it via the
+reliable JSON path. Default mode is dry-run (prints the body); --apply posts it.
+This helper performs no claim/state gating — the calling phase must run its
+claim-revalidation gate before --apply, as the manual POST path it replaces does.
+
+  --type <type>        one of: ${MARKER_TYPES.join(', ')}
+  --target <issue|pr>  the comment target kind (both use the issues comments API)
+  <number>             issue or PR number (positional, required)
+  --apply              POST the marker (default: dry-run, print the body)
+  --owner <owner>      repo owner (default: gh repo view)
+  --repo <repo>        repo name (default: gh repo view)
+  -h, --help           show this help
+
+Per-type field flags:
+  claim              --agent-id --claim-id --supersedes --timestamp --branch
+  unclaim            --agent-id --claim-id --timestamp
+  watermark          --agent-id --claim-id --head-sha --max-activity-at --total-item-count --ci-completed-at
+  baseline           --agent-id --claim-id --sha
+  advisory           --agent-id --head-sha --timestamp
+  advisory-recovery  --agent-id --head-sha --timestamp
+`;
+
+function ghText(args: string[]): string {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+
+/**
+ * POST the marker body as a JSON document (`{"body": …}`) read from stdin via
+ * `gh api --input -`. The JSON path is mandatory because HTML-comment-first
+ * bodies are silently dropped by `gh issue comment` / `gh api -f body=`.
+ *
+ * Both `--target issue` and `--target pr` POST to the same
+ * `repos/{owner}/{repo}/issues/{number}/comments` endpoint (a PR is an issue
+ * for the comments API); `target` is descriptive-only and never changes routing.
+ */
+function postMarker(
+  owner: string,
+  repo: string,
+  number: number,
+  body: string,
+): { id: number; html_url: string } {
+  const out = execFileSync(
+    'gh',
+    [
+      'api',
+      '--method',
+      'POST',
+      `repos/${owner}/${repo}/issues/${number}/comments`,
+      '--input',
+      '-',
+    ],
+    { input: JSON.stringify({ body }), encoding: 'utf8' },
+  );
+  return JSON.parse(out) as { id: number; html_url: string };
+}
+
+function isMainModule(moduleUrl: string): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return moduleUrl === `file://${entry}` || moduleUrl.endsWith(entry);
+}
+
+if (isMainModule(import.meta.url)) {
+  let args: CliArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.exit(1);
+    throw error;
+  }
+
+  if (args.help) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+  if (!MARKER_TYPES.includes(args.type as MarkerType)) {
+    process.stderr.write(
+      `--type is required and must be one of: ${MARKER_TYPES.join(', ')}\n`,
+    );
+    process.exit(1);
+  }
+  if (!TARGET_KINDS.includes(args.target as TargetKind)) {
+    process.stderr.write(
+      `--target is required and must be one of: ${TARGET_KINDS.join(', ')}\n`,
+    );
+    process.exit(1);
+  }
+  if (args.number === null) {
+    process.stderr.write('a positional issue/PR <number> is required\n');
+    process.exit(1);
+  }
+
+  let body: string;
+  try {
+    body = buildMarkerBody(args.type, args.fields);
+  } catch (error) {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.exit(1);
+    throw error;
+  }
+
+  const number = args.number;
+  if (!args.apply) {
+    const result: PostIddMarkerResult = {
+      mode: 'dry-run',
+      type: args.type as MarkerType,
+      target: args.target as TargetKind,
+      number,
+      body,
+    };
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.exit(0);
+  }
+
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+
+  const posted = postMarker(owner, repo, number, body);
+  const result: PostIddMarkerResult = {
+    mode: 'apply',
+    type: args.type as MarkerType,
+    target: args.target as TargetKind,
+    number,
+    commentId: posted.id,
+    url: posted.html_url,
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  process.exit(0);
+}

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1006,6 +1006,63 @@ export function renderReviewBaselineMarker(payload: {
   ].join('\n');
 }
 
+// --- Write-side companion renderers (#1047) ---
+//
+// The post-idd-marker helper POSTs the same operational markers an agent emits
+// per cycle, so it needs a renderer for every type it can post. claim /
+// watermark / baseline already have renderers above; these three cover the
+// remaining post-idd-marker types so the body formats stay single-sourced.
+
+export function renderUnclaimedByMarker(payload: {
+  agentId?: unknown;
+  claimId?: unknown;
+  timestamp?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !claimId || !timestamp) {
+    throw new Error('invalid unclaimed-by marker payload');
+  }
+  return [
+    `<!-- unclaimed-by: ${agentId} ${claimId} ${timestamp} -->`,
+    '',
+    `_${agentId}: issue claim released — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+
+// advisory-wait / advisory-wait-recovery are PLAIN-TEXT markers (no visible
+// note): the AW2 / shell-fallback recognizers anchor on `-->$` / `\s*$`, so a
+// trailing visible note would break them. They carry the PR HEAD SHA (not a
+// claim id) per the AW3 protocol.
+export function renderAdvisoryWaitMarker(payload: {
+  agentId?: unknown;
+  headSha?: unknown;
+  timestamp?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-wait marker payload');
+  }
+  return `advisory-wait: ${agentId} ${headSha} ${timestamp}`;
+}
+
+export function renderAdvisoryWaitRecoveryMarker(payload: {
+  agentId?: unknown;
+  headSha?: unknown;
+  timestamp?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-wait-recovery marker payload');
+  }
+  return `advisory-wait-recovery: ${agentId} ${headSha} ${timestamp}`;
+}
+
 function matchCheckSelectorLocal(
   name: unknown,
   selector: unknown,

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -545,3 +545,22 @@ test('manifest CLI rejects flags that are missing required values', () => {
     /missing value for argument: --profile/,
   );
 });
+
+test("every manifest helper binName is exposed in package.json's bin map", () => {
+  // Guard against a registered helper whose executable is never published for
+  // package-manager-profile installs (the gap #1053 review caught for
+  // idd-post-idd-marker): the manifest, package.json bin map, and bin shim file
+  // must agree for every helper.
+  const { commandCatalog } = buildHelperRuntimeManifest({
+    targetRoot: REPO_ROOT,
+  });
+  const bin = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'))
+    .bin as Record<string, string>;
+  for (const command of commandCatalog) {
+    assert.equal(
+      bin[command.binName],
+      `./bin/${command.binName}.mjs`,
+      `package.json bin map must expose ${command.binName} as ./bin/${command.binName}.mjs`,
+    );
+  }
+});

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -1,5 +1,10 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   buildMarkerBody,
@@ -23,6 +28,7 @@ const SHA = '0123456789abcdef0123456789abcdef01234567';
 const TS = '2026-06-17T09:47:08Z';
 
 const schema = loadJson('schemas/post-idd-marker.schema.json');
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 test('schema uses only supported keywords', () => {
   assert.deepEqual(checkSchemaKeywords(schema), []);
@@ -305,4 +311,93 @@ test('the schema rejects an unknown field and a missing required field', () => {
     validate({ mode: 'dry-run', type: 'claim', target: 'issue' }, schema),
     [],
   );
+});
+
+test('--apply CLI POSTs via gh api --input - and prints the apply envelope', () => {
+  // Stub `gh` on PATH (the discover-roadmap-graph.test.mts pattern) so the
+  // --apply POST path is exercised without network access. The stub records its
+  // argv and the JSON request body piped to stdin, then returns a comment object.
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-post-idd-marker-cli-'));
+  const ghPath = join(tempRoot, 'gh');
+  const argsFile = join(tempRoot, 'gh-args.json');
+  const stdinFile = join(tempRoot, 'gh-stdin.txt');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.writeFileSync(${JSON.stringify(argsFile)}, JSON.stringify(args));
+if (args[0] === 'api' && args.includes('--input') && args[args.indexOf('--input') + 1] === '-') {
+  fs.writeFileSync(${JSON.stringify(stdinFile)}, fs.readFileSync(0, 'utf8'));
+  process.stdout.write(JSON.stringify({ id: 4242, html_url: 'https://github.com/o/r/issues/1047#issuecomment-4242' }));
+  process.exit(0);
+}
+process.stderr.write('unexpected gh invocation: ' + args.join(' '));
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+
+  const output = execFileSync(
+    process.execPath,
+    [
+      join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+      '--type',
+      'claim',
+      '--target',
+      'issue',
+      '1047',
+      '--owner',
+      'o',
+      '--repo',
+      'r',
+      '--agent-id',
+      'claude-417b737f',
+      '--claim-id',
+      'c3009f22b5f6',
+      '--supersedes',
+      'none',
+      '--timestamp',
+      TS,
+      '--branch',
+      'issue/1047-foo',
+      '--apply',
+    ],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${tempRoot}:${process.env.PATH ?? ''}` },
+    },
+  );
+
+  // (3) apply mode prints the envelope with the created comment id / url.
+  assert.deepEqual(JSON.parse(output), {
+    mode: 'apply',
+    type: 'claim',
+    target: 'issue',
+    number: 1047,
+    commentId: 4242,
+    url: 'https://github.com/o/r/issues/1047#issuecomment-4242',
+  });
+
+  // (1) the exact gh api arguments (JSON `--input -` path, not `-f body=`).
+  assert.deepEqual(JSON.parse(readFileSync(argsFile, 'utf8')), [
+    'api',
+    '--method',
+    'POST',
+    'repos/o/r/issues/1047/comments',
+    '--input',
+    '-',
+  ]);
+
+  // (2) the JSON request body piped to stdin carries the exact marker body.
+  assert.deepEqual(JSON.parse(readFileSync(stdinFile, 'utf8')), {
+    body: buildMarkerBody('claim', {
+      'agent-id': 'claude-417b737f',
+      'claim-id': 'c3009f22b5f6',
+      supersedes: 'none',
+      timestamp: TS,
+      branch: 'issue/1047-foo',
+    }),
+  });
 });

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -260,9 +260,14 @@ test('parseArgs reads structural flags, the positional number, and renderer fiel
   });
 });
 
-test('parseArgs rejects a second positional and a non-numeric number', () => {
+test('parseArgs rejects a second positional, non-numeric, and suffixed numbers', () => {
   assert.throws(() => parseArgs(['1047', '2048']), /unexpected positional/);
   assert.throws(() => parseArgs(['not-a-number']), /invalid issue\/PR number/);
+  // A numeric prefix plus a typo/suffix must fail closed, not parse to 1047 —
+  // otherwise --apply could post the marker to the wrong target.
+  assert.throws(() => parseArgs(['1047abc']), /invalid issue\/PR number/);
+  assert.throws(() => parseArgs(['1047-draft']), /invalid issue\/PR number/);
+  assert.throws(() => parseArgs(['0']), /invalid issue\/PR number/);
 });
 
 test('a dry-run envelope validates against the schema', () => {

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -1,0 +1,303 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildMarkerBody,
+  MARKER_TYPES,
+  parseArgs,
+} from '../src/scripts/post-idd-marker.mts';
+import {
+  operationalMarkerPrefix,
+  parseClaimComment,
+  parseReleaseComment,
+  parseReviewWatermarkComment,
+} from '../src/scripts/protocol-helpers.mts';
+import {
+  checkSchemaKeywords,
+  loadJson,
+  validate,
+} from '../src/scripts/validate-schemas.mts';
+
+// A real 40-hex SHA — the watermark/baseline/advisory renderers require it.
+const SHA = '0123456789abcdef0123456789abcdef01234567';
+const TS = '2026-06-17T09:47:08Z';
+
+const schema = loadJson('schemas/post-idd-marker.schema.json');
+
+test('schema uses only supported keywords', () => {
+  assert.deepEqual(checkSchemaKeywords(schema), []);
+});
+
+test('buildMarkerBody renders the exact claim body (reuses renderClaimedByMarker)', () => {
+  assert.equal(
+    buildMarkerBody('claim', {
+      'agent-id': 'claude-417b737f',
+      'claim-id': 'c3009f22b5f6',
+      supersedes: 'none',
+      timestamp: TS,
+      branch: 'issue/1047-add-post-idd-marker-write-side-helper',
+    }),
+    '<!-- claimed-by: claude-417b737f c3009f22b5f6 supersedes: none 2026-06-17T09:47:08Z branch: issue/1047-add-post-idd-marker-write-side-helper -->\n\n_claude-417b737f: issue claim — IDD automation marker. Do not edit._',
+  );
+});
+
+test('buildMarkerBody renders the exact unclaim body', () => {
+  assert.equal(
+    buildMarkerBody('unclaim', {
+      'agent-id': 'claude-417b737f',
+      'claim-id': 'c3009f22b5f6',
+      timestamp: TS,
+    }),
+    '<!-- unclaimed-by: claude-417b737f c3009f22b5f6 2026-06-17T09:47:08Z -->\n\n_claude-417b737f: issue claim released — IDD automation marker. Do not edit._',
+  );
+});
+
+test('buildMarkerBody renders the exact watermark body (reuses renderReviewWatermarkMarker)', () => {
+  assert.equal(
+    buildMarkerBody('watermark', {
+      'agent-id': 'a',
+      'claim-id': 'c',
+      'head-sha': SHA,
+      'max-activity-at': 'none',
+      'total-item-count': '0',
+      'ci-completed-at': 'none',
+    }),
+    `<!-- review-watermark: a c ${SHA} none 0 none -->\n\n_a: review triage snapshot — IDD automation marker. Do not edit._`,
+  );
+});
+
+test('buildMarkerBody renders the exact baseline body (reuses renderReviewBaselineMarker)', () => {
+  assert.equal(
+    buildMarkerBody('baseline', { 'agent-id': 'a', 'claim-id': 'c', sha: SHA }),
+    `<!-- review-baseline: a c ${SHA} -->\n\n_a: critique baseline — IDD automation marker. Do not edit._`,
+  );
+});
+
+test('buildMarkerBody renders advisory markers as plain text with no visible note', () => {
+  const advisory = buildMarkerBody('advisory', {
+    'agent-id': 'claude-417b737f',
+    'head-sha': SHA,
+    timestamp: TS,
+  });
+  assert.equal(advisory, `advisory-wait: claude-417b737f ${SHA} ${TS}`);
+  // Plain-text canonical form: no HTML comment and no visible note, so the
+  // AW2 / shell-fallback recognizers (anchored on `\s*$`) still match.
+  assert.doesNotMatch(advisory, /<!--/);
+  assert.doesNotMatch(advisory, /\n/);
+
+  const recovery = buildMarkerBody('advisory-recovery', {
+    'agent-id': 'claude-417b737f',
+    'head-sha': SHA,
+    timestamp: TS,
+  });
+  assert.equal(
+    recovery,
+    `advisory-wait-recovery: claude-417b737f ${SHA} ${TS}`,
+  );
+  assert.doesNotMatch(recovery, /<!--/);
+});
+
+test('buildMarkerBody normalizes an upper-case head SHA for advisory markers', () => {
+  assert.equal(
+    buildMarkerBody('advisory', {
+      'agent-id': 'a',
+      'head-sha': SHA.toUpperCase(),
+      timestamp: TS,
+    }),
+    `advisory-wait: a ${SHA} ${TS}`,
+  );
+});
+
+// The helper's central guarantee is that what it POSTs is what the IDD
+// parsers/recognizers accept. These round-trip assertions guard against future
+// renderer/parser drift (the failure mode behind several past gate bugs).
+const CREATED_AT = '2026-06-25T13:48:09Z';
+
+test('claim body round-trips through parseClaimComment (non-none supersedes)', () => {
+  const body = buildMarkerBody('claim', {
+    'agent-id': 'claude-417b737f',
+    'claim-id': 'c3009f22b5f6',
+    supersedes: 'prior9',
+    timestamp: TS,
+    branch: 'issue/1047-foo',
+  });
+  assert.equal(operationalMarkerPrefix(body), '<!-- claimed-by:');
+  assert.deepEqual(parseClaimComment(body, CREATED_AT), {
+    agentId: 'claude-417b737f',
+    claimId: 'c3009f22b5f6',
+    supersedes: 'prior9',
+    branch: 'issue/1047-foo',
+    createdAt: CREATED_AT,
+  });
+});
+
+test('unclaim body round-trips through parseReleaseComment', () => {
+  const body = buildMarkerBody('unclaim', {
+    'agent-id': 'claude-417b737f',
+    'claim-id': 'c3009f22b5f6',
+    timestamp: TS,
+  });
+  assert.equal(operationalMarkerPrefix(body), '<!-- unclaimed-by:');
+  assert.deepEqual(parseReleaseComment(body), {
+    agentId: 'claude-417b737f',
+    claimId: 'c3009f22b5f6',
+  });
+});
+
+test('watermark body round-trips through parseReviewWatermarkComment (real ISO + non-zero count)', () => {
+  const body = buildMarkerBody('watermark', {
+    'agent-id': 'claude-417b737f',
+    'claim-id': 'c3009f22b5f6',
+    'head-sha': SHA,
+    'max-activity-at': '2026-06-25T12:00:00Z',
+    'total-item-count': '7',
+    'ci-completed-at': '2026-06-25T11:59:00Z',
+  });
+  assert.equal(operationalMarkerPrefix(body), '<!-- review-watermark:');
+  assert.deepEqual(parseReviewWatermarkComment(body, CREATED_AT), {
+    agentId: 'claude-417b737f',
+    claimId: 'c3009f22b5f6',
+    headSha: SHA,
+    maxActivityUpdatedAt: '2026-06-25T12:00:00Z',
+    totalItemCount: 7,
+    latestCiCompletedAt: '2026-06-25T11:59:00Z',
+    createdAt: CREATED_AT,
+  });
+});
+
+test('advisory markers are recognized by operationalMarkerPrefix', () => {
+  assert.equal(
+    operationalMarkerPrefix(
+      buildMarkerBody('advisory', {
+        'agent-id': 'a',
+        'head-sha': SHA,
+        timestamp: TS,
+      }),
+    ),
+    'advisory-wait:',
+  );
+  assert.equal(
+    operationalMarkerPrefix(
+      buildMarkerBody('advisory-recovery', {
+        'agent-id': 'a',
+        'head-sha': SHA,
+        timestamp: TS,
+      }),
+    ),
+    'advisory-wait-recovery:',
+  );
+});
+
+test('buildMarkerBody throws on an unknown type', () => {
+  assert.throws(() => buildMarkerBody('bogus', {}), /must be one of/);
+});
+
+test('buildMarkerBody throws on an invalid field set (renderer validation)', () => {
+  // Missing branch for a claim.
+  assert.throws(
+    () =>
+      buildMarkerBody('claim', {
+        'agent-id': 'a',
+        'claim-id': 'c',
+        timestamp: TS,
+      }),
+    /invalid claimed-by marker payload/,
+  );
+  // Non-hex head SHA for an advisory marker.
+  assert.throws(
+    () =>
+      buildMarkerBody('advisory', {
+        'agent-id': 'a',
+        'head-sha': 'not-a-sha',
+        timestamp: TS,
+      }),
+    /invalid advisory-wait marker payload/,
+  );
+  // Missing timestamp for an unclaim.
+  assert.throws(
+    () => buildMarkerBody('unclaim', { 'agent-id': 'a', 'claim-id': 'c' }),
+    /invalid unclaimed-by marker payload/,
+  );
+});
+
+test('MARKER_TYPES lists exactly the six supported types', () => {
+  assert.deepEqual(
+    [...MARKER_TYPES],
+    [
+      'claim',
+      'unclaim',
+      'watermark',
+      'baseline',
+      'advisory',
+      'advisory-recovery',
+    ],
+  );
+});
+
+test('parseArgs reads structural flags, the positional number, and renderer fields', () => {
+  const args = parseArgs([
+    '--type',
+    'claim',
+    '--target',
+    'issue',
+    '1047',
+    '--agent-id',
+    'claude-417b737f',
+    '--claim-id',
+    'c3009f22b5f6',
+    '--branch',
+    'issue/1047-foo',
+    '--apply',
+  ]);
+  assert.equal(args.type, 'claim');
+  assert.equal(args.target, 'issue');
+  assert.equal(args.number, 1047);
+  assert.equal(args.apply, true);
+  assert.deepEqual(args.fields, {
+    'agent-id': 'claude-417b737f',
+    'claim-id': 'c3009f22b5f6',
+    branch: 'issue/1047-foo',
+  });
+});
+
+test('parseArgs rejects a second positional and a non-numeric number', () => {
+  assert.throws(() => parseArgs(['1047', '2048']), /unexpected positional/);
+  assert.throws(() => parseArgs(['not-a-number']), /invalid issue\/PR number/);
+});
+
+test('a dry-run envelope validates against the schema', () => {
+  const envelope = {
+    mode: 'dry-run',
+    type: 'advisory',
+    target: 'pr',
+    number: 1047,
+    body: `advisory-wait: a ${SHA} ${TS}`,
+  };
+  assert.deepEqual(validate(envelope, schema), []);
+});
+
+test('an apply envelope validates against the schema', () => {
+  const envelope = {
+    mode: 'apply',
+    type: 'claim',
+    target: 'issue',
+    number: 1047,
+    commentId: 4800026123,
+    url: 'https://github.com/kurone-kito/idd-skill/issues/1047#issuecomment-4800026123',
+  };
+  assert.deepEqual(validate(envelope, schema), []);
+});
+
+test('the schema rejects an unknown field and a missing required field', () => {
+  assert.notDeepEqual(
+    validate(
+      { mode: 'dry-run', type: 'claim', target: 'issue', number: 1, extra: 1 },
+      schema,
+    ),
+    [],
+  );
+  assert.notDeepEqual(
+    validate({ mode: 'dry-run', type: 'claim', target: 'issue' }, schema),
+    [],
+  );
+});

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -8,6 +8,7 @@ import type { BranchConflictResult } from '../src/scripts/branch-conflict-state.
 import type { RoadmapGraphUnionReport } from '../src/scripts/discover-roadmap-graph.mts';
 import type { DispositionReport } from '../src/scripts/disposition-non-review-notices.mts';
 import type { IddMergeExecuteVerdict } from '../src/scripts/idd-merge-execute.mts';
+import type { PostIddMarkerResult } from '../src/scripts/post-idd-marker.mts';
 import type { PreMergeReadinessReport } from '../src/scripts/pre-merge-readiness.mts';
 import type {
   LiveStatusDigestFields,
@@ -957,6 +958,25 @@ const dispositionNonReviewNoticesFixture = {
   ],
 } satisfies DispositionReport;
 
+const postIddMarkerKeys = [
+  'mode',
+  'type',
+  'target',
+  'number',
+  'body',
+  'commentId',
+  'url',
+] as const satisfies readonly (keyof PostIddMarkerResult)[];
+
+const postIddMarkerFixture = {
+  mode: 'apply',
+  type: 'claim',
+  target: 'issue',
+  number: 1047,
+  commentId: 4800026123,
+  url: 'https://github.com/kurone-kito/idd-skill/issues/1047#issuecomment-4800026123',
+} satisfies PostIddMarkerResult;
+
 const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
   {
     schemaFile: 'disposition-non-review-notices.schema.json',
@@ -964,6 +984,13 @@ const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
     owningModule: 'src/scripts/disposition-non-review-notices.mts',
     keys: dispositionNonReviewNoticesKeys,
     fixture: dispositionNonReviewNoticesFixture,
+  },
+  {
+    schemaFile: 'post-idd-marker.schema.json',
+    exportedType: 'PostIddMarkerResult',
+    owningModule: 'src/scripts/post-idd-marker.mts',
+    keys: postIddMarkerKeys,
+    fixture: postIddMarkerFixture,
   },
   {
     schemaFile: 'advisory-wait-state.schema.json',


### PR DESCRIPTION
## Summary

Adds the `post-idd-marker` write-side helper — the POST-capable companion to
`emit-marker`. IDD operational markers are HTML-comment-first, so an agent must
POST them as a JSON body (`gh issue comment` / `gh api -f body=` silently reject
HTML-only bodies). `emit-marker` renders those bodies but does not POST; this
helper renders **and** POSTs.

It renders the canonical body for each of the six operational marker types by
reusing the single-sourced `protocol-helpers` renderers, then POSTs via
`gh api --method POST .../comments --input -` (JSON over stdin):

| Type | Form |
| --- | --- |
| `claim` / `unclaim` / `watermark` / `baseline` | HTML-comment-first + visible "Do not edit" note |
| `advisory` / `advisory-recovery` | plain-text `advisory-wait:` / `advisory-wait-recovery:` (no visible note) |

## Design notes

- **advisory markers are plain-text, no visible note** (operator-confirmed):
  the AW2 / shell-fallback recognizers anchor on `-->$` / `\s*$`, so a trailing
  visible note on an HTML advisory form would break the existing parsers. The
  issue's generalized "HTML-comment-first + visible note" wording applies to the
  four claim-family markers; advisory uses its true canonical form (AW3-R).
- **No claim/state gating** (the `emit-marker` philosophy): this is a
  single-marker render+POST primitive, so the wiring phases (#1049/#1050/#1051)
  run their claim-revalidation gate before `--apply`, exactly as the manual POST
  path it replaces already requires.
- Three new pure renderers (`renderUnclaimedByMarker`, `renderAdvisoryWaitMarker`,
  `renderAdvisoryWaitRecoveryMarker`) live in `protocol-helpers` so formats stay
  single-sourced. Tests assert byte-exact bodies **and** parser round-trips for
  every type (guarding against renderer/parser drift). A stable output schema is
  added and reconciled in the schema⇄type table; the helper is registered in the
  runtime manifest and documented in `docs/idd-helper-scripts.md` (mirrored from
  the `idd-template` source).

Closes #1047
