### PR TITLE
docs(idd): document the secondary advisory-bot fallback

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -236,6 +236,18 @@ contracts and any instruction text that references the effective wait
 values. The three duration keys accept positive whole-minute ISO 8601
 durations only; zero-length values and second-based values are invalid.
 
+`advisoryWait.primaryBotLogin` selects the advisory bot whose review the
+advisory-wait gate tracks (default Copilot), and
+`advisoryWait.secondaryBotLogin` names an **optional, non-gating** secondary
+bot. When the primary is cap-exhausted or stalled / rate-limited, the
+secondary is requested once per HEAD as a supplement; it never satisfies the
+primary advisory-wait gate, never receives a primary `advisory-wait` marker,
+and its review is ordinary advisory input. Omitting `secondaryBotLogin` (or
+setting it equal to the primary) disables the supplement, keeping behavior
+identical to a primary-only policy. Configure the secondary to a requestable
+reviewer whose request appears on the PR timeline so the once-per-HEAD guard
+can observe it.
+
 `advisoryWait.capExhaustedRoute` is intentionally fail-closed. The
 default `phase-specific` behavior keeps the current E14 skip / F2-F3
 hold split, while `hold` is a stricter override that also stops E14 on

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -242,9 +242,10 @@ advisory-wait gate tracks (default Copilot), and
 bot. When the primary is cap-exhausted or stalled / rate-limited, the
 secondary is requested once per HEAD as a supplement; it never satisfies the
 primary advisory-wait gate, never receives a primary `advisory-wait` marker,
-and its review is ordinary advisory input. Omitting `secondaryBotLogin` (or
-setting it equal to the primary) disables the supplement, keeping behavior
-identical to a primary-only policy. Configure the secondary to a requestable
+and its review is ordinary advisory input. Omitting
+`advisoryWait.secondaryBotLogin` (or setting it equal to the primary) disables
+the supplement, keeping behavior identical to a primary-only policy. Configure
+the secondary to a requestable
 reviewer whose request appears on the PR timeline so the once-per-HEAD guard
 can observe it.
 

--- a/docs/idd-review-policy-profiles.md
+++ b/docs/idd-review-policy-profiles.md
@@ -108,6 +108,22 @@ If the external bot can produce blocking `CHANGES_REQUESTED` reviews or
 decision-relevant comments, classify those items as PATH A unless the
 operator explicitly narrows them.
 
+### Configuring a primary and an optional secondary advisory bot
+
+The `advisoryWait.primaryBotLogin` and `advisoryWait.secondaryBotLogin`
+config fields let a profile choose which bot the advisory-wait gate tracks and
+add an **optional, non-gating** fallback. Set `primaryBotLogin` to route the
+gate to a non-Copilot bot (it defaults to Copilot). Set `secondaryBotLogin`
+to a second requestable review bot when the repository wants a fallback while
+the primary is throttled: IDD then requests the secondary **once per HEAD**
+only when the primary is cap-exhausted or stalled / rate-limited. The
+secondary is a **supplement only** — it never satisfies the primary
+advisory-wait gate, never receives a primary `advisory-wait` marker, and its
+output is ordinary advisory input (classified PATH A / PATH B by the snapshot
+and triage rules). Leaving `secondaryBotLogin` unset (or equal to the primary)
+keeps single-bot behavior. Pick a secondary whose `--add-reviewer` request
+appears on the PR timeline so the once-per-HEAD guard can observe it.
+
 ## PR Review Profile Edit Surfaces
 
 Use this checklist when a repository records a PR review profile during

--- a/docs/idd-review-policy-profiles.md
+++ b/docs/idd-review-policy-profiles.md
@@ -112,17 +112,18 @@ operator explicitly narrows them.
 
 The `advisoryWait.primaryBotLogin` and `advisoryWait.secondaryBotLogin`
 config fields let a profile choose which bot the advisory-wait gate tracks and
