### PR TITLE
fix(idd): yield empty for an allowed gh http status, not the error body

### DIFF
--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -752,6 +752,35 @@ function resolvePrFirstCommitAt(commits) {
   }
   return earliestIso;
 }
+/**
+ * Decide how a thrown `gh` failure is tolerated, returning the string result to
+ * use or `undefined` when the caller must re-throw.
+ *
+ * - `allowStatuses` matches the process exit code and returns stdout **only**
+ *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
+ *   yet still print the data, e.g. the checks rollup).
+ * - `allowHttpStatuses` matches the HTTP status parsed from stderr and yields an
+ *   **empty** string. `gh api` writes the JSON error body to stdout on a
+ *   non-2xx response (a 404 prints `{"message":"Not Found",…}`), so returning
+ *   that body would make `ghApiJson` parse the error object instead of `{}` /
+ *   `[]`. An allowed status never carries useful data, so the empty result lets
+ *   `ghApiJson` resolve it to an empty object / array.
+ */
+export function resolveToleratedGhFailure(error, options = {}) {
+  const status = Number(error?.status ?? -1);
+  if ((options.allowStatuses ?? []).includes(status)) {
+    const stdout = String(error?.stdout ?? '');
+    if (/^\s*[[{]/.test(stdout)) {
+      return stdout;
+    }
+  }
+  const stderr = String(error?.stderr ?? '');
+  const httpStatus = Number(stderr.match(/HTTP\s+(\d+)/i)?.[1] ?? -1);
+  if ((options.allowHttpStatuses ?? []).includes(httpStatus)) {
+    return '';
+  }
+  return undefined;
+}
 function runGh(args, options = {}) {
   try {
     return execFileSync('gh', args, {
@@ -759,17 +788,9 @@ function runGh(args, options = {}) {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (error) {
-    const status = Number(error?.status ?? -1);
-    if ((options.allowStatuses ?? []).includes(status)) {
-      const stdout = String(error?.stdout ?? '');
-      if (/^\s*[[{]/.test(stdout)) {
-        return stdout;
-      }
-    }
-    const stderr = String(error?.stderr ?? '');
-    const httpStatus = Number(stderr.match(/HTTP\s+(\d+)/i)?.[1] ?? -1);
-    if ((options.allowHttpStatuses ?? []).includes(httpStatus)) {
-      return String(error?.stdout ?? '');
+    const tolerated = resolveToleratedGhFailure(error, options);
+    if (tolerated !== undefined) {
+      return tolerated;
     }
     throw error;
   }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -756,28 +756,35 @@ function resolvePrFirstCommitAt(commits) {
  * Decide how a thrown `gh` failure is tolerated, returning the string result to
  * use or `undefined` when the caller must re-throw.
  *
- * - `allowStatuses` matches the process exit code and returns stdout **only**
- *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
- *   yet still print the data, e.g. the checks rollup).
  * - `allowHttpStatuses` matches the HTTP status parsed from stderr and yields an
  *   **empty** string. `gh api` writes the JSON error body to stdout on a
  *   non-2xx response (a 404 prints `{"message":"Not Found",…}`), so returning
  *   that body would make `ghApiJson` parse the error object instead of `{}` /
  *   `[]`. An allowed status never carries useful data, so the empty result lets
  *   `ghApiJson` resolve it to an empty object / array.
+ * - `allowStatuses` matches the process exit code and returns stdout **only**
+ *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
+ *   yet still print the data, e.g. the checks rollup).
+ *
+ * The HTTP-status branch is checked **first**: an explicitly tolerated HTTP
+ * status must always yield empty, even when the exit code is also tolerated and
+ * the error body on stdout happens to be JSON. Checking `allowStatuses` first
+ * would return that error body and reintroduce the very parsing bug this guards
+ * against. No current caller sets both options, so the order is behavior-neutral
+ * today; it keeps the resolver correct for any future combined call.
  */
 export function resolveToleratedGhFailure(error, options = {}) {
+  const stderr = String(error?.stderr ?? '');
+  const httpStatus = Number(stderr.match(/HTTP\s+(\d+)/i)?.[1] ?? -1);
+  if ((options.allowHttpStatuses ?? []).includes(httpStatus)) {
+    return '';
+  }
   const status = Number(error?.status ?? -1);
   if ((options.allowStatuses ?? []).includes(status)) {
     const stdout = String(error?.stdout ?? '');
     if (/^\s*[[{]/.test(stdout)) {
       return stdout;
     }
-  }
-  const stderr = String(error?.stderr ?? '');
-  const httpStatus = Number(stderr.match(/HTTP\s+(\d+)/i)?.[1] ?? -1);
-  if ((options.allowHttpStatuses ?? []).includes(httpStatus)) {
-    return '';
   }
   return undefined;
 }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -756,12 +756,13 @@ function resolvePrFirstCommitAt(commits) {
  * Decide how a thrown `gh` failure is tolerated, returning the string result to
  * use or `undefined` when the caller must re-throw.
  *
- * - `allowHttpStatuses` matches the HTTP status parsed from stderr and yields an
- *   **empty** string. `gh api` writes the JSON error body to stdout on a
- *   non-2xx response (a 404 prints `{"message":"Not Found",…}`), so returning
- *   that body would make `ghApiJson` parse the error object instead of `{}` /
- *   `[]`. An allowed status never carries useful data, so the empty result lets
- *   `ghApiJson` resolve it to an empty object / array.
+ * - `allowHttpStatuses` matches the HTTP status derived from the gh error via
+ *   the shared `deriveGhHttpStatus` (the same extractor `fetchBranchRulesets`
+ *   uses) and yields an **empty** string. `gh api` writes the JSON error body to
+ *   stdout on a non-2xx response (a 404 prints `{"message":"Not Found",…}`), so
+ *   returning that body would make `ghApiJson` parse the error object instead of
+ *   `{}` / `[]`. An allowed status never carries useful data, so the empty
+ *   result lets `ghApiJson` resolve it to an empty object / array.
  * - `allowStatuses` matches the process exit code and returns stdout **only**
  *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
  *   yet still print the data, e.g. the checks rollup).
@@ -774,9 +775,11 @@ function resolvePrFirstCommitAt(commits) {
  * today; it keeps the resolver correct for any future combined call.
  */
 export function resolveToleratedGhFailure(error, options = {}) {
-  const stderr = String(error?.stderr ?? '');
-  const httpStatus = Number(stderr.match(/HTTP\s+(\d+)/i)?.[1] ?? -1);
-  if ((options.allowHttpStatuses ?? []).includes(httpStatus)) {
+  const httpStatus = deriveGhHttpStatus(error);
+  if (
+    httpStatus !== null &&
+    (options.allowHttpStatuses ?? []).includes(httpStatus)
+  ) {
     return '';
   }
   const status = Number(error?.status ?? -1);

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -1015,6 +1015,39 @@ function resolvePrFirstCommitAt(commits: PrCommitPayload[]): string | null {
   return earliestIso;
 }
 
+/**
+ * Decide how a thrown `gh` failure is tolerated, returning the string result to
+ * use or `undefined` when the caller must re-throw.
+ *
+ * - `allowStatuses` matches the process exit code and returns stdout **only**
+ *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
+ *   yet still print the data, e.g. the checks rollup).
+ * - `allowHttpStatuses` matches the HTTP status parsed from stderr and yields an
+ *   **empty** string. `gh api` writes the JSON error body to stdout on a
+ *   non-2xx response (a 404 prints `{"message":"Not Found",…}`), so returning
+ *   that body would make `ghApiJson` parse the error object instead of `{}` /
+ *   `[]`. An allowed status never carries useful data, so the empty result lets
+ *   `ghApiJson` resolve it to an empty object / array.
+ */
+export function resolveToleratedGhFailure(
+  error: unknown,
+  options: RunGhOptions = {},
+): string | undefined {
+  const status = Number((error as { status?: unknown } | null)?.status ?? -1);
+  if ((options.allowStatuses ?? []).includes(status)) {
+    const stdout = String((error as { stdout?: unknown } | null)?.stdout ?? '');
+    if (/^\s*[[{]/.test(stdout)) {
+      return stdout;
+    }
+  }
+  const stderr = String((error as { stderr?: unknown } | null)?.stderr ?? '');
+  const httpStatus = Number(stderr.match(/HTTP\s+(\d+)/i)?.[1] ?? -1);
+  if ((options.allowHttpStatuses ?? []).includes(httpStatus)) {
+    return '';
+  }
+  return undefined;
+}
+
 function runGh(args: string[], options: RunGhOptions = {}): string {
   try {
     return execFileSync('gh', args, {
@@ -1022,19 +1055,9 @@ function runGh(args: string[], options: RunGhOptions = {}): string {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (error) {
-    const status = Number((error as { status?: unknown } | null)?.status ?? -1);
-    if ((options.allowStatuses ?? []).includes(status)) {
-      const stdout = String(
-        (error as { stdout?: unknown } | null)?.stdout ?? '',
-      );
-      if (/^\s*[[{]/.test(stdout)) {
-        return stdout;
-      }
-    }
-    const stderr = String((error as { stderr?: unknown } | null)?.stderr ?? '');
-    const httpStatus = Number(stderr.match(/HTTP\s+(\d+)/i)?.[1] ?? -1);
-    if ((options.allowHttpStatuses ?? []).includes(httpStatus)) {
-      return String((error as { stdout?: unknown } | null)?.stdout ?? '');
+    const tolerated = resolveToleratedGhFailure(error, options);
+    if (tolerated !== undefined) {
+      return tolerated;
     }
     throw error;
   }

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -1019,31 +1019,38 @@ function resolvePrFirstCommitAt(commits: PrCommitPayload[]): string | null {
  * Decide how a thrown `gh` failure is tolerated, returning the string result to
  * use or `undefined` when the caller must re-throw.
  *
- * - `allowStatuses` matches the process exit code and returns stdout **only**
- *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
- *   yet still print the data, e.g. the checks rollup).
  * - `allowHttpStatuses` matches the HTTP status parsed from stderr and yields an
  *   **empty** string. `gh api` writes the JSON error body to stdout on a
  *   non-2xx response (a 404 prints `{"message":"Not Found",…}`), so returning
  *   that body would make `ghApiJson` parse the error object instead of `{}` /
  *   `[]`. An allowed status never carries useful data, so the empty result lets
  *   `ghApiJson` resolve it to an empty object / array.
+ * - `allowStatuses` matches the process exit code and returns stdout **only**
+ *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
+ *   yet still print the data, e.g. the checks rollup).
+ *
+ * The HTTP-status branch is checked **first**: an explicitly tolerated HTTP
+ * status must always yield empty, even when the exit code is also tolerated and
+ * the error body on stdout happens to be JSON. Checking `allowStatuses` first
+ * would return that error body and reintroduce the very parsing bug this guards
+ * against. No current caller sets both options, so the order is behavior-neutral
+ * today; it keeps the resolver correct for any future combined call.
  */
 export function resolveToleratedGhFailure(
   error: unknown,
   options: RunGhOptions = {},
 ): string | undefined {
+  const stderr = String((error as { stderr?: unknown } | null)?.stderr ?? '');
+  const httpStatus = Number(stderr.match(/HTTP\s+(\d+)/i)?.[1] ?? -1);
+  if ((options.allowHttpStatuses ?? []).includes(httpStatus)) {
+    return '';
+  }
   const status = Number((error as { status?: unknown } | null)?.status ?? -1);
   if ((options.allowStatuses ?? []).includes(status)) {
     const stdout = String((error as { stdout?: unknown } | null)?.stdout ?? '');
     if (/^\s*[[{]/.test(stdout)) {
       return stdout;
     }
-  }
-  const stderr = String((error as { stderr?: unknown } | null)?.stderr ?? '');
-  const httpStatus = Number(stderr.match(/HTTP\s+(\d+)/i)?.[1] ?? -1);
-  if ((options.allowHttpStatuses ?? []).includes(httpStatus)) {
-    return '';
   }
   return undefined;
 }

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -1019,12 +1019,13 @@ function resolvePrFirstCommitAt(commits: PrCommitPayload[]): string | null {
  * Decide how a thrown `gh` failure is tolerated, returning the string result to
  * use or `undefined` when the caller must re-throw.
  *
- * - `allowHttpStatuses` matches the HTTP status parsed from stderr and yields an
- *   **empty** string. `gh api` writes the JSON error body to stdout on a
- *   non-2xx response (a 404 prints `{"message":"Not Found",…}`), so returning
- *   that body would make `ghApiJson` parse the error object instead of `{}` /
- *   `[]`. An allowed status never carries useful data, so the empty result lets
- *   `ghApiJson` resolve it to an empty object / array.
+ * - `allowHttpStatuses` matches the HTTP status derived from the gh error via
+ *   the shared `deriveGhHttpStatus` (the same extractor `fetchBranchRulesets`
+ *   uses) and yields an **empty** string. `gh api` writes the JSON error body to
+ *   stdout on a non-2xx response (a 404 prints `{"message":"Not Found",…}`), so
+ *   returning that body would make `ghApiJson` parse the error object instead of
+ *   `{}` / `[]`. An allowed status never carries useful data, so the empty
+ *   result lets `ghApiJson` resolve it to an empty object / array.
  * - `allowStatuses` matches the process exit code and returns stdout **only**
  *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
  *   yet still print the data, e.g. the checks rollup).
@@ -1040,9 +1041,11 @@ export function resolveToleratedGhFailure(
   error: unknown,
   options: RunGhOptions = {},
 ): string | undefined {
-  const stderr = String((error as { stderr?: unknown } | null)?.stderr ?? '');
-  const httpStatus = Number(stderr.match(/HTTP\s+(\d+)/i)?.[1] ?? -1);
-  if ((options.allowHttpStatuses ?? []).includes(httpStatus)) {
+  const httpStatus = deriveGhHttpStatus(error);
+  if (
+    httpStatus !== null &&
+    (options.allowHttpStatuses ?? []).includes(httpStatus)
+  ) {
     return '';
   }
   const status = Number((error as { status?: unknown } | null)?.status ?? -1);

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -5,6 +5,7 @@ import { test } from 'node:test';
 import {
   fetchBranchRulesets,
   parseArgs,
+  resolveToleratedGhFailure,
 } from '../src/scripts/pre-merge-readiness.mts';
 import {
   buildActivitySnapshotSummary,
@@ -3950,6 +3951,67 @@ test('fetchBranchRulesets propagates a non-404 fetch error instead of coercing t
         throw boom;
       }),
     (error: unknown) => error === boom,
+  );
+});
+
+// gh api writes the JSON error body to stdout on a non-2xx response, so an
+// allowed HTTP status must yield an empty result rather than that error object.
+const ghHttpErrorWithStdout = (
+  httpStatus: number,
+  label: string,
+  stdout: string,
+) => Object.assign(ghHttpError(httpStatus, label), { stdout });
+
+test('resolveToleratedGhFailure yields empty for an allowed HTTP status, not the gh error body on stdout', () => {
+  const error = ghHttpErrorWithStdout(
+    404,
+    'Not Found',
+    '{"message":"Not Found","documentation_url":"https://docs","status":"404"}',
+  );
+  // Empty (not the 3-key error object) is what ghApiJson coerces to {} / []
+  // for an allowed 404 — see its `if (!raw) return paginate ? [] : {}` branch.
+  assert.equal(
+    resolveToleratedGhFailure(error, { allowHttpStatuses: [404] }),
+    '',
+  );
+});
+
+test('resolveToleratedGhFailure re-throws (returns undefined) for a non-allowed HTTP status', () => {
+  const error = ghHttpErrorWithStdout(
+    403,
+    'API rate limit exceeded',
+    '{"message":"API rate limit exceeded"}',
+  );
+  assert.equal(
+    resolveToleratedGhFailure(error, { allowHttpStatuses: [404] }),
+    undefined,
+  );
+});
+
+test('resolveToleratedGhFailure keeps the allowStatuses path returning JSON stdout', () => {
+  // The exit-code path is unchanged: it returns stdout when the body is the
+  // wanted JSON (e.g. the checks rollup exits non-zero but still prints data).
+  const error = Object.assign(new Error('Command failed'), {
+    status: 8,
+    stdout: '[{"state":"SUCCESS"}]',
+  });
+  assert.equal(
+    resolveToleratedGhFailure(error, { allowStatuses: [1, 8] }),
+    '[{"state":"SUCCESS"}]',
+  );
+});
+
+test('resolveToleratedGhFailure ignores non-JSON allowStatuses stdout and falls through', () => {
+  // A tolerated exit code whose stdout is not JSON is not a usable result; with
+  // no matching HTTP status it returns undefined so runGh re-throws.
+  const error = Object.assign(new Error('Command failed'), {
+    status: 1,
+    stdout: 'some plain log line',
+    stderr: 'gh: boom',
+  });
+  assert.equal(
+    resolveToleratedGhFailure(error, { allowStatuses: [1] }),
+    undefined,
   );
 });
 

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -3994,6 +3994,20 @@ test('resolveToleratedGhFailure prefers an allowed HTTP status over a tolerated 
   );
 });
 
+test('resolveToleratedGhFailure derives an allowed status from a JSON error body when stderr lacks (HTTP nnn)', () => {
+  // deriveGhHttpStatus also reads a JSON "status" field, so a 404 whose status
+  // appears only in the body (not in an stderr `(HTTP 404)` suffix) still
+  // resolves to empty for an allowed 404 — robustness the local regex lacked.
+  const error = Object.assign(new Error('Command failed'), {
+    status: 1,
+    stdout: '{"message":"Not Found","status":"404"}',
+  });
+  assert.equal(
+    resolveToleratedGhFailure(error, { allowHttpStatuses: [404] }),
+    '',
+  );
+});
+
 test('resolveToleratedGhFailure re-throws (returns undefined) for a non-allowed HTTP status', () => {
   const error = ghHttpErrorWithStdout(
     403,

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -3976,6 +3976,24 @@ test('resolveToleratedGhFailure yields empty for an allowed HTTP status, not the
   );
 });
 
+test('resolveToleratedGhFailure prefers an allowed HTTP status over a tolerated exit code', () => {
+  // Both options set on the same failure: a tolerated 404 whose JSON error body
+  // also lands on stdout under a tolerated exit code must still yield empty — the
+  // allowHttpStatuses branch wins so the error body never leaks through.
+  const error = ghHttpErrorWithStdout(
+    404,
+    'Not Found',
+    '{"message":"Not Found","status":"404"}',
+  );
+  assert.equal(
+    resolveToleratedGhFailure(error, {
+      allowStatuses: [1],
+      allowHttpStatuses: [404],
+    }),
+    '',
+  );
+});
+
 test('resolveToleratedGhFailure re-throws (returns undefined) for a non-allowed HTTP status', () => {
   const error = ghHttpErrorWithStdout(
     403,


### PR DESCRIPTION
## Summary

`runGh` in `src/scripts/pre-merge-readiness.mts` returned
`String(error.stdout)` for an allowed HTTP status (`allowHttpStatuses`), but
`gh api` writes the JSON error body to stdout on a non-2xx response — a 404
yields `{"message":"Not Found",…}`. `ghApiJson` then parsed that 3-key error
object instead of `{}` / `[]`, so any `allowHttpStatuses: [404]` consumer that
checks object emptiness could silently keep a junk object (the footgun #1078
fixed locally for `fetchBranchRulesets`).

## Change

- Extract the tolerated-failure decision from `runGh` into a pure, exported
  `resolveToleratedGhFailure(error, options)` — it returns the string result,
  or `undefined` when the caller must re-throw.
- The `allowHttpStatuses` branch now returns `''` instead of
  `String(error.stdout)`, so `ghApiJson` resolves an allowed 404 to `{}`
  (non-paginate) or `[]` (paginate). An allowed `gh api` error status never
  carries useful body data.
- The `allowStatuses` (exit-code) branch is byte-for-byte unchanged — it still
  returns stdout only when the body is genuinely the wanted JSON.

## No regression for the three benign 404 sites

`branchRules` (paginate listing), `branchProtection`, and `fetchCodeownersText`
already tolerated the junk error body (skipped non-`ruleset_id` entries, absent
fields, or a missing `content` key). They now receive `[]` / `{}` and reach the
identical "no rules / no protection / no CODEOWNERS" outcome for a real 404.

## Tests

Four tests cover `resolveToleratedGhFailure`: the allowed-404→empty fix
(acceptance criterion 2), a non-allowed status re-throwing, and the unchanged
`allowStatuses` JSON / non-JSON paths. `pnpm test` (1385) and
`pnpm run lint:minimum` pass; the generated `scripts/pre-merge-readiness.mjs`
was regenerated via `pnpm run build`.

`fetchBranchRulesets`'s explicit `deriveGhHttpStatus` discrimination is left
as-is — its default `fetchRulesetDetail` does not pass `allowHttpStatuses`, so
it is already correct and untouched; the issue marks that simplification
optional.

Closes #1133


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tolerated GitHub CLI failures so error responses are no longer mistaken for valid data.
  * Allowed HTTP failures now return an empty result instead of passing through error bodies.
  * Exit-code-based tolerances now only return data when the output looks like JSON, reducing unexpected parsing issues.
  * Added coverage for tolerated and non-tolerated failure cases to keep behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->