### PR TITLE
fix(idd): mark waiverEvidence required in the pre-merge-readiness schema

### DIFF
--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -15,7 +15,8 @@
     "reviewerStates",
     "advisoryWait",
     "ci",
-    "claim"
+    "claim",
+    "waiverEvidence"
   ],
   "additionalProperties": false,
   "properties": {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -95,6 +95,37 @@ test('pre-merge readiness optionally emits disposition evidence', () => {
   assert.deepEqual(validate(summary, readinessSchema), []);
 });
 
+test('pre-merge readiness always carries waiverEvidence and the schema requires it', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const summary = buildPreMergeReadinessSummary(fixture.input, fixture.options);
+
+  // The summary literal always attaches waiverEvidence (unlike the gated
+  // dispositionEvidence), so a normal output carries it and validates.
+  assert.ok(
+    summary.waiverEvidence && typeof summary.waiverEvidence === 'object',
+    'waiverEvidence is always present',
+  );
+  assert.equal('dispositionEvidence' in summary, false);
+  assert.deepEqual(validate(summary, readinessSchema), []);
+
+  // Dropping the always-present envelope must fail validation now that the
+  // schema lists waiverEvidence in its root `required`.
+  const withoutWaiver = JSON.parse(JSON.stringify(summary));
+  delete withoutWaiver.waiverEvidence;
+  assert.ok(validate(withoutWaiver, readinessSchema).length > 0);
+
+  // dispositionEvidence stays optional: an output that never emits it still
+  // validates (the clean summary above), and dropping it from an output that
+  // did emit it also validates.
+  const withDisposition = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+  });
+  const withoutDisposition = JSON.parse(JSON.stringify(withDisposition));
+  delete withoutDisposition.dispositionEvidence;
+  assert.deepEqual(validate(withoutDisposition, readinessSchema), []);
+});
+
 test('pre-merge readiness exposes effective advisory policy', () => {
   const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
   const summary = buildPreMergeReadinessSummary(fixture.input, {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -97,15 +97,18 @@ test('pre-merge readiness optionally emits disposition evidence', () => {
 
 test('pre-merge readiness always carries waiverEvidence and the schema requires it', () => {
   const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
-  const summary = buildPreMergeReadinessSummary(fixture.input, fixture.options);
+  const summary = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    includeDispositionEvidence: false,
+  });
 
   // The summary literal always attaches waiverEvidence (unlike the gated
   // dispositionEvidence), so a normal output carries it and validates.
   assert.ok(
-    summary.waiverEvidence && typeof summary.waiverEvidence === 'object',
+    Object.hasOwn(summary, 'waiverEvidence'),
     'waiverEvidence is always present',
   );
-  assert.equal('dispositionEvidence' in summary, false);
+  assert.equal(Object.hasOwn(summary, 'dispositionEvidence'), false);
   assert.deepEqual(validate(summary, readinessSchema), []);
 
   // Dropping the always-present envelope must fail validation now that the
@@ -121,6 +124,10 @@ test('pre-merge readiness always carries waiverEvidence and the schema requires 
     ...fixture.options,
     includeDispositionEvidence: true,
   });
+  assert.ok(
+    Object.hasOwn(withDisposition, 'dispositionEvidence'),
+    'includeDispositionEvidence should emit dispositionEvidence',
+  );
   const withoutDisposition = JSON.parse(JSON.stringify(withDisposition));
   delete withoutDisposition.dispositionEvidence;
   assert.deepEqual(validate(withoutDisposition, readinessSchema), []);


### PR DESCRIPTION
## Summary

`buildPreMergeReadinessSummary` attaches `waiverEvidence` to the summary
**unconditionally** (the summary literal always sets it via
`summarizeExternalCheckWaivers`, which always returns all buckets). Only
`dispositionEvidence` is gated, on `includeDispositionEvidence`. The schema,
however, listed `waiverEvidence` as a property but **not** in the root
`required` array, so consumers had to branch on its presence even though it is
always there.

This marks `waiverEvidence` required so consumers can parse the envelope
unconditionally, while leaving `dispositionEvidence` optional.

## Changes

- `schemas/pre-merge-readiness.schema.json` — add `"waiverEvidence"` to the
  root `required` array.
- `tests/pre-merge-readiness.test.mts` — add a regression test: a normal output
  always carries `waiverEvidence` and validates; an output without it fails
  validation; `dispositionEvidence` stays optional.

## Verification

- `pnpm test` (incl. the schema-type reconciliation suite, which already lists
  `waiverEvidence` in `preMergeReadinessKeys`) — green.
- `pnpm run lint:minimum` — green.

Closes #1087


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation rules so a required waiver evidence section must be present in pre-merge readiness documents.
  * Improved checks to ensure summaries still validate with the expected default content and optional evidence fields remain optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->