### PR TITLE
docs(issue-authoring): add a deliberate-divergence fidelity check

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -278,6 +278,19 @@ Ask these checks:
    codebase — do not overload a name with a new shape or source.
 2. Flag values that are mutable at runtime — specify a live read at the
    point of use rather than a one-time capture at construction.
+3. When an issue proposes to **delete, replace, or "align to upstream"**
+   code, first check the target for an intentional-divergence signal — a
+   local change made on purpose to differ from upstream. If one is present,
+   require the issue body to acknowledge that divergence and justify
+   overriding it, rather than silently reverting hardening a consumer added
+   deliberately (blind "resync to upstream" resets are a recurring
+   Discover→plan-cycle waste when the divergence turns out to be
+   intentional). The recommended portable signal is a canonical inline
+   code-comment convention (for example a `do-not-revert:` / `idd-divergence:`
+   marker) — it travels with vendored files and needs no repo-wide label
+   taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
+   also serve, but the code-comment convention is the recommended default.
+   Do not hard-code any single consumer's divergence-tracking mechanism.
 
 ## Dependency minimization
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -349,6 +349,19 @@ Ask these checks:
    codebase — do not overload a name with a new shape or source.
 2. Flag values that are mutable at runtime — specify a live read at the
    point of use rather than a one-time capture at construction.
+3. When an issue proposes to **delete, replace, or "align to upstream"**
+   code, first check the target for an intentional-divergence signal — a
+   local change made on purpose to differ from upstream. If one is present,
+   require the issue body to acknowledge that divergence and justify
+   overriding it, rather than silently reverting hardening a consumer added
+   deliberately (blind "resync to upstream" resets are a recurring
+   Discover→plan-cycle waste when the divergence turns out to be
+   intentional). The recommended portable signal is a canonical inline
+   code-comment convention (for example a `do-not-revert:` / `idd-divergence:`
+   marker) — it travels with vendored files and needs no repo-wide label
+   taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
+   also serve, but the code-comment convention is the recommended default.
+   Do not hard-code any single consumer's divergence-tracking mechanism.
 
 ## Alignment with A4.5 Suitability Gate
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -278,6 +278,19 @@ Ask these checks:
    codebase — do not overload a name with a new shape or source.
 2. Flag values that are mutable at runtime — specify a live read at the
    point of use rather than a one-time capture at construction.
+3. When an issue proposes to **delete, replace, or "align to upstream"**
+   code, first check the target for an intentional-divergence signal — a
+   local change made on purpose to differ from upstream. If one is present,
+   require the issue body to acknowledge that divergence and justify
+   overriding it, rather than silently reverting hardening a consumer added
+   deliberately (blind "resync to upstream" resets are a recurring
+   Discover→plan-cycle waste when the divergence turns out to be
+   intentional). The recommended portable signal is a canonical inline
+   code-comment convention (for example a `do-not-revert:` / `idd-divergence:`
+   marker) — it travels with vendored files and needs no repo-wide label
+   taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
+   also serve, but the code-comment convention is the recommended default.
+   Do not hard-code any single consumer's divergence-tracking mechanism.
 
 ## Dependency minimization
 


### PR DESCRIPTION
## Summary

The issue-authoring skill's **Codebase-fidelity validation** section validated
identifier semantics and runtime-mutability only. It had no notion that a
"delete / replace / align to upstream" proposal might be **reverting an
intentional local change**, so blind resync issues repeatedly proposed deleting
deliberately-hardened consumer code — each burning a Discover→plan cycle before
the divergence was re-derived.

## Change

Add a third fidelity check (a routing aid, consistent with the section's
existing framing):

- For a **delete / replace / "align to upstream"** change, first check the
  target for an intentional-divergence signal; when present, require the issue
  body to acknowledge that divergence and justify overriding it.
- Recommend a canonical inline **code-comment convention**
  (`do-not-revert:` / `idd-divergence:`) as the portable default signal — it
  travels with vendored files and needs no repo-wide label taxonomy. Note that
  an owner/CODEOWNERS marker or a referenced tracking issue may also serve.
- Deliberately does **not** hard-code any single consumer's
  divergence-tracking mechanism (upstream has no such label/issue-type).

## Verification

`skills/issue-authoring/references/contract.md` (canonical) and
`docs/issue-authoring-skill.md` (mirror) are updated in the same commit, and
the `.claude/skills/issue-authoring/` copy is regenerated via
`node scripts/sync-docs.mjs --apply`. `node scripts/audit-docs.mjs --check`
(no drift) and `pnpm run lint:minimum` pass.

Closes #1148
