### PR TITLE
docs(idd): skip the agent-side F4 cleanup-evidence post when one exists

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -276,12 +276,12 @@ Before any mutating action in F3, apply the
      ```
 
      After apply, record the outcome — but **skip the post when the PR
-     already carries a fresh `<!-- idd-cleanup-evidence:` comment** (for
-     example one the `post-merge-cleanup` workflow posted within seconds
-     of the merge). The marker is a resume-detection token, so a second
-     copy is only noise; this mirrors the workflow's own
-     duplicate-evidence guard. See `docs/idd-comment-minimization.md`
-     for the exact formats:
+     already carries a `<!-- idd-cleanup-evidence:` comment**: the check
+     is presence-based — any comment whose body starts with that token,
+     matching the workflow's own guard — for example one the
+     `post-merge-cleanup` workflow posted within seconds of the merge.
+     The marker is a resume-detection token, so a second copy is only
+     noise. See `docs/idd-comment-minimization.md` for the exact formats:
 
      If the apply `status` is `applied`: post the evidence comment
      format (with `status`, `applied`, `failed`, `skipped`, and
@@ -309,10 +309,10 @@ Before any mutating action in F3, apply the
    Re-validate the active claim before each mutation. After GraphQL
    cleanup, post an evidence comment summarizing the outcome (status,
    applied count, skipped count with reasons) — unless the PR already
-   carries a fresh `<!-- idd-cleanup-evidence:` comment, in which case
-   skip the duplicate post. If the viewer cannot minimize any detected
-   candidates, post a cleanup-permission-blocked comment instead of
-   exiting silently.
+   carries a `<!-- idd-cleanup-evidence:` comment (presence-based: any
+   body starting with that token), in which case skip the duplicate
+   post. If the viewer cannot minimize any detected candidates, post a
+   cleanup-permission-blocked comment instead of exiting silently.
 
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -275,12 +275,22 @@ Before any mutating action in F3, apply the
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-     After apply, post a comment to the PR recording the outcome. See
-     `docs/idd-comment-minimization.md` for the exact format:
+     After apply, record the outcome — but **skip the post when the PR
+     already carries a fresh `<!-- idd-cleanup-evidence:` comment** (for
+     example one the `post-merge-cleanup` workflow posted within seconds
+     of the merge). The marker is a resume-detection token, so a second
+     copy is only noise; this mirrors the workflow's own
+     duplicate-evidence guard. See `docs/idd-comment-minimization.md`
+     for the exact formats:
 
      If the apply `status` is `applied`: post the evidence comment
      format (with `status`, `applied`, `failed`, `skipped`, and
      `viewer-cannot-minimize` counts). Proceed to step 3.
+
+     If the apply `status` is `clean`: no candidates remained — the
+     cleanup already converged (typically the workflow minimized them
+     first). Do not post a duplicate evidence comment; proceed to
+     step 3.
 
      If the apply `status` is `failed` or `incomplete`: post the
      cleanup-failure comment format instead. Include the
@@ -298,9 +308,11 @@ Before any mutating action in F3, apply the
    already-minimized comments and comments the viewer cannot minimize.
    Re-validate the active claim before each mutation. After GraphQL
    cleanup, post an evidence comment summarizing the outcome (status,
-   applied count, skipped count with reasons). If the viewer cannot
-   minimize any detected candidates, post a
-   cleanup-permission-blocked comment instead of exiting silently.
+   applied count, skipped count with reasons) — unless the PR already
+   carries a fresh `<!-- idd-cleanup-evidence:` comment, in which case
+   skip the duplicate post. If the viewer cannot minimize any detected
+   candidates, post a cleanup-permission-blocked comment instead of
+   exiting silently.
 
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -275,22 +275,25 @@ Before any mutating action in F3, apply the
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-     After apply, record the outcome — but **skip the post when the PR
-     already carries a `<!-- idd-cleanup-evidence:` comment**: the check
-     is presence-based — any comment whose body starts with that token,
-     matching the workflow's own guard — for example one the
-     `post-merge-cleanup` workflow posted within seconds of the merge.
-     The marker is a resume-detection token, so a second copy is only
-     noise. See `docs/idd-comment-minimization.md` for the exact formats:
+     After apply, record the outcome. **First apply the dedupe guard:
+     skip posting when the PR already carries a `<!-- idd-cleanup-evidence:`
+     comment that records a successful outcome** (`status` `applied` or
+     `clean`) — for example one the `post-merge-cleanup` workflow posted
+     within seconds of the merge — so the agent never stacks a second
+     success record. The guard does **not** fire on an existing `failed`
+     / `incomplete` / `permission-blocked` record: post your evidence so
+     a converged manual run corrects the PR rather than leaving a stale
+     failure as the record. When you post, see
+     `docs/idd-comment-minimization.md` for the exact formats:
 
      If the apply `status` is `applied`: post the evidence comment
      format (with `status`, `applied`, `failed`, `skipped`, and
      `viewer-cannot-minimize` counts). Proceed to step 3.
 
-     If the apply `status` is `clean`: no candidates remained — the
-     cleanup already converged (typically the workflow minimized them
-     first). Do not post a duplicate evidence comment; proceed to
-     step 3.
+     If the apply `status` is `clean`: the cleanup already converged
+     (typically the workflow minimized first), so the guard above
+     usually skips this post; otherwise record the converged outcome.
+     Proceed to step 3.
 
      If the apply `status` is `failed` or `incomplete`: post the
      cleanup-failure comment format instead. Include the
@@ -309,9 +312,10 @@ Before any mutating action in F3, apply the
    Re-validate the active claim before each mutation. After GraphQL
    cleanup, post an evidence comment summarizing the outcome (status,
    applied count, skipped count with reasons) — unless the PR already
-   carries a `<!-- idd-cleanup-evidence:` comment (presence-based: any
-   body starting with that token), in which case skip the duplicate
-   post. If the viewer cannot minimize any detected candidates, post a
+   carries a `<!-- idd-cleanup-evidence:` comment recording a successful
+   outcome (`applied` / `clean`), in which case skip the duplicate post
+   (still post to correct an existing `failed` / `incomplete` record).
+   If the viewer cannot minimize any detected candidates, post a
    cleanup-permission-blocked comment instead of exiting silently.
 
    See `docs/idd-comment-minimization.md` for the evidence comment

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -275,25 +275,22 @@ Before any mutating action in F3, apply the
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-     After apply, record the outcome. **First apply the dedupe guard:
-     skip posting when the PR already carries a `<!-- idd-cleanup-evidence:`
-     comment that records a successful outcome** (`status` is `applied`
-     or `clean`) — for example one the `post-merge-cleanup` workflow posted
-     within seconds of the merge — so the agent never stacks a second
-     success record. The guard does **not** fire on an existing `failed`
-     / `incomplete` / `permission-blocked` record: post your evidence so
-     a converged manual run corrects the PR rather than leaving a stale
-     failure as the record. When you post, see
+     After apply, record the outcome by the apply `status`. See
      `docs/idd-comment-minimization.md` for the exact formats:
 
-     If the apply `status` is `applied`: post the evidence comment
-     format (with `status`, `applied`, `failed`, `skipped`, and
-     `viewer-cannot-minimize` counts). Proceed to step 3.
+     If the apply `status` is `applied`: this run minimized candidates,
+     so **always** post the evidence comment (with `status`, `applied`,
+     `failed`, `skipped`, and `viewer-cannot-minimize` counts) — never
+     suppress a record of work this run actually did. Proceed to step 3.
 
-     If the apply `status` is `clean`: the cleanup already converged
-     (typically the workflow minimized first), so the guard above
-     usually skips this post; otherwise record the converged outcome.
-     Proceed to step 3.
+     If the apply `status` is `clean`: this run was a no-op (nothing left
+     to minimize). **Skip the post when the PR already carries a
+     `<!-- idd-cleanup-evidence:` comment recording a successful outcome**
+     (`applied` or `clean`) — for example one the `post-merge-cleanup`
+     workflow posted within seconds of the merge — to avoid a duplicate
+     success record. Otherwise (only a `failed` / `incomplete` /
+     `permission-blocked` record exists, or none) post a converged
+     `clean` record so the cleanup is documented. Proceed to step 3.
 
      If the apply `status` is `failed` or `incomplete`: post the
      cleanup-failure comment format instead. Include the
@@ -311,11 +308,12 @@ Before any mutating action in F3, apply the
    already-minimized comments and comments the viewer cannot minimize.
    Re-validate the active claim before each mutation. After GraphQL
    cleanup, post an evidence comment summarizing the outcome (status,
-   applied count, skipped count with reasons) — unless the PR already
-   carries a `<!-- idd-cleanup-evidence:` comment recording a successful
-   outcome (`applied` / `clean`), in which case skip the duplicate post
-   (still post to correct an existing `failed` / `incomplete` /
-   `permission-blocked` record). If the viewer cannot minimize any
+   applied count, skipped count with reasons). Skip the post only when
+   this run minimized nothing new **and** the PR already carries a
+   `<!-- idd-cleanup-evidence:` comment recording a successful outcome
+   (`applied` / `clean`); still post when this run minimized candidates,
+   or to correct an existing `failed` / `incomplete` /
+   `permission-blocked` record. If the viewer cannot minimize any
    detected candidates, post a
    cleanup-permission-blocked comment instead of exiting silently.
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -277,8 +277,8 @@ Before any mutating action in F3, apply the
 
      After apply, record the outcome. **First apply the dedupe guard:
      skip posting when the PR already carries a `<!-- idd-cleanup-evidence:`
-     comment that records a successful outcome** (`status` `applied` or
-     `clean`) — for example one the `post-merge-cleanup` workflow posted
+     comment that records a successful outcome** (`status` is `applied`
+     or `clean`) — for example one the `post-merge-cleanup` workflow posted
      within seconds of the merge — so the agent never stacks a second
      success record. The guard does **not** fire on an existing `failed`
      / `incomplete` / `permission-blocked` record: post your evidence so
@@ -314,8 +314,9 @@ Before any mutating action in F3, apply the
    applied count, skipped count with reasons) — unless the PR already
    carries a `<!-- idd-cleanup-evidence:` comment recording a successful
    outcome (`applied` / `clean`), in which case skip the duplicate post
-   (still post to correct an existing `failed` / `incomplete` record).
-   If the viewer cannot minimize any detected candidates, post a
+   (still post to correct an existing `failed` / `incomplete` /
+   `permission-blocked` record). If the viewer cannot minimize any
+   detected candidates, post a
    cleanup-permission-blocked comment instead of exiting silently.
 
    See `docs/idd-comment-minimization.md` for the evidence comment

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -358,8 +358,11 @@ does not re-block the merge; it is an explicit record only.
 
 Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
-marker so a resuming agent can detect whether the evidence was already
-posted:
+marker so a resuming agent — or a concurrent `post-merge-cleanup`
+workflow run — can detect whether the evidence was already posted.
+**Skip the post when a fresh `<!-- idd-cleanup-evidence:` comment
+already exists on the PR**, so the agent and the workflow never stack a
+duplicate; both honor the same guard:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -363,8 +363,8 @@ workflow run — can detect whether the evidence was already posted.
 **Skip the post when a `<!-- idd-cleanup-evidence:` comment recording a
 successful outcome (`applied` / `clean`) already exists on the PR**, so
 the agent and the workflow never stack a duplicate success record; still
-post to correct an existing `failed` / `incomplete` record when your own
-run converged:
+post to correct an existing `failed` / `incomplete` / `permission-blocked`
+record when your own run converged:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -360,8 +360,9 @@ Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
 workflow run — can detect whether the evidence was already posted.
-**Skip the post when a fresh `<!-- idd-cleanup-evidence:` comment
-already exists on the PR**, so the agent and the workflow never stack a
+**Skip the post when a `<!-- idd-cleanup-evidence:` comment already
+exists on the PR** — the check is presence-based (any comment whose body
+starts with that token), so the agent and the workflow never stack a
 duplicate; both honor the same guard:
 
 ```markdown

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -359,13 +359,16 @@ does not re-block the merge; it is an explicit record only.
 Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
