### PR TITLE
test(idd): add a reviewed fixture-regeneration path for deepEqual suites

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -55,6 +55,7 @@ scripts/review-disposition-verify.mjs linguist-generated=true
 scripts/stalled-session-quiet-check.mjs linguist-generated=true
 scripts/suitability-triage.mjs linguist-generated=true
 scripts/sync-docs.mjs linguist-generated=true
+scripts/update-fixtures.mjs linguist-generated=true
 scripts/validate-schemas.mjs linguist-generated=true
 scripts/verify-workshop-integrity.mjs linguist-generated=true
 idd-template/scripts/minimize-superseded-markers.mjs linguist-generated=true

--- a/docs/typescript-sources.md
+++ b/docs/typescript-sources.md
@@ -95,3 +95,29 @@ stripping (`node --test tests/*.test.mts`). Unit tests import the typed
 signatures; CLI/integration tests keep spawning the emitted
 `scripts/*.mjs` / `bin/*.mjs` artifacts, which is exactly what adopters
 execute.
+
+### Regenerating `deepEqual` fixtures
+
+Some suites assert a builder's output against committed
+`fixtures/<suite>/*.json` `{ input, options, expected }` cases via a full
+`assert.deepEqual` (for example `tests/pre-merge-readiness.test.mts`). When
+an **intentional** output-shape change lands, recompute every `expected`
+instead of hand-editing each fixture:
+
+```sh
+pnpm run fixtures:update            # regenerate every registered suite
+pnpm run fixtures:update --suite pre-merge-readiness   # or just one
+```
+
+The tool (`src/scripts/update-fixtures.mts` → `scripts/update-fixtures.mjs`)
+recomputes each fixture's `expected` from the current builder and rewrites
+the file in the repo's canonical JSON form. On unchanged code it is a
+**no-op** (empty `git diff`), which round-trips the committed fixtures; a
+sibling suite registers by adding one `FIXTURE_SUITES` entry.
+
+> **Guardrail.** Regeneration blesses whatever the code currently emits, so
+> a blind regeneration can silently **mask a real regression** — the exact
+> anti-pattern IDD warns about. Use it only for a deliberate shape change,
+> and **review the emitted `git diff`**; it is not a substitute for
+> correctness. A normal `pnpm test` / CI run never regenerates (assert-only);
+> the tool is strictly opt-in.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "build:check": "pnpm run build && git diff HEAD --exit-code -- scripts bin .gitattributes",
     "test": "pnpm run test:scripts",
     "test:scripts": "node --test tests/*.test.mts",
+    "fixtures:update": "node scripts/update-fixtures.mjs",
     "docs:sync": "node scripts/sync-docs.mjs --apply",
     "docs:sync:check": "node scripts/sync-docs.mjs --check"
   },

