### PR TITLE
feat(idd): add a ready/blockers rollup to pre-merge-readiness

### DIFF
--- a/fixtures/pre-merge-readiness/ack-only-current.json
+++ b/fixtures/pre-merge-readiness/ack-only-current.json
@@ -331,6 +331,13 @@
       "unauthorized": [],
       "malformed": [],
       "notConfigured": []
-    }
+    },
+    "ready": false,
+    "blockers": [
+      {
+        "gate": "disposition-evidence",
+        "detail": "dispositionEvidence.route is \"missing\" (expected \"proceed\"), blockingCount=-1 (expected 0)"
+      }
+    ]
   }
 }

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -265,6 +265,17 @@
       "unauthorized": [],
       "malformed": [],
       "notConfigured": []
-    }
+    },
+    "ready": false,
+    "blockers": [
+      {
+        "gate": "required-reviews",
+        "detail": "required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=false, codeownerApprovalSatisfied=false, codeownerSelfApproval.status=\"clear\")"
+      },
+      {
+        "gate": "disposition-evidence",
+        "detail": "dispositionEvidence.route is \"missing\" (expected \"proceed\"), blockingCount=-1 (expected 0)"
+      }
+    ]
   }
 }

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -269,6 +269,17 @@
       "unauthorized": [],
       "malformed": [],
       "notConfigured": []
-    }
+    },
+    "ready": false,
+    "blockers": [
+      {
+        "gate": "ci",
+        "detail": "CI is not all-passing (status=\"missing\", noRequiredChecksConfigured=false, presentRunConclusion=\"all-passing\")"
+      },
+      {
+        "gate": "disposition-evidence",
+        "detail": "dispositionEvidence.route is \"missing\" (expected \"proceed\"), blockingCount=-1 (expected 0)"
+      }
+    ]
   }
 }

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -293,6 +293,17 @@
       "unauthorized": [],
       "malformed": [],
       "notConfigured": []
-    }
+    },
+    "ready": false,
+    "blockers": [
+      {
+        "gate": "claim-ownership",
+        "detail": "claim ownership does not match (reason=\"claim-id-mismatch\")"
+      },
+      {
+        "gate": "disposition-evidence",
+        "detail": "dispositionEvidence.route is \"missing\" (expected \"proceed\"), blockingCount=-1 (expected 0)"
+      }
+    ]
   }
 }

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -293,6 +293,13 @@
       "unauthorized": [],
       "malformed": [],
       "notConfigured": []
-    }
+    },
+    "ready": false,
+    "blockers": [
+      {
+        "gate": "disposition-evidence",
+        "detail": "dispositionEvidence.route is \"missing\" (expected \"proceed\"), blockingCount=-1 (expected 0)"
+      }
+    ]
   }
 }

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -293,6 +293,17 @@
       "unauthorized": [],
       "malformed": [],
       "notConfigured": []
-    }
+    },
+    "ready": false,
+    "blockers": [
+      {
+        "gate": "review-currency",
+        "detail": "comparisonRoute is \"return-to-e1\" (expected \"proceed\"): newer-activity"
+      },
+      {
+        "gate": "disposition-evidence",
+        "detail": "dispositionEvidence.route is \"missing\" (expected \"proceed\"), blockingCount=-1 (expected 0)"
+      }
+    ]
   }
 }

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -279,6 +279,13 @@
       "unauthorized": [],
       "malformed": [],
       "notConfigured": []
-    }
+    },
+    "ready": false,
+    "blockers": [
+      {
+        "gate": "disposition-evidence",
+        "detail": "dispositionEvidence.route is \"missing\" (expected \"proceed\"), blockingCount=-1 (expected 0)"
+      }
+    ]
   }
 }

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -293,6 +293,17 @@
       "unauthorized": [],
       "malformed": [],
       "notConfigured": []
-    }
+    },
+    "ready": false,
+    "blockers": [
+      {
+        "gate": "unresolved-threads",
+        "detail": "actionableCount is 1 (expected 0)"
+      },
+      {
+        "gate": "disposition-evidence",
+        "detail": "dispositionEvidence.route is \"missing\" (expected \"proceed\"), blockingCount=-1 (expected 0)"
+      }
+    ]
   }
 }

--- a/fixtures/schemas/pre-merge-readiness.invalid.json
+++ b/fixtures/schemas/pre-merge-readiness.invalid.json
@@ -53,7 +53,9 @@
     "requiresConversationResolution": false,
     "requiredReviewerLogins": [],
     "requiredReviewerTeams": [],
