### PR TITLE
fix(idd): match [bot]-suffixed author logins against suffixless advisory-bot config

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -4471,11 +4471,27 @@ function hasCodeownerOwners(rule) {
     (rule?.emails?.length ?? 0) > 0
   );
 }
-function isGateAdvisoryBotLogin(login, advisoryBotLogins) {
-  const normalized = String(login ?? '')
-    .trim()
-    .toLowerCase();
-  return isKnownReviewBot(normalized) || advisoryBotLogins.has(normalized);
+// True when a PR-author login belongs to a gate-relevant advisory bot — a known
+// review bot (CodeRabbit/Codex/Copilot defaults) or a configured
+// `advisoryBotLogins` entry. The GitHub `[bot]` suffix is normalized
+// symmetrically via `advisoryBotIdentityToken` on both the incoming login and
+// each configured entry, so a custom bot matches whether the config or the
+// author login stores the suffixed (`my-bot[bot]`) or suffixless (`my-bot`)
+// form. Fail-closed on an empty token.
+export function isGateAdvisoryBotLogin(login, advisoryBotLogins) {
+  const token = advisoryBotIdentityToken(login);
+  if (!token) {
+    return false;
+  }
+  if (isKnownReviewBot(token)) {
+    return true;
+  }
+  for (const configured of advisoryBotLogins) {
+    if (advisoryBotIdentityToken(configured) === token) {
+      return true;
+    }
+  }
+  return false;
 }
 function _isOperationalOrDigestComment(body) {
   return (

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -5744,14 +5744,30 @@ function hasCodeownerOwners(rule: CodeownersRule | null | undefined): boolean {
   );
 }
 
-function isGateAdvisoryBotLogin(
+// True when a PR-author login belongs to a gate-relevant advisory bot — a known
+// review bot (CodeRabbit/Codex/Copilot defaults) or a configured
+// `advisoryBotLogins` entry. The GitHub `[bot]` suffix is normalized
+// symmetrically via `advisoryBotIdentityToken` on both the incoming login and
+// each configured entry, so a custom bot matches whether the config or the
+// author login stores the suffixed (`my-bot[bot]`) or suffixless (`my-bot`)
+// form. Fail-closed on an empty token.
+export function isGateAdvisoryBotLogin(
   login: unknown,
   advisoryBotLogins: Set<string>,
 ): boolean {
-  const normalized = String(login ?? '')
-    .trim()
-    .toLowerCase();
-  return isKnownReviewBot(normalized) || advisoryBotLogins.has(normalized);
+  const token = advisoryBotIdentityToken(login);
+  if (!token) {
+    return false;
+  }
+  if (isKnownReviewBot(token)) {
+    return true;
+  }
+  for (const configured of advisoryBotLogins) {
+    if (advisoryBotIdentityToken(configured) === token) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function _isOperationalOrDigestComment(body: string): boolean {

--- a/tests/protocol-helpers-advisory-bot-login.test.mts
+++ b/tests/protocol-helpers-advisory-bot-login.test.mts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  isGateAdvisoryBotLogin,
+  normalizeTrustedMarkerLogins,
+} from '../src/scripts/protocol-helpers.mts';
+
+// Build the advisory-bot set exactly as the gate callers do, so the test
+// exercises the real construction path rather than a hand-rolled Set.
+const buildSet = (logins: string[]): Set<string> =>
+  new Set(normalizeTrustedMarkerLogins(logins));
+
+test('isGateAdvisoryBotLogin matches a custom bot across the [bot] suffix cross-product', () => {
+  // config stores the suffixless form
+  const suffixlessConfig = buildSet(['my-bot']);
+  assert.equal(isGateAdvisoryBotLogin('my-bot', suffixlessConfig), true);
+  assert.equal(isGateAdvisoryBotLogin('my-bot[bot]', suffixlessConfig), true);
+
+  // config stores the suffixed form
+  const suffixedConfig = buildSet(['my-bot[bot]']);
+  assert.equal(isGateAdvisoryBotLogin('my-bot', suffixedConfig), true);
+  assert.equal(isGateAdvisoryBotLogin('my-bot[bot]', suffixedConfig), true);
+});
+
+test('isGateAdvisoryBotLogin normalizes case and surrounding whitespace', () => {
+  const config = buildSet(['my-bot']);
+  assert.equal(isGateAdvisoryBotLogin('  My-Bot[BOT] ', config), true);
+});
+
+test('isGateAdvisoryBotLogin keeps the CodeRabbit/Codex/Copilot defaults working', () => {
+  const empty = buildSet([]);
+  for (const login of [
+    'coderabbitai',
+    'coderabbitai[bot]',
+    'chatgpt-codex-connector',
+    'chatgpt-codex-connector[bot]',
+    'copilot-pull-request-reviewer[bot]',
+  ]) {
+    assert.equal(
+      isGateAdvisoryBotLogin(login, empty),
+      true,
+      `default review bot should match: ${login}`,
+    );
+  }
+});
+
+test('isGateAdvisoryBotLogin rejects unconfigured and empty logins', () => {
+  const config = buildSet(['my-bot']);
+  assert.equal(isGateAdvisoryBotLogin('some-human', config), false);
+  assert.equal(isGateAdvisoryBotLogin('other-bot[bot]', config), false);
+  assert.equal(isGateAdvisoryBotLogin('', config), false);
+  assert.equal(isGateAdvisoryBotLogin(null, config), false);
+  assert.equal(isGateAdvisoryBotLogin(undefined, config), false);
+  // A bare `[bot]` reduces to an empty token and must not match.
+  assert.equal(isGateAdvisoryBotLogin('[bot]', config), false);
+});


### PR DESCRIPTION
## Summary

`isGateAdvisoryBotLogin` only `.trim().toLowerCase()`-normalized the
PR-author login before a plain `advisoryBotLogins.has(...)` lookup, so it
never stripped the GitHub `[bot]` suffix. A repository that configures a
**custom** advisory bot **without** the `[bot]` suffix (the policy schema does
not mandate a format) therefore silently failed to classify an author login
that arrives **with** `[bot]`, and vice-versa. The shipped CodeRabbit/Codex
defaults escaped this only because `REVIEW_BOT_LOGINS` happens to store both
the suffixed and suffixless forms.

The exact normalization already existed in the same file
(`advisoryBotIdentityToken`, which strips a trailing `[bot]`); the gate just
did not reuse it.

## Change

- Rewrite `isGateAdvisoryBotLogin` to normalize the `[bot]` suffix
  **symmetrically** by reusing `advisoryBotIdentityToken` on **both** the
  incoming login and each configured set entry — no second ad-hoc regex.
- Run the `isKnownReviewBot` fast-path on the stripped token; the defaults are
  unchanged (`REVIEW_BOT_LOGINS` already carries the suffixless forms and the
  `copilot-pull-request-reviewer` prefix check is suffix-agnostic).
- Fail closed on an empty token (e.g. a bare `[bot]`).
- `export` the predicate and add a focused unit test
  (`tests/protocol-helpers-advisory-bot-login.test.mts`) covering the
  suffix × suffixless cross-product for a custom bot, the unchanged
  CodeRabbit/Codex/Copilot defaults, and non-bot/empty rejection.

The generated `scripts/protocol-helpers.mjs` is regenerated via
`pnpm run build` and committed alongside the `.mts` source.

## Verification

- `pnpm test` — 1339 tests pass (includes the 4 new cases).
- `pnpm run lint:minimum` gate (typecheck, build:check, biome, dprint, full
  test suite, cspell, markdownlint) green after commit.

## Possible follow-up (out of scope here)

The local `isAdvisoryBot` closures in `buildActivitySnapshotSummary` and
`summarizeReviewerStates` use the same un-stripped `advisoryBotLogins.has(...)`
pattern and share the latent asymmetry. This PR keeps to the
`isGateAdvisoryBotLogin` scope stated in the issue; a follow-up could
generalize the normalization to those call sites.

Closes #1080
