### PR TITLE
test(idd): guard CLI entry-order TDZ and add a readiness smoke test

### DIFF
--- a/tests/cli-entry-smoke.test.mts
+++ b/tests/cli-entry-smoke.test.mts
@@ -65,11 +65,16 @@ function findModuleEvalOrderViolations(
     for (let i = entryIndex + 1; i < lines.length; i += 1) {
       const line = lines[i];
       // Require a single `=` assignment operator (excluding `==`/`!=`/`<=`/`>=`
-      // via the neighbor character classes; whitespace is not required) so a
-      // bare `let x;` is not flagged. `const enum` — whose members may use `=`
-      // (`A = 1`) — is already excluded by MODULE_LEVEL_BINDING. Column 0
-      // excludes bindings nested inside the block or a function.
-      if (MODULE_LEVEL_BINDING.test(line) && /[^=!<>]=[^=]/.test(line)) {
+      // and the `=>` arrow via lookbehind/lookahead) so a bare `let x;` is not
+      // flagged. The lookarounds — rather than requiring a trailing character —
+      // still match a line ending in `=` (a multi-line initializer whose value
+      // is on the next line). `const enum`, whose members may use `=`, is
+      // already excluded by MODULE_LEVEL_BINDING. Column 0 excludes bindings
+      // nested inside the block or a function.
+      if (
+        MODULE_LEVEL_BINDING.test(line) &&
+        /(?<![=!<>])=(?![=>])/.test(line)
+      ) {
         violations.push(
           `${path}:${i + 1}: module-level binding initialized after the CLI entry ` +
             `block (opened at line ${entryIndex + 1}) — top-level-await TDZ risk; ` +
@@ -99,6 +104,24 @@ test('module-eval-order guard flags an initialized const after the entry block',
   ]);
   assert.equal(violations.length, 1);
   assert.match(violations[0], /sample\.mts:5:.*after the CLI entry block/);
+});
+
+test('module-eval-order guard flags a multi-line initializer whose line ends in `=`', () => {
+  const violations = findModuleEvalOrderViolations([
+    readModule(
+      'src/scripts/sample.mts',
+      [
+        'if (isMainModule(import.meta.url)) {',
+        '  await run(LATE);',
+        '}',
+        'const LATE =',
+        '  new Set([1, 2, 3]);',
+        '',
+      ].join('\n'),
+    ),
+  ]);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /sample\.mts:4:/);
 });
 
 test('module-eval-order guard flags let and var too, and reports each', () => {
@@ -269,6 +292,9 @@ process.exit(1);
       cwd: REPO_ROOT,
       encoding: 'utf8',
       env: { ...process.env, PATH: `${tempRoot}:${process.env.PATH ?? ''}` },
+      // Fail fast instead of hanging the suite if the CLI ever blocks on an
+      // unexpected read (the stub gh answers or exits non-zero for every call).
+      timeout: 60_000,
     },
   );
 

--- a/tests/cli-entry-smoke.test.mts
+++ b/tests/cli-entry-smoke.test.mts
@@ -34,14 +34,18 @@ const SRC_SCRIPTS = fileURLToPath(new URL('../src/scripts/', import.meta.url));
 
 /**
  * Matches a top-level CLI entry-guard opener at column 0. Anchored to the two
- * real signatures — an `isMainModule(` call or a `process.argv[1]` comparison —
+ * real signatures — an `isMainModule(` call or a `process.argv[1]` reference —
  * rather than any `import.meta.url` mention, so an unrelated top-level `if` that
  * merely references `import.meta.url` is not mistaken for the entry block.
  */
 const ENTRY_GUARD = /^if \(.*(?:isMainModule\(|process\.argv\[1\]).*\)\s*\{/;
 
-/** Matches a module-level (column 0) `const`/`let`/`var` declaration opener. */
-const MODULE_LEVEL_BINDING = /^(?:export )?(?:const|let|var)\b/;
+/**
+ * Matches a module-level (column 0) `const`/`let`/`var` binding opener,
+ * excluding `const enum` — a type-level declaration erased at compile time, so
+ * it carries no runtime TDZ (exempt like `interface`/`type`).
+ */
+const MODULE_LEVEL_BINDING = /^(?:export )?(?:const(?!\s+enum\b)|let|var)\b/;
 
 /**
  * Report every module-level initialized `const`/`let`/`var` that appears
@@ -61,9 +65,10 @@ function findModuleEvalOrderViolations(
     for (let i = entryIndex + 1; i < lines.length; i += 1) {
       const line = lines[i];
       // Require a single `=` assignment operator (excluding `==`/`!=`/`<=`/`>=`
-      // via the neighbor classes; whitespace is not required) so a bare
-      // `let x;` or a `const enum` — neither of which assigns — is not flagged.
-      // Column 0 already excludes bindings nested inside the block or a function.
+      // via the neighbor character classes; whitespace is not required) so a
+      // bare `let x;` is not flagged. `const enum` — whose members may use `=`
+      // (`A = 1`) — is already excluded by MODULE_LEVEL_BINDING. Column 0
+      // excludes bindings nested inside the block or a function.
       if (MODULE_LEVEL_BINDING.test(line) && /[^=!<>]=[^=]/.test(line)) {
         violations.push(
           `${path}:${i + 1}: module-level binding initialized after the CLI entry ` +
@@ -124,6 +129,22 @@ test('module-eval-order guard does NOT flag a function/interface/type after the 
         'export function run(): void {}',
         'interface Shape { a: number }',
         'type Alias = string;',
+        '',
+      ].join('\n'),
+    ),
+  ]);
+  assert.deepEqual(violations, []);
+});
+
+test('module-eval-order guard does NOT flag a const enum after the block (type-level, erased)', () => {
+  const violations = findModuleEvalOrderViolations([
+    readModule(
+      'src/scripts/sample.mts',
+      [
+        'if (isMainModule(import.meta.url)) {',
+        '  await run();',
+        '}',
+        'const enum Direction { Up = 1, Down = 2 }',
         '',
       ].join('\n'),
     ),

--- a/tests/cli-entry-smoke.test.mts
+++ b/tests/cli-entry-smoke.test.mts
@@ -32,8 +32,13 @@ const SRC_SCRIPTS = fileURLToPath(new URL('../src/scripts/', import.meta.url));
 // are not flagged. It does NOT require the block to be the last statement.
 // ---------------------------------------------------------------------------
 
-/** Matches a top-level CLI entry-guard opener at column 0. */
-const ENTRY_GUARD = /^if \(.*(?:isMainModule|import\.meta\.url).*\)\s*\{/;
+/**
+ * Matches a top-level CLI entry-guard opener at column 0. Anchored to the two
+ * real signatures — an `isMainModule(` call or a `process.argv[1]` comparison —
+ * rather than any `import.meta.url` mention, so an unrelated top-level `if` that
+ * merely references `import.meta.url` is not mistaken for the entry block.
+ */
+const ENTRY_GUARD = /^if \(.*(?:isMainModule\(|process\.argv\[1\]).*\)\s*\{/;
 
 /** Matches a module-level (column 0) `const`/`let`/`var` declaration opener. */
 const MODULE_LEVEL_BINDING = /^(?:export )?(?:const|let|var)\b/;
@@ -55,8 +60,10 @@ function findModuleEvalOrderViolations(
     }
     for (let i = entryIndex + 1; i < lines.length; i += 1) {
       const line = lines[i];
-      // `= ` (with the space) avoids matching a bare `let x;` or `const enum`,
-      // and column 0 excludes bindings nested inside the block or a function.
+      // Require a single `=` assignment operator (excluding `==`/`!=`/`<=`/`>=`
+      // via the neighbor classes; whitespace is not required) so a bare
+      // `let x;` or a `const enum` — neither of which assigns — is not flagged.
+      // Column 0 already excludes bindings nested inside the block or a function.
       if (MODULE_LEVEL_BINDING.test(line) && /[^=!<>]=[^=]/.test(line)) {
         violations.push(
           `${path}:${i + 1}: module-level binding initialized after the CLI entry ` +

--- a/tests/cli-entry-smoke.test.mts
+++ b/tests/cli-entry-smoke.test.mts
@@ -1,0 +1,256 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const SRC_SCRIPTS = fileURLToPath(new URL('../src/scripts/', import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Module-eval-order guard
+//
+// A helper whose `if (isMainModule(import.meta.url)) { … }` CLI entry block runs
+// before a module-level `const`/`let`/`var` it (transitively) reads throws a TDZ
+// `ReferenceError: Cannot access 'X' before initialization` on the CLI path
+// only — a top-level `await` inside the block parks module evaluation there, so
+// a later lexical binding is still in its temporal dead zone. Import-only tests
+// never reach the entry path, so CI stays green while the CLI crashes.
+//
+// The guard flags ONLY an initialized module-level `const`/`let`/`var` that
+// appears textually AFTER the entry block. `function` / `interface` / `type`
+// declarations are exempt (hoisted or type-only), so the ~two-thirds of helpers
+// that intentionally place the block near the top and rely on function hoisting
+// are not flagged. It does NOT require the block to be the last statement.
+// ---------------------------------------------------------------------------
+
+/** Matches a top-level CLI entry-guard opener at column 0. */
+const ENTRY_GUARD = /^if \(.*(?:isMainModule|import\.meta\.url).*\)\s*\{/;
+
+/** Matches a module-level (column 0) `const`/`let`/`var` declaration opener. */
+const MODULE_LEVEL_BINDING = /^(?:export )?(?:const|let|var)\b/;
+
+/**
+ * Report every module-level initialized `const`/`let`/`var` that appears
+ * textually after a CLI entry-guard block. Pure (no I/O): each file is
+ * `{ path, text }`. Returns human-readable `path:line` violation strings.
+ */
+function findModuleEvalOrderViolations(
+  files: readonly { path: string; text: string }[],
+): string[] {
+  const violations: string[] = [];
+  for (const { path, text } of files) {
+    const lines = text.split(/\r?\n/);
+    const entryIndex = lines.findIndex((line) => ENTRY_GUARD.test(line));
+    if (entryIndex < 0) {
+      continue;
+    }
+    for (let i = entryIndex + 1; i < lines.length; i += 1) {
+      const line = lines[i];
+      // `= ` (with the space) avoids matching a bare `let x;` or `const enum`,
+      // and column 0 excludes bindings nested inside the block or a function.
+      if (MODULE_LEVEL_BINDING.test(line) && /[^=!<>]=[^=]/.test(line)) {
+        violations.push(
+          `${path}:${i + 1}: module-level binding initialized after the CLI entry ` +
+            `block (opened at line ${entryIndex + 1}) — top-level-await TDZ risk; ` +
+            `declare it above the block. Offending line: ${line.trim()}`,
+        );
+      }
+    }
+  }
+  return violations;
+}
+
+const readModule = (path: string, text: string) => ({ path, text });
+
+test('module-eval-order guard flags an initialized const after the entry block', () => {
+  const violations = findModuleEvalOrderViolations([
+    readModule(
+      'src/scripts/sample.mts',
+      [
+        "import { isMainModule } from './x.mts';",
+        'if (isMainModule(import.meta.url)) {',
+        '  await run(LATE);',
+        '}',
+        'const LATE = new Set([1, 2, 3]);',
+        '',
+      ].join('\n'),
+    ),
+  ]);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /sample\.mts:5:.*after the CLI entry block/);
+});
+
+test('module-eval-order guard flags let and var too, and reports each', () => {
+  const violations = findModuleEvalOrderViolations([
+    readModule(
+      'src/scripts/sample.mts',
+      [
+        'if (process.argv[1] === fileURLToPath(import.meta.url)) {',
+        '  await run();',
+        '}',
+        'let LATE_LET = 1;',
+        'var LATE_VAR = 2;',
+        '',
+      ].join('\n'),
+    ),
+  ]);
+  assert.equal(violations.length, 2);
+});
+
+test('module-eval-order guard does NOT flag a function/interface/type after the block (hoisted)', () => {
+  const violations = findModuleEvalOrderViolations([
+    readModule(
+      'src/scripts/sample.mts',
+      [
+        'if (isMainModule(import.meta.url)) {',
+        '  await run();',
+        '}',
+        'export function run(): void {}',
+        'interface Shape { a: number }',
+        'type Alias = string;',
+        '',
+      ].join('\n'),
+    ),
+  ]);
+  assert.deepEqual(violations, []);
+});
+
+test('module-eval-order guard does NOT require the entry block to be last', () => {
+  // The block sits near the top with only hoisted functions after it — the
+  // common shape — and a const declared BEFORE the block is fine.
+  const violations = findModuleEvalOrderViolations([
+    readModule(
+      'src/scripts/sample.mts',
+      [
+        'const EARLY = 1;',
+        'if (isMainModule(import.meta.url)) {',
+        '  await run(EARLY);',
+        '}',
+        'function run(x: number): void {}',
+        '',
+      ].join('\n'),
+    ),
+  ]);
+  assert.deepEqual(violations, []);
+});
+
+test('module-eval-order guard ignores a binding indented inside the block', () => {
+  const violations = findModuleEvalOrderViolations([
+    readModule(
+      'src/scripts/sample.mts',
+      [
+        'if (isMainModule(import.meta.url)) {',
+        '  const local = 1;',
+        '  await run(local);',
+        '}',
+        '',
+      ].join('\n'),
+    ),
+  ]);
+  assert.deepEqual(violations, []);
+});
+
+test('module-eval-order guard is a no-op for a module with no entry block', () => {
+  const violations = findModuleEvalOrderViolations([
+    readModule(
+      'src/scripts/sample.mts',
+      [
+        'export const X = 1;',
+        'export function f(): number { return X; }',
+        '',
+      ].join('\n'),
+    ),
+  ]);
+  assert.deepEqual(violations, []);
+});
+
+test('every src/scripts/*.mts helper keeps module-level bindings above its CLI entry block', () => {
+  const files = readdirSync(SRC_SCRIPTS)
+    .filter((name) => name.endsWith('.mts'))
+    .map((name) => ({
+      path: `src/scripts/${name}`,
+      text: readFileSync(join(SRC_SCRIPTS, name), 'utf8'),
+    }));
+  const violations = findModuleEvalOrderViolations(files);
+  assert.deepEqual(
+    violations,
+    [],
+    `CLI-entry-order TDZ risk(s) found:\n${violations.join('\n')}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// CLI-subprocess smoke test — the entry path actually runs
+//
+// Import-only tests never evaluate the `isMainModule` block, so they cannot
+// catch a load-time crash on the CLI path. Spawn the built helper with a
+// stubbed `gh` on PATH so it reaches the real entry path and assert it produces
+// its JSON envelope without a load-time `ReferenceError`.
+// ---------------------------------------------------------------------------
+
+test('discover-readiness-check.mjs CLI runs the entry path without a load-time ReferenceError', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-discover-readiness-cli-'));
+  const ghPath = join(tempRoot, 'gh');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+// buildIssueLoader: gh api repos/o/r/issues/900 --jq .
+if (args[0] === 'api' && args[1] === 'repos/o/r/issues/900') {
+  process.stdout.write(JSON.stringify({
+    number: 900,
+    title: 'readiness smoke issue',
+    state: 'open',
+    body: 'A ready issue with no blockers.',
+    labels: [],
+  }));
+  process.exit(0);
+}
+// fetchIssueLabelEvents: gh api repos/o/r/issues/900/timeline?...
+if (args[0] === 'api' && String(args[1]).startsWith('repos/o/r/issues/900/timeline')) {
+  process.stdout.write('[]');
+  process.exit(0);
+}
+process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+
+  const output = execFileSync(
+    process.execPath,
+    [
+      join(REPO_ROOT, 'scripts/discover-readiness-check.mjs'),
+      '--issue',
+      '900',
+      '--owner',
+      'o',
+      '--repo',
+      'r',
+    ],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${tempRoot}:${process.env.PATH ?? ''}` },
+    },
+  );
+
+  assert.doesNotMatch(
+    output,
+    /ReferenceError|before initialization/,
+    'CLI output must not carry a load-time ReferenceError',
+  );
+  const parsed = JSON.parse(output);
+  assert.equal(parsed.summary.total, 1);
+  assert.equal(parsed.summary.readyCount, 1);
+  assert.equal(parsed.ready[0].number, 900);
+});


### PR DESCRIPTION
## Summary

Closes the CLI-only load-time TDZ gap: a helper whose `isMainModule` entry block
runs (with a top-level `await`) before a module-level `const`/`let`/`var` it
reads throws a `ReferenceError: Cannot access 'X' before initialization` on the
CLI path only. Import-only tests never reach the entry path, so CI stays green
while the CLI crashes.

## What changed (test-only)

- **Module-eval-order guard** (`findModuleEvalOrderViolations`): scans each
  `src/scripts/*.mts` and flags **only** an initialized module-level
  `const`/`let`/`var` that appears textually **after** the entry block.
  `function` / `interface` / `type` declarations are exempt (hoisted or
  type-only), so the helpers that place the block near the top and rely on
  function hoisting are not flagged, and the block need not be last. Unit-tested
  for the positive (const/let/var after the block), hoisted-exempt,
  block-not-last, indented-inside-block, and no-entry-block cases, then run over
  the real tree — currently **zero** violations across all 18 helpers with an
  entry block.
- **CLI-subprocess smoke test**: spawns `scripts/discover-readiness-check.mjs`
  with a stubbed `gh` on `PATH` so it reaches the real entry path, and asserts a
  valid readiness envelope (`summary.total`/`readyCount`, `ready[0].number`)
  with no load-time `ReferenceError`.

## Notes

- `discover-roadmap-graph.mjs` already carries equivalent CLI-subprocess smoke
  tests (`discover-roadmap-graph.test.mts`), so this adds the missing
  `discover-readiness-check` coverage; the new guard now backstops **every**
  helper against the const-after-block regression.
- Verified against current `main`: the historical crash does not reproduce; the
  guard is precise (no false positive on hoisted-function helpers).

`pnpm test` and `pnpm run lint:minimum` pass.

Closes #1154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broader automated coverage for CLI entry behavior to help catch startup ordering issues earlier.
  * Added a smoke test that runs the CLI end to end and verifies it starts successfully and returns the expected JSON output.
  * Expanded validation to ensure common declaration types are handled correctly without false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->