### PR TITLE
fix(idd): match the advisory bot login in hasExplicitDispositionAfter

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -4681,6 +4681,14 @@ function hasExplicitDispositionAfter(targetComment, comments, options = {}) {
       ? options.isDispositionAuthor
       : (login) => !isKnownReviewBot(login);
   const targetTime = Date.parse(targetComment.createdAt ?? '');
+  // The disposition must attribute itself to this sticky's advisory bot. Accept
+  // either the product word (`CodeRabbit`) or the bot **login**
+  // (`coderabbitai[bot]`) — the canonical disposition-non-review-notices output
+  // names the login, which `\bCodeRabbit\b` misses (no word boundary before the
+  // trailing `ai`). Naming the login reuses the same `advisoryBotIdentityToken`
+  // attribution the rest of the gate relies on. Fail-closed: an unattributable
+  // disposition still matches nothing.
+  const targetBotLogin = String(targetComment.author?.login ?? '');
   return comments.some((comment) => {
     const author = String(comment.author?.login ?? '')
       .trim()
@@ -4688,7 +4696,10 @@ function hasExplicitDispositionAfter(targetComment, comments, options = {}) {
     if (!isDispositionAuthor(author) || !isDispositionComment(comment)) {
       return false;
     }
-    if (!/\bCodeRabbit\b/i.test(comment.body ?? '')) {
+    if (
+      !/\bCodeRabbit\b/i.test(comment.body ?? '') &&
+      !dispositionNamesAdvisoryBot(comment.body ?? '', targetBotLogin)
+    ) {
       return false;
     }
     const dispositionTime = Date.parse(comment.createdAt ?? '');

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -5991,6 +5991,14 @@ function hasExplicitDispositionAfter(
       ? options.isDispositionAuthor
       : (login: string) => !isKnownReviewBot(login);
   const targetTime = Date.parse(targetComment.createdAt ?? '');
+  // The disposition must attribute itself to this sticky's advisory bot. Accept
+  // either the product word (`CodeRabbit`) or the bot **login**
+  // (`coderabbitai[bot]`) — the canonical disposition-non-review-notices output
+  // names the login, which `\bCodeRabbit\b` misses (no word boundary before the
+  // trailing `ai`). Naming the login reuses the same `advisoryBotIdentityToken`
+  // attribution the rest of the gate relies on. Fail-closed: an unattributable
+  // disposition still matches nothing.
+  const targetBotLogin = String(targetComment.author?.login ?? '');
   return comments.some((comment) => {
     const author = String(comment.author?.login ?? '')
       .trim()
@@ -5998,7 +6006,10 @@ function hasExplicitDispositionAfter(
     if (!isDispositionAuthor(author) || !isDispositionComment(comment)) {
       return false;
     }
-    if (!/\bCodeRabbit\b/i.test(comment.body ?? '')) {
+    if (
+      !/\bCodeRabbit\b/i.test(comment.body ?? '') &&
+      !dispositionNamesAdvisoryBot(comment.body ?? '', targetBotLogin)
+    ) {
       return false;
     }
     const dispositionTime = Date.parse(comment.createdAt ?? '');

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -11,6 +11,8 @@ import {
   buildActivitySnapshotSummary,
   buildAdvisoryWaitSummary,
   buildPreMergeReadinessSummary,
+  CODERABBIT_SUMMARY_MARKER,
+  classifyRegularBotComment,
   computePreMergeReadinessBlockers,
   deriveIddAgentLogins,
   findLastCopilotReviewCommit,
@@ -4290,3 +4292,66 @@ test('a trusted machine-disposition clears the notice/summary in both merge gate
   assert.equal(proceeds(general), false);
   assert.equal(unreplied(general), 2);
 });
+
+// #1191: classifyRegularBotComment → hasExplicitDispositionAfter must accept a
+// disposition that names the advisory bot LOGIN (`coderabbitai[bot]`) — the
+// canonical disposition-non-review-notices form — not only the `\bCodeRabbit\b`
+// product word, which the login never matches (no boundary before the `ai`).
+{
+  const summarySticky = {
+    id: 1,
+    createdAt: '2026-07-01T00:00:00Z',
+    body: `${CODERABBIT_SUMMARY_MARKER}\n\nSummary of changes.`,
+    author: { login: 'coderabbitai[bot]' },
+  };
+  const laterDisposition = (body: string) => ({
+    id: 2,
+    createdAt: '2026-07-01T01:00:00Z',
+    body,
+    author: { login: 'kurone-kito' },
+  });
+  const classify = (dispositionBody: string) =>
+    classifyRegularBotComment(
+      summarySticky,
+      [summarySticky, laterDisposition(dispositionBody)],
+      [],
+      { isDispositionAuthor: (login: string) => login === 'kurone-kito' },
+    );
+
+  test('#1191: a login-named disposition resolves a CodeRabbit summary sticky', () => {
+    const result = classify(
+      '**Accepted** — coderabbitai[bot] summary walkthrough confirmed; no action required.',
+    );
+    assert.equal(result?.classifier, 'RESOLVED');
+  });
+
+  test('#1191: the product-word disposition form still resolves the sticky', () => {
+    const result = classify(
+      "**Accepted** — CodeRabbit's summary reviewed; no action required.",
+    );
+    assert.equal(result?.classifier, 'RESOLVED');
+  });
+
+  test('#1191: a disposition naming neither login nor product word does not resolve (fail-closed)', () => {
+    const result = classify('**Accepted** — reviewed; no action required.');
+    assert.equal(result, null);
+  });
+
+  test('#1191: an IDD-scoped disposition author still excludes a reviewer-authored marker', () => {
+    const result = classifyRegularBotComment(
+      summarySticky,
+      [
+        summarySticky,
+        {
+          id: 3,
+          createdAt: '2026-07-01T01:00:00Z',
+          body: '**Accepted** — coderabbitai[bot] summary walkthrough looks fine.',
+          author: { login: 'some-reviewer' },
+        },
+      ],
+      [],
+      { isDispositionAuthor: (login: string) => login === 'kurone-kito' },
+    );
+    assert.equal(result, null);
+  });
+}


### PR DESCRIPTION
## Summary

`classifyRegularBotComment` marks a CodeRabbit summary sticky `RESOLVED` when
`hasExplicitDispositionAfter` finds a later IDD disposition, but that predicate
only matched the product word `\bCodeRabbit\b` — never the bot **login**
`coderabbitai[bot]` (no word boundary before the trailing `ai`) that the
canonical `disposition-non-review-notices` output names. So the
`RESOLVED`-via-`hasExplicitDispositionAfter` branch was **unreachable for the
canonical disposition form** — a latent inconsistency / effectively-dead branch
(found while implementing #1182 / PR #1184).

Accept a disposition whose body names the advisory bot **login** as well,
reusing the existing `dispositionNamesAdvisoryBot` / `advisoryBotIdentityToken`
attribution (token `coderabbitai`) in addition to the product-word match. The
sticky's own author login is the attribution source, so the check stays generic
to whatever advisory bot posted it. Every path stays fail-closed (an
unattributable disposition matches nothing new) and the IDD-scoped
`isDispositionAuthor` behavior is preserved; `idd-merge-execute` is untouched.

## Test plan

- New regression tests in `tests/pre-merge-readiness.test.mts` via
  `classifyRegularBotComment`: a login-named disposition resolves the sticky;
  the product-word form still resolves it; a disposition naming neither does not
  (fail-closed); an IDD-scoped author still excludes a reviewer-authored marker.
- Generated `scripts/protocol-helpers.mjs` regenerated via `pnpm run build`.
- `pnpm test` (1498 tests) and `pnpm run lint:minimum` pass.

Closes #1191
