### PR TITLE
feat(idd): post review-watermark from the live snapshot in one step

### DIFF
--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -80,15 +80,19 @@ the snapshot is
 empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
 PR comment with this format (when helper runtime is enabled, prefer the
-profile-selected post-idd-marker command — `--type watermark --target pr
-<pr-number> <watermark-fields> --apply`, passing the same six values shown
-below as `--agent-id` / `--claim-id` / `--head-sha` / `--max-activity-at` /
-`--total-item-count` / `--ci-completed-at`, to render and POST this marker in
-one step, so a hand-typed head SHA cannot mis-route the F2 review-currency
-check;
-`emit-marker --type review-watermark` stays the emit-only render path and
-the manual HTTP `POST` below remains the fallback; see
-`docs/idd-helper-scripts.md`):
+**one-command** profile-selected post-idd-marker watermark path —
+`--type watermark --from-pr <pr-number> --agent-id <id> --claim-id <id> --apply`
+— which derives `{head-SHA}` / `{max-activity-updatedAt}` /
+`{total-item-count}` / `{latest-ci-completed-at}` from a fresh
+`review-activity-snapshot` of the PR and POSTs the marker in one step, so a
+hand-typed head SHA cannot mis-route the F2 review-currency check (forward
+`--trusted-marker-logins` here too when you pass it to the snapshot). The
+manual six-field form — `--type watermark --target pr <pr-number>
+<watermark-fields> --apply`, passing the same six values shown below as
+`--agent-id` / `--claim-id` / `--head-sha` / `--max-activity-at` /
+`--total-item-count` / `--ci-completed-at` — stays the fallback, as do
+`emit-marker --type review-watermark` for emit-only rendering and the manual
+HTTP `POST` below; see `docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-watermark: {agent-id} {claim-id} {head-SHA} {max-activity-updatedAt|none} {total-item-count} {latest-ci-completed-at|none} -->

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -195,7 +195,7 @@
         ".github/instructions/idd-review-snapshot.instructions.md",
         ".github/instructions/idd-review-triage.instructions.md"
       ],
-      "limitBytes": 108200
+      "limitBytes": 108800
     },
     {
       "id": "bundle-merge",

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -828,6 +828,17 @@ Interpretation rules:
   --total-item-count --ci-completed-at`; `baseline` takes `--agent-id
   --claim-id --sha`; `advisory` / `advisory-recovery` take `--agent-id
   --head-sha --timestamp`.
+- One-command watermark (`watermark` only): `--from-pr <n>` derives
+  `--head-sha` / `--max-activity-at` / `--total-item-count` /
+  `--ci-completed-at` from a fresh `review-activity-snapshot` of PR `<n>` and
+  posts the marker to PR `<n>`, so only `--agent-id` / `--claim-id` (+ `--apply`)
+  are still supplied (`--target` defaults to `pr`). It maps the snapshot's
+  `latestPassingCiCompletedAt` to `--ci-completed-at` (the latest _passing_ CI
+  completion, matching the E1 `{latest-ci-completed-at}` contract), forwards
+  optional `--trusted-marker-logins` / `--advisory-bot-logins` to the snapshot
+  child so its counts match the manual path, and rejects the four manual
+  snapshot fields as ambiguous. Unlike the manual dry-run it reads from GitHub
+  (it spawns the snapshot), but still posts nothing without `--apply`.
 - **No claim/state gating** (the `emit-marker` philosophy): this is a
   single-marker render+POST primitive, so the calling phase must run its
   claim-revalidation gate before `--apply`, exactly as the manual POST path it

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -832,7 +832,8 @@ Interpretation rules:
   `--head-sha` / `--max-activity-at` / `--total-item-count` /
   `--ci-completed-at` from a fresh `review-activity-snapshot` of PR `<n>` and
   posts the marker to PR `<n>`, so only `--agent-id` / `--claim-id` (+ `--apply`)
-  are still supplied (`--target` defaults to `pr`). It maps the snapshot's
+  are still supplied (it always targets the PR; an explicit non-pr `--target`
+  is rejected). It maps the snapshot's
   `latestPassingCiCompletedAt` to `--ci-completed-at` (the latest _passing_ CI
   completion, matching the E1 `{latest-ci-completed-at}` contract), forwards
   optional `--trusted-marker-logins` / `--advisory-bot-logins` to the snapshot

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -80,15 +80,19 @@ the snapshot is
 empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
 PR comment with this format (when helper runtime is enabled, prefer the
-profile-selected post-idd-marker command — `--type watermark --target pr
-<pr-number> <watermark-fields> --apply`, passing the same six values shown
-below as `--agent-id` / `--claim-id` / `--head-sha` / `--max-activity-at` /
-`--total-item-count` / `--ci-completed-at`, to render and POST this marker in
-one step, so a hand-typed head SHA cannot mis-route the F2 review-currency
-check;
-`emit-marker --type review-watermark` stays the emit-only render path and
-the manual HTTP `POST` below remains the fallback; see
-`docs/idd-helper-scripts.md`):
+**one-command** profile-selected post-idd-marker watermark path —
+`--type watermark --from-pr <pr-number> --agent-id <id> --claim-id <id> --apply`
+— which derives `{head-SHA}` / `{max-activity-updatedAt}` /
+`{total-item-count}` / `{latest-ci-completed-at}` from a fresh
+`review-activity-snapshot` of the PR and POSTs the marker in one step, so a
+hand-typed head SHA cannot mis-route the F2 review-currency check (forward
+`--trusted-marker-logins` here too when you pass it to the snapshot). The
+manual six-field form — `--type watermark --target pr <pr-number>
+<watermark-fields> --apply`, passing the same six values shown below as
+`--agent-id` / `--claim-id` / `--head-sha` / `--max-activity-at` /
+`--total-item-count` / `--ci-completed-at` — stays the fallback, as do
+`emit-marker --type review-watermark` for emit-only rendering and the manual
+HTTP `POST` below; see `docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-watermark: {agent-id} {claim-id} {head-SHA} {max-activity-updatedAt|none} {total-item-count} {latest-ci-completed-at|none} -->

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -828,6 +828,17 @@ Interpretation rules:
   --total-item-count --ci-completed-at`; `baseline` takes `--agent-id
   --claim-id --sha`; `advisory` / `advisory-recovery` take `--agent-id
   --head-sha --timestamp`.
