### PR TITLE
fix(idd): dedup F4 applied-path cleanup-evidence against prior success

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -278,10 +278,17 @@ Before any mutating action in F3, apply the
      After apply, record the outcome by the apply `status`. See
      `docs/idd-comment-minimization.md` for the exact formats:
 
-     If the apply `status` is `applied`: this run minimized candidates,
-     so **always** post the evidence comment (with `status`, `applied`,
-     `failed`, `skipped`, and `viewer-cannot-minimize` counts) — never
-     suppress a record of work this run actually did. Proceed to step 3.
+     If the apply `status` is `applied`: this run minimized residual
+     candidates. **Skip the post when the PR already carries a
+     `<!-- idd-cleanup-evidence:` comment recording a successful outcome**
+     (`applied` or `clean`) — for example one the `post-merge-cleanup`
+     workflow posted within seconds of the merge — to avoid a duplicate
+     success record, since that prior record already documents that
+     cleanup occurred on this PR. Otherwise (only a `failed` /
+     `incomplete` / `permission-blocked` record exists, or none) post the
+     evidence comment (with `status`, `applied`, `failed`, `skipped`, and
+     `viewer-cannot-minimize` counts) so this run's work is recorded.
+     Proceed to step 3.
 
      If the apply `status` is `clean`: this run was a no-op (nothing left
      to minimize). **Skip the post when the PR already carries a
@@ -308,13 +315,13 @@ Before any mutating action in F3, apply the
    already-minimized comments and comments the viewer cannot minimize.
    Re-validate the active claim before each mutation. After GraphQL
    cleanup, post an evidence comment summarizing the outcome (status,
-   applied count, skipped count with reasons). Skip the post only when
-   this run minimized nothing new **and** the PR already carries a
-   `<!-- idd-cleanup-evidence:` comment recording a successful outcome
-   (`applied` / `clean`); still post when this run minimized candidates,
-   or to correct an existing `failed` / `incomplete` /
-   `permission-blocked` record. If the viewer cannot minimize any
-   detected candidates, post a
+   applied count, skipped count with reasons). Skip the post when the PR
+   already carries a `<!-- idd-cleanup-evidence:` comment recording a
+   successful outcome (`applied` / `clean`) — whether or not this run
+   minimized new candidates — to avoid a duplicate success record; still
+   post when no prior success record exists, or to correct an existing
+   `failed` / `incomplete` / `permission-blocked` record. If the viewer
+   cannot minimize any detected candidates, post a
    cleanup-permission-blocked comment instead of exiting silently.
 
    See `docs/idd-comment-minimization.md` for the evidence comment

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -156,9 +156,13 @@ post comments under a writeable `GITHUB_TOKEN`.
 The agent F4 step in `idd-merge.instructions.md` remains the
 canonical, mandatory contract. The server-side workflow is a
 backstop, not a replacement: same helper, same candidate rules,
