### PR TITLE
docs(idd): narrow issue-authoring recovery to close, not delete

### DIFF
--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -72,8 +72,10 @@ needs-decision, blocked-by-human, and out-of-scope.
    - apply the label before updating an existing issue
    - create new issues with the label when supported, or apply the label
      immediately after creation
-   - if post-create label application fails, close, delete, or otherwise
-     make the created issue undiscoverable before stopping
+   - if post-create label application fails, close the created issue
+     before stopping; deletion needs repo-admin permission the authoring
+     agent typically lacks (and `docs/permissions.md` forbids for normal
+     IDD), so it is not the default path
    - remove the label from all published issues only after the full set is
      published, the user confirms the result, and the user explicitly
      requests release from the authoring hold for IDD execution

--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -73,7 +73,7 @@ needs-decision, blocked-by-human, and out-of-scope.
    - create new issues with the label when supported, or apply the label
      immediately after creation
    - if post-create label application fails, close the created issue
-     before stopping; deletion needs repo-admin permission the authoring
+     before stopping; deletion needs admin permission the authoring
      agent typically lacks (and `docs/permissions.md` forbids for normal
      IDD), so it is not the default path
    - remove the label from all published issues only after the full set is

--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -27,7 +27,7 @@ The issue-authoring bundle fits into a three-phase handoff:
   when the publication command supports that; otherwise it applies the
   label immediately after creation
 - If post-create label application fails, bundled skill closes the created
-  issue before stopping; deletion needs repo-admin permission the authoring
+  issue before stopping; deletion needs admin permission the authoring
   agent typically lacks (and `docs/permissions.md` forbids for normal IDD),
   so it is not the default path
 - User verifies the published issues look correct

--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -26,8 +26,10 @@ The issue-authoring bundle fits into a three-phase handoff:
 - For new issues, bundled skill creates the issue with the authoring label
   when the publication command supports that; otherwise it applies the
   label immediately after creation
-- If post-create label application fails, bundled skill closes, deletes,
-  or otherwise makes the created issue undiscoverable before stopping
+- If post-create label application fails, bundled skill closes the created
+  issue before stopping; deletion needs repo-admin permission the authoring
+  agent typically lacks (and `docs/permissions.md` forbids for normal IDD),
+  so it is not the default path
 - User verifies the published issues look correct
 - Bundled skill removes the authoring label from all published issues only
   after the full issue set is published, the user confirms the result, and

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -402,9 +402,9 @@ label in the same publication command, such as `gh issue create --label`
 when the bundled GitHub CLI flow can use it. If the flow cannot label
 the issue atomically, apply the label immediately after creation. If
 post-create label application fails, close the created issue before
-stopping. Deletion needs repo-admin permission the authoring agent
-typically lacks (and `docs/permissions.md` forbids for normal IDD), so it
-is not the default path.
+stopping. Deletion needs admin permission the authoring agent typically
+lacks (and `docs/permissions.md` forbids for normal IDD), so it is not the
+default path.
 
 These guards keep partially published issue sets visible to the IDD
 discover guard while the full set is still being authored. Remove the

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -401,8 +401,10 @@ content. For new issues, prefer creating the issue with the authoring
 label in the same publication command, such as `gh issue create --label`
 when the bundled GitHub CLI flow can use it. If the flow cannot label
 the issue atomically, apply the label immediately after creation. If
-post-create label application fails, close, delete, or otherwise make
-the created issue undiscoverable before stopping.
+post-create label application fails, close the created issue before
+stopping. Deletion needs repo-admin permission the authoring agent
+typically lacks (and `docs/permissions.md` forbids for normal IDD), so it
+is not the default path.
 
 These guards keep partially published issue sets visible to the IDD
 discover guard while the full set is still being authored. Remove the

--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -72,8 +72,10 @@ needs-decision, blocked-by-human, and out-of-scope.
    - apply the label before updating an existing issue
    - create new issues with the label when supported, or apply the label
      immediately after creation
-   - if post-create label application fails, close, delete, or otherwise
-     make the created issue undiscoverable before stopping
+   - if post-create label application fails, close the created issue
+     before stopping; deletion needs repo-admin permission the authoring
+     agent typically lacks (and `docs/permissions.md` forbids for normal
+     IDD), so it is not the default path
    - remove the label from all published issues only after the full set is
      published, the user confirms the result, and the user explicitly
      requests release from the authoring hold for IDD execution

--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -73,7 +73,7 @@ needs-decision, blocked-by-human, and out-of-scope.
    - create new issues with the label when supported, or apply the label
      immediately after creation
    - if post-create label application fails, close the created issue
-     before stopping; deletion needs repo-admin permission the authoring
+     before stopping; deletion needs admin permission the authoring
      agent typically lacks (and `docs/permissions.md` forbids for normal
      IDD), so it is not the default path
    - remove the label from all published issues only after the full set is

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -27,7 +27,7 @@ The issue-authoring bundle fits into a three-phase handoff:
   when the publication command supports that; otherwise it applies the
   label immediately after creation
 - If post-create label application fails, bundled skill closes the created
-  issue before stopping; deletion needs repo-admin permission the authoring
+  issue before stopping; deletion needs admin permission the authoring
   agent typically lacks (and `docs/permissions.md` forbids for normal IDD),
   so it is not the default path
 - User verifies the published issues look correct

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -26,8 +26,10 @@ The issue-authoring bundle fits into a three-phase handoff:
 - For new issues, bundled skill creates the issue with the authoring label
   when the publication command supports that; otherwise it applies the
   label immediately after creation
-- If post-create label application fails, bundled skill closes, deletes,
-  or otherwise makes the created issue undiscoverable before stopping
+- If post-create label application fails, bundled skill closes the created
+  issue before stopping; deletion needs repo-admin permission the authoring
+  agent typically lacks (and `docs/permissions.md` forbids for normal IDD),
+  so it is not the default path
 - User verifies the published issues look correct
 - Bundled skill removes the authoring label from all published issues only
   after the full issue set is published, the user confirms the result, and


### PR DESCRIPTION
## Summary

The issue-authoring post-create recovery guidance said "close, **delete**,
or otherwise make the created issue undiscoverable." GitHub issue deletion
requires repo-admin permission a write-scoped authoring agent does not have
— and that `docs/permissions.md` explicitly forbids for normal IDD — so
`delete` is an unreachable default. `close` is the correct primary path.

## Change

Narrow the guidance to **close** the half-published issue, with a brief
rationale that deletion needs repo-admin permission the authoring agent
typically lacks. Updated across all three canonical surfaces and the two
generated copies:

- `skills/issue-authoring/SKILL.md` (Workflow step 6)
- `skills/issue-authoring/references/workflow-boundary.md` (Phase 2)
- `docs/issue-authoring-skill.md`
- regenerated `.claude/skills/issue-authoring/**` via `sync-docs.mjs --apply`

`audit-docs.mjs --check`, markdownlint, dprint, and cspell pass.

Closes #1090