+- One-command watermark (`watermark` only): `--from-pr <n>` derives
+  `--head-sha` / `--max-activity-at` / `--total-item-count` /
+  `--ci-completed-at` from a fresh `review-activity-snapshot` of PR `<n>` and
+  posts the marker to PR `<n>`, so only `--agent-id` / `--claim-id` (+ `--apply`)
+  are still supplied (`--target` defaults to `pr`). It maps the snapshot's
+  `latestPassingCiCompletedAt` to `--ci-completed-at` (the latest _passing_ CI
+  completion, matching the E1 `{latest-ci-completed-at}` contract), forwards
+  optional `--trusted-marker-logins` / `--advisory-bot-logins` to the snapshot
+  child so its counts match the manual path, and rejects the four manual
+  snapshot fields as ambiguous. Unlike the manual dry-run it reads from GitHub
+  (it spawns the snapshot), but still posts nothing without `--apply`.
 - **No claim/state gating** (the `emit-marker` philosophy): this is a
   single-marker render+POST primitive, so the calling phase must run its
   claim-revalidation gate before `--apply`, exactly as the manual POST path it

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -832,7 +832,8 @@ Interpretation rules:
   `--head-sha` / `--max-activity-at` / `--total-item-count` /
   `--ci-completed-at` from a fresh `review-activity-snapshot` of PR `<n>` and
   posts the marker to PR `<n>`, so only `--agent-id` / `--claim-id` (+ `--apply`)
-  are still supplied (`--target` defaults to `pr`). It maps the snapshot's
+  are still supplied (it always targets the PR; an explicit non-pr `--target`
+  is rejected). It maps the snapshot's
   `latestPassingCiCompletedAt` to `--ci-completed-at` (the latest _passing_ CI
   completion, matching the E1 `{latest-ci-completed-at}` contract), forwards
   optional `--trusted-marker-logins` / `--advisory-bot-logins` to the snapshot

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -226,7 +226,8 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
                        --total-item-count / --ci-completed-at from the live
                        review-activity-snapshot of PR <n> and post the watermark
                        to PR <n>, so only --agent-id / --claim-id (and --apply)
-                       are still needed (target defaults to pr). Not network-free.
+                       are still needed (always targets the PR; an explicit
+                       non-pr --target is rejected). Not network-free.
   --apply              POST the marker (default: dry-run prints it in a JSON envelope)
   --owner <owner>      repo owner (default: gh repo view)
   --repo <repo>        repo name (default: gh repo view)
@@ -355,9 +356,17 @@ if (isMainModule(import.meta.url)) {
       process.stderr.write('--from-pr is only valid for --type watermark\n');
       process.exit(1);
     }
