### PR TITLE
test(idd): auto-discover schema/fixture cases and add missing pairs

### DIFF
--- a/fixtures/schemas/disposition-non-review-notices.invalid.json
+++ b/fixtures/schemas/disposition-non-review-notices.invalid.json
@@ -1,0 +1,6 @@
+{
+  "mode": "apply",
+  "prNumber": 994,
+  "headSha": "not-a-sha",
+  "skipped": []
+}

--- a/fixtures/schemas/disposition-non-review-notices.valid.json
+++ b/fixtures/schemas/disposition-non-review-notices.valid.json
@@ -1,0 +1,20 @@
+{
+  "mode": "apply",
+  "prNumber": 994,
+  "headSha": "0123456789abcdef0123456789abcdef01234567",
+  "status": "applied",
+  "applied": [
+    {
+      "noticeId": 4200000001,
+      "commentId": 4200009001
+    }
+  ],
+  "failed": [],
+  "skipped": [
+    {
+      "noticeId": 4200000002,
+      "botLogin": "chatgpt-codex-connector[bot]",
+      "reason": "already-dispositioned"
+    }
+  ]
+}

--- a/fixtures/schemas/idd-roadmap-audit-execute.invalid.json
+++ b/fixtures/schemas/idd-roadmap-audit-execute.invalid.json
@@ -1,0 +1,17 @@
+{
+  "protocolVersion": "1",
+  "decisionAuthority": "instructions",
+  "mode": "apply",
+  "roadmapNumber": 1156,
+  "ready": false,
+  "blockers": [
+    {
+      "kind": "not-a-kind",
+      "detail": "example blocker with an out-of-enum kind"
+    }
+  ],
+  "evidenceBody": "Roadmap still has an open child.",
+  "closed": false,
+  "claimReleased": false,
+  "result": "blocked"
+}

--- a/fixtures/schemas/idd-roadmap-audit-execute.valid.json
+++ b/fixtures/schemas/idd-roadmap-audit-execute.valid.json
@@ -1,0 +1,12 @@
+{
+  "protocolVersion": "1",
+  "decisionAuthority": "instructions",
+  "mode": "dry-run",
+  "roadmapNumber": 1156,
+  "ready": true,
+  "blockers": [],
+  "evidenceBody": "All child issues are closed; the roadmap is ready to be audited closed.",
+  "closed": false,
+  "claimReleased": false,
+  "result": "ready"
+}

--- a/fixtures/schemas/post-idd-marker.invalid.json
+++ b/fixtures/schemas/post-idd-marker.invalid.json
@@ -1,0 +1,6 @@
+{
+  "mode": "apply",
+  "type": "heartbeat",
+  "target": "issue",
+  "number": 1146
+}

--- a/fixtures/schemas/post-idd-marker.valid.json
+++ b/fixtures/schemas/post-idd-marker.valid.json
@@ -1,0 +1,9 @@
+{
+  "mode": "apply",
+  "type": "claim",
+  "target": "issue",
+  "number": 1146,
+  "body": "<!-- claimed-by: agent-abc claim-123 supersedes: none 2026-07-01T17:11:51Z branch: issue/1146-example -->\n\n_agent: issue claim — IDD automation marker. Do not edit._",
+  "commentId": 4858165950,
+  "url": "https://github.com/kurone-kito/idd-skill/issues/1146#issuecomment-4858165950"
+}

--- a/fixtures/schemas/resolve-review-thread.invalid.json
+++ b/fixtures/schemas/resolve-review-thread.invalid.json
@@ -1,0 +1,7 @@
+{
+  "mode": "apply",
+  "prNumber": 1171,
+  "commentId": 3507490719,
+  "alreadyResolved": false,
+  "status": "resolved"
+}

--- a/fixtures/schemas/resolve-review-thread.valid.json
+++ b/fixtures/schemas/resolve-review-thread.valid.json
@@ -1,0 +1,9 @@
+{
+  "mode": "apply",
+  "prNumber": 1171,
+  "commentId": 3507490719,
+  "threadId": "review-thread-node-id",
+  "alreadyResolved": false,
+  "status": "applied",
+  "replyId": 3507513424
+}

