### PR TITLE
docs(idd): reference post-idd-marker for E1/AW marker posts

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -233,6 +233,14 @@ Use only when AW3 outcome is `RECOVERY_NEEDED`:
 advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time}
 ```
 
+When helper runtime is enabled, render and POST this marker with the
+profile-selected post-idd-marker command — `--type advisory-recovery
+--target pr <pr-number> --apply` — which emits the plain-text
+`advisory-wait-recovery:` form with no visible note so the AW2 recognizer
+still matches; the manual JSON `POST` stays the fallback. The same helper
+posts the `advisory-wait:` request form (the marker E14 sends on
+`REQUEST_NEEDED`) via `--type advisory`. See `docs/idd-helper-scripts.md`.
+
 Rules:
 
 - do not request another Copilot review in this path

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -235,11 +235,13 @@ advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time}
 
 When helper runtime is enabled, render and POST this marker with the
 profile-selected post-idd-marker command — `--type advisory-recovery
---target pr <pr-number> --apply` — which emits the plain-text
+--target pr <pr-number> --agent-id <id> --head-sha <PR_HEAD_SHA>
+--timestamp <ISO8601> --apply` — which emits the plain-text
 `advisory-wait-recovery:` form with no visible note so the AW2 recognizer
 still matches; the manual JSON `POST` stays the fallback. The same helper
 posts the `advisory-wait:` request form (the marker E14 sends on
-`REQUEST_NEEDED`) via `--type advisory`. See `docs/idd-helper-scripts.md`.
+`REQUEST_NEEDED`) via `--type advisory` with the same `--agent-id` /
+`--head-sha` / `--timestamp` fields. See `docs/idd-helper-scripts.md`.
 
 Rules:
 

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -81,8 +81,11 @@ empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
 PR comment with this format (when helper runtime is enabled, prefer the
 profile-selected post-idd-marker command — `--type watermark --target pr
-<pr-number> --apply` — to render and POST this marker in one step, so a
-hand-typed head SHA cannot mis-route the F2 review-currency check;
+<pr-number> <watermark-fields> --apply`, passing the same six values shown
+below as `--agent-id` / `--claim-id` / `--head-sha` / `--max-activity-at` /
+`--total-item-count` / `--ci-completed-at`, to render and POST this marker in
+one step, so a hand-typed head SHA cannot mis-route the F2 review-currency
+check;
 `emit-marker --type review-watermark` stays the emit-only render path and
 the manual HTTP `POST` below remains the fallback; see
 `docs/idd-helper-scripts.md`):
@@ -227,9 +230,10 @@ comments.
 After the critique pass completes, post a new `review-baseline` comment
 with the current HEAD SHA using this format (when helper runtime is
 enabled, prefer the profile-selected post-idd-marker command — `--type
-baseline --target pr <pr-number> --apply` — to render and POST it in one
-step; `emit-marker --type review-baseline` stays the emit-only render
-path; see `docs/idd-helper-scripts.md`):
+baseline --target pr <pr-number> --agent-id <id> --claim-id <id> --sha
+<head-sha> --apply` — to render and POST it in one step; `emit-marker
+--type review-baseline` stays the emit-only render path; see
+`docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-baseline: {agent-id} {claim-id} {SHA} -->

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -79,9 +79,13 @@ the items that will appear in ReviewItems_snapshot). Write `none` if
 the snapshot is
 empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
-PR comment with this format (when helper runtime is enabled, render the
-body with the profile-selected emit-marker command — `--type
-review-watermark`, emit-only; see `docs/idd-helper-scripts.md`):
+PR comment with this format (when helper runtime is enabled, prefer the
+profile-selected post-idd-marker command — `--type watermark --target pr
+<pr-number> --apply` — to render and POST this marker in one step, so a
+hand-typed head SHA cannot mis-route the F2 review-currency check;
+`emit-marker --type review-watermark` stays the emit-only render path and
+the manual HTTP `POST` below remains the fallback; see
+`docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-watermark: {agent-id} {claim-id} {head-SHA} {max-activity-updatedAt|none} {total-item-count} {latest-ci-completed-at|none} -->
@@ -123,7 +127,8 @@ reject bodies that consist entirely of HTML comments; this format
 includes visible text so that is not an issue, but the HTTP `POST` path
 is still recommended for reliability (`curl` with
 `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->\n\n_note_"}'`).
+`-d '{"body":"<!-- ... -->\n\n_note_"}'`). The post-idd-marker helper
+referenced above performs exactly this JSON `POST` under `--apply`.
 
 On resume or restart, read the latest
 `<!-- review-watermark: {agent-id} {claim-id} … -->` comment whose