-    if (!args.target) {
-      args.target = 'pr';
+    // --from-pr always posts the watermark to PR <n>. `--target` is
+    // descriptive-only (issue/pr both POST to the same /issues/<n>/comments
+    // endpoint), but an `issue`-targeted snapshot watermark is incoherent, so
+    // fail closed on an explicit non-pr target rather than recording it.
+    if (args.target && args.target !== 'pr') {
+      process.stderr.write(
+        `--from-pr always targets the PR; remove --target ${args.target}\n`,
+      );
+      process.exit(1);
     }
+    args.target = 'pr';
     if (args.number === null) {
       args.number = args.fromPr;
     } else if (args.number !== args.fromPr) {

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -17,7 +17,7 @@
 // claim-revalidation gate immediately before invoking `--apply`, exactly as the
 // manual POST path it replaces already requires.
 import { execFileSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   renderAdvisoryWaitMarker,
@@ -92,14 +92,74 @@ export function buildMarkerBody(type, fields) {
       );
   }
 }
+/**
+ * Map a `review-activity-snapshot` JSON object to the four snapshot-derived
+ * `--type watermark` field flags, so `--from-pr` can fill them automatically
+ * instead of the agent hand-copying a 40-char HEAD SHA and three timestamps.
+ *
+ * `ci-completed-at` is taken from `latestPassingCiCompletedAt` — the latest
+ * *passing* (or treated-as-passed) CI completion — NOT `latestCiCompletedAt`.
+ * That matches the E1 Step 2 `{latest-ci-completed-at}` definition and the
+ * pre-merge-readiness currency diff, which compares the watermark CI field
+ * against the live `latestPassingCiCompletedAt`; using the all-completed field
+ * would post a value that differs from the hand-computed one and trips a false
+ * F2 `ci-pass-drift`.
+ *
+ * The snapshot emits the `none` sentinel string (never `null`) for empty
+ * timestamps; both are tolerated and forwarded as `none`. Throws (fail-closed)
+ * when `headSha` / `totalItemCount` are absent or malformed so a broken
+ * snapshot can never post a bogus watermark. ISO/count shape validation is left
+ * to the single-sourced `renderReviewWatermarkMarker` reached via
+ * `buildMarkerBody`.
+ */
+export function watermarkFieldsFromSnapshot(snapshot) {
+  const snap = snapshot ?? {};
+  const headSha = snap.headSha;
+  const totalItemCount = snap.totalItemCount;
+  if (typeof headSha !== 'string' || headSha.trim() === '') {
+    throw new Error('review-activity-snapshot is missing a usable headSha');
+  }
+  if (
+    typeof totalItemCount !== 'number' ||
+    !Number.isInteger(totalItemCount) ||
+    totalItemCount < 0
+  ) {
+    throw new Error(
+      'review-activity-snapshot is missing a usable totalItemCount',
+    );
+  }
+  const isoOrNone = (value) =>
+    typeof value === 'string' && value.trim() !== '' ? value : 'none';
+  return {
+    'head-sha': headSha,
+    'max-activity-at': isoOrNone(snap.maxActivityUpdatedAt),
+    'total-item-count': String(totalItemCount),
+    'ci-completed-at': isoOrNone(snap.latestPassingCiCompletedAt),
+  };
+}
+/**
+ * Parse a whole-token positive integer, failing closed on a suffixed typo
+ * (`1047abc`), a non-numeric token, or a non-positive / unsafe magnitude — a
+ * mis-parsed target number could POST a marker to the wrong issue/PR.
+ */
+function parsePositiveIntToken(token, label) {
+  const parsed = Number.parseInt(token, 10);
+  if (!/^\d+$/.test(token) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label}: ${token}`);
+  }
+  return parsed;
+}
 export function parseArgs(argv) {
   const args = {
     type: '',
     target: '',
     number: null,
+    fromPr: null,
     apply: false,
     owner: '',
     repo: '',
+    trustedMarkerLogins: '',
+    advisoryBotLogins: '',
     help: false,
     fields: {},
   };
@@ -121,15 +181,7 @@ export function parseArgs(argv) {
       if (args.number !== null) {
         throw new Error(`unexpected positional argument: ${token}`);
       }
-      const parsed = Number.parseInt(token, 10);
-      if (
-        !/^\d+$/.test(token) ||
-        !Number.isSafeInteger(parsed) ||
-        parsed <= 0
-      ) {
-        throw new Error(`invalid issue/PR number: ${token}`);
-      }
-      args.number = parsed;
+      args.number = parsePositiveIntToken(token, 'invalid issue/PR number');
       continue;
     }
     const value = argv[index + 1];
@@ -141,10 +193,16 @@ export function parseArgs(argv) {
       args.type = value;
     } else if (token === '--target') {
       args.target = value;
+    } else if (token === '--from-pr') {
+      args.fromPr = parsePositiveIntToken(value, 'invalid --from-pr number');
     } else if (token === '--owner') {
       args.owner = value;
     } else if (token === '--repo') {
       args.repo = value;
+    } else if (token === '--trusted-marker-logins') {
+      args.trustedMarkerLogins = value;
+    } else if (token === '--advisory-bot-logins') {
+      args.advisoryBotLogins = value;
     } else {
       // Any other --flag is a renderer field, stored under its kebab name.
       args.fields[token.slice(2)] = value;
@@ -163,7 +221,12 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
 
   --type <type>        one of: ${MARKER_TYPES.join(', ')}
   --target <issue|pr>  the comment target kind (both use the issues comments API)
-  <number>             issue or PR number (positional, required)
+  <number>             issue or PR number (positional; required unless --from-pr)
+  --from-pr <n>        watermark only: derive --head-sha / --max-activity-at /
+                       --total-item-count / --ci-completed-at from the live
+                       review-activity-snapshot of PR <n> and post the watermark
+                       to PR <n>, so only --agent-id / --claim-id (and --apply)
+                       are still needed (target defaults to pr). Not network-free.
   --apply              POST the marker (default: dry-run prints it in a JSON envelope)
   --owner <owner>      repo owner (default: gh repo view)
   --repo <repo>        repo name (default: gh repo view)
@@ -173,9 +236,13 @@ Per-type field flags:
   claim              --agent-id --claim-id --supersedes --timestamp --branch
   unclaim            --agent-id --claim-id --timestamp
   watermark          --agent-id --claim-id --head-sha --max-activity-at --total-item-count --ci-completed-at
+                     (or --agent-id --claim-id --from-pr <n>)
   baseline           --agent-id --claim-id --sha
   advisory           --agent-id --head-sha --timestamp
   advisory-recovery  --agent-id --head-sha --timestamp
+
+--from-pr forwards optional --trusted-marker-logins / --advisory-bot-logins to
+the snapshot child so its counts match the manual review-activity-snapshot path.
 `;
 function ghText(args) {
   return execFileSync('gh', args, { encoding: 'utf8' }).trim();
@@ -202,6 +269,49 @@ function postMarker(owner, repo, number, body) {
     ],
     { input: JSON.stringify({ body }), encoding: 'utf8' },
   );
+  return JSON.parse(out);
+}
+/**
+ * Run the sibling read-only `review-activity-snapshot.mjs` for a PR and return
+ * its parsed JSON. This is the `--from-pr` half of the "compose the two existing
+ * helpers" path; the snapshot stays the single source of the activity/CI metrics
+ * and this write-side helper only renders+posts the watermark over them.
+ *
+ * The sibling is resolved relative to this module (both generated artifacts live
+ * in `scripts/`), so it works from any cwd. `--owner` / `--repo` are forwarded
+ * to avoid an extra `gh repo view` in the child, and the optional marker-actor
+ * lists are forwarded so the child's `totalItemCount` / `maxActivityUpdatedAt`
+ * filtering matches the manual `review-activity-snapshot` invocation.
+ */
+function runReviewActivitySnapshot(
+  prNumber,
+  owner,
+  repo,
+  trustedMarkerLogins,
+  advisoryBotLogins,
+) {
+  const script = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    'review-activity-snapshot.mjs',
+  );
+  const snapshotArgs = [
+    script,
+    '--pr',
+    String(prNumber),
+    '--owner',
+    owner,
+    '--repo',
+    repo,
+  ];
+  if (trustedMarkerLogins) {
+    snapshotArgs.push('--trusted-marker-logins', trustedMarkerLogins);
+  }
+  if (advisoryBotLogins) {
+    snapshotArgs.push('--advisory-bot-logins', advisoryBotLogins);
+  }
+  const out = execFileSync(process.execPath, snapshotArgs, {
+    encoding: 'utf8',
+  });
   return JSON.parse(out);
 }
 function isMainModule(moduleUrl) {
@@ -233,6 +343,69 @@ if (isMainModule(import.meta.url)) {
       `--type is required and must be one of: ${MARKER_TYPES.join(', ')}\n`,
     );
     process.exit(1);
+  }
+  // `--from-pr <n>` snapshot-derivation mode (watermark only): default the post
+  // target to PR <n>, reject the manual snapshot fields as ambiguous, then
+  // derive head-sha / max-activity-at / total-item-count / ci-completed-at from
+  // the live review-activity-snapshot before the shared render + dry-run/apply
+  // path below. owner/repo are resolved here because the snapshot child needs
+  // them and the dry-run branch returns before the apply-path resolution.
+  if (args.fromPr !== null) {
+    if (args.type !== 'watermark') {
+      process.stderr.write('--from-pr is only valid for --type watermark\n');
+      process.exit(1);
+    }
+    if (!args.target) {
+      args.target = 'pr';
+    }
+    if (args.number === null) {
+      args.number = args.fromPr;
+    } else if (args.number !== args.fromPr) {
+      process.stderr.write(
+        'in --from-pr mode the positional number must be omitted or equal --from-pr\n',
+      );
+      process.exit(1);
+    }
+    const derivedFlags = [
+      'head-sha',
+      'max-activity-at',
+      'total-item-count',
+      'ci-completed-at',
+    ];
+    const conflicting = derivedFlags.filter((flag) => flag in args.fields);
+    if (conflicting.length > 0) {
+      process.stderr.write(
+        `--from-pr derives ${derivedFlags.join(' / ')} from the live snapshot; do not also pass: ${conflicting
+          .map((flag) => `--${flag}`)
+          .join(', ')}\n`,
+      );
+      process.exit(1);
+    }
+    // Resolve owner/repo inside the try: in --from-pr mode they are read
+    // eagerly (the snapshot child needs them and the dry-run branch returns
+    // before the apply-path resolution), so a `gh repo view` failure here is
+    // part of "derive from PR" and should report cleanly, not throw a raw stack.
+    try {
+      args.owner =
+        args.owner ||
+        ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+      args.repo =
+        args.repo ||
+        ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+      const snapshot = runReviewActivitySnapshot(
+        args.fromPr,
+        args.owner,
+        args.repo,
+        args.trustedMarkerLogins,
+        args.advisoryBotLogins,
+      );
+      Object.assign(args.fields, watermarkFieldsFromSnapshot(snapshot));
+    } catch (error) {
+      process.stderr.write(
+        `failed to derive watermark fields from PR ${args.fromPr}: ${error.message}\n`,
+      );
+      process.exit(1);
+    }
   }
   if (!TARGET_KINDS.includes(args.target)) {
     process.stderr.write(

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -18,7 +18,7 @@
 // manual POST path it replaces already requires.
 
 import { execFileSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -118,6 +118,52 @@ export function buildMarkerBody(type: string, fields: MarkerFields): string {
   }
 }
 
+/**
+ * Map a `review-activity-snapshot` JSON object to the four snapshot-derived
+ * `--type watermark` field flags, so `--from-pr` can fill them automatically
+ * instead of the agent hand-copying a 40-char HEAD SHA and three timestamps.
+ *
+ * `ci-completed-at` is taken from `latestPassingCiCompletedAt` — the latest
+ * *passing* (or treated-as-passed) CI completion — NOT `latestCiCompletedAt`.
+ * That matches the E1 Step 2 `{latest-ci-completed-at}` definition and the
+ * pre-merge-readiness currency diff, which compares the watermark CI field
+ * against the live `latestPassingCiCompletedAt`; using the all-completed field
+ * would post a value that differs from the hand-computed one and trips a false
+ * F2 `ci-pass-drift`.
+ *
+ * The snapshot emits the `none` sentinel string (never `null`) for empty
+ * timestamps; both are tolerated and forwarded as `none`. Throws (fail-closed)
+ * when `headSha` / `totalItemCount` are absent or malformed so a broken
+ * snapshot can never post a bogus watermark. ISO/count shape validation is left
+ * to the single-sourced `renderReviewWatermarkMarker` reached via
+ * `buildMarkerBody`.
+ */
+export function watermarkFieldsFromSnapshot(snapshot: unknown): MarkerFields {
+  const snap = (snapshot ?? {}) as Record<string, unknown>;
+  const headSha = snap.headSha;
+  const totalItemCount = snap.totalItemCount;
+  if (typeof headSha !== 'string' || headSha.trim() === '') {
+    throw new Error('review-activity-snapshot is missing a usable headSha');
+  }
+  if (
+    typeof totalItemCount !== 'number' ||
+    !Number.isInteger(totalItemCount) ||
+    totalItemCount < 0
+  ) {
+    throw new Error(
+      'review-activity-snapshot is missing a usable totalItemCount',
+    );
+  }
+  const isoOrNone = (value: unknown): string =>
+    typeof value === 'string' && value.trim() !== '' ? value : 'none';
+  return {
+    'head-sha': headSha,
+    'max-activity-at': isoOrNone(snap.maxActivityUpdatedAt),
+    'total-item-count': String(totalItemCount),
+    'ci-completed-at': isoOrNone(snap.latestPassingCiCompletedAt),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
@@ -126,11 +172,30 @@ interface CliArgs {
   type: string;
   target: string;
   number: number | null;
+  /** `--from-pr <n>`: derive the watermark snapshot fields from PR <n>. */
+  fromPr: number | null;
   apply: boolean;
   owner: string;
   repo: string;
+  /** Forwarded to the `--from-pr` snapshot child (snapshot input, not a field). */
+  trustedMarkerLogins: string;
+  /** Forwarded to the `--from-pr` snapshot child (snapshot input, not a field). */
+  advisoryBotLogins: string;
   help: boolean;
   fields: MarkerFields;
+}
+
+/**
+ * Parse a whole-token positive integer, failing closed on a suffixed typo
+ * (`1047abc`), a non-numeric token, or a non-positive / unsafe magnitude — a
+ * mis-parsed target number could POST a marker to the wrong issue/PR.
+ */
+function parsePositiveIntToken(token: string, label: string): number {
+  const parsed = Number.parseInt(token, 10);
+  if (!/^\d+$/.test(token) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label}: ${token}`);
+  }
+  return parsed;
 }
 
 export function parseArgs(argv: string[]): CliArgs {
@@ -138,9 +203,12 @@ export function parseArgs(argv: string[]): CliArgs {
     type: '',
     target: '',
     number: null,
+    fromPr: null,
     apply: false,
     owner: '',
     repo: '',
+    trustedMarkerLogins: '',
+    advisoryBotLogins: '',
     help: false,
     fields: {},
   };
@@ -162,15 +230,7 @@ export function parseArgs(argv: string[]): CliArgs {
       if (args.number !== null) {
         throw new Error(`unexpected positional argument: ${token}`);
       }
-      const parsed = Number.parseInt(token, 10);
-      if (
-        !/^\d+$/.test(token) ||
-        !Number.isSafeInteger(parsed) ||
-        parsed <= 0
-      ) {
-        throw new Error(`invalid issue/PR number: ${token}`);
-      }
-      args.number = parsed;
+      args.number = parsePositiveIntToken(token, 'invalid issue/PR number');
       continue;
     }
     const value = argv[index + 1];
@@ -182,10 +242,16 @@ export function parseArgs(argv: string[]): CliArgs {
       args.type = value;
     } else if (token === '--target') {
       args.target = value;
+    } else if (token === '--from-pr') {
+      args.fromPr = parsePositiveIntToken(value, 'invalid --from-pr number');
     } else if (token === '--owner') {
       args.owner = value;
     } else if (token === '--repo') {
       args.repo = value;
+    } else if (token === '--trusted-marker-logins') {
+      args.trustedMarkerLogins = value;
+    } else if (token === '--advisory-bot-logins') {
+      args.advisoryBotLogins = value;
     } else {
       // Any other --flag is a renderer field, stored under its kebab name.
       args.fields[token.slice(2)] = value;
@@ -205,7 +271,12 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
 
   --type <type>        one of: ${MARKER_TYPES.join(', ')}
   --target <issue|pr>  the comment target kind (both use the issues comments API)
-  <number>             issue or PR number (positional, required)
+  <number>             issue or PR number (positional; required unless --from-pr)
+  --from-pr <n>        watermark only: derive --head-sha / --max-activity-at /
+                       --total-item-count / --ci-completed-at from the live
+                       review-activity-snapshot of PR <n> and post the watermark
+                       to PR <n>, so only --agent-id / --claim-id (and --apply)
+                       are still needed (target defaults to pr). Not network-free.
   --apply              POST the marker (default: dry-run prints it in a JSON envelope)
   --owner <owner>      repo owner (default: gh repo view)
   --repo <repo>        repo name (default: gh repo view)
@@ -215,9 +286,13 @@ Per-type field flags:
   claim              --agent-id --claim-id --supersedes --timestamp --branch
   unclaim            --agent-id --claim-id --timestamp
   watermark          --agent-id --claim-id --head-sha --max-activity-at --total-item-count --ci-completed-at
+                     (or --agent-id --claim-id --from-pr <n>)
   baseline           --agent-id --claim-id --sha
   advisory           --agent-id --head-sha --timestamp
   advisory-recovery  --agent-id --head-sha --timestamp
+
+--from-pr forwards optional --trusted-marker-logins / --advisory-bot-logins to
+the snapshot child so its counts match the manual review-activity-snapshot path.
 `;
 
 function ghText(args: string[]): string {
@@ -254,6 +329,50 @@ function postMarker(
   return JSON.parse(out) as { id: number; html_url: string };
 }
 
+/**
+ * Run the sibling read-only `review-activity-snapshot.mjs` for a PR and return
+ * its parsed JSON. This is the `--from-pr` half of the "compose the two existing
+ * helpers" path; the snapshot stays the single source of the activity/CI metrics
+ * and this write-side helper only renders+posts the watermark over them.
+ *
+ * The sibling is resolved relative to this module (both generated artifacts live
+ * in `scripts/`), so it works from any cwd. `--owner` / `--repo` are forwarded
+ * to avoid an extra `gh repo view` in the child, and the optional marker-actor
+ * lists are forwarded so the child's `totalItemCount` / `maxActivityUpdatedAt`
+ * filtering matches the manual `review-activity-snapshot` invocation.
+ */
+function runReviewActivitySnapshot(
+  prNumber: number,
+  owner: string,
+  repo: string,
+  trustedMarkerLogins: string,
+  advisoryBotLogins: string,
+): unknown {
+  const script = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    'review-activity-snapshot.mjs',
+  );
+  const snapshotArgs = [
+    script,
+    '--pr',
+    String(prNumber),
+    '--owner',
+    owner,
+    '--repo',
+    repo,
+  ];
+  if (trustedMarkerLogins) {
+    snapshotArgs.push('--trusted-marker-logins', trustedMarkerLogins);
+  }
+  if (advisoryBotLogins) {
+    snapshotArgs.push('--advisory-bot-logins', advisoryBotLogins);
+  }
+  const out = execFileSync(process.execPath, snapshotArgs, {
+    encoding: 'utf8',
+  });
+  return JSON.parse(out);
+}
+
 function isMainModule(moduleUrl: string): boolean {
   const entry = process.argv[1];
   if (!entry) {
@@ -286,6 +405,71 @@ if (isMainModule(import.meta.url)) {
     );
     process.exit(1);
   }
+
+  // `--from-pr <n>` snapshot-derivation mode (watermark only): default the post
+  // target to PR <n>, reject the manual snapshot fields as ambiguous, then
+  // derive head-sha / max-activity-at / total-item-count / ci-completed-at from
+  // the live review-activity-snapshot before the shared render + dry-run/apply
+  // path below. owner/repo are resolved here because the snapshot child needs
+  // them and the dry-run branch returns before the apply-path resolution.
+  if (args.fromPr !== null) {
+    if (args.type !== 'watermark') {
+      process.stderr.write('--from-pr is only valid for --type watermark\n');
+      process.exit(1);
+    }
+    if (!args.target) {
+      args.target = 'pr';
+    }
+    if (args.number === null) {
+      args.number = args.fromPr;
+    } else if (args.number !== args.fromPr) {
+      process.stderr.write(
+        'in --from-pr mode the positional number must be omitted or equal --from-pr\n',
+      );
+      process.exit(1);
+    }
+    const derivedFlags = [
+      'head-sha',
+      'max-activity-at',
+      'total-item-count',
+      'ci-completed-at',
+    ];
+    const conflicting = derivedFlags.filter((flag) => flag in args.fields);
+    if (conflicting.length > 0) {
+      process.stderr.write(
+        `--from-pr derives ${derivedFlags.join(' / ')} from the live snapshot; do not also pass: ${conflicting
+          .map((flag) => `--${flag}`)
+          .join(', ')}\n`,
+      );
+      process.exit(1);
+    }
+    // Resolve owner/repo inside the try: in --from-pr mode they are read
+    // eagerly (the snapshot child needs them and the dry-run branch returns
+    // before the apply-path resolution), so a `gh repo view` failure here is
+    // part of "derive from PR" and should report cleanly, not throw a raw stack.
+    try {
+      args.owner =
+        args.owner ||
+        ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+      args.repo =
+        args.repo ||
+        ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+      const snapshot = runReviewActivitySnapshot(
+        args.fromPr,
+        args.owner,
+        args.repo,
+        args.trustedMarkerLogins,
+        args.advisoryBotLogins,
+      );
+      Object.assign(args.fields, watermarkFieldsFromSnapshot(snapshot));
+    } catch (error) {
+      process.stderr.write(
+        `failed to derive watermark fields from PR ${args.fromPr}: ${(error as Error).message}\n`,
+      );
+      process.exit(1);
+    }
+  }
+
   if (!TARGET_KINDS.includes(args.target as TargetKind)) {
     process.stderr.write(
       `--target is required and must be one of: ${TARGET_KINDS.join(', ')}\n`,

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -276,7 +276,8 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
                        --total-item-count / --ci-completed-at from the live
                        review-activity-snapshot of PR <n> and post the watermark
                        to PR <n>, so only --agent-id / --claim-id (and --apply)
-                       are still needed (target defaults to pr). Not network-free.
+                       are still needed (always targets the PR; an explicit
+                       non-pr --target is rejected). Not network-free.
   --apply              POST the marker (default: dry-run prints it in a JSON envelope)
   --owner <owner>      repo owner (default: gh repo view)
   --repo <repo>        repo name (default: gh repo view)
@@ -417,9 +418,17 @@ if (isMainModule(import.meta.url)) {
       process.stderr.write('--from-pr is only valid for --type watermark\n');
       process.exit(1);
     }
-    if (!args.target) {
-      args.target = 'pr';
+    // --from-pr always posts the watermark to PR <n>. `--target` is
+    // descriptive-only (issue/pr both POST to the same /issues/<n>/comments
+    // endpoint), but an `issue`-targeted snapshot watermark is incoherent, so
+    // fail closed on an explicit non-pr target rather than recording it.
+    if (args.target && args.target !== 'pr') {
+      process.stderr.write(
+        `--from-pr always targets the PR; remove --target ${args.target}\n`,
+      );
+      process.exit(1);
     }
+    args.target = 'pr';
     if (args.number === null) {
       args.number = args.fromPr;
     } else if (args.number !== args.fromPr) {

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -643,3 +643,22 @@ test('--from-pr is rejected for a non-watermark type', () => {
   ]);
   assert.match(stderr, /--from-pr is only valid for --type watermark/);
 });
+
+test('--from-pr fails closed on an explicit non-pr --target', () => {
+  // A watermark always belongs on the PR; an issue-targeted snapshot watermark
+  // is incoherent, so an explicit --target issue is rejected (not defaulted).
+  const stderr = runCliExpectingFailure([
+    join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+    '--type',
+    'watermark',
+    '--target',
+    'issue',
+    '--from-pr',
+    '1200',
+    '--agent-id',
+    'a',
+    '--claim-id',
+    'c',
+  ]);
+  assert.match(stderr, /--from-pr always targets the PR/);
+});

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -10,6 +10,7 @@ import {
   buildMarkerBody,
   MARKER_TYPES,
   parseArgs,
+  watermarkFieldsFromSnapshot,
 } from '../src/scripts/post-idd-marker.mts';
 import {
   operationalMarkerPrefix,
@@ -400,4 +401,245 @@ process.exit(1);
       branch: 'issue/1047-foo',
     }),
   });
+});
+
+// --- #1134: --from-pr snapshot-derivation mode for the watermark ---
+
+test('watermarkFieldsFromSnapshot maps the four snapshot fields (real values)', () => {
+  assert.deepEqual(
+    watermarkFieldsFromSnapshot({
+      headSha: SHA,
+      totalItemCount: 7,
+      maxActivityUpdatedAt: '2026-06-25T12:00:00Z',
+      latestPassingCiCompletedAt: '2026-06-25T11:59:00Z',
+    }),
+    {
+      'head-sha': SHA,
+      'max-activity-at': '2026-06-25T12:00:00Z',
+      'total-item-count': '7',
+      'ci-completed-at': '2026-06-25T11:59:00Z',
+    },
+  );
+});
+
+test('watermarkFieldsFromSnapshot uses latestPassingCiCompletedAt, NOT latestCiCompletedAt', () => {
+  // A failing/in-progress check can complete AFTER the latest pass, so the two
+  // snapshot CI fields differ. The watermark must record the latest *pass*, or
+  // F2 review-currency trips a false `ci-pass-drift`.
+  const fields = watermarkFieldsFromSnapshot({
+    headSha: SHA,
+    totalItemCount: 1,
+    maxActivityUpdatedAt: 'none',
+    latestPassingCiCompletedAt: '2026-06-25T11:00:00Z',
+    latestCiCompletedAt: '2026-06-25T11:30:00Z',
+  });
+  assert.equal(fields['ci-completed-at'], '2026-06-25T11:00:00Z');
+});
+
+test('watermarkFieldsFromSnapshot forwards the none sentinel for empty timestamps', () => {
+  // The snapshot emits the string `none` (never null) for an empty universe.
+  assert.deepEqual(
+    watermarkFieldsFromSnapshot({
+      headSha: SHA,
+      totalItemCount: 0,
+      maxActivityUpdatedAt: 'none',
+      latestPassingCiCompletedAt: 'none',
+    }),
+    {
+      'head-sha': SHA,
+      'max-activity-at': 'none',
+      'total-item-count': '0',
+      'ci-completed-at': 'none',
+    },
+  );
+});
+
+test('watermarkFieldsFromSnapshot fails closed on a malformed snapshot', () => {
+  assert.throws(
+    () => watermarkFieldsFromSnapshot({ totalItemCount: 0 }),
+    /missing a usable headSha/,
+  );
+  assert.throws(
+    () => watermarkFieldsFromSnapshot({ headSha: SHA }),
+    /missing a usable totalItemCount/,
+  );
+  assert.throws(
+    () => watermarkFieldsFromSnapshot({ headSha: SHA, totalItemCount: -1 }),
+    /missing a usable totalItemCount/,
+  );
+  assert.throws(() => watermarkFieldsFromSnapshot(null), /headSha/);
+});
+
+test('watermarkFieldsFromSnapshot output round-trips through the watermark parser', () => {
+  const body = buildMarkerBody('watermark', {
+    'agent-id': 'claude-02f8159e',
+    'claim-id': 'claim-1134-02f8159e',
+    ...watermarkFieldsFromSnapshot({
+      headSha: SHA,
+      totalItemCount: 3,
+      maxActivityUpdatedAt: '2026-06-25T12:00:00Z',
+      latestPassingCiCompletedAt: '2026-06-25T11:59:00Z',
+    }),
+  });
+  assert.deepEqual(parseReviewWatermarkComment(body, CREATED_AT), {
+    agentId: 'claude-02f8159e',
+    claimId: 'claim-1134-02f8159e',
+    headSha: SHA,
+    maxActivityUpdatedAt: '2026-06-25T12:00:00Z',
+    totalItemCount: 3,
+    // The parser stores the 6th field under `latestCiCompletedAt`; pre-merge
+    // currency reads it back AS the latest-passing CI time.
+    latestCiCompletedAt: '2026-06-25T11:59:00Z',
+    createdAt: CREATED_AT,
+  });
+});
+
+test('parseArgs reads --from-pr and the forwarded snapshot-actor lists', () => {
+  const args = parseArgs([
+    '--type',
+    'watermark',
+    '--from-pr',
+    '1200',
+    '--agent-id',
+    'a',
+    '--claim-id',
+    'c',
+    '--trusted-marker-logins',
+    'kurone-kito',
+    '--apply',
+  ]);
+  assert.equal(args.fromPr, 1200);
+  assert.equal(args.trustedMarkerLogins, 'kurone-kito');
+  // --from-pr / --trusted-marker-logins are structural, not renderer fields.
+  assert.deepEqual(args.fields, { 'agent-id': 'a', 'claim-id': 'c' });
+});
+
+test('parseArgs rejects a non-numeric / suffixed --from-pr', () => {
+  assert.throws(
+    () => parseArgs(['--from-pr', '1200abc']),
+    /invalid --from-pr number/,
+  );
+  assert.throws(
+    () => parseArgs(['--from-pr', '0']),
+    /invalid --from-pr number/,
+  );
+});
+
+test('--from-pr CLI composes review-activity-snapshot and prints the derived watermark (dry-run)', () => {
+  // Stub `gh` on PATH so the real subprocess composition runs offline: the
+  // post-idd-marker.mjs CLI resolves its sibling review-activity-snapshot.mjs,
+  // which makes the read calls below; the stub answers each by argv.
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-cli-'));
+  const ghPath = join(tempRoot, 'gh');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const out = (s) => { fs.writeSync(1, s); process.exit(0); };
+if (args[0] === 'pr' && args[1] === 'view') out('${SHA}\\n');
+if (args[0] === 'pr' && args[1] === 'checks') {
+  out(JSON.stringify([{ name: 'ci', state: 'SUCCESS', completedAt: '2026-06-25T11:00:00Z' }]));
+}
+if (args[0] === 'api' && args[1] === 'graphql') {
+  out(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false }, nodes: [] } } } } }));
+}
+if (args[0] === 'api' && /\\/reviews$/.test(args[1])) out('[]');
+if (args[0] === 'api' && /\\/comments$/.test(args[1])) {
+  out(JSON.stringify([{ body: 'hi', created_at: '2026-06-25T10:00:00Z', updated_at: '2026-06-25T10:30:00Z', user: { login: 'someone' } }]));
+}
+fs.writeSync(2, 'unexpected gh invocation: ' + args.join(' '));
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+
+  const output = execFileSync(
+    process.execPath,
+    [
+      join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+      '--type',
+      'watermark',
+      '--from-pr',
+      '1200',
+      '--owner',
+      'o',
+      '--repo',
+      'r',
+      '--agent-id',
+      'claude-02f8159e',
+      '--claim-id',
+      'claim-1134-02f8159e',
+    ],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${tempRoot}:${process.env.PATH ?? ''}` },
+    },
+  );
+
+  assert.deepEqual(JSON.parse(output), {
+    mode: 'dry-run',
+    type: 'watermark',
+    target: 'pr',
+    number: 1200,
+    body: buildMarkerBody('watermark', {
+      'agent-id': 'claude-02f8159e',
+      'claim-id': 'claim-1134-02f8159e',
+      'head-sha': SHA,
+      'max-activity-at': '2026-06-25T10:30:00Z',
+      'total-item-count': '1',
+      'ci-completed-at': '2026-06-25T11:00:00Z',
+    }),
+  });
+});
+
+// Run the CLI expecting a non-zero exit; return its stderr. These guards fire
+// before any `gh` call, so no stub is needed (and `gh` is removed from PATH to
+// prove the rejection is argument-only, never a network side effect).
+function runCliExpectingFailure(argv: string[]): string {
+  try {
+    execFileSync(process.execPath, [...argv], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: '' },
+    });
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    assert.equal(failure.status, 1);
+    return failure.stderr ?? '';
+  }
+  throw new Error('expected the CLI to exit non-zero');
+}
+
+test('--from-pr rejects manual snapshot fields as ambiguous (before any gh call)', () => {
+  const stderr = runCliExpectingFailure([
+    join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+    '--type',
+    'watermark',
+    '--from-pr',
+    '1200',
+    '--head-sha',
+    SHA,
+    '--agent-id',
+    'a',
+    '--claim-id',
+    'c',
+  ]);
+  assert.match(stderr, /--from-pr derives .* do not also pass: --head-sha/);
+});
+
+test('--from-pr is rejected for a non-watermark type', () => {
+  const stderr = runCliExpectingFailure([
+    join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+    '--type',
+    'claim',
+    '--from-pr',
+    '1200',
+    '--agent-id',
+    'a',
+    '--claim-id',
+    'c',
+  ]);
+  assert.match(stderr, /--from-pr is only valid for --type watermark/);
 });


### PR DESCRIPTION
## Summary

Adds a one-command path to post the E1/F2 `review-watermark`: a `--from-pr <n>` mode on `post-idd-marker --type watermark` that derives the four snapshot-driven fields (`--head-sha` / `--max-activity-at` / `--total-item-count` / `--ci-completed-at`) from a fresh `review-activity-snapshot` of the PR and posts the marker, so an agent supplies only `--agent-id` / `--claim-id` (+ `--apply`) instead of hand-copying a 40-char HEAD SHA and three timestamps. (A mistyped HEAD SHA otherwise mis-routes the F2 review-currency check, and the copy recurred on every cycle.)

## Design

- **Composition, not duplication.** The read-only `review-activity-snapshot` is left byte-for-byte untouched (it is the load-bearing E1 safety-net helper); the write-side `post-idd-marker` invokes it as a subprocess — forwarding optional `--trusted-marker-logins` / `--advisory-bot-logins` so its `totalItemCount` / `maxActivityUpdatedAt` filtering matches the manual path — then renders + POSTs via the single-sourced `renderReviewWatermarkMarker` / JSON-POST path. (Rejected: a `--post-watermark` mode *on* the snapshot helper would turn a documented read-only helper into a comment-writer and duplicate the POST primitive.)
- **`ci-completed-at` ← `latestPassingCiCompletedAt`** (the latest *passing* / treated-as-passed CI completion), not `latestCiCompletedAt`. This matches the E1 Step 2 `{latest-ci-completed-at}` definition and the `pre-merge-readiness` currency diff (which feeds the parsed watermark CI field in as `latestPassingCiCompletedAt`), so the one-command value equals the hand-computed one and cannot trip a false F2 `ci-pass-drift`.
- A dry preview (no `--apply`) prints the exact marker body and posts nothing (it does read GitHub to build the snapshot, unlike the network-free manual dry-run); `--apply` posts via the reliable JSON path. The manual six-field path is unchanged — no breaking change.

## Docs & budget

- E1 Step 2 (`idd-review-snapshot.instructions.md`) and the write-side section of `idd-helper-scripts.md` now present the one-command path as preferred with the manual form as fallback. Edited in the `idd-template/` source and synced to the live copies; `audit-docs --check` stays green.
- **Budget ratchet:** `bundle-review.limitBytes` 108200 → 108800 (actual 108535; small non-exact-fit headroom of 265 B) to fit the E1 edit — a budget *raise*, called out here per the documented sync-manifest ratchet rule.

## Tests

`watermarkFieldsFromSnapshot` unit tests (including the `latestPassingCiCompletedAt`-not-`latestCiCompletedAt` guard, the `none` sentinel, and fail-closed on a malformed snapshot), a render→parse round-trip, `parseArgs --from-pr` parsing, a **real-subprocess** `--from-pr` dry-run integration test (stubbed `gh` answers the snapshot's read calls and the printed body is asserted), and negative tests for the non-watermark and manual-field-conflict rejections.

## Non-goals

The new runtime coupling (post-idd-marker → review-activity-snapshot) is not declared in `helper-runtime-manifest` — there is no `dependsOn` mechanism today, and the path fails closed with a reason-bearing message if the sibling is absent, consistent with the existing whole-set vendoring among helpers.

Closes #1134
