### PR TITLE
feat(discover): add a --swarm-floor eligibility sweep query

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -220,7 +220,12 @@ default below is unchanged.
   - `summary`: `{ rootCount: number, leafCount: number,`
     `scoredLeafCount: number, sharedLeafCount: number,`
     `duplicateReferenceCount: number, cycleCount: number,`
-    `inaccessibleReferenceCount: number, unresolvedReferenceCount: number }`
+    `inaccessibleReferenceCount: number, unresolvedReferenceCount: number }`.
+    Under `--with-readiness` the summary additionally carries
+    `startableCount` and `readyCount` (integers aggregating the leaves'
+    `readiness.startable` / `readiness.ready`), so a swarm controller reads
+    "is there more startable work?" without iterating every leaf; both are
+    absent otherwise so the flag-absent shape stays byte-stable.
   - **Ranking** (global-by-score): `leaves` is sorted by
     `autopilotSuitability` **descending**, tie-broken by issue number
     **ascending** (stable). A missing or out-of-range score is treated as
@@ -245,6 +250,34 @@ default below is unchanged.
   parsing; a zero-byte or partial read from a still-running (or
   just-finished) helper means **"still running," not** an A2 enumeration
   failure.
+
+### Discover Readiness Sweep (`--swarm-floor`)
+
+`scripts/discover-readiness-check.mjs --swarm-floor <N>` is the canonical
+end-of-session "is any startable work left?" one-liner. It ignores
+`--issue` / `--issues`, sweeps **every** open issue in the repository
+(orphans included, pull requests excluded), runs the same A3 readiness plus
+autopilot-suitability evaluation, and reports the issues that are ready
+**and** at or above floor `N`:
+
+```sh
+node scripts/discover-readiness-check.mjs --swarm-floor <N>
+```
+
+- **Output**: `{ eligible, eligible_count, total }` — `eligible` is the
+  ready-and-at/above-floor set (each `{ number, title, autopilotSuitability,
+  belowFloor }`), `eligible_count` its length, and `total` the number of open
+  issues swept. A "no score" issue is never below floor, matching the
+  discovery ranker, so it stays eligible.
+- **Use**: an `eligible_count == 0` result means Discover has no startable
+  work at floor `N`, so an autopilot / swarm loop may stop scriptably.
+- **Floor range**: `N` is the autopilot-suitability 1-5 band. A non-integer
+  or out-of-range `N` is a **hard error**, not a silent coercion to the
+  default floor — otherwise a typo (e.g. `--swarm-floor 50`) would quietly
+  answer at floor 3 and be misread as "floor-50 work exists."
+- **Boundary**: read-only and advisory — selecting the next issue still runs
+  the A3/A4/A4.5/A5 gates. Optional flags: `--owner` / `--repo` / `--policy`
+  / `--now`.
 
 ### Discover Viability Gate Contract
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -220,7 +220,12 @@ default below is unchanged.
   - `summary`: `{ rootCount: number, leafCount: number,`
     `scoredLeafCount: number, sharedLeafCount: number,`
     `duplicateReferenceCount: number, cycleCount: number,`
-    `inaccessibleReferenceCount: number, unresolvedReferenceCount: number }`
+    `inaccessibleReferenceCount: number, unresolvedReferenceCount: number }`.
+    Under `--with-readiness` the summary additionally carries
+    `startableCount` and `readyCount` (integers aggregating the leaves'
+    `readiness.startable` / `readiness.ready`), so a swarm controller reads
+    "is there more startable work?" without iterating every leaf; both are
+    absent otherwise so the flag-absent shape stays byte-stable.
   - **Ranking** (global-by-score): `leaves` is sorted by
     `autopilotSuitability` **descending**, tie-broken by issue number
     **ascending** (stable). A missing or out-of-range score is treated as
@@ -245,6 +250,34 @@ default below is unchanged.
   parsing; a zero-byte or partial read from a still-running (or
   just-finished) helper means **"still running," not** an A2 enumeration
   failure.
+
+### Discover Readiness Sweep (`--swarm-floor`)
+
+`scripts/discover-readiness-check.mjs --swarm-floor <N>` is the canonical
+end-of-session "is any startable work left?" one-liner. It ignores
+`--issue` / `--issues`, sweeps **every** open issue in the repository
+(orphans included, pull requests excluded), runs the same A3 readiness plus
+autopilot-suitability evaluation, and reports the issues that are ready
+**and** at or above floor `N`:
+
+```sh
+node scripts/discover-readiness-check.mjs --swarm-floor <N>
+```
+
+- **Output**: `{ eligible, eligible_count, total }` — `eligible` is the
+  ready-and-at/above-floor set (each `{ number, title, autopilotSuitability,
+  belowFloor }`), `eligible_count` its length, and `total` the number of open
+  issues swept. A "no score" issue is never below floor, matching the
+  discovery ranker, so it stays eligible.
+- **Use**: an `eligible_count == 0` result means Discover has no startable
+  work at floor `N`, so an autopilot / swarm loop may stop scriptably.
+- **Floor range**: `N` is the autopilot-suitability 1-5 band. A non-integer
+  or out-of-range `N` is a **hard error**, not a silent coercion to the
+  default floor — otherwise a typo (e.g. `--swarm-floor 50`) would quietly
+  answer at floor 3 and be misread as "floor-50 work exists."
+- **Boundary**: read-only and advisory — selecting the next issue still runs
+  the A3/A4/A4.5/A5 gates. Optional flags: `--owner` / `--repo` / `--policy`
+  / `--now`.
 
 ### Discover Viability Gate Contract
 

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -327,6 +327,16 @@
           "type": "integer",
           "minimum": 0
         },
