### PR TITLE
feat(idd): read trustedMarkerActors from config in live-status-digest

### DIFF
--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -18,6 +18,7 @@ import {
   normalizeTrustedMarkerLogins,
   parsePaginatedGhNdjson,
   planLiveStatusDigestUpsert,
+  resolveTrustedMarkerActors,
   summarizeClaimValidation,
 } from './protocol-helpers.mjs';
 
@@ -328,12 +329,20 @@ function configuredTrustedMarkerAuthors() {
   if (cachedConfiguredTrustedMarkerAuthors) {
     return cachedConfiguredTrustedMarkerAuthors;
   }
-  cachedConfiguredTrustedMarkerAuthors = new Set(
-    (process.env.IDD_TRUSTED_MARKER_ACTORS ?? '')
-      .split(',')
-      .map((login) => login.trim().toLowerCase())
-      .filter(Boolean),
-  );
+  // Read config.json the same way trustCollaboratorMarkers() does, then defer
+  // to the shared flag-less env -> config ladder (env still wins over config),
+  // so trusted-marker authors are no longer env-only in this script.
+  let config = null;
+  try {
+    config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    // No readable config; fall back to env-only resolution.
+  }
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config,
+  });
+  cachedConfiguredTrustedMarkerAuthors = new Set(actors);
   return cachedConfiguredTrustedMarkerAuthors;
 }
 function trustCollaboratorMarkers() {

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -336,7 +336,7 @@ function configuredTrustedMarkerAuthors() {
   try {
     config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
   } catch {
-    // No readable config; fall back to env-only resolution.
+    // No readable or parseable config; fall back to env-only resolution.
   }
   const { actors } = resolveTrustedMarkerActors({
     envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',

--- a/src/scripts/live-status-digest.mts
+++ b/src/scripts/live-status-digest.mts
@@ -21,6 +21,7 @@ import {
   normalizeTrustedMarkerLogins,
   parsePaginatedGhNdjson,
   planLiveStatusDigestUpsert,
+  resolveTrustedMarkerActors,
   summarizeClaimValidation,
 } from './protocol-helpers.mts';
 
@@ -480,12 +481,20 @@ function configuredTrustedMarkerAuthors(): Set<string> {
     return cachedConfiguredTrustedMarkerAuthors;
   }
 
-  cachedConfiguredTrustedMarkerAuthors = new Set(
-    (process.env.IDD_TRUSTED_MARKER_ACTORS ?? '')
-      .split(',')
-      .map((login) => login.trim().toLowerCase())
-      .filter(Boolean),
-  );
+  // Read config.json the same way trustCollaboratorMarkers() does, then defer
+  // to the shared flag-less env -> config ladder (env still wins over config),
+  // so trusted-marker authors are no longer env-only in this script.
+  let config: { trustedMarkerActors?: unknown } | null = null;
+  try {
+    config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    // No readable config; fall back to env-only resolution.
+  }
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config,
+  });
+  cachedConfiguredTrustedMarkerAuthors = new Set(actors);
   return cachedConfiguredTrustedMarkerAuthors;
 }
 

--- a/src/scripts/live-status-digest.mts
+++ b/src/scripts/live-status-digest.mts
@@ -488,7 +488,7 @@ function configuredTrustedMarkerAuthors(): Set<string> {
   try {
     config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
   } catch {
-    // No readable config; fall back to env-only resolution.
+    // No readable or parseable config; fall back to env-only resolution.
   }
   const { actors } = resolveTrustedMarkerActors({
     envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',

--- a/tests/live-status-digest.test.mts
+++ b/tests/live-status-digest.test.mts
@@ -7,6 +7,7 @@ import {
   LIVE_STATUS_DIGEST_MARKER,
   planLiveStatusDigestUpsert,
   renderLiveStatusDigest,
+  resolveTrustedMarkerActors,
 } from '../src/scripts/protocol-helpers.mts';
 
 const fields = {
@@ -210,4 +211,42 @@ test('applyDigestUpsert skips the claim check and mutation on a duplicate plan',
   });
   assert.equal(result.outcome, 'duplicate');
   assert.deepEqual(calls, []);
+});
+
+// configuredTrustedMarkerAuthors() in live-status-digest.mts now builds its
+// cached set from new Set(resolveTrustedMarkerActors({ envValue, config }).actors),
+// reading .github/idd/config.json the same way trustCollaboratorMarkers() does.
+// live-status-digest.mts itself runs its CLI on import (top-level statements),
+// so these tests lock the env -> config ladder it now relies on via the shared
+// resolver rather than importing the un-importable CLI module.
+function configuredTrustedMarkerSet(
+  envValue: string,
+  config: { trustedMarkerActors?: unknown } | null,
+): Set<string> {
+  return new Set(resolveTrustedMarkerActors({ envValue, config }).actors);
+}
+
+test('configured trusted-marker authors fall back to config.json trustedMarkerActors', () => {
+  // No env var, but config supplies trustedMarkerActors -> use config
+  // (the env -> config fallback this script previously lacked).
+  const authors = configuredTrustedMarkerSet('', {
+    trustedMarkerActors: ['Config-Bot', 'another-bot'],
+  });
+  assert.deepEqual([...authors].sort(), ['another-bot', 'config-bot']);
+});
+
+test('configured trusted-marker authors keep env winning over config', () => {
+  // Env still wins when both are present (unchanged precedence).
+  const authors = configuredTrustedMarkerSet('env-bot', {
+    trustedMarkerActors: ['config-bot'],
+  });
+  assert.deepEqual([...authors], ['env-bot']);
+});
+
+test('configured trusted-marker authors are empty with neither env nor config', () => {
+  assert.deepEqual([...configuredTrustedMarkerSet('', null)], []);
+  assert.deepEqual(
+    [...configuredTrustedMarkerSet('', { trustedMarkerActors: [] })],
+    [],
+  );
 });


### PR DESCRIPTION
## Summary

`configuredTrustedMarkerAuthors()` in `src/scripts/live-status-digest.mts` read
the trusted-marker author set **only** from `IDD_TRUSTED_MARKER_ACTORS`, while
its sibling `trustCollaboratorMarkers()` in the same file already read
`.github/idd/config.json`. So trusted-marker authors could only be set via env
in `live-status-digest`, an inconsistency with the rest of the suite (e.g.
`pre-merge-readiness`, which already uses the shared resolver against
`config.trustedMarkerActors`).

This defers to the shared `resolveTrustedMarkerActors` flag-less `env -> config`
ladder (env still wins over config) and reads `config.json` the same way
`trustCollaboratorMarkers()` does, so trusted-marker authors are no longer
env-only here. The module-level cache is preserved.

## Changes

- `src/scripts/live-status-digest.mts` — `configuredTrustedMarkerAuthors()` now
  reads `.github/idd/config.json` and resolves via `resolveTrustedMarkerActors`.
- `scripts/live-status-digest.mjs` — regenerated via `pnpm run build`.
- `tests/live-status-digest.test.mts` — cover the env -> config fallback, env
  precedence, and the empty case. (The CLI module runs on import — top-level
  statements — so the tests lock the ladder via the shared resolver rather than
  importing the un-importable module.)

## Verification

- `pnpm test` and `pnpm run lint:minimum` — green (incl. `build:check`).

Closes #1085
