### PR TITLE
feat(idd): register minimize-superseded-markers in the runtime manifest

### DIFF
--- a/bin/idd-minimize-superseded-markers.mjs
+++ b/bin/idd-minimize-superseded-markers.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-minimize-superseded-markers.mts
+//
+// The bin/idd-minimize-superseded-markers.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/minimize-superseded-markers.mjs');

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "idd-live-status-digest": "./bin/idd-live-status-digest.mjs",
     "idd-merge-execute": "./bin/idd-merge-execute.mjs",
     "idd-merged-pr-feedback-sweep": "./bin/idd-merged-pr-feedback-sweep.mjs",
+    "idd-minimize-superseded-markers": "./bin/idd-minimize-superseded-markers.mjs",
     "idd-phase-id-resolver": "./bin/idd-phase-id-resolver.mjs",
     "idd-post-idd-marker": "./bin/idd-post-idd-marker.mjs",
     "idd-pre-merge-readiness": "./bin/idd-pre-merge-readiness.mjs",

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -271,6 +271,15 @@ const HELPER_COMMANDS = [
     contractPaths: ['schemas/idd-merge-execute.schema.json'],
   },
   {
+    id: 'minimize-superseded-markers',
+    scriptName: 'idd:minimize-superseded-markers',
+    binName: 'idd-minimize-superseded-markers',
+    entryPath: 'scripts/minimize-superseded-markers.mjs',
+    vendoredCommand: 'node scripts/minimize-superseded-markers.mjs',
+    description:
+      'Minimize superseded claim-chain or resolved review markers as OUTDATED/RESOLVED, gated by trusted marker author.',
+  },
+  {
     id: 'phase-id-resolver',
     scriptName: 'idd:phase-id-resolver',
     binName: 'idd-phase-id-resolver',

--- a/src/bin/idd-minimize-superseded-markers.mts
+++ b/src/bin/idd-minimize-superseded-markers.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-minimize-superseded-markers.mts
+//
+// The bin/idd-minimize-superseded-markers.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/minimize-superseded-markers.mjs');

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -343,6 +343,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
     contractPaths: ['schemas/idd-merge-execute.schema.json'],
   },
   {
+    id: 'minimize-superseded-markers',
+    scriptName: 'idd:minimize-superseded-markers',
+    binName: 'idd-minimize-superseded-markers',
+    entryPath: 'scripts/minimize-superseded-markers.mjs',
+    vendoredCommand: 'node scripts/minimize-superseded-markers.mjs',
+    description:
+      'Minimize superseded claim-chain or resolved review markers as OUTDATED/RESOLVED, gated by trusted marker author.',
+  },
+  {
     id: 'phase-id-resolver',
     scriptName: 'idd:phase-id-resolver',
     binName: 'idd-phase-id-resolver',

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -561,6 +567,139 @@ test("every manifest helper binName is exposed in package.json's bin map", () =>
       bin[command.binName],
       `./bin/${command.binName}.mjs`,
       `package.json bin map must expose ${command.binName} as ./bin/${command.binName}.mjs`,
+    );
+  }
+});
+
+const INSTRUCTIONS_DIR = join(REPO_ROOT, '.github/instructions');
+
+function readInstructionFiles(): { name: string; source: string }[] {
+  return readdirSync(INSTRUCTIONS_DIR)
+    .filter((name) => name.endsWith('.instructions.md'))
+    .map((name) => ({
+      name,
+      source: readFileSync(join(INSTRUCTIONS_DIR, name), 'utf8'),
+    }));
+}
+
+// Collect every helper the instruction files tell adopters to RUN as
+// `node scripts/<name>.mjs`. That runnable-invocation form is the scoped signal
+// for a "documented CLI adopter helper": it deliberately excludes shared
+// libraries that appear only as bare `scripts/<name>.mjs` import/function
+// mentions (protocol-helpers, policy-helpers) and dev/CI tooling the
+// instructions never invoke (build-ts, sync-docs, verify-workshop-integrity,
+// merged-pr-feedback-sweep).
+function collectDocumentedCliAdopterHelpers(): Set<string> {
+  const referenced = new Set<string>();
+  for (const { source } of readInstructionFiles()) {
+    for (const match of source.matchAll(
+      /\bnode (scripts\/[a-z0-9-]+\.mjs)\b/g,
+    )) {
+      referenced.add(match[1]);
+    }
+  }
+  return referenced;
+}
+
+test('every documented CLI adopter helper (node scripts/<name>.mjs in instructions) is registered', () => {
+  // A documented CLI adopter helper that is neither registered in HELPER_COMMANDS
+  // nor imported by a registered helper is silently absent from vendored-node
+  // `managedFiles`, so an adopter copying that list never receives it and the
+  // documented `node scripts/<name>.mjs` invocation fails. Guards the
+  // kurone-kito/idd-skill#1084 gap where minimize-superseded-markers was a real
+  // invocable, instruction-documented CLI yet unregistered (it imports only node
+  // builtins, so nothing pulled it into the import closure either).
+  const referenced = collectDocumentedCliAdopterHelpers();
+
+  // Sanity: the scan still finds the documented-helper surface, so this guard
+  // cannot silently pass if the instruction invocation form is restructured.
+  assert.ok(
+    referenced.size > 0,
+    'expected the instruction files to document at least one `node scripts/<name>.mjs` adopter helper',
+  );
+  // Anchor on the #1084 subject helper so the guard stays bound to the regression
+  // it closes; idd-claim / idd-review-snapshot / idd-advisory-wait document it.
+  assert.ok(
+    referenced.has('scripts/minimize-superseded-markers.mjs'),
+    'expected the instruction files to document `node scripts/minimize-superseded-markers.mjs`',
+  );
+
+  const { commandCatalog } = buildHelperRuntimeManifest({
+    targetRoot: REPO_ROOT,
+  });
+  const registeredEntryPaths = new Set(
+    commandCatalog.map((command) => command.entryPath),
+  );
+  const unregistered = [...referenced]
+    .filter((entryPath) => !registeredEntryPaths.has(entryPath))
+    .sort();
+
+  assert.deepEqual(
+    unregistered,
+    [],
+    `documented CLI adopter helpers missing from HELPER_COMMANDS: ${unregistered.join(', ')}`,
+  );
+});
+
+test('the registration guard scopes out instruction-referenced libraries and dev tooling', () => {
+  // Pins why the guard above does not false-positive: shared libraries are
+  // referenced in the instructions as bare `scripts/<name>.mjs` paths (import /
+  // function sources) but are never `node`-invoked, so they stay out of the
+  // documented-CLI domain and out of HELPER_COMMANDS — they reach vendored
+  // `managedFiles` transitively through the registered helpers that import them.
+  const allInstructions = readInstructionFiles()
+    .map((file) => file.source)
+    .join('\n');
+  const documentedCliHelpers = collectDocumentedCliAdopterHelpers();
+  const { commandCatalog } = buildHelperRuntimeManifest({
+    targetRoot: REPO_ROOT,
+  });
+  const registeredEntryPaths = new Set(
+    commandCatalog.map((command) => command.entryPath),
+  );
+
+  for (const library of [
+    'scripts/protocol-helpers.mjs',
+    'scripts/policy-helpers.mjs',
+  ]) {
+    assert.ok(
+      allInstructions.includes(library),
+      `expected the instruction files to reference the ${library} library`,
+    );
+    assert.equal(
+      allInstructions.includes(`node ${library}`),
+      false,
+      `${library} is a library and must not be documented as a runnable node command`,
+    );
+    assert.equal(
+      documentedCliHelpers.has(library),
+      false,
+      `${library} must not be treated as a documented CLI adopter helper`,
+    );
+    assert.equal(
+      registeredEntryPaths.has(library),
+      false,
+      `${library} is a library and must not be registered in HELPER_COMMANDS`,
+    );
+  }
+
+  // Dev/CI tooling and the maintainer-only post-merge sweep are likewise never
+  // adopter-run commands, so they stay unregistered too.
+  for (const nonAdopterTool of [
+    'scripts/build-ts.mjs',
+    'scripts/sync-docs.mjs',
+    'scripts/verify-workshop-integrity.mjs',
+    'scripts/merged-pr-feedback-sweep.mjs',
+  ]) {
+    assert.equal(
+      documentedCliHelpers.has(nonAdopterTool),
+      false,
+      `${nonAdopterTool} is not an adopter CLI helper and must not be in the documented domain`,
+    );
+    assert.equal(
+      registeredEntryPaths.has(nonAdopterTool),
+      false,
+      `${nonAdopterTool} is not an adopter CLI helper and must not be registered in HELPER_COMMANDS`,
     );
   }
 });

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -592,8 +592,11 @@ function readInstructionFiles(): { name: string; source: string }[] {
 function collectDocumentedCliAdopterHelpers(): Set<string> {
   const referenced = new Set<string>();
   for (const { source } of readInstructionFiles()) {
+    // Tolerate any inter-token whitespace (tabs, runs of spaces, a wrapped
+    // line) between `node` and the script path so a harmless reformat of an
+    // instruction snippet cannot silently shrink the guard's domain.
     for (const match of source.matchAll(
-      /\bnode (scripts\/[a-z0-9-]+\.mjs)\b/g,
+      /\bnode\s+(scripts\/[a-z0-9-]+\.mjs)\b/g,
     )) {
       referenced.add(match[1]);
     }
@@ -666,11 +669,9 @@ test('the registration guard scopes out instruction-referenced libraries and dev
       allInstructions.includes(library),
       `expected the instruction files to reference the ${library} library`,
     );
-    assert.equal(
-      allInstructions.includes(`node ${library}`),
-      false,
-      `${library} is a library and must not be documented as a runnable node command`,
-    );
+    // The shared scan uses the same whitespace-tolerant `node\s+scripts/...`
+    // regex, so this also proves the library is never written as a runnable
+    // node command (only as a bare import/function-source path).
     assert.equal(
       documentedCliHelpers.has(library),
       false,


### PR DESCRIPTION
## Summary

`minimize-superseded-markers` is a real invocable CLI helper that the IDD
instructions tell adopters to run directly (`node scripts/minimize-superseded-markers.mjs ...`
in idd-claim, idd-review-snapshot, idd-advisory-wait), but it was **not** registered
in `HELPER_COMMANDS` (`src/scripts/helper-runtime-manifest.mts`), had no bin shim or
`package.json` bin entry, and imports only node builtins — so the import-closure walk
that derives vendored-node `managedFiles` never included it. A vendored-node adopter
copying `managedFiles` never received the file, and the documented invocation failed.

This PR closes that gap:

- **Register** the helper in `HELPER_COMMANDS` (alphabetical by `id`, between
  `merge-execute` and `phase-id-resolver`; no `contractPaths` — it has no schema and
  reads only the optional adopter-owned `.github/idd/config.json`). Its file now lands
  in vendored-node `managedFiles`.
- **Bin shim + bin entry**: add `src/bin/idd-minimize-superseded-markers.mts` (+ the
  generated `bin/idd-minimize-superseded-markers.mjs`) and the matching `package.json`
  bin entry. The pre-existing bin-map agreement test then enforces the shim.
- **Scoped completeness guard** in `tests/helper-runtime-manifest.test.mts`: its domain
  is every `node scripts/<name>.mjs` runnable invocation in
  `.github/instructions/*.instructions.md` — the form the instructions tell adopters to
  run — and it asserts each such helper is registered, so a future documented-but-
  unregistered CLI fails the build. The guard is **scoped**: library mentions
  (`protocol-helpers`, `policy-helpers` — referenced as bare paths, never `node`-invoked)
  and dev/CI tooling (`build-ts`, `sync-docs`, `verify-workshop-integrity`,
  `merged-pr-feedback-sweep`) stay outside the domain, with a second test pinning those
  exclusions so the guard cannot false-positive.

## Non-goals

`authoring-label-guard` stays an **unregistered library**: the adopter report that also
flagged it does not hold on current `main` — it is imported by the registered
`discover-orphan-filter` / `discover-readiness-check`, so it already reaches
`managedFiles` transitively.

## Verification

`pnpm run build` (artifacts regenerated + committed), `pnpm test` (1340 pass), and
`pnpm run lint:minimum` (typecheck, build:check drift, audit-docs generated-pair check,
bin-map agreement, the new guard, cspell, markdownlint) all pass.

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)
