### PR TITLE
perf(discover): reduce discover-roadmap-graph latency on large roadmaps

### DIFF
--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -337,10 +337,20 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
     if (cached) {
       return cached;
     }
+    // #1072: skip the per-node native sub-issue GraphQL round-trip when the
+    // REST `sub_issues_summary.total` proves the issue has zero native
+    // sub-issues. `loadSubIssues` would return `[]` in that case, so the
+    // reference set — and every downstream edge, node, provenance path, and
+    // diagnostic — is byte-identical. A null total (summary absent / unknown)
+    // still queries, so behavior is unchanged for callers without the field.
+    const nativeSubIssues =
+      issue.subIssueSummaryTotal === 0
+        ? []
+        : normalizeSubIssueReferences(await loadSubIssues(issue.number));
     const references = [
       ...extractTaskListReferences(issue.body),
       ...extractKeywordReferences(issue.body, { currentRepoRef }),
-      ...normalizeSubIssueReferences(await loadSubIssues(issue.number)),
+      ...nativeSubIssues,
     ];
     referenceCache.set(issue.number, references);
     return references;
@@ -1119,7 +1129,20 @@ function normalizeIssue(issue) {
     body: String(issue.body ?? ''),
     labels: normalizeLabels(issue.labels),
     isPullRequest: Boolean(issue.pull_request),
+    subIssueSummaryTotal: extractSubIssueSummaryTotal(issue.sub_issues_summary),
   };
