### PR TITLE
feat(discover): surface autopilot-suitability score and below-floor flag in readiness check

### DIFF
--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -12,8 +12,13 @@ import {
   buildAuthoringLabelWarning,
   resolveAuthoringGuardPolicy,
 } from './authoring-label-guard.mjs';
+import {
+  normalizeAutopilotSuitabilityFloor,
+  parseAutopilotSuitability,
+} from './autopilot-suitability.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
 });
@@ -30,7 +35,8 @@ if (isMainModule(import.meta.url)) {
     ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
   const repo =
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const authoringPolicy = resolveAuthoringGuardPolicy(loadPolicy(args.policy));
+  const policyConfig = loadPolicy(args.policy);
+  const authoringPolicy = resolveAuthoringGuardPolicy(policyConfig);
   const summary = await evaluateDiscoverReadiness(args.issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
     loadIssue: buildIssueLoader(owner, repo),
@@ -38,6 +44,8 @@ if (isMainModule(import.meta.url)) {
     findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo),
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+    markerPrefix: resolveMarkerPrefix(policyConfig),
+    autopilotSuitabilityFloor: resolveSuitabilityFloor(policyConfig),
     now: args.now || new Date(),
   });
   if (args.csv) {
@@ -54,6 +62,8 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     loadIssueLabelEvents,
     authoringLabelName = 'status:authoring',
     authoringStaleAgeMs = 4 * 60 * 60 * 1000,
+    markerPrefix,
+    autopilotSuitabilityFloor,
     now = new Date(),
   } = options ?? {};
   if (typeof loadIssue !== 'function') {
@@ -66,6 +76,24 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
       'evaluateDiscoverReadiness requires findRoadmapsByMarker(markerId)',
     );
   }
+  const resolvedMarkerPrefix =
+    typeof markerPrefix === 'string' && markerPrefix.length > 0
+      ? markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  // Delegate range/default validation to the shared normalizer so the 1-5
+  // rule and the default floor cannot drift from the discovery rankers.
+  const suitabilityFloor = normalizeAutopilotSuitabilityFloor(
+    autopilotSuitabilityFloor,
+  );
+  // Parse the authored autopilot-suitability score once per body and derive
+  // the below-floor flag. A null score ("no score") is never below floor.
+  const suitabilitySignal = (body) => {
+    const score = parseAutopilotSuitability(body, resolvedMarkerPrefix);
+    return {
+      autopilotSuitability: score,
+      belowFloor: score !== null && score < suitabilityFloor,
+    };
+  };
   const ready = [];
   const filteredOut = [];
   const unresolvable = [];
@@ -88,6 +116,9 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
         number: issueNumber,
         title: '',
         reasons: [issueReason],
+        // No body is available for a not-found / inaccessible issue, so the
+        // score is "no score" and the issue is never flagged below floor.
+        ...suitabilitySignal(''),
       });
       continue;
     }
@@ -96,6 +127,7 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
         number: issue.number,
         title: issue.title,
         reasons: ['issue_not_open'],
+        ...suitabilitySignal(issue.body),
       });
       continue;
     }
@@ -185,10 +217,12 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
         reasons.add(`blocked_by_open_roadmap_marker:${marker}`);
       }
     }
+    const signal = suitabilitySignal(issue.body);
     if (reasons.size === 0) {
       ready.push({
         number: issue.number,
         title: issue.title,
+        ...signal,
       });
       continue;
     }
@@ -196,6 +230,7 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
       number: issue.number,
       title: issue.title,
       reasons: [...reasons].sort(),
+      ...signal,
     });
   }
   const filteredByReason = countReasons(filteredOut);
@@ -307,8 +342,8 @@ function printHelp() {
 
 Output schema (JSON mode):
   {
-    "ready": [{ "number": 123, "title": "..." }],
-    "filteredOut": [{ "number": 124, "title": "...", "reasons": ["..."] }],
+    "ready": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false }],
+    "filteredOut": [{ "number": 124, "title": "...", "reasons": ["..."], "autopilotSuitability": null, "belowFloor": false }],
     "unresolvable": [{ "issueNumber": 124, "kind": "...", "reference": "...", "reason": "..." }],
     "warnings": [{ "issueNumber": 124, "message": "Warning: ..." }],
     "summary": { "total": 2, "readyCount": 1, "filteredCount": 1, "unresolvableCount": 0, "filteredByReason": { "...": 1 } }
