### PR TITLE
docs(idd): reference resolve-review-thread in E13 reply-and-resolve steps

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -85,9 +85,10 @@ unambiguous:
 - `**Accepted** — fixed in {commit-sha or comma-separated list}: {brief explanation}`
 
 - **Review threads**: after posting your reply, **immediately resolve
-  the thread**. When helper runtime is enabled,
-  `resolve-review-thread --pr <number> --comment-id <id> --apply` (with
-  `--body`, `--claim-issue`, `--claim-id`; see `docs/idd-helper-scripts.md`)
+  the thread**. When helper runtime is enabled, the profile-selected
+  resolve-review-thread command (`--pr <number> --comment-id <id> --apply`,
+  with `--body` / `--claim-issue` / `--claim-id`; see
+  `docs/idd-helper-scripts.md`)
   posts the reply and resolves the thread in one call — dry-run without
   `--apply`, replying before resolving so a failed reply never leaves a
   silently-resolved thread; the manual REST reply + GraphQL

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -85,10 +85,16 @@ unambiguous:
 - `**Accepted** — fixed in {commit-sha or comma-separated list}: {brief explanation}`
 
 - **Review threads**: after posting your reply, **immediately resolve
-  the thread**. Resolution means "agent has responded and acted on the
-  feedback", not "reviewer has agreed". If the reviewer disagrees, they
-  can reopen the thread and add a new reply, which will re-surface it in
-  the next E1 pass.
+  the thread**. When helper runtime is enabled,
+  `resolve-review-thread --pr <number> --comment-id <id> --apply` (with
+  `--body`, `--claim-issue`, `--claim-id`; see `docs/idd-helper-scripts.md`)
+  posts the reply and resolves the thread in one call — dry-run without
+  `--apply`, replying before resolving so a failed reply never leaves a
+  silently-resolved thread; the manual REST reply + GraphQL
+  `resolveReviewThread` sequence stays the fallback. Resolution means "agent
+  has responded and acted on the feedback", not "reviewer has agreed". If the
+  reviewer disagrees, they can reopen the thread and add a new reply, which
+  will re-surface it in the next E1 pass.
 - **Regular comments**: reply only; do not resolve.
 - **Persistent non-review notices**: a non-review notice (rate-limit /
   usage-limit / review-limit) already dispositioned `**Rejected** — {bot}

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -112,7 +112,12 @@ For each Rejected PATH A item whose source is reviewer feedback:
   `**Awaiting maintainer decision** — {your reasoning}` and wait for the
   maintainer's response.
 - After posting your reply, **immediately resolve the thread** — except
-  when the reply is `**Awaiting maintainer decision**`. Resolving means
+  when the reply is `**Awaiting maintainer decision**`. When helper runtime
+  is enabled, `resolve-review-thread --pr <number> --comment-id <id> --apply`
+  (with `--body`, `--claim-issue`, `--claim-id`; see
+  `docs/idd-helper-scripts.md`) posts the reply and resolves the thread in one
+  call (dry-run without `--apply`); the manual REST reply + GraphQL
+  `resolveReviewThread` sequence stays the fallback. Resolving means
   "agent has acted (fixed or definitively rejected)", not "reviewer has
   agreed". If the reviewer disagrees with a regular rejection, they can
   reopen the thread and add a reply, which will re-surface it in a

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -116,8 +116,9 @@ For each Rejected PATH A item whose source is reviewer feedback:
   is enabled, the profile-selected resolve-review-thread command
   (`--pr <number> --comment-id <id> --apply`, with `--body` /
   `--claim-issue` / `--claim-id`; see `docs/idd-helper-scripts.md`) posts the
-  reply and resolves the thread in one call (dry-run without `--apply`); the
-  manual REST reply + GraphQL
+  reply and resolves the thread in one call — dry-run without `--apply`,
+  replying before resolving so a failed reply never leaves a
+  silently-resolved thread; the manual REST reply + GraphQL
   `resolveReviewThread` sequence stays the fallback. Resolving means
   "agent has acted (fixed or definitively rejected)", not "reviewer has
   agreed". If the reviewer disagrees with a regular rejection, they can

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -113,10 +113,11 @@ For each Rejected PATH A item whose source is reviewer feedback:
   maintainer's response.
 - After posting your reply, **immediately resolve the thread** — except
   when the reply is `**Awaiting maintainer decision**`. When helper runtime
-  is enabled, `resolve-review-thread --pr <number> --comment-id <id> --apply`
-  (with `--body`, `--claim-issue`, `--claim-id`; see
-  `docs/idd-helper-scripts.md`) posts the reply and resolves the thread in one
-  call (dry-run without `--apply`); the manual REST reply + GraphQL
+  is enabled, the profile-selected resolve-review-thread command
+  (`--pr <number> --comment-id <id> --apply`, with `--body` /
+  `--claim-issue` / `--claim-id`; see `docs/idd-helper-scripts.md`) posts the
+  reply and resolves the thread in one call (dry-run without `--apply`); the
+  manual REST reply + GraphQL
   `resolveReviewThread` sequence stays the fallback. Resolving means
   "agent has acted (fixed or definitively rejected)", not "reviewer has
   agreed". If the reviewer disagrees with a regular rejection, they can

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -85,9 +85,10 @@ unambiguous:
 - `**Accepted** — fixed in {commit-sha or comma-separated list}: {brief explanation}`
 
 - **Review threads**: after posting your reply, **immediately resolve
-  the thread**. When helper runtime is enabled,
-  `resolve-review-thread --pr <number> --comment-id <id> --apply` (with
-  `--body`, `--claim-issue`, `--claim-id`; see `docs/idd-helper-scripts.md`)
+  the thread**. When helper runtime is enabled, the profile-selected
+  resolve-review-thread command (`--pr <number> --comment-id <id> --apply`,
+  with `--body` / `--claim-issue` / `--claim-id`; see
+  `docs/idd-helper-scripts.md`)
   posts the reply and resolves the thread in one call — dry-run without
   `--apply`, replying before resolving so a failed reply never leaves a
   silently-resolved thread; the manual REST reply + GraphQL

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -85,10 +85,16 @@ unambiguous:
 - `**Accepted** — fixed in {commit-sha or comma-separated list}: {brief explanation}`
 
 - **Review threads**: after posting your reply, **immediately resolve
-  the thread**. Resolution means "agent has responded and acted on the
-  feedback", not "reviewer has agreed". If the reviewer disagrees, they
-  can reopen the thread and add a new reply, which will re-surface it in
-  the next E1 pass.
+  the thread**. When helper runtime is enabled,
+  `resolve-review-thread --pr <number> --comment-id <id> --apply` (with
+  `--body`, `--claim-issue`, `--claim-id`; see `docs/idd-helper-scripts.md`)
+  posts the reply and resolves the thread in one call — dry-run without
+  `--apply`, replying before resolving so a failed reply never leaves a
+  silently-resolved thread; the manual REST reply + GraphQL
+  `resolveReviewThread` sequence stays the fallback. Resolution means "agent
+  has responded and acted on the feedback", not "reviewer has agreed". If the
+  reviewer disagrees, they can reopen the thread and add a new reply, which
+  will re-surface it in the next E1 pass.
 - **Regular comments**: reply only; do not resolve.
 - **Persistent non-review notices**: a non-review notice (rate-limit /
   usage-limit / review-limit) already dispositioned `**Rejected** — {bot}

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -112,7 +112,12 @@ For each Rejected PATH A item whose source is reviewer feedback:
   `**Awaiting maintainer decision** — {your reasoning}` and wait for the
   maintainer's response.
 - After posting your reply, **immediately resolve the thread** — except
