### PR TITLE
fix(idd): tolerate trailing punctuation in disposition markers

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1400,8 +1400,11 @@ export function hasFreshDisposition(thread, options = {}) {
 // equivalents — so a reply that punctuates the marker is still recognized. The
 // tolerance is bounded to that one char before `**`, so an interior-text body
 // like `**Accepted by reviewer, but…**` is NOT matched (fail-closed: a false
-// positive is a false merge). Start-anchored, so the marker must remain the
-// first bytes of the (leading-trimmed) body.
+// positive is a false merge). Start-anchored (`^`), so the marker must be the
+// first bytes of the body each caller passes: `isDispositionComment` uses
+// `trimEnd()` only, so leading whitespace is NOT stripped (preserving the
+// marker-first-bytes contract), while the notice / summary predicates below
+// `trimStart()` first.
 const DISPOSITION_ACCEPTED_PREFIX_RE = /^\*\*Accepted[.!:]?\*\*/;
 const DISPOSITION_REJECTED_PREFIX_RE = /^\*\*Rejected[.!:]?\*\*/;
 export function isDispositionComment(comment) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1394,9 +1394,22 @@ export function hasFreshDisposition(thread, options = {}) {
     );
   });
 }
+// A disposition marker may carry a single interior punctuation char `[.!:]`
+// immediately before the closing `**` — `**Accepted.**` (natural English
+// "Accepted. Fixed in…"), `**Accepted:**`, `**Accepted!**`, and the `Rejected`
+// equivalents — so a reply that punctuates the marker is still recognized. The
+// tolerance is bounded to that one char before `**`, so an interior-text body
+// like `**Accepted by reviewer, but…**` is NOT matched (fail-closed: a false
+// positive is a false merge). Start-anchored, so the marker must remain the
+// first bytes of the (leading-trimmed) body.
+const DISPOSITION_ACCEPTED_PREFIX_RE = /^\*\*Accepted[.!:]?\*\*/;
+const DISPOSITION_REJECTED_PREFIX_RE = /^\*\*Rejected[.!:]?\*\*/;
 export function isDispositionComment(comment) {
   const body = (comment.body ?? '').trimEnd();
-  return body.startsWith('**Accepted**') || body.startsWith('**Rejected**');
+  return (
+    DISPOSITION_ACCEPTED_PREFIX_RE.test(body) ||
+    DISPOSITION_REJECTED_PREFIX_RE.test(body)
+  );
 }
 // Terminal AMD-rejection marker. When a maintainer agrees with a rejection the
 // agent replies `**Rejection confirmed by maintainer** — {summary}` and resolves
