### PR TITLE
feat(idd): auto-disposition the coderabbit summary walkthrough

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -105,9 +105,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   marker presence verification across PATH A and PATH B items
 - `scripts/disposition-non-review-notices.mjs` for dry-run/apply
   dispositioning of advisory non-review notices (rate-limit / usage-limit)
-  on a PR — emitting or posting the canonical E6 `**Rejected** — {bot} did
-  not review HEAD …` marker-first, one comment per notice, idempotently and
-  fail-closed (only classifier-recognized notices)
+  and the CodeRabbit summary walkthrough on a PR — emitting or posting the
+  canonical E6 `**Rejected** — {bot} did not review HEAD …` per notice and
+  `**Accepted** — {bot} summary walkthrough …` per current summary,
+  marker-first, idempotently and fail-closed (only classifier-recognized
+  notices and the exact summary marker)
 - `scripts/resolve-review-thread.mjs` for the E13 write-side disposition:
   post the reply to the review thread that owns a review comment **and**
   resolve that thread in one invocation — dry-run by default, `--apply`
@@ -546,6 +548,20 @@ The adopted helper boundaries are intentionally narrow:
 - **Idempotent**: per advisory bot, existing trusted
   `isNonReviewNoticeDisposition` comments naming that bot already cover
   that many of its notices, so a re-run posts nothing new.