-add an **optional, non-gating** fallback. Set `primaryBotLogin` to route the
-gate to a non-Copilot bot (it defaults to Copilot). Set `secondaryBotLogin`
-to a second requestable review bot when the repository wants a fallback while
-the primary is throttled: IDD then requests the secondary **once per HEAD**
-only when the primary is cap-exhausted or stalled / rate-limited. The
-secondary is a **supplement only** — it never satisfies the primary
-advisory-wait gate, never receives a primary `advisory-wait` marker, and its
-output is ordinary advisory input (classified PATH A / PATH B by the snapshot
-and triage rules). Leaving `secondaryBotLogin` unset (or equal to the primary)
-keeps single-bot behavior. Pick a secondary whose `--add-reviewer` request
-appears on the PR timeline so the once-per-HEAD guard can observe it.
+add an **optional, non-gating** fallback. Set
+`advisoryWait.primaryBotLogin` to route the gate to a non-Copilot bot (it
+defaults to Copilot). Set `advisoryWait.secondaryBotLogin` to a second
+requestable review bot when the repository wants a fallback while the primary
+is throttled: IDD then requests the secondary **once per HEAD** only when the
+primary is cap-exhausted or stalled / rate-limited. The secondary is a
+**supplement only** — it never satisfies the primary advisory-wait gate, never
+receives a primary `advisory-wait` marker, and its output is ordinary advisory
+input (classified PATH A / PATH B by the snapshot and triage rules). Leaving
+`advisoryWait.secondaryBotLogin` unset (or equal to the primary) keeps
+single-bot behavior. Pick a secondary whose `--add-reviewer` request appears
+on the PR timeline so the once-per-HEAD guard can observe it.
 
 ## PR Review Profile Edit Surfaces
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -236,6 +236,18 @@ contracts and any instruction text that references the effective wait
 values. The three duration keys accept positive whole-minute ISO 8601
 durations only; zero-length values and second-based values are invalid.
 
+`advisoryWait.primaryBotLogin` selects the advisory bot whose review the
+advisory-wait gate tracks (default Copilot), and
+`advisoryWait.secondaryBotLogin` names an **optional, non-gating** secondary
+bot. When the primary is cap-exhausted or stalled / rate-limited, the
+secondary is requested once per HEAD as a supplement; it never satisfies the
+primary advisory-wait gate, never receives a primary `advisory-wait` marker,
+and its review is ordinary advisory input. Omitting `secondaryBotLogin` (or
+setting it equal to the primary) disables the supplement, keeping behavior
+identical to a primary-only policy. Configure the secondary to a requestable
+reviewer whose request appears on the PR timeline so the once-per-HEAD guard
+can observe it.
+
 `advisoryWait.capExhaustedRoute` is intentionally fail-closed. The
 default `phase-specific` behavior keeps the current E14 skip / F2-F3
 hold split, while `hold` is a stricter override that also stops E14 on

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -242,9 +242,10 @@ advisory-wait gate tracks (default Copilot), and
 bot. When the primary is cap-exhausted or stalled / rate-limited, the
 secondary is requested once per HEAD as a supplement; it never satisfies the
 primary advisory-wait gate, never receives a primary `advisory-wait` marker,
-and its review is ordinary advisory input. Omitting `secondaryBotLogin` (or
-setting it equal to the primary) disables the supplement, keeping behavior
-identical to a primary-only policy. Configure the secondary to a requestable
+and its review is ordinary advisory input. Omitting
+`advisoryWait.secondaryBotLogin` (or setting it equal to the primary) disables
+the supplement, keeping behavior identical to a primary-only policy. Configure
+the secondary to a requestable
 reviewer whose request appears on the PR timeline so the once-per-HEAD guard
 can observe it.
 

--- a/idd-template/docs/idd-review-policy-profiles.md
+++ b/idd-template/docs/idd-review-policy-profiles.md
@@ -108,6 +108,22 @@ If the external bot can produce blocking `CHANGES_REQUESTED` reviews or
 decision-relevant comments, classify those items as PATH A unless the
 operator explicitly narrows them.
 