@@ -1457,7 +1470,8 @@ export function isAdvisoryNonReviewNotice(body) {
 export function isNonReviewNoticeDisposition(comment) {
   const body = (comment.body ?? '').trimStart();
   return (
-    body.startsWith('**Rejected**') && /\bdid not review HEAD\b/i.test(body)
+    DISPOSITION_REJECTED_PREFIX_RE.test(body) &&
+    /\bdid not review HEAD\b/i.test(body)
   );
 }
 // #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
@@ -1488,7 +1502,8 @@ export function isReviewSummaryComment(body) {
 export function isReviewSummaryDisposition(comment) {
   const body = (comment.body ?? '').trimStart();
   return (
-    body.startsWith('**Accepted**') && /\bsummary walkthrough\b/i.test(body)
+    DISPOSITION_ACCEPTED_PREFIX_RE.test(body) &&
+    /\bsummary walkthrough\b/i.test(body)
   );
 }
 // The stable identity token of an advisory bot, used to attribute a non-review

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1467,9 +1467,11 @@ export function isAdvisoryNonReviewNotice(body) {
 }
 // A trusted IDD disposition of a non-review notice: the canonical
 // `**Rejected** — {bot} did not review HEAD {sha} ({reason}); this is not a
-// completed review` reply. Requires the `**Rejected**` prefix (a notice is
-// always rejected, never accepted) and the `did not review HEAD` phrase that
-// names the notice, so an ordinary rejection of reviewer feedback is excluded.
+// completed review` reply. Requires the `**Rejected**` prefix (via
+// `DISPOSITION_REJECTED_PREFIX_RE`, so the bounded trailing-punctuation variants
+// like `**Rejected.**` also count; a notice is always rejected, never accepted)
+// and the `did not review HEAD` phrase that names the notice, so an ordinary
+// rejection of reviewer feedback is excluded.
 export function isNonReviewNoticeDisposition(comment) {
   const body = (comment.body ?? '').trimStart();
   return (
@@ -1497,11 +1499,13 @@ export function isReviewSummaryComment(body) {
 }
 // A trusted IDD disposition of a CodeRabbit summary walkthrough: the canonical
 // `**Accepted** — {bot} summary walkthrough …` reply the helper posts. Requires
-// the `**Accepted**` prefix (a summary is a completed review, so it is accepted,
-// never rejected) AND the `summary walkthrough` phrase, so an ordinary acceptance
-// of reviewer feedback is excluded. Tightly matched to `buildSummaryDispositionBody`
-// so a loose acceptance can never be miscredited (which would under-post and
-// strand the gate).
+// the `**Accepted**` prefix (via `DISPOSITION_ACCEPTED_PREFIX_RE`, so the bounded
+// trailing-punctuation variants like `**Accepted.**` also count; a summary is a
+// completed review, so it is accepted, never rejected) AND the
+// `summary walkthrough` phrase, so an ordinary acceptance of reviewer feedback is
+// excluded. Tightly matched to `buildSummaryDispositionBody` so a loose
+// acceptance can never be miscredited (which would under-post and strand the
+// gate).
 export function isReviewSummaryDisposition(comment) {
   const body = (comment.body ?? '').trimStart();
   return (

--- a/scripts/review-disposition-verify.mjs
+++ b/scripts/review-disposition-verify.mjs
@@ -7,8 +7,12 @@
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const MARKER_ACCEPTED_RE = /^\*\*Accepted\*\*\s+—/;
-const MARKER_REJECTED_RE = /^\*\*Rejected\*\*\s+—/;
+// Tolerate a single interior punctuation char `[.!:]` before the closing `**`
+// (`**Accepted.** — …`) so a punctuated marker still verifies, while keeping the
+// required `— ` separator. Bounded so an interior-text body is not matched —
+// mirrors the disposition-marker predicates in protocol-helpers.mts.
+const MARKER_ACCEPTED_RE = /^\*\*Accepted[.!:]?\*\*\s+—/;
+const MARKER_REJECTED_RE = /^\*\*Rejected[.!:]?\*\*\s+—/;
 const MARKER_REJECTION_CONFIRMED_RE =
   /^\*\*Rejection confirmed by maintainer\*\*\s+—/;
 const MARKER_AMD_RE = /^\*\*Awaiting maintainer decision\*\*\s+—/;

--- a/scripts/review-disposition-verify.mjs
+++ b/scripts/review-disposition-verify.mjs
@@ -9,8 +9,9 @@ import { pathToFileURL } from 'node:url';
 
 // Tolerate a single interior punctuation char `[.!:]` before the closing `**`
 // (`**Accepted.** — …`) so a punctuated marker still verifies, while keeping the
-// required `— ` separator. Bounded so an interior-text body is not matched —
-// mirrors the disposition-marker predicates in protocol-helpers.mts.
+// required `\s+—` separator (whitespace before the em-dash; nothing after it is
+// enforced). Bounded so an interior-text body is not matched — mirrors the
+// disposition-marker predicates in protocol-helpers.mts.
 const MARKER_ACCEPTED_RE = /^\*\*Accepted[.!:]?\*\*\s+—/;
 const MARKER_REJECTED_RE = /^\*\*Rejected[.!:]?\*\*\s+—/;
 const MARKER_REJECTION_CONFIRMED_RE =

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2252,9 +2252,11 @@ export function isAdvisoryNonReviewNotice(body: unknown): boolean {
 
 // A trusted IDD disposition of a non-review notice: the canonical
 // `**Rejected** — {bot} did not review HEAD {sha} ({reason}); this is not a
-// completed review` reply. Requires the `**Rejected**` prefix (a notice is
-// always rejected, never accepted) and the `did not review HEAD` phrase that
-// names the notice, so an ordinary rejection of reviewer feedback is excluded.
+// completed review` reply. Requires the `**Rejected**` prefix (via
+// `DISPOSITION_REJECTED_PREFIX_RE`, so the bounded trailing-punctuation variants
+// like `**Rejected.**` also count; a notice is always rejected, never accepted)
+// and the `did not review HEAD` phrase that names the notice, so an ordinary
+// rejection of reviewer feedback is excluded.
 export function isNonReviewNoticeDisposition(comment: {
   body?: string | null;
 }): boolean {
@@ -2287,11 +2289,13 @@ export function isReviewSummaryComment(body: unknown): boolean {
 
 // A trusted IDD disposition of a CodeRabbit summary walkthrough: the canonical
 // `**Accepted** — {bot} summary walkthrough …` reply the helper posts. Requires
-// the `**Accepted**` prefix (a summary is a completed review, so it is accepted,
-// never rejected) AND the `summary walkthrough` phrase, so an ordinary acceptance
-// of reviewer feedback is excluded. Tightly matched to `buildSummaryDispositionBody`
-// so a loose acceptance can never be miscredited (which would under-post and
-// strand the gate).
+// the `**Accepted**` prefix (via `DISPOSITION_ACCEPTED_PREFIX_RE`, so the bounded
+// trailing-punctuation variants like `**Accepted.**` also count; a summary is a
+// completed review, so it is accepted, never rejected) AND the
+// `summary walkthrough` phrase, so an ordinary acceptance of reviewer feedback is
+// excluded. Tightly matched to `buildSummaryDispositionBody` so a loose
+// acceptance can never be miscredited (which would under-post and strand the
+// gate).
 export function isReviewSummaryDisposition(comment: {
   body?: string | null;
 }): boolean {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2168,11 +2168,25 @@ export function hasFreshDisposition(
   });
 }
 
+// A disposition marker may carry a single interior punctuation char `[.!:]`
+// immediately before the closing `**` — `**Accepted.**` (natural English
+// "Accepted. Fixed in…"), `**Accepted:**`, `**Accepted!**`, and the `Rejected`
+// equivalents — so a reply that punctuates the marker is still recognized. The
+// tolerance is bounded to that one char before `**`, so an interior-text body
+// like `**Accepted by reviewer, but…**` is NOT matched (fail-closed: a false
+// positive is a false merge). Start-anchored, so the marker must remain the
+// first bytes of the (leading-trimmed) body.
+const DISPOSITION_ACCEPTED_PREFIX_RE = /^\*\*Accepted[.!:]?\*\*/;
+const DISPOSITION_REJECTED_PREFIX_RE = /^\*\*Rejected[.!:]?\*\*/;
+
 export function isDispositionComment(comment: {
   body?: string | null;
 }): boolean {
   const body = (comment.body ?? '').trimEnd();
-  return body.startsWith('**Accepted**') || body.startsWith('**Rejected**');
+  return (
+    DISPOSITION_ACCEPTED_PREFIX_RE.test(body) ||
+    DISPOSITION_REJECTED_PREFIX_RE.test(body)
+  );
 }
 
 // Terminal AMD-rejection marker. When a maintainer agrees with a rejection the
@@ -2243,7 +2257,8 @@ export function isNonReviewNoticeDisposition(comment: {
 }): boolean {
   const body = (comment.body ?? '').trimStart();
   return (
-    body.startsWith('**Rejected**') && /\bdid not review HEAD\b/i.test(body)
+    DISPOSITION_REJECTED_PREFIX_RE.test(body) &&
+    /\bdid not review HEAD\b/i.test(body)
   );
 }
 
@@ -2279,7 +2294,8 @@ export function isReviewSummaryDisposition(comment: {
 }): boolean {
   const body = (comment.body ?? '').trimStart();
   return (
-    body.startsWith('**Accepted**') && /\bsummary walkthrough\b/i.test(body)
+    DISPOSITION_ACCEPTED_PREFIX_RE.test(body) &&
+    /\bsummary walkthrough\b/i.test(body)
   );
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2174,8 +2174,11 @@ export function hasFreshDisposition(
 // equivalents — so a reply that punctuates the marker is still recognized. The
 // tolerance is bounded to that one char before `**`, so an interior-text body
 // like `**Accepted by reviewer, but…**` is NOT matched (fail-closed: a false
-// positive is a false merge). Start-anchored, so the marker must remain the
-// first bytes of the (leading-trimmed) body.
+// positive is a false merge). Start-anchored (`^`), so the marker must be the
+// first bytes of the body each caller passes: `isDispositionComment` uses
+// `trimEnd()` only, so leading whitespace is NOT stripped (preserving the
+// marker-first-bytes contract), while the notice / summary predicates below
+// `trimStart()` first.
 const DISPOSITION_ACCEPTED_PREFIX_RE = /^\*\*Accepted[.!:]?\*\*/;
 const DISPOSITION_REJECTED_PREFIX_RE = /^\*\*Rejected[.!:]?\*\*/;
 

--- a/src/scripts/review-disposition-verify.mts
+++ b/src/scripts/review-disposition-verify.mts
@@ -10,8 +10,9 @@ import { pathToFileURL } from 'node:url';
 
 // Tolerate a single interior punctuation char `[.!:]` before the closing `**`
 // (`**Accepted.** — …`) so a punctuated marker still verifies, while keeping the
-// required `— ` separator. Bounded so an interior-text body is not matched —
-// mirrors the disposition-marker predicates in protocol-helpers.mts.
+// required `\s+—` separator (whitespace before the em-dash; nothing after it is
+// enforced). Bounded so an interior-text body is not matched — mirrors the
+// disposition-marker predicates in protocol-helpers.mts.
 const MARKER_ACCEPTED_RE = /^\*\*Accepted[.!:]?\*\*\s+—/;
 const MARKER_REJECTED_RE = /^\*\*Rejected[.!:]?\*\*\s+—/;
 const MARKER_REJECTION_CONFIRMED_RE =

--- a/src/scripts/review-disposition-verify.mts
+++ b/src/scripts/review-disposition-verify.mts
@@ -8,8 +8,12 @@
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const MARKER_ACCEPTED_RE = /^\*\*Accepted\*\*\s+—/;
-const MARKER_REJECTED_RE = /^\*\*Rejected\*\*\s+—/;
+// Tolerate a single interior punctuation char `[.!:]` before the closing `**`
+// (`**Accepted.** — …`) so a punctuated marker still verifies, while keeping the
+// required `— ` separator. Bounded so an interior-text body is not matched —
+// mirrors the disposition-marker predicates in protocol-helpers.mts.
+const MARKER_ACCEPTED_RE = /^\*\*Accepted[.!:]?\*\*\s+—/;
+const MARKER_REJECTED_RE = /^\*\*Rejected[.!:]?\*\*\s+—/;
 const MARKER_REJECTION_CONFIRMED_RE =
   /^\*\*Rejection confirmed by maintainer\*\*\s+—/;
 const MARKER_AMD_RE = /^\*\*Awaiting maintainer decision\*\*\s+—/;

--- a/tests/disposition-marker-punctuation.test.mts
+++ b/tests/disposition-marker-punctuation.test.mts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  isDispositionComment,
+  isNonReviewNoticeDisposition,
+  isReviewSummaryDisposition,
+} from '../src/scripts/protocol-helpers.mts';
+import { classifyMarker } from '../src/scripts/review-disposition-verify.mts';
+
+// #1151: a single interior punctuation char `[.!:]` immediately before the
+// closing `**` (natural English "Accepted. Fixed in…") is tolerated across the
+// disposition-marker predicate family, while an interior-text body is still
+// rejected (fail-closed: a false positive is a false merge).
+const PUNCT_SUFFIXES = ['', '.', ':', '!'];
+
+test('isDispositionComment tolerates a single trailing punctuation before the closing **', () => {
+  for (const p of PUNCT_SUFFIXES) {
+    assert.equal(
+      isDispositionComment({ body: `**Accepted${p}** — fixed in abc123` }),
+      true,
+      `Accepted variant "${p}" should be recognized`,
+    );
+    assert.equal(
+      isDispositionComment({ body: `**Rejected${p}** — out of scope` }),
+      true,
+      `Rejected variant "${p}" should be recognized`,
+    );
+  }
+  // Interior-text and non-bold bodies stay unrecognized.
+  assert.equal(
+    isDispositionComment({ body: '**Accepted by reviewer, but I disagree**' }),
+    false,
+  );
+  assert.equal(isDispositionComment({ body: '**Accepted, done**' }), false);
+  assert.equal(isDispositionComment({ body: 'Accepted — some note' }), false);
+  // Two interior punctuation chars exceed the single-char tolerance.
+  assert.equal(isDispositionComment({ body: '**Accepted..**' }), false);
+});
+
+test('isNonReviewNoticeDisposition tolerates the punctuation while keeping its notice phrase', () => {
+  for (const p of PUNCT_SUFFIXES) {
+    assert.equal(
+      isNonReviewNoticeDisposition({
+        body: `**Rejected${p}** — coderabbitai[bot] did not review HEAD abc (rate limited); this is not a completed review`,
+      }),
+      true,
+      `Rejected variant "${p}" should be recognized`,
+    );
+  }
+  // A plain rejection without the notice phrase is not a non-review-notice
+  // disposition, and interior-text stays unrecognized.
+  assert.equal(
+    isNonReviewNoticeDisposition({ body: '**Rejected.** — out of scope' }),
+    false,
+  );
+  assert.equal(
+    isNonReviewNoticeDisposition({
+      body: '**Rejected by bot** did not review HEAD abc',
+    }),
+    false,
+  );
+});
+
+test('isReviewSummaryDisposition tolerates the punctuation while keeping its walkthrough phrase', () => {
+  for (const p of PUNCT_SUFFIXES) {
+    assert.equal(
+      isReviewSummaryDisposition({
+        body: `**Accepted${p}** — coderabbitai[bot] summary walkthrough; no action required`,
+      }),
+      true,
+      `Accepted variant "${p}" should be recognized`,
+    );
+  }
+  // A plain acceptance without the walkthrough phrase is excluded, and
+  // interior-text stays unrecognized.
+  assert.equal(
+    isReviewSummaryDisposition({ body: '**Accepted.** — confirmed' }),
+    false,
+  );
+  assert.equal(
+    isReviewSummaryDisposition({
+      body: '**Accepted the summary walkthrough**',
+    }),
+    false,
+  );
+});
+
+test('classifyMarker tolerates the punctuation but keeps the required — separator', () => {
+  for (const p of PUNCT_SUFFIXES) {
+    assert.equal(
+      classifyMarker(`**Accepted${p}** — the advisory confirmed no action`),
+      'accepted',
+      `Accepted variant "${p}"`,
+    );
+    assert.equal(
+      classifyMarker(`**Rejected${p}** — not applicable`),
+      'rejected',
+      `Rejected variant "${p}"`,
+    );
+  }
+  // Interior-text body and a missing — separator are still not classified.
+  assert.equal(classifyMarker('**Accepted by reviewer, but** — note'), null);
+  assert.equal(classifyMarker('**Accepted.** no separator'), null);
+});


### PR DESCRIPTION
## Summary

`isDispositionComment` and its sibling predicates required the exact
`**Accepted**` / `**Rejected**` prefix, so a reply that punctuates the marker —
`**Accepted.**` ("Accepted. Fixed in…"), `**Accepted:**`, `**Accepted!**` — was
not recognized, and F2/F3 `pre-merge-readiness` reported
`missing-fresh-disposition` in a loop.

## Change

A bounded relaxation: tolerate a single interior punctuation char `[.!:]`
immediately before the closing `**`, uniformly across the predicate family, so
the punctuated variants are recognized while interior-text bodies like
`**Accepted by reviewer, but…**` are still NOT (fail-closed preserved).

- `src/scripts/protocol-helpers.mts`: shared start-anchored
  `DISPOSITION_ACCEPTED_PREFIX_RE` / `DISPOSITION_REJECTED_PREFIX_RE`
  (`/^\*\*Accepted[.!:]?\*\*/`), consumed by `isDispositionComment`,
  `isNonReviewNoticeDisposition`, and `isReviewSummaryDisposition` in lockstep.
- `src/scripts/review-disposition-verify.mts`: `MARKER_ACCEPTED_RE` /
  `MARKER_REJECTED_RE` gain the same tolerance while keeping the required `— `
  separator. AMD / rejection-confirmed markers are unchanged (out of scope).
- The canonical `**Accepted** — {summary}` form stays the recommended format;
  this is a robustness backstop, not a new format.

## Verification

- Table-driven tests (`tests/disposition-marker-punctuation.test.mts`) cover the
  `.` / `:` / `!` variants (positive) and interior-text (negative) across all
  three predicates and `classifyMarker`.
- Generated `.mjs` regenerated via `pnpm run build`; `pnpm test`,
  `pnpm run lint:minimum` pass.

Closes #1151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of accepted/rejected disposition markers when they include a single punctuation mark before the closing emphasis, such as `Accepted!` or `Rejected:`.
  * Updated marker validation so these punctuated forms are treated as valid as long as the required separator is present.
* **Tests**
  * Added coverage for the new punctuation-tolerant marker behavior and continued rejection of invalid formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->