### PR TITLE
fix(idd): resolve the Esync route via phase-id-resolver

### DIFF
--- a/scripts/phase-id-resolver.mjs
+++ b/scripts/phase-id-resolver.mjs
@@ -4,6 +4,19 @@
 // The scripts/phase-id-resolver.mjs copy is generated from the .mts
 // source named above by `pnpm run build`. Edit the .mts source, never
 // the generated .mjs. See docs/typescript-sources.md.
+// Canonical machine-facing phase IDs. This set must cover every phase route
+// `resume-route-selection` can emit (documented enum
+// `D1|D4|E1|E15|Esync|F1|F2|stop`) so a route the resume helper selects always
+// resolves here instead of throwing `unknown_phase_id`;
+// `tests/phase-id-resolver.test.mts` guards that union. `Esync` (the E-phase
+// branch-resync route) is therefore listed below. Two deliberate boundaries:
+//   - `stop` is a terminal control signal (stop-and-report), not a phase, so it
+//     is intentionally NOT canonical and resolves to `unknown_phase_id`.
+//   - bare `A` is the collapsed routing-graph-only node in
+//     `schemas/phase-graph.json`; `resume-route-selection` never emits it, and
+//     this list enumerates the concrete discovery sub-phases `A0..A5` instead,
+//     so bare `A` is intentionally non-canonical (it resolves to
+//     `unknown_phase_id`) rather than being added here.
 const DEFAULT_CANONICAL_PHASE_IDS = [
   'A0',
   'A0_O',
@@ -44,6 +57,7 @@ const DEFAULT_CANONICAL_PHASE_IDS = [
   'E13',
   'E14',
   'E15',
+  'Esync',
   'F1',
   'F2',
   'F2_5',

--- a/src/scripts/phase-id-resolver.mts
+++ b/src/scripts/phase-id-resolver.mts
@@ -5,6 +5,19 @@
 // source named above by `pnpm run build`. Edit the .mts source, never
 // the generated .mjs. See docs/typescript-sources.md.
 
+// Canonical machine-facing phase IDs. This set must cover every phase route
+// `resume-route-selection` can emit (documented enum
+// `D1|D4|E1|E15|Esync|F1|F2|stop`) so a route the resume helper selects always
+// resolves here instead of throwing `unknown_phase_id`;
+// `tests/phase-id-resolver.test.mts` guards that union. `Esync` (the E-phase
+// branch-resync route) is therefore listed below. Two deliberate boundaries:
+//   - `stop` is a terminal control signal (stop-and-report), not a phase, so it
+//     is intentionally NOT canonical and resolves to `unknown_phase_id`.
+//   - bare `A` is the collapsed routing-graph-only node in
+//     `schemas/phase-graph.json`; `resume-route-selection` never emits it, and
+//     this list enumerates the concrete discovery sub-phases `A0..A5` instead,
+//     so bare `A` is intentionally non-canonical (it resolves to
+//     `unknown_phase_id`) rather than being added here.
 const DEFAULT_CANONICAL_PHASE_IDS = [
   'A0',
   'A0_O',
@@ -45,6 +58,7 @@ const DEFAULT_CANONICAL_PHASE_IDS = [
   'E13',
   'E14',
   'E15',
+  'Esync',
   'F1',
   'F2',
   'F2_5',

--- a/tests/phase-id-resolver.test.mts
+++ b/tests/phase-id-resolver.test.mts
@@ -208,9 +208,19 @@ test('every resume-route-selection route resolves except the terminal stop senti
       continue;
     }
     const resolution = resolvePhaseId(route);
-    assert.ok(
+    // Assert canonical self-resolution, not merely "resolves to some canonical
+    // id": resume routes are themselves canonical phases, so a future route
+    // wired up as a legacy alias (matchedBy 'legacy-alias', or a canonicalPhaseId
+    // other than the route) must fail this guard rather than silently pass.
+    assert.equal(
+      resolution.matchedBy,
+      'canonical',
+      `resume route ${route} must stay canonical in the phase-id resolver`,
+    );
+    assert.equal(
       resolution.canonicalPhaseId,
-      `resume route ${route} must resolve via the phase-id resolver`,
+      route,
+      `resume route ${route} must resolve to itself`,
     );
   }
 

--- a/tests/phase-id-resolver.test.mts
+++ b/tests/phase-id-resolver.test.mts
@@ -170,6 +170,94 @@ test('resolves separator-normalized canonical forms to the canonical id', () => 
   assert.equal(resolvePhaseId('A4.5').matchedBy, 'legacy-alias');
 });
 
+test('every resume-route-selection route resolves except the terminal stop sentinel', () => {
+  // resume-route-selection.mts can route a resume into one of the phases in its
+  // documented route enum (printHelp: "route": "D1|D4|E1|E15|Esync|F1|F2|stop").
+  // Every *phase* route in that union must resolve through the canonical
+  // phase-id resolver so the two helpers cannot drift apart; this guard fails if
+  // resume-route-selection gains a documented route the resolver cannot resolve
+  // (the reason `Esync` was reconciled into the canonical list). Two routes are
+  // deliberately NOT canonical — documented here rather than silently added:
+  //   - `stop` is a terminal control signal (stop-and-report), not a phase, so
+  //     it must throw `unknown_phase_id` (asserted below).
+  //   - bare `A` is the collapsed routing-graph-only node in
+  //     schemas/phase-graph.json; resume-route-selection never emits it, and the
+  //     canonical list enumerates the concrete discovery sub-phases A0..A5
+  //     instead, so bare `A` is non-canonical and also throws (asserted below).
+  //     (A broader "every phase-graph node resolves" guard is a separate
+  //     concern, not this one.)
+  const documentedRoutes = readResumeRouteEnum();
+  const tableRoutes = readResumeDecisionTableRoutes();
+
+  // The two in-file route descriptions (help-text enum and decision table) must
+  // list the same routes, so a route added to one but not the other is caught.
+  assert.deepEqual(
+    [...new Set(documentedRoutes)].sort(),
+    [...new Set(tableRoutes)].sort(),
+    'resume-route-selection help enum and decision table must list the same routes',
+  );
+  assert.ok(
+    documentedRoutes.includes('Esync'),
+    'resume-route-selection route enum must include Esync',
+  );
+
+  const terminalSentinels = new Set(['stop']);
+  for (const route of documentedRoutes) {
+    if (terminalSentinels.has(route)) {
+      assertUnknownPhaseId(route);
+      continue;
+    }
+    const resolution = resolvePhaseId(route);
+    assert.ok(
+      resolution.canonicalPhaseId,
+      `resume route ${route} must resolve via the phase-id resolver`,
+    );
+  }
+
+  // Bare `A` is intentionally absent from the canonical list (see above).
+  assertUnknownPhaseId('A');
+});
+
 function readJson(relativePath: string): unknown {
   return JSON.parse(readFileSync(join(REPO_ROOT, relativePath), 'utf8'));
+}
+
+function assertUnknownPhaseId(input: string): void {
+  assert.throws(
+    () => resolvePhaseId(input),
+    (error) =>
+      Boolean(error) &&
+      (error as { code?: unknown }).code === 'unknown_phase_id',
+    `${input} must not resolve as a canonical phase id`,
+  );
+}
+
+function readResumeRouteSource(): string {
+  return readFileSync(
+    join(REPO_ROOT, 'src/scripts/resume-route-selection.mts'),
+    'utf8',
+  );
+}
+
+function readResumeRouteEnum(): string[] {
+  const match = readResumeRouteSource().match(/"route":\s*"([^"]+)"/);
+  assert.ok(
+    match,
+    'resume-route-selection.mts must document its route enum as "route": "..."',
+  );
+  return (match[1] ?? '')
+    .split('|')
+    .map((route) => route.trim())
+    .filter(Boolean);
+}
+
+function readResumeDecisionTableRoutes(): string[] {
+  const routes = [
+    ...readResumeRouteSource().matchAll(/route:\s*'([^']+)'/g),
+  ].map((entry) => entry[1]);
+  assert.ok(
+    routes.length > 0,
+    'resume-route-selection.mts decisionTable() must list route literals',
+  );
+  return routes;
 }


### PR DESCRIPTION
## Summary

`resume-route-selection` can emit the `Esync` route (documented route enum
`D1|D4|E1|E15|Esync|F1|F2|stop`), but `DEFAULT_CANONICAL_PHASE_IDS` in
`src/scripts/phase-id-resolver.mts` omitted it, so resolving that route threw
`unknown_phase_id`. This reconciles the two helpers in code.

- Add `Esync` to `DEFAULT_CANONICAL_PHASE_IDS` (grouped with the E-phase IDs)
  so the route resolves via the canonical resolver. Regenerated
  `scripts/phase-id-resolver.mjs` via `pnpm run build`.
- Add a guard test in `tests/phase-id-resolver.test.mts` that reads the
  documented route enum straight from `resume-route-selection.mts`,
  cross-checks it against that file's in-file decision table, and asserts every
  phase route resolves — so the test fails if `resume-route-selection` gains a
  documented route the resolver cannot resolve.

### Boundaries (documented, not silently widened)

- `stop` is a terminal control signal (stop-and-report), not a phase, so it
  stays non-canonical; the test asserts it throws `unknown_phase_id`.
- bare `A` is the collapsed routing-graph-only node in
  `schemas/phase-graph.json` that `resume-route-selection` never emits; the
  canonical list enumerates the concrete discovery sub-phases `A0..A5` instead,
  so bare `A` stays non-canonical (the test asserts it throws too). The issue
  text described this as the resolver "expanding" `A`; the code comment is
  worded to match actual behavior — bare `A` resolves to `unknown_phase_id`.

### Non-goals / possible follow-up

A broader "every `schemas/phase-graph.json` node resolves through the resolver"
guard is intentionally out of scope (the issue defers it).

## Verification

`pnpm run build` (no `build:check` drift), `pnpm test` (1316 pass), and
`pnpm run lint:minimum` all green.

Closes #1095


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for the `Esync` phase so it now resolves correctly instead of being treated as unknown.
* **Tests**
  * Expanded coverage to verify all documented phase routes resolve to a canonical phase ID.
  * Confirmed terminal/special sentinels continue to raise the expected unknown-phase error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->