### PR TITLE
docs(idd): reference post-idd-marker for claim/unclaim marker posting

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -270,10 +270,12 @@ minting one (see _Claim verification_ below). Determine `{prior-claim-id}`:
 Post the claim comment to the issue. Keep the HTML token at the start
 of the body, followed by the visible note. When helper runtime is enabled,
 post it with the profile-selected post-idd-marker command (`--type claim
---target issue`; see `docs/idd-helper-scripts.md`), which renders the canonical
-body and POSTs it via the reliable JSON path; emit-marker
-(`--type claimed-by`, emit-only) renders the body without posting. The written
-format below stays the canonical fallback — post it via the documented direct
+--target issue <issue-number> --apply` plus the claim fields; see
+`docs/idd-helper-scripts.md`), which renders the canonical body and POSTs it via
+the reliable JSON path — it is dry-run (prints the body, posts nothing) without
+`--apply`; emit-marker (`--type claimed-by`, emit-only) renders the body without
+posting. The written format below stays the canonical fallback — post it via the
+documented direct
 HTTP `POST` with a JSON body when the helper runtime is unavailable:
 
 ```markdown

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -270,7 +270,7 @@ minting one (see _Claim verification_ below). Determine `{prior-claim-id}`:
 Post the claim comment to the issue. Keep the HTML token at the start
 of the body, followed by the visible note. When helper runtime is enabled,
 post it with the profile-selected post-idd-marker command (`--type claim
---target issue <issue-number> --apply` plus the claim fields; see
+--target issue <number> --apply` plus the claim fields; see
 `docs/idd-helper-scripts.md`), which renders the canonical body and POSTs it via
 the reliable JSON path — it is dry-run (posts nothing) without
 `--apply`; emit-marker (`--type claimed-by`, emit-only) renders the body without

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -269,9 +269,12 @@ minting one (see _Claim verification_ below). Determine `{prior-claim-id}`:
 
 Post the claim comment to the issue. Keep the HTML token at the start
 of the body, followed by the visible note. When helper runtime is enabled,
-render this body with the profile-selected emit-marker command
-(`--type claimed-by`, emit-only; see `docs/idd-helper-scripts.md`); the
-written format below stays the canonical fallback:
+post it with the profile-selected post-idd-marker command (`--type claim
+--target issue`; see `docs/idd-helper-scripts.md`), which renders the canonical
+body and POSTs it via the reliable JSON path; emit-marker
+(`--type claimed-by`, emit-only) renders the body without posting. The written
+format below stays the canonical fallback — post it via the documented direct
+HTTP `POST` with a JSON body when the helper runtime is unavailable:
 
 ```markdown
 <!-- claimed-by: {agent-id} {claim-id} supersedes: {prior-claim-id|none} {ISO8601-timestamp} branch: {branch-name} -->

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -272,7 +272,7 @@ of the body, followed by the visible note. When helper runtime is enabled,
 post it with the profile-selected post-idd-marker command (`--type claim
 --target issue <issue-number> --apply` plus the claim fields; see
 `docs/idd-helper-scripts.md`), which renders the canonical body and POSTs it via
-the reliable JSON path — it is dry-run (prints the body, posts nothing) without
+the reliable JSON path — it is dry-run (posts nothing) without
 `--apply`; emit-marker (`--type claimed-by`, emit-only) renders the body without
 posting. The written format below stays the canonical fallback — post it via the
 documented direct

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -30,7 +30,7 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 (e.g., `gh issue comment`, `gh api -f body=`) silently reject
 HTML-only bodies — always include the visible note and post via direct
 HTTP `POST` with a JSON body for reliability. When helper runtime is enabled,
-the `post-idd-marker` helper (`--type claim --target issue <n> --apply` plus the
+the `post-idd-marker` helper (`--type claim --target issue <number> --apply` plus the
 claim fields; see `docs/idd-helper-scripts.md`) posts this marker through that
 JSON path (dry-run, posting nothing, without `--apply`); the direct `POST` stays
 the canonical fallback.
@@ -73,7 +73,7 @@ _{agent-id}: issue claim released — IDD automation marker. Do not edit._
 ```
 
 When helper runtime is enabled, post this release marker with
-`post-idd-marker --type unclaim --target issue <n> --apply` (plus the
+`post-idd-marker --type unclaim --target issue <number> --apply` (plus the
 agent-id / claim-id / timestamp fields; see `docs/idd-helper-scripts.md`),
 which renders the canonical body and POSTs it via the reliable JSON path — it is
 dry-run (posting nothing) without `--apply`; the direct HTTP `POST` fallback

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -30,10 +30,10 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 (e.g., `gh issue comment`, `gh api -f body=`) silently reject
 HTML-only bodies — always include the visible note and post via direct
 HTTP `POST` with a JSON body for reliability. When helper runtime is enabled,
-the `post-idd-marker` helper (`--type claim --target issue <number> --apply` plus the
-claim fields; see `docs/idd-helper-scripts.md`) posts this marker through that
-JSON path (dry-run, posting nothing, without `--apply`); the direct `POST` stays
-the canonical fallback.
+the `post-idd-marker` helper (`--type claim --target issue <number> --apply`
+plus the claim fields; see `docs/idd-helper-scripts.md`) posts this marker
+through that JSON path (dry-run, posting nothing, without `--apply`); the direct
+`POST` stays the canonical fallback.
 
 Every new HTML-comment operational marker comment must include a short
 visible note after the HTML comment token. `review-watermark` and

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -29,7 +29,10 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 **Important**: operational marker bodies are HTML comments. Some tools
 (e.g., `gh issue comment`, `gh api -f body=`) silently reject
 HTML-only bodies — always include the visible note and post via direct
-HTTP `POST` with a JSON body for reliability.
+HTTP `POST` with a JSON body for reliability. When helper runtime is enabled,
+the `post-idd-marker` helper (`--type claim`; see
+`docs/idd-helper-scripts.md`) posts this marker through that JSON path; the
+direct `POST` stays the canonical fallback.
 
 Every new HTML-comment operational marker comment must include a short
 visible note after the HTML comment token. `review-watermark` and
@@ -67,6 +70,11 @@ Post this comment to release a claim (on abort or voluntary release):
 
 _{agent-id}: issue claim released — IDD automation marker. Do not edit._
 ```
+
+When helper runtime is enabled, post this release marker with
+`post-idd-marker --type unclaim` (see `docs/idd-helper-scripts.md`), which
+renders the canonical body and POSTs it via the reliable JSON path; the direct
+HTTP `POST` fallback above applies when the helper runtime is unavailable.
 
 ## Trusted marker actors
 

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -30,9 +30,10 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 (e.g., `gh issue comment`, `gh api -f body=`) silently reject
 HTML-only bodies — always include the visible note and post via direct
 HTTP `POST` with a JSON body for reliability. When helper runtime is enabled,
-the `post-idd-marker` helper (`--type claim`; see
-`docs/idd-helper-scripts.md`) posts this marker through that JSON path; the
-direct `POST` stays the canonical fallback.
+the `post-idd-marker` helper (`--type claim --target issue <n> --apply` plus the
+claim fields; see `docs/idd-helper-scripts.md`) posts this marker through that
+JSON path (dry-run, posting nothing, without `--apply`); the direct `POST` stays
+the canonical fallback.
 
 Every new HTML-comment operational marker comment must include a short
 visible note after the HTML comment token. `review-watermark` and
@@ -72,9 +73,11 @@ _{agent-id}: issue claim released — IDD automation marker. Do not edit._
 ```
 
 When helper runtime is enabled, post this release marker with
-`post-idd-marker --type unclaim` (see `docs/idd-helper-scripts.md`), which
-renders the canonical body and POSTs it via the reliable JSON path; the direct
-HTTP `POST` fallback above applies when the helper runtime is unavailable.
+`post-idd-marker --type unclaim --target issue <n> --apply` (plus the
+agent-id / claim-id / timestamp fields; see `docs/idd-helper-scripts.md`),
+which renders the canonical body and POSTs it via the reliable JSON path — it is
+dry-run (posting nothing) without `--apply`; the direct HTTP `POST` fallback
+above applies when the helper runtime is unavailable.
 
 ## Trusted marker actors
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -270,10 +270,12 @@ minting one (see _Claim verification_ below). Determine `{prior-claim-id}`:
 Post the claim comment to the issue. Keep the HTML token at the start
 of the body, followed by the visible note. When helper runtime is enabled,
 post it with the profile-selected post-idd-marker command (`--type claim
---target issue`; see `docs/idd-helper-scripts.md`), which renders the canonical
-body and POSTs it via the reliable JSON path; emit-marker
-(`--type claimed-by`, emit-only) renders the body without posting. The written
-format below stays the canonical fallback — post it via the documented direct
+--target issue <issue-number> --apply` plus the claim fields; see
+`docs/idd-helper-scripts.md`), which renders the canonical body and POSTs it via
+the reliable JSON path — it is dry-run (prints the body, posts nothing) without
+`--apply`; emit-marker (`--type claimed-by`, emit-only) renders the body without
+posting. The written format below stays the canonical fallback — post it via the
+documented direct
 HTTP `POST` with a JSON body when the helper runtime is unavailable:
 
 ```markdown

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -270,7 +270,7 @@ minting one (see _Claim verification_ below). Determine `{prior-claim-id}`:
 Post the claim comment to the issue. Keep the HTML token at the start
 of the body, followed by the visible note. When helper runtime is enabled,
 post it with the profile-selected post-idd-marker command (`--type claim
---target issue <issue-number> --apply` plus the claim fields; see
+--target issue <number> --apply` plus the claim fields; see
 `docs/idd-helper-scripts.md`), which renders the canonical body and POSTs it via
 the reliable JSON path — it is dry-run (posts nothing) without
 `--apply`; emit-marker (`--type claimed-by`, emit-only) renders the body without

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -269,9 +269,12 @@ minting one (see _Claim verification_ below). Determine `{prior-claim-id}`:
 
 Post the claim comment to the issue. Keep the HTML token at the start
 of the body, followed by the visible note. When helper runtime is enabled,