-workflow run — can detect whether the evidence was already posted.
-**Skip the post only when this run minimized nothing new and a
-`<!-- idd-cleanup-evidence:` comment recording a successful outcome
-(`applied` / `clean`) already exists on the PR**, so the agent and the
-workflow never stack a duplicate success record. Still post when this
-run minimized candidates, or to correct an existing `failed` /
-`incomplete` / `permission-blocked` record:
+workflow run — can detect that evidence was already posted. The
+**agent-side** rule is status-aware: **skip the post only when this run
+minimized nothing new and a `<!-- idd-cleanup-evidence:` comment
+recording a successful outcome (`applied` / `clean`) already exists on
+the PR**, so the agent never stacks a duplicate success record; still
+post when this run minimized candidates, or to correct an existing
+`failed` / `incomplete` / `permission-blocked` record. The
+`post-merge-cleanup` workflow instead uses a simpler presence-only guard
+(it skips on any existing marker), which suffices for its single-shot
+post-merge run:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -360,10 +360,11 @@ Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
 workflow run — can detect whether the evidence was already posted.
-**Skip the post when a `<!-- idd-cleanup-evidence:` comment already
-exists on the PR** — the check is presence-based (any comment whose body
-starts with that token), so the agent and the workflow never stack a
-duplicate; both honor the same guard:
+**Skip the post when a `<!-- idd-cleanup-evidence:` comment recording a
+successful outcome (`applied` / `clean`) already exists on the PR**, so
+the agent and the workflow never stack a duplicate success record; still
+post to correct an existing `failed` / `incomplete` record when your own
+run converged:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -360,11 +360,12 @@ Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
 workflow run — can detect whether the evidence was already posted.