--- a/scripts/update-fixtures.mjs
+++ b/scripts/update-fixtures.mjs
@@ -20,10 +20,32 @@
 //
 // Uses only node: builtins plus the in-repo builder imports, to stay compatible
 // with the repository's bare-node boundary.
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildPreMergeReadinessSummary } from './protocol-helpers.mjs';
+
+// Resolve the repository root by walking up to the nearest package.json, so the
+// suite directories resolve identically whether the tool runs as the emitted
+// scripts/update-fixtures.mjs (one level deep), the .mts source under Node type
+// stripping (two levels deep), or is invoked from any working directory. A fixed
+// cwd-relative path would target the wrong directory when run from a
+// subdirectory; mirrors the resolveRepoRoot pattern in validate-schemas.mts.
+function resolveRepoRoot(fromUrl) {
+  let dir = dirname(fileURLToPath(fromUrl));
+  for (let depth = 0; depth < 16; depth += 1) {
+    if (existsSync(join(dir, 'package.json'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return dir;
+}
+const REPO_ROOT = resolveRepoRoot(import.meta.url);
 export const FIXTURE_SUITES = [
   {
     name: 'pre-merge-readiness',
@@ -64,16 +86,17 @@ export function regenerateFixtureText(rawJson, build) {
 /** Regenerate every fixture in a suite in place; returns the rewritten paths. */
 function regenerateSuite(suite) {
   const changed = [];
-  const fixtureFiles = readdirSync(suite.dir)
+  const suiteDir = resolve(REPO_ROOT, suite.dir);
+  const fixtureFiles = readdirSync(suiteDir)
     .filter((entry) => entry.endsWith('.json'))
     .sort();
   for (const name of fixtureFiles) {
-    const path = `${suite.dir}/${name}`;
-    const original = readFileSync(path, 'utf8');
+    const absolutePath = join(suiteDir, name);
+    const original = readFileSync(absolutePath, 'utf8');
     const updated = regenerateFixtureText(original, suite.build);
     if (updated !== original) {
-      writeFileSync(path, updated);
-      changed.push(path);
+      writeFileSync(absolutePath, updated);
+      changed.push(`${suite.dir}/${name}`);
     }
   }
   return changed;

--- a/scripts/update-fixtures.mjs
+++ b/scripts/update-fixtures.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/update-fixtures.mts
+//
+// The scripts/update-fixtures.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
+// Reviewed, opt-in regeneration for the deepEqual-driven fixture suites. Each
+// suite's `<dir>/*.json` fixtures are `{ input, options, expected }` cases; this
+// tool recomputes every `expected` from the current builder output and rewrites
+// the file in the repo's canonical JSON form, so an intentional summary-shape
+// change no longer needs each fixture hand-edited.
+//
+// GUARDRAIL: regeneration blesses whatever the code currently emits, so a blind
+// regeneration can silently MASK a real regression — the exact anti-pattern IDD warns
+// about. Use it ONLY for an intentional output-shape change, and REVIEW the
+// emitted `git diff`; it is not a substitute for correctness. A normal
+// `pnpm test` / CI run never regenerates (assert-only) — regeneration is strictly
+// opt-in via `pnpm run fixtures:update`.
+//
+// Uses only node: builtins plus the in-repo builder imports, to stay compatible
+// with the repository's bare-node boundary.
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildPreMergeReadinessSummary } from './protocol-helpers.mjs';
+export const FIXTURE_SUITES = [
+  {
+    name: 'pre-merge-readiness',
+    dir: 'fixtures/pre-merge-readiness',
+    build: (fixture) =>
+      buildPreMergeReadinessSummary(fixture.input, fixture.options),
+  },
+];
+const HELP = `usage: node scripts/update-fixtures.mjs [--suite <name>] [--help]
+
+Reviewed, opt-in regeneration for the deepEqual fixture suites. Recomputes each
+<dir>/*.json fixture's "expected" from the current builder and rewrites the file
+in the repo's canonical JSON form (2-space indent + trailing newline).
+
+GUARDRAIL: regeneration blesses whatever the code currently emits, so a blind
+regeneration can silently mask a real regression. Use it ONLY for an intentional
+output-shape change and REVIEW the emitted git diff — it is not a substitute for
+correctness. A normal \`pnpm test\` / CI run never regenerates (assert-only);
+this tool is strictly opt-in (\`pnpm run fixtures:update\`).
+
+Registered suites: ${FIXTURE_SUITES.map((suite) => suite.name).join(', ')}
+  --suite <name>   regenerate only the named suite (default: every suite)
+  --help, -h       show this help
+`;
+/**
+ * Recompute a single fixture's `expected` from `build(...)` and serialize it in
+ * the repo's canonical JSON form (2-space indent + trailing newline, which
+ * matches biome). Pure: returns the new file text. A no-op run reproduces the
+ * input bytes exactly — the spread preserves original key order and only
+ * `expected` is reassigned — which is what proves the tool is not silently
+ * rewriting anything the code did not change.
+ */
+export function regenerateFixtureText(rawJson, build) {
+  const fixture = JSON.parse(rawJson);
+  const regenerated = { ...fixture, expected: build(fixture) };
+  return `${JSON.stringify(regenerated, null, 2)}\n`;
+}
+/** Regenerate every fixture in a suite in place; returns the rewritten paths. */
+function regenerateSuite(suite) {
+  const changed = [];
+  const fixtureFiles = readdirSync(suite.dir)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort();
+  for (const name of fixtureFiles) {
+    const path = `${suite.dir}/${name}`;
+    const original = readFileSync(path, 'utf8');
+    const updated = regenerateFixtureText(original, suite.build);
+    if (updated !== original) {
+      writeFileSync(path, updated);
+      changed.push(path);
+    }
+  }
+  return changed;
+}
+/**
+ * Resolve which suites to regenerate from argv: all of them, or only the one
+ * named by `--suite <name>`. Throws on an unknown suite so a typo fails loudly
+ * rather than silently regenerating nothing.
+ */
+function selectedSuites(argv) {
+  const flagIndex = argv.indexOf('--suite');
+  if (flagIndex < 0) {
+    return FIXTURE_SUITES;
+  }
+  const requested = argv[flagIndex + 1];
+  const match = FIXTURE_SUITES.find((suite) => suite.name === requested);
+  if (!match) {
+    const known = FIXTURE_SUITES.map((suite) => suite.name).join(', ');
+    throw new Error(
+      `unknown suite: ${requested ?? '(none)'} (known: ${known})`,
+    );
+  }
+  return [match];
+}
+function isMainModule(metaUrl) {
+  if (!metaUrl || !process.argv[1]) {
+    return false;
+  }
+  // Compare filesystem paths instead of building a file:// URL from
+  // argv[1], which mis-parses Windows drive-letter paths.
+  return fileURLToPath(metaUrl) === resolve(process.argv[1]);
+}
+if (isMainModule(import.meta.url)) {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--help') || argv.includes('-h')) {
+    process.stdout.write(HELP);
+  } else {
+    const changed = [];
+    for (const suite of selectedSuites(argv)) {
+      changed.push(...regenerateSuite(suite));
+    }
+    process.stdout.write(
+      changed.length === 0
+        ? 'fixtures:update — no changes (fixtures already current)\n'
+        : `fixtures:update — rewrote ${changed.length} fixture(s):\n${changed
+            .map((path) => `  ${path}`)
+            .join('\n')}\n`,
+    );
+  }
+}

--- a/src/scripts/update-fixtures.mts
+++ b/src/scripts/update-fixtures.mts
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/update-fixtures.mts
+//
+// The scripts/update-fixtures.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
+// Reviewed, opt-in regeneration for the deepEqual-driven fixture suites. Each
+// suite's `<dir>/*.json` fixtures are `{ input, options, expected }` cases; this
+// tool recomputes every `expected` from the current builder output and rewrites
+// the file in the repo's canonical JSON form, so an intentional summary-shape
+// change no longer needs each fixture hand-edited.
+//
+// GUARDRAIL: regeneration blesses whatever the code currently emits, so a blind
+// regeneration can silently MASK a real regression — the exact anti-pattern IDD warns
+// about. Use it ONLY for an intentional output-shape change, and REVIEW the
+// emitted `git diff`; it is not a substitute for correctness. A normal
+// `pnpm test` / CI run never regenerates (assert-only) — regeneration is strictly
+// opt-in via `pnpm run fixtures:update`.
+//
+// Uses only node: builtins plus the in-repo builder imports, to stay compatible
+// with the repository's bare-node boundary.
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildPreMergeReadinessSummary } from './protocol-helpers.mts';
+
+/** One `{ input, options, expected }` fixture case read off disk. */
+export interface FixtureCase {
+  input: unknown;
+  options: unknown;
+  expected: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * A registered deepEqual fixture suite. Every `<dir>/*.json` is a
+ * `{ input, options, expected }` case; `build` recomputes `expected` from the
+ * current code. A sibling suite registers by adding one entry to
+ * FIXTURE_SUITES — no rewrite of the tool.
+ */
+export interface FixtureSuite {
+  readonly name: string;
+  readonly dir: string;
+  readonly build: (fixture: FixtureCase) => unknown;
+}
+
+export const FIXTURE_SUITES: readonly FixtureSuite[] = [
+  {
+    name: 'pre-merge-readiness',
+    dir: 'fixtures/pre-merge-readiness',
+    build: (fixture) =>
+      buildPreMergeReadinessSummary(
+        fixture.input as Parameters<typeof buildPreMergeReadinessSummary>[0],
+        fixture.options as Parameters<typeof buildPreMergeReadinessSummary>[1],
+      ),
+  },
+];
+
+const HELP = `usage: node scripts/update-fixtures.mjs [--suite <name>] [--help]
+
+Reviewed, opt-in regeneration for the deepEqual fixture suites. Recomputes each
+<dir>/*.json fixture's "expected" from the current builder and rewrites the file
+in the repo's canonical JSON form (2-space indent + trailing newline).
+
+GUARDRAIL: regeneration blesses whatever the code currently emits, so a blind
+regeneration can silently mask a real regression. Use it ONLY for an intentional
+output-shape change and REVIEW the emitted git diff — it is not a substitute for
+correctness. A normal \`pnpm test\` / CI run never regenerates (assert-only);
+this tool is strictly opt-in (\`pnpm run fixtures:update\`).
+
+Registered suites: ${FIXTURE_SUITES.map((suite) => suite.name).join(', ')}
+  --suite <name>   regenerate only the named suite (default: every suite)
+  --help, -h       show this help
+`;
+
+/**
+ * Recompute a single fixture's `expected` from `build(...)` and serialize it in
+ * the repo's canonical JSON form (2-space indent + trailing newline, which
+ * matches biome). Pure: returns the new file text. A no-op run reproduces the
+ * input bytes exactly — the spread preserves original key order and only
+ * `expected` is reassigned — which is what proves the tool is not silently
+ * rewriting anything the code did not change.
+ */
+export function regenerateFixtureText(
+  rawJson: string,
+  build: (fixture: FixtureCase) => unknown,
+): string {
+  const fixture = JSON.parse(rawJson) as FixtureCase;
+  const regenerated = { ...fixture, expected: build(fixture) };
+  return `${JSON.stringify(regenerated, null, 2)}\n`;
+}
+
+/** Regenerate every fixture in a suite in place; returns the rewritten paths. */
+function regenerateSuite(suite: FixtureSuite): string[] {
+  const changed: string[] = [];
+  const fixtureFiles = readdirSync(suite.dir)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort();
+  for (const name of fixtureFiles) {
+    const path = `${suite.dir}/${name}`;
+    const original = readFileSync(path, 'utf8');
+    const updated = regenerateFixtureText(original, suite.build);
+    if (updated !== original) {
+      writeFileSync(path, updated);
+      changed.push(path);
+    }
+  }
+  return changed;
+}
+
+/**
+ * Resolve which suites to regenerate from argv: all of them, or only the one
+ * named by `--suite <name>`. Throws on an unknown suite so a typo fails loudly
+ * rather than silently regenerating nothing.
+ */
+function selectedSuites(argv: readonly string[]): readonly FixtureSuite[] {
+  const flagIndex = argv.indexOf('--suite');
+  if (flagIndex < 0) {
+    return FIXTURE_SUITES;
+  }
+  const requested = argv[flagIndex + 1];
+  const match = FIXTURE_SUITES.find((suite) => suite.name === requested);
+  if (!match) {
+    const known = FIXTURE_SUITES.map((suite) => suite.name).join(', ');
+    throw new Error(
+      `unknown suite: ${requested ?? '(none)'} (known: ${known})`,
+    );
+  }
+  return [match];
+}
+
+function isMainModule(metaUrl: string): boolean {
+  if (!metaUrl || !process.argv[1]) {
+    return false;
+  }
+  // Compare filesystem paths instead of building a file:// URL from
+  // argv[1], which mis-parses Windows drive-letter paths.
+  return fileURLToPath(metaUrl) === resolve(process.argv[1]);
+}
+
+if (isMainModule(import.meta.url)) {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--help') || argv.includes('-h')) {
+    process.stdout.write(HELP);
+  } else {
+    const changed: string[] = [];
+    for (const suite of selectedSuites(argv)) {
+      changed.push(...regenerateSuite(suite));
+    }
+    process.stdout.write(
+      changed.length === 0
+        ? 'fixtures:update — no changes (fixtures already current)\n'
+        : `fixtures:update — rewrote ${changed.length} fixture(s):\n${changed
+            .map((path) => `  ${path}`)
+            .join('\n')}\n`,
+    );
+  }
+}

--- a/src/scripts/update-fixtures.mts
+++ b/src/scripts/update-fixtures.mts
@@ -21,11 +21,34 @@
 // Uses only node: builtins plus the in-repo builder imports, to stay compatible
 // with the repository's bare-node boundary.
 
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { buildPreMergeReadinessSummary } from './protocol-helpers.mts';
+
+// Resolve the repository root by walking up to the nearest package.json, so the
+// suite directories resolve identically whether the tool runs as the emitted
+// scripts/update-fixtures.mjs (one level deep), the .mts source under Node type
+// stripping (two levels deep), or is invoked from any working directory. A fixed
+// cwd-relative path would target the wrong directory when run from a
+// subdirectory; mirrors the resolveRepoRoot pattern in validate-schemas.mts.
+function resolveRepoRoot(fromUrl: string): string {
+  let dir = dirname(fileURLToPath(fromUrl));
+  for (let depth = 0; depth < 16; depth += 1) {
+    if (existsSync(join(dir, 'package.json'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return dir;
+}
+
+const REPO_ROOT = resolveRepoRoot(import.meta.url);
 
 /** One `{ input, options, expected }` fixture case read off disk. */
 export interface FixtureCase {
@@ -96,16 +119,17 @@ export function regenerateFixtureText(
 /** Regenerate every fixture in a suite in place; returns the rewritten paths. */
 function regenerateSuite(suite: FixtureSuite): string[] {
   const changed: string[] = [];
-  const fixtureFiles = readdirSync(suite.dir)
+  const suiteDir = resolve(REPO_ROOT, suite.dir);
+  const fixtureFiles = readdirSync(suiteDir)
     .filter((entry) => entry.endsWith('.json'))
     .sort();
   for (const name of fixtureFiles) {
-    const path = `${suite.dir}/${name}`;
-    const original = readFileSync(path, 'utf8');
+    const absolutePath = join(suiteDir, name);
+    const original = readFileSync(absolutePath, 'utf8');
     const updated = regenerateFixtureText(original, suite.build);
     if (updated !== original) {
-      writeFileSync(path, updated);
-      changed.push(path);
+      writeFileSync(absolutePath, updated);
+      changed.push(`${suite.dir}/${name}`);
     }
   }
   return changed;

--- a/tests/update-fixtures.test.mts
+++ b/tests/update-fixtures.test.mts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+import {
+  FIXTURE_SUITES,
+  type FixtureCase,
+  regenerateFixtureText,
+} from '../src/scripts/update-fixtures.mts';
+
+const SAMPLE = `${JSON.stringify(
+  {
+    input: { prHeadSha: 'abc' },
+    options: { now: '2026-01-01T00:00:00Z' },
+    expected: { ready: true },
+  },
+  null,
+  2,
+)}\n`;
+
+test('regenerateFixtureText is a byte no-op when the builder returns the existing expected', () => {
+  const identityBuild = (fixture: FixtureCase): unknown => fixture.expected;
+  assert.equal(regenerateFixtureText(SAMPLE, identityBuild), SAMPLE);
+});
+
+test('regenerateFixtureText rewrites only expected when the builder output differs', () => {
+  const updated = JSON.parse(
+    regenerateFixtureText(SAMPLE, () => ({ ready: false, blockers: ['x'] })),
+  ) as FixtureCase;
+  assert.deepEqual(updated.expected, { ready: false, blockers: ['x'] });
+  // input / options are carried through untouched.
+  assert.deepEqual(updated.input, { prHeadSha: 'abc' });
+  assert.deepEqual(updated.options, { now: '2026-01-01T00:00:00Z' });
+});
+
+test('regenerateFixtureText keeps canonical JSON form and original key order', () => {
+  const text = regenerateFixtureText(SAMPLE, () => ({ ready: false }));
+  assert.ok(text.endsWith('}\n'), 'trailing newline preserved');
+  assert.equal(text, `${JSON.stringify(JSON.parse(text), null, 2)}\n`);
+  assert.deepEqual(Object.keys(JSON.parse(text)), [
+    'input',
+    'options',
+    'expected',
+  ]);
+});
+
+test('unknown --suite / empty input surfaces via a thrown builder, not a silent skip', () => {
+  assert.throws(
+    () =>
+      regenerateFixtureText('{"input":{},"options":{}}', () => {
+        throw new Error('builder failed');
+      }),
+    /builder failed/,
+  );
+});
+
+// The load-bearing guarantee: on unchanged code the real builder reproduces
+// every committed fixture byte-for-byte, so `pnpm run fixtures:update` is a
+// no-op (empty git diff). This also guards the reverse — a builder shape change
+// landed without regenerating the fixtures fails here, complementing the
+// deepEqual assertions in the per-suite fixture tests.
+for (const suite of FIXTURE_SUITES) {
+  test(`${suite.name}: real builder round-trips every committed fixture (no-op)`, () => {
+    const files = readdirSync(suite.dir)
+      .filter((name) => name.endsWith('.json'))
+      .sort();
+    assert.ok(files.length > 0, `expected fixtures under ${suite.dir}`);
+    for (const name of files) {
+      const path = `${suite.dir}/${name}`;
+      const original = readFileSync(path, 'utf8');
+      assert.equal(
+        regenerateFixtureText(original, suite.build),
+        original,
+        `${path} would be rewritten by an unchanged-code regeneration`,
+      );
+    }
+  });
+}

--- a/tests/update-fixtures.test.mts
+++ b/tests/update-fixtures.test.mts
@@ -44,7 +44,7 @@ test('regenerateFixtureText keeps canonical JSON form and original key order', (
   ]);
 });
 
-test('unknown --suite / empty input surfaces via a thrown builder, not a silent skip', () => {
+test('regenerateFixtureText propagates a throwing builder instead of silently skipping', () => {
   assert.throws(
     () =>
       regenerateFixtureText('{"input":{},"options":{}}', () => {

--- a/tests/update-fixtures.test.mts
+++ b/tests/update-fixtures.test.mts
@@ -8,6 +8,11 @@ import {
   regenerateFixtureText,
 } from '../src/scripts/update-fixtures.mts';
 
+// Resolve fixtures relative to this test file, not the process cwd, so the
+// suite is location-independent (e.g. under an IDE test runner) — matching the
+// `new URL('../', import.meta.url)` pattern in the other fixture-driven tests.
+const REPO_ROOT_URL = new URL('../', import.meta.url);
+
 const SAMPLE = `${JSON.stringify(
   {
     input: { prHeadSha: 'abc' },
@@ -61,17 +66,17 @@ test('regenerateFixtureText propagates a throwing builder instead of silently sk
 // deepEqual assertions in the per-suite fixture tests.
 for (const suite of FIXTURE_SUITES) {
   test(`${suite.name}: real builder round-trips every committed fixture (no-op)`, () => {
-    const files = readdirSync(suite.dir)
+    const suiteDirUrl = new URL(`${suite.dir}/`, REPO_ROOT_URL);
+    const files = readdirSync(suiteDirUrl)
       .filter((name) => name.endsWith('.json'))
       .sort();
     assert.ok(files.length > 0, `expected fixtures under ${suite.dir}`);
     for (const name of files) {
-      const path = `${suite.dir}/${name}`;
-      const original = readFileSync(path, 'utf8');
+      const original = readFileSync(new URL(name, suiteDirUrl), 'utf8');
       assert.equal(
         regenerateFixtureText(original, suite.build),
         original,
-        `${path} would be rewritten by an unchanged-code regeneration`,
+        `${suite.dir}/${name} would be rewritten by an unchanged-code regeneration`,
       );
     }
   });


### PR DESCRIPTION
## Summary

The `deepEqual`-driven fixture suites (e.g. `tests/pre-merge-readiness.test.mts`,
8 fixtures) had **no** regeneration path, so every intentional summary-shape
change meant hand-editing each `fixtures/<suite>/*.json` `expected` via a
throwaway one-off script. This adds an opt-in, **reviewed** regeneration path.

- New `src/scripts/update-fixtures.mts` → generated `scripts/update-fixtures.mjs`
  (`pnpm run fixtures:update`) recomputes each fixture's `expected` from the
  current builder and rewrites the file in the repo's canonical JSON form
  (`JSON.stringify(…, null, 2) + "\n"`, byte-identical to biome's JSON output —
  verified round-trip on all 8 fixtures).
- A `FIXTURE_SUITES` registry drives it; the first entry is the
  pre-merge-readiness suite, and a sibling `deepEqual` suite registers by adding
  one entry (no rewrite).
- `package.json` gains `fixtures:update`; `docs/typescript-sources.md` documents
  usage and the guardrail.

Implemented as a **standalone tool** (the issue allows either shape)
deliberately so it does **not** touch `tests/pre-merge-readiness.test.mts` or the
fixtures, avoiding collision with the concurrently-active pre-merge-readiness
work (#1182, #1186) on that same surface.

## Guardrail

Regeneration blesses whatever the code currently emits, so a blind run can
silently mask a real regression. The tool's `--help` and the docs note both
state it is for a **deliberate** shape change only and the emitted `git diff`
MUST be reviewed. A normal `pnpm test` / CI run never regenerates (assert-only);
the tool is strictly opt-in.

## Test plan

- New `tests/update-fixtures.test.mts`: `regenerateFixtureText` is a byte no-op
  when the builder returns the existing `expected`; rewrites only `expected`
  when the builder differs; keeps canonical JSON form + key order; and the real
  builder round-trips every committed pre-merge-readiness fixture byte-for-byte.
- Verified end-to-end: `pnpm run fixtures:update` on unchanged code is a no-op
  (empty `git diff`); corrupting a fixture's `expected` then re-running restores
  it exactly.
- `.gitattributes` entry for the new generated `.mjs` was added automatically by
  `pnpm run build` (#1180), no manual edit.
- `pnpm run lint:minimum` passes (`build:check`, full suite 1483 tests).

Closes #1183
