### PR TITLE
feat(idd): annotate discover-roadmap-graph leaves with a startable signal

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -191,10 +191,23 @@ default below is unchanged.
   - `leaves`: `[{ number: number, title: string, state: string,`
     `labels: string[], classification: "execution",`
     `roadmapMarkerId: string, autopilotSuitability: number | null,`
-    `sourceRoots: number[] }]` — the union of open execution leaves. Each
-    leaf records every roadmap root it is reachable from in `sourceRoots`
-    (provenance); a leaf shared by sibling epics appears **once** and is
-    never double-counted.
+    `effort: "S" | "M" | "L" | null, sourceRoots: number[] }]` — the union of
+    open execution leaves. Each leaf records every roadmap root it is reachable
+    from in `sourceRoots` (provenance); a leaf shared by sibling epics appears
+    **once** and is never double-counted.
+  - **Opt-in leaf annotations** (additive; absent flags leave the leaf shape
+    byte-stable and make no extra API call). `--with-claim-state` adds
+    `activeClaim` (always an object: `{ present, stale, claimId, agentId }`,
+    plus `ownedByCurrentSession` when `--current-claim-id` is passed) and
+    `claimEligible: boolean` on each open leaf. `--with-readiness` adds
+    `readiness: { ready: boolean, reasons: string[], authoringHeld: boolean,`
+    `startable: boolean }` — the A3 startability of each open leaf
+    (blocked-by-dependency resolution + authoring-hold), where `reasons` lists
+    the sorted filter reasons (e.g. `blocked_by_open_issue:#N`) and is empty
+    when `ready`, and `startable` is `ready` **and** not claim-blocked (it folds
+    in `claimEligible` when `--with-claim-state` also ran; otherwise claim
+    eligibility is unknown and treated as non-blocking). Both annotations are
+    **soft** discovery hints — the A3/A4/A4.5/A5 gates remain authoritative.
   - `diagnostics`: same four buckets as single-root mode, deduped across
     every per-root enumeration.
   - `summary`: `{ rootCount: number, leafCount: number,`

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -201,10 +201,12 @@ default below is unchanged.
     plus `ownedByCurrentSession` when `--current-claim-id` is passed) and
     `claimEligible: boolean` on each open leaf. `--with-readiness` adds
     `readiness: { ready: boolean, reasons: string[], authoringHeld: boolean,`
-    `startable: boolean }` — the A3 startability of each open leaf
-    (blocked-by-dependency resolution + authoring-hold), where `reasons` lists
-    the sorted filter reasons (e.g. `blocked_by_open_issue:#N`) and is empty
-    when `ready`, and `startable` is `ready` **and** not claim-blocked (it folds
+    `startable: boolean }` — the A3 startability of each open leaf (dependency
+    resolution across visible `Blocked by #N` / `Depends on #N` / task-list refs
+    and hidden `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers, plus
+    authoring-hold), where `reasons` lists the sorted filter reasons (e.g.
+    `blocked_by_open_issue:#N`) and is empty when `ready`, and `startable` is
+    `ready` **and** not claim-blocked (it folds
     in `claimEligible` when `--with-claim-state` also ran; otherwise claim
     eligibility is unknown and treated as non-blocking). Both annotations are
     **soft** discovery hints — the A3/A4/A4.5/A5 gates remain authoritative.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -208,8 +208,11 @@ default below is unchanged.
     `blocked_by_open_issue:#N`) and is empty when `ready`, and `startable` is
     `ready` **and** not claim-blocked (it folds
     in `claimEligible` when `--with-claim-state` also ran; otherwise claim
-    eligibility is unknown and treated as non-blocking). Both annotations are
-    **soft** discovery hints — the A3/A4/A4.5/A5 gates remain authoritative.
+    eligibility is unknown and treated as non-blocking). `authoringHeld`
+    reports label **presence** only — `--with-readiness` does not compute the
+    stale-authoring warning (it would cost a discarded per-leaf timeline fetch
+    and does not change startability). Both annotations are **soft** discovery
+    hints — the A3/A4/A4.5/A5 gates remain authoritative.
   - `diagnostics`: same four buckets as single-root mode, deduped across
     every per-root enumeration.
   - `summary`: `{ rootCount: number, leafCount: number,`

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -191,10 +191,23 @@ default below is unchanged.
   - `leaves`: `[{ number: number, title: string, state: string,`
     `labels: string[], classification: "execution",`
     `roadmapMarkerId: string, autopilotSuitability: number | null,`
-    `sourceRoots: number[] }]` — the union of open execution leaves. Each
-    leaf records every roadmap root it is reachable from in `sourceRoots`
-    (provenance); a leaf shared by sibling epics appears **once** and is
-    never double-counted.
+    `effort: "S" | "M" | "L" | null, sourceRoots: number[] }]` — the union of
+    open execution leaves. Each leaf records every roadmap root it is reachable
+    from in `sourceRoots` (provenance); a leaf shared by sibling epics appears
+    **once** and is never double-counted.
+  - **Opt-in leaf annotations** (additive; absent flags leave the leaf shape
+    byte-stable and make no extra API call). `--with-claim-state` adds
+    `activeClaim` (always an object: `{ present, stale, claimId, agentId }`,
+    plus `ownedByCurrentSession` when `--current-claim-id` is passed) and
+    `claimEligible: boolean` on each open leaf. `--with-readiness` adds
+    `readiness: { ready: boolean, reasons: string[], authoringHeld: boolean,`
+    `startable: boolean }` — the A3 startability of each open leaf
+    (blocked-by-dependency resolution + authoring-hold), where `reasons` lists
+    the sorted filter reasons (e.g. `blocked_by_open_issue:#N`) and is empty
+    when `ready`, and `startable` is `ready` **and** not claim-blocked (it folds
+    in `claimEligible` when `--with-claim-state` also ran; otherwise claim
+    eligibility is unknown and treated as non-blocking). Both annotations are
+    **soft** discovery hints — the A3/A4/A4.5/A5 gates remain authoritative.
   - `diagnostics`: same four buckets as single-root mode, deduped across
     every per-root enumeration.
   - `summary`: `{ rootCount: number, leafCount: number,`

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -201,10 +201,12 @@ default below is unchanged.
     plus `ownedByCurrentSession` when `--current-claim-id` is passed) and
     `claimEligible: boolean` on each open leaf. `--with-readiness` adds
     `readiness: { ready: boolean, reasons: string[], authoringHeld: boolean,`