-**Skip the post when a `<!-- idd-cleanup-evidence:` comment recording a
-successful outcome (`applied` / `clean`) already exists on the PR**, so
-the agent and the workflow never stack a duplicate success record; still
-post to correct an existing `failed` / `incomplete` / `permission-blocked`
-record when your own run converged:
+**Skip the post only when this run minimized nothing new and a
+`<!-- idd-cleanup-evidence:` comment recording a successful outcome
+(`applied` / `clean`) already exists on the PR**, so the agent and the
+workflow never stack a duplicate success record. Still post when this
+run minimized candidates, or to correct an existing `failed` /
+`incomplete` / `permission-blocked` record:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -276,12 +276,12 @@ Before any mutating action in F3, apply the
      ```
 
      After apply, record the outcome — but **skip the post when the PR
-     already carries a fresh `<!-- idd-cleanup-evidence:` comment** (for
-     example one the `post-merge-cleanup` workflow posted within seconds
-     of the merge). The marker is a resume-detection token, so a second
-     copy is only noise; this mirrors the workflow's own
-     duplicate-evidence guard. See `docs/idd-comment-minimization.md`
-     for the exact formats:
+     already carries a `<!-- idd-cleanup-evidence:` comment**: the check
+     is presence-based — any comment whose body starts with that token,
+     matching the workflow's own guard — for example one the
+     `post-merge-cleanup` workflow posted within seconds of the merge.
+     The marker is a resume-detection token, so a second copy is only
+     noise. See `docs/idd-comment-minimization.md` for the exact formats:
 
      If the apply `status` is `applied`: post the evidence comment
      format (with `status`, `applied`, `failed`, `skipped`, and
@@ -309,10 +309,10 @@ Before any mutating action in F3, apply the
    Re-validate the active claim before each mutation. After GraphQL
    cleanup, post an evidence comment summarizing the outcome (status,
    applied count, skipped count with reasons) — unless the PR already
-   carries a fresh `<!-- idd-cleanup-evidence:` comment, in which case
-   skip the duplicate post. If the viewer cannot minimize any detected
-   candidates, post a cleanup-permission-blocked comment instead of
-   exiting silently.
+   carries a `<!-- idd-cleanup-evidence:` comment (presence-based: any
+   body starting with that token), in which case skip the duplicate
+   post. If the viewer cannot minimize any detected candidates, post a
+   cleanup-permission-blocked comment instead of exiting silently.
 
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -275,12 +275,22 @@ Before any mutating action in F3, apply the
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-     After apply, post a comment to the PR recording the outcome. See
-     `docs/idd-comment-minimization.md` for the exact format:
+     After apply, record the outcome — but **skip the post when the PR
+     already carries a fresh `<!-- idd-cleanup-evidence:` comment** (for
+     example one the `post-merge-cleanup` workflow posted within seconds
+     of the merge). The marker is a resume-detection token, so a second
+     copy is only noise; this mirrors the workflow's own
+     duplicate-evidence guard. See `docs/idd-comment-minimization.md`
+     for the exact formats:
 
      If the apply `status` is `applied`: post the evidence comment
      format (with `status`, `applied`, `failed`, `skipped`, and
      `viewer-cannot-minimize` counts). Proceed to step 3.
+
+     If the apply `status` is `clean`: no candidates remained — the
+     cleanup already converged (typically the workflow minimized them
+     first). Do not post a duplicate evidence comment; proceed to
+     step 3.
 
      If the apply `status` is `failed` or `incomplete`: post the
      cleanup-failure comment format instead. Include the
@@ -298,9 +308,11 @@ Before any mutating action in F3, apply the
    already-minimized comments and comments the viewer cannot minimize.
    Re-validate the active claim before each mutation. After GraphQL
    cleanup, post an evidence comment summarizing the outcome (status,
-   applied count, skipped count with reasons). If the viewer cannot
-   minimize any detected candidates, post a
-   cleanup-permission-blocked comment instead of exiting silently.
+   applied count, skipped count with reasons) — unless the PR already
+   carries a fresh `<!-- idd-cleanup-evidence:` comment, in which case
+   skip the duplicate post. If the viewer cannot minimize any detected
+   candidates, post a cleanup-permission-blocked comment instead of
+   exiting silently.
 
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -275,22 +275,25 @@ Before any mutating action in F3, apply the
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-     After apply, record the outcome — but **skip the post when the PR
-     already carries a `<!-- idd-cleanup-evidence:` comment**: the check
-     is presence-based — any comment whose body starts with that token,
-     matching the workflow's own guard — for example one the
-     `post-merge-cleanup` workflow posted within seconds of the merge.
-     The marker is a resume-detection token, so a second copy is only
-     noise. See `docs/idd-comment-minimization.md` for the exact formats:
+     After apply, record the outcome. **First apply the dedupe guard:
+     skip posting when the PR already carries a `<!-- idd-cleanup-evidence:`
+     comment that records a successful outcome** (`status` `applied` or
+     `clean`) — for example one the `post-merge-cleanup` workflow posted
+     within seconds of the merge — so the agent never stacks a second
+     success record. The guard does **not** fire on an existing `failed`
+     / `incomplete` / `permission-blocked` record: post your evidence so
+     a converged manual run corrects the PR rather than leaving a stale
+     failure as the record. When you post, see
+     `docs/idd-comment-minimization.md` for the exact formats:
 
      If the apply `status` is `applied`: post the evidence comment
      format (with `status`, `applied`, `failed`, `skipped`, and
      `viewer-cannot-minimize` counts). Proceed to step 3.
 
-     If the apply `status` is `clean`: no candidates remained — the
-     cleanup already converged (typically the workflow minimized them
-     first). Do not post a duplicate evidence comment; proceed to
-     step 3.
+     If the apply `status` is `clean`: the cleanup already converged
+     (typically the workflow minimized first), so the guard above
+     usually skips this post; otherwise record the converged outcome.
+     Proceed to step 3.
 
      If the apply `status` is `failed` or `incomplete`: post the
      cleanup-failure comment format instead. Include the
@@ -309,9 +312,10 @@ Before any mutating action in F3, apply the
    Re-validate the active claim before each mutation. After GraphQL
    cleanup, post an evidence comment summarizing the outcome (status,
    applied count, skipped count with reasons) — unless the PR already
-   carries a `<!-- idd-cleanup-evidence:` comment (presence-based: any
-   body starting with that token), in which case skip the duplicate
-   post. If the viewer cannot minimize any detected candidates, post a
+   carries a `<!-- idd-cleanup-evidence:` comment recording a successful
+   outcome (`applied` / `clean`), in which case skip the duplicate post
+   (still post to correct an existing `failed` / `incomplete` record).
+   If the viewer cannot minimize any detected candidates, post a
    cleanup-permission-blocked comment instead of exiting silently.
 
    See `docs/idd-comment-minimization.md` for the evidence comment

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -275,25 +275,22 @@ Before any mutating action in F3, apply the
        --claim-issue <issue-number> --claim-id <claim-id> --format table
      ```
 
