### PR TITLE
feat(idd): auto-maintain .gitattributes generated block in pnpm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint:precommit": "biome check && dprint check \"**/*.md\" && markdownlint-cli2 \"**/*.md\"",
     "typecheck": "tsc -p tsconfig.json",
     "build": "node scripts/build-ts.mjs",
-    "build:check": "pnpm run build && git diff HEAD --exit-code -- scripts bin",
+    "build:check": "pnpm run build && git diff HEAD --exit-code -- scripts bin .gitattributes",
     "test": "pnpm run test:scripts",
     "test:scripts": "node --test tests/*.test.mts",
     "docs:sync": "node scripts/sync-docs.mjs --apply",

--- a/scripts/build-ts.mjs
+++ b/scripts/build-ts.mjs
@@ -13,6 +13,12 @@
 // hand-written helpers during the migration window — those are validated
 // (not rewritten) by the standalone `biome check` in lint:minimum.
 //
+// After emitting, it also rewrites the `.gitattributes`
+// `scripts/*.mjs linguist-generated=true` block so it lists exactly the
+// generated set — the same banner-keyed set tests/inventory-ordering.test.mts
+// guards — instead of relying on a hand-edit that today only surfaces as an
+// `inventory-ordering` CI failure plus an extra commit. See #1180.
+//
 // Bootstrap note: this file is itself one of the emitted artifacts. The
 // committed scripts/build-ts.mjs runs the build that regenerates it, and
 // `pnpm run build:check` fails on drift exactly as for any other
@@ -22,20 +28,115 @@
 // PATH. Uses only node: builtins to stay compatible with the repository's
 // bare-node boundary.
 import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const EMITTED_PREFIX = 'TSFILE: ';