@@ -415,16 +450,21 @@ function countReasons(filteredOut) {
   return counts;
 }
 function renderCsv(summary) {
-  const lines = ['number,title,status,reasons'];
+  const lines = ['number,title,status,reasons,suitability,belowFloor'];
   for (const item of summary.ready) {
-    lines.push(`${item.number},${escapeCsv(item.title)},ready,`);
+    lines.push(
+      `${item.number},${escapeCsv(item.title)},ready,,${formatScore(item.autopilotSuitability)},${item.belowFloor}`,
+    );
   }
   for (const item of summary.filteredOut) {
     lines.push(
-      `${item.number},${escapeCsv(item.title)},filtered,${escapeCsv(item.reasons.join(';'))}`,
+      `${item.number},${escapeCsv(item.title)},filtered,${escapeCsv(item.reasons.join(';'))},${formatScore(item.autopilotSuitability)},${item.belowFloor}`,
     );
   }
   return `${lines.join('\n')}\n`;
+}
+function formatScore(score) {
+  return score === null ? '' : String(score);
 }
 function escapeCsv(value) {
   const text = String(value ?? '');
@@ -511,6 +551,19 @@ function loadPolicy(policyPath) {
   } catch {
     return {};
   }
+}
+function resolveMarkerPrefix(config) {
+  const prefix = config?.markerPrefix;
+  return typeof prefix === 'string' && prefix.length > 0
+    ? prefix
+    : DEFAULT_MARKER_PREFIX;
+}
+function resolveSuitabilityFloor(config) {
+  // Delegate range/default validation to the shared normalizer so the 1-5
+  // rule and the default cannot drift between modules.
+  return normalizeAutopilotSuitabilityFloor(
+    config?.autopilotSuitability?.floor,
+  );
 }
 function runGh(args) {
   try {

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -46,6 +46,7 @@ if (isMainModule(import.meta.url)) {
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
     markerPrefix: resolveMarkerPrefix(policyConfig),
     autopilotSuitabilityFloor: resolveSuitabilityFloor(policyConfig),
+    autopilotSuitabilityEnabled: resolveSuitabilityEnabled(policyConfig),
     now: args.now || new Date(),
   });
   if (args.csv) {
@@ -64,6 +65,7 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     authoringStaleAgeMs = 4 * 60 * 60 * 1000,
     markerPrefix,
     autopilotSuitabilityFloor,
+    autopilotSuitabilityEnabled,
     now = new Date(),
   } = options ?? {};
   if (typeof loadIssue !== 'function') {
@@ -85,9 +87,18 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
   const suitabilityFloor = normalizeAutopilotSuitabilityFloor(
     autopilotSuitabilityFloor,
   );
+  // `autopilotSuitability.enabled: false` is the discovery kill switch: the
+  // ranker ignores the score entirely (see rankAndRouteBySuitability). Mirror
+  // that here so this readiness signal does not flag below-floor work the
+  // operator turned the suitability system off for.
+  const suitabilityEnabled = autopilotSuitabilityEnabled !== false;
   // Parse the authored autopilot-suitability score once per body and derive
-  // the below-floor flag. A null score ("no score") is never below floor.
+  // the below-floor flag. A null score ("no score") is never below floor; when
+  // the kill switch is off, force a fully neutral signal (ignore the score).
   const suitabilitySignal = (body) => {
+    if (!suitabilityEnabled) {
+      return { autopilotSuitability: null, belowFloor: false };
+    }
     const score = parseAutopilotSuitability(body, resolvedMarkerPrefix);
     return {
       autopilotSuitability: score,
@@ -564,6 +575,11 @@ function resolveSuitabilityFloor(config) {
   return normalizeAutopilotSuitabilityFloor(
     config?.autopilotSuitability?.floor,
   );
+}
+function resolveSuitabilityEnabled(config) {
+  // Match resolveAutopilotSuitabilityEnabled in discover-orphan-filter.mts:
+  // the kill switch is off only when explicitly set to `false`.
+  return config?.autopilotSuitability?.enabled !== false;
 }
 function runGh(args) {
   try {

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -14,7 +14,13 @@ import {
   buildAuthoringLabelWarning,
   resolveAuthoringGuardPolicy,
 } from './authoring-label-guard.mts';
+import {
+  normalizeAutopilotSuitabilityFloor,
+  parseAutopilotSuitability,
+} from './autopilot-suitability.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
@@ -23,14 +29,29 @@ const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
 
 type InaccessibleIssueSentinel = typeof INACCESSIBLE_ISSUE_SENTINEL;
 
+/**
+ * The authored autopilot-suitability signal for one evaluated issue.
+ *
+ * `autopilotSuitability` is the parsed 1-5 score, or `null` ("no score")
+ * when the marker is absent, out of range, or incoherent (fail-safe).
+ * `belowFloor` is `true` only when a score is present and strictly below
+ * the configured floor; a "no score" issue is never flagged below floor,
+ * matching the existing score semantics. The signal is advisory evidence
+ * only — it never changes whether an issue is `ready` or `filteredOut`.
+ */
+export interface ReadinessSuitabilitySignal {
+  autopilotSuitability: number | null;
+  belowFloor: boolean;
+}
+
 /** One issue that passed every readiness filter. */
-export interface ReadinessReadyIssue {
+export interface ReadinessReadyIssue extends ReadinessSuitabilitySignal {
   number: number;
   title: string;
 }
 
 /** One issue removed by a readiness filter, with the failed reasons. */
-export interface ReadinessFilteredIssue {
+export interface ReadinessFilteredIssue extends ReadinessSuitabilitySignal {
   number: number;
   title: string;
   reasons: string[];
@@ -76,6 +97,8 @@ interface EvaluateDiscoverReadinessOptions {
   loadIssueLabelEvents?: (issueNumber: number) => unknown;
   authoringLabelName?: string;
   authoringStaleAgeMs?: number;
+  markerPrefix?: string;
+  autopilotSuitabilityFloor?: number;
   now?: Date | string;
 }
 
@@ -104,7 +127,8 @@ if (isMainModule(import.meta.url)) {
     ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
   const repo =
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const authoringPolicy = resolveAuthoringGuardPolicy(loadPolicy(args.policy));
+  const policyConfig = loadPolicy(args.policy);
+  const authoringPolicy = resolveAuthoringGuardPolicy(policyConfig);
 
   const summary = await evaluateDiscoverReadiness(args.issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
@@ -113,6 +137,8 @@ if (isMainModule(import.meta.url)) {
     findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo),
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+    markerPrefix: resolveMarkerPrefix(policyConfig),
+    autopilotSuitabilityFloor: resolveSuitabilityFloor(policyConfig),
     now: args.now || new Date(),
   });
 
@@ -134,6 +160,8 @@ export async function evaluateDiscoverReadiness(
     loadIssueLabelEvents,
     authoringLabelName = 'status:authoring',
     authoringStaleAgeMs = 4 * 60 * 60 * 1000,
+    markerPrefix,
+    autopilotSuitabilityFloor,
     now = new Date(),
   } = options ?? {};
   if (typeof loadIssue !== 'function') {
@@ -146,6 +174,25 @@ export async function evaluateDiscoverReadiness(
       'evaluateDiscoverReadiness requires findRoadmapsByMarker(markerId)',
     );
   }
+
+  const resolvedMarkerPrefix =
+    typeof markerPrefix === 'string' && markerPrefix.length > 0
+      ? markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  // Delegate range/default validation to the shared normalizer so the 1-5
+  // rule and the default floor cannot drift from the discovery rankers.
+  const suitabilityFloor = normalizeAutopilotSuitabilityFloor(
+    autopilotSuitabilityFloor,
+  );
+  // Parse the authored autopilot-suitability score once per body and derive
+  // the below-floor flag. A null score ("no score") is never below floor.
+  const suitabilitySignal = (body: string): ReadinessSuitabilitySignal => {
+    const score = parseAutopilotSuitability(body, resolvedMarkerPrefix);
+    return {
+      autopilotSuitability: score,
+      belowFloor: score !== null && score < suitabilityFloor,
+    };
+  };
 
   const ready: ReadinessReadyIssue[] = [];
   const filteredOut: ReadinessFilteredIssue[] = [];
@@ -171,6 +218,9 @@ export async function evaluateDiscoverReadiness(
         number: issueNumber,
         title: '',
         reasons: [issueReason],
+        // No body is available for a not-found / inaccessible issue, so the
+        // score is "no score" and the issue is never flagged below floor.
+        ...suitabilitySignal(''),
       });
       continue;
     }
@@ -179,6 +229,7 @@ export async function evaluateDiscoverReadiness(
         number: issue.number,
         title: issue.title,
         reasons: ['issue_not_open'],
+        ...suitabilitySignal(issue.body),
       });
       continue;
     }
@@ -273,10 +324,12 @@ export async function evaluateDiscoverReadiness(
       }
     }
 
+    const signal = suitabilitySignal(issue.body);
     if (reasons.size === 0) {
       ready.push({
         number: issue.number,
         title: issue.title,
+        ...signal,
       });
       continue;
     }
@@ -285,6 +338,7 @@ export async function evaluateDiscoverReadiness(
       number: issue.number,
       title: issue.title,
       reasons: [...reasons].sort(),
+      ...signal,
     });
   }
 
@@ -412,8 +466,8 @@ function printHelp() {
 
 Output schema (JSON mode):
   {
-    "ready": [{ "number": 123, "title": "..." }],
-    "filteredOut": [{ "number": 124, "title": "...", "reasons": ["..."] }],
+    "ready": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false }],
+    "filteredOut": [{ "number": 124, "title": "...", "reasons": ["..."], "autopilotSuitability": null, "belowFloor": false }],
     "unresolvable": [{ "issueNumber": 124, "kind": "...", "reference": "...", "reason": "..." }],
     "warnings": [{ "issueNumber": 124, "message": "Warning: ..." }],
     "summary": { "total": 2, "readyCount": 1, "filteredCount": 1, "unresolvableCount": 0, "filteredByReason": { "...": 1 } }
@@ -554,16 +608,22 @@ function countReasons(
 }
 
 function renderCsv(summary: ReadinessSummary): string {
-  const lines = ['number,title,status,reasons'];
+  const lines = ['number,title,status,reasons,suitability,belowFloor'];
   for (const item of summary.ready) {
-    lines.push(`${item.number},${escapeCsv(item.title)},ready,`);
+    lines.push(
+      `${item.number},${escapeCsv(item.title)},ready,,${formatScore(item.autopilotSuitability)},${item.belowFloor}`,
+    );
   }
   for (const item of summary.filteredOut) {
     lines.push(
-      `${item.number},${escapeCsv(item.title)},filtered,${escapeCsv(item.reasons.join(';'))}`,
+      `${item.number},${escapeCsv(item.title)},filtered,${escapeCsv(item.reasons.join(';'))},${formatScore(item.autopilotSuitability)},${item.belowFloor}`,
     );
   }
   return `${lines.join('\n')}\n`;
+}
+
+function formatScore(score: number | null): string {
+  return score === null ? '' : String(score);
 }
 
 function escapeCsv(value: unknown): string {
@@ -659,6 +719,22 @@ function loadPolicy(policyPath: string): unknown {
   } catch {
     return {};
   }
+}
+
+function resolveMarkerPrefix(config: unknown): string {
+  const prefix = (config as { markerPrefix?: unknown } | null)?.markerPrefix;
+  return typeof prefix === 'string' && prefix.length > 0
+    ? prefix
+    : DEFAULT_MARKER_PREFIX;
+}
+
+function resolveSuitabilityFloor(config: unknown): number {
+  // Delegate range/default validation to the shared normalizer so the 1-5
+  // rule and the default cannot drift between modules.
+  return normalizeAutopilotSuitabilityFloor(
+    (config as { autopilotSuitability?: { floor?: unknown } } | null)
+      ?.autopilotSuitability?.floor,
+  );
 }
 
 function runGh(args: string[]): string {

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -36,8 +36,11 @@ type InaccessibleIssueSentinel = typeof INACCESSIBLE_ISSUE_SENTINEL;
  * when the marker is absent, out of range, or incoherent (fail-safe).
  * `belowFloor` is `true` only when a score is present and strictly below
  * the configured floor; a "no score" issue is never flagged below floor,
- * matching the existing score semantics. The signal is advisory evidence
- * only — it never changes whether an issue is `ready` or `filteredOut`.
+ * matching the existing score semantics. When the `autopilotSuitability`
+ * kill switch is off (`enabled: false`), the signal is forced fully neutral
+ * (`null` / `false`), mirroring the discovery ranker that ignores the score
+ * entirely. The signal is advisory evidence only — it never changes whether
+ * an issue is `ready` or `filteredOut`.
  */
 export interface ReadinessSuitabilitySignal {
   autopilotSuitability: number | null;
@@ -99,6 +102,7 @@ interface EvaluateDiscoverReadinessOptions {
   authoringStaleAgeMs?: number;
   markerPrefix?: string;
   autopilotSuitabilityFloor?: number;
+  autopilotSuitabilityEnabled?: boolean;
   now?: Date | string;
 }
 
@@ -139,6 +143,7 @@ if (isMainModule(import.meta.url)) {
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
     markerPrefix: resolveMarkerPrefix(policyConfig),
     autopilotSuitabilityFloor: resolveSuitabilityFloor(policyConfig),
+    autopilotSuitabilityEnabled: resolveSuitabilityEnabled(policyConfig),
     now: args.now || new Date(),
   });
 
@@ -162,6 +167,7 @@ export async function evaluateDiscoverReadiness(
     authoringStaleAgeMs = 4 * 60 * 60 * 1000,
     markerPrefix,
     autopilotSuitabilityFloor,
+    autopilotSuitabilityEnabled,
     now = new Date(),
   } = options ?? {};
   if (typeof loadIssue !== 'function') {
@@ -184,9 +190,18 @@ export async function evaluateDiscoverReadiness(
   const suitabilityFloor = normalizeAutopilotSuitabilityFloor(
     autopilotSuitabilityFloor,
   );
+  // `autopilotSuitability.enabled: false` is the discovery kill switch: the
+  // ranker ignores the score entirely (see rankAndRouteBySuitability). Mirror
+  // that here so this readiness signal does not flag below-floor work the
+  // operator turned the suitability system off for.
+  const suitabilityEnabled = autopilotSuitabilityEnabled !== false;
   // Parse the authored autopilot-suitability score once per body and derive
-  // the below-floor flag. A null score ("no score") is never below floor.
+  // the below-floor flag. A null score ("no score") is never below floor; when
+  // the kill switch is off, force a fully neutral signal (ignore the score).
   const suitabilitySignal = (body: string): ReadinessSuitabilitySignal => {
+    if (!suitabilityEnabled) {
+      return { autopilotSuitability: null, belowFloor: false };
+    }
     const score = parseAutopilotSuitability(body, resolvedMarkerPrefix);
     return {
       autopilotSuitability: score,
@@ -734,6 +749,15 @@ function resolveSuitabilityFloor(config: unknown): number {
   return normalizeAutopilotSuitabilityFloor(
     (config as { autopilotSuitability?: { floor?: unknown } } | null)
       ?.autopilotSuitability?.floor,
+  );
+}
+
+function resolveSuitabilityEnabled(config: unknown): boolean {
+  // Match resolveAutopilotSuitabilityEnabled in discover-orphan-filter.mts:
+  // the kill switch is off only when explicitly set to `false`.
+  return (
+    (config as { autopilotSuitability?: { enabled?: unknown } } | null)
+      ?.autopilotSuitability?.enabled !== false
   );
 }
 

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -506,3 +506,29 @@ test('parses the suitability score using a configured marker prefix', async () =
   assert.equal(summary.ready[0].autopilotSuitability, 1);
   assert.equal(summary.ready[0].belowFloor, true);
 });
+
+test('forces a neutral signal when the suitability kill switch is off', async () => {
+  const summary = await evaluateDiscoverReadiness([1501], {
+    autopilotSuitabilityEnabled: false,
+    loadIssue: async () => ({
+      number: 1501,
+      title: 'below floor but kill switch off',
+      state: 'OPEN',
+      body: 'human-led\n<!-- idd-skill-autopilot-suitability: 2 -->',
+      labels: [],
+    }),
+    findRoadmapsByMarker: async () => [],
+  });
+
+  // Kill switch off: the score is ignored entirely, so the signal is neutral
+  // even though the body carries a below-floor score. Classification is
+  // unchanged — the issue is still ready.
+  assert.deepEqual(summary.ready, [
+    {
+      number: 1501,
+      title: 'below floor but kill switch off',
+      autopilotSuitability: null,
+      belowFloor: false,
+    },
+  ]);
+});

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -173,7 +173,14 @@ test('open roadmap dependencies are ignored as parent epics', async () => {
   });
 
   assert.deepEqual(summary.filteredOut, []);
-  assert.deepEqual(summary.ready, [{ number: 401, title: 'candidate' }]);
+  assert.deepEqual(summary.ready, [
+    {
+      number: 401,
+      title: 'candidate',
+      autopilotSuitability: null,
+      belowFloor: false,
+    },
+  ]);
 });
 
 test('returns empty unresolvable list when include-unresolvable is disabled', async () => {
@@ -247,6 +254,8 @@ test('treats inaccessible target issue as unresolvable', async () => {
       number: 701,
       title: '',
       reasons: ['issue_inaccessible'],
+      autopilotSuitability: null,
+      belowFloor: false,
     },
   ]);
   assert.deepEqual(summary.unresolvable, [
@@ -316,4 +325,184 @@ test('isInaccessibleIssueLookupError fails closed on auth, rate-limit, and 404',
     isInaccessibleIssueLookupError(ghError('connect ETIMEDOUT')),
     false,
   );
+});
+
+test('surfaces autopilot-suitability score and below-floor flag without changing classification', async () => {
+  const issues = new Map([
+    [
+      1001,
+      {
+        number: 1001,
+        title: 'scored above floor',
+        state: 'OPEN',
+        body: 'work\n<!-- idd-skill-autopilot-suitability: 4 -->',
+        labels: [],
+      },
+    ],
+    [
+      1002,
+      {
+        number: 1002,
+        title: 'scored below floor',
+        state: 'OPEN',
+        body: 'human-led\n<!-- idd-skill-autopilot-suitability: 2 -->',
+        labels: [],
+      },
+    ],
+    [
+      1003,
+      {
+        number: 1003,
+        title: 'unscored',
+        state: 'OPEN',
+        body: 'no marker here',
+        labels: [],
+      },
+    ],
+  ]);
+
+  const summary = await evaluateDiscoverReadiness([1001, 1002, 1003], {
+    loadIssue: async (number) => issues.get(number) ?? null,
+    findRoadmapsByMarker: async () => [],
+  });
+
+  // Signal-only: every issue clears the readiness filters and stays `ready`,
+  // including the below-floor one. The new fields never reclassify.
+  assert.deepEqual(
+    summary.ready.map((item) => item.number),
+    [1001, 1002, 1003],
+  );
+  assert.equal(summary.filteredOut.length, 0);
+
+  const byNumber = new Map(summary.ready.map((item) => [item.number, item]));
+  assert.deepEqual(
+    { ...byNumber.get(1001) },
+    {
+      number: 1001,
+      title: 'scored above floor',
+      autopilotSuitability: 4,
+      belowFloor: false,
+    },
+  );
+  assert.deepEqual(
+    { ...byNumber.get(1002) },
+    {
+      number: 1002,
+      title: 'scored below floor',
+      autopilotSuitability: 2,
+      belowFloor: true,
+    },
+  );
+  assert.deepEqual(
+    { ...byNumber.get(1003) },
+    {
+      number: 1003,
+      title: 'unscored',
+      autopilotSuitability: null,
+      belowFloor: false,
+    },
+  );
+});
+
+test('surfaces the suitability signal on filtered-out issues too', async () => {
+  const summary = await evaluateDiscoverReadiness([1101], {
+    loadIssue: async () => ({
+      number: 1101,
+      title: 'blocked and scored',
+      state: 'OPEN',
+      body: 'blocked\n<!-- idd-skill-autopilot-suitability: 5 -->',
+      labels: [{ name: 'status:needs-decision' }],
+    }),
+    findRoadmapsByMarker: async () => [],
+  });
+
+  assert.equal(summary.ready.length, 0);
+  assert.deepEqual(summary.filteredOut, [
+    {
+      number: 1101,
+      title: 'blocked and scored',
+      reasons: ['label:status:needs-decision'],
+      autopilotSuitability: 5,
+      belowFloor: false,
+    },
+  ]);
+});
+
+test('honors a configured floor and treats an out-of-range score as no score', async () => {
+  const issues = new Map([
+    [
+      1201,
+      {
+        number: 1201,
+        title: 'score 3 under floor 4',
+        state: 'OPEN',
+        body: '<!-- idd-skill-autopilot-suitability: 3 -->',
+        labels: [],
+      },
+    ],
+    [
+      1202,
+      {
+        number: 1202,
+        title: 'out of range score',
+        state: 'OPEN',
+        body: '<!-- idd-skill-autopilot-suitability: 9 -->',
+        labels: [],
+      },
+    ],
+  ]);
+
+  const summary = await evaluateDiscoverReadiness([1201, 1202], {
+    autopilotSuitabilityFloor: 4,
+    loadIssue: async (number) => issues.get(number) ?? null,
+    findRoadmapsByMarker: async () => [],
+  });
+
+  const byNumber = new Map(summary.ready.map((item) => [item.number, item]));
+  assert.equal(byNumber.get(1201)?.autopilotSuitability, 3);
+  assert.equal(byNumber.get(1201)?.belowFloor, true);
+  // An out-of-range marker is "no score" (fail-safe) and never below floor.
+  assert.equal(byNumber.get(1202)?.autopilotSuitability, null);
+  assert.equal(byNumber.get(1202)?.belowFloor, false);
+});
+
+test('surfaces the suitability signal on a not-open scored issue', async () => {
+  const summary = await evaluateDiscoverReadiness([1401], {
+    loadIssue: async () => ({
+      number: 1401,
+      title: 'closed but scored',
+      state: 'CLOSED',
+      body: 'done\n<!-- idd-skill-autopilot-suitability: 3 -->',
+      labels: [],
+    }),
+    findRoadmapsByMarker: async () => [],
+  });
+
+  assert.equal(summary.ready.length, 0);
+  assert.deepEqual(summary.filteredOut, [
+    {
+      number: 1401,
+      title: 'closed but scored',
+      reasons: ['issue_not_open'],
+      autopilotSuitability: 3,
+      belowFloor: false,
+    },
+  ]);
+});
+
+test('parses the suitability score using a configured marker prefix', async () => {
+  const summary = await evaluateDiscoverReadiness([1301], {
+    markerPrefix: 'acme',
+    loadIssue: async () => ({
+      number: 1301,
+      title: 'custom prefix',
+      state: 'OPEN',
+      body: '<!-- acme-autopilot-suitability: 1 -->',
+      labels: [],
+    }),
+    findRoadmapsByMarker: async () => [],
+  });
+
+  assert.equal(summary.ready[0].autopilotSuitability, 1);
+  assert.equal(summary.ready[0].belowFloor, true);
 });


### PR DESCRIPTION
## Summary

`discover-readiness-check` now reports each evaluated issue's authored
autopilot-suitability score and a derived below-floor flag, so an autopilot
loop can tell below-floor, human-oriented `ready` issues apart from
autopilot-actionable ones without a separate score lookup.

## What changed

- Added `autopilotSuitability` (the parsed 1-5 score, or `null` = "no score")
  and `belowFloor` (boolean) to every evaluated-issue entry — both `ready`
  and `filteredOut`, at every push site.
- Reuses the shared `parseAutopilotSuitability` parser and the
  `autopilotSuitability.floor` config (default `3`) already used by the
  discovery rankers, resolved the same way `discover-orphan-filter` does
  (top-level `markerPrefix`, nested `autopilotSuitability.floor`).
- Fail-safe: a missing / out-of-range / incoherent score is "no score" and is
  never flagged below floor.
- **Signal-only**: which issues are `ready` vs `filteredOut` is unchanged —
  the score is computed after the readiness reasons are fully built and only
  spread into the output entries.
- Surfaced the new fields in the CSV view and the `--help` schema doc.

## Tests

Added cases for scored-above-floor, scored-below-floor, unscored,
filtered+scored, not-open+scored, configured floor, out-of-range, and a custom
marker prefix; the existing classification assertions are unchanged.

## Verification

`pnpm test`, `pnpm run build:check`, biome, dprint, markdownlint, cspell, and
`node scripts/audit-docs.mjs --check` all pass. The generated
`scripts/discover-readiness-check.mjs` is regenerated by `pnpm run build`,
not hand-edited.

Closes #1070


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “autopilot suitability” scoring to readiness results, including a floor-based `belowFloor` indicator.
  * Extended JSON and CSV outputs with `autopilotSuitability` and `belowFloor` fields for `ready` and `filteredOut` issues.
  * Added support for configurable suitability floors, marker prefixes, and an enable/disable kill switch for scoring.

* **Bug Fixes**
  * Ensured inaccessible and unscored issues preserve prior behavior (no below-floor flag when no score is available).
  * Updated below-floor classification to follow the configured floor and treat out-of-range markers as no score.

* **Tests**
  * Expanded coverage for scoring, parsing, configuration behavior, and kill-switch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->