### PR TITLE
docs(idd): add E9 fix-side convergence rules

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -25,6 +25,21 @@ Fix all Accepted PATH A items from ReviewItems_snapshot. Run **fix-validate**.
 
 Commit fixes atomically — one logical change per commit.
 
+These two fix-side rules are the complement of the accept-side
+"Verify before accept" rule in `idd-review-triage.instructions.md` (E5);
+both cut the advisory-review round count:
+
+- **Fix the whole class, not just the flagged line.** When an accepted
+  finding is one instance of a systemic class, sweep the current diff
+  (and the adjacent touched sections) and fix every instance in the same
+  commit. Advisory reviewers surface issues incrementally, so a
+  whole-class fix converges in fewer rounds than fixing only the flagged
+  line and waiting for the next instance to be re-flagged.
+- **Verify any claim a fix adds.** When a fix introduces a precision — a
+  name, value, path, or described behavior — to satisfy a reviewer, check
+  it against the actual implementation before committing, so the fix does
+  not trade one inaccuracy for another and cost an extra round.
+
 ## E10 — Validate fixes with critique pass
 
 Run a critique pass to verify that the fixes in E9 address the root

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -25,6 +25,21 @@ Fix all Accepted PATH A items from ReviewItems_snapshot. Run **fix-validate**.
 
 Commit fixes atomically — one logical change per commit.
 
+These two fix-side rules are the complement of the accept-side
+"Verify before accept" rule in `idd-review-triage.instructions.md` (E5);
+both cut the advisory-review round count:
+
+- **Fix the whole class, not just the flagged line.** When an accepted
+  finding is one instance of a systemic class, sweep the current diff
+  (and the adjacent touched sections) and fix every instance in the same
+  commit. Advisory reviewers surface issues incrementally, so a
+  whole-class fix converges in fewer rounds than fixing only the flagged
+  line and waiting for the next instance to be re-flagged.
+- **Verify any claim a fix adds.** When a fix introduces a precision — a
+  name, value, path, or described behavior — to satisfy a reviewer, check
+  it against the actual implementation before committing, so the fix does
+  not trade one inaccuracy for another and cost an extra round.
+
 ## E10 — Validate fixes with critique pass
 
 Run a critique pass to verify that the fixes in E9 address the root


### PR DESCRIPTION
## Summary

E-phase review fixing already has an accept-side guardrail ("Verify before
accept" in `idd-review-triage.instructions.md` E5) but lacked the symmetric
**fix-side** guidance, so advisory-review rounds churned more than necessary.
This adds two reusable fix-side rules to **E9** of
`idd-review-fix.instructions.md`:

- **Fix the whole class, not just the flagged line** — advisory reviewers
  surface a systemic issue one instance at a time, so a whole-class fix in
  one commit converges in fewer rounds.
- **Verify any claim a fix adds** — when a fix introduces a precision
  (name/value/path/behavior) to satisfy a reviewer, check it against the
  actual implementation before committing, so the fix does not trade one
  inaccuracy for another.

## Mechanics

`idd-review-fix.instructions.md` is **generated** from the `idd-template/`
source. The edit is made in
`idd-template/.github/instructions/idd-review-fix.instructions.md`, and the
live `.github/instructions/` copy is regenerated via
`node scripts/sync-docs.mjs --apply`. `node scripts/audit-docs.mjs --check`
confirms no drift; `pnpm run lint:minimum` passes.

Closes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)
