### PR TITLE
fix(discover): capture all same-line blocked-by/depends-on refs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -38,6 +38,7 @@ scripts/idd-doctor.mjs linguist-generated=true
 scripts/idd-merge-execute.mjs linguist-generated=true
 scripts/idd-roadmap-audit-execute.mjs linguist-generated=true
 scripts/live-status-digest.mjs linguist-generated=true
+scripts/markdown-code.mjs linguist-generated=true
 scripts/marker-regex.mjs linguist-generated=true
 scripts/merged-pr-feedback-sweep.mjs linguist-generated=true
 scripts/minimize-superseded-markers.mjs linguist-generated=true

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -276,27 +276,55 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
   };
 }
 /**
- * Collect every `#N` reference declared on a dependency-keyword line.
+ * Collect the `#N` references declared on a dependency-keyword line.
  *
  * A line is a dependency declaration when, after the shared
  * `DEPENDENCY_LINE_PREFIX` (indentation, blockquote, and/or a list bullet), it
- * begins with `keyword` immediately followed by at least one `#N`. Once such a
- * line is found, every `#(\d+)` on that same line is captured, so
+ * begins with `keyword` immediately followed by at least one `#N`. From there
+ * `consumeDependencyRefList` collects the contiguous dependency-ref list, so
  * `Blocked by #A, #B, #C` (comma- or space-separated) yields `[A, B, C]`. The
- * scan is bounded to the single matched line (`.*$` with the `m` flag, no `s`
- * flag), so refs never bleed across lines, and the backtick-excluding prefix
- * keeps inline-code markers unmatched (see `DEPENDENCY_LINE_PREFIX`).
+ * `m` flag (no `s` flag) keeps the match on the single keyword line, and the
+ * backtick-excluding prefix keeps inline-code markers unmatched (see
+ * `DEPENDENCY_LINE_PREFIX`).
  */
 function extractKeywordLineRefs(body, keyword) {
   const linePattern = new RegExp(
-    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}\\s+#\\d+.*$`,
+    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}\\s+(#\\d+.*)$`,
     'gim',
   );
   const numbers = [];
   for (const lineMatch of body.matchAll(linePattern)) {
-    for (const refMatch of lineMatch[0].matchAll(/#(\d+)\b/g)) {
-      numbers.push(Number.parseInt(refMatch[1], 10));
+    numbers.push(...consumeDependencyRefList(lineMatch[1]));
+  }
+  return numbers;
+}
+/**
+ * Consume the contiguous dependency-ref list at the start of `segment`: bare
+ * local `#N` entries separated by commas, "and", and/or whitespace. Parsing
+ * stops at the first token that is neither a bare local ref nor such a
+ * separator, so trailing prose (`; similar to #402`) and cross-repo mentions
+ * (`(see other/repo#20)`) are excluded instead of being mis-read as local
+ * blockers. This mirrors the separator-bounded reference parsing in
+ * `discover-roadmap-graph.mts`, extended to also accept a plain-whitespace
+ * separator so the space-separated multi-ref form is captured too.
+ */
+function consumeDependencyRefList(segment) {
+  const numbers = [];
+  let remaining = segment;
+  while (remaining) {
+    const refMatch = remaining.match(/^#(\d+)\b/);
+    if (!refMatch) {
+      break;
     }
+    numbers.push(Number.parseInt(refMatch[1], 10));
+    remaining = remaining.slice(refMatch[0].length);
+    const separatorMatch = remaining.match(
+      /^(?:\s*,\s*(?:and\s+)?|\s+and\s+|\s+)/i,
+    );
+    if (!separatorMatch) {
+      break;
+    }
+    remaining = remaining.slice(separatorMatch[0].length);
   }
   return numbers;
 }

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -17,19 +17,22 @@ import {
   parseAutopilotSuitability,
 } from './autopilot-suitability.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import { escapeRegex } from './marker-regex.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // Leading-anchor source shared by the `Blocked by` / `Depends on` line parsers.
 // It tolerates optional indentation, nested blockquote (`>`) markers, and a
 // single list bullet (`-`/`*`/`+`) while staying line-anchored, so a dependency
-// written as `- Blocked by #55` or `> Depends on #66` is still recognized. It
-// deliberately excludes backticks: an inline-code marker such as
-// `` `Blocked by #77` `` therefore stays unmatched, keeping code-quoted markers
-// treated as false positives — consistent with the #1121 repo behavior. This
-// const is declared before the `isMainModule` CLI block on purpose so it is
-// initialized when the CLI path runs `extractBlockedByIssueNumbers` (a const
-// declared after that block would be in the temporal dead zone).
+// written as `- Blocked by #55` or `> Depends on #66` is still recognized. The
+// extractors run `stripMarkdownCodeRegions` over the body first, so a
+// dependency line merely quoted inside inline code or a fenced block is already
+// masked out — treating code-quoted markers as false positives, consistent with
+// the #1121 repo behavior; excluding backticks from this prefix is a second
+// line of defense for the inline-code case. This const is declared before the
+// `isMainModule` CLI block on purpose so it is initialized when the CLI path
+// runs `extractBlockedByIssueNumbers` (a const declared after that block would
+// be in the temporal dead zone).
 const DEPENDENCY_LINE_PREFIX = String.raw`^[ \t]*(?:>[ \t]*)*(?:[-*+][ \t]+)?`;
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
@@ -280,16 +283,18 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
  *
  * A line is a dependency declaration when, after the shared
  * `DEPENDENCY_LINE_PREFIX` (indentation, blockquote, and/or a list bullet), it
- * begins with `keyword` immediately followed by at least one `#N`. From there
- * `consumeDependencyRefList` collects the contiguous dependency-ref list, so
- * `Blocked by #A, #B, #C` (comma- or space-separated) yields `[A, B, C]`. The
- * `m` flag (no `s` flag) keeps the match on the single keyword line, and the
- * backtick-excluding prefix keeps inline-code markers unmatched (see
- * `DEPENDENCY_LINE_PREFIX`).
+ * begins with `keyword` followed by horizontal whitespace and at least one
+ * `#N`. From there `consumeDependencyRefList` collects the contiguous
+ * dependency-ref list, so `Blocked by #A, #B, #C` (comma- or space-separated)
+ * yields `[A, B, C]`. The keyword-to-ref gap is `[ \t]+` (not `\s+`) so it
+ * cannot span a newline and swallow a bare `#N` on the following line, and the
+ * `.*$` capture plus the `m` flag (no `s` flag) keeps the match on the single
+ * keyword line. Callers pass a code-region-stripped body, so a quoted example
+ * line is already masked (see `DEPENDENCY_LINE_PREFIX`).
  */
 function extractKeywordLineRefs(body, keyword) {
   const linePattern = new RegExp(
-    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}\\s+(#\\d+.*)$`,
+    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}[ \\t]+(#\\d+.*)$`,
     'gim',
   );
   const numbers = [];
@@ -329,7 +334,9 @@ function consumeDependencyRefList(segment) {
   return numbers;
 }
 export function extractBlockedByIssueNumbers(body) {
-  return dedupeNumbers(extractKeywordLineRefs(body, 'Blocked by'));
+  return dedupeNumbers(
+    extractKeywordLineRefs(stripMarkdownCodeRegions(body), 'Blocked by'),
+  );
 }
 export function extractBlockedByRoadmapMarkers(
   body,
@@ -348,9 +355,10 @@ export function extractBlockedByRoadmapMarkers(
   return [...new Set([...matches].map((match) => match[1]))];
 }
 export function extractDependencyIssueNumbers(body) {
-  const explicitDependencies = extractKeywordLineRefs(body, 'Depends on');
+  const stripped = stripMarkdownCodeRegions(body);
+  const explicitDependencies = extractKeywordLineRefs(stripped, 'Depends on');
   const taskListDependencies = [
-    ...body.matchAll(/^\s*-\s*\[(?: |x)\]\s+#(\d+)\b/gim),
+    ...stripped.matchAll(/^\s*-\s*\[(?: |x)\]\s+#(\d+)\b/gim),
   ];
   return dedupeNumbers([
     ...explicitDependencies,

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -20,6 +20,17 @@ import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { escapeRegex } from './marker-regex.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// Leading-anchor source shared by the `Blocked by` / `Depends on` line parsers.
+// It tolerates optional indentation, nested blockquote (`>`) markers, and a
+// single list bullet (`-`/`*`/`+`) while staying line-anchored, so a dependency
+// written as `- Blocked by #55` or `> Depends on #66` is still recognized. It
+// deliberately excludes backticks: an inline-code marker such as
+// `` `Blocked by #77` `` therefore stays unmatched, keeping code-quoted markers
+// treated as false positives — consistent with the #1121 repo behavior. This
+// const is declared before the `isMainModule` CLI block on purpose so it is
+// initialized when the CLI path runs `extractBlockedByIssueNumbers` (a const
+// declared after that block would be in the temporal dead zone).
+const DEPENDENCY_LINE_PREFIX = String.raw`^[ \t]*(?:>[ \t]*)*(?:[-*+][ \t]+)?`;
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
 });
@@ -264,11 +275,33 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     },
   };
 }
-export function extractBlockedByIssueNumbers(body) {
-  const matches = body.matchAll(/^\s*Blocked by\s+#(\d+)\b/gim);
-  return dedupeNumbers(
-    [...matches].map((match) => Number.parseInt(match[1], 10)),
+/**
+ * Collect every `#N` reference declared on a dependency-keyword line.
+ *
+ * A line is a dependency declaration when, after the shared
+ * `DEPENDENCY_LINE_PREFIX` (indentation, blockquote, and/or a list bullet), it
+ * begins with `keyword` immediately followed by at least one `#N`. Once such a
+ * line is found, every `#(\d+)` on that same line is captured, so
+ * `Blocked by #A, #B, #C` (comma- or space-separated) yields `[A, B, C]`. The
+ * scan is bounded to the single matched line (`.*$` with the `m` flag, no `s`
+ * flag), so refs never bleed across lines, and the backtick-excluding prefix
+ * keeps inline-code markers unmatched (see `DEPENDENCY_LINE_PREFIX`).
+ */
+function extractKeywordLineRefs(body, keyword) {
+  const linePattern = new RegExp(
+    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}\\s+#\\d+.*$`,
+    'gim',
   );
+  const numbers = [];
+  for (const lineMatch of body.matchAll(linePattern)) {
+    for (const refMatch of lineMatch[0].matchAll(/#(\d+)\b/g)) {
+      numbers.push(Number.parseInt(refMatch[1], 10));
+    }
+  }
+  return numbers;
+}
+export function extractBlockedByIssueNumbers(body) {
+  return dedupeNumbers(extractKeywordLineRefs(body, 'Blocked by'));
 }
 export function extractBlockedByRoadmapMarkers(
   body,
@@ -287,14 +320,12 @@ export function extractBlockedByRoadmapMarkers(
   return [...new Set([...matches].map((match) => match[1]))];
 }
 export function extractDependencyIssueNumbers(body) {
-  const explicitDependencies = [
-    ...body.matchAll(/^\s*Depends on\s+#(\d+)\b/gim),
-  ];
+  const explicitDependencies = extractKeywordLineRefs(body, 'Depends on');
   const taskListDependencies = [
     ...body.matchAll(/^\s*-\s*\[(?: |x)\]\s+#(\d+)\b/gim),
   ];
   return dedupeNumbers([
-    ...explicitDependencies.map((match) => Number.parseInt(match[1], 10)),
+    ...explicitDependencies,
     ...taskListDependencies.map((match) => Number.parseInt(match[1], 10)),
   ]);
 }

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -19,6 +19,7 @@ import {
   evaluateDiscoverReadiness,
 } from './discover-readiness-check.mjs';
 import { effortOrdinal, parseEffort } from './effort.mjs';
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import { parseIsoDurationToMs } from './policy-helpers.mjs';
 import {
   isStaleAt,
@@ -1092,59 +1093,6 @@ function buildCommentLoader(owner, repo) {
  */
 export function parseClaimStaleAgeMs(value) {
   return parseIsoDurationToMs(String(value ?? '').trim());
-}
-/**
- * Strip Markdown code regions (fenced blocks and inline code spans) from a body
- * before scanning it for a roadmap-id marker. A genuine roadmap marker is a raw
- * HTML comment GitHub renders invisibly, never inside a code span or fence, so
- * an example marker an execution-leaf issue merely *quotes* in code (e.g. an
- * issue about the marker system) must not be read as roadmap identity. The
- * marker is itself an HTML comment, so HTML comments are deliberately NOT
- * stripped here — only code regions are. Masked regions keep their line count
- * and surrounding text so a real marker elsewhere in the body still matches.
- */
-function stripMarkdownCodeRegions(text) {
-  // Fenced blocks (``` or ~~~), tracking the fence char + length so a longer
-  // opening fence is not closed by a shorter inner fence (CommonMark §4.5).
-  const lines = text.split(/\r?\n/);
-  const out = [];
-  let fence = null;
-  for (const line of lines) {
-    const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
-    if (openMatch) {
-      const marker = openMatch[1];
-      const info = openMatch[2];
-      const fenceChar = marker[0];
-      if (fence === null) {
-        // CommonMark §4.5: a backtick-fence opener's info string may not
-        // contain a backtick (that would be ambiguous with a close or inline
-        // code), so such a line is not a fence opener and stays content.
-        if (fenceChar !== '`' || !info.includes('`')) {
-          fence = { char: fenceChar, length: marker.length };
-          out.push('');
-          continue;
-        }
-      } else if (
-        fenceChar === fence.char &&
-        marker.length >= fence.length &&
-        /^\s*$/.test(info)
-      ) {
-        fence = null;
-        out.push('');
-        continue;
-      }
-    }
-    out.push(fence === null ? line : '');
-  }
-  // Inline code spans (`...`, ``...``): mask the inner content so a quoted
-  // marker no longer matches, keeping the backticks and surrounding text.
-  return out
-    .join('\n')
-    .replace(
-      /(`+)((?:(?!\1)[\s\S])+?)\1/g,
-      (_match, ticks, inner) =>
-        `${ticks}${inner.replace(/[^\r\n]/g, ' ')}${ticks}`,
-    );
 }
 export function extractRoadmapMarkerId(
   body,

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -1,0 +1,54 @@
+/**
+ * Strip Markdown code regions (fenced blocks and inline code spans) from a body
+ * before scanning it for machine-readable markers or dependency references. A
+ * genuine marker is raw text GitHub renders as intended (an HTML comment it
+ * hides, or a `Blocked by #N` line it links), never inside a code span or
+ * fence, so an example an issue merely *quotes* in code (e.g. an issue about
+ * the marker or dependency syntax) must not be read as real. HTML comments are
+ * deliberately NOT stripped here — only code regions are, since some markers
+ * are themselves HTML comments. Masked regions keep their line count and
+ * surrounding text so a real marker elsewhere in the body still matches.
+ */
+export function stripMarkdownCodeRegions(text) {
+  // Fenced blocks (``` or ~~~), tracking the fence char + length so a longer
+  // opening fence is not closed by a shorter inner fence (CommonMark §4.5).
+  const lines = text.split(/\r?\n/);
+  const out = [];
+  let fence = null;
+  for (const line of lines) {
+    const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
+    if (openMatch) {
+      const marker = openMatch[1];
+      const info = openMatch[2];
+      const fenceChar = marker[0];
+      if (fence === null) {
+        // CommonMark §4.5: a backtick-fence opener's info string may not
+        // contain a backtick (that would be ambiguous with a close or inline
+        // code), so such a line is not a fence opener and stays content.
+        if (fenceChar !== '`' || !info.includes('`')) {
+          fence = { char: fenceChar, length: marker.length };
+          out.push('');
+          continue;
+        }
+      } else if (
+        fenceChar === fence.char &&
+        marker.length >= fence.length &&
+        /^\s*$/.test(info)
+      ) {
+        fence = null;
+        out.push('');
+        continue;
+      }
+    }
+    out.push(fence === null ? line : '');
+  }
+  // Inline code spans (`...`, ``...``): mask the inner content so a quoted
+  // marker no longer matches, keeping the backticks and surrounding text.
+  return out
+    .join('\n')
+    .replace(
+      /(`+)((?:(?!\1)[\s\S])+?)\1/g,
+      (_match, ticks, inner) =>
+        `${ticks}${inner.replace(/[^\r\n]/g, ' ')}${ticks}`,
+    );
+}

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -21,7 +21,11 @@ export function stripMarkdownCodeRegions(text) {
   const out = [];
   let fence = null;
   for (const line of lines) {
-    const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
+    // CommonMark §4.5: a fence marker may be indented by at most three spaces;
+    // a marker with four or more leading spaces is an indented code line, not a
+    // fence, so accepting arbitrary leading whitespace here would wrongly enter
+    // fence mode on `    ~~~` and blank the real content that follows it.
+    const openMatch = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
     if (openMatch) {
       const marker = openMatch[1];
       const info = openMatch[2];

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -1,3 +1,8 @@
+// idd-generated-from: src/scripts/markdown-code.mts
+//
+// The scripts/markdown-code.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
 /**
  * Strip Markdown code regions (fenced blocks and inline code spans) from a body
  * before scanning it for machine-readable markers or dependency references. A

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -52,11 +52,15 @@ export function stripMarkdownCodeRegions(text) {
     out.push(fence === null ? line : '');
   }
   // Inline code spans (`...`, ``...``): mask the inner content so a quoted
-  // marker no longer matches, keeping the backticks and surrounding text.
+  // marker no longer matches, keeping the backticks and surrounding text. The
+  // inner match allows a single newline (CommonMark renders it as a space) but
+  // stops at a blank line, which ends the paragraph: a code span cannot cross
+  // it. Allowing a blank line would let a stray unclosed backtick mask a real
+  // dependency line in a later paragraph — a fail-open miss.
   return out
     .join('\n')
     .replace(
-      /(`+)((?:(?!\1)[\s\S])+?)\1/g,
+      /(`+)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)\1/g,
       (_match, ticks, inner) =>
         `${ticks}${inner.replace(/[^\r\n]/g, ' ')}${ticks}`,
     );

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -391,27 +391,56 @@ export async function evaluateDiscoverReadiness(
 }
 
 /**
- * Collect every `#N` reference declared on a dependency-keyword line.
+ * Collect the `#N` references declared on a dependency-keyword line.
  *
  * A line is a dependency declaration when, after the shared
  * `DEPENDENCY_LINE_PREFIX` (indentation, blockquote, and/or a list bullet), it
- * begins with `keyword` immediately followed by at least one `#N`. Once such a
- * line is found, every `#(\d+)` on that same line is captured, so
+ * begins with `keyword` immediately followed by at least one `#N`. From there
+ * `consumeDependencyRefList` collects the contiguous dependency-ref list, so
  * `Blocked by #A, #B, #C` (comma- or space-separated) yields `[A, B, C]`. The
- * scan is bounded to the single matched line (`.*$` with the `m` flag, no `s`
- * flag), so refs never bleed across lines, and the backtick-excluding prefix
- * keeps inline-code markers unmatched (see `DEPENDENCY_LINE_PREFIX`).
+ * `m` flag (no `s` flag) keeps the match on the single keyword line, and the
+ * backtick-excluding prefix keeps inline-code markers unmatched (see
+ * `DEPENDENCY_LINE_PREFIX`).
  */
 function extractKeywordLineRefs(body: string, keyword: string): number[] {
   const linePattern = new RegExp(
-    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}\\s+#\\d+.*$`,
+    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}\\s+(#\\d+.*)$`,
     'gim',
   );
   const numbers: number[] = [];
   for (const lineMatch of body.matchAll(linePattern)) {
-    for (const refMatch of lineMatch[0].matchAll(/#(\d+)\b/g)) {
-      numbers.push(Number.parseInt(refMatch[1], 10));
+    numbers.push(...consumeDependencyRefList(lineMatch[1]));
+  }
+  return numbers;
+}
+
+/**
+ * Consume the contiguous dependency-ref list at the start of `segment`: bare
+ * local `#N` entries separated by commas, "and", and/or whitespace. Parsing
+ * stops at the first token that is neither a bare local ref nor such a
+ * separator, so trailing prose (`; similar to #402`) and cross-repo mentions
+ * (`(see other/repo#20)`) are excluded instead of being mis-read as local
+ * blockers. This mirrors the separator-bounded reference parsing in
+ * `discover-roadmap-graph.mts`, extended to also accept a plain-whitespace
+ * separator so the space-separated multi-ref form is captured too.
+ */
+function consumeDependencyRefList(segment: string): number[] {
+  const numbers: number[] = [];
+  let remaining = segment;
+  while (remaining) {
+    const refMatch = remaining.match(/^#(\d+)\b/);
+    if (!refMatch) {
+      break;
     }
+    numbers.push(Number.parseInt(refMatch[1], 10));
+    remaining = remaining.slice(refMatch[0].length);
+    const separatorMatch = remaining.match(
+      /^(?:\s*,\s*(?:and\s+)?|\s+and\s+|\s+)/i,
+    );
+    if (!separatorMatch) {
+      break;
+    }
+    remaining = remaining.slice(separatorMatch[0].length);
   }
   return numbers;
 }

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -23,6 +23,18 @@ import { escapeRegex } from './marker-regex.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
+// Leading-anchor source shared by the `Blocked by` / `Depends on` line parsers.
+// It tolerates optional indentation, nested blockquote (`>`) markers, and a
+// single list bullet (`-`/`*`/`+`) while staying line-anchored, so a dependency
+// written as `- Blocked by #55` or `> Depends on #66` is still recognized. It
+// deliberately excludes backticks: an inline-code marker such as
+// `` `Blocked by #77` `` therefore stays unmatched, keeping code-quoted markers
+// treated as false positives — consistent with the #1121 repo behavior. This
+// const is declared before the `isMainModule` CLI block on purpose so it is
+// initialized when the CLI path runs `extractBlockedByIssueNumbers` (a const
+// declared after that block would be in the temporal dead zone).
+const DEPENDENCY_LINE_PREFIX = String.raw`^[ \t]*(?:>[ \t]*)*(?:[-*+][ \t]+)?`;
+
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
 });
@@ -378,11 +390,34 @@ export async function evaluateDiscoverReadiness(
   };
 }
 
-export function extractBlockedByIssueNumbers(body: string): number[] {
-  const matches = body.matchAll(/^\s*Blocked by\s+#(\d+)\b/gim);
-  return dedupeNumbers(
-    [...matches].map((match) => Number.parseInt(match[1], 10)),
+/**
+ * Collect every `#N` reference declared on a dependency-keyword line.
+ *
+ * A line is a dependency declaration when, after the shared
+ * `DEPENDENCY_LINE_PREFIX` (indentation, blockquote, and/or a list bullet), it
+ * begins with `keyword` immediately followed by at least one `#N`. Once such a
+ * line is found, every `#(\d+)` on that same line is captured, so
+ * `Blocked by #A, #B, #C` (comma- or space-separated) yields `[A, B, C]`. The
+ * scan is bounded to the single matched line (`.*$` with the `m` flag, no `s`
+ * flag), so refs never bleed across lines, and the backtick-excluding prefix
+ * keeps inline-code markers unmatched (see `DEPENDENCY_LINE_PREFIX`).
+ */
+function extractKeywordLineRefs(body: string, keyword: string): number[] {
+  const linePattern = new RegExp(
+    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}\\s+#\\d+.*$`,
+    'gim',
   );
+  const numbers: number[] = [];
+  for (const lineMatch of body.matchAll(linePattern)) {
+    for (const refMatch of lineMatch[0].matchAll(/#(\d+)\b/g)) {
+      numbers.push(Number.parseInt(refMatch[1], 10));
+    }
+  }
+  return numbers;
+}
+
+export function extractBlockedByIssueNumbers(body: string): number[] {
+  return dedupeNumbers(extractKeywordLineRefs(body, 'Blocked by'));
 }
 
 export function extractBlockedByRoadmapMarkers(
@@ -403,14 +438,12 @@ export function extractBlockedByRoadmapMarkers(
 }
 
 export function extractDependencyIssueNumbers(body: string): number[] {
-  const explicitDependencies = [
-    ...body.matchAll(/^\s*Depends on\s+#(\d+)\b/gim),
-  ];
+  const explicitDependencies = extractKeywordLineRefs(body, 'Depends on');
   const taskListDependencies = [
     ...body.matchAll(/^\s*-\s*\[(?: |x)\]\s+#(\d+)\b/gim),
   ];
   return dedupeNumbers([
-    ...explicitDependencies.map((match) => Number.parseInt(match[1], 10)),
+    ...explicitDependencies,
     ...taskListDependencies.map((match) => Number.parseInt(match[1], 10)),
   ]);
 }

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -19,6 +19,7 @@ import {
   parseAutopilotSuitability,
 } from './autopilot-suitability.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
+import { stripMarkdownCodeRegions } from './markdown-code.mts';
 import { escapeRegex } from './marker-regex.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
@@ -26,13 +27,15 @@ const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // Leading-anchor source shared by the `Blocked by` / `Depends on` line parsers.
 // It tolerates optional indentation, nested blockquote (`>`) markers, and a
 // single list bullet (`-`/`*`/`+`) while staying line-anchored, so a dependency
-// written as `- Blocked by #55` or `> Depends on #66` is still recognized. It
-// deliberately excludes backticks: an inline-code marker such as
-// `` `Blocked by #77` `` therefore stays unmatched, keeping code-quoted markers
-// treated as false positives — consistent with the #1121 repo behavior. This
-// const is declared before the `isMainModule` CLI block on purpose so it is
-// initialized when the CLI path runs `extractBlockedByIssueNumbers` (a const
-// declared after that block would be in the temporal dead zone).
+// written as `- Blocked by #55` or `> Depends on #66` is still recognized. The
+// extractors run `stripMarkdownCodeRegions` over the body first, so a
+// dependency line merely quoted inside inline code or a fenced block is already
+// masked out — treating code-quoted markers as false positives, consistent with
+// the #1121 repo behavior; excluding backticks from this prefix is a second
+// line of defense for the inline-code case. This const is declared before the
+// `isMainModule` CLI block on purpose so it is initialized when the CLI path
+// runs `extractBlockedByIssueNumbers` (a const declared after that block would
+// be in the temporal dead zone).
 const DEPENDENCY_LINE_PREFIX = String.raw`^[ \t]*(?:>[ \t]*)*(?:[-*+][ \t]+)?`;
 
 const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
@@ -395,16 +398,18 @@ export async function evaluateDiscoverReadiness(
  *
  * A line is a dependency declaration when, after the shared
  * `DEPENDENCY_LINE_PREFIX` (indentation, blockquote, and/or a list bullet), it
- * begins with `keyword` immediately followed by at least one `#N`. From there
- * `consumeDependencyRefList` collects the contiguous dependency-ref list, so
- * `Blocked by #A, #B, #C` (comma- or space-separated) yields `[A, B, C]`. The
- * `m` flag (no `s` flag) keeps the match on the single keyword line, and the
- * backtick-excluding prefix keeps inline-code markers unmatched (see
- * `DEPENDENCY_LINE_PREFIX`).
+ * begins with `keyword` followed by horizontal whitespace and at least one
+ * `#N`. From there `consumeDependencyRefList` collects the contiguous
+ * dependency-ref list, so `Blocked by #A, #B, #C` (comma- or space-separated)
+ * yields `[A, B, C]`. The keyword-to-ref gap is `[ \t]+` (not `\s+`) so it
+ * cannot span a newline and swallow a bare `#N` on the following line, and the
+ * `.*$` capture plus the `m` flag (no `s` flag) keeps the match on the single
+ * keyword line. Callers pass a code-region-stripped body, so a quoted example
+ * line is already masked (see `DEPENDENCY_LINE_PREFIX`).
  */
 function extractKeywordLineRefs(body: string, keyword: string): number[] {
   const linePattern = new RegExp(
-    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}\\s+(#\\d+.*)$`,
+    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}[ \\t]+(#\\d+.*)$`,
     'gim',
   );
   const numbers: number[] = [];
@@ -446,7 +451,9 @@ function consumeDependencyRefList(segment: string): number[] {
 }
 
 export function extractBlockedByIssueNumbers(body: string): number[] {
-  return dedupeNumbers(extractKeywordLineRefs(body, 'Blocked by'));
+  return dedupeNumbers(
+    extractKeywordLineRefs(stripMarkdownCodeRegions(body), 'Blocked by'),
+  );
 }
 
 export function extractBlockedByRoadmapMarkers(
@@ -467,9 +474,10 @@ export function extractBlockedByRoadmapMarkers(
 }
 
 export function extractDependencyIssueNumbers(body: string): number[] {
-  const explicitDependencies = extractKeywordLineRefs(body, 'Depends on');
+  const stripped = stripMarkdownCodeRegions(body);
+  const explicitDependencies = extractKeywordLineRefs(stripped, 'Depends on');
   const taskListDependencies = [
-    ...body.matchAll(/^\s*-\s*\[(?: |x)\]\s+#(\d+)\b/gim),
+    ...stripped.matchAll(/^\s*-\s*\[(?: |x)\]\s+#(\d+)\b/gim),
   ];
   return dedupeNumbers([
     ...explicitDependencies,

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -21,6 +21,7 @@ import {
   evaluateDiscoverReadiness,
 } from './discover-readiness-check.mts';
 import { type EffortHint, effortOrdinal, parseEffort } from './effort.mts';
+import { stripMarkdownCodeRegions } from './markdown-code.mts';
 import { parseIsoDurationToMs } from './policy-helpers.mts';
 import {
   isStaleAt,
@@ -1631,60 +1632,6 @@ function buildCommentLoader(owner: string, repo: string) {
  */
 export function parseClaimStaleAgeMs(value: unknown): number | null {
   return parseIsoDurationToMs(String(value ?? '').trim());
-}
-
-/**
- * Strip Markdown code regions (fenced blocks and inline code spans) from a body
- * before scanning it for a roadmap-id marker. A genuine roadmap marker is a raw
- * HTML comment GitHub renders invisibly, never inside a code span or fence, so
- * an example marker an execution-leaf issue merely *quotes* in code (e.g. an
- * issue about the marker system) must not be read as roadmap identity. The
- * marker is itself an HTML comment, so HTML comments are deliberately NOT
- * stripped here — only code regions are. Masked regions keep their line count
- * and surrounding text so a real marker elsewhere in the body still matches.
- */
-function stripMarkdownCodeRegions(text: string): string {
-  // Fenced blocks (``` or ~~~), tracking the fence char + length so a longer
-  // opening fence is not closed by a shorter inner fence (CommonMark §4.5).
-  const lines = text.split(/\r?\n/);
-  const out: string[] = [];
-  let fence: { char: string; length: number } | null = null;
-  for (const line of lines) {
-    const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
-    if (openMatch) {
-      const marker = openMatch[1];
-      const info = openMatch[2];
-      const fenceChar = marker[0];
-      if (fence === null) {
-        // CommonMark §4.5: a backtick-fence opener's info string may not
-        // contain a backtick (that would be ambiguous with a close or inline
-        // code), so such a line is not a fence opener and stays content.
-        if (fenceChar !== '`' || !info.includes('`')) {
-          fence = { char: fenceChar, length: marker.length };
-          out.push('');
-          continue;
-        }
-      } else if (
-        fenceChar === fence.char &&
-        marker.length >= fence.length &&
-        /^\s*$/.test(info)
-      ) {
-        fence = null;
-        out.push('');
-        continue;
-      }
-    }
-    out.push(fence === null ? line : '');
-  }
-  // Inline code spans (`...`, ``...``): mask the inner content so a quoted
-  // marker no longer matches, keeping the backticks and surrounding text.
-  return out
-    .join('\n')
-    .replace(
-      /(`+)((?:(?!\1)[\s\S])+?)\1/g,
-      (_match, ticks: string, inner: string) =>
-        `${ticks}${inner.replace(/[^\r\n]/g, ' ')}${ticks}`,
-    );
 }
 
 export function extractRoadmapMarkerId(

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -1,3 +1,9 @@
+// idd-generated-from: src/scripts/markdown-code.mts
+//
+// The scripts/markdown-code.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
 /**
  * Strip Markdown code regions (fenced blocks and inline code spans) from a body
  * before scanning it for machine-readable markers or dependency references. A

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -22,7 +22,11 @@ export function stripMarkdownCodeRegions(text: string): string {
   const out: string[] = [];
   let fence: { char: string; length: number } | null = null;
   for (const line of lines) {
-    const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
+    // CommonMark §4.5: a fence marker may be indented by at most three spaces;
+    // a marker with four or more leading spaces is an indented code line, not a
+    // fence, so accepting arbitrary leading whitespace here would wrongly enter
+    // fence mode on `    ~~~` and blank the real content that follows it.
+    const openMatch = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
     if (openMatch) {
       const marker = openMatch[1];
       const info = openMatch[2];

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -53,11 +53,15 @@ export function stripMarkdownCodeRegions(text: string): string {
     out.push(fence === null ? line : '');
   }
   // Inline code spans (`...`, ``...``): mask the inner content so a quoted
-  // marker no longer matches, keeping the backticks and surrounding text.
+  // marker no longer matches, keeping the backticks and surrounding text. The
+  // inner match allows a single newline (CommonMark renders it as a space) but
+  // stops at a blank line, which ends the paragraph: a code span cannot cross
+  // it. Allowing a blank line would let a stray unclosed backtick mask a real
+  // dependency line in a later paragraph — a fail-open miss.
   return out
     .join('\n')
     .replace(
-      /(`+)((?:(?!\1)[\s\S])+?)\1/g,
+      /(`+)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)\1/g,
       (_match, ticks: string, inner: string) =>
         `${ticks}${inner.replace(/[^\r\n]/g, ' ')}${ticks}`,
     );

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -1,0 +1,54 @@
+/**
+ * Strip Markdown code regions (fenced blocks and inline code spans) from a body
+ * before scanning it for machine-readable markers or dependency references. A
+ * genuine marker is raw text GitHub renders as intended (an HTML comment it
+ * hides, or a `Blocked by #N` line it links), never inside a code span or
+ * fence, so an example an issue merely *quotes* in code (e.g. an issue about
+ * the marker or dependency syntax) must not be read as real. HTML comments are
+ * deliberately NOT stripped here — only code regions are, since some markers
+ * are themselves HTML comments. Masked regions keep their line count and
+ * surrounding text so a real marker elsewhere in the body still matches.
+ */
+export function stripMarkdownCodeRegions(text: string): string {
+  // Fenced blocks (``` or ~~~), tracking the fence char + length so a longer
+  // opening fence is not closed by a shorter inner fence (CommonMark §4.5).
+  const lines = text.split(/\r?\n/);
+  const out: string[] = [];
+  let fence: { char: string; length: number } | null = null;
+  for (const line of lines) {
+    const openMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
+    if (openMatch) {
+      const marker = openMatch[1];
+      const info = openMatch[2];
+      const fenceChar = marker[0];
+      if (fence === null) {
+        // CommonMark §4.5: a backtick-fence opener's info string may not
+        // contain a backtick (that would be ambiguous with a close or inline
+        // code), so such a line is not a fence opener and stays content.
+        if (fenceChar !== '`' || !info.includes('`')) {
+          fence = { char: fenceChar, length: marker.length };
+          out.push('');
+          continue;
+        }
+      } else if (
+        fenceChar === fence.char &&
+        marker.length >= fence.length &&
+        /^\s*$/.test(info)
+      ) {
+        fence = null;
+        out.push('');
+        continue;
+      }
+    }
+    out.push(fence === null ? line : '');
+  }
+  // Inline code spans (`...`, ``...``): mask the inner content so a quoted
+  // marker no longer matches, keeping the backticks and surrounding text.
+  return out
+    .join('\n')
+    .replace(
+      /(`+)((?:(?!\1)[\s\S])+?)\1/g,
+      (_match, ticks: string, inner: string) =>
+        `${ticks}${inner.replace(/[^\r\n]/g, ' ')}${ticks}`,
+    );
+}

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -31,6 +31,52 @@ Depends on #56
   assert.deepEqual(extractBlockedByRoadmapMarkers(body), ['parent-roadmap']);
 });
 
+test('extractBlockedByIssueNumbers captures every same-line ref and tolerates list/blockquote prefixes', () => {
+  // Comma- and space-separated multi-ref on one line.
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('Blocked by #100, #200'),
+    [100, 200],
+  );
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('Blocked by #100 #200'),
+    [100, 200],
+  );
+  // List-bullet and blockquote prefixes are matched.
+  assert.deepEqual(extractBlockedByIssueNumbers('- Blocked by #55'), [55]);
+  assert.deepEqual(extractBlockedByIssueNumbers('> Blocked by #66'), [66]);
+  // Mid-sentence prose is not a dependency declaration.
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('this is not blocked by #5'),
+    [],
+  );
+  // Inline-code markers stay ignored (backtick prefix, #1121 boundary).
+  assert.deepEqual(extractBlockedByIssueNumbers('`Blocked by #77`'), []);
+});
+
+test('extractDependencyIssueNumbers captures every same-line Depends on ref and tolerates prefixes', () => {
+  assert.deepEqual(
+    extractDependencyIssueNumbers('Depends on #100, #200'),
+    [100, 200],
+  );
+  assert.deepEqual(
+    extractDependencyIssueNumbers('Depends on #100 #200'),
+    [100, 200],
+  );
+  assert.deepEqual(extractDependencyIssueNumbers('- Depends on #55'), [55]);
+  assert.deepEqual(extractDependencyIssueNumbers('> Depends on #66'), [66]);
+  assert.deepEqual(
+    extractDependencyIssueNumbers('this does not depend on #5'),
+    [],
+  );
+  assert.deepEqual(extractDependencyIssueNumbers('`Depends on #77`'), []);
+  // The `- [ ] #N` task-list branch keeps working alongside the relaxed
+  // `Depends on` bullet prefix without double counting.
+  assert.deepEqual(
+    extractDependencyIssueNumbers('- Depends on #55, #56\n- [ ] #78'),
+    [55, 56, 78],
+  );
+});
+
 test('extractBlockedByRoadmapMarkers honors a configured marker prefix', () => {
   const body = `
 <!-- idd-skill-blocked-by: default-prefixed -->

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -131,6 +131,11 @@ test('dependency parsers ignore code-fenced examples and stay on one line', () =
     '\n',
   );
   assert.deepEqual(extractBlockedByIssueNumbers(mixedBody), [12]);
+
+  // A 4-space-indented `~~~` is indented code, not a fence opener (CommonMark
+  // §4.5), so it must not swallow a real following blocker — a fail-open miss.
+  const indentedFakeFence = ['    ~~~', 'Blocked by #123'].join('\n');
+  assert.deepEqual(extractBlockedByIssueNumbers(indentedFakeFence), [123]);
 });
 
 test('extractBlockedByRoadmapMarkers honors a configured marker prefix', () => {

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -32,13 +32,17 @@ Depends on #56
 });
 
 test('extractBlockedByIssueNumbers captures every same-line ref and tolerates list/blockquote prefixes', () => {
-  // Comma- and space-separated multi-ref on one line.
+  // Comma-, space-, and "and"-separated multi-ref on one line.
   assert.deepEqual(
     extractBlockedByIssueNumbers('Blocked by #100, #200'),
     [100, 200],
   );
   assert.deepEqual(
     extractBlockedByIssueNumbers('Blocked by #100 #200'),
+    [100, 200],
+  );
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('Blocked by #100 and #200'),
     [100, 200],
   );
   // List-bullet and blockquote prefixes are matched.
@@ -51,6 +55,16 @@ test('extractBlockedByIssueNumbers captures every same-line ref and tolerates li
   );
   // Inline-code markers stay ignored (backtick prefix, #1121 boundary).
   assert.deepEqual(extractBlockedByIssueNumbers('`Blocked by #77`'), []);
+  // The contiguous dependency list is bounded: trailing prose and cross-repo
+  // mentions are excluded rather than mis-read as local blockers.
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('Blocked by #10 (see other/repo#20)'),
+    [10],
+  );
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('Blocked by #403; similar to #402'),
+    [403],
+  );
 });
 
 test('extractDependencyIssueNumbers captures every same-line Depends on ref and tolerates prefixes', () => {
@@ -62,6 +76,10 @@ test('extractDependencyIssueNumbers captures every same-line Depends on ref and 
     extractDependencyIssueNumbers('Depends on #100 #200'),
     [100, 200],
   );
+  assert.deepEqual(
+    extractDependencyIssueNumbers('Depends on #100 and #200'),
+    [100, 200],
+  );
   assert.deepEqual(extractDependencyIssueNumbers('- Depends on #55'), [55]);
   assert.deepEqual(extractDependencyIssueNumbers('> Depends on #66'), [66]);
   assert.deepEqual(
@@ -69,6 +87,15 @@ test('extractDependencyIssueNumbers captures every same-line Depends on ref and 
     [],
   );
   assert.deepEqual(extractDependencyIssueNumbers('`Depends on #77`'), []);
+  // Bounded list: prose and cross-repo mentions are excluded.
+  assert.deepEqual(
+    extractDependencyIssueNumbers('Depends on #403; similar to #402'),
+    [403],
+  );
+  assert.deepEqual(
+    extractDependencyIssueNumbers('Depends on #10 (see other/repo#20)'),
+    [10],
+  );
   // The `- [ ] #N` task-list branch keeps working alongside the relaxed
   // `Depends on` bullet prefix without double counting.
   assert.deepEqual(

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -104,6 +104,35 @@ test('extractDependencyIssueNumbers captures every same-line Depends on ref and 
   );
 });
 
+test('dependency parsers ignore code-fenced examples and stay on one line', () => {
+  // A fenced example quoting the relaxed bullet/blockquote syntax is masked,
+  // so it is not read as a real blocker (the leading fence uses ~ to keep this
+  // template literal free of nested backtick fences).
+  const fencedBody = [
+    'Intro text',
+    '~~~markdown',
+    '- Blocked by #55',
+    '> Depends on #66',
+    '- [ ] #78',
+    '~~~',
+    'Outro text',
+  ].join('\n');
+  assert.deepEqual(extractBlockedByIssueNumbers(fencedBody), []);
+  assert.deepEqual(extractDependencyIssueNumbers(fencedBody), []);
+
+  // The keyword-to-ref gap must not span a newline: a bullet keyword line with
+  // a bare `#N` on the *next* line is not a same-line dependency declaration.
+  assert.deepEqual(extractBlockedByIssueNumbers('- Blocked by\n#123'), []);
+  assert.deepEqual(extractDependencyIssueNumbers('> Depends on\n#123'), []);
+
+  // A real out-of-fence dependency line alongside a fenced example still
+  // resolves to just the real reference.
+  const mixedBody = ['Blocked by #12', '~~~', 'Blocked by #999', '~~~'].join(
+    '\n',
+  );
+  assert.deepEqual(extractBlockedByIssueNumbers(mixedBody), [12]);
+});
+
 test('extractBlockedByRoadmapMarkers honors a configured marker prefix', () => {
   const body = `
 <!-- idd-skill-blocked-by: default-prefixed -->

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -24,6 +24,18 @@ test('stripMarkdownCodeRegions leaves HTML comments and plain text intact', () =
   assert.equal(stripMarkdownCodeRegions(body), body);
 });
 
+test('stripMarkdownCodeRegions treats a 4-space-indented fence marker as code, not a fence', () => {
+  // CommonMark §4.5: `    ~~~` (4 leading spaces) is indented code, not a fence
+  // opener, so it must NOT enter fence mode and blank the real lines after it.
+  const body = ['    ~~~', 'Blocked by #123', 'Depends on #456'].join('\n');
+  assert.equal(stripMarkdownCodeRegions(body), body);
+  // Up to three spaces still opens a fence.
+  assert.equal(
+    stripMarkdownCodeRegions(['   ~~~', 'inside #1', '   ~~~'].join('\n')),
+    ['', '', ''].join('\n'),
+  );
+});
+
 test('stripMarkdownCodeRegions does not let a shorter inner fence close a longer one', () => {
   const body = ['~~~~', '~~~', 'still inside #9', '~~~~', 'out'].join('\n');
   assert.equal(

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -19,6 +19,26 @@ test('stripMarkdownCodeRegions masks inline code spans, preserving delimiters', 
   );
 });
 
+test('stripMarkdownCodeRegions keeps an inline span within one paragraph', () => {
+  // A single newline inside a span is still masked (CommonMark renders it as a
+  // space); the newline itself is preserved so line offsets do not shift.
+  assert.equal(
+    stripMarkdownCodeRegions('`multi\nline` tail'),
+    '`     \n    ` tail',
+  );
+  // A stray unclosed backtick must NOT mask across a blank line: the real
+  // `Blocked by #5` in the next paragraph stays intact (fail-open guard).
+  const body = ['a stray tick `', '', 'Blocked by #5', '', 'then `code`'].join(
+    '\n',
+  );
+  const stripped = stripMarkdownCodeRegions(body);
+  assert.ok(
+    stripped.includes('Blocked by #5'),
+    'a blank line ends the span, so the later dependency line is preserved',
+  );
+  assert.equal(stripped.split('\n')[4], 'then `    `');
+});
+
 test('stripMarkdownCodeRegions leaves HTML comments and plain text intact', () => {
   const body = 'plain <!-- idd-skill-blocked-by: parent --> text';
   assert.equal(stripMarkdownCodeRegions(body), body);

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { stripMarkdownCodeRegions } from '../src/scripts/markdown-code.mts';
+
+test('stripMarkdownCodeRegions blanks fenced blocks but keeps line count', () => {
+  const body = ['before', '~~~', 'inside #1', '~~~', 'after'].join('\n');
+  assert.equal(
+    stripMarkdownCodeRegions(body),
+    ['before', '', '', '', 'after'].join('\n'),
+  );
+});
+
+test('stripMarkdownCodeRegions masks inline code spans, preserving delimiters', () => {
+  const masked = ' '.repeat('Blocked by #7'.length);
+  assert.equal(
+    stripMarkdownCodeRegions('see `Blocked by #7` here'),
+    `see \`${masked}\` here`,
+  );
+});
+
+test('stripMarkdownCodeRegions leaves HTML comments and plain text intact', () => {
+  const body = 'plain <!-- idd-skill-blocked-by: parent --> text';
+  assert.equal(stripMarkdownCodeRegions(body), body);
+});
+
+test('stripMarkdownCodeRegions does not let a shorter inner fence close a longer one', () => {
+  const body = ['~~~~', '~~~', 'still inside #9', '~~~~', 'out'].join('\n');
+  assert.equal(
+    stripMarkdownCodeRegions(body),
+    ['', '', '', '', 'out'].join('\n'),
+  );
+});


### PR DESCRIPTION
## Summary

`discover-readiness-check`'s `Blocked by` / `Depends on` parsers used a single
line-anchored regex (`/^\s*Blocked by\s+#(\d+)\b/gim` and its `Depends on`
sibling) that captured only the **first** `#N` on a line and rejected
list/blockquote prefixes. Two silent readiness gaps resulted — nothing errored,
the issue was just reported **startable** when it was not:

- **Multi-ref same line dropped.** `Blocked by #100, #200` captured only `#100`;
  once `#100` closed, the issue was wrongly startable while `#200` stayed open
  (observed live as `Blocked by #1098, #1099`).
- **List/blockquote prefixes dropped.** `- Blocked by #55` and `> Blocked by #66`
  did not match because the leading anchor tolerated only whitespace.

## Change

- Share a module-level `DEPENDENCY_LINE_PREFIX` (indentation + nested `>`
  blockquote + a single `-`/`*`/`+` bullet, still line-anchored, backticks
  excluded), declared **before** the `isMainModule` CLI block so it is
  initialized when the CLI path runs `extractBlockedByIssueNumbers` (a const
  after that block would be in the temporal dead zone).
- Add a hoisted `extractKeywordLineRefs(body, keyword)` helper that, once a
  keyword line matches, scans that single line for **every** `#(\d+)`, so
  `Blocked by #A, #B, #C` (comma- or space-separated) yields `[A, B, C]`.
  `keyword` passes through the existing `escapeRegex` for defense-in-depth.
- Rewire both `extractBlockedByIssueNumbers` and the `Depends on` branch of
  `extractDependencyIssueNumbers` onto the helper; the `- [ ] #N` task-list
  branch is unchanged (no collision, no double counting).

Inline-code markers such as `` `Blocked by #77` `` stay ignored via the
backtick-excluding prefix, consistent with the #1121 code-quoted-marker
boundary (a code comment records this).

## Verification

New regression fixtures in `tests/discover-readiness-check.test.mts` cover, for
**both** parsers: comma-separated multi-ref, space-separated multi-ref,
list-bullet prefix, blockquote prefix, the mid-sentence negative, and the
inline-code negative. `pnpm test` (1424 tests), `pnpm run lint:minimum`, and
`build:check` (generated `scripts/discover-readiness-check.mjs` regenerated via
`pnpm run build`) all pass.

Closes #1143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recognition of dependency and blocker references in issue text, including multiple references on one line and common formatting variants.
  * Added support for safely ignoring references that appear inside Markdown code regions.

* **Bug Fixes**
  * Reduced false matches from inline code, fenced code blocks, blockquotes, and list items.
  * Prevented cross-repository references and trailing prose from being misread as local issue links.

* **Tests**
  * Expanded coverage for Markdown masking and dependency parsing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->