### PR TITLE
feat(idd): add a mechanical fresh-claim (A5) claimability gate

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -40,6 +40,7 @@ words:
   - pylint
   - pytest
   - pyproject
+  - TOCTOU
   - tsfile
   - undispositioned
   - unioned

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -71,6 +71,33 @@ set. If the project is in use, the project status must be "not started".
 **(c) Claim state** — Re-read the issue and parse the **active claim**
 using the shared claim-state rules:
 
+When helper runtime is enabled, run the mechanical fresh-claim claimability
+gate on a fresh marker fetch **immediately before** the claim write as the
+canonical A5(c) evidence collector:
+
+```sh
+# source repo / vendored-node
+node scripts/resume-claim-routing.mjs --issue <number> --fresh-claim-gate
+```
+
+It reuses the shared `resolveActiveClaim` / `evaluateResumeClaimRouting`
+resolver (no forked claim-state logic) and returns a `fresh_claim_gate.verdict`
+of `claimable | already-claimed | stale-reclaimable` with the winning
+`{claim-id}`:
+
+- `claimable` → proceed to the claim write below.
+- `stale-reclaimable` → proceed with takeover (the stale path below).
+- `already-claimed` → the issue is held by a live competitor, or a later
+  competing / same-second claim raced in: **return to Discover** using the same
+  selection mode that produced this target (orphan-first: continue the A0-O
+  capable path; roadmap mode: continue the A3-ready path). Do not post a claim.
+
+GitHub issue comments have no compare-and-swap, so this **narrows** the
+claim→write TOCTOU window rather than closing it; the 24 h stale-takeover and
+same-second tie-break in the written rules below remain the race-recovery
+backstop. If the helper is unavailable or its output is malformed, fall back to
+the written rules below, which stay authoritative.
+
 Use the `claim-stale-age` policy default from `docs/policy-constants.md`
 for these stale checks (distributed default: `24 h`).
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -71,6 +71,33 @@ set. If the project is in use, the project status must be "not started".
 **(c) Claim state** — Re-read the issue and parse the **active claim**
 using the shared claim-state rules:
 
+When helper runtime is enabled, run the mechanical fresh-claim claimability
+gate on a fresh marker fetch **immediately before** the claim write as the
+canonical A5(c) evidence collector:
+
+```sh
+# source repo / vendored-node
+node scripts/resume-claim-routing.mjs --issue <number> --fresh-claim-gate
+```
+
+It reuses the shared `resolveActiveClaim` / `evaluateResumeClaimRouting`
+resolver (no forked claim-state logic) and returns a `fresh_claim_gate.verdict`
+of `claimable | already-claimed | stale-reclaimable` with the winning
+`{claim-id}`:
+
+- `claimable` → proceed to the claim write below.
+- `stale-reclaimable` → proceed with takeover (the stale path below).
+- `already-claimed` → the issue is held by a live competitor, or a later
+  competing / same-second claim raced in: **return to Discover** using the same
+  selection mode that produced this target (orphan-first: continue the A0-O
+  capable path; roadmap mode: continue the A3-ready path). Do not post a claim.
+
+GitHub issue comments have no compare-and-swap, so this **narrows** the
+claim→write TOCTOU window rather than closing it; the 24 h stale-takeover and
+same-second tie-break in the written rules below remain the race-recovery
+backstop. If the helper is unavailable or its output is malformed, fall back to
+the written rules below, which stay authoritative.
+
 Use the `claim-stale-age` policy default from `docs/policy-constants.md`
 for these stale checks (distributed default: `24 h`).
 

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -162,6 +162,42 @@ export function evaluateResumeClaimRouting(input, options = {}) {
     },
   };
 }
