### PR TITLE
perf(idd): stream idd-doctor cleanup-backlog scan progress

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -143,7 +143,11 @@ future inventory reviews do not need to re-infer their role from code.
 
 - `scripts/idd-doctor.mjs` (`idd-doctor`) — onboarding and configuration
   diagnostics; reads repository config and helper runtime wiring, reports
-  gaps without mutating any state.
+  gaps without mutating any state. Its post-merge cleanup-backlog check
+  scans merged PRs in a default 14-day window with one serial `gh api`
+  call per PR and streams per-PR progress to stderr (stdout, including
+  `--json`, stays clean). For a local run during a merge burst, pass
+  `--cleanup-backlog-window-days 1` to keep it fast, mirroring CI.
 - `scripts/helper-runtime-manifest.mjs` (`idd-helper-bundle-manifest`) —
   import helper and manifest inspector; emits machine-readable helper wiring
   for `package-manager`, `vendored-node`, and `ephemeral-npx` profiles.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -143,7 +143,11 @@ future inventory reviews do not need to re-infer their role from code.
 
 - `scripts/idd-doctor.mjs` (`idd-doctor`) — onboarding and configuration
   diagnostics; reads repository config and helper runtime wiring, reports
-  gaps without mutating any state.
+  gaps without mutating any state. Its post-merge cleanup-backlog check
+  scans merged PRs in a default 14-day window with one serial `gh api`
+  call per PR and streams per-PR progress to stderr (stdout, including
+  `--json`, stays clean). For a local run during a merge burst, pass
+  `--cleanup-backlog-window-days 1` to keep it fast, mirroring CI.
 - `scripts/helper-runtime-manifest.mjs` (`idd-helper-bundle-manifest`) —
   import helper and manifest inspector; emits machine-readable helper wiring
   for `package-manager`, `vendored-node`, and `ephemeral-npx` profiles.

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -999,6 +999,31 @@ export function classifyBacklog(missingPrNumbers, warnThreshold) {
       : [],
   };
 }