@@ -221,8 +226,10 @@ comments.
 
 After the critique pass completes, post a new `review-baseline` comment
 with the current HEAD SHA using this format (when helper runtime is
-enabled, render the body with the profile-selected emit-marker command —
-`--type review-baseline`, emit-only; see `docs/idd-helper-scripts.md`):
+enabled, prefer the profile-selected post-idd-marker command — `--type
+baseline --target pr <pr-number> --apply` — to render and POST it in one
+step; `emit-marker --type review-baseline` stays the emit-only render
+path; see `docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-baseline: {agent-id} {claim-id} {SHA} -->
@@ -235,7 +242,8 @@ watermark). Example Japanese note:
 `_{agent-id}: クリティークのベースライン — IDD 自動化マーカー。編集しないでください。_`
 
 Post using the GitHub REST API directly (the body begins with an HTML
-comment token; use the HTTP `POST` path for reliability).
+comment token; use the HTTP `POST` path for reliability) — or the
+post-idd-marker `--apply` helper above, which performs that JSON `POST`.
 
 ## E3 — Empty list check
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -233,6 +233,14 @@ Use only when AW3 outcome is `RECOVERY_NEEDED`:
 advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time}
 ```
 
+When helper runtime is enabled, render and POST this marker with the
+profile-selected post-idd-marker command — `--type advisory-recovery
+--target pr <pr-number> --apply` — which emits the plain-text
+`advisory-wait-recovery:` form with no visible note so the AW2 recognizer
+still matches; the manual JSON `POST` stays the fallback. The same helper
+posts the `advisory-wait:` request form (the marker E14 sends on
+`REQUEST_NEEDED`) via `--type advisory`. See `docs/idd-helper-scripts.md`.
+
 Rules:
 
 - do not request another Copilot review in this path

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -235,11 +235,13 @@ advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time}
 
 When helper runtime is enabled, render and POST this marker with the
 profile-selected post-idd-marker command — `--type advisory-recovery
---target pr <pr-number> --apply` — which emits the plain-text
+--target pr <pr-number> --agent-id <id> --head-sha <PR_HEAD_SHA>
+--timestamp <ISO8601> --apply` — which emits the plain-text
 `advisory-wait-recovery:` form with no visible note so the AW2 recognizer
 still matches; the manual JSON `POST` stays the fallback. The same helper
 posts the `advisory-wait:` request form (the marker E14 sends on
-`REQUEST_NEEDED`) via `--type advisory`. See `docs/idd-helper-scripts.md`.
+`REQUEST_NEEDED`) via `--type advisory` with the same `--agent-id` /
+`--head-sha` / `--timestamp` fields. See `docs/idd-helper-scripts.md`.
 
 Rules:
 

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -81,8 +81,11 @@ empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
 PR comment with this format (when helper runtime is enabled, prefer the
 profile-selected post-idd-marker command — `--type watermark --target pr
-<pr-number> --apply` — to render and POST this marker in one step, so a
-hand-typed head SHA cannot mis-route the F2 review-currency check;
+<pr-number> <watermark-fields> --apply`, passing the same six values shown
+below as `--agent-id` / `--claim-id` / `--head-sha` / `--max-activity-at` /
+`--total-item-count` / `--ci-completed-at`, to render and POST this marker in
+one step, so a hand-typed head SHA cannot mis-route the F2 review-currency
+check;
 `emit-marker --type review-watermark` stays the emit-only render path and
 the manual HTTP `POST` below remains the fallback; see
 `docs/idd-helper-scripts.md`):
