### PR TITLE
perf(discover): parallelize roadmap-graph traversal I/O

### DIFF
--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -36,8 +36,8 @@ const GH_SEARCH_RESULT_CAP = 1000;
 // in-flight slot is one live `gh` subprocess (one network round-trip), so the
 // bound caps parallel I/O without risking GitHub secondary rate limits. The
 // default trades a comfortable speed-up against politeness; `--concurrency`
-// (or the `concurrency` option) tunes it, and `1` reproduces the old serial
-// fetch exactly.
+// (or the `concurrency` option) tunes it, and `1` runs the fetches serially
+// (one in flight at a time).
 const DEFAULT_TRAVERSAL_CONCURRENCY = 8;
 // Promisified `gh` runner used ONLY by the traversal hot-path loaders
 // (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking
@@ -1310,8 +1310,14 @@ function parseArgs(argv) {
       continue;
     }
     if (token === '--concurrency') {
-      parsed.concurrency = Number.parseInt(String(value ?? ''), 10);
-      index += 1;
+      // Only consume the next token as the value when it exists and is not
+      // itself a flag, mirroring --current-claim-id, so
+      // `--concurrency --issue 700` does not swallow the following flag. A
+      // missing/flag value leaves concurrency unset (0 → normalized default).
+      if (value !== undefined && !value.startsWith('--')) {
+        parsed.concurrency = Number.parseInt(value, 10);
+        index += 1;
+      }
       continue;
     }
     if (token === '--current-claim-id') {
@@ -1342,7 +1348,7 @@ function printHelp() {
 
   --concurrency <n> (default 8) bounds how many issue fetches the traversal
   prefetch keeps in flight at once. The graph is byte-identical for any n;
-  only wall-clock changes. Pass 1 to force the previous serial traversal.
+  only fetch ordering and wall-clock change. Pass 1 to fetch serially.
   --all-roadmaps enumerates open execution leaves across every open roadmap
   root (the union), each tagged with its sourceRoots and ranked by
   autopilotSuitability (descending, tie-broken by ascending issue number).

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -4,10 +4,11 @@
 // The scripts/discover-roadmap-graph.mjs copy is generated from the .mts
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 import { resolveAuthoringGuardPolicy } from './authoring-label-guard.mjs';
 import {
   isAutopilotSuitabilityScore,
@@ -31,6 +32,21 @@ const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // open-roadmap-roots loader pins each search at this cap and warns when a
 // single search returns the full cap (a possible silent truncation).
 const GH_SEARCH_RESULT_CAP = 1000;
+// #1136: default in-flight bound for the concurrent prefetch crawl. Each
+// in-flight slot is one live `gh` subprocess (one network round-trip), so the
+// bound caps parallel I/O without risking GitHub secondary rate limits. The
+// default trades a comfortable speed-up against politeness; `--concurrency`
+// (or the `concurrency` option) tunes it, and `1` reproduces the old serial
+// fetch exactly.
+const DEFAULT_TRAVERSAL_CONCURRENCY = 8;
+// Promisified `gh` runner used ONLY by the traversal hot-path loaders
+// (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking
+// `execFileSync` runner — which serializes even concurrent `await`s because it
+// holds the event loop — `execFile` lets up to `DEFAULT_TRAVERSAL_CONCURRENCY`
+// `gh` subprocesses run in parallel. The non-hot-path callers (owner/repo
+// resolution, claim-state comments, `--all-roadmaps` search) keep the sync
+// runner, so their behavior is byte-unchanged.
+const execFileAsync = promisify(execFile);
 // Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
 // the default baked into protocol-helpers' `isStaleAt`, so when the configured
 // stale age equals this default the shared `isStaleAt` path is
@@ -109,6 +125,7 @@ if (isMainModule(import.meta.url)) {
         ),
         claimState,
         readiness,
+        concurrency: args.concurrency,
       })
     : await enumerateRoadmapGraph(args.issue, {
         markerPrefix: policy.markerPrefix,
@@ -118,8 +135,44 @@ if (isMainModule(import.meta.url)) {
         loadSubIssues: buildSubIssueLoader(owner, repo),
         claimState,
         readiness,
+        concurrency: args.concurrency,
       });
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+/**
+ * Normalize the traversal `concurrency` option to an integer `>= 1`, falling
+ * back to {@link DEFAULT_TRAVERSAL_CONCURRENCY} for unset, non-integer, or
+ * `< 1` values. `1` is preserved so callers can force the serial path.
+ */
+function normalizeConcurrency(value) {
+  const numeric =
+    typeof value === 'number'
+      ? value
+      : Number.parseInt(String(value ?? ''), 10);
+  return Number.isInteger(numeric) && numeric >= 1
+    ? numeric
+    : DEFAULT_TRAVERSAL_CONCURRENCY;
+}
+/**
+ * Run `task` over `items` with at most `limit` invocations in flight at once,
+ * returning results in input order. A fixed pool of workers pulls from a shared
+ * cursor, so a slow item never blocks faster siblings (continuous, not
+ * lock-step batches). An empty input runs no workers; the first rejection
+ * propagates (mirroring the previous serial traversal's fail-closed abort).
+ */
+async function mapPool(items, limit, task) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await task(items[index]);
+    }
+  };
+  const workerCount = Math.min(Math.max(1, limit), items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
 }
 export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
@@ -166,6 +219,16 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   // Re-bind after the guards so the hoisted helper closures below see the
   // narrowed issue type.
   const rootIssue = fetchedRoot;
