### PR TITLE
fix(idd): thread + regex-escape markerPrefix in readiness-check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -38,6 +38,7 @@ scripts/idd-doctor.mjs linguist-generated=true
 scripts/idd-merge-execute.mjs linguist-generated=true
 scripts/idd-roadmap-audit-execute.mjs linguist-generated=true
 scripts/live-status-digest.mjs linguist-generated=true
+scripts/marker-regex.mjs linguist-generated=true
 scripts/merged-pr-feedback-sweep.mjs linguist-generated=true
 scripts/minimize-superseded-markers.mjs linguist-generated=true
 scripts/phase-id-resolver.mjs linguist-generated=true

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -19,6 +19,7 @@ import {
   rankAndRouteBySuitability,
 } from './autopilot-suitability.mjs';
 import { effortOrdinal, parseEffort } from './effort.mjs';
+import { createMarkerRegex } from './marker-regex.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 const BLOCKED_LABELS = new Set([
@@ -528,12 +529,6 @@ function isCliExecution() {
       fileURLToPath(import.meta.url) === resolve(process.argv[1]),
   );
 }
-function createMarkerRegex(prefix, suffix) {
-  return new RegExp(
-    `<!--\\s*${escapeRegex(prefix)}-${suffix}\\b[\\s\\S]*?-->`,
-    'i',
-  );
-}
 function normalizeMarkerPrefix(prefix) {
   if (typeof prefix !== 'string' || prefix.length === 0) {
     return DEFAULT_MARKER_PREFIX;
@@ -544,9 +539,6 @@ function normalizeAuthoringLabelName(labelName) {
   return typeof labelName === 'string' && labelName.length > 0
     ? labelName
     : 'status:authoring';
-}
-function escapeRegex(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 function fetchOpenIssues(repoRef) {
   const issues = [];

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -17,6 +17,7 @@ import {
   parseAutopilotSuitability,
 } from './autopilot-suitability.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import { escapeRegex } from './marker-regex.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
@@ -37,14 +38,15 @@ if (isMainModule(import.meta.url)) {
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
   const policyConfig = loadPolicy(args.policy);
   const authoringPolicy = resolveAuthoringGuardPolicy(policyConfig);
+  const markerPrefix = resolveMarkerPrefix(policyConfig);
   const summary = await evaluateDiscoverReadiness(args.issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
     loadIssue: buildIssueLoader(owner, repo),
     loadIssueLabelEvents: buildIssueLabelEventsLoader(owner, repo),
-    findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo),
+    findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo, markerPrefix),
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
-    markerPrefix: resolveMarkerPrefix(policyConfig),
+    markerPrefix,
     autopilotSuitabilityFloor: resolveSuitabilityFloor(policyConfig),
     autopilotSuitabilityEnabled: resolveSuitabilityEnabled(policyConfig),
     now: args.now || new Date(),
@@ -208,7 +210,10 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
         reasons.add(`blocked_by_open_issue:#${blockedNumber}`);
       }
     }
-    for (const marker of extractBlockedByRoadmapMarkers(issue.body)) {
+    for (const marker of extractBlockedByRoadmapMarkers(
+      issue.body,
+      resolvedMarkerPrefix,
+    )) {
       const markerMatches = await getRoadmapsByMarker(
         marker,
         markerCache,
@@ -265,9 +270,19 @@ export function extractBlockedByIssueNumbers(body) {
     [...matches].map((match) => Number.parseInt(match[1], 10)),
   );
 }
-export function extractBlockedByRoadmapMarkers(body) {
+export function extractBlockedByRoadmapMarkers(
+  body,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+) {
+  // Regex-escape the configurable prefix so a namespaced adopter prefix
+  // (which may contain a metacharacter) cannot corrupt or break the
+  // extraction pattern. For the default `idd-skill` this is byte-identical
+  // to the prior hardcoded literal.
   const matches = body.matchAll(
-    /<!--\s*idd-skill-blocked-by:\s*([^\s>]+)\s*-->/gi,
+    new RegExp(
+      `<!--\\s*${escapeRegex(markerPrefix)}-blocked-by:\\s*([^\\s>]+)\\s*-->`,
+      'gi',
+    ),
   );
   return [...new Set([...matches].map((match) => match[1]))];
 }
@@ -537,9 +552,25 @@ function fetchIssueLabelEvents(repoRef, issueNumber) {
   }
   return events;
 }
-function buildRoadmapMarkerResolver(owner, repo) {
+export function buildRoadmapMarkerSearchQuery(
+  owner,
+  repo,
+  markerPrefix,
+  marker,
+) {
+  // Thread the configurable prefix into the GitHub search query WITHOUT
+  // regex-escaping: this is a literal `in:body` search term, so escaping the
+  // prefix would corrupt the exact marker string the resolver looks for.
+  return `repo:${owner}/${repo} is:issue in:body "<!-- ${markerPrefix}-roadmap-id: ${marker} -->"`;
+}
+function buildRoadmapMarkerResolver(owner, repo, markerPrefix) {
   return async (marker) => {
-    const query = `repo:${owner}/${repo} is:issue in:body "<!-- idd-skill-roadmap-id: ${marker} -->"`;
+    const query = buildRoadmapMarkerSearchQuery(
+      owner,
+      repo,
+      markerPrefix,
+      marker,
+    );
     const encodedQuery = encodeURIComponent(query);
     const result = runGh([
       'api',

--- a/scripts/marker-regex.mjs
+++ b/scripts/marker-regex.mjs
@@ -1,0 +1,35 @@
+// idd-generated-from: src/scripts/marker-regex.mts
+//
+// The scripts/marker-regex.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
+// Shared helpers for building marker-detection regexes from a configurable
+// marker prefix. Centralizing escapeRegex + createMarkerRegex keeps the
+// discover-phase helpers (orphan filter, readiness check) from re-deriving
+// the escaping rules, so an adopter's namespaced marker prefix flows through
+// one regex builder instead of a per-file hardcoded literal.
+/**
+ * Escape every RegExp metacharacter in `value` so it can be embedded as a
+ * literal inside a larger pattern. Used to make a configurable marker prefix
+ * (which a namespaced adopter may write with `.`, `+`, `(`, ... ) safe to
+ * interpolate into a marker regex.
+ */
+export function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+/**
+ * Build a case-insensitive detection regex for an HTML-comment marker of the
+ * form `<!-- {prefix}-{suffix} ... -->`. The prefix is regex-escaped so a
+ * namespaced adopter prefix cannot corrupt the pattern; the suffix is a fixed
+ * internal literal (e.g. `roadmap-id`, `blocked-by`). The pattern is
+ * detection-only — no capture group and non-global — so callers that must
+ * extract the marker value build their own capturing regex from
+ * {@link escapeRegex}.
+ */
+export function createMarkerRegex(prefix, suffix) {
+  return new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-${suffix}\\b[\\s\\S]*?-->`,
+    'i',
+  );
+}

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -21,6 +21,7 @@ import {
   rankAndRouteBySuitability,
 } from './autopilot-suitability.mts';
 import { type EffortHint, effortOrdinal, parseEffort } from './effort.mts';
+import { createMarkerRegex } from './marker-regex.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 const BLOCKED_LABELS = new Set([
@@ -703,13 +704,6 @@ function isCliExecution(): boolean {
   );
 }
 
-function createMarkerRegex(prefix: string, suffix: string): RegExp {
-  return new RegExp(
-    `<!--\\s*${escapeRegex(prefix)}-${suffix}\\b[\\s\\S]*?-->`,
-    'i',
-  );
-}
-
 function normalizeMarkerPrefix(prefix: unknown): string {
   if (typeof prefix !== 'string' || prefix.length === 0) {
     return DEFAULT_MARKER_PREFIX;
@@ -721,10 +715,6 @@ function normalizeAuthoringLabelName(labelName: unknown): string {
   return typeof labelName === 'string' && labelName.length > 0
     ? labelName
     : 'status:authoring';
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function fetchOpenIssues(repoRef: string) {

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -19,6 +19,7 @@ import {
   parseAutopilotSuitability,
 } from './autopilot-suitability.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
+import { escapeRegex } from './marker-regex.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
@@ -133,15 +134,16 @@ if (isMainModule(import.meta.url)) {
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
   const policyConfig = loadPolicy(args.policy);
   const authoringPolicy = resolveAuthoringGuardPolicy(policyConfig);
+  const markerPrefix = resolveMarkerPrefix(policyConfig);
 
   const summary = await evaluateDiscoverReadiness(args.issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
     loadIssue: buildIssueLoader(owner, repo),
     loadIssueLabelEvents: buildIssueLabelEventsLoader(owner, repo),
-    findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo),
+    findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo, markerPrefix),
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
-    markerPrefix: resolveMarkerPrefix(policyConfig),
+    markerPrefix,
     autopilotSuitabilityFloor: resolveSuitabilityFloor(policyConfig),
     autopilotSuitabilityEnabled: resolveSuitabilityEnabled(policyConfig),
     now: args.now || new Date(),
@@ -318,7 +320,10 @@ export async function evaluateDiscoverReadiness(
       }
     }
 
-    for (const marker of extractBlockedByRoadmapMarkers(issue.body)) {
+    for (const marker of extractBlockedByRoadmapMarkers(
+      issue.body,
+      resolvedMarkerPrefix,
+    )) {
       const markerMatches = await getRoadmapsByMarker(
         marker,
         markerCache,
@@ -380,9 +385,19 @@ export function extractBlockedByIssueNumbers(body: string): number[] {
   );
 }
 
-export function extractBlockedByRoadmapMarkers(body: string): string[] {
+export function extractBlockedByRoadmapMarkers(
+  body: string,
+  markerPrefix: string = DEFAULT_MARKER_PREFIX,
+): string[] {
+  // Regex-escape the configurable prefix so a namespaced adopter prefix
+  // (which may contain a metacharacter) cannot corrupt or break the
+  // extraction pattern. For the default `idd-skill` this is byte-identical
+  // to the prior hardcoded literal.
   const matches = body.matchAll(
-    /<!--\s*idd-skill-blocked-by:\s*([^\s>]+)\s*-->/gi,
+    new RegExp(
+      `<!--\\s*${escapeRegex(markerPrefix)}-blocked-by:\\s*([^\\s>]+)\\s*-->`,
+      'gi',
+    ),
   );
   return [...new Set([...matches].map((match) => match[1]))];
 }
@@ -707,9 +722,30 @@ function fetchIssueLabelEvents(repoRef: string, issueNumber: number) {
   return events;
 }
 
-function buildRoadmapMarkerResolver(owner: string, repo: string) {
+export function buildRoadmapMarkerSearchQuery(
+  owner: string,
+  repo: string,
+  markerPrefix: string,
+  marker: string,
+): string {
+  // Thread the configurable prefix into the GitHub search query WITHOUT
+  // regex-escaping: this is a literal `in:body` search term, so escaping the
+  // prefix would corrupt the exact marker string the resolver looks for.
+  return `repo:${owner}/${repo} is:issue in:body "<!-- ${markerPrefix}-roadmap-id: ${marker} -->"`;
+}
+
+function buildRoadmapMarkerResolver(
+  owner: string,
+  repo: string,
+  markerPrefix: string,
+) {
   return async (marker: string) => {
-    const query = `repo:${owner}/${repo} is:issue in:body "<!-- idd-skill-roadmap-id: ${marker} -->"`;
+    const query = buildRoadmapMarkerSearchQuery(
+      owner,
+      repo,
+      markerPrefix,
+      marker,
+    );
     const encodedQuery = encodeURIComponent(query);
     const result = runGh([
       'api',

--- a/src/scripts/marker-regex.mts
+++ b/src/scripts/marker-regex.mts
@@ -1,0 +1,37 @@
+// idd-generated-from: src/scripts/marker-regex.mts
+//
+// The scripts/marker-regex.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
+// Shared helpers for building marker-detection regexes from a configurable
+// marker prefix. Centralizing escapeRegex + createMarkerRegex keeps the
+// discover-phase helpers (orphan filter, readiness check) from re-deriving
+// the escaping rules, so an adopter's namespaced marker prefix flows through
+// one regex builder instead of a per-file hardcoded literal.
+
+/**
+ * Escape every RegExp metacharacter in `value` so it can be embedded as a
+ * literal inside a larger pattern. Used to make a configurable marker prefix
+ * (which a namespaced adopter may write with `.`, `+`, `(`, ... ) safe to
+ * interpolate into a marker regex.
+ */
+export function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Build a case-insensitive detection regex for an HTML-comment marker of the
+ * form `<!-- {prefix}-{suffix} ... -->`. The prefix is regex-escaped so a
+ * namespaced adopter prefix cannot corrupt the pattern; the suffix is a fixed
+ * internal literal (e.g. `roadmap-id`, `blocked-by`). The pattern is
+ * detection-only — no capture group and non-global — so callers that must
+ * extract the marker value build their own capturing regex from
+ * {@link escapeRegex}.
+ */
+export function createMarkerRegex(prefix: string, suffix: string): RegExp {
+  return new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-${suffix}\\b[\\s\\S]*?-->`,
+    'i',
+  );
+}

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  buildRoadmapMarkerSearchQuery,
   evaluateDiscoverReadiness,
   extractBlockedByIssueNumbers,
   extractBlockedByRoadmapMarkers,
@@ -28,6 +29,91 @@ Depends on #56
   assert.deepEqual(extractBlockedByIssueNumbers(body), [12, 34]);
   assert.deepEqual(extractDependencyIssueNumbers(body), [56, 78]);
   assert.deepEqual(extractBlockedByRoadmapMarkers(body), ['parent-roadmap']);
+});
+
+test('extractBlockedByRoadmapMarkers honors a configured marker prefix', () => {
+  const body = `
+<!-- idd-skill-blocked-by: default-prefixed -->
+<!-- acme-blocked-by: custom-prefixed -->
+`;
+  // The default prefix extracts only its own marker.
+  assert.deepEqual(extractBlockedByRoadmapMarkers(body), ['default-prefixed']);
+  // A configured prefix extracts only the matching marker, ignoring the
+  // default-prefixed one.
+  assert.deepEqual(extractBlockedByRoadmapMarkers(body, 'acme'), [
+    'custom-prefixed',
+  ]);
+});
+
+test('extractBlockedByRoadmapMarkers regex-escapes a metacharacter prefix', () => {
+  // Without escaping, the unbalanced parenthesis would make `a(b` an invalid
+  // regex (unterminated group) and throw; escaping keeps it a literal match.
+  const body = '<!-- a(b-blocked-by: grouped -->';
+  assert.deepEqual(extractBlockedByRoadmapMarkers(body, 'a(b'), ['grouped']);
+});
+
+test('buildRoadmapMarkerSearchQuery threads the prefix as a literal, unescaped term', () => {
+  // Default prefix.
+  assert.equal(
+    buildRoadmapMarkerSearchQuery('o', 'r', 'idd-skill', '1076'),
+    'repo:o/r is:issue in:body "<!-- idd-skill-roadmap-id: 1076 -->"',
+  );
+  // A configured prefix threads through verbatim.
+  assert.equal(
+    buildRoadmapMarkerSearchQuery('o', 'r', 'acme', '1076'),
+    'repo:o/r is:issue in:body "<!-- acme-roadmap-id: 1076 -->"',
+  );
+  // A regex metacharacter in the prefix stays LITERAL (not escaped): the
+  // search query is a plain string, so escaping would corrupt the term.
+  assert.equal(
+    buildRoadmapMarkerSearchQuery('o', 'r', 'a.b', '1076'),
+    'repo:o/r is:issue in:body "<!-- a.b-roadmap-id: 1076 -->"',
+  );
+});
+
+test('threads a configured marker prefix into blocked-by extraction and roadmap-id search', async () => {
+  const issues = new Map([
+    [
+      1601,
+      {
+        number: 1601,
+        title: 'custom-prefixed blocked-by',
+        state: 'OPEN',
+        body: '<!-- acme-blocked-by: roadmap-y -->',
+        labels: [],
+      },
+    ],
+  ]);
+  const searchedMarkers: string[] = [];
+  const summary = await evaluateDiscoverReadiness([1601], {
+    includeUnresolvable: true,
+    markerPrefix: 'acme',
+    loadIssue: async (number) => issues.get(number) ?? null,
+    findRoadmapsByMarker: async (marker) => {
+      searchedMarkers.push(marker);
+      return marker === 'roadmap-y'
+        ? [
+            {
+              number: 998,
+              title: 'roadmap',
+              state: 'OPEN',
+              body: '',
+              labels: [{ name: 'roadmap' }],
+            },
+          ]
+        : [];
+    },
+  });
+
+  // The acme-prefixed blocked-by marker is extracted (the default idd-skill
+  // prefix would not have matched it) and resolved through the roadmap-id
+  // lookup, so the issue is filtered as blocked by the open roadmap.
+  assert.deepEqual(searchedMarkers, ['roadmap-y']);
+  assert.equal(summary.ready.length, 0);
+  assert.match(
+    summary.filteredOut[0].reasons.join(','),
+    /blocked_by_open_roadmap_marker:roadmap-y/,
+  );
 });
 
 test('filters issue with blocked labels', async () => {


### PR DESCRIPTION
## Summary

`discover-readiness-check` resolves a configurable `markerPrefix` but two
paths still hardcoded `idd-skill`, so for any adopter that namespaces its
markers, blocked-by and roadmap-id resolution silently missed. This threads
the resolved prefix through both paths.

- **`extractBlockedByRoadmapMarkers(body, markerPrefix)`** — now takes the
  resolved prefix and **regex-escapes** it, so a prefix containing a regex
  metacharacter can no longer corrupt or break the extraction regex. For the
  default `idd-skill` the produced pattern is byte-identical to the prior
  hardcoded literal (the hyphen is not a metacharacter).
- **`buildRoadmapMarkerResolver(owner, repo, markerPrefix)`** — threads the
  prefix into the GitHub search query as a **literal, unescaped** term
  (escaping would corrupt the exact `in:body` marker string it searches for).
  The query string is carved into an exported, pure
  `buildRoadmapMarkerSearchQuery` so the threading is unit-testable.
- **Shared module `src/scripts/marker-regex.mts`** — `escapeRegex` and
  `createMarkerRegex` are moved here verbatim from `discover-orphan-filter.mts`
  and imported by both helpers instead of being duplicated. The orphan
  filter's behavior is unchanged (`createMarkerRegex` keeps its
  detection-only shape).

Callers updated: the CLI block resolves the prefix once and feeds both the
search resolver and the extraction option; `evaluateDiscoverReadiness` passes
its resolved prefix into the blocked-by extraction.

## Tests

`tests/discover-readiness-check.test.mts` keeps the default-prefix case and
adds: a custom-prefix extraction case, a regex-metacharacter prefix case
(proves escaping — the unescaped prefix would be an invalid regex and throw),
a `buildRoadmapMarkerSearchQuery` case (prefix threads literally and
unescaped), and an end-to-end `evaluateDiscoverReadiness` case threading a
custom prefix through blocked-by extraction into roadmap-id resolution.
`pnpm test` (1339), `pnpm run lint:minimum`, and `pnpm run build` all pass.

## Non-goals

Four sibling modules (`autopilot-suitability`, `discover-roadmap-graph`,
`effort`, `idd-doctor`) still carry their own private `escapeRegex`.
Consolidating all of them is intentionally out of scope for this issue,
which is narrowly about the two `discover-readiness-check` paths.

Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RULXEb2aFJRDichpPAcG99