-const tscOutput = execFileSync(
-  'tsc',
-  ['-p', 'tsconfig.build.json', '--listEmittedFiles'],
-  { encoding: 'utf8' },
-);
-const emittedFiles = tscOutput
-  .split(/\r?\n/)
-  .filter((line) => line.startsWith(EMITTED_PREFIX))
-  .map((line) => line.slice(EMITTED_PREFIX.length).trim())
-  .filter((file) => file.endsWith('.mjs'));
-if (emittedFiles.length > 0) {
-  execFileSync('biome', ['check', '--write', ...emittedFiles], {
-    stdio: 'inherit',
-  });
+// The provenance header every emitted artifact carries; a hand-written helper
+// (e.g. scripts/gh-http-status.mjs) does not. Kept identical to the
+// `idd-generated-from` scan in tests/inventory-ordering.test.mts so the build
+// and that test always agree on the generated set.
+const GENERATED_MARKER = 'idd-generated-from';
+const GENERATED_MARKER_SCAN_BYTES = 200;
+// Only the top-level scripts/*.mjs block is auto-maintained here. The
+// idd-template/scripts/* entry and the bin/**/*.mjs directory glob in
+// .gitattributes are left untouched — the inventory-ordering completeness
+// guard is likewise scoped to scripts/*.mjs.
+const GITATTRIBUTES_PATH = '.gitattributes';
+const SCRIPTS_DIR = 'scripts';
+const SCRIPT_ATTRIBUTE_PATTERN =
+  /^scripts\/[^/]+\.mjs linguist-generated=true$/;
+/** The linguist-generated attribute line for a top-level scripts/*.mjs name. */
+function scriptAttributeLine(name) {
+  return `scripts/${name} linguist-generated=true`;
+}
+/**
+ * The generated scripts/*.mjs set, derived exactly as
+ * tests/inventory-ordering.test.mts derives it: a top-level scripts/*.mjs whose
+ * first `GENERATED_MARKER_SCAN_BYTES` bytes carry the generated-from banner,
+ * ascending string-sorted. Deriving it the same way — rather than from
+ * `tsc --listEmittedFiles` — is what keeps a fresh build's .gitattributes green
+ * under that test's completeness check even if a stale generated .mjs lingers.
+ */
+function generatedScriptNames(scriptsDir) {
+  return readdirSync(scriptsDir)
+    .filter((name) => name.endsWith('.mjs'))
+    .filter((name) =>
+      readFileSync(`${scriptsDir}/${name}`, 'utf8')
+        .slice(0, GENERATED_MARKER_SCAN_BYTES)
+        .includes(GENERATED_MARKER),
+    )
+    .sort();
+}
+/**
+ * Rewrite the scripts/*.mjs linguist-generated block of a .gitattributes body
+ * so it lists exactly `names` (assumed already sorted) in place, leaving every
+ * other line — the header comment, the idd-template entry, the bin glob, the
+ * binary/export-ignore rules — byte identical. Pure: returns the new body.
+ * Throws if no block is present so a silently vanished block cannot slip by.
+ */
+export function rewriteGitattributesBlock(original, names) {
+  const lines = original.split('\n');
+  const firstBlockIndex = lines.findIndex((line) =>
+    SCRIPT_ATTRIBUTE_PATTERN.test(line),
+  );
+  if (firstBlockIndex < 0) {
+    throw new Error(
+      `${GITATTRIBUTES_PATH}: no scripts/*.mjs linguist-generated block found`,
+    );
+  }
+  // Drop every existing block line, then splice the regenerated block back in
+  // at the first block line's slot. Every line before firstBlockIndex is a
+  // non-block line (firstBlockIndex is the FIRST match), so it survives the
+  // filter at the same index — firstBlockIndex is the correct insertion slot.
+  const withoutBlock = lines.filter(
+    (line) => !SCRIPT_ATTRIBUTE_PATTERN.test(line),
+  );
+  withoutBlock.splice(firstBlockIndex, 0, ...names.map(scriptAttributeLine));
+  return withoutBlock.join('\n');
+}
+/**
+ * Rewrite .gitattributes on disk to match the generated scripts set, writing
+ * only when the body changes so `pnpm run build` stays idempotent.
+ */
+function syncGitattributes() {
+  const original = readFileSync(GITATTRIBUTES_PATH, 'utf8');
+  const updated = rewriteGitattributesBlock(
+    original,
+    generatedScriptNames(SCRIPTS_DIR),
+  );
+  if (updated !== original) {
+    writeFileSync(GITATTRIBUTES_PATH, updated);
+  }
+}
+/** Emit the .mjs artifacts with tsc, then Biome-normalize only the emitted set. */
+function build() {
+  const tscOutput = execFileSync(
+    'tsc',
+    ['-p', 'tsconfig.build.json', '--listEmittedFiles'],
+    { encoding: 'utf8' },
+  );
+  const emittedFiles = tscOutput
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith(EMITTED_PREFIX))
+    .map((line) => line.slice(EMITTED_PREFIX.length).trim())
+    .filter((file) => file.endsWith('.mjs'));
+  if (emittedFiles.length > 0) {
+    execFileSync('biome', ['check', '--write', ...emittedFiles], {
+      stdio: 'inherit',
+    });
+  }
+}
+function isMainModule(metaUrl) {
+  if (!metaUrl || !process.argv[1]) {
+    return false;
+  }
+  // Compare filesystem paths instead of building a file:// URL from
+  // argv[1], which mis-parses Windows drive-letter paths.
+  return fileURLToPath(metaUrl) === resolve(process.argv[1]);
+}
+if (isMainModule(import.meta.url)) {
+  build();
+  syncGitattributes();
 }

--- a/src/scripts/build-ts.mts
+++ b/src/scripts/build-ts.mts
@@ -13,6 +13,12 @@
 // hand-written helpers during the migration window — those are validated
 // (not rewritten) by the standalone `biome check` in lint:minimum.
 //
+// After emitting, it also rewrites the `.gitattributes`
+// `scripts/*.mjs linguist-generated=true` block so it lists exactly the
+// generated set — the same banner-keyed set tests/inventory-ordering.test.mts
+// guards — instead of relying on a hand-edit that today only surfaces as an
+// `inventory-ordering` CI failure plus an extra commit. See #1180.
+//
 // Bootstrap note: this file is itself one of the emitted artifacts. The
 // committed scripts/build-ts.mjs runs the build that regenerates it, and
 // `pnpm run build:check` fails on drift exactly as for any other