-    "codeownerUserLogins": ["owner-reviewer"],
+    "codeownerUserLogins": [
+      "owner-reviewer"
+    ],
     "codeownerTeamSlugs": [],
     "unmatchedCodeownerFiles": [],
     "latestByAuthor": [
@@ -96,7 +98,9 @@
     "generatedRequiredCheckCount": 1,
     "requiredChecksGenerated": true,
     "requiredChecksPassing": true,
-    "requiredCheckNames": ["lint"],
+    "requiredCheckNames": [
+      "lint"
+    ],
     "missingRequiredCheckNames": [],
     "checks": [
       {
@@ -121,5 +125,7 @@
     "matchesExpectedClaim": true,
     "claimLost": false,
     "reason": "match"
-  }
+  },
+  "ready": true,
+  "blockers": []
 }

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -172,5 +172,12 @@
     "unauthorized": [],
     "malformed": [],
     "notConfigured": []
-  }
+  },
+  "ready": false,
+  "blockers": [
+    {
+      "gate": "ci",
+      "detail": "CI is not all-passing (example)"
+    }
+  ]
 }

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -16,7 +16,9 @@
     "advisoryWait",
     "ci",
     "claim",
-    "waiverEvidence"
+    "waiverEvidence",
+    "ready",
+    "blockers"
   ],
   "additionalProperties": false,
   "properties": {
@@ -1136,6 +1138,27 @@
     "trustedMarkerActorsSource": {
       "type": "string",
       "enum": ["flag", "env", "config", "none"]
+    },
+    "ready": {
+      "description": "Strict merge-gate rollup: true only when blockers is empty. Does NOT apply the dispositionEvidence.soleCauseAckOnlyPostDisposition override (a separate flag the F2 checklist layers on top).",
+      "type": "boolean"
+    },
+    "blockers": {
+      "description": "One entry per unmet F3 merge gate, in gate order; empty when ready.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["gate", "detail"],
+        "additionalProperties": false,
+        "properties": {
+          "gate": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -15,112 +15,21 @@
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { collectPreMergeReadiness } from './pre-merge-readiness.mjs';
+import { computePreMergeReadinessBlockers } from './protocol-helpers.mjs';
 /**
- * Evaluate every F3 gate against `report` (the pre-merge-readiness
- * summary). A gate failure is collected as a blocker; `ready` is true
- * only when no blocker is collected. The conditions mirror the written
- * F3 gate checklist exactly — this helper adds no stricter sub-condition.
+ * Evaluate every F3 gate against `report` (the pre-merge-readiness summary),
+ * returning one blocker per unmet gate (`ready` is true only when the list is
+ * empty). Delegates to the shared `computePreMergeReadinessBlockers` rollup in
+ * `protocol-helpers.mts` — the single source of the merge-gate AND that
+ * `buildPreMergeReadinessSummary` also embeds as `{ ready, blockers }` — so the
+ * conjunction is defined once and no caller re-implements it. Recomputing from
+ * the report's nested evidence (rather than trusting a possibly-absent
+ * `report.blockers` field) keeps the merge gate fail-closed; the conditions
+ * mirror the written F3 gate checklist exactly and add no stricter
+ * sub-condition.
  */
 export function evaluateMergeGates(report) {
-  const blockers = [];
-  // Fail closed on a missing/invalid head: `prHeadSha` binds
-  // `--match-head-commit`, so a non-40-hex value must never yield a
-  // "ready" verdict with an unsafe merge binding.
-  const prHeadSha = String(report.prHeadSha ?? '');
-  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
-    blockers.push({
-      gate: 'head-sha',
-      detail: `prHeadSha "${prHeadSha}" is not a 40-hex commit SHA; cannot bind a safe merge`,
-    });
-  }
-  const reviewCurrency = asRecord(report.reviewCurrency);
-  const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
-  if (comparisonRoute !== 'proceed') {
-    blockers.push({
-      gate: 'review-currency',
-      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${String(reviewCurrency.comparisonReason ?? 'unknown')}`,
-    });
-  }
-  const threads = asRecord(report.threads);
-  const actionableCount = Number(threads.actionableCount ?? -1);
-  if (actionableCount !== 0) {
-    blockers.push({
-      gate: 'unresolved-threads',
-      detail: `actionableCount is ${actionableCount} (expected 0)`,
-    });
-  }
-  const advisoryWait = asRecord(report.advisoryWait);
-  const f3Outcome = String(advisoryWait.f3Outcome ?? '');
-  if (f3Outcome !== 'SATISFIED') {
-    blockers.push({
-      gate: 'advisory-wait',
-      detail: `f3Outcome is "${f3Outcome}" (expected "SATISFIED")`,
-    });
-  }
-  const ci = asRecord(report.ci);
-  if (!isCiAllPassing(ci)) {
-    blockers.push({
-      gate: 'ci',
-      detail: `CI is not all-passing (status="${String(ci.status ?? '')}", noRequiredChecksConfigured=${Boolean(ci.noRequiredChecksConfigured)}, presentRunConclusion="${String(ci.presentRunConclusion ?? '')}")`,
-    });
-  }
-  const reviewerStates = asRecord(report.reviewerStates);
-  if (!isReviewSatisfied(reviewerStates)) {
-    const selfApproval = asRecord(reviewerStates.codeownerSelfApproval);
-    blockers.push({
-      gate: 'required-reviews',
-      detail: `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(reviewerStates.requiredApprovalsSatisfied)}, codeownerApprovalSatisfied=${Boolean(reviewerStates.codeownerApprovalSatisfied)}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`,
-    });
-  }
-  const claim = asRecord(report.claim);
-  if (claim.matchesExpectedClaim !== true) {
-    blockers.push({
-      gate: 'claim-ownership',
-      detail: `claim ownership does not match (reason="${String(claim.reason ?? 'unknown')}")`,
-    });
-  }
-  const dispositionEvidence = asRecord(report.dispositionEvidence);
-  // The written F2/F3 gate requires BOTH `route === 'proceed'` AND
-  // `blockingCount === 0`. Fail closed on a non-zero or non-numeric
-  // blockingCount so a missing/garbled count is treated as a blocker.
-  const dispositionRoute = String(dispositionEvidence.route ?? '');
-  const dispositionBlockingCount = Number(
-    dispositionEvidence.blockingCount ?? -1,
-  );
-  if (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0) {
-    blockers.push({
-      gate: 'disposition-evidence',
-      detail: `dispositionEvidence.route is "${dispositionRoute || 'missing'}" (expected "proceed"), blockingCount=${dispositionBlockingCount} (expected 0)`,
-    });
-  }
-  return blockers;
-}
-// CI all-passing mirrors the F2/F3 rule: required checks pass, OR (no
-// required checks are configured AND every present run concludes passing).
-// `status === 'success'` already implies required checks passed; the
-// no-required-checks branch must not satisfy CI vacuously, so it requires
-// `presentRunConclusion === 'all-passing'`.
-function isCiAllPassing(ci) {
-  if (ci.requiredChecksPassing === true || ci.status === 'success') {
-    return true;
-  }
-  return (
-    ci.noRequiredChecksConfigured === true &&
-    String(ci.presentRunConclusion ?? '') === 'all-passing'
-  );
-}
-// Required + CODEOWNER reviews are satisfied when the approval-count gate
-// passes and the CODEOWNER gate either passes outright or the self-approval
-// diagnostic is `clear` (a satisfiable bypass topology).
-function isReviewSatisfied(reviewerStates) {
-  if (reviewerStates.requiredApprovalsSatisfied !== true) {
-    return false;
-  }
-  if (reviewerStates.codeownerApprovalSatisfied === true) {
-    return true;
-  }
-  const selfApproval = asRecord(reviewerStates.codeownerSelfApproval);
-  return String(selfApproval.status ?? '') === 'clear';
+  return computePreMergeReadinessBlockers(report);
 }
 function asRecord(value) {
   return value && typeof value === 'object' ? value : {};

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3668,6 +3668,114 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
     reason,
   };
 }
+function preMergeAsRecord(value) {
+  return value && typeof value === 'object' ? value : {};
+}
+function isPreMergeCiAllPassing(ci) {
+  if (ci.requiredChecksPassing === true || ci.status === 'success') {
+    return true;
+  }
+  return (
+    ci.noRequiredChecksConfigured === true &&
+    String(ci.presentRunConclusion ?? '') === 'all-passing'
+  );
+}
+function isPreMergeReviewSatisfied(reviewerStates) {
+  if (reviewerStates.requiredApprovalsSatisfied !== true) {
+    return false;
+  }
+  if (reviewerStates.codeownerApprovalSatisfied === true) {
+    return true;
+  }
+  const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
+  return String(selfApproval.status ?? '') === 'clear';
+}
+/**
+ * Roll up the F2/F3 merge gates from a pre-merge-readiness report into the
+ * ordered blocker list. This is the single source of the merge-gate AND:
+ * `buildPreMergeReadinessSummary` embeds `{ ready, blockers }` computed from it,
+ * and `idd-merge-execute.evaluateMergeGates` delegates to it, so no caller
+ * re-implements the conjunction. The rollup is **strict** — it reads
+ * `dispositionEvidence.route === 'proceed'` directly and does NOT apply the
+ * `soleCauseAckOnlyPostDisposition` override (a separate flag the F2 checklist
+ * layers on top), so the fully-autonomous F3 executor keeps its fail-closed
+ * behavior. A gate whose evidence is missing or garbled fails closed (recorded
+ * as a blocker) rather than passing vacuously.
+ */
+export function computePreMergeReadinessBlockers(report) {
+  const blockers = [];
+  // Fail closed on a missing/invalid head: `prHeadSha` binds
+  // `--match-head-commit`, so a non-40-hex value must never yield a "ready"
+  // verdict with an unsafe merge binding.
+  const prHeadSha = String(report.prHeadSha ?? '');
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    blockers.push({
+      gate: 'head-sha',
+      detail: `prHeadSha "${prHeadSha}" is not a 40-hex commit SHA; cannot bind a safe merge`,
+    });
+  }
+  const reviewCurrency = preMergeAsRecord(report.reviewCurrency);
+  const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
+  if (comparisonRoute !== 'proceed') {
+    blockers.push({
+      gate: 'review-currency',
+      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${String(reviewCurrency.comparisonReason ?? 'unknown')}`,
+    });
+  }
+  const threads = preMergeAsRecord(report.threads);
+  const actionableCount = Number(threads.actionableCount ?? -1);
+  if (actionableCount !== 0) {
+    blockers.push({
+      gate: 'unresolved-threads',
+      detail: `actionableCount is ${actionableCount} (expected 0)`,
+    });
+  }
+  const advisoryWait = preMergeAsRecord(report.advisoryWait);
+  const f3Outcome = String(advisoryWait.f3Outcome ?? '');
+  if (f3Outcome !== 'SATISFIED') {
+    blockers.push({
+      gate: 'advisory-wait',
+      detail: `f3Outcome is "${f3Outcome}" (expected "SATISFIED")`,
+    });
+  }
+  const ci = preMergeAsRecord(report.ci);
+  if (!isPreMergeCiAllPassing(ci)) {
+    blockers.push({
+      gate: 'ci',
+      detail: `CI is not all-passing (status="${String(ci.status ?? '')}", noRequiredChecksConfigured=${Boolean(ci.noRequiredChecksConfigured)}, presentRunConclusion="${String(ci.presentRunConclusion ?? '')}")`,
+    });
+  }
+  const reviewerStates = preMergeAsRecord(report.reviewerStates);
+  if (!isPreMergeReviewSatisfied(reviewerStates)) {
+    const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
+    blockers.push({
+      gate: 'required-reviews',
+      detail: `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(reviewerStates.requiredApprovalsSatisfied)}, codeownerApprovalSatisfied=${Boolean(reviewerStates.codeownerApprovalSatisfied)}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`,
+    });
+  }
+  const claim = preMergeAsRecord(report.claim);
+  if (claim.matchesExpectedClaim !== true) {
+    blockers.push({
+      gate: 'claim-ownership',
+      detail: `claim ownership does not match (reason="${String(claim.reason ?? 'unknown')}")`,
+    });
+  }
+  const dispositionEvidence = preMergeAsRecord(report.dispositionEvidence);
+  // The written F2/F3 gate requires BOTH `route === 'proceed'` AND
+  // `blockingCount === 0`. Fail closed on a non-zero or non-numeric
+  // blockingCount so a missing/garbled count is treated as a blocker.
+  const dispositionRoute = String(dispositionEvidence.route ?? '');
+  const dispositionBlockingCount = Number(
+    dispositionEvidence.blockingCount ?? -1,
+  );
+  if (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0) {
+    blockers.push({
+      gate: 'disposition-evidence',
+      detail: `dispositionEvidence.route is "${dispositionRoute || 'missing'}" (expected "proceed"), blockingCount=${dispositionBlockingCount} (expected 0)`,
+    });
+  }
+  return blockers;
+}
 export function buildPreMergeReadinessSummary(
   {
     prHeadSha,
@@ -3894,6 +4002,13 @@ export function buildPreMergeReadinessSummary(
   if (dispositionEvidence) {
     summary.dispositionEvidence = dispositionEvidence;
   }
+  // Top-level rollup so a consumer reads one `ready` boolean + `blockers[]`
+  // instead of hand-ANDing ~8 nested gates (a dropped clause would fail open).
+  // Strict by construction (see `computePreMergeReadinessBlockers`): the F2
+  // checklist applies the ack-only override on top of this, not inside it.
+  const blockers = computePreMergeReadinessBlockers(summary);
+  summary.ready = blockers.length === 0;
+  summary.blockers = blockers;
   return summary;
 }
 function normalizeLiveStatusDigestFields(fields) {

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -17,6 +17,7 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 import { collectPreMergeReadiness } from './pre-merge-readiness.mts';
+import { computePreMergeReadinessBlockers } from './protocol-helpers.mts';
 
 /** One failing F3 gate, keyed by the gate name plus a human detail. */
 export interface MergeBlocker {
@@ -59,138 +60,21 @@ interface IddMergeExecuteArgs {
 }
 
 /**
- * Evaluate every F3 gate against `report` (the pre-merge-readiness
- * summary). A gate failure is collected as a blocker; `ready` is true
- * only when no blocker is collected. The conditions mirror the written
- * F3 gate checklist exactly — this helper adds no stricter sub-condition.
+ * Evaluate every F3 gate against `report` (the pre-merge-readiness summary),
+ * returning one blocker per unmet gate (`ready` is true only when the list is
+ * empty). Delegates to the shared `computePreMergeReadinessBlockers` rollup in
+ * `protocol-helpers.mts` — the single source of the merge-gate AND that
+ * `buildPreMergeReadinessSummary` also embeds as `{ ready, blockers }` — so the
+ * conjunction is defined once and no caller re-implements it. Recomputing from
+ * the report's nested evidence (rather than trusting a possibly-absent
+ * `report.blockers` field) keeps the merge gate fail-closed; the conditions
+ * mirror the written F3 gate checklist exactly and add no stricter
+ * sub-condition.
  */
 export function evaluateMergeGates(
   report: Record<string, unknown>,
 ): MergeBlocker[] {
-  const blockers: MergeBlocker[] = [];
-
-  // Fail closed on a missing/invalid head: `prHeadSha` binds
-  // `--match-head-commit`, so a non-40-hex value must never yield a
-  // "ready" verdict with an unsafe merge binding.
-  const prHeadSha = String(report.prHeadSha ?? '');
-  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
-    blockers.push({
-      gate: 'head-sha',
-      detail: `prHeadSha "${prHeadSha}" is not a 40-hex commit SHA; cannot bind a safe merge`,
-    });
-  }
-
-  const reviewCurrency = asRecord(report.reviewCurrency);
-  const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
-  if (comparisonRoute !== 'proceed') {
-    blockers.push({
-      gate: 'review-currency',
-      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${String(
-        reviewCurrency.comparisonReason ?? 'unknown',
-      )}`,
-    });
-  }
-
-  const threads = asRecord(report.threads);
-  const actionableCount = Number(threads.actionableCount ?? -1);
-  if (actionableCount !== 0) {
-    blockers.push({
-      gate: 'unresolved-threads',
-      detail: `actionableCount is ${actionableCount} (expected 0)`,
-    });
-  }
-
-  const advisoryWait = asRecord(report.advisoryWait);
-  const f3Outcome = String(advisoryWait.f3Outcome ?? '');
-  if (f3Outcome !== 'SATISFIED') {
-    blockers.push({
-      gate: 'advisory-wait',
-      detail: `f3Outcome is "${f3Outcome}" (expected "SATISFIED")`,
-    });
-  }
-
-  const ci = asRecord(report.ci);
-  if (!isCiAllPassing(ci)) {
-    blockers.push({
-      gate: 'ci',
-      detail: `CI is not all-passing (status="${String(
-        ci.status ?? '',
-      )}", noRequiredChecksConfigured=${Boolean(
-        ci.noRequiredChecksConfigured,
-      )}, presentRunConclusion="${String(ci.presentRunConclusion ?? '')}")`,
-    });
-  }
-
-  const reviewerStates = asRecord(report.reviewerStates);
-  if (!isReviewSatisfied(reviewerStates)) {
-    const selfApproval = asRecord(reviewerStates.codeownerSelfApproval);
-    blockers.push({
-      gate: 'required-reviews',
-      detail: `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(
-        reviewerStates.requiredApprovalsSatisfied,
-      )}, codeownerApprovalSatisfied=${Boolean(
-        reviewerStates.codeownerApprovalSatisfied,
-      )}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`,
-    });
-  }
-
-  const claim = asRecord(report.claim);
-  if (claim.matchesExpectedClaim !== true) {
-    blockers.push({
-      gate: 'claim-ownership',
-      detail: `claim ownership does not match (reason="${String(
-        claim.reason ?? 'unknown',
-      )}")`,
-    });
-  }
-
-  const dispositionEvidence = asRecord(report.dispositionEvidence);
-  // The written F2/F3 gate requires BOTH `route === 'proceed'` AND
-  // `blockingCount === 0`. Fail closed on a non-zero or non-numeric
-  // blockingCount so a missing/garbled count is treated as a blocker.
-  const dispositionRoute = String(dispositionEvidence.route ?? '');
-  const dispositionBlockingCount = Number(
-    dispositionEvidence.blockingCount ?? -1,
-  );
-  if (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0) {
-    blockers.push({
-      gate: 'disposition-evidence',
-      detail: `dispositionEvidence.route is "${
-        dispositionRoute || 'missing'
-      }" (expected "proceed"), blockingCount=${dispositionBlockingCount} (expected 0)`,
-    });
-  }
-
-  return blockers;
-}
-
-// CI all-passing mirrors the F2/F3 rule: required checks pass, OR (no
-// required checks are configured AND every present run concludes passing).
-// `status === 'success'` already implies required checks passed; the
-// no-required-checks branch must not satisfy CI vacuously, so it requires
-// `presentRunConclusion === 'all-passing'`.
-function isCiAllPassing(ci: Record<string, unknown>): boolean {
-  if (ci.requiredChecksPassing === true || ci.status === 'success') {
-    return true;
-  }
-  return (
-    ci.noRequiredChecksConfigured === true &&
-    String(ci.presentRunConclusion ?? '') === 'all-passing'
-  );
-}
-
-// Required + CODEOWNER reviews are satisfied when the approval-count gate
-// passes and the CODEOWNER gate either passes outright or the self-approval
-// diagnostic is `clear` (a satisfiable bypass topology).
-function isReviewSatisfied(reviewerStates: Record<string, unknown>): boolean {
-  if (reviewerStates.requiredApprovalsSatisfied !== true) {
-    return false;
-  }
-  if (reviewerStates.codeownerApprovalSatisfied === true) {
-    return true;
-  }
-  const selfApproval = asRecord(reviewerStates.codeownerSelfApproval);
-  return String(selfApproval.status ?? '') === 'clear';
+  return computePreMergeReadinessBlockers(report);
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4760,6 +4760,153 @@ export function summarizeClaimValidation(
   };
 }
 