-    `startable: boolean }` — the A3 startability of each open leaf
-    (blocked-by-dependency resolution + authoring-hold), where `reasons` lists
-    the sorted filter reasons (e.g. `blocked_by_open_issue:#N`) and is empty
-    when `ready`, and `startable` is `ready` **and** not claim-blocked (it folds
+    `startable: boolean }` — the A3 startability of each open leaf (dependency
+    resolution across visible `Blocked by #N` / `Depends on #N` / task-list refs
+    and hidden `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers, plus
+    authoring-hold), where `reasons` lists the sorted filter reasons (e.g.
+    `blocked_by_open_issue:#N`) and is empty when `ready`, and `startable` is
+    `ready` **and** not claim-blocked (it folds
     in `claimEligible` when `--with-claim-state` also ran; otherwise claim
     eligibility is unknown and treated as non-blocking). Both annotations are
     **soft** discovery hints — the A3/A4/A4.5/A5 gates remain authoritative.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -208,8 +208,11 @@ default below is unchanged.
     `blocked_by_open_issue:#N`) and is empty when `ready`, and `startable` is
     `ready` **and** not claim-blocked (it folds
     in `claimEligible` when `--with-claim-state` also ran; otherwise claim
-    eligibility is unknown and treated as non-blocking). Both annotations are
-    **soft** discovery hints — the A3/A4/A4.5/A5 gates remain authoritative.
+    eligibility is unknown and treated as non-blocking). `authoringHeld`
+    reports label **presence** only — `--with-readiness` does not compute the
+    stale-authoring warning (it would cost a discarded per-leaf timeline fetch
+    and does not change startability). Both annotations are **soft** discovery
+    hints — the A3/A4/A4.5/A5 gates remain authoritative.
   - `diagnostics`: same four buckets as single-root mode, deduped across
     every per-root enumeration.
   - `summary`: `{ rootCount: number, leafCount: number,`

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -563,7 +563,7 @@ export function buildRoadmapMarkerSearchQuery(
   // prefix would corrupt the exact marker string the resolver looks for.
   return `repo:${owner}/${repo} is:issue in:body "<!-- ${markerPrefix}-roadmap-id: ${marker} -->"`;
 }
