### PR TITLE
fix(idd): normalize [bot] suffix at the ack-only advisory-bot matchers

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1967,11 +1967,7 @@ export function buildActivitySnapshotSummary(
     dispositionAuthorLogins.delete(login);
   }
   const isAdvisoryBot = (login) =>
-    advisoryBotLogins.has(
-      String(login ?? '')
-        .trim()
-        .toLowerCase(),
-    );
+    isConfiguredAdvisoryBotLogin(login, advisoryBotLogins);
   const isDispositionAuthor = (login) =>
     dispositionAuthorLogins.has(
       String(login ?? '')
@@ -2579,10 +2575,9 @@ export function summarizeDispositionEvidenceForGate(
     // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
     return postDispositionBlockingFeedback.every(
       (comment) =>
-        advisoryBotLogins.has(
-          String(comment.author?.login ?? '')
-            .trim()
-            .toLowerCase(),
+        isConfiguredAdvisoryBotLogin(
+          comment.author?.login,
+          advisoryBotLogins,
         ) &&
         !isDispositionComment({ body: String(comment.body ?? '') }) &&
         !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
@@ -4559,8 +4554,23 @@ export function isGateAdvisoryBotLogin(login, advisoryBotLogins) {
   if (!token) {
     return false;
   }
-  if (isKnownReviewBot(token)) {
-    return true;
+  return (
+    isKnownReviewBot(token) ||
+    isConfiguredAdvisoryBotLogin(login, advisoryBotLogins)
+  );
+}
+// True when a login matches a **configured** `advisoryBotLogins` entry, with the
+// GitHub `[bot]` suffix normalized symmetrically via `advisoryBotIdentityToken`
+// on both the incoming login and each configured entry — so a custom bot matches
+// whether either side stores the suffixed (`my-bot[bot]`) or suffixless
+// (`my-bot`) form. Unlike `isGateAdvisoryBotLogin`, this does **not** also match
+// `isKnownReviewBot`: the advisory courtesy-ack carve-outs must recognize only
+// configured advisory bots, so a Copilot/known-review-bot ack is never
+// reclassified as a configured-advisory-bot ack. Fail-closed on an empty token.
+export function isConfiguredAdvisoryBotLogin(login, advisoryBotLogins) {
+  const token = advisoryBotIdentityToken(login);
+  if (!token) {
+    return false;
   }
   for (const configured of advisoryBotLogins) {
     if (advisoryBotIdentityToken(configured) === token) {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2847,11 +2847,7 @@ export function buildActivitySnapshotSummary(
     dispositionAuthorLogins.delete(login);
   }
   const isAdvisoryBot = (login: unknown) =>
-    advisoryBotLogins.has(
-      String(login ?? '')
-        .trim()
-        .toLowerCase(),
-    );
+    isConfiguredAdvisoryBotLogin(login, advisoryBotLogins);
   const isDispositionAuthor = (login: unknown) =>
     dispositionAuthorLogins.has(
       String(login ?? '')
@@ -3517,10 +3513,9 @@ export function summarizeDispositionEvidenceForGate(
     // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
     return postDispositionBlockingFeedback.every(
       (comment) =>
-        advisoryBotLogins.has(
-          String(comment.author?.login ?? '')
-            .trim()
-            .toLowerCase(),
+        isConfiguredAdvisoryBotLogin(
+          comment.author?.login,
+          advisoryBotLogins,
         ) &&
         !isDispositionComment({ body: String(comment.body ?? '') }) &&
         !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
@@ -5843,8 +5838,27 @@ export function isGateAdvisoryBotLogin(
   if (!token) {
     return false;
   }
-  if (isKnownReviewBot(token)) {
-    return true;
+  return (
+    isKnownReviewBot(token) ||
+    isConfiguredAdvisoryBotLogin(login, advisoryBotLogins)
+  );
+}
+
+// True when a login matches a **configured** `advisoryBotLogins` entry, with the
+// GitHub `[bot]` suffix normalized symmetrically via `advisoryBotIdentityToken`
+// on both the incoming login and each configured entry — so a custom bot matches
+// whether either side stores the suffixed (`my-bot[bot]`) or suffixless
+// (`my-bot`) form. Unlike `isGateAdvisoryBotLogin`, this does **not** also match
+// `isKnownReviewBot`: the advisory courtesy-ack carve-outs must recognize only
+// configured advisory bots, so a Copilot/known-review-bot ack is never
+// reclassified as a configured-advisory-bot ack. Fail-closed on an empty token.
+export function isConfiguredAdvisoryBotLogin(
+  login: unknown,
+  advisoryBotLogins: Set<string>,
+): boolean {
+  const token = advisoryBotIdentityToken(login);
+  if (!token) {
+    return false;
   }
   for (const configured of advisoryBotLogins) {
     if (advisoryBotIdentityToken(configured) === token) {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1860,6 +1860,63 @@ test('disposition evidence flags an ack-only-post-disposition resolved thread wi
   assert.equal(summary.soleCauseAckOnlyPostDisposition, true);
 });
 
+test('disposition evidence recognizes a post-disposition ack across the advisory-bot [bot] suffix (#1118)', () => {
+  // A custom advisory bot configured suffixless whose courtesy ack arrives
+  // suffixed (or vice-versa) must still be recognized as ack-only — the
+  // pre-#1118 raw Set.has() lookup missed it and forced a needless
+  // return-to-e1.
+  const make = (configLogin: string, ackAuthorLogin: string) =>
+    summarizeDispositionEvidenceForGate(
+      {
+        comments: [],
+        threads: [
+          {
+            id: 'thread-ack',
+            isResolved: true,
+            comments: {
+              pageInfo: { hasNextPage: false },
+              nodes: [
+                {
+                  author: { login: 'reviewer-a' },
+                  createdAt: '2026-05-12T00:00:00Z',
+                  body: 'please reconsider this',
+                },
+                {
+                  author: { login: 'idd-bot' },
+                  createdAt: '2026-05-12T00:30:00Z',
+                  body: '**Rejected** — verified: not applicable here',
+                },
+                {
+                  author: { login: ackAuthorLogin },
+                  createdAt: '2026-05-12T02:00:00Z',
+                  body: 'Thanks for confirming.',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        iddAgentLogins: ['idd-bot'],
+        advisoryBotLogins: [configLogin],
+        snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+      },
+    );
+
+  for (const [configLogin, ackAuthorLogin] of [
+    ['advisory-bot', 'advisory-bot[bot]'],
+    ['advisory-bot[bot]', 'advisory-bot'],
+  ] as const) {
+    const summary = make(configLogin, ackAuthorLogin);
+    assert.equal(
+      summary.missingThreads[0].ackOnlyPostDisposition,
+      true,
+      `config ${configLogin} should ack-classify ${ackAuthorLogin}`,
+    );
+    assert.equal(summary.soleCauseAckOnlyPostDisposition, true);
+  }
+});
+
 test('disposition evidence does not flag a resolved thread with substantive post-disposition feedback (#978)', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {

--- a/tests/protocol-helpers-advisory-bot-login.test.mts
+++ b/tests/protocol-helpers-advisory-bot-login.test.mts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
+  isConfiguredAdvisoryBotLogin,
   isGateAdvisoryBotLogin,
   normalizeTrustedMarkerLogins,
 } from '../src/scripts/protocol-helpers.mts';
@@ -53,4 +54,69 @@ test('isGateAdvisoryBotLogin rejects unconfigured and empty logins', () => {
   assert.equal(isGateAdvisoryBotLogin(undefined, config), false);
   // A bare `[bot]` reduces to an empty token and must not match.
   assert.equal(isGateAdvisoryBotLogin('[bot]', config), false);
+});
+
+test('isConfiguredAdvisoryBotLogin matches a custom bot across the [bot] suffix cross-product', () => {
+  // config stores the suffixless form
+  const suffixlessConfig = buildSet(['my-bot']);
+  assert.equal(isConfiguredAdvisoryBotLogin('my-bot', suffixlessConfig), true);
+  assert.equal(
+    isConfiguredAdvisoryBotLogin('my-bot[bot]', suffixlessConfig),
+    true,
+  );
+
+  // config stores the suffixed form
+  const suffixedConfig = buildSet(['my-bot[bot]']);
+  assert.equal(isConfiguredAdvisoryBotLogin('my-bot', suffixedConfig), true);
+  assert.equal(
+    isConfiguredAdvisoryBotLogin('my-bot[bot]', suffixedConfig),
+    true,
+  );
+
+  // case and surrounding whitespace are normalized like the gate callers expect
+  assert.equal(
+    isConfiguredAdvisoryBotLogin('  My-Bot[BOT] ', suffixlessConfig),
+    true,
+  );
+});
+
+test('isConfiguredAdvisoryBotLogin matches ONLY configured bots, not known review bots', () => {
+  // Unlike isGateAdvisoryBotLogin, the ack-only carve-out predicate must not
+  // fold in the CodeRabbit/Codex/Copilot defaults: a known-review-bot ack must
+  // never be reclassified as a configured-advisory-bot courtesy ack.
+  const empty = buildSet([]);
+  for (const login of [
+    'coderabbitai',
+    'coderabbitai[bot]',
+    'chatgpt-codex-connector[bot]',
+    'copilot-pull-request-reviewer[bot]',
+  ]) {
+    assert.equal(
+      isConfiguredAdvisoryBotLogin(login, empty),
+      false,
+      `known review bot must not match when unconfigured: ${login}`,
+    );
+    // isGateAdvisoryBotLogin still folds the same default in — the two
+    // predicates intentionally differ on exactly this class.
+    assert.equal(isGateAdvisoryBotLogin(login, empty), true);
+  }
+  // It does match a known review bot once that bot is explicitly configured.
+  assert.equal(
+    isConfiguredAdvisoryBotLogin(
+      'coderabbitai[bot]',
+      buildSet(['coderabbitai']),
+    ),
+    true,
+  );
+});
+
+test('isConfiguredAdvisoryBotLogin rejects unconfigured and empty logins', () => {
+  const config = buildSet(['my-bot']);
+  assert.equal(isConfiguredAdvisoryBotLogin('some-human', config), false);
+  assert.equal(isConfiguredAdvisoryBotLogin('other-bot[bot]', config), false);
+  assert.equal(isConfiguredAdvisoryBotLogin('', config), false);
+  assert.equal(isConfiguredAdvisoryBotLogin(null, config), false);
+  assert.equal(isConfiguredAdvisoryBotLogin(undefined, config), false);
+  // A bare `[bot]` reduces to an empty token and must not match.
+  assert.equal(isConfiguredAdvisoryBotLogin('[bot]', config), false);
 });

--- a/tests/review-snapshot.test.mts
+++ b/tests/review-snapshot.test.mts
@@ -358,6 +358,54 @@ test('classifies post-disposition advisory-bot comments as ack-only', () => {
   assert.equal(summary.effective.totalItemCount, 1);
 });
 
+test('ack-only classification matches a configured advisory bot across the [bot] suffix', () => {
+  // config stores one form, the bot's courtesy ack arrives in the other — the
+  // pre-#1118 raw Set.has() lookup missed this and broke the ack-only carve-out
+  // for a custom suffixless-configured bot.
+  const make = (configLogin: string, authorLogin: string) =>
+    buildActivitySnapshotSummary(
+      {
+        comments: [
+          {
+            id: 'C-1',
+            author: { login: 'idd-bot' },
+            body: '**Rejected** — rate-limit notice is not a completed review.',
+            createdAt: '2026-05-10T10:00:00Z',
+            updatedAt: '2026-05-10T10:00:00Z',
+          },
+          {
+            id: 'C-2',
+            author: { login: authorLogin },
+            body: 'Thanks for confirming!',
+            createdAt: '2026-05-10T09:00:00Z',
+            updatedAt: '2026-05-10T10:05:00Z',
+          },
+        ],
+        reviews: [],
+        threads: [],
+        checks: [],
+      },
+      {
+        trustedMarkerLogins: ['idd-bot'],
+        advisoryBotLogins: [configLogin],
+        advisoryBotLoginsSource: 'config',
+        dispositionAuthorLogins: ['idd-bot'],
+      },
+    );
+
+  for (const [configLogin, authorLogin] of [
+    ['advisory-bot', 'advisory-bot[bot]'],
+    ['advisory-bot[bot]', 'advisory-bot'],
+  ] as const) {
+    const summary = make(configLogin, authorLogin);
+    assert.deepEqual(
+      summary.ackOnly.items.map((item) => [item.kind, item.id]),
+      [['comment', 'C-2']],
+      `config ${configLogin} should ack-classify author ${authorLogin}`,
+    );
+  }
+});
+
 test('ack-only classification fails closed without config or dispositions', () => {
   const comments = [
     {


### PR DESCRIPTION
## Summary

Follow-up to #1080. Two ack-only sites in `src/scripts/protocol-helpers.mts`
still did the raw, un-normalized `advisoryBotLogins.has(login.trim().toLowerCase())`
lookup and carried the same `[bot]`-suffix asymmetry #1080 fixed for
`isGateAdvisoryBotLogin`:

- `buildActivitySnapshotSummary`'s `isAdvisoryBot` closure — drives the F2/F3
  review-currency `ackOnly` carve-out.
- `summarizeDispositionEvidenceForGate`'s post-disposition courtesy-ack check —
  drives `dispositionEvidence.soleCauseAckOnlyPostDisposition`.

A repository that configures a **custom** advisory bot with a **suffixless**
login (`my-bot`) would not match an author login arriving as `my-bot[bot]`
(and vice-versa), so the bot's post-disposition courtesy ack went unrecognised
and F2/F3 routed back to E1 — the avoidable round-trip the carve-out exists to
prevent. The shipped CodeRabbit/Codex defaults escaped it only because the
config stores the suffixed forms.

## Change

- New shared predicate `isConfiguredAdvisoryBotLogin(login, advisoryBotLogins)`
  that normalizes both the incoming login and each configured entry via the
  existing `advisoryBotIdentityToken` (no new regex). Both sites use it.
- It matches **only** configured `advisoryBotLogins`, **not** `isKnownReviewBot`
  — so a known-review-bot (e.g. Copilot) ack is never reclassified as a
  configured-advisory-bot courtesy ack. This is the deliberate difference from
  `isGateAdvisoryBotLogin`, which is refactored to reuse the predicate
  (`isKnownReviewBot(token) || isConfiguredAdvisoryBotLogin(...)`) with identical
  behaviour.
- Audit anchor satisfied: no raw `advisoryBotLogins.has(<un-normalized login>)`
  remains in the file.

## Non-goal

The `for (const login of advisoryBotLogins) dispositionAuthorLogins.delete(login)`
loop and the `dispositionAuthorLogins`/`iddAgentLogins` membership checks stay
raw-exact: those actor classes are humans/PAT accounts that don't receive
GitHub's `[bot]` suffix, so the asymmetry isn't realistically reachable there.
Out of #1118's named two-site scope.

## Test

- `pnpm test` (1358 pass) and `pnpm run lint:minimum` green.
- `isConfiguredAdvisoryBotLogin` unit tests: suffix × suffixless cross-product,
  and the load-bearing "matches only configured bots, not known review bots"
  distinction (empty config → predicate false while `isGateAdvisoryBotLogin`
  stays true for the same Copilot/CodeRabbit/Codex logins).
- Integration coverage drives the cross-product through **both** ack-only paths
  (`buildActivitySnapshotSummary` `ackOnly` and
  `summarizeDispositionEvidenceForGate` `soleCauseAckOnlyPostDisposition`); these
  assert ack-only = true and would fail against the pre-fix raw `.has()`.

Closes #1118
