### PR TITLE
docs(idd): add a near-ceiling exception to bundle-budget growth

### DIFF
--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -297,6 +297,20 @@ rather than bumping to an exact fit** — an exact-fit bump leaves the next
 concurrent session with zero free bytes, forcing an immediate rebase and
 re-bump.
 
+**Near-ceiling exception.** That prefer-raise default assumes there is still
+headroom to ratchet into. When a bundle, or an individual per-file
+instruction file, already sits in a high-utilization band — roughly **95%
+or more** of its `limitBytes` (or of the per-file phase cap) — flip the
+default and **prefer trimming or splitting the net addition over another
+ratchet bump**. The trade-off inverts only here, at the top of the range:
+below the band, the churn and terminology-drift cost of trimming outweighs a
+small raise; near the ceiling, each further bump raises the
+**always-resident review/merge instruction floor** — the `bundle-review` and
+`bundle-merge` members load on every F-phase session — which is the scarcest
+budget for smaller-context models. Read the two as one policy: raise by
+default while headroom remains, and trim or split once headroom is nearly
+gone.
+
 ### High-contention shared files
 
 A small set of files concentrates concurrent autopilot edits and therefore

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -297,6 +297,20 @@ rather than bumping to an exact fit** — an exact-fit bump leaves the next
 concurrent session with zero free bytes, forcing an immediate rebase and
 re-bump.
 
+**Near-ceiling exception.** That prefer-raise default assumes there is still
+headroom to ratchet into. When a bundle, or an individual per-file
+instruction file, already sits in a high-utilization band — roughly **95%
+or more** of its `limitBytes` (or of the per-file phase cap) — flip the
+default and **prefer trimming or splitting the net addition over another
+ratchet bump**. The trade-off inverts only here, at the top of the range:
+below the band, the churn and terminology-drift cost of trimming outweighs a
+small raise; near the ceiling, each further bump raises the
+**always-resident review/merge instruction floor** — the `bundle-review` and
+`bundle-merge` members load on every F-phase session — which is the scarcest
+budget for smaller-context models. Read the two as one policy: raise by
+default while headroom remains, and trim or split once headroom is nearly
+gone.
+
 ### High-contention shared files
 
 A small set of files concentrates concurrent autopilot edits and therefore


### PR DESCRIPTION
Closes #1062 (parent roadmap #1059)

## Problem

`docs/policy-constants.md` → "Bundle-budget growth" advises preferring to
**raise** a `limitBytes` over **trimming** shared, terminology-sensitive
instruction content (trimming churns multi-phase text and draws repeated
terminology-drift review comments). That default is sound below the ceiling,
but it says nothing about bundles/files already near their cap — where each
ratchet bump steadily raises the **always-resident review/merge instruction
floor** (the `bundle-review` / `bundle-merge` members load on every F-phase
session), the scarcest budget for smaller-context models.

## Change

Add a bounded **near-ceiling exception** that *refines, not reverses* the
prefer-raise default:

- When a bundle or an individual per-file instruction file sits at **roughly
  95% or more** of its cap, flip the default and prefer **trimming or
  splitting** the net addition over another ratchet bump.
- Keep prefer-raise as the default **below** that band, and reconcile the two
  explicitly — the trade-off inverts only when headroom is nearly gone, so the
  two statements read as one coherent policy rather than a contradiction.
- The threshold is stated as a percentage (no exact byte number that would
  itself drift).

Edited the `idd-template/docs/policy-constants.md` **source**; the root
`docs/policy-constants.md` mirror is regenerated via `sync-docs` (mode
`exact`). Per the roadmap, #1062 only edits policy prose and never touches the
budget numbers #1060 corrects, so it is independent of #1060/#1061.

## Verification

- `node scripts/audit-docs.mjs --check` passes (mirror parity).
- Full `pnpm run lint:minimum` passes (typecheck, build:check, biome, dprint,
  tests, cspell, markdownlint — 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)