-render this body with the profile-selected emit-marker command
-(`--type claimed-by`, emit-only; see `docs/idd-helper-scripts.md`); the
-written format below stays the canonical fallback:
+post it with the profile-selected post-idd-marker command (`--type claim
+--target issue`; see `docs/idd-helper-scripts.md`), which renders the canonical
+body and POSTs it via the reliable JSON path; emit-marker
+(`--type claimed-by`, emit-only) renders the body without posting. The written
+format below stays the canonical fallback — post it via the documented direct
+HTTP `POST` with a JSON body when the helper runtime is unavailable:
 
 ```markdown
 <!-- claimed-by: {agent-id} {claim-id} supersedes: {prior-claim-id|none} {ISO8601-timestamp} branch: {branch-name} -->

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -272,7 +272,7 @@ of the body, followed by the visible note. When helper runtime is enabled,
 post it with the profile-selected post-idd-marker command (`--type claim
 --target issue <issue-number> --apply` plus the claim fields; see
 `docs/idd-helper-scripts.md`), which renders the canonical body and POSTs it via
-the reliable JSON path — it is dry-run (prints the body, posts nothing) without
+the reliable JSON path — it is dry-run (posts nothing) without
 `--apply`; emit-marker (`--type claimed-by`, emit-only) renders the body without
 posting. The written format below stays the canonical fallback — post it via the
 documented direct

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -30,7 +30,7 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 (e.g., `gh issue comment`, `gh api -f body=`) silently reject
 HTML-only bodies — always include the visible note and post via direct
 HTTP `POST` with a JSON body for reliability. When helper runtime is enabled,
-the `post-idd-marker` helper (`--type claim --target issue <n> --apply` plus the
+the `post-idd-marker` helper (`--type claim --target issue <number> --apply` plus the
 claim fields; see `docs/idd-helper-scripts.md`) posts this marker through that
 JSON path (dry-run, posting nothing, without `--apply`); the direct `POST` stays
 the canonical fallback.
@@ -73,7 +73,7 @@ _{agent-id}: issue claim released — IDD automation marker. Do not edit._
 ```
 
 When helper runtime is enabled, post this release marker with