+/**
+ * Preamble line announcing how many merged PRs the backlog scan will visit.
+ * Pure so tests can assert the exact wording without running the network scan.
+ */
+export function formatCleanupBacklogScanPreamble(total) {
+  const plural = total === 1 ? '' : 's';
+  return `post-merge cleanup backlog: scanning ${total} merged PR${plural} for F4 cleanup evidence…`;
+}
+/**
+ * Per-PR progress line for the backlog scan. Pure for the same reason as the
+ * preamble above.
+ */
+export function formatCleanupBacklogScanProgress(scanned, total, prNumber) {
+  return `  [${scanned}/${total}] merged PR #${prNumber}`;
+}
+/**
+ * Emit a backlog-scan progress line. It writes to **stderr** by default so the
+ * `--json` report on stdout stays machine-parseable — a slow network-bound scan
+ * is then distinguishable from a hang without polluting stdout. The `stream`
+ * parameter exists only so tests can capture the output and assert it never
+ * reaches stdout.
+ */
+export function emitCleanupBacklogProgress(line, stream = process.stderr) {
+  stream.write(`${line}\n`);
+}
 function checkPostMergeCleanupBacklog(root, options, report) {
   const windowDays = options.windowDays;
   const warnThreshold = options.warnThreshold;
@@ -1077,13 +1102,24 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   if (!Array.isArray(mergedPrs) || mergedPrs.length === 0) {
     return;
   }
+  // Stream per-PR progress to stderr so a slow, serial, network-bound scan of a
+  // large merge burst is distinguishable from a hang. Progress must stay on
+  // stderr so the `--json` report on stdout is never polluted.
+  emitCleanupBacklogProgress(
+    formatCleanupBacklogScanPreamble(mergedPrs.length),
+  );
   const missing = [];
   const evidenceFailures = [];
+  let scanned = 0;
   for (const pr of mergedPrs) {
     const number = pr?.number;
     if (!Number.isInteger(number)) {
       continue;
     }
+    scanned += 1;
+    emitCleanupBacklogProgress(
+      formatCleanupBacklogScanProgress(scanned, mergedPrs.length, number),
+    );
     const evidence = runCommand(
       'gh',
       [
@@ -1935,7 +1971,11 @@ results; repositories with > 1000 merged PRs in the window get a
 representative sample. The check makes one gh api .../comments
 call per merged PR returned, which is intentionally simple — for
 very large or rate-limited repos consider raising the warn
-threshold or shortening the window.
+threshold or shortening the window. The scan streams per-PR
+progress to stderr so a slow network-bound run is distinguishable
+from a hang; stdout (including --json) stays free of progress. For
+a local run during a merge burst, pass --cleanup-backlog-window-days 1
+to keep it fast, mirroring what CI already does.
 `);
 }
 function listFiles(root) {

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1174,6 +1174,41 @@ export function classifyBacklog(
   };
 }
 
+/**
+ * Preamble line announcing how many merged PRs the backlog scan will visit.
+ * Pure so tests can assert the exact wording without running the network scan.
+ */
+export function formatCleanupBacklogScanPreamble(total: number): string {
+  const plural = total === 1 ? '' : 's';
+  return `post-merge cleanup backlog: scanning ${total} merged PR${plural} for F4 cleanup evidence…`;
+}
+
+/**
+ * Per-PR progress line for the backlog scan. Pure for the same reason as the
+ * preamble above.
+ */
+export function formatCleanupBacklogScanProgress(
+  scanned: number,
+  total: number,
+  prNumber: number,
+): string {
+  return `  [${scanned}/${total}] merged PR #${prNumber}`;
+}
+
+/**
+ * Emit a backlog-scan progress line. It writes to **stderr** by default so the
+ * `--json` report on stdout stays machine-parseable — a slow network-bound scan
+ * is then distinguishable from a hang without polluting stdout. The `stream`
+ * parameter exists only so tests can capture the output and assert it never
+ * reaches stdout.
+ */
+export function emitCleanupBacklogProgress(
+  line: string,
+  stream: { write: (chunk: string) => unknown } = process.stderr,
+): void {
+  stream.write(`${line}\n`);
+}
+
 function checkPostMergeCleanupBacklog(
   root: string,
   options: {
@@ -1265,13 +1300,29 @@ function checkPostMergeCleanupBacklog(
     return;
   }
 
+  // Stream per-PR progress to stderr so a slow, serial, network-bound scan of a
+  // large merge burst is distinguishable from a hang. Progress must stay on
+  // stderr so the `--json` report on stdout is never polluted.
+  emitCleanupBacklogProgress(
+    formatCleanupBacklogScanPreamble(mergedPrs.length),
+  );
+
   const missing: number[] = [];
   const evidenceFailures: number[] = [];
+  let scanned = 0;
   for (const pr of mergedPrs) {
     const number = (pr as { number?: unknown } | null)?.number;
     if (!Number.isInteger(number)) {
       continue;
     }
+    scanned += 1;
+    emitCleanupBacklogProgress(
+      formatCleanupBacklogScanProgress(
+        scanned,
+        mergedPrs.length,
+        number as number,
+      ),
+    );
     const evidence = runCommand(
       'gh',
       [
@@ -2198,7 +2249,11 @@ results; repositories with > 1000 merged PRs in the window get a
 representative sample. The check makes one gh api .../comments
 call per merged PR returned, which is intentionally simple — for
 very large or rate-limited repos consider raising the warn
-threshold or shortening the window.
+threshold or shortening the window. The scan streams per-PR
+progress to stderr so a slow network-bound run is distinguishable
+from a hang; stdout (including --json) stays free of progress. For
+a local run during a merge burst, pass --cleanup-backlog-window-days 1
+to keep it fast, mirroring what CI already does.
 `);
 }
 

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -15,12 +15,15 @@ import {
   containsWorkshopReference,
   DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
   decodeGithubReadmeBase64,
+  emitCleanupBacklogProgress,
   evaluateAutopilotSuitabilityConsistency,
   evaluateMarkerPrefixConsistency,
   extractMarkerPrefixes,
   findMissingWorkshopReferences,
   findMissingWorktreeHardening,
   findPlaceholders,
+  formatCleanupBacklogScanPreamble,
+  formatCleanupBacklogScanProgress,
   isGithubBackLinkHost,
   parsePrimaryWorktreePath,
   parseProjectCommandRows,
@@ -722,6 +725,56 @@ test('computeWindowStartIso returns null for non-positive or non-finite windows'
   assert.equal(computeWindowStartIso(now, 'abc'), null);
   assert.equal(computeWindowStartIso(now, NaN), null);
   assert.equal(computeWindowStartIso(now, Infinity), null);
+});
+
+test('formatCleanupBacklogScan* produce the expected progress wording', () => {
+  assert.equal(
+    formatCleanupBacklogScanPreamble(3),
+    'post-merge cleanup backlog: scanning 3 merged PRs for F4 cleanup evidence…',
+  );
+  // Singular for exactly one PR.
+  assert.equal(
+    formatCleanupBacklogScanPreamble(1),
+    'post-merge cleanup backlog: scanning 1 merged PR for F4 cleanup evidence…',
+  );
+  assert.equal(
+    formatCleanupBacklogScanProgress(2, 10, 42),
+    '  [2/10] merged PR #42',
+  );
+});
+
+test('emitCleanupBacklogProgress writes to stderr, keeping --json stdout clean', () => {
+  // Capture both streams: the progress line must land on stderr and stdout
+  // (which carries the --json report) must stay untouched.
+  const stderrChunks: string[] = [];
+  const stdoutChunks: string[] = [];
+  const originalStderrWrite = process.stderr.write;
+  const originalStdoutWrite = process.stdout.write;
+  process.stderr.write = ((chunk: string) => {
+    stderrChunks.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+  process.stdout.write = ((chunk: string) => {
+    stdoutChunks.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    // Default sink is process.stderr.
+    emitCleanupBacklogProgress('  [1/2] merged PR #7');
+  } finally {
+    process.stderr.write = originalStderrWrite;
+    process.stdout.write = originalStdoutWrite;
+  }
+  assert.deepEqual(stderrChunks, ['  [1/2] merged PR #7\n']);
+  assert.deepEqual(stdoutChunks, []);
+});
+
+test('emitCleanupBacklogProgress writes to an injected sink verbatim', () => {
+  const sink: string[] = [];
+  emitCleanupBacklogProgress('preamble', {
+    write: (chunk) => sink.push(chunk),
+  });
+  assert.deepEqual(sink, ['preamble\n']);
 });
 
 test('classifyBacklog warns only when count strictly exceeds the threshold', () => {


### PR DESCRIPTION
## Summary

`idd-doctor`'s post-merge cleanup-backlog check
(`checkPostMergeCleanupBacklog`) scans merged PRs in a default 14-day window
with one serial, individually-paginated `gh api .../issues/<n>/comments` call
per PR, buffering the whole report until the end. During a merge burst a plain
`node scripts/idd-doctor.mjs` could run for >110s with no output and look like a
hang.

## Change

Two behavior-preserving improvements (the default window stays 14; no verdict
changes):

- Stream progress to **stderr** during the scan — a
  `scanning N merged PR(s)…` preamble plus a `[scanned/total] merged PR #N`
  line per PR — so a slow, network-bound run is distinguishable from a hang.
  Progress stays on stderr so stdout (including `--json`) is never polluted.
- Document the local merge-burst `--cleanup-backlog-window-days 1`
  recommendation in `--help` and `docs/idd-helper-scripts.md` (mirrored into
  `idd-template/docs/`), matching what CI already passes.

The progress plumbing is factored into three pure/injectable exports
(`formatCleanupBacklogScanPreamble`, `formatCleanupBacklogScanProgress`,
`emitCleanupBacklogProgress`) so it is unit-testable without the network scan.

## Verification

New tests assert the progress wording and prove `emitCleanupBacklogProgress`
routes to stderr while leaving stdout untouched (the `--json`-cleanliness
guarantee). `pnpm test` (1434), `pnpm run lint:minimum`, and `build:check`
(generated `scripts/idd-doctor.mjs` regenerated via `pnpm run build`) all pass.

Out of scope (noted in the issue for a possible follow-up): lowering the 14-day
default and parallelizing the per-PR fetch (needs a secondary-rate-limit-safe
concurrency cap).

Closes #1145
