### PR TITLE
docs(idd): document strict-resume vs lenient-merge handoff split

### DIFF
--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -80,10 +80,10 @@ and that difference is intentional policy, not drift:
   claim.
 - **The merge write-gate is lenient.** It leaves `requireAuthorMatchesForcedBy`
   at its off default and passes `prFirstCommitAt`, applying the Part-B allowance
-  (#1058, an issue-only handoff predating the PR). The merge gate re-validates
-  an _already-verified_ session and must tolerate a maintainer-authorized
-  handoff relayed by a separate automation actor; authorization then rests on
-  `isAuthorizedForcedHandoff` alone.
+  (kurone-kito/idd-skill#1058, an issue-only handoff predating the PR). The
+  merge gate re-validates an _already-verified_ session and must tolerate a
+  maintainer-authorized handoff relayed by a separate automation actor;
+  authorization then rests on `isAuthorizedForcedHandoff` alone.
 
 Because the two callers apply different strictness, they can return **different
 verdicts for the same corrected-handoff state** — resume may report
@@ -91,8 +91,9 @@ verdicts for the same corrected-handoff state** — resume may report
 verdicts answer different questions (may I take over? vs. does this verified
 session still own the write?).
 
-The split is kept intentionally (see #1155): the structural risk the adopter
-raised — two divergent resolvers — is already removed by the shared
-`resolveActiveClaim`, and forcing both sides strict would break the legitimate
-relay use-case. Any future change here must preserve the single resolver (do not
-fork `resolveActiveClaim`) and the resume-side self-signed-hijack block.
+The split is kept intentionally (see kurone-kito/idd-skill#1155): the structural
+risk the adopter raised — two divergent resolvers — is already removed by the
+shared `resolveActiveClaim`, and forcing both sides strict would break the
+legitimate relay use-case. Any future change here must preserve the single
+resolver (do not fork `resolveActiveClaim`) and the resume-side
+self-signed-hijack block.

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -61,3 +61,38 @@ same-issue branch convergence that A5(e) and the `branch-name` helper rely
 on. The desync never crosses score bands and never bypasses the A4.5/A5
 gates; the in-band offset function is replaceable without affecting these
 invariants.
+
+## Claim resolution
+
+### Forced-handoff strictness: strict resume vs. lenient relay-merge
+
+Both the resume-routing read (`evaluateResumeClaimRouting` in
+`resume-claim-routing.mts`) and the pre-merge write-gate
+(`summarizeClaimValidation` in `protocol-helpers.mts`) resolve the active claim
+through the **single** shared `resolveActiveClaim`, so there is no forked
+claim-state logic. They deliberately pass **different** forced-handoff options,
+and that difference is intentional policy, not drift:
+
+- **Resume routing is strict.** It sets `requireAuthorMatchesForcedBy: true`
+  (rule 7's author/`forcedBy` binding) and never passes `prFirstCommitAt`.
+  Resume is a _takeover_ decision, so it must block the same-identity
+  self-signed hijack and reject an issue-only handoff that targets a PR-backed
+  claim.
+- **The merge write-gate is lenient.** It leaves `requireAuthorMatchesForcedBy`
+  at its off default and passes `prFirstCommitAt`, applying the Part-B allowance
+  (#1058, an issue-only handoff predating the PR). The merge gate re-validates
+  an _already-verified_ session and must tolerate a maintainer-authorized
+  handoff relayed by a separate automation actor; authorization then rests on
+  `isAuthorizedForcedHandoff` alone.
+
+Because the two callers apply different strictness, they can return **different
+verdicts for the same corrected-handoff state** — resume may report
+`already_owned` while the merge gate reports `claimLost`. This is expected: the
+verdicts answer different questions (may I take over? vs. does this verified
+session still own the write?).
+
+The split is kept intentionally (see #1155): the structural risk the adopter
+raised — two divergent resolvers — is already removed by the shared
+`resolveActiveClaim`, and forcing both sides strict would break the legitimate
+relay use-case. Any future change here must preserve the single resolver (do not
+fork `resolveActiveClaim`) and the resume-side self-signed-hijack block.

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -80,10 +80,10 @@ and that difference is intentional policy, not drift:
   claim.
 - **The merge write-gate is lenient.** It leaves `requireAuthorMatchesForcedBy`
   at its off default and passes `prFirstCommitAt`, applying the Part-B allowance
-  (#1058, an issue-only handoff predating the PR). The merge gate re-validates
-  an _already-verified_ session and must tolerate a maintainer-authorized
-  handoff relayed by a separate automation actor; authorization then rests on
-  `isAuthorizedForcedHandoff` alone.
+  (kurone-kito/idd-skill#1058, an issue-only handoff predating the PR). The
+  merge gate re-validates an _already-verified_ session and must tolerate a
+  maintainer-authorized handoff relayed by a separate automation actor;
+  authorization then rests on `isAuthorizedForcedHandoff` alone.
 
 Because the two callers apply different strictness, they can return **different
 verdicts for the same corrected-handoff state** — resume may report
@@ -91,8 +91,9 @@ verdicts for the same corrected-handoff state** — resume may report
 verdicts answer different questions (may I take over? vs. does this verified
 session still own the write?).
 
-The split is kept intentionally (see #1155): the structural risk the adopter
-raised — two divergent resolvers — is already removed by the shared
-`resolveActiveClaim`, and forcing both sides strict would break the legitimate
-relay use-case. Any future change here must preserve the single resolver (do not
-fork `resolveActiveClaim`) and the resume-side self-signed-hijack block.
+The split is kept intentionally (see kurone-kito/idd-skill#1155): the structural
+risk the adopter raised — two divergent resolvers — is already removed by the
+shared `resolveActiveClaim`, and forcing both sides strict would break the
+legitimate relay use-case. Any future change here must preserve the single
+resolver (do not fork `resolveActiveClaim`) and the resume-side
+self-signed-hijack block.

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -61,3 +61,38 @@ same-issue branch convergence that A5(e) and the `branch-name` helper rely
 on. The desync never crosses score bands and never bypasses the A4.5/A5
 gates; the in-band offset function is replaceable without affecting these
 invariants.
+
+## Claim resolution
+
+### Forced-handoff strictness: strict resume vs. lenient relay-merge
+
+Both the resume-routing read (`evaluateResumeClaimRouting` in
+`resume-claim-routing.mts`) and the pre-merge write-gate
+(`summarizeClaimValidation` in `protocol-helpers.mts`) resolve the active claim
+through the **single** shared `resolveActiveClaim`, so there is no forked
+claim-state logic. They deliberately pass **different** forced-handoff options,
+and that difference is intentional policy, not drift:
+
+- **Resume routing is strict.** It sets `requireAuthorMatchesForcedBy: true`
+  (rule 7's author/`forcedBy` binding) and never passes `prFirstCommitAt`.
+  Resume is a _takeover_ decision, so it must block the same-identity
+  self-signed hijack and reject an issue-only handoff that targets a PR-backed
+  claim.
+- **The merge write-gate is lenient.** It leaves `requireAuthorMatchesForcedBy`
+  at its off default and passes `prFirstCommitAt`, applying the Part-B allowance
+  (#1058, an issue-only handoff predating the PR). The merge gate re-validates
+  an _already-verified_ session and must tolerate a maintainer-authorized
+  handoff relayed by a separate automation actor; authorization then rests on
+  `isAuthorizedForcedHandoff` alone.
+
+Because the two callers apply different strictness, they can return **different
+verdicts for the same corrected-handoff state** — resume may report
+`already_owned` while the merge gate reports `claimLost`. This is expected: the
+verdicts answer different questions (may I take over? vs. does this verified
+session still own the write?).
+
+The split is kept intentionally (see #1155): the structural risk the adopter
+raised — two divergent resolvers — is already removed by the shared
+`resolveActiveClaim`, and forcing both sides strict would break the legitimate
+relay use-case. Any future change here must preserve the single resolver (do not
+fork `resolveActiveClaim`) and the resume-side self-signed-hijack block.

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -184,9 +184,14 @@ export function collectPreMergeReadiness(argv) {
   const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
   // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
   // a legitimate issue-only handoff that predates the PR is honored even
-  // against a PR-backed claim. Resolve it only when forced handoffs are
-  // enabled, and fail closed to `null` (reject) on any lookup/parse error so
-  // a transient commits-API failure never aborts the readiness gate.
+  // against a PR-backed claim. This allowance is applied on the merge side
+  // only; resume-claim-routing.mts intentionally never passes prFirstCommitAt
+  // (an issue-only handoff against a PR-backed claim stays rejected there) —
+  // the merge-only half of the documented strict-resume vs. lenient-relay-merge
+  // split (see docs/idd-design-rationale.md, "Claim resolution"). Resolve it
+  // only when forced handoffs are enabled, and fail closed to `null` (reject)
+  // on any lookup/parse error so a transient commits-API failure never aborts
+  // the readiness gate.
   let prFirstCommitAt = null;
   if (forcedHandoffEnabled) {
     try {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3850,6 +3850,20 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
               .trim()
               .toLowerCase(),
           );
+  // Merge-side write-gate forced-handoff strictness — intentionally the
+  // lenient half of the strict-resume vs. lenient-relay-merge split (see
+  // docs/idd-design-rationale.md, "Claim resolution"). This call leaves
+  // `requireAuthorMatchesForcedBy` at its lenient default (off) so a
+  // maintainer-authorized handoff relayed by a separate automation actor is
+  // still honored — authorization rests on `isAuthorizedForcedHandoff` alone —
+  // and it passes `prFirstCommitAt` so the Part-B allowance (#1058, an
+  // issue-only handoff predating the PR) applies. resume-claim-routing.mts
+  // deliberately does the opposite (`requireAuthorMatchesForcedBy: true`, no
+  // `prFirstCommitAt`) because a takeover decision must block the same-identity
+  // self-signed hijack. The two callers can therefore return different verdicts
+  // for the same corrected-handoff state (resume `already_owned` vs. merge
+  // `claimLost`) by design; both still funnel through the single
+  // resolveActiveClaim resolver.
   const activeClaim = resolveActiveClaim(claimEvents, {
     isTrustedAuthor: trustedAuthorPredicate,
     isForcedHandoffEnabled:

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -359,10 +359,14 @@ function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
         isStale: (activeCreatedAt, nextCreatedAt) =>
           isStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs),
         // Resume routing enforces the rule-7 author/forcedBy binding to
-        // block the same-identity self-signed hijack path. Other callers
-        // of summarizeClaimValidation default to off because they may
-        // receive maintainer-authorized handoffs posted by a separate
-        // automation actor on behalf of the maintainer.
+        // block the same-identity self-signed hijack path — the strict half
+        // of the strict-resume vs. lenient-relay-merge split (see
+        // docs/idd-design-rationale.md, "Claim resolution"). The merge-side
+        // summarizeClaimValidation path leaves it off because it may receive a
+        // maintainer-authorized handoff relayed by a separate automation actor,
+        // so the two callers can return different verdicts for the same
+        // corrected-handoff state (resume `already_owned` vs. merge
+        // `claimLost`) by design.
         requireAuthorMatchesForcedBy: true,
         onAnomalousHeartbeat,
         onIgnoredForcedHandoff,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -363,9 +363,14 @@ export function collectPreMergeReadiness(
   const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
   // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
   // a legitimate issue-only handoff that predates the PR is honored even
-  // against a PR-backed claim. Resolve it only when forced handoffs are
-  // enabled, and fail closed to `null` (reject) on any lookup/parse error so
-  // a transient commits-API failure never aborts the readiness gate.
+  // against a PR-backed claim. This allowance is applied on the merge side
+  // only; resume-claim-routing.mts intentionally never passes prFirstCommitAt
+  // (an issue-only handoff against a PR-backed claim stays rejected there) —
+  // the merge-only half of the documented strict-resume vs. lenient-relay-merge
+  // split (see docs/idd-design-rationale.md, "Claim resolution"). Resolve it
+  // only when forced handoffs are enabled, and fail closed to `null` (reject)
+  // on any lookup/parse error so a transient commits-API failure never aborts
+  // the readiness gate.
   let prFirstCommitAt: string | null = null;
   if (forcedHandoffEnabled) {
     try {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4949,6 +4949,20 @@ export function summarizeClaimValidation(
               .toLowerCase(),
           );
 
+  // Merge-side write-gate forced-handoff strictness — intentionally the
+  // lenient half of the strict-resume vs. lenient-relay-merge split (see
+  // docs/idd-design-rationale.md, "Claim resolution"). This call leaves
+  // `requireAuthorMatchesForcedBy` at its lenient default (off) so a
+  // maintainer-authorized handoff relayed by a separate automation actor is
+  // still honored — authorization rests on `isAuthorizedForcedHandoff` alone —
+  // and it passes `prFirstCommitAt` so the Part-B allowance (#1058, an
+  // issue-only handoff predating the PR) applies. resume-claim-routing.mts
+  // deliberately does the opposite (`requireAuthorMatchesForcedBy: true`, no
+  // `prFirstCommitAt`) because a takeover decision must block the same-identity
+  // self-signed hijack. The two callers can therefore return different verdicts
+  // for the same corrected-handoff state (resume `already_owned` vs. merge
+  // `claimLost`) by design; both still funnel through the single
+  // resolveActiveClaim resolver.
   const activeClaim = resolveActiveClaim(claimEvents, {
     isTrustedAuthor: trustedAuthorPredicate,
     isForcedHandoffEnabled:

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -520,10 +520,14 @@ function resolveClaimState(
         isStale: (activeCreatedAt, nextCreatedAt) =>
           isStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs),
         // Resume routing enforces the rule-7 author/forcedBy binding to
-        // block the same-identity self-signed hijack path. Other callers
-        // of summarizeClaimValidation default to off because they may
-        // receive maintainer-authorized handoffs posted by a separate
-        // automation actor on behalf of the maintainer.
+        // block the same-identity self-signed hijack path — the strict half
+        // of the strict-resume vs. lenient-relay-merge split (see
+        // docs/idd-design-rationale.md, "Claim resolution"). The merge-side
+        // summarizeClaimValidation path leaves it off because it may receive a
+        // maintainer-authorized handoff relayed by a separate automation actor,
+        // so the two callers can return different verdicts for the same
+        // corrected-handoff state (resume `already_owned` vs. merge
+        // `claimLost`) by design.
         requireAuthorMatchesForcedBy: true,
         onAnomalousHeartbeat,
         onIgnoredForcedHandoff,


### PR DESCRIPTION
## Summary

Documents the **intentional** strict-resume vs. lenient-relay-merge
forced-handoff split so its two-verdict surface stops surprising readers. No
behavior change.

`evaluateResumeClaimRouting` (resume) and `summarizeClaimValidation` (pre-merge
write-gate) both funnel through the single shared `resolveActiveClaim`, but pass
deliberately different forced-handoff options:

- **resume is strict** — `requireAuthorMatchesForcedBy: true`, no
  `prFirstCommitAt` — because a takeover decision must block the same-identity
  self-signed hijack;
- **the merge write-gate is lenient** — author-match left off, Part-B
  `prFirstCommitAt` (#1058) applied — because it re-validates an
  already-verified session and must tolerate a maintainer-authorized handoff
  relayed by a separate automation actor (authorization then rests on
  `isAuthorizedForcedHandoff`).

They can therefore return different verdicts for the same corrected-handoff
state (resume `already_owned` vs. merge `claimLost`) by design.

## Changes

- Cross-referencing rationale comments at the resume strict site
  (`resume-claim-routing.mts`), the merge lenient site (`protocol-helpers.mts`
  `summarizeClaimValidation`), and the Part-B asymmetry
  (`pre-merge-readiness.mts`), each naming the other.
- A new "Claim resolution" section in `docs/idd-design-rationale.md` (and its
  `idd-template/` source) summarizing the policy and the two-verdict surface.

## Non-goals

- No behavior change: no `requireAuthorMatchesForcedBy` / `prFirstCommitAt`
  value is modified; the full test suite passes with existing assertions
  unchanged.
- `resolveActiveClaim` is **not** forked — both callers keep the single shared
  resolver (the #1142 fresh-claim-gate track depends on it).

## Decision

The strict-vs-relay split was a documented `needs-decision` (this issue). The
maintainer decided to **keep it and document it** rather than unify — the
structural risk (dual resolvers) is already removed by the shared resolver, and
forcing both sides strict would break the relay use-case.

Closes #1155.