--- a/fixtures/schemas/stalled-session-quiet-check.invalid.json
+++ b/fixtures/schemas/stalled-session-quiet-check.invalid.json
@@ -1,0 +1,35 @@
+{
+  "repository": {
+    "owner": "kurone-kito",
+    "repo": "idd-skill"
+  },
+  "pr": {
+    "number": 994,
+    "title": "Example stalled-session PR",
+    "head_sha": "0123456789abcdef0123456789abcdef01234567",
+    "html_url": "https://github.com/kurone-kito/idd-skill/pull/994"
+  },
+  "policy": {
+    "quiet_window_ms": 3600000,
+    "claim_created_at": null
+  },
+  "quiet_window_met": false,
+  "quiet_window_ms": 3600000,
+  "window_start": "2026-05-11T16:00:00Z",
+  "now": "2026-05-11T17:00:00Z",
+  "latest_activity": 12345,
+  "latest_activity_type": "review_comment",
+  "reason": "latest_activity must be a string or null, not a number",
+  "evidence": {
+    "activity_count_in_window": 1,
+    "blocking_activities": [
+      {
+        "type": "review_comment",
+        "timestamp": "2026-05-11T16:30:00Z"
+      }
+    ],
+    "has_heartbeat_in_window": false,
+    "has_ci_running": false,
+    "has_branch_tip_movement": false
+  }
+}

--- a/fixtures/schemas/stalled-session-quiet-check.valid.json
+++ b/fixtures/schemas/stalled-session-quiet-check.valid.json
@@ -1,0 +1,30 @@
+{
+  "repository": {
+    "owner": "kurone-kito",
+    "repo": "idd-skill"
+  },
+  "pr": {
+    "number": 994,
+    "title": "Example stalled-session PR",
+    "head_sha": "0123456789abcdef0123456789abcdef01234567",
+    "html_url": "https://github.com/kurone-kito/idd-skill/pull/994"
+  },
+  "policy": {
+    "quiet_window_ms": 3600000,
+    "claim_created_at": "2026-05-11T16:00:00Z"
+  },
+  "quiet_window_met": true,
+  "quiet_window_ms": 3600000,
+  "window_start": "2026-05-11T16:00:00Z",
+  "now": "2026-05-11T17:00:00Z",
+  "latest_activity": null,
+  "latest_activity_type": null,
+  "reason": "quiet window satisfied; no blocking activity in window",
+  "evidence": {
+    "activity_count_in_window": 0,
+    "blocking_activities": [],
+    "has_heartbeat_in_window": false,
+    "has_ci_running": false,
+    "has_branch_tip_movement": false
+  }
+}

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -17,7 +17,7 @@
  * Any other keyword in a schema triggers an error, preventing false
  * confidence from silently-ignored constraints.
  */
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -64,8 +64,13 @@ const ALLOWED_KEYWORDS = new Set([
   ...ANNOTATION_KEYWORDS,
   ...ENFORCED_KEYWORDS,
 ]);
-/** Format values this validator actively enforces. */
-const SUPPORTED_FORMATS = new Set(['date-time']);
+/**
+ * Format values this validator recognizes. `date-time` is actively enforced
+ * (see `validate`); `uri` is accepted as a documentation-only annotation that a
+ * full JSON Schema validator enforces but this lightweight one does not, so a
+ * schema may declare it without tripping the unsupported-format guard.
+ */
+const SUPPORTED_FORMATS = new Set(['date-time', 'uri']);
 /**
  * Check that a schema object only uses allowed keywords, recursively.
  */