+  // #1136: warm issueCache + referenceCache with a bounded-concurrency prefetch
+  // crawl BEFORE the (unchanged) serial graph build below, so `visitIssue` runs
+  // entirely against warm caches and issues zero I/O. The crawl visits exactly
+  // the same reachable, accessible, non-PR node set the DFS expands, so the
+  // resulting graph stays byte-identical to a fully serial run — only the
+  // wall-clock changes.
+  await prefetchReachableIssues(
+    rootIssue.number,
+    normalizeConcurrency(options.concurrency),
+  );
   await visitIssue(rootIssue.number, [rootIssue.number]);
   const nodes = [...nodeRecords.values()]
     .map((node) => ({
@@ -390,6 +453,45 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
     referenceCache.set(issue.number, references);
     return references;
   }
+  // #1136: bounded-concurrency BFS that warms issueCache + referenceCache for
+  // every reachable node before the serial graph build. It calls the same
+  // getIssue / getReferences the DFS uses (so caches and the
+  // subIssueSummaryTotal===0 skip are shared), but fans the frontier out
+  // through `mapPool`. A genuine loader error rejects here and propagates,
+  // matching the previous serial traversal's fail-closed abort; 404→null and
+  // 403/410/451→sentinel still resolve without throwing.
+  async function prefetchReachableIssues(startNumber, concurrency) {
+    const scheduled = new Set([startNumber]);
+    let frontier = [startNumber];
+    while (frontier.length > 0) {
+      const targetLists = await mapPool(
+        frontier,
+        concurrency,
+        expandForPrefetch,
+      );
+      const next = [];
+      for (const targets of targetLists) {
+        for (const target of targets) {
+          if (!scheduled.has(target)) {
+            scheduled.add(target);
+            next.push(target);
+          }
+        }
+      }
+      frontier = next;
+    }
+  }
+  // Fetch one node and return its reference targets for the next BFS frontier.
+  // Mirrors the DFS expansion guard: only accessible, non-PR issues are
+  // expanded (PRs / inaccessible / not-found contribute no children), so the
+  // crawl's reachable set equals the DFS's.
+  async function expandForPrefetch(issueNumber) {
+    const issue = await getIssue(issueNumber, issueCache, loadIssue);
+    if (!issue || isInaccessibleIssue(issue) || issue.isPullRequest) {
+      return [];
+    }
+    return (await getReferences(issue)).map((reference) => reference.target);
+  }
   function recordNode(issue, path) {
     const existing = nodeRecords.get(issue.number);
     const classification = classifyIssue(issue, markerPrefix);
@@ -491,6 +593,9 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
       repo: options.repo,
       loadIssue: options.loadIssue,
       loadSubIssues: options.loadSubIssues,
+      // #1136: each per-root enumeration prefetches its own subtree
+      // concurrently; thread the same bound through.
+      concurrency: options.concurrency,
     });
     roots.push({
       number: graph.root.number,
@@ -1166,6 +1271,7 @@ function parseArgs(argv) {
     withClaimState: false,
     withReadiness: false,
     currentClaimId: '',
+    concurrency: 0,
     help: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -1203,6 +1309,11 @@ function parseArgs(argv) {
       parsed.withReadiness = true;
       continue;
     }
+    if (token === '--concurrency') {
+      parsed.concurrency = Number.parseInt(String(value ?? ''), 10);
+      index += 1;
+      continue;
+    }
     if (token === '--current-claim-id') {
       // Only consume the next token as the id when it exists and is not itself
       // a flag, so `--current-claim-id --with-claim-state` does not swallow the
@@ -1224,10 +1335,14 @@ function parseArgs(argv) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>]
-  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>]
+  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>] [--concurrency <n>]
+  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>] [--concurrency <n>]
 
   --issue and --all-roadmaps are mutually exclusive; exactly one is required.
+
+  --concurrency <n> (default 8) bounds how many issue fetches the traversal
+  prefetch keeps in flight at once. The graph is byte-identical for any n;
+  only wall-clock changes. Pass 1 to force the previous serial traversal.
   --all-roadmaps enumerates open execution leaves across every open roadmap
   root (the union), each tagged with its sourceRoots and ranked by
   autopilotSuitability (descending, tie-broken by ascending issue number).
@@ -1389,7 +1504,7 @@ export function buildIssueLoader(owner, repo) {
       '.',
     ];
     try {
-      const result = runGh(args, { allowStatuses: [404] }).trim();
+      const result = (await runGhAsync(args, { allowStatuses: [404] })).trim();
       if (!result || result === 'null') {
         return null;
       }
@@ -1418,7 +1533,7 @@ export function buildSubIssueLoader(owner, repo) {
       if (after) {
         variables.after = after;
       }
-      const result = runGraphqlQuery(SUB_ISSUES_QUERY, variables);
+      const result = await runGraphqlQuery(SUB_ISSUES_QUERY, variables);
       const connection = result?.data?.repository?.issue?.subIssues;
       if (
         !connection ||
@@ -1597,7 +1712,14 @@ function buildSearchIssuesRunner() {
     return Array.isArray(parsed) ? parsed : [];
   };
 }
-function runGraphqlQuery(query, variables) {
+/**
+ * Async GraphQL runner for the traversal sub-issue loader. Its sole caller
+ * (`buildSubIssueLoader`) is already async, so the runner uses the non-blocking
+ * `execFile` path — letting several sub-issue queries run in parallel under the
+ * prefetch crawl — while keeping the exact arg construction, error-array
+ * detection, and `gh api graphql failed: …` wrapping of the previous sync form.
+ */
+async function runGraphqlQuery(query, variables) {
   const args = ['api', 'graphql', '-f', `query=${query}`];
   for (const [name, value] of Object.entries(variables)) {
     if (value === '' || value === null || value === undefined) {
@@ -1607,11 +1729,8 @@ function runGraphqlQuery(query, variables) {
     args.push(flag, `${name}=${value}`);
   }
   try {
-    const raw = execFileSync('gh', args, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-    const parsed = JSON.parse(raw || '{}');
+    const { stdout } = await execFileAsync('gh', args, { encoding: 'utf8' });
+    const parsed = JSON.parse(stdout.trim() || '{}');
     if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
       throw new Error(formatGraphqlErrors(parsed.errors));
     }
@@ -1639,6 +1758,41 @@ function loadPolicy(policyPath) {
 function ghText(args) {
   return runGh(args).trim();
 }
+/**
+ * Normalize a failed-`gh` error's exit status to a number.
+ *
+ * The synchronous `execFileSync` runner exposes the process exit code on
+ * `.status`; the promisified `execFile` runner exposes it on `.code`. Read
+ * `.status` first (sync), then fall back to `.code` (async), keeping only a
+ * numeric value so a spawn-error string code (e.g. `ENOENT`) resolves to
+ * `null` exactly as the previous sync-only path did.
+ */
+function resolveGhExitStatus(error) {
+  const candidate = error;
+  const rawStatus = candidate?.status ?? candidate?.code;
+  return typeof rawStatus === 'number' ? rawStatus : null;
+}
+/**
+ * Wrap a failed-`gh` error into the canonical `{ status, stderr }` shape that
+ * the issue-lookup classifiers (`isNotFoundIssueLookupError` /
+ * `isInaccessibleIssueLookupError`) read, so the sync and async runners produce
+ * byte-identical errors. Returns `''` when the exit status is tolerated
+ * (`allowStatuses`); otherwise throws the wrapped error.
+ */
+function wrapGhFailure(error, args, allowStatuses) {
+  const status = resolveGhExitStatus(error);
+  if (status !== null && allowStatuses.includes(status)) {
+    return '';
+  }
+  const stderr = String(error?.stderr ?? '').trim();
+  const prefix = `gh ${args.join(' ')}`;
+  const wrapped = new Error(
+    stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`,
+  );
+  wrapped.status = status;
+  wrapped.stderr = stderr;
+  throw wrapped;
+}
 function runGh(args, options = {}) {
   const { allowStatuses = [] } = options;
   try {
@@ -1647,19 +1801,23 @@ function runGh(args, options = {}) {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (error) {
-    const rawStatus = error?.status;
-    const status = typeof rawStatus === 'number' ? rawStatus : null;
-    if (status !== null && allowStatuses.includes(status)) {
-      return '';
-    }
-    const stderr = String(error?.stderr ?? '').trim();
-    const prefix = `gh ${args.join(' ')}`;
-    const wrapped = new Error(
-      stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`,
-    );
-    wrapped.status = status;
-    wrapped.stderr = stderr;
-    throw wrapped;
+    return wrapGhFailure(error, args, allowStatuses);
+  }
+}
+/**
+ * Async sibling of {@link runGh} used only by the traversal hot-path loaders
+ * (`buildIssueLoader` / `buildSubIssueLoader`), so the bounded prefetch crawl
+ * can keep several `gh` subprocesses in flight. Behaviorally identical to
+ * {@link runGh}: same tolerated-status handling and the same wrapped-error
+ * shape (via {@link wrapGhFailure}).
+ */
+async function runGhAsync(args, options = {}) {
+  const { allowStatuses = [] } = options;
+  try {
+    const { stdout } = await execFileAsync('gh', args, { encoding: 'utf8' });
+    return stdout;
+  } catch (error) {
+    return wrapGhFailure(error, args, allowStatuses);
   }
 }
 function isInaccessibleIssue(value) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -4,11 +4,10 @@
 // The scripts/discover-roadmap-graph.mjs copy is generated from the .mts
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
-import { execFile, execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 import { resolveAuthoringGuardPolicy } from './authoring-label-guard.mjs';
 import {
   isAutopilotSuitabilityScore,
@@ -39,16 +38,50 @@ const GH_SEARCH_RESULT_CAP = 1000;
 // (or the `concurrency` option) tunes it, and `1` runs the fetches serially
 // (one in flight at a time).
 const DEFAULT_TRAVERSAL_CONCURRENCY = 8;
-// Promisified `gh` runner used ONLY by the traversal hot-path loaders
-// (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking
-// `execFileSync` runner — which serializes even concurrent `await`s because it
-// holds the event loop — `execFile` lets multiple `gh` subprocesses run in
-// parallel; the actual in-flight bound is enforced by the prefetch crawl's
-// `mapPool` using the resolved `concurrency` (default
-// `DEFAULT_TRAVERSAL_CONCURRENCY`). The non-hot-path callers (owner/repo
-// resolution, claim-state comments, `--all-roadmaps` search) keep the sync
-// runner, so their behavior is byte-unchanged.
-const execFileAsync = promisify(execFile);
+/**
+ * Async `gh` invocation used ONLY by the traversal hot-path loaders
+ * (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking
+ * `execFileSync` runner — which serializes even concurrent `await`s because it
+ * holds the event loop — this `spawn`-based runner lets multiple `gh`
+ * subprocesses run in parallel; the actual in-flight bound is enforced by the
+ * prefetch crawl's `mapPool` using the resolved `concurrency` (default
+ * {@link DEFAULT_TRAVERSAL_CONCURRENCY}). The non-hot-path callers (owner/repo
+ * resolution, claim-state comments, `--all-roadmaps` search) keep the sync
+ * runner, so their behavior is byte-unchanged.
+ *
+ * Stdio matches the sync runner exactly (`['ignore', 'pipe', 'pipe']`): stdin
+ * is ignored so `gh` never blocks on or reads an inherited/open stdin pipe,
+ * and stdout/stderr are piped for capture. Resolves with stdout on a zero
+ * exit; on a non-zero exit (or spawn error) rejects with an error carrying
+ * `.code` (exit status) and `.stderr`, the shape {@link wrapGhFailure} reads.
+ */
+function runGhCapture(args) {
+  return new Promise((resolveOutput, rejectOutput) => {
+    const child = spawn('gh', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', rejectOutput);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolveOutput(stdout);
+        return;
+      }
+      const error = new Error(`gh exited with code ${code}`);
+      error.code = code;
+      error.stderr = stderr;
+      error.stdout = stdout;
+      rejectOutput(error);
+    });
+  });
+}
 // Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
 // the default baked into protocol-helpers' `isStaleAt`, so when the configured
 // stale age equals this default the shared `isStaleAt` path is
@@ -1743,7 +1776,7 @@ async function runGraphqlQuery(query, variables) {
     args.push(flag, `${name}=${value}`);
   }
   try {
-    const { stdout } = await execFileAsync('gh', args, { encoding: 'utf8' });
+    const stdout = await runGhCapture(args);
     const parsed = JSON.parse(stdout.trim() || '{}');
     if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
       throw new Error(formatGraphqlErrors(parsed.errors));
@@ -1828,7 +1861,7 @@ function runGh(args, options = {}) {
 async function runGhAsync(args, options = {}) {
   const { allowStatuses = [] } = options;
   try {
-    const { stdout } = await execFileAsync('gh', args, { encoding: 'utf8' });
+    const stdout = await runGhCapture(args);
     return stdout;
   } catch (error) {
     return wrapGhFailure(error, args, allowStatuses);

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -143,12 +143,15 @@ if (isMainModule(import.meta.url)) {
  * Normalize the traversal `concurrency` option to an integer `>= 1`, falling
  * back to {@link DEFAULT_TRAVERSAL_CONCURRENCY} for unset, non-integer, or
  * `< 1` values. `1` is preserved so callers can force the serial path.
+ *
+ * String input is parsed with `Number` (not `parseInt`) so a non-integer
+ * string such as `"2.5"` fails the `Number.isInteger` check and falls back to
+ * the default, instead of being silently truncated to `2`. This keeps CLI
+ * string input and typed numeric input consistent.
  */
-function normalizeConcurrency(value) {
+export function normalizeConcurrency(value) {
   const numeric =
-    typeof value === 'number'
-      ? value
-      : Number.parseInt(String(value ?? ''), 10);
+    typeof value === 'number' ? value : Number(String(value ?? '').trim());
   return Number.isInteger(numeric) && numeric >= 1
     ? numeric
     : DEFAULT_TRAVERSAL_CONCURRENCY;
@@ -1315,7 +1318,10 @@ function parseArgs(argv) {
       // `--concurrency --issue 700` does not swallow the following flag. A
       // missing/flag value leaves concurrency unset (0 → normalized default).
       if (value !== undefined && !value.startsWith('--')) {
-        parsed.concurrency = Number.parseInt(value, 10);
+        // Use Number (not parseInt) so a non-integer like "2.5" stays
+        // non-integer and normalizeConcurrency falls back to the default,
+        // rather than being truncated to 2.
+        parsed.concurrency = Number(value);
         index += 1;
       }
       continue;

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -42,8 +42,10 @@ const DEFAULT_TRAVERSAL_CONCURRENCY = 8;
 // Promisified `gh` runner used ONLY by the traversal hot-path loaders
 // (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking
 // `execFileSync` runner — which serializes even concurrent `await`s because it
-// holds the event loop — `execFile` lets up to `DEFAULT_TRAVERSAL_CONCURRENCY`
-// `gh` subprocesses run in parallel. The non-hot-path callers (owner/repo
+// holds the event loop — `execFile` lets multiple `gh` subprocesses run in
+// parallel; the actual in-flight bound is enforced by the prefetch crawl's
+// `mapPool` using the resolved `concurrency` (default
+// `DEFAULT_TRAVERSAL_CONCURRENCY`). The non-hot-path callers (owner/repo
 // resolution, claim-state comments, `--all-roadmaps` search) keep the sync
 // runner, so their behavior is byte-unchanged.
 const execFileAsync = promisify(execFile);

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -5,10 +5,11 @@
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
 
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
 import { resolveAuthoringGuardPolicy } from './authoring-label-guard.mts';
 import {
@@ -33,6 +34,21 @@ const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // open-roadmap-roots loader pins each search at this cap and warns when a
 // single search returns the full cap (a possible silent truncation).
 const GH_SEARCH_RESULT_CAP = 1000;
+// #1136: default in-flight bound for the concurrent prefetch crawl. Each
+// in-flight slot is one live `gh` subprocess (one network round-trip), so the
+// bound caps parallel I/O without risking GitHub secondary rate limits. The
+// default trades a comfortable speed-up against politeness; `--concurrency`
+// (or the `concurrency` option) tunes it, and `1` reproduces the old serial
+// fetch exactly.
+const DEFAULT_TRAVERSAL_CONCURRENCY = 8;
+// Promisified `gh` runner used ONLY by the traversal hot-path loaders
+// (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking
+// `execFileSync` runner — which serializes even concurrent `await`s because it
+// holds the event loop — `execFile` lets up to `DEFAULT_TRAVERSAL_CONCURRENCY`
+// `gh` subprocesses run in parallel. The non-hot-path callers (owner/repo
+// resolution, claim-state comments, `--all-roadmaps` search) keep the sync
+// runner, so their behavior is byte-unchanged.
+const execFileAsync = promisify(execFile);
 // Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
 // the default baked into protocol-helpers' `isStaleAt`, so when the configured
 // stale age equals this default the shared `isStaleAt` path is
@@ -400,6 +416,14 @@ interface EnumerateRoadmapGraphOptions
   repo?: string;
   loadIssue?: (issueNumber: number) => unknown;
   loadSubIssues?: (issueNumber: number) => unknown;
+  /**
+   * Max in-flight node fetches for the concurrent prefetch crawl (#1136).
+   * Normalized to an integer `>= 1`, falling back to
+   * {@link DEFAULT_TRAVERSAL_CONCURRENCY} when unset or invalid. `1`
+   * reproduces the previous serial traversal exactly. Latency-only: the
+   * report is byte-identical regardless of this value.
+   */
+  concurrency?: unknown;
 }
 
 interface EnumerateAllRoadmapsGraphOptions
@@ -429,6 +453,8 @@ interface ParsedArgs {
   withClaimState: boolean;
   withReadiness: boolean;
   currentClaimId: string;
+  /** `--concurrency <n>` prefetch bound; `0` (unset) → normalized default. */
+  concurrency: number;
   help: boolean;
 }
 
@@ -493,6 +519,7 @@ if (isMainModule(import.meta.url)) {
         ),
         claimState,
         readiness,
+        concurrency: args.concurrency,
       })
     : await enumerateRoadmapGraph(args.issue, {
         markerPrefix: policy.markerPrefix,
@@ -502,9 +529,51 @@ if (isMainModule(import.meta.url)) {
         loadSubIssues: buildSubIssueLoader(owner, repo),
         claimState,
         readiness,
+        concurrency: args.concurrency,
       });
 
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+/**
+ * Normalize the traversal `concurrency` option to an integer `>= 1`, falling
+ * back to {@link DEFAULT_TRAVERSAL_CONCURRENCY} for unset, non-integer, or
+ * `< 1` values. `1` is preserved so callers can force the serial path.
+ */
+function normalizeConcurrency(value: unknown): number {
+  const numeric =
+    typeof value === 'number'
+      ? value
+      : Number.parseInt(String(value ?? ''), 10);
+  return Number.isInteger(numeric) && numeric >= 1
+    ? numeric
+    : DEFAULT_TRAVERSAL_CONCURRENCY;
+}
+
+/**
+ * Run `task` over `items` with at most `limit` invocations in flight at once,
+ * returning results in input order. A fixed pool of workers pulls from a shared
+ * cursor, so a slow item never blocks faster siblings (continuous, not
+ * lock-step batches). An empty input runs no workers; the first rejection
+ * propagates (mirroring the previous serial traversal's fail-closed abort).
+ */
+async function mapPool<Item, Result>(
+  items: readonly Item[],
+  limit: number,
+  task: (item: Item) => Promise<Result>,
+): Promise<Result[]> {
+  const results = new Array<Result>(items.length);
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await task(items[index]);
+    }
+  };
+  const workerCount = Math.min(Math.max(1, limit), items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
 }
 
 export async function enumerateRoadmapGraph(
@@ -557,6 +626,17 @@ export async function enumerateRoadmapGraph(
   // Re-bind after the guards so the hoisted helper closures below see the
   // narrowed issue type.
   const rootIssue = fetchedRoot;
+
+  // #1136: warm issueCache + referenceCache with a bounded-concurrency prefetch
+  // crawl BEFORE the (unchanged) serial graph build below, so `visitIssue` runs
+  // entirely against warm caches and issues zero I/O. The crawl visits exactly
+  // the same reachable, accessible, non-PR node set the DFS expands, so the
+  // resulting graph stays byte-identical to a fully serial run — only the
+  // wall-clock changes.
+  await prefetchReachableIssues(
+    rootIssue.number,
+    normalizeConcurrency(options.concurrency),
+  );
 
   await visitIssue(rootIssue.number, [rootIssue.number]);
 
@@ -800,6 +880,50 @@ export async function enumerateRoadmapGraph(
     return references;
   }
 
+  // #1136: bounded-concurrency BFS that warms issueCache + referenceCache for
+  // every reachable node before the serial graph build. It calls the same
+  // getIssue / getReferences the DFS uses (so caches and the
+  // subIssueSummaryTotal===0 skip are shared), but fans the frontier out
+  // through `mapPool`. A genuine loader error rejects here and propagates,
+  // matching the previous serial traversal's fail-closed abort; 404→null and
+  // 403/410/451→sentinel still resolve without throwing.
+  async function prefetchReachableIssues(
+    startNumber: number,
+    concurrency: number,
+  ): Promise<void> {
+    const scheduled = new Set<number>([startNumber]);
+    let frontier: number[] = [startNumber];
+    while (frontier.length > 0) {
+      const targetLists = await mapPool(
+        frontier,
+        concurrency,
+        expandForPrefetch,
+      );
+      const next: number[] = [];
+      for (const targets of targetLists) {
+        for (const target of targets) {
+          if (!scheduled.has(target)) {
+            scheduled.add(target);
+            next.push(target);
+          }
+        }
+      }
+      frontier = next;
+    }
+  }
+
+  // Fetch one node and return its reference targets for the next BFS frontier.
+  // Mirrors the DFS expansion guard: only accessible, non-PR issues are
+  // expanded (PRs / inaccessible / not-found contribute no children), so the
+  // crawl's reachable set equals the DFS's.
+  async function expandForPrefetch(issueNumber: number): Promise<number[]> {
+    const issue = await getIssue(issueNumber, issueCache, loadIssue);
+    if (!issue || isInaccessibleIssue(issue) || issue.isPullRequest) {
+      return [];
+    }
+    return (await getReferences(issue)).map((reference) => reference.target);
+  }
+
   function recordNode(issue: NormalizedIssue, path: number[]) {
     const existing = nodeRecords.get(issue.number);
     const classification = classifyIssue(issue, markerPrefix);
@@ -916,6 +1040,9 @@ export async function enumerateAllRoadmapsGraph(
       repo: options.repo,
       loadIssue: options.loadIssue,
       loadSubIssues: options.loadSubIssues,
+      // #1136: each per-root enumeration prefetches its own subtree
+      // concurrently; thread the same bound through.
+      concurrency: options.concurrency,
     });
 
     roots.push({
@@ -1709,6 +1836,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     withClaimState: false,
     withReadiness: false,
     currentClaimId: '',
+    concurrency: 0,
     help: false,
   };
 
@@ -1747,6 +1875,11 @@ function parseArgs(argv: string[]): ParsedArgs {
       parsed.withReadiness = true;
       continue;
     }
+    if (token === '--concurrency') {
+      parsed.concurrency = Number.parseInt(String(value ?? ''), 10);
+      index += 1;
+      continue;
+    }
     if (token === '--current-claim-id') {
       // Only consume the next token as the id when it exists and is not itself
       // a flag, so `--current-claim-id --with-claim-state` does not swallow the
@@ -1770,10 +1903,14 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>]
-  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>]
+  node scripts/discover-roadmap-graph.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>] [--concurrency <n>]
+  node scripts/discover-roadmap-graph.mjs --all-roadmaps [--owner <owner>] [--repo <repo>] [--policy <path>] [--with-claim-state] [--with-readiness] [--current-claim-id <id>] [--concurrency <n>]
 
   --issue and --all-roadmaps are mutually exclusive; exactly one is required.
+
+  --concurrency <n> (default 8) bounds how many issue fetches the traversal
+  prefetch keeps in flight at once. The graph is byte-identical for any n;
+  only wall-clock changes. Pass 1 to force the previous serial traversal.
   --all-roadmaps enumerates open execution leaves across every open roadmap
   root (the union), each tagged with its sourceRoots and ranked by
   autopilotSuitability (descending, tie-broken by ascending issue number).
@@ -1955,7 +2092,7 @@ export function buildIssueLoader(owner: string, repo: string) {
       '.',
     ];
     try {
-      const result = runGh(args, { allowStatuses: [404] }).trim();
+      const result = (await runGhAsync(args, { allowStatuses: [404] })).trim();
       if (!result || result === 'null') {
         return null;
       }
@@ -1986,7 +2123,7 @@ export function buildSubIssueLoader(owner: string, repo: string) {
       if (after) {
         variables.after = after;
       }
-      const result = runGraphqlQuery(SUB_ISSUES_QUERY, variables) as {
+      const result = (await runGraphqlQuery(SUB_ISSUES_QUERY, variables)) as {
         data?: {
           repository?: {
             issue?: {
@@ -2206,10 +2343,17 @@ function buildSearchIssuesRunner(): SearchIssuesFn {
   };
 }
 
-function runGraphqlQuery(
+/**
+ * Async GraphQL runner for the traversal sub-issue loader. Its sole caller
+ * (`buildSubIssueLoader`) is already async, so the runner uses the non-blocking
+ * `execFile` path — letting several sub-issue queries run in parallel under the
+ * prefetch crawl — while keeping the exact arg construction, error-array
+ * detection, and `gh api graphql failed: …` wrapping of the previous sync form.
+ */
+async function runGraphqlQuery(
   query: string,
   variables: Record<string, string | number>,
-): unknown {
+): Promise<unknown> {
   const args = ['api', 'graphql', '-f', `query=${query}`];
   for (const [name, value] of Object.entries(variables)) {
     if (value === '' || value === null || value === undefined) {
@@ -2220,11 +2364,8 @@ function runGraphqlQuery(
   }
 
   try {
-    const raw = execFileSync('gh', args, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-    const parsed = JSON.parse(raw || '{}') as { errors?: unknown };
+    const { stdout } = await execFileAsync('gh', args, { encoding: 'utf8' });
+    const parsed = JSON.parse(stdout.trim() || '{}') as { errors?: unknown };
     if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
       throw new Error(formatGraphqlErrors(parsed.errors));
     }
@@ -2257,6 +2398,49 @@ function ghText(args: string[]): string {
   return runGh(args).trim();
 }
 
+/**
+ * Normalize a failed-`gh` error's exit status to a number.
+ *
+ * The synchronous `execFileSync` runner exposes the process exit code on
+ * `.status`; the promisified `execFile` runner exposes it on `.code`. Read
+ * `.status` first (sync), then fall back to `.code` (async), keeping only a
+ * numeric value so a spawn-error string code (e.g. `ENOENT`) resolves to
+ * `null` exactly as the previous sync-only path did.
+ */
+function resolveGhExitStatus(error: unknown): number | null {
+  const candidate = error as { status?: unknown; code?: unknown } | null;
+  const rawStatus = candidate?.status ?? candidate?.code;
+  return typeof rawStatus === 'number' ? rawStatus : null;
+}
+
+/**
+ * Wrap a failed-`gh` error into the canonical `{ status, stderr }` shape that
+ * the issue-lookup classifiers (`isNotFoundIssueLookupError` /
+ * `isInaccessibleIssueLookupError`) read, so the sync and async runners produce
+ * byte-identical errors. Returns `''` when the exit status is tolerated
+ * (`allowStatuses`); otherwise throws the wrapped error.
+ */
+function wrapGhFailure(
+  error: unknown,
+  args: string[],
+  allowStatuses: number[],
+): string {
+  const status = resolveGhExitStatus(error);
+  if (status !== null && allowStatuses.includes(status)) {
+    return '';
+  }
+  const stderr = String(
+    (error as { stderr?: unknown } | null)?.stderr ?? '',
+  ).trim();
+  const prefix = `gh ${args.join(' ')}`;
+  const wrapped = new Error(
+    stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`,
+  ) as Error & { status?: number | null; stderr?: string };
+  wrapped.status = status;
+  wrapped.stderr = stderr;
+  throw wrapped;
+}
+
 function runGh(
   args: string[],
   options: { allowStatuses?: number[] } = {},
@@ -2269,21 +2453,28 @@ function runGh(
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (error) {
-    const rawStatus = (error as { status?: unknown } | null)?.status;
-    const status = typeof rawStatus === 'number' ? rawStatus : null;
-    if (status !== null && allowStatuses.includes(status)) {
-      return '';
-    }
-    const stderr = String(
-      (error as { stderr?: unknown } | null)?.stderr ?? '',
-    ).trim();
-    const prefix = `gh ${args.join(' ')}`;
-    const wrapped = new Error(
-      stderr ? `${prefix} failed: ${stderr}` : `${prefix} failed`,
-    ) as Error & { status?: number | null; stderr?: string };
-    wrapped.status = status;
-    wrapped.stderr = stderr;
-    throw wrapped;
+    return wrapGhFailure(error, args, allowStatuses);
+  }
+}
+
+/**
+ * Async sibling of {@link runGh} used only by the traversal hot-path loaders
+ * (`buildIssueLoader` / `buildSubIssueLoader`), so the bounded prefetch crawl
+ * can keep several `gh` subprocesses in flight. Behaviorally identical to
+ * {@link runGh}: same tolerated-status handling and the same wrapped-error
+ * shape (via {@link wrapGhFailure}).
+ */
+async function runGhAsync(
+  args: string[],
+  options: { allowStatuses?: number[] } = {},
+): Promise<string> {
+  const { allowStatuses = [] } = options;
+
+  try {
+    const { stdout } = await execFileAsync('gh', args, { encoding: 'utf8' });
+    return stdout;
+  } catch (error) {
+    return wrapGhFailure(error, args, allowStatuses);
   }
 }
 

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -540,12 +540,15 @@ if (isMainModule(import.meta.url)) {
  * Normalize the traversal `concurrency` option to an integer `>= 1`, falling
  * back to {@link DEFAULT_TRAVERSAL_CONCURRENCY} for unset, non-integer, or
  * `< 1` values. `1` is preserved so callers can force the serial path.
+ *
+ * String input is parsed with `Number` (not `parseInt`) so a non-integer
+ * string such as `"2.5"` fails the `Number.isInteger` check and falls back to
+ * the default, instead of being silently truncated to `2`. This keeps CLI
+ * string input and typed numeric input consistent.
  */
-function normalizeConcurrency(value: unknown): number {
+export function normalizeConcurrency(value: unknown): number {
   const numeric =
-    typeof value === 'number'
-      ? value
-      : Number.parseInt(String(value ?? ''), 10);
+    typeof value === 'number' ? value : Number(String(value ?? '').trim());
   return Number.isInteger(numeric) && numeric >= 1
     ? numeric
     : DEFAULT_TRAVERSAL_CONCURRENCY;
@@ -1882,7 +1885,10 @@ function parseArgs(argv: string[]): ParsedArgs {
       // `--concurrency --issue 700` does not swallow the following flag. A
       // missing/flag value leaves concurrency unset (0 → normalized default).
       if (value !== undefined && !value.startsWith('--')) {
-        parsed.concurrency = Number.parseInt(value, 10);
+        // Use Number (not parseInt) so a non-integer like "2.5" stays
+        // non-integer and normalizeConcurrency falls back to the default,
+        // rather than being truncated to 2.
+        parsed.concurrency = Number(value);
         index += 1;
       }
       continue;

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -38,8 +38,8 @@ const GH_SEARCH_RESULT_CAP = 1000;
 // in-flight slot is one live `gh` subprocess (one network round-trip), so the
 // bound caps parallel I/O without risking GitHub secondary rate limits. The
 // default trades a comfortable speed-up against politeness; `--concurrency`
-// (or the `concurrency` option) tunes it, and `1` reproduces the old serial
-// fetch exactly.
+// (or the `concurrency` option) tunes it, and `1` runs the fetches serially
+// (one in flight at a time).
 const DEFAULT_TRAVERSAL_CONCURRENCY = 8;
 // Promisified `gh` runner used ONLY by the traversal hot-path loaders
 // (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking
@@ -419,9 +419,10 @@ interface EnumerateRoadmapGraphOptions
   /**
    * Max in-flight node fetches for the concurrent prefetch crawl (#1136).
    * Normalized to an integer `>= 1`, falling back to
-   * {@link DEFAULT_TRAVERSAL_CONCURRENCY} when unset or invalid. `1`
-   * reproduces the previous serial traversal exactly. Latency-only: the
-   * report is byte-identical regardless of this value.
+   * {@link DEFAULT_TRAVERSAL_CONCURRENCY} when unset or invalid. `1` runs the
+   * fetches serially (no parallelism). Latency-only: the report is
+   * byte-identical regardless of this value — only fetch ordering and
+   * wall-clock change.
    */
   concurrency?: unknown;
 }
@@ -1876,8 +1877,14 @@ function parseArgs(argv: string[]): ParsedArgs {
       continue;
     }
     if (token === '--concurrency') {
-      parsed.concurrency = Number.parseInt(String(value ?? ''), 10);
-      index += 1;
+      // Only consume the next token as the value when it exists and is not
+      // itself a flag, mirroring --current-claim-id, so
+      // `--concurrency --issue 700` does not swallow the following flag. A
+      // missing/flag value leaves concurrency unset (0 → normalized default).
+      if (value !== undefined && !value.startsWith('--')) {
+        parsed.concurrency = Number.parseInt(value, 10);
+        index += 1;
+      }
       continue;
     }
     if (token === '--current-claim-id') {
@@ -1910,7 +1917,7 @@ function printHelp() {
 
   --concurrency <n> (default 8) bounds how many issue fetches the traversal
   prefetch keeps in flight at once. The graph is byte-identical for any n;
-  only wall-clock changes. Pass 1 to force the previous serial traversal.
+  only fetch ordering and wall-clock change. Pass 1 to fetch serially.
   --all-roadmaps enumerates open execution leaves across every open roadmap
   root (the union), each tagged with its sourceRoots and ranked by
   autopilotSuitability (descending, tie-broken by ascending issue number).

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -5,11 +5,10 @@
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
 
-import { execFile, execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 
 import { resolveAuthoringGuardPolicy } from './authoring-label-guard.mts';
 import {
@@ -41,16 +40,54 @@ const GH_SEARCH_RESULT_CAP = 1000;
 // (or the `concurrency` option) tunes it, and `1` runs the fetches serially
 // (one in flight at a time).
 const DEFAULT_TRAVERSAL_CONCURRENCY = 8;
-// Promisified `gh` runner used ONLY by the traversal hot-path loaders
-// (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking
-// `execFileSync` runner — which serializes even concurrent `await`s because it
-// holds the event loop — `execFile` lets multiple `gh` subprocesses run in
-// parallel; the actual in-flight bound is enforced by the prefetch crawl's
-// `mapPool` using the resolved `concurrency` (default
-// `DEFAULT_TRAVERSAL_CONCURRENCY`). The non-hot-path callers (owner/repo
-// resolution, claim-state comments, `--all-roadmaps` search) keep the sync
-// runner, so their behavior is byte-unchanged.
-const execFileAsync = promisify(execFile);
+/**
+ * Async `gh` invocation used ONLY by the traversal hot-path loaders
+ * (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking
+ * `execFileSync` runner — which serializes even concurrent `await`s because it
+ * holds the event loop — this `spawn`-based runner lets multiple `gh`
+ * subprocesses run in parallel; the actual in-flight bound is enforced by the
+ * prefetch crawl's `mapPool` using the resolved `concurrency` (default
+ * {@link DEFAULT_TRAVERSAL_CONCURRENCY}). The non-hot-path callers (owner/repo
+ * resolution, claim-state comments, `--all-roadmaps` search) keep the sync
+ * runner, so their behavior is byte-unchanged.
+ *
+ * Stdio matches the sync runner exactly (`['ignore', 'pipe', 'pipe']`): stdin
+ * is ignored so `gh` never blocks on or reads an inherited/open stdin pipe,
+ * and stdout/stderr are piped for capture. Resolves with stdout on a zero
+ * exit; on a non-zero exit (or spawn error) rejects with an error carrying
+ * `.code` (exit status) and `.stderr`, the shape {@link wrapGhFailure} reads.
+ */
+function runGhCapture(args: string[]): Promise<string> {
+  return new Promise((resolveOutput, rejectOutput) => {
+    const child = spawn('gh', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', rejectOutput);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolveOutput(stdout);
+        return;
+      }
+      const error = new Error(`gh exited with code ${code}`) as Error & {
+        code?: number | null;
+        stderr?: string;
+        stdout?: string;
+      };
+      error.code = code;
+      error.stderr = stderr;
+      error.stdout = stdout;
+      rejectOutput(error);
+    });
+  });
+}
 // Policy default claim stale age (`claimTiming.staleAge`, `PT24H`). Mirrors
 // the default baked into protocol-helpers' `isStaleAt`, so when the configured
 // stale age equals this default the shared `isStaleAt` path is
@@ -2379,7 +2416,7 @@ async function runGraphqlQuery(
   }
 
   try {
-    const { stdout } = await execFileAsync('gh', args, { encoding: 'utf8' });
+    const stdout = await runGhCapture(args);
     const parsed = JSON.parse(stdout.trim() || '{}') as { errors?: unknown };
     if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
       throw new Error(formatGraphqlErrors(parsed.errors));
@@ -2486,7 +2523,7 @@ async function runGhAsync(
   const { allowStatuses = [] } = options;
 
   try {
-    const { stdout } = await execFileAsync('gh', args, { encoding: 'utf8' });
+    const stdout = await runGhCapture(args);
     return stdout;
   } catch (error) {
     return wrapGhFailure(error, args, allowStatuses);

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -44,8 +44,10 @@ const DEFAULT_TRAVERSAL_CONCURRENCY = 8;
 // Promisified `gh` runner used ONLY by the traversal hot-path loaders
 // (`buildIssueLoader` / `buildSubIssueLoader`). Unlike the blocking
 // `execFileSync` runner — which serializes even concurrent `await`s because it
-// holds the event loop — `execFile` lets up to `DEFAULT_TRAVERSAL_CONCURRENCY`
-// `gh` subprocesses run in parallel. The non-hot-path callers (owner/repo
+// holds the event loop — `execFile` lets multiple `gh` subprocesses run in
+// parallel; the actual in-flight bound is enforced by the prefetch crawl's
+// `mapPool` using the resolved `concurrency` (default
+// `DEFAULT_TRAVERSAL_CONCURRENCY`). The non-hot-path callers (owner/repo
 // resolution, claim-state comments, `--all-roadmaps` search) keep the sync
 // runner, so their behavior is byte-unchanged.
 const execFileAsync = promisify(execFile);

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -1943,3 +1943,107 @@ test('--with-readiness on a single root annotates only open execution-leaf nodes
     false,
   );
 });
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Build a `loadIssue` that records the peak number of concurrently in-flight
+ * fetches. Each call holds for a short delay so overlapping fetches are
+ * observable, letting a test assert whether siblings are issued in parallel.
+ */
+function trackingIssueLoader(issues: Map<number, unknown>) {
+  let inFlight = 0;
+  let peak = 0;
+  return {
+    peak: () => peak,
+    loadIssue: async (issueNumber: number) => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      try {
+        await delay(5);
+        return issues.get(issueNumber) ?? null;
+      } finally {
+        inFlight -= 1;
+      }
+    },
+  };
+}
+
+test('prefetch crawl fetches sibling leaves concurrently (#1136)', async () => {
+  const leafNumbers = Array.from({ length: 20 }, (_, index) => 801 + index);
+  const body = leafNumbers.map((leaf) => `- [ ] #${leaf}`).join('\n');
+  const buildIssues = () => {
+    const map = new Map<number, unknown>();
+    map.set(800, roadmapIssue(800, body, 'wide-roadmap'));
+    for (const leaf of leafNumbers) {
+      map.set(leaf, {
+        ...executionIssue(leaf, `leaf ${leaf}`),
+        sub_issues_summary: { total: 0 },
+      });
+    }
+    return map;
+  };
+
+  // Default concurrency: the 20 sibling leaves must overlap in flight, proving
+  // the prefetch is parallel rather than serial.
+  const concurrent = trackingIssueLoader(buildIssues());
+  const concurrentGraph = await enumerateRoadmapGraph(800, {
+    loadIssue: concurrent.loadIssue,
+  });
+  assert.ok(
+    concurrent.peak() >= 2,
+    `expected overlapping sibling fetches, peak in-flight was ${concurrent.peak()}`,
+  );
+
+  // concurrency: 1 reproduces the old fully serial traversal (peak in-flight 1).
+  const serial = trackingIssueLoader(buildIssues());
+  const serialGraph = await enumerateRoadmapGraph(800, {
+    loadIssue: serial.loadIssue,
+    concurrency: 1,
+  });
+  assert.equal(
+    serial.peak(),
+    1,
+    `concurrency:1 must stay serial, peak in-flight was ${serial.peak()}`,
+  );
+
+  // Latency-only change: the report is byte-identical regardless of concurrency.
+  assert.deepEqual(concurrentGraph, serialGraph);
+  assert.deepEqual(concurrentGraph.executionCandidates, leafNumbers);
+});
+
+test('prefetch crawl output is invariant across concurrency on a nested graph (#1136)', async () => {
+  // A graph with a nested roadmap, a shared leaf reached from two parents, a
+  // cycle, and a 404 reference — exercises every detection path under
+  // concurrency to confirm the byte-identical contract holds beyond the wide
+  // fan-out case.
+  const issues = new Map<number, unknown>([
+    [840, roadmapIssue(840, '- [ ] #841\n- [ ] #842\nRefs #899', 'outer')],
+    [841, roadmapIssue(841, '- [ ] #843\n- [ ] #844', 'inner')],
+    [842, executionIssue(842, 'shared via two parents\nRefs #844')],
+    [843, executionIssue(843, 'leaf 843\nDepends on #840')],
+    [844, executionIssue(844, 'shared leaf 844')],
+  ]);
+  const run = (concurrency: number) =>
+    enumerateRoadmapGraph(840, {
+      loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+      concurrency,
+    });
+
+  const serialGraph = await run(1);
+  const concurrentGraph = await run(8);
+  assert.deepEqual(concurrentGraph, serialGraph);
+  // Sanity: the nested roadmap, cycle, and unresolved reference were detected.
+  assert.deepEqual(serialGraph.roadmapNodes, [841]);
+  assert.ok(serialGraph.summary.cycleCount >= 1);
+  assert.deepEqual(serialGraph.diagnostics.unresolvedReferences, [
+    {
+      source: 840,
+      target: 899,
+      relationship: 'reference',
+      evidence: 'Refs #899',
+      reason: 'issue_not_found',
+    },
+  ]);
+});

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -15,6 +15,7 @@ import {
   extractKeywordReferences,
   extractRoadmapMarkerId,
   extractTaskListReferences,
+  normalizeConcurrency,
   parseClaimStaleAgeMs,
   type SearchIssuesQuery,
   warnOnSearchResultCap,
@@ -2046,4 +2047,30 @@ test('prefetch crawl output is invariant across concurrency on a nested graph (#
       reason: 'issue_not_found',
     },
   ]);
+});
+
+test('normalizeConcurrency keeps integers >= 1 and falls back otherwise (#1136)', () => {
+  // DEFAULT_TRAVERSAL_CONCURRENCY is 8 (not exported); the fallback is asserted
+  // against that literal.
+  const DEFAULT = 8;
+
+  // Valid integers >= 1 (including the serial value 1) pass through.
+  assert.equal(normalizeConcurrency(1), 1);
+  assert.equal(normalizeConcurrency(4), 4);
+  assert.equal(normalizeConcurrency(16), 16);
+
+  // Out-of-range, non-integer, and garbage numbers fall back to the default.
+  assert.equal(normalizeConcurrency(0), DEFAULT);
+  assert.equal(normalizeConcurrency(-3), DEFAULT);
+  assert.equal(normalizeConcurrency(2.5), DEFAULT);
+  assert.equal(normalizeConcurrency(Number.NaN), DEFAULT);
+  assert.equal(normalizeConcurrency(undefined), DEFAULT);
+
+  // String input (the CLI path) parses with Number, not parseInt: a clean
+  // integer string is accepted; a non-integer string is NOT truncated.
+  assert.equal(normalizeConcurrency('4'), 4);
+  assert.equal(normalizeConcurrency('  3 '), 3);
+  assert.equal(normalizeConcurrency('2.5'), DEFAULT);
+  assert.equal(normalizeConcurrency('3px'), DEFAULT);
+  assert.equal(normalizeConcurrency(''), DEFAULT);
 });


### PR DESCRIPTION
## Summary

Parallelizes `discover-roadmap-graph` traversal I/O so wall-clock no
longer grows ~linearly at ~0.8 s/node, removing the thin margin #1072 /
PR #1074 left behind (a ~145+ child roadmap would otherwise breach the
two-minute command budget again).

The traversal was fully serial blocking `execFileSync` `gh` calls. This
PR replaces that with a **bounded-concurrency prefetch crawl** that warms
the issue and reference caches **before** the existing graph-building
DFS, which is left completely unchanged.

## Approach

- **Async `gh` runners for the traversal hot path only.** Add
  `runGhAsync` / an async `runGraphqlQuery` (`promisify(execFile)`) used
  solely by `buildIssueLoader` / `buildSubIssueLoader`. `execFileSync`
  blocks the event loop, so even concurrent `await`s serialize; `execFile`
  lets a bounded set of `gh` subprocesses run in parallel. A shared
  `wrapGhFailure` keeps the wrapped-error shape (`.status` / `.stderr`)
  byte-identical, so the existing 404 / inaccessible classification is
  unchanged.
- **Wave-based BFS prefetch** (`mapPool` worker pool) bounded by a new
  `concurrency` option / `--concurrency <n>` flag (default 8; `1`
  reproduces the previous serial traversal exactly).
- **Graph build untouched.** `visitIssue` runs entirely against warm
  caches (zero I/O in phase 2), and the prefetch visits exactly the same
  reachable, accessible, non-PR node set the DFS expands. So the report
  is **byte-identical for any concurrency**.

## Blast radius (scoped down)

The issue guessed the shared `gh` runner likely lived in
`protocol-helpers.mts`. It does not — `runGh` / `runGraphqlQuery` /
`buildIssueLoader` / `buildSubIssueLoader` are all **local to
`discover-roadmap-graph.mts`**, so this is a fully roadmap-graph-local
change. The non-hot-path sync callers (owner/repo resolution,
`--with-claim-state` comments, `--all-roadmaps` search) keep the sync
runner and are byte-unchanged.

## Preserved (latency-only, not semantics)

Per-node caching, the `sub_issues_summary.total === 0` skip,
nested-roadmap classification, and cycle / duplicate / unresolved-
reference detection. Output still validates against
`schemas/discover-roadmap-union.schema.json` (no new emitted fields; the
knob is input-only).

## Tests

- New: a prefetch concurrency test asserts sibling leaves overlap in
  flight under the default while `concurrency: 1` stays serial, and that
  both runs produce a `deepEqual` report.
- New: a nested-roadmap + shared-leaf + cycle + 404 graph asserts the
  report is invariant across `concurrency` 1 vs 8.
- All existing unit and real-`gh` CLI integration tests pass unchanged
  (including the loader-throw fail-closed propagation test).

`pnpm test` (1421 passing), `pnpm run build:check`, and lint all pass.

Closes #1136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional concurrency setting for roadmap graph discovery, allowing faster traversal prefetching.
  * Roadmap generation can now run multiple GitHub CLI requests in parallel, with a serial mode available for prior behavior.

* **Bug Fixes**
  * Improved consistency of graph discovery while keeping the final output unchanged.
  * Expanded support for larger roadmap traversals, including nested and shared references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->