### PR TITLE
refactor(idd): guard live-status-digest CLI behind isCliExecution for testability

### DIFF
--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -6,6 +6,8 @@
 // generated .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   collaboratorPermission,
   isAuthorizedForcedHandoffActor,
@@ -27,143 +29,161 @@ const trustedMarkerAuthorCache = new Map();
 const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerAuthors = null;
 let cachedCurrentViewerLogin = null;
-const args = parseArgs(process.argv.slice(2));
-if (args.help) {
-  printUsage();
-  process.exit(0);
+if (isCliExecution()) {
+  main();
 }
-if (args.issue && args.pr) {
-  fail('choose only one of --issue or --pr');
-}
-if (!args.issue && !args.pr) {
-  fail('missing required --issue <number> or --pr <number>');
-}
-if (args.apply && args.dryRun) {
-  fail('choose only one of --dry-run or --apply');
-}
-if (!args.apply) {
-  args.dryRun = true;
-}
-if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
-  fail(
-    '--skip-claim-check cannot be combined with --claim-issue or --claim-id',
+// The CLI body. Guarded behind isCliExecution() so importing this module (for
+// unit tests) does not parse process.argv, fail, or process.exit — matching the
+// sibling-helper convention (see isCliExecution() in branch-name.mts).
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+  if (args.issue && args.pr) {
+    fail('choose only one of --issue or --pr');
+  }
+  if (!args.issue && !args.pr) {
+    fail('missing required --issue <number> or --pr <number>');
+  }
+  if (args.apply && args.dryRun) {
+    fail('choose only one of --dry-run or --apply');
+  }
+  if (!args.apply) {
+    args.dryRun = true;
+  }
+  if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
+    fail(
+      '--skip-claim-check cannot be combined with --claim-issue or --claim-id',
+    );
+  }
+  if (
+    args.apply &&
+    !args.skipClaimCheck &&
+    (!args.claimIssue || !args.claimId)
+  ) {
+    fail(
+      '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
+    );
+  }
+  const repository = args.repo ?? detectRepository();
+  const [owner, repo] = parseRepository(repository);
+  const targetType = args.issue ? 'issue' : 'pr';
+  const targetNumber = parsePositiveInteger(
+    args.issue ?? args.pr,
+    `--${targetType}`,
   );
-}
-if (args.apply && !args.skipClaimCheck && (!args.claimIssue || !args.claimId)) {
-  fail(
-    '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
-  );
-}
-const repository = args.repo ?? detectRepository();
-const [owner, repo] = parseRepository(repository);
-const targetType = args.issue ? 'issue' : 'pr';
-const targetNumber = parsePositiveInteger(
-  args.issue ?? args.pr,
-  `--${targetType}`,
-);
-const claimContext =
-  targetType === 'pr'
-    ? {
-        expectedLinkedPrs: buildExpectedLinkedPrReferences(
-          owner,
-          repo,
-          targetNumber,
-        ),
-      }
-    : {};
-if (args.claimIssue) {
-  args.claimIssue = String(
-    parsePositiveInteger(args.claimIssue, '--claim-issue'),
-  );
-}
-const fields = {
-  phase: args.phase,
-  claim: args.claim,
-  branch: args.branch,
-  lastChecked: args.lastChecked ?? currentIsoTimestamp(),
-  openBlockers: args.openBlockers,
-  nextAction: args.nextAction,
-  authoritativeBy: args.authoritativeBy,
-};
-const comments = fetchIssueComments(owner, repo, targetNumber);
-let planned;
-try {
-  planned = planLiveStatusDigestUpsert(comments, fields);
-} catch (error) {
-  fail(error.message);
-}
-const report = {
-  repository: `${owner}/${repo}`,
-  target: {
-    type: targetType,
-    number: targetNumber,
-  },
-  mode: args.apply ? 'apply' : 'dry-run',
-  action: planned.action,
-  canApply: planned.canApply,
-  commentId: planned.commentId ?? null,
-  url: planned.url ?? null,
-  duplicates: planned.duplicates ?? [],
-  repairPath: planned.repairPath ?? null,
-  applied: false,
-  body: args.includeBody ? planned.body : undefined,
-};
-if (planned.action === 'duplicate') {
-  writeReport(report, args.format);
-  process.exit(1);
-}
-if (args.apply) {
-  // The ordering invariant — re-fetch and re-plan, then revalidate the
-  // active claim immediately before the create/update mutation, with no
-  // write if the claim check throws — lives in applyDigestUpsert. The live
-  // `gh` I/O is injected here so that invariant stays unit-testable.
-  let outcome;
+  const claimContext =
+    targetType === 'pr'
+      ? {
+          expectedLinkedPrs: buildExpectedLinkedPrReferences(
+            owner,
+            repo,
+            targetNumber,
+          ),
+        }
+      : {};
+  if (args.claimIssue) {
+    args.claimIssue = String(
+      parsePositiveInteger(args.claimIssue, '--claim-issue'),
+    );
+  }
+  const fields = {
+    phase: args.phase,
+    claim: args.claim,
+    branch: args.branch,
+    lastChecked: args.lastChecked ?? currentIsoTimestamp(),
+    openBlockers: args.openBlockers,
+    nextAction: args.nextAction,
+    authoritativeBy: args.authoritativeBy,
+  };
+  const comments = fetchIssueComments(owner, repo, targetNumber);
+  let planned;
   try {
-    outcome = applyDigestUpsert({
-      skipClaimCheck: Boolean(args.skipClaimCheck),
-      refetchAndPlan: () =>
-        planLiveStatusDigestUpsert(
-          fetchIssueComments(owner, repo, targetNumber),
-          fields,
-        ),
-      assertClaim: () =>
-        assertActiveClaim(
-          owner,
-          repo,
-          args.claimIssue,
-          args.agentId,
-          args.claimId,
-          claimContext,
-        ),
-      createComment: (body) =>
-        createIssueComment(owner, repo, targetNumber, body),
-      updateComment: (commentId, body) =>
-        updateIssueComment(owner, repo, commentId, body),
-    });
+    planned = planLiveStatusDigestUpsert(comments, fields);
   } catch (error) {
     fail(error.message);
   }
-  planned = outcome.planned;
-  updateReportFromPlan(report, planned);
-  if (outcome.outcome === 'duplicate') {
+  const report = {
+    repository: `${owner}/${repo}`,
+    target: {
+      type: targetType,
+      number: targetNumber,
+    },
+    mode: args.apply ? 'apply' : 'dry-run',
+    action: planned.action,
+    canApply: planned.canApply,
+    commentId: planned.commentId ?? null,
+    url: planned.url ?? null,
+    duplicates: planned.duplicates ?? [],
+    repairPath: planned.repairPath ?? null,
+    applied: false,
+    body: args.includeBody ? planned.body : undefined,
+  };
+  if (planned.action === 'duplicate') {
     writeReport(report, args.format);
     process.exit(1);
   }
-  if (outcome.outcome === 'created' || outcome.outcome === 'updated') {
-    report.applied = true;
-    report.commentId = outcome.commentId ?? report.commentId;
-    report.url = outcome.url ?? report.url;
+  if (args.apply) {
+    // The ordering invariant — re-fetch and re-plan, then revalidate the
+    // active claim immediately before the create/update mutation, with no
+    // write if the claim check throws — lives in applyDigestUpsert. The live
+    // `gh` I/O is injected here so that invariant stays unit-testable.
+    let outcome;
+    try {
+      outcome = applyDigestUpsert({
+        skipClaimCheck: Boolean(args.skipClaimCheck),
+        refetchAndPlan: () =>
+          planLiveStatusDigestUpsert(
+            fetchIssueComments(owner, repo, targetNumber),
+            fields,
+          ),
+        assertClaim: () =>
+          assertActiveClaim(
+            owner,
+            repo,
+            args.claimIssue,
+            args.agentId,
+            args.claimId,
+            claimContext,
+          ),
+        createComment: (body) =>
+          createIssueComment(owner, repo, targetNumber, body),
+        updateComment: (commentId, body) =>
+          updateIssueComment(owner, repo, commentId, body),
+      });
+    } catch (error) {
+      fail(error.message);
+    }
+    planned = outcome.planned;
+    updateReportFromPlan(report, planned, args.includeBody);
+    if (outcome.outcome === 'duplicate') {
+      writeReport(report, args.format);
+      process.exit(1);
+    }
+    if (outcome.outcome === 'created' || outcome.outcome === 'updated') {
+      report.applied = true;
+      report.commentId = outcome.commentId ?? report.commentId;
+      report.url = outcome.url ?? report.url;
+    }
   }
+  writeReport(report, args.format);
 }
-writeReport(report, args.format);
-function updateReportFromPlan(report, planned) {
+function isCliExecution() {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+function updateReportFromPlan(report, planned, includeBody = false) {
   report.action = planned.action;
   report.canApply = planned.canApply;
   report.commentId = planned.commentId ?? null;
   report.url = planned.url ?? null;
   report.duplicates = planned.duplicates ?? [];
   report.repairPath = planned.repairPath ?? null;
-  if (args.includeBody) {
+  if (includeBody) {
     report.body = planned.body;
   }
 }
@@ -283,7 +303,7 @@ function buildExpectedLinkedPrReferences(owner, repo, prNumber) {
     `https://github.com/${owner}/${repo}/pull/${normalized}`,
   ];
 }
-function isTrustedMarkerAuthor(owner, repo, login) {
+export function isTrustedMarkerAuthor(owner, repo, login) {
   if (!login) {
     return false;
   }
@@ -325,7 +345,7 @@ function currentViewerLogin() {
   }
   return cachedCurrentViewerLogin;
 }
-function configuredTrustedMarkerAuthors() {
+export function configuredTrustedMarkerAuthors() {
   if (cachedConfiguredTrustedMarkerAuthors) {
     return cachedConfiguredTrustedMarkerAuthors;
   }
@@ -345,7 +365,7 @@ function configuredTrustedMarkerAuthors() {
   cachedConfiguredTrustedMarkerAuthors = new Set(actors);
   return cachedConfiguredTrustedMarkerAuthors;
 }
-function trustCollaboratorMarkers() {
+export function trustCollaboratorMarkers() {
   try {
     return resolveCollaboratorMarkerTrust(
       JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
@@ -357,6 +377,18 @@ function trustCollaboratorMarkers() {
   return /^(1|true|yes)$/i.test(
     process.env.IDD_TRUST_COLLABORATOR_MARKERS ?? '',
   );
+}
+/**
+ * Test-only seam: clear the module-level trusted-marker caches so each unit
+ * test starts from a known state, and optionally seed the cached current-viewer
+ * login so `isTrustedMarkerAuthor` is deterministic without shelling out to
+ * `gh`. Not part of the CLI contract.
+ */
+export function __resetTrustedMarkerCachesForTest(seed = {}) {
+  trustedMarkerAuthorCache.clear();
+  collaboratorPermissionCache.clear();
+  cachedConfiguredTrustedMarkerAuthors = null;
+  cachedCurrentViewerLogin = seed.currentViewerLogin ?? null;
 }
 function detectRepository() {
   if (process.env.GITHUB_REPOSITORY) {

--- a/src/scripts/live-status-digest.mts
+++ b/src/scripts/live-status-digest.mts
@@ -7,6 +7,8 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
 import {
   collaboratorPermission,
@@ -107,149 +109,170 @@ const collaboratorPermissionCache: CollaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerAuthors: Set<string> | null = null;
 let cachedCurrentViewerLogin: string | null = null;
 
-const args = parseArgs(process.argv.slice(2));
-
-if (args.help) {
-  printUsage();
-  process.exit(0);
+if (isCliExecution()) {
+  main();
 }
 
-if (args.issue && args.pr) {
-  fail('choose only one of --issue or --pr');
-}
-if (!args.issue && !args.pr) {
-  fail('missing required --issue <number> or --pr <number>');
-}
-if (args.apply && args.dryRun) {
-  fail('choose only one of --dry-run or --apply');
-}
-if (!args.apply) {
-  args.dryRun = true;
-}
-if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
-  fail(
-    '--skip-claim-check cannot be combined with --claim-issue or --claim-id',
+// The CLI body. Guarded behind isCliExecution() so importing this module (for
+// unit tests) does not parse process.argv, fail, or process.exit — matching the
+// sibling-helper convention (see isCliExecution() in branch-name.mts).
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (args.issue && args.pr) {
+    fail('choose only one of --issue or --pr');
+  }
+  if (!args.issue && !args.pr) {
+    fail('missing required --issue <number> or --pr <number>');
+  }
+  if (args.apply && args.dryRun) {
+    fail('choose only one of --dry-run or --apply');
+  }
+  if (!args.apply) {
+    args.dryRun = true;
+  }
+  if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
+    fail(
+      '--skip-claim-check cannot be combined with --claim-issue or --claim-id',
+    );
+  }
+  if (
+    args.apply &&
+    !args.skipClaimCheck &&
+    (!args.claimIssue || !args.claimId)
+  ) {
+    fail(
+      '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
+    );
+  }
+
+  const repository = args.repo ?? detectRepository();
+  const [owner, repo] = parseRepository(repository);
+  const targetType = args.issue ? 'issue' : 'pr';
+  const targetNumber = parsePositiveInteger(
+    args.issue ?? args.pr,
+    `--${targetType}`,
   );
-}
-if (args.apply && !args.skipClaimCheck && (!args.claimIssue || !args.claimId)) {
-  fail(
-    '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
-  );
-}
+  const claimContext =
+    targetType === 'pr'
+      ? {
+          expectedLinkedPrs: buildExpectedLinkedPrReferences(
+            owner,
+            repo,
+            targetNumber,
+          ),
+        }
+      : {};
 
-const repository = args.repo ?? detectRepository();
-const [owner, repo] = parseRepository(repository);
-const targetType = args.issue ? 'issue' : 'pr';
-const targetNumber = parsePositiveInteger(
-  args.issue ?? args.pr,
-  `--${targetType}`,
-);
-const claimContext =
-  targetType === 'pr'
-    ? {
-        expectedLinkedPrs: buildExpectedLinkedPrReferences(
-          owner,
-          repo,
-          targetNumber,
-        ),
-      }
-    : {};
+  if (args.claimIssue) {
+    args.claimIssue = String(
+      parsePositiveInteger(args.claimIssue, '--claim-issue'),
+    );
+  }
 
-if (args.claimIssue) {
-  args.claimIssue = String(
-    parsePositiveInteger(args.claimIssue, '--claim-issue'),
-  );
-}
+  const fields = {
+    phase: args.phase,
+    claim: args.claim,
+    branch: args.branch,
+    lastChecked: args.lastChecked ?? currentIsoTimestamp(),
+    openBlockers: args.openBlockers,
+    nextAction: args.nextAction,
+    authoritativeBy: args.authoritativeBy,
+  };
 
-const fields = {
-  phase: args.phase,
-  claim: args.claim,
-  branch: args.branch,
-  lastChecked: args.lastChecked ?? currentIsoTimestamp(),
-  openBlockers: args.openBlockers,
-  nextAction: args.nextAction,
-  authoritativeBy: args.authoritativeBy,
-};
-
-const comments = fetchIssueComments(owner, repo, targetNumber);
-let planned: LiveStatusDigestPlan;
-try {
-  planned = planLiveStatusDigestUpsert(comments, fields);
-} catch (error) {
-  fail((error as Error).message);
-}
-const report: LiveStatusDigestReport = {
-  repository: `${owner}/${repo}`,
-  target: {
-    type: targetType,
-    number: targetNumber,
-  },
-  mode: args.apply ? 'apply' : 'dry-run',
-  action: planned.action,
-  canApply: planned.canApply,
-  commentId: planned.commentId ?? null,
-  url: planned.url ?? null,
-  duplicates: planned.duplicates ?? [],
-  repairPath: planned.repairPath ?? null,
-  applied: false,
-  body: args.includeBody ? planned.body : undefined,
-};
-
-if (planned.action === 'duplicate') {
-  writeReport(report, args.format);
-  process.exit(1);
-}
-
-if (args.apply) {
-  // The ordering invariant — re-fetch and re-plan, then revalidate the
-  // active claim immediately before the create/update mutation, with no
-  // write if the claim check throws — lives in applyDigestUpsert. The live
-  // `gh` I/O is injected here so that invariant stays unit-testable.
-  let outcome: DigestUpsertOutcome<LiveStatusDigestPlan>;
+  const comments = fetchIssueComments(owner, repo, targetNumber);
+  let planned: LiveStatusDigestPlan;
   try {
-    outcome = applyDigestUpsert<LiveStatusDigestPlan>({
-      skipClaimCheck: Boolean(args.skipClaimCheck),
-      refetchAndPlan: () =>
-        planLiveStatusDigestUpsert(
-          fetchIssueComments(owner, repo, targetNumber),
-          fields,
-        ),
-      assertClaim: () =>
-        assertActiveClaim(
-          owner,
-          repo,
-          args.claimIssue,
-          args.agentId,
-          args.claimId,
-          claimContext,
-        ),
-      createComment: (body) =>
-        createIssueComment(owner, repo, targetNumber, body),
-      updateComment: (commentId, body) =>
-        updateIssueComment(owner, repo, commentId, body),
-    });
+    planned = planLiveStatusDigestUpsert(comments, fields);
   } catch (error) {
     fail((error as Error).message);
   }
+  const report: LiveStatusDigestReport = {
+    repository: `${owner}/${repo}`,
+    target: {
+      type: targetType,
+      number: targetNumber,
+    },
+    mode: args.apply ? 'apply' : 'dry-run',
+    action: planned.action,
+    canApply: planned.canApply,
+    commentId: planned.commentId ?? null,
+    url: planned.url ?? null,
+    duplicates: planned.duplicates ?? [],
+    repairPath: planned.repairPath ?? null,
+    applied: false,
+    body: args.includeBody ? planned.body : undefined,
+  };
 
-  planned = outcome.planned;
-  updateReportFromPlan(report, planned);
-  if (outcome.outcome === 'duplicate') {
+  if (planned.action === 'duplicate') {
     writeReport(report, args.format);
     process.exit(1);
   }
-  if (outcome.outcome === 'created' || outcome.outcome === 'updated') {
-    report.applied = true;
-    report.commentId = outcome.commentId ?? report.commentId;
-    report.url = outcome.url ?? report.url;
+
+  if (args.apply) {
+    // The ordering invariant — re-fetch and re-plan, then revalidate the
+    // active claim immediately before the create/update mutation, with no
+    // write if the claim check throws — lives in applyDigestUpsert. The live
+    // `gh` I/O is injected here so that invariant stays unit-testable.
+    let outcome: DigestUpsertOutcome<LiveStatusDigestPlan>;
+    try {
+      outcome = applyDigestUpsert<LiveStatusDigestPlan>({
+        skipClaimCheck: Boolean(args.skipClaimCheck),
+        refetchAndPlan: () =>
+          planLiveStatusDigestUpsert(
+            fetchIssueComments(owner, repo, targetNumber),
+            fields,
+          ),
+        assertClaim: () =>
+          assertActiveClaim(
+            owner,
+            repo,
+            args.claimIssue,
+            args.agentId,
+            args.claimId,
+            claimContext,
+          ),
+        createComment: (body) =>
+          createIssueComment(owner, repo, targetNumber, body),
+        updateComment: (commentId, body) =>
+          updateIssueComment(owner, repo, commentId, body),
+      });
+    } catch (error) {
+      fail((error as Error).message);
+    }
+
+    planned = outcome.planned;
+    updateReportFromPlan(report, planned, args.includeBody);
+    if (outcome.outcome === 'duplicate') {
+      writeReport(report, args.format);
+      process.exit(1);
+    }
+    if (outcome.outcome === 'created' || outcome.outcome === 'updated') {
+      report.applied = true;
+      report.commentId = outcome.commentId ?? report.commentId;
+      report.url = outcome.url ?? report.url;
+    }
   }
+
+  writeReport(report, args.format);
 }
 
-writeReport(report, args.format);
+function isCliExecution(): boolean {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
 
 function updateReportFromPlan(
   report: LiveStatusDigestReport,
   planned: LiveStatusDigestPlan,
+  includeBody = false,
 ): void {
   report.action = planned.action;
   report.canApply = planned.canApply;
@@ -257,7 +280,7 @@ function updateReportFromPlan(
   report.url = planned.url ?? null;
   report.duplicates = planned.duplicates ?? [];
   report.repairPath = planned.repairPath ?? null;
-  if (args.includeBody) {
+  if (includeBody) {
     report.body = planned.body;
   }
 }
@@ -422,7 +445,7 @@ function buildExpectedLinkedPrReferences(
   ];
 }
 
-function isTrustedMarkerAuthor(
+export function isTrustedMarkerAuthor(
   owner: string,
   repo: string,
   login: string,
@@ -476,7 +499,7 @@ function currentViewerLogin(): string {
   return cachedCurrentViewerLogin;
 }
 
-function configuredTrustedMarkerAuthors(): Set<string> {
+export function configuredTrustedMarkerAuthors(): Set<string> {
   if (cachedConfiguredTrustedMarkerAuthors) {
     return cachedConfiguredTrustedMarkerAuthors;
   }
@@ -498,7 +521,7 @@ function configuredTrustedMarkerAuthors(): Set<string> {
   return cachedConfiguredTrustedMarkerAuthors;
 }
 
-function trustCollaboratorMarkers(): boolean {
+export function trustCollaboratorMarkers(): boolean {
   try {
     return resolveCollaboratorMarkerTrust(
       JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
@@ -510,6 +533,21 @@ function trustCollaboratorMarkers(): boolean {
   return /^(1|true|yes)$/i.test(
     process.env.IDD_TRUST_COLLABORATOR_MARKERS ?? '',
   );
+}
+
+/**
+ * Test-only seam: clear the module-level trusted-marker caches so each unit
+ * test starts from a known state, and optionally seed the cached current-viewer
+ * login so `isTrustedMarkerAuthor` is deterministic without shelling out to
+ * `gh`. Not part of the CLI contract.
+ */
+export function __resetTrustedMarkerCachesForTest(
+  seed: { currentViewerLogin?: string } = {},
+): void {
+  trustedMarkerAuthorCache.clear();
+  collaboratorPermissionCache.clear();
+  cachedConfiguredTrustedMarkerAuthors = null;
+  cachedCurrentViewerLogin = seed.currentViewerLogin ?? null;
 }
 
 function detectRepository(): string {

--- a/tests/live-status-digest.test.mts
+++ b/tests/live-status-digest.test.mts
@@ -1,6 +1,14 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-
+// Importing the CLI module directly is only possible now that its top-level
+// statements are guarded behind isCliExecution(); previously the import parsed
+// process.argv and called process.exit, aborting the test process.
+import {
+  __resetTrustedMarkerCachesForTest,
+  configuredTrustedMarkerAuthors,
+  isTrustedMarkerAuthor,
+  trustCollaboratorMarkers,
+} from '../src/scripts/live-status-digest.mts';
 import {
   applyDigestUpsert,
   findLiveStatusDigestComments,
@@ -213,12 +221,14 @@ test('applyDigestUpsert skips the claim check and mutation on a duplicate plan',
   assert.deepEqual(calls, []);
 });
 
-// configuredTrustedMarkerAuthors() in live-status-digest.mts now builds its
-// cached set from new Set(resolveTrustedMarkerActors({ envValue, config }).actors),
+// configuredTrustedMarkerAuthors() in live-status-digest.mts builds its cached
+// set from new Set(resolveTrustedMarkerActors({ envValue, config }).actors),
 // reading .github/idd/config.json the same way trustCollaboratorMarkers() does.
-// live-status-digest.mts itself runs its CLI on import (top-level statements),
-// so these tests lock the env -> config ladder it now relies on via the shared
-// resolver rather than importing the un-importable CLI module.
+// These cases lock the env -> config ladder against synthetic config objects via
+// the shared resolver, in isolation from the module's real-config read. The
+// module's own configuredTrustedMarkerAuthors() is now exercised directly in the
+// "Direct-import coverage" tests below, which #1120 made possible by guarding the
+// CLI behind isCliExecution().
 function configuredTrustedMarkerSet(
   envValue: string,
   config: { trustedMarkerActors?: unknown } | null,
@@ -249,4 +259,95 @@ test('configured trusted-marker authors are empty with neither env nor config', 
     [...configuredTrustedMarkerSet('', { trustedMarkerActors: [] })],
     [],
   );
+});
+
+// --- Direct-import coverage of the CLI module's trusted-marker-author logic.
+// These exercise paths that could not be unit-tested before #1120, because
+// importing live-status-digest.mts parsed process.argv and called
+// process.exit, aborting the test process. They stay hermetic (no `gh`
+// subprocess) by seeding the cached current-viewer login.
+
+function withEnv(
+  vars: Record<string, string | undefined>,
+  body: () => void,
+): void {
+  const saved = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(vars)) {
+    saved.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    body();
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test('configuredTrustedMarkerAuthors resolves the env actor and caches it', () => {
+  withEnv({ IDD_TRUSTED_MARKER_ACTORS: 'alpha-bot' }, () => {
+    __resetTrustedMarkerCachesForTest();
+    assert.deepEqual([...configuredTrustedMarkerAuthors()], ['alpha-bot']);
+
+    // The set is cached: a later env change is ignored until the cache resets.
+    process.env.IDD_TRUSTED_MARKER_ACTORS = 'beta-bot';
+    assert.deepEqual([...configuredTrustedMarkerAuthors()], ['alpha-bot']);
+
+    // After a reset the new env value is resolved.
+    __resetTrustedMarkerCachesForTest();
+    assert.deepEqual([...configuredTrustedMarkerAuthors()], ['beta-bot']);
+  });
+  __resetTrustedMarkerCachesForTest();
+});
+
+test('trustCollaboratorMarkers gates on the env flag (config has no override)', () => {
+  withEnv({ IDD_TRUST_COLLABORATOR_MARKERS: 'true' }, () => {
+    assert.equal(trustCollaboratorMarkers(), true);
+  });
+  withEnv({ IDD_TRUST_COLLABORATOR_MARKERS: undefined }, () => {
+    assert.equal(trustCollaboratorMarkers(), false);
+  });
+});
+
+test('isTrustedMarkerAuthor matches a configured author without touching gh', () => {
+  withEnv(
+    {
+      IDD_TRUSTED_MARKER_ACTORS: 'configured-bot',
+      IDD_TRUST_COLLABORATOR_MARKERS: undefined,
+    },
+    () => {
+      // Seed an empty viewer login so the viewer branch never matches and no
+      // `gh api user` subprocess runs.
+      __resetTrustedMarkerCachesForTest({ currentViewerLogin: '' });
+
+      // Configured-author match (case-insensitive).
+      assert.equal(isTrustedMarkerAuthor('o', 'r', 'configured-bot'), true);
+      assert.equal(isTrustedMarkerAuthor('o', 'r', 'Configured-Bot'), true);
+
+      // Empty login fails closed.
+      assert.equal(isTrustedMarkerAuthor('o', 'r', ''), false);
+
+      // Not configured + collaborator-trust gate off -> false, without
+      // consulting the collaborator permission API.
+      assert.equal(isTrustedMarkerAuthor('o', 'r', 'random-bot'), false);
+    },
+  );
+  __resetTrustedMarkerCachesForTest();
+});
+
+test('isTrustedMarkerAuthor matches the seeded current viewer login', () => {
+  __resetTrustedMarkerCachesForTest({ currentViewerLogin: 'me-the-viewer' });
+  assert.equal(isTrustedMarkerAuthor('o', 'r', 'me-the-viewer'), true);
+  // Case-insensitive against the normalized viewer login.
+  assert.equal(isTrustedMarkerAuthor('o', 'r', 'Me-The-Viewer'), true);
+  __resetTrustedMarkerCachesForTest();
 });


### PR DESCRIPTION
## Summary

`src/scripts/live-status-digest.mts` ran its CLI **on import**: unguarded
top-level statements parsed `process.argv` and, with no `--phase`, called
`fail()` → `process.exit(2)`. Importing the module therefore aborted the test
process, so its module-private trusted-marker-author helpers
(`configuredTrustedMarkerAuthors`, `isTrustedMarkerAuthor`,
`trustCollaboratorMarkers`) could not be unit-tested — unlike every sibling CLI
helper, which already guards execution behind an `isCliExecution()` check.

## Change

- Move the CLI body into a `main()` called only under an `isCliExecution()`
  guard (the same `import.meta.url === resolve(process.argv[1])` convention as
  `branch-name.mts`). This is a refactor: the exact CLI behavior and
  `process.exit(0|1|2)` codes are preserved. `updateReportFromPlan` now takes
  `includeBody` as a parameter instead of reading the module-level `args`.
- `export` the three trusted-marker-author helpers, plus a minimal **test-only**
  cache-reset seam (`__resetTrustedMarkerCachesForTest`, which can also seed the
  cached viewer login so tests stay hermetic — no `gh` subprocess).
- Add direct-import cases to `tests/live-status-digest.test.mts` covering the
  configured-author match, the seeded viewer match, the empty-login fail-closed,
  the env→config cache, and the collaborator-trust gate — cases that previously
  aborted the test process on import. The pre-existing stale comment about the
  "un-importable CLI module" is updated.

The generated `scripts/live-status-digest.mjs` is regenerated via
`pnpm run build` and committed.

## Verification

- CLI behavior unchanged: `--help` → exit 0, missing/duplicate `--issue`/`--pr`
  → exit 2 (re-checked against the built `.mjs`).
- Importing the module no longer parses `process.argv` or exits.
- `pnpm test` (1365 tests) and `pnpm run lint:minimum` green.

Closes #1120
