### PR TITLE
fix(idd): default unrecognized branchState to unknown (fail closed)

### DIFF
--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -23,6 +23,20 @@ const PASS_EQUIVALENT_STATES = new Set([
   'neutral',
   'not_applicable',
 ]);
+/**
+ * The documented branch-state taxonomy: every value {@link classifyBranchState}
+ * can return and that {@link selectResumeRoute} routes on. A caller-supplied
+ * `branchState` outside this set is unrecognized and normalizes to the cautious
+ * `'unknown'` (which routes to `stop`) rather than the permissive `'clean'`.
+ */
+const BRANCH_STATES = new Set([
+  'clean',
+  'behind-no-conflict',
+  'content-conflict',
+  'dirty',
+  'computing',
+  'unknown',
+]);
 if (isCliExecution()) {
   runCli();
 }
@@ -369,7 +383,10 @@ function normalizeState(input) {
     reviewExists: input.reviewExists === true,
     reviewPending: input.reviewPending === true,
     branchState:
-      typeof input.branchState === 'string' ? input.branchState : 'clean',
+      typeof input.branchState === 'string' &&
+      BRANCH_STATES.has(input.branchState)
+        ? input.branchState
+        : 'unknown',
   };
 }
 function result(route, reason, state, reasonParts) {

--- a/src/scripts/resume-route-selection.mts
+++ b/src/scripts/resume-route-selection.mts
@@ -114,6 +114,21 @@ const PASS_EQUIVALENT_STATES = new Set([
   'not_applicable',
 ]);
 
+/**
+ * The documented branch-state taxonomy: every value {@link classifyBranchState}
+ * can return and that {@link selectResumeRoute} routes on. A caller-supplied
+ * `branchState` outside this set is unrecognized and normalizes to the cautious
+ * `'unknown'` (which routes to `stop`) rather than the permissive `'clean'`.
+ */
+const BRANCH_STATES = new Set([
+  'clean',
+  'behind-no-conflict',
+  'content-conflict',
+  'dirty',
+  'computing',
+  'unknown',
+]);
+
 if (isCliExecution()) {
   runCli();
 }
@@ -520,7 +535,10 @@ function normalizeState(input: ResumeRouteInput): NormalizedResumeRouteState {
     reviewExists: input.reviewExists === true,
     reviewPending: input.reviewPending === true,
     branchState:
-      typeof input.branchState === 'string' ? input.branchState : 'clean',
+      typeof input.branchState === 'string' &&
+      BRANCH_STATES.has(input.branchState)
+        ? input.branchState
+        : 'unknown',
   };
 }
 

--- a/tests/resume-route-selection.test.mts
+++ b/tests/resume-route-selection.test.mts
@@ -159,7 +159,7 @@ test('routes F1 when PR exists, CI succeeded, no pending reviews, and branch sta
   assert.equal(result.reason, 'pr-ci-success-branch-computing');
 });
 
-test('routes F2 when PR exists, CI succeeded, no pending reviews, and branchState is not provided (defaults to clean)', () => {
+test('routes stop when PR exists, CI succeeded, no pending reviews, and branchState is not provided (fail-closed to unknown)', () => {
   const result = selectResumeRoute({
     prExists: true,
     requiredChecksGenerated: true,
@@ -167,7 +167,41 @@ test('routes F2 when PR exists, CI succeeded, no pending reviews, and branchStat
     reviewExists: false,
     reviewPending: false,
   });
-  assert.equal(result.route, 'F2');
+  assert.equal(result.route, 'stop');
+  assert.equal(result.reason, 'pr-ci-success-branch-dirty-or-unknown');
+  assert.equal(result.state.branchState, 'unknown');
+});
+
+test('routes stop when a non-string branchState is supplied (fail-closed to unknown)', () => {
+  for (const branchState of [123, null, true, {}, ['clean']]) {
+    const result = selectResumeRoute({
+      prExists: true,
+      requiredChecksGenerated: true,
+      ciSuccess: true,
+      reviewExists: false,
+      reviewPending: false,
+      branchState,
+    });
+    assert.equal(result.route, 'stop');
+    assert.equal(result.reason, 'pr-ci-success-branch-dirty-or-unknown');
+    assert.equal(result.state.branchState, 'unknown');
+  }
+});
+
+test('routes stop when an unrecognized branchState string is supplied (fail-closed to unknown)', () => {
+  for (const branchState of ['GARBAGE', 'CORRUPT', 'Clean', '']) {
+    const result = selectResumeRoute({
+      prExists: true,
+      requiredChecksGenerated: true,
+      ciSuccess: true,
+      reviewExists: false,
+      reviewPending: false,
+      branchState,
+    });
+    assert.equal(result.route, 'stop');
+    assert.equal(result.reason, 'pr-ci-success-branch-dirty-or-unknown');
+    assert.equal(result.state.branchState, 'unknown');
+  }
 });
 
 test('routes E15 when PR exists, CI fails, and reviews exist', () => {


### PR DESCRIPTION
## Summary

`normalizeState` in `resume-route-selection.mts` had two fail-open gaps:

- a non-string `branchState` defaulted to `'clean'` — the most permissive
  value;
- any string passed through with no taxonomy validation, so a garbled or
  miscased value (`"CORRUPT"`) matched no cautious branch and fell through
  to the `F2` merge-gate sink.

Either way a missing or garbled branch state silently routed a resume to
**proceed** instead of **stop**.

## Change

- Add a `BRANCH_STATES` allow-set mirroring the taxonomy that
  `classifyBranchState` produces (`clean`, `behind-no-conflict`,
  `content-conflict`, `dirty`, `computing`, `unknown`).
- `normalizeState` now fails closed to `'unknown'` (which routes to
  `stop`) for any unrecognized or non-string `branchState`, instead of the
  permissive `'clean'`.
- Tests cover non-string input (`123`, `null`, `true`, `{}`, array) and
  unrecognized/miscased strings (`"GARBAGE"`, `"CORRUPT"`, `"Clean"`, `""`);
  the previously-passing "defaults to clean" case is updated to the new
  fail-closed expectation. All six documented states still route as before.

The production CLI path is unaffected: the with-PR path always computes
`branchState` via `classifyBranchState` (always an in-set value), and the
no-PR path never reaches the `ciSuccess` branch where `branchState` is read.

Closes #1081
