### PR TITLE
feat(audit): guard documented budget numbers against the manifest

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -212,6 +212,16 @@
       "limitBytes": 95900
     }
   ],
+  "docBudgetGuard": {
+    "id": "doc-budget-drift",
+    "files": [
+      "README.md",
+      "README.ja.md",
+      "docs/policy-constants.md",
+      "idd-template/docs/policy-constants.md",
+      "docs/claude-skill-strategy.md"
+    ]
+  },
   "syncPairs": [
     {
       "id": "claude-skills-issue-authoring-contract",

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -252,6 +252,13 @@ pull-request-only bypass actor that can satisfy GitHub at F3.
 
 CI enforces two layers of instruction file size limits via `audit/sync-manifest.json`.
 
+A separate `audit-docs` guard (`docBudgetGuard` in
+`audit/sync-manifest.json`) cross-checks every hardcoded byte value in the
+maintained docs against these manifest budgets, so a documented number
+cannot silently drift from the manifest. Keep non-budget byte sizes out of
+the guarded files — or express them without the `bytes` suffix — because the
+guard flags any `bytes`-suffixed number that is not a current budget value.
+
 ### Per-file limits
 
 | Limit type    | Value        | Applies to                                                                 |

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -253,11 +253,12 @@ pull-request-only bypass actor that can satisfy GitHub at F3.
 CI enforces two layers of instruction file size limits via `audit/sync-manifest.json`.
 
 A separate `audit-docs` guard (`docBudgetGuard` in
-`audit/sync-manifest.json`) cross-checks every hardcoded byte value in the
+`audit/sync-manifest.json`) cross-checks the hardcoded budget values in the
 maintained docs against these manifest budgets, so a documented number
-cannot silently drift from the manifest. Keep non-budget byte sizes out of
-the guarded files — or express them without the `bytes` suffix — because the
-guard flags any `bytes`-suffixed number that is not a current budget value.
+cannot silently drift from the manifest. It matches budget-shaped byte
+values — four or more digits, optionally comma-grouped, followed by
+`bytes` — so keep any non-budget value of that shape out of the guarded
+files, or express it without the `bytes` suffix.
 
 ### Per-file limits
 

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -252,6 +252,13 @@ pull-request-only bypass actor that can satisfy GitHub at F3.
 
 CI enforces two layers of instruction file size limits via `audit/sync-manifest.json`.
 
+A separate `audit-docs` guard (`docBudgetGuard` in
+`audit/sync-manifest.json`) cross-checks every hardcoded byte value in the
+maintained docs against these manifest budgets, so a documented number
+cannot silently drift from the manifest. Keep non-budget byte sizes out of
+the guarded files — or express them without the `bytes` suffix — because the
+guard flags any `bytes`-suffixed number that is not a current budget value.
+
 ### Per-file limits
 
 | Limit type    | Value        | Applies to                                                                 |

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -253,11 +253,12 @@ pull-request-only bypass actor that can satisfy GitHub at F3.
 CI enforces two layers of instruction file size limits via `audit/sync-manifest.json`.
 
 A separate `audit-docs` guard (`docBudgetGuard` in
-`audit/sync-manifest.json`) cross-checks every hardcoded byte value in the
+`audit/sync-manifest.json`) cross-checks the hardcoded budget values in the
 maintained docs against these manifest budgets, so a documented number
-cannot silently drift from the manifest. Keep non-budget byte sizes out of
-the guarded files — or express them without the `bytes` suffix — because the
-guard flags any `bytes`-suffixed number that is not a current budget value.
+cannot silently drift from the manifest. It matches budget-shaped byte
+values — four or more digits, optionally comma-grouped, followed by
+`bytes` — so keep any non-budget value of that shape out of the guarded
+files, or express it without the `bytes` suffix.
 
 ### Per-file limits
 

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -8,6 +8,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  collectDocBudgetDriftViolations,
   collectDuplicateSyncPairTargets,
   collectInstructionSizeBudgetViolations,
   collectPolicyConfigDrift,
@@ -37,6 +38,7 @@ checkShellFileLists(
 checkSyncPairs(manifest.syncPairs ?? []);
 checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? null);
 checkBundleBudgets(manifest.bundleBudgets ?? []);
