### PR TITLE
fix(idd): pass a defined assert.ok message in the idd-doctor prefix test

### DIFF
--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -252,7 +252,10 @@ test('evaluateMarkerPrefixConsistency catches a cross-type prefix mismatch hidde
     { roadmap: ['alpha'], blockedBy: [] },
     { roadmap: [], blockedBy: ['beta'] },
   );
-  assert.ok(result.error && /inconsistent/.test(result.error), result.error);
+  assert.ok(
+    result.error && /inconsistent/.test(result.error),
+    result.error ?? 'expected an inconsistency error, got none',
+  );
 });
 
 test('evaluateMarkerPrefixConsistency reports a within-file roadmap/blocked-by mismatch', () => {


### PR DESCRIPTION
## Summary

`#1164` bumped `@types/node` `22.19.21 → 26.1.0`, whose `assert.ok` overloads
narrowed the `message` parameter to `Error | AssertMessageFunction` (overload 1)
or a **required** `string` (overload 2) — a `string | undefined` argument now
matches neither. `tests/idd-doctor.test.mts:255` passed `result.error`
(`string | undefined`) as the message, so a fresh install
(`pnpm install --frozen-lockfile` → 26.1.0) fails `pnpm run typecheck`:

```
tests/idd-doctor.test.mts(255,64): error TS2769: No overload matches this call.
```

This is a **main-breaking regression** that blocks the `lint` CI job for every
new PR built on the current `main`. It stayed masked on environments whose
`node_modules` predated the bump (stale `@types/node 22.x`), which is why
`#1164`'s own `lint` check passed against a stale base — the combined 26.1.0 +
this call site was never typechecked until a fresh install exposed it.

The fix passes `result.error ?? 'expected an inconsistency error, got none'` so
the message is always a `string` (overload 2), preserving the assertion's
behavior and still surfacing the actual error on failure. Exactly one call site
is affected (verified: a clean-tree `tsc -p tsconfig.json` now reports zero
errors).

## Test plan

- `pnpm run typecheck` passes on `@types/node 26.1.0` (0 errors).
- `pnpm test` (1494 tests) and `pnpm run lint:minimum` pass.

Closes #1193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved a test assertion so missing error cases now report a clear default failure message.
  * Clarified the expected outcome when an inconsistency error is not returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->