### PR TITLE
test(idd): add a CLI-subprocess smoke test for discover-viability-gate

### DIFF
--- a/tests/cli-entry-smoke.test.mts
+++ b/tests/cli-entry-smoke.test.mts
@@ -308,3 +308,60 @@ process.exit(1);
   assert.equal(parsed.summary.readyCount, 1);
   assert.equal(parsed.ready[0].number, 900);
 });
+
+test('discover-viability-gate.mjs CLI runs the entry path without a load-time ReferenceError', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-discover-viability-cli-'));
+  const ghPath = join(tempRoot, 'gh');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+// buildIssueLoader: gh api repos/o/r/issues/901 --jq .
+if (args[0] === 'api' && args[1] === 'repos/o/r/issues/901') {
+  process.stdout.write(JSON.stringify({
+    number: 901,
+    title: 'viability smoke issue',
+    state: 'open',
+    // Wording clears all three A4 criteria (narrow scope + objective
+    // verification + no external coordination) so the issue lands in "viable".
+    body: 'A targeted single-file change verified by tests and acceptance criteria.',
+  }));
+  process.exit(0);
+}
+process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+
+  const output = execFileSync(
+    process.execPath,
+    [
+      join(REPO_ROOT, 'scripts/discover-viability-gate.mjs'),
+      '--issue',
+      '901',
+      '--owner',
+      'o',
+      '--repo',
+      'r',
+    ],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${tempRoot}:${process.env.PATH ?? ''}` },
+      // Fail fast instead of hanging the suite if the CLI ever blocks on an
+      // unexpected read (the stub gh answers or exits non-zero for every call).
+      timeout: 60_000,
+    },
+  );
+
+  assert.doesNotMatch(
+    output,
+    /ReferenceError|before initialization/,
+    'CLI output must not carry a load-time ReferenceError',
+  );
+  const parsed = JSON.parse(output);
+  assert.equal(parsed.summary.total, 1);
+  assert.equal(parsed.summary.viableCount, 1);
+  assert.equal(parsed.viable[0].number, 901);
+});


### PR DESCRIPTION
## Summary

Adds a CLI-subprocess smoke test for `discover-viability-gate.mjs` so a
load-time crash on the `isMainModule` entry path (for example a
top-level-await TDZ `ReferenceError`) fails CI, complementing the
module-eval-order guard added in #1154.

The helper runs a top-level `await evaluateDiscoverViability(...)` inside its
`isMainModule` block, but `tests/discover-viability-gate.test.mts` imports only
its named exports — it never spawns the CLI, so an entry-path load-time crash
would pass CI silently. The new test spawns the built helper with a stubbed
`gh` on `PATH`, following the pattern #1154 established for
`discover-readiness-check` in `tests/cli-entry-smoke.test.mts`, and asserts the
entry path runs end-to-end (no `ReferenceError`) and emits its documented JSON
envelope (a `viable` array).

## Scope

Test-only; no helper source change. Per the issue, `discover-orphan-filter.mjs`
and `discover-shared-file-overlap.mjs` have no top-level `await`, so smoke tests
for them are out of scope.

Refs #1154.

Closes #1181.