+checkDocBudgetNumbers();
 checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
 checkRootMarkdownAllowlist(manifest.rootMarkdownAllowlist ?? null);
 checkTypeSuppressionBudgets(manifest.typeSuppressionBudgets ?? null);
@@ -553,6 +555,19 @@ function checkBundleBudgets(budgets) {
       );
     }
   }
+}
+function checkDocBudgetNumbers() {
+  // Cross-check every hardcoded byte value in the guarded docs against the
+  // live manifest budgets. The pure helper supplies the logic; the audit
+  // pipeline supplies the file reader.
+  const result = collectDocBudgetDriftViolations(
+    manifest.docBudgetGuard ?? null,
+    manifest.instructionSizeBudgets ?? null,
+    manifest.bundleBudgets ?? [],
+    readText,
+  );
+  errors.push(...result.errors);
+  notices.push(...result.notices);
 }
 function listChangedFiles() {
   const candidates = [];

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -422,6 +422,84 @@ export function collectInstructionSizeBudgetViolations(
   return { errors, notices: [] };
 }
 /**
+ * Collect "documentation budget drift" violations: a hardcoded byte value in a
+ * guarded doc that no longer matches any current `audit/sync-manifest.json`
+ * budget. Content-mirror checks only compare doc copies to each other, so a
+ * number that drifts from the *manifest* (the source of truth) passes them —
+ * this guard is the missing cross-check.
+ *
+ * Pure (no direct I/O) so it can be unit-tested; the audit pipeline supplies
+ * the reader. Unlike `collectInstructionSizeBudgetViolations` this runs
+ * unconditionally rather than scoped to changed files: the drift is triggered
+ * by editing the manifest (which leaves the doc file unchanged), so a
+ * doc-scoped check would miss a manifest-only budget bump.
+ *
+ * The valid set is the *union* of all current budget values, so the guard
+ * verifies membership, not position: it catches a value that drifted away from
+ * every budget (the manifest-bumped / doc-stale case this targets), but a
+ * value mislabeled with a *different* budget's number still passes — acceptable
+ * for the drift this guards.
+ *
+ * Matching requires a `bytes` suffix, so a doc that reads its limits live via
+ * `jq` carries no hardcoded number and is never flagged. The configured
+ * `files` must therefore not contain non-budget "N bytes" prose, or it would
+ * false-positive; keep the list tight.
+ */
+export function collectDocBudgetDriftViolations(
+  config,
+  sizeBudgets,
+  bundleBudgets,
+  readFile,
+) {
+  if (!config) {
+    return { errors: [], notices: [] };
+  }
+  const id = config.id ?? 'doc-budget-drift';
+  // Build the valid-value set only from manifest budgets actually present;
+  // never re-apply a default (a `?? 30000` fallback would let the set hold a
+  // value the manifest no longer declares, producing a false positive).
+  const validValues = new Set();
+  if (typeof sizeBudgets?.alwaysLoadedLimitBytes === 'number') {
+    validValues.add(sizeBudgets.alwaysLoadedLimitBytes);
+  }
+  if (typeof sizeBudgets?.phaseLimitBytes === 'number') {
+    validValues.add(sizeBudgets.phaseLimitBytes);
+  }
+  for (const budget of bundleBudgets ?? []) {
+    const limit = Number(budget.limitBytes);
+    if (Number.isFinite(limit)) {
+      validValues.add(limit);
+    }
+  }
+  if (validValues.size === 0) {
+    return {
+      errors: [],
+      notices: [
+        `${id}: skipped doc budget guard because no manifest budget values were available`,
+      ],
+    };
+  }
+  const sortedValid = [...validValues].sort((a, b) => a - b).join(', ');
+  const errors = [];
+  for (const path of config.files ?? []) {
+    const text = String(readFile(path) ?? '');
+    // Capture group 1 is the documented number; the `bytes` suffix keeps
+    // `\d{4,}` from matching years or issue numbers. Compare as integers so a
+    // comma-grouped doc value matches a plain manifest number.
+    for (const match of text.matchAll(
+      /(\d{1,3}(?:,\d{3})+|\d{4,})\s*bytes?\b/gi,
+    )) {
+      const documented = match[1];
+      if (!validValues.has(Number(documented.replace(/,/g, '')))) {
+        errors.push(
+          `${id}: ${path} states ${documented} bytes, which is not a current sync-manifest budget value (valid: ${sortedValid}); update the doc to a live value or read it via jq`,
+        );
+      }
+    }
+  }
+  return { errors, notices: [] };
+}
+/**
  * Collect duplicate `syncPairs` target violations. Pure (no I/O) so it can be
  * unit-tested and shared between the docs audit and sync-docs.
  *

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -9,11 +9,13 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type {
+  DocBudgetGuardConfig,
   InstructionSizeBudgetConfig,
   RootMarkdownAllowlistConfig,
   TypeSuppressionBudgetConfig,
 } from './consistency-helpers.mts';
 import {
+  collectDocBudgetDriftViolations,
   collectDuplicateSyncPairTargets,
   collectInstructionSizeBudgetViolations,
   collectPolicyConfigDrift,
@@ -87,6 +89,7 @@ interface AuditManifest {
   syncPairs?: SyncPair[];
   instructionSizeBudgets?: InstructionSizeBudgetConfig | null;
   bundleBudgets?: BundleBudget[];
+  docBudgetGuard?: DocBudgetGuardConfig | null;
   forbiddenPatterns?: ForbiddenPattern[];
   rootMarkdownAllowlist?: RootMarkdownAllowlistConfig | null;
   typeSuppressionBudgets?: TypeSuppressionBudgetConfig | null;
@@ -117,6 +120,7 @@ checkShellFileLists(
 checkSyncPairs(manifest.syncPairs ?? []);
 checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? null);
 checkBundleBudgets(manifest.bundleBudgets ?? []);
+checkDocBudgetNumbers();
 checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
 checkRootMarkdownAllowlist(manifest.rootMarkdownAllowlist ?? null);
 checkTypeSuppressionBudgets(manifest.typeSuppressionBudgets ?? null);
@@ -697,6 +701,20 @@ function checkBundleBudgets(budgets: BundleBudget[]) {
       );
     }
   }
+}
+
+function checkDocBudgetNumbers() {
+  // Cross-check every hardcoded byte value in the guarded docs against the
+  // live manifest budgets. The pure helper supplies the logic; the audit
+  // pipeline supplies the file reader.
+  const result = collectDocBudgetDriftViolations(
+    manifest.docBudgetGuard ?? null,
+    manifest.instructionSizeBudgets ?? null,
+    manifest.bundleBudgets ?? [],
+    readText,
+  );
+  errors.push(...result.errors);
+  notices.push(...result.notices);
 }
 
 function listChangedFiles(): Set<string> | null {

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -508,6 +508,95 @@ export function collectInstructionSizeBudgetViolations(
   return { errors, notices: [] };
 }
 
+export interface DocBudgetGuardConfig {
+  id?: string;
+  files?: string[];
+}
+
+/**
+ * Collect "documentation budget drift" violations: a hardcoded byte value in a
+ * guarded doc that no longer matches any current `audit/sync-manifest.json`
+ * budget. Content-mirror checks only compare doc copies to each other, so a
+ * number that drifts from the *manifest* (the source of truth) passes them —
+ * this guard is the missing cross-check.
+ *
+ * Pure (no direct I/O) so it can be unit-tested; the audit pipeline supplies
+ * the reader. Unlike `collectInstructionSizeBudgetViolations` this runs
+ * unconditionally rather than scoped to changed files: the drift is triggered
+ * by editing the manifest (which leaves the doc file unchanged), so a
+ * doc-scoped check would miss a manifest-only budget bump.
+ *
+ * The valid set is the *union* of all current budget values, so the guard
+ * verifies membership, not position: it catches a value that drifted away from
+ * every budget (the manifest-bumped / doc-stale case this targets), but a
+ * value mislabeled with a *different* budget's number still passes — acceptable
+ * for the drift this guards.
+ *
+ * Matching requires a `bytes` suffix, so a doc that reads its limits live via
+ * `jq` carries no hardcoded number and is never flagged. The configured
+ * `files` must therefore not contain non-budget "N bytes" prose, or it would
+ * false-positive; keep the list tight.
+ */
+export function collectDocBudgetDriftViolations(
+  config: DocBudgetGuardConfig | null | undefined,
+  sizeBudgets:
+    | { alwaysLoadedLimitBytes?: number; phaseLimitBytes?: number }
+    | null
+    | undefined,
+  bundleBudgets: readonly { limitBytes?: number | string }[] | undefined,
+  readFile: (path: string) => string,
+): { errors: string[]; notices: string[] } {
+  if (!config) {
+    return { errors: [], notices: [] };
+  }
+  const id = config.id ?? 'doc-budget-drift';
+
+  // Build the valid-value set only from manifest budgets actually present;
+  // never re-apply a default (a `?? 30000` fallback would let the set hold a
+  // value the manifest no longer declares, producing a false positive).
+  const validValues = new Set<number>();
+  if (typeof sizeBudgets?.alwaysLoadedLimitBytes === 'number') {
+    validValues.add(sizeBudgets.alwaysLoadedLimitBytes);
+  }
+  if (typeof sizeBudgets?.phaseLimitBytes === 'number') {
+    validValues.add(sizeBudgets.phaseLimitBytes);
+  }
+  for (const budget of bundleBudgets ?? []) {
+    const limit = Number(budget.limitBytes);
+    if (Number.isFinite(limit)) {
+      validValues.add(limit);
+    }
+  }
+  if (validValues.size === 0) {
+    return {
+      errors: [],
+      notices: [
+        `${id}: skipped doc budget guard because no manifest budget values were available`,
+      ],
+    };
+  }
+
+  const sortedValid = [...validValues].sort((a, b) => a - b).join(', ');
+  const errors: string[] = [];
+  for (const path of config.files ?? []) {
+    const text = String(readFile(path) ?? '');
+    // Capture group 1 is the documented number; the `bytes` suffix keeps
+    // `\d{4,}` from matching years or issue numbers. Compare as integers so a
+    // comma-grouped doc value matches a plain manifest number.
+    for (const match of text.matchAll(
+      /(\d{1,3}(?:,\d{3})+|\d{4,})\s*bytes?\b/gi,
+    )) {
+      const documented = match[1];
+      if (!validValues.has(Number(documented.replace(/,/g, '')))) {
+        errors.push(
+          `${id}: ${path} states ${documented} bytes, which is not a current sync-manifest budget value (valid: ${sortedValid}); update the doc to a live value or read it via jq`,
+        );
+      }
+    }
+  }
+  return { errors, notices: [] };
+}
+
 /**
  * Collect duplicate `syncPairs` target violations. Pure (no I/O) so it can be
  * unit-tested and shared between the docs audit and sync-docs.

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -5,6 +5,7 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  collectDocBudgetDriftViolations,
   collectDuplicateSyncPairTargets,
   collectInstructionSizeBudgetViolations,
   collectPolicyConfigDrift,
@@ -112,6 +113,67 @@ test('instruction size budget returns nothing for absent config', () => {
     },
   );
   assert.deepEqual(result, { errors: [], notices: [] });
+});
+
+const DOC_BUDGET_SIZE = {
+  alwaysLoadedLimitBytes: 20_000,
+  phaseLimitBytes: 32_200,
+};
+const DOC_BUDGET_BUNDLES = [{ limitBytes: 100_400 }, { limitBytes: 43_300 }];
+
+test('doc budget guard passes when documented values match the manifest', () => {
+  const texts: Record<string, string> = {
+    'README.md': '| Phase | 32,200 bytes |\n| Always | 20,000 bytes |',
+    // a hardcoded bundle value that still matches the manifest is allowed
+    'strategy.md': 'discovery bundle is 100,400 bytes',
+    // a doc that reads limits live via jq carries no number → never flagged
+    'jq.md':
+      "read the live values with jq '.bundleBudgets' audit/sync-manifest.json",
+  };
+  const result = collectDocBudgetDriftViolations(
+    { files: ['README.md', 'strategy.md', 'jq.md'] },
+    DOC_BUDGET_SIZE,
+    DOC_BUDGET_BUNDLES,
+    (path) => texts[path],
+  );
+  assert.deepEqual(result, { errors: [], notices: [] });
+});
+
+test('doc budget guard flags a value that drifted from every manifest budget', () => {
+  const result = collectDocBudgetDriftViolations(
+    { id: 'doc-budget-drift', files: ['README.md'] },
+    DOC_BUDGET_SIZE,
+    DOC_BUDGET_BUNDLES,
+    () => '| Phase instruction file | 30,000 bytes |',
+  );
+  assert.equal(result.errors.length, 1);
+  assert.match(
+    result.errors[0],
+    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 20000, 32200, 43300, 100400\)/,
+  );
+});
+
+test('doc budget guard is a no-op without config and notices on empty budgets', () => {
+  assert.deepEqual(
+    collectDocBudgetDriftViolations(
+      null,
+      DOC_BUDGET_SIZE,
+      DOC_BUDGET_BUNDLES,
+      () => {
+        throw new Error('must not read files when config is absent');
+      },
+    ),
+    { errors: [], notices: [] },
+  );
+  const noBudgets = collectDocBudgetDriftViolations(
+    { id: 'doc-budget-drift', files: ['README.md'] },
+    null,
+    [],
+    () => '32,200 bytes',
+  );
+  assert.deepEqual(noBudgets.errors, []);
+  assert.equal(noBudgets.notices.length, 1);
+  assert.match(noBudgets.notices[0], /skipped doc budget guard/);
 });
 
 test('config drift scenarios detect mismatches between config and overview defaults', () => {


### PR DESCRIPTION
## Summary

`audit-docs --check` only verifies content mirroring (en↔ja, root↔template,
the skills copy), so a hardcoded budget number that drifts from
`audit/sync-manifest.json` — the source of truth — passes CI unnoticed. That
is the exact gap that let the #1060 drift land. This adds the missing
doc-vs-manifest cross-check.

## Change

- `audit/sync-manifest.json`: new `docBudgetGuard.files` entry listing the
  five docs that carry budget numbers.
- `src/scripts/consistency-helpers.mts`: pure
  `collectDocBudgetDriftViolations` helper — builds the union of current
  manifest budgets (`instructionSizeBudgets` + each
  `bundleBudgets[].limitBytes`) and flags any hardcoded `N bytes` value in a
  guarded doc that is not in that set, naming the file, the documented value,
  and the valid values.
- `src/scripts/audit-docs.mts`: `checkDocBudgetNumbers()` wired after the
  bundle-budget check.
- `tests/consistency.test.mts`: unit tests (in-sync pass, drift fail, jq-only
  pass, absent-config no-op, empty-budgets notice).
- `docs/policy-constants.md` (+ idd-template mirror): documents the guard.

## Design notes

- **Runs unconditionally** (not changed-file-scoped, unlike the size-budget
  check): the drift is triggered by a *manifest* bump, which leaves the doc
  file unchanged, so a doc-scoped check would miss it. Mirrors the existing
  unconditional bundle-budget check.
- **Membership, not position**: the valid set is the union of all budgets, so
  a value mislabeled with a *different* budget's number still passes — fine
  for the targeted drift (a stale value dropping out of every budget).
  Documented in the helper.
- **jq-read docs are never flagged** — no hardcoded `N bytes` to match. The
  guarded file list is kept tight, and policy-constants warns against putting
  non-budget `N bytes` prose in those files (the regex requires a `bytes`
  suffix).
- `audit-docs.mts` is TS-sourced; the regenerated `scripts/*.mjs` artifacts
  are committed.

## Verification

- `pnpm test` (17 consistency tests incl. 3 new), `pnpm run build:check`,
  fix-validate + pre-push-validate all pass.
- End-to-end proof: injecting a stale `30,000 bytes` into README fails
  `audit-docs --check` with the guard message; reverting restores green.

## Related

Sibling of the #1059 roadmap. #1060 (fix the drift) merged; #1062
(growth-policy note) merged by a concurrent session.

Closes #1061


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documentation budget check that flags hardcoded byte values in maintained docs when they no longer match current limits.
  * Expanded audit reporting to surface skipped checks and mismatches more clearly.

* **Bug Fixes**
  * Prevented documented byte sizes from silently drifting out of sync with approved budget values.

* **Tests**
  * Added coverage for matching values, drift detection, missing configuration, and empty budget cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->