### PR TITLE
fix(idd): harden branch-conflict-state + pre-merge-readiness parseArgs

### DIFF
--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -346,18 +346,43 @@ function isMainModule(metaUrl) {
     return false;
   }
 }
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = { help: false, prNumber: null, owner: null, repo: null };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--help' || argv[i] === '-h') {
+    const token = argv[i];
+    const value = argv[i + 1];
+    // Reject a missing value (undefined) or a flag-shaped value so that
+    // `--pr --json` fails fast instead of consuming `--json` as the value.
+    const requireValue = () => {
+      if (value === undefined || String(value).startsWith('--')) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    if (token === '--help' || token === '-h') {
       args.help = true;
-    } else if (argv[i] === '--pr' && argv[i + 1]) {
-      args.prNumber = String(argv[++i]);
-    } else if (argv[i] === '--owner' && argv[i + 1]) {
-      args.owner = String(argv[++i]);
-    } else if (argv[i] === '--repo' && argv[i + 1]) {
-      args.repo = String(argv[++i]);
+      continue;
     }
+    if (token === '--pr') {
+      const raw = requireValue();
+      if (!/^[1-9]\d*$/.test(raw)) {
+        throw new Error(`invalid --pr value: ${raw}`);
+      }
+      args.prNumber = raw;
+      i++;
+      continue;
+    }
+    if (token === '--owner') {
+      args.owner = requireValue();
+      i++;
+      continue;
+    }
+    if (token === '--repo') {
+      args.repo = requireValue();
+      i++;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
   }
   return args;
 }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -266,7 +266,7 @@ function warnDeprecatedFlag(deprecated, canonical) {
     `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
   );
 }
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const parsed = {
     prNumber: null,
     claimIssueNumber: null,
@@ -282,65 +282,81 @@ function parseArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     const value = argv[index + 1];
+    // Reject a missing value (undefined) or a flag-shaped value so that
+    // `--pr --json` fails fast instead of consuming `--json` as the value.
+    const requireValue = () => {
+      if (value === undefined || String(value).startsWith('--')) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    // Positive-integer guard shared by both numeric flags below.
+    const requirePositiveInteger = () => {
+      const raw = requireValue();
+      if (!/^[1-9]\d*$/.test(raw)) {
+        throw new Error(`invalid ${token} value: ${raw}`);
+      }
+      return Number(raw);
+    };
     if (token === '--pr') {
-      parsed.prNumber = Number.parseInt(value ?? '', 10);
+      parsed.prNumber = requirePositiveInteger();
       index += 1;
       continue;
     }
     if (token === '--claim-issue') {
-      parsed.claimIssueNumber = Number.parseInt(value ?? '', 10);
+      parsed.claimIssueNumber = requirePositiveInteger();
       index += 1;
       continue;
     }
     if (token === '--owner') {
-      parsed.owner = value ?? '';
+      parsed.owner = requireValue();
       index += 1;
       continue;
     }
     if (token === '--repo') {
-      parsed.repo = value ?? '';
+      parsed.repo = requireValue();
       index += 1;
       continue;
     }
     if (token === '--trusted-marker-logins') {
-      parsed.trustedMarkerLogins = value ?? '';
+      parsed.trustedMarkerLogins = requireValue();
       index += 1;
       continue;
     }
     if (token === '--idd-agent-logins') {
-      parsed.iddAgentLogins = value ?? '';
+      parsed.iddAgentLogins = requireValue();
       index += 1;
       continue;
     }
     if (token === '--advisory-bot-logins') {
-      parsed.advisoryBotLogins = value ?? '';
+      parsed.advisoryBotLogins = requireValue();
       index += 1;
       continue;
     }
     if (token === '--claim-id') {
-      parsed.expectedClaimId = value ?? '';
+      parsed.expectedClaimId = requireValue();
       index += 1;
       continue;
     }
     if (token === '--expected-claim-id') {
       warnDeprecatedFlag('--expected-claim-id', '--claim-id');
-      parsed.expectedClaimId = value ?? '';
+      parsed.expectedClaimId = requireValue();
       index += 1;
       continue;
     }
     if (token === '--agent-id') {
-      parsed.expectedAgentId = value ?? '';
+      parsed.expectedAgentId = requireValue();
       index += 1;
       continue;
     }
     if (token === '--expected-agent-id') {
       warnDeprecatedFlag('--expected-agent-id', '--agent-id');
-      parsed.expectedAgentId = value ?? '';
+      parsed.expectedAgentId = requireValue();
       index += 1;
       continue;
     }
     if (token === '--now') {
-      parsed.now = value ?? '';
+      parsed.now = requireValue();
       index += 1;
       continue;
     }
@@ -349,15 +365,6 @@ function parseArgs(argv) {
       process.exit(0);
     }
     throw new Error(`unknown argument: ${token}`);
-  }
-  if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
-    parsed.prNumber = null;
-  }
-  if (
-    !Number.isInteger(parsed.claimIssueNumber) ||
-    (parsed.claimIssueNumber ?? 0) < 1
-  ) {
-    parsed.claimIssueNumber = null;
   }
   return parsed;
 }

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -441,7 +441,7 @@ function isMainModule(metaUrl: string): boolean {
   }
 }
 
-function parseArgs(argv: string[]): {
+export function parseArgs(argv: string[]): {
   help: boolean;
   prNumber: string | null;
   owner: string | null;
@@ -454,15 +454,40 @@ function parseArgs(argv: string[]): {
     repo: string | null;
   } = { help: false, prNumber: null, owner: null, repo: null };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--help' || argv[i] === '-h') {
+    const token = argv[i];
+    const value = argv[i + 1];
+    // Reject a missing value (undefined) or a flag-shaped value so that
+    // `--pr --json` fails fast instead of consuming `--json` as the value.
+    const requireValue = (): string => {
+      if (value === undefined || String(value).startsWith('--')) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    if (token === '--help' || token === '-h') {
       args.help = true;
-    } else if (argv[i] === '--pr' && argv[i + 1]) {
-      args.prNumber = String(argv[++i]);
-    } else if (argv[i] === '--owner' && argv[i + 1]) {
-      args.owner = String(argv[++i]);
-    } else if (argv[i] === '--repo' && argv[i + 1]) {
-      args.repo = String(argv[++i]);
+      continue;
     }
+    if (token === '--pr') {
+      const raw = requireValue();
+      if (!/^[1-9]\d*$/.test(raw)) {
+        throw new Error(`invalid --pr value: ${raw}`);
+      }
+      args.prNumber = raw;
+      i++;
+      continue;
+    }
+    if (token === '--owner') {
+      args.owner = requireValue();
+      i++;
+      continue;
+    }
+    if (token === '--repo') {
+      args.repo = requireValue();
+      i++;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
   }
   return args;
 }

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -450,7 +450,7 @@ function warnDeprecatedFlag(deprecated: string, canonical: string): void {
   );
 }
 
-function parseArgs(argv: string[]): PreMergeReadinessArgs {
+export function parseArgs(argv: string[]): PreMergeReadinessArgs {
   const parsed: PreMergeReadinessArgs = {
     prNumber: null,
     claimIssueNumber: null,
@@ -467,65 +467,81 @@ function parseArgs(argv: string[]): PreMergeReadinessArgs {
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     const value = argv[index + 1];
+    // Reject a missing value (undefined) or a flag-shaped value so that
+    // `--pr --json` fails fast instead of consuming `--json` as the value.
+    const requireValue = (): string => {
+      if (value === undefined || String(value).startsWith('--')) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    // Positive-integer guard shared by both numeric flags below.
+    const requirePositiveInteger = (): number => {
+      const raw = requireValue();
+      if (!/^[1-9]\d*$/.test(raw)) {
+        throw new Error(`invalid ${token} value: ${raw}`);
+      }
+      return Number(raw);
+    };
     if (token === '--pr') {
-      parsed.prNumber = Number.parseInt(value ?? '', 10);
+      parsed.prNumber = requirePositiveInteger();
       index += 1;
       continue;
     }
     if (token === '--claim-issue') {
-      parsed.claimIssueNumber = Number.parseInt(value ?? '', 10);
+      parsed.claimIssueNumber = requirePositiveInteger();
       index += 1;
       continue;
     }
     if (token === '--owner') {
-      parsed.owner = value ?? '';
+      parsed.owner = requireValue();
       index += 1;
       continue;
     }
     if (token === '--repo') {
-      parsed.repo = value ?? '';
+      parsed.repo = requireValue();
       index += 1;
       continue;
     }
     if (token === '--trusted-marker-logins') {
-      parsed.trustedMarkerLogins = value ?? '';
+      parsed.trustedMarkerLogins = requireValue();
       index += 1;
       continue;
     }
     if (token === '--idd-agent-logins') {
-      parsed.iddAgentLogins = value ?? '';
+      parsed.iddAgentLogins = requireValue();
       index += 1;
       continue;
     }
     if (token === '--advisory-bot-logins') {
-      parsed.advisoryBotLogins = value ?? '';
+      parsed.advisoryBotLogins = requireValue();
       index += 1;
       continue;
     }
     if (token === '--claim-id') {
-      parsed.expectedClaimId = value ?? '';
+      parsed.expectedClaimId = requireValue();
       index += 1;
       continue;
     }
     if (token === '--expected-claim-id') {
       warnDeprecatedFlag('--expected-claim-id', '--claim-id');
-      parsed.expectedClaimId = value ?? '';
+      parsed.expectedClaimId = requireValue();
       index += 1;
       continue;
     }
     if (token === '--agent-id') {
-      parsed.expectedAgentId = value ?? '';
+      parsed.expectedAgentId = requireValue();
       index += 1;
       continue;
     }
     if (token === '--expected-agent-id') {
       warnDeprecatedFlag('--expected-agent-id', '--agent-id');
-      parsed.expectedAgentId = value ?? '';
+      parsed.expectedAgentId = requireValue();
       index += 1;
       continue;
     }
     if (token === '--now') {
-      parsed.now = value ?? '';
+      parsed.now = requireValue();
       index += 1;
       continue;
     }
@@ -534,16 +550,6 @@ function parseArgs(argv: string[]): PreMergeReadinessArgs {
       process.exit(0);
     }
     throw new Error(`unknown argument: ${token}`);
-  }
-
-  if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
-    parsed.prNumber = null;
-  }
-  if (
-    !Number.isInteger(parsed.claimIssueNumber) ||
-    (parsed.claimIssueNumber ?? 0) < 1
-  ) {
-    parsed.claimIssueNumber = null;
   }
 
   return parsed;

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 
 import {
   classifyBranchConflictState,
+  parseArgs,
   parseConflictFiles,
 } from '../src/scripts/branch-conflict-state.mts';
 
@@ -232,4 +233,31 @@ test('classifyBranchConflictState: published is false when head SHA is absent', 
     _testPrData: fixture.prData,
   });
   assert.equal(result.published, false);
+});
+
+test('parseArgs: valid --pr parses to a positive-integer string', () => {
+  const args = parseArgs(['--pr', '1082', '--owner', 'o', '--repo', 'r']);
+  assert.equal(args.prNumber, '1082');
+  assert.equal(args.owner, 'o');
+  assert.equal(args.repo, 'r');
+  assert.equal(args.help, false);
+});
+
+test('parseArgs: a flag-shaped --pr value throws instead of consuming the flag', () => {
+  // `--pr --json` must fail fast, not assign `--json` as the PR number.
+  assert.throws(() => parseArgs(['--pr', '--json']), /missing value/);
+  assert.throws(() => parseArgs(['--owner', '--repo']), /missing value/);
+  // A trailing flag with no value at all also fails closed.
+  assert.throws(() => parseArgs(['--pr']), /missing value/);
+});
+
+test('parseArgs: an unknown argument throws', () => {
+  assert.throws(() => parseArgs(['--bogus']), /unknown argument/);
+  assert.throws(() => parseArgs(['1082']), /unknown argument/);
+});
+
+test('parseArgs: a non-positive / non-integer --pr throws a clear message', () => {
+  assert.throws(() => parseArgs(['--pr', '0']), /invalid --pr value/);
+  assert.throws(() => parseArgs(['--pr', '-5']), /invalid --pr value/);
+  assert.throws(() => parseArgs(['--pr', '12abc']), /invalid --pr value/);
 });

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
-import { fetchBranchRulesets } from '../src/scripts/pre-merge-readiness.mts';
+import {
+  fetchBranchRulesets,
+  parseArgs,
+} from '../src/scripts/pre-merge-readiness.mts';
 import {
   buildActivitySnapshotSummary,
   buildAdvisoryWaitSummary,
@@ -3766,6 +3769,37 @@ test('fetchBranchRulesets propagates a non-404 fetch error instead of coercing t
         throw boom;
       }),
     (error: unknown) => error === boom,
+  );
+});
+
+test('parseArgs: valid --pr / --claim-issue parse to positive integers', () => {
+  const args = parseArgs(['--pr', '1082', '--claim-issue', '1076']);
+  assert.equal(args.prNumber, 1082);
+  assert.equal(args.claimIssueNumber, 1076);
+});
+
+test('parseArgs: a flag-shaped value throws instead of consuming the flag', () => {
+  // `--pr --json` must fail fast, not parse `--json` into the PR number.
+  assert.throws(() => parseArgs(['--pr', '--json']), /missing value/);
+  assert.throws(
+    () => parseArgs(['--pr', '1082', '--claim-issue', '--owner']),
+    /missing value/,
+  );
+  assert.throws(() => parseArgs(['--pr']), /missing value/);
+});
+
+test('parseArgs: an unknown argument throws', () => {
+  assert.throws(() => parseArgs(['--bogus']), /unknown argument/);
+  assert.throws(() => parseArgs(['1082']), /unknown argument/);
+});
+
+test('parseArgs: a non-positive / non-integer number throws a clear message', () => {
+  assert.throws(() => parseArgs(['--pr', '0']), /invalid --pr value/);
+  assert.throws(() => parseArgs(['--pr', '-5']), /invalid --pr value/);
+  assert.throws(() => parseArgs(['--pr', '12abc']), /invalid --pr value/);
+  assert.throws(
+    () => parseArgs(['--claim-issue', '0']),
+    /invalid --claim-issue value/,
   );
 });
 


### PR DESCRIPTION
## Summary

Harden the loose `parseArgs` in two helper CLIs so a malformed invocation
fails fast instead of mis-parsing:

- **`src/scripts/branch-conflict-state.mts`** and
  **`src/scripts/pre-merge-readiness.mts`**: reuse the in-repo idioms — a
  `requireValue()` that rejects a missing or flag-shaped value
  (`startsWith('--')`), the `/^[1-9]\d*$/` positive-integer guard for
  `--pr` (and `--claim-issue`), and a final `throw` on unknown arguments
  (branch-conflict-state previously ignored them).
- Both `parseArgs` are now exported so the rejection paths can be unit
  tested directly, mirroring the existing `post-idd-marker.mts` /
  `resolve-review-thread.mts` export-and-test pattern.
- Removed the now-redundant post-loop `Number.isInteger`/`< 1` nullify
  block in `pre-merge-readiness.mts`; invalid numeric input throws inline
  with a clear message instead of being silently nullified.
- Regenerated the committed `scripts/*.mjs` via `pnpm run build`.

## Behavior change

- `--pr --json` now throws `missing value for argument: --pr` instead of
  consuming `--json` as the PR number.
- A non-positive / non-integer `--pr` (`0`, `-5`, `12abc`) throws
  `invalid --pr value: <raw>` (previously `12abc` truncated to `12`, and
  `0` was silently nullified).
- An unknown argument throws `unknown argument: <token>`.

## Tests

New `parseArgs` tests in `tests/branch-conflict-state.test.mts` and
`tests/pre-merge-readiness.test.mts` assert the flag-shaped, unknown, and
non-positive rejection paths plus a valid parse. `pnpm test` and
`pnpm run lint:minimum` pass; `build:check` confirms the generated `.mjs`
is byte-consistent.

## Follow-up (out of scope)

`src/scripts/idd-merge-execute.mts` carries the same loose
`Number.parseInt` `--pr` parsing; its own upstream guard short-circuits a
malformed value before the passthrough, so it is safe today but worth a
separate same-class hardening issue.

Closes #1082