-same evidence comment shape, non-blocking on errors. Concurrency
-keyed on PR number prevents double-posting when an agent F4 and
-the workflow happen to run in the same minute.
+same evidence comment shape, non-blocking on errors. Double-posting is
+prevented by the cleanup-evidence record itself, not by Actions
+concurrency: the workflow skips when any `<!-- idd-cleanup-evidence:`
+comment already exists, and the agent F4 step skips its own post when a
+prior success record (the workflow's included) is present. The
+workflow's PR-keyed `concurrency` group only serializes workflow runs
+against each other; it does not gate the agent's local F4.
 
 ## GitHub mechanism
 
@@ -360,15 +364,16 @@ Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
 workflow run — can detect that evidence was already posted. The
-**agent-side** rule is status-aware: **skip the post only when this run
-minimized nothing new and a `<!-- idd-cleanup-evidence:` comment
-recording a successful outcome (`applied` / `clean`) already exists on
-the PR**, so the agent never stacks a duplicate success record; still
-post when this run minimized candidates, or to correct an existing
-`failed` / `incomplete` / `permission-blocked` record. The
-`post-merge-cleanup` workflow instead uses a simpler presence-only guard
-(it skips on any existing marker), which suffices for its single-shot
-post-merge run:
+**agent-side** rule keys on the prior **success** record: **skip the
+post when a `<!-- idd-cleanup-evidence:` comment recording a successful
+outcome (`applied` / `clean`) already exists on the PR**, so the agent
+never stacks a duplicate success record — even when this run's own apply
+returned `applied` for residual markers a concurrent `post-merge-cleanup`
+workflow run minimized first; still post when no prior success record
+exists, or to correct an existing `failed` / `incomplete` /
+`permission-blocked` record. The `post-merge-cleanup` workflow instead
+uses a simpler presence-only guard (it skips on any existing marker),
+which suffices for its single-shot post-merge run:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -160,9 +160,9 @@ same evidence comment shape, non-blocking on errors. Double-posting is
 prevented by the cleanup-evidence record itself, not by Actions
 concurrency: the workflow skips when any `<!-- idd-cleanup-evidence:`
 comment already exists, and the agent F4 step skips its own post when a
-prior success record (the workflow's included) is present. The
-workflow's PR-keyed `concurrency` group only serializes workflow runs
-against each other; it does not gate the agent's local F4.
+prior success record is already present — including the one the workflow
+posted. The workflow's PR-keyed `concurrency` group only serializes
+workflow runs against each other; it does not gate the agent's local F4.
 
 ## GitHub mechanism
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -278,10 +278,17 @@ Before any mutating action in F3, apply the
      After apply, record the outcome by the apply `status`. See
      `docs/idd-comment-minimization.md` for the exact formats:
 
-     If the apply `status` is `applied`: this run minimized candidates,
-     so **always** post the evidence comment (with `status`, `applied`,
-     `failed`, `skipped`, and `viewer-cannot-minimize` counts) — never
-     suppress a record of work this run actually did. Proceed to step 3.
+     If the apply `status` is `applied`: this run minimized residual
+     candidates. **Skip the post when the PR already carries a
+     `<!-- idd-cleanup-evidence:` comment recording a successful outcome**
+     (`applied` or `clean`) — for example one the `post-merge-cleanup`
+     workflow posted within seconds of the merge — to avoid a duplicate
+     success record, since that prior record already documents that
+     cleanup occurred on this PR. Otherwise (only a `failed` /
+     `incomplete` / `permission-blocked` record exists, or none) post the
+     evidence comment (with `status`, `applied`, `failed`, `skipped`, and
+     `viewer-cannot-minimize` counts) so this run's work is recorded.
+     Proceed to step 3.
 
      If the apply `status` is `clean`: this run was a no-op (nothing left
      to minimize). **Skip the post when the PR already carries a
@@ -308,13 +315,13 @@ Before any mutating action in F3, apply the
    already-minimized comments and comments the viewer cannot minimize.
    Re-validate the active claim before each mutation. After GraphQL
    cleanup, post an evidence comment summarizing the outcome (status,
-   applied count, skipped count with reasons). Skip the post only when
-   this run minimized nothing new **and** the PR already carries a
-   `<!-- idd-cleanup-evidence:` comment recording a successful outcome
-   (`applied` / `clean`); still post when this run minimized candidates,
-   or to correct an existing `failed` / `incomplete` /
-   `permission-blocked` record. If the viewer cannot minimize any
-   detected candidates, post a
+   applied count, skipped count with reasons). Skip the post when the PR
+   already carries a `<!-- idd-cleanup-evidence:` comment recording a
+   successful outcome (`applied` / `clean`) — whether or not this run
+   minimized new candidates — to avoid a duplicate success record; still
+   post when no prior success record exists, or to correct an existing
+   `failed` / `incomplete` / `permission-blocked` record. If the viewer
+   cannot minimize any detected candidates, post a
    cleanup-permission-blocked comment instead of exiting silently.
 
    See `docs/idd-comment-minimization.md` for the evidence comment

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -156,9 +156,13 @@ post comments under a writeable `GITHUB_TOKEN`.
 The agent F4 step in `idd-merge.instructions.md` remains the
 canonical, mandatory contract. The server-side workflow is a
 backstop, not a replacement: same helper, same candidate rules,
-same evidence comment shape, non-blocking on errors. Concurrency
-keyed on PR number prevents double-posting when an agent F4 and
-the workflow happen to run in the same minute.
+same evidence comment shape, non-blocking on errors. Double-posting is
+prevented by the cleanup-evidence record itself, not by Actions
+concurrency: the workflow skips when any `<!-- idd-cleanup-evidence:`
+comment already exists, and the agent F4 step skips its own post when a
+prior success record (the workflow's included) is present. The
+workflow's PR-keyed `concurrency` group only serializes workflow runs
+against each other; it does not gate the agent's local F4.
 
 ## GitHub mechanism
 
@@ -360,15 +364,16 @@ Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
 workflow run — can detect that evidence was already posted. The
-**agent-side** rule is status-aware: **skip the post only when this run
-minimized nothing new and a `<!-- idd-cleanup-evidence:` comment
-recording a successful outcome (`applied` / `clean`) already exists on
-the PR**, so the agent never stacks a duplicate success record; still
-post when this run minimized candidates, or to correct an existing
-`failed` / `incomplete` / `permission-blocked` record. The
-`post-merge-cleanup` workflow instead uses a simpler presence-only guard
-(it skips on any existing marker), which suffices for its single-shot
-post-merge run:
+**agent-side** rule keys on the prior **success** record: **skip the
+post when a `<!-- idd-cleanup-evidence:` comment recording a successful
+outcome (`applied` / `clean`) already exists on the PR**, so the agent
+never stacks a duplicate success record — even when this run's own apply
+returned `applied` for residual markers a concurrent `post-merge-cleanup`
+workflow run minimized first; still post when no prior success record
+exists, or to correct an existing `failed` / `incomplete` /
+`permission-blocked` record. The `post-merge-cleanup` workflow instead
+uses a simpler presence-only guard (it skips on any existing marker),
+which suffices for its single-shot post-merge run:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -160,9 +160,9 @@ same evidence comment shape, non-blocking on errors. Double-posting is
 prevented by the cleanup-evidence record itself, not by Actions
 concurrency: the workflow skips when any `<!-- idd-cleanup-evidence:`
 comment already exists, and the agent F4 step skips its own post when a
-prior success record (the workflow's included) is present. The
-workflow's PR-keyed `concurrency` group only serializes workflow runs
-against each other; it does not gate the agent's local F4.
+prior success record is already present — including the one the workflow
+posted. The workflow's PR-keyed `concurrency` group only serializes
+workflow runs against each other; it does not gate the agent's local F4.
 
 ## GitHub mechanism
 


### PR DESCRIPTION
## Summary

The F4 `applied`-path cleanup rule in `idd-merge.instructions.md` posted a
`<!-- idd-cleanup-evidence:` comment unconditionally. When the
`post-merge-cleanup.yml` workflow races ahead on the same merged PR and posts
its own success record first, the agent's later `audit-pr-cleanup --apply`
returns `applied` for the residual markers that arrived after the workflow's
snapshot, so the "always post" rule stacked a **second**, near-identical
success record (observed on PRs #1103, #1109, #1117).

This mirrors the existing `clean`-path dedup (#1067 / #1068) onto the
`applied` path.

## Changes

- **`applied`-path rule** (`idd-merge.instructions.md`): skip the agent-side
  post when the PR already carries a `<!-- idd-cleanup-evidence:` comment
  recording a **success** outcome (`applied` / `clean`); still post when only a
  `failed` / `incomplete` / `permission-blocked` record exists, or none.
- **GraphQL-fallback clause** (same file): aligned to the same
  prior-success-skip rule so all three agent-side paths (`applied`, `clean`,
  fallback) are uniform and the unified doc rule stays contradiction-free.
- **`docs/idd-comment-minimization.md`**: updated the agent-side evidence-post
  rule to key on the prior success record, and corrected a false claim that
  Actions `concurrency` prevents double-posting — the workflow's concurrency
  group only serializes workflow-vs-workflow runs, never the agent's local F4
  (the exact false premise behind the duplicates).
- Mirrored from the `idd-template/` source via `sync-docs --apply`;
  `audit-docs --check` passes.

## Rationale / non-goals

- **Presence-only detection (not a trusted-marker-actor gate).** The racing
  record is authored by `github-actions[bot]`, which is **not** in
  `trustedMarkerActors`. A trusted-actor gate would ignore that record and
  double-post anyway, so this matches the `clean` path's deliberate
  presence-only detection. The issue's "trusted prior comment" is satisfied in
  spirit by a well-formed success record, not by marker-actor authentication
  (cleanup-evidence is evidence, not a minimizable operational marker).
- **Optional helper field deferred.** #1124 lists an optional
  `existingCleanupEvidence` field on `audit-pr-cleanup`'s `CleanupAuditReport`.
  It is not required: the agent detects the prior record by comment scan exactly
  as the `clean` path already does. Adding it would require new test scaffolding
  (no `tests/audit-pr-cleanup.test.mts` exists today) for a ~42 KB module,
  disproportionate to the author-estimated effort (S); it is a clean follow-up
  if the determinism improvement is wanted.

## Verification

- `pnpm test` (1371 pass / 0 fail), `pnpm run lint:minimum`,
  `node scripts/audit-docs.mjs --check` all green.

Closes #1124
