### PR TITLE
fix(idd): reject whitespace-only branchPatterns in policy schema

### DIFF
--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -460,7 +460,9 @@
           "minItems": 1,
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Each entry must contain a non-whitespace character. This mirrors the runtime, which trims each glob and ignores blank entries (falling back to the defaults), so a whitespace-only pattern is rejected at validation time instead of silently never matching."
           },
           "description": "Branch globs the guard treats as implementation branches that must not live in the primary worktree (default [\"issue/*\", \"roadmap-audit/*\"] when absent)."
         }

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -333,6 +333,33 @@ test('policy schema rejects an unknown worktreeGuard subkey', () => {
   );
 });
 
+test('policy schema rejects a whitespace-only branchPatterns entry', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  // A whitespace-only glob can never match a branch; the runtime already
+  // trims it away and falls back to the defaults, so the `\S` pattern
+  // rejects it at validation time instead of letting it pass silently.
+  instance.worktreeGuard = { enabled: true, branchPatterns: ['   '] };
+  assert.ok(
+    validate(instance, schema).length > 0,
+    'expected a whitespace-only branchPatterns entry to be rejected',
+  );
+});
+
+test('policy schema accepts non-whitespace branchPatterns globs', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.worktreeGuard = {
+    enabled: true,
+    branchPatterns: ['issue/*', 'roadmap-audit/*'],
+  };
+  assert.deepEqual(validate(instance, schema), []);
+});
+
 test('policy schema accepts missing helperRuntime as instructions-only fallback', () => {
   const schema = loadJson('schemas/policy.schema.json');
   const instance = JSON.parse(


### PR DESCRIPTION
## Summary

`worktreeGuard.branchPatterns.items` in `schemas/policy.schema.json` only
constrained `type: string` + `minLength: 1`, so a whitespace-only glob
(`"   "`) passed schema validation even though it can never match a branch.
`idd-doctor`'s runtime reader (`readWorktreeGuardBranchPatterns`) already
trims each entry and falls back to the defaults, so the schema was looser
than the runtime; this tightens the two into alignment and catches the bad
config at validation time.

## Changes

- `schemas/policy.schema.json` — add `pattern` `\S` (plus a short item-level
  description noting the runtime-trim alignment) to
  `worktreeGuard.branchPatterns.items`, so each glob must contain a
  non-whitespace character.
- `tests/schema-validation.test.mts` — add coverage that a whitespace-only
  entry (`["   "]`) is rejected and that normal globs
  (`["issue/*", "roadmap-audit/*"]`) still validate.

## Notes

- The in-repo validator already supports the `pattern` keyword; no validator
  change is needed.
- `idd-doctor`'s runtime fallback tests are intentionally unchanged — the
  runtime keeps fail-closing defensively even though the schema now rejects
  such config at validation time.
- No schema mirror exists under `idd-template/`, so nothing else to sync.

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RULXEb2aFJRDichpPAcG99
