### PR TITLE
fix(idd): authorize permission "maintain" in default authority branch

### DIFF
--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -478,7 +478,10 @@ function normalizeAuthorityEvidence(evidence, actor, repoOwner, policy) {
       permission === 'write';
   } else {
     authorized =
-      roleName === 'admin' || roleName === 'maintain' || permission === 'admin';
+      roleName === 'admin' ||
+      roleName === 'maintain' ||
+      permission === 'admin' ||
+      permission === 'maintain';
   }
   const error = known
     ? ''

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -763,7 +763,10 @@ function normalizeAuthorityEvidence(
       permission === 'write';
   } else {
     authorized =
-      roleName === 'admin' || roleName === 'maintain' || permission === 'admin';
+      roleName === 'admin' ||
+      roleName === 'maintain' ||
+      permission === 'admin' ||
+      permission === 'maintain';
   }
 
   const error = known

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -150,6 +150,28 @@ test('planExternalCheckWaiver fails closed for unauthorized write-only actors', 
   assert.match(report.blockingReasons.join('\n'), /not authorized/);
 });
 
+test('planExternalCheckWaiver authorizes a permission:maintain actor with empty role_name under the default policy', () => {
+  const input = buildBaseInput();
+  // A real maintainer that the collaborator-permission endpoint reports with
+  // permission: "maintain" and an absent role_name (e.g. GitHub Enterprise
+  // Server / custom org roles). Under owners-and-maintainers-only (the default
+  // policy) this must resolve as authorized, mirroring the rest of the file.
+  input.actor = 'maintain-collaborator';
+  input.authority = {
+    known: true,
+    permission: 'maintain',
+    roleName: '',
+  };
+
+  const report = planExternalCheckWaiver(input, {
+    now: new Date('2026-05-17T06:00:00Z'),
+    repoOwner: 'kurone-kito',
+  });
+
+  assert.equal(report.canApply, true);
+  assert.equal(report.blockingReasons.length, 0);
+});
+
 test('planExternalCheckWaiver fails closed for non-waivable checks', () => {
   const input = buildBaseInput();
   input.requestedSelector = 'lint';


### PR DESCRIPTION
## Summary

`normalizeAuthorityEvidence` in `src/scripts/external-check-waiver.mts` decides
whether a collaborator may post an external-check waiver. Its default
`owners-and-maintainers-only` branch checked
`roleName === 'admin' || roleName === 'maintain' || permission === 'admin'` but
omitted `permission === 'maintain'`.

GitHub's collaborator-permission REST endpoint can return `permission: "maintain"`
with an empty `role_name` (notably on GitHub Enterprise Server and custom org
roles). Under the default policy such a real maintainer was treated as
known-but-unauthorized and the waiver was blocked. The same file already
authorizes `permission === 'maintain'` in its forced-handoff authority check and
trust evaluation, so the default branch was the lone outlier.

## Changes

- `src/scripts/external-check-waiver.mts` — add `|| permission === 'maintain'`
  to the default/`else` branch of `normalizeAuthorityEvidence`.
- `scripts/external-check-waiver.mjs` — regenerated via `pnpm run build`.
- `tests/external-check-waiver.test.mts` — cover `permission: "maintain"` +
  empty `role_name` under the default policy (resolves as authorized).

## Verification

- `pnpm test` and `pnpm run lint:minimum` — green (incl. `build:check`).
- `admin` role/permission still authorizes; `write`/`read`/`none` still do not
  under the default policy (existing coverage unchanged).

Closes #1079