+### Configuring a primary and an optional secondary advisory bot
+
+The `advisoryWait.primaryBotLogin` and `advisoryWait.secondaryBotLogin`
+config fields let a profile choose which bot the advisory-wait gate tracks and
+add an **optional, non-gating** fallback. Set `primaryBotLogin` to route the
+gate to a non-Copilot bot (it defaults to Copilot). Set `secondaryBotLogin`
+to a second requestable review bot when the repository wants a fallback while
+the primary is throttled: IDD then requests the secondary **once per HEAD**
+only when the primary is cap-exhausted or stalled / rate-limited. The
+secondary is a **supplement only** — it never satisfies the primary
+advisory-wait gate, never receives a primary `advisory-wait` marker, and its
+output is ordinary advisory input (classified PATH A / PATH B by the snapshot
+and triage rules). Leaving `secondaryBotLogin` unset (or equal to the primary)
+keeps single-bot behavior. Pick a secondary whose `--add-reviewer` request
+appears on the PR timeline so the once-per-HEAD guard can observe it.
+
 ## PR Review Profile Edit Surfaces
 
 Use this checklist when a repository records a PR review profile during

--- a/idd-template/docs/idd-review-policy-profiles.md
+++ b/idd-template/docs/idd-review-policy-profiles.md
@@ -112,17 +112,18 @@ operator explicitly narrows them.
 
 The `advisoryWait.primaryBotLogin` and `advisoryWait.secondaryBotLogin`
 config fields let a profile choose which bot the advisory-wait gate tracks and
-add an **optional, non-gating** fallback. Set `primaryBotLogin` to route the
-gate to a non-Copilot bot (it defaults to Copilot). Set `secondaryBotLogin`
-to a second requestable review bot when the repository wants a fallback while
-the primary is throttled: IDD then requests the secondary **once per HEAD**
-only when the primary is cap-exhausted or stalled / rate-limited. The
-secondary is a **supplement only** — it never satisfies the primary
-advisory-wait gate, never receives a primary `advisory-wait` marker, and its
-output is ordinary advisory input (classified PATH A / PATH B by the snapshot
-and triage rules). Leaving `secondaryBotLogin` unset (or equal to the primary)
-keeps single-bot behavior. Pick a secondary whose `--add-reviewer` request
-appears on the PR timeline so the once-per-HEAD guard can observe it.
+add an **optional, non-gating** fallback. Set
+`advisoryWait.primaryBotLogin` to route the gate to a non-Copilot bot (it
+defaults to Copilot). Set `advisoryWait.secondaryBotLogin` to a second
+requestable review bot when the repository wants a fallback while the primary
+is throttled: IDD then requests the secondary **once per HEAD** only when the
+primary is cap-exhausted or stalled / rate-limited. The secondary is a
+**supplement only** — it never satisfies the primary advisory-wait gate, never
+receives a primary `advisory-wait` marker, and its output is ordinary advisory
+input (classified PATH A / PATH B by the snapshot and triage rules). Leaving
+`advisoryWait.secondaryBotLogin` unset (or equal to the primary) keeps
+single-bot behavior. Pick a secondary whose `--add-reviewer` request appears
+on the PR timeline so the once-per-HEAD guard can observe it.
 
 ## PR Review Profile Edit Surfaces
 


### PR DESCRIPTION
## Summary

Documents the configured primary / optional secondary advisory bot shipped by
#1098 and #1099 (the final child of roadmap #1094). No behavior change.

- **`docs/customization.md`** — the `advisoryWait.primaryBotLogin` and
  `advisoryWait.secondaryBotLogin` config fields, and the secondary's
  **non-gating** contract: requested once per HEAD only when the primary is
  cap-exhausted or stalled / rate-limited; never satisfies the primary
  advisory-wait gate; never receives a primary `advisory-wait` marker; output
  is ordinary advisory input. Notes that the secondary must be a requestable
  reviewer (so the once-per-HEAD guard can observe its request) and that
  omitting it keeps primary-only behavior.
- **`docs/idd-review-policy-profiles.md`** — how an `external-bot` profile
  selects a primary and an optional secondary advisory bot, and that the
  secondary is a supplement that never satisfies the primary gate.

Edited the `idd-template/docs/` sources and regenerated the live docs via
`sync-docs`; `audit-docs --check` confirms no drift. `pnpm run lint:minimum`
(markdownlint, dprint, cspell, audit-docs) passes.

Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
