### PR TITLE
docs(idd): sign rebase/merge --continue with the fallback wrapper

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -43,10 +43,11 @@ before proceeding.
 
 On a signed-commit repo whose primary signing is non-interactive-hostile
 (GPG pinentry or a hardware-touch path) but that provides a fallback
-signing wrapper for arbitrary git subcommands (prefix
+signing wrapper for arbitrary git subcommands (pass
 `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
-to the subcommand, or use a repo alias that wraps any subcommand — a
-commit-only alias like `git commit-ssh` will not run `rebase`),
+to `git` before the subcommand — `git -c … rebase`, not `git rebase -c …`
+— or use a repo alias that wraps any subcommand; a commit-only alias like
+`git commit-ssh` will not run `rebase`),
 **run the initial `git rebase origin/main` above through that wrapper —
 not the plain command — and continue it with the wrapper's own
 `--continue` form**; the wrapper must own the whole operation. Plain

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -41,6 +41,17 @@ them and continue the rebase. After completing the rebase, if any files
 were manually edited during conflict resolution, run **fix-validate**
 before proceeding.
 
+On a signed-commit repo whose primary signing is non-interactive-hostile
+(GPG pinentry or a hardware-touch path) but that provides a fallback
+signing wrapper (e.g. a `git commit-ssh` alias, or
+`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
+**start the rebase with that wrapper and continue it with the wrapper's
+own `--continue` form**. Plain `git rebase --continue` re-signs the
+replayed commit through the configured primary signing, which stalls
+non-interactively right after the conflict is already resolved. This is
+the normal-path complement to the recovery-path re-signing in Post-rebase
+verification below.
+
 ### Post-rebase verification
 
 In a sibling-worktree setup, a rebase can leave HEAD **detached at the

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -43,8 +43,10 @@ before proceeding.
 
 On a signed-commit repo whose primary signing is non-interactive-hostile
 (GPG pinentry or a hardware-touch path) but that provides a fallback
-signing wrapper (e.g. a `git commit-ssh` alias, or
-`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
+signing wrapper for arbitrary git subcommands (prefix
+`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
+to the subcommand, or use a repo alias that wraps any subcommand — a
+commit-only alias like `git commit-ssh` will not run `rebase`),
 **run the initial `git rebase origin/main` above through that wrapper —
 not the plain command — and continue it with the wrapper's own
 `--continue` form**; the wrapper must own the whole operation. Plain
@@ -69,7 +71,10 @@ If HEAD is detached (current branch empty), **auto-recover once**: re-attach
 to the claimed branch with `git checkout {branch-name}` (the local commit is
 preserved on the branch ref), re-run the D1 rebase, then re-verify both
 checks. The re-rebase re-signs through the configured commit-signing path —
-do not pin a key. If recovery still fails (HEAD still detached or the
+do not pin a key — but on the signed-commit repos in the rebase note
+above, run the re-rebase through that same fallback wrapper, since its
+configured primary signing would otherwise stall non-interactively. If
+recovery still fails (HEAD still detached or the
 expected commit absent), post a hold note documenting the branch state and
 stop; do not push.
 

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -71,9 +71,10 @@ If HEAD is detached (current branch empty), **auto-recover once**: re-attach
 to the claimed branch with `git checkout {branch-name}` (the local commit is
 preserved on the branch ref), re-run the D1 rebase, then re-verify both
 checks. The re-rebase re-signs through the configured commit-signing path —
-do not pin a key — but on the signed-commit repos in the rebase note
-above, run the re-rebase through that same fallback wrapper, since its
-configured primary signing would otherwise stall non-interactively. If
+do not hardcode an ad-hoc key. On the signed-commit repos in the rebase
+note above, run the re-rebase through that same fallback wrapper (the
+repo's blessed fallback, not an ad-hoc pin), since the plain re-rebase
+would stall on the non-interactive primary signing. If
 recovery still fails (HEAD still detached or the
 expected commit absent), post a hold note documenting the branch state and
 stop; do not push.

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -45,12 +45,13 @@ On a signed-commit repo whose primary signing is non-interactive-hostile
 (GPG pinentry or a hardware-touch path) but that provides a fallback
 signing wrapper (e.g. a `git commit-ssh` alias, or
 `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
-**start the rebase with that wrapper and continue it with the wrapper's
-own `--continue` form**. Plain `git rebase --continue` re-signs the
-replayed commit through the configured primary signing, which stalls
-non-interactively right after the conflict is already resolved. This is
-the normal-path complement to the recovery-path re-signing in Post-rebase
-verification below.
+**run the initial `git rebase origin/main` above through that wrapper —
+not the plain command — and continue it with the wrapper's own
+`--continue` form**; the wrapper must own the whole operation. Plain
+`git rebase --continue` re-signs the replayed commit through the
+configured primary signing, which stalls non-interactively right after
+the conflict is already resolved. This is the normal-path complement to
+the recovery-path re-signing in Post-rebase verification below.
 
 ### Post-rebase verification
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -62,10 +62,11 @@ conflicts, and complete the merge. On a signed-commit repo with
 non-interactive-hostile primary signing (GPG pinentry / hardware touch)
 and a fallback signing wrapper (a `git commit-ssh`-style alias or
 `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
-**start the merge with that wrapper and continue with the wrapper's own
-`--continue` form**, so `git merge --continue` does not revert the merge
-commit to the stalling primary signing — the normal-path complement to
-the existing detach/cherry-pick recovery re-signing.
+**run that `git merge origin/main` through the wrapper — not the plain
+command — and continue with the wrapper's own `--continue` form**; the
+wrapper must own the whole operation, so `git merge --continue` does not
+revert the merge commit to the stalling primary signing — the normal-path
+complement to the existing detach/cherry-pick recovery re-signing.
 
 **Active review gate**: if the PR has unresolved review threads,
 unreplied comments, or any reviewer's latest state is

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -59,7 +59,7 @@ Check for conflicts between the feature branch and `main`. If conflicts
 exist, merge `main` into the feature branch
 (`git fetch origin main && git merge origin/main`), resolve any
 conflicts, and complete the merge. On a signed-commit repo with
-non-interactive-hostile primary signing (GPG pinentry / hardware touch)
+non-interactive-hostile primary signing (GPG pinentry / hardware-touch)
 and a fallback signing wrapper for arbitrary git subcommands (pass
 `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
 to `git` before the subcommand — `git -c … merge`, not `git merge -c …`; a

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -60,10 +60,11 @@ exist, merge `main` into the feature branch
 (`git fetch origin main && git merge origin/main`), resolve any
 conflicts, and complete the merge. On a signed-commit repo with
 non-interactive-hostile primary signing (GPG pinentry / hardware touch)
-and a fallback signing wrapper (a `git commit-ssh`-style alias or
-`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
-**run that `git merge origin/main` through the wrapper — not the plain
-command — and continue with the wrapper's own `--continue` form**; the
+and a fallback signing wrapper for arbitrary git subcommands (prefix
+`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
+to the subcommand; a commit-only alias like `git commit-ssh` will not run
+`merge`), **run that `git merge origin/main` through the wrapper — not the
+plain command — and continue with the wrapper's own `--continue` form**; the
 wrapper must own the whole operation, so `git merge --continue` does not
 revert the merge commit to the stalling primary signing — the normal-path
 complement to the existing detach/cherry-pick recovery re-signing.

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -65,9 +65,9 @@ and a fallback signing wrapper for arbitrary git subcommands (pass
 to `git` before the subcommand — `git -c … merge`, not `git merge -c …`; a
 commit-only alias like `git commit-ssh` will not run `merge`), **run that
 `git merge origin/main` through the wrapper — not the plain command — and
-continue with the wrapper's own `--continue` form**; the
-wrapper must own the whole operation, so `git merge --continue` does not
-revert the merge commit to the stalling primary signing — the normal-path
+continue with the wrapper's own `--continue` (`git -c … merge --continue`)**;
+the wrapper must own the whole operation, so the merge commit is not
+reverted to the stalling primary signing — the normal-path
 complement to the recovery-path re-signing (the D1 Post-rebase
 detached-HEAD recovery in `idd-pr-submit.instructions.md` and the
 cwd-vs-claim cherry-pick recovery in `idd-overview-core.instructions.md`).

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -58,7 +58,14 @@ Convergence guardrails:
 Check for conflicts between the feature branch and `main`. If conflicts
 exist, merge `main` into the feature branch
 (`git fetch origin main && git merge origin/main`), resolve any
-conflicts, and complete the merge.
+conflicts, and complete the merge. On a signed-commit repo with
+non-interactive-hostile primary signing (GPG pinentry / hardware touch)
+and a fallback signing wrapper (a `git commit-ssh`-style alias or
+`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
+**start the merge with that wrapper and continue with the wrapper's own
+`--continue` form**, so `git merge --continue` does not revert the merge
+commit to the stalling primary signing — the normal-path complement to
+the existing detach/cherry-pick recovery re-signing.
 
 **Active review gate**: if the PR has unresolved review threads,
 unreplied comments, or any reviewer's latest state is

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -60,11 +60,12 @@ exist, merge `main` into the feature branch
 (`git fetch origin main && git merge origin/main`), resolve any
 conflicts, and complete the merge. On a signed-commit repo with
 non-interactive-hostile primary signing (GPG pinentry / hardware touch)
-and a fallback signing wrapper for arbitrary git subcommands (prefix
+and a fallback signing wrapper for arbitrary git subcommands (pass
 `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
-to the subcommand; a commit-only alias like `git commit-ssh` will not run
-`merge`), **run that `git merge origin/main` through the wrapper — not the
-plain command — and continue with the wrapper's own `--continue` form**; the
+to `git` before the subcommand — `git -c … merge`, not `git merge -c …`; a
+commit-only alias like `git commit-ssh` will not run `merge`), **run that
+`git merge origin/main` through the wrapper — not the plain command — and
+continue with the wrapper's own `--continue` form**; the
 wrapper must own the whole operation, so `git merge --continue` does not
 revert the merge commit to the stalling primary signing — the normal-path
 complement to the recovery-path re-signing (the D1 Post-rebase

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -67,7 +67,9 @@ to the subcommand; a commit-only alias like `git commit-ssh` will not run
 plain command — and continue with the wrapper's own `--continue` form**; the
 wrapper must own the whole operation, so `git merge --continue` does not
 revert the merge commit to the stalling primary signing — the normal-path
-complement to the existing detach/cherry-pick recovery re-signing.
+complement to the recovery-path re-signing (the D1 Post-rebase
+detached-HEAD recovery in `idd-pr-submit.instructions.md` and the
+cwd-vs-claim cherry-pick recovery in `idd-overview-core.instructions.md`).
 
 **Active review gate**: if the PR has unresolved review threads,
 unreplied comments, or any reviewer's latest state is

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -426,16 +426,18 @@ Route based on `branchState` from the helper (or `mergeable` /
    `main` into the feature branch, as the merge commit will appear in the
    PR history.
 2. Merge `main` into the feature branch:
-   `git fetch origin main && git merge origin/main`
-3. If conflicts arise, resolve them and complete the merge. On a
-   signed-commit repo with non-interactive-hostile primary signing (GPG
-   pinentry / hardware touch) and a fallback signing wrapper (a
-   `git commit-ssh`-style alias or
-   `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
-   **run the step 2 `git merge origin/main` through that wrapper — not the
-   plain command — and continue with the wrapper's own `--continue` form**;
-   the wrapper must own the whole operation, so `git merge --continue` does
-   not revert the merge commit to the stalling primary signing. This is the
+   `git fetch origin main && git merge origin/main`. On a signed-commit
+   repo with non-interactive-hostile primary signing (GPG pinentry /
+   hardware touch) and a fallback signing wrapper for arbitrary git
+   subcommands (prefix
+   `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
+   to the subcommand; a commit-only alias like `git commit-ssh` will not
+   run `merge`), **run this `git merge origin/main` through that wrapper —
+   not the plain command** — even a clean merge commits immediately, so the
+   wrapper must own the whole operation.
+3. If conflicts arise, resolve them and complete the merge with the
+   wrapper's own `git merge --continue` form, so `--continue` does not
+   revert the merge commit to the stalling primary signing. This is the
    normal-path complement to the recovery re-signing and mirrors the D1
    rebase note in `idd-pr-submit.instructions.md`.
 4. Run **post-fix-validate**.

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -427,7 +427,16 @@ Route based on `branchState` from the helper (or `mergeable` /
    PR history.
 2. Merge `main` into the feature branch:
    `git fetch origin main && git merge origin/main`
-3. If conflicts arise, resolve them and complete the merge.
+3. If conflicts arise, resolve them and complete the merge. On a
+   signed-commit repo with non-interactive-hostile primary signing (GPG
+   pinentry / hardware touch) and a fallback signing wrapper (a
+   `git commit-ssh`-style alias or
+   `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
+   **start the merge with that wrapper and continue with the wrapper's
+   own `--continue` form**, so `git merge --continue` does not revert the
+   merge commit to the stalling primary signing. This is the normal-path
+   complement to the recovery re-signing and mirrors the D1 rebase note
+   in `idd-pr-submit.instructions.md`.
 4. Run **post-fix-validate**.
 5. Push the feature branch normally (no force push required for merge
    commits).

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -437,9 +437,10 @@ Route based on `branchState` from the helper (or `mergeable` /
    command** — even a clean merge commits immediately, so the wrapper must
    own the whole operation.
 3. If conflicts arise, resolve them and complete the merge — on the
-   signed-commit repos above, with the wrapper's own `git merge --continue`
-   so `--continue` does not revert the merge commit to the stalling primary
-   signing (otherwise the plain `git merge --continue`). This is the
+   signed-commit repos above, run the `--continue` through the wrapper too
+   (`git -c … merge --continue`) so it does not revert the merge commit to
+   the stalling primary signing; otherwise the plain `git merge --continue`
+   is fine. This is the
    normal-path complement to the recovery-path re-signing documented in
    `idd-pr-submit.instructions.md` (Post-rebase verification) and
    `idd-overview-core.instructions.md` (cwd-vs-claim cherry-pick

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -438,8 +438,10 @@ Route based on `branchState` from the helper (or `mergeable` /
 3. If conflicts arise, resolve them and complete the merge with the
    wrapper's own `git merge --continue` form, so `--continue` does not
    revert the merge commit to the stalling primary signing. This is the
-   normal-path complement to the recovery re-signing and mirrors the D1
-   rebase note in `idd-pr-submit.instructions.md`.
+   normal-path complement to the recovery-path re-signing documented in
+   `idd-pr-submit.instructions.md` (Post-rebase verification) and
+   `idd-overview-core.instructions.md` (cwd-vs-claim cherry-pick
+   recovery), mirroring the D1 rebase note.
 4. Run **post-fix-validate**.
 5. Push the feature branch normally (no force push required for merge
    commits).

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -432,11 +432,12 @@ Route based on `branchState` from the helper (or `mergeable` /
    pinentry / hardware touch) and a fallback signing wrapper (a
    `git commit-ssh`-style alias or
    `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
-   **start the merge with that wrapper and continue with the wrapper's
-   own `--continue` form**, so `git merge --continue` does not revert the
-   merge commit to the stalling primary signing. This is the normal-path
-   complement to the recovery re-signing and mirrors the D1 rebase note
-   in `idd-pr-submit.instructions.md`.
+   **run the step 2 `git merge origin/main` through that wrapper — not the
+   plain command — and continue with the wrapper's own `--continue` form**;
+   the wrapper must own the whole operation, so `git merge --continue` does
+   not revert the merge commit to the stalling primary signing. This is the
+   normal-path complement to the recovery re-signing and mirrors the D1
+   rebase note in `idd-pr-submit.instructions.md`.
 4. Run **post-fix-validate**.
 5. Push the feature branch normally (no force push required for merge
    commits).

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -428,7 +428,7 @@ Route based on `branchState` from the helper (or `mergeable` /
 2. Merge `main` into the feature branch:
    `git fetch origin main && git merge origin/main`. On a signed-commit
    repo with non-interactive-hostile primary signing (GPG pinentry /
-   hardware touch) and a fallback signing wrapper for arbitrary git
+   hardware-touch) and a fallback signing wrapper for arbitrary git
    subcommands (pass
    `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
    to `git` before the subcommand — `git -c … merge`, not `git merge -c …`;

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -429,15 +429,17 @@ Route based on `branchState` from the helper (or `mergeable` /
    `git fetch origin main && git merge origin/main`. On a signed-commit
    repo with non-interactive-hostile primary signing (GPG pinentry /
    hardware touch) and a fallback signing wrapper for arbitrary git
-   subcommands (prefix
+   subcommands (pass
    `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
-   to the subcommand; a commit-only alias like `git commit-ssh` will not
-   run `merge`), **run this `git merge origin/main` through that wrapper —
-   not the plain command** — even a clean merge commits immediately, so the
-   wrapper must own the whole operation.
-3. If conflicts arise, resolve them and complete the merge with the
-   wrapper's own `git merge --continue` form, so `--continue` does not
-   revert the merge commit to the stalling primary signing. This is the
+   to `git` before the subcommand — `git -c … merge`, not `git merge -c …`;
+   a commit-only alias like `git commit-ssh` will not run `merge`), **run
+   this `git merge origin/main` through that wrapper — not the plain
+   command** — even a clean merge commits immediately, so the wrapper must
+   own the whole operation.
+3. If conflicts arise, resolve them and complete the merge — on the
+   signed-commit repos above, with the wrapper's own `git merge --continue`
+   so `--continue` does not revert the merge commit to the stalling primary
+   signing (otherwise the plain `git merge --continue`). This is the
    normal-path complement to the recovery-path re-signing documented in
    `idd-pr-submit.instructions.md` (Post-rebase verification) and
    `idd-overview-core.instructions.md` (cwd-vs-claim cherry-pick

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -43,10 +43,11 @@ before proceeding.
 
 On a signed-commit repo whose primary signing is non-interactive-hostile
 (GPG pinentry or a hardware-touch path) but that provides a fallback
-signing wrapper for arbitrary git subcommands (prefix
+signing wrapper for arbitrary git subcommands (pass
 `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
-to the subcommand, or use a repo alias that wraps any subcommand — a
-commit-only alias like `git commit-ssh` will not run `rebase`),
+to `git` before the subcommand — `git -c … rebase`, not `git rebase -c …`
+— or use a repo alias that wraps any subcommand; a commit-only alias like
+`git commit-ssh` will not run `rebase`),
 **run the initial `git rebase origin/main` above through that wrapper —
 not the plain command — and continue it with the wrapper's own
 `--continue` form**; the wrapper must own the whole operation. Plain

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -41,6 +41,17 @@ them and continue the rebase. After completing the rebase, if any files
 were manually edited during conflict resolution, run **fix-validate**
 before proceeding.
 
+On a signed-commit repo whose primary signing is non-interactive-hostile
+(GPG pinentry or a hardware-touch path) but that provides a fallback
+signing wrapper (e.g. a `git commit-ssh` alias, or
+`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
+**start the rebase with that wrapper and continue it with the wrapper's
+own `--continue` form**. Plain `git rebase --continue` re-signs the
+replayed commit through the configured primary signing, which stalls
+non-interactively right after the conflict is already resolved. This is
+the normal-path complement to the recovery-path re-signing in Post-rebase
+verification below.
+
 ### Post-rebase verification
 
 In a sibling-worktree setup, a rebase can leave HEAD **detached at the

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -43,8 +43,10 @@ before proceeding.
 
 On a signed-commit repo whose primary signing is non-interactive-hostile
 (GPG pinentry or a hardware-touch path) but that provides a fallback
-signing wrapper (e.g. a `git commit-ssh` alias, or
-`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
+signing wrapper for arbitrary git subcommands (prefix
+`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
+to the subcommand, or use a repo alias that wraps any subcommand — a
+commit-only alias like `git commit-ssh` will not run `rebase`),
 **run the initial `git rebase origin/main` above through that wrapper —
 not the plain command — and continue it with the wrapper's own
 `--continue` form**; the wrapper must own the whole operation. Plain
@@ -69,7 +71,10 @@ If HEAD is detached (current branch empty), **auto-recover once**: re-attach
 to the claimed branch with `git checkout {branch-name}` (the local commit is
 preserved on the branch ref), re-run the D1 rebase, then re-verify both
 checks. The re-rebase re-signs through the configured commit-signing path —
-do not pin a key. If recovery still fails (HEAD still detached or the
+do not pin a key — but on the signed-commit repos in the rebase note
+above, run the re-rebase through that same fallback wrapper, since its
+configured primary signing would otherwise stall non-interactively. If
+recovery still fails (HEAD still detached or the
 expected commit absent), post a hold note documenting the branch state and
 stop; do not push.
 

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -71,9 +71,10 @@ If HEAD is detached (current branch empty), **auto-recover once**: re-attach
 to the claimed branch with `git checkout {branch-name}` (the local commit is
 preserved on the branch ref), re-run the D1 rebase, then re-verify both
 checks. The re-rebase re-signs through the configured commit-signing path —
-do not pin a key — but on the signed-commit repos in the rebase note
-above, run the re-rebase through that same fallback wrapper, since its
-configured primary signing would otherwise stall non-interactively. If
+do not hardcode an ad-hoc key. On the signed-commit repos in the rebase
+note above, run the re-rebase through that same fallback wrapper (the
+repo's blessed fallback, not an ad-hoc pin), since the plain re-rebase
+would stall on the non-interactive primary signing. If
 recovery still fails (HEAD still detached or the
 expected commit absent), post a hold note documenting the branch state and
 stop; do not push.

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -45,12 +45,13 @@ On a signed-commit repo whose primary signing is non-interactive-hostile
 (GPG pinentry or a hardware-touch path) but that provides a fallback
 signing wrapper (e.g. a `git commit-ssh` alias, or
 `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
-**start the rebase with that wrapper and continue it with the wrapper's
-own `--continue` form**. Plain `git rebase --continue` re-signs the
-replayed commit through the configured primary signing, which stalls
-non-interactively right after the conflict is already resolved. This is
-the normal-path complement to the recovery-path re-signing in Post-rebase
-verification below.
+**run the initial `git rebase origin/main` above through that wrapper —
+not the plain command — and continue it with the wrapper's own
+`--continue` form**; the wrapper must own the whole operation. Plain
+`git rebase --continue` re-signs the replayed commit through the
+configured primary signing, which stalls non-interactively right after
+the conflict is already resolved. This is the normal-path complement to
+the recovery-path re-signing in Post-rebase verification below.
 
 ### Post-rebase verification
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -62,10 +62,11 @@ conflicts, and complete the merge. On a signed-commit repo with
 non-interactive-hostile primary signing (GPG pinentry / hardware touch)
 and a fallback signing wrapper (a `git commit-ssh`-style alias or
 `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
-**start the merge with that wrapper and continue with the wrapper's own
-`--continue` form**, so `git merge --continue` does not revert the merge
-commit to the stalling primary signing — the normal-path complement to
-the existing detach/cherry-pick recovery re-signing.
+**run that `git merge origin/main` through the wrapper — not the plain
+command — and continue with the wrapper's own `--continue` form**; the
+wrapper must own the whole operation, so `git merge --continue` does not
+revert the merge commit to the stalling primary signing — the normal-path
+complement to the existing detach/cherry-pick recovery re-signing.
 
 **Active review gate**: if the PR has unresolved review threads,
 unreplied comments, or any reviewer's latest state is

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -59,7 +59,7 @@ Check for conflicts between the feature branch and `main`. If conflicts
 exist, merge `main` into the feature branch
 (`git fetch origin main && git merge origin/main`), resolve any
 conflicts, and complete the merge. On a signed-commit repo with
-non-interactive-hostile primary signing (GPG pinentry / hardware touch)
+non-interactive-hostile primary signing (GPG pinentry / hardware-touch)
 and a fallback signing wrapper for arbitrary git subcommands (pass
 `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
 to `git` before the subcommand — `git -c … merge`, not `git merge -c …`; a

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -60,10 +60,11 @@ exist, merge `main` into the feature branch
 (`git fetch origin main && git merge origin/main`), resolve any
 conflicts, and complete the merge. On a signed-commit repo with
 non-interactive-hostile primary signing (GPG pinentry / hardware touch)
-and a fallback signing wrapper (a `git commit-ssh`-style alias or
-`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
-**run that `git merge origin/main` through the wrapper — not the plain
-command — and continue with the wrapper's own `--continue` form**; the
+and a fallback signing wrapper for arbitrary git subcommands (prefix
+`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
+to the subcommand; a commit-only alias like `git commit-ssh` will not run
+`merge`), **run that `git merge origin/main` through the wrapper — not the
+plain command — and continue with the wrapper's own `--continue` form**; the
 wrapper must own the whole operation, so `git merge --continue` does not
 revert the merge commit to the stalling primary signing — the normal-path
 complement to the existing detach/cherry-pick recovery re-signing.

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -65,9 +65,9 @@ and a fallback signing wrapper for arbitrary git subcommands (pass
 to `git` before the subcommand — `git -c … merge`, not `git merge -c …`; a
 commit-only alias like `git commit-ssh` will not run `merge`), **run that
 `git merge origin/main` through the wrapper — not the plain command — and
-continue with the wrapper's own `--continue` form**; the
-wrapper must own the whole operation, so `git merge --continue` does not
-revert the merge commit to the stalling primary signing — the normal-path
+continue with the wrapper's own `--continue` (`git -c … merge --continue`)**;
+the wrapper must own the whole operation, so the merge commit is not
+reverted to the stalling primary signing — the normal-path
 complement to the recovery-path re-signing (the D1 Post-rebase
 detached-HEAD recovery in `idd-pr-submit.instructions.md` and the
 cwd-vs-claim cherry-pick recovery in `idd-overview-core.instructions.md`).

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -58,7 +58,14 @@ Convergence guardrails:
 Check for conflicts between the feature branch and `main`. If conflicts
 exist, merge `main` into the feature branch
 (`git fetch origin main && git merge origin/main`), resolve any
-conflicts, and complete the merge.
+conflicts, and complete the merge. On a signed-commit repo with
+non-interactive-hostile primary signing (GPG pinentry / hardware touch)
+and a fallback signing wrapper (a `git commit-ssh`-style alias or
+`-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
+**start the merge with that wrapper and continue with the wrapper's own
+`--continue` form**, so `git merge --continue` does not revert the merge
+commit to the stalling primary signing — the normal-path complement to
+the existing detach/cherry-pick recovery re-signing.
 
 **Active review gate**: if the PR has unresolved review threads,
 unreplied comments, or any reviewer's latest state is

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -60,11 +60,12 @@ exist, merge `main` into the feature branch
 (`git fetch origin main && git merge origin/main`), resolve any
 conflicts, and complete the merge. On a signed-commit repo with
 non-interactive-hostile primary signing (GPG pinentry / hardware touch)
-and a fallback signing wrapper for arbitrary git subcommands (prefix
+and a fallback signing wrapper for arbitrary git subcommands (pass
 `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
-to the subcommand; a commit-only alias like `git commit-ssh` will not run
-`merge`), **run that `git merge origin/main` through the wrapper — not the
-plain command — and continue with the wrapper's own `--continue` form**; the
+to `git` before the subcommand — `git -c … merge`, not `git merge -c …`; a
+commit-only alias like `git commit-ssh` will not run `merge`), **run that
+`git merge origin/main` through the wrapper — not the plain command — and
+continue with the wrapper's own `--continue` form**; the
 wrapper must own the whole operation, so `git merge --continue` does not
 revert the merge commit to the stalling primary signing — the normal-path
 complement to the recovery-path re-signing (the D1 Post-rebase

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -67,7 +67,9 @@ to the subcommand; a commit-only alias like `git commit-ssh` will not run
 plain command — and continue with the wrapper's own `--continue` form**; the
 wrapper must own the whole operation, so `git merge --continue` does not
 revert the merge commit to the stalling primary signing — the normal-path
-complement to the existing detach/cherry-pick recovery re-signing.
+complement to the recovery-path re-signing (the D1 Post-rebase
+detached-HEAD recovery in `idd-pr-submit.instructions.md` and the
+cwd-vs-claim cherry-pick recovery in `idd-overview-core.instructions.md`).
 
 **Active review gate**: if the PR has unresolved review threads,
 unreplied comments, or any reviewer's latest state is

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -426,16 +426,18 @@ Route based on `branchState` from the helper (or `mergeable` /
    `main` into the feature branch, as the merge commit will appear in the
    PR history.
 2. Merge `main` into the feature branch:
-   `git fetch origin main && git merge origin/main`
-3. If conflicts arise, resolve them and complete the merge. On a
-   signed-commit repo with non-interactive-hostile primary signing (GPG
-   pinentry / hardware touch) and a fallback signing wrapper (a
-   `git commit-ssh`-style alias or
-   `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
-   **run the step 2 `git merge origin/main` through that wrapper — not the
-   plain command — and continue with the wrapper's own `--continue` form**;
-   the wrapper must own the whole operation, so `git merge --continue` does
-   not revert the merge commit to the stalling primary signing. This is the
+   `git fetch origin main && git merge origin/main`. On a signed-commit
+   repo with non-interactive-hostile primary signing (GPG pinentry /
+   hardware touch) and a fallback signing wrapper for arbitrary git
+   subcommands (prefix
+   `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
+   to the subcommand; a commit-only alias like `git commit-ssh` will not
+   run `merge`), **run this `git merge origin/main` through that wrapper —
+   not the plain command** — even a clean merge commits immediately, so the
+   wrapper must own the whole operation.
+3. If conflicts arise, resolve them and complete the merge with the
+   wrapper's own `git merge --continue` form, so `--continue` does not
+   revert the merge commit to the stalling primary signing. This is the
    normal-path complement to the recovery re-signing and mirrors the D1
    rebase note in `idd-pr-submit.instructions.md`.
 4. Run **post-fix-validate**.

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -427,7 +427,16 @@ Route based on `branchState` from the helper (or `mergeable` /
    PR history.
 2. Merge `main` into the feature branch:
    `git fetch origin main && git merge origin/main`
-3. If conflicts arise, resolve them and complete the merge.
+3. If conflicts arise, resolve them and complete the merge. On a
+   signed-commit repo with non-interactive-hostile primary signing (GPG
+   pinentry / hardware touch) and a fallback signing wrapper (a
+   `git commit-ssh`-style alias or
+   `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
+   **start the merge with that wrapper and continue with the wrapper's
+   own `--continue` form**, so `git merge --continue` does not revert the
+   merge commit to the stalling primary signing. This is the normal-path
+   complement to the recovery re-signing and mirrors the D1 rebase note
+   in `idd-pr-submit.instructions.md`.
 4. Run **post-fix-validate**.
 5. Push the feature branch normally (no force push required for merge
    commits).

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -437,9 +437,10 @@ Route based on `branchState` from the helper (or `mergeable` /
    command** — even a clean merge commits immediately, so the wrapper must
    own the whole operation.
 3. If conflicts arise, resolve them and complete the merge — on the
-   signed-commit repos above, with the wrapper's own `git merge --continue`
-   so `--continue` does not revert the merge commit to the stalling primary
-   signing (otherwise the plain `git merge --continue`). This is the
+   signed-commit repos above, run the `--continue` through the wrapper too
+   (`git -c … merge --continue`) so it does not revert the merge commit to
+   the stalling primary signing; otherwise the plain `git merge --continue`
+   is fine. This is the
    normal-path complement to the recovery-path re-signing documented in
    `idd-pr-submit.instructions.md` (Post-rebase verification) and
    `idd-overview-core.instructions.md` (cwd-vs-claim cherry-pick

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -438,8 +438,10 @@ Route based on `branchState` from the helper (or `mergeable` /
 3. If conflicts arise, resolve them and complete the merge with the
    wrapper's own `git merge --continue` form, so `--continue` does not
    revert the merge commit to the stalling primary signing. This is the
-   normal-path complement to the recovery re-signing and mirrors the D1
-   rebase note in `idd-pr-submit.instructions.md`.
+   normal-path complement to the recovery-path re-signing documented in
+   `idd-pr-submit.instructions.md` (Post-rebase verification) and
+   `idd-overview-core.instructions.md` (cwd-vs-claim cherry-pick
+   recovery), mirroring the D1 rebase note.
 4. Run **post-fix-validate**.
 5. Push the feature branch normally (no force push required for merge
    commits).

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -432,11 +432,12 @@ Route based on `branchState` from the helper (or `mergeable` /
    pinentry / hardware touch) and a fallback signing wrapper (a
    `git commit-ssh`-style alias or
    `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`),
-   **start the merge with that wrapper and continue with the wrapper's
-   own `--continue` form**, so `git merge --continue` does not revert the
-   merge commit to the stalling primary signing. This is the normal-path
-   complement to the recovery re-signing and mirrors the D1 rebase note
-   in `idd-pr-submit.instructions.md`.
+   **run the step 2 `git merge origin/main` through that wrapper — not the
+   plain command — and continue with the wrapper's own `--continue` form**;
+   the wrapper must own the whole operation, so `git merge --continue` does
+   not revert the merge commit to the stalling primary signing. This is the
+   normal-path complement to the recovery re-signing and mirrors the D1
+   rebase note in `idd-pr-submit.instructions.md`.
 4. Run **post-fix-validate**.
 5. Push the feature branch normally (no force push required for merge
    commits).

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -428,7 +428,7 @@ Route based on `branchState` from the helper (or `mergeable` /
 2. Merge `main` into the feature branch:
    `git fetch origin main && git merge origin/main`. On a signed-commit
    repo with non-interactive-hostile primary signing (GPG pinentry /
-   hardware touch) and a fallback signing wrapper for arbitrary git
+   hardware-touch) and a fallback signing wrapper for arbitrary git
    subcommands (pass
    `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
    to `git` before the subcommand — `git -c … merge`, not `git merge -c …`;

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -429,15 +429,17 @@ Route based on `branchState` from the helper (or `mergeable` /
    `git fetch origin main && git merge origin/main`. On a signed-commit
    repo with non-interactive-hostile primary signing (GPG pinentry /
    hardware touch) and a fallback signing wrapper for arbitrary git
-   subcommands (prefix
+   subcommands (pass
    `-c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true`
-   to the subcommand; a commit-only alias like `git commit-ssh` will not
-   run `merge`), **run this `git merge origin/main` through that wrapper —
-   not the plain command** — even a clean merge commits immediately, so the
-   wrapper must own the whole operation.
-3. If conflicts arise, resolve them and complete the merge with the
-   wrapper's own `git merge --continue` form, so `--continue` does not
-   revert the merge commit to the stalling primary signing. This is the
+   to `git` before the subcommand — `git -c … merge`, not `git merge -c …`;
+   a commit-only alias like `git commit-ssh` will not run `merge`), **run
+   this `git merge origin/main` through that wrapper — not the plain
+   command** — even a clean merge commits immediately, so the wrapper must
+   own the whole operation.
+3. If conflicts arise, resolve them and complete the merge — on the
+   signed-commit repos above, with the wrapper's own `git merge --continue`
+   so `--continue` does not revert the merge commit to the stalling primary
+   signing (otherwise the plain `git merge --continue`). This is the
    normal-path complement to the recovery-path re-signing documented in
    `idd-pr-submit.instructions.md` (Post-rebase verification) and
    `idd-overview-core.instructions.md` (cwd-vs-claim cherry-pick


### PR DESCRIPTION
## Summary

On a signed-commit repo whose **primary** signing is non-interactive-hostile
(GPG pinentry / hardware-touch) but that provides an **SSH-signing fallback
wrapper**, a conflict-resolving git op started with the plain command re-signs
the replayed/merge commit on `--continue` through the configured primary
signing — which stalls non-interactively right after the conflict is already
resolved. The wrapper must own the **whole** operation.

Adds tool-agnostic guidance to **start the operation with the signing wrapper
and continue it with the wrapper's own `--continue` form** at the three
conflict-resolving git steps:

- **D1 rebase** — `idd-pr-submit.instructions.md`
- **E11 merge-from-`main`** — `idd-review-fix.instructions.md`
- **E-phase branch-sync merge** — `idd-review-triage.instructions.md`

Each note describes the pattern (`-c gpg.format=ssh -c user.signingkey=<abs-path>
-c commit.gpgsign=true` or the repo's blessed alias), ships no wrapper, and
cross-references the existing detach/cherry-pick **recovery** re-signing as the
complementary path (recovery vs normal path).

## Notes

- Edited the `idd-template/` source; the three **exact-mode** root mirrors are
  regenerated via `sync-docs`. `audit-docs --check` parity passes; no bundle /
  instruction-size budget bump needed.
- **Recovered via operator-approved forced handoff** (`claim-d8f4edde95fa4f90`,
  human-gated, `forced-by: kurone-kito`, 2026-06-25T22:31Z). The prior session's
  uncommitted draft was re-applied on current `main`.

Closes #1022