-     After apply, record the outcome. **First apply the dedupe guard:
-     skip posting when the PR already carries a `<!-- idd-cleanup-evidence:`
-     comment that records a successful outcome** (`status` is `applied`
-     or `clean`) — for example one the `post-merge-cleanup` workflow posted
-     within seconds of the merge — so the agent never stacks a second
-     success record. The guard does **not** fire on an existing `failed`
-     / `incomplete` / `permission-blocked` record: post your evidence so
-     a converged manual run corrects the PR rather than leaving a stale
-     failure as the record. When you post, see
+     After apply, record the outcome by the apply `status`. See
      `docs/idd-comment-minimization.md` for the exact formats:
 
-     If the apply `status` is `applied`: post the evidence comment
-     format (with `status`, `applied`, `failed`, `skipped`, and
-     `viewer-cannot-minimize` counts). Proceed to step 3.
+     If the apply `status` is `applied`: this run minimized candidates,
+     so **always** post the evidence comment (with `status`, `applied`,
+     `failed`, `skipped`, and `viewer-cannot-minimize` counts) — never
+     suppress a record of work this run actually did. Proceed to step 3.
 
-     If the apply `status` is `clean`: the cleanup already converged
-     (typically the workflow minimized first), so the guard above
-     usually skips this post; otherwise record the converged outcome.
-     Proceed to step 3.
+     If the apply `status` is `clean`: this run was a no-op (nothing left
+     to minimize). **Skip the post when the PR already carries a
+     `<!-- idd-cleanup-evidence:` comment recording a successful outcome**
+     (`applied` or `clean`) — for example one the `post-merge-cleanup`
+     workflow posted within seconds of the merge — to avoid a duplicate
+     success record. Otherwise (only a `failed` / `incomplete` /
+     `permission-blocked` record exists, or none) post a converged
+     `clean` record so the cleanup is documented. Proceed to step 3.
 
      If the apply `status` is `failed` or `incomplete`: post the
      cleanup-failure comment format instead. Include the