+/**
+ * Mechanical fresh-claim (A5) claimability gate.
+ *
+ * It reuses the shared `evaluateResumeClaimRouting` resolver (which itself
+ * builds on `resolveActiveClaim`) over a fresh marker fetch and maps the
+ * routing state to the fresh-claim vocabulary, so the write-side path never
+ * forks claim-state logic:
+ *
+ * - `unclaimed` → `claimable`
+ * - `stale` → `stale-reclaimable`
+ * - `non_inheritable` / `disputed` (a live competitor) → `already-claimed`
+ *
+ * A fresh claim owns no prior claim-id, so any `claimId` on `input` is ignored
+ * (the resolver's already-owned / same-second-loss branches need a checked id
+ * and would otherwise mask pure contention). `winningClaimId` names the active
+ * claim, if any. GitHub issue comments have no compare-and-swap, so this
+ * **narrows** the A5(c) TOCTOU window rather than closing it; the 24 h
+ * stale-takeover and same-second tie-break remain the race-recovery backstop.
+ */
+export function evaluateFreshClaimGate(input, options = {}) {
+  const routing = evaluateResumeClaimRouting(
+    { ...input, claimId: undefined },
+    options,
+  );
+  const verdict =
+    routing.state === 'unclaimed'
+      ? 'claimable'
+      : routing.state === 'stale'
+        ? 'stale-reclaimable'
+        : 'already-claimed';
+  return {
+    verdict,
+    winningClaimId: routing.active_claim?.claim_id ?? null,
+    reason: routing.reason,
+  };
+}
 function runCli() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -202,38 +238,49 @@ function runCli() {
   const expectedLinkedPrReferences = forcedHandoffEnabled
     ? fetchOpenLinkedPrReferences(repository, args.issue)
     : new Set();
+  const routingEvents = comments.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  }));
+  const routingOptions = {
+    isTrustedAuthor: (login) =>
+      trustedSet.has(
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      ),
+    isForcedHandoffEnabled: buildForcedHandoffEnabledGate({
+      forcedHandoffEnabled,
+      expectedLinkedPrReferences,
+    }),
+    isAuthorizedForcedHandoff: (forcedBy) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy,
+        permissionCache,
+      ),
+  };
   const result = evaluateResumeClaimRouting(
     {
-      events: comments.map((comment) => ({
-        body: comment.body ?? '',
-        createdAt: comment.created_at ?? '',
-        author: { login: comment.user?.login ?? '' },
-      })),
+      events: routingEvents,
       claimId: args.claimId,
       staleAgeMs,
       now: args.now || undefined,
     },
-    {
-      isTrustedAuthor: (login) =>
-        trustedSet.has(
-          String(login ?? '')
-            .trim()
-            .toLowerCase(),
-        ),
-      isForcedHandoffEnabled: buildForcedHandoffEnabledGate({
-        forcedHandoffEnabled,
-        expectedLinkedPrReferences,
-      }),
-      isAuthorizedForcedHandoff: (forcedBy) =>
-        isAuthorizedForcedHandoffActor(
-          owner,
-          repo,
-          forcedBy,
-          forcedHandoffAuthorityPolicy,
-          permissionCache,
-        ),
-    },
+    routingOptions,
   );