@@ -227,9 +230,10 @@ comments.
 After the critique pass completes, post a new `review-baseline` comment
 with the current HEAD SHA using this format (when helper runtime is
 enabled, prefer the profile-selected post-idd-marker command — `--type
-baseline --target pr <pr-number> --apply` — to render and POST it in one
-step; `emit-marker --type review-baseline` stays the emit-only render
-path; see `docs/idd-helper-scripts.md`):
+baseline --target pr <pr-number> --agent-id <id> --claim-id <id> --sha
+<head-sha> --apply` — to render and POST it in one step; `emit-marker
+--type review-baseline` stays the emit-only render path; see
+`docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-baseline: {agent-id} {claim-id} {SHA} -->

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -79,9 +79,13 @@ the items that will appear in ReviewItems_snapshot). Write `none` if
 the snapshot is
 empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
-PR comment with this format (when helper runtime is enabled, render the
-body with the profile-selected emit-marker command — `--type
-review-watermark`, emit-only; see `docs/idd-helper-scripts.md`):
+PR comment with this format (when helper runtime is enabled, prefer the
+profile-selected post-idd-marker command — `--type watermark --target pr
+<pr-number> --apply` — to render and POST this marker in one step, so a
+hand-typed head SHA cannot mis-route the F2 review-currency check;
+`emit-marker --type review-watermark` stays the emit-only render path and
+the manual HTTP `POST` below remains the fallback; see
+`docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-watermark: {agent-id} {claim-id} {head-SHA} {max-activity-updatedAt|none} {total-item-count} {latest-ci-completed-at|none} -->
@@ -123,7 +127,8 @@ reject bodies that consist entirely of HTML comments; this format
 includes visible text so that is not an issue, but the HTTP `POST` path
 is still recommended for reliability (`curl` with
 `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->\n\n_note_"}'`).
+`-d '{"body":"<!-- ... -->\n\n_note_"}'`). The post-idd-marker helper
+referenced above performs exactly this JSON `POST` under `--apply`.
 
 On resume or restart, read the latest
 `<!-- review-watermark: {agent-id} {claim-id} … -->` comment whose
@@ -221,8 +226,10 @@ comments.
 
 After the critique pass completes, post a new `review-baseline` comment
 with the current HEAD SHA using this format (when helper runtime is
-enabled, render the body with the profile-selected emit-marker command —
-`--type review-baseline`, emit-only; see `docs/idd-helper-scripts.md`):
+enabled, prefer the profile-selected post-idd-marker command — `--type
+baseline --target pr <pr-number> --apply` — to render and POST it in one
+step; `emit-marker --type review-baseline` stays the emit-only render
+path; see `docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-baseline: {agent-id} {claim-id} {SHA} -->
@@ -235,7 +242,8 @@ watermark). Example Japanese note:
 `_{agent-id}: クリティークのベースライン — IDD 自動化マーカー。編集しないでください。_`
 
 Post using the GitHub REST API directly (the body begins with an HTML
-comment token; use the HTTP `POST` path for reliability).
+comment token; use the HTTP `POST` path for reliability) — or the
+post-idd-marker `--apply` helper above, which performs that JSON `POST`.
 
 ## E3 — Empty list check
 


### PR DESCRIPTION
## Summary

Points `idd-review-snapshot.instructions.md` and
`idd-advisory-wait.instructions.md` at the shipped `post-idd-marker` helper
(#1047) as the helper-first render+POST path for their operational markers,
while **keeping** the manual `gh api` fallback and the emit-only `emit-marker`
render path.

- **review-snapshot**: `review-watermark` (E1 Step 2) →
  `post-idd-marker --type watermark --target pr <n> --apply`;
  `review-baseline` (E2) → `--type baseline ...`. A hand-typed head SHA in a
  hand-built `review-watermark` can mis-route the F2 review-currency check;
  the helper renders the canonical body so that is less likely.
- **advisory-wait**: AW3-R `advisory-wait-recovery` →
  `--type advisory-recovery ...` (plain-text form, no visible note, so the AW2
  recognizer still matches); the same helper posts the `advisory-wait:` request
  form via `--type advisory`.

Edits the `idd-template/` sources under the same headings; root mirrors
regenerated via `node scripts/sync-docs.mjs --apply`. `audit-docs --check`
parity passes and no bundle-budget bump was needed (net growth stayed under the
limits).

## Verification

`pnpm run lint:minimum` passes (audit-docs parity, dprint, markdownlint, cspell,
node --test).

Closes #1050
