### PR TITLE
feat(idd): add the idd-roadmap-audit-execute helper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -36,6 +36,7 @@ scripts/forced-handoff-marker.mjs linguist-generated=true
 scripts/helper-runtime-manifest.mjs linguist-generated=true
 scripts/idd-doctor.mjs linguist-generated=true
 scripts/idd-merge-execute.mjs linguist-generated=true
+scripts/idd-roadmap-audit-execute.mjs linguist-generated=true
 scripts/live-status-digest.mjs linguist-generated=true
 scripts/merged-pr-feedback-sweep.mjs linguist-generated=true
 scripts/minimize-superseded-markers.mjs linguist-generated=true

--- a/bin/idd-roadmap-audit-execute.mjs
+++ b/bin/idd-roadmap-audit-execute.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-roadmap-audit-execute.mts
+//
+// The bin/idd-roadmap-audit-execute.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/idd-roadmap-audit-execute.mjs');

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "idd-resume-route-selection": "./bin/idd-resume-route-selection.mjs",
     "idd-review-activity-snapshot": "./bin/idd-review-activity-snapshot.mjs",
     "idd-review-disposition-verify": "./bin/idd-review-disposition-verify.mjs",
+    "idd-roadmap-audit-execute": "./bin/idd-roadmap-audit-execute.mjs",
     "idd-stalled-session-quiet-check": "./bin/idd-stalled-session-quiet-check.mjs",
     "idd-suitability-triage": "./bin/idd-suitability-triage.mjs"
   },

--- a/schemas/idd-roadmap-audit-execute.schema.json
+++ b/schemas/idd-roadmap-audit-execute.schema.json
@@ -49,6 +49,7 @@
               "childless",
               "open-child",
               "nested-roadmap",
+              "open-linked-pr",
               "unresolved-reference",
               "inaccessible-reference",
               "cycle"

