### PR TITLE
feat(idd-doctor): warn when the worktree guard is enabled but inert

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -963,13 +963,19 @@ export function classifyWorktreeHeadFinding(
   };
 }
 /**
- * True when a git hook file body wires the B1 worktree guard, i.e. it sources
- * the shared `_idd-worktree-guard.sh` helper. Pure (no I/O) so the
+ * True when a git hook file body wires the B1 worktree guard, i.e. a `.`/
+ * `source` command loads the shared `_idd-worktree-guard.sh` helper. Matching
+ * the sourcing line (not a bare mention) means a hook that only names the
+ * helper in a comment — e.g. a leftover doc line after the source was removed —
+ * correctly reads as inert rather than wired. Pure (no I/O) so the
  * wired/unwired classification can be unit-tested directly. A non-string
  * (absent/unreadable hook) is treated as not wiring the guard.
  */
 export function hookWiresWorktreeGuard(content) {
-  return typeof content === 'string' && /_idd-worktree-guard\.sh/.test(content);
+  return (
+    typeof content === 'string' &&
+    /^[ \t]*(?:\.|source)[ \t]+[^\n]*_idd-worktree-guard\.sh/m.test(content)
+  );
 }
 /**
  * Decide whether the worktree guard is enabled-but-inert in the current

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -6,7 +6,7 @@
 // .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   normalizeAutopilotSuitabilityFloor,
@@ -59,6 +59,7 @@ export function runDoctor({
   const worktreeGuardEnforced =
     strict === true || readWorktreeGuardEnabled(root);
   checkPrimaryWorktreeHead(root, report, { enforce: worktreeGuardEnforced });
+  checkWorktreeGuardActive(root, report);
   checkWorktreeHardeningPresence(root, report);
   checkPostMergeCleanupBacklog(
     root,
@@ -960,6 +961,120 @@ export function classifyWorktreeHeadFinding(
     level: enforce ? 'error' : 'warning',
     message: `primary worktree HEAD is on ${kindLabel} (${branch}) at ${primaryPath} — ${severity}. See B1 in .github/instructions/idd-work.instructions.md.`,
   };
+}
+/**
+ * True when a git hook file body wires the B1 worktree guard, i.e. it sources
+ * the shared `_idd-worktree-guard.sh` helper. Pure (no I/O) so the
+ * wired/unwired classification can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not wiring the guard.
+ */
+export function hookWiresWorktreeGuard(content) {
+  return typeof content === 'string' && /_idd-worktree-guard\.sh/.test(content);
+}
+/**
+ * Decide whether the worktree guard is enabled-but-inert in the current
+ * environment and, if so, produce a warning finding. Pure (no I/O) so it can
+ * be unit-tested directly.
+ *
+ * The finding is intentionally a **warning**, never a blocking error: the
+ * idd-doctor CI health gate checks out a detached HEAD (which never wires the
+ * local hook) and must stay green. `headDetached` short-circuits that CI case,
+ * and a warning-level finding keeps the exit code zero even if it ever fires.
+ */
+export function classifyWorktreeGuardActivation({
+  guardEnabled,
+  headDetached,
+  hooksPath,
+  guardWired,
+}) {
+  // Only runs when the guard is opted in.
+  if (!guardEnabled) {
+    return null;
+  }
+  // CI-safe: a detached HEAD (CI checkout of a raw SHA) never wires the hook
+  // and is not a real B1 environment, so stay silent — matching how
+  // `classifyPrimaryHead('HEAD')` reports no violation.
+  if (headDetached) {
+    return null;
+  }
+  // Correctly wired → nothing to report.
+  if (guardWired) {
+    return null;
+  }
+  const shown =
+    typeof hooksPath === 'string' && hooksPath.trim().length > 0
+      ? hooksPath.trim()
+      : '(unset)';
+  return {
+    level: 'warning',
+    message:
+      `worktreeGuard.enabled is true but the commit/push guard is not active ` +
+      `in this environment (core.hooksPath = ${shown}); B1 primary-worktree ` +
+      `commits will NOT be blocked here. Wire it with: ` +
+      `git config core.hooksPath .githooks`,
+  };
+}
+/**
+ * Read the `pre-commit` and `pre-push` hooks at the resolved `core.hooksPath`
+ * and report whether both wire the B1 guard. A relative hooks path resolves
+ * against the repository root; an absolute one is used as-is.
+ */
+function worktreeGuardWiredAt(root, hooksPath) {
+  const directory = isAbsolute(hooksPath) ? hooksPath : join(root, hooksPath);
+  const read = (name) => {
+    try {
+      return readFileSync(join(directory, name), 'utf8');
+    } catch {
+      return null;
+    }
+  };
+  return (
+    hookWiresWorktreeGuard(read('pre-commit')) &&
+    hookWiresWorktreeGuard(read('pre-push'))
+  );
+}
+/**
+ * Warn when `worktreeGuard.enabled` is true but the commit/push guard is not
+ * actually wired in this environment (`core.hooksPath` unset or pointing at a
+ * directory that does not source the guard). A fresh coding-agent / ephemeral
+ * checkout never inherits the local `core.hooksPath`, so `enabled` alone can be
+ * silently unenforced. Warning-only and inert on a detached HEAD so the
+ * idd-doctor CI health gate stays green.
+ */
+function checkWorktreeGuardActive(root, report) {
+  if (!readWorktreeGuardEnabled(root)) {
+    return;
+  }
+  // Resolve HEAD; skip on a detached HEAD (CI checks out a raw SHA) or when
+  // git is unavailable (fail-safe: no finding).
+  const headResult = runCommand(
+    'git',
+    ['rev-parse', '--abbrev-ref', 'HEAD'],
+    root,
+  );
+  if (!headResult.ok) {
+    return;
+  }
+  const headDetached = headResult.stdout.trim() === 'HEAD';
+  // Resolve the active hooks path. An unset core.hooksPath makes git exit
+  // non-zero, which reads as unset here.
+  const hooksResult = runCommand(
+    'git',
+    ['config', '--get', 'core.hooksPath'],
+    root,
+  );
+  const hooksPath = hooksResult.ok ? hooksResult.stdout.trim() : '';
+  const guardWired =
+    hooksPath.length > 0 && worktreeGuardWiredAt(root, hooksPath);
+  const finding = classifyWorktreeGuardActivation({
+    guardEnabled: true,
+    headDetached,
+    hooksPath: hooksPath.length > 0 ? hooksPath : null,
+    guardWired,
+  });
+  if (finding) {
+    report.warnings.push(finding.message);
+  }
 }
 export function computeWindowStartIso(now, windowDays) {
   const ms = Number(windowDays) * 24 * 60 * 60 * 1000;

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1061,7 +1061,13 @@ function checkWorktreeGuardActive(root, report) {
   if (!headResult.ok) {
     return;
   }
-  const headDetached = headResult.stdout.trim() === 'HEAD';
+  // A detached HEAD (CI checks out a raw SHA) never wires the local hook and is
+  // not a real B1 environment — return before touching core.hooksPath so the
+  // idd-doctor CI health gate stays green. classifyWorktreeGuardActivation also
+  // guards this case so it can be unit-tested directly.
+  if (headResult.stdout.trim() === 'HEAD') {
+    return;
+  }
   // Resolve the active hooks path. An unset core.hooksPath makes git exit
   // non-zero, which reads as unset here.
   const hooksResult = runCommand(
@@ -1074,7 +1080,7 @@ function checkWorktreeGuardActive(root, report) {
     hooksPath.length > 0 && worktreeGuardWiredAt(root, hooksPath);
   const finding = classifyWorktreeGuardActivation({
     guardEnabled: true,
-    headDetached,
+    headDetached: false,
     hooksPath: hooksPath.length > 0 ? hooksPath : null,
     guardWired,
   });

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1142,13 +1142,19 @@ export interface WorktreeGuardActivationInput {
 }
 
 /**
- * True when a git hook file body wires the B1 worktree guard, i.e. it sources
- * the shared `_idd-worktree-guard.sh` helper. Pure (no I/O) so the
+ * True when a git hook file body wires the B1 worktree guard, i.e. a `.`/
+ * `source` command loads the shared `_idd-worktree-guard.sh` helper. Matching
+ * the sourcing line (not a bare mention) means a hook that only names the
+ * helper in a comment — e.g. a leftover doc line after the source was removed —
+ * correctly reads as inert rather than wired. Pure (no I/O) so the
  * wired/unwired classification can be unit-tested directly. A non-string
  * (absent/unreadable hook) is treated as not wiring the guard.
  */
 export function hookWiresWorktreeGuard(content: unknown): boolean {
-  return typeof content === 'string' && /_idd-worktree-guard\.sh/.test(content);
+  return (
+    typeof content === 'string' &&
+    /^[ \t]*(?:\.|source)[ \t]+[^\n]*_idd-worktree-guard\.sh/m.test(content)
+  );
 }
 
 /**

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -7,7 +7,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   normalizeAutopilotSuitabilityFloor,
@@ -132,6 +132,7 @@ export function runDoctor({
   const worktreeGuardEnforced =
     strict === true || readWorktreeGuardEnabled(root);
   checkPrimaryWorktreeHead(root, report, { enforce: worktreeGuardEnforced });
+  checkWorktreeGuardActive(root, report);
   checkWorktreeHardeningPresence(root, report);
   checkPostMergeCleanupBacklog(
     root,
@@ -1126,6 +1127,136 @@ export function classifyWorktreeHeadFinding(
     level: enforce ? 'error' : 'warning',
     message: `primary worktree HEAD is on ${kindLabel} (${branch}) at ${primaryPath} — ${severity}. See B1 in .github/instructions/idd-work.instructions.md.`,
   };
+}
+
+/** Signals consumed by `classifyWorktreeGuardActivation` (all pre-resolved). */
+export interface WorktreeGuardActivationInput {
+  /** `worktreeGuard.enabled === true` in `.github/idd/config.json`. */
+  guardEnabled: boolean;
+  /** HEAD is detached (`git rev-parse --abbrev-ref HEAD` === `HEAD`). */
+  headDetached: boolean;
+  /** Resolved `core.hooksPath` value, or `null`/empty when unset. */
+  hooksPath: string | null;
+  /** The resolved hooks path actually wires the B1 guard. */
+  guardWired: boolean;
+}
+
+/**
+ * True when a git hook file body wires the B1 worktree guard, i.e. it sources
+ * the shared `_idd-worktree-guard.sh` helper. Pure (no I/O) so the
+ * wired/unwired classification can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not wiring the guard.
+ */
+export function hookWiresWorktreeGuard(content: unknown): boolean {
+  return typeof content === 'string' && /_idd-worktree-guard\.sh/.test(content);
+}
+
+/**
+ * Decide whether the worktree guard is enabled-but-inert in the current
+ * environment and, if so, produce a warning finding. Pure (no I/O) so it can
+ * be unit-tested directly.
+ *
+ * The finding is intentionally a **warning**, never a blocking error: the
+ * idd-doctor CI health gate checks out a detached HEAD (which never wires the
+ * local hook) and must stay green. `headDetached` short-circuits that CI case,
+ * and a warning-level finding keeps the exit code zero even if it ever fires.
+ */
+export function classifyWorktreeGuardActivation({
+  guardEnabled,
+  headDetached,
+  hooksPath,
+  guardWired,
+}: WorktreeGuardActivationInput): WorktreeHeadFinding | null {
+  // Only runs when the guard is opted in.
+  if (!guardEnabled) {
+    return null;
+  }
+  // CI-safe: a detached HEAD (CI checkout of a raw SHA) never wires the hook
+  // and is not a real B1 environment, so stay silent — matching how
+  // `classifyPrimaryHead('HEAD')` reports no violation.
+  if (headDetached) {
+    return null;
+  }
+  // Correctly wired → nothing to report.
+  if (guardWired) {
+    return null;
+  }
+  const shown =
+    typeof hooksPath === 'string' && hooksPath.trim().length > 0
+      ? hooksPath.trim()
+      : '(unset)';
+  return {
+    level: 'warning',
+    message:
+      `worktreeGuard.enabled is true but the commit/push guard is not active ` +
+      `in this environment (core.hooksPath = ${shown}); B1 primary-worktree ` +
+      `commits will NOT be blocked here. Wire it with: ` +
+      `git config core.hooksPath .githooks`,
+  };
+}
+
+/**
+ * Read the `pre-commit` and `pre-push` hooks at the resolved `core.hooksPath`
+ * and report whether both wire the B1 guard. A relative hooks path resolves
+ * against the repository root; an absolute one is used as-is.
+ */
+function worktreeGuardWiredAt(root: string, hooksPath: string): boolean {
+  const directory = isAbsolute(hooksPath) ? hooksPath : join(root, hooksPath);
+  const read = (name: string): string | null => {
+    try {
+      return readFileSync(join(directory, name), 'utf8');
+    } catch {
+      return null;
+    }
+  };
+  return (
+    hookWiresWorktreeGuard(read('pre-commit')) &&
+    hookWiresWorktreeGuard(read('pre-push'))
+  );
+}
+
+/**
+ * Warn when `worktreeGuard.enabled` is true but the commit/push guard is not
+ * actually wired in this environment (`core.hooksPath` unset or pointing at a
+ * directory that does not source the guard). A fresh coding-agent / ephemeral
+ * checkout never inherits the local `core.hooksPath`, so `enabled` alone can be
+ * silently unenforced. Warning-only and inert on a detached HEAD so the
+ * idd-doctor CI health gate stays green.
+ */
+function checkWorktreeGuardActive(root: string, report: DoctorReport) {
+  if (!readWorktreeGuardEnabled(root)) {
+    return;
+  }
+  // Resolve HEAD; skip on a detached HEAD (CI checks out a raw SHA) or when
+  // git is unavailable (fail-safe: no finding).
+  const headResult = runCommand(
+    'git',
+    ['rev-parse', '--abbrev-ref', 'HEAD'],
+    root,
+  );
+  if (!headResult.ok) {
+    return;
+  }
+  const headDetached = headResult.stdout.trim() === 'HEAD';
+  // Resolve the active hooks path. An unset core.hooksPath makes git exit
+  // non-zero, which reads as unset here.
+  const hooksResult = runCommand(
+    'git',
+    ['config', '--get', 'core.hooksPath'],
+    root,
+  );
+  const hooksPath = hooksResult.ok ? hooksResult.stdout.trim() : '';
+  const guardWired =
+    hooksPath.length > 0 && worktreeGuardWiredAt(root, hooksPath);
+  const finding = classifyWorktreeGuardActivation({
+    guardEnabled: true,
+    headDetached,
+    hooksPath: hooksPath.length > 0 ? hooksPath : null,
+    guardWired,
+  });
+  if (finding) {
+    report.warnings.push(finding.message);
+  }
 }
 
 export function computeWindowStartIso(

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1243,7 +1243,13 @@ function checkWorktreeGuardActive(root: string, report: DoctorReport) {
   if (!headResult.ok) {
     return;
   }
-  const headDetached = headResult.stdout.trim() === 'HEAD';
+  // A detached HEAD (CI checks out a raw SHA) never wires the local hook and is
+  // not a real B1 environment — return before touching core.hooksPath so the
+  // idd-doctor CI health gate stays green. classifyWorktreeGuardActivation also
+  // guards this case so it can be unit-tested directly.
+  if (headResult.stdout.trim() === 'HEAD') {
+    return;
+  }
   // Resolve the active hooks path. An unset core.hooksPath makes git exit
   // non-zero, which reads as unset here.
   const hooksResult = runCommand(
@@ -1256,7 +1262,7 @@ function checkWorktreeGuardActive(root: string, report: DoctorReport) {
     hooksPath.length > 0 && worktreeGuardWiredAt(root, hooksPath);
   const finding = classifyWorktreeGuardActivation({
     guardEnabled: true,
-    headDetached,
+    headDetached: false,
     hooksPath: hooksPath.length > 0 ? hooksPath : null,
     guardWired,
   });

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -9,6 +9,7 @@ import {
   checkProjectCommands,
   classifyBacklog,
   classifyPrimaryHead,
+  classifyWorktreeGuardActivation,
   classifyWorktreeHeadFinding,
   computeWindowStartIso,
   containsExampleRepoBackLink,
@@ -24,6 +25,7 @@ import {
   findPlaceholders,
   formatCleanupBacklogScanPreamble,
   formatCleanupBacklogScanProgress,
+  hookWiresWorktreeGuard,
   isGithubBackLinkHost,
   parsePrimaryWorktreePath,
   parseProjectCommandRows,
@@ -433,6 +435,85 @@ test('classifyWorktreeHeadFinding labels roadmap-audit branches', () => {
   );
   assert.equal(finding?.level, 'error');
   assert.match(finding?.message ?? '', /a roadmap-audit branch/);
+});
+
+test('hookWiresWorktreeGuard detects a hook that sources the guard', () => {
+  assert.equal(
+    hookWiresWorktreeGuard(
+      '#!/bin/sh\n. "$(dirname "$0")/_idd-worktree-guard.sh"\n',
+    ),
+    true,
+  );
+});
+
+test('hookWiresWorktreeGuard rejects hooks that do not source the guard', () => {
+  assert.equal(hookWiresWorktreeGuard('#!/bin/sh\npnpm run lint\n'), false);
+  assert.equal(hookWiresWorktreeGuard(''), false);
+});
+
+test('hookWiresWorktreeGuard treats a non-string (absent hook) as unwired', () => {
+  assert.equal(hookWiresWorktreeGuard(null), false);
+  assert.equal(hookWiresWorktreeGuard(undefined), false);
+});
+
+test('classifyWorktreeGuardActivation returns null when the guard is disabled', () => {
+  assert.equal(
+    classifyWorktreeGuardActivation({
+      guardEnabled: false,
+      headDetached: false,
+      hooksPath: null,
+      guardWired: false,
+    }),
+    null,
+  );
+});
+
+test('classifyWorktreeGuardActivation stays silent on a detached HEAD (CI-safe)', () => {
+  assert.equal(
+    classifyWorktreeGuardActivation({
+      guardEnabled: true,
+      headDetached: true,
+      hooksPath: null,
+      guardWired: false,
+    }),
+    null,
+  );
+});
+
+test('classifyWorktreeGuardActivation returns null when the guard is wired', () => {
+  assert.equal(
+    classifyWorktreeGuardActivation({
+      guardEnabled: true,
+      headDetached: false,
+      hooksPath: '.githooks',
+      guardWired: true,
+    }),
+    null,
+  );
+});
+
+test('classifyWorktreeGuardActivation warns (never errors) when enabled-but-inert', () => {
+  const finding = classifyWorktreeGuardActivation({
+    guardEnabled: true,
+    headDetached: false,
+    hooksPath: '.husky/_',
+    guardWired: false,
+  });
+  assert.equal(finding?.level, 'warning');
+  assert.match(finding?.message ?? '', /worktreeGuard\.enabled is true/);
+  assert.match(finding?.message ?? '', /core\.hooksPath = \.husky\/_/);
+  assert.match(finding?.message ?? '', /git config core\.hooksPath \.githooks/);
+});
+
+test('classifyWorktreeGuardActivation shows (unset) when core.hooksPath is absent', () => {
+  const finding = classifyWorktreeGuardActivation({
+    guardEnabled: true,
+    headDetached: false,
+    hooksPath: null,
+    guardWired: false,
+  });
+  assert.equal(finding?.level, 'warning');
+  assert.match(finding?.message ?? '', /core\.hooksPath = \(unset\)/);
 });
 
 test('readWorktreeGuardEnabled reads worktreeGuard.enabled from config', () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -451,6 +451,24 @@ test('hookWiresWorktreeGuard rejects hooks that do not source the guard', () => 
   assert.equal(hookWiresWorktreeGuard(''), false);
 });
 
+test('hookWiresWorktreeGuard ignores a bare mention in a comment', () => {
+  // A leftover doc/comment line that names the helper but no longer sources
+  // it is inert and must not read as wired.
+  assert.equal(
+    hookWiresWorktreeGuard(
+      '#!/bin/sh\n# was: . "$(dirname "$0")/_idd-worktree-guard.sh"\necho hi\n',
+    ),
+    false,
+  );
+  // The `source` keyword variant (with indentation) still counts as wired.
+  assert.equal(
+    hookWiresWorktreeGuard(
+      '#!/bin/bash\n  source ./.githooks/_idd-worktree-guard.sh\n',
+    ),
+    true,
+  );
+});
+
 test('hookWiresWorktreeGuard treats a non-string (absent hook) as unwired', () => {
   assert.equal(hookWiresWorktreeGuard(null), false);
   assert.equal(hookWiresWorktreeGuard(undefined), false);


### PR DESCRIPTION
## Summary

Adds an `idd-doctor` check that warns when `worktreeGuard.enabled` is `true` but
the B1 commit/push guard is not actually wired in the current environment.

Because `core.hooksPath` is local and uncommitted, a fresh coding-agent /
ephemeral checkout never inherits it, so a repo with `worktreeGuard.enabled:
true` can be silently unenforced — a lightweight model can commit from the
primary worktree with nothing warning. idd-doctor already flags a stale
worktree-hardening import and a primary-worktree implementation-branch HEAD, but
never verified the hook is *active*; this closes that residual.

## What it does

- Runs only when `worktreeGuard.enabled === true`.
- Resolves `core.hooksPath` and checks that the `pre-commit` and `pre-push`
  hooks there source `_idd-worktree-guard.sh`; emits an **enabled-but-inert**
  warning otherwise (e.g. `core.hooksPath = .husky/_`).
- **CI-safe:** the finding is a warning, never a blocking error, and is skipped
  on a detached HEAD — so the idd-doctor CI health gate (which checks out a raw
  SHA) stays green.

## Verification

- New pure classifiers `classifyWorktreeGuardActivation` /
  `hookWiresWorktreeGuard` are unit-tested for the wired / unwired / absent /
  disabled / detached cases (`tests/idd-doctor.test.mts`).
- Generated `scripts/idd-doctor.mjs` regenerated via `pnpm run build`.
- Verified live: on this issue branch idd-doctor emits the warning and exits 0
  (`result: passed`); on a detached-HEAD checkout the warning is absent.
- `pnpm run lint:minimum` passes.

Pairs with the coding-agent activation docs (#1158, merged) under roadmap #1156.

Closes #1157