@@ -23,23 +29,129 @@
 // bare-node boundary.
 
 import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const EMITTED_PREFIX = 'TSFILE: ';
 
-const tscOutput: string = execFileSync(
-  'tsc',
-  ['-p', 'tsconfig.build.json', '--listEmittedFiles'],
-  { encoding: 'utf8' },
-);
+// The provenance header every emitted artifact carries; a hand-written helper
+// (e.g. scripts/gh-http-status.mjs) does not. Kept identical to the
+// `idd-generated-from` scan in tests/inventory-ordering.test.mts so the build
+// and that test always agree on the generated set.
+const GENERATED_MARKER = 'idd-generated-from';
+const GENERATED_MARKER_SCAN_BYTES = 200;
 
-const emittedFiles: string[] = tscOutput
-  .split(/\r?\n/)
-  .filter((line) => line.startsWith(EMITTED_PREFIX))
-  .map((line) => line.slice(EMITTED_PREFIX.length).trim())
-  .filter((file) => file.endsWith('.mjs'));
+// Only the top-level scripts/*.mjs block is auto-maintained here. The
+// idd-template/scripts/* entry and the bin/**/*.mjs directory glob in
+// .gitattributes are left untouched — the inventory-ordering completeness
+// guard is likewise scoped to scripts/*.mjs.
+const GITATTRIBUTES_PATH = '.gitattributes';
+const SCRIPTS_DIR = 'scripts';
+const SCRIPT_ATTRIBUTE_PATTERN =
+  /^scripts\/[^/]+\.mjs linguist-generated=true$/;
 
-if (emittedFiles.length > 0) {
-  execFileSync('biome', ['check', '--write', ...emittedFiles], {
-    stdio: 'inherit',
-  });
+/** The linguist-generated attribute line for a top-level scripts/*.mjs name. */
+function scriptAttributeLine(name: string): string {
+  return `scripts/${name} linguist-generated=true`;
+}
+
+/**
+ * The generated scripts/*.mjs set, derived exactly as
+ * tests/inventory-ordering.test.mts derives it: a top-level scripts/*.mjs whose
+ * first `GENERATED_MARKER_SCAN_BYTES` bytes carry the generated-from banner,
+ * ascending string-sorted. Deriving it the same way — rather than from
+ * `tsc --listEmittedFiles` — is what keeps a fresh build's .gitattributes green
+ * under that test's completeness check even if a stale generated .mjs lingers.
+ */
+function generatedScriptNames(scriptsDir: string): string[] {
+  return readdirSync(scriptsDir)
+    .filter((name) => name.endsWith('.mjs'))
+    .filter((name) =>
+      readFileSync(`${scriptsDir}/${name}`, 'utf8')
+        .slice(0, GENERATED_MARKER_SCAN_BYTES)
+        .includes(GENERATED_MARKER),
+    )
+    .sort();
+}
+
+/**
+ * Rewrite the scripts/*.mjs linguist-generated block of a .gitattributes body
+ * so it lists exactly `names` (assumed already sorted) in place, leaving every
+ * other line — the header comment, the idd-template entry, the bin glob, the
+ * binary/export-ignore rules — byte identical. Pure: returns the new body.
+ * Throws if no block is present so a silently vanished block cannot slip by.
+ */
+export function rewriteGitattributesBlock(
+  original: string,
+  names: readonly string[],
+): string {
+  const lines = original.split('\n');
+  const firstBlockIndex = lines.findIndex((line) =>
+    SCRIPT_ATTRIBUTE_PATTERN.test(line),
+  );
+  if (firstBlockIndex < 0) {
+    throw new Error(
+      `${GITATTRIBUTES_PATH}: no scripts/*.mjs linguist-generated block found`,
+    );
+  }
+  // Drop every existing block line, then splice the regenerated block back in
+  // at the first block line's slot. Every line before firstBlockIndex is a
+  // non-block line (firstBlockIndex is the FIRST match), so it survives the
+  // filter at the same index — firstBlockIndex is the correct insertion slot.
+  const withoutBlock = lines.filter(
+    (line) => !SCRIPT_ATTRIBUTE_PATTERN.test(line),
+  );
+  withoutBlock.splice(firstBlockIndex, 0, ...names.map(scriptAttributeLine));
+  return withoutBlock.join('\n');
+}
+
+/**
+ * Rewrite .gitattributes on disk to match the generated scripts set, writing
+ * only when the body changes so `pnpm run build` stays idempotent.
+ */
+function syncGitattributes(): void {
+  const original = readFileSync(GITATTRIBUTES_PATH, 'utf8');
+  const updated = rewriteGitattributesBlock(
+    original,
+    generatedScriptNames(SCRIPTS_DIR),
+  );
+  if (updated !== original) {
+    writeFileSync(GITATTRIBUTES_PATH, updated);
+  }
+}
+
+/** Emit the .mjs artifacts with tsc, then Biome-normalize only the emitted set. */
+function build(): void {
+  const tscOutput: string = execFileSync(
+    'tsc',
+    ['-p', 'tsconfig.build.json', '--listEmittedFiles'],
+    { encoding: 'utf8' },
+  );
+
+  const emittedFiles: string[] = tscOutput
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith(EMITTED_PREFIX))
+    .map((line) => line.slice(EMITTED_PREFIX.length).trim())
+    .filter((file) => file.endsWith('.mjs'));
+
+  if (emittedFiles.length > 0) {
+    execFileSync('biome', ['check', '--write', ...emittedFiles], {
+      stdio: 'inherit',
+    });
+  }
+}
+
+function isMainModule(metaUrl: string): boolean {
+  if (!metaUrl || !process.argv[1]) {
+    return false;
+  }
+  // Compare filesystem paths instead of building a file:// URL from
+  // argv[1], which mis-parses Windows drive-letter paths.
+  return fileURLToPath(metaUrl) === resolve(process.argv[1]);
+}
+
+if (isMainModule(import.meta.url)) {
+  build();
+  syncGitattributes();
 }

