### PR TITLE
fix(idd): harden external-check-waiver consume-side gate

### DIFF
--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -197,6 +197,7 @@ export function collectPreMergeReadiness(argv) {
   }
   const forcedHandoffPermissionCache = new Map();
   const waivableCheckSelectors = readWaivableCheckSelectors();
+  const externalCheckWaiverMaxValidity = readExternalCheckWaiverMaxValidity();
   const summary = buildPreMergeReadinessSummary(
     {
       prHeadSha,
@@ -231,6 +232,7 @@ export function collectPreMergeReadiness(argv) {
       pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
       capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
       waivableCheckSelectors,
+      externalCheckWaiverMaxValidity,
       forcedHandoffEnabled,
       expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
       prFirstCommitAt,
@@ -793,6 +795,20 @@ function readWaivableCheckSelectors() {
     ];
   } catch {
     return [];
+  }
+}
+// Configured external-check waiver validity window (`ciGate.
+// externalCheckWaivers.maxValidity`). The consume side re-enforces it so a
+// waiver whose `expiresAt - createdAt` outlives the policy window cannot count
+// as valid. `normalizePolicyConfig` already defaults this to `PT24H`; an absent
+// or unreadable config falls back to the same authoring default.
+function readExternalCheckWaiverMaxValidity() {
+  try {
+    return normalizePolicyConfig(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+    ).ciGate.externalCheckWaivers.maxValidity;
+  } catch {
+    return 'PT24H';
   }
 }
 function loadIddConfig() {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -5,7 +5,10 @@
 // generated .mjs. See docs/typescript-sources.md.
 import { Buffer } from 'node:buffer';
 import { normalizeAdvisoryWaitRuntimeOptions } from './advisory-wait-policy.mjs';
-import { getReviewEscalationChangesRequestedPolicy } from './policy-helpers.mjs';
+import {
+  getReviewEscalationChangesRequestedPolicy,
+  parseIsoDurationToMs,
+} from './policy-helpers.mjs';
 
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
 const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
@@ -555,12 +558,14 @@ export function summarizeExternalCheckWaivers(
     trustedMarkerLogins = [],
     now = '',
     waivableSelectors = null,
+    maxValidity = '',
   } = {},
 ) {
   const trustedSet = new Set(normalizeTrustedMarkerLogins(trustedMarkerLogins));
   const nowMs = isValidIsoTimestamp(now) ? new Date(now).getTime() : Date.now();
   const headShaLower = String(prHeadSha).toLowerCase();
   const activeClaimLower = String(activeClaimId);
+  const maxValidityMs = parseIsoDurationToMs(maxValidity);
   const valid = [];
   const expired = [];
   const wrongHead = [];
@@ -593,7 +598,9 @@ export function summarizeExternalCheckWaivers(
       });
       continue;
     }