@@ -311,11 +308,12 @@ Before any mutating action in F3, apply the
    already-minimized comments and comments the viewer cannot minimize.
    Re-validate the active claim before each mutation. After GraphQL
    cleanup, post an evidence comment summarizing the outcome (status,
-   applied count, skipped count with reasons) — unless the PR already
-   carries a `<!-- idd-cleanup-evidence:` comment recording a successful
-   outcome (`applied` / `clean`), in which case skip the duplicate post
-   (still post to correct an existing `failed` / `incomplete` /
-   `permission-blocked` record). If the viewer cannot minimize any
+   applied count, skipped count with reasons). Skip the post only when
+   this run minimized nothing new **and** the PR already carries a
+   `<!-- idd-cleanup-evidence:` comment recording a successful outcome
+   (`applied` / `clean`); still post when this run minimized candidates,
+   or to correct an existing `failed` / `incomplete` /
+   `permission-blocked` record. If the viewer cannot minimize any
    detected candidates, post a
    cleanup-permission-blocked comment instead of exiting silently.
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -277,8 +277,8 @@ Before any mutating action in F3, apply the
 
      After apply, record the outcome. **First apply the dedupe guard:
      skip posting when the PR already carries a `<!-- idd-cleanup-evidence:`
-     comment that records a successful outcome** (`status` `applied` or
-     `clean`) — for example one the `post-merge-cleanup` workflow posted
+     comment that records a successful outcome** (`status` is `applied`
+     or `clean`) — for example one the `post-merge-cleanup` workflow posted
      within seconds of the merge — so the agent never stacks a second
      success record. The guard does **not** fire on an existing `failed`
      / `incomplete` / `permission-blocked` record: post your evidence so