+        "startableCount": {
+          "description": "Count of union leaves with readiness.startable === true; present only under --with-readiness, absent otherwise so the flag-absent output stays byte-stable.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "readyCount": {
+          "description": "Count of union leaves with readiness.ready === true; present only under --with-readiness, absent otherwise.",
+          "type": "integer",
+          "minimum": 0
+        },
         "duplicateReferenceCount": {
           "type": "integer",
           "minimum": 0

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -26,7 +26,7 @@ const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
-  if (args.issueNumbers.length === 0) {
+  if (args.swarmFloor === null && args.issueNumbers.length === 0) {
     throw new Error(
       'missing required --issue <number> (repeatable) or --issues <n1,n2,...>',
     );
@@ -39,7 +39,13 @@ if (isMainModule(import.meta.url)) {
   const policyConfig = loadPolicy(args.policy);
   const authoringPolicy = resolveAuthoringGuardPolicy(policyConfig);
   const markerPrefix = resolveMarkerPrefix(policyConfig);
-  const summary = await evaluateDiscoverReadiness(args.issueNumbers, {
+  // `--swarm-floor` sweeps every open issue (orphans included); otherwise
+  // evaluate exactly the issues the caller named.
+  const issueNumbers =
+    args.swarmFloor === null
+      ? args.issueNumbers
+      : listOpenIssueNumbers(owner, repo);
+  const summary = await evaluateDiscoverReadiness(issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
     loadIssue: buildIssueLoader(owner, repo),
     loadIssueLabelEvents: buildIssueLabelEventsLoader(owner, repo),
@@ -47,11 +53,16 @@ if (isMainModule(import.meta.url)) {
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
     markerPrefix,
-    autopilotSuitabilityFloor: resolveSuitabilityFloor(policyConfig),
+    autopilotSuitabilityFloor:
+      args.swarmFloor ?? resolveSuitabilityFloor(policyConfig),
     autopilotSuitabilityEnabled: resolveSuitabilityEnabled(policyConfig),
     now: args.now || new Date(),
   });
-  if (args.csv) {
+  if (args.swarmFloor !== null) {
+    process.stdout.write(
+      `${JSON.stringify(summarizeSwarmFloorEligibility(summary), null, 2)}\n`,
+    );
+  } else if (args.csv) {
     process.stdout.write(renderCsv(summary));
   } else {
     process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
@@ -264,6 +275,36 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     },
   };
 }
+/**
+ * Reduce a full readiness summary to the swarm-floor answer: the ready issues
+ * at or above the configured floor (a "no score" issue is never below floor,
+ * so it stays eligible, matching the discovery ranker), plus counts. Pure so
+ * the `--swarm-floor` CLI sweep and the tests share one definition.
+ */
+export function summarizeSwarmFloorEligibility(summary) {
+  const eligible = summary.ready.filter((issue) => !issue.belowFloor);
+  return {
+    eligible,
+    eligible_count: eligible.length,
+    total: summary.summary.total,
+  };
+}
+/**
+ * Parse and range-check the `--swarm-floor <N>` value. The floor is the
+ * autopilot-suitability 1-5 band, so a non-integer, fractional, or
+ * out-of-range value is a hard error rather than being silently coerced to
+ * the default floor — coercion would loosen the eligibility gate on a typo
+ * (e.g. `--swarm-floor 50` quietly answering at floor 3), which is exactly
+ * the mis-read this stop-condition query must avoid.
+ */
+export function parseSwarmFloorArg(value) {
+  const raw = String(value ?? '').trim();
+  const floor = Number.parseInt(raw, 10);
+  if (!/^\d+$/.test(raw) || floor < 1 || floor > 5) {
+    throw new Error('--swarm-floor requires an integer 1-5');
+  }
+  return floor;
+}
 export function extractBlockedByIssueNumbers(body) {
   const matches = body.matchAll(/^\s*Blocked by\s+#(\d+)\b/gim);
   return dedupeNumbers(
@@ -307,6 +348,7 @@ function parseArgs(argv) {
     repo: '',
     policy: '',
     now: '',
+    swarmFloor: null,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -341,6 +383,11 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (token === '--swarm-floor') {
+      parsed.swarmFloor = parseSwarmFloorArg(value ?? '');
+      index += 1;
+      continue;
+    }
     if (token === '--include-unresolvable') {
       parsed.includeUnresolvable = true;
       continue;
@@ -365,6 +412,15 @@ function printHelp() {
   node scripts/discover-readiness-check.mjs --issue <number> [--issue <number> ...]
   node scripts/discover-readiness-check.mjs --issues <n1,n2,...>
     [--include-unresolvable] [--csv] [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>]
+  node scripts/discover-readiness-check.mjs --swarm-floor <N>
+    [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>]
+
+  --swarm-floor <N> ignores --issue/--issues, sweeps every open issue in the
+  repository (orphans included, pull requests excluded), runs readiness, and
+  reports the ready issues at or above autopilot-suitability floor N (an
+  integer 1-5) in one call. An out-of-range or non-integer N is a hard error
+  rather than a silent coercion. A "no score" issue is never below floor,
+  matching discovery ranking.
 
 Output schema (JSON mode):
   {
@@ -373,6 +429,13 @@ Output schema (JSON mode):
     "unresolvable": [{ "issueNumber": 124, "kind": "...", "reference": "...", "reason": "..." }],
     "warnings": [{ "issueNumber": 124, "message": "Warning: ..." }],
     "summary": { "total": 2, "readyCount": 1, "filteredCount": 1, "unresolvableCount": 0, "filteredByReason": { "...": 1 } }
+  }
+
+Output schema (--swarm-floor mode):
+  {
+    "eligible": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false }],
+    "eligible_count": 1,
+    "total": 7
   }
 `);
 }
@@ -580,6 +643,24 @@ export function buildRoadmapMarkerResolver(owner, repo, markerPrefix) {
     ]).trim();
     return JSON.parse(result || '[]');
   };
+}
+/**
+ * Every open issue number in the repository, orphans included. `--paginate`
+ * walks all pages; `select(.pull_request == null)` drops pull requests, which
+ * the REST issues endpoint otherwise returns alongside issues. Used by the
+ * `--swarm-floor` sweep to answer "is there any eligible work left?".
+ */
+function listOpenIssueNumbers(owner, repo) {
+  const raw = ghText([
+    'api',
+    '--paginate',
+    `repos/${owner}/${repo}/issues?state=open&per_page=100`,
+    '--jq',
+    '.[] | select(.pull_request == null) | .number',
+  ]);
+  return dedupeNumbers(
+    raw.split('\n').map((line) => Number.parseInt(line.trim(), 10)),
+  );
 }
 function ghText(args) {
   return runGh(args).trim();

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -726,13 +726,25 @@ export function buildRoadmapMarkerResolver(owner, repo, markerPrefix) {
  * `--swarm-floor` sweep to answer "is there any eligible work left?".
  */
 function listOpenIssueNumbers(owner, repo) {
-  const raw = ghText([
-    'api',
-    '--paginate',
-    `repos/${owner}/${repo}/issues?state=open&per_page=100`,
-    '--jq',
-    '.[] | select(.pull_request == null) | .number',
-  ]);
+  return parseIssueNumberLines(
+    ghText([
+      'api',
+      '--paginate',
+      `repos/${owner}/${repo}/issues?state=open&per_page=100`,
+      '--jq',
+      '.[] | select(.pull_request == null) | .number',
+    ]),
+  );
+}
+/**
+ * Parse the newline-delimited issue numbers emitted by the
+ * `listOpenIssueNumbers` `gh api --jq` sweep into a deduped list of positive
+ * integers. Blank lines and any non-numeric output are dropped (via
+ * `dedupeNumbers`), so an empty sweep yields `[]`. Exported so the parse
+ * contract is unit-testable without a live `gh` call — pull requests are
+ * already excluded upstream by the `select(.pull_request == null)` jq filter.
+ */
+export function parseIssueNumberLines(raw) {
   return dedupeNumbers(
     raw.split('\n').map((line) => Number.parseInt(line.trim(), 10)),
   );

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -48,7 +48,15 @@ if (isMainModule(import.meta.url)) {
   const summary = await evaluateDiscoverReadiness(issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
     loadIssue: buildIssueLoader(owner, repo),
-    loadIssueLabelEvents: buildIssueLabelEventsLoader(owner, repo),
+    // `--swarm-floor` output never surfaces the stale-authoring warning, so
+    // skip the per-issue timeline fetch this loader runs — over a whole-repo
+    // sweep that is one extra paginated API call per open issue. The
+    // authoring-label *filter* reads issue labels (always loaded), so
+    // eligibility is unchanged; only the unsurfaced warning is dropped.
+    loadIssueLabelEvents:
+      args.swarmFloor === null
+        ? buildIssueLabelEventsLoader(owner, repo)
+        : undefined,
     findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo, markerPrefix),
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -739,14 +739,19 @@ function listOpenIssueNumbers(owner, repo) {
 /**
  * Parse the newline-delimited issue numbers emitted by the
  * `listOpenIssueNumbers` `gh api --jq` sweep into a deduped list of positive
- * integers. Blank lines and any non-numeric output are dropped (via
- * `dedupeNumbers`), so an empty sweep yields `[]`. Exported so the parse
+ * integers. Only **full-integer** lines are kept: blank, partially-numeric
+ * (`5abc`), or non-positive lines are dropped rather than truncated by
+ * `Number.parseInt`, so an empty sweep yields `[]`. Exported so the parse
  * contract is unit-testable without a live `gh` call — pull requests are
  * already excluded upstream by the `select(.pull_request == null)` jq filter.
  */
 export function parseIssueNumberLines(raw) {
   return dedupeNumbers(
-    raw.split('\n').map((line) => Number.parseInt(line.trim(), 10)),
+    raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => /^\d+$/.test(line))
+      .map((line) => Number.parseInt(line, 10)),
   );
 }
 function ghText(args) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -734,6 +734,20 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
   const sharedLeafCount = leaves.filter(
     (leaf) => leaf.sourceRoots.length > 1,
   ).length;
+  // Only meaningful when readiness was annotated above; the same gate keeps
+  // the flag-absent summary byte-stable (both counts stay absent).
+  const readinessAnnotated = Boolean(
+    options.readiness && typeof options.loadIssue === 'function',
+  );
+  const readinessCounts = readinessAnnotated
+    ? {
+        startableCount: leaves.filter(
+          (leaf) => leaf.readiness?.startable === true,
+        ).length,
+        readyCount: leaves.filter((leaf) => leaf.readiness?.ready === true)
+          .length,
+      }
+    : {};
   return {
     mode: 'all-roadmaps',
     roots: roots.sort(compareByNumber),
@@ -755,6 +769,7 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
       leafCount: leaves.length,
       scoredLeafCount,
       sharedLeafCount,
+      ...readinessCounts,
       duplicateReferenceCount: duplicateReferences.size,
       cycleCount: cycles.size,
       inaccessibleReferenceCount: inaccessibleReferences.size,
@@ -1474,6 +1489,9 @@ top-level shape from the single-root report above):
       "unresolvedReferenceCount": 0
     }
   }
+  (Under --with-readiness the summary also carries "startableCount" and
+  "readyCount" aggregating the union leaves' readiness; both are absent
+  otherwise so the flag-absent output stays byte-stable.)
 `);
 }
 function normalizeIssue(issue) {

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -150,7 +150,15 @@ if (isMainModule(import.meta.url)) {
   const summary = await evaluateDiscoverReadiness(issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
     loadIssue: buildIssueLoader(owner, repo),
-    loadIssueLabelEvents: buildIssueLabelEventsLoader(owner, repo),
+    // `--swarm-floor` output never surfaces the stale-authoring warning, so
+    // skip the per-issue timeline fetch this loader runs — over a whole-repo
+    // sweep that is one extra paginated API call per open issue. The
+    // authoring-label *filter* reads issue labels (always loaded), so
+    // eligibility is unchanged; only the unsurfaced warning is dropped.
+    loadIssueLabelEvents:
+      args.swarmFloor === null
+        ? buildIssueLabelEventsLoader(owner, repo)
+        : undefined,
     findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo, markerPrefix),
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -935,14 +935,19 @@ function listOpenIssueNumbers(owner: string, repo: string): number[] {
 /**
  * Parse the newline-delimited issue numbers emitted by the
  * `listOpenIssueNumbers` `gh api --jq` sweep into a deduped list of positive
- * integers. Blank lines and any non-numeric output are dropped (via
- * `dedupeNumbers`), so an empty sweep yields `[]`. Exported so the parse
+ * integers. Only **full-integer** lines are kept: blank, partially-numeric
+ * (`5abc`), or non-positive lines are dropped rather than truncated by
+ * `Number.parseInt`, so an empty sweep yields `[]`. Exported so the parse
  * contract is unit-testable without a live `gh` call — pull requests are
  * already excluded upstream by the `select(.pull_request == null)` jq filter.
  */
 export function parseIssueNumberLines(raw: string): number[] {
   return dedupeNumbers(
-    raw.split('\n').map((line) => Number.parseInt(line.trim(), 10)),
+    raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => /^\d+$/.test(line))
+      .map((line) => Number.parseInt(line, 10)),
   );
 }
 

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -921,13 +921,26 @@ export function buildRoadmapMarkerResolver(
  * `--swarm-floor` sweep to answer "is there any eligible work left?".
  */
 function listOpenIssueNumbers(owner: string, repo: string): number[] {
-  const raw = ghText([
-    'api',
-    '--paginate',
-    `repos/${owner}/${repo}/issues?state=open&per_page=100`,
-    '--jq',
-    '.[] | select(.pull_request == null) | .number',
-  ]);
+  return parseIssueNumberLines(
+    ghText([
+      'api',
+      '--paginate',
+      `repos/${owner}/${repo}/issues?state=open&per_page=100`,
+      '--jq',
+      '.[] | select(.pull_request == null) | .number',
+    ]),
+  );
+}
+
+/**
+ * Parse the newline-delimited issue numbers emitted by the
+ * `listOpenIssueNumbers` `gh api --jq` sweep into a deduped list of positive
+ * integers. Blank lines and any non-numeric output are dropped (via
+ * `dedupeNumbers`), so an empty sweep yields `[]`. Exported so the parse
+ * contract is unit-testable without a live `gh` call — pull requests are
+ * already excluded upstream by the `select(.pull_request == null)` jq filter.
+ */
+export function parseIssueNumberLines(raw: string): number[] {
   return dedupeNumbers(
     raw.split('\n').map((line) => Number.parseInt(line.trim(), 10)),
   );

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -115,13 +115,17 @@ interface ParsedArgs {
   repo: string;
   policy: string;
   now: string;
+  // `--swarm-floor <N>`: when set, the CLI ignores the `--issue`/`--issues`
+  // requirement, sweeps every open issue (orphans included), and reports the
+  // at-or-above-floor eligible set. `null` keeps the default per-issue mode.
+  swarmFloor: number | null;
 }
 
 type CachedIssue = NormalizedIssue | InaccessibleIssueSentinel | null;
 
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
-  if (args.issueNumbers.length === 0) {
+  if (args.swarmFloor === null && args.issueNumbers.length === 0) {
     throw new Error(
       'missing required --issue <number> (repeatable) or --issues <n1,n2,...>',
     );
@@ -136,7 +140,14 @@ if (isMainModule(import.meta.url)) {
   const authoringPolicy = resolveAuthoringGuardPolicy(policyConfig);
   const markerPrefix = resolveMarkerPrefix(policyConfig);
 
-  const summary = await evaluateDiscoverReadiness(args.issueNumbers, {
+  // `--swarm-floor` sweeps every open issue (orphans included); otherwise
+  // evaluate exactly the issues the caller named.
+  const issueNumbers =
+    args.swarmFloor === null
+      ? args.issueNumbers
+      : listOpenIssueNumbers(owner, repo);
+
+  const summary = await evaluateDiscoverReadiness(issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
     loadIssue: buildIssueLoader(owner, repo),
     loadIssueLabelEvents: buildIssueLabelEventsLoader(owner, repo),
@@ -144,12 +155,17 @@ if (isMainModule(import.meta.url)) {
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
     markerPrefix,
-    autopilotSuitabilityFloor: resolveSuitabilityFloor(policyConfig),
+    autopilotSuitabilityFloor:
+      args.swarmFloor ?? resolveSuitabilityFloor(policyConfig),
     autopilotSuitabilityEnabled: resolveSuitabilityEnabled(policyConfig),
     now: args.now || new Date(),
   });
 
-  if (args.csv) {
+  if (args.swarmFloor !== null) {
+    process.stdout.write(
+      `${JSON.stringify(summarizeSwarmFloorEligibility(summary), null, 2)}\n`,
+    );
+  } else if (args.csv) {
     process.stdout.write(renderCsv(summary));
   } else {
     process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
@@ -378,6 +394,46 @@ export async function evaluateDiscoverReadiness(
   };
 }
 
+export interface SwarmFloorEligibility {
+  eligible: ReadinessReadyIssue[];
+  eligible_count: number;
+  total: number;
+}
+
+/**
+ * Reduce a full readiness summary to the swarm-floor answer: the ready issues
+ * at or above the configured floor (a "no score" issue is never below floor,
+ * so it stays eligible, matching the discovery ranker), plus counts. Pure so
+ * the `--swarm-floor` CLI sweep and the tests share one definition.
+ */
+export function summarizeSwarmFloorEligibility(
+  summary: ReadinessSummary,
+): SwarmFloorEligibility {
+  const eligible = summary.ready.filter((issue) => !issue.belowFloor);
+  return {
+    eligible,
+    eligible_count: eligible.length,
+    total: summary.summary.total,
+  };
+}
+
+/**
+ * Parse and range-check the `--swarm-floor <N>` value. The floor is the
+ * autopilot-suitability 1-5 band, so a non-integer, fractional, or
+ * out-of-range value is a hard error rather than being silently coerced to
+ * the default floor — coercion would loosen the eligibility gate on a typo
+ * (e.g. `--swarm-floor 50` quietly answering at floor 3), which is exactly
+ * the mis-read this stop-condition query must avoid.
+ */
+export function parseSwarmFloorArg(value: string): number {
+  const raw = String(value ?? '').trim();
+  const floor = Number.parseInt(raw, 10);
+  if (!/^\d+$/.test(raw) || floor < 1 || floor > 5) {
+    throw new Error('--swarm-floor requires an integer 1-5');
+  }
+  return floor;
+}
+
 export function extractBlockedByIssueNumbers(body: string): number[] {
   const matches = body.matchAll(/^\s*Blocked by\s+#(\d+)\b/gim);
   return dedupeNumbers(
@@ -424,6 +480,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     repo: string;
     policy: string;
     now: string;
+    swarmFloor: number | null;
   } = {
     issueNumbers: [],
     includeUnresolvable: false,
@@ -432,6 +489,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     repo: '',
     policy: '',
     now: '',
+    swarmFloor: null,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -467,6 +525,11 @@ function parseArgs(argv: string[]): ParsedArgs {
       index += 1;
       continue;
     }
+    if (token === '--swarm-floor') {
+      parsed.swarmFloor = parseSwarmFloorArg(value ?? '');
+      index += 1;
+      continue;
+    }
     if (token === '--include-unresolvable') {
       parsed.includeUnresolvable = true;
       continue;
@@ -493,6 +556,15 @@ function printHelp() {
   node scripts/discover-readiness-check.mjs --issue <number> [--issue <number> ...]
   node scripts/discover-readiness-check.mjs --issues <n1,n2,...>
     [--include-unresolvable] [--csv] [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>]
+  node scripts/discover-readiness-check.mjs --swarm-floor <N>
+    [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>]
+
+  --swarm-floor <N> ignores --issue/--issues, sweeps every open issue in the
+  repository (orphans included, pull requests excluded), runs readiness, and
+  reports the ready issues at or above autopilot-suitability floor N (an
+  integer 1-5) in one call. An out-of-range or non-integer N is a hard error
+  rather than a silent coercion. A "no score" issue is never below floor,
+  matching discovery ranking.
 
 Output schema (JSON mode):
   {
@@ -501,6 +573,13 @@ Output schema (JSON mode):
     "unresolvable": [{ "issueNumber": 124, "kind": "...", "reference": "...", "reason": "..." }],
     "warnings": [{ "issueNumber": 124, "message": "Warning: ..." }],
     "summary": { "total": 2, "readyCount": 1, "filteredCount": 1, "unresolvableCount": 0, "filteredByReason": { "...": 1 } }
+  }
+
+Output schema (--swarm-floor mode):
+  {
+    "eligible": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false }],
+    "eligible_count": 1,
+    "total": 7
   }
 `);
 }
@@ -755,6 +834,25 @@ export function buildRoadmapMarkerResolver(
     ]).trim();
     return JSON.parse(result || '[]');
   };
+}
+
+/**
+ * Every open issue number in the repository, orphans included. `--paginate`
+ * walks all pages; `select(.pull_request == null)` drops pull requests, which
+ * the REST issues endpoint otherwise returns alongside issues. Used by the
+ * `--swarm-floor` sweep to answer "is there any eligible work left?".
+ */
+function listOpenIssueNumbers(owner: string, repo: string): number[] {
+  const raw = ghText([
+    'api',
+    '--paginate',
+    `repos/${owner}/${repo}/issues?state=open&per_page=100`,
+    '--jq',
+    '.[] | select(.pull_request == null) | .number',
+  ]);
+  return dedupeNumbers(
+    raw.split('\n').map((line) => Number.parseInt(line.trim(), 10)),
+  );
 }
 
 function ghText(args: string[]): string {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -364,6 +364,13 @@ export interface RoadmapGraphUnionReport {
     leafCount: number;
     scoredLeafCount: number;
     sharedLeafCount: number;
+    // Aggregate readiness counts over the union leaves. Present only when
+    // `--with-readiness` annotated them; absent otherwise (like the per-leaf
+    // `readiness` field) so the flag-absent output stays byte-stable. Let a
+    // swarm controller read "is there more startable work?" without iterating
+    // every leaf.
+    startableCount?: number;
+    readyCount?: number;
     duplicateReferenceCount: number;
     cycleCount: number;
     inaccessibleReferenceCount: number;
@@ -1193,6 +1200,20 @@ export async function enumerateAllRoadmapsGraph(
   const sharedLeafCount = leaves.filter(
     (leaf) => leaf.sourceRoots.length > 1,
   ).length;
+  // Only meaningful when readiness was annotated above; the same gate keeps
+  // the flag-absent summary byte-stable (both counts stay absent).
+  const readinessAnnotated = Boolean(
+    options.readiness && typeof options.loadIssue === 'function',
+  );
+  const readinessCounts = readinessAnnotated
+    ? {
+        startableCount: leaves.filter(
+          (leaf) => leaf.readiness?.startable === true,
+        ).length,
+        readyCount: leaves.filter((leaf) => leaf.readiness?.ready === true)
+          .length,
+      }
+    : {};
 
   return {
     mode: 'all-roadmaps',
@@ -1215,6 +1236,7 @@ export async function enumerateAllRoadmapsGraph(
       leafCount: leaves.length,
       scoredLeafCount,
       sharedLeafCount,
+      ...readinessCounts,
       duplicateReferenceCount: duplicateReferences.size,
       cycleCount: cycles.size,
       inaccessibleReferenceCount: inaccessibleReferences.size,
@@ -2047,6 +2069,9 @@ top-level shape from the single-root report above):
       "unresolvedReferenceCount": 0
     }
   }
+  (Under --with-readiness the summary also carries "startableCount" and
+  "readyCount" aggregating the union leaves' readiness; both are absent
+  otherwise so the flag-absent output stays byte-stable.)
 `);
 }
 

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -864,4 +864,7 @@ test('parseIssueNumberLines dedupes positive integers and yields [] on empty out
   assert.deepEqual(parseIssueNumberLines('  42 \n\n 7 \n'), [42, 7]);
   // Non-numeric or non-positive lines are dropped (fail-safe parsing).
   assert.deepEqual(parseIssueNumberLines('5\nabc\n-1\n0\n8'), [5, 8]);
+  // A partially-numeric line is dropped whole, not truncated by parseInt:
+  // `99abc` must NOT become `99`.
+  assert.deepEqual(parseIssueNumberLines('99abc\n7'), [7]);
 });

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -8,6 +8,8 @@ import {
   extractBlockedByRoadmapMarkers,
   extractDependencyIssueNumbers,
   isInaccessibleIssueLookupError,
+  parseSwarmFloorArg,
+  summarizeSwarmFloorEligibility,
 } from '../src/scripts/discover-readiness-check.mts';
 
 // Shape of a wrapped runGh failure: process exit code 1 with the true
@@ -617,4 +619,130 @@ test('forces a neutral signal when the suitability kill switch is off', async ()
       belowFloor: false,
     },
   ]);
+});
+
+test('summarizeSwarmFloorEligibility keeps ready issues at or above the floor', () => {
+  // `belowFloor` drives eligibility: a scored-below-floor issue is dropped,
+  // while an at/above-floor score and a no-score (belowFloor:false) issue stay.
+  const result = summarizeSwarmFloorEligibility({
+    ready: [
+      {
+        number: 10,
+        title: 'above',
+        autopilotSuitability: 5,
+        belowFloor: false,
+      },
+      { number: 20, title: 'below', autopilotSuitability: 2, belowFloor: true },
+      {
+        number: 30,
+        title: 'no score',
+        autopilotSuitability: null,
+        belowFloor: false,
+      },
+    ],
+    filteredOut: [],
+    unresolvable: [],
+    warnings: [],
+    summary: {
+      total: 4,
+      readyCount: 3,
+      filteredCount: 1,
+      unresolvableCount: 0,
+      filteredByReason: { 'label:status:needs-decision': 1 },
+    },
+  });
+
+  assert.deepEqual(result, {
+    eligible: [
+      {
+        number: 10,
+        title: 'above',
+        autopilotSuitability: 5,
+        belowFloor: false,
+      },
+      {
+        number: 30,
+        title: 'no score',
+        autopilotSuitability: null,
+        belowFloor: false,
+      },
+    ],
+    eligible_count: 2,
+    total: 4,
+  });
+});
+
+test('swarm-floor sweep filters a swept issue set by the floor', async () => {
+  const issues = new Map([
+    [
+      10,
+      {
+        number: 10,
+        title: 'above floor',
+        state: 'OPEN',
+        body: '<!-- idd-skill-autopilot-suitability: 5 -->',
+        labels: [],
+      },
+    ],
+    [
+      20,
+      {
+        number: 20,
+        title: 'below floor',
+        state: 'OPEN',
+        body: '<!-- idd-skill-autopilot-suitability: 2 -->',
+        labels: [],
+      },
+    ],
+    [
+      30,
+      {
+        number: 30,
+        title: 'no score',
+        state: 'OPEN',
+        body: 'unscored',
+        labels: [],
+      },
+    ],
+    [
+      40,
+      {
+        number: 40,
+        title: 'blocked',
+        state: 'OPEN',
+        body: 'x',
+        labels: [{ name: 'status:needs-decision' }],
+      },
+    ],
+  ]);
+  const summary = await evaluateDiscoverReadiness([10, 20, 30, 40], {
+    autopilotSuitabilityFloor: 3,
+    loadIssue: async (number) => issues.get(number) ?? null,
+    findRoadmapsByMarker: async () => [],
+  });
+  const result = summarizeSwarmFloorEligibility(summary);
+
+  // #20 is ready but below the floor (dropped); #40 is filtered out (blocked);
+  // #10 (scored >= floor) and #30 (no score) stay eligible.
+  assert.deepEqual(
+    result.eligible.map((issue) => issue.number),
+    [10, 30],
+  );
+  assert.equal(result.eligible_count, 2);
+  assert.equal(result.total, 4);
+});
+
+test('parseSwarmFloorArg accepts 1-5 and rejects out-of-range or non-integer values', () => {
+  // In-band integers pass through.
+  for (const n of [1, 2, 3, 4, 5]) {
+    assert.equal(parseSwarmFloorArg(String(n)), n);
+  }
+  // Out-of-range and non-integer inputs are hard errors, not silent coercion
+  // to the default floor (which would loosen the eligibility gate on a typo).
+  for (const bad of ['0', '6', '50', '-1', '3.5', '', '  ', 'abc', '3abc']) {
+    assert.throws(
+      () => parseSwarmFloorArg(bad),
+      /--swarm-floor requires an integer 1-5/,
+    );
+  }
 });

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -8,6 +8,7 @@ import {
   extractBlockedByRoadmapMarkers,
   extractDependencyIssueNumbers,
   isInaccessibleIssueLookupError,
+  parseIssueNumberLines,
   parseSwarmFloorArg,
   summarizeSwarmFloorEligibility,
 } from '../src/scripts/discover-readiness-check.mts';
@@ -852,4 +853,15 @@ test('parseSwarmFloorArg accepts 1-5 and rejects out-of-range or non-integer val
       /--swarm-floor requires an integer 1-5/,
     );
   }
+});
+
+test('parseIssueNumberLines dedupes positive integers and yields [] on empty output', () => {
+  // Empty / whitespace-only sweep output → no issues (the swarm loop stops).
+  assert.deepEqual(parseIssueNumberLines(''), []);
+  assert.deepEqual(parseIssueNumberLines('   \n\n  '), []);
+  // Newline-delimited numbers are parsed, trimmed, and de-duplicated in order.
+  assert.deepEqual(parseIssueNumberLines('10\n20\n10\n30'), [10, 20, 30]);
+  assert.deepEqual(parseIssueNumberLines('  42 \n\n 7 \n'), [42, 7]);
+  // Non-numeric or non-positive lines are dropped (fail-safe parsing).
+  assert.deepEqual(parseIssueNumberLines('5\nabc\n-1\n0\n8'), [5, 8]);
 });

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -1868,6 +1868,9 @@ test('--with-readiness annotates open union leaves with a combined startable sig
   assert.equal(r923?.startable, false);
   assert.equal(r923?.authoringHeld, true);
   assert.ok(r923?.reasons.includes('label:status:authoring'));
+  // The summary aggregates the same signal: only 921 is ready and startable.
+  assert.equal(report.summary.readyCount, 1);
+  assert.equal(report.summary.startableCount, 1);
 });
 
 test('--with-readiness is byte-stable when the flag is absent', async () => {
@@ -1883,6 +1886,11 @@ test('--with-readiness is byte-stable when the flag is absent', async () => {
       false,
     );
   }
+  // The summary aggregate counts are likewise absent without the flag, so the
+  // flag-absent output shape is unchanged.
+  const summaryKeys = report.summary as unknown as Record<string, unknown>;
+  assert.equal(Object.hasOwn(summaryKeys, 'startableCount'), false);
+  assert.equal(Object.hasOwn(summaryKeys, 'readyCount'), false);
 });
 
 test('startable folds in claimEligible: a ready but claimed leaf is not startable', async () => {


### PR DESCRIPTION
## Summary

Adds a one-read "is there more eligible work?" query to the discover
helpers, so an autopilot / swarm controller can decide to stop at the end
of a Discover pass without re-deriving a multi-step pipeline each session.

## Changes

- **`discover-readiness-check` `--swarm-floor <N>` mode**: ignores
  `--issue` / `--issues`, sweeps **all** open issues (orphans included, PRs
  excluded via `select(.pull_request == null)`), runs A3 readiness, and
  prints `{ eligible, eligible_count, total }` for the ready-and-at/above
  -floor set. A "no score" issue is never below floor, matching the
  discovery ranker. Exposes pure `summarizeSwarmFloorEligibility` and
  `parseSwarmFloorArg`. An out-of-range/non-integer `N` is a **hard error**
  (not a silent coercion to the default floor, which would loosen the gate
  on a typo).
- **`discover-roadmap-graph` `--all-roadmaps` summary**: gains
  `startableCount` and `readyCount`, present only under `--with-readiness`
  and absent otherwise (matching the per-leaf `readiness` byte-stability
  convention). Union schema updated (`schemas/discover-roadmap-union`).
- **Docs**: `docs/idd-helper-scripts.md` documents the `--swarm-floor`
  one-liner and the summary counts.
- **Tests**: `summarizeSwarmFloorEligibility` (floor filtering + no-score),
  a swarm-floor end-to-end sweep, `parseSwarmFloorArg` range validation,
  and the `--all-roadmaps` summary counts (present + byte-stable-absent).

## Acceptance criteria

- [x] One helper call returns `{ eligible, eligible_count, total }` for a
  floor over all open issues including orphans.
- [x] `--all-roadmaps` summary includes `startableCount` (and `readyCount`).
- [x] The canonical end-of-session one-liner is documented.
- [x] No new helper added → no manifest/bin registration needed (both
  existing helpers extended, per the issue's "prefer extending").
- [x] Generated `.mjs` regenerated via `pnpm run build`; `pnpm test`,
  `pnpm run lint:minimum` pass.

## Deliberate deviation — doc placement

The issue asks for the one-liner in `idd-overview*.instructions.md`. That
file (`idd-overview-appendix`) is a member of the **`bundle-review`**
budget, which is already at **~99.8%** of its `limitBytes` — squarely in
the ≥95% band where
[policy-constants → Bundle-budget growth → Near-ceiling exception](docs/policy-constants.md)
says to **trim or split the addition rather than grow the always-resident
review/merge instruction floor**. `idd-discover` is likewise at ~99% of
its per-file phase cap. So the substance is documented in the uncapped
canonical helper-reference doc (`docs/idd-helper-scripts.md`) — where the
sibling discover helpers already live — and the helper `--help` output.
Happy to add a minimal `idd-overview` pointer (or ratchet the budget with
a callout) if you'd prefer the literal placement.

Closes #1152