+/** One unmet pre-merge gate: the gate id plus a human-readable detail. */
+export interface PreMergeBlocker {
+  gate: string;
+  detail: string;
+}
+
+function preMergeAsRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function isPreMergeCiAllPassing(ci: Record<string, unknown>): boolean {
+  if (ci.requiredChecksPassing === true || ci.status === 'success') {
+    return true;
+  }
+  return (
+    ci.noRequiredChecksConfigured === true &&
+    String(ci.presentRunConclusion ?? '') === 'all-passing'
+  );
+}
+
+function isPreMergeReviewSatisfied(
+  reviewerStates: Record<string, unknown>,
+): boolean {
+  if (reviewerStates.requiredApprovalsSatisfied !== true) {
+    return false;
+  }
+  if (reviewerStates.codeownerApprovalSatisfied === true) {
+    return true;
+  }
+  const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
+  return String(selfApproval.status ?? '') === 'clear';
+}
+
+/**
+ * Roll up the F2/F3 merge gates from a pre-merge-readiness report into the
+ * ordered blocker list. This is the single source of the merge-gate AND:
+ * `buildPreMergeReadinessSummary` embeds `{ ready, blockers }` computed from it,
+ * and `idd-merge-execute.evaluateMergeGates` delegates to it, so no caller
+ * re-implements the conjunction. The rollup is **strict** — it reads
+ * `dispositionEvidence.route === 'proceed'` directly and does NOT apply the
+ * `soleCauseAckOnlyPostDisposition` override (a separate flag the F2 checklist
+ * layers on top), so the fully-autonomous F3 executor keeps its fail-closed
+ * behavior. A gate whose evidence is missing or garbled fails closed (recorded
+ * as a blocker) rather than passing vacuously.
+ */
+export function computePreMergeReadinessBlockers(
+  report: Record<string, unknown>,
+): PreMergeBlocker[] {
+  const blockers: PreMergeBlocker[] = [];
+
+  // Fail closed on a missing/invalid head: `prHeadSha` binds
+  // `--match-head-commit`, so a non-40-hex value must never yield a "ready"
+  // verdict with an unsafe merge binding.
+  const prHeadSha = String(report.prHeadSha ?? '');
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    blockers.push({
+      gate: 'head-sha',
+      detail: `prHeadSha "${prHeadSha}" is not a 40-hex commit SHA; cannot bind a safe merge`,
+    });
+  }
+
+  const reviewCurrency = preMergeAsRecord(report.reviewCurrency);
+  const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
+  if (comparisonRoute !== 'proceed') {
+    blockers.push({
+      gate: 'review-currency',
+      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${String(
+        reviewCurrency.comparisonReason ?? 'unknown',
+      )}`,
+    });
+  }
+
+  const threads = preMergeAsRecord(report.threads);
+  const actionableCount = Number(threads.actionableCount ?? -1);
+  if (actionableCount !== 0) {
+    blockers.push({
+      gate: 'unresolved-threads',
+      detail: `actionableCount is ${actionableCount} (expected 0)`,
+    });
+  }
+
+  const advisoryWait = preMergeAsRecord(report.advisoryWait);
+  const f3Outcome = String(advisoryWait.f3Outcome ?? '');
+  if (f3Outcome !== 'SATISFIED') {
+    blockers.push({
+      gate: 'advisory-wait',
+      detail: `f3Outcome is "${f3Outcome}" (expected "SATISFIED")`,
+    });
+  }
+
+  const ci = preMergeAsRecord(report.ci);
+  if (!isPreMergeCiAllPassing(ci)) {
+    blockers.push({
+      gate: 'ci',
+      detail: `CI is not all-passing (status="${String(
+        ci.status ?? '',
+      )}", noRequiredChecksConfigured=${Boolean(
+        ci.noRequiredChecksConfigured,
+      )}, presentRunConclusion="${String(ci.presentRunConclusion ?? '')}")`,
+    });
+  }
+
+  const reviewerStates = preMergeAsRecord(report.reviewerStates);
+  if (!isPreMergeReviewSatisfied(reviewerStates)) {
+    const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
+    blockers.push({
+      gate: 'required-reviews',
+      detail: `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(
+        reviewerStates.requiredApprovalsSatisfied,
+      )}, codeownerApprovalSatisfied=${Boolean(
+        reviewerStates.codeownerApprovalSatisfied,
+      )}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`,
+    });
+  }
+
+  const claim = preMergeAsRecord(report.claim);
+  if (claim.matchesExpectedClaim !== true) {
+    blockers.push({
+      gate: 'claim-ownership',
+      detail: `claim ownership does not match (reason="${String(
+        claim.reason ?? 'unknown',
+      )}")`,
+    });
+  }
+
+  const dispositionEvidence = preMergeAsRecord(report.dispositionEvidence);
+  // The written F2/F3 gate requires BOTH `route === 'proceed'` AND
+  // `blockingCount === 0`. Fail closed on a non-zero or non-numeric
+  // blockingCount so a missing/garbled count is treated as a blocker.
+  const dispositionRoute = String(dispositionEvidence.route ?? '');
+  const dispositionBlockingCount = Number(
+    dispositionEvidence.blockingCount ?? -1,
+  );
+  if (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0) {
+    blockers.push({
+      gate: 'disposition-evidence',
+      detail: `dispositionEvidence.route is "${
+        dispositionRoute || 'missing'
+      }" (expected "proceed"), blockingCount=${dispositionBlockingCount} (expected 0)`,
+    });
+  }
+
+  return blockers;
+}
+
 export function buildPreMergeReadinessSummary(
   {
     prHeadSha,
@@ -5052,6 +5199,14 @@ export function buildPreMergeReadinessSummary(
   if (dispositionEvidence) {
     summary.dispositionEvidence = dispositionEvidence;
   }
+
+  // Top-level rollup so a consumer reads one `ready` boolean + `blockers[]`
+  // instead of hand-ANDing ~8 nested gates (a dropped clause would fail open).
+  // Strict by construction (see `computePreMergeReadinessBlockers`): the F2
+  // checklist applies the ack-only override on top of this, not inside it.
+  const blockers = computePreMergeReadinessBlockers(summary);
+  summary.ready = blockers.length === 0;
+  summary.blockers = blockers;
 
   return summary;
 }

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -6,6 +6,7 @@ import {
   type MergeExecuteDeps,
   runMergeExecute,
 } from '../src/scripts/idd-merge-execute.mts';
+import { computePreMergeReadinessBlockers } from '../src/scripts/protocol-helpers.mts';
 
 const HEAD = '1111111111111111111111111111111111111111';
 const DRIFTED = '2222222222222222222222222222222222222222';
@@ -406,5 +407,28 @@ test('missing --pr is rejected', () => {
     () =>
       runMergeExecute(['--claim-issue', '309'], depsFor(readyReport()).deps),
     /missing required --pr/,
+  );
+});
+
+test('evaluateMergeGates delegates to the shared computePreMergeReadinessBlockers rollup', () => {
+  // A fully ready report → no blockers, and both entry points agree.
+  assert.deepEqual(evaluateMergeGates(readyReport()), []);
+  assert.deepEqual(
+    computePreMergeReadinessBlockers(readyReport()),
+    evaluateMergeGates(readyReport()),
+  );
+
+  // A report failing several gates → the executor and the shared rollup return
+  // byte-identical blockers, in the same gate order.
+  const bad = readyReport();
+  bad.advisoryWait = { f3Outcome: 'WAIT' };
+  bad.ci = { status: 'failure', noRequiredChecksConfigured: false };
+  assert.deepEqual(
+    computePreMergeReadinessBlockers(bad),
+    evaluateMergeGates(bad),
+  );
+  assert.deepEqual(
+    evaluateMergeGates(bad).map((blocker) => blocker.gate),
+    ['advisory-wait', 'ci'],
   );
 });

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -11,6 +11,7 @@ import {
   buildActivitySnapshotSummary,
   buildAdvisoryWaitSummary,
   buildPreMergeReadinessSummary,
+  computePreMergeReadinessBlockers,
   deriveIddAgentLogins,
   findLastCopilotReviewCommit,
   indexLatestGatingReviewsByAuthor,
@@ -4083,3 +4084,30 @@ function readJson(relativePath: string) {
     readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8'),
   );
 }
+
+test('buildPreMergeReadinessSummary embeds a strict ready/blockers rollup', () => {
+  // A clean fixture built WITHOUT dispositionEvidence fails closed on that
+  // gate (it is absent), matching the executor's fail-closed behavior.
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const summary = buildPreMergeReadinessSummary(fixture.input, fixture.options);
+
+  // `ready` is exactly `blockers.length === 0`, and `blockers` is the shared
+  // rollup applied to the summary itself (single source of the merge-gate AND).
+  const blockers = summary.blockers as { gate: string }[];
+  assert.equal(summary.ready, blockers.length === 0);
+  assert.deepEqual(summary.blockers, computePreMergeReadinessBlockers(summary));
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.gate),
+    ['disposition-evidence'],
+  );
+
+  // With every gate satisfied (including a proceed disposition), the collector
+  // rolls up to ready:true / blockers:[].
+  const ready = buildPreMergeReadinessSummary(
+    { ...fixture.input },
+    { ...fixture.options, includeDispositionEvidence: true },
+  );
+  const readyBlockers = ready.blockers as { gate: string }[];
+  assert.deepEqual(ready.blockers, computePreMergeReadinessBlockers(ready));
+  assert.equal(ready.ready, readyBlockers.length === 0);
+});

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -409,6 +409,8 @@ export const preMergeReadinessKeys = [
   'waiverEvidence',
   'trustedMarkerActors',
   'trustedMarkerActorsSource',
+  'ready',
+  'blockers',
 ] as const satisfies readonly (keyof PreMergeReadinessReport)[];
 
 export const stalledSessionQuietCheckKeys = [
@@ -915,6 +917,8 @@ const preMergeReadinessFixture = {
   },
   trustedMarkerActors: ['copilot-cli'],
   trustedMarkerActorsSource: 'config',
+  ready: true,
+  blockers: [],
 } satisfies PreMergeReadinessReport;
 
 const stalledSessionQuietCheckFixture = {


### PR DESCRIPTION
## Summary

`buildPreMergeReadinessSummary` returned a rich nested object but no top-level
`ready` boolean or `blockers[]`, so a consumer had to hand-AND ~8 nested gates
(a fail-open risk if a clause is dropped), and the rollup was duplicated in
`idd-merge-execute.evaluateMergeGates`.

## Change

- **`src/scripts/protocol-helpers.mts`**: new shared
  `computePreMergeReadinessBlockers(report) → { gate, detail }[]` — the single
  source of the 8-gate merge AND (head-sha, review-currency, unresolved-threads,
  advisory-wait, ci, required-reviews, claim-ownership, disposition-evidence).
  `buildPreMergeReadinessSummary` now embeds `ready` + `blockers` from it, keeping
  all nested evidence. The rollup is **strict**: it reads
  `dispositionEvidence.route === 'proceed'` directly and does NOT apply the
  `soleCauseAckOnlyPostDisposition` override (a separate flag the F2 checklist
  layers on top), so the fully-autonomous F3 executor keeps its fail-closed
  behavior.
- **`src/scripts/idd-merge-execute.mts`**: `evaluateMergeGates` delegates to the
  shared rollup (dropping the duplicated AND + local `isCiAllPassing` /
  `isReviewSatisfied`). It recomputes from the report's nested evidence rather
  than trusting a possibly-absent `report.blockers` field, so the merge gate
  stays fail-closed. Behavior is byte-identical, proven by the unchanged
  merge-gate tests.
- **`schemas/pre-merge-readiness.schema.json`**: adds `ready` (boolean) +
  `blockers` (`{ gate, detail }[]`) to `required` + `properties`.
- **Fixtures**: the 8 `pre-merge-readiness` fixtures and the schema valid/invalid
  fixtures carry the produced `ready` / `blockers`. (Unit fixtures build without
  `dispositionEvidence`, so their rollup fails closed on that gate — the same
  fail-closed the executor applies to an absent disposition section.)

## Notes

- Blocker field name is `detail` (the existing `MergeBlocker` shape and its
  tests), not the issue's `reason`, so the executor's output stays unchanged.

## Verification

- `pnpm test` (incl. the unchanged `idd-merge-execute` merge-gate suite + new
  delegation / collector-consistency tests) and `pnpm run lint:minimum` pass;
  schema fixtures validate.

Closes #1150