--- a/schemas/idd-roadmap-audit-execute.schema.json
+++ b/schemas/idd-roadmap-audit-execute.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/idd-roadmap-audit-execute.schema.json",
+  "title": "IDD Roadmap Audit Execute",
+  "description": "A1.5 roadmap-completion-audit verdict and (under --apply) execution result for a roadmap issue.",
+  "type": "object",
+  "required": [
+    "protocolVersion",
+    "decisionAuthority",
+    "mode",
+    "roadmapNumber",
+    "ready",
+    "blockers",
+    "evidenceBody",
+    "closed",
+    "claimReleased",
+    "result"
+  ],
+  "properties": {
+    "protocolVersion": {
+      "type": "string",
+      "pattern": "^1$"
+    },
+    "decisionAuthority": {
+      "type": "string",
+      "enum": ["instructions"]
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["dry-run", "apply"]
+    },
+    "roadmapNumber": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "ready": {
+      "type": "boolean"
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "detail"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "roadmap-blocked",
+              "childless",
+              "open-child",
+              "nested-roadmap",
+              "unresolved-reference",
+              "inaccessible-reference",
+              "cycle"
+            ]
+          },
+          "target": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "provenance": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "detail": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "evidenceBody": {
+      "type": "string"
+    },
+    "closed": {
+      "type": "boolean"
+    },
+    "claimReleased": {
+      "type": "boolean"
+    },
+    "result": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -728,7 +728,7 @@ function normalizeClaimComments(raw) {
  * comparison is applied with the configured age. Mirrors
  * resume-claim-routing's `isStaleByAge`.
  */
-function isClaimStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs) {
+export function isClaimStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs) {
   if (staleAgeMs === DEFAULT_CLAIM_STALE_AGE_MS) {
     return isStaleAt(activeCreatedAt, nextCreatedAt);
   }

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1187,7 +1187,7 @@ async function getIssue(issueNumber, cache, loadIssue) {
   cache.set(issueNumber, issue);
   return issue;
 }
-function buildIssueLoader(owner, repo) {
+export function buildIssueLoader(owner, repo) {
   return async (issueNumber) => {
     const args = [
       'api',
@@ -1212,7 +1212,7 @@ function buildIssueLoader(owner, repo) {
     }
   };
 }
-function buildSubIssueLoader(owner, repo) {
+export function buildSubIssueLoader(owner, repo) {
   return async (issueNumber) => {
     const numbers = [];
     let after = '';

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -343,6 +343,16 @@ const HELPER_COMMANDS = [
       'Verify disposition marker presence on review items for E7 meta-check.',
   },
   {
+    id: 'roadmap-audit-execute',
+    scriptName: 'idd:roadmap-audit-execute',
+    binName: 'idd-roadmap-audit-execute',
+    entryPath: 'scripts/idd-roadmap-audit-execute.mjs',
+    vendoredCommand: 'node scripts/idd-roadmap-audit-execute.mjs',
+    description:
+      'Evaluate the A1.5 roadmap completion audit (dry-run) and, with --apply, post the evidence comment, close the roadmap, and release the claim.',
+    contractPaths: ['schemas/idd-roadmap-audit-execute.schema.json'],
+  },
+  {
     id: 'stalled-session-quiet-check',
     scriptName: 'idd:stalled-session-quiet-check',
     binName: 'idd-stalled-session-quiet-check',

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -438,6 +438,18 @@ export async function runRoadmapAuditExecute(argv, deps) {
     verdict.result = `claim-issue #${args.claimIssue} must equal the roadmap #${roadmapNumber}; roadmap-audit ownership is scoped to the exact roadmap`;
     return { verdict, exitCode: 1 };
   }
+  // Validate + normalize the apply-time clock ONCE, before any mutation: an
+  // unparseable "now" would mis-evaluate claim staleness, and an offset /
+  // sub-second form would reach the unclaim renderer (which accepts only `…Z`
+  // second-precision) and throw AFTER the comment + close had already landed.
+  // The single normalized value is reused for every staleness check AND the
+  // release marker.
+  const rawNow = resolvedDeps.now();
+  const nowIso = normalizeApplyNow(rawNow);
+  if (nowIso === null) {
+    verdict.result = `invalid "now" value "${rawNow}"; expected a parseable ISO timestamp (no mutation)`;
+    return { verdict, exitCode: 1 };
+  }
   // Early claim re-validation (defense in depth): bail before the graph
   // re-fetch if ownership is already gone.
   const earlyClaim = resolvedDeps.revalidateClaim({
@@ -445,7 +457,7 @@ export async function runRoadmapAuditExecute(argv, deps) {
     roadmapNumber,
     expectedClaimId: args.claimId,
     expectedAgentId: args.agentId,
-    nowIso: resolvedDeps.now(),
+    nowIso,
   });
   if (!earlyClaim.owned) {
     verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}"); no mutation`;
@@ -470,9 +482,7 @@ export async function runRoadmapAuditExecute(argv, deps) {
     return { verdict, exitCode: 1 };
   }
   // The graph re-fetch can span many API calls during which another session
-  // can take over, so the LAST gate before any mutation is a fresh claim
-  // re-validation. Its activeClaim + "now" are the ones used for the release.
-  const nowIso = resolvedDeps.now();
+  // can take over, so re-validate ownership immediately before posting.
   const claim = resolvedDeps.revalidateClaim({
     issueNumber: roadmapNumber,
     roadmapNumber,
@@ -484,19 +494,32 @@ export async function runRoadmapAuditExecute(argv, deps) {
     verdict.result = `claim not owned immediately before mutation (reason="${claim.reason}"); no mutation`;
     return { verdict, exitCode: 1 };
   }
-  // All gates hold: compose the body from the re-validated graph, then post
-  // the evidence comment, close the roadmap, and release the claim in order.
+  // Post the evidence comment (non-destructive), THEN re-validate ownership one
+  // final time immediately before the CLOSE: a takeover landing in the
+  // comment→close gap must not let us close under a claim we no longer own. An
+  // already-posted evidence comment before an aborted close is harmless — the
+  // successor session simply re-audits — but a wrongful close is destructive.
   const finalEvidenceBody = buildRoadmapCompletionAuditBody(revalidated);
   verdict.evidenceBody = finalEvidenceBody;
   resolvedDeps.postEvidenceComment(roadmapNumber, finalEvidenceBody);
+  const preCloseClaim = resolvedDeps.revalidateClaim({
+    issueNumber: roadmapNumber,
+    roadmapNumber,
+    expectedClaimId: args.claimId,
+    expectedAgentId: args.agentId,
+    nowIso,
+  });
+  if (!preCloseClaim.owned) {
+    verdict.result = `claim lost in the comment→close gap (reason="${preCloseClaim.reason}"); evidence comment posted but roadmap NOT closed`;
+    return { verdict, exitCode: 1 };
+  }
+  // Ownership held through the comment: close, then release using the last
+  // verdict's activeClaim and the normalized second-precision "now".
   resolvedDeps.closeRoadmap(roadmapNumber);
   resolvedDeps.releaseClaim(roadmapNumber, {
-    agentId: claim.activeClaim.agentId,
-    claimId: claim.activeClaim.claimId,
-    // The unclaim marker only accepts second-precision ISO; truncate any
-    // sub-second digits so a millisecond `now()` never throws after the
-    // comment + close already landed (a partial, unrecoverable mutation).
-    timestamp: toSecondPrecisionIso(nowIso),
+    agentId: preCloseClaim.activeClaim.agentId,
+    claimId: preCloseClaim.activeClaim.claimId,
+    timestamp: nowIso,
   });
   verdict.closed = true;
   verdict.claimReleased = true;
@@ -515,6 +538,24 @@ function closedDescendantNumbers(report) {
 /** Truncate any sub-second fraction so an ISO stamp is `YYYY-MM-DDTHH:mm:ssZ`. */
 function toSecondPrecisionIso(iso) {
   return String(iso).replace(/\.\d+Z$/, 'Z');
+}
+/**
+ * Validate and normalize the apply-time "now" to UTC second-precision ISO
+ * (`YYYY-MM-DDTHH:mm:ssZ`), or `null` when unparseable. The caller fails closed
+ * on `null` BEFORE any mutation: an unparseable value would mis-evaluate claim
+ * staleness (NaN comparisons read as not-stale), and an offset / sub-second
+ * form (e.g. `…+09:00`) would otherwise reach `renderUnclaimedByMarker` — which
+ * accepts only `…Z` second-precision — and throw AFTER the comment + close had
+ * already landed. Normalizing through `toISOString()` also converts any zone
+ * offset to UTC, so the single normalized value is safe for both the staleness
+ * checks and the release marker.
+ */
+function normalizeApplyNow(raw) {
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return toSecondPrecisionIso(parsed.toISOString());
 }
 // ---------------------------------------------------------------------------
 // Production dependency wiring (live gh + roadmap-graph traversal).
@@ -664,34 +705,61 @@ function loadIssueComments(owner, repo, issueNumber) {
  *     `fetchOpenLinkedPrReferences` shape.
  *
  * Both queries paginate fully (the connected stream MUST be read whole so a
- * later DISCONNECTED is never missed). On a per-issue lookup error the issue is
- * conservatively treated as blocked (fail closed) so a transient failure can
- * never green-light a close.
+ * later DISCONNECTED is never missed). Fails closed: a per-issue lookup error,
+ * OR an ABSENT lookup connection (`issue: null` / connection `null`|`undefined`
+ * — a deleted / transferred / inaccessible issue, or partial GraphQL data),
+ * treats the issue as blocked. An absent connection is distinct from a
+ * genuinely present-but-empty `nodes: []` (legitimately no PR on that signal),
+ * which does NOT block on that signal. The GraphQL runner is injectable so the
+ * absence distinction is unit-testable without `gh`.
  */
-function resolveOpenLinkedPrIssues(owner, repo, issueNumbers) {
+export function resolveOpenLinkedPrIssues(
+  owner,
+  repo,
+  issueNumbers,
+  runGraphql = ghGraphql,
+) {
   const blocked = [];
   for (const issueNumber of issueNumbers) {
     try {
       if (
-        hasOpenClosingPr(owner, repo, issueNumber) ||
-        hasOpenConnectedPr(owner, repo, issueNumber)
+        hasOpenClosingPr(owner, repo, issueNumber, runGraphql) ||
+        hasOpenConnectedPr(owner, repo, issueNumber, runGraphql)
       ) {
         blocked.push(issueNumber);
       }
     } catch {
-      // Fail closed: an undeterminable PR state blocks the close.
+      // Fail closed: an undeterminable / absent PR state blocks the close.
       blocked.push(issueNumber);
     }
   }
   return blocked;
 }
 /**
+ * Narrow a parsed GraphQL response to the named connection on its issue node,
+ * THROWING (→ fail closed) when the issue is `null`/absent or the connection
+ * itself is `null`/`undefined`. A present connection (even with empty `nodes`)
+ * is returned as-is so a legitimately PR-free issue is not treated as blocked.
+ */
+function requireIssueConnection(parsed, pick, label) {
+  const issue = parsed?.data?.repository?.issue;
+  if (issue === null || issue === undefined) {
+    throw new Error(`${label}: issue is null/absent (fail closed)`);
+  }
+  const connection = pick(issue);
+  if (connection === null || connection === undefined) {
+    throw new Error(`${label}: connection is null/absent (fail closed)`);
+  }
+  return connection;
+}
+/**
  * True when the issue has an OPEN PR that reference-closes it. Pages through
  * `closedByPullRequestsReferences` and short-circuits on the first OPEN PR
  * (one is enough to block); truncating the list could miss an OPEN blocker on
- * a later page, wrongly green-lighting a close.
+ * a later page, wrongly green-lighting a close. Throws (→ blocked) on an absent
+ * connection.
  */
-function hasOpenClosingPr(owner, repo, issueNumber) {
+function hasOpenClosingPr(owner, repo, issueNumber, runGraphql) {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
@@ -704,14 +772,17 @@ function hasOpenClosingPr(owner, repo, issueNumber) {
 }`;
   let after = null;
   for (;;) {
-    const parsed = ghGraphql(query, owner, repo, issueNumber, after);
-    const connection =
-      parsed.data?.repository?.issue?.closedByPullRequestsReferences;
-    const nodes = connection?.nodes ?? [];
+    const parsed = runGraphql(query, owner, repo, issueNumber, after);
+    const connection = requireIssueConnection(
+      parsed,
+      (issue) => issue.closedByPullRequestsReferences,
+      'closedByPullRequestsReferences',
+    );
+    const nodes = connection.nodes ?? [];
     if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
       return true;
     }
-    if (!connection?.pageInfo?.hasNextPage) {
+    if (!connection.pageInfo?.hasNextPage) {
       return false;
     }
     after = connection.pageInfo.endCursor ?? null;
@@ -725,8 +796,9 @@ function hasOpenClosingPr(owner, repo, issueNumber) {
  * relationship without a closing keyword). Pages the CONNECTED/DISCONNECTED
  * timeline in full — the whole stream is needed so a later DISCONNECTED is not
  * missed — then reconciles it via the pure {@link reconcileConnectedOpenPrs}.
+ * Throws (→ blocked) on an absent connection.
  */
-function hasOpenConnectedPr(owner, repo, issueNumber) {
+function hasOpenConnectedPr(owner, repo, issueNumber, runGraphql) {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
@@ -744,10 +816,14 @@ function hasOpenConnectedPr(owner, repo, issueNumber) {
   const events = [];
   let after = null;
   for (;;) {
-    const parsed = ghGraphql(query, owner, repo, issueNumber, after);
-    const connection = parsed.data?.repository?.issue?.timelineItems;
-    events.push(...parseConnectedPrEvents(connection?.nodes ?? []));
-    if (!connection?.pageInfo?.hasNextPage) {
+    const parsed = runGraphql(query, owner, repo, issueNumber, after);
+    const connection = requireIssueConnection(
+      parsed,
+      (issue) => issue.timelineItems,
+      'timelineItems',
+    );
+    events.push(...parseConnectedPrEvents(connection.nodes ?? []));
+    if (!connection.pageInfo?.hasNextPage) {
       break;
     }
     after = connection.pageInfo.endCursor ?? null;

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -787,7 +787,12 @@ function hasOpenClosingPr(owner, repo, issueNumber, runGraphql) {
     }
     after = connection.pageInfo.endCursor ?? null;
     if (!after) {
-      return false;
+      // hasNextPage with no endCursor: an incomplete / unexpected connection
+      // read. Throw so the per-issue catch fails closed (blocks the child)
+      // rather than treating a partial page as "no open PR".
+      throw new Error(
+        'incomplete closing-PR pagination: hasNextPage with no endCursor',
+      );
     }
   }
 }
@@ -828,7 +833,12 @@ function hasOpenConnectedPr(owner, repo, issueNumber, runGraphql) {
     }
     after = connection.pageInfo.endCursor ?? null;
     if (!after) {
-      break;
+      // hasNextPage with no endCursor: reconciling a truncated timeline could
+      // miss a later CONNECTED open PR. Throw so the per-issue catch fails
+      // closed (blocks the child) instead of trusting the partial stream.
+      throw new Error(
+        'incomplete connected-PR timeline pagination: hasNextPage with no endCursor',
+      );
     }
   }
   return reconcileConnectedOpenPrs(events).length > 0;

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -42,6 +42,14 @@ const BLOCKED_LABELS = new Set([
   'status:blocked-by-human',
   'status:needs-decision',
 ]);
+// Scope caveat (A1.5): this helper gates only the MECHANICAL completion
+// preconditions. It deliberately does NOT verify the roadmap's free-form
+// success criteria or autonomy-gap items — that is agent judgment "where
+// feasible" per the instruction — so the caller must confirm those separately
+// before --apply, exactly as the merge gate trusts that review actually
+// happened.
+const MECHANICAL_GATE_NOTE =
+  'Mechanical preconditions only: every descendant is closed/complete with no open / unresolved / inaccessible / linked-PR / nested-roadmap / childless / cycle / human-gate blocker. Separately verify the roadmap’s free-form success criteria and autonomy-gap items before --apply (this helper does not, just as the merge gate trusts that review happened).';
 /** Branch field that scopes a roadmap-audit coordination claim to one roadmap. */
 function roadmapAuditBranchPattern(roadmapNumber) {
   return new RegExp(`^roadmap-audit/${roadmapNumber}-`);
@@ -269,6 +277,37 @@ export function buildRoadmapCompletionAuditBody(report) {
   ].join('\n');
 }
 /**
+ * Reconcile a chronological CONNECTED / DISCONNECTED linked-PR event stream
+ * into the PR numbers that are CURRENTLY connected (the last event for the PR
+ * is a connect, with no later disconnect) AND in the `OPEN` state. Mirrors
+ * resume-claim-routing's `fetchOpenLinkedPrReferences` reconciliation so an
+ * open PR merely linked (no closing keyword) still blocks a roadmap close,
+ * while a CONNECTED-then-DISCONNECTED PR or a connected MERGED PR does not.
+ * Pure so it is unit-testable without `gh`.
+ */
+export function reconcileConnectedOpenPrs(events) {
+  const connected = new Map();
+  const states = new Map();
+  for (const event of events) {
+    if (!Number.isInteger(event.prNumber)) {
+      continue;
+    }
+    if (event.type === 'connected') {
+      connected.set(event.prNumber, true);
+      states.set(event.prNumber, String(event.state ?? ''));
+    } else if (event.type === 'disconnected') {
+      connected.set(event.prNumber, false);
+    }
+  }
+  const open = [];
+  for (const [prNumber, isConnected] of connected) {
+    if (isConnected && states.get(prNumber) === 'OPEN') {
+      open.push(prNumber);
+    }
+  }
+  return open.sort((left, right) => left - right);
+}
+/**
  * Re-validate the roadmap-audit claim from the live claim-marker stream. The
  * shared `summarizeClaimValidation` resolver decides claim ownership exactly
  * as the merge gate does (trusted-author gated, claim-id / agent-id match).
@@ -375,7 +414,9 @@ export async function runRoadmapAuditExecute(argv, deps) {
     result: '',
   };
   if (!args.apply) {
-    // Dry-run: read-only. Never mutate.
+    // Dry-run: read-only. Never mutate. Surface the scope caveat so a caller
+    // does not mistake a mechanical "ready" for a full success-criteria audit.
+    verdict.result = MECHANICAL_GATE_NOTE;
     return { verdict, exitCode: ready ? 0 : 1 };
   }
   if (!ready) {
@@ -608,17 +649,49 @@ function loadIssueComments(owner, repo, issueNumber) {
   });
 }
 /**
- * Resolve which of `issueNumbers` still have an OPEN linked / closing PR.
+ * Resolve which of `issueNumbers` still have an OPEN linked PR — covering A1.5's
+ * "open linked OR closing PR". Two GraphQL signals per issue, either of which
+ * blocks (issue-level short-circuit, `||`):
  *
- * Uses one GraphQL field per issue — `closedByPullRequestsReferences`, the PRs
- * that reference-close the issue — and keeps a number only when at least one
- * such PR is still in the `OPEN` state. MERGED / CLOSED PRs are obsolete and
- * never block (the field returns merged PRs even with
- * `includeClosedPrs:false`, so the `OPEN`-state filter is what matters). On a
- * per-issue lookup error the issue is conservatively treated as having an open
- * PR (fail closed) so a transient failure can never green-light a close.
+ *  1. `closedByPullRequestsReferences` — PRs that reference-CLOSE the issue via
+ *     a closing keyword — kept only when at least one is still `OPEN` (MERGED /
+ *     CLOSED are obsolete; the field returns merged PRs even with
+ *     `includeClosedPrs:false`, so the `OPEN`-state filter is what matters); and
+ *  2. CONNECTED / DISCONNECTED timeline events — a PR manually linked via
+ *     GitHub's Development relationship with NO closing keyword — reconciled
+ *     (`CONNECTED_EVENT` with no later `DISCONNECTED_EVENT` for the same PR) and
+ *     kept only when that PR is still `OPEN`. Mirrors resume-claim-routing's
+ *     `fetchOpenLinkedPrReferences` shape.
+ *
+ * Both queries paginate fully (the connected stream MUST be read whole so a
+ * later DISCONNECTED is never missed). On a per-issue lookup error the issue is
+ * conservatively treated as blocked (fail closed) so a transient failure can
+ * never green-light a close.
  */
 function resolveOpenLinkedPrIssues(owner, repo, issueNumbers) {
+  const blocked = [];
+  for (const issueNumber of issueNumbers) {
+    try {
+      if (
+        hasOpenClosingPr(owner, repo, issueNumber) ||
+        hasOpenConnectedPr(owner, repo, issueNumber)
+      ) {
+        blocked.push(issueNumber);
+      }
+    } catch {
+      // Fail closed: an undeterminable PR state blocks the close.
+      blocked.push(issueNumber);
+    }
+  }
+  return blocked;
+}
+/**
+ * True when the issue has an OPEN PR that reference-closes it. Pages through
+ * `closedByPullRequestsReferences` and short-circuits on the first OPEN PR
+ * (one is enough to block); truncating the list could miss an OPEN blocker on
+ * a later page, wrongly green-lighting a close.
+ */
+function hasOpenClosingPr(owner, repo, issueNumber) {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
@@ -629,56 +702,105 @@ function resolveOpenLinkedPrIssues(owner, repo, issueNumbers) {
     }
   }
 }`;
-  const blocked = [];
-  for (const issueNumber of issueNumbers) {
-    try {
-      // Page through every reference until an OPEN PR is found (short-circuit:
-      // one is enough to block) or the connection is exhausted; `first:20`
-      // could otherwise truncate the list and miss an OPEN blocker on a later
-      // page, which for a fail-closed gate would wrongly green-light a close.
-      let after = null;
-      let isBlocked = false;
-      for (;;) {
-        const apiArgs = [
-          'api',
-          'graphql',
-          '-f',
-          `query=${query}`,
-          '-f',
-          `owner=${owner}`,
-          '-f',
-          `repo=${repo}`,
-          '-F',
-          `number=${issueNumber}`,
-        ];
-        if (after) {
-          apiArgs.push('-f', `after=${after}`);
-        }
-        const parsed = JSON.parse(ghText(apiArgs));
-        const connection =
-          parsed.data?.repository?.issue?.closedByPullRequestsReferences;
-        const nodes = connection?.nodes ?? [];
-        if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
-          isBlocked = true;
-          break;
-        }
-        if (!connection?.pageInfo?.hasNextPage) {
-          break;
-        }
-        after = connection.pageInfo.endCursor ?? null;
-        if (!after) {
-          break;
-        }
-      }
-      if (isBlocked) {
-        blocked.push(issueNumber);
-      }
-    } catch {
-      // Fail closed: an undeterminable PR state blocks the close.
-      blocked.push(issueNumber);
+  let after = null;
+  for (;;) {
+    const parsed = ghGraphql(query, owner, repo, issueNumber, after);
+    const connection =
+      parsed.data?.repository?.issue?.closedByPullRequestsReferences;
+    const nodes = connection?.nodes ?? [];
+    if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
+      return true;
+    }
+    if (!connection?.pageInfo?.hasNextPage) {
+      return false;
+    }
+    after = connection.pageInfo.endCursor ?? null;
+    if (!after) {
+      return false;
     }
   }
-  return blocked;
+}
+/**
+ * True when the issue has a currently-CONNECTED, OPEN linked PR (Development
+ * relationship without a closing keyword). Pages the CONNECTED/DISCONNECTED
+ * timeline in full — the whole stream is needed so a later DISCONNECTED is not
+ * missed — then reconciles it via the pure {@link reconcileConnectedOpenPrs}.
+ */
+function hasOpenConnectedPr(owner, repo, issueNumber) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      timelineItems(first:50,after:$after,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT]){
+        nodes {
+          __typename
+          ... on ConnectedEvent { subject { __typename ... on PullRequest { number state } } }
+          ... on DisconnectedEvent { subject { __typename ... on PullRequest { number } } }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+  const events = [];
+  let after = null;
+  for (;;) {
+    const parsed = ghGraphql(query, owner, repo, issueNumber, after);
+    const connection = parsed.data?.repository?.issue?.timelineItems;
+    events.push(...parseConnectedPrEvents(connection?.nodes ?? []));
+    if (!connection?.pageInfo?.hasNextPage) {
+      break;
+    }
+    after = connection.pageInfo.endCursor ?? null;
+    if (!after) {
+      break;
+    }
+  }
+  return reconcileConnectedOpenPrs(events).length > 0;
+}
+/** Run one `gh api graphql` page, passing `after` only when set. */
+function ghGraphql(query, owner, repo, issueNumber, after) {
+  const apiArgs = [
+    'api',
+    'graphql',
+    '-f',
+    `query=${query}`,
+    '-f',
+    `owner=${owner}`,
+    '-f',
+    `repo=${repo}`,
+    '-F',
+    `number=${issueNumber}`,
+  ];
+  if (after) {
+    apiArgs.push('-f', `after=${after}`);
+  }
+  return JSON.parse(ghText(apiArgs));
+}
+/** Coerce raw CONNECTED/DISCONNECTED timeline nodes into reconcile events. */
+function parseConnectedPrEvents(nodes) {
+  const events = [];
+  for (const node of nodes) {
+    const record = node;
+    const subject = record?.subject;
+    if (subject?.__typename !== 'PullRequest') {
+      continue;
+    }
+    const prNumber =
+      typeof subject.number === 'number' ? subject.number : Number.NaN;
+    if (!Number.isInteger(prNumber)) {
+      continue;
+    }
+    if (record?.__typename === 'ConnectedEvent') {
+      events.push({
+        type: 'connected',
+        prNumber,
+        state: String(subject.state ?? ''),
+      });
+    } else if (record?.__typename === 'DisconnectedEvent') {
+      events.push({ type: 'disconnected', prNumber });
+    }
+  }
+  return events;
 }
 /**
  * POST a comment body as a JSON document (`{"body": …}`) via `gh api --input
@@ -825,6 +947,13 @@ function printHelp() {
   (branch roadmap-audit/<roadmap>-<slug>) and match --claim-id (required under
   --apply) and, when given, --agent-id. --owner and --repo must be passed
   together or not at all.
+
+  SCOPE: this helper gates only the MECHANICAL completion preconditions (all
+  descendants closed/complete; no open / unresolved / inaccessible / linked-PR
+  / nested-roadmap / childless / cycle / human-gate blocker). It does NOT verify
+  the roadmap's free-form success criteria or autonomy-gap items — the caller
+  must confirm those separately before --apply, exactly as the merge gate
+  trusts that review actually happened.
 `);
 }
 function isMainModule(moduleUrl) {

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -14,7 +14,8 @@
 // marker) happen under `--apply` once the roadmap is ready AND the
 // roadmap-audit claim re-validates immediately before the close. A roadmap
 // with an open / unresolved / inaccessible / nested-roadmap descendant, a
-// traversal cycle, or no explicit child work is NEVER closed.
+// closed child with an open linked PR, a traversal cycle, or no explicit child
+// work is NEVER closed.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -23,19 +24,28 @@ import {
   buildIssueLoader,
   buildSubIssueLoader,
   enumerateRoadmapGraph,
+  isClaimStaleByAge,
+  parseClaimStaleAgeMs,
 } from './discover-roadmap-graph.mjs';
 import {
-  isStaleAt,
   renderUnclaimedByMarker,
   resolveTrustedMarkerActors,
   summarizeClaimValidation,
 } from './protocol-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// Distributed `claim-stale-age` default (docs/policy-constants.md: 24 h). Used
+// only as the fallback when the policy declares no (or an invalid)
+// `claimTiming.staleAge`; mirrors discover-roadmap-graph's own default.
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 const BLOCKED_LABELS = new Set([
   'status:blocked-by-human',
   'status:needs-decision',
 ]);
+/** Branch field that scopes a roadmap-audit coordination claim to one roadmap. */
+function roadmapAuditBranchPattern(roadmapNumber) {
+  return new RegExp(`^roadmap-audit/${roadmapNumber}-`);
+}
 /**
  * Evaluate roadmap completion against `report` (a discover-roadmap-graph
  * single-root traversal). Every open / unresolved / inaccessible / nested-
@@ -45,10 +55,12 @@ const BLOCKED_LABELS = new Set([
  * criteria exactly — this helper adds no stricter sub-condition. Pure and
  * network-free so it is unit-testable apart from live GitHub.
  */
-export function evaluateRoadmapAuditGates(report) {
+export function evaluateRoadmapAuditGates(report, options = {}) {
   const blockers = [];
   const rootNumber = report.root.number;
   const pathTo = buildProvenanceLookup(report);
+  const openLinkedPrIssues = new Set(options.openLinkedPrIssues ?? []);
+  const reachableExecutionLeafCount = buildReachableLeafCounter(report);
   // Root carrying a human-gate label is never auto-closed.
   const rootNode = report.nodes.find((node) => node.number === rootNumber);
   const rootBlockedLabel = (rootNode?.labels ?? []).find((label) =>
@@ -80,25 +92,56 @@ export function evaluateRoadmapAuditGates(report) {
       detail: `execution leaf #${target}${node ? ` "${node.title}"` : ''} is OPEN`,
     });
   }
-  // Open nested roadmaps: a coordination/audit node that is still open blocks
-  // the parent close, regardless of its own leaf state (the parent can only
-  // close after the nested roadmap closes).
-  const openNestedRoadmaps = report.nodes
+  // Nested roadmaps block the parent close when they are either (a) still
+  // OPEN — a coordination/audit node closes bottom-up before its parent — or
+  // (b) malformed: zero reachable execution-leaf descendants, so a CLOSED
+  // nested roadmap can never be taken as proof of completion (A1.5). A closed
+  // nested roadmap WITH reachable leaves is fine on its own; any open leaf
+  // beneath it is surfaced separately as its own blocker.
+  const nestedRoadmaps = report.nodes
+    .filter(
+      (node) => node.classification === 'roadmap' && node.number !== rootNumber,
+    )
+    .sort((left, right) => left.number - right.number);
+  for (const node of nestedRoadmaps) {
+    if (reachableExecutionLeafCount(node.number) === 0) {
+      blockers.push({
+        kind: 'nested-roadmap',
+        target: node.number,
+        provenance: pathTo(node.number),
+        detail: `nested roadmap #${node.number} "${node.title}" has no reachable execution-leaf descendants; childless or malformed, not proof of completion`,
+      });
+      continue;
+    }
+    if (node.state === 'OPEN') {
+      blockers.push({
+        kind: 'nested-roadmap',
+        target: node.number,
+        provenance: pathTo(node.number),
+        detail: `nested roadmap #${node.number} "${node.title}" is OPEN; close it (bottom-up) before its parent`,
+      });
+    }
+  }
+  // A CLOSED child that still has an OPEN linked / closing PR is unresolved:
+  // the child looks done but its work is in flight (A1.5). Open children are
+  // already blocked above, so only closed descendants are flagged here. The
+  // open-PR set is injected as data so the evaluator stays pure.
+  const openLinkedPrTargets = report.nodes
     .filter(
       (node) =>
-        node.classification === 'roadmap' &&
         node.number !== rootNumber &&
-        node.state === 'OPEN',
+        node.state !== 'OPEN' &&
+        openLinkedPrIssues.has(node.number),
     )
     .map((node) => node.number)
-    .sort((a, b) => a - b);
-  for (const target of openNestedRoadmaps) {
+    .sort((left, right) => left - right);
+  for (const target of openLinkedPrTargets) {
     const node = report.nodes.find((entry) => entry.number === target);
     blockers.push({
-      kind: 'nested-roadmap',
+      kind: 'open-linked-pr',
       target,
       provenance: pathTo(target),
-      detail: `nested roadmap #${target}${node ? ` "${node.title}"` : ''} is OPEN; close it (bottom-up) before its parent`,
+      detail: `closed child #${target}${node ? ` "${node.title}"` : ''} still has an OPEN linked/closing PR; treat as unresolved until it merges or is obsoleted`,
     });
   }
   // Unresolved references (target issue not found / is a PR).
@@ -141,6 +184,48 @@ function buildProvenanceLookup(report) {
   return (target) => lookup.get(target) ?? [];
 }
 /**
+ * Count, for any node, how many distinct execution-leaf descendants are
+ * reachable from it via the enumerated graph edges (an execution-classified
+ * node present in `nodes`, open or closed). Uses only the graph/edge data the
+ * traversal already produced; a cycle-safe `visited` set bounds the walk. A
+ * count of 0 means the node has no reachable leaf descendants — childless /
+ * malformed per A1.5.
+ */
+function buildReachableLeafCounter(report) {
+  const adjacency = new Map();
+  for (const edge of report.edges) {
+    const targets = adjacency.get(edge.source) ?? [];
+    targets.push(edge.target);
+    adjacency.set(edge.source, targets);
+  }
+  const executionLeaves = new Set(
+    report.nodes
+      .filter((node) => node.classification === 'execution')
+      .map((node) => node.number),
+  );
+  return (from) => {
+    const visited = new Set([from]);
+    const stack = [from];
+    const leaves = new Set();
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (current === undefined) {
+        break;
+      }
+      for (const next of adjacency.get(current) ?? []) {
+        if (executionLeaves.has(next)) {
+          leaves.add(next);
+        }
+        if (!visited.has(next)) {
+          visited.add(next);
+          stack.push(next);
+        }
+      }
+    }
+    return leaves.size;
+  };
+}
+/**
  * Compose the canonical `IDD roadmap completion audit` evidence comment body.
  * Deterministic and network-free: it summarizes the audited graph (node /
  * edge / depth counts, closed descendants split by classification, and the
@@ -175,7 +260,7 @@ export function buildRoadmapCompletionAuditBody(report) {
     `- Closed descendants: ${descendants.length} (${executionCount} execution leaves, ${nestedRoadmapCount} nested roadmaps).`,
     `- Closed execution leaves: ${closedExecution || 'none'}.`,
     `- Closed nested roadmaps: ${closedNested || 'none'}.`,
-    '- Open / unresolved / inaccessible / nested-roadmap descendants: none.',
+    '- Open / unresolved / inaccessible / nested-roadmap / open-linked-PR descendants: none.',
     `- Diagnostics: ${report.summary.cycleCount} cycles, ${report.summary.unresolvedReferenceCount} unresolved references, ${report.summary.inaccessibleReferenceCount} inaccessible references, ${report.summary.duplicateReferenceCount} duplicate references.`,
     '',
     'Closing the roadmap as completed.',
@@ -186,12 +271,20 @@ export function buildRoadmapCompletionAuditBody(report) {
 /**
  * Re-validate the roadmap-audit claim from the live claim-marker stream. The
  * shared `summarizeClaimValidation` resolver decides claim ownership exactly
- * as the merge gate does (trusted-author gated, claim-id / agent-id match);
- * this helper additionally fails closed on a STALE claim (older than the
- * distributed `claim-stale-age` default of 24 h relative to `nowIso`), because
- * a stale claim is takeover-eligible and so cannot prove the caller still owns
- * the roadmap. Pure and network-free: the comment stream and trusted-author
- * predicate are injected so the fail-closed paths are unit-testable.
+ * as the merge gate does (trusted-author gated, claim-id / agent-id match).
+ * This helper additionally enforces the two roadmap-side ownership rules of
+ * A1.5:
+ *
+ *  1. the active claim's `branch` must be the `roadmap-audit/<roadmapNumber>-…`
+ *     coordination branch for THIS roadmap — a normal execution claim such as
+ *     `issue/123-fix` on the roadmap issue does NOT authorize closure; and
+ *  2. the claim must not be STALE relative to `nowIso`, using the configured
+ *     `claimTiming.staleAge` (`staleAgeMs`, default 24 h) via the shared
+ *     `isClaimStaleByAge` — a stale claim is takeover-eligible and so cannot
+ *     prove ongoing ownership.
+ *
+ * Pure and network-free: the comment stream, trusted-author predicate, and
+ * stale age are injected so every fail-closed path is unit-testable.
  */
 export function evaluateRoadmapClaim(comments, options) {
   const summary = summarizeClaimValidation(comments, {
@@ -207,10 +300,28 @@ export function evaluateRoadmapClaim(comments, options) {
       activeClaim: summary.activeClaim,
     };
   }
-  // The 24h stale math lives in the shared `isStaleAt`; reuse it verbatim
-  // against "now" so a claim older than the distributed default is takeover-
-  // eligible and therefore not owned for the purpose of a roadmap mutation.
-  const stale = isStaleAt(summary.activeClaim.createdAt, options.nowIso);
+  // Roadmap-side ownership requires the roadmap-audit coordination branch for
+  // exactly this roadmap; a normal execution claim on the roadmap issue does
+  // not authorize the close.
+  if (
+    !roadmapAuditBranchPattern(options.roadmapNumber).test(
+      summary.activeClaim.branch,
+    )
+  ) {
+    return {
+      owned: false,
+      reason: 'claim-branch-mismatch',
+      stale: false,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  // Staleness uses the configured stale age (default 24 h); the math is reused
+  // verbatim from the shared `isClaimStaleByAge` rather than re-derived here.
+  const stale = isClaimStaleByAge(
+    summary.activeClaim.createdAt,
+    options.nowIso,
+    options.staleAgeMs ?? DEFAULT_CLAIM_STALE_AGE_MS,
+  );
   if (stale) {
     return {
       owned: false,
@@ -242,10 +353,13 @@ export async function runRoadmapAuditExecute(argv, deps) {
     throw new Error('missing required --roadmap <number> argument');
   }
   const roadmapNumber = args.roadmapNumber;
-  const claimIssue = args.claimIssue ?? roadmapNumber;
   const resolvedDeps = deps ?? createProductionDeps(args);
   const report = await resolvedDeps.collect(roadmapNumber);
-  const blockers = evaluateRoadmapAuditGates(report);
+  const blockers = evaluateRoadmapAuditGates(report, {
+    openLinkedPrIssues: resolvedDeps.resolveOpenLinkedPrIssues(
+      closedDescendantNumbers(report),
+    ),
+  });
   const ready = blockers.length === 0;
   const evidenceBody = ready ? buildRoadmapCompletionAuditBody(report) : '';
   const verdict = {
@@ -276,24 +390,36 @@ export async function runRoadmapAuditExecute(argv, deps) {
       'not-applied: --claim-id is required under --apply to re-validate roadmap-audit ownership';
     return { verdict, exitCode: 1 };
   }
-  const nowIso = resolvedDeps.now();
-  // Re-validate the roadmap-audit claim immediately before mutating; fail
-  // closed (no mutation) on any lost / stale / non-owned claim.
-  const claim = resolvedDeps.revalidateClaim({
-    issueNumber: claimIssue,
+  // The roadmap-audit claim is scoped to the EXACT roadmap being mutated; a
+  // divergent --claim-issue would validate ownership elsewhere while closing
+  // this roadmap. Reject it (fail closed) and always validate on the roadmap.
+  if (args.claimIssue !== null && args.claimIssue !== roadmapNumber) {
+    verdict.result = `claim-issue #${args.claimIssue} must equal the roadmap #${roadmapNumber}; roadmap-audit ownership is scoped to the exact roadmap`;
+    return { verdict, exitCode: 1 };
+  }
+  // Early claim re-validation (defense in depth): bail before the graph
+  // re-fetch if ownership is already gone.
+  const earlyClaim = resolvedDeps.revalidateClaim({
+    issueNumber: roadmapNumber,
+    roadmapNumber,
     expectedClaimId: args.claimId,
     expectedAgentId: args.agentId,
-    nowIso,
+    nowIso: resolvedDeps.now(),
   });
-  if (!claim.owned) {
-    verdict.result = `claim not owned on re-validation (reason="${claim.reason}"); no mutation`;
+  if (!earlyClaim.owned) {
+    verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}"); no mutation`;
     return { verdict, exitCode: 1 };
   }
   // Re-fetch the roadmap + child state and confirm the audit input still
-  // holds; a roadmap that gained an open / unresolved / nested-roadmap
-  // descendant between the first read and now must NEVER be closed.
+  // holds; a roadmap that gained an open / unresolved / nested-roadmap /
+  // open-linked-PR descendant between the first read and now must NEVER be
+  // closed.
   const revalidated = await resolvedDeps.collect(roadmapNumber);
-  const revalidatedBlockers = evaluateRoadmapAuditGates(revalidated);
+  const revalidatedBlockers = evaluateRoadmapAuditGates(revalidated, {
+    openLinkedPrIssues: resolvedDeps.resolveOpenLinkedPrIssues(
+      closedDescendantNumbers(revalidated),
+    ),
+  });
   if (revalidatedBlockers.length > 0) {
     verdict.blockers = revalidatedBlockers;
     verdict.ready = false;
@@ -302,22 +428,52 @@ export async function runRoadmapAuditExecute(argv, deps) {
       're-validation found new completion blockers immediately before close; no mutation';
     return { verdict, exitCode: 1 };
   }
-  // Both gates hold: compose the body from the re-validated graph, then post
+  // The graph re-fetch can span many API calls during which another session
+  // can take over, so the LAST gate before any mutation is a fresh claim
+  // re-validation. Its activeClaim + "now" are the ones used for the release.
+  const nowIso = resolvedDeps.now();
+  const claim = resolvedDeps.revalidateClaim({
+    issueNumber: roadmapNumber,
+    roadmapNumber,
+    expectedClaimId: args.claimId,
+    expectedAgentId: args.agentId,
+    nowIso,
+  });
+  if (!claim.owned) {
+    verdict.result = `claim not owned immediately before mutation (reason="${claim.reason}"); no mutation`;
+    return { verdict, exitCode: 1 };
+  }
+  // All gates hold: compose the body from the re-validated graph, then post
   // the evidence comment, close the roadmap, and release the claim in order.
   const finalEvidenceBody = buildRoadmapCompletionAuditBody(revalidated);
   verdict.evidenceBody = finalEvidenceBody;
   resolvedDeps.postEvidenceComment(roadmapNumber, finalEvidenceBody);
   resolvedDeps.closeRoadmap(roadmapNumber);
-  resolvedDeps.releaseClaim(claimIssue, {
+  resolvedDeps.releaseClaim(roadmapNumber, {
     agentId: claim.activeClaim.agentId,
     claimId: claim.activeClaim.claimId,
-    timestamp: nowIso,
+    // The unclaim marker only accepts second-precision ISO; truncate any
+    // sub-second digits so a millisecond `now()` never throws after the
+    // comment + close already landed (a partial, unrecoverable mutation).
+    timestamp: toSecondPrecisionIso(nowIso),
   });
   verdict.closed = true;
   verdict.claimReleased = true;
   verdict.result =
     'roadmap closed as completed; evidence comment posted and roadmap-audit claim released';
   return { verdict, exitCode: 0 };
+}
+/** Closed (non-root) descendant issue numbers — the open-linked-PR candidates. */
+function closedDescendantNumbers(report) {
+  return report.nodes
+    .filter(
+      (node) => node.number !== report.root.number && node.state !== 'OPEN',
+    )
+    .map((node) => node.number);
+}
+/** Truncate any sub-second fraction so an ISO stamp is `YYYY-MM-DDTHH:mm:ssZ`. */
+function toSecondPrecisionIso(iso) {
+  return String(iso).replace(/\.\d+Z$/, 'Z');
 }
 // ---------------------------------------------------------------------------
 // Production dependency wiring (live gh + roadmap-graph traversal).
@@ -338,6 +494,12 @@ function createProductionDeps(args) {
     viewerLogin,
     rawConfig: rawConfig,
   });
+  // Honor the configured `claimTiming.staleAge` (docs/policy-constants.md);
+  // reuse discover-roadmap-graph's ISO-duration parser, falling back to the
+  // distributed 24 h default on an absent/invalid value.
+  const staleAgeMs =
+    parseClaimStaleAgeMs(rawConfig?.claimTiming?.staleAge) ??
+    DEFAULT_CLAIM_STALE_AGE_MS;
   const loadIssue = buildIssueLoader(owner, repo);
   const loadSubIssues = buildSubIssueLoader(owner, repo);
   return {
@@ -349,17 +511,22 @@ function createProductionDeps(args) {
         loadIssue,
         loadSubIssues,
       }),
+    resolveOpenLinkedPrIssues: (issueNumbers) =>
+      resolveOpenLinkedPrIssues(owner, repo, issueNumbers),
     revalidateClaim: ({
       issueNumber,
+      roadmapNumber,
       expectedClaimId,
       expectedAgentId,
       nowIso,
     }) =>
       evaluateRoadmapClaim(loadIssueComments(owner, repo, issueNumber), {
+        roadmapNumber,
         expectedClaimId,
         expectedAgentId,
         isTrustedAuthor,
         nowIso,
+        staleAgeMs,
       }),
     postEvidenceComment: (issueNumber, body) =>
       postIssueComment(owner, repo, issueNumber, body),
@@ -437,6 +604,56 @@ function loadIssueComments(owner, repo, issueNumber) {
       },
     };
   });
+}
+/**
+ * Resolve which of `issueNumbers` still have an OPEN linked / closing PR.
+ *
+ * Uses one GraphQL field per issue — `closedByPullRequestsReferences`, the PRs
+ * that reference-close the issue — and keeps a number only when at least one
+ * such PR is still in the `OPEN` state. MERGED / CLOSED PRs are obsolete and
+ * never block (the field returns merged PRs even with
+ * `includeClosedPrs:false`, so the `OPEN`-state filter is what matters). On a
+ * per-issue lookup error the issue is conservatively treated as having an open
+ * PR (fail closed) so a transient failure can never green-light a close.
+ */
+function resolveOpenLinkedPrIssues(owner, repo, issueNumbers) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:20,includeClosedPrs:false){
+        nodes { number state }
+      }
+    }
+  }
+}`;
+  const blocked = [];
+  for (const issueNumber of issueNumbers) {
+    try {
+      const raw = ghText([
+        'api',
+        'graphql',
+        '-f',
+        `query=${query}`,
+        '-f',
+        `owner=${owner}`,
+        '-f',
+        `repo=${repo}`,
+        '-F',
+        `number=${issueNumber}`,
+      ]);
+      const parsed = JSON.parse(raw);
+      const nodes =
+        parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ??
+        [];
+      if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
+        blocked.push(issueNumber);
+      }
+    } catch {
+      // Fail closed: an undeterminable PR state blocks the close.
+      blocked.push(issueNumber);
+    }
+  }
+  return blocked;
 }
 /**
  * POST a comment body as a JSON document (`{"body": …}`) via `gh api --input

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -547,7 +547,9 @@ function createProductionDeps(args) {
         issueNumber,
         renderUnclaimedByMarker(fields),
       ),
-    now: () => new Date().toISOString(),
+    // Honor a caller-supplied --now (deterministic staleness + release
+    // timestamps for tests / replays); fall back to the wall clock.
+    now: () => args.now || new Date().toISOString(),
   };
 }
 /**
@@ -617,11 +619,12 @@ function loadIssueComments(owner, repo, issueNumber) {
  * PR (fail closed) so a transient failure can never green-light a close.
  */
 function resolveOpenLinkedPrIssues(owner, repo, issueNumbers) {
-  const query = `query($owner:String!,$repo:String!,$number:Int!){
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
-      closedByPullRequestsReferences(first:20,includeClosedPrs:false){
-        nodes { number state }
+      closedByPullRequestsReferences(first:50,after:$after,includeClosedPrs:false){
+        nodes { state }
+        pageInfo { hasNextPage endCursor }
       }
     }
   }
@@ -629,23 +632,45 @@ function resolveOpenLinkedPrIssues(owner, repo, issueNumbers) {
   const blocked = [];
   for (const issueNumber of issueNumbers) {
     try {
-      const raw = ghText([
-        'api',
-        'graphql',
-        '-f',
-        `query=${query}`,
-        '-f',
-        `owner=${owner}`,
-        '-f',
-        `repo=${repo}`,
-        '-F',
-        `number=${issueNumber}`,
-      ]);
-      const parsed = JSON.parse(raw);
-      const nodes =
-        parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ??
-        [];
-      if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
+      // Page through every reference until an OPEN PR is found (short-circuit:
+      // one is enough to block) or the connection is exhausted; `first:20`
+      // could otherwise truncate the list and miss an OPEN blocker on a later
+      // page, which for a fail-closed gate would wrongly green-light a close.
+      let after = null;
+      let isBlocked = false;
+      for (;;) {
+        const apiArgs = [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-f',
+          `owner=${owner}`,
+          '-f',
+          `repo=${repo}`,
+          '-F',
+          `number=${issueNumber}`,
+        ];
+        if (after) {
+          apiArgs.push('-f', `after=${after}`);
+        }
+        const parsed = JSON.parse(ghText(apiArgs));
+        const connection =
+          parsed.data?.repository?.issue?.closedByPullRequestsReferences;
+        const nodes = connection?.nodes ?? [];
+        if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
+          isBlocked = true;
+          break;
+        }
+        if (!connection?.pageInfo?.hasNextPage) {
+          break;
+        }
+        after = connection.pageInfo.endCursor ?? null;
+        if (!after) {
+          break;
+        }
+      }
+      if (isBlocked) {
         blocked.push(issueNumber);
       }
     } catch {
@@ -795,9 +820,11 @@ function printHelp() {
   roadmap graph immediately before mutating, then post the evidence comment,
   close the roadmap as completed, and release the claim. Fails closed (exit 1,
   no mutation) on any lost / stale / non-owned claim or any blocker. The claim
-  is re-validated against --claim-issue (default: the roadmap) and must match
-  --claim-id (required under --apply) and, when given, --agent-id. --owner and
-  --repo must be passed together or not at all.
+  is re-validated against the roadmap issue; --claim-issue, when provided, must
+  equal --roadmap. The active claim must be a roadmap-audit-scoped claim
+  (branch roadmap-audit/<roadmap>-<slug>) and match --claim-id (required under
+  --apply) and, when given, --agent-id. --owner and --repo must be passed
+  together or not at all.
 `);
 }
 function isMainModule(moduleUrl) {

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -1,0 +1,607 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-roadmap-audit-execute.mts
+//
+// The scripts/idd-roadmap-audit-execute.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Thin A1.5 roadmap-completion-audit evaluator + executor. It WRAPS the
+// read-only discover-roadmap-graph traversal (reuses its child enumeration
+// verbatim) and introduces NO new decision authority: `decisionAuthority`
+// stays `instructions`. In the default dry-run it only evaluates completion
+// and reports the canonical `IDD roadmap completion audit` evidence body; the
+// ONLY mutations anywhere (the evidence comment, the close, and the unclaim
+// marker) happen under `--apply` once the roadmap is ready AND the
+// roadmap-audit claim re-validates immediately before the close. A roadmap
+// with an open / unresolved / inaccessible / nested-roadmap descendant, a
+// traversal cycle, or no explicit child work is NEVER closed.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  buildIssueLoader,
+  buildSubIssueLoader,
+  enumerateRoadmapGraph,
+} from './discover-roadmap-graph.mjs';
+import {
+  isStaleAt,
+  renderUnclaimedByMarker,
+  resolveTrustedMarkerActors,
+  summarizeClaimValidation,
+} from './protocol-helpers.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+const BLOCKED_LABELS = new Set([
+  'status:blocked-by-human',
+  'status:needs-decision',
+]);
+/**
+ * Evaluate roadmap completion against `report` (a discover-roadmap-graph
+ * single-root traversal). Every open / unresolved / inaccessible / nested-
+ * roadmap descendant, every traversal cycle, a blocked roadmap root, and a
+ * childless/malformed roadmap is collected as a blocker; `ready` is true only
+ * when no blocker is collected. The rules mirror the written A1.5 completion
+ * criteria exactly — this helper adds no stricter sub-condition. Pure and
+ * network-free so it is unit-testable apart from live GitHub.
+ */
+export function evaluateRoadmapAuditGates(report) {
+  const blockers = [];
+  const rootNumber = report.root.number;
+  const pathTo = buildProvenanceLookup(report);
+  // Root carrying a human-gate label is never auto-closed.
+  const rootNode = report.nodes.find((node) => node.number === rootNumber);
+  const rootBlockedLabel = (rootNode?.labels ?? []).find((label) =>
+    BLOCKED_LABELS.has(label),
+  );
+  if (rootBlockedLabel) {
+    blockers.push({
+      kind: 'roadmap-blocked',
+      target: rootNumber,
+      provenance: [rootNumber],
+      detail: `roadmap #${rootNumber} carries "${rootBlockedLabel}"; resolve the human gate before closing`,
+    });
+  }
+  // No explicit child work → childless / malformed. Do not infer completion
+  // from the absence of candidates.
+  if (report.edges.length === 0) {
+    blockers.push({
+      kind: 'childless',
+      detail: `roadmap #${rootNumber} has no explicit child references (task-list, closing-keyword, or GitHub sub-issue); childless or malformed, not complete`,
+    });
+  }
+  // Open execution leaves (already classification === 'execution' && OPEN).
+  for (const target of [...report.executionCandidates].sort((a, b) => a - b)) {
+    const node = report.nodes.find((entry) => entry.number === target);
+    blockers.push({
+      kind: 'open-child',
+      target,
+      provenance: pathTo(target),
+      detail: `execution leaf #${target}${node ? ` "${node.title}"` : ''} is OPEN`,
+    });
+  }
+  // Open nested roadmaps: a coordination/audit node that is still open blocks
+  // the parent close, regardless of its own leaf state (the parent can only
+  // close after the nested roadmap closes).
+  const openNestedRoadmaps = report.nodes
+    .filter(
+      (node) =>
+        node.classification === 'roadmap' &&
+        node.number !== rootNumber &&
+        node.state === 'OPEN',
+    )
+    .map((node) => node.number)
+    .sort((a, b) => a - b);
+  for (const target of openNestedRoadmaps) {
+    const node = report.nodes.find((entry) => entry.number === target);
+    blockers.push({
+      kind: 'nested-roadmap',
+      target,
+      provenance: pathTo(target),
+      detail: `nested roadmap #${target}${node ? ` "${node.title}"` : ''} is OPEN; close it (bottom-up) before its parent`,
+    });
+  }
+  // Unresolved references (target issue not found / is a PR).
+  for (const diagnostic of report.diagnostics.unresolvedReferences) {
+    blockers.push({
+      kind: 'unresolved-reference',
+      target: diagnostic.target,
+      provenance: [...pathTo(diagnostic.source), diagnostic.target],
+      detail: `reference #${diagnostic.source} → #${diagnostic.target} (${diagnostic.relationship}) is unresolved: ${diagnostic.reason}`,
+    });
+  }
+  // Inaccessible references (403/410/451): cannot prove completion.
+  for (const diagnostic of report.diagnostics.inaccessibleReferences) {
+    blockers.push({
+      kind: 'inaccessible-reference',
+      target: diagnostic.target,
+      provenance: [...pathTo(diagnostic.source), diagnostic.target],
+      detail: `reference #${diagnostic.source} → #${diagnostic.target} (${diagnostic.relationship}) is inaccessible: ${diagnostic.reason}`,
+    });
+  }
+  // Cycles / ambiguous graph: do not guess a closure order.
+  for (const cycle of report.diagnostics.cycles) {
+    blockers.push({
+      kind: 'cycle',
+      target: cycle.target,
+      provenance: cycle.path,
+      detail: `traversal cycle ${cycle.path.join(' → ')} (${cycle.relationship}); graph is ambiguous, treat as unresolved`,
+    });
+  }
+  return blockers;
+}
+/** First (sorted) root→target provenance path, or `[]` when none is recorded. */
+function buildProvenanceLookup(report) {
+  const lookup = new Map();
+  for (const entry of report.provenancePaths) {
+    if (!lookup.has(entry.target)) {
+      lookup.set(entry.target, entry.path);
+    }
+  }
+  return (target) => lookup.get(target) ?? [];
+}
+/**
+ * Compose the canonical `IDD roadmap completion audit` evidence comment body.
+ * Deterministic and network-free: it summarizes the audited graph (node /
+ * edge / depth counts, closed descendants split by classification, and the
+ * traversal diagnostics) and asserts no open / unresolved / inaccessible /
+ * nested-roadmap descendant remains. Only called when the roadmap is ready,
+ * so every descendant is closed or otherwise complete.
+ */
+export function buildRoadmapCompletionAuditBody(report) {
+  const rootNumber = report.root.number;
+  const descendants = report.nodes.filter((node) => node.number !== rootNumber);
+  const executionCount = descendants.filter(
+    (node) => node.classification === 'execution',
+  ).length;
+  const nestedRoadmapCount = descendants.filter(
+    (node) => node.classification === 'roadmap',
+  ).length;
+  const closedExecution = descendants
+    .filter((node) => node.classification === 'execution')
+    .map((node) => `#${node.number}`)
+    .join(', ');
+  const closedNested = descendants
+    .filter((node) => node.classification === 'roadmap')
+    .map((node) => `#${node.number}`)
+    .join(', ');
+  return [
+    '**IDD roadmap completion audit**',
+    '',
+    `Roadmap #${rootNumber} "${report.root.title}" audited as complete: every referenced child and descendant issue is closed or otherwise complete.`,
+    '',
+    'Evidence:',
+    `- Graph: ${report.summary.nodeCount} nodes, ${report.summary.edgeCount} edges, max depth ${report.summary.maxDepth}.`,
+    `- Closed descendants: ${descendants.length} (${executionCount} execution leaves, ${nestedRoadmapCount} nested roadmaps).`,
+    `- Closed execution leaves: ${closedExecution || 'none'}.`,
+    `- Closed nested roadmaps: ${closedNested || 'none'}.`,
+    '- Open / unresolved / inaccessible / nested-roadmap descendants: none.',
+    `- Diagnostics: ${report.summary.cycleCount} cycles, ${report.summary.unresolvedReferenceCount} unresolved references, ${report.summary.inaccessibleReferenceCount} inaccessible references, ${report.summary.duplicateReferenceCount} duplicate references.`,
+    '',
+    'Closing the roadmap as completed.',
+    '',
+    '_IDD roadmap-audit automation. Do not edit._',
+  ].join('\n');
+}
+/**
+ * Re-validate the roadmap-audit claim from the live claim-marker stream. The
+ * shared `summarizeClaimValidation` resolver decides claim ownership exactly
+ * as the merge gate does (trusted-author gated, claim-id / agent-id match);
+ * this helper additionally fails closed on a STALE claim (older than the
+ * distributed `claim-stale-age` default of 24 h relative to `nowIso`), because
+ * a stale claim is takeover-eligible and so cannot prove the caller still owns
+ * the roadmap. Pure and network-free: the comment stream and trusted-author
+ * predicate are injected so the fail-closed paths are unit-testable.
+ */
+export function evaluateRoadmapClaim(comments, options) {
+  const summary = summarizeClaimValidation(comments, {
+    isTrustedAuthor: options.isTrustedAuthor,
+    expectedClaimId: options.expectedClaimId,
+    expectedAgentId: options.expectedAgentId,
+  });
+  if (!summary.matchesExpectedClaim) {
+    return {
+      owned: false,
+      reason: summary.reason,
+      stale: false,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  // The 24h stale math lives in the shared `isStaleAt`; reuse it verbatim
+  // against "now" so a claim older than the distributed default is takeover-
+  // eligible and therefore not owned for the purpose of a roadmap mutation.
+  const stale = isStaleAt(summary.activeClaim.createdAt, options.nowIso);
+  if (stale) {
+    return {
+      owned: false,
+      reason: 'claim-stale',
+      stale: true,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  return {
+    owned: true,
+    reason: 'match',
+    stale: false,
+    activeClaim: summary.activeClaim,
+  };
+}
+/**
+ * Build the A1.5 verdict and, under `--apply`, execute the audit. The dry-run
+ * path performs NO mutation. The apply path fails closed: if the roadmap is
+ * not ready it exits without mutating; if it is ready it RE-VALIDATES the
+ * roadmap-audit claim and RE-EVALUATES the roadmap graph immediately before
+ * mutating, then refuses to mutate (clear message) on any lost / stale / non-
+ * owned claim or any newly-discovered blocker. Only after both re-validations
+ * pass does it post the evidence comment, close the roadmap, and release the
+ * claim — in that order.
+ */
+export async function runRoadmapAuditExecute(argv, deps) {
+  const args = parseArgs(argv);
+  if (!args.roadmapNumber) {
+    throw new Error('missing required --roadmap <number> argument');
+  }
+  const roadmapNumber = args.roadmapNumber;
+  const claimIssue = args.claimIssue ?? roadmapNumber;
+  const resolvedDeps = deps ?? createProductionDeps(args);
+  const report = await resolvedDeps.collect(roadmapNumber);
+  const blockers = evaluateRoadmapAuditGates(report);
+  const ready = blockers.length === 0;
+  const evidenceBody = ready ? buildRoadmapCompletionAuditBody(report) : '';
+  const verdict = {
+    protocolVersion: '1',
+    decisionAuthority: 'instructions',
+    mode: args.apply ? 'apply' : 'dry-run',
+    roadmapNumber,
+    ready,
+    blockers,
+    evidenceBody,
+    closed: false,
+    claimReleased: false,
+    result: '',
+  };
+  if (!args.apply) {
+    // Dry-run: read-only. Never mutate.
+    return { verdict, exitCode: ready ? 0 : 1 };
+  }
+  if (!ready) {
+    // Apply but not ready: fail closed, do not mutate.
+    verdict.result =
+      'not-ready: completion blockers present; no comment, close, or claim release attempted';
+    return { verdict, exitCode: 1 };
+  }
+  if (!args.claimId) {
+    // Apply requires the caller to assert which claim it owns; fail closed.
+    verdict.result =
+      'not-applied: --claim-id is required under --apply to re-validate roadmap-audit ownership';
+    return { verdict, exitCode: 1 };
+  }
+  const nowIso = resolvedDeps.now();
+  // Re-validate the roadmap-audit claim immediately before mutating; fail
+  // closed (no mutation) on any lost / stale / non-owned claim.
+  const claim = resolvedDeps.revalidateClaim({
+    issueNumber: claimIssue,
+    expectedClaimId: args.claimId,
+    expectedAgentId: args.agentId,
+    nowIso,
+  });
+  if (!claim.owned) {
+    verdict.result = `claim not owned on re-validation (reason="${claim.reason}"); no mutation`;
+    return { verdict, exitCode: 1 };
+  }
+  // Re-fetch the roadmap + child state and confirm the audit input still
+  // holds; a roadmap that gained an open / unresolved / nested-roadmap
+  // descendant between the first read and now must NEVER be closed.
+  const revalidated = await resolvedDeps.collect(roadmapNumber);
+  const revalidatedBlockers = evaluateRoadmapAuditGates(revalidated);
+  if (revalidatedBlockers.length > 0) {
+    verdict.blockers = revalidatedBlockers;
+    verdict.ready = false;
+    verdict.evidenceBody = '';
+    verdict.result =
+      're-validation found new completion blockers immediately before close; no mutation';
+    return { verdict, exitCode: 1 };
+  }
+  // Both gates hold: compose the body from the re-validated graph, then post
+  // the evidence comment, close the roadmap, and release the claim in order.
+  const finalEvidenceBody = buildRoadmapCompletionAuditBody(revalidated);
+  verdict.evidenceBody = finalEvidenceBody;
+  resolvedDeps.postEvidenceComment(roadmapNumber, finalEvidenceBody);
+  resolvedDeps.closeRoadmap(roadmapNumber);
+  resolvedDeps.releaseClaim(claimIssue, {
+    agentId: claim.activeClaim.agentId,
+    claimId: claim.activeClaim.claimId,
+    timestamp: nowIso,
+  });
+  verdict.closed = true;
+  verdict.claimReleased = true;
+  verdict.result =
+    'roadmap closed as completed; evidence comment posted and roadmap-audit claim released';
+  return { verdict, exitCode: 0 };
+}
+// ---------------------------------------------------------------------------
+// Production dependency wiring (live gh + roadmap-graph traversal).
+// ---------------------------------------------------------------------------
+function createProductionDeps(args) {
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const rawConfig = loadPolicy(args.policy);
+  const markerPrefix = normalizeMarkerPrefix(rawConfig.markerPrefix);
+  const viewerLogin = String(safeGhText(['api', 'user', '--jq', '.login']))
+    .trim()
+    .toLowerCase();
+  const isTrustedAuthor = buildTrustedAuthorPredicate({
+    owner,
+    viewerLogin,
+    rawConfig: rawConfig,
+  });
+  const loadIssue = buildIssueLoader(owner, repo);
+  const loadSubIssues = buildSubIssueLoader(owner, repo);
+  return {
+    collect: (roadmapNumber) =>
+      enumerateRoadmapGraph(roadmapNumber, {
+        markerPrefix,
+        owner,
+        repo,
+        loadIssue,
+        loadSubIssues,
+      }),
+    revalidateClaim: ({
+      issueNumber,
+      expectedClaimId,
+      expectedAgentId,
+      nowIso,
+    }) =>
+      evaluateRoadmapClaim(loadIssueComments(owner, repo, issueNumber), {
+        expectedClaimId,
+        expectedAgentId,
+        isTrustedAuthor,
+        nowIso,
+      }),
+    postEvidenceComment: (issueNumber, body) =>
+      postIssueComment(owner, repo, issueNumber, body),
+    closeRoadmap: (issueNumber) =>
+      ghText([
+        'issue',
+        'close',
+        String(issueNumber),
+        '--repo',
+        `${owner}/${repo}`,
+        '--reason',
+        'completed',
+      ]),
+    releaseClaim: (issueNumber, fields) =>
+      postIssueComment(
+        owner,
+        repo,
+        issueNumber,
+        renderUnclaimedByMarker(fields),
+      ),
+    now: () => new Date().toISOString(),
+  };
+}
+/**
+ * Trusted marker-author predicate for claim re-validation. Mirrors the
+ * external-check-waiver write-gate set: the repo owner and the authenticated
+ * viewer (the agent posting the claim) are always trusted, plus the configured
+ * `trustedMarkerActors` and the `IDD_TRUSTED_MARKER_ACTORS` env override
+ * (resolved through the shared `resolveTrustedMarkerActors`).
+ */
+function buildTrustedAuthorPredicate({ owner, viewerLogin, rawConfig }) {
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: rawConfig,
+  });
+  const trusted = new Set(
+    [owner, viewerLogin, ...actors]
+      .filter(Boolean)
+      .map((login) => login.trim().toLowerCase()),
+  );
+  return (login) =>
+    trusted.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+}
+/** Load every issue comment (paginated) as the claim-marker event stream. */
+function loadIssueComments(owner, repo, issueNumber) {
+  const comments = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const raw = ghText([
+      'api',
+      `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+      '--jq',
+      '.',
+    ]);
+    const pageItems = raw && raw !== 'null' ? JSON.parse(raw) : [];
+    if (!Array.isArray(pageItems) || pageItems.length === 0) {
+      break;
+    }
+    comments.push(...pageItems);
+    if (pageItems.length < pageSize) {
+      break;
+    }
+  }
+  return comments.map((entry) => {
+    const comment = entry ?? {};
+    return {
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? comment.created_at ?? ''),
+      author: {
+        login: String(comment.author?.login ?? comment.user?.login ?? ''),
+      },
+    };
+  });
+}
+/**
+ * POST a comment body as a JSON document (`{"body": …}`) via `gh api --input
+ * -`. The JSON path is mandatory because HTML-comment-first bodies (the
+ * unclaim marker) are silently dropped by `gh issue comment` / `gh api -f
+ * body=`; the same path is reused for the evidence comment for consistency.
+ */
+function postIssueComment(owner, repo, issueNumber, body) {
+  execFileSync(
+    'gh',
+    [
+      'api',
+      '--method',
+      'POST',
+      `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+      '--input',
+      '-',
+    ],
+    { input: JSON.stringify({ body }), encoding: 'utf8' },
+  );
+}
+function loadPolicy(policyPath) {
+  const targetPath = policyPath
+    ? resolve(process.cwd(), policyPath)
+    : resolve(process.cwd(), '.github/idd/config.json');
+  try {
+    return JSON.parse(readFileSync(targetPath, 'utf8'));
+  } catch (error) {
+    if (!policyPath) {
+      return {};
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to load policy from ${targetPath}: ${detail}`);
+  }
+}
+function normalizeMarkerPrefix(markerPrefix) {
+  const normalized = String(markerPrefix ?? '').trim();
+  return normalized || DEFAULT_MARKER_PREFIX;
+}
+function ghText(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+function safeGhText(args) {
+  try {
+    return ghText(args);
+  } catch {
+    return '';
+  }
+}
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const parsed = {
+    roadmapNumber: null,
+    apply: false,
+    claimIssue: null,
+    claimId: '',
+    agentId: '',
+    owner: '',
+    repo: '',
+    policy: '',
+    now: '',
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--apply') {
+      parsed.apply = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`missing value for argument: ${token}`);
+    }
+    index += 1;
+    switch (token) {
+      case '--roadmap':
+        parsed.roadmapNumber = parsePositiveInteger(value, token);
+        break;
+      case '--claim-issue':
+        parsed.claimIssue = parsePositiveInteger(value, token);
+        break;
+      case '--claim-id':
+        parsed.claimId = value.trim();
+        break;
+      case '--agent-id':
+        parsed.agentId = value.trim();
+        break;
+      case '--owner':
+        parsed.owner = value.trim();
+        break;
+      case '--repo':
+        parsed.repo = value.trim();
+        break;
+      case '--policy':
+        parsed.policy = value.trim();
+        break;
+      case '--now':
+        parsed.now = value.trim();
+        break;
+      default:
+        throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  // Fail closed on exactly one of --owner / --repo: a single flag would
+  // validate one repo while the traversal / mutation runs against the
+  // current-directory repo. Require both or neither.
+  if ((parsed.owner === '') !== (parsed.repo === '')) {
+    throw new Error(
+      'idd-roadmap-audit-execute: --owner and --repo must be provided together or not at all',
+    );
+  }
+  return parsed;
+}
+function parsePositiveInteger(value, flag) {
+  const raw = String(value ?? '').trim();
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`invalid ${flag} value: ${value}`);
+  }
+  return Number(raw);
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/idd-roadmap-audit-execute.mjs --roadmap <number> [--owner <owner>] [--repo <repo>] [--policy <path>]
+  node scripts/idd-roadmap-audit-execute.mjs --roadmap <number> --claim-id <claim-id> [--claim-issue <number>] [--agent-id <agent-id>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--apply]
+
+  Default (no --apply): dry-run. Evaluates A1.5 roadmap completion via the
+  read-only discover-roadmap-graph traversal and prints { ready, blockers,
+  evidenceBody } without mutating. Exit 0 when ready, 1 otherwise. evidenceBody
+  is the canonical "IDD roadmap completion audit" comment body (empty when the
+  roadmap is not ready).
+
+  --apply: when ready, re-validate the roadmap-audit claim and re-evaluate the
+  roadmap graph immediately before mutating, then post the evidence comment,
+  close the roadmap as completed, and release the claim. Fails closed (exit 1,
+  no mutation) on any lost / stale / non-owned claim or any blocker. The claim
+  is re-validated against --claim-issue (default: the roadmap) and must match
+  --claim-id (required under --apply) and, when given, --agent-id. --owner and
+  --repo must be passed together or not at all.
+`);
+}
+function isMainModule(moduleUrl) {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return fileURLToPath(moduleUrl) === resolve(entry);
+}
+if (isMainModule(import.meta.url)) {
+  if (process.argv.slice(2).some((arg) => arg === '--help' || arg === '-h')) {
+    printHelp();
+    process.exit(0);
+  }
+  runRoadmapAuditExecute(process.argv.slice(2))
+    .then(({ verdict, exitCode }) => {
+      process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+      process.exit(exitCode);
+    })
+    .catch((error) => {
+      process.stderr.write(`Error: ${error.message}\n`);
+      process.exit(1);
+    });
+}

--- a/src/bin/idd-roadmap-audit-execute.mts
+++ b/src/bin/idd-roadmap-audit-execute.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-roadmap-audit-execute.mts
+//
+// The bin/idd-roadmap-audit-execute.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/idd-roadmap-audit-execute.mjs');

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1126,7 +1126,7 @@ function normalizeClaimComments(
  * comparison is applied with the configured age. Mirrors
  * resume-claim-routing's `isStaleByAge`.
  */
-function isClaimStaleByAge(
+export function isClaimStaleByAge(
   activeCreatedAt: string,
   nextCreatedAt: string,
   staleAgeMs: number,

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1656,7 +1656,7 @@ async function getIssue(
   return issue;
 }
 
-function buildIssueLoader(owner: string, repo: string) {
+export function buildIssueLoader(owner: string, repo: string) {
   return async (issueNumber: number) => {
     const args = [
       'api',
@@ -1682,7 +1682,7 @@ function buildIssueLoader(owner: string, repo: string) {
   };
 }
 
-function buildSubIssueLoader(owner: string, repo: string) {
+export function buildSubIssueLoader(owner: string, repo: string) {
   return async (issueNumber: number) => {
     const numbers: number[] = [];
     let after = '';

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -415,6 +415,16 @@ const HELPER_COMMANDS: HelperCommand[] = [
       'Verify disposition marker presence on review items for E7 meta-check.',
   },
   {
+    id: 'roadmap-audit-execute',
+    scriptName: 'idd:roadmap-audit-execute',
+    binName: 'idd-roadmap-audit-execute',
+    entryPath: 'scripts/idd-roadmap-audit-execute.mjs',
+    vendoredCommand: 'node scripts/idd-roadmap-audit-execute.mjs',
+    description:
+      'Evaluate the A1.5 roadmap completion audit (dry-run) and, with --apply, post the evidence comment, close the roadmap, and release the claim.',
+    contractPaths: ['schemas/idd-roadmap-audit-execute.schema.json'],
+  },
+  {
     id: 'stalled-session-quiet-check',
     scriptName: 'idd:stalled-session-quiet-check',
     binName: 'idd-stalled-session-quiet-check',

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -1027,7 +1027,12 @@ function hasOpenClosingPr(
     }
     after = connection.pageInfo.endCursor ?? null;
     if (!after) {
-      return false;
+      // hasNextPage with no endCursor: an incomplete / unexpected connection
+      // read. Throw so the per-issue catch fails closed (blocks the child)
+      // rather than treating a partial page as "no open PR".
+      throw new Error(
+        'incomplete closing-PR pagination: hasNextPage with no endCursor',
+      );
     }
   }
 }
@@ -1081,7 +1086,12 @@ function hasOpenConnectedPr(
     }
     after = connection.pageInfo.endCursor ?? null;
     if (!after) {
-      break;
+      // hasNextPage with no endCursor: reconciling a truncated timeline could
+      // miss a later CONNECTED open PR. Throw so the per-issue catch fails
+      // closed (blocks the child) instead of trusting the partial stream.
+      throw new Error(
+        'incomplete connected-PR timeline pagination: hasNextPage with no endCursor',
+      );
     }
   }
   return reconcileConnectedOpenPrs(events).length > 0;

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -720,7 +720,9 @@ function createProductionDeps(
         issueNumber,
         renderUnclaimedByMarker(fields),
       ),
-    now: () => new Date().toISOString(),
+    // Honor a caller-supplied --now (deterministic staleness + release
+    // timestamps for tests / replays); fall back to the wall clock.
+    now: () => args.now || new Date().toISOString(),
   };
 }
 
@@ -815,11 +817,12 @@ function resolveOpenLinkedPrIssues(
   repo: string,
   issueNumbers: number[],
 ): number[] {
-  const query = `query($owner:String!,$repo:String!,$number:Int!){
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
-      closedByPullRequestsReferences(first:20,includeClosedPrs:false){
-        nodes { number state }
+      closedByPullRequestsReferences(first:50,after:$after,includeClosedPrs:false){
+        nodes { state }
+        pageInfo { hasNextPage endCursor }
       }
     }
   }
@@ -827,33 +830,59 @@ function resolveOpenLinkedPrIssues(
   const blocked: number[] = [];
   for (const issueNumber of issueNumbers) {
     try {
-      const raw = ghText([
-        'api',
-        'graphql',
-        '-f',
-        `query=${query}`,
-        '-f',
-        `owner=${owner}`,
-        '-f',
-        `repo=${repo}`,
-        '-F',
-        `number=${issueNumber}`,
-      ]);
-      const parsed = JSON.parse(raw) as {
-        data?: {
-          repository?: {
-            issue?: {
-              closedByPullRequestsReferences?: {
-                nodes?: { state?: unknown }[] | null;
+      // Page through every reference until an OPEN PR is found (short-circuit:
+      // one is enough to block) or the connection is exhausted; `first:20`
+      // could otherwise truncate the list and miss an OPEN blocker on a later
+      // page, which for a fail-closed gate would wrongly green-light a close.
+      let after: string | null = null;
+      let isBlocked = false;
+      for (;;) {
+        const apiArgs = [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-f',
+          `owner=${owner}`,
+          '-f',
+          `repo=${repo}`,
+          '-F',
+          `number=${issueNumber}`,
+        ];
+        if (after) {
+          apiArgs.push('-f', `after=${after}`);
+        }
+        const parsed = JSON.parse(ghText(apiArgs)) as {
+          data?: {
+            repository?: {
+              issue?: {
+                closedByPullRequestsReferences?: {
+                  nodes?: { state?: unknown }[] | null;
+                  pageInfo?: {
+                    hasNextPage?: boolean;
+                    endCursor?: string | null;
+                  } | null;
+                } | null;
               } | null;
             } | null;
-          } | null;
+          };
         };
-      };
-      const nodes =
-        parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ??
-        [];
-      if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
+        const connection =
+          parsed.data?.repository?.issue?.closedByPullRequestsReferences;
+        const nodes = connection?.nodes ?? [];
+        if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
+          isBlocked = true;
+          break;
+        }
+        if (!connection?.pageInfo?.hasNextPage) {
+          break;
+        }
+        after = connection.pageInfo.endCursor ?? null;
+        if (!after) {
+          break;
+        }
+      }
+      if (isBlocked) {
         blocked.push(issueNumber);
       }
     } catch {
@@ -1020,9 +1049,11 @@ function printHelp(): void {
   roadmap graph immediately before mutating, then post the evidence comment,
   close the roadmap as completed, and release the claim. Fails closed (exit 1,
   no mutation) on any lost / stale / non-owned claim or any blocker. The claim
-  is re-validated against --claim-issue (default: the roadmap) and must match
-  --claim-id (required under --apply) and, when given, --agent-id. --owner and
-  --repo must be passed together or not at all.
+  is re-validated against the roadmap issue; --claim-issue, when provided, must
+  equal --roadmap. The active claim must be a roadmap-audit-scoped claim
+  (branch roadmap-audit/<roadmap>-<slug>) and match --claim-id (required under
+  --apply) and, when given, --agent-id. --owner and --repo must be passed
+  together or not at all.
 `);
 }
 

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -47,6 +47,15 @@ const BLOCKED_LABELS = new Set([
   'status:needs-decision',
 ]);
 
+// Scope caveat (A1.5): this helper gates only the MECHANICAL completion
+// preconditions. It deliberately does NOT verify the roadmap's free-form
+// success criteria or autonomy-gap items — that is agent judgment "where
+// feasible" per the instruction — so the caller must confirm those separately
+// before --apply, exactly as the merge gate trusts that review actually
+// happened.
+const MECHANICAL_GATE_NOTE =
+  'Mechanical preconditions only: every descendant is closed/complete with no open / unresolved / inaccessible / linked-PR / nested-roadmap / childless / cycle / human-gate blocker. Separately verify the roadmap’s free-form success criteria and autonomy-gap items before --apply (this helper does not, just as the merge gate trusts that review happened).';
+
 /** Distinct blocker categories surfaced by the completion audit. */
 export type RoadmapAuditBlockerKind =
   | 'roadmap-blocked'
@@ -369,6 +378,48 @@ export function buildRoadmapCompletionAuditBody(
   ].join('\n');
 }
 
+/** One CONNECTED / DISCONNECTED linked-PR timeline event, in chronological order. */
+export interface ConnectedPrEvent {
+  type: 'connected' | 'disconnected';
+  prNumber: number;
+  /** PR state captured on a `connected` event (e.g. `OPEN` / `MERGED`). */
+  state?: string;
+}
+
+/**
+ * Reconcile a chronological CONNECTED / DISCONNECTED linked-PR event stream
+ * into the PR numbers that are CURRENTLY connected (the last event for the PR
+ * is a connect, with no later disconnect) AND in the `OPEN` state. Mirrors
+ * resume-claim-routing's `fetchOpenLinkedPrReferences` reconciliation so an
+ * open PR merely linked (no closing keyword) still blocks a roadmap close,
+ * while a CONNECTED-then-DISCONNECTED PR or a connected MERGED PR does not.
+ * Pure so it is unit-testable without `gh`.
+ */
+export function reconcileConnectedOpenPrs(
+  events: ConnectedPrEvent[],
+): number[] {
+  const connected = new Map<number, boolean>();
+  const states = new Map<number, string>();
+  for (const event of events) {
+    if (!Number.isInteger(event.prNumber)) {
+      continue;
+    }
+    if (event.type === 'connected') {
+      connected.set(event.prNumber, true);
+      states.set(event.prNumber, String(event.state ?? ''));
+    } else if (event.type === 'disconnected') {
+      connected.set(event.prNumber, false);
+    }
+  }
+  const open: number[] = [];
+  for (const [prNumber, isConnected] of connected) {
+    if (isConnected && states.get(prNumber) === 'OPEN') {
+      open.push(prNumber);
+    }
+  }
+  return open.sort((left, right) => left - right);
+}
+
 /**
  * Re-validate the roadmap-audit claim from the live claim-marker stream. The
  * shared `summarizeClaimValidation` resolver decides claim ownership exactly
@@ -528,7 +579,9 @@ export async function runRoadmapAuditExecute(
   };
 
   if (!args.apply) {
-    // Dry-run: read-only. Never mutate.
+    // Dry-run: read-only. Never mutate. Surface the scope caveat so a caller
+    // does not mistake a mechanical "ready" for a full success-criteria audit.
+    verdict.result = MECHANICAL_GATE_NOTE;
     return { verdict, exitCode: ready ? 0 : 1 };
   }
 
@@ -802,21 +855,58 @@ function loadIssueComments(
 }
 
 /**
- * Resolve which of `issueNumbers` still have an OPEN linked / closing PR.
+ * Resolve which of `issueNumbers` still have an OPEN linked PR — covering A1.5's
+ * "open linked OR closing PR". Two GraphQL signals per issue, either of which
+ * blocks (issue-level short-circuit, `||`):
  *
- * Uses one GraphQL field per issue — `closedByPullRequestsReferences`, the PRs
- * that reference-close the issue — and keeps a number only when at least one
- * such PR is still in the `OPEN` state. MERGED / CLOSED PRs are obsolete and
- * never block (the field returns merged PRs even with
- * `includeClosedPrs:false`, so the `OPEN`-state filter is what matters). On a
- * per-issue lookup error the issue is conservatively treated as having an open
- * PR (fail closed) so a transient failure can never green-light a close.
+ *  1. `closedByPullRequestsReferences` — PRs that reference-CLOSE the issue via
+ *     a closing keyword — kept only when at least one is still `OPEN` (MERGED /
+ *     CLOSED are obsolete; the field returns merged PRs even with
+ *     `includeClosedPrs:false`, so the `OPEN`-state filter is what matters); and
+ *  2. CONNECTED / DISCONNECTED timeline events — a PR manually linked via
+ *     GitHub's Development relationship with NO closing keyword — reconciled
+ *     (`CONNECTED_EVENT` with no later `DISCONNECTED_EVENT` for the same PR) and
+ *     kept only when that PR is still `OPEN`. Mirrors resume-claim-routing's
+ *     `fetchOpenLinkedPrReferences` shape.
+ *
+ * Both queries paginate fully (the connected stream MUST be read whole so a
+ * later DISCONNECTED is never missed). On a per-issue lookup error the issue is
+ * conservatively treated as blocked (fail closed) so a transient failure can
+ * never green-light a close.
  */
 function resolveOpenLinkedPrIssues(
   owner: string,
   repo: string,
   issueNumbers: number[],
 ): number[] {
+  const blocked: number[] = [];
+  for (const issueNumber of issueNumbers) {
+    try {
+      if (
+        hasOpenClosingPr(owner, repo, issueNumber) ||
+        hasOpenConnectedPr(owner, repo, issueNumber)
+      ) {
+        blocked.push(issueNumber);
+      }
+    } catch {
+      // Fail closed: an undeterminable PR state blocks the close.
+      blocked.push(issueNumber);
+    }
+  }
+  return blocked;
+}
+
+/**
+ * True when the issue has an OPEN PR that reference-closes it. Pages through
+ * `closedByPullRequestsReferences` and short-circuits on the first OPEN PR
+ * (one is enough to block); truncating the list could miss an OPEN blocker on
+ * a later page, wrongly green-lighting a close.
+ */
+function hasOpenClosingPr(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): boolean {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
@@ -827,70 +917,143 @@ function resolveOpenLinkedPrIssues(
     }
   }
 }`;
-  const blocked: number[] = [];
-  for (const issueNumber of issueNumbers) {
-    try {
-      // Page through every reference until an OPEN PR is found (short-circuit:
-      // one is enough to block) or the connection is exhausted; `first:20`
-      // could otherwise truncate the list and miss an OPEN blocker on a later
-      // page, which for a fail-closed gate would wrongly green-light a close.
-      let after: string | null = null;
-      let isBlocked = false;
-      for (;;) {
-        const apiArgs = [
-          'api',
-          'graphql',
-          '-f',
-          `query=${query}`,
-          '-f',
-          `owner=${owner}`,
-          '-f',
-          `repo=${repo}`,
-          '-F',
-          `number=${issueNumber}`,
-        ];
-        if (after) {
-          apiArgs.push('-f', `after=${after}`);
-        }
-        const parsed = JSON.parse(ghText(apiArgs)) as {
-          data?: {
-            repository?: {
-              issue?: {
-                closedByPullRequestsReferences?: {
-                  nodes?: { state?: unknown }[] | null;
-                  pageInfo?: {
-                    hasNextPage?: boolean;
-                    endCursor?: string | null;
-                  } | null;
-                } | null;
-              } | null;
+  let after: string | null = null;
+  for (;;) {
+    const parsed = ghGraphql(query, owner, repo, issueNumber, after) as {
+      data?: {
+        repository?: {
+          issue?: {
+            closedByPullRequestsReferences?: {
+              nodes?: { state?: unknown }[] | null;
+              pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
             } | null;
-          };
-        };
-        const connection =
-          parsed.data?.repository?.issue?.closedByPullRequestsReferences;
-        const nodes = connection?.nodes ?? [];
-        if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
-          isBlocked = true;
-          break;
-        }
-        if (!connection?.pageInfo?.hasNextPage) {
-          break;
-        }
-        after = connection.pageInfo.endCursor ?? null;
-        if (!after) {
-          break;
-        }
-      }
-      if (isBlocked) {
-        blocked.push(issueNumber);
-      }
-    } catch {
-      // Fail closed: an undeterminable PR state blocks the close.
-      blocked.push(issueNumber);
+          } | null;
+        } | null;
+      };
+    };
+    const connection =
+      parsed.data?.repository?.issue?.closedByPullRequestsReferences;
+    const nodes = connection?.nodes ?? [];
+    if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
+      return true;
+    }
+    if (!connection?.pageInfo?.hasNextPage) {
+      return false;
+    }
+    after = connection.pageInfo.endCursor ?? null;
+    if (!after) {
+      return false;
     }
   }
-  return blocked;
+}
+
+/**
+ * True when the issue has a currently-CONNECTED, OPEN linked PR (Development
+ * relationship without a closing keyword). Pages the CONNECTED/DISCONNECTED
+ * timeline in full — the whole stream is needed so a later DISCONNECTED is not
+ * missed — then reconciles it via the pure {@link reconcileConnectedOpenPrs}.
+ */
+function hasOpenConnectedPr(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): boolean {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      timelineItems(first:50,after:$after,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT]){
+        nodes {
+          __typename
+          ... on ConnectedEvent { subject { __typename ... on PullRequest { number state } } }
+          ... on DisconnectedEvent { subject { __typename ... on PullRequest { number } } }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+  const events: ConnectedPrEvent[] = [];
+  let after: string | null = null;
+  for (;;) {
+    const parsed = ghGraphql(query, owner, repo, issueNumber, after) as {
+      data?: {
+        repository?: {
+          issue?: {
+            timelineItems?: {
+              nodes?: unknown[] | null;
+              pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+            } | null;
+          } | null;
+        } | null;
+      };
+    };
+    const connection = parsed.data?.repository?.issue?.timelineItems;
+    events.push(...parseConnectedPrEvents(connection?.nodes ?? []));
+    if (!connection?.pageInfo?.hasNextPage) {
+      break;
+    }
+    after = connection.pageInfo.endCursor ?? null;
+    if (!after) {
+      break;
+    }
+  }
+  return reconcileConnectedOpenPrs(events).length > 0;
+}
+
+/** Run one `gh api graphql` page, passing `after` only when set. */
+function ghGraphql(
+  query: string,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  after: string | null,
+): unknown {
+  const apiArgs = [
+    'api',
+    'graphql',
+    '-f',
+    `query=${query}`,
+    '-f',
+    `owner=${owner}`,
+    '-f',
+    `repo=${repo}`,
+    '-F',
+    `number=${issueNumber}`,
+  ];
+  if (after) {
+    apiArgs.push('-f', `after=${after}`);
+  }
+  return JSON.parse(ghText(apiArgs));
+}
+
+/** Coerce raw CONNECTED/DISCONNECTED timeline nodes into reconcile events. */
+function parseConnectedPrEvents(nodes: unknown[]): ConnectedPrEvent[] {
+  const events: ConnectedPrEvent[] = [];
+  for (const node of nodes) {
+    const record = node as {
+      __typename?: unknown;
+      subject?: { __typename?: unknown; number?: unknown; state?: unknown };
+    } | null;
+    const subject = record?.subject;
+    if (subject?.__typename !== 'PullRequest') {
+      continue;
+    }
+    const prNumber =
+      typeof subject.number === 'number' ? subject.number : Number.NaN;
+    if (!Number.isInteger(prNumber)) {
+      continue;
+    }
+    if (record?.__typename === 'ConnectedEvent') {
+      events.push({
+        type: 'connected',
+        prNumber,
+        state: String(subject.state ?? ''),
+      });
+    } else if (record?.__typename === 'DisconnectedEvent') {
+      events.push({ type: 'disconnected', prNumber });
+    }
+  }
+  return events;
 }
 
 /**
@@ -1054,6 +1217,13 @@ function printHelp(): void {
   (branch roadmap-audit/<roadmap>-<slug>) and match --claim-id (required under
   --apply) and, when given, --agent-id. --owner and --repo must be passed
   together or not at all.
+
+  SCOPE: this helper gates only the MECHANICAL completion preconditions (all
+  descendants closed/complete; no open / unresolved / inaccessible / linked-PR
+  / nested-roadmap / childless / cycle / human-gate blocker). It does NOT verify
+  the roadmap's free-form success criteria or autonomy-gap items — the caller
+  must confirm those separately before --apply, exactly as the merge gate
+  trusts that review actually happened.
 `);
 }
 

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -607,6 +607,19 @@ export async function runRoadmapAuditExecute(
     return { verdict, exitCode: 1 };
   }
 
+  // Validate + normalize the apply-time clock ONCE, before any mutation: an
+  // unparseable "now" would mis-evaluate claim staleness, and an offset /
+  // sub-second form would reach the unclaim renderer (which accepts only `…Z`
+  // second-precision) and throw AFTER the comment + close had already landed.
+  // The single normalized value is reused for every staleness check AND the
+  // release marker.
+  const rawNow = resolvedDeps.now();
+  const nowIso = normalizeApplyNow(rawNow);
+  if (nowIso === null) {
+    verdict.result = `invalid "now" value "${rawNow}"; expected a parseable ISO timestamp (no mutation)`;
+    return { verdict, exitCode: 1 };
+  }
+
   // Early claim re-validation (defense in depth): bail before the graph
   // re-fetch if ownership is already gone.
   const earlyClaim = resolvedDeps.revalidateClaim({
@@ -614,7 +627,7 @@ export async function runRoadmapAuditExecute(
     roadmapNumber,
     expectedClaimId: args.claimId,
     expectedAgentId: args.agentId,
-    nowIso: resolvedDeps.now(),
+    nowIso,
   });
   if (!earlyClaim.owned) {
     verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}"); no mutation`;
@@ -641,9 +654,7 @@ export async function runRoadmapAuditExecute(
   }
 
   // The graph re-fetch can span many API calls during which another session
-  // can take over, so the LAST gate before any mutation is a fresh claim
-  // re-validation. Its activeClaim + "now" are the ones used for the release.
-  const nowIso = resolvedDeps.now();
+  // can take over, so re-validate ownership immediately before posting.
   const claim = resolvedDeps.revalidateClaim({
     issueNumber: roadmapNumber,
     roadmapNumber,
@@ -656,20 +667,34 @@ export async function runRoadmapAuditExecute(
     return { verdict, exitCode: 1 };
   }
 
-  // All gates hold: compose the body from the re-validated graph, then post
-  // the evidence comment, close the roadmap, and release the claim in order.
+  // Post the evidence comment (non-destructive), THEN re-validate ownership one
+  // final time immediately before the CLOSE: a takeover landing in the
+  // comment→close gap must not let us close under a claim we no longer own. An
+  // already-posted evidence comment before an aborted close is harmless — the
+  // successor session simply re-audits — but a wrongful close is destructive.
   const finalEvidenceBody = buildRoadmapCompletionAuditBody(revalidated);
   verdict.evidenceBody = finalEvidenceBody;
-
   resolvedDeps.postEvidenceComment(roadmapNumber, finalEvidenceBody);
+
+  const preCloseClaim = resolvedDeps.revalidateClaim({
+    issueNumber: roadmapNumber,
+    roadmapNumber,
+    expectedClaimId: args.claimId,
+    expectedAgentId: args.agentId,
+    nowIso,
+  });
+  if (!preCloseClaim.owned) {
+    verdict.result = `claim lost in the comment→close gap (reason="${preCloseClaim.reason}"); evidence comment posted but roadmap NOT closed`;
+    return { verdict, exitCode: 1 };
+  }
+
+  // Ownership held through the comment: close, then release using the last
+  // verdict's activeClaim and the normalized second-precision "now".
   resolvedDeps.closeRoadmap(roadmapNumber);
   resolvedDeps.releaseClaim(roadmapNumber, {
-    agentId: claim.activeClaim.agentId,
-    claimId: claim.activeClaim.claimId,
-    // The unclaim marker only accepts second-precision ISO; truncate any
-    // sub-second digits so a millisecond `now()` never throws after the
-    // comment + close already landed (a partial, unrecoverable mutation).
-    timestamp: toSecondPrecisionIso(nowIso),
+    agentId: preCloseClaim.activeClaim.agentId,
+    claimId: preCloseClaim.activeClaim.claimId,
+    timestamp: nowIso,
   });
 
   verdict.closed = true;
@@ -691,6 +716,25 @@ function closedDescendantNumbers(report: RoadmapGraphReport): number[] {
 /** Truncate any sub-second fraction so an ISO stamp is `YYYY-MM-DDTHH:mm:ssZ`. */
 function toSecondPrecisionIso(iso: string): string {
   return String(iso).replace(/\.\d+Z$/, 'Z');
+}
+
+/**
+ * Validate and normalize the apply-time "now" to UTC second-precision ISO
+ * (`YYYY-MM-DDTHH:mm:ssZ`), or `null` when unparseable. The caller fails closed
+ * on `null` BEFORE any mutation: an unparseable value would mis-evaluate claim
+ * staleness (NaN comparisons read as not-stale), and an offset / sub-second
+ * form (e.g. `…+09:00`) would otherwise reach `renderUnclaimedByMarker` — which
+ * accepts only `…Z` second-precision — and throw AFTER the comment + close had
+ * already landed. Normalizing through `toISOString()` also converts any zone
+ * offset to UTC, so the single normalized value is safe for both the staleness
+ * checks and the release marker.
+ */
+function normalizeApplyNow(raw: string): string | null {
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return toSecondPrecisionIso(parsed.toISOString());
 }
 
 // ---------------------------------------------------------------------------
@@ -870,42 +914,84 @@ function loadIssueComments(
  *     `fetchOpenLinkedPrReferences` shape.
  *
  * Both queries paginate fully (the connected stream MUST be read whole so a
- * later DISCONNECTED is never missed). On a per-issue lookup error the issue is
- * conservatively treated as blocked (fail closed) so a transient failure can
- * never green-light a close.
+ * later DISCONNECTED is never missed). Fails closed: a per-issue lookup error,
+ * OR an ABSENT lookup connection (`issue: null` / connection `null`|`undefined`
+ * — a deleted / transferred / inaccessible issue, or partial GraphQL data),
+ * treats the issue as blocked. An absent connection is distinct from a
+ * genuinely present-but-empty `nodes: []` (legitimately no PR on that signal),
+ * which does NOT block on that signal. The GraphQL runner is injectable so the
+ * absence distinction is unit-testable without `gh`.
  */
-function resolveOpenLinkedPrIssues(
+export function resolveOpenLinkedPrIssues(
   owner: string,
   repo: string,
   issueNumbers: number[],
+  runGraphql: LinkedPrGraphqlRunner = ghGraphql,
 ): number[] {
   const blocked: number[] = [];
   for (const issueNumber of issueNumbers) {
     try {
       if (
-        hasOpenClosingPr(owner, repo, issueNumber) ||
-        hasOpenConnectedPr(owner, repo, issueNumber)
+        hasOpenClosingPr(owner, repo, issueNumber, runGraphql) ||
+        hasOpenConnectedPr(owner, repo, issueNumber, runGraphql)
       ) {
         blocked.push(issueNumber);
       }
     } catch {
-      // Fail closed: an undeterminable PR state blocks the close.
+      // Fail closed: an undeterminable / absent PR state blocks the close.
       blocked.push(issueNumber);
     }
   }
   return blocked;
 }
 
+/** One paginated `gh api graphql` page runner (injectable for tests). */
+type LinkedPrGraphqlRunner = (
+  query: string,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  after: string | null,
+) => unknown;
+
+/**
+ * Narrow a parsed GraphQL response to the named connection on its issue node,
+ * THROWING (→ fail closed) when the issue is `null`/absent or the connection
+ * itself is `null`/`undefined`. A present connection (even with empty `nodes`)
+ * is returned as-is so a legitimately PR-free issue is not treated as blocked.
+ */
+function requireIssueConnection<T>(
+  parsed: unknown,
+  pick: (issue: Record<string, unknown>) => T | null | undefined,
+  label: string,
+): T {
+  const issue = (
+    parsed as {
+      data?: { repository?: { issue?: Record<string, unknown> | null } | null };
+    } | null
+  )?.data?.repository?.issue;
+  if (issue === null || issue === undefined) {
+    throw new Error(`${label}: issue is null/absent (fail closed)`);
+  }
+  const connection = pick(issue);
+  if (connection === null || connection === undefined) {
+    throw new Error(`${label}: connection is null/absent (fail closed)`);
+  }
+  return connection;
+}
+
 /**
  * True when the issue has an OPEN PR that reference-closes it. Pages through
  * `closedByPullRequestsReferences` and short-circuits on the first OPEN PR
  * (one is enough to block); truncating the list could miss an OPEN blocker on
- * a later page, wrongly green-lighting a close.
+ * a later page, wrongly green-lighting a close. Throws (→ blocked) on an absent
+ * connection.
  */
 function hasOpenClosingPr(
   owner: string,
   repo: string,
   issueNumber: number,
+  runGraphql: LinkedPrGraphqlRunner,
 ): boolean {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
   repository(owner:$owner,name:$repo){
@@ -919,25 +1005,24 @@ function hasOpenClosingPr(
 }`;
   let after: string | null = null;
   for (;;) {
-    const parsed = ghGraphql(query, owner, repo, issueNumber, after) as {
-      data?: {
-        repository?: {
-          issue?: {
-            closedByPullRequestsReferences?: {
+    const parsed = runGraphql(query, owner, repo, issueNumber, after);
+    const connection = requireIssueConnection(
+      parsed,
+      (issue) =>
+        issue.closedByPullRequestsReferences as
+          | {
               nodes?: { state?: unknown }[] | null;
               pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
-            } | null;
-          } | null;
-        } | null;
-      };
-    };
-    const connection =
-      parsed.data?.repository?.issue?.closedByPullRequestsReferences;
-    const nodes = connection?.nodes ?? [];
+            }
+          | null
+          | undefined,
+      'closedByPullRequestsReferences',
+    );
+    const nodes = connection.nodes ?? [];
     if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
       return true;
     }
-    if (!connection?.pageInfo?.hasNextPage) {
+    if (!connection.pageInfo?.hasNextPage) {
       return false;
     }
     after = connection.pageInfo.endCursor ?? null;
@@ -952,11 +1037,13 @@ function hasOpenClosingPr(
  * relationship without a closing keyword). Pages the CONNECTED/DISCONNECTED
  * timeline in full — the whole stream is needed so a later DISCONNECTED is not
  * missed — then reconciles it via the pure {@link reconcileConnectedOpenPrs}.
+ * Throws (→ blocked) on an absent connection.
  */
 function hasOpenConnectedPr(
   owner: string,
   repo: string,
   issueNumber: number,
+  runGraphql: LinkedPrGraphqlRunner,
 ): boolean {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
   repository(owner:$owner,name:$repo){
@@ -975,21 +1062,21 @@ function hasOpenConnectedPr(
   const events: ConnectedPrEvent[] = [];
   let after: string | null = null;
   for (;;) {
-    const parsed = ghGraphql(query, owner, repo, issueNumber, after) as {
-      data?: {
-        repository?: {
-          issue?: {
-            timelineItems?: {
+    const parsed = runGraphql(query, owner, repo, issueNumber, after);
+    const connection = requireIssueConnection(
+      parsed,
+      (issue) =>
+        issue.timelineItems as
+          | {
               nodes?: unknown[] | null;
               pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
-            } | null;
-          } | null;
-        } | null;
-      };
-    };
-    const connection = parsed.data?.repository?.issue?.timelineItems;
-    events.push(...parseConnectedPrEvents(connection?.nodes ?? []));
-    if (!connection?.pageInfo?.hasNextPage) {
+            }
+          | null
+          | undefined,
+      'timelineItems',
+    );
+    events.push(...parseConnectedPrEvents(connection.nodes ?? []));
+    if (!connection.pageInfo?.hasNextPage) {
       break;
     }
     after = connection.pageInfo.endCursor ?? null;

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -14,7 +14,8 @@
 // marker) happen under `--apply` once the roadmap is ready AND the
 // roadmap-audit claim re-validates immediately before the close. A roadmap
 // with an open / unresolved / inaccessible / nested-roadmap descendant, a
-// traversal cycle, or no explicit child work is NEVER closed.
+// closed child with an open linked PR, a traversal cycle, or no explicit child
+// work is NEVER closed.
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
@@ -25,17 +26,22 @@ import {
   buildIssueLoader,
   buildSubIssueLoader,
   enumerateRoadmapGraph,
+  isClaimStaleByAge,
+  parseClaimStaleAgeMs,
   type RoadmapGraphReport,
 } from './discover-roadmap-graph.mts';
 import type { ClaimValidationSummary } from './protocol-helpers.mts';
 import {
-  isStaleAt,
   renderUnclaimedByMarker,
   resolveTrustedMarkerActors,
   summarizeClaimValidation,
 } from './protocol-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// Distributed `claim-stale-age` default (docs/policy-constants.md: 24 h). Used
+// only as the fallback when the policy declares no (or an invalid)
+// `claimTiming.staleAge`; mirrors discover-roadmap-graph's own default.
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 const BLOCKED_LABELS = new Set([
   'status:blocked-by-human',
   'status:needs-decision',
@@ -47,9 +53,15 @@ export type RoadmapAuditBlockerKind =
   | 'childless'
   | 'open-child'
   | 'nested-roadmap'
+  | 'open-linked-pr'
   | 'unresolved-reference'
   | 'inaccessible-reference'
   | 'cycle';
+
+/** Branch field that scopes a roadmap-audit coordination claim to one roadmap. */
+function roadmapAuditBranchPattern(roadmapNumber: number): RegExp {
+  return new RegExp(`^roadmap-audit/${roadmapNumber}-`);
+}
 
 /**
  * One reason the roadmap is not ready to close, with the concrete issue it
@@ -122,10 +134,13 @@ interface RoadmapAuditExecuteArgs {
  */
 export function evaluateRoadmapAuditGates(
   report: RoadmapGraphReport,
+  options: { openLinkedPrIssues?: Iterable<number> } = {},
 ): RoadmapAuditBlocker[] {
   const blockers: RoadmapAuditBlocker[] = [];
   const rootNumber = report.root.number;
   const pathTo = buildProvenanceLookup(report);
+  const openLinkedPrIssues = new Set(options.openLinkedPrIssues ?? []);
+  const reachableExecutionLeafCount = buildReachableLeafCounter(report);
 
   // Root carrying a human-gate label is never auto-closed.
   const rootNode = report.nodes.find((node) => node.number === rootNumber);
@@ -161,25 +176,57 @@ export function evaluateRoadmapAuditGates(
     });
   }
 
-  // Open nested roadmaps: a coordination/audit node that is still open blocks
-  // the parent close, regardless of its own leaf state (the parent can only
-  // close after the nested roadmap closes).
-  const openNestedRoadmaps = report.nodes
+  // Nested roadmaps block the parent close when they are either (a) still
+  // OPEN — a coordination/audit node closes bottom-up before its parent — or
+  // (b) malformed: zero reachable execution-leaf descendants, so a CLOSED
+  // nested roadmap can never be taken as proof of completion (A1.5). A closed
+  // nested roadmap WITH reachable leaves is fine on its own; any open leaf
+  // beneath it is surfaced separately as its own blocker.
+  const nestedRoadmaps = report.nodes
+    .filter(
+      (node) => node.classification === 'roadmap' && node.number !== rootNumber,
+    )
+    .sort((left, right) => left.number - right.number);
+  for (const node of nestedRoadmaps) {
+    if (reachableExecutionLeafCount(node.number) === 0) {
+      blockers.push({
+        kind: 'nested-roadmap',
+        target: node.number,
+        provenance: pathTo(node.number),
+        detail: `nested roadmap #${node.number} "${node.title}" has no reachable execution-leaf descendants; childless or malformed, not proof of completion`,
+      });
+      continue;
+    }
+    if (node.state === 'OPEN') {
+      blockers.push({
+        kind: 'nested-roadmap',
+        target: node.number,
+        provenance: pathTo(node.number),
+        detail: `nested roadmap #${node.number} "${node.title}" is OPEN; close it (bottom-up) before its parent`,
+      });
+    }
+  }
+
+  // A CLOSED child that still has an OPEN linked / closing PR is unresolved:
+  // the child looks done but its work is in flight (A1.5). Open children are
+  // already blocked above, so only closed descendants are flagged here. The
+  // open-PR set is injected as data so the evaluator stays pure.
+  const openLinkedPrTargets = report.nodes
     .filter(
       (node) =>
-        node.classification === 'roadmap' &&
         node.number !== rootNumber &&
-        node.state === 'OPEN',
+        node.state !== 'OPEN' &&
+        openLinkedPrIssues.has(node.number),
     )
     .map((node) => node.number)
-    .sort((a, b) => a - b);
-  for (const target of openNestedRoadmaps) {
+    .sort((left, right) => left - right);
+  for (const target of openLinkedPrTargets) {
     const node = report.nodes.find((entry) => entry.number === target);
     blockers.push({
-      kind: 'nested-roadmap',
+      kind: 'open-linked-pr',
       target,
       provenance: pathTo(target),
-      detail: `nested roadmap #${target}${node ? ` "${node.title}"` : ''} is OPEN; close it (bottom-up) before its parent`,
+      detail: `closed child #${target}${node ? ` "${node.title}"` : ''} still has an OPEN linked/closing PR; treat as unresolved until it merges or is obsoleted`,
     });
   }
 
@@ -230,6 +277,52 @@ function buildProvenanceLookup(
 }
 
 /**
+ * Count, for any node, how many distinct execution-leaf descendants are
+ * reachable from it via the enumerated graph edges (an execution-classified
+ * node present in `nodes`, open or closed). Uses only the graph/edge data the
+ * traversal already produced; a cycle-safe `visited` set bounds the walk. A
+ * count of 0 means the node has no reachable leaf descendants — childless /
+ * malformed per A1.5.
+ */
+function buildReachableLeafCounter(
+  report: RoadmapGraphReport,
+): (from: number) => number {
+  const adjacency = new Map<number, number[]>();
+  for (const edge of report.edges) {
+    const targets = adjacency.get(edge.source) ?? [];
+    targets.push(edge.target);
+    adjacency.set(edge.source, targets);
+  }
+  const executionLeaves = new Set(
+    report.nodes
+      .filter((node) => node.classification === 'execution')
+      .map((node) => node.number),
+  );
+
+  return (from) => {
+    const visited = new Set<number>([from]);
+    const stack = [from];
+    const leaves = new Set<number>();
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (current === undefined) {
+        break;
+      }
+      for (const next of adjacency.get(current) ?? []) {
+        if (executionLeaves.has(next)) {
+          leaves.add(next);
+        }
+        if (!visited.has(next)) {
+          visited.add(next);
+          stack.push(next);
+        }
+      }
+    }
+    return leaves.size;
+  };
+}
+
+/**
  * Compose the canonical `IDD roadmap completion audit` evidence comment body.
  * Deterministic and network-free: it summarizes the audited graph (node /
  * edge / depth counts, closed descendants split by classification, and the
@@ -267,7 +360,7 @@ export function buildRoadmapCompletionAuditBody(
     `- Closed descendants: ${descendants.length} (${executionCount} execution leaves, ${nestedRoadmapCount} nested roadmaps).`,
     `- Closed execution leaves: ${closedExecution || 'none'}.`,
     `- Closed nested roadmaps: ${closedNested || 'none'}.`,
-    '- Open / unresolved / inaccessible / nested-roadmap descendants: none.',
+    '- Open / unresolved / inaccessible / nested-roadmap / open-linked-PR descendants: none.',
     `- Diagnostics: ${report.summary.cycleCount} cycles, ${report.summary.unresolvedReferenceCount} unresolved references, ${report.summary.inaccessibleReferenceCount} inaccessible references, ${report.summary.duplicateReferenceCount} duplicate references.`,
     '',
     'Closing the roadmap as completed.',
@@ -279,20 +372,30 @@ export function buildRoadmapCompletionAuditBody(
 /**
  * Re-validate the roadmap-audit claim from the live claim-marker stream. The
  * shared `summarizeClaimValidation` resolver decides claim ownership exactly
- * as the merge gate does (trusted-author gated, claim-id / agent-id match);
- * this helper additionally fails closed on a STALE claim (older than the
- * distributed `claim-stale-age` default of 24 h relative to `nowIso`), because
- * a stale claim is takeover-eligible and so cannot prove the caller still owns
- * the roadmap. Pure and network-free: the comment stream and trusted-author
- * predicate are injected so the fail-closed paths are unit-testable.
+ * as the merge gate does (trusted-author gated, claim-id / agent-id match).
+ * This helper additionally enforces the two roadmap-side ownership rules of
+ * A1.5:
+ *
+ *  1. the active claim's `branch` must be the `roadmap-audit/<roadmapNumber>-…`
+ *     coordination branch for THIS roadmap — a normal execution claim such as
+ *     `issue/123-fix` on the roadmap issue does NOT authorize closure; and
+ *  2. the claim must not be STALE relative to `nowIso`, using the configured
+ *     `claimTiming.staleAge` (`staleAgeMs`, default 24 h) via the shared
+ *     `isClaimStaleByAge` — a stale claim is takeover-eligible and so cannot
+ *     prove ongoing ownership.
+ *
+ * Pure and network-free: the comment stream, trusted-author predicate, and
+ * stale age are injected so every fail-closed path is unit-testable.
  */
 export function evaluateRoadmapClaim(
   comments: Parameters<typeof summarizeClaimValidation>[0],
   options: {
+    roadmapNumber: number;
     expectedClaimId: string;
     expectedAgentId?: string;
     isTrustedAuthor: (login: string) => boolean;
     nowIso: string;
+    staleAgeMs?: number;
   },
 ): RoadmapClaimVerdict {
   const summary = summarizeClaimValidation(comments, {
@@ -308,10 +411,28 @@ export function evaluateRoadmapClaim(
       activeClaim: summary.activeClaim,
     };
   }
-  // The 24h stale math lives in the shared `isStaleAt`; reuse it verbatim
-  // against "now" so a claim older than the distributed default is takeover-
-  // eligible and therefore not owned for the purpose of a roadmap mutation.
-  const stale = isStaleAt(summary.activeClaim.createdAt, options.nowIso);
+  // Roadmap-side ownership requires the roadmap-audit coordination branch for
+  // exactly this roadmap; a normal execution claim on the roadmap issue does
+  // not authorize the close.
+  if (
+    !roadmapAuditBranchPattern(options.roadmapNumber).test(
+      summary.activeClaim.branch,
+    )
+  ) {
+    return {
+      owned: false,
+      reason: 'claim-branch-mismatch',
+      stale: false,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  // Staleness uses the configured stale age (default 24 h); the math is reused
+  // verbatim from the shared `isClaimStaleByAge` rather than re-derived here.
+  const stale = isClaimStaleByAge(
+    summary.activeClaim.createdAt,
+    options.nowIso,
+    options.staleAgeMs ?? DEFAULT_CLAIM_STALE_AGE_MS,
+  );
   if (stale) {
     return {
       owned: false,
@@ -336,9 +457,16 @@ export function evaluateRoadmapClaim(
 export interface RoadmapAuditExecuteDeps {
   /** Enumerate the read-only single-root roadmap graph from live state. */
   collect: (roadmapNumber: number) => Promise<RoadmapGraphReport>;
+  /**
+   * Resolve which of the given (closed) child/descendant issues still have an
+   * OPEN linked / closing PR. Returned as data so the pure evaluator can flag
+   * them without any network access.
+   */
+  resolveOpenLinkedPrIssues: (issueNumbers: number[]) => number[];
   /** Re-validate the roadmap-audit claim immediately before mutating. */
   revalidateClaim: (params: {
     issueNumber: number;
+    roadmapNumber: number;
     expectedClaimId: string;
     expectedAgentId: string;
     nowIso: string;
@@ -375,11 +503,14 @@ export async function runRoadmapAuditExecute(
     throw new Error('missing required --roadmap <number> argument');
   }
   const roadmapNumber = args.roadmapNumber;
-  const claimIssue = args.claimIssue ?? roadmapNumber;
   const resolvedDeps = deps ?? createProductionDeps(args);
 
   const report = await resolvedDeps.collect(roadmapNumber);
-  const blockers = evaluateRoadmapAuditGates(report);
+  const blockers = evaluateRoadmapAuditGates(report, {
+    openLinkedPrIssues: resolvedDeps.resolveOpenLinkedPrIssues(
+      closedDescendantNumbers(report),
+    ),
+  });
   const ready = blockers.length === 0;
   const evidenceBody = ready ? buildRoadmapCompletionAuditBody(report) : '';
 
@@ -415,26 +546,38 @@ export async function runRoadmapAuditExecute(
     return { verdict, exitCode: 1 };
   }
 
-  const nowIso = resolvedDeps.now();
+  // The roadmap-audit claim is scoped to the EXACT roadmap being mutated; a
+  // divergent --claim-issue would validate ownership elsewhere while closing
+  // this roadmap. Reject it (fail closed) and always validate on the roadmap.
+  if (args.claimIssue !== null && args.claimIssue !== roadmapNumber) {
+    verdict.result = `claim-issue #${args.claimIssue} must equal the roadmap #${roadmapNumber}; roadmap-audit ownership is scoped to the exact roadmap`;
+    return { verdict, exitCode: 1 };
+  }
 
-  // Re-validate the roadmap-audit claim immediately before mutating; fail
-  // closed (no mutation) on any lost / stale / non-owned claim.
-  const claim = resolvedDeps.revalidateClaim({
-    issueNumber: claimIssue,
+  // Early claim re-validation (defense in depth): bail before the graph
+  // re-fetch if ownership is already gone.
+  const earlyClaim = resolvedDeps.revalidateClaim({
+    issueNumber: roadmapNumber,
+    roadmapNumber,
     expectedClaimId: args.claimId,
     expectedAgentId: args.agentId,
-    nowIso,
+    nowIso: resolvedDeps.now(),
   });
-  if (!claim.owned) {
-    verdict.result = `claim not owned on re-validation (reason="${claim.reason}"); no mutation`;
+  if (!earlyClaim.owned) {
+    verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}"); no mutation`;
     return { verdict, exitCode: 1 };
   }
 
   // Re-fetch the roadmap + child state and confirm the audit input still
-  // holds; a roadmap that gained an open / unresolved / nested-roadmap
-  // descendant between the first read and now must NEVER be closed.
+  // holds; a roadmap that gained an open / unresolved / nested-roadmap /
+  // open-linked-PR descendant between the first read and now must NEVER be
+  // closed.
   const revalidated = await resolvedDeps.collect(roadmapNumber);
-  const revalidatedBlockers = evaluateRoadmapAuditGates(revalidated);
+  const revalidatedBlockers = evaluateRoadmapAuditGates(revalidated, {
+    openLinkedPrIssues: resolvedDeps.resolveOpenLinkedPrIssues(
+      closedDescendantNumbers(revalidated),
+    ),
+  });
   if (revalidatedBlockers.length > 0) {
     verdict.blockers = revalidatedBlockers;
     verdict.ready = false;
@@ -444,17 +587,36 @@ export async function runRoadmapAuditExecute(
     return { verdict, exitCode: 1 };
   }
 
-  // Both gates hold: compose the body from the re-validated graph, then post
+  // The graph re-fetch can span many API calls during which another session
+  // can take over, so the LAST gate before any mutation is a fresh claim
+  // re-validation. Its activeClaim + "now" are the ones used for the release.
+  const nowIso = resolvedDeps.now();
+  const claim = resolvedDeps.revalidateClaim({
+    issueNumber: roadmapNumber,
+    roadmapNumber,
+    expectedClaimId: args.claimId,
+    expectedAgentId: args.agentId,
+    nowIso,
+  });
+  if (!claim.owned) {
+    verdict.result = `claim not owned immediately before mutation (reason="${claim.reason}"); no mutation`;
+    return { verdict, exitCode: 1 };
+  }
+
+  // All gates hold: compose the body from the re-validated graph, then post
   // the evidence comment, close the roadmap, and release the claim in order.
   const finalEvidenceBody = buildRoadmapCompletionAuditBody(revalidated);
   verdict.evidenceBody = finalEvidenceBody;
 
   resolvedDeps.postEvidenceComment(roadmapNumber, finalEvidenceBody);
   resolvedDeps.closeRoadmap(roadmapNumber);
-  resolvedDeps.releaseClaim(claimIssue, {
+  resolvedDeps.releaseClaim(roadmapNumber, {
     agentId: claim.activeClaim.agentId,
     claimId: claim.activeClaim.claimId,
-    timestamp: nowIso,
+    // The unclaim marker only accepts second-precision ISO; truncate any
+    // sub-second digits so a millisecond `now()` never throws after the
+    // comment + close already landed (a partial, unrecoverable mutation).
+    timestamp: toSecondPrecisionIso(nowIso),
   });
 
   verdict.closed = true;
@@ -462,6 +624,20 @@ export async function runRoadmapAuditExecute(
   verdict.result =
     'roadmap closed as completed; evidence comment posted and roadmap-audit claim released';
   return { verdict, exitCode: 0 };
+}
+
+/** Closed (non-root) descendant issue numbers — the open-linked-PR candidates. */
+function closedDescendantNumbers(report: RoadmapGraphReport): number[] {
+  return report.nodes
+    .filter(
+      (node) => node.number !== report.root.number && node.state !== 'OPEN',
+    )
+    .map((node) => node.number);
+}
+
+/** Truncate any sub-second fraction so an ISO stamp is `YYYY-MM-DDTHH:mm:ssZ`. */
+function toSecondPrecisionIso(iso: string): string {
+  return String(iso).replace(/\.\d+Z$/, 'Z');
 }
 
 // ---------------------------------------------------------------------------
@@ -488,6 +664,14 @@ function createProductionDeps(
     viewerLogin,
     rawConfig: rawConfig as { trustedMarkerActors?: unknown } | null,
   });
+  // Honor the configured `claimTiming.staleAge` (docs/policy-constants.md);
+  // reuse discover-roadmap-graph's ISO-duration parser, falling back to the
+  // distributed 24 h default on an absent/invalid value.
+  const staleAgeMs =
+    parseClaimStaleAgeMs(
+      (rawConfig as { claimTiming?: { staleAge?: unknown } } | null)
+        ?.claimTiming?.staleAge,
+    ) ?? DEFAULT_CLAIM_STALE_AGE_MS;
   const loadIssue = buildIssueLoader(owner, repo);
   const loadSubIssues = buildSubIssueLoader(owner, repo);
 
@@ -500,17 +684,22 @@ function createProductionDeps(
         loadIssue,
         loadSubIssues,
       }),
+    resolveOpenLinkedPrIssues: (issueNumbers) =>
+      resolveOpenLinkedPrIssues(owner, repo, issueNumbers),
     revalidateClaim: ({
       issueNumber,
+      roadmapNumber,
       expectedClaimId,
       expectedAgentId,
       nowIso,
     }) =>
       evaluateRoadmapClaim(loadIssueComments(owner, repo, issueNumber), {
+        roadmapNumber,
         expectedClaimId,
         expectedAgentId,
         isTrustedAuthor,
         nowIso,
+        staleAgeMs,
       }),
     postEvidenceComment: (issueNumber, body) =>
       postIssueComment(owner, repo, issueNumber, body),
@@ -608,6 +797,71 @@ function loadIssueComments(
       },
     };
   });
+}
+
+/**
+ * Resolve which of `issueNumbers` still have an OPEN linked / closing PR.
+ *
+ * Uses one GraphQL field per issue — `closedByPullRequestsReferences`, the PRs
+ * that reference-close the issue — and keeps a number only when at least one
+ * such PR is still in the `OPEN` state. MERGED / CLOSED PRs are obsolete and
+ * never block (the field returns merged PRs even with
+ * `includeClosedPrs:false`, so the `OPEN`-state filter is what matters). On a
+ * per-issue lookup error the issue is conservatively treated as having an open
+ * PR (fail closed) so a transient failure can never green-light a close.
+ */
+function resolveOpenLinkedPrIssues(
+  owner: string,
+  repo: string,
+  issueNumbers: number[],
+): number[] {
+  const query = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:20,includeClosedPrs:false){
+        nodes { number state }
+      }
+    }
+  }
+}`;
+  const blocked: number[] = [];
+  for (const issueNumber of issueNumbers) {
+    try {
+      const raw = ghText([
+        'api',
+        'graphql',
+        '-f',
+        `query=${query}`,
+        '-f',
+        `owner=${owner}`,
+        '-f',
+        `repo=${repo}`,
+        '-F',
+        `number=${issueNumber}`,
+      ]);
+      const parsed = JSON.parse(raw) as {
+        data?: {
+          repository?: {
+            issue?: {
+              closedByPullRequestsReferences?: {
+                nodes?: { state?: unknown }[] | null;
+              } | null;
+            } | null;
+          } | null;
+        };
+      };
+      const nodes =
+        parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ??
+        [];
+      if (nodes.some((node) => String(node?.state ?? '') === 'OPEN')) {
+        blocked.push(issueNumber);
+      }
+    } catch {
+      // Fail closed: an undeterminable PR state blocks the close.
+      blocked.push(issueNumber);
+    }
+  }
+  return blocked;
 }
 
 /**

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -1,0 +1,797 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-roadmap-audit-execute.mts
+//
+// The scripts/idd-roadmap-audit-execute.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Thin A1.5 roadmap-completion-audit evaluator + executor. It WRAPS the
+// read-only discover-roadmap-graph traversal (reuses its child enumeration
+// verbatim) and introduces NO new decision authority: `decisionAuthority`
+// stays `instructions`. In the default dry-run it only evaluates completion
+// and reports the canonical `IDD roadmap completion audit` evidence body; the
+// ONLY mutations anywhere (the evidence comment, the close, and the unclaim
+// marker) happen under `--apply` once the roadmap is ready AND the
+// roadmap-audit claim re-validates immediately before the close. A roadmap
+// with an open / unresolved / inaccessible / nested-roadmap descendant, a
+// traversal cycle, or no explicit child work is NEVER closed.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildIssueLoader,
+  buildSubIssueLoader,
+  enumerateRoadmapGraph,
+  type RoadmapGraphReport,
+} from './discover-roadmap-graph.mts';
+import type { ClaimValidationSummary } from './protocol-helpers.mts';
+import {
+  isStaleAt,
+  renderUnclaimedByMarker,
+  resolveTrustedMarkerActors,
+  summarizeClaimValidation,
+} from './protocol-helpers.mts';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+const BLOCKED_LABELS = new Set([
+  'status:blocked-by-human',
+  'status:needs-decision',
+]);
+
+/** Distinct blocker categories surfaced by the completion audit. */
+export type RoadmapAuditBlockerKind =
+  | 'roadmap-blocked'
+  | 'childless'
+  | 'open-child'
+  | 'nested-roadmap'
+  | 'unresolved-reference'
+  | 'inaccessible-reference'
+  | 'cycle';
+
+/**
+ * One reason the roadmap is not ready to close, with the concrete issue it
+ * concerns (`target`) and the provenance path from the root roadmap when one
+ * is known. `target` / `provenance` are omitted for graph-level blockers
+ * (`childless`).
+ */
+export interface RoadmapAuditBlocker {
+  kind: RoadmapAuditBlockerKind;
+  target?: number;
+  provenance?: number[];
+  detail: string;
+}
+
+/**
+ * JSON verdict document printed by the `idd-roadmap-audit-execute` CLI. The
+ * helper is evidence + execution convenience only, so `decisionAuthority`
+ * stays `instructions` (consistent with discover-roadmap-graph and
+ * idd-merge-execute).
+ */
+export interface IddRoadmapAuditExecuteVerdict {
+  protocolVersion: '1';
+  decisionAuthority: 'instructions';
+  mode: 'dry-run' | 'apply';
+  roadmapNumber: number;
+  ready: boolean;
+  blockers: RoadmapAuditBlocker[];
+  /**
+   * Canonical `IDD roadmap completion audit` comment body that would be (dry-
+   * run) or was (apply) posted. Empty when the roadmap is not ready: a
+   * completion comment is never composed for an incomplete roadmap.
+   */
+  evidenceBody: string;
+  closed: boolean;
+  claimReleased: boolean;
+  result: string;
+}
+
+/** Outcome of re-validating the roadmap-audit claim before any mutation. */
+export interface RoadmapClaimVerdict {
+  /** True only for a present, owned (claim-id/agent-id match), non-stale claim. */
+  owned: boolean;
+  reason: string;
+  stale: boolean;
+  activeClaim: ClaimValidationSummary['activeClaim'];
+}
+
+/** Parsed CLI arguments. */
+interface RoadmapAuditExecuteArgs {
+  roadmapNumber: number | null;
+  apply: boolean;
+  claimIssue: number | null;
+  claimId: string;
+  agentId: string;
+  owner: string;
+  repo: string;
+  policy: string;
+  now: string;
+  help: boolean;
+}
+
+/**
+ * Evaluate roadmap completion against `report` (a discover-roadmap-graph
+ * single-root traversal). Every open / unresolved / inaccessible / nested-
+ * roadmap descendant, every traversal cycle, a blocked roadmap root, and a
+ * childless/malformed roadmap is collected as a blocker; `ready` is true only
+ * when no blocker is collected. The rules mirror the written A1.5 completion
+ * criteria exactly — this helper adds no stricter sub-condition. Pure and
+ * network-free so it is unit-testable apart from live GitHub.
+ */
+export function evaluateRoadmapAuditGates(
+  report: RoadmapGraphReport,
+): RoadmapAuditBlocker[] {
+  const blockers: RoadmapAuditBlocker[] = [];
+  const rootNumber = report.root.number;
+  const pathTo = buildProvenanceLookup(report);
+
+  // Root carrying a human-gate label is never auto-closed.
+  const rootNode = report.nodes.find((node) => node.number === rootNumber);
+  const rootBlockedLabel = (rootNode?.labels ?? []).find((label) =>
+    BLOCKED_LABELS.has(label),
+  );
+  if (rootBlockedLabel) {
+    blockers.push({
+      kind: 'roadmap-blocked',
+      target: rootNumber,
+      provenance: [rootNumber],
+      detail: `roadmap #${rootNumber} carries "${rootBlockedLabel}"; resolve the human gate before closing`,
+    });
+  }
+
+  // No explicit child work → childless / malformed. Do not infer completion
+  // from the absence of candidates.
+  if (report.edges.length === 0) {
+    blockers.push({
+      kind: 'childless',
+      detail: `roadmap #${rootNumber} has no explicit child references (task-list, closing-keyword, or GitHub sub-issue); childless or malformed, not complete`,
+    });
+  }
+
+  // Open execution leaves (already classification === 'execution' && OPEN).
+  for (const target of [...report.executionCandidates].sort((a, b) => a - b)) {
+    const node = report.nodes.find((entry) => entry.number === target);
+    blockers.push({
+      kind: 'open-child',
+      target,
+      provenance: pathTo(target),
+      detail: `execution leaf #${target}${node ? ` "${node.title}"` : ''} is OPEN`,
+    });
+  }
+
+  // Open nested roadmaps: a coordination/audit node that is still open blocks
+  // the parent close, regardless of its own leaf state (the parent can only
+  // close after the nested roadmap closes).
+  const openNestedRoadmaps = report.nodes
+    .filter(
+      (node) =>
+        node.classification === 'roadmap' &&
+        node.number !== rootNumber &&
+        node.state === 'OPEN',
+    )
+    .map((node) => node.number)
+    .sort((a, b) => a - b);
+  for (const target of openNestedRoadmaps) {
+    const node = report.nodes.find((entry) => entry.number === target);
+    blockers.push({
+      kind: 'nested-roadmap',
+      target,
+      provenance: pathTo(target),
+      detail: `nested roadmap #${target}${node ? ` "${node.title}"` : ''} is OPEN; close it (bottom-up) before its parent`,
+    });
+  }
+
+  // Unresolved references (target issue not found / is a PR).
+  for (const diagnostic of report.diagnostics.unresolvedReferences) {
+    blockers.push({
+      kind: 'unresolved-reference',
+      target: diagnostic.target,
+      provenance: [...pathTo(diagnostic.source), diagnostic.target],
+      detail: `reference #${diagnostic.source} → #${diagnostic.target} (${diagnostic.relationship}) is unresolved: ${diagnostic.reason}`,
+    });
+  }
+
+  // Inaccessible references (403/410/451): cannot prove completion.
+  for (const diagnostic of report.diagnostics.inaccessibleReferences) {
+    blockers.push({
+      kind: 'inaccessible-reference',
+      target: diagnostic.target,
+      provenance: [...pathTo(diagnostic.source), diagnostic.target],
+      detail: `reference #${diagnostic.source} → #${diagnostic.target} (${diagnostic.relationship}) is inaccessible: ${diagnostic.reason}`,
+    });
+  }
+
+  // Cycles / ambiguous graph: do not guess a closure order.
+  for (const cycle of report.diagnostics.cycles) {
+    blockers.push({
+      kind: 'cycle',
+      target: cycle.target,
+      provenance: cycle.path,
+      detail: `traversal cycle ${cycle.path.join(' → ')} (${cycle.relationship}); graph is ambiguous, treat as unresolved`,
+    });
+  }
+
+  return blockers;
+}
+
+/** First (sorted) root→target provenance path, or `[]` when none is recorded. */
+function buildProvenanceLookup(
+  report: RoadmapGraphReport,
+): (target: number) => number[] {
+  const lookup = new Map<number, number[]>();
+  for (const entry of report.provenancePaths) {
+    if (!lookup.has(entry.target)) {
+      lookup.set(entry.target, entry.path);
+    }
+  }
+  return (target) => lookup.get(target) ?? [];
+}
+
+/**
+ * Compose the canonical `IDD roadmap completion audit` evidence comment body.
+ * Deterministic and network-free: it summarizes the audited graph (node /
+ * edge / depth counts, closed descendants split by classification, and the
+ * traversal diagnostics) and asserts no open / unresolved / inaccessible /
+ * nested-roadmap descendant remains. Only called when the roadmap is ready,
+ * so every descendant is closed or otherwise complete.
+ */
+export function buildRoadmapCompletionAuditBody(
+  report: RoadmapGraphReport,
+): string {
+  const rootNumber = report.root.number;
+  const descendants = report.nodes.filter((node) => node.number !== rootNumber);
+  const executionCount = descendants.filter(
+    (node) => node.classification === 'execution',
+  ).length;
+  const nestedRoadmapCount = descendants.filter(
+    (node) => node.classification === 'roadmap',
+  ).length;
+  const closedExecution = descendants
+    .filter((node) => node.classification === 'execution')
+    .map((node) => `#${node.number}`)
+    .join(', ');
+  const closedNested = descendants
+    .filter((node) => node.classification === 'roadmap')
+    .map((node) => `#${node.number}`)
+    .join(', ');
+
+  return [
+    '**IDD roadmap completion audit**',
+    '',
+    `Roadmap #${rootNumber} "${report.root.title}" audited as complete: every referenced child and descendant issue is closed or otherwise complete.`,
+    '',
+    'Evidence:',
+    `- Graph: ${report.summary.nodeCount} nodes, ${report.summary.edgeCount} edges, max depth ${report.summary.maxDepth}.`,
+    `- Closed descendants: ${descendants.length} (${executionCount} execution leaves, ${nestedRoadmapCount} nested roadmaps).`,
+    `- Closed execution leaves: ${closedExecution || 'none'}.`,
+    `- Closed nested roadmaps: ${closedNested || 'none'}.`,
+    '- Open / unresolved / inaccessible / nested-roadmap descendants: none.',
+    `- Diagnostics: ${report.summary.cycleCount} cycles, ${report.summary.unresolvedReferenceCount} unresolved references, ${report.summary.inaccessibleReferenceCount} inaccessible references, ${report.summary.duplicateReferenceCount} duplicate references.`,
+    '',
+    'Closing the roadmap as completed.',
+    '',
+    '_IDD roadmap-audit automation. Do not edit._',
+  ].join('\n');
+}
+
+/**
+ * Re-validate the roadmap-audit claim from the live claim-marker stream. The
+ * shared `summarizeClaimValidation` resolver decides claim ownership exactly
+ * as the merge gate does (trusted-author gated, claim-id / agent-id match);
+ * this helper additionally fails closed on a STALE claim (older than the
+ * distributed `claim-stale-age` default of 24 h relative to `nowIso`), because
+ * a stale claim is takeover-eligible and so cannot prove the caller still owns
+ * the roadmap. Pure and network-free: the comment stream and trusted-author
+ * predicate are injected so the fail-closed paths are unit-testable.
+ */
+export function evaluateRoadmapClaim(
+  comments: Parameters<typeof summarizeClaimValidation>[0],
+  options: {
+    expectedClaimId: string;
+    expectedAgentId?: string;
+    isTrustedAuthor: (login: string) => boolean;
+    nowIso: string;
+  },
+): RoadmapClaimVerdict {
+  const summary = summarizeClaimValidation(comments, {
+    isTrustedAuthor: options.isTrustedAuthor,
+    expectedClaimId: options.expectedClaimId,
+    expectedAgentId: options.expectedAgentId,
+  });
+  if (!summary.matchesExpectedClaim) {
+    return {
+      owned: false,
+      reason: summary.reason,
+      stale: false,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  // The 24h stale math lives in the shared `isStaleAt`; reuse it verbatim
+  // against "now" so a claim older than the distributed default is takeover-
+  // eligible and therefore not owned for the purpose of a roadmap mutation.
+  const stale = isStaleAt(summary.activeClaim.createdAt, options.nowIso);
+  if (stale) {
+    return {
+      owned: false,
+      reason: 'claim-stale',
+      stale: true,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  return {
+    owned: true,
+    reason: 'match',
+    stale: false,
+    activeClaim: summary.activeClaim,
+  };
+}
+
+/**
+ * Injectable side-effecting dependencies. Tests substitute these to drive the
+ * dry-run / apply / fail-closed paths without faking live GitHub state;
+ * production uses the real roadmap-graph traversal, claim stream, and `gh`.
+ */
+export interface RoadmapAuditExecuteDeps {
+  /** Enumerate the read-only single-root roadmap graph from live state. */
+  collect: (roadmapNumber: number) => Promise<RoadmapGraphReport>;
+  /** Re-validate the roadmap-audit claim immediately before mutating. */
+  revalidateClaim: (params: {
+    issueNumber: number;
+    expectedClaimId: string;
+    expectedAgentId: string;
+    nowIso: string;
+  }) => RoadmapClaimVerdict;
+  /** POST the canonical `IDD roadmap completion audit` evidence comment. */
+  postEvidenceComment: (issueNumber: number, body: string) => void;
+  /** Close the roadmap issue as completed. */
+  closeRoadmap: (issueNumber: number) => void;
+  /** POST the `unclaimed-by` marker that releases the roadmap-audit claim. */
+  releaseClaim: (
+    issueNumber: number,
+    fields: { agentId: string; claimId: string; timestamp: string },
+  ) => void;
+  /** Resolution "now" (ISO8601); defaults to the wall clock. */
+  now: () => string;
+}
+
+/**
+ * Build the A1.5 verdict and, under `--apply`, execute the audit. The dry-run
+ * path performs NO mutation. The apply path fails closed: if the roadmap is
+ * not ready it exits without mutating; if it is ready it RE-VALIDATES the
+ * roadmap-audit claim and RE-EVALUATES the roadmap graph immediately before
+ * mutating, then refuses to mutate (clear message) on any lost / stale / non-
+ * owned claim or any newly-discovered blocker. Only after both re-validations
+ * pass does it post the evidence comment, close the roadmap, and release the
+ * claim — in that order.
+ */
+export async function runRoadmapAuditExecute(
+  argv: string[],
+  deps?: RoadmapAuditExecuteDeps,
+): Promise<{ verdict: IddRoadmapAuditExecuteVerdict; exitCode: number }> {
+  const args = parseArgs(argv);
+  if (!args.roadmapNumber) {
+    throw new Error('missing required --roadmap <number> argument');
+  }
+  const roadmapNumber = args.roadmapNumber;
+  const claimIssue = args.claimIssue ?? roadmapNumber;
+  const resolvedDeps = deps ?? createProductionDeps(args);
+
+  const report = await resolvedDeps.collect(roadmapNumber);
+  const blockers = evaluateRoadmapAuditGates(report);
+  const ready = blockers.length === 0;
+  const evidenceBody = ready ? buildRoadmapCompletionAuditBody(report) : '';
+
+  const verdict: IddRoadmapAuditExecuteVerdict = {
+    protocolVersion: '1',
+    decisionAuthority: 'instructions',
+    mode: args.apply ? 'apply' : 'dry-run',
+    roadmapNumber,
+    ready,
+    blockers,
+    evidenceBody,
+    closed: false,
+    claimReleased: false,
+    result: '',
+  };
+
+  if (!args.apply) {
+    // Dry-run: read-only. Never mutate.
+    return { verdict, exitCode: ready ? 0 : 1 };
+  }
+
+  if (!ready) {
+    // Apply but not ready: fail closed, do not mutate.
+    verdict.result =
+      'not-ready: completion blockers present; no comment, close, or claim release attempted';
+    return { verdict, exitCode: 1 };
+  }
+
+  if (!args.claimId) {
+    // Apply requires the caller to assert which claim it owns; fail closed.
+    verdict.result =
+      'not-applied: --claim-id is required under --apply to re-validate roadmap-audit ownership';
+    return { verdict, exitCode: 1 };
+  }
+
+  const nowIso = resolvedDeps.now();
+
+  // Re-validate the roadmap-audit claim immediately before mutating; fail
+  // closed (no mutation) on any lost / stale / non-owned claim.
+  const claim = resolvedDeps.revalidateClaim({
+    issueNumber: claimIssue,
+    expectedClaimId: args.claimId,
+    expectedAgentId: args.agentId,
+    nowIso,
+  });
+  if (!claim.owned) {
+    verdict.result = `claim not owned on re-validation (reason="${claim.reason}"); no mutation`;
+    return { verdict, exitCode: 1 };
+  }
+
+  // Re-fetch the roadmap + child state and confirm the audit input still
+  // holds; a roadmap that gained an open / unresolved / nested-roadmap
+  // descendant between the first read and now must NEVER be closed.
+  const revalidated = await resolvedDeps.collect(roadmapNumber);
+  const revalidatedBlockers = evaluateRoadmapAuditGates(revalidated);
+  if (revalidatedBlockers.length > 0) {
+    verdict.blockers = revalidatedBlockers;
+    verdict.ready = false;
+    verdict.evidenceBody = '';
+    verdict.result =
+      're-validation found new completion blockers immediately before close; no mutation';
+    return { verdict, exitCode: 1 };
+  }
+
+  // Both gates hold: compose the body from the re-validated graph, then post
+  // the evidence comment, close the roadmap, and release the claim in order.
+  const finalEvidenceBody = buildRoadmapCompletionAuditBody(revalidated);
+  verdict.evidenceBody = finalEvidenceBody;
+
+  resolvedDeps.postEvidenceComment(roadmapNumber, finalEvidenceBody);
+  resolvedDeps.closeRoadmap(roadmapNumber);
+  resolvedDeps.releaseClaim(claimIssue, {
+    agentId: claim.activeClaim.agentId,
+    claimId: claim.activeClaim.claimId,
+    timestamp: nowIso,
+  });
+
+  verdict.closed = true;
+  verdict.claimReleased = true;
+  verdict.result =
+    'roadmap closed as completed; evidence comment posted and roadmap-audit claim released';
+  return { verdict, exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Production dependency wiring (live gh + roadmap-graph traversal).
+// ---------------------------------------------------------------------------
+
+function createProductionDeps(
+  args: RoadmapAuditExecuteArgs,
+): RoadmapAuditExecuteDeps {
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const rawConfig = loadPolicy(args.policy);
+  const markerPrefix = normalizeMarkerPrefix(
+    (rawConfig as { markerPrefix?: unknown }).markerPrefix,
+  );
+  const viewerLogin = String(safeGhText(['api', 'user', '--jq', '.login']))
+    .trim()
+    .toLowerCase();
+  const isTrustedAuthor = buildTrustedAuthorPredicate({
+    owner,
+    viewerLogin,
+    rawConfig: rawConfig as { trustedMarkerActors?: unknown } | null,
+  });
+  const loadIssue = buildIssueLoader(owner, repo);
+  const loadSubIssues = buildSubIssueLoader(owner, repo);
+
+  return {
+    collect: (roadmapNumber) =>
+      enumerateRoadmapGraph(roadmapNumber, {
+        markerPrefix,
+        owner,
+        repo,
+        loadIssue,
+        loadSubIssues,
+      }),
+    revalidateClaim: ({
+      issueNumber,
+      expectedClaimId,
+      expectedAgentId,
+      nowIso,
+    }) =>
+      evaluateRoadmapClaim(loadIssueComments(owner, repo, issueNumber), {
+        expectedClaimId,
+        expectedAgentId,
+        isTrustedAuthor,
+        nowIso,
+      }),
+    postEvidenceComment: (issueNumber, body) =>
+      postIssueComment(owner, repo, issueNumber, body),
+    closeRoadmap: (issueNumber) =>
+      ghText([
+        'issue',
+        'close',
+        String(issueNumber),
+        '--repo',
+        `${owner}/${repo}`,
+        '--reason',
+        'completed',
+      ]),
+    releaseClaim: (issueNumber, fields) =>
+      postIssueComment(
+        owner,
+        repo,
+        issueNumber,
+        renderUnclaimedByMarker(fields),
+      ),
+    now: () => new Date().toISOString(),
+  };
+}
+
+/**
+ * Trusted marker-author predicate for claim re-validation. Mirrors the
+ * external-check-waiver write-gate set: the repo owner and the authenticated
+ * viewer (the agent posting the claim) are always trusted, plus the configured
+ * `trustedMarkerActors` and the `IDD_TRUSTED_MARKER_ACTORS` env override
+ * (resolved through the shared `resolveTrustedMarkerActors`).
+ */
+function buildTrustedAuthorPredicate({
+  owner,
+  viewerLogin,
+  rawConfig,
+}: {
+  owner: string;
+  viewerLogin: string;
+  rawConfig: { trustedMarkerActors?: unknown } | null;
+}): (login: string) => boolean {
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: rawConfig,
+  });
+  const trusted = new Set(
+    [owner, viewerLogin, ...actors]
+      .filter(Boolean)
+      .map((login) => login.trim().toLowerCase()),
+  );
+  return (login) =>
+    trusted.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+}
+
+/** Load every issue comment (paginated) as the claim-marker event stream. */
+function loadIssueComments(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): { body: string; createdAt: string; author: { login: string } }[] {
+  const comments: unknown[] = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const raw = ghText([
+      'api',
+      `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+      '--jq',
+      '.',
+    ]);
+    const pageItems = raw && raw !== 'null' ? JSON.parse(raw) : [];
+    if (!Array.isArray(pageItems) || pageItems.length === 0) {
+      break;
+    }
+    comments.push(...pageItems);
+    if (pageItems.length < pageSize) {
+      break;
+    }
+  }
+  return comments.map((entry) => {
+    const comment = (entry ?? {}) as {
+      body?: unknown;
+      created_at?: unknown;
+      createdAt?: unknown;
+      user?: { login?: unknown } | null;
+      author?: { login?: unknown } | null;
+    };
+    return {
+      body: String(comment.body ?? ''),
+      createdAt: String(comment.createdAt ?? comment.created_at ?? ''),
+      author: {
+        login: String(comment.author?.login ?? comment.user?.login ?? ''),
+      },
+    };
+  });
+}
+
+/**
+ * POST a comment body as a JSON document (`{"body": …}`) via `gh api --input
+ * -`. The JSON path is mandatory because HTML-comment-first bodies (the
+ * unclaim marker) are silently dropped by `gh issue comment` / `gh api -f
+ * body=`; the same path is reused for the evidence comment for consistency.
+ */
+function postIssueComment(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+): void {
+  execFileSync(
+    'gh',
+    [
+      'api',
+      '--method',
+      'POST',
+      `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+      '--input',
+      '-',
+    ],
+    { input: JSON.stringify({ body }), encoding: 'utf8' },
+  );
+}
+
+function loadPolicy(policyPath: string): unknown {
+  const targetPath = policyPath
+    ? resolve(process.cwd(), policyPath)
+    : resolve(process.cwd(), '.github/idd/config.json');
+  try {
+    return JSON.parse(readFileSync(targetPath, 'utf8'));
+  } catch (error) {
+    if (!policyPath) {
+      return {};
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to load policy from ${targetPath}: ${detail}`);
+  }
+}
+
+function normalizeMarkerPrefix(markerPrefix: unknown): string {
+  const normalized = String(markerPrefix ?? '').trim();
+  return normalized || DEFAULT_MARKER_PREFIX;
+}
+
+function ghText(args: string[]): string {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+
+function safeGhText(args: string[]): string {
+  try {
+    return ghText(args);
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]): RoadmapAuditExecuteArgs {
+  const parsed: RoadmapAuditExecuteArgs = {
+    roadmapNumber: null,
+    apply: false,
+    claimIssue: null,
+    claimId: '',
+    agentId: '',
+    owner: '',
+    repo: '',
+    policy: '',
+    now: '',
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--apply') {
+      parsed.apply = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`missing value for argument: ${token}`);
+    }
+    index += 1;
+    switch (token) {
+      case '--roadmap':
+        parsed.roadmapNumber = parsePositiveInteger(value, token);
+        break;
+      case '--claim-issue':
+        parsed.claimIssue = parsePositiveInteger(value, token);
+        break;
+      case '--claim-id':
+        parsed.claimId = value.trim();
+        break;
+      case '--agent-id':
+        parsed.agentId = value.trim();
+        break;
+      case '--owner':
+        parsed.owner = value.trim();
+        break;
+      case '--repo':
+        parsed.repo = value.trim();
+        break;
+      case '--policy':
+        parsed.policy = value.trim();
+        break;
+      case '--now':
+        parsed.now = value.trim();
+        break;
+      default:
+        throw new Error(`unknown argument: ${token}`);
+    }
+  }
+
+  // Fail closed on exactly one of --owner / --repo: a single flag would
+  // validate one repo while the traversal / mutation runs against the
+  // current-directory repo. Require both or neither.
+  if ((parsed.owner === '') !== (parsed.repo === '')) {
+    throw new Error(
+      'idd-roadmap-audit-execute: --owner and --repo must be provided together or not at all',
+    );
+  }
+
+  return parsed;
+}
+
+function parsePositiveInteger(value: string, flag: string): number {
+  const raw = String(value ?? '').trim();
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`invalid ${flag} value: ${value}`);
+  }
+  return Number(raw);
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/idd-roadmap-audit-execute.mjs --roadmap <number> [--owner <owner>] [--repo <repo>] [--policy <path>]
+  node scripts/idd-roadmap-audit-execute.mjs --roadmap <number> --claim-id <claim-id> [--claim-issue <number>] [--agent-id <agent-id>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--apply]
+
+  Default (no --apply): dry-run. Evaluates A1.5 roadmap completion via the
+  read-only discover-roadmap-graph traversal and prints { ready, blockers,
+  evidenceBody } without mutating. Exit 0 when ready, 1 otherwise. evidenceBody
+  is the canonical "IDD roadmap completion audit" comment body (empty when the
+  roadmap is not ready).
+
+  --apply: when ready, re-validate the roadmap-audit claim and re-evaluate the
+  roadmap graph immediately before mutating, then post the evidence comment,
+  close the roadmap as completed, and release the claim. Fails closed (exit 1,
+  no mutation) on any lost / stale / non-owned claim or any blocker. The claim
+  is re-validated against --claim-issue (default: the roadmap) and must match
+  --claim-id (required under --apply) and, when given, --agent-id. --owner and
+  --repo must be passed together or not at all.
+`);
+}
+
+function isMainModule(moduleUrl: string): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return fileURLToPath(moduleUrl) === resolve(entry);
+}
+
+if (isMainModule(import.meta.url)) {
+  if (process.argv.slice(2).some((arg) => arg === '--help' || arg === '-h')) {
+    printHelp();
+    process.exit(0);
+  }
+  runRoadmapAuditExecute(process.argv.slice(2))
+    .then(({ verdict, exitCode }) => {
+      process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+      process.exit(exitCode);
+    })
+    .catch((error: unknown) => {
+      process.stderr.write(`Error: ${(error as Error).message}\n`);
+      process.exit(1);
+    });
+}

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -460,6 +460,54 @@ test('resolveOpenLinkedPrIssues blocks a present connection with an OPEN closing
   assert.deepEqual(resolveOpenLinkedPrIssues('o', 'r', [1048], runner), [1048]);
 });
 
+test('resolveOpenLinkedPrIssues fails closed on a truncated closing-PR page (hasNextPage, no endCursor)', () => {
+  const runner = fakeGraphqlRunner({
+    closing: {
+      data: {
+        repository: {
+          issue: {
+            closedByPullRequestsReferences: {
+              nodes: [{ state: 'MERGED' }],
+              pageInfo: { hasNextPage: true, endCursor: null },
+            },
+          },
+        },
+      },
+    },
+  });
+  assert.deepEqual(resolveOpenLinkedPrIssues('o', 'r', [1048], runner), [1048]);
+});
+
+test('resolveOpenLinkedPrIssues fails closed on a truncated connected-PR timeline (hasNextPage, no endCursor)', () => {
+  const runner = fakeGraphqlRunner({
+    closing: {
+      data: {
+        repository: {
+          issue: {
+            closedByPullRequestsReferences: {
+              nodes: [],
+              pageInfo: { hasNextPage: false },
+            },
+          },
+        },
+      },
+    },
+    timeline: {
+      data: {
+        repository: {
+          issue: {
+            timelineItems: {
+              nodes: [],
+              pageInfo: { hasNextPage: true, endCursor: null },
+            },
+          },
+        },
+      },
+    },
+  });
+  assert.deepEqual(resolveOpenLinkedPrIssues('o', 'r', [1048], runner), [1048]);
+});
+
 test('unresolved, inaccessible, and cycle diagnostics each surface a blocker', () => {
   const report = readyReport();
   report.diagnostics.unresolvedReferences = [

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -4,9 +4,11 @@ import { test } from 'node:test';
 import type { RoadmapGraphReport } from '../src/scripts/discover-roadmap-graph.mts';
 import {
   buildRoadmapCompletionAuditBody,
+  type ConnectedPrEvent,
   evaluateRoadmapAuditGates,
   evaluateRoadmapClaim,
   type RoadmapAuditExecuteDeps,
+  reconcileConnectedOpenPrs,
   runRoadmapAuditExecute,
 } from '../src/scripts/idd-roadmap-audit-execute.mts';
 import { renderClaimedByMarker } from '../src/scripts/protocol-helpers.mts';
@@ -289,6 +291,84 @@ test('a closed child with an OPEN linked PR is unresolved; a merged PR is not', 
   // With no open linked PRs (the merged-PR case), nothing blocks.
   assert.deepEqual(
     evaluateRoadmapAuditGates(report, { openLinkedPrIssues: [] }),
+    [],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// reconcileConnectedOpenPrs (pure) — CONNECTED/DISCONNECTED linked-PR signal
+// ---------------------------------------------------------------------------
+
+test('a CONNECTED OPEN PR with no later DISCONNECT reconciles as open-linked', () => {
+  const events: ConnectedPrEvent[] = [
+    { type: 'connected', prNumber: 2001, state: 'OPEN' },
+  ];
+  assert.deepEqual(reconcileConnectedOpenPrs(events), [2001]);
+});
+
+test('a CONNECTED then DISCONNECTED PR is not open-linked', () => {
+  const events: ConnectedPrEvent[] = [
+    { type: 'connected', prNumber: 2001, state: 'OPEN' },
+    { type: 'disconnected', prNumber: 2001 },
+  ];
+  assert.deepEqual(reconcileConnectedOpenPrs(events), []);
+});
+
+test('a CONNECTED MERGED PR is not open-linked', () => {
+  const events: ConnectedPrEvent[] = [
+    { type: 'connected', prNumber: 2001, state: 'MERGED' },
+  ];
+  assert.deepEqual(reconcileConnectedOpenPrs(events), []);
+});
+
+test('a DISCONNECTED then re-CONNECTED OPEN PR is open-linked again (last event wins)', () => {
+  const events: ConnectedPrEvent[] = [
+    { type: 'connected', prNumber: 2001, state: 'OPEN' },
+    { type: 'disconnected', prNumber: 2001 },
+    { type: 'connected', prNumber: 2001, state: 'OPEN' },
+  ];
+  assert.deepEqual(reconcileConnectedOpenPrs(events), [2001]);
+});
+
+test('reconciliation keeps only the still-connected OPEN PRs across several', () => {
+  const events: ConnectedPrEvent[] = [
+    { type: 'connected', prNumber: 3001, state: 'OPEN' }, // stays open
+    { type: 'connected', prNumber: 3002, state: 'OPEN' },
+    { type: 'disconnected', prNumber: 3002 }, // disconnected
+    { type: 'connected', prNumber: 3003, state: 'MERGED' }, // merged
+  ];
+  assert.deepEqual(reconcileConnectedOpenPrs(events), [3001]);
+});
+
+test('a closed child with an OPEN CONNECTED-only PR yields an open-linked-pr blocker', () => {
+  // End-to-end wiring without mocking gh: the resolver maps a child to the
+  // blocked set when reconcileConnectedOpenPrs over its timeline is non-empty.
+  const connectedOpen: ConnectedPrEvent[] = [
+    { type: 'connected', prNumber: 2001, state: 'OPEN' },
+  ];
+  const childBlocked = reconcileConnectedOpenPrs(connectedOpen).length > 0;
+  assert.equal(childBlocked, true);
+
+  const report = readyReport(); // #1048 is a closed child
+  const blockers = evaluateRoadmapAuditGates(report, {
+    openLinkedPrIssues: childBlocked ? [1048] : [],
+  });
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['open-linked-pr'],
+  );
+
+  // A connected-then-disconnected PR leaves the child unblocked.
+  const disconnected: ConnectedPrEvent[] = [
+    ...connectedOpen,
+    { type: 'disconnected', prNumber: 2001 },
+  ];
+  const stillBlocked = reconcileConnectedOpenPrs(disconnected).length > 0;
+  assert.equal(stillBlocked, false);
+  assert.deepEqual(
+    evaluateRoadmapAuditGates(report, {
+      openLinkedPrIssues: stillBlocked ? [1048] : [],
+    }),
     [],
   );
 });

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -117,34 +117,50 @@ function makeDeps(
   deps: RoadmapAuditExecuteDeps;
   calls: {
     collects: number;
+    claimChecks: number;
     comments: { issue: number; body: string }[];
     closed: number[];
-    released: { issue: number; agentId: string; claimId: string }[];
+    released: {
+      issue: number;
+      agentId: string;
+      claimId: string;
+      timestamp: string;
+    }[];
   };
 } {
   const calls = {
     collects: 0,
+    claimChecks: 0,
     comments: [] as { issue: number; body: string }[],
     closed: [] as number[],
-    released: [] as { issue: number; agentId: string; claimId: string }[],
+    released: [] as {
+      issue: number;
+      agentId: string;
+      claimId: string;
+      timestamp: string;
+    }[],
   };
   const deps: RoadmapAuditExecuteDeps = {
     collect: async () => {
       calls.collects += 1;
       return report;
     },
-    revalidateClaim: () => ({
-      owned: true,
-      reason: 'match',
-      stale: false,
-      activeClaim: {
-        agentId: AGENT_ID,
-        claimId: CLAIM_ID,
-        supersedes: 'none',
-        branch: CLAIM_BRANCH,
-        createdAt: '2026-06-26T00:00:00Z',
-      },
-    }),
+    resolveOpenLinkedPrIssues: () => [],
+    revalidateClaim: () => {
+      calls.claimChecks += 1;
+      return {
+        owned: true,
+        reason: 'match',
+        stale: false,
+        activeClaim: {
+          agentId: AGENT_ID,
+          claimId: CLAIM_ID,
+          supersedes: 'none',
+          branch: CLAIM_BRANCH,
+          createdAt: '2026-06-26T00:00:00Z',
+        },
+      };
+    },
     postEvidenceComment: (issue, body) => calls.comments.push({ issue, body }),
     closeRoadmap: (issue) => calls.closed.push(issue),
     releaseClaim: (issue, fields) =>
@@ -152,6 +168,7 @@ function makeDeps(
         issue,
         agentId: fields.agentId,
         claimId: fields.claimId,
+        timestamp: fields.timestamp,
       }),
     now: () => '2026-06-26T01:00:00Z',
     ...overrides,
@@ -207,14 +224,73 @@ test('an open nested roadmap descendant is never closeable', () => {
   assert.equal(blockers[0]?.target, 1100);
 });
 
-test('a closed nested roadmap does not block (bottom-up completion)', () => {
+test('a closed nested roadmap WITH a reachable closed leaf does not block', () => {
+  const report = readyReport();
+  report.nodes = [
+    ...report.nodes,
+    node({ number: 1100, classification: 'roadmap', state: 'CLOSED' }),
+    node({ number: 1101, classification: 'execution', state: 'CLOSED' }),
+  ];
+  report.edges = [
+    ...report.edges,
+    {
+      source: ROADMAP,
+      target: 1100,
+      relationship: 'task-list',
+      evidence: '- [x] #1100',
+    },
+    {
+      source: 1100,
+      target: 1101,
+      relationship: 'task-list',
+      evidence: '- [x] #1101',
+    },
+  ];
+  report.roadmapNodes = [1100];
+  assert.deepEqual(evaluateRoadmapAuditGates(report), []);
+});
+
+test('a closed nested roadmap with NO reachable leaves is childless/malformed → blocked', () => {
   const report = readyReport();
   report.nodes = [
     ...report.nodes,
     node({ number: 1100, classification: 'roadmap', state: 'CLOSED' }),
   ];
+  report.edges = [
+    ...report.edges,
+    {
+      source: ROADMAP,
+      target: 1100,
+      relationship: 'task-list',
+      evidence: '- [x] #1100',
+    },
+  ];
   report.roadmapNodes = [1100];
-  assert.deepEqual(evaluateRoadmapAuditGates(report), []);
+  const blockers = evaluateRoadmapAuditGates(report);
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['nested-roadmap'],
+  );
+  assert.match(blockers[0]?.detail ?? '', /no reachable execution-leaf/);
+});
+
+test('a closed child with an OPEN linked PR is unresolved; a merged PR is not', () => {
+  const report = readyReport();
+  // #1048 is a closed child; inject it as still having an open linked PR.
+  const blocked = evaluateRoadmapAuditGates(report, {
+    openLinkedPrIssues: [1048],
+  });
+  assert.deepEqual(
+    blocked.map((blocker) => blocker.kind),
+    ['open-linked-pr'],
+  );
+  assert.equal(blocked[0]?.target, 1048);
+
+  // With no open linked PRs (the merged-PR case), nothing blocks.
+  assert.deepEqual(
+    evaluateRoadmapAuditGates(report, { openLinkedPrIssues: [] }),
+    [],
+  );
 });
 
 test('unresolved, inaccessible, and cycle diagnostics each surface a blocker', () => {
@@ -294,7 +370,7 @@ test('the evidence body is the canonical IDD roadmap completion audit comment', 
   assert.match(body, /Closed execution leaves: #1047, #1048\./);
   assert.match(
     body,
-    /Open \/ unresolved \/ inaccessible \/ nested-roadmap descendants: none\./,
+    /Open \/ unresolved \/ inaccessible \/ nested-roadmap \/ open-linked-PR descendants: none\./,
   );
   assert.match(body, /Closing the roadmap as completed\./);
 });
@@ -303,8 +379,9 @@ test('the evidence body is the canonical IDD roadmap completion audit comment', 
 // evaluateRoadmapClaim (pure)
 // ---------------------------------------------------------------------------
 
-test('a present, matching, fresh claim is owned', () => {
+test('a present, matching, fresh, roadmap-audit-branch claim is owned', () => {
   const verdict = evaluateRoadmapClaim([claimComment()], {
+    roadmapNumber: ROADMAP,
     expectedClaimId: CLAIM_ID,
     expectedAgentId: AGENT_ID,
     isTrustedAuthor: () => true,
@@ -316,6 +393,7 @@ test('a present, matching, fresh claim is owned', () => {
 
 test('a missing or mismatched claim is not owned', () => {
   const missing = evaluateRoadmapClaim([], {
+    roadmapNumber: ROADMAP,
     expectedClaimId: CLAIM_ID,
     isTrustedAuthor: () => true,
     nowIso: '2026-06-26T01:00:00Z',
@@ -324,6 +402,7 @@ test('a missing or mismatched claim is not owned', () => {
   assert.equal(missing.reason, 'missing-active-claim');
 
   const mismatch = evaluateRoadmapClaim([claimComment({ claimId: 'other' })], {
+    roadmapNumber: ROADMAP,
     expectedClaimId: CLAIM_ID,
     isTrustedAuthor: () => true,
     nowIso: '2026-06-26T01:00:00Z',
@@ -332,8 +411,67 @@ test('a missing or mismatched claim is not owned', () => {
   assert.equal(mismatch.reason, 'claim-id-mismatch');
 });
 
-test('a stale (takeover-eligible) claim is not owned', () => {
+test('a non-roadmap-audit branch on the roadmap issue does NOT authorize closure', () => {
+  // A normal execution claim (issue/<n>-...) on the roadmap issue must not pass.
+  const executionClaim = {
+    body: renderClaimedByMarker({
+      agentId: AGENT_ID,
+      claimId: CLAIM_ID,
+      supersedes: 'none',
+      timestamp: '2026-06-26T00:00:00Z',
+      branch: `issue/${ROADMAP}-some-execution-task`,
+    }),
+    createdAt: '2026-06-26T00:00:00Z',
+    author: { login: 'kurone-kito' },
+  };
+  const verdict = evaluateRoadmapClaim([executionClaim], {
+    roadmapNumber: ROADMAP,
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: '2026-06-26T01:00:00Z',
+  });
+  assert.equal(verdict.owned, false);
+  assert.equal(verdict.reason, 'claim-branch-mismatch');
+
+  // ...and a roadmap-audit/<n>-... branch IS accepted.
+  const accepted = evaluateRoadmapClaim([claimComment()], {
+    roadmapNumber: ROADMAP,
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: '2026-06-26T01:00:00Z',
+  });
+  assert.equal(accepted.owned, true);
+});
+
+test('staleness honors the configured claim stale age', () => {
+  const comment = [claimComment()]; // claim createdAt 2026-06-26T00:00:00Z
+  const oneHourLater = '2026-06-26T01:00:00Z';
+
+  // A 30-minute stale age makes the 1h-old claim stale → not owned.
+  const shortened = evaluateRoadmapClaim(comment, {
+    roadmapNumber: ROADMAP,
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: oneHourLater,
+    staleAgeMs: 30 * 60 * 1000,
+  });
+  assert.equal(shortened.owned, false);
+  assert.equal(shortened.reason, 'claim-stale');
+
+  // A 48-hour stale age keeps the same 1h-old claim fresh → owned.
+  const lengthened = evaluateRoadmapClaim(comment, {
+    roadmapNumber: ROADMAP,
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: oneHourLater,
+    staleAgeMs: 48 * 60 * 60 * 1000,
+  });
+  assert.equal(lengthened.owned, true);
+});
+
+test('a stale (takeover-eligible) claim is not owned at the default age', () => {
   const verdict = evaluateRoadmapClaim([claimComment()], {
+    roadmapNumber: ROADMAP,
     expectedClaimId: CLAIM_ID,
     isTrustedAuthor: () => true,
     // > 24h after the claim createdAt → stale per the distributed default.
@@ -346,6 +484,7 @@ test('a stale (takeover-eligible) claim is not owned', () => {
 
 test('an untrusted claim author yields no active claim', () => {
   const verdict = evaluateRoadmapClaim([claimComment()], {
+    roadmapNumber: ROADMAP,
     expectedClaimId: CLAIM_ID,
     isTrustedAuthor: () => false,
     nowIso: '2026-06-26T01:00:00Z',
@@ -495,6 +634,109 @@ test('--apply without --claim-id fails closed (no mutation)', async () => {
   assert.match(verdict.result, /--claim-id is required/);
   assert.equal(exitCode, 1);
   assert.deepEqual(calls.closed, []);
+});
+
+test('--apply releases the claim with a second-precision timestamp even when now() has ms', async () => {
+  // Regression: renderUnclaimedByMarker rejects millisecond ISO, which would
+  // throw AFTER the comment + close already landed (a partial mutation).
+  const { deps, calls } = makeDeps(readyReport(), {
+    now: () => '2026-06-26T01:00:00.123Z',
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(exitCode, 0);
+  assert.equal(verdict.claimReleased, true);
+  assert.equal(calls.released.length, 1);
+  assert.equal(calls.released[0]?.timestamp, '2026-06-26T01:00:00Z');
+});
+
+test('--apply rejects a --claim-issue that differs from the roadmap (no mutation)', async () => {
+  const { deps, calls } = makeDeps(readyReport());
+  const { verdict, exitCode } = await runRoadmapAuditExecute(
+    [
+      '--roadmap',
+      String(ROADMAP),
+      '--claim-issue',
+      '994',
+      '--claim-id',
+      CLAIM_ID,
+      '--apply',
+    ],
+    deps,
+  );
+
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /must equal the roadmap/);
+  assert.equal(exitCode, 1);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.released, []);
+});
+
+test('--apply accepts a --claim-issue that equals the roadmap', async () => {
+  const { deps, calls } = makeDeps(readyReport());
+  const { verdict, exitCode } = await runRoadmapAuditExecute(
+    [
+      '--roadmap',
+      String(ROADMAP),
+      '--claim-issue',
+      String(ROADMAP),
+      '--claim-id',
+      CLAIM_ID,
+      '--apply',
+    ],
+    deps,
+  );
+
+  assert.equal(verdict.closed, true);
+  assert.equal(exitCode, 0);
+  assert.deepEqual(calls.closed, [ROADMAP]);
+});
+
+test('--apply re-validates the claim AFTER the graph re-fetch (last gate before mutation)', async () => {
+  // Owned on the early check, lost on the pre-mutation check → no mutation.
+  let claimChecks = 0;
+  const { deps, calls } = makeDeps(readyReport(), {
+    revalidateClaim: () => {
+      claimChecks += 1;
+      if (claimChecks >= 2) {
+        return {
+          owned: false,
+          reason: 'claim-stale',
+          stale: true,
+          activeClaim: {
+            agentId: AGENT_ID,
+            claimId: CLAIM_ID,
+            supersedes: 'none',
+            branch: CLAIM_BRANCH,
+            createdAt: '2026-06-26T00:00:00Z',
+          },
+        };
+      }
+      return {
+        owned: true,
+        reason: 'match',
+        stale: false,
+        activeClaim: {
+          agentId: AGENT_ID,
+          claimId: CLAIM_ID,
+          supersedes: 'none',
+          branch: CLAIM_BRANCH,
+          createdAt: '2026-06-26T00:00:00Z',
+        },
+      };
+    },
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.closed, false);
+  assert.equal(verdict.claimReleased, false);
+  assert.match(verdict.result, /immediately before mutation/);
+  assert.equal(exitCode, 1);
+  // Two claim checks ran: the early one AND the post-re-fetch gate.
+  assert.equal(claimChecks, 2);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
 });
 
 test('missing --roadmap is rejected', async () => {

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -9,6 +9,7 @@ import {
   evaluateRoadmapClaim,
   type RoadmapAuditExecuteDeps,
   reconcileConnectedOpenPrs,
+  resolveOpenLinkedPrIssues,
   runRoadmapAuditExecute,
 } from '../src/scripts/idd-roadmap-audit-execute.mts';
 import { renderClaimedByMarker } from '../src/scripts/protocol-helpers.mts';
@@ -371,6 +372,92 @@ test('a closed child with an OPEN CONNECTED-only PR yields an open-linked-pr blo
     }),
     [],
   );
+});
+
+// ---------------------------------------------------------------------------
+// resolveOpenLinkedPrIssues (injected GraphQL runner) — absent-connection
+// fail-closed distinction
+// ---------------------------------------------------------------------------
+
+// Build a fake page runner that answers the closing-refs vs timeline queries.
+function fakeGraphqlRunner(responses: {
+  closing?: unknown;
+  timeline?: unknown;
+}) {
+  return (query: string) =>
+    query.includes('timelineItems') ? responses.timeline : responses.closing;
+}
+
+test('resolveOpenLinkedPrIssues fails closed when the issue node is null/absent', () => {
+  const runner = fakeGraphqlRunner({
+    closing: { data: { repository: { issue: null } } },
+    timeline: { data: { repository: { issue: null } } },
+  });
+  assert.deepEqual(resolveOpenLinkedPrIssues('o', 'r', [1048], runner), [1048]);
+});
+
+test('resolveOpenLinkedPrIssues fails closed when a lookup connection is null/absent', () => {
+  // Present (empty) timeline, but a null closing-refs connection → blocked.
+  const runner = fakeGraphqlRunner({
+    closing: {
+      data: { repository: { issue: { closedByPullRequestsReferences: null } } },
+    },
+    timeline: {
+      data: {
+        repository: {
+          issue: {
+            timelineItems: { nodes: [], pageInfo: { hasNextPage: false } },
+          },
+        },
+      },
+    },
+  });
+  assert.deepEqual(resolveOpenLinkedPrIssues('o', 'r', [1048], runner), [1048]);
+});
+
+test('resolveOpenLinkedPrIssues does NOT block a present-but-empty connection', () => {
+  const runner = fakeGraphqlRunner({
+    closing: {
+      data: {
+        repository: {
+          issue: {
+            closedByPullRequestsReferences: {
+              nodes: [],
+              pageInfo: { hasNextPage: false },
+            },
+          },
+        },
+      },
+    },
+    timeline: {
+      data: {
+        repository: {
+          issue: {
+            timelineItems: { nodes: [], pageInfo: { hasNextPage: false } },
+          },
+        },
+      },
+    },
+  });
+  assert.deepEqual(resolveOpenLinkedPrIssues('o', 'r', [1048], runner), []);
+});
+
+test('resolveOpenLinkedPrIssues blocks a present connection with an OPEN closing PR', () => {
+  const runner = fakeGraphqlRunner({
+    closing: {
+      data: {
+        repository: {
+          issue: {
+            closedByPullRequestsReferences: {
+              nodes: [{ state: 'OPEN' }],
+              pageInfo: { hasNextPage: false },
+            },
+          },
+        },
+      },
+    },
+  });
+  assert.deepEqual(resolveOpenLinkedPrIssues('o', 'r', [1048], runner), [1048]);
 });
 
 test('unresolved, inaccessible, and cycle diagnostics each surface a blocker', () => {
@@ -817,6 +904,77 @@ test('--apply re-validates the claim AFTER the graph re-fetch (last gate before 
   assert.equal(claimChecks, 2);
   assert.deepEqual(calls.closed, []);
   assert.deepEqual(calls.comments, []);
+});
+
+test('--apply fails closed on an unparseable now (no mutation, no claim check)', async () => {
+  const { deps, calls } = makeDeps(readyReport(), {
+    now: () => 'not-a-real-date',
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /invalid "now"/);
+  assert.equal(exitCode, 1);
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.released, []);
+  // Validation precedes any claim check (and thus any mutation).
+  assert.equal(calls.claimChecks, 0);
+});
+
+test('--apply normalizes an offset-form now to second-precision UTC for the release marker', async () => {
+  const { deps, calls } = makeDeps(readyReport(), {
+    now: () => '2026-06-26T01:00:00+09:00',
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(exitCode, 0);
+  assert.equal(verdict.closed, true);
+  // 2026-06-26T01:00:00+09:00 == 2026-06-25T16:00:00Z, truncated to seconds.
+  assert.equal(calls.released[0]?.timestamp, '2026-06-25T16:00:00Z');
+});
+
+test('--apply aborts the CLOSE when the claim is lost in the comment→close gap', async () => {
+  // Owned through the early + pre-comment checks, lost on the pre-close check.
+  let checks = 0;
+  const ownedVerdict = () => ({
+    owned: true,
+    reason: 'match',
+    stale: false,
+    activeClaim: {
+      agentId: AGENT_ID,
+      claimId: CLAIM_ID,
+      supersedes: 'none',
+      branch: CLAIM_BRANCH,
+      createdAt: '2026-06-26T00:00:00Z',
+    },
+  });
+  const { deps, calls } = makeDeps(readyReport(), {
+    revalidateClaim: () => {
+      checks += 1;
+      if (checks >= 3) {
+        return {
+          owned: false,
+          reason: 'claim-stale',
+          stale: true,
+          activeClaim: ownedVerdict().activeClaim,
+        };
+      }
+      return ownedVerdict();
+    },
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.closed, false);
+  assert.equal(verdict.claimReleased, false);
+  assert.match(verdict.result, /comment→close gap/);
+  assert.equal(exitCode, 1);
+  // The evidence comment WAS posted (harmless), but the close/release were not.
+  assert.equal(calls.comments.length, 1);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.released, []);
+  // early + pre-comment + pre-close re-validations all ran.
+  assert.equal(checks, 3);
 });
 
 test('missing --roadmap is rejected', async () => {

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -1,0 +1,506 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { RoadmapGraphReport } from '../src/scripts/discover-roadmap-graph.mts';
+import {
+  buildRoadmapCompletionAuditBody,
+  evaluateRoadmapAuditGates,
+  evaluateRoadmapClaim,
+  type RoadmapAuditExecuteDeps,
+  runRoadmapAuditExecute,
+} from '../src/scripts/idd-roadmap-audit-execute.mts';
+import { renderClaimedByMarker } from '../src/scripts/protocol-helpers.mts';
+
+const ROADMAP = 995;
+const CLAIM_ID = 'claim-20260626T000000Z-995';
+const AGENT_ID = 'github-copilot-cli';
+const CLAIM_BRANCH = 'roadmap-audit/995-completed-roadmap';
+
+interface NodeOverride {
+  number: number;
+  title?: string;
+  state?: string;
+  classification?: 'roadmap' | 'execution';
+  labels?: string[];
+}
+
+function node(override: NodeOverride) {
+  return {
+    number: override.number,
+    title: override.title ?? `issue ${override.number}`,
+    state: override.state ?? 'CLOSED',
+    labels: override.labels ?? [],
+    classification: override.classification ?? 'execution',
+    roadmapMarkerId: override.classification === 'roadmap' ? 'epic' : '',
+    autopilotSuitability: null,
+    effort: null,
+    depth: override.number === ROADMAP ? 0 : 1,
+  };
+}
+
+// A roadmap graph whose every referenced child is closed (ready to close).
+// Each test deep-mutates a fresh copy to flip exactly one completion fact.
+function readyReport(): RoadmapGraphReport {
+  return {
+    root: {
+      number: ROADMAP,
+      title: 'completed roadmap',
+      state: 'OPEN',
+      classification: 'roadmap',
+      roadmapMarkerId: 'epic',
+    },
+    nodes: [
+      node({ number: ROADMAP, classification: 'roadmap', state: 'OPEN' }),
+      node({ number: 1047, classification: 'execution', state: 'CLOSED' }),
+      node({ number: 1048, classification: 'execution', state: 'CLOSED' }),
+    ],
+    edges: [
+      {
+        source: ROADMAP,
+        target: 1047,
+        relationship: 'task-list',
+        evidence: '- [x] #1047',
+      },
+      {
+        source: ROADMAP,
+        target: 1048,
+        relationship: 'task-list',
+        evidence: '- [x] #1048',
+      },
+    ],
+    provenancePaths: [
+      { target: ROADMAP, path: [ROADMAP] },
+      { target: 1047, path: [ROADMAP, 1047] },
+      { target: 1048, path: [ROADMAP, 1048] },
+    ],
+    roadmapNodes: [],
+    executionCandidates: [],
+    diagnostics: {
+      duplicateReferences: [],
+      cycles: [],
+      inaccessibleReferences: [],
+      unresolvedReferences: [],
+    },
+    summary: {
+      rootNumber: ROADMAP,
+      nodeCount: 3,
+      edgeCount: 2,
+      roadmapNodeCount: 0,
+      executionCandidateCount: 0,
+      duplicateReferenceCount: 0,
+      cycleCount: 0,
+      inaccessibleReferenceCount: 0,
+      unresolvedReferenceCount: 0,
+      maxDepth: 1,
+    },
+  };
+}
+
+function claimComment(overrides: { claimId?: string; agentId?: string } = {}) {
+  return {
+    body: renderClaimedByMarker({
+      agentId: overrides.agentId ?? AGENT_ID,
+      claimId: overrides.claimId ?? CLAIM_ID,
+      supersedes: 'none',
+      timestamp: '2026-06-26T00:00:00Z',
+      branch: CLAIM_BRANCH,
+    }),
+    createdAt: '2026-06-26T00:00:00Z',
+    author: { login: 'kurone-kito' },
+  };
+}
+
+function makeDeps(
+  report: RoadmapGraphReport,
+  overrides: Partial<RoadmapAuditExecuteDeps> = {},
+): {
+  deps: RoadmapAuditExecuteDeps;
+  calls: {
+    collects: number;
+    comments: { issue: number; body: string }[];
+    closed: number[];
+    released: { issue: number; agentId: string; claimId: string }[];
+  };
+} {
+  const calls = {
+    collects: 0,
+    comments: [] as { issue: number; body: string }[],
+    closed: [] as number[],
+    released: [] as { issue: number; agentId: string; claimId: string }[],
+  };
+  const deps: RoadmapAuditExecuteDeps = {
+    collect: async () => {
+      calls.collects += 1;
+      return report;
+    },
+    revalidateClaim: () => ({
+      owned: true,
+      reason: 'match',
+      stale: false,
+      activeClaim: {
+        agentId: AGENT_ID,
+        claimId: CLAIM_ID,
+        supersedes: 'none',
+        branch: CLAIM_BRANCH,
+        createdAt: '2026-06-26T00:00:00Z',
+      },
+    }),
+    postEvidenceComment: (issue, body) => calls.comments.push({ issue, body }),
+    closeRoadmap: (issue) => calls.closed.push(issue),
+    releaseClaim: (issue, fields) =>
+      calls.released.push({
+        issue,
+        agentId: fields.agentId,
+        claimId: fields.claimId,
+      }),
+    now: () => '2026-06-26T01:00:00Z',
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+const APPLY_ARGS = [
+  '--roadmap',
+  String(ROADMAP),
+  '--claim-id',
+  CLAIM_ID,
+  '--apply',
+];
+
+// ---------------------------------------------------------------------------
+// evaluateRoadmapAuditGates (pure)
+// ---------------------------------------------------------------------------
+
+test('evaluateRoadmapAuditGates returns no blockers when every child is closed', () => {
+  assert.deepEqual(evaluateRoadmapAuditGates(readyReport()), []);
+});
+
+test('an open execution child becomes an open-child blocker with provenance', () => {
+  const report = readyReport();
+  report.nodes = report.nodes.map((entry) =>
+    entry.number === 1048 ? { ...entry, state: 'OPEN' } : entry,
+  );
+  report.executionCandidates = [1048];
+  const blockers = evaluateRoadmapAuditGates(report);
+  assert.equal(blockers.length, 1);
+  assert.equal(blockers[0]?.kind, 'open-child');
+  assert.equal(blockers[0]?.target, 1048);
+  assert.deepEqual(blockers[0]?.provenance, [ROADMAP, 1048]);
+});
+
+test('an open nested roadmap descendant is never closeable', () => {
+  const report = readyReport();
+  report.nodes = [
+    ...report.nodes,
+    node({ number: 1100, classification: 'roadmap', state: 'OPEN' }),
+  ];
+  report.roadmapNodes = [1100];
+  report.provenancePaths = [
+    ...report.provenancePaths,
+    { target: 1100, path: [ROADMAP, 1100] },
+  ];
+  const blockers = evaluateRoadmapAuditGates(report);
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['nested-roadmap'],
+  );
+  assert.equal(blockers[0]?.target, 1100);
+});
+
+test('a closed nested roadmap does not block (bottom-up completion)', () => {
+  const report = readyReport();
+  report.nodes = [
+    ...report.nodes,
+    node({ number: 1100, classification: 'roadmap', state: 'CLOSED' }),
+  ];
+  report.roadmapNodes = [1100];
+  assert.deepEqual(evaluateRoadmapAuditGates(report), []);
+});
+
+test('unresolved, inaccessible, and cycle diagnostics each surface a blocker', () => {
+  const report = readyReport();
+  report.diagnostics.unresolvedReferences = [
+    {
+      source: ROADMAP,
+      target: 4242,
+      relationship: 'task-list',
+      evidence: '- [ ] #4242',
+      reason: 'issue_not_found',
+    },
+  ];
+  report.diagnostics.inaccessibleReferences = [
+    {
+      source: ROADMAP,
+      target: 4343,
+      relationship: 'task-list',
+      evidence: '- [ ] #4343',
+      reason: 'issue_inaccessible',
+    },
+  ];
+  report.diagnostics.cycles = [
+    {
+      source: 1047,
+      target: ROADMAP,
+      relationship: 'dependency',
+      path: [ROADMAP, 1047, ROADMAP],
+    },
+  ];
+  const kinds = evaluateRoadmapAuditGates(report)
+    .map((blocker) => blocker.kind)
+    .sort();
+  assert.deepEqual(kinds, [
+    'cycle',
+    'inaccessible-reference',
+    'unresolved-reference',
+  ]);
+});
+
+test('a childless roadmap (no edges) is reported, never closed', () => {
+  const report = readyReport();
+  report.nodes = [
+    node({ number: ROADMAP, classification: 'roadmap', state: 'OPEN' }),
+  ];
+  report.edges = [];
+  report.provenancePaths = [{ target: ROADMAP, path: [ROADMAP] }];
+  const blockers = evaluateRoadmapAuditGates(report);
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['childless'],
+  );
+});
+
+test('a human-gate label on the roadmap root blocks the close', () => {
+  const report = readyReport();
+  report.nodes = report.nodes.map((entry) =>
+    entry.number === ROADMAP
+      ? { ...entry, labels: ['roadmap', 'status:blocked-by-human'] }
+      : entry,
+  );
+  const blockers = evaluateRoadmapAuditGates(report);
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['roadmap-blocked'],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// buildRoadmapCompletionAuditBody (pure)
+// ---------------------------------------------------------------------------
+
+test('the evidence body is the canonical IDD roadmap completion audit comment', () => {
+  const body = buildRoadmapCompletionAuditBody(readyReport());
+  assert.match(body, /^\*\*IDD roadmap completion audit\*\*/);
+  assert.match(body, /Roadmap #995 "completed roadmap"/);
+  assert.match(body, /Closed execution leaves: #1047, #1048\./);
+  assert.match(
+    body,
+    /Open \/ unresolved \/ inaccessible \/ nested-roadmap descendants: none\./,
+  );
+  assert.match(body, /Closing the roadmap as completed\./);
+});
+
+// ---------------------------------------------------------------------------
+// evaluateRoadmapClaim (pure)
+// ---------------------------------------------------------------------------
+
+test('a present, matching, fresh claim is owned', () => {
+  const verdict = evaluateRoadmapClaim([claimComment()], {
+    expectedClaimId: CLAIM_ID,
+    expectedAgentId: AGENT_ID,
+    isTrustedAuthor: () => true,
+    nowIso: '2026-06-26T01:00:00Z',
+  });
+  assert.equal(verdict.owned, true);
+  assert.equal(verdict.reason, 'match');
+});
+
+test('a missing or mismatched claim is not owned', () => {
+  const missing = evaluateRoadmapClaim([], {
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: '2026-06-26T01:00:00Z',
+  });
+  assert.equal(missing.owned, false);
+  assert.equal(missing.reason, 'missing-active-claim');
+
+  const mismatch = evaluateRoadmapClaim([claimComment({ claimId: 'other' })], {
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: '2026-06-26T01:00:00Z',
+  });
+  assert.equal(mismatch.owned, false);
+  assert.equal(mismatch.reason, 'claim-id-mismatch');
+});
+
+test('a stale (takeover-eligible) claim is not owned', () => {
+  const verdict = evaluateRoadmapClaim([claimComment()], {
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    // > 24h after the claim createdAt → stale per the distributed default.
+    nowIso: '2026-06-28T00:00:01Z',
+  });
+  assert.equal(verdict.owned, false);
+  assert.equal(verdict.reason, 'claim-stale');
+  assert.equal(verdict.stale, true);
+});
+
+test('an untrusted claim author yields no active claim', () => {
+  const verdict = evaluateRoadmapClaim([claimComment()], {
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => false,
+    nowIso: '2026-06-26T01:00:00Z',
+  });
+  assert.equal(verdict.owned, false);
+  assert.equal(verdict.reason, 'missing-active-claim');
+});
+
+// ---------------------------------------------------------------------------
+// runRoadmapAuditExecute (orchestration with injected deps)
+// ---------------------------------------------------------------------------
+
+test('dry-run on a ready roadmap reports ready with the evidence body, no mutation', async () => {
+  const { deps, calls } = makeDeps(readyReport());
+  const { verdict, exitCode } = await runRoadmapAuditExecute(
+    ['--roadmap', String(ROADMAP)],
+    deps,
+  );
+
+  assert.equal(verdict.mode, 'dry-run');
+  assert.equal(verdict.decisionAuthority, 'instructions');
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.blockers, []);
+  assert.match(verdict.evidenceBody, /IDD roadmap completion audit/);
+  assert.equal(verdict.closed, false);
+  assert.equal(verdict.claimReleased, false);
+  assert.equal(exitCode, 0);
+  // Dry-run never mutates.
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.released, []);
+});
+
+test('dry-run on a blocked roadmap reports the open-child blocker, empty body', async () => {
+  const report = readyReport();
+  report.nodes = report.nodes.map((entry) =>
+    entry.number === 1048 ? { ...entry, state: 'OPEN' } : entry,
+  );
+  report.executionCandidates = [1048];
+  const { deps, calls } = makeDeps(report);
+  const { verdict, exitCode } = await runRoadmapAuditExecute(
+    ['--roadmap', String(ROADMAP)],
+    deps,
+  );
+
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.blockers[0]?.kind, 'open-child');
+  assert.equal(verdict.evidenceBody, '');
+  assert.equal(exitCode, 1);
+  assert.deepEqual(calls.closed, []);
+});
+
+test('--apply on a ready roadmap posts the comment, closes, and releases the claim in order', async () => {
+  const { deps, calls } = makeDeps(readyReport());
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.mode, 'apply');
+  assert.equal(verdict.ready, true);
+  assert.equal(verdict.closed, true);
+  assert.equal(verdict.claimReleased, true);
+  assert.equal(exitCode, 0);
+  assert.equal(calls.comments.length, 1);
+  assert.equal(calls.comments[0]?.issue, ROADMAP);
+  assert.match(calls.comments[0]?.body ?? '', /IDD roadmap completion audit/);
+  assert.deepEqual(calls.closed, [ROADMAP]);
+  assert.equal(calls.released[0]?.claimId, CLAIM_ID);
+  // collect runs twice: initial evaluation + immediate-pre-close re-validation.
+  assert.equal(calls.collects, 2);
+});
+
+test('--apply on a blocked roadmap fails closed without mutating', async () => {
+  const report = readyReport();
+  report.nodes = report.nodes.map((entry) =>
+    entry.number === 1047 ? { ...entry, state: 'OPEN' } : entry,
+  );
+  report.executionCandidates = [1047];
+  const { deps, calls } = makeDeps(report);
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /not-ready/);
+  assert.equal(exitCode, 1);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.released, []);
+});
+
+test('--apply fails closed (no close) when the claim is lost / not owned', async () => {
+  const { deps, calls } = makeDeps(readyReport(), {
+    revalidateClaim: () => ({
+      owned: false,
+      reason: 'claim-id-mismatch',
+      stale: false,
+      activeClaim: {
+        agentId: '',
+        claimId: '',
+        supersedes: '',
+        branch: '',
+        createdAt: '',
+      },
+    }),
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.closed, false);
+  assert.equal(verdict.claimReleased, false);
+  assert.match(verdict.result, /claim not owned/);
+  assert.equal(exitCode, 1);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+});
+
+test('--apply fails closed when re-validation finds a new blocker before close', async () => {
+  let collectCount = 0;
+  const blockedReport = readyReport();
+  blockedReport.nodes = blockedReport.nodes.map((entry) =>
+    entry.number === 1048 ? { ...entry, state: 'OPEN' } : entry,
+  );
+  blockedReport.executionCandidates = [1048];
+  const { deps, calls } = makeDeps(readyReport(), {
+    collect: async () => {
+      collectCount += 1;
+      // First read is ready; the immediate-pre-close re-read finds drift.
+      return collectCount >= 2 ? blockedReport : readyReport();
+    },
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.closed, false);
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.blockers[0]?.kind, 'open-child');
+  assert.match(verdict.result, /new completion blockers/);
+  assert.equal(exitCode, 1);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+});
+
+test('--apply without --claim-id fails closed (no mutation)', async () => {
+  const { deps, calls } = makeDeps(readyReport());
+  const { verdict, exitCode } = await runRoadmapAuditExecute(
+    ['--roadmap', String(ROADMAP), '--apply'],
+    deps,
+  );
+
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /--claim-id is required/);
+  assert.equal(exitCode, 1);
+  assert.deepEqual(calls.closed, []);
+});
+
+test('missing --roadmap is rejected', async () => {
+  const { deps } = makeDeps(readyReport());
+  await assert.rejects(
+    () => runRoadmapAuditExecute(['--claim-id', CLAIM_ID], deps),
+    /missing required --roadmap/,
+  );
+});

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -8,6 +8,7 @@ import type { BranchConflictResult } from '../src/scripts/branch-conflict-state.
 import type { RoadmapGraphUnionReport } from '../src/scripts/discover-roadmap-graph.mts';
 import type { DispositionReport } from '../src/scripts/disposition-non-review-notices.mts';
 import type { IddMergeExecuteVerdict } from '../src/scripts/idd-merge-execute.mts';
+import type { IddRoadmapAuditExecuteVerdict } from '../src/scripts/idd-roadmap-audit-execute.mts';
 import type { PostIddMarkerResult } from '../src/scripts/post-idd-marker.mts';
 import type { PreMergeReadinessReport } from '../src/scripts/pre-merge-readiness.mts';
 import type {
@@ -312,6 +313,19 @@ export const iddMergeExecuteKeys = [
   'mergeResult',
 ] as const satisfies readonly (keyof IddMergeExecuteVerdict)[];
 
+export const iddRoadmapAuditExecuteKeys = [
+  'protocolVersion',
+  'decisionAuthority',
+  'mode',
+  'roadmapNumber',
+  'ready',
+  'blockers',
+  'evidenceBody',
+  'closed',
+  'claimReleased',
+  'result',
+] as const satisfies readonly (keyof IddRoadmapAuditExecuteVerdict)[];
+
 export const forcedHandoffMarkerKeys = [
   'oldAgentId',
   'oldClaimId',
@@ -465,6 +479,10 @@ const exhaustivenessWitnesses: {
     IddMergeExecuteVerdict,
     (typeof iddMergeExecuteKeys)[number]
   >;
+  iddRoadmapAuditExecute: CoversAllKeysOf<
+    IddRoadmapAuditExecuteVerdict,
+    (typeof iddRoadmapAuditExecuteKeys)[number]
+  >;
   liveStatusDigest: CoversAllKeysOf<
     LiveStatusDigestFields,
     (typeof liveStatusDigestKeys)[number]
@@ -488,6 +506,7 @@ const exhaustivenessWitnesses: {
   discoverRoadmapUnion: true,
   forcedHandoffMarker: true,
   iddMergeExecute: true,
+  iddRoadmapAuditExecute: true,
   liveStatusDigest: true,
   phaseGraph: true,
   policyConfig: true,
@@ -648,6 +667,26 @@ const iddMergeExecuteFixture = {
   merged: false,
   mergeResult: '',
 } satisfies IddMergeExecuteVerdict;
+
+const iddRoadmapAuditExecuteFixture = {
+  protocolVersion: '1',
+  decisionAuthority: 'instructions',
+  mode: 'dry-run',
+  roadmapNumber: 995,
+  ready: false,
+  blockers: [
+    {
+      kind: 'open-child',
+      target: 1071,
+      provenance: [995, 1071],
+      detail: 'execution leaf #1071 is OPEN',
+    },
+  ],
+  evidenceBody: '',
+  closed: false,
+  claimReleased: false,
+  result: '',
+} satisfies IddRoadmapAuditExecuteVerdict;
 
 const liveStatusDigestFixture = {
   phase: 'E1',
@@ -1063,6 +1102,13 @@ const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
     owningModule: 'src/scripts/idd-merge-execute.mts',
     keys: iddMergeExecuteKeys,
     fixture: iddMergeExecuteFixture,
+  },
+  {
+    schemaFile: 'idd-roadmap-audit-execute.schema.json',
+    exportedType: 'IddRoadmapAuditExecuteVerdict',
+    owningModule: 'src/scripts/idd-roadmap-audit-execute.mts',
+    keys: iddRoadmapAuditExecuteKeys,
+    fixture: iddRoadmapAuditExecuteFixture,
   },
   {
     schemaFile: 'live-status-digest.schema.json',


### PR DESCRIPTION
Closes #1071 (parent roadmap #1069)

## Problem

Closing a completed roadmap (A1.5, `idd-roadmap-audit.instructions.md`) is fully
manual — post/verify the `roadmap-audit/<n>-<slug>` claim, confirm every
descendant is complete, compose the `IDD roadmap completion audit` evidence,
close, and release. There was no execute-helper counterpart to
`idd-merge-execute` (which wraps the read-only gate for F3 and then performs the
claim-revalidated merge); `discover-roadmap-graph` gives the completion graph
but no verdict / evidence / close.

## Change

Add the TS-sourced `idd-roadmap-audit-execute` helper, a sibling of
`idd-merge-execute`:

- **Dry-run (default)**: evaluate completion via the existing roadmap-graph
  traversal (reused, not re-implemented) and emit `{ ready, blockers,
  evidenceBody }`, where `evidenceBody` is the canonical `IDD roadmap completion
  audit` comment body. Read-only. Exit 0 when ready, 1 otherwise.
- **`--apply` (only when ready)**: re-validate the roadmap-audit claim
  (`--claim-issue` / `--claim-id` / optional `--agent-id`) **and** re-evaluate
  the graph immediately before mutating, then post the evidence comment → close
  the roadmap → release the claim, in that order.

**Fail-closed throughout.** `--apply` aborts (no mutation, exit 1) on a lost /
stale / non-owned claim (via the shared `summarizeClaimValidation` + `isStaleAt`)
or on any blocker. A roadmap with an open / unresolved / nested-roadmap /
inaccessible / cyclic descendant, a human-gate label, or no children is **never**
closed. The TOCTOU window is closed by re-collecting the graph after claim
re-validation.

Reuses the roadmap-graph loaders (exported `buildIssueLoader` /
`buildSubIssueLoader`) and the marker helpers. Adds
`schemas/idd-roadmap-audit-execute.schema.json` (+ schema-type-reconciliation
entry), registers the helper in the runtime manifest + `package.json` bin (both
test-guarded), and adds `bin/idd-roadmap-audit-execute.mjs`.

## Verification

- `pnpm run build` regenerates the committed `.mjs` (no drift); full
  `pnpm run lint:minimum` passes (1285 tests / 0 fail, +20 new).
- Live smoke: dry-run on the closed #995 roadmap → `ready: true` with the
  canonical evidence body; on the open #1069 roadmap → `ready: false` blocked on
  open child #1071.
- Rebased onto `main` after #1072 (PR #1074) merged — both touch
  `discover-roadmap-graph` (my export additions vs its perf change) and integrate
  cleanly (75 graph+audit tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new roadmap audit command with a dry-run option.
  * The command can evaluate whether a roadmap is ready to close, generate a standard evidence comment, and complete the close/release flow when approved.
  * Added clearer validation for roadmap audit inputs and claim eligibility, helping prevent unsafe or incomplete executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->