### PR TITLE
fix(idd): ignore code-quoted roadmap-id markers when classifying issues

### DIFF
--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -848,16 +848,21 @@ function stripMarkdownCodeRegions(text) {
     const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
     if (openMatch) {
       const marker = openMatch[1];
-      const onlyWhitespaceAfter = /^\s*$/.test(openMatch[2]);
+      const info = openMatch[2];
+      const fenceChar = marker[0];
       if (fence === null) {
-        fence = { char: marker[0], length: marker.length };
-        out.push('');
-        continue;
-      }
-      if (
-        marker[0] === fence.char &&
+        // CommonMark §4.5: a backtick-fence opener's info string may not
+        // contain a backtick (that would be ambiguous with a close or inline
+        // code), so such a line is not a fence opener and stays content.
+        if (fenceChar !== '`' || !info.includes('`')) {
+          fence = { char: fenceChar, length: marker.length };
+          out.push('');
+          continue;
+        }
+      } else if (
+        fenceChar === fence.char &&
         marker.length >= fence.length &&
-        onlyWhitespaceAfter
+        /^\s*$/.test(info)
       ) {
         fence = null;
         out.push('');

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -828,6 +828,54 @@ function buildCommentLoader(owner, repo) {
 export function parseClaimStaleAgeMs(value) {
   return parseIsoDurationToMs(String(value ?? '').trim());
 }
+/**
+ * Strip Markdown code regions (fenced blocks and inline code spans) from a body
+ * before scanning it for a roadmap-id marker. A genuine roadmap marker is a raw
+ * HTML comment GitHub renders invisibly, never inside a code span or fence, so
+ * an example marker an execution-leaf issue merely *quotes* in code (e.g. an
+ * issue about the marker system) must not be read as roadmap identity. The
+ * marker is itself an HTML comment, so HTML comments are deliberately NOT
+ * stripped here — only code regions are. Masked regions keep their line count
+ * and surrounding text so a real marker elsewhere in the body still matches.
+ */
+function stripMarkdownCodeRegions(text) {
+  // Fenced blocks (``` or ~~~), tracking the fence char + length so a longer
+  // opening fence is not closed by a shorter inner fence (CommonMark §4.5).
+  const lines = text.split(/\r?\n/);
+  const out = [];
+  let fence = null;
+  for (const line of lines) {
+    const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
+    if (openMatch) {
+      const marker = openMatch[1];
+      const onlyWhitespaceAfter = /^\s*$/.test(openMatch[2]);
+      if (fence === null) {
+        fence = { char: marker[0], length: marker.length };
+        out.push('');
+        continue;
+      }
+      if (
+        marker[0] === fence.char &&
+        marker.length >= fence.length &&
+        onlyWhitespaceAfter
+      ) {
+        fence = null;
+        out.push('');
+        continue;
+      }
+    }
+    out.push(fence === null ? line : '');
+  }
+  // Inline code spans (`...`, ``...``): mask the inner content so a quoted
+  // marker no longer matches, keeping the backticks and surrounding text.
+  return out
+    .join('\n')
+    .replace(
+      /(`+)((?:(?!\1)[\s\S])+?)\1/g,
+      (_match, ticks, inner) =>
+        `${ticks}${inner.replace(/[^\r\n]/g, ' ')}${ticks}`,
+    );
+}
 export function extractRoadmapMarkerId(
   body,
   markerPrefix = DEFAULT_MARKER_PREFIX,
@@ -836,7 +884,7 @@ export function extractRoadmapMarkerId(
     `<!--\\s*${escapeRegex(markerPrefix)}-roadmap-id:\\s*([^\\s>]+)\\s*-->`,
     'i',
   );
-  const match = regex.exec(String(body ?? ''));
+  const match = regex.exec(stripMarkdownCodeRegions(String(body ?? '')));
   return match ? match[1] : '';
 }
 export function classifyIssue(issue, markerPrefix = DEFAULT_MARKER_PREFIX) {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1245,6 +1245,55 @@ export function parseClaimStaleAgeMs(value: unknown): number | null {
   return parseIsoDurationToMs(String(value ?? '').trim());
 }
 
+/**
+ * Strip Markdown code regions (fenced blocks and inline code spans) from a body
+ * before scanning it for a roadmap-id marker. A genuine roadmap marker is a raw
+ * HTML comment GitHub renders invisibly, never inside a code span or fence, so
+ * an example marker an execution-leaf issue merely *quotes* in code (e.g. an
+ * issue about the marker system) must not be read as roadmap identity. The
+ * marker is itself an HTML comment, so HTML comments are deliberately NOT
+ * stripped here — only code regions are. Masked regions keep their line count
+ * and surrounding text so a real marker elsewhere in the body still matches.
+ */
+function stripMarkdownCodeRegions(text: string): string {
+  // Fenced blocks (``` or ~~~), tracking the fence char + length so a longer
+  // opening fence is not closed by a shorter inner fence (CommonMark §4.5).
+  const lines = text.split(/\r?\n/);
+  const out: string[] = [];
+  let fence: { char: string; length: number } | null = null;
+  for (const line of lines) {
+    const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
+    if (openMatch) {
+      const marker = openMatch[1];
+      const onlyWhitespaceAfter = /^\s*$/.test(openMatch[2]);
+      if (fence === null) {
+        fence = { char: marker[0], length: marker.length };
+        out.push('');
+        continue;
+      }
+      if (
+        marker[0] === fence.char &&
+        marker.length >= fence.length &&
+        onlyWhitespaceAfter
+      ) {
+        fence = null;
+        out.push('');
+        continue;
+      }
+    }
+    out.push(fence === null ? line : '');
+  }
+  // Inline code spans (`...`, ``...``): mask the inner content so a quoted
+  // marker no longer matches, keeping the backticks and surrounding text.
+  return out
+    .join('\n')
+    .replace(
+      /(`+)((?:(?!\1)[\s\S])+?)\1/g,
+      (_match, ticks: string, inner: string) =>
+        `${ticks}${inner.replace(/[^\r\n]/g, ' ')}${ticks}`,
+    );
+}
+
 export function extractRoadmapMarkerId(
   body: unknown,
   markerPrefix: string = DEFAULT_MARKER_PREFIX,
@@ -1253,7 +1302,7 @@ export function extractRoadmapMarkerId(
     `<!--\\s*${escapeRegex(markerPrefix)}-roadmap-id:\\s*([^\\s>]+)\\s*-->`,
     'i',
   );
-  const match = regex.exec(String(body ?? ''));
+  const match = regex.exec(stripMarkdownCodeRegions(String(body ?? '')));
   return match ? match[1] : '';
 }
 

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1265,16 +1265,21 @@ function stripMarkdownCodeRegions(text: string): string {
     const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
     if (openMatch) {
       const marker = openMatch[1];
-      const onlyWhitespaceAfter = /^\s*$/.test(openMatch[2]);
+      const info = openMatch[2];
+      const fenceChar = marker[0];
       if (fence === null) {
-        fence = { char: marker[0], length: marker.length };
-        out.push('');
-        continue;
-      }
-      if (
-        marker[0] === fence.char &&
+        // CommonMark §4.5: a backtick-fence opener's info string may not
+        // contain a backtick (that would be ambiguous with a close or inline
+        // code), so such a line is not a fence opener and stays content.
+        if (fenceChar !== '`' || !info.includes('`')) {
+          fence = { char: fenceChar, length: marker.length };
+          out.push('');
+          continue;
+        }
+      } else if (
+        fenceChar === fence.char &&
         marker.length >= fence.length &&
-        onlyWhitespaceAfter
+        /^\s*$/.test(info)
       ) {
         fence = null;
         out.push('');

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -75,6 +75,50 @@ Resolve #107
   );
 });
 
+test('ignores roadmap-id markers quoted inside code regions (#1083)', () => {
+  // The #1083 shape: an execution-leaf issue *about* the marker system that
+  // quotes the marker inside inline code. It must not read as roadmap identity.
+  // (#1083 quoted the marker with a literal `${marker}` value; the value is
+  // irrelevant here — what matters is that a marker inside code is ignored.)
+  const inlineQuoted = [
+    '## Background',
+    '',
+    'buildRoadmapMarkerResolver builds a query',
+    '`"<!-- idd-skill-roadmap-id: some-prefix -->"` — fixed prefix.',
+  ].join('\n');
+  assert.equal(extractRoadmapMarkerId(inlineQuoted), '');
+  assert.deepEqual(classifyIssue({ body: inlineQuoted, labels: [] }), {
+    kind: 'execution',
+    roadmapMarkerId: '',
+  });
+
+  // Same for a marker quoted inside a fenced code block.
+  const fencedQuoted = [
+    'Example marker:',
+    '',
+    '```html',
+    '<!-- idd-skill-roadmap-id: example -->',
+    '```',
+  ].join('\n');
+  assert.equal(extractRoadmapMarkerId(fencedQuoted), '');
+  assert.equal(
+    classifyIssue({ body: fencedQuoted, labels: [] }).kind,
+    'execution',
+  );
+
+  // A real raw-HTML-comment marker outside any code region still matches, and a
+  // real marker elsewhere in a body that also quotes one in code is still found.
+  assert.equal(
+    extractRoadmapMarkerId('<!-- idd-skill-roadmap-id: real -->'),
+    'real',
+  );
+  const mixed = [
+    '<!-- idd-skill-roadmap-id: real-root -->',
+    'and an example: `<!-- idd-skill-roadmap-id: nope -->`',
+  ].join('\n');
+  assert.equal(extractRoadmapMarkerId(mixed), 'real-root');
+});
+
 test('extractKeywordReferences parses blocked dependencies and multi-target lists', () => {
   const body = `
 Refs #201, #202

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -119,6 +119,26 @@ test('ignores roadmap-id markers quoted inside code regions (#1083)', () => {
   assert.equal(extractRoadmapMarkerId(mixed), 'real-root');
 });
 
+test('an invalid backtick fence opener does not mask a later roadmap marker', () => {
+  // CommonMark §4.5: a backtick-fence opener's info string may not contain a
+  // backtick, so this line is NOT a fence opener and must not blank the rest of
+  // the body — the real marker below it still resolves.
+  const body = [
+    '```js `not a fence`',
+    '<!-- idd-skill-roadmap-id: real -->',
+  ].join('\n');
+  assert.equal(extractRoadmapMarkerId(body), 'real');
+
+  // A tilde fence's info string MAY contain a backtick, so it is a real opener
+  // and does mask a quoted marker inside it.
+  const tildeFenced = [
+    '~~~ has`backtick',
+    '<!-- idd-skill-roadmap-id: hidden -->',
+    '~~~',
+  ].join('\n');
+  assert.equal(extractRoadmapMarkerId(tildeFenced), '');
+});
+
 test('extractKeywordReferences parses blocked dependencies and multi-target lists', () => {
   const body = `
 Refs #201, #202


### PR DESCRIPTION
## Summary

`extractRoadmapMarkerId` in `src/scripts/discover-roadmap-graph.mts` matched the
`<!-- {prefix}-roadmap-id: ... -->` marker against the **raw** issue body, so an
**execution-leaf** issue that merely _quotes_ the marker inside inline code or a
fenced block (e.g. an issue about the marker system) was classified as a
`roadmap` node and silently dropped from `executionCandidates`.

This was observed live on #1083, whose body contains
`` `"<!-- idd-skill-roadmap-id: ${marker} -->"` `` in inline code; the discover
helper classified it as `roadmap` with `roadmapMarkerId: "${marker}"`. A genuine
roadmap marker is always a raw HTML comment GitHub renders invisibly — never
inside a code span/fence — so stripping code regions before matching
distinguishes the two without affecting real roadmaps.

## Changes

- `src/scripts/discover-roadmap-graph.mts` — add `stripMarkdownCodeRegions`
  (fenced blocks + inline code spans, masking inner content; HTML comments are
  deliberately **not** stripped since the marker itself is one) and run
  `extractRoadmapMarkerId` against the stripped body. This also covers the
  `--all-roadmaps` marker-root re-confirmation, which uses the same function.
- `scripts/discover-roadmap-graph.mjs` — regenerated via `pnpm run build`.
- `tests/discover-roadmap-graph.test.mts` — regression test for the
  quoted-in-inline-code (#1083 shape) and quoted-in-fenced-block cases, plus
  confirmation that a real raw-HTML-comment marker (and a real marker alongside a
  code-quoted example) still matches.

## Verification

- `pnpm test` and `pnpm run lint:minimum` — green (incl. `build:check`).

Closes #1121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved roadmap marker detection so markers inside inline code or fenced code blocks are no longer mistaken for real values.
  * Real markers in plain text or HTML comments still work as expected, even when mixed with quoted examples.
* **Tests**
  * Added coverage for code-quoted markers and mixed-content issue bodies to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->