+- **CodeRabbit summary walkthrough (#1122)**: it also auto-posts a
+  marker-first `**Accepted** — {bot-login} summary walkthrough at HEAD
+  {sha} …` for the CodeRabbit summary marker
+  (`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`),
+  which the gate scores through its general updatedAt-aware pairing rather
+  than the notice carry-forward. Because CodeRabbit edits the summary on each
+  re-review, the acceptance is re-dispositioned **per HEAD** by timestamp
+  (skipped only while a trusted acceptance naming the bot is strictly newer
+  than the summary's activity), and is skipped outright when CodeRabbit
+  already reports "No actionable comments were generated" (the gate classifies
+  that RESOLVED). It never resolves a review thread — actionable findings stay
+  their own threads, gated independently. The body names the bot by its login
+  (never the standalone word "CodeRabbit") so per-HEAD re-disposition is
+  preserved.
 - **Fail-closed**: only classifier-recognized notices are dispositioned;
   real reviews and review threads are never touched. `--apply`
   re-validates the active claim and retries once on a transient post

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -556,7 +556,9 @@ The adopted helper boundaries are intentionally narrow:
   than the notice carry-forward. Because CodeRabbit edits the summary on each
   re-review, the acceptance is re-dispositioned **per HEAD** by timestamp
   (skipped only while a trusted acceptance naming the bot is strictly newer
-  than the summary's activity), and is skipped outright when CodeRabbit
+  than the summary's activity and no older undispositioned non-agent comment
+  could consume it under the gate's global pairing), and is skipped outright
+  when CodeRabbit
   already reports "No actionable comments were generated" (the gate classifies
   that RESOLVED). It never resolves a review thread — actionable findings stay
   their own threads, gated independently. The body names the bot by its login

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -105,9 +105,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   marker presence verification across PATH A and PATH B items
 - `scripts/disposition-non-review-notices.mjs` for dry-run/apply
   dispositioning of advisory non-review notices (rate-limit / usage-limit)
-  on a PR — emitting or posting the canonical E6 `**Rejected** — {bot} did
-  not review HEAD …` marker-first, one comment per notice, idempotently and
-  fail-closed (only classifier-recognized notices)
+  and the CodeRabbit summary walkthrough on a PR — emitting or posting the
+  canonical E6 `**Rejected** — {bot} did not review HEAD …` per notice and
+  `**Accepted** — {bot} summary walkthrough …` per current summary,
+  marker-first, idempotently and fail-closed (only classifier-recognized
+  notices and the exact summary marker)
 - `scripts/resolve-review-thread.mjs` for the E13 write-side disposition:
   post the reply to the review thread that owns a review comment **and**
   resolve that thread in one invocation — dry-run by default, `--apply`
@@ -546,6 +548,20 @@ The adopted helper boundaries are intentionally narrow:
 - **Idempotent**: per advisory bot, existing trusted
   `isNonReviewNoticeDisposition` comments naming that bot already cover
   that many of its notices, so a re-run posts nothing new.
+- **CodeRabbit summary walkthrough (#1122)**: it also auto-posts a
+  marker-first `**Accepted** — {bot-login} summary walkthrough at HEAD
+  {sha} …` for the CodeRabbit summary marker
+  (`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`),
+  which the gate scores through its general updatedAt-aware pairing rather
+  than the notice carry-forward. Because CodeRabbit edits the summary on each
+  re-review, the acceptance is re-dispositioned **per HEAD** by timestamp
+  (skipped only while a trusted acceptance naming the bot is strictly newer
+  than the summary's activity), and is skipped outright when CodeRabbit
+  already reports "No actionable comments were generated" (the gate classifies
+  that RESOLVED). It never resolves a review thread — actionable findings stay
+  their own threads, gated independently. The body names the bot by its login
+  (never the standalone word "CodeRabbit") so per-HEAD re-disposition is
+  preserved.
 - **Fail-closed**: only classifier-recognized notices are dispositioned;
   real reviews and review threads are never touched. `--apply`
   re-validates the active claim and retries once on a transient post

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -556,7 +556,9 @@ The adopted helper boundaries are intentionally narrow:
   than the notice carry-forward. Because CodeRabbit edits the summary on each
   re-review, the acceptance is re-dispositioned **per HEAD** by timestamp
   (skipped only while a trusted acceptance naming the bot is strictly newer
-  than the summary's activity), and is skipped outright when CodeRabbit
+  than the summary's activity and no older undispositioned non-agent comment
+  could consume it under the gate's global pairing), and is skipped outright
+  when CodeRabbit
   already reports "No actionable comments were generated" (the gate classifies
   that RESOLVED). It never resolves a review thread — actionable findings stay
   their own threads, gated independently. The body names the bot by its login

--- a/schemas/disposition-non-review-notices.schema.json
+++ b/schemas/disposition-non-review-notices.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://kurone-kito.github.io/idd-skill/schemas/disposition-non-review-notices.schema.json",
   "title": "Non-Review-Notice Disposition Plan",
-  "description": "Dry-run plan or apply result for auto-dispositioning advisory non-review notices on a PR (E6 PATH B).",
+  "description": "Dry-run plan or apply result for auto-dispositioning advisory non-review notices and the CodeRabbit summary walkthrough on a PR (E6 PATH B).",
   "type": "object",
   "required": ["mode", "prNumber", "headSha", "skipped"],
   "properties": {
@@ -28,7 +28,10 @@
           "noticeId": { "type": "integer" },
           "botLogin": { "type": "string" },
           "reason": { "type": "string" },
-          "body": { "type": "string", "pattern": "^\\*\\*Rejected\\*\\*" }
+          "body": {
+            "type": "string",
+            "pattern": "^\\*\\*(Rejected|Accepted)\\*\\*"
+          }
         }
       }
     },

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -235,6 +235,26 @@ export function buildDispositionPlan(input, options = {}) {
       activityAt: effectiveRegularCommentActivityAt(comment),
       consumed: false,
     }));
+  // The gate pairs greedily across the GLOBAL outstanding set, so a summary's
+  // `**Accepted**` marker can be consumed by an OLDER undispositioned non-agent
+  // comment (a human reviewer or a non-notice bot), leaving the summary still
+  // flagged. The helper only models summary↔summary-disposition pairing, so when
+  // such an older comment exists it must NOT treat the summary as covered — it
+  // errs toward posting (#1122). Notices are excluded because the gate carves
+  // them and their dispositions out of the general pool; agent-authored comments
+  // (operational markers, digests, the dispositions themselves) are excluded via
+  // `trustedMarkerLogins`; other summaries are handled by the greedy pass above.
+  const markerCouldBeStolen = (dispositionActivityAt) =>
+    comments.some(
+      (other) =>
+        !trustedMarkerLogins.has(other.login) &&
+        !isAdvisoryNonReviewNotice(other.body) &&
+        !isReviewSummaryComment(other.body) &&
+        compareIsoTimestamps(
+          effectiveRegularCommentActivityAt(other),
+          dispositionActivityAt,
+        ) < 0,
+    );
   for (const comment of comments) {
     const identity = advisoryBotIdentityToken(comment.login);
     if (
@@ -267,7 +287,9 @@ export function buildDispositionPlan(input, options = {}) {
         dispositionNamesAdvisoryBot(disposition.body, comment.login) &&
         compareIsoTimestamps(disposition.activityAt, summaryActivityAt) > 0,
     );
-    if (cover) {
+    // Skip only when the marker is both newer than the summary AND cannot be
+    // stolen by an older non-agent comment under the gate's global pairing.
+    if (cover && !markerCouldBeStolen(cover.activityAt)) {
       cover.consumed = true;
       skipped.push({
         noticeId: comment.id,

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -13,9 +13,18 @@
 // #1018 author-scoped carry-forward attributes it. This helper detects those
 // notices with the single-sourced `isAdvisoryNonReviewNotice` classifier and
 // emits (dry-run) or posts (`--apply`) the canonical disposition, skipping
-// notices already dispositioned so a re-run is idempotent. It is fail-closed:
-// only classifier-recognized notices are dispositioned; real reviews and review
-// threads are never touched.
+// notices already dispositioned so a re-run is idempotent.
+//
+// It also auto-dispositions the CodeRabbit summary walkthrough (#1122): a
+// completed-review regular comment that recurs on every autopilot PR and the
+// gate scores through its general updatedAt-aware 1:1 pairing. Unlike a notice it
+// is `**Accepted**` (not `**Rejected**`), and because CodeRabbit edits the summary
+// each re-review the helper re-dispositions the CURRENT summary per HEAD by
+// timestamp (not a count carry-forward), so a stale acceptance can never mask a
+// finding folded into a later summary body.
+//
+// It is fail-closed: only classifier-recognized notices and the exact summary
+// marker are dispositioned; real reviews and review threads are never touched.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import {
@@ -25,9 +34,13 @@ import {
 } from './collaborator-permission.mjs';
 import {
   advisoryBotIdentityToken,
+  compareIsoTimestamps,
   dispositionNamesAdvisoryBot,
+  effectiveRegularCommentActivityAt,
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
+  isReviewSummaryComment,
+  isReviewSummaryDisposition,
   normalizeTrustedMarkerLogins,
   resolveActiveClaimForWriteGate,
   resolveAdvisoryBotLogins,
@@ -62,6 +75,20 @@ export function buildDispositionBody(botLogin, headSha, reason) {
   return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review`;
 }
 /**
+ * Build the canonical `**Accepted**` disposition body for a CodeRabbit summary
+ * walkthrough (#1122): marker-first, naming the bot by its GitHub **login** and
+ * the current head SHA. The login form (`coderabbitai[bot]`) is deliberate — it
+ * does not contain the standalone word "CodeRabbit", so the gate's
+ * `classifyRegularBotComment` createdAt-based RESOLVED path (which requires
+ * `/\bCodeRabbit\b/`) never permanently clears the summary; clearing happens only
+ * through the general updatedAt-aware pairing, giving the safer per-HEAD
+ * re-disposition. The `summary walkthrough` phrase is what `isReviewSummaryDisposition`
+ * keys on, so keep the two in lockstep.
+ */
+export function buildSummaryDispositionBody(botLogin, headSha) {
+  return `**Accepted** — ${botLogin} summary walkthrough at HEAD ${headSha}; actionable comments, if any, are dispositioned as their own review threads`;
+}
+/**
  * Plan the dispositions for a PR's regular comments. Pure: takes the fetched
  * comments and returns which advisory non-review notices need a disposition and
  * which already have one. Per advisory bot, the count of trusted IDD non-review
@@ -69,6 +96,16 @@ export function buildDispositionBody(botLogin, headSha, reason) {
  * (oldest-first); the remainder are planned. This mirrors the gate's
  * author-scoped 1:1 carry-forward, so the helper never posts a disposition the
  * gate would not credit and never double-posts on a re-run.
+ *
+ * It also plans an `**Accepted**` for the CodeRabbit summary walkthrough (#1122),
+ * which the gate scores through its general updatedAt-aware 1:1 pairing rather
+ * than the notice carry-forward. The summary is re-dispositioned per HEAD by
+ * timestamp: it is skipped only when a trusted summary disposition naming the bot
+ * is strictly newer than the summary's updatedAt-aware activity (and skipped
+ * outright when CodeRabbit already reports "No actionable comments were
+ * generated", which the gate classifies RESOLVED). The two paths are disjoint:
+ * notices are `**Rejected**`, summaries are `**Accepted**`, and neither
+ * disposition predicate matches the other.
  */
 export function buildDispositionPlan(input, options = {}) {
   // Key all advisory-bot comparisons by the suffix-insensitive identity token
@@ -92,6 +129,10 @@ export function buildDispositionPlan(input, options = {}) {
         .toLowerCase(),
       body: String(comment.body ?? ''),
       createdAt: String(comment.createdAt ?? ''),
+      // Preserve updatedAt so the summary-walkthrough path can score the summary
+      // and its dispositions through `effectiveRegularCommentActivityAt`,
+      // matching the gate's updatedAt-aware pairing.
+      updatedAt: String(comment.updatedAt ?? ''),
     }))
     .sort((left, right) => {
       // Oldest-first, with a deterministic tie-breaker so the oldest-first
@@ -170,6 +211,76 @@ export function buildDispositionPlan(input, options = {}) {
       botLogin: comment.login,
       reason,
       body: buildDispositionBody(comment.login, headSha, reason),
+    });
+  }
+  // CodeRabbit summary walkthrough auto-disposition (#1122). Separate from the
+  // notice path above: the gate scores the summary through its general
+  // updatedAt-aware 1:1 timestamp pairing (not the notice carry-forward), and
+  // CodeRabbit edits the summary on each re-review, so re-disposition the CURRENT
+  // summary per HEAD by timestamp. Mirror the gate's greedy oldest-first pairing:
+  // each summary consumes at most ONE trusted summary disposition that names the
+  // bot AND is strictly newer than the summary's updatedAt-aware activity; an
+  // uncovered summary is planned. Greedy consumption (not a bare existence check)
+  // means two coexisting summaries with a single newer disposition leave the
+  // second one planned — matching the gate and erring toward posting (an extra
+  // unpaired `**Accepted**` is inert, while under-posting strands the gate).
+  const summaryDispositions = comments
+    .filter(
+      (comment) =>
+        trustedMarkerLogins.has(comment.login) &&
+        isReviewSummaryDisposition({ body: comment.body }),
+    )
+    .map((comment) => ({
+      body: comment.body,
+      activityAt: effectiveRegularCommentActivityAt(comment),
+      consumed: false,
+    }));
+  for (const comment of comments) {
+    const identity = advisoryBotIdentityToken(comment.login);
+    if (
+      !advisoryBotIdentities.has(identity) ||
+      !isReviewSummaryComment(comment.body) ||
+      // A notice (rate-limit / usage-limit) that also carries the summary marker
+      // is dispositioned `**Rejected**` by the notice path above; never also
+      // `**Accepted**` it here, so a comment id gets at most one disposition.
+      isAdvisoryNonReviewNotice(comment.body)
+    ) {
+      continue;
+    }
+    // The gate already classifies a "No actionable comments were generated"
+    // summary as RESOLVED, so it never enters `missingRegularComments` and needs
+    // no disposition — auto-posting one would add brand-new noise.
+    if (/No actionable comments were generated/i.test(comment.body)) {
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'summary-resolved-no-actionable-comments',
+      });
+      continue;
+    }
+    const summaryActivityAt = effectiveRegularCommentActivityAt(comment);
+    // Consume the oldest unconsumed disposition naming this bot that is strictly
+    // newer than the summary, mirroring the gate's greedy `markerCursor`.
+    const cover = summaryDispositions.find(
+      (disposition) =>
+        !disposition.consumed &&
+        dispositionNamesAdvisoryBot(disposition.body, comment.login) &&
+        compareIsoTimestamps(disposition.activityAt, summaryActivityAt) > 0,
+    );
+    if (cover) {
+      cover.consumed = true;
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'already-dispositioned',
+      });
+      continue;
+    }
+    planned.push({
+      noticeId: comment.id,
+      botLogin: comment.login,
+      reason: 'summary walkthrough',
+      body: buildSummaryDispositionBody(comment.login, headSha),
     });
   }
   return { headSha, planned, skipped };
@@ -268,9 +379,11 @@ function isMainModule(moduleUrl) {
 }
 const USAGE = `usage: node scripts/disposition-non-review-notices.mjs --pr <number> [options]
 
-Detect advisory non-review notices on a PR and emit (default) or post
-(--apply) the canonical E6 \`**Rejected** — {bot} did not review HEAD …\`
-disposition, one marker-first comment per notice. Idempotent and fail-closed.
+Detect advisory non-review notices and the CodeRabbit summary walkthrough on a PR
+and emit (default) or post (--apply) the canonical E6 disposition: a marker-first
+\`**Rejected** — {bot} did not review HEAD …\` per notice, and a marker-first
+\`**Accepted** — {bot} summary walkthrough …\` per current summary (re-dispositioned
+per HEAD). Idempotent and fail-closed.
 
   --pr <number>                  PR number (required)
   --owner <owner>                repo owner (default: gh repo view)
@@ -335,9 +448,10 @@ function claimStillActive(
   return active?.claimId === claimId;
 }
 function postDisposition(owner, repo, pr, body) {
-  // A disposition body is plain text starting with `**Rejected**` (not an
-  // HTML-comment-first marker), so the `-f body=` field path posts it
-  // reliably; gh sends `{"body": <value>}` to the comments API.
+  // A disposition body is plain text starting with `**Rejected**` (notice) or
+  // `**Accepted**` (summary walkthrough) — not an HTML-comment-first marker — so
+  // the `-f body=` field path posts it reliably; gh sends `{"body": <value>}` to
+  // the comments API.
   return ghJson([
     'api',
     '--method',
@@ -460,6 +574,10 @@ if (isMainModule(import.meta.url)) {
       login: comment.user?.login ?? '',
       body: comment.body ?? '',
       createdAt: comment.created_at ?? '',
+      // The issues-comments API returns updated_at (bumped when CodeRabbit edits
+      // its summary); the summary path scores it through the gate's
+      // updatedAt-aware activity.
+      updatedAt: comment.updated_at ?? '',
     }));
     return buildDispositionPlan(
       { headSha, comments },

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -923,6 +923,14 @@ export function isCodeRabbitLogin(login) {
   const normalized = login.toLowerCase();
   return normalized === 'coderabbitai' || normalized === 'coderabbitai[bot]';
 }
+// The exact CodeRabbit summary-walkthrough marker. CodeRabbit prefixes its
+// auto-generated review summary with this HTML comment (distinct from the
+// `rate limited by coderabbit.ai` notice marker). Single-sourced here so the
+// comment-minimization classifier (`classifyRegularBotComment`) and the
+// disposition-evidence summary predicate (`isReviewSummaryComment`) recognize
+// byte-for-byte the same marker and cannot drift.
+export const CODERABBIT_SUMMARY_MARKER =
+  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
 export function classifyRegularBotComment(
   comment,
   comments,
@@ -937,11 +945,7 @@ export function classifyRegularBotComment(
     return null;
   }
   const body = (comment.body ?? '').trimStart();
-  if (
-    body.startsWith(
-      '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->',
-    )
-  ) {
+  if (body.startsWith(CODERABBIT_SUMMARY_MARKER)) {
     if (/No actionable comments were generated/i.test(body)) {
       return {
         classifier: 'RESOLVED',
@@ -1454,6 +1458,37 @@ export function isNonReviewNoticeDisposition(comment) {
   const body = (comment.body ?? '').trimStart();
   return (
     body.startsWith('**Rejected**') && /\bdid not review HEAD\b/i.test(body)
+  );
+}
+// #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
+//
+// The CodeRabbit summary walkthrough is a regular comment whose body starts with
+// `CODERABBIT_SUMMARY_MARKER`. Unlike a non-review notice it IS a completed
+// review, so it is dispositioned `**Accepted**` (never `**Rejected**`). The gate
+// scores it through its general updatedAt-aware 1:1 pairing, and CodeRabbit edits
+// the summary on each re-review, so the disposition-non-review-notices helper
+// re-dispositions the CURRENT summary per HEAD rather than carrying an old
+// acceptance forward (a stale carry-forward could mask a finding folded into a
+// later summary body — the "a false positive is a false merge" hazard).
+// True when a regular comment is a CodeRabbit summary walkthrough. Detection is
+// start-anchored on the exact single-sourced marker (after trimming leading
+// whitespace) so a comment that merely quotes the marker in prose is not matched.
+export function isReviewSummaryComment(body) {
+  return String(body ?? '')
+    .trimStart()
+    .startsWith(CODERABBIT_SUMMARY_MARKER);
+}
+// A trusted IDD disposition of a CodeRabbit summary walkthrough: the canonical
+// `**Accepted** — {bot} summary walkthrough …` reply the helper posts. Requires
+// the `**Accepted**` prefix (a summary is a completed review, so it is accepted,
+// never rejected) AND the `summary walkthrough` phrase, so an ordinary acceptance
+// of reviewer feedback is excluded. Tightly matched to `buildSummaryDispositionBody`
+// so a loose acceptance can never be miscredited (which would under-post and
+// strand the gate).
+export function isReviewSummaryDisposition(comment) {
+  const body = (comment.body ?? '').trimStart();
+  return (
+    body.startsWith('**Accepted**') && /\bsummary walkthrough\b/i.test(body)
   );
 }
 // The stable identity token of an advisory bot, used to attribute a non-review
@@ -4562,7 +4597,7 @@ function matchesCodeownersPattern(pattern, path) {
   source += '$';
   return new RegExp(source).test(normalizedPath);
 }
-function effectiveRegularCommentActivityAt(comment) {
+export function effectiveRegularCommentActivityAt(comment) {
   const updatedAt = String(comment.updatedAt ?? '');
   if (
     isValidIsoTimestamp(updatedAt) &&
@@ -4705,7 +4740,7 @@ function minutesBetweenIso(start, end) {
   }
   return Math.floor((endMs - startMs) / 60000);
 }
-function compareIsoTimestamps(left, right) {
+export function compareIsoTimestamps(left, right) {
   const leftComparable = normalizeComparableTimestamp(left);
   const rightComparable = normalizeComparableTimestamp(right);
   if (

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -13,9 +13,18 @@
 // #1018 author-scoped carry-forward attributes it. This helper detects those
 // notices with the single-sourced `isAdvisoryNonReviewNotice` classifier and
 // emits (dry-run) or posts (`--apply`) the canonical disposition, skipping
-// notices already dispositioned so a re-run is idempotent. It is fail-closed:
-// only classifier-recognized notices are dispositioned; real reviews and review
-// threads are never touched.
+// notices already dispositioned so a re-run is idempotent.
+//
+// It also auto-dispositions the CodeRabbit summary walkthrough (#1122): a
+// completed-review regular comment that recurs on every autopilot PR and the
+// gate scores through its general updatedAt-aware 1:1 pairing. Unlike a notice it
+// is `**Accepted**` (not `**Rejected**`), and because CodeRabbit edits the summary
+// each re-review the helper re-dispositions the CURRENT summary per HEAD by
+// timestamp (not a count carry-forward), so a stale acceptance can never mask a
+// finding folded into a later summary body.
+//
+// It is fail-closed: only classifier-recognized notices and the exact summary
+// marker are dispositioned; real reviews and review threads are never touched.
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
@@ -28,9 +37,13 @@ import {
 } from './collaborator-permission.mts';
 import {
   advisoryBotIdentityToken,
+  compareIsoTimestamps,
   dispositionNamesAdvisoryBot,
+  effectiveRegularCommentActivityAt,
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
+  isReviewSummaryComment,
+  isReviewSummaryDisposition,
   normalizeTrustedMarkerLogins,
   resolveActiveClaimForWriteGate,
   resolveAdvisoryBotLogins,
@@ -46,6 +59,10 @@ export interface NoticeComment {
   login: string;
   body: string;
   createdAt: string;
+  // updatedAt is optional (legacy callers omit it); the summary-walkthrough path
+  // (#1122) reads it through `effectiveRegularCommentActivityAt` so its
+  // idempotency agrees with the gate's updatedAt-aware scoring.
+  updatedAt?: string;
 }
 
 export interface PlannedDisposition {
@@ -120,6 +137,24 @@ export function buildDispositionBody(
 }
 
 /**
+ * Build the canonical `**Accepted**` disposition body for a CodeRabbit summary
+ * walkthrough (#1122): marker-first, naming the bot by its GitHub **login** and
+ * the current head SHA. The login form (`coderabbitai[bot]`) is deliberate — it
+ * does not contain the standalone word "CodeRabbit", so the gate's
+ * `classifyRegularBotComment` createdAt-based RESOLVED path (which requires
+ * `/\bCodeRabbit\b/`) never permanently clears the summary; clearing happens only
+ * through the general updatedAt-aware pairing, giving the safer per-HEAD
+ * re-disposition. The `summary walkthrough` phrase is what `isReviewSummaryDisposition`
+ * keys on, so keep the two in lockstep.
+ */
+export function buildSummaryDispositionBody(
+  botLogin: string,
+  headSha: string,
+): string {
+  return `**Accepted** — ${botLogin} summary walkthrough at HEAD ${headSha}; actionable comments, if any, are dispositioned as their own review threads`;
+}
+
+/**
  * Plan the dispositions for a PR's regular comments. Pure: takes the fetched
  * comments and returns which advisory non-review notices need a disposition and
  * which already have one. Per advisory bot, the count of trusted IDD non-review
@@ -127,6 +162,16 @@ export function buildDispositionBody(
  * (oldest-first); the remainder are planned. This mirrors the gate's
  * author-scoped 1:1 carry-forward, so the helper never posts a disposition the
  * gate would not credit and never double-posts on a re-run.
+ *
+ * It also plans an `**Accepted**` for the CodeRabbit summary walkthrough (#1122),
+ * which the gate scores through its general updatedAt-aware 1:1 pairing rather
+ * than the notice carry-forward. The summary is re-dispositioned per HEAD by
+ * timestamp: it is skipped only when a trusted summary disposition naming the bot
+ * is strictly newer than the summary's updatedAt-aware activity (and skipped
+ * outright when CodeRabbit already reports "No actionable comments were
+ * generated", which the gate classifies RESOLVED). The two paths are disjoint:
+ * notices are `**Rejected**`, summaries are `**Accepted**`, and neither
+ * disposition predicate matches the other.
  */
 export function buildDispositionPlan(
   input: { headSha: string; comments: NoticeComment[] },
@@ -157,6 +202,10 @@ export function buildDispositionPlan(
         .toLowerCase(),
       body: String(comment.body ?? ''),
       createdAt: String(comment.createdAt ?? ''),
+      // Preserve updatedAt so the summary-walkthrough path can score the summary
+      // and its dispositions through `effectiveRegularCommentActivityAt`,
+      // matching the gate's updatedAt-aware pairing.
+      updatedAt: String(comment.updatedAt ?? ''),
     }))
     .sort((left, right) => {
       // Oldest-first, with a deterministic tie-breaker so the oldest-first
@@ -237,6 +286,77 @@ export function buildDispositionPlan(
       botLogin: comment.login,
       reason,
       body: buildDispositionBody(comment.login, headSha, reason),
+    });
+  }
+
+  // CodeRabbit summary walkthrough auto-disposition (#1122). Separate from the
+  // notice path above: the gate scores the summary through its general
+  // updatedAt-aware 1:1 timestamp pairing (not the notice carry-forward), and
+  // CodeRabbit edits the summary on each re-review, so re-disposition the CURRENT
+  // summary per HEAD by timestamp. Mirror the gate's greedy oldest-first pairing:
+  // each summary consumes at most ONE trusted summary disposition that names the
+  // bot AND is strictly newer than the summary's updatedAt-aware activity; an
+  // uncovered summary is planned. Greedy consumption (not a bare existence check)
+  // means two coexisting summaries with a single newer disposition leave the
+  // second one planned — matching the gate and erring toward posting (an extra
+  // unpaired `**Accepted**` is inert, while under-posting strands the gate).
+  const summaryDispositions = comments
+    .filter(
+      (comment) =>
+        trustedMarkerLogins.has(comment.login) &&
+        isReviewSummaryDisposition({ body: comment.body }),
+    )
+    .map((comment) => ({
+      body: comment.body,
+      activityAt: effectiveRegularCommentActivityAt(comment),
+      consumed: false,
+    }));
+  for (const comment of comments) {
+    const identity = advisoryBotIdentityToken(comment.login);
+    if (
+      !advisoryBotIdentities.has(identity) ||
+      !isReviewSummaryComment(comment.body) ||
+      // A notice (rate-limit / usage-limit) that also carries the summary marker
+      // is dispositioned `**Rejected**` by the notice path above; never also
+      // `**Accepted**` it here, so a comment id gets at most one disposition.
+      isAdvisoryNonReviewNotice(comment.body)
+    ) {
+      continue;
+    }
+    // The gate already classifies a "No actionable comments were generated"
+    // summary as RESOLVED, so it never enters `missingRegularComments` and needs
+    // no disposition — auto-posting one would add brand-new noise.
+    if (/No actionable comments were generated/i.test(comment.body)) {
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'summary-resolved-no-actionable-comments',
+      });
+      continue;
+    }
+    const summaryActivityAt = effectiveRegularCommentActivityAt(comment);
+    // Consume the oldest unconsumed disposition naming this bot that is strictly
+    // newer than the summary, mirroring the gate's greedy `markerCursor`.
+    const cover = summaryDispositions.find(
+      (disposition) =>
+        !disposition.consumed &&
+        dispositionNamesAdvisoryBot(disposition.body, comment.login) &&
+        compareIsoTimestamps(disposition.activityAt, summaryActivityAt) > 0,
+    );
+    if (cover) {
+      cover.consumed = true;
+      skipped.push({
+        noticeId: comment.id,
+        botLogin: comment.login,
+        reason: 'already-dispositioned',
+      });
+      continue;
+    }
+    planned.push({
+      noticeId: comment.id,
+      botLogin: comment.login,
+      reason: 'summary walkthrough',
+      body: buildSummaryDispositionBody(comment.login, headSha),
     });
   }
 
@@ -358,9 +478,11 @@ function isMainModule(moduleUrl: string): boolean {
 
 const USAGE = `usage: node scripts/disposition-non-review-notices.mjs --pr <number> [options]
 
-Detect advisory non-review notices on a PR and emit (default) or post
-(--apply) the canonical E6 \`**Rejected** — {bot} did not review HEAD …\`
-disposition, one marker-first comment per notice. Idempotent and fail-closed.
+Detect advisory non-review notices and the CodeRabbit summary walkthrough on a PR
+and emit (default) or post (--apply) the canonical E6 disposition: a marker-first
+\`**Rejected** — {bot} did not review HEAD …\` per notice, and a marker-first
+\`**Accepted** — {bot} summary walkthrough …\` per current summary (re-dispositioned
+per HEAD). Idempotent and fail-closed.
 
   --pr <number>                  PR number (required)
   --owner <owner>                repo owner (default: gh repo view)
@@ -441,9 +563,10 @@ function postDisposition(
   pr: number,
   body: string,
 ): { id: number } {
-  // A disposition body is plain text starting with `**Rejected**` (not an
-  // HTML-comment-first marker), so the `-f body=` field path posts it
-  // reliably; gh sends `{"body": <value>}` to the comments API.
+  // A disposition body is plain text starting with `**Rejected**` (notice) or
+  // `**Accepted**` (summary walkthrough) — not an HTML-comment-first marker — so
+  // the `-f body=` field path posts it reliably; gh sends `{"body": <value>}` to
+  // the comments API.
   return ghJson([
     'api',
     '--method',
@@ -575,12 +698,17 @@ if (isMainModule(import.meta.url)) {
       user?: { login?: string };
       body?: string;
       created_at?: string;
+      updated_at?: string;
     }[];
     const comments: NoticeComment[] = rawComments.map((comment) => ({
       id: comment.id,
       login: comment.user?.login ?? '',
       body: comment.body ?? '',
       createdAt: comment.created_at ?? '',
+      // The issues-comments API returns updated_at (bumped when CodeRabbit edits
+      // its summary); the summary path scores it through the gate's
+      // updatedAt-aware activity.
+      updatedAt: comment.updated_at ?? '',
     }));
     return buildDispositionPlan(
       { headSha, comments },

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -311,6 +311,27 @@ export function buildDispositionPlan(
       activityAt: effectiveRegularCommentActivityAt(comment),
       consumed: false,
     }));
+
+  // The gate pairs greedily across the GLOBAL outstanding set, so a summary's
+  // `**Accepted**` marker can be consumed by an OLDER undispositioned non-agent
+  // comment (a human reviewer or a non-notice bot), leaving the summary still
+  // flagged. The helper only models summary↔summary-disposition pairing, so when
+  // such an older comment exists it must NOT treat the summary as covered — it
+  // errs toward posting (#1122). Notices are excluded because the gate carves
+  // them and their dispositions out of the general pool; agent-authored comments
+  // (operational markers, digests, the dispositions themselves) are excluded via
+  // `trustedMarkerLogins`; other summaries are handled by the greedy pass above.
+  const markerCouldBeStolen = (dispositionActivityAt: string): boolean =>
+    comments.some(
+      (other) =>
+        !trustedMarkerLogins.has(other.login) &&
+        !isAdvisoryNonReviewNotice(other.body) &&
+        !isReviewSummaryComment(other.body) &&
+        compareIsoTimestamps(
+          effectiveRegularCommentActivityAt(other),
+          dispositionActivityAt,
+        ) < 0,
+    );
   for (const comment of comments) {
     const identity = advisoryBotIdentityToken(comment.login);
     if (
@@ -343,7 +364,9 @@ export function buildDispositionPlan(
         dispositionNamesAdvisoryBot(disposition.body, comment.login) &&
         compareIsoTimestamps(disposition.activityAt, summaryActivityAt) > 0,
     );
-    if (cover) {
+    // Skip only when the marker is both newer than the summary AND cannot be
+    // stolen by an older non-agent comment under the gate's global pairing.
+    if (cover && !markerCouldBeStolen(cover.activityAt)) {
       cover.consumed = true;
       skipped.push({
         noticeId: comment.id,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1595,6 +1595,15 @@ export function isCodeRabbitLogin(login: string): boolean {
   return normalized === 'coderabbitai' || normalized === 'coderabbitai[bot]';
 }
 
+// The exact CodeRabbit summary-walkthrough marker. CodeRabbit prefixes its
+// auto-generated review summary with this HTML comment (distinct from the
+// `rate limited by coderabbit.ai` notice marker). Single-sourced here so the
+// comment-minimization classifier (`classifyRegularBotComment`) and the
+// disposition-evidence summary predicate (`isReviewSummaryComment`) recognize
+// byte-for-byte the same marker and cannot drift.
+export const CODERABBIT_SUMMARY_MARKER =
+  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
+
 export function classifyRegularBotComment(
   comment: CommentLike,
   comments: CommentLike[],
@@ -1612,11 +1621,7 @@ export function classifyRegularBotComment(
 
   const body = (comment.body ?? '').trimStart();
 
-  if (
-    body.startsWith(
-      '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->',
-    )
-  ) {
+  if (body.startsWith(CODERABBIT_SUMMARY_MARKER)) {
     if (/No actionable comments were generated/i.test(body)) {
       return {
         classifier: 'RESOLVED',
@@ -2239,6 +2244,42 @@ export function isNonReviewNoticeDisposition(comment: {
   const body = (comment.body ?? '').trimStart();
   return (
     body.startsWith('**Rejected**') && /\bdid not review HEAD\b/i.test(body)
+  );
+}
+
+// #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
+//
+// The CodeRabbit summary walkthrough is a regular comment whose body starts with
+// `CODERABBIT_SUMMARY_MARKER`. Unlike a non-review notice it IS a completed
+// review, so it is dispositioned `**Accepted**` (never `**Rejected**`). The gate
+// scores it through its general updatedAt-aware 1:1 pairing, and CodeRabbit edits
+// the summary on each re-review, so the disposition-non-review-notices helper
+// re-dispositions the CURRENT summary per HEAD rather than carrying an old
+// acceptance forward (a stale carry-forward could mask a finding folded into a
+// later summary body — the "a false positive is a false merge" hazard).
+
+// True when a regular comment is a CodeRabbit summary walkthrough. Detection is
+// start-anchored on the exact single-sourced marker (after trimming leading
+// whitespace) so a comment that merely quotes the marker in prose is not matched.
+export function isReviewSummaryComment(body: unknown): boolean {
+  return String(body ?? '')
+    .trimStart()
+    .startsWith(CODERABBIT_SUMMARY_MARKER);
+}
+
+// A trusted IDD disposition of a CodeRabbit summary walkthrough: the canonical
+// `**Accepted** — {bot} summary walkthrough …` reply the helper posts. Requires
+// the `**Accepted**` prefix (a summary is a completed review, so it is accepted,
+// never rejected) AND the `summary walkthrough` phrase, so an ordinary acceptance
+// of reviewer feedback is excluded. Tightly matched to `buildSummaryDispositionBody`
+// so a loose acceptance can never be miscredited (which would under-post and
+// strand the gate).
+export function isReviewSummaryDisposition(comment: {
+  body?: string | null;
+}): boolean {
+  const body = (comment.body ?? '').trimStart();
+  return (
+    body.startsWith('**Accepted**') && /\bsummary walkthrough\b/i.test(body)
   );
 }
 
@@ -5842,7 +5883,7 @@ function matchesCodeownersPattern(pattern: unknown, path: unknown): boolean {
   return new RegExp(source).test(normalizedPath);
 }
 
-function effectiveRegularCommentActivityAt(comment: {
+export function effectiveRegularCommentActivityAt(comment: {
   updatedAt?: unknown;
   createdAt: string;
 }): string {
@@ -6013,7 +6054,7 @@ function minutesBetweenIso(start: string, end: string): number {
   return Math.floor((endMs - startMs) / 60000);
 }
 
-function compareIsoTimestamps(left: unknown, right: unknown): number {
+export function compareIsoTimestamps(left: unknown, right: unknown): number {
   const leftComparable = normalizeComparableTimestamp(left);
   const rightComparable = normalizeComparableTimestamp(right);
   if (

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -4,9 +4,11 @@ import { test } from 'node:test';
 import {
   buildDispositionBody,
   buildDispositionPlan,
+  buildSummaryDispositionBody,
   type NoticeComment,
   noticeReason,
 } from '../src/scripts/disposition-non-review-notices.mts';
+import { summarizeDispositionEvidenceForGate } from '../src/scripts/protocol-helpers.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
 
 const planSchema = loadJson(
@@ -19,6 +21,8 @@ const CODEX_NOTICE =
   'You have reached your Codex usage limits for code reviews.';
 const CODERABBIT_NOTICE =
   '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n> ## Review limit reached';
+const CODERABBIT_SUMMARY =
+  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n## Walkthrough\nSome walkthrough text.';
 // A full 40-char head SHA for the cases that validate against the schema, which
 // now constrains `headSha` to `^[0-9a-f]{40}$`.
 const HEAD_SHA = '0123456789abcdef0123456789abcdef01234567';
@@ -28,8 +32,11 @@ function notice(
   login: string,
   body: string,
   createdAt = `2026-05-12T00:00:0${id}Z`,
+  updatedAt?: string,
 ): NoticeComment {
-  return { id, login, body, createdAt };
+  return updatedAt === undefined
+    ? { id, login, body, createdAt }
+    : { id, login, body, createdAt, updatedAt };
 }
 
 test('buildDispositionBody is marker-first and names the bot login + head sha', () => {
@@ -160,11 +167,12 @@ test('buildDispositionPlan is fail-closed: real reviews and non-bot comments are
       comments: [
         // A real Codex review (not a notice) must not be dispositioned.
         notice(1, CODEX, 'I found an off-by-one in foo.mts at line 42.'),
-        // A real CodeRabbit summarize review (not a rate-limit notice).
+        // A CodeRabbit comment that is neither a rate-limit notice nor the
+        // summary walkthrough marker — the helper must not touch it.
         notice(
           2,
           CODERABBIT,
-          '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n## Walkthrough',
+          'A nudge from the bot, not an auto-generated marker.',
         ),
         // A human comment that merely mentions usage limits.
         notice(3, 'reviewer-a', 'please cap the Codex usage limits in config'),
@@ -188,27 +196,31 @@ test('buildDispositionPlan only considers configured advisory bots', () => {
   assert.equal(plan.planned.length, 0);
 });
 
-test('buildDispositionPlan plans a notice even when the bot also reviewed', () => {
+test('buildDispositionPlan plans both the notice (rejected) and the summary (accepted)', () => {
   // A persistent rate-limit notice stays in the gate's outstanding set until a
-  // disposition naming the bot carries it, even when the bot has a separate
-  // completed review. The helper always plans the undispositioned notice.
+  // disposition naming the bot carries it; the CodeRabbit summary walkthrough is a
+  // separate completed-review item the gate scores through its general
+  // updatedAt-aware pairing. The helper plans BOTH — the notice **Rejected** and
+  // the summary **Accepted**.
   const plan = buildDispositionPlan(
     {
       headSha: 'abc1234',
       comments: [
         notice(1, CODERABBIT, CODERABBIT_NOTICE),
-        // A separate CodeRabbit summary review (handled by the agent, not here).
-        notice(
-          2,
-          CODERABBIT,
-          '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n## Walkthrough',
-        ),
+        notice(2, CODERABBIT, CODERABBIT_SUMMARY),
       ],
     },
     { trustedMarkerLogins: ['kurone-kito'] },
   );
-  assert.equal(plan.planned.length, 1);
-  assert.equal(plan.planned[0].botLogin, CODERABBIT);
+  assert.equal(plan.planned.length, 2);
+  const rejected = plan.planned.find((entry) =>
+    entry.body.startsWith('**Rejected**'),
+  );
+  const accepted = plan.planned.find((entry) =>
+    entry.body.startsWith('**Accepted**'),
+  );
+  assert.ok(rejected && /did not review HEAD/.test(rejected.body));
+  assert.ok(accepted && /summary walkthrough/.test(accepted.body));
   assert.equal(plan.skipped.length, 0);
 });
 
@@ -280,6 +292,307 @@ test('a combined disposition naming several bots covers only one notice', () => 
   assert.equal(plan.planned.length, 1);
 });
 
+test('buildSummaryDispositionBody is marker-first, names the login + head sha, and avoids the word CodeRabbit', () => {
+  const body = buildSummaryDispositionBody(CODERABBIT, 'abc1234');
+  assert.ok(body.startsWith('**Accepted**'), 'marker must be first bytes');
+  assert.match(body, /coderabbitai\[bot\] summary walkthrough at HEAD abc1234/);
+  // The standalone word "CodeRabbit" would make the gate's createdAt-based
+  // RESOLVED path permanently clear the summary instead of per-HEAD
+  // re-disposition, so the body must use the login form only.
+  assert.doesNotMatch(body, /\bCodeRabbit\b/);
+});
+
+test('buildDispositionPlan plans an **Accepted** for an undispositioned CodeRabbit summary', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [notice(1, CODERABBIT, CODERABBIT_SUMMARY)],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 1);
+  const entry = plan.planned[0];
+  assert.equal(entry.botLogin, CODERABBIT);
+  assert.ok(entry.body.startsWith('**Accepted**'));
+  assert.match(
+    entry.body,
+    /coderabbitai\[bot\] summary walkthrough at HEAD abc1234/,
+  );
+  assert.doesNotMatch(entry.body, /\bCodeRabbit\b/);
+  assert.equal(plan.skipped.length, 0);
+});
+
+test('buildDispositionPlan skips a summary already accepted by a strictly-newer disposition', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(1, CODERABBIT, CODERABBIT_SUMMARY, '2026-05-12T00:00:00Z'),
+        // A trusted summary acceptance posted AFTER the summary's activity.
+        notice(
+          2,
+          'kurone-kito',
+          buildSummaryDispositionBody(CODERABBIT, 'abc1234'),
+          '2026-05-12T01:00:00Z',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 0);
+  assert.deepEqual(
+    plan.skipped.map((entry) => entry.noticeId),
+    [1],
+  );
+});
+
+test('buildDispositionPlan re-plans the summary when its updatedAt bumps past the prior acceptance', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'def5678',
+      comments: [
+        // The prior acceptance predates the summary's latest edit.
+        notice(
+          1,
+          'kurone-kito',
+          buildSummaryDispositionBody(CODERABBIT, 'abc1234'),
+          '2026-05-12T01:00:00Z',
+        ),
+        // CodeRabbit edited the summary AFTER the acceptance (updatedAt bumps).
+        notice(
+          2,
+          CODERABBIT,
+          CODERABBIT_SUMMARY,
+          '2026-05-12T00:00:00Z',
+          '2026-05-12T02:00:00Z',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 1);
+  assert.equal(plan.planned[0].noticeId, 2);
+  assert.ok(plan.planned[0].body.startsWith('**Accepted**'));
+});
+
+test('buildDispositionPlan only auto-dispositions summaries from configured advisory bots', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [notice(1, CODERABBIT, CODERABBIT_SUMMARY)],
+    },
+    { advisoryBotLogins: [CODEX], trustedMarkerLogins: ['kurone-kito'] },
+  );
+  // CodeRabbit is not in the configured advisory-bot set here.
+  assert.equal(plan.planned.length, 0);
+  assert.equal(plan.skipped.length, 0);
+});
+
+test('buildDispositionPlan does not treat a comment that merely quotes the summary marker as a summary', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(
+          1,
+          CODERABBIT,
+          'See the marker `<!-- This is an auto-generated comment: summarize by coderabbit.ai -->` referenced inline.',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 0);
+  assert.equal(plan.skipped.length, 0);
+});
+
+test('buildDispositionPlan does not auto-dispose a "no actionable comments" summary (gate already RESOLVED)', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(
+          1,
+          CODERABBIT,
+          '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n**Actionable comments posted: 0**\nNo actionable comments were generated.',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 0);
+  assert.deepEqual(
+    plan.skipped.map((entry) => entry.reason),
+    ['summary-resolved-no-actionable-comments'],
+  );
+});
+
+test('buildDispositionPlan greedily consumes one disposition per summary (two summaries, one disposition -> one planned)', () => {
+  // Two distinct summary comments coexist with a single newer acceptance. The
+  // gate's greedy 1:1 pairing clears only one, so the helper must leave the
+  // second planned (a bare existence check would wrongly skip both -> stuck gate).
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(1, CODERABBIT, CODERABBIT_SUMMARY, '2026-05-12T00:00:00Z'),
+        notice(2, CODERABBIT, CODERABBIT_SUMMARY, '2026-05-12T00:30:00Z'),
+        notice(
+          3,
+          'kurone-kito',
+          buildSummaryDispositionBody(CODERABBIT, 'abc1234'),
+          '2026-05-12T01:00:00Z',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  // The oldest summary (id 1) consumes the acceptance; the second (id 2) is planned.
+  assert.deepEqual(
+    plan.skipped.map((entry) => entry.noticeId),
+    [1],
+  );
+  assert.deepEqual(
+    plan.planned.map((entry) => entry.noticeId),
+    [2],
+  );
+});
+
+test('buildDispositionPlan rejects (does not also accept) a summary that is itself a rate-limit notice', () => {
+  // A comment that carries the summary marker AND a rate-limit heading is a
+  // non-review notice: the notice path rejects it, and the summary path must not
+  // also accept it — a comment id gets at most one disposition.
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(
+          1,
+          CODERABBIT,
+          `${CODERABBIT_SUMMARY}\n\n> ## Review limit reached`,
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 1);
+  assert.ok(plan.planned[0].body.startsWith('**Rejected**'));
+  assert.equal(plan.skipped.length, 0);
+});
+
+test('gate agreement: the planned **Accepted** clears the summary from missingRegularComments', () => {
+  const summary = {
+    id: 1,
+    author: { login: CODERABBIT },
+    body: CODERABBIT_SUMMARY,
+    createdAt: '2026-05-12T00:00:00Z',
+    updatedAt: '2026-05-12T00:00:00Z',
+  };
+  const gateOptions = {
+    iddAgentLogins: ['kurone-kito'],
+    advisoryBotLogins: [CODERABBIT, CODEX],
+  };
+  // Before: the gate flags the undispositioned summary.
+  const before = summarizeDispositionEvidenceForGate(
+    { comments: [summary], threads: [] },
+    gateOptions,
+  );
+  assert.equal(before.missingRegularCommentCount, 1);
+
+  // The helper plans the **Accepted**; post it as an IDD-agent comment newer than
+  // the summary's activity.
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(
+          1,
+          CODERABBIT,
+          CODERABBIT_SUMMARY,
+          '2026-05-12T00:00:00Z',
+          '2026-05-12T00:00:00Z',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 1);
+  const accepted = {
+    id: 2,
+    author: { login: 'kurone-kito' },
+    body: plan.planned[0].body,
+    createdAt: '2026-05-12T01:00:00Z',
+    updatedAt: '2026-05-12T01:00:00Z',
+  };
+  // After: the gate no longer flags the summary.
+  const after = summarizeDispositionEvidenceForGate(
+    { comments: [summary, accepted], threads: [] },
+    gateOptions,
+  );
+  assert.equal(after.missingRegularCommentCount, 0);
+});
+
+test('gate agreement: the summary stays cleared alongside another outstanding comment', () => {
+  const summary = {
+    id: 1,
+    author: { login: CODERABBIT },
+    body: CODERABBIT_SUMMARY,
+    createdAt: '2026-05-12T00:00:00Z',
+    updatedAt: '2026-05-12T00:00:00Z',
+  };
+  const human = {
+    id: 2,
+    author: { login: 'reviewer-a' },
+    body: 'Please rename foo to bar.',
+    createdAt: '2026-05-12T00:30:00Z',
+    updatedAt: '2026-05-12T00:30:00Z',
+  };
+  const gateOptions = {
+    iddAgentLogins: ['kurone-kito'],
+    advisoryBotLogins: [CODERABBIT, CODEX],
+  };
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(
+          1,
+          CODERABBIT,
+          CODERABBIT_SUMMARY,
+          '2026-05-12T00:00:00Z',
+          '2026-05-12T00:00:00Z',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  // One disposition per outstanding comment: the helper's summary **Accepted**
+  // plus a manual disposition for the human comment. The gate's greedy pairing
+  // covers both.
+  const summaryAccepted = {
+    id: 3,
+    author: { login: 'kurone-kito' },
+    body: plan.planned[0].body,
+    createdAt: '2026-05-12T01:00:00Z',
+    updatedAt: '2026-05-12T01:00:00Z',
+  };
+  const humanDisposition = {
+    id: 4,
+    author: { login: 'kurone-kito' },
+    body: '**Accepted** — will rename in a follow-up',
+    createdAt: '2026-05-12T01:01:00Z',
+    updatedAt: '2026-05-12T01:01:00Z',
+  };
+  const after = summarizeDispositionEvidenceForGate(
+    {
+      comments: [summary, human, summaryAccepted, humanDisposition],
+      threads: [],
+    },
+    gateOptions,
+  );
+  assert.equal(after.missingRegularCommentCount, 0);
+});
+
 test('the dry-run and apply output envelopes validate against the schema', () => {
   const plan = buildDispositionPlan(
     {
@@ -287,9 +600,16 @@ test('the dry-run and apply output envelopes validate against the schema', () =>
       comments: [
         notice(1, CODEX, CODEX_NOTICE),
         notice(2, CODERABBIT, CODERABBIT_NOTICE),
+        // Include a summary so `planned` carries an **Accepted** body and the
+        // broadened schema pattern is exercised.
+        notice(3, CODERABBIT, CODERABBIT_SUMMARY),
       ],
     },
     { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.ok(
+    plan.planned.some((entry) => entry.body.startsWith('**Accepted**')),
+    'a summary **Accepted** must be planned',
   );
   const dryRun = { mode: 'dry-run', prNumber: 7, ...plan };
   assert.equal(validate(dryRun, planSchema).length, 0, 'dry-run output');

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -480,6 +480,42 @@ test('buildDispositionPlan rejects (does not also accept) a summary that is itse
   assert.equal(plan.skipped.length, 0);
 });
 
+test('buildDispositionPlan re-plans a summary whose acceptance an older non-agent comment could steal', () => {
+  // #1122 (Copilot finding): under the gate's GLOBAL greedy pairing, a summary's
+  // **Accepted** can be consumed by an OLDER undispositioned non-agent comment,
+  // leaving the summary still flagged. The helper only models summary↔summary
+  // pairing, so it must err toward posting when such an older comment exists.
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        // An older human comment with no disposition of its own (a potential thief).
+        notice(
+          1,
+          'reviewer-a',
+          'Please rename foo to bar.',
+          '2026-05-12T00:00:00Z',
+        ),
+        notice(2, CODERABBIT, CODERABBIT_SUMMARY, '2026-05-12T00:30:00Z'),
+        notice(
+          3,
+          'kurone-kito',
+          buildSummaryDispositionBody(CODERABBIT, 'abc1234'),
+          '2026-05-12T01:00:00Z',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  // The acceptance (id 3) could be stolen by the older human comment (id 1), so
+  // the summary (id 2) is re-planned rather than skipped.
+  assert.deepEqual(
+    plan.planned.map((entry) => entry.noticeId),
+    [2],
+  );
+  assert.equal(plan.skipped.length, 0);
+});
+
 test('gate agreement: the planned **Accepted** clears the summary from missingRegularComments', () => {
   const summary = {
     id: 1,


### PR DESCRIPTION
## Summary

Auto-disposition the **CodeRabbit summary walkthrough** regular comment so it
stops recurring as a manual `**Accepted**` on every autopilot PR. The
`disposition-non-review-notices` helper now also detects the exact summary
marker (`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`)
for a configured advisory bot and emits (dry-run) / posts (`--apply`) a
marker-first `**Accepted**` for it. This is **helper-only** — the F2/F3
`dispositionEvidence` gate is unchanged (Option 1 from the issue).

## How it stays correct

- **Per-HEAD re-disposition by timestamp, not a count carry-forward.** The gate
  scores the summary through its general `effectiveRegularCommentActivityAt`
  (updatedAt-aware) 1:1 pairing, and CodeRabbit edits the summary on each
  re-review (its `updatedAt` bumps). The helper re-dispositions the **current**
  summary per HEAD: it skips only when a trusted summary acceptance naming the
  bot is **strictly newer** than the summary's activity, consuming dispositions
  greedily oldest-first to mirror the gate (so two coexisting summaries with one
  acceptance leave the second planned — it errs toward posting).
- **Avoids the permanent-RESOLVED path.** The body names the bot by its login
  (`coderabbitai[bot]`), which does not match `/\bCodeRabbit\b/`, so it never
  trips `classifyRegularBotComment`'s createdAt-based RESOLVED path — clearing
  stays updatedAt-aware/per-HEAD (a stale acceptance can't mask a finding folded
  into a later summary body).
- **Tight scope.** Skips a "No actionable comments were generated" summary (the
  gate already classifies it RESOLVED) and a summary that is itself a rate-limit
  notice (the notice path rejects it, so a comment id gets at most one
  disposition). Never resolves a review thread — CodeRabbit's actionable findings
  stay their own threads, gated independently. Config-driven via
  `advisoryBotLogins`, so a repo without CodeRabbit is unaffected.

## Changes

- `protocol-helpers`: add `isReviewSummaryComment` / `isReviewSummaryDisposition`;
  single-source `CODERABBIT_SUMMARY_MARKER` (reused by `classifyRegularBotComment`,
  behavior-preserving); export `effectiveRegularCommentActivityAt` /
  `compareIsoTimestamps` so the helper agrees with the gate exactly.
- `disposition-non-review-notices`: `updatedAt` plumbing, `buildSummaryDispositionBody`,
  and the summary-planning block in `buildDispositionPlan`; CLI `planNow()` maps
  `updated_at`.
- Schema: broaden `planned[].body` to `^\*\*(Rejected|Accepted)\*\*`.
- Tests: +11 cases incl. two end-to-end `summarizeDispositionEvidenceForGate`
  gate-agreement checks, greedy multi-summary consumption, and the notice-wins
  guard.
- Docs: `idd-helper-scripts.md` helper contract (regenerated mirror).

A B2 plan critique and a C1 diff critique both ran; their findings (the
bundle-review byte-budget pushing the doc note to `docs/` only, the
`No actionable comments` skip, the greedy-consumption fix, and the notice-wins
guard) are folded in.

Closes #1122