-`post-idd-marker --type unclaim --target issue <n> --apply` (plus the
+`post-idd-marker --type unclaim --target issue <number> --apply` (plus the
 agent-id / claim-id / timestamp fields; see `docs/idd-helper-scripts.md`),
 which renders the canonical body and POSTs it via the reliable JSON path — it is
 dry-run (posting nothing) without `--apply`; the direct HTTP `POST` fallback

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -30,10 +30,10 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 (e.g., `gh issue comment`, `gh api -f body=`) silently reject
 HTML-only bodies — always include the visible note and post via direct
 HTTP `POST` with a JSON body for reliability. When helper runtime is enabled,
-the `post-idd-marker` helper (`--type claim --target issue <number> --apply` plus the
-claim fields; see `docs/idd-helper-scripts.md`) posts this marker through that
-JSON path (dry-run, posting nothing, without `--apply`); the direct `POST` stays
-the canonical fallback.
+the `post-idd-marker` helper (`--type claim --target issue <number> --apply`
+plus the claim fields; see `docs/idd-helper-scripts.md`) posts this marker
+through that JSON path (dry-run, posting nothing, without `--apply`); the direct
+`POST` stays the canonical fallback.
 
 Every new HTML-comment operational marker comment must include a short
 visible note after the HTML comment token. `review-watermark` and

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -29,7 +29,10 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 **Important**: operational marker bodies are HTML comments. Some tools
 (e.g., `gh issue comment`, `gh api -f body=`) silently reject
 HTML-only bodies — always include the visible note and post via direct
-HTTP `POST` with a JSON body for reliability.
+HTTP `POST` with a JSON body for reliability. When helper runtime is enabled,
+the `post-idd-marker` helper (`--type claim`; see
+`docs/idd-helper-scripts.md`) posts this marker through that JSON path; the
+direct `POST` stays the canonical fallback.
 
 Every new HTML-comment operational marker comment must include a short
 visible note after the HTML comment token. `review-watermark` and
@@ -67,6 +70,11 @@ Post this comment to release a claim (on abort or voluntary release):
 
 _{agent-id}: issue claim released — IDD automation marker. Do not edit._
 ```
+
+When helper runtime is enabled, post this release marker with
+`post-idd-marker --type unclaim` (see `docs/idd-helper-scripts.md`), which
+renders the canonical body and POSTs it via the reliable JSON path; the direct
+HTTP `POST` fallback above applies when the helper runtime is unavailable.
 
 ## Trusted marker actors
 

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -30,9 +30,10 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 (e.g., `gh issue comment`, `gh api -f body=`) silently reject
 HTML-only bodies — always include the visible note and post via direct
 HTTP `POST` with a JSON body for reliability. When helper runtime is enabled,
-the `post-idd-marker` helper (`--type claim`; see
-`docs/idd-helper-scripts.md`) posts this marker through that JSON path; the
-direct `POST` stays the canonical fallback.
+the `post-idd-marker` helper (`--type claim --target issue <n> --apply` plus the
+claim fields; see `docs/idd-helper-scripts.md`) posts this marker through that
+JSON path (dry-run, posting nothing, without `--apply`); the direct `POST` stays
+the canonical fallback.
 
 Every new HTML-comment operational marker comment must include a short
 visible note after the HTML comment token. `review-watermark` and
@@ -72,9 +73,11 @@ _{agent-id}: issue claim released — IDD automation marker. Do not edit._
 ```
 
 When helper runtime is enabled, post this release marker with
-`post-idd-marker --type unclaim` (see `docs/idd-helper-scripts.md`), which
-renders the canonical body and POSTs it via the reliable JSON path; the direct
-HTTP `POST` fallback above applies when the helper runtime is unavailable.
+`post-idd-marker --type unclaim --target issue <n> --apply` (plus the
+agent-id / claim-id / timestamp fields; see `docs/idd-helper-scripts.md`),
+which renders the canonical body and POSTs it via the reliable JSON path — it is
+dry-run (posting nothing) without `--apply`; the direct HTTP `POST` fallback
+above applies when the helper runtime is unavailable.
 
 ## Trusted marker actors
 


### PR DESCRIPTION
## Summary

Wires the now-shipped `post-idd-marker` helper (#1047) into the claim-lifecycle
instructions, so agents post `claimed-by` / `unclaimed-by` markers through the
helper's reliable JSON path while the manual `gh api` POST stays the documented
fallback (mirroring how the read-side helpers are documented).

- **`idd-claim` Claim execution**: post the claim with `post-idd-marker
  --type claim --target issue` (renders **and** POSTs); `emit-marker
  --type claimed-by` remains the render-only path; the written format + direct
  HTTP `POST` stay the fallback.
- **`idd-overview-core` Claim format note**: prefer `post-idd-marker --type claim`.
- **`idd-overview-core` Unclaim format**: post the release marker with
  `post-idd-marker --type unclaim`.

## Notes

- Edited the `idd-template/` source; the root `.github/instructions/` mirrors are
  regenerated via `sync-docs` (`idd-claim` = exact mirror, `idd-overview-core` =
  concreted). `audit-docs --check` parity passes.
- No bundle/instruction-size budget bump was needed — the additions are concise
  enough that `audit-docs --check` stays green.

Closes #1049


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to post claim and unclaim markers using the supported helper flow.
  * Added clearer guidance for dry-run behavior versus actually posting changes.
  * Reaffirmed the direct HTTP JSON request as the fallback when the helper is unavailable.
  * Updated wording to better distinguish rendering a marker from posting it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->