+  // The fresh-claim (A5) gate re-uses the same resolver over the same markers
+  // but ignores any --claim-id (a fresh claim owns none yet), mapping the
+  // routing state to the write-side claimability vocabulary.
+  const freshClaimGate = args.freshClaimGate
+    ? evaluateFreshClaimGate(
+        { events: routingEvents, staleAgeMs, now: args.now || undefined },
+        routingOptions,
+      )
+    : null;
   const output = {
     repository: { owner, repo },
     issue: {
@@ -250,6 +297,14 @@ function runCli() {
       forced_handoff_authority_policy: forcedHandoffAuthorityPolicy,
     },
     ...result,
+    ...(freshClaimGate
+      ? {
+          fresh_claim_gate: {
+            verdict: freshClaimGate.verdict,
+            winning_claim_id: freshClaimGate.winningClaimId,
+          },
+        }
+      : {}),
   };
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }
@@ -480,6 +535,7 @@ function parseArgs(argv) {
     policy: '',
     staleAgeMs: 0,
     trustedMarkerLogins: '',
+    freshClaimGate: false,
     help: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -536,6 +592,10 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (token === '--fresh-claim-gate') {
+      parsed.freshClaimGate = true;
+      continue;
+    }
     if (token === '--help' || token === '-h') {
       parsed.help = true;
       continue;
@@ -546,14 +606,21 @@ function parseArgs(argv) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/resume-claim-routing.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--claim-id <token>] [--now <ISO8601>] [--policy <path>] [--stale-age-ms <ms>] [--trusted-marker-logins "<a,b,...>"]
+  node scripts/resume-claim-routing.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--claim-id <token>] [--now <ISO8601>] [--policy <path>] [--stale-age-ms <ms>] [--trusted-marker-logins "<a,b,...>"] [--fresh-claim-gate]
+
+  --fresh-claim-gate  emit the write-side A5(c) claimability verdict for the
+                      issue from current marker state, ignoring --claim-id (a
+                      fresh claim owns none yet). Run it on a fresh fetch
+                      immediately before the claim write; it re-uses the same
+                      resolver so claim-state logic never forks.
 
 Output schema:
 {
   "state": "unclaimed|already_owned|stale|non_inheritable|disputed",
   "action": "re_claim|takeover|keep|stop",
   "reason": "...",
-  "active_claim": {"agent_id":"...","claim_id":"...","created_at":"...","branch":"..."} | null
+  "active_claim": {"agent_id":"...","claim_id":"...","created_at":"...","branch":"..."} | null,
+  "fresh_claim_gate": {"verdict":"claimable|already-claimed|stale-reclaimable","winning_claim_id":"..."|null}  // only with --fresh-claim-gate
 }
 `);
 }

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -176,10 +176,12 @@ export function evaluateResumeClaimRouting(input, options = {}) {
  *
  * A fresh claim owns no prior claim-id, so any `claimId` on `input` is ignored
  * (the resolver's already-owned / same-second-loss branches need a checked id
- * and would otherwise mask pure contention). `winningClaimId` names the active
- * claim, if any. GitHub issue comments have no compare-and-swap, so this
- * **narrows** the A5(c) TOCTOU window rather than closing it; the 24 h
- * stale-takeover and same-second tie-break remain the race-recovery backstop.
+ * and would otherwise mask pure contention). `winningClaimId` is the active
+ * claim's `{claim-id}`, or `null` when there is no active claim or the active
+ * claim is a legacy (claim-id-less) marker. GitHub issue comments have no
+ * compare-and-swap, so this **narrows** the A5(c) TOCTOU window rather than
+ * closing it; the 24 h stale-takeover and same-second tie-break remain the
+ * race-recovery backstop.
  */
 export function evaluateFreshClaimGate(input, options = {}) {
   const routing = evaluateResumeClaimRouting(

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -614,7 +614,8 @@ function printHelp() {
                       immediately before the claim write; it re-uses the same
                       resolver so claim-state logic never forks.
 
-Output schema:
+Output (selected fields; the JSON also carries repository / issue / policy /
+warnings / evidence):
 {
   "state": "unclaimed|already_owned|stale|non_inheritable|disputed",
   "action": "re_claim|takeover|keep|stop",

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -810,7 +810,8 @@ function printHelp(): void {
                       immediately before the claim write; it re-uses the same
                       resolver so claim-state logic never forks.
 
-Output schema:
+Output (selected fields; the JSON also carries repository / issue / policy /
+warnings / evidence):
 {
   "state": "unclaimed|already_owned|stale|non_inheritable|disputed",
   "action": "re_claim|takeover|keep|stop",

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -99,6 +99,7 @@ interface ResumeClaimRoutingArgs {
   policy: string;
   staleAgeMs: number;
   trustedMarkerLogins: string;
+  freshClaimGate: boolean;
   help: boolean;
 }
 
@@ -260,6 +261,59 @@ export function evaluateResumeClaimRouting(
   };
 }
 
+/** Verdict vocabulary for the fresh-claim (A5) claimability gate. */
+export type FreshClaimVerdict =
+  | 'claimable'
+  | 'already-claimed'
+  | 'stale-reclaimable';
+
+/** Result of {@link evaluateFreshClaimGate}. */
+export interface FreshClaimGateResult {
+  verdict: FreshClaimVerdict;
+  winningClaimId: string | null;
+  reason: string;
+}
+
+/**
+ * Mechanical fresh-claim (A5) claimability gate.
+ *
+ * It reuses the shared `evaluateResumeClaimRouting` resolver (which itself
+ * builds on `resolveActiveClaim`) over a fresh marker fetch and maps the
+ * routing state to the fresh-claim vocabulary, so the write-side path never
+ * forks claim-state logic:
+ *
+ * - `unclaimed` → `claimable`
+ * - `stale` → `stale-reclaimable`
+ * - `non_inheritable` / `disputed` (a live competitor) → `already-claimed`
+ *
+ * A fresh claim owns no prior claim-id, so any `claimId` on `input` is ignored
+ * (the resolver's already-owned / same-second-loss branches need a checked id
+ * and would otherwise mask pure contention). `winningClaimId` names the active
+ * claim, if any. GitHub issue comments have no compare-and-swap, so this
+ * **narrows** the A5(c) TOCTOU window rather than closing it; the 24 h
+ * stale-takeover and same-second tie-break remain the race-recovery backstop.
+ */
+export function evaluateFreshClaimGate(
+  input: ResumeClaimRoutingInput,
+  options: ResumeClaimRoutingOptions = {},
+): FreshClaimGateResult {
+  const routing = evaluateResumeClaimRouting(
+    { ...input, claimId: undefined },
+    options,
+  );
+  const verdict: FreshClaimVerdict =
+    routing.state === 'unclaimed'
+      ? 'claimable'
+      : routing.state === 'stale'
+        ? 'stale-reclaimable'
+        : 'already-claimed';
+  return {
+    verdict,
+    winningClaimId: routing.active_claim?.claim_id ?? null,
+    reason: routing.reason,
+  };
+}
+
 function runCli(): void {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -308,38 +362,50 @@ function runCli(): void {
     ? fetchOpenLinkedPrReferences(repository, args.issue)
     : new Set<string>();
 
+  const routingEvents = comments.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.created_at ?? '',
+    author: { login: comment.user?.login ?? '' },
+  }));
+  const routingOptions = {
+    isTrustedAuthor: (login: string) =>
+      trustedSet.has(
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      ),
+    isForcedHandoffEnabled: buildForcedHandoffEnabledGate({
+      forcedHandoffEnabled,
+      expectedLinkedPrReferences,
+    }),
+    isAuthorizedForcedHandoff: (forcedBy: string) =>
+      isAuthorizedForcedHandoffActor(
+        owner,
+        repo,
+        forcedBy,
+        forcedHandoffAuthorityPolicy,
+        permissionCache,
+      ),
+  };
   const result = evaluateResumeClaimRouting(
     {
-      events: comments.map((comment) => ({
-        body: comment.body ?? '',
-        createdAt: comment.created_at ?? '',
-        author: { login: comment.user?.login ?? '' },
-      })),
+      events: routingEvents,
       claimId: args.claimId,
       staleAgeMs,
       now: args.now || undefined,
     },
-    {
-      isTrustedAuthor: (login) =>
-        trustedSet.has(
-          String(login ?? '')
-            .trim()
-            .toLowerCase(),
-        ),
-      isForcedHandoffEnabled: buildForcedHandoffEnabledGate({
-        forcedHandoffEnabled,
-        expectedLinkedPrReferences,
-      }),
-      isAuthorizedForcedHandoff: (forcedBy) =>
-        isAuthorizedForcedHandoffActor(
-          owner,
-          repo,
-          forcedBy,
-          forcedHandoffAuthorityPolicy,
-          permissionCache,
-        ),
-    },
+    routingOptions,
   );
+
+  // The fresh-claim (A5) gate re-uses the same resolver over the same markers
+  // but ignores any --claim-id (a fresh claim owns none yet), mapping the
+  // routing state to the write-side claimability vocabulary.
+  const freshClaimGate = args.freshClaimGate
+    ? evaluateFreshClaimGate(
+        { events: routingEvents, staleAgeMs, now: args.now || undefined },
+        routingOptions,
+      )
+    : null;
 
   const output = {
     repository: { owner, repo },
@@ -357,6 +423,14 @@ function runCli(): void {
       forced_handoff_authority_policy: forcedHandoffAuthorityPolicy,
     },
     ...result,
+    ...(freshClaimGate
+      ? {
+          fresh_claim_gate: {
+            verdict: freshClaimGate.verdict,
+            winning_claim_id: freshClaimGate.winningClaimId,
+          },
+        }
+      : {}),
   };
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }
@@ -656,6 +730,7 @@ function parseArgs(argv: string[]): ResumeClaimRoutingArgs {
     policy: '',
     staleAgeMs: 0,
     trustedMarkerLogins: '',
+    freshClaimGate: false,
     help: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -712,6 +787,10 @@ function parseArgs(argv: string[]): ResumeClaimRoutingArgs {
       index += 1;
       continue;
     }
+    if (token === '--fresh-claim-gate') {
+      parsed.freshClaimGate = true;
+      continue;
+    }
     if (token === '--help' || token === '-h') {
       parsed.help = true;
       continue;
@@ -723,14 +802,21 @@ function parseArgs(argv: string[]): ResumeClaimRoutingArgs {
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/resume-claim-routing.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--claim-id <token>] [--now <ISO8601>] [--policy <path>] [--stale-age-ms <ms>] [--trusted-marker-logins "<a,b,...>"]
+  node scripts/resume-claim-routing.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--claim-id <token>] [--now <ISO8601>] [--policy <path>] [--stale-age-ms <ms>] [--trusted-marker-logins "<a,b,...>"] [--fresh-claim-gate]
+
+  --fresh-claim-gate  emit the write-side A5(c) claimability verdict for the
+                      issue from current marker state, ignoring --claim-id (a
+                      fresh claim owns none yet). Run it on a fresh fetch
+                      immediately before the claim write; it re-uses the same
+                      resolver so claim-state logic never forks.
 
 Output schema:
 {
   "state": "unclaimed|already_owned|stale|non_inheritable|disputed",
   "action": "re_claim|takeover|keep|stop",
   "reason": "...",
-  "active_claim": {"agent_id":"...","claim_id":"...","created_at":"...","branch":"..."} | null
+  "active_claim": {"agent_id":"...","claim_id":"...","created_at":"...","branch":"..."} | null,
+  "fresh_claim_gate": {"verdict":"claimable|already-claimed|stale-reclaimable","winning_claim_id":"..."|null}  // only with --fresh-claim-gate
 }
 `);
 }

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -288,10 +288,12 @@ export interface FreshClaimGateResult {
  *
  * A fresh claim owns no prior claim-id, so any `claimId` on `input` is ignored
  * (the resolver's already-owned / same-second-loss branches need a checked id
- * and would otherwise mask pure contention). `winningClaimId` names the active
- * claim, if any. GitHub issue comments have no compare-and-swap, so this
- * **narrows** the A5(c) TOCTOU window rather than closing it; the 24 h
- * stale-takeover and same-second tie-break remain the race-recovery backstop.
+ * and would otherwise mask pure contention). `winningClaimId` is the active
+ * claim's `{claim-id}`, or `null` when there is no active claim or the active
+ * claim is a legacy (claim-id-less) marker. GitHub issue comments have no
+ * compare-and-swap, so this **narrows** the A5(c) TOCTOU window rather than
+ * closing it; the 24 h stale-takeover and same-second tie-break remain the
+ * race-recovery backstop.
  */
 export function evaluateFreshClaimGate(
   input: ResumeClaimRoutingInput,

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 
 import {
   buildForcedHandoffEnabledGate,
+  evaluateFreshClaimGate,
   evaluateResumeClaimRouting,
 } from '../src/scripts/resume-claim-routing.mts';
 
@@ -84,6 +85,81 @@ test('returns stale for stale active claim from another session', () => {
   assert.equal(result.state, 'stale');
   assert.equal(result.action, 'takeover');
   assert.equal(result.reason, 'active-claim-stale');
+});
+
+test('evaluateFreshClaimGate: no markers → claimable', () => {
+  const gate = evaluateFreshClaimGate(
+    { events: [], now: '2026-05-12T10:00:00Z' },
+    { isTrustedAuthor: trusted(['maintainer']) },
+  );
+
+  assert.equal(gate.verdict, 'claimable');
+  assert.equal(gate.winningClaimId, null);
+});
+
+test('evaluateFreshClaimGate: fresh active claim from another session → already-claimed', () => {
+  const gate = evaluateFreshClaimGate(
+    {
+      // A stray --claim-id must be ignored: a fresh claim owns none yet, so a
+      // matching id must not mask an active competitor.
+      claimId: 'claim-other',
+      now: '2026-05-12T10:00:00Z',
+      events: [
+        {
+          createdAt: '2026-05-12T09:30:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-other supersedes: none 2026-05-12T09:30:00Z branch: issue/2-task -->',
+        },
+      ],
+    },
+    { isTrustedAuthor: trusted(['maintainer']) },
+  );
+
+  assert.equal(gate.verdict, 'already-claimed');
+  assert.equal(gate.winningClaimId, 'claim-other');
+});
+
+test('evaluateFreshClaimGate: stale active claim → stale-reclaimable', () => {
+  const gate = evaluateFreshClaimGate(
+    {
+      now: '2026-05-13T10:00:01Z',
+      events: [
+        {
+          createdAt: '2026-05-12T10:00:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-old supersedes: none 2026-05-12T10:00:00Z branch: issue/3-task -->',
+        },
+      ],
+    },
+    { isTrustedAuthor: trusted(['maintainer']) },
+  );
+
+  assert.equal(gate.verdict, 'stale-reclaimable');
+  assert.equal(gate.winningClaimId, 'claim-old');
+});
+
+test('evaluateFreshClaimGate: later competing claim → already-claimed (disputed)', () => {
+  const gate = evaluateFreshClaimGate(
+    {
+      now: '2026-05-12T10:00:00Z',
+      events: [
+        {
+          createdAt: '2026-05-12T09:00:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-first supersedes: none 2026-05-12T09:00:00Z branch: issue/4-task -->',
+        },
+        {
+          createdAt: '2026-05-12T09:00:30Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-second supersedes: none 2026-05-12T09:00:30Z branch: issue/4-task -->',
+        },
+      ],
+    },
+    { isTrustedAuthor: trusted(['maintainer']) },
+  );
+
+  assert.equal(gate.verdict, 'already-claimed');
+  assert.equal(gate.reason, 'later-competing-claim');
 });
 
 test('detects same-second tie-break loss as disputed', () => {


### PR DESCRIPTION
## Summary

The mechanical claimability verdict already exists in
`evaluateResumeClaimRouting` (`unclaimed | already_owned | stale |
non_inheritable | disputed`), but only the **Resume** phase used it. The
**fresh-claim** A5(c) path resolved claim state by prose only, leaving a TOCTOU
window where, under a concurrent swarm, an agent could post a claim ~1 min after
a sibling already claimed the same issue whose marker had not yet appeared.

## Change

- Export **`evaluateFreshClaimGate`** in `src/scripts/resume-claim-routing.mts`
  — a thin wrapper that **reuses** `evaluateResumeClaimRouting` (built on
  `resolveActiveClaim`), so claim-state logic never forks. It forces any
  `claimId` undefined (a fresh claim owns none yet) and maps the routing state
  to `claimable | already-claimed | stale-reclaimable` plus the winning
  claim-id.
- Add a **`--fresh-claim-gate`** CLI mode that emits
  `fresh_claim_gate.{verdict, winning_claim_id}` for an issue from current
  marker state.
- Wire **A5(c)** in `idd-claim.instructions.md` to run the gate on a fresh fetch
  immediately before the claim write, routing `already-claimed` back to
  Discover. It notes explicitly that GitHub issue comments have no
  compare-and-swap, so this **narrows** rather than closes the window; the 24 h
  stale-takeover and same-second tie-break remain the race-recovery backstop.

## Verification

Unit tests cover the unclaimed→claimable, fresh-active→already-claimed,
stale→stale-reclaimable, and later-competing→already-claimed branches. The A5(c)
text is edited in the `idd-template/` source and regenerated via
`node scripts/sync-docs.mjs --apply`; the generated
`scripts/resume-claim-routing.mjs` is regenerated via `pnpm run build`.
`audit-docs --check`, `pnpm test` (1451), and `pnpm run lint:minimum` pass.

Closes #1147
