### PR TITLE
test(idd): cover untested authoring-label-guard exports

### DIFF
--- a/tests/authoring-label-guard.test.mts
+++ b/tests/authoring-label-guard.test.mts
@@ -4,7 +4,18 @@ import { test } from 'node:test';
 import {
   buildAuthoringLabelWarning,
   findLatestLabeledAt,
+  formatElapsedDuration,
+  resolveAuthoringGuardPolicy,
 } from '../src/scripts/authoring-label-guard.mts';
+import {
+  POLICY_DEFAULTS,
+  parseIsoDurationToMs,
+} from '../src/scripts/policy-helpers.mts';
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const DEFAULT_AUTHORING = POLICY_DEFAULTS.issueAuthoring;
 
 test('findLatestLabeledAt only accepts explicit labeled events', () => {
   const latest = findLatestLabeledAt(
@@ -98,4 +109,126 @@ test('buildAuthoringLabelWarning treats implicit events as timestamp unavailable
 
   assert.equal(warning?.status, 'timestamp_unavailable');
   assert.match(warning?.message ?? '', /timestamp could not be resolved/);
+});
+
+test('buildAuthoringLabelWarning reports timestamp_unavailable without a labeled event', () => {
+  // No event matches the label, so findLatestLabeledAt yields '' and the
+  // warning falls into the timestamp_unavailable branch with null age fields.
+  const warning = buildAuthoringLabelWarning({
+    issueNumber: 1088,
+    labelName: 'status:authoring',
+    labelEvents: [],
+    now: '2026-05-15T12:00:00Z',
+    staleAgeMs: 4 * HOUR_MS,
+  });
+
+  assert.equal(warning?.status, 'timestamp_unavailable');
+  assert.equal(warning?.labeledAt, null);
+  assert.equal(warning?.ageMs, null);
+});
+
+test('buildAuthoringLabelWarning flags an age exactly at the stale threshold', () => {
+  // ageMs === staleAgeMs is NOT `< staleAgeMs`, so the boundary is stale.
+  const staleAgeMs = 4 * HOUR_MS;
+  const warning = buildAuthoringLabelWarning({
+    issueNumber: 1088,
+    labelName: 'status:authoring',
+    labelEvents: [
+      {
+        event: 'labeled',
+        label: { name: 'status:authoring' },
+        created_at: '2026-05-15T08:00:00Z',
+      },
+    ],
+    now: '2026-05-15T12:00:00Z', // exactly staleAgeMs after the labeled event
+    staleAgeMs,
+  });
+
+  assert.equal(warning?.status, 'stale');
+  assert.equal(warning?.ageMs, staleAgeMs);
+  // The message renders the elapsed age through formatElapsedDuration.
+  assert.match(warning?.message ?? '', /carried the authoring label for 4h;/);
+});
+
+test('buildAuthoringLabelWarning stays silent one millisecond under the threshold', () => {
+  const warning = buildAuthoringLabelWarning({
+    issueNumber: 1088,
+    labelName: 'status:authoring',
+    labelEvents: [
+      {
+        event: 'labeled',
+        label: { name: 'status:authoring' },
+        created_at: '2026-05-15T08:00:00.001Z',
+      },
+    ],
+    now: '2026-05-15T12:00:00Z', // 1 ms short of the stale threshold
+    staleAgeMs: 4 * HOUR_MS,
+  });
+
+  assert.equal(warning, null);
+});
+
+test('formatElapsedDuration composes days, hours, and minutes', () => {
+  assert.equal(
+    formatElapsedDuration(DAY_MS + 2 * HOUR_MS + 3 * MINUTE_MS),
+    '1d 2h 3m',
+  );
+});
+
+test('formatElapsedDuration omits zero-valued units', () => {
+  // Zero hours between a non-zero day and non-zero minutes.
+  assert.equal(formatElapsedDuration(DAY_MS + 5 * MINUTE_MS), '1d 5m');
+  // Zero trailing minutes are dropped when a larger unit is present.
+  assert.equal(formatElapsedDuration(2 * DAY_MS + 3 * HOUR_MS), '2d 3h');
+  // A lone hour drops both the day and the minute parts.
+  assert.equal(formatElapsedDuration(2 * HOUR_MS), '2h');
+});
+
+test('formatElapsedDuration clamps sub-minute and negative inputs to 0m', () => {
+  assert.equal(formatElapsedDuration(30 * 1000), '0m'); // 30s, under a minute
+  assert.equal(formatElapsedDuration(0), '0m');
+  assert.equal(formatElapsedDuration(-5 * MINUTE_MS), '0m'); // negative clamps
+});
+
+test('formatElapsedDuration floors fractional milliseconds down to a minute', () => {
+  assert.equal(formatElapsedDuration(MINUTE_MS + 0.9), '1m');
+});
+
+test('resolveAuthoringGuardPolicy returns the policy defaults for an absent config', () => {
+  const policy = resolveAuthoringGuardPolicy(undefined);
+
+  assert.equal(policy.labelName, DEFAULT_AUTHORING.authoringLabelName);
+  assert.equal(policy.staleAge, DEFAULT_AUTHORING.authoringStaleAge);
+  assert.equal(
+    policy.staleAgeMs,
+    parseIsoDurationToMs(DEFAULT_AUTHORING.authoringStaleAge),
+  );
+});
+
+test('resolveAuthoringGuardPolicy honors label and stale-age overrides', () => {
+  const policy = resolveAuthoringGuardPolicy({
+    issueAuthoring: {
+      authoringLabelName: 'status:drafting',
+      authoringStaleAge: 'PT2H',
+    },
+  });
+
+  assert.equal(policy.labelName, 'status:drafting');
+  assert.equal(policy.staleAge, 'PT2H');
+  assert.equal(policy.staleAgeMs, 2 * HOUR_MS);
+});
+
+test('resolveAuthoringGuardPolicy falls back to the default for an invalid duration', () => {
+  // An unparseable ISO-8601 duration is rejected by normalizePolicyConfig's
+  // parseDuration, so the normalize -> resolve chain yields the default age.
+  const policy = resolveAuthoringGuardPolicy({
+    issueAuthoring: { authoringStaleAge: 'not-a-duration' },
+  });
+
+  assert.notEqual(policy.staleAge, 'not-a-duration');
+  assert.equal(policy.staleAge, DEFAULT_AUTHORING.authoringStaleAge);
+  assert.equal(
+    policy.staleAgeMs,
+    parseIsoDurationToMs(DEFAULT_AUTHORING.authoringStaleAge),
+  );
 });


### PR DESCRIPTION
## Summary

Adds `node:test` regression coverage for the two previously-uncovered
exports of `src/scripts/authoring-label-guard.mts`:

- `formatElapsedDuration` — d/h/m composition, zero-unit omission, the
  sub-minute / negative clamp to `0m`, and a fractional-ms floor.
- `resolveAuthoringGuardPolicy` — default and label/stale-age override
  resolution, plus an invalid ISO-8601 `authoringStaleAge` falling back
  to the default age. The fallback is exercised through the real
  `normalizePolicyConfig` (`parseDuration`) -> resolve chain rather than a
  pre-normalized input, per the issue.

Also asserts the `buildAuthoringLabelWarning` stale boundary — exactly at
the threshold is `stale` (and its message renders `formatElapsedDuration`),
one millisecond under is silent — and `timestamp_unavailable` when no
labeled event matches.

## Notes

Test-only change: tests are not emitted, so no `.mjs` rebuild is needed and
`scripts` / `bin` are unchanged. The new assertions for the default and
invalid-duration paths track `POLICY_DEFAULTS` (via `parseIsoDurationToMs`),
while the override case independently pins `PT2H` to keep those assertions
non-tautological. `pnpm run lint:minimum` and `pnpm test` pass.

Closes #1088
