### PR TITLE
fix(idd): stop fetchBranchRulesets swallowing non-404 failures

### DIFF
--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -13,6 +13,7 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import {
   normalizePolicyConfig,
   resolveCollaboratorMarkerTrust,
@@ -468,7 +469,31 @@ function fetchCodeownersText(owner, repo, ref) {
   );
   return selectCodeownersText(payloads);
 }
-function fetchBranchRulesets(owner, repo, branchRules) {
+/**
+ * Fetch each referenced ruleset's detail, skipping ones that no longer exist.
+ *
+ * A 404 means the ruleset is gone, so it is mapped to `{}` and dropped by the
+ * trailing empty-object filter. Any other status (403, rate limit, transient
+ * failure) is re-thrown so the F2/F3 merge gate fails closed and falls back to
+ * the written-rules path, instead of fabricating a "no ruleset" result that
+ * would silently over-block a legitimately configured bypass.
+ *
+ * The 404 must be discriminated on the *thrown* status: `gh api` writes a 404
+ * response body to stdout, so `allowHttpStatuses: [404]` would return that
+ * non-empty error object and the `Object.keys(...).length > 0` filter would
+ * keep it as a junk ruleset. Letting the 404 throw and matching it here yields
+ * the empty/skipped result the gate expects.
+ *
+ * `fetchRulesetDetail` is injectable for tests; production uses the default
+ * `gh api` call.
+ */
+export function fetchBranchRulesets(
+  owner,
+  repo,
+  branchRules,
+  fetchRulesetDetail = (path) =>
+    ghApiJson(path, false, ['-H', 'Accept: application/vnd.github+json']),
+) {
   const rulesetPaths = [];
   const seenPaths = new Set();
   for (const rule of branchRules ?? []) {
@@ -486,14 +511,12 @@ function fetchBranchRulesets(owner, repo, branchRules) {
   return rulesetPaths
     .map((path) => {
       try {
-        return ghApiJson(
-          path,
-          false,
-          ['-H', 'Accept: application/vnd.github+json'],
-          { allowHttpStatuses: [404] },
-        );
-      } catch {
-        return {};
+        return fetchRulesetDetail(path);
+      } catch (error) {
+        if (deriveGhHttpStatus(error) === 404) {
+          return {};
+        }
+        throw error;
       }
     })
     .filter((ruleset) => Object.keys(ruleset).length > 0);

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -16,6 +16,7 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mts';
+import { deriveGhHttpStatus } from './gh-http-status.mts';
 import {
   normalizePolicyConfig,
   resolveCollaboratorMarkerTrust,
@@ -676,10 +677,33 @@ function fetchCodeownersText(owner: string, repo: string, ref: string): string {
   return selectCodeownersText(payloads);
 }
 
-function fetchBranchRulesets(
+/**
+ * Fetch each referenced ruleset's detail, skipping ones that no longer exist.
+ *
+ * A 404 means the ruleset is gone, so it is mapped to `{}` and dropped by the
+ * trailing empty-object filter. Any other status (403, rate limit, transient
+ * failure) is re-thrown so the F2/F3 merge gate fails closed and falls back to
+ * the written-rules path, instead of fabricating a "no ruleset" result that
+ * would silently over-block a legitimately configured bypass.
+ *
+ * The 404 must be discriminated on the *thrown* status: `gh api` writes a 404
+ * response body to stdout, so `allowHttpStatuses: [404]` would return that
+ * non-empty error object and the `Object.keys(...).length > 0` filter would
+ * keep it as a junk ruleset. Letting the 404 throw and matching it here yields
+ * the empty/skipped result the gate expects.
+ *
+ * `fetchRulesetDetail` is injectable for tests; production uses the default
+ * `gh api` call.
+ */
+export function fetchBranchRulesets(
   owner: string,
   repo: string,
   branchRules: BranchRulePayload[],
+  fetchRulesetDetail: (path: string) => Record<string, unknown> = (path) =>
+    ghApiJson(path, false, [
+      '-H',
+      'Accept: application/vnd.github+json',
+    ]) as Record<string, unknown>,
 ) {
   const rulesetPaths: string[] = [];
   const seenPaths = new Set<string>();
@@ -699,14 +723,12 @@ function fetchBranchRulesets(
   return rulesetPaths
     .map((path) => {
       try {
-        return ghApiJson(
-          path,
-          false,
-          ['-H', 'Accept: application/vnd.github+json'],
-          { allowHttpStatuses: [404] },
-        ) as Record<string, unknown>;
-      } catch {
-        return {};
+        return fetchRulesetDetail(path);
+      } catch (error) {
+        if (deriveGhHttpStatus(error) === 404) {
+          return {};
+        }
+        throw error;
       }
     })
     .filter((ruleset) => Object.keys(ruleset).length > 0);

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
+import { fetchBranchRulesets } from '../src/scripts/pre-merge-readiness.mts';
 import {
   buildActivitySnapshotSummary,
   buildAdvisoryWaitSummary,
@@ -3720,6 +3721,52 @@ test('Part B: summarizeClaimValidation rejects an issue-only handoff after the P
   assert.equal(summary.claimLost, false);
   assert.equal(summary.reason, 'match');
   assert.equal(summary.activeClaim.claimId, 'claim-20260512T090000Z-337-old');
+});
+
+// Shape of a real execFileSync('gh', ...) failure: exit code 1 with the true
+// HTTP status carried in stderr (mirrors gh-http-status.test.mts). gh writes a
+// 404 response body to stdout, so fetchBranchRulesets must discriminate on the
+// thrown status rather than on an empty body.
+const ghHttpError = (httpStatus: number, label: string) =>
+  Object.assign(new Error('Command failed'), {
+    status: 1,
+    stderr: `gh: ${label} (HTTP ${httpStatus})`,
+  });
+
+const oneRulesetRule = [{ ruleset_id: 1 }] as Parameters<
+  typeof fetchBranchRulesets
+>[2];
+
+test('fetchBranchRulesets skips a 404 ruleset detail without throwing', () => {
+  const seen: string[] = [];
+  const result = fetchBranchRulesets('o', 'r', oneRulesetRule, (path) => {
+    seen.push(path);
+    throw ghHttpError(404, 'Not Found');
+  });
+  assert.equal(seen.length, 1);
+  assert.match(seen[0] ?? '', /\/rulesets\/1$/);
+  assert.deepEqual(result, []);
+});
+
+test('fetchBranchRulesets keeps real rulesets and drops empty results', () => {
+  const rules = [{ ruleset_id: 1 }, { ruleset_id: 2 }] as Parameters<
+    typeof fetchBranchRulesets
+  >[2];
+  const result = fetchBranchRulesets('o', 'r', rules, (path) =>
+    path.endsWith('/1') ? { id: 1, current_user_can_bypass: 'always' } : {},
+  );
+  assert.deepEqual(result, [{ id: 1, current_user_can_bypass: 'always' }]);
+});
+
+test('fetchBranchRulesets propagates a non-404 fetch error instead of coercing to "no ruleset"', () => {
+  const boom = ghHttpError(403, 'API rate limit exceeded');
+  assert.throws(
+    () =>
+      fetchBranchRulesets('o', 'r', oneRulesetRule, () => {
+        throw boom;
+      }),
+    (error: unknown) => error === boom,
+  );
 });
 
 function readJson(relativePath: string) {


### PR DESCRIPTION
## Summary

`fetchBranchRulesets` in `src/scripts/pre-merge-readiness.mts` wrapped each
per-ruleset detail fetch in a blanket `try { … } catch { return {}; }`. A
403 / rate-limit / transient failure was therefore coerced into an empty
ruleset and dropped by the `Object.keys(...).length > 0` filter — fabricating
"no ruleset", which makes `summarizeRulesetPullRequestBypass` drop a
legitimately configured pull-request bypass and **over-block the F2/F3 merge
gate** while masking the API outage behind a confident verdict.

## Notable finding

While fixing this I verified empirically that `gh api` writes a **404 response
body to stdout**, so the prior `allowHttpStatuses: [404]` did *not* yield `{}` —
it returned a 3-key error object (`{message, documentation_url, status}`) that
the empty-object filter **kept** as a junk ruleset. So the 404 path was also
latently wrong, not just the non-404 swallow.

## Change

- Discriminate on the **thrown** status instead of relying on an empty body:
  the default fetcher drops `allowHttpStatuses: [404]` so a 404 throws, and the
  per-path `catch` maps a 404 (via the existing tested `deriveGhHttpStatus`
  helper) to `{}` (skipped), while **re-throwing every other status** so the
  gate fails closed and falls back to the written-rules path — matching the
  sibling `branchRules`/`branchProtection` fetches.
- `fetchBranchRulesets` gains an injectable `fetchRulesetDetail` parameter
  (repo loader-injection convention) and is `export`ed so the behavior is unit
  testable without a live `gh`.
- Regenerated `scripts/pre-merge-readiness.mjs` via `pnpm run build`.

## Tests

Three new tests in `tests/pre-merge-readiness.test.mts`:

- a **404** detail fetch is skipped (result `[]`), not thrown;
- real rulesets are kept and empty results dropped;
- a **non-404** (403 / rate-limit) error **propagates** instead of being
  coerced into "no ruleset" (this fails against the old `catch { return {}; }`).

`pnpm run lint:minimum` passes (typecheck, build:check, biome, 1317 tests,
cspell, markdownlint, workshop integrity).

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