-    if (headShaLower && parsed.headSha !== headShaLower) {
+    // Fail closed on an empty head SHA: an unbound waiver must never ride
+    // along when the gate cannot prove it targets the current PR HEAD.
+    if (!headShaLower || parsed.headSha !== headShaLower) {
       wrongHead.push({
         authorLogin,
         checkSelector: parsed.checkSelector,
@@ -601,7 +608,10 @@ export function summarizeExternalCheckWaivers(
       });
       continue;
     }
-    if (activeClaimLower && parsed.claimId !== activeClaimLower) {
+    // Fail closed on an empty active claim: when no claim resolves at the gate
+    // (`activeClaimLower === ''`), a waiver cannot be bound to an owner and is
+    // rejected rather than passing unbound.
+    if (!activeClaimLower || parsed.claimId !== activeClaimLower) {
       wrongClaim.push({
         authorLogin,
         checkSelector: parsed.checkSelector,
@@ -617,6 +627,25 @@ export function summarizeExternalCheckWaivers(
         expiresAt: parsed.expiresAt,
       });
       continue;
+    }
+    // Re-enforce the configured maxValidity window at consume time. Authoring
+    // already clamps `expiresAt - createdAt` (planExternalCheckWaiver's
+    // withinMaxValidity), but a hand-edited or policy-drifted marker can still
+    // carry an over-long window, so the shared merge gate re-checks it and
+    // fails closed when the creation timestamp is unknown (`createdAt: 'none'`).
+    if (typeof maxValidityMs === 'number' && Number.isFinite(maxValidityMs)) {
+      const createdMs = new Date(parsed.createdAt).getTime();
+      if (
+        !Number.isFinite(createdMs) ||
+        expiresMs - createdMs > maxValidityMs
+      ) {
+        expired.push({
+          authorLogin,
+          checkSelector: parsed.checkSelector,
+          expiresAt: parsed.expiresAt,
+        });
+        continue;
+      }
     }
     // When the policy declares its waivable surface, a valid waiver still only
     // counts when its selector can name a configured-waivable check; otherwise
@@ -3612,6 +3641,7 @@ export function buildPreMergeReadinessSummary(
     trustedMarkerLogins,
     now,
     waivableSelectors: waivableCheckSelectors,
+    maxValidity: options.externalCheckWaiverMaxValidity ?? '',
   });
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
     waivers: waiverEvidence,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -376,6 +376,7 @@ export function collectPreMergeReadiness(
   }
   const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
   const waivableCheckSelectors = readWaivableCheckSelectors();
+  const externalCheckWaiverMaxValidity = readExternalCheckWaiverMaxValidity();
 
   const summary = buildPreMergeReadinessSummary(
     {
@@ -411,6 +412,7 @@ export function collectPreMergeReadiness(
       pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
       capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
       waivableCheckSelectors,
+      externalCheckWaiverMaxValidity,
       forcedHandoffEnabled,
       expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
       prFirstCommitAt,
@@ -1066,6 +1068,21 @@ function readWaivableCheckSelectors(): {
     ];
   } catch {
     return [];
+  }
+}
+
+// Configured external-check waiver validity window (`ciGate.
+// externalCheckWaivers.maxValidity`). The consume side re-enforces it so a
+// waiver whose `expiresAt - createdAt` outlives the policy window cannot count
+// as valid. `normalizePolicyConfig` already defaults this to `PT24H`; an absent
+// or unreadable config falls back to the same authoring default.
+function readExternalCheckWaiverMaxValidity(): string {
+  try {
+    return normalizePolicyConfig(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+    ).ciGate.externalCheckWaivers.maxValidity;
+  } catch {
+    return 'PT24H';
   }
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -6,7 +6,10 @@
 
 import { Buffer } from 'node:buffer';
 import { normalizeAdvisoryWaitRuntimeOptions } from './advisory-wait-policy.mts';
-import { getReviewEscalationChangesRequestedPolicy } from './policy-helpers.mts';
+import {
+  getReviewEscalationChangesRequestedPolicy,
+  parseIsoDurationToMs,
+} from './policy-helpers.mts';
 
 // ---------------------------------------------------------------------------
 // Structural input shapes (GitHub REST/GraphQL payloads as consumed here).
@@ -1135,18 +1138,25 @@ export function summarizeExternalCheckWaivers(
     trustedMarkerLogins = [],
     now = '',
     waivableSelectors = null,
+    maxValidity = '',
   }: {
     prHeadSha?: string;
     activeClaimId?: unknown;
     trustedMarkerLogins?: unknown[];
     now?: string;
     waivableSelectors?: { selector?: unknown; matchMode?: unknown }[] | null;
+    // Configured `ciGate.externalCheckWaivers.maxValidity` (ISO-8601 duration).
+    // An empty/unparseable value leaves the consume-side window check off, so
+    // direct callers that omit it keep the legacy behavior; the F2/F3 gate
+    // always threads the policy value (default `PT24H`).
+    maxValidity?: string;
   } = {},
 ): ExternalCheckWaiverEvidence {
   const trustedSet = new Set(normalizeTrustedMarkerLogins(trustedMarkerLogins));
   const nowMs = isValidIsoTimestamp(now) ? new Date(now).getTime() : Date.now();
   const headShaLower = String(prHeadSha).toLowerCase();
   const activeClaimLower = String(activeClaimId);
+  const maxValidityMs = parseIsoDurationToMs(maxValidity);
 
   const valid: ExternalCheckWaiverEvidence['valid'] = [];
   const expired: ExternalCheckWaiverEvidence['expired'] = [];
@@ -1185,7 +1195,9 @@ export function summarizeExternalCheckWaivers(
       continue;
     }
 
-    if (headShaLower && parsed.headSha !== headShaLower) {
+    // Fail closed on an empty head SHA: an unbound waiver must never ride
+    // along when the gate cannot prove it targets the current PR HEAD.
+    if (!headShaLower || parsed.headSha !== headShaLower) {
       wrongHead.push({
         authorLogin,
         checkSelector: parsed.checkSelector,
@@ -1194,7 +1206,10 @@ export function summarizeExternalCheckWaivers(
       continue;
     }
 
-    if (activeClaimLower && parsed.claimId !== activeClaimLower) {
+    // Fail closed on an empty active claim: when no claim resolves at the gate
+    // (`activeClaimLower === ''`), a waiver cannot be bound to an owner and is
+    // rejected rather than passing unbound.
+    if (!activeClaimLower || parsed.claimId !== activeClaimLower) {
       wrongClaim.push({
         authorLogin,
         checkSelector: parsed.checkSelector,
@@ -1211,6 +1226,26 @@ export function summarizeExternalCheckWaivers(
         expiresAt: parsed.expiresAt,
       });
       continue;
+    }
+
+    // Re-enforce the configured maxValidity window at consume time. Authoring
+    // already clamps `expiresAt - createdAt` (planExternalCheckWaiver's
+    // withinMaxValidity), but a hand-edited or policy-drifted marker can still
+    // carry an over-long window, so the shared merge gate re-checks it and
+    // fails closed when the creation timestamp is unknown (`createdAt: 'none'`).
+    if (typeof maxValidityMs === 'number' && Number.isFinite(maxValidityMs)) {
+      const createdMs = new Date(parsed.createdAt).getTime();
+      if (
+        !Number.isFinite(createdMs) ||
+        expiresMs - createdMs > maxValidityMs
+      ) {
+        expired.push({
+          authorLogin,
+          checkSelector: parsed.checkSelector,
+          expiresAt: parsed.expiresAt,
+        });
+        continue;
+      }
     }
 
     // When the policy declares its waivable surface, a valid waiver still only
@@ -4616,6 +4651,11 @@ export function buildPreMergeReadinessSummary(
     waivableCheckSelectors?:
       | { selector?: unknown; matchMode?: unknown }[]
       | null;
+    // Configured `ciGate.externalCheckWaivers.maxValidity` (ISO-8601 duration),
+    // threaded to the consume-side waiver window check. Omitted by unit callers
+    // (window check off); `collectPreMergeReadiness` always sources the policy
+    // value (default `PT24H`).
+    externalCheckWaiverMaxValidity?: string;
   } = {},
 ) {
   const now = String(options.now ?? '');
@@ -4741,6 +4781,7 @@ export function buildPreMergeReadinessSummary(
     trustedMarkerLogins,
     now,
     waivableSelectors: waivableCheckSelectors,
+    maxValidity: options.externalCheckWaiverMaxValidity ?? '',
   });
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
     waivers: waiverEvidence,

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -3082,6 +3082,130 @@ test('summarizeExternalCheckWaivers: mixed valid, expired, and wrongClaim in sep
   assert.equal(result.wrongClaim.length, 1, 'one wrong-claim waiver');
 });
 
+test('summarizeExternalCheckWaivers: an empty active claim fails closed to wrongClaim', () => {
+  const head = 'a'.repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: 'claim-123' });
+  const comment = {
+    body,
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  // No active claim resolves at the gate (`activeClaimId === ''`); the
+  // otherwise-matching waiver must be rejected, not pass unbound.
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: '',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T00:00:00Z',
+  });
+  assert.equal(result.valid.length, 0, 'unbound waiver must not be valid');
+  assert.equal(result.wrongClaim.length, 1);
+});
+
+test('summarizeExternalCheckWaivers: an empty head SHA fails closed to wrongHead', () => {
+  const head = 'a'.repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: 'claim-123' });
+  const comment = {
+    body,
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  // No head SHA is known at the gate; the waiver cannot be bound to the
+  // current PR HEAD and must be rejected.
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: '',
+    activeClaimId: 'claim-123',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T00:00:00Z',
+  });
+  assert.equal(result.valid.length, 0, 'unbound waiver must not be valid');
+  assert.equal(result.wrongHead.length, 1);
+});
+
+test('summarizeExternalCheckWaivers: a window longer than maxValidity is rejected as expired', () => {
+  const head = 'a'.repeat(40);
+  // 48h validity window (created → expires), still in the future vs `now` so
+  // the ordinary already-expired check passes and the new window check fires.
+  const body = makeWaiverComment({
+    headSha: head,
+    claimId: 'claim-123',
+    expiresAt: '2026-05-19T00:00:00Z',
+  });
+  const comment = {
+    body,
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  const opts = {
+    prHeadSha: head,
+    activeClaimId: 'claim-123',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T01:00:00Z',
+  };
+  // Off by default: the window check does not fire, so the waiver is valid.
+  assert.equal(
+    summarizeExternalCheckWaivers([comment], opts).valid.length,
+    1,
+    'window check stays off when maxValidity is omitted',
+  );
+  // On: the 48h window exceeds PT24H, so the same waiver is now rejected.
+  const gated = summarizeExternalCheckWaivers([comment], {
+    ...opts,
+    maxValidity: 'PT24H',
+  });
+  assert.equal(gated.valid.length, 0, 'over-long window must not be valid');
+  assert.equal(gated.expired.length, 1);
+});
+
+test('summarizeExternalCheckWaivers: a window within maxValidity stays valid', () => {
+  const head = 'a'.repeat(40);
+  // 12h window, under the PT24H policy ceiling.
+  const body = makeWaiverComment({
+    headSha: head,
+    claimId: 'claim-123',
+    expiresAt: '2026-05-17T12:00:00Z',
+  });
+  const comment = {
+    body,
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: 'claim-123',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T01:00:00Z',
+    maxValidity: 'PT24H',
+  });
+  assert.equal(result.valid.length, 1);
+  assert.equal(result.expired.length, 0);
+});
+
+test('summarizeExternalCheckWaivers: an unknown creation time fails closed to expired when maxValidity is set', () => {
+  const head = 'a'.repeat(40);
+  const body = makeWaiverComment({
+    headSha: head,
+    claimId: 'claim-123',
+    expiresAt: '2026-05-19T00:00:00Z',
+  });
+  // No created_at / createdAt on the comment → parsed.createdAt resolves to
+  // 'none', so the window cannot be measured and the gate fails closed.
+  const comment = { body, author: { login: 'kurone-kito' } };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: 'claim-123',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T01:00:00Z',
+    maxValidity: 'PT24H',
+  });
+  assert.equal(
+    result.valid.length,
+    0,
+    'unknown creation time must not be valid',
+  );
+  assert.equal(result.expired.length, 1);
+});
+
 test('summarizeExternalCheckWaivers: non-waiver comments are skipped without error', () => {
   const comments = [
     {


### PR DESCRIPTION
## Summary

`summarizeExternalCheckWaivers` (the F2/F3 merge-gate consume side) had two
checks looser than the authoring side, so a hand-edited or policy-drifted
external-check waiver could still land in the `valid` bucket:

- **Empty-value short-circuit.** The head-SHA and active-claim guards used
  `if (headShaLower && …)` / `if (activeClaimLower && …)`, so when no head or
  claim resolved at the gate the binding check was skipped and an *unbound*
  waiver passed. Both now fail closed (`!headShaLower || …` /
  `!activeClaimLower || …`), routing such markers to `wrongHead` / `wrongClaim`.
- **`maxValidity` not re-enforced at consume time.** Expiry was only checked as
  `expiresMs <= nowMs`, so a marker with an arbitrarily distant `expires:`
  outlived the policy window. The configured
  `ciGate.externalCheckWaivers.maxValidity` is now threaded from
  `pre-merge-readiness` into the function, which rejects a waiver whose
  `expiresAt - createdAt` exceeds the window — or whose creation timestamp is
  unknown — into `expired`.

Both are defense-in-depth (the marker author must already be a trusted actor),
but fail-closed is the right posture for a shared merge gate.

## Notes

- The window check is **opt-in**: direct callers that omit `maxValidity` keep
  the legacy behavior, so existing unit tests are unaffected; only the live
  F2/F3 gate (`collectPreMergeReadiness`) always sources the policy value
  (default `PT24H`).
- The over-long-window and unknown-creation-time rejections reuse the existing
  `expired` bucket (no schema change). The pre-merge instruction already routes
  non-empty `expired` waivers as suspicious context that must not be treated as
  valid, so no instruction-file change was needed.
- Source-of-truth `.mts` edited; `scripts/*.mjs` regenerated via
  `pnpm run build` and committed.

## Test

- `pnpm test` (1340 pass) and `pnpm run lint:minimum` green.
- New consume-side cases: empty `activeClaimId` → `wrongClaim`; empty
  `prHeadSha` → `wrongHead`; over-`maxValidity` window → `expired` (with a
  gate-off/on contrast); within-window → `valid`; unknown `createdAt` +
  `maxValidity` → `expired`.

Closes #1077