--- a/tests/build-ts.test.mts
+++ b/tests/build-ts.test.mts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { rewriteGitattributesBlock } from '../src/scripts/build-ts.mts';
+
+// A representative .gitattributes body: a header comment, a two-entry
+// scripts/*.mjs block, then the entries the build must NOT touch — the
+// idd-template/scripts/* line, the bin/**/*.mjs glob (with its own comment),
+// and unrelated binary rules. The trailing '' preserves the final newline.
+const FIXTURE = [
+  '# Normalize line endings',
+  '* text=auto eol=lf',
+  '',
+  '# Generated from TypeScript sources.',
+  'scripts/alpha.mjs linguist-generated=true',
+  'scripts/gamma.mjs linguist-generated=true',
+  'idd-template/scripts/keep-me.mjs linguist-generated=true',
+  '# Every bin/ shim is generated from src/bin/*.mts (whole directory).',
+  'bin/**/*.mjs linguist-generated=true',
+  '',
+  '*.gif binary',
+  '',
+].join('\n');
+
+const blockLinesOf = (body: string): string[] =>
+  body
+    .split('\n')
+    .filter((line) =>
+      /^scripts\/[^/]+\.mjs linguist-generated=true$/.test(line),
+    );
+
+const nonBlockLinesOf = (body: string): string[] =>
+  body
+    .split('\n')
+    .filter(
+      (line) => !/^scripts\/[^/]+\.mjs linguist-generated=true$/.test(line),
+    );
+
+test('rewriteGitattributesBlock is idempotent on an already-correct body', () => {
+  assert.equal(
+    rewriteGitattributesBlock(FIXTURE, ['alpha.mjs', 'gamma.mjs']),
+    FIXTURE,
+  );
+});
+
+test('rewriteGitattributesBlock inserts a newly generated script in sorted position', () => {
+  const updated = rewriteGitattributesBlock(FIXTURE, [
+    'alpha.mjs',
+    'beta.mjs',
+    'gamma.mjs',
+  ]);
+  assert.deepEqual(blockLinesOf(updated), [
+    'scripts/alpha.mjs linguist-generated=true',
+    'scripts/beta.mjs linguist-generated=true',
+    'scripts/gamma.mjs linguist-generated=true',
+  ]);
+});
+
+test('rewriteGitattributesBlock leaves every non-block line byte-identical', () => {
+  const updated = rewriteGitattributesBlock(FIXTURE, [
+    'alpha.mjs',
+    'beta.mjs',
+    'gamma.mjs',
+  ]);
+  // The header, the idd-template/scripts/* entry, the bin glob + its comment,
+  // and the binary rule / trailing newline are all preserved verbatim.
+  assert.deepEqual(nonBlockLinesOf(updated), [
+    '# Normalize line endings',
+    '* text=auto eol=lf',
+    '',
+    '# Generated from TypeScript sources.',
+    'idd-template/scripts/keep-me.mjs linguist-generated=true',
+    '# Every bin/ shim is generated from src/bin/*.mts (whole directory).',
+    'bin/**/*.mjs linguist-generated=true',
+    '',
+    '*.gif binary',
+    '',
+  ]);
+});
+
+test('rewriteGitattributesBlock drops a stale entry whose script no longer exists', () => {
+  const updated = rewriteGitattributesBlock(FIXTURE, ['alpha.mjs']);
+  assert.deepEqual(blockLinesOf(updated), [
+    'scripts/alpha.mjs linguist-generated=true',
+  ]);
+});
+
+test('rewriteGitattributesBlock throws when no scripts/*.mjs block is present', () => {
+  assert.throws(
+    () => rewriteGitattributesBlock('* text=auto eol=lf\n', ['alpha.mjs']),
+    /no scripts\/\*\.mjs linguist-generated block/,
+  );
+});


