### PR TITLE
fix(idd): make merge-gate write-side helpers forced-handoff-aware

### DIFF
--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -61,6 +61,12 @@ const [owner, repo] = parseRepository(repository);
 const prNumber = parsePositiveInteger(args.pr, '--pr');
 const claimContext = {
   expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, prNumber),
+  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
+  // a legitimate issue-only handoff that predates the PR is honored even
+  // against this PR-backed claim. Resolve it once for both claim asserts.
+  prFirstCommitAt: args.apply
+    ? fetchPrFirstCommitAt(owner, repo, prNumber)
+    : null,
 };
 if (args.claimIssue) {
   args.claimIssue = String(
@@ -514,6 +520,70 @@ function fetchPullRequest(owner, repo, number, options = {}) {
   }
   return pr;
 }
+/**
+ * Resolve the PR's first-commit time as an ISO string for the Part B
+ * forced-handoff rule (#1058): the minimum committed date (falling back to
+ * authored date) across the PR's commits. Returns `null` when no commit
+ * carries a parseable date — which makes the Part B gate fail closed
+ * (issue-only handoffs against a PR-backed claim stay rejected). Fails safe to
+ * `null` on any lookup error rather than aborting the claim assertion.
+ */
+function fetchPrFirstCommitAt(owner, repo, number) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        commits(first:100,after:$after){
+          nodes{commit{committedDate authoredDate}}
+          pageInfo{hasNextPage endCursor}
+        }
+      }
+    }
+  }`;
+  let earliestMs = null;
+  let earliestIso = null;
+  let after = null;
+  try {
+    for (;;) {
+      const result = ghGraphql(
+        query,
+        { owner, repo, number, after },
+        // Fail safe: a lookup error throws (caught below) instead of aborting
+        // the whole claim assertion via the default process-exit path.
+        { throwOnError: true },
+      );
+      const connection = result?.data?.repository?.pullRequest?.commits;
+      if (!connection) {
+        break;
+      }
+      for (const node of connection.nodes ?? []) {
+        const date =
+          String(node?.commit?.committedDate ?? '').trim() ||
+          String(node?.commit?.authoredDate ?? '').trim();
+        if (!date) {
+          continue;
+        }
+        const ms = Date.parse(date);
+        if (!Number.isFinite(ms)) {
+          continue;
+        }
+        if (earliestMs === null || ms < earliestMs) {
+          earliestMs = ms;
+          earliestIso = date;
+        }
+      }
+      if (!connection.pageInfo?.hasNextPage) {
+        break;
+      }
+      after = connection.pageInfo.endCursor ?? null;
+      if (!after) {
+        break;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return earliestIso;
+}
 function fetchIssueComments(owner, repo, number, options = {}) {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
     repository(owner:$owner,name:$repo){
@@ -773,6 +843,7 @@ function readActiveClaim(owner, repo, issueNumber, options = {}) {
     trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
     forcedHandoffEnabled: readForcedHandoffMode() === 'human-gated',
     expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
     isAuthorizedForcedHandoff: (forcedBy) =>
       isAuthorizedForcedHandoffActor(
         owner,

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -19,13 +19,17 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from './collaborator-permission.mjs';
+import {
   advisoryBotIdentityToken,
   dispositionNamesAdvisoryBot,
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
   normalizeTrustedMarkerLogins,
-  parseForcedHandoffComment,
-  resolveActiveClaim,
+  resolveActiveClaimForWriteGate,
   resolveAdvisoryBotLogins,
 } from './protocol-helpers.mjs';
 
@@ -291,32 +295,44 @@ function loadIddConfig() {
 /**
  * Re-fetch the claim issue and decide whether the supplied claim id is still the
  * active claim. Scoped to trusted marker authors via the shared
- * `resolveActiveClaim` state machine (so a copied/forged `claimed-by` marker
- * from an untrusted author cannot satisfy the gate), and fails closed on any
- * `forced-handoff` marker that targets this claim — regardless of the marker's
- * author, since an authorizing maintainer is typically not in the trusted set.
- * Aborting on a contested claim is always safe (the manual E6 path remains).
+ * `resolveActiveClaimForWriteGate` state machine (so a copied/forged
+ * `claimed-by` marker from an untrusted author cannot satisfy the gate). A
+ * forced-handoff marker is honored only when it is an operator-approved,
+ * authorized handoff (forced-handoff mode enabled, `forced-by` is an
+ * authorized maintainer, and the comment author matches `forced-by`);
+ * otherwise the original claim stays active and an unauthorized/forged
+ * successor `--claim-id` still fails the `=== claimId` comparison. This is an
+ * issue-scoped revalidation (`expectedLinkedPrs: null`), so a legitimate
+ * issue-only handoff is accepted. Aborting on a contested claim is always
+ * safe (the manual E6 path remains).
  */
-function claimStillActive(owner, repo, issue, claimId, isTrustedAuthor) {
+function claimStillActive(
+  owner,
+  repo,
+  issue,
+  claimId,
+  isTrustedAuthor,
+  forcedHandoffOptions,
+) {
   const comments = ghJsonPaginated([
     'api',
     `repos/${owner}/${repo}/issues/${issue}/comments`,
   ]);
-  for (const comment of comments) {
-    const forcedHandoff = parseForcedHandoffComment(
-      comment.body ?? '',
-      comment.created_at ?? '',
-    );
-    if (forcedHandoff && forcedHandoff.oldClaimId === claimId) {
-      return false;
-    }
-  }
   const events = comments.map((comment) => ({
     body: comment.body ?? '',
     createdAt: comment.created_at ?? '',
     author: { login: comment.user?.login ?? '' },
   }));
-  return resolveActiveClaim(events, isTrustedAuthor)?.claimId === claimId;
+  const active = resolveActiveClaimForWriteGate(events, {
+    isTrustedAuthor,
+    forcedHandoffEnabled: forcedHandoffOptions.forcedHandoffEnabled,
+    // Issue-scoped revalidation: accept a legitimate issue-only handoff.
+    expectedLinkedPrs: null,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      forcedHandoffOptions.isAuthorizedForcedHandoff(forcedBy),
+    requireAuthorMatchesForcedBy: true,
+  });
+  return active?.claimId === claimId;
 }
 function postDisposition(owner, repo, pr, body) {
   // A disposition body is plain text starting with `**Rejected**` (not an
@@ -470,8 +486,34 @@ if (isMainModule(import.meta.url)) {
         .trim()
         .toLowerCase(),
     );
+  // Resolve the forced-handoff policy and build the collaborator-permission
+  // cache ONCE per CLI invocation (not per revalidation loop): re-reading
+  // .github/idd/config.json and re-hitting the collaborators API on every
+  // post would be a needless I/O hot path. Mirrors force-handoff.mjs and the
+  // audit-pr-cleanup readActiveClaim comment.
+  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const forcedHandoffPermissionCache = new Map();
+  const forcedHandoffOptions = {
+    forcedHandoffEnabled,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy,
+        forcedHandoffPermissionCache,
+      ),
+  };
   const revalidateClaim = () =>
-    claimStillActive(owner, repo, claimIssue, args.claimId, isTrustedAuthor);
+    claimStillActive(
+      owner,
+      repo,
+      claimIssue,
+      args.claimId,
+      isTrustedAuthor,
+      forcedHandoffOptions,
+    );
   if (!revalidateClaim()) {
     process.stderr.write(
       `claim revalidation failed: "${args.claimId}" is no longer the active claim on issue #${claimIssue}\n`,

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -146,6 +146,14 @@ export function collectPreMergeReadiness(argv) {
   )
     .map((file) => String(file.filename ?? ''))
     .filter(Boolean);