@@ -314,8 +314,9 @@ Before any mutating action in F3, apply the
    applied count, skipped count with reasons) — unless the PR already
    carries a `<!-- idd-cleanup-evidence:` comment recording a successful
    outcome (`applied` / `clean`), in which case skip the duplicate post
-   (still post to correct an existing `failed` / `incomplete` record).
-   If the viewer cannot minimize any detected candidates, post a
+   (still post to correct an existing `failed` / `incomplete` /
+   `permission-blocked` record). If the viewer cannot minimize any
+   detected candidates, post a
    cleanup-permission-blocked comment instead of exiting silently.
 
    See `docs/idd-comment-minimization.md` for the evidence comment

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -358,8 +358,11 @@ does not re-block the merge; it is an explicit record only.
 
 Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
-marker so a resuming agent can detect whether the evidence was already
-posted:
+marker so a resuming agent — or a concurrent `post-merge-cleanup`
+workflow run — can detect whether the evidence was already posted.
+**Skip the post when a fresh `<!-- idd-cleanup-evidence:` comment
+already exists on the PR**, so the agent and the workflow never stack a
+duplicate; both honor the same guard:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -363,8 +363,8 @@ workflow run — can detect whether the evidence was already posted.
 **Skip the post when a `<!-- idd-cleanup-evidence:` comment recording a
 successful outcome (`applied` / `clean`) already exists on the PR**, so
 the agent and the workflow never stack a duplicate success record; still
