### PR TITLE
docs(onboarding): explain the shared-core bump in helper re-imports

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -70,9 +70,10 @@ IDD, treat the upgrade as a **named-gap import**, not a blind resync:
 3. Re-apply the Step 2 file import for the changed files, then re-run the
    Step 6 verification checklist and `idd-doctor` after reconciling.
 
-**Anatomy of a helper re-import (vendored-helper case).** If you vendor the
+**Anatomy of a helper re-import (`vendored-node` profile).** If you vendor the
 shared helper bundle — the `vendored-node` profile, which physically copies the
-core — a new **leaf helper** is rarely a standalone file drop:
+shared `protocol-helpers` core — a new **leaf helper** is rarely a standalone
+file drop:
 
 1. **Diff the shared core first.** The new helper usually imports a newer
    `protocol-helpers` shared-core API absent from your older snapshot, so the

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -70,6 +70,25 @@ IDD, treat the upgrade as a **named-gap import**, not a blind resync:
 3. Re-apply the Step 2 file import for the changed files, then re-run the
    Step 6 verification checklist and `idd-doctor` after reconciling.
 
+**Anatomy of a helper re-import (vendored-helper case).** If you vendor the
+shared helper bundle — the `vendored-node` profile, which physically copies the
+core — a new **leaf helper** is rarely a standalone file drop:
+
+1. **Diff the shared core first.** The new helper usually imports a newer
+   `protocol-helpers` shared-core API absent from your older snapshot, so the
+   real work is a shared-core bump — budget that prerequisite before scoping the
+   leaf-helper slices.
+2. **Reconcile a hardened core additively.** If you hardened that core, treat
+   the bump as additive named-divergence reconciliation gated on your protected
+   tests: preserve the local hardening and append only the new exports rather
+   than wholesale-vendoring the core over it.
+3. **Watch the silent revert.** A wholesale core vendor can green-build while
+   silently reverting your protected local tests, so verify against those tests,
+   not just a clean compile.
+
+(npx-resolved profiles do not vend the core this way, so this note applies only
+when you copy helper files.)
+
 When you then audit whether re-imported roadmap work is actually done, judge
 **completion by auditing the implementation against the acceptance criteria**,
 not by a child issue's closed state — a skeleton or scaffold PR can merge and


### PR DESCRIPTION
## Summary

Adds an "anatomy of a helper re-import" note to the Re-importing section
of `idd-template/ONBOARDING.md`, scoped to the `vendored-node`
(vendored-helper) profile.

The existing section covers the general named-gap discipline but not the
dominant cost of vendoring a **new leaf helper**: the new helper usually
imports a newer `protocol-helpers` shared-core API absent from the older
snapshot, so the real work is a shared-core bump — and if the consumer
hardened that core, a wholesale core vendor can green-build while silently
reverting the consumer's protected tests.

The new three-point note tells adopters to:

1. diff the shared core first and budget a core-bump prerequisite;
2. reconcile a hardened core additively, gated on the consumer's protected
   tests (append only new exports);
3. watch for the silent revert a wholesale core vendor can cause.

## Scope notes

- Prose-only change in a non-generated region, so the auto-generated
  file-list blocks in `ONBOARDING.md` are untouched;
  `node scripts/audit-docs.mjs --check` passes.
- The optional `docs/idd-helper-scripts.md` cross-link is deliberately
  skipped to keep the diff atomic: that file is a `docs/idd-*.md` sync
  target mirrored from `idd-template/docs/`, so editing it would widen the
  change beyond the single required file. Acceptance criteria require only
  the ONBOARDING.md note.

## Verification

- `node scripts/audit-docs.mjs --check` passes.
- `pnpm run lint:minimum` passes locally (biome, dprint, markdownlint,
  cspell all clean).

Closes #1149