+  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
+  // a legitimate issue-only handoff that predates the PR is honored even
+  // against a PR-backed claim. Resolve it from the earliest commit on the PR.
+  const prCommits = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
+    true,
+  );
+  const prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
   const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
   const eligibleCodeownerUserLogins = resolveEligibleCodeownerUserLogins(
     owner,
@@ -215,6 +223,7 @@ export function collectPreMergeReadiness(argv) {
       waivableCheckSelectors,
       forcedHandoffEnabled,
       expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
+      prFirstCommitAt,
       isAuthorizedForcedHandoff: (forcedBy) =>
         isAuthorizedForcedHandoffActor(
           owner,
@@ -667,6 +676,35 @@ function ghApiJson(path, paginate = false, extraArgs = [], options = {}) {
     return parsePaginatedGhNdjson(raw);
   }
   return JSON.parse(raw);
+}
+/**
+ * Resolve the PR's first-commit time as an ISO string: the minimum across all
+ * commits of each commit's committer date (falling back to author date). The
+ * GitHub `pulls/{pr}/commits` listing is chronological, but compute the
+ * minimum defensively rather than relying on order. Returns `null` when no
+ * commit carries a parseable date, which makes the Part B gate fail closed
+ * (issue-only handoffs against a PR-backed claim stay rejected).
+ */
+function resolvePrFirstCommitAt(commits) {
+  let earliestMs = null;
+  let earliestIso = null;
+  for (const commit of commits) {
+    const date =
+      String(commit?.commit?.committer?.date ?? '').trim() ||
+      String(commit?.commit?.author?.date ?? '').trim();
+    if (!date) {
+      continue;
+    }
+    const ms = Date.parse(date);
+    if (!Number.isFinite(ms)) {
+      continue;
+    }
+    if (earliestMs === null || ms < earliestMs) {
+      earliestMs = ms;
+      earliestIso = date;
+    }
+  }
+  return earliestIso;
 }
 function runGh(args, options = {}) {
   try {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -146,14 +146,6 @@ export function collectPreMergeReadiness(argv) {
   )
     .map((file) => String(file.filename ?? ''))
     .filter(Boolean);
-  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
-  // a legitimate issue-only handoff that predates the PR is honored even
-  // against a PR-backed claim. Resolve it from the earliest commit on the PR.
-  const prCommits = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
-    true,
-  );
-  const prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
   const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
   const eligibleCodeownerUserLogins = resolveEligibleCodeownerUserLogins(
     owner,
@@ -185,6 +177,23 @@ export function collectPreMergeReadiness(argv) {
   const advisoryWaitPolicy = readAdvisoryWaitPolicy();
   const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
   const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
+  // a legitimate issue-only handoff that predates the PR is honored even
+  // against a PR-backed claim. Resolve it only when forced handoffs are
+  // enabled, and fail closed to `null` (reject) on any lookup/parse error so
+  // a transient commits-API failure never aborts the readiness gate.
+  let prFirstCommitAt = null;
+  if (forcedHandoffEnabled) {
+    try {
+      const prCommits = ghApiJson(
+        `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
+        true,
+      );
+      prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
+    } catch {
+      prFirstCommitAt = null;
+    }
+  }
   const forcedHandoffPermissionCache = new Map();
   const waivableCheckSelectors = readWaivableCheckSelectors();
   const summary = buildPreMergeReadinessSummary(

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3312,6 +3312,93 @@ export function resolveRulesetDetailPath(owner, repo, rule, rulesetId) {
   }
   return `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/rulesets/${rulesetId}`;
 }
+/**
+ * Build the `isForcedHandoffEnabled` gate shared by every claim-revalidation
+ * path (resume routing, the merge-gate, and the write-side helpers).
+ *
+ * Semantics:
+ *
+ * - forced-handoff mode disabled → never honor;
+ * - no open linked PR backs the claim (`expectedLinkedPrReferences` empty) →
+ *   honor an `issue-only` (or any) handoff as before;
+ * - an open linked PR backs the claim:
+ *   - `issue-plus-pr` handoff → require `linkedPr` to match one of the
+ *     expected PRs (unchanged behavior);
+ *   - `issue-only` handoff → accept it IFF a `prFirstCommitAt` is supplied
+ *     AND the handoff's `createdAt` is a valid ISO timestamp strictly before
+ *     it (the handoff predates the PR, so the successor created the PR after
+ *     taking over the issue). Any other `issue-only` handoff is rejected.
+ *
+ * The `prFirstCommitAt` parameter is the Part B extension (#1058). Callers
+ * that do not pass it keep the original behavior byte-identical: an
+ * `issue-only` handoff against a PR-backed claim is rejected.
+ */
+export function buildForcedHandoffEnableGate(options) {
+  const { forcedHandoffEnabled, expectedLinkedPrReferences } = options;
+  const prFirstCommitAt =
+    typeof options.prFirstCommitAt === 'string' ? options.prFirstCommitAt : '';
+  return (forcedHandoff) => {
+    if (!forcedHandoffEnabled) {
+      return false;
+    }
+    if (expectedLinkedPrReferences.size === 0) {
+      return true;
+    }
+    if (forcedHandoff.contextScope === 'issue-plus-pr') {
+      return expectedLinkedPrReferences.has(
+        normalizeLinkedPrReference(forcedHandoff.linkedPr),
+      );
+    }
+    // issue-only handoff against a PR-backed claim: accept only when it
+    // predates the PR's first commit (a robust ISO compare; either side
+    // unparseable → fail closed = reject).
+    return isStrictlyBeforeIso(forcedHandoff.createdAt, prFirstCommitAt);
+  };
+}
+/**
+ * Resolve the active claim for a write-side merge-gate revalidation, honoring
+ * an operator-approved forced handoff while failing closed on
+ * unauthorized/forged markers exactly as the Resume routing path does.
+ *
+ * This is the centralized, pure (no I/O) helper used by the write-side
+ * helpers (disposition-non-review-notices, resolve-review-thread) so they no
+ * longer ignore forced handoffs. It builds the same forced-handoff enable
+ * gate as `summarizeClaimValidation` / `buildForcedHandoffEnabledGate`
+ * (extended with the Part B time rule) and delegates the rest of the
+ * fail-closed enforcement to `applyClaimEvent` rule 7.
+ *
+ * - `forcedHandoffEnabled` defaults to `false` (forced handoffs ignored).
+ * - `expectedLinkedPrs` of `null`/empty marks an issue-scoped revalidation:
+ *   an `issue-only` handoff is accepted (issue takeover). A non-empty set
+ *   marks a PR-backed claim and applies the `issue-plus-pr` / `prFirstCommitAt`
+ *   rules.
+ * - `isAuthorizedForcedHandoff` defaults to an allowlist of ∅ ⇒ always false
+ *   (every handoff is treated as unauthorized) when not supplied, so callers
+ *   that forget to wire it fail closed.
+ * - `requireAuthorMatchesForcedBy` defaults to `true` (the strict
+ *   self-signed-hijack block used by Resume routing).
+ */
+export function resolveActiveClaimForWriteGate(events, options) {
+  const expectedLinkedPrReferences = new Set(
+    (options.expectedLinkedPrs ?? [])
+      .map((value) => normalizeLinkedPrReference(value))
+      .filter(Boolean),
+  );
+  const isForcedHandoffEnabled = buildForcedHandoffEnableGate({
+    forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+    expectedLinkedPrReferences,
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
+  });
+  return resolveActiveClaim(events, {
+    isTrustedAuthor: options.isTrustedAuthor,
+    isForcedHandoffEnabled,
+    isAuthorizedForcedHandoff:
+      typeof options.isAuthorizedForcedHandoff === 'function'
+        ? options.isAuthorizedForcedHandoff
+        : () => false,
+    requireAuthorMatchesForcedBy: options.requireAuthorMatchesForcedBy ?? true,
+  });
+}
 export function summarizeClaimValidation(claimEvents = [], options = {}) {
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
@@ -3340,20 +3427,11 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
     isForcedHandoffEnabled:
       typeof options.isForcedHandoffEnabled === 'function'
         ? options.isForcedHandoffEnabled
-        : (forcedHandoff) => {
-            if (options.forcedHandoffEnabled !== true) {
-              return false;
-            }
-            if (expectedLinkedPrReferences.size === 0) {
-              return true;
-            }
-            if (forcedHandoff.contextScope !== 'issue-plus-pr') {
-              return false;
-            }
-            return expectedLinkedPrReferences.has(
-              normalizeLinkedPrReference(forcedHandoff.linkedPr),
-            );
-          },
+        : buildForcedHandoffEnableGate({
+            forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+            expectedLinkedPrReferences,
+            prFirstCommitAt: options.prFirstCommitAt ?? null,
+          }),
     isAuthorizedForcedHandoff:
       typeof options.isAuthorizedForcedHandoff === 'function'
         ? options.isAuthorizedForcedHandoff
@@ -3520,6 +3598,7 @@ export function buildPreMergeReadinessSummary(
     trustedMarkerLogins,
     forcedHandoffEnabled: options.forcedHandoffEnabled === true,
     expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
     authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
     isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
     isForcedHandoffEnabled: options.isForcedHandoffEnabled,
@@ -3680,6 +3759,21 @@ function createdAtToSecond(createdAt) {
     return null;
   }
   return Math.floor(time / 1000);
+}
+/**
+ * Robust ISO timestamp comparison: returns true only when both `left` and
+ * `right` parse to valid instants and `left` is strictly before `right`. If
+ * either side is missing or unparseable, returns false (fail closed). Used by
+ * the forced-handoff enable gate to decide whether an `issue-only` handoff
+ * predates a PR's first commit.
+ */
+function isStrictlyBeforeIso(left, right) {
+  const leftTime = createdAtToTime(left);
+  const rightTime = createdAtToTime(right);
+  if (leftTime === null || rightTime === null) {
+    return false;
+  }
+  return leftTime < rightTime;
 }
 export function resolveActiveClaim(events, isTrustedAuthor = () => true) {
   const options = normalizeClaimResolutionOptions(isTrustedAuthor);

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -16,9 +16,11 @@
 // thread with no disposition.
 import { execFileSync } from 'node:child_process';
 import {
-  parseForcedHandoffComment,
-  resolveActiveClaim,
-} from './protocol-helpers.mjs';
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from './collaborator-permission.mjs';
+import { resolveActiveClaimForWriteGate } from './protocol-helpers.mjs';
 /**
  * Find the review thread that owns the review comment whose REST database id is
  * `commentId`. The GraphQL `PullRequestReviewComment.databaseId` equals the REST
@@ -334,11 +336,17 @@ function resolveThread(threadId) {
 /**
  * Re-fetch the claim issue and return the active claim **owned by this session**
  * (its `claimId`, and `agentId` when supplied, match), or `null` when the claim
- * was lost. Scoped to trusted marker authors via the shared `resolveActiveClaim`
- * state machine, and fails closed (returns `null`) on any `forced-handoff`
- * marker that targets this claim. Aborting on a contested claim is always safe
- * (the manual E13 path remains). The returned `branch` lets the caller bind the
- * mutation to the PR whose head is that branch.
+ * was lost. Scoped to trusted marker authors via the shared
+ * `resolveActiveClaimForWriteGate` state machine. A forced-handoff marker is
+ * honored only when it is an operator-approved, authorized handoff
+ * (forced-handoff mode enabled, `forced-by` is an authorized maintainer, and
+ * the comment author matches `forced-by`); otherwise the original claim stays
+ * active and an unauthorized/forged successor's `--claim-id` still fails the
+ * ownership comparison below. This is an issue-scoped revalidation
+ * (`expectedLinkedPrs: null`), so a legitimate issue-only handoff is accepted.
+ * Aborting on a contested claim is always safe (the manual E13 path remains).
+ * The returned `branch` lets the caller bind the mutation to the PR whose head
+ * is that branch.
  */
 function activeOwnedClaim(
   owner,
@@ -347,26 +355,26 @@ function activeOwnedClaim(
   agentId,
   claimId,
   isTrustedAuthor,
+  forcedHandoffOptions,
 ) {
   const comments = ghJsonPaginated([
     'api',
     `repos/${owner}/${repo}/issues/${issue}/comments`,
   ]);
-  for (const comment of comments) {
-    const forcedHandoff = parseForcedHandoffComment(
-      comment.body ?? '',
-      comment.created_at ?? '',
-    );
-    if (forcedHandoff && forcedHandoff.oldClaimId === claimId) {
-      return null;
-    }
-  }
   const events = comments.map((comment) => ({
     body: comment.body ?? '',
     createdAt: comment.created_at ?? '',
     author: { login: comment.user?.login ?? '' },
   }));
-  const active = resolveActiveClaim(events, isTrustedAuthor);
+  const active = resolveActiveClaimForWriteGate(events, {
+    isTrustedAuthor,
+    forcedHandoffEnabled: forcedHandoffOptions.forcedHandoffEnabled,
+    // Issue-scoped revalidation: accept a legitimate issue-only handoff.
+    expectedLinkedPrs: null,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      forcedHandoffOptions.isAuthorizedForcedHandoff(forcedBy),
+    requireAuthorMatchesForcedBy: true,
+  });
   if (active?.claimId !== claimId) {
     return null;
   }
@@ -473,6 +481,25 @@ if (isMainModule(import.meta.url)) {
         .trim()
         .toLowerCase(),
     );
+  // Resolve the forced-handoff policy and build the collaborator-permission
+  // cache ONCE per CLI invocation (not on each assertClaim retry): re-reading
+  // .github/idd/config.json and re-hitting the collaborators API would be a
+  // needless I/O hot path. Mirrors force-handoff.mjs and the audit-pr-cleanup
+  // readActiveClaim comment.
+  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const forcedHandoffPermissionCache = new Map();
+  const forcedHandoffOptions = {
+    forcedHandoffEnabled,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy,
+        forcedHandoffPermissionCache,
+      ),
+  };
   // Retain the posted reply id across a later failure so a partial apply (reply
   // posted, resolve not confirmed) reports the reply id instead of looking like
   // nothing was posted — that distinguishes "retry the resolve" from "re-post".
@@ -487,6 +514,7 @@ if (isMainModule(import.meta.url)) {
           args.agentId,
           args.claimId,
           isTrustedAuthor,
+          forcedHandoffOptions,
         );
         if (!active) {
           throw new Error(

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
 import {
+  buildForcedHandoffEnableGate,
   isStaleAt,
   normalizeLinkedPrReference,
   parseClaimComment,
@@ -40,21 +41,14 @@ if (isCliExecution()) {
  *   `issue-plus-pr` whose `linkedPr` matches one of the expected PRs.
  */
 export function buildForcedHandoffEnabledGate(options) {
-  const { forcedHandoffEnabled, expectedLinkedPrReferences } = options;
-  return (forcedHandoff) => {
-    if (!forcedHandoffEnabled) {
-      return false;
-    }
-    if (expectedLinkedPrReferences.size === 0) {
-      return true;
-    }
-    if (forcedHandoff.contextScope !== 'issue-plus-pr') {
-      return false;
-    }
-    return expectedLinkedPrReferences.has(
-      normalizeLinkedPrReference(forcedHandoff.linkedPr),
-    );
-  };
+  // Delegate to the shared builder so resume routing and the merge-gate /
+  // write-side helpers cannot drift. Resume routing never passes
+  // `prFirstCommitAt`, so this stays byte-identical to the prior behavior:
+  // an issue-only handoff against a PR-backed claim is rejected.
+  return buildForcedHandoffEnableGate({
+    forcedHandoffEnabled: options.forcedHandoffEnabled,
+    expectedLinkedPrReferences: options.expectedLinkedPrReferences,
+  });
 }
 export function evaluateResumeClaimRouting(input, options = {}) {
   const nowIso =

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -225,6 +225,12 @@ const [owner, repo] = parseRepository(repository);
 const prNumber = parsePositiveInteger(args.pr, '--pr');
 const claimContext = {
   expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, prNumber),
+  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
+  // a legitimate issue-only handoff that predates the PR is honored even
+  // against this PR-backed claim. Resolve it once for both claim asserts.
+  prFirstCommitAt: args.apply
+    ? fetchPrFirstCommitAt(owner, repo, prNumber)
+    : null,
 };
 
 if (args.claimIssue) {
@@ -780,6 +786,93 @@ function fetchPullRequest(
   return pr;
 }
 
+/**
+ * Resolve the PR's first-commit time as an ISO string for the Part B
+ * forced-handoff rule (#1058): the minimum committed date (falling back to
+ * authored date) across the PR's commits. Returns `null` when no commit
+ * carries a parseable date — which makes the Part B gate fail closed
+ * (issue-only handoffs against a PR-backed claim stay rejected). Fails safe to
+ * `null` on any lookup error rather than aborting the claim assertion.
+ */
+function fetchPrFirstCommitAt(
+  owner: string,
+  repo: string,
+  number: number,
+): string | null {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        commits(first:100,after:$after){
+          nodes{commit{committedDate authoredDate}}
+          pageInfo{hasNextPage endCursor}
+        }
+      }
+    }
+  }`;
+  let earliestMs: number | null = null;
+  let earliestIso: string | null = null;
+  let after: string | null = null;
+  try {
+    for (;;) {
+      const result = ghGraphql(
+        query,
+        { owner, repo, number, after },
+        // Fail safe: a lookup error throws (caught below) instead of aborting
+        // the whole claim assertion via the default process-exit path.
+        { throwOnError: true },
+      ) as {
+        data?: {
+          repository?: {
+            pullRequest?: {
+              commits?: {
+                nodes?:
+                  | {
+                      commit?: {
+                        committedDate?: string | null;
+                        authoredDate?: string | null;
+                      } | null;
+                    }[]
+                  | null;
+                pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+              } | null;
+            } | null;
+          } | null;
+        } | null;
+      } | null;
+      const connection = result?.data?.repository?.pullRequest?.commits;
+      if (!connection) {
+        break;
+      }
+      for (const node of connection.nodes ?? []) {
+        const date =
+          String(node?.commit?.committedDate ?? '').trim() ||
+          String(node?.commit?.authoredDate ?? '').trim();
+        if (!date) {
+          continue;
+        }
+        const ms = Date.parse(date);
+        if (!Number.isFinite(ms)) {
+          continue;
+        }
+        if (earliestMs === null || ms < earliestMs) {
+          earliestMs = ms;
+          earliestIso = date;
+        }
+      }
+      if (!connection.pageInfo?.hasNextPage) {
+        break;
+      }
+      after = connection.pageInfo.endCursor ?? null;
+      if (!after) {
+        break;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return earliestIso;
+}
+
 function fetchIssueComments(
   owner: string,
   repo: string,
@@ -1070,7 +1163,10 @@ function assertActiveClaim(
   issueNumber: string | undefined,
   agentId: string | undefined,
   claimId: string | undefined,
-  options: { expectedLinkedPrs?: string[] } = {},
+  options: {
+    expectedLinkedPrs?: string[];
+    prFirstCommitAt?: string | null;
+  } = {},
 ): void {
   const active = readActiveClaim(owner, repo, issueNumber, options);
   if (
@@ -1089,7 +1185,10 @@ function readActiveClaim(
   owner: string,
   repo: string,
   issueNumber: string | undefined,
-  options: { expectedLinkedPrs?: string[] } = {},
+  options: {
+    expectedLinkedPrs?: string[];
+    prFirstCommitAt?: string | null;
+  } = {},
 ): ActiveClaim | null {
   const result = JSON.parse(
     execFileSync(
@@ -1130,6 +1229,7 @@ function readActiveClaim(
     trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
     forcedHandoffEnabled: readForcedHandoffMode() === 'human-gated',
     expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
     isAuthorizedForcedHandoff: (forcedBy) =>
       isAuthorizedForcedHandoffActor(
         owner,

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -20,14 +20,19 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
+import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from './collaborator-permission.mts';
 import {
   advisoryBotIdentityToken,
   dispositionNamesAdvisoryBot,
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
   normalizeTrustedMarkerLogins,
-  parseForcedHandoffComment,
-  resolveActiveClaim,
+  resolveActiveClaimForWriteGate,
   resolveAdvisoryBotLogins,
 } from './protocol-helpers.mts';
 
@@ -381,14 +386,25 @@ function loadIddConfig(): { advisoryBotLogins?: unknown } | null {
   }
 }
 
+/** Forced-handoff revalidation inputs, resolved once per CLI invocation. */
+interface ForcedHandoffGateOptions {
+  forcedHandoffEnabled: boolean;
+  isAuthorizedForcedHandoff: (forcedBy: string) => boolean;
+}
+
 /**
  * Re-fetch the claim issue and decide whether the supplied claim id is still the
  * active claim. Scoped to trusted marker authors via the shared
- * `resolveActiveClaim` state machine (so a copied/forged `claimed-by` marker
- * from an untrusted author cannot satisfy the gate), and fails closed on any
- * `forced-handoff` marker that targets this claim — regardless of the marker's
- * author, since an authorizing maintainer is typically not in the trusted set.
- * Aborting on a contested claim is always safe (the manual E6 path remains).
+ * `resolveActiveClaimForWriteGate` state machine (so a copied/forged
+ * `claimed-by` marker from an untrusted author cannot satisfy the gate). A
+ * forced-handoff marker is honored only when it is an operator-approved,
+ * authorized handoff (forced-handoff mode enabled, `forced-by` is an
+ * authorized maintainer, and the comment author matches `forced-by`);
+ * otherwise the original claim stays active and an unauthorized/forged
+ * successor `--claim-id` still fails the `=== claimId` comparison. This is an
+ * issue-scoped revalidation (`expectedLinkedPrs: null`), so a legitimate
+ * issue-only handoff is accepted. Aborting on a contested claim is always
+ * safe (the manual E6 path remains).
  */
 function claimStillActive(
   owner: string,
@@ -396,26 +412,27 @@ function claimStillActive(
   issue: number,
   claimId: string,
   isTrustedAuthor: (login: string) => boolean,
+  forcedHandoffOptions: ForcedHandoffGateOptions,
 ): boolean {
   const comments = ghJsonPaginated([
     'api',
     `repos/${owner}/${repo}/issues/${issue}/comments`,
   ]) as { body?: string; created_at?: string; user?: { login?: string } }[];
-  for (const comment of comments) {
-    const forcedHandoff = parseForcedHandoffComment(
-      comment.body ?? '',
-      comment.created_at ?? '',
-    );
-    if (forcedHandoff && forcedHandoff.oldClaimId === claimId) {
-      return false;
-    }
-  }
   const events = comments.map((comment) => ({
     body: comment.body ?? '',
     createdAt: comment.created_at ?? '',
     author: { login: comment.user?.login ?? '' },
   }));
-  return resolveActiveClaim(events, isTrustedAuthor)?.claimId === claimId;
+  const active = resolveActiveClaimForWriteGate(events, {
+    isTrustedAuthor,
+    forcedHandoffEnabled: forcedHandoffOptions.forcedHandoffEnabled,
+    // Issue-scoped revalidation: accept a legitimate issue-only handoff.
+    expectedLinkedPrs: null,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      forcedHandoffOptions.isAuthorizedForcedHandoff(forcedBy),
+    requireAuthorMatchesForcedBy: true,
+  });
+  return active?.claimId === claimId;
 }
 
 function postDisposition(
@@ -592,8 +609,34 @@ if (isMainModule(import.meta.url)) {
         .trim()
         .toLowerCase(),
     );
+  // Resolve the forced-handoff policy and build the collaborator-permission
+  // cache ONCE per CLI invocation (not per revalidation loop): re-reading
+  // .github/idd/config.json and re-hitting the collaborators API on every
+  // post would be a needless I/O hot path. Mirrors force-handoff.mjs and the
+  // audit-pr-cleanup readActiveClaim comment.
+  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
+  const forcedHandoffOptions: ForcedHandoffGateOptions = {
+    forcedHandoffEnabled,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy,
+        forcedHandoffPermissionCache,
+      ),
+  };
   const revalidateClaim = (): boolean =>
-    claimStillActive(owner, repo, claimIssue, args.claimId, isTrustedAuthor);
+    claimStillActive(
+      owner,
+      repo,
+      claimIssue,
+      args.claimId,
+      isTrustedAuthor,
+      forcedHandoffOptions,
+    );
 
   if (!revalidateClaim()) {
     process.stderr.write(

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -324,14 +324,6 @@ export function collectPreMergeReadiness(
   )
     .map((file) => String(file.filename ?? ''))
     .filter(Boolean);
-  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
-  // a legitimate issue-only handoff that predates the PR is honored even
-  // against a PR-backed claim. Resolve it from the earliest commit on the PR.
-  const prCommits = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
-    true,
-  ) as PrCommitPayload[];
-  const prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
   const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
   const eligibleCodeownerUserLogins = resolveEligibleCodeownerUserLogins(
     owner,
@@ -364,6 +356,23 @@ export function collectPreMergeReadiness(
   const advisoryWaitPolicy = readAdvisoryWaitPolicy();
   const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
   const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
+  // a legitimate issue-only handoff that predates the PR is honored even
+  // against a PR-backed claim. Resolve it only when forced handoffs are
+  // enabled, and fail closed to `null` (reject) on any lookup/parse error so
+  // a transient commits-API failure never aborts the readiness gate.
+  let prFirstCommitAt: string | null = null;
+  if (forcedHandoffEnabled) {
+    try {
+      const prCommits = ghApiJson(
+        `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
+        true,
+      ) as PrCommitPayload[];
+      prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
+    } catch {
+      prFirstCommitAt = null;
+    }
+  }
   const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
   const waivableCheckSelectors = readWaivableCheckSelectors();
 

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -64,6 +64,14 @@ interface CheckPayload {
   completedAt?: string | null;
 }
 
+/** Commit payload fields consumed by the Part B first-commit-time resolver. */
+interface PrCommitPayload {
+  commit?: {
+    author?: { date?: string | null } | null;
+    committer?: { date?: string | null } | null;
+  } | null;
+}
+
 /** Timeline event payload fields consumed by the Copilot coverage check. */
 interface TimelineEventPayload {
   event?: string | null;
@@ -316,6 +324,14 @@ export function collectPreMergeReadiness(
   )
     .map((file) => String(file.filename ?? ''))
     .filter(Boolean);
+  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
+  // a legitimate issue-only handoff that predates the PR is honored even
+  // against a PR-backed claim. Resolve it from the earliest commit on the PR.
+  const prCommits = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
+    true,
+  ) as PrCommitPayload[];
+  const prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
   const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
   const eligibleCodeownerUserLogins = resolveEligibleCodeownerUserLogins(
     owner,
@@ -387,6 +403,7 @@ export function collectPreMergeReadiness(
       waivableCheckSelectors,
       forcedHandoffEnabled,
       expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
+      prFirstCommitAt,
       isAuthorizedForcedHandoff: (forcedBy) =>
         isAuthorizedForcedHandoffActor(
           owner,
@@ -922,6 +939,36 @@ function ghApiJson(
     return parsePaginatedGhNdjson(raw);
   }
   return JSON.parse(raw);
+}
+
+/**
+ * Resolve the PR's first-commit time as an ISO string: the minimum across all
+ * commits of each commit's committer date (falling back to author date). The
+ * GitHub `pulls/{pr}/commits` listing is chronological, but compute the
+ * minimum defensively rather than relying on order. Returns `null` when no
+ * commit carries a parseable date, which makes the Part B gate fail closed
+ * (issue-only handoffs against a PR-backed claim stay rejected).
+ */
+function resolvePrFirstCommitAt(commits: PrCommitPayload[]): string | null {
+  let earliestMs: number | null = null;
+  let earliestIso: string | null = null;
+  for (const commit of commits) {
+    const date =
+      String(commit?.commit?.committer?.date ?? '').trim() ||
+      String(commit?.commit?.author?.date ?? '').trim();
+    if (!date) {
+      continue;
+    }
+    const ms = Date.parse(date);
+    if (!Number.isFinite(ms)) {
+      continue;
+    }
+    if (earliestMs === null || ms < earliestMs) {
+      earliestMs = ms;
+      earliestIso = date;
+    }
+  }
+  return earliestIso;
 }
 
 function runGh(args: string[], options: RunGhOptions = {}): string {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4342,12 +4342,120 @@ export function resolveRulesetDetailPath(
   return `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/rulesets/${rulesetId}`;
 }
 
+/**
+ * Build the `isForcedHandoffEnabled` gate shared by every claim-revalidation
+ * path (resume routing, the merge-gate, and the write-side helpers).
+ *
+ * Semantics:
+ *
+ * - forced-handoff mode disabled → never honor;
+ * - no open linked PR backs the claim (`expectedLinkedPrReferences` empty) →
+ *   honor an `issue-only` (or any) handoff as before;
+ * - an open linked PR backs the claim:
+ *   - `issue-plus-pr` handoff → require `linkedPr` to match one of the
+ *     expected PRs (unchanged behavior);
+ *   - `issue-only` handoff → accept it IFF a `prFirstCommitAt` is supplied
+ *     AND the handoff's `createdAt` is a valid ISO timestamp strictly before
+ *     it (the handoff predates the PR, so the successor created the PR after
+ *     taking over the issue). Any other `issue-only` handoff is rejected.
+ *
+ * The `prFirstCommitAt` parameter is the Part B extension (#1058). Callers
+ * that do not pass it keep the original behavior byte-identical: an
+ * `issue-only` handoff against a PR-backed claim is rejected.
+ */
+export function buildForcedHandoffEnableGate(options: {
+  forcedHandoffEnabled: boolean;
+  expectedLinkedPrReferences: Set<string>;
+  prFirstCommitAt?: string | null;
+}): (forcedHandoff: ParsedForcedHandoffMarker) => boolean {
+  const { forcedHandoffEnabled, expectedLinkedPrReferences } = options;
+  const prFirstCommitAt =
+    typeof options.prFirstCommitAt === 'string' ? options.prFirstCommitAt : '';
+  return (forcedHandoff: ParsedForcedHandoffMarker) => {
+    if (!forcedHandoffEnabled) {
+      return false;
+    }
+    if (expectedLinkedPrReferences.size === 0) {
+      return true;
+    }
+    if (forcedHandoff.contextScope === 'issue-plus-pr') {
+      return expectedLinkedPrReferences.has(
+        normalizeLinkedPrReference(forcedHandoff.linkedPr),
+      );
+    }
+    // issue-only handoff against a PR-backed claim: accept only when it
+    // predates the PR's first commit (a robust ISO compare; either side
+    // unparseable → fail closed = reject).
+    return isStrictlyBeforeIso(forcedHandoff.createdAt, prFirstCommitAt);
+  };
+}
+
+/**
+ * Resolve the active claim for a write-side merge-gate revalidation, honoring
+ * an operator-approved forced handoff while failing closed on
+ * unauthorized/forged markers exactly as the Resume routing path does.
+ *
+ * This is the centralized, pure (no I/O) helper used by the write-side
+ * helpers (disposition-non-review-notices, resolve-review-thread) so they no
+ * longer ignore forced handoffs. It builds the same forced-handoff enable
+ * gate as `summarizeClaimValidation` / `buildForcedHandoffEnabledGate`
+ * (extended with the Part B time rule) and delegates the rest of the
+ * fail-closed enforcement to `applyClaimEvent` rule 7.
+ *
+ * - `forcedHandoffEnabled` defaults to `false` (forced handoffs ignored).
+ * - `expectedLinkedPrs` of `null`/empty marks an issue-scoped revalidation:
+ *   an `issue-only` handoff is accepted (issue takeover). A non-empty set
+ *   marks a PR-backed claim and applies the `issue-plus-pr` / `prFirstCommitAt`
+ *   rules.
+ * - `isAuthorizedForcedHandoff` defaults to an allowlist of ∅ ⇒ always false
+ *   (every handoff is treated as unauthorized) when not supplied, so callers
+ *   that forget to wire it fail closed.
+ * - `requireAuthorMatchesForcedBy` defaults to `true` (the strict
+ *   self-signed-hijack block used by Resume routing).
+ */
+export function resolveActiveClaimForWriteGate(
+  events: CommentLike[],
+  options: {
+    isTrustedAuthor: (login: string) => boolean;
+    forcedHandoffEnabled?: boolean;
+    expectedLinkedPrs?: unknown[] | null;
+    prFirstCommitAt?: string | null;
+    isAuthorizedForcedHandoff?: (
+      forcedBy: string,
+      forcedHandoff: ParsedForcedHandoffMarker,
+      event: CommentLike,
+    ) => boolean;
+    requireAuthorMatchesForcedBy?: boolean;
+  },
+): ParsedClaimMarker | null {
+  const expectedLinkedPrReferences = new Set(
+    (options.expectedLinkedPrs ?? [])
+      .map((value) => normalizeLinkedPrReference(value))
+      .filter(Boolean),
+  );
+  const isForcedHandoffEnabled = buildForcedHandoffEnableGate({
+    forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+    expectedLinkedPrReferences,
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
+  });
+  return resolveActiveClaim(events, {
+    isTrustedAuthor: options.isTrustedAuthor,
+    isForcedHandoffEnabled,
+    isAuthorizedForcedHandoff:
+      typeof options.isAuthorizedForcedHandoff === 'function'
+        ? options.isAuthorizedForcedHandoff
+        : () => false,
+    requireAuthorMatchesForcedBy: options.requireAuthorMatchesForcedBy ?? true,
+  });
+}
+
 export function summarizeClaimValidation(
   claimEvents: CommentLike[] = [],
   options: {
     trustedMarkerLogins?: unknown[] | null;
     authorizedForcedHandoffLogins?: unknown[] | null;
     expectedLinkedPrs?: unknown[] | null;
+    prFirstCommitAt?: string | null;
     expectedClaimId?: unknown;
     expectedAgentId?: unknown;
     isTrustedAuthor?: (login: string) => boolean;
@@ -4391,20 +4499,11 @@ export function summarizeClaimValidation(
     isForcedHandoffEnabled:
       typeof options.isForcedHandoffEnabled === 'function'
         ? options.isForcedHandoffEnabled
-        : (forcedHandoff: ParsedForcedHandoffMarker) => {
-            if (options.forcedHandoffEnabled !== true) {
-              return false;
-            }
-            if (expectedLinkedPrReferences.size === 0) {
-              return true;
-            }
-            if (forcedHandoff.contextScope !== 'issue-plus-pr') {
-              return false;
-            }
-            return expectedLinkedPrReferences.has(
-              normalizeLinkedPrReference(forcedHandoff.linkedPr),
-            );
-          },
+        : buildForcedHandoffEnableGate({
+            forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+            expectedLinkedPrReferences,
+            prFirstCommitAt: options.prFirstCommitAt ?? null,
+          }),
     isAuthorizedForcedHandoff:
       typeof options.isAuthorizedForcedHandoff === 'function'
         ? options.isAuthorizedForcedHandoff
@@ -4496,6 +4595,7 @@ export function buildPreMergeReadinessSummary(
     configuredTrustedActors?: unknown[] | null;
     forcedHandoffEnabled?: boolean;
     expectedLinkedPrs?: unknown[] | null;
+    prFirstCommitAt?: string | null;
     authorizedForcedHandoffLogins?: unknown[] | null;
     isAuthorizedForcedHandoff?: (
       forcedBy: string,
@@ -4627,6 +4727,7 @@ export function buildPreMergeReadinessSummary(
     trustedMarkerLogins,
     forcedHandoffEnabled: options.forcedHandoffEnabled === true,
     expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
     authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
     isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
     isForcedHandoffEnabled: options.isForcedHandoffEnabled,
@@ -4810,6 +4911,25 @@ function createdAtToSecond(
     return null;
   }
   return Math.floor(time / 1000);
+}
+
+/**
+ * Robust ISO timestamp comparison: returns true only when both `left` and
+ * `right` parse to valid instants and `left` is strictly before `right`. If
+ * either side is missing or unparseable, returns false (fail closed). Used by
+ * the forced-handoff enable gate to decide whether an `issue-only` handoff
+ * predates a PR's first commit.
+ */
+function isStrictlyBeforeIso(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): boolean {
+  const leftTime = createdAtToTime(left);
+  const rightTime = createdAtToTime(right);
+  if (leftTime === null || rightTime === null) {
+    return false;
+  }
+  return leftTime < rightTime;
 }
 
 export function resolveActiveClaim(

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -17,10 +17,15 @@
 
 import { execFileSync } from 'node:child_process';
 
+import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
+import {
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+} from './collaborator-permission.mts';
 import {
   type ParsedClaimMarker,
-  parseForcedHandoffComment,
-  resolveActiveClaim,
+  resolveActiveClaimForWriteGate,
 } from './protocol-helpers.mts';
 
 /** A comment-id page within a review thread's `comments` connection. */
@@ -449,14 +454,26 @@ function resolveThread(threadId: string): void {
   }
 }
 
+/** Forced-handoff revalidation inputs, resolved once per CLI invocation. */
+interface ForcedHandoffGateOptions {
+  forcedHandoffEnabled: boolean;
+  isAuthorizedForcedHandoff: (forcedBy: string) => boolean;
+}
+
 /**
  * Re-fetch the claim issue and return the active claim **owned by this session**
  * (its `claimId`, and `agentId` when supplied, match), or `null` when the claim
- * was lost. Scoped to trusted marker authors via the shared `resolveActiveClaim`
- * state machine, and fails closed (returns `null`) on any `forced-handoff`
- * marker that targets this claim. Aborting on a contested claim is always safe
- * (the manual E13 path remains). The returned `branch` lets the caller bind the
- * mutation to the PR whose head is that branch.
+ * was lost. Scoped to trusted marker authors via the shared
+ * `resolveActiveClaimForWriteGate` state machine. A forced-handoff marker is
+ * honored only when it is an operator-approved, authorized handoff
+ * (forced-handoff mode enabled, `forced-by` is an authorized maintainer, and
+ * the comment author matches `forced-by`); otherwise the original claim stays
+ * active and an unauthorized/forged successor's `--claim-id` still fails the
+ * ownership comparison below. This is an issue-scoped revalidation
+ * (`expectedLinkedPrs: null`), so a legitimate issue-only handoff is accepted.
+ * Aborting on a contested claim is always safe (the manual E13 path remains).
+ * The returned `branch` lets the caller bind the mutation to the PR whose head
+ * is that branch.
  */
 function activeOwnedClaim(
   owner: string,
@@ -465,26 +482,26 @@ function activeOwnedClaim(
   agentId: string,
   claimId: string,
   isTrustedAuthor: (login: string) => boolean,
+  forcedHandoffOptions: ForcedHandoffGateOptions,
 ): ParsedClaimMarker | null {
   const comments = ghJsonPaginated([
     'api',
     `repos/${owner}/${repo}/issues/${issue}/comments`,
   ]) as { body?: string; created_at?: string; user?: { login?: string } }[];
-  for (const comment of comments) {
-    const forcedHandoff = parseForcedHandoffComment(
-      comment.body ?? '',
-      comment.created_at ?? '',
-    );
-    if (forcedHandoff && forcedHandoff.oldClaimId === claimId) {
-      return null;
-    }
-  }
   const events = comments.map((comment) => ({
     body: comment.body ?? '',
     createdAt: comment.created_at ?? '',
     author: { login: comment.user?.login ?? '' },
   }));
-  const active = resolveActiveClaim(events, isTrustedAuthor);
+  const active = resolveActiveClaimForWriteGate(events, {
+    isTrustedAuthor,
+    forcedHandoffEnabled: forcedHandoffOptions.forcedHandoffEnabled,
+    // Issue-scoped revalidation: accept a legitimate issue-only handoff.
+    expectedLinkedPrs: null,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      forcedHandoffOptions.isAuthorizedForcedHandoff(forcedBy),
+    requireAuthorMatchesForcedBy: true,
+  });
   if (active?.claimId !== claimId) {
     return null;
   }
@@ -601,6 +618,26 @@ if (isMainModule(import.meta.url)) {
         .toLowerCase(),
     );
 
+  // Resolve the forced-handoff policy and build the collaborator-permission
+  // cache ONCE per CLI invocation (not on each assertClaim retry): re-reading
+  // .github/idd/config.json and re-hitting the collaborators API would be a
+  // needless I/O hot path. Mirrors force-handoff.mjs and the audit-pr-cleanup
+  // readActiveClaim comment.
+  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+  const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
+  const forcedHandoffOptions: ForcedHandoffGateOptions = {
+    forcedHandoffEnabled,
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy,
+        forcedHandoffPermissionCache,
+      ),
+  };
+
   // Retain the posted reply id across a later failure so a partial apply (reply
   // posted, resolve not confirmed) reports the reply id instead of looking like
   // nothing was posted — that distinguishes "retry the resolve" from "re-post".
@@ -615,6 +652,7 @@ if (isMainModule(import.meta.url)) {
           args.agentId,
           args.claimId,
           isTrustedAuthor,
+          forcedHandoffOptions,
         );
         if (!active) {
           throw new Error(

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -17,6 +17,7 @@ import type {
   ParsedForcedHandoffMarker,
 } from './protocol-helpers.mts';
 import {
+  buildForcedHandoffEnableGate,
   isStaleAt,
   normalizeLinkedPrReference,
   parseClaimComment,
@@ -129,21 +130,14 @@ export function buildForcedHandoffEnabledGate(options: {
   forcedHandoffEnabled: boolean;
   expectedLinkedPrReferences: Set<string>;
 }): (forcedHandoff: ParsedForcedHandoffMarker) => boolean {
-  const { forcedHandoffEnabled, expectedLinkedPrReferences } = options;
-  return (forcedHandoff: ParsedForcedHandoffMarker) => {
-    if (!forcedHandoffEnabled) {
-      return false;
-    }
-    if (expectedLinkedPrReferences.size === 0) {
-      return true;
-    }
-    if (forcedHandoff.contextScope !== 'issue-plus-pr') {
-      return false;
-    }
-    return expectedLinkedPrReferences.has(
-      normalizeLinkedPrReference(forcedHandoff.linkedPr),
-    );
-  };
+  // Delegate to the shared builder so resume routing and the merge-gate /
+  // write-side helpers cannot drift. Resume routing never passes
+  // `prFirstCommitAt`, so this stays byte-identical to the prior behavior:
+  // an issue-only handoff against a PR-backed claim is rejected.
+  return buildForcedHandoffEnableGate({
+    forcedHandoffEnabled: options.forcedHandoffEnabled,
+    expectedLinkedPrReferences: options.expectedLinkedPrReferences,
+  });
 }
 
 export function evaluateResumeClaimRouting(

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -11,6 +11,7 @@ import {
   indexLatestGatingReviewsByAuthor,
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
+  resolveActiveClaimForWriteGate,
   resolveCodeownersForFiles,
   resolveRulesetDetailPath,
   selectCodeownersText,
@@ -3404,6 +3405,283 @@ test('waiverEvidence with wrong-shape valid item fails schema validation', () =>
     validate(bad, readinessSchema).length > 0,
     'invalid waiverEvidence.valid shape must fail schema',
   );
+});
+
+// ---------------------------------------------------------------------------
+// resolveActiveClaimForWriteGate (#1058): the write-side merge-gate revalidator
+// must recognize an operator-approved forced-handoff successor's claim while
+// failing closed on unauthorized/forged markers exactly as Resume routing does.
+// ---------------------------------------------------------------------------
+
+const WG_OLD_CLAIM =
+  '<!-- claimed-by: cli-old claim-20260512T090000Z-337-old supersedes: none 2026-05-12T09:00:00Z branch: issue/337-feat -->';
+
+function wgClaimEvent() {
+  return {
+    body: [WG_OLD_CLAIM, '', '_cli-old: issue claim - IDD marker._'].join('\n'),
+    createdAt: '2026-05-12T09:00:00Z',
+    author: { login: 'cli-old' },
+  };
+}
+
+function wgHandoffEvent(
+  overrides: {
+    contextScope?: string;
+    linkedPr?: string;
+    forcedBy?: string;
+    author?: string;
+    oldClaimId?: string;
+    branch?: string;
+    createdAt?: string;
+    timestamp?: string;
+  } = {},
+) {
+  const payload: Record<string, string> = {
+    'old-agent-id': 'cli-old',
+    'old-claim-id': overrides.oldClaimId ?? 'claim-20260512T090000Z-337-old',
+    'new-agent-id': 'cli-new',
+    'new-claim-id': 'claim-20260512T110000Z-337-new',
+    branch: overrides.branch ?? 'issue/337-feat',
+    'forced-by': overrides.forcedBy ?? 'kurone-kito',
+    reason: 'operator-approved-recovery',
+    timestamp: overrides.timestamp ?? '2026-05-12T11:00:00Z',
+    'context-scope': overrides.contextScope ?? 'issue-only',
+  };
+  if (overrides.linkedPr) {
+    payload['linked-pr'] = overrides.linkedPr;
+  }
+  return {
+    body: [
+      `<!-- forced-handoff: ${JSON.stringify(payload)} -->`,
+      '',
+      `Forced handoff approved by ${overrides.forcedBy ?? 'kurone-kito'}.`,
+    ].join('\n'),
+    createdAt: overrides.createdAt ?? '2026-05-12T11:00:05Z',
+    author: { login: overrides.author ?? overrides.forcedBy ?? 'kurone-kito' },
+  };
+}
+
+const wgTrusted = (login: string): boolean =>
+  ['cli-old', 'cli-new', 'kurone-kito', 'attacker'].includes(login);
+
+test('resolveActiveClaimForWriteGate recognizes an authorized issue-only handoff', () => {
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgHandoffEvent()],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: null,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T110000Z-337-new');
+  assert.equal(active?.agentId, 'cli-new');
+});
+
+test('resolveActiveClaimForWriteGate keeps the original on an unauthorized approver', () => {
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgHandoffEvent({ forcedBy: 'attacker' })],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: null,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T090000Z-337-old');
+  assert.equal(active?.agentId, 'cli-old');
+});
+
+test('resolveActiveClaimForWriteGate keeps the original on a self-signed handoff', () => {
+  // Author (cli-old) does not match forced-by (kurone-kito): the strict
+  // requireAuthorMatchesForcedBy default rejects this self-attested handoff.
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgHandoffEvent({ author: 'cli-old' })],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: null,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T090000Z-337-old');
+});
+
+test('resolveActiveClaimForWriteGate keeps the original when mode is disabled', () => {
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgHandoffEvent()],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: false,
+      expectedLinkedPrs: null,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T090000Z-337-old');
+});
+
+test('resolveActiveClaimForWriteGate is inert on an old-claim-id mismatch', () => {
+  const active = resolveActiveClaimForWriteGate(
+    [
+      wgClaimEvent(),
+      wgHandoffEvent({ oldClaimId: 'claim-does-not-match-active' }),
+    ],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: null,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T090000Z-337-old');
+});
+
+test('resolveActiveClaimForWriteGate is inert on a branch mismatch', () => {
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgHandoffEvent({ branch: 'issue/999-other' })],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: null,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T090000Z-337-old');
+});
+
+test('resolveActiveClaimForWriteGate defaults isAuthorizedForcedHandoff to fail closed', () => {
+  // No isAuthorizedForcedHandoff supplied → allowlist ∅ → every handoff is
+  // treated as unauthorized, so the original claim stays active.
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgHandoffEvent()],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: null,
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T090000Z-337-old');
+});
+
+test('resolveActiveClaimForWriteGate resolves a plain claim like a bare predicate call', () => {
+  const events = [wgClaimEvent()];
+  const writeGate = resolveActiveClaimForWriteGate(events, {
+    isTrustedAuthor: wgTrusted,
+  });
+  // A non-FH repo (no handoff marker) must resolve identically to the bare
+  // resolveActiveClaim(events, predicate) path.
+  assert.equal(writeGate?.claimId, 'claim-20260512T090000Z-337-old');
+  assert.equal(writeGate?.agentId, 'cli-old');
+});
+
+test('Part B: PR-backed claim accepts an issue-only handoff that predates the PR', () => {
+  // Handoff createdAt 2026-05-12T11:00:05Z is strictly before the PR first
+  // commit at 2026-05-12T12:00:00Z → accepted even though it is issue-only.
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgHandoffEvent()],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: ['#359'],
+      prFirstCommitAt: '2026-05-12T12:00:00Z',
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T110000Z-337-new');
+});
+
+test('Part B: PR-backed claim rejects an issue-only handoff at/after the PR first commit', () => {
+  // Handoff createdAt 2026-05-12T11:00:05Z is NOT before the PR first commit
+  // at 2026-05-12T10:00:00Z → rejected; the original claim stays active.
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgHandoffEvent()],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: ['#359'],
+      prFirstCommitAt: '2026-05-12T10:00:00Z',
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T090000Z-337-old');
+});
+
+test('Part B: PR-backed claim rejects an issue-only handoff with no prFirstCommitAt', () => {
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgHandoffEvent()],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: ['#359'],
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T090000Z-337-old');
+});
+
+test('Part B: PR-backed claim accepts an issue-plus-pr handoff with a matching linked-pr', () => {
+  const active = resolveActiveClaimForWriteGate(
+    [
+      wgClaimEvent(),
+      wgHandoffEvent({ contextScope: 'issue-plus-pr', linkedPr: '359' }),
+    ],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: ['#359'],
+      // prFirstCommitAt before the handoff: proves issue-plus-pr is honored
+      // by the linked-pr match, not by the predates-PR rule.
+      prFirstCommitAt: '2026-05-12T10:00:00Z',
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T110000Z-337-new');
+});
+
+test('Part B: PR-backed claim rejects an issue-plus-pr handoff with a mismatching linked-pr', () => {
+  const active = resolveActiveClaimForWriteGate(
+    [
+      wgClaimEvent(),
+      wgHandoffEvent({ contextScope: 'issue-plus-pr', linkedPr: '999' }),
+    ],
+    {
+      isTrustedAuthor: wgTrusted,
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: ['#359'],
+      prFirstCommitAt: '2026-05-12T12:00:00Z',
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T090000Z-337-old');
+});
+
+test('Part B: summarizeClaimValidation accepts an issue-only handoff predating the PR', () => {
+  const summary = summarizeClaimValidation([wgClaimEvent(), wgHandoffEvent()], {
+    trustedMarkerLogins: ['cli-old', 'cli-new', 'kurone-kito'],
+    forcedHandoffEnabled: true,
+    isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    expectedLinkedPrs: ['#359'],
+    prFirstCommitAt: '2026-05-12T12:00:00Z',
+    expectedClaimId: 'claim-20260512T110000Z-337-new',
+    expectedAgentId: 'cli-new',
+  });
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, 'match');
+});
+
+test('Part B: summarizeClaimValidation rejects an issue-only handoff after the PR first commit', () => {
+  const summary = summarizeClaimValidation([wgClaimEvent(), wgHandoffEvent()], {
+    trustedMarkerLogins: ['cli-old', 'cli-new', 'kurone-kito'],
+    forcedHandoffEnabled: true,
+    isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'kurone-kito',
+    expectedLinkedPrs: ['#359'],
+    prFirstCommitAt: '2026-05-12T10:00:00Z',
+    expectedClaimId: 'claim-20260512T090000Z-337-old',
+    expectedAgentId: 'cli-old',
+  });
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, 'match');
+  assert.equal(summary.activeClaim.claimId, 'claim-20260512T090000Z-337-old');
 });
 
 function readJson(relativePath: string) {


### PR DESCRIPTION
Closes #1058

## Problem

The merge-gate / write-side helpers resolved the active claim with a parser
that **ignored `forced-handoff` markers**, so a legitimate forced-handoff
*successor* failed every `--claim-id` revalidation — they reported the
**displaced original** claim as active (`claimLost: true`,
`matchesExpectedClaim: false`). A maintainer-approved forced handoff (the
documented recovery path, idd-claim rule 7) therefore left the successor
unable to disposition notices, pass F2, merge via `idd-merge-execute`, or run
F4 cleanup through the helpers. Empirically confirmed while completing #1022
(PR #1057) via an operator-approved forced handoff.

## Change

Thread the forced-handoff authorization (mode + authority policy +
collaborator-permission check, `requireAuthorMatchesForcedBy`) into the claim
revalidation used by the affected helpers, via two new **shared, pure** helpers
in `protocol-helpers`:

- `buildForcedHandoffEnableGate(...)` — the single source of the FH-enable gate
  (extended with the Part B time rule below). `resume-claim-routing`'s
  `buildForcedHandoffEnabledGate` now **delegates** to it so the routing and
  merge-gate paths cannot drift (byte-identical when no PR time is supplied).
- `resolveActiveClaimForWriteGate(events, { isTrustedAuthor, forcedHandoffEnabled,
  expectedLinkedPrs, prFirstCommitAt?, isAuthorizedForcedHandoff?,
  requireAuthorMatchesForcedBy? })` — centralizes the write-side claim resolution
  and **fails closed** on unauthorized/forged markers exactly as Resume routing
  does (`isAuthorizedForcedHandoff` defaults to `() => false`,
  `requireAuthorMatchesForcedBy` defaults to `true`).

Wired into:

- **`disposition-non-review-notices`**, **`resolve-review-thread`** — issue-scoped
  revalidation (`expectedLinkedPrs: null`), so a legitimate issue-only handoff is
  honored. The previous unconditional FH pre-scan is removed.
- **`pre-merge-readiness`**, **`audit-pr-cleanup`** — PR-backed gates. For these,
  an **issue-only** handoff is accepted **only when it predates the PR's first
  commit** (a successor that later opened the PR), while a handoff that takes over
  an **existing** PR still requires `issue-plus-pr` scope. The PR first-commit
  time is resolved **fail-safe to `null` (reject)** on any lookup error or
  unparseable date.

## Verification

- `+16` new pure-function tests in `tests/pre-merge-readiness.test.mts`
  (FH enable-gate scenarios incl. Part B time accept/reject and issue-plus-pr
  match/mismatch). Full suite: **1252 pass / 0 fail**.
- `biome check` clean, `tsc --noEmit` clean, fresh `pnpm run build` reproduces
  the committed `.mjs` artifacts exactly.
- No new CLI command, schemas unchanged, helper-runtime-manifest guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved claim and merge-readiness checks with a more precise review-state evaluation.
  * Added support for time-based handling of eligible handoff cases on PR-backed work.

* **Bug Fixes**
  * Fixed claim validation so authorized handoffs are accepted more consistently.
  * Reduced false rejections by using the PR’s commit history when evaluating active claims.
  * Made claim revalidation more reliable and fail-closed when required dates can’t be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->