-post to correct an existing `failed` / `incomplete` record when your own
-run converged:
+post to correct an existing `failed` / `incomplete` / `permission-blocked`
+record when your own run converged:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -360,8 +360,9 @@ Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
 workflow run — can detect whether the evidence was already posted.
-**Skip the post when a fresh `<!-- idd-cleanup-evidence:` comment
-already exists on the PR**, so the agent and the workflow never stack a
+**Skip the post when a `<!-- idd-cleanup-evidence:` comment already
+exists on the PR** — the check is presence-based (any comment whose body
+starts with that token), so the agent and the workflow never stack a
 duplicate; both honor the same guard:
 
 ```markdown

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -359,13 +359,16 @@ does not re-block the merge; it is an explicit record only.
 Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
-workflow run — can detect whether the evidence was already posted.
-**Skip the post only when this run minimized nothing new and a
-`<!-- idd-cleanup-evidence:` comment recording a successful outcome
-(`applied` / `clean`) already exists on the PR**, so the agent and the
-workflow never stack a duplicate success record. Still post when this
-run minimized candidates, or to correct an existing `failed` /
-`incomplete` / `permission-blocked` record:
+workflow run — can detect that evidence was already posted. The
+**agent-side** rule is status-aware: **skip the post only when this run
+minimized nothing new and a `<!-- idd-cleanup-evidence:` comment
+recording a successful outcome (`applied` / `clean`) already exists on
+the PR**, so the agent never stacks a duplicate success record; still
+post when this run minimized candidates, or to correct an existing
+`failed` / `incomplete` / `permission-blocked` record. The
+`post-merge-cleanup` workflow instead uses a simpler presence-only guard
+(it skips on any existing marker), which suffices for its single-shot
+post-merge run:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -360,10 +360,11 @@ Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
 workflow run — can detect whether the evidence was already posted.
-**Skip the post when a `<!-- idd-cleanup-evidence:` comment already
-exists on the PR** — the check is presence-based (any comment whose body
-starts with that token), so the agent and the workflow never stack a
-duplicate; both honor the same guard:
+**Skip the post when a `<!-- idd-cleanup-evidence:` comment recording a
+successful outcome (`applied` / `clean`) already exists on the PR**, so
+the agent and the workflow never stack a duplicate success record; still
+post to correct an existing `failed` / `incomplete` record when your own
+run converged:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -360,11 +360,12 @@ Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
 workflow run — can detect whether the evidence was already posted.
-**Skip the post when a `<!-- idd-cleanup-evidence:` comment recording a
-successful outcome (`applied` / `clean`) already exists on the PR**, so
-the agent and the workflow never stack a duplicate success record; still
-post to correct an existing `failed` / `incomplete` / `permission-blocked`
-record when your own run converged:
+**Skip the post only when this run minimized nothing new and a
+`<!-- idd-cleanup-evidence:` comment recording a successful outcome
+(`applied` / `clean`) already exists on the PR**, so the agent and the
+workflow never stack a duplicate success record. Still post when this
+run minimized candidates, or to correct an existing `failed` /
+`incomplete` / `permission-blocked` record:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->


### PR DESCRIPTION
Closes #1067

## Problem

The `post-merge-cleanup.yml` workflow guards against duplicate
`idd-cleanup-evidence` comments — it skips posting when one already exists on
the PR. The **agent-side F4 instruction** (`idd-merge.instructions.md`) lacked
the symmetric guard: its evidence step said to post the comment without first
checking for an existing one. Because the workflow runs within seconds of the
merge and the agent's manual F4 typically runs minutes later, the agent stacks
a **duplicate** evidence comment.

Observed dogfooding PR #1063: `@github-actions[bot]` posted
`idd-cleanup-evidence: applied applied:5 …` at 01:18Z (it did the
minimization); the agent's manual F4 then posted a redundant
`idd-cleanup-evidence: clean applied:0 …` at 01:21Z. `docs/idd-comment-minimization.md`
already states the marker exists "so a resuming agent can detect whether the
evidence was already posted" — but only the workflow implemented that check.

## Change

- Add the symmetric **skip-if-present** guard to the agent-side F4 evidence
  step (both the `--apply` path and the GraphQL fallback): skip posting when a
  fresh `<!-- idd-cleanup-evidence:` comment already exists on the PR.
- Document the **`--apply` → `clean`** decision-tree outcome (cleanup already
  converged → do not post a duplicate evidence comment).
- Make the dedup actionable in `docs/idd-comment-minimization.md` (the marker's
  resume-detection purpose now reads as an explicit "skip the duplicate" rule
  honored by both the agent and the workflow).

Edited the `idd-template/` sources; root mirrors regenerated via `sync-docs`.
**No behavior change for repos without the workflow**: with no prior evidence
comment, the agent posts evidence exactly as before (this is purely a
skip-if-already-present guard, never a skip of the cleanup itself).
`idd-merge.instructions.md` sits at ~52% of the per-file phase cap, so the
addition is well clear of the near-ceiling band.

## Verification

- `node scripts/audit-docs.mjs --check` passes (mirror parity + size budgets).
- Full `pnpm run lint:minimum` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup evidence handling to avoid posting duplicate “successful cleanup” comments when a successful record already exists.
  * Allowed follow-up posts when an earlier cleanup result was failed, incomplete, or permission-blocked so stale records can be corrected.
  * Clarified the fallback behavior when cleanup candidates can’t be minimized, ensuring the appropriate blocked-status comment is posted instead of exiting silently.

* **Documentation**
  * Updated cleanup guidance to describe when success evidence should be skipped or updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->