### PR TITLE
docs(idd): record pre-merge gate iddAgentLogins invariants

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1294,6 +1294,17 @@ export function classifyReviewThreadForGate(thread, options = {}) {
   }
   return { classification: 'awaiting-reviewer' };
 }
+// Pre-merge gate invariant (review threads -> `threads.actionableCount`):
+// MERGE-BLOCKING. `computePreMergeReadinessBlockers` fails closed unless
+// `actionableCount === 0`. An IDD agent's (or the PR author's) latest thread
+// comment classifies `awaiting-reviewer`, which does NOT add to
+// `actionableCount`, so a recognition error here can fail OPEN: globally
+// promoting a non-agent into `iddAgentLogins` makes that actor's genuine
+// unresolved feedback classify `awaiting-reviewer` and stop blocking (when
+// conversation resolution is not required; otherwise it stays a blocking
+// `conversation-resolve-*`). Recognize dispositions PER ITEM; never globally
+// promote a non-agent into `iddAgentLogins`. See the consolidated invariants
+// above `summarizeDispositionEvidenceForGate` (#1182 / PR #1184).
 export function summarizeReviewThreadsForGate(threads, options = {}) {
   const summary = {
     actionableCount: 0,
@@ -2445,6 +2456,14 @@ export function resolveLatestReviewWatermark(comments, options = {}) {
   }
   return latest;
 }
+// Pre-merge gate invariant (unreplied regular comments -> `unrepliedComments`):
+// INFORMATIONAL, NOT merge-blocking. `computePreMergeReadinessBlockers` pushes
+// no blocker for this count, so a wrong `iddAgentLogins` recognition only
+// miscounts cosmetically (promoting a non-agent here under-counts, since its
+// comments are excluded and its reply advances the watermark; missing a real
+// agent over-counts) -- it never opens or closes the merge gate. See the
+// consolidated invariants above `summarizeDispositionEvidenceForGate`
+// (#1182 / PR #1184).
 export function summarizeRegularCommentsForGate(comments, options = {}) {
   const iddAgentLogins = new Set(
     normalizeTrustedMarkerLogins(options.iddAgentLogins ?? []),
@@ -2578,6 +2597,31 @@ export function summarizeRegularCommentsForGate(comments, options = {}) {
     items,
   };
 }
+// Pre-merge gate invariants -- READ BEFORE MODIFYING ANY `iddAgentLogins`-KEYED
+// GATE HELPER. Three functions key disposition/reply recognition on
+// `iddAgentLogins`, and each reacts DIFFERENTLY when that recognition is wrong:
+//   1. `summarizeDispositionEvidenceForGate` (this fn) -- MERGE-BLOCKING (feeds
+//      `computePreMergeReadinessBlockers` via `dispositionEvidence`). Wrong
+//      recognition -> over-block (fail-closed).
+//   2. `summarizeReviewThreadsForGate` (`actionableCount`) -- MERGE-BLOCKING.
+//      Without required conversation resolution, an IDD agent's latest thread
+//      comment is `awaiting-reviewer` (non-blocking), so GLOBALLY promoting a
+//      non-agent into `iddAgentLogins` makes that actor's genuine unresolved
+//      feedback stop blocking -> fail-OPEN. Recognize dispositions PER ITEM;
+//      never globally promote a non-agent into `iddAgentLogins`.
+//   3. `summarizeRegularCommentsForGate` (`unrepliedComments`) --
+//      INFORMATIONAL, NOT a merge blocker. Wrong recognition -> cosmetic
+//      miscount only (never opens or closes the gate).
+// Notice vs summary matching asymmetry (implemented and documented in detail on
+// `matchTrustedAdvisoryStickyDispositions`): a non-review NOTICE disposition
+// matches time-agnostically -- it carries forward across a re-posted notice
+// while the bot still has not reviewed (the #1018 carry-forward) -- while a
+// SUMMARY disposition must be STRICTLY NEWER than the sticky, so a stale
+// `**Accepted**` cannot clear a summary re-edited after it (the #1122 "a false
+// positive is a false merge" hazard).
+// Working rule: verify every advisory finding on this code with a byte-exact
+// repro before accepting it. #1182 / PR #1184 cycled through five advisory
+// rounds, each surfacing a distinct fail mode of exactly these gates.
 export function summarizeDispositionEvidenceForGate(
   { comments = [], threads = [] },
   options = {},

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1302,9 +1302,11 @@ export function classifyReviewThreadForGate(thread, options = {}) {
 // promoting a non-agent into `iddAgentLogins` makes that actor's genuine
 // unresolved feedback classify `awaiting-reviewer` and stop blocking (when
 // conversation resolution is not required; otherwise it stays a blocking
-// `conversation-resolve-*`). Recognize dispositions PER ITEM; never globally
-// promote a non-agent into `iddAgentLogins`. See the consolidated invariants
-// above `summarizeDispositionEvidenceForGate` (#1182 / PR #1184).
+// `conversation-resolve-*`). This gate classifies each thread by its own
+// latest-author identity (IDD agent / PR author), not by disposition
+// recognition; never globally promote a non-agent into `iddAgentLogins`. See
+// the consolidated invariants above `summarizeDispositionEvidenceForGate`
+// (#1182 / PR #1184).
 export function summarizeReviewThreadsForGate(threads, options = {}) {
   const summary = {
     actionableCount: 0,
@@ -2457,11 +2459,13 @@ export function resolveLatestReviewWatermark(comments, options = {}) {
   return latest;
 }
 // Pre-merge gate invariant (unreplied regular comments -> `unrepliedComments`):
-// INFORMATIONAL, NOT merge-blocking. `computePreMergeReadinessBlockers` pushes
-// no blocker for this count, so a wrong `iddAgentLogins` recognition only
-// miscounts cosmetically (promoting a non-agent here under-counts, since its
-// comments are excluded and its reply advances the watermark; missing a real
-// agent over-counts) -- it never opens or closes the merge gate. See the
+// does NOT feed `computePreMergeReadinessBlockers` (no code-rollup blocker), but
+// it is NOT harmless -- the written F2 gate "Unreplied comments = 0" in
+// `idd-pre-merge.instructions.md` routes any non-IDD regular comment without a
+// later IDD reply back to review triage. So globally promoting a non-agent into
+// `iddAgentLogins` filters that actor's genuine unreplied feedback out of the F2
+// gate (fail-OPEN at the process level; its comments are excluded and its reply
+// advances the watermark), while missing a real agent over-counts. See the
 // consolidated invariants above `summarizeDispositionEvidenceForGate`
 // (#1182 / PR #1184).
 export function summarizeRegularCommentsForGate(comments, options = {}) {
@@ -2598,8 +2602,9 @@ export function summarizeRegularCommentsForGate(comments, options = {}) {
   };
 }
 // Pre-merge gate invariants -- READ BEFORE MODIFYING ANY `iddAgentLogins`-KEYED
-// GATE HELPER. Three functions key disposition/reply recognition on
-// `iddAgentLogins`, and each reacts DIFFERENTLY when that recognition is wrong:
+// GATE HELPER. Three functions key disposition, reply, and thread-author
+// recognition on `iddAgentLogins`, and each reacts DIFFERENTLY when that
+// recognition is wrong:
 //   1. `summarizeDispositionEvidenceForGate` (this fn) -- MERGE-BLOCKING (feeds
 //      `computePreMergeReadinessBlockers` via `dispositionEvidence`). Both
 //      recognition-error directions matter: FAILING to recognize a real agent
@@ -2612,11 +2617,15 @@ export function summarizeRegularCommentsForGate(comments, options = {}) {
 //      Without required conversation resolution, an IDD agent's latest thread
 //      comment is `awaiting-reviewer` (non-blocking), so GLOBALLY promoting a
 //      non-agent into `iddAgentLogins` makes that actor's genuine unresolved
-//      feedback stop blocking -> fail-OPEN. Recognize dispositions PER ITEM;
-//      never globally promote a non-agent into `iddAgentLogins`.
-//   3. `summarizeRegularCommentsForGate` (`unrepliedComments`) --
-//      INFORMATIONAL, NOT a merge blocker. Wrong recognition -> cosmetic
-//      miscount only (never opens or closes the gate).
+//      feedback stop blocking -> fail-OPEN. This gate keys on latest-author
+//      identity, not disposition recognition.
+//   3. `summarizeRegularCommentsForGate` (`unrepliedComments`) -- does NOT feed
+//      `computePreMergeReadinessBlockers`, but the written F2 gate "Unreplied
+//      comments = 0" (`idd-pre-merge.instructions.md`) still consumes it, so
+//      promoting a non-agent filters that actor's unreplied feedback out of
+//      that gate -> fail-OPEN at the process level (not harmless).
+// Across all three: never globally promote a non-agent into `iddAgentLogins` --
+// recognize each item by its own author.
 // Notice vs summary matching asymmetry (implemented and documented in detail on
 // `matchTrustedAdvisoryStickyDispositions`): a non-review NOTICE disposition
 // matches time-agnostically -- it carries forward across a re-posted notice

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2601,8 +2601,13 @@ export function summarizeRegularCommentsForGate(comments, options = {}) {
 // GATE HELPER. Three functions key disposition/reply recognition on
 // `iddAgentLogins`, and each reacts DIFFERENTLY when that recognition is wrong:
 //   1. `summarizeDispositionEvidenceForGate` (this fn) -- MERGE-BLOCKING (feeds
-//      `computePreMergeReadinessBlockers` via `dispositionEvidence`). Wrong
-//      recognition -> over-block (fail-closed).
+//      `computePreMergeReadinessBlockers` via `dispositionEvidence`). Both
+//      recognition-error directions matter: FAILING to recognize a real agent
+//      leaves its own disposition/reply in the outstanding set -> over-block
+//      (fail-closed); GLOBALLY promoting a non-agent instead drops that actor's
+//      genuine outstanding feedback (this fn excludes `iddAgentLogins` authors
+//      from `outstandingComments`), so `blockingCount` can fall to 0 ->
+//      fail-OPEN.
 //   2. `summarizeReviewThreadsForGate` (`actionableCount`) -- MERGE-BLOCKING.
 //      Without required conversation resolution, an IDD agent's latest thread
 //      comment is `awaiting-reviewer` (non-blocking), so GLOBALLY promoting a

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2050,6 +2050,17 @@ export function classifyReviewThreadForGate(
   return { classification: 'awaiting-reviewer' };
 }
 
+// Pre-merge gate invariant (review threads -> `threads.actionableCount`):
+// MERGE-BLOCKING. `computePreMergeReadinessBlockers` fails closed unless
+// `actionableCount === 0`. An IDD agent's (or the PR author's) latest thread
+// comment classifies `awaiting-reviewer`, which does NOT add to
+// `actionableCount`, so a recognition error here can fail OPEN: globally
+// promoting a non-agent into `iddAgentLogins` makes that actor's genuine
+// unresolved feedback classify `awaiting-reviewer` and stop blocking (when
+// conversation resolution is not required; otherwise it stays a blocking
+// `conversation-resolve-*`). Recognize dispositions PER ITEM; never globally
+// promote a non-agent into `iddAgentLogins`. See the consolidated invariants
+// above `summarizeDispositionEvidenceForGate` (#1182 / PR #1184).
 export function summarizeReviewThreadsForGate(
   threads: ThreadLike[],
   options: {
@@ -3374,6 +3385,14 @@ export function resolveLatestReviewWatermark(
   return latest;
 }
 
+// Pre-merge gate invariant (unreplied regular comments -> `unrepliedComments`):
+// INFORMATIONAL, NOT merge-blocking. `computePreMergeReadinessBlockers` pushes
+// no blocker for this count, so a wrong `iddAgentLogins` recognition only
+// miscounts cosmetically (promoting a non-agent here under-counts, since its
+// comments are excluded and its reply advances the watermark; missing a real
+// agent over-counts) -- it never opens or closes the merge gate. See the
+// consolidated invariants above `summarizeDispositionEvidenceForGate`
+// (#1182 / PR #1184).
 export function summarizeRegularCommentsForGate(
   comments: CommentLike[],
   options: {
@@ -3522,6 +3541,31 @@ export function summarizeRegularCommentsForGate(
   };
 }
 
+// Pre-merge gate invariants -- READ BEFORE MODIFYING ANY `iddAgentLogins`-KEYED
+// GATE HELPER. Three functions key disposition/reply recognition on
+// `iddAgentLogins`, and each reacts DIFFERENTLY when that recognition is wrong:
+//   1. `summarizeDispositionEvidenceForGate` (this fn) -- MERGE-BLOCKING (feeds
+//      `computePreMergeReadinessBlockers` via `dispositionEvidence`). Wrong
+//      recognition -> over-block (fail-closed).
+//   2. `summarizeReviewThreadsForGate` (`actionableCount`) -- MERGE-BLOCKING.
+//      Without required conversation resolution, an IDD agent's latest thread
+//      comment is `awaiting-reviewer` (non-blocking), so GLOBALLY promoting a
+//      non-agent into `iddAgentLogins` makes that actor's genuine unresolved
+//      feedback stop blocking -> fail-OPEN. Recognize dispositions PER ITEM;
+//      never globally promote a non-agent into `iddAgentLogins`.
+//   3. `summarizeRegularCommentsForGate` (`unrepliedComments`) --
+//      INFORMATIONAL, NOT a merge blocker. Wrong recognition -> cosmetic
+//      miscount only (never opens or closes the gate).
+// Notice vs summary matching asymmetry (implemented and documented in detail on
+// `matchTrustedAdvisoryStickyDispositions`): a non-review NOTICE disposition
+// matches time-agnostically -- it carries forward across a re-posted notice
+// while the bot still has not reviewed (the #1018 carry-forward) -- while a
+// SUMMARY disposition must be STRICTLY NEWER than the sticky, so a stale
+// `**Accepted**` cannot clear a summary re-edited after it (the #1122 "a false
+// positive is a false merge" hazard).
+// Working rule: verify every advisory finding on this code with a byte-exact
+// repro before accepting it. #1182 / PR #1184 cycled through five advisory
+// rounds, each surfacing a distinct fail mode of exactly these gates.
 export function summarizeDispositionEvidenceForGate(
   {
     comments = [],

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2058,9 +2058,11 @@ export function classifyReviewThreadForGate(
 // promoting a non-agent into `iddAgentLogins` makes that actor's genuine
 // unresolved feedback classify `awaiting-reviewer` and stop blocking (when
 // conversation resolution is not required; otherwise it stays a blocking
-// `conversation-resolve-*`). Recognize dispositions PER ITEM; never globally
-// promote a non-agent into `iddAgentLogins`. See the consolidated invariants
-// above `summarizeDispositionEvidenceForGate` (#1182 / PR #1184).
+// `conversation-resolve-*`). This gate classifies each thread by its own
+// latest-author identity (IDD agent / PR author), not by disposition
+// recognition; never globally promote a non-agent into `iddAgentLogins`. See
+// the consolidated invariants above `summarizeDispositionEvidenceForGate`
+// (#1182 / PR #1184).
 export function summarizeReviewThreadsForGate(
   threads: ThreadLike[],
   options: {
@@ -3386,11 +3388,13 @@ export function resolveLatestReviewWatermark(
 }
 
 // Pre-merge gate invariant (unreplied regular comments -> `unrepliedComments`):
-// INFORMATIONAL, NOT merge-blocking. `computePreMergeReadinessBlockers` pushes
-// no blocker for this count, so a wrong `iddAgentLogins` recognition only
-// miscounts cosmetically (promoting a non-agent here under-counts, since its
-// comments are excluded and its reply advances the watermark; missing a real
-// agent over-counts) -- it never opens or closes the merge gate. See the
+// does NOT feed `computePreMergeReadinessBlockers` (no code-rollup blocker), but
+// it is NOT harmless -- the written F2 gate "Unreplied comments = 0" in
+// `idd-pre-merge.instructions.md` routes any non-IDD regular comment without a
+// later IDD reply back to review triage. So globally promoting a non-agent into
+// `iddAgentLogins` filters that actor's genuine unreplied feedback out of the F2
+// gate (fail-OPEN at the process level; its comments are excluded and its reply
+// advances the watermark), while missing a real agent over-counts. See the
 // consolidated invariants above `summarizeDispositionEvidenceForGate`
 // (#1182 / PR #1184).
 export function summarizeRegularCommentsForGate(
@@ -3542,8 +3546,9 @@ export function summarizeRegularCommentsForGate(
 }
 
 // Pre-merge gate invariants -- READ BEFORE MODIFYING ANY `iddAgentLogins`-KEYED
-// GATE HELPER. Three functions key disposition/reply recognition on
-// `iddAgentLogins`, and each reacts DIFFERENTLY when that recognition is wrong:
+// GATE HELPER. Three functions key disposition, reply, and thread-author
+// recognition on `iddAgentLogins`, and each reacts DIFFERENTLY when that
+// recognition is wrong:
 //   1. `summarizeDispositionEvidenceForGate` (this fn) -- MERGE-BLOCKING (feeds
 //      `computePreMergeReadinessBlockers` via `dispositionEvidence`). Both
 //      recognition-error directions matter: FAILING to recognize a real agent
@@ -3556,11 +3561,15 @@ export function summarizeRegularCommentsForGate(
 //      Without required conversation resolution, an IDD agent's latest thread
 //      comment is `awaiting-reviewer` (non-blocking), so GLOBALLY promoting a
 //      non-agent into `iddAgentLogins` makes that actor's genuine unresolved
-//      feedback stop blocking -> fail-OPEN. Recognize dispositions PER ITEM;
-//      never globally promote a non-agent into `iddAgentLogins`.
-//   3. `summarizeRegularCommentsForGate` (`unrepliedComments`) --
-//      INFORMATIONAL, NOT a merge blocker. Wrong recognition -> cosmetic
-//      miscount only (never opens or closes the gate).
+//      feedback stop blocking -> fail-OPEN. This gate keys on latest-author
+//      identity, not disposition recognition.
+//   3. `summarizeRegularCommentsForGate` (`unrepliedComments`) -- does NOT feed
+//      `computePreMergeReadinessBlockers`, but the written F2 gate "Unreplied
+//      comments = 0" (`idd-pre-merge.instructions.md`) still consumes it, so
+//      promoting a non-agent filters that actor's unreplied feedback out of
+//      that gate -> fail-OPEN at the process level (not harmless).
+// Across all three: never globally promote a non-agent into `iddAgentLogins` --
+// recognize each item by its own author.
 // Notice vs summary matching asymmetry (implemented and documented in detail on
 // `matchTrustedAdvisoryStickyDispositions`): a non-review NOTICE disposition
 // matches time-agnostically -- it carries forward across a re-posted notice

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -3545,8 +3545,13 @@ export function summarizeRegularCommentsForGate(
 // GATE HELPER. Three functions key disposition/reply recognition on
 // `iddAgentLogins`, and each reacts DIFFERENTLY when that recognition is wrong:
 //   1. `summarizeDispositionEvidenceForGate` (this fn) -- MERGE-BLOCKING (feeds
-//      `computePreMergeReadinessBlockers` via `dispositionEvidence`). Wrong
-//      recognition -> over-block (fail-closed).
+//      `computePreMergeReadinessBlockers` via `dispositionEvidence`). Both
+//      recognition-error directions matter: FAILING to recognize a real agent
+//      leaves its own disposition/reply in the outstanding set -> over-block
+//      (fail-closed); GLOBALLY promoting a non-agent instead drops that actor's
+//      genuine outstanding feedback (this fn excludes `iddAgentLogins` authors
+//      from `outstandingComments`), so `blockingCount` can fall to 0 ->
+//      fail-OPEN.
 //   2. `summarizeReviewThreadsForGate` (`actionableCount`) -- MERGE-BLOCKING.
 //      Without required conversation resolution, an IDD agent's latest thread
 //      comment is `awaiting-reviewer` (non-blocking), so GLOBALLY promoting a


### PR DESCRIPTION
## Summary

Adds developer-facing "pre-merge gate invariants" doc-comments adjacent to the
three `iddAgentLogins`-keyed pre-merge gate helpers in
`src/scripts/protocol-helpers.mts`, so anyone modifying a gate helper sees how
each one reacts when login recognition is wrong. **Docs-only — no runtime
behavior change.**

- `summarizeReviewThreadsForGate` (`actionableCount`) — **merge-blocking**;
  documents the fail-**open** hazard: an IDD agent's latest thread comment
  classifies `awaiting-reviewer` (non-blocking), so globally promoting a
  non-agent into `iddAgentLogins` makes that actor's genuine unresolved feedback
  stop blocking. Rule: recognize dispositions **per item**; never globally
  promote a non-agent.
- `summarizeRegularCommentsForGate` (`unrepliedComments`) — **informational**,
  not a merge blocker (wrong recognition is a cosmetic over-count).
- `summarizeDispositionEvidenceForGate` — **merge-blocking**; carries the
  consolidated anchor block, including the notice (time-agnostic, #1018) vs
  summary (recency-required, #1122) matching asymmetry (referencing the detailed
  `matchTrustedAdvisoryStickyDispositions` comment) and the byte-exact-repro
  working rule.

All three claims were verified against `computePreMergeReadinessBlockers`,
`classifyReviewThreadForGate`, and `matchTrustedAdvisoryStickyDispositions`.

## Rationale / non-goals

The issue's motivation is that these internal invariants were only tribal
knowledge from #1182 / PR #1184 (five advisory rounds, each a distinct fail mode
of exactly these gates). Placed as code-adjacent doc-comments — the AC's "and/or"
allows this alone — deliberately **not** touching the mirrored
`docs/idd-helper-scripts.md` surface to keep the change minimal and additive.
No logic change; `idd-merge-execute` untouched. Generated
`scripts/protocol-helpers.mjs` regenerated via `pnpm run build` (the build
preserves comments, so the artifact changes).

Closes #1192