-function buildRoadmapMarkerResolver(owner, repo, markerPrefix) {
+export function buildRoadmapMarkerResolver(owner, repo, markerPrefix) {
   return async (marker) => {
     const query = buildRoadmapMarkerSearchQuery(
       owner,

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -573,7 +573,11 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
   // single batch call. Runs after the claim loop so `startable` can fold in
   // `claimEligible`. Gated on `options.readiness`, so the default path adds no
   // extra API call and the output shape stays byte-stable.
-  if (options.readiness) {
+  // `options.loadIssue` is required for any enumeration to succeed (each
+  // per-root `enumerateRoadmapGraph` above throws without it), so by here it is
+  // always a function; the typeof guard narrows the optional option type for
+  // the required `annotateReadiness` parameter without an unsafe cast.
+  if (options.readiness && typeof options.loadIssue === 'function') {
     await annotateReadiness(
       leaves,
       options.readiness,

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1245,10 +1245,11 @@ function printHelp() {
   claim gate (idd-claim.instructions.md) remains the real protection.
 
   --with-readiness (opt-in) annotates each OPEN execution leaf with its A3
-  startability by composing the discover-readiness-check helper (blocked-by
+  startability by composing the discover-readiness-check helper (dependency
   resolution + authoring-hold). Each annotated leaf gains:
     "readiness": { "ready": bool, "reasons": [str], "authoringHeld": bool, "startable": bool }
-      ready      = no blocking label + every Blocked by #N / {prefix}-blocked-by dep is closed
+      ready      = no blocking label + every dep closed (Blocked by #N / Depends on #N
+                   / task-list refs / {prefix}-blocked-by markers)
       reasons    = sorted filter reasons (e.g. "blocked_by_open_issue:#N"); empty when ready
       startable  = ready AND not claim-blocked (folds in claimEligible when --with-claim-state
                    also ran; otherwise claim eligibility is unknown and treated as non-blocking)

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -8,11 +8,16 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveAuthoringGuardPolicy } from './authoring-label-guard.mjs';
 import {
   isAutopilotSuitabilityScore,
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mjs';
+import {
+  buildRoadmapMarkerResolver,
+  evaluateDiscoverReadiness,
+} from './discover-readiness-check.mjs';
 import { effortOrdinal, parseEffort } from './effort.mjs';
 import { parseIsoDurationToMs } from './policy-helpers.mjs';
 import {
@@ -82,6 +87,13 @@ if (isMainModule(import.meta.url)) {
   const claimState = args.withClaimState
     ? buildClaimStateResolution(owner, repo, policy, args.currentClaimId)
     : undefined;
+  // The readiness annotation is strictly opt-in: only when --with-readiness is
+  // passed do we build the marker / label-event loaders and resolve the
+  // authoring-hold policy. The default path leaves `readiness` undefined, so no
+  // extra fetch is made and the output is byte-stable.
+  const readiness = args.withReadiness
+    ? buildReadinessResolution(owner, repo, policy)
+    : undefined;
   const report = args.allRoadmaps
     ? await enumerateAllRoadmapsGraph({
         markerPrefix: policy.markerPrefix,
@@ -96,6 +108,7 @@ if (isMainModule(import.meta.url)) {
           policy.markerPrefix,
         ),
         claimState,
+        readiness,
       })
     : await enumerateRoadmapGraph(args.issue, {
         markerPrefix: policy.markerPrefix,
@@ -104,6 +117,7 @@ if (isMainModule(import.meta.url)) {
         loadIssue: buildIssueLoader(owner, repo),
         loadSubIssues: buildSubIssueLoader(owner, repo),
         claimState,
+        readiness,
       });
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
 }
@@ -183,11 +197,17 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   if (!rootNode) {
     throw new Error(`root issue #${rootIssueNumber} was not recorded`);
   }
+  // Both opt-in annotation passes below operate on the open execution-leaf
+  // nodes, so resolve the execution-candidate set once — only when a pass
+  // actually runs, keeping the default path allocation-free and byte-stable.
+  const executionCandidateSet =
+    options.claimState || options.readiness
+      ? new Set(executionCandidates)
+      : null;
   // Opt-in (#1008): annotate each open execution-leaf node with active-claim
   // eligibility. Gated on `options.claimState` so the default path makes no
   // extra GitHub API call and the output shape stays byte-stable.
-  if (options.claimState) {
-    const executionCandidateSet = new Set(executionCandidates);
+  if (options.claimState && executionCandidateSet) {
     for (const node of nodes) {
       if (!executionCandidateSet.has(node.number)) {
         continue;
@@ -199,6 +219,21 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
       node.activeClaim = annotated.activeClaim;
       node.claimEligible = annotated.claimEligible;
     }
+  }
+  // Opt-in (#1123): annotate each open execution-leaf node with its A3
+  // readiness in a single batch call, after the claim loop so `startable` can
+  // fold in `claimEligible`. Gated on `options.readiness` so the default path
+  // makes no extra API call and the output shape stays byte-stable.
+  if (options.readiness && executionCandidateSet) {
+    const executionNodes = nodes.filter((node) =>
+      executionCandidateSet.has(node.number),
+    );
+    await annotateReadiness(
+      executionNodes,
+      options.readiness,
+      loadIssue,
+      markerPrefix,
+    );
   }
   return {
     root: {
@@ -534,6 +569,18 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
       leaf.claimEligible = annotated.claimEligible;
     }
   }
+  // Opt-in (#1123): annotate the open union leaves with their A3 readiness in a
+  // single batch call. Runs after the claim loop so `startable` can fold in
+  // `claimEligible`. Gated on `options.readiness`, so the default path adds no
+  // extra API call and the output shape stays byte-stable.
+  if (options.readiness) {
+    await annotateReadiness(
+      leaves,
+      options.readiness,
+      options.loadIssue,
+      markerPrefix,
+    );
+  }
   const scoredLeafCount = leaves.filter((leaf) =>
     isAutopilotSuitabilityScore(leaf.autopilotSuitability),
   ).length;
@@ -629,6 +676,61 @@ function normalizeOpenRoadmapRootNumbers(roots) {
         .filter((value) => Number.isInteger(value) && value > 0),
     ),
   ].sort((left, right) => left - right);
+}
+/**
+ * Annotate each OPEN entry with its A3 readiness verdict (`--with-readiness`)
+ * by composing the batch `evaluateDiscoverReadiness` helper over the open
+ * entry numbers — one call, reusing the enclosing enumeration's `loadIssue`
+ * and `markerPrefix` so no second issue loader is constructed. Closed entries
+ * are skipped (only open execution work is a start candidate).
+ *
+ * `evaluateDiscoverReadiness` classifies every input number into `ready` or
+ * `filteredOut` (an inaccessible/closed issue lands in `filteredOut` with a
+ * sentinel reason), so each open entry resolves to a definite verdict. The
+ * combined `startable` hint folds in `claimEligible` when `--with-claim-state`
+ * also ran; otherwise claim eligibility is unknown and treated as
+ * non-blocking. The suitability floor is left to the helper default because
+ * the readiness classification (labels + dependencies) does not read the
+ * score.
+ */
+async function annotateReadiness(entries, readiness, loadIssue, markerPrefix) {
+  const openEntries = entries.filter(
+    (entry) => String(entry.state).toUpperCase() === 'OPEN',
+  );
+  if (openEntries.length === 0) {
+    return;
+  }
+  const summary = await evaluateDiscoverReadiness(
+    openEntries.map((entry) => entry.number),
+    {
+      // We read only `ready` / `filteredOut[].reasons`, so the unresolvable
+      // bucket and the authoring-stale `warning` (and thus its
+      // `loadIssueLabelEvents` timeline fetch) are intentionally not wired —
+      // `authoringHeld` is label-presence-based and needs neither.
+      includeUnresolvable: false,
+      loadIssue,
+      findRoadmapsByMarker: readiness.findRoadmapsByMarker,
+      authoringLabelName: readiness.authoringLabelName,
+      authoringStaleAgeMs: readiness.authoringStaleAgeMs,
+      markerPrefix,
+      now: readiness.nowIso,
+    },
+  );
+  const readyNumbers = new Set(summary.ready.map((entry) => entry.number));
+  const reasonsByNumber = new Map(
+    summary.filteredOut.map((entry) => [entry.number, entry.reasons]),
+  );
+  const authoringReason = `label:${readiness.authoringLabelName}`;
+  for (const entry of openEntries) {
+    const ready = readyNumbers.has(entry.number);
+    const reasons = reasonsByNumber.get(entry.number) ?? [];
+    entry.readiness = {
+      ready,
+      reasons,
+      authoringHeld: reasons.includes(authoringReason),
+      startable: ready && entry.claimEligible !== false,
+    };
+  }
 }
 /**
  * Resolve one execution leaf's active-claim eligibility (#1008).
@@ -755,6 +857,22 @@ function buildClaimStateResolution(owner, repo, policy, currentClaimId) {
     staleAgeMs,
     nowIso: new Date().toISOString(),
     currentClaimId: String(currentClaimId ?? '').trim(),
+  };
+}
+/**
+ * Build the CLI-side readiness resolution: the roadmap-marker resolver (the
+ * one new GitHub API surface, an A3-authorized scoped body search) plus the
+ * resolved authoring-hold policy. Only invoked when `--with-readiness` is
+ * passed, so the resolver is never wired in the default path.
+ */
+function buildReadinessResolution(owner, repo, policy) {
+  const authoringPolicy = resolveAuthoringGuardPolicy(policy);
+  const markerPrefix = normalizeMarkerPrefix(policy.markerPrefix);
+  return {
+    findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo, markerPrefix),
+    authoringLabelName: authoringPolicy.labelName,
+    authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+    nowIso: new Date().toISOString(),
   };
 }
 /**
@@ -1042,6 +1160,7 @@ function parseArgs(argv) {
     repo: '',
     policy: '',
     withClaimState: false,
+    withReadiness: false,
     currentClaimId: '',
     help: false,
   };
@@ -1076,6 +1195,10 @@ function parseArgs(argv) {
       parsed.withClaimState = true;
       continue;
     }
+    if (token === '--with-readiness') {
+      parsed.withReadiness = true;
+      continue;
+    }
     if (token === '--current-claim-id') {
       // Only consume the next token as the id when it exists and is not itself
       // a flag, so `--current-claim-id --with-claim-state` does not swallow the
@@ -1097,8 +1220,8 @@ function parseArgs(argv) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--current-claim-id <id>]
-  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--current-claim-id <id>]
+  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>]
+  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>]
 
   --issue and --all-roadmaps are mutually exclusive; exactly one is required.
   --all-roadmaps enumerates open execution leaves across every open roadmap
@@ -1120,6 +1243,18 @@ function printHelp() {
   new-format claimed-by markers and intentionally does NOT account for legacy
   claim-id-less markers or forced-handoff transfers; the authoritative A5
   claim gate (idd-claim.instructions.md) remains the real protection.
+
+  --with-readiness (opt-in) annotates each OPEN execution leaf with its A3
+  startability by composing the discover-readiness-check helper (blocked-by
+  resolution + authoring-hold). Each annotated leaf gains:
+    "readiness": { "ready": bool, "reasons": [str], "authoringHeld": bool, "startable": bool }
+      ready      = no blocking label + every Blocked by #N / {prefix}-blocked-by dep is closed
+      reasons    = sorted filter reasons (e.g. "blocked_by_open_issue:#N"); empty when ready
+      startable  = ready AND not claim-blocked (folds in claimEligible when --with-claim-state
+                   also ran; otherwise claim eligibility is unknown and treated as non-blocking)
+  Absent the flag, NO extra API calls are made and no readiness field is emitted
+  (the output shape is byte-stable). Like claimEligible this is a SOFT hint; the
+  A3/A4/A4.5/A5 gates remain authoritative.
 
 Output schema (JSON mode) — --issue single-root report:
   {

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -734,7 +734,7 @@ export function buildRoadmapMarkerSearchQuery(
   return `repo:${owner}/${repo} is:issue in:body "<!-- ${markerPrefix}-roadmap-id: ${marker} -->"`;
 }
 
-function buildRoadmapMarkerResolver(
+export function buildRoadmapMarkerResolver(
   owner: string,
   repo: string,
   markerPrefix: string,

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -10,11 +10,16 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { resolveAuthoringGuardPolicy } from './authoring-label-guard.mts';
 import {
   isAutopilotSuitabilityScore,
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mts';
+import {
+  buildRoadmapMarkerResolver,
+  evaluateDiscoverReadiness,
+} from './discover-readiness-check.mts';
 import { type EffortHint, effortOrdinal, parseEffort } from './effort.mts';
 import { parseIsoDurationToMs } from './policy-helpers.mts';
 import {
@@ -99,6 +104,36 @@ export interface LeafActiveClaim {
   ownedByCurrentSession?: boolean;
 }
 
+/**
+ * One open execution leaf's A3 readiness annotation (`--with-readiness`
+ * output). Present only under that opt-in flag, and only on open execution
+ * leaves. Like `claimEligible` this is a soft discovery hint: the
+ * A3/A4/A4.5/A5 written gates remain authoritative.
+ */
+export interface LeafReadiness {
+  /**
+   * Passes every A3 readiness filter — no `status:blocked-by-human` /
+   * `status:needs-decision` / authoring-hold label, and every visible
+   * `Blocked by #N` / hidden `{prefix}-blocked-by` dependency resolves to a
+   * closed issue.
+   */
+  ready: boolean;
+  /**
+   * Sorted filter reasons (empty when `ready`); e.g. `blocked_by_open_issue:#N`,
+   * `blocked_by_open_roadmap_marker:<id>`, `label:status:authoring`.
+   */
+  reasons: string[];
+  /** True when the configured authoring-hold label is present on this leaf. */
+  authoringHeld: boolean;
+  /**
+   * Combined soft start hint: `ready` AND not claim-blocked. When claim state
+   * was not also fetched (`--with-claim-state` absent), claim-eligibility is
+   * unknown and treated as non-blocking, so `startable` reflects readiness
+   * alone. Advisory only — never a gate.
+   */
+  startable: boolean;
+}
+
 /** One node of the enumerated roadmap graph in report form. */
 export interface RoadmapGraphNode {
   number: number;
@@ -124,6 +159,12 @@ export interface RoadmapGraphNode {
    * execution-leaf nodes.
    */
   claimEligible?: boolean;
+  /**
+   * A3 readiness annotation, present only under `--with-readiness` on open
+   * execution-leaf nodes. Absent on every node in the default (flag-absent)
+   * path so the byte-stable output shape is unchanged.
+   */
+  readiness?: LeafReadiness;
 }
 
 /** Provenance path from the root roadmap to one discovered node. */
@@ -223,6 +264,12 @@ export interface RoadmapUnionLeaf {
    * claim blocks this leaf. Present only under `--with-claim-state`.
    */
   claimEligible?: boolean;
+  /**
+   * A3 readiness annotation, present only under `--with-readiness`. Absent on
+   * every leaf in the default (flag-absent) path so the byte-stable output
+   * shape is unchanged.
+   */
+  readiness?: LeafReadiness;
 }
 
 /** One discovered open roadmap root the union enumeration started from. */
@@ -317,7 +364,30 @@ interface ClaimStateOptions {
   claimState?: ClaimStateResolution;
 }
 
-interface EnumerateRoadmapGraphOptions extends ClaimStateOptions {
+/**
+ * Opt-in A3-readiness annotation inputs (the `--with-readiness` surface). The
+ * loaders mirror the `--with-claim-state` injection pattern so tests stay
+ * network-free; `loadIssue` and `markerPrefix` are reused from the enclosing
+ * enumeration rather than rebuilt here.
+ */
+interface ReadinessResolution {
+  /** Resolve a `{prefix}-blocked-by` roadmap-id marker to its roadmap issues. */
+  findRoadmapsByMarker: (markerId: string) => unknown;
+  /** Configured authoring-hold label (`issueAuthoring.authoringLabelName`). */
+  authoringLabelName: string;
+  /** Configured authoring stale age in ms (`issueAuthoring.authoringStaleAge`). */
+  authoringStaleAgeMs: number;
+  /** Resolution "now" (ISO8601); defaults to the wall clock in the CLI. */
+  nowIso: string;
+}
+
+interface ReadinessOptions {
+  readiness?: ReadinessResolution;
+}
+
+interface EnumerateRoadmapGraphOptions
+  extends ClaimStateOptions,
+    ReadinessOptions {
   markerPrefix?: unknown;
   owner?: string;
   repo?: string;
@@ -350,6 +420,7 @@ interface ParsedArgs {
   repo: string;
   policy: string;
   withClaimState: boolean;
+  withReadiness: boolean;
   currentClaimId: string;
   help: boolean;
 }
@@ -392,6 +463,14 @@ if (isMainModule(import.meta.url)) {
     ? buildClaimStateResolution(owner, repo, policy, args.currentClaimId)
     : undefined;
 
+  // The readiness annotation is strictly opt-in: only when --with-readiness is
+  // passed do we build the marker / label-event loaders and resolve the
+  // authoring-hold policy. The default path leaves `readiness` undefined, so no
+  // extra fetch is made and the output is byte-stable.
+  const readiness = args.withReadiness
+    ? buildReadinessResolution(owner, repo, policy)
+    : undefined;
+
   const report = args.allRoadmaps
     ? await enumerateAllRoadmapsGraph({
         markerPrefix: policy.markerPrefix,
@@ -406,6 +485,7 @@ if (isMainModule(import.meta.url)) {
           policy.markerPrefix,
         ),
         claimState,
+        readiness,
       })
     : await enumerateRoadmapGraph(args.issue, {
         markerPrefix: policy.markerPrefix,
@@ -414,6 +494,7 @@ if (isMainModule(import.meta.url)) {
         loadIssue: buildIssueLoader(owner, repo),
         loadSubIssues: buildSubIssueLoader(owner, repo),
         claimState,
+        readiness,
       });
 
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
@@ -503,11 +584,18 @@ export async function enumerateRoadmapGraph(
     throw new Error(`root issue #${rootIssueNumber} was not recorded`);
   }
 
+  // Both opt-in annotation passes below operate on the open execution-leaf
+  // nodes, so resolve the execution-candidate set once — only when a pass
+  // actually runs, keeping the default path allocation-free and byte-stable.
+  const executionCandidateSet =
+    options.claimState || options.readiness
+      ? new Set(executionCandidates)
+      : null;
+
   // Opt-in (#1008): annotate each open execution-leaf node with active-claim
   // eligibility. Gated on `options.claimState` so the default path makes no
   // extra GitHub API call and the output shape stays byte-stable.
-  if (options.claimState) {
-    const executionCandidateSet = new Set(executionCandidates);
+  if (options.claimState && executionCandidateSet) {
     for (const node of nodes) {
       if (!executionCandidateSet.has(node.number)) {
         continue;
@@ -519,6 +607,22 @@ export async function enumerateRoadmapGraph(
       (node as RoadmapGraphNode).activeClaim = annotated.activeClaim;
       (node as RoadmapGraphNode).claimEligible = annotated.claimEligible;
     }
+  }
+
+  // Opt-in (#1123): annotate each open execution-leaf node with its A3
+  // readiness in a single batch call, after the claim loop so `startable` can
+  // fold in `claimEligible`. Gated on `options.readiness` so the default path
+  // makes no extra API call and the output shape stays byte-stable.
+  if (options.readiness && executionCandidateSet) {
+    const executionNodes = nodes.filter((node) =>
+      executionCandidateSet.has(node.number),
+    );
+    await annotateReadiness(
+      executionNodes,
+      options.readiness,
+      loadIssue,
+      markerPrefix,
+    );
   }
 
   return {
@@ -889,6 +993,19 @@ export async function enumerateAllRoadmapsGraph(
     }
   }
 
+  // Opt-in (#1123): annotate the open union leaves with their A3 readiness in a
+  // single batch call. Runs after the claim loop so `startable` can fold in
+  // `claimEligible`. Gated on `options.readiness`, so the default path adds no
+  // extra API call and the output shape stays byte-stable.
+  if (options.readiness) {
+    await annotateReadiness(
+      leaves,
+      options.readiness,
+      options.loadIssue,
+      markerPrefix,
+    );
+  }
+
   const scoredLeafCount = leaves.filter((leaf) =>
     isAutopilotSuitabilityScore(leaf.autopilotSuitability),
   ).length;
@@ -1003,6 +1120,75 @@ function normalizeOpenRoadmapRootNumbers(roots: unknown): number[] {
         .filter((value) => Number.isInteger(value) && value > 0),
     ),
   ].sort((left, right) => left - right);
+}
+
+/** An execution leaf/node that can carry the optional readiness annotation. */
+interface ReadinessAnnotatable {
+  number: number;
+  state: string;
+  claimEligible?: boolean;
+  readiness?: LeafReadiness;
+}
+
+/**
+ * Annotate each OPEN entry with its A3 readiness verdict (`--with-readiness`)
+ * by composing the batch `evaluateDiscoverReadiness` helper over the open
+ * entry numbers — one call, reusing the enclosing enumeration's `loadIssue`
+ * and `markerPrefix` so no second issue loader is constructed. Closed entries
+ * are skipped (only open execution work is a start candidate).
+ *
+ * `evaluateDiscoverReadiness` classifies every input number into `ready` or
+ * `filteredOut` (an inaccessible/closed issue lands in `filteredOut` with a
+ * sentinel reason), so each open entry resolves to a definite verdict. The
+ * combined `startable` hint folds in `claimEligible` when `--with-claim-state`
+ * also ran; otherwise claim eligibility is unknown and treated as
+ * non-blocking. The suitability floor is left to the helper default because
+ * the readiness classification (labels + dependencies) does not read the
+ * score.
+ */
+async function annotateReadiness(
+  entries: ReadinessAnnotatable[],
+  readiness: ReadinessResolution,
+  loadIssue: ((issueNumber: number) => unknown) | undefined,
+  markerPrefix: string,
+): Promise<void> {
+  const openEntries = entries.filter(
+    (entry) => String(entry.state).toUpperCase() === 'OPEN',
+  );
+  if (openEntries.length === 0) {
+    return;
+  }
+  const summary = await evaluateDiscoverReadiness(
+    openEntries.map((entry) => entry.number),
+    {
+      // We read only `ready` / `filteredOut[].reasons`, so the unresolvable
+      // bucket and the authoring-stale `warning` (and thus its
+      // `loadIssueLabelEvents` timeline fetch) are intentionally not wired —
+      // `authoringHeld` is label-presence-based and needs neither.
+      includeUnresolvable: false,
+      loadIssue,
+      findRoadmapsByMarker: readiness.findRoadmapsByMarker,
+      authoringLabelName: readiness.authoringLabelName,
+      authoringStaleAgeMs: readiness.authoringStaleAgeMs,
+      markerPrefix,
+      now: readiness.nowIso,
+    },
+  );
+  const readyNumbers = new Set(summary.ready.map((entry) => entry.number));
+  const reasonsByNumber = new Map(
+    summary.filteredOut.map((entry) => [entry.number, entry.reasons]),
+  );
+  const authoringReason = `label:${readiness.authoringLabelName}`;
+  for (const entry of openEntries) {
+    const ready = readyNumbers.has(entry.number);
+    const reasons = reasonsByNumber.get(entry.number) ?? [];
+    entry.readiness = {
+      ready,
+      reasons,
+      authoringHeld: reasons.includes(authoringReason),
+      startable: ready && entry.claimEligible !== false,
+    };
+  }
 }
 
 /** One leaf's resolved claim annotation (`--with-claim-state` output). */
@@ -1166,6 +1352,27 @@ function buildClaimStateResolution(
     staleAgeMs,
     nowIso: new Date().toISOString(),
     currentClaimId: String(currentClaimId ?? '').trim(),
+  };
+}
+
+/**
+ * Build the CLI-side readiness resolution: the roadmap-marker resolver (the
+ * one new GitHub API surface, an A3-authorized scoped body search) plus the
+ * resolved authoring-hold policy. Only invoked when `--with-readiness` is
+ * passed, so the resolver is never wired in the default path.
+ */
+function buildReadinessResolution(
+  owner: string,
+  repo: string,
+  policy: { markerPrefix?: unknown },
+): ReadinessResolution {
+  const authoringPolicy = resolveAuthoringGuardPolicy(policy);
+  const markerPrefix = normalizeMarkerPrefix(policy.markerPrefix);
+  return {
+    findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo, markerPrefix),
+    authoringLabelName: authoringPolicy.labelName,
+    authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+    nowIso: new Date().toISOString(),
   };
 }
 
@@ -1489,6 +1696,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     repo: '',
     policy: '',
     withClaimState: false,
+    withReadiness: false,
     currentClaimId: '',
     help: false,
   };
@@ -1524,6 +1732,10 @@ function parseArgs(argv: string[]): ParsedArgs {
       parsed.withClaimState = true;
       continue;
     }
+    if (token === '--with-readiness') {
+      parsed.withReadiness = true;
+      continue;
+    }
     if (token === '--current-claim-id') {
       // Only consume the next token as the id when it exists and is not itself
       // a flag, so `--current-claim-id --with-claim-state` does not swallow the
@@ -1547,8 +1759,8 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--current-claim-id <id>]
-  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--current-claim-id <id>]
+  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>]
+  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>]
 
   --issue and --all-roadmaps are mutually exclusive; exactly one is required.
   --all-roadmaps enumerates open execution leaves across every open roadmap
@@ -1570,6 +1782,18 @@ function printHelp() {
   new-format claimed-by markers and intentionally does NOT account for legacy
   claim-id-less markers or forced-handoff transfers; the authoritative A5
   claim gate (idd-claim.instructions.md) remains the real protection.
+
+  --with-readiness (opt-in) annotates each OPEN execution leaf with its A3
+  startability by composing the discover-readiness-check helper (blocked-by
+  resolution + authoring-hold). Each annotated leaf gains:
+    "readiness": { "ready": bool, "reasons": [str], "authoringHeld": bool, "startable": bool }
+      ready      = no blocking label + every Blocked by #N / {prefix}-blocked-by dep is closed
+      reasons    = sorted filter reasons (e.g. "blocked_by_open_issue:#N"); empty when ready
+      startable  = ready AND not claim-blocked (folds in claimEligible when --with-claim-state
+                   also ran; otherwise claim eligibility is unknown and treated as non-blocking)
+  Absent the flag, NO extra API calls are made and no readiness field is emitted
+  (the output shape is byte-stable). Like claimEligible this is a SOFT hint; the
+  A3/A4/A4.5/A5 gates remain authoritative.
 
 Output schema (JSON mode) — --issue single-root report:
   {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -113,9 +113,10 @@ export interface LeafActiveClaim {
 export interface LeafReadiness {
   /**
    * Passes every A3 readiness filter — no `status:blocked-by-human` /
-   * `status:needs-decision` / authoring-hold label, and every visible
-   * `Blocked by #N` / hidden `{prefix}-blocked-by` dependency resolves to a
-   * closed issue.
+   * `status:needs-decision` / authoring-hold label, and every dependency
+   * resolves to a closed issue: visible `Blocked by #N` / `Depends on #N` /
+   * task-list refs and hidden `{prefix}-blocked-by` roadmap markers, exactly
+   * as `evaluateDiscoverReadiness` evaluates them.
    */
   ready: boolean;
   /**
@@ -1784,10 +1785,11 @@ function printHelp() {
   claim gate (idd-claim.instructions.md) remains the real protection.
 
   --with-readiness (opt-in) annotates each OPEN execution leaf with its A3
-  startability by composing the discover-readiness-check helper (blocked-by
+  startability by composing the discover-readiness-check helper (dependency
   resolution + authoring-hold). Each annotated leaf gains:
     "readiness": { "ready": bool, "reasons": [str], "authoringHeld": bool, "startable": bool }
-      ready      = no blocking label + every Blocked by #N / {prefix}-blocked-by dep is closed
+      ready      = no blocking label + every dep closed (Blocked by #N / Depends on #N
+                   / task-list refs / {prefix}-blocked-by markers)
       reasons    = sorted filter reasons (e.g. "blocked_by_open_issue:#N"); empty when ready
       startable  = ready AND not claim-blocked (folds in claimEligible when --with-claim-state
                    also ran; otherwise claim eligibility is unknown and treated as non-blocking)

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -124,7 +124,13 @@ export interface LeafReadiness {
    * `blocked_by_open_roadmap_marker:<id>`, `label:status:authoring`.
    */
   reasons: string[];
-  /** True when the configured authoring-hold label is present on this leaf. */
+  /**
+   * True when the configured authoring-hold label is **present** on this leaf.
+   * Label-presence only: `--with-readiness` intentionally does not compute the
+   * stale-authoring warning (it would cost a discarded per-leaf timeline
+   * fetch and does not change startability — an authoring-held leaf is not
+   * startable regardless of staleness).
+   */
   authoringHeld: boolean;
   /**
    * Combined soft start hint: `ready` AND not claim-blocked. When claim state
@@ -998,7 +1004,11 @@ export async function enumerateAllRoadmapsGraph(
   // single batch call. Runs after the claim loop so `startable` can fold in
   // `claimEligible`. Gated on `options.readiness`, so the default path adds no
   // extra API call and the output shape stays byte-stable.
-  if (options.readiness) {
+  // `options.loadIssue` is required for any enumeration to succeed (each
+  // per-root `enumerateRoadmapGraph` above throws without it), so by here it is
+  // always a function; the typeof guard narrows the optional option type for
+  // the required `annotateReadiness` parameter without an unsafe cast.
+  if (options.readiness && typeof options.loadIssue === 'function') {
     await annotateReadiness(
       leaves,
       options.readiness,
@@ -1150,7 +1160,7 @@ interface ReadinessAnnotatable {
 async function annotateReadiness(
   entries: ReadinessAnnotatable[],
   readiness: ReadinessResolution,
-  loadIssue: ((issueNumber: number) => unknown) | undefined,
+  loadIssue: (issueNumber: number) => unknown,
   markerPrefix: string,
 ): Promise<void> {
   const openEntries = entries.filter(

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -1795,3 +1795,151 @@ test('a PT0S staleAge falls back to the default 24h window, not 0ms', async () =
     assert.equal(leaf701?.claimEligible, false);
   }
 });
+
+// One epic (920) → a ready leaf (921), a leaf blocked by an open roadmap
+// marker (922), and an authoring-held leaf (923).
+function readinessGraphIssues() {
+  return new Map<number, unknown>([
+    [
+      920,
+      roadmapIssue(920, '- [ ] #921\n- [ ] #922\n- [ ] #923', 'epic-readiness'),
+    ],
+    [921, executionIssue(921, 'ready leaf 921')],
+    [
+      922,
+      executionIssue(
+        922,
+        'blocked leaf 922\n<!-- idd-skill-blocked-by: blocker-roadmap -->',
+      ),
+    ],
+    [
+      923,
+      {
+        number: 923,
+        title: 'issue 923',
+        state: 'open',
+        body: 'authoring leaf 923',
+        labels: [{ name: 'status:authoring' }],
+      },
+    ],
+  ]);
+}
+
+function readinessResolution() {
+  return {
+    findRoadmapsByMarker: async (markerId: string) =>
+      markerId === 'blocker-roadmap' ? [{ number: 990, state: 'OPEN' }] : [],
+    loadIssueLabelEvents: async () => [],
+    authoringLabelName: 'status:authoring',
+    authoringStaleAgeMs: 4 * 60 * 60 * 1000,
+    nowIso: '2026-06-26T00:00:00Z',
+  };
+}
+
+test('--with-readiness annotates open union leaves with a combined startable signal', async () => {
+  const issues = readinessGraphIssues();
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [920],
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    readiness: readinessResolution(),
+  });
+
+  const byNumber = new Map(report.leaves.map((leaf) => [leaf.number, leaf]));
+  // A fully-ready leaf is startable (no claim state was fetched, so claim
+  // eligibility is unknown and treated as non-blocking).
+  assert.deepEqual(byNumber.get(921)?.readiness, {
+    ready: true,
+    reasons: [],
+    authoringHeld: false,
+    startable: true,
+  });
+  // A leaf blocked by an open roadmap marker is not ready and not startable.
+  const r922 = byNumber.get(922)?.readiness;
+  assert.equal(r922?.ready, false);
+  assert.equal(r922?.startable, false);
+  assert.equal(r922?.authoringHeld, false);
+  assert.deepEqual(r922?.reasons, [
+    'blocked_by_open_roadmap_marker:blocker-roadmap',
+  ]);
+  // An authoring-held leaf is flagged and not startable.
+  const r923 = byNumber.get(923)?.readiness;
+  assert.equal(r923?.ready, false);
+  assert.equal(r923?.startable, false);
+  assert.equal(r923?.authoringHeld, true);
+  assert.ok(r923?.reasons.includes('label:status:authoring'));
+});
+
+test('--with-readiness is byte-stable when the flag is absent', async () => {
+  const issues = readinessGraphIssues();
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [920],
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  for (const leaf of report.leaves) {
+    assert.equal(
+      Object.hasOwn(leaf as unknown as Record<string, unknown>, 'readiness'),
+      false,
+    );
+  }
+});
+
+test('startable folds in claimEligible: a ready but claimed leaf is not startable', async () => {
+  const issues = claimGraphIssues();
+  const commentsByIssue = new Map<number, unknown[]>([
+    [701, [claimComment('agent-a', 'claim-701', FRESH_CLAIM_AT)]],
+  ]);
+  const { resolution } = buildClaimState(commentsByIssue);
+
+  const report = await enumerateAllRoadmapsGraph({
+    loadOpenRoadmapRoots: async () => [700],
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    claimState: resolution,
+    readiness: readinessResolution(),
+  });
+
+  const byNumber = new Map(report.leaves.map((leaf) => [leaf.number, leaf]));
+  // 701 is readiness-ready but holds a fresh trusted claim → not startable.
+  assert.equal(byNumber.get(701)?.readiness?.ready, true);
+  assert.equal(byNumber.get(701)?.claimEligible, false);
+  assert.equal(byNumber.get(701)?.readiness?.startable, false);
+  // 702 is ready and unclaimed → startable.
+  assert.equal(byNumber.get(702)?.readiness?.ready, true);
+  assert.equal(byNumber.get(702)?.claimEligible, true);
+  assert.equal(byNumber.get(702)?.readiness?.startable, true);
+});
+
+test('--with-readiness on a single root annotates only open execution-leaf nodes', async () => {
+  const issues = new Map<number, unknown>([
+    [930, roadmapIssue(930, '- [ ] #931\n- [ ] #932', 'epic-single')],
+    // An open NESTED ROADMAP node (carries a roadmap-id marker), not a leaf.
+    [931, roadmapIssue(931, '', 'nested-single')],
+    [932, executionIssue(932, 'ready execution leaf')],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(930, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    readiness: readinessResolution(),
+  });
+
+  const byNumber = new Map(graph.nodes.map((node) => [node.number, node]));
+  // The open execution leaf is annotated and ready/startable.
+  assert.equal(byNumber.get(932)?.readiness?.ready, true);
+  assert.equal(byNumber.get(932)?.readiness?.startable, true);
+  // The open nested-roadmap node and the root roadmap are NOT annotated — the
+  // executionCandidateSet filter excludes every non-execution node.
+  assert.equal(
+    Object.hasOwn(
+      byNumber.get(931) as unknown as Record<string, unknown>,
+      'readiness',
+    ),
+    false,
+  );
+  assert.equal(
+    Object.hasOwn(
+      byNumber.get(930) as unknown as Record<string, unknown>,
+      'readiness',
+    ),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

During autopilot Discover, `discover-roadmap-graph --with-claim-state`
annotated each open leaf only with `claimEligible`; A3 startability
(blocked-by resolution + authoring-hold) required a separate per-candidate
body/label fetch. This adds an opt-in `--with-readiness` flag that composes
the existing `evaluateDiscoverReadiness` over the union's (and single-root's)
open execution leaves so a single read tells Discover whether each candidate
is actually startable.

## Change

- New `LeafReadiness` (`{ ready, reasons, authoringHeld, startable }`) on each
  open execution leaf/node under `--with-readiness`. `startable` = `ready`
  **and** not claim-blocked — it folds in `claimEligible` when
  `--with-claim-state` also ran; otherwise claim-eligibility is unknown and
  treated as non-blocking.
- A shared `annotateReadiness` helper runs **one** batch
  `evaluateDiscoverReadiness` call after the claim loop (so `startable` can read
  `claimEligible`), reusing the enumeration's `loadIssue` / `markerPrefix`. No
  blocked-by/authoring logic is reimplemented; the marker lookup stays the
  A3-authorized scoped search.
- Soft hint only: the A3/A4/A4.5/A5 gates remain authoritative, exactly like
  `claimEligible`. Without the flag the output is **byte-identical** and makes
  no extra API call (verified by a flag-absent test).
- Refreshes the union-leaf "Stable Helper Evidence Outputs" doc (adds the
  previously-missing `effort`, the `--with-claim-state` fields, and the new
  `--with-readiness` fields).

## Verification

`pnpm test` (1365 pass; 4 new tests cover ready→startable, blocked→reason +
`startable:false`, authoring→`authoringHeld`, claim-fold, single-root
execution-only filter, and flag-absent byte-stability), `pnpm run typecheck`,
`pnpm run build` (no artifact drift), biome, dprint, markdownlint, cspell, and
`audit-docs --check` all pass.

Dogfooded live on this repo: `--all-roadmaps --with-readiness --with-claim-state`
correctly reported a leaf whose `Blocked by` deps had just closed as
`ready:true` but `startable:false` while another session held its claim.

Closes #1123