@@ -126,7 +131,21 @@ export function validate(data, schema, path = '$') {
   const errors = [];
   const actualType = getType(data);
   if (s.type !== undefined) {
-    if (s.type === 'integer') {
+    if (Array.isArray(s.type)) {
+      // Union type (e.g. ["string", "null"]): valid when the value matches any
+      // listed type, where 'integer' means an integer-valued number.
+      const matches = s.type.some((t) =>
+        t === 'integer'
+          ? actualType === 'number' && Number.isInteger(data)
+          : actualType === t,
+      );
+      if (!matches) {
+        errors.push(
+          `${path}: expected type "${s.type.join('|')}", got "${actualType}"`,
+        );
+        return errors;
+      }
+    } else if (s.type === 'integer') {
       if (actualType !== 'number') {
         errors.push(`${path}: expected type "integer", got "${actualType}"`);
         return errors;
@@ -304,89 +323,70 @@ export function validateFixture(schemaPath, fixturePath, expectValid) {
   }
   return { ok: true, errors: [] };
 }
+/**
+ * Auto-discover schema/fixture validation cases under `root`: every
+ * `schemas/*.schema.json` is paired with `fixtures/schemas/<name>.valid.json`
+ * (expect-pass) and `<name>.invalid.json` (expect-fail). A schema missing
+ * either fixture is reported in `missing` rather than silently skipped, so the
+ * CLI can fail closed and a new schema cannot slip through unvalidated. Pure
+ * over the filesystem (globs and stats only), so it is unit-testable.
+ */
+export function discoverSchemaCases(root) {
+  const schemaFiles = readdirSync(join(root, 'schemas'))
+    .filter((file) => file.endsWith('.schema.json'))
+    .sort();
+  const cases = [];
+  const missing = [];
+  for (const file of schemaFiles) {
+    const name = file.slice(0, -'.schema.json'.length);
+    const schemaPath = `schemas/${file}`;
+    const validFixture = `fixtures/schemas/${name}.valid.json`;
+    const invalidFixture = `fixtures/schemas/${name}.invalid.json`;
+    const missingFixtures = [];
+    if (!existsSync(join(root, validFixture))) {
+      missingFixtures.push(validFixture);
+    }
+    if (!existsSync(join(root, invalidFixture))) {
+      missingFixtures.push(invalidFixture);
+    }
+    if (missingFixtures.length > 0) {
+      missing.push({ schema: schemaPath, missingFixtures });
+      continue;
+    }
+    cases.push({ schemaPath, fixturePath: validFixture, expectValid: true });
+    cases.push({
+      schemaPath,
+      fixturePath: invalidFixture,
+      expectValid: false,
+    });
+  }
+  return { cases, missing };
+}
 // CLI: run all schemas and fixtures when invoked directly.
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const cases = [
-    [
-      'schemas/claim-marker.schema.json',
-      'fixtures/schemas/claim-marker.valid.json',
-      true,
-    ],
-    [
-      'schemas/claim-marker.schema.json',
-      'fixtures/schemas/claim-marker.invalid.json',
-      false,
-    ],
-    [
-      'schemas/forced-handoff-marker.schema.json',
-      'fixtures/schemas/forced-handoff-marker.valid.json',
-      true,
-    ],
-    [
-      'schemas/forced-handoff-marker.schema.json',
-      'fixtures/schemas/forced-handoff-marker.invalid.json',
-      false,
-    ],
-    [
-      'schemas/live-status-digest.schema.json',
-      'fixtures/schemas/live-status-digest.valid.json',
-      true,
-    ],
-    [
-      'schemas/live-status-digest.schema.json',
-      'fixtures/schemas/live-status-digest.invalid.json',
-      false,
-    ],
-    [
-      'schemas/advisory-wait-state.schema.json',
-      'fixtures/schemas/advisory-wait-state.valid.json',
-      true,
-    ],
-    [
-      'schemas/advisory-wait-state.schema.json',
-      'fixtures/schemas/advisory-wait-state.invalid.json',
-      false,
-    ],
-    [
-      'schemas/pre-merge-readiness.schema.json',
-      'fixtures/schemas/pre-merge-readiness.valid.json',
-      true,
-    ],
-    [
-      'schemas/pre-merge-readiness.schema.json',
-      'fixtures/schemas/pre-merge-readiness.invalid.json',
-      false,
-    ],
-    [
-      'schemas/idd-merge-execute.schema.json',
-      'fixtures/schemas/idd-merge-execute.valid.json',
-      true,
-    ],
-    [
-      'schemas/idd-merge-execute.schema.json',
-      'fixtures/schemas/idd-merge-execute.invalid.json',
-      false,
-    ],
-    ['schemas/policy.schema.json', 'fixtures/schemas/policy.valid.json', true],
-    [
-      'schemas/policy.schema.json',
-      'fixtures/schemas/policy.invalid.json',
-      false,
-    ],
-    [
-      'schemas/phase-graph.schema.json',
-      'fixtures/schemas/phase-graph.valid.json',
-      true,
-    ],
-    [
-      'schemas/phase-graph.schema.json',
-      'fixtures/schemas/phase-graph.invalid.json',
-      false,
-    ],
-    ['schemas/phase-graph.schema.json', 'schemas/phase-graph.json', true],
-  ];
+  const { cases, missing } = discoverSchemaCases(ROOT);
+  if (missing.length > 0) {
+    for (const entry of missing) {
+      console.error(
+        `✗  ${entry.schema}: missing fixture(s) ${entry.missingFixtures.join(', ')}`,
+      );
+    }
+    console.error(
+      `\n${missing.length} schema(s) have no fixtures. Add ` +
+        `fixtures/schemas/<name>.valid.json and <name>.invalid.json for each.`,
+    );
+    process.exit(1);
+  }
+  // phase-graph additionally validates its live data file (referential
+  // integrity via validateFixture's dedicated validatePhaseGraph hook) as an
+  // explicit override beyond the discovered valid/invalid fixture pair.
+  cases.push({
+    schemaPath: 'schemas/phase-graph.schema.json',
+    fixturePath: 'schemas/phase-graph.json',
+    expectValid: true,
+  });
   let failed = 0;
-  for (const [schemaPath, fixturePath, expectValid] of cases) {
+  for (const { schemaPath, fixturePath, expectValid } of cases) {
     const result = validateFixture(schemaPath, fixturePath, expectValid);
     const label = expectValid ? 'valid' : 'invalid';
     if (result.ok) {

--- a/src/scripts/validate-schemas.mts
+++ b/src/scripts/validate-schemas.mts
@@ -19,7 +19,7 @@
  * confidence from silently-ignored constraints.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -47,7 +47,7 @@ function resolveRepoRoot(fromUrl: string): string {
 const ROOT = resolveRepoRoot(import.meta.url);
 
 interface SchemaNode {
-  type?: string;
+  type?: string | string[];
   required?: string[];
   properties?: Record<string, SchemaNode>;
   patternProperties?: Record<string, SchemaNode>;
@@ -88,8 +88,13 @@ const ALLOWED_KEYWORDS = new Set([
   ...ENFORCED_KEYWORDS,
 ]);
 
-/** Format values this validator actively enforces. */
-const SUPPORTED_FORMATS = new Set(['date-time']);
+/**
+ * Format values this validator recognizes. `date-time` is actively enforced
+ * (see `validate`); `uri` is accepted as a documentation-only annotation that a
+ * full JSON Schema validator enforces but this lightweight one does not, so a
+ * schema may declare it without tripping the unsupported-format guard.
+ */
+const SUPPORTED_FORMATS = new Set(['date-time', 'uri']);
 
 /**
  * Check that a schema object only uses allowed keywords, recursively.
@@ -154,7 +159,21 @@ export function validate(data: unknown, schema: unknown, path = '$'): string[] {
   const actualType = getType(data);
 
   if (s.type !== undefined) {
-    if (s.type === 'integer') {
+    if (Array.isArray(s.type)) {
+      // Union type (e.g. ["string", "null"]): valid when the value matches any
+      // listed type, where 'integer' means an integer-valued number.
+      const matches = s.type.some((t) =>
+        t === 'integer'
+          ? actualType === 'number' && Number.isInteger(data)
+          : actualType === t,
+      );
+      if (!matches) {
+        errors.push(
+          `${path}: expected type "${s.type.join('|')}", got "${actualType}"`,
+        );
+        return errors;
+      }
+    } else if (s.type === 'integer') {
       if (actualType !== 'number') {
         errors.push(`${path}: expected type "integer", got "${actualType}"`);
         return errors;
@@ -357,90 +376,88 @@ export function validateFixture(
   return { ok: true, errors: [] };
 }
 
+/** One schema/fixture validation case. */
+export interface SchemaCase {
+  schemaPath: string;
+  fixturePath: string;
+  expectValid: boolean;
+}
+
+/** A schema that is missing one or both of its fixture files. */
+export interface MissingFixtureSchema {
+  schema: string;
+  missingFixtures: string[];
+}
+
+/**
+ * Auto-discover schema/fixture validation cases under `root`: every
+ * `schemas/*.schema.json` is paired with `fixtures/schemas/<name>.valid.json`
+ * (expect-pass) and `<name>.invalid.json` (expect-fail). A schema missing
+ * either fixture is reported in `missing` rather than silently skipped, so the
+ * CLI can fail closed and a new schema cannot slip through unvalidated. Pure
+ * over the filesystem (globs and stats only), so it is unit-testable.
+ */
+export function discoverSchemaCases(root: string): {
+  cases: SchemaCase[];
+  missing: MissingFixtureSchema[];
+} {
+  const schemaFiles = readdirSync(join(root, 'schemas'))
+    .filter((file) => file.endsWith('.schema.json'))
+    .sort();
+  const cases: SchemaCase[] = [];
+  const missing: MissingFixtureSchema[] = [];
+  for (const file of schemaFiles) {
+    const name = file.slice(0, -'.schema.json'.length);
+    const schemaPath = `schemas/${file}`;
+    const validFixture = `fixtures/schemas/${name}.valid.json`;
+    const invalidFixture = `fixtures/schemas/${name}.invalid.json`;
+    const missingFixtures: string[] = [];
+    if (!existsSync(join(root, validFixture))) {
+      missingFixtures.push(validFixture);
+    }
+    if (!existsSync(join(root, invalidFixture))) {
+      missingFixtures.push(invalidFixture);
+    }
+    if (missingFixtures.length > 0) {
+      missing.push({ schema: schemaPath, missingFixtures });
+      continue;
+    }
+    cases.push({ schemaPath, fixturePath: validFixture, expectValid: true });
+    cases.push({
+      schemaPath,
+      fixturePath: invalidFixture,
+      expectValid: false,
+    });
+  }
+  return { cases, missing };
+}
+
 // CLI: run all schemas and fixtures when invoked directly.
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const cases: [string, string, boolean][] = [
-    [
-      'schemas/claim-marker.schema.json',
-      'fixtures/schemas/claim-marker.valid.json',
-      true,
-    ],
-    [
-      'schemas/claim-marker.schema.json',
-      'fixtures/schemas/claim-marker.invalid.json',
-      false,
-    ],
-    [
-      'schemas/forced-handoff-marker.schema.json',
-      'fixtures/schemas/forced-handoff-marker.valid.json',
-      true,
-    ],
-    [
-      'schemas/forced-handoff-marker.schema.json',
-      'fixtures/schemas/forced-handoff-marker.invalid.json',
-      false,
-    ],
-    [
-      'schemas/live-status-digest.schema.json',
-      'fixtures/schemas/live-status-digest.valid.json',
-      true,
-    ],
-    [
-      'schemas/live-status-digest.schema.json',
-      'fixtures/schemas/live-status-digest.invalid.json',
-      false,
-    ],
-    [
-      'schemas/advisory-wait-state.schema.json',
-      'fixtures/schemas/advisory-wait-state.valid.json',
-      true,
-    ],
-    [
-      'schemas/advisory-wait-state.schema.json',
-      'fixtures/schemas/advisory-wait-state.invalid.json',
-      false,
-    ],
-    [
-      'schemas/pre-merge-readiness.schema.json',
-      'fixtures/schemas/pre-merge-readiness.valid.json',
-      true,
-    ],
-    [
-      'schemas/pre-merge-readiness.schema.json',
-      'fixtures/schemas/pre-merge-readiness.invalid.json',
-      false,
-    ],
-    [
-      'schemas/idd-merge-execute.schema.json',
-      'fixtures/schemas/idd-merge-execute.valid.json',
-      true,
-    ],
-    [
-      'schemas/idd-merge-execute.schema.json',
-      'fixtures/schemas/idd-merge-execute.invalid.json',
-      false,
-    ],
-    ['schemas/policy.schema.json', 'fixtures/schemas/policy.valid.json', true],
-    [
-      'schemas/policy.schema.json',
-      'fixtures/schemas/policy.invalid.json',
-      false,
-    ],
-    [
-      'schemas/phase-graph.schema.json',
-      'fixtures/schemas/phase-graph.valid.json',
-      true,
-    ],
-    [
-      'schemas/phase-graph.schema.json',
-      'fixtures/schemas/phase-graph.invalid.json',
-      false,
-    ],
-    ['schemas/phase-graph.schema.json', 'schemas/phase-graph.json', true],
-  ];
+  const { cases, missing } = discoverSchemaCases(ROOT);
+  if (missing.length > 0) {
+    for (const entry of missing) {
+      console.error(
+        `✗  ${entry.schema}: missing fixture(s) ${entry.missingFixtures.join(', ')}`,
+      );
+    }
+    console.error(
+      `\n${missing.length} schema(s) have no fixtures. Add ` +
+        `fixtures/schemas/<name>.valid.json and <name>.invalid.json for each.`,
+    );
+    process.exit(1);
+  }
+  // phase-graph additionally validates its live data file (referential
+  // integrity via validateFixture's dedicated validatePhaseGraph hook) as an
+  // explicit override beyond the discovered valid/invalid fixture pair.
+  cases.push({
+    schemaPath: 'schemas/phase-graph.schema.json',
+    fixturePath: 'schemas/phase-graph.json',
+    expectValid: true,
+  });
 
   let failed = 0;
-  for (const [schemaPath, fixturePath, expectValid] of cases) {
+  for (const { schemaPath, fixturePath, expectValid } of cases) {
     const result = validateFixture(schemaPath, fixturePath, expectValid);
     const label = expectValid ? 'valid' : 'invalid';
     if (result.ok) {

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -44,13 +44,13 @@ import {
 //      equal the schema's top-level `properties` keys, with `required`
 //      a subset. Adding a field on either side alone fails the suite.
 //
-// Documented, pinned discrepancies (do NOT silently widen these — each
-// pin breaks loudly when either side changes so a maintainer re-decides):
-//
-//   - stalled-session-quiet-check: the schema uses `format: "uri"` and
-//     union `type: ["string", "null"]`, which the in-repo validator
-//     does not support, so full-document validation cannot pass today.
-//     Tracked as `knownKeywordGaps` / `knownValidationGaps`.
+// Pinned-discrepancy mechanism (`knownKeywordGaps` / `knownValidationGaps`):
+// when a mapped schema uses a construct the in-repo validator does not
+// support, its expected checkSchemaKeywords / validate() output is pinned on
+// its entry so the gap breaks loudly if either side changes. There are
+// currently no pinned gaps: the validator supports every construct the mapped
+// schemas use — `format: "uri"` and union `type: ["string", "null"]` (both
+// exercised by stalled-session-quiet-check) are recognized.
 //
 // Depth limit: parity is asserted for top-level `properties` keys only;
 // nested object shapes are covered by the fixture + `satisfies` pair.
@@ -1127,19 +1127,6 @@ const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
     exportedType: 'StalledSessionQuietCheckReport',
     owningModule: 'src/scripts/stalled-session-quiet-check.mts',
     keys: stalledSessionQuietCheckKeys,
-    // Pinned validator gaps: the in-repo validator supports neither
-    // `format: "uri"` nor union `type: ["string", "null"]`, so the
-    // schema cannot fully validate any document today. Each pin breaks
-    // when the schema or the validator changes, forcing a re-decision.
-    knownKeywordGaps: [
-      '$.properties.pr.properties.html_url: unsupported format value "uri"',
-    ],
-    knownValidationGaps: [
-      '$.policy.claim_created_at: expected type "string,null", got "null"',
-      '$.latest_activity: expected type "string,null", got "null"',
-      '$.latest_activity_type: expected type "string,null", got "null"',
-      '$.evidence.blocking_activities[0].timestamp: expected type "string,null", got "string"',
-    ],
     fixture: stalledSessionQuietCheckFixture,
   },
 ];

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -1,17 +1,30 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import {
   parseClaimComment,
   parseForcedHandoffComment,
 } from '../src/scripts/protocol-helpers.mts';
 import {
   checkSchemaKeywords,
+  discoverSchemaCases,
   loadJson,
   validate,
   validateFixture,
   validatePhaseGraph,
 } from '../src/scripts/validate-schemas.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 
 // Structural views of loaded JSON fixtures. Tests mutate or spread the
 // parsed documents to probe schema acceptance, so these casts stay
@@ -593,6 +606,89 @@ test('.github/idd/config.json validates against policy schema', () => {
     true,
   );
   assert.ok(ok, errors.join('\n'));
+});
+
+// ---------------------------------------------------------------------------
+// Auto-discovered schema/fixture coverage — no schema may be silently skipped
+// ---------------------------------------------------------------------------
+
+test('discoverSchemaCases covers every schemas/*.schema.json with a valid+invalid pair', () => {
+  const { cases, missing } = discoverSchemaCases(REPO_ROOT);
+  assert.deepEqual(
+    missing,
+    [],
+    `every schema needs valid+invalid fixtures; missing: ${JSON.stringify(missing)}`,
+  );
+  const schemaFiles = readdirSync(new URL('../schemas/', import.meta.url))
+    .filter((file) => file.endsWith('.schema.json'))
+    .sort();
+  // Every schema is covered by both a valid and an invalid case, so a newly
+  // added schema without fixtures can no longer slip past the CLI runner.
+  for (const file of schemaFiles) {
+    const forSchema = cases.filter((c) => c.schemaPath === `schemas/${file}`);
+    assert.ok(
+      forSchema.some((c) => c.expectValid),
+      `${file} is missing an expect-valid case`,
+    );
+    assert.ok(
+      forSchema.some((c) => !c.expectValid),
+      `${file} is missing an expect-invalid case`,
+    );
+  }
+});
+
+test('every auto-discovered schema case validates as expected', () => {
+  const { cases } = discoverSchemaCases(REPO_ROOT);
+  for (const { schemaPath, fixturePath, expectValid } of cases) {
+    const { ok, errors } = validateFixture(
+      schemaPath,
+      fixturePath,
+      expectValid,
+    );
+    assert.ok(
+      ok,
+      `${fixturePath} (${expectValid ? 'valid' : 'invalid'}): ${errors.join('; ')}`,
+    );
+  }
+});
+
+test('discoverSchemaCases reports a schema that has no fixtures', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-schema-discovery-'));
+  try {
+    mkdirSync(join(dir, 'schemas'));
+    writeFileSync(
+      join(dir, 'schemas', 'example.schema.json'),
+      '{"type":"object"}',
+    );
+    const { cases, missing } = discoverSchemaCases(dir);
+    assert.equal(cases.length, 0);
+    assert.deepEqual(missing, [
+      {
+        schema: 'schemas/example.schema.json',
+        missingFixtures: [
+          'fixtures/schemas/example.valid.json',
+          'fixtures/schemas/example.invalid.json',
+        ],
+      },
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkSchemaKeywords accepts supported format: uri', () => {
+  assert.deepEqual(checkSchemaKeywords({ type: 'string', format: 'uri' }), []);
+});
+
+test('validate accepts a ["string","null"] union type and rejects other types', () => {
+  const schema = { type: ['string', 'null'] };
+  assert.deepEqual(validate(null, schema), []);
+  assert.deepEqual(validate('activity', schema), []);
+  const errors = validate(12345, schema);
+  assert.ok(
+    errors.some((e) => e.includes('expected type "string|null"')),
+    errors.join('\n'),
+  );
 });
 
 test('policy schema accepts foundation policy namespaces', () => {


### PR DESCRIPTION
## Summary

Removes the hand-maintained `cases[]` array in `validate-schemas` and its drift,
and gives every schema a fixture pair so no schema can be silently skipped.

## What changed

- **Auto-discovery**: `discoverSchemaCases(root)` globs `schemas/*.schema.json`,
  pairs each with `fixtures/schemas/<name>.valid.json` (expect-pass) and
  `<name>.invalid.json` (expect-fail), and **fails closed** on any schema
  missing a fixture. The `phase-graph` data-file case (`schemas/phase-graph.json`)
  stays an explicit override; its `validatePhaseGraph` hook is unchanged. This
  also fixes the existing drift — `branch-conflict-state` and
  `discover-roadmap-union` had fixtures but were absent from the old `cases[]`.
- **Five new fixture pairs**: `disposition-non-review-notices`,
  `idd-roadmap-audit-execute`, `post-idd-marker`, `resolve-review-thread`,
  `stalled-session-quiet-check` — so all 15 schemas now carry valid + invalid
  fixtures.
- **Validator support** for the two constructs `stalled-session-quiet-check`
  uses: `format: "uri"` (recognized as a documentation-only annotation, like a
  full JSON Schema validator) and union `type: ["string", "null"]`. This closes
  the previously-pinned `knownKeywordGaps` / `knownValidationGaps` in the
  schema-type reconciliation sweep.
- **Tests**: assert the discovered set covers every schema, that every
  discovered case validates as expected, that a fixture-less schema is reported,
  and cover the new uri/union support.

## Verification

- `node scripts/validate-schemas.mjs` runs all 31 auto-discovered cases green.
- Generated `scripts/validate-schemas.mjs` regenerated via `pnpm run build`.
- `pnpm run lint:minimum` passes (1452 tests).

Closes #1146
