### PR TITLE
docs(issue-authoring): encode Blocked by on finalize-track siblings

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -301,6 +301,15 @@ availability, or ordering constraint.
   tense is a recurring advisory-review-thrash pattern; "describe shipped
   behavior" is a true ordering constraint, so this edge is consistent
   with the encode-only-a-real-constraint rule above
+- when authoring a **finalize or verify track whose acceptance criteria
+  assert state produced by sibling implementation tracks**, encode
+  `Blocked by #NNN` on **each** such sibling rather than stating the
+  ordering only in prose. Discover and A4.5 honor the hard `Blocked by`
+  edge, not a prose "runs after the siblings" note: A4.5 Actionability
+  inspects the body, not completability, so a prose-sequenced finalize
+  track reports startable the moment its build foundation closes, and
+  claiming it then means either failing its acceptance criteria or doing
+  the siblings' unmerged work
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -212,6 +212,42 @@ This is an artificial split when the three edits form one natural,
 cohesive authoring change. Do not break a single reviewable task into
 multiple sibling issues only to widen parallel execution.
 
+### Finalize or verify track that asserts sibling-produced state
+
+Anti-pattern — prose sequencing only:
+
+```md
+#450 — finalize the config, reconcile the docs, verify the combined result
+
+Blocked by #440
+
+_Runs after the wiring tracks #441-#445._
+```
+
+The hard `Blocked by #440` names only the build foundation, and the
+after-the-siblings ordering lives in prose. Once `#440` closes, Discover
+reports `#450` startable and A4.5 passes it (Actionability inspects the body,
+not completability) — but its acceptance criteria assert state that only the
+unmerged `#441`–`#445` produce, so claiming it means failing acceptance or
+doing the siblings' work.
+
+Correct — encode `Blocked by` on each sibling whose output the acceptance
+criteria depend on:
+
+```md
+#450 — finalize the config, reconcile the docs, verify the combined result
+
+Blocked by #440
+Blocked by #441
+Blocked by #442
+Blocked by #443
+Blocked by #444
+Blocked by #445
+```
+
+Now Discover and A4.5 defer `#450` until every sibling merges, so it is
+claimed only when its acceptance criteria can actually pass.
+
 Resolve `<marker-prefix>` from the target repository's onboarding or IDD
 docs before publishing the draft. Use `idd-skill` only when the target
 repository actually configured that prefix.

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -529,6 +529,15 @@ availability, or ordering constraint.
   tense is a recurring advisory-review-thrash pattern; "describe shipped
   behavior" is a true ordering constraint, so this edge is consistent
   with the encode-only-a-real-constraint rule above
+- when authoring a **finalize or verify track whose acceptance criteria
+  assert state produced by sibling implementation tracks**, encode
+  `Blocked by #NNN` on **each** such sibling rather than stating the
+  ordering only in prose. Discover and A4.5 honor the hard `Blocked by`
+  edge, not a prose "runs after the siblings" note: A4.5 Actionability
+  inspects the body, not completability, so a prose-sequenced finalize
+  track reports startable the moment its build foundation closes, and
+  claiming it then means either failing its acceptance criteria or doing
+  the siblings' unmerged work
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -301,6 +301,15 @@ availability, or ordering constraint.
   tense is a recurring advisory-review-thrash pattern; "describe shipped
   behavior" is a true ordering constraint, so this edge is consistent
   with the encode-only-a-real-constraint rule above
+- when authoring a **finalize or verify track whose acceptance criteria
+  assert state produced by sibling implementation tracks**, encode
+  `Blocked by #NNN` on **each** such sibling rather than stating the
+  ordering only in prose. Discover and A4.5 honor the hard `Blocked by`
+  edge, not a prose "runs after the siblings" note: A4.5 Actionability
+  inspects the body, not completability, so a prose-sequenced finalize
+  track reports startable the moment its build foundation closes, and
+  claiming it then means either failing its acceptance criteria or doing
+  the siblings' unmerged work
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -212,6 +212,42 @@ This is an artificial split when the three edits form one natural,
 cohesive authoring change. Do not break a single reviewable task into
 multiple sibling issues only to widen parallel execution.
 
+### Finalize or verify track that asserts sibling-produced state
+
+Anti-pattern — prose sequencing only:
+
+```md
+#450 — finalize the config, reconcile the docs, verify the combined result
+
+Blocked by #440
+
+_Runs after the wiring tracks #441-#445._
+```
+
+The hard `Blocked by #440` names only the build foundation, and the
+after-the-siblings ordering lives in prose. Once `#440` closes, Discover
+reports `#450` startable and A4.5 passes it (Actionability inspects the body,
+not completability) — but its acceptance criteria assert state that only the
+unmerged `#441`–`#445` produce, so claiming it means failing acceptance or
+doing the siblings' work.
+
+Correct — encode `Blocked by` on each sibling whose output the acceptance
+criteria depend on:
+
+```md
+#450 — finalize the config, reconcile the docs, verify the combined result
+
+Blocked by #440
+Blocked by #441
+Blocked by #442
+Blocked by #443
+Blocked by #444
+Blocked by #445
+```
+
+Now Discover and A4.5 defer `#450` until every sibling merges, so it is
+claimed only when its acceptance criteria can actually pass.
+
 Resolve `<marker-prefix>` from the target repository's onboarding or IDD
 docs before publishing the draft. Use `idd-skill` only when the target
 repository actually configured that prefix.


### PR DESCRIPTION
## Summary

Strengthens the issue-authoring contract so a **finalize or verify track
whose acceptance criteria assert state produced by sibling implementation
tracks** encodes `Blocked by #NNN` on each such sibling, rather than
sequencing them only in prose.

Discover and A4.5 honor only the hard `Blocked by` edge, not a prose
"runs after #A–#E" note. A4.5 Actionability inspects the body, not
completability, so a prose-sequenced finalize track reports startable the
moment its build foundation closes — and claiming it then means either
failing its acceptance criteria or doing the siblings' unmerged work.

## Changes

- `skills/issue-authoring/references/contract.md`: new Dependency
  minimization bullet stating the finalize/verify-track rule.
- `skills/issue-authoring/references/draft-patterns.md`: a new example
  contrasting the prose-sequencing anti-pattern with the correct
  per-sibling `Blocked by` encoding.
- `docs/issue-authoring-skill.md`: the mirrored Dependency minimization
  section updated to match the contract.
- `.claude/skills/issue-authoring/references/{contract,draft-patterns}.md`:
  regenerated byte-for-byte via `node scripts/sync-docs.mjs --apply`.

Authoring-side only — no new marker, consistent with the contract's stance
of reserving markers for true start blockers.

## Verification

- `node scripts/audit-docs.mjs --check` passes (sync pairs + `contains`
  anchors intact).
- `pnpm run lint:minimum` passes locally.

Closes #1153