### PR DESCRIPTION
## Summary

Adding or removing an emitted `scripts/*.mjs` helper required a manual
`.gitattributes` `linguist-generated=true` edit that only surfaced as an
`inventory-ordering` CI failure plus an extra commit. `pnpm run build` now
keeps that block in sync automatically.

- `build-ts` rewrites the `scripts/*.mjs` block in place after the `tsc` emit,
  deriving the set **exactly as `tests/inventory-ordering.test.mts` does** —
  top-level `scripts/*.mjs` carrying the `idd-generated-from` banner, ascending
  sorted — so a fresh build always leaves that test green (both key off the
  banner). The header comment, the `idd-template/scripts/*` entry, and the
  `bin/**/*.mjs` glob are left byte-identical, and it writes only on change
  (idempotent — re-running `build` produces no diff).
- `build-ts` is refactored behind an `isMainModule` entry guard so the pure
  `rewriteGitattributesBlock` is unit-testable without running `tsc`; every
  module-level binding stays above the guard (module-eval-order guard clean).
- `build:check`'s diff scope is widened to `.gitattributes` so a stale block
  fails mechanically in CI, alongside the `inventory-ordering` invariant guard
  that stays as the completeness check.

## Rationale / non-goals

- The set is derived from the on-disk banner scan rather than
  `tsc --listEmittedFiles` on purpose: that guarantees agreement with the
  `inventory-ordering` completeness check even if a stale generated `.mjs`
  lingers on disk.
- Scoped to the individually-listed `scripts/*.mjs` block. The
  `idd-template/scripts/*` entry and the `bin/**/*.mjs` directory glob need no
  per-file maintenance and are intentionally left untouched.
- Out of scope (per the issue): auto-injecting the `idd-generated-from` banner
  into new `.mts` sources during build.

## Test plan

- New `tests/build-ts.test.mts` unit-tests `rewriteGitattributesBlock`:
  idempotency, sorted insertion of a new entry, stale-entry drop, non-block
  line preservation, and the missing-block throw.
- Verified end-to-end: dropping a `scripts/*.mjs` entry then running
  `pnpm run build` restores it in sorted position; a second build is a no-op.
- `pnpm run lint:minimum` passes (`build:check`, `inventory-ordering`, full
  suite 1477 tests).

Closes #1180