+}
+/**
+ * Read the native sub-issue count from a REST `sub_issues_summary` object.
+ * Returns the non-negative integer `total`, or null when the field is absent
+ * or not a coherent count — the "unknown" case that keeps the sub-issue query
+ * (fail-safe), so only a proven `0` skips it.
+ */
+function extractSubIssueSummaryTotal(summary) {
+  const total = summary?.total;
+  return typeof total === 'number' && Number.isInteger(total) && total >= 0
+    ? total
+    : null;
 }
 function normalizeLabels(labelsInput) {
   if (!labelsInput) {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -269,6 +269,11 @@ interface NormalizedIssue {
   body: string;
   labels: Set<string>;
   isPullRequest: boolean;
+  // Native GitHub sub-issue count from the REST `sub_issues_summary.total`, or
+  // null when the field is absent (e.g. injected test issues). `0` lets the
+  // traversal skip the per-node sub-issue GraphQL round-trip (#1072); null is
+  // "unknown" and falls back to querying so behavior is unchanged.
+  subIssueSummaryTotal: number | null;
 }
 
 interface RoadmapNodeRecord {
@@ -665,10 +670,20 @@ export async function enumerateRoadmapGraph(
     if (cached) {
       return cached;
     }
+    // #1072: skip the per-node native sub-issue GraphQL round-trip when the
+    // REST `sub_issues_summary.total` proves the issue has zero native
+    // sub-issues. `loadSubIssues` would return `[]` in that case, so the
+    // reference set — and every downstream edge, node, provenance path, and
+    // diagnostic — is byte-identical. A null total (summary absent / unknown)
+    // still queries, so behavior is unchanged for callers without the field.
+    const nativeSubIssues =
+      issue.subIssueSummaryTotal === 0
+        ? []
+        : normalizeSubIssueReferences(await loadSubIssues(issue.number));
     const references = [
       ...extractTaskListReferences(issue.body),
       ...extractKeywordReferences(issue.body, { currentRepoRef }),
-      ...normalizeSubIssueReferences(await loadSubIssues(issue.number)),
+      ...nativeSubIssues,
     ];
     referenceCache.set(issue.number, references);
     return references;
@@ -1564,6 +1579,7 @@ function normalizeIssue(issue: {
   body?: unknown;
   labels?: unknown;
   pull_request?: unknown;
+  sub_issues_summary?: unknown;
 }): NormalizedIssue {
   return {
     number: Number.parseInt(String(issue.number ?? issue.id ?? 0), 10),
@@ -1572,7 +1588,21 @@ function normalizeIssue(issue: {
     body: String(issue.body ?? ''),
     labels: normalizeLabels(issue.labels),
     isPullRequest: Boolean(issue.pull_request),
+    subIssueSummaryTotal: extractSubIssueSummaryTotal(issue.sub_issues_summary),
   };
+}
+
+/**
+ * Read the native sub-issue count from a REST `sub_issues_summary` object.
+ * Returns the non-negative integer `total`, or null when the field is absent
+ * or not a coherent count — the "unknown" case that keeps the sub-issue query
+ * (fail-safe), so only a proven `0` skips it.
+ */
+function extractSubIssueSummaryTotal(summary: unknown): number | null {
+  const total = (summary as { total?: unknown } | null)?.total;
+  return typeof total === 'number' && Number.isInteger(total) && total >= 0
+    ? total
+    : null;
 }
 
 function normalizeLabels(labelsInput: unknown): Set<string> {

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -476,6 +476,160 @@ test('includes GitHub sub-issue relationships in the graph', async () => {
   assert.deepEqual(graph.executionCandidates, [501]);
 });
 
+test('skips the native sub-issue query when sub_issues_summary.total is zero (#1072)', async () => {
+  const issues = new Map<number, unknown>([
+    [
+      600,
+      {
+        ...roadmapIssue(600, '- [ ] #601\n- [ ] #602', 'root-roadmap'),
+        sub_issues_summary: { total: 0, completed: 0, percent_completed: 0 },
+      },
+    ],
+    [
+      601,
+      { ...executionIssue(601, 'alpha'), sub_issues_summary: { total: 0 } },
+    ],
+    [602, { ...executionIssue(602, 'beta'), sub_issues_summary: { total: 0 } }],
+  ]);
+  let subIssueCalls = 0;
+
+  const graph = await enumerateRoadmapGraph(600, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    loadSubIssues: async (issueNumber) => {
+      subIssueCalls += 1;
+      return issueNumber === 600 ? [601, 602] : [];
+    },
+  });
+
+  // Reduced request count: every node proves zero native sub-issues via its
+  // summary, so the per-node sub-issue GraphQL round-trip is never made.
+  assert.equal(subIssueCalls, 0);
+  // Body task-list references are still traversed, so the graph is identical.
+  assert.deepEqual(graph.executionCandidates, [601, 602]);
+  assert.deepEqual(
+    graph.edges.map(
+      (edge) => `${edge.source}->${edge.target}:${edge.relationship}`,
+    ),
+    ['600->601:task-list', '600->602:task-list'],
+  );
+});
+
+test('still queries native sub-issues when sub_issues_summary.total is positive (#1072)', async () => {
+  const issues = new Map<number, unknown>([
+    [
+      610,
+      {
+        ...roadmapIssue(610, '', 'root-roadmap'),
+        sub_issues_summary: { total: 1 },
+      },
+    ],
+    [
+      611,
+      { ...executionIssue(611, 'child'), sub_issues_summary: { total: 0 } },
+    ],
+  ]);
+  let subIssueCalls = 0;
+
+  const graph = await enumerateRoadmapGraph(610, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    loadSubIssues: async (issueNumber) => {
+      subIssueCalls += 1;
+      return issueNumber === 610 ? [611] : [];
+    },
+  });
+
+  // Only the root (total:1) queries; the leaf #611 (total:0) is skipped.
+  assert.equal(subIssueCalls, 1);
+  assert.deepEqual(graph.edges, [
+    {
+      source: 610,
+      target: 611,
+      relationship: 'sub-issue',
+      evidence: 'GitHub sub-issue #611',
+    },
+  ]);
+  assert.deepEqual(graph.executionCandidates, [611]);
+});
+
+test('still queries native sub-issues when the summary is absent (fail-safe, #1072)', async () => {
+  const issues = new Map([
+    [620, roadmapIssue(620, '', 'root-roadmap')],
+    [621, executionIssue(621, 'child')],
+  ]);
+  let subIssueCalls = 0;
+
+  await enumerateRoadmapGraph(620, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    loadSubIssues: async (issueNumber) => {
+      subIssueCalls += 1;
+      return issueNumber === 620 ? [621] : [];
+    },
+  });
+
+  // No summary on either issue -> total unknown -> the query still runs for
+  // every node, so the skip never regresses callers without the field.
+  assert.equal(subIssueCalls, 2);
+});
+
+test('treats a malformed sub_issues_summary.total as unknown and still queries (#1072)', async () => {
+  // Only a coherent non-negative integer `0` skips; negative, non-integer, and
+  // string totals are "unknown" and must still query (fail-safe).
+  for (const malformedTotal of [-1, 1.5, '0', Number.NaN] as unknown[]) {
+    const issues = new Map<number, unknown>([
+      [
+        630,
+        {
+          ...roadmapIssue(630, '', 'root-roadmap'),
+          sub_issues_summary: { total: malformedTotal },
+        },
+      ],
+      [
+        631,
+        { ...executionIssue(631, 'child'), sub_issues_summary: { total: 0 } },
+      ],
+    ]);
+    let subIssueCalls = 0;
+
+    await enumerateRoadmapGraph(630, {
+      loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+      loadSubIssues: async (issueNumber) => {
+        subIssueCalls += 1;
+        return issueNumber === 630 ? [631] : [];
+      },
+    });
+
+    // #630's total is malformed -> unknown -> still queried; #631 (total:0)
+    // is skipped, so exactly one query is made regardless of the bad value.
+    assert.equal(subIssueCalls, 1, `total=${String(malformedTotal)}`);
+  }
+});
+
+test('never emits subIssueSummaryTotal in the report node shape (#1072)', async () => {
+  const issues = new Map<number, unknown>([
+    [
+      640,
+      {
+        ...roadmapIssue(640, '- [ ] #641', 'root-roadmap'),
+        sub_issues_summary: { total: 0 },
+      },
+    ],
+    [641, { ...executionIssue(641, 'leaf'), sub_issues_summary: { total: 0 } }],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(640, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  // The internal summary count must never leak into the byte-stable report
+  // node shape (it is a traversal-only field on NormalizedIssue).
+  for (const node of graph.nodes) {
+    assert.ok(
+      !Object.hasOwn(node, 'subIssueSummaryTotal'),
+      `node #${node.number} unexpectedly emitted subIssueSummaryTotal`,
+    );
+  }
+});
+
 test('surfaces incomplete descendant lookups instead of silently dropping them', async () => {
   const issues = new Map([[550, roadmapIssue(550, '', 'root-roadmap')]]);
 


### PR DESCRIPTION
## Summary

`discover-roadmap-graph` resolved each node with **two** round-trips — a REST
issue fetch (needed for the body) plus a paginated GraphQL `subIssues` query.
The REST issue payload already carries `sub_issues_summary.total`, so when it is
`0` the sub-issue query is provably empty and is now **skipped**, removing the
avoidable second round-trip for every node with no native sub-issues — the
common case (e.g. roadmap #612's task-list children).

## What changed

- `normalizeIssue` reads `sub_issues_summary.total` into a new internal
  `NormalizedIssue.subIssueSummaryTotal` (via `extractSubIssueSummaryTotal`).
- `getReferences` uses `[]` for native sub-issues when
  `subIssueSummaryTotal === 0` instead of calling `loadSubIssues`.
- **Fail-safe**: a null total (summary absent — e.g. injected test issues — or
  malformed: negative / non-integer / string / NaN) is "unknown" and still
  queries, so callers without the field are unaffected.

## Why semantics are preserved

`loadSubIssues` returns `[]` for an issue with zero native sub-issues, and the
REST `sub_issues_summary.total` counts exactly those same direct native
sub-issues, so `total === 0 ⟺ empty connection`. Body task-list / keyword
references are still extracted independently, so every edge, node, provenance
path, cycle, duplicate, and unresolved diagnostic is byte-identical. The new
field is internal to the traversal — it is never emitted in the report node
shape (asserted by a test), so the `discover-roadmap-union.schema.json` output
contract is unchanged.

## Reduced request count

For a flat task-list roadmap of N children (none with native sub-issues), this
removes N+1 GraphQL sub-issue round-trips, roughly halving the traversal's gh
calls. The live `gh api repos/{owner}/{repo}/issues/{n}` payload returns
`sub_issues_summary` by default on github.com (verified against this repo's
#1069 / #1072, both `total: 0`), so the gain applies in production; the
fail-safe means a hypothetical API/GHES version omitting the field degrades
silently to the prior behavior rather than misbehaving.

This is the focused per-node round-trip reduction the issue calls for, kept
small and semantics-preserving. Full I/O parallelization would require
converting the synchronous `execFileSync` gh layer to async across every call
site (a broader, separate change) and is intentionally out of scope.

## Tests

`tests/discover-roadmap-graph.test.mts` — skip-on-zero (reduced request count:
`loadSubIssues` never called, graph derived from body refs), still-query on
`total > 0`, fail-safe on absent and malformed totals, and a shape-stability
assertion that `subIssueSummaryTotal` is never emitted on report nodes.

## Verification

`pnpm test` (1266), `pnpm run build:check`, biome, dprint, markdownlint, cspell,
and `node scripts/audit-docs.mjs --check` all pass. The generated
`scripts/discover-roadmap-graph.mjs` is regenerated by `pnpm run build`, not
hand-edited.

Closes #1072