-  when the reply is `**Awaiting maintainer decision**`. Resolving means
+  when the reply is `**Awaiting maintainer decision**`. When helper runtime
+  is enabled, `resolve-review-thread --pr <number> --comment-id <id> --apply`
+  (with `--body`, `--claim-issue`, `--claim-id`; see
+  `docs/idd-helper-scripts.md`) posts the reply and resolves the thread in one
+  call (dry-run without `--apply`); the manual REST reply + GraphQL
+  `resolveReviewThread` sequence stays the fallback. Resolving means
   "agent has acted (fixed or definitively rejected)", not "reviewer has
   agreed". If the reviewer disagrees with a regular rejection, they can
   reopen the thread and add a reply, which will re-surface it in a

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -116,8 +116,9 @@ For each Rejected PATH A item whose source is reviewer feedback:
   is enabled, the profile-selected resolve-review-thread command
   (`--pr <number> --comment-id <id> --apply`, with `--body` /
   `--claim-issue` / `--claim-id`; see `docs/idd-helper-scripts.md`) posts the
-  reply and resolves the thread in one call (dry-run without `--apply`); the
-  manual REST reply + GraphQL
+  reply and resolves the thread in one call — dry-run without `--apply`,
+  replying before resolving so a failed reply never leaves a
+  silently-resolved thread; the manual REST reply + GraphQL
   `resolveReviewThread` sequence stays the fallback. Resolving means
   "agent has acted (fixed or definitively rejected)", not "reviewer has
   agreed". If the reviewer disagrees with a regular rejection, they can

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -113,10 +113,11 @@ For each Rejected PATH A item whose source is reviewer feedback:
   maintainer's response.
 - After posting your reply, **immediately resolve the thread** — except
   when the reply is `**Awaiting maintainer decision**`. When helper runtime
-  is enabled, `resolve-review-thread --pr <number> --comment-id <id> --apply`
-  (with `--body`, `--claim-issue`, `--claim-id`; see
-  `docs/idd-helper-scripts.md`) posts the reply and resolves the thread in one
-  call (dry-run without `--apply`); the manual REST reply + GraphQL
+  is enabled, the profile-selected resolve-review-thread command
+  (`--pr <number> --comment-id <id> --apply`, with `--body` /
+  `--claim-issue` / `--claim-id`; see `docs/idd-helper-scripts.md`) posts the
+  reply and resolves the thread in one call (dry-run without `--apply`); the
+  manual REST reply + GraphQL
   `resolveReviewThread` sequence stays the fallback. Resolving means
   "agent has acted (fixed or definitively rejected)", not "reviewer has
   agreed". If the reviewer disagrees with a regular rejection, they can


### PR DESCRIPTION
## Summary

Wires the now-shipped `resolve-review-thread` helper (#1048) into the E13
reply-then-resolve steps, so agents can reply-and-resolve a review thread in one
call while the manual REST reply + GraphQL `resolveReviewThread` sequence stays
the documented fallback.

- **`idd-review-fix` E13** (Accepted PATH A review-thread replies)
- **`idd-review-triage` E6** (Rejected PATH A review-thread replies)

Each reference spells out the dry-run default (`--apply` mutates), the required
`--body` / `--claim-issue` / `--claim-id`, and the reply-before-resolve order (a
failed reply never leaves a silently-resolved thread).

## Notes

- Edited the `idd-template/` source; the root `.github/instructions/` mirrors are
  regenerated via `sync-docs`. `audit-docs --check` parity passes.
- No bundle/instruction-size budget bump needed (`audit-docs --check` green).

Closes #1051
