### PR TITLE
feat(discover): fall back to A0-O on A4 viability/claim exhaustion

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -100,9 +100,8 @@ Read the **issue-scope** value from the Project commands table in
   discards every A3.5-startable candidate, or A4 Step 1.5 eliminates the
   last one). Run A0-O **at most once** as this fallback per Discover pass;
   once spent, a later A4 exhaustion reports and stops per A4 Step 1 / Step
-  1.5 (not an abort) without re-entering A0-O (A0-O's own zero-orphan exit
-  still routes to the A3 decision tree). This reuses A0-O **only** as a
-  post-roadmap fallback;
+  1.5 (not an abort) without re-entering A0-O. This reuses A0-O **only** as
+  a post-roadmap fallback;
   the roadmap path stays primary (unlike `orphan-first`). If candidates
   reach A3.5 but it holds them all as approval-needed, do **not** fall
   back: the approval hold governs and a non-empty approval-needed bucket
@@ -165,8 +164,10 @@ next step depends on which path invoked A0-O:
   to **A1** and continue with the normal
   A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence.
 - **`roadmap-first` fallback**: the roadmap path already ran, so do **not**
-  re-enter A1. Per the guard at the top of A0-O, this exit goes straight to
-  the **A3 decision tree**.
+  re-enter A1. A **trigger (a)** entry (zero-reach-A3.5) goes straight to
+  the **A3 decision tree** (per the guard atop A0-O). A **trigger (b)**
+  entry (A4 Step 1 / Step 1.5 exhaustion) instead **reports and stops (not
+  an abort)** via that invoking A4 terminal.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: for
@@ -466,12 +467,12 @@ If **no issue** survives the gate:
   that only approval-needed issues remain and stop without claim in
   unattended mode. In attended mode, ask the operator whether to obtain
   approval or opt out explicitly;
-- otherwise, under `roadmap-first` discovery, route to the **A0-O**
-  roadmap-first fallback (A0 trigger (b)) if it has not run this pass;
-  else (already spent, or `issue-scope` is not `roadmap-first` — e.g. the
-  A0-T explicit-target gate) report the discarded issues with the
-  criterion each failed, then **stop** — do not post `unclaimed-by`
-  because no claim was made. This is not an abort.
+- otherwise, in the **roadmap-traversal** candidate flow (A2→A3→A4 only;
+  the A0-T explicit-target gate never reaches here — a failed target stops
+  in A0-T with no fallback), route to the **A0-O** roadmap-first fallback
+  (A0 trigger (b)) if it has not run this pass; once spent, report the
+  discarded issues with the criterion each failed, then **stop** — do not
+  post `unclaimed-by` because no claim was made. This is not an abort.
 
 ### Step 1.5 — Active-claim pre-scan
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -116,10 +116,11 @@ in `idd-overview-core.instructions.md` before any repo-wide orphan issue
 search.
 
 When A0-O runs as the `roadmap-first` fallback (not the `orphan-first`
-primary path), every "proceed to A1" / "skip to A1" exit below instead
-goes to the **A3 decision tree** — the roadmap path already ran and must
-not be re-entered (this prevents an A1 ↔ A0-O loop, e.g. under
-`public-disabled` on a public repo).
+primary path), every exit below that would re-enter **A1** or reach the
+**A3 decision tree** is redirected by the invoking trigger — trigger (a)
+to the A3 decision tree, trigger (b) (A4 exhaustion) to the A4 **"report
+and stop (not an abort)"** terminal — because the roadmap path already ran
+and must not be re-entered (no A1 ↔ A0-O or A4 ↔ A0-O loop).
 
 - If `orphan-first-policy` is `public-disabled`, first determine the
   repository visibility. If the repository is public, skip A0-O without
@@ -164,10 +165,8 @@ next step depends on which path invoked A0-O:
   to **A1** and continue with the normal
   A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence.
 - **`roadmap-first` fallback**: the roadmap path already ran, so do **not**
-  re-enter A1. A **trigger (a)** entry (zero-reach-A3.5) goes straight to
-  the **A3 decision tree** (per the guard atop A0-O). A **trigger (b)**
-  entry (A4 Step 1 / Step 1.5 exhaustion) instead **reports and stops (not
-  an abort)** via that invoking A4 terminal.
+  re-enter A1. This exit is redirected by the invoking trigger per the
+  guard atop A0-O.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: for
@@ -467,12 +466,13 @@ If **no issue** survives the gate:
   that only approval-needed issues remain and stop without claim in
   unattended mode. In attended mode, ask the operator whether to obtain
   approval or opt out explicitly;
-- otherwise, in the **roadmap-traversal** candidate flow (A2→A3→A4 only;
-  the A0-T explicit-target gate never reaches here — a failed target stops
-  in A0-T with no fallback), route to the **A0-O** roadmap-first fallback
-  (A0 trigger (b)) if it has not run this pass; once spent, report the
-  discarded issues with the criterion each failed, then **stop** — do not
-  post `unclaimed-by` because no claim was made. This is not an abort.
+- otherwise, under **`roadmap-first`** scope in the roadmap-traversal flow
+  (A2→A3→A4; not the A0-T gate, which stops a failed target with no
+  fallback), route to the **A0-O** roadmap-first fallback (A0 trigger (b))
+  if it has not run this pass. Once spent, or under `issue-scope: roadmap`
+  (A0-O skipped), report the discarded issues with the criterion each
+  failed, then **stop** — do not post `unclaimed-by` because no claim was
+  made. This is not an abort.
 
 ### Step 1.5 — Active-claim pre-scan
 
@@ -505,12 +505,12 @@ After scanning the current batch:
 When the entire viable candidate set is exhausted (the last row above),
 resolve the exit by scope: if the A3.5 approval-needed bucket is
 non-empty, stop with the approval-needed message (the approval hold takes
-precedence — not a true zero); otherwise, under `roadmap-first`
-discovery, route to the A0-O roadmap-first fallback (A0 trigger (b)) if it
-has not run this pass, else report that all viable issues are currently
-claimed and stop (not an abort). Do not post `unclaimed-by` (no claim was
-made); retry later when claims may have become stale or new viable
-candidates appear.
+precedence — not a true zero); otherwise, under `roadmap-first` scope
+route to the A0-O roadmap-first fallback (A0 trigger (b)) if it has not run
+this pass; under `issue-scope: roadmap`, or once that fallback is spent,
+report that all viable issues are currently claimed and stop (not an
+abort). Do not post `unclaimed-by` (no claim was made); retry later as
+claims go stale or new work appears.
 
 See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
 for why this pre-scan exists.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -92,16 +92,22 @@ Read the **issue-scope** value from the Project commands table in
 
 - If `issue-scope` is `roadmap`: skip A0-O and proceed to A1 as normal.
 - If `issue-scope` is `roadmap-first` (the default): proceed to A1 as
-  normal. When the
-  roadmap path yields **zero candidates reaching A3.5** — i.e. A2
-  enumerated no open execution leaves, or A3 filtered them all out as
-  blocked — fall back to **A0-O** before entering the A3 decision tree.
-  This reuses the A0-O orphan search **only** as a post-roadmap fallback;
-  the roadmap path stays primary (unlike `orphan-first`, where A0-O is the
-  first path). If candidates do reach A3.5 but it holds
-  them all as
-  approval-needed, do **not** fall back: A3.5's stop/ask behavior
-  governs, so the fallback never re-scopes around the approval gate.
+  normal. Fall back to **A0-O** before entering the A3 decision tree when
+  the roadmap path yields **no viable, startable, unclaimed candidate** —
+  either (a) **zero candidates reach A3.5** (A2 enumerated no open
+  execution leaves, or A3 filtered them all out as blocked), or (b)
+  **candidates reach A3.5 but none is workable** (A4 Step 1 viability
+  discards every A3.5-startable candidate, or A4 Step 1.5 eliminates the
+  last one). Run A0-O **at most once** as this fallback per Discover pass;
+  once spent, a later A4 exhaustion reports and stops per A4 Step 1 / Step
+  1.5 (not an abort) without re-entering A0-O (A0-O's own zero-orphan exit
+  still routes to the A3 decision tree). This reuses A0-O **only** as a
+  post-roadmap fallback;
+  the roadmap path stays primary (unlike `orphan-first`). If candidates
+  reach A3.5 but it holds them all as approval-needed, do **not** fall
+  back: the approval hold governs and a non-empty approval-needed bucket
+  is not a true zero. See
+  [A0-O fallback triggers](../../docs/idd-design-rationale.md#a0-o-roadmap-first-fallback-triggers).
 - If `issue-scope` is `orphan-first`: proceed to A0-O.
 
 ## A0-O — Discover orphan issues
@@ -460,8 +466,11 @@ If **no issue** survives the gate:
   that only approval-needed issues remain and stop without claim in
   unattended mode. In attended mode, ask the operator whether to obtain
   approval or opt out explicitly;
-- otherwise report the full list of discarded issues with the criterion
-  or criteria each failed, then **stop** — do not post `unclaimed-by`
+- otherwise, under `roadmap-first` discovery, route to the **A0-O**
+  roadmap-first fallback (A0 trigger (b)) if it has not run this pass;
+  else (already spent, or `issue-scope` is not `roadmap-first` — e.g. the
+  A0-T explicit-target gate) report the discarded issues with the
+  criterion each failed, then **stop** — do not post `unclaimed-by`
   because no claim was made. This is not an abort.
 
 ### Step 1.5 — Active-claim pre-scan
@@ -486,11 +495,21 @@ in ascending issue-number order:
 
 After scanning the current batch:
 
-| Batch outcome                                                                       | Action                                                                                                                                                                                                  |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| At least one eligible candidate in the batch                                        | Proceed to Step 2 to rank and select.                                                                                                                                                                   |
-| All `N` in this batch are claimed but viable survivors remain                       | Continue with the next batch (`N+1`–`2N`, then `2N+1`–`3N`, …) until an eligible candidate is found.                                                                                                    |
-| Entire viable candidate set exhausted (all surviving viable candidates are claimed) | Report that all viable issues are currently claimed; stop. Do not post `unclaimed-by` (no claim was made). Not an abort; retry later when claims may have become stale or new viable candidates appear. |
+| Batch outcome                                                                       | Action                                                                                               |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| At least one eligible candidate in the batch                                        | Proceed to Step 2 to rank and select.                                                                |
+| All `N` in this batch are claimed but viable survivors remain                       | Continue with the next batch (`N+1`–`2N`, then `2N+1`–`3N`, …) until an eligible candidate is found. |
+| Entire viable candidate set exhausted (all surviving viable candidates are claimed) | Resolve the exit by scope (see the note below).                                                      |
+
+When the entire viable candidate set is exhausted (the last row above),
+resolve the exit by scope: if the A3.5 approval-needed bucket is
+non-empty, stop with the approval-needed message (the approval hold takes
+precedence — not a true zero); otherwise, under `roadmap-first`
+discovery, route to the A0-O roadmap-first fallback (A0 trigger (b)) if it
+has not run this pass, else report that all viable issues are currently
+claimed and stop (not an abort). Do not post `unclaimed-by` (no claim was
+made); retry later when claims may have become stale or new viable
+candidates appear.
 
 See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
 for why this pre-scan exists.
@@ -514,47 +533,36 @@ neither skip below-floor candidates nor reorder by score — and select by
 `.github/idd/config.json` `discover.selectionDesync` is `session-offset`
 (default `off`) and the chosen highest-score tie band has more than one
 eligible candidate, pick the band entry at index
-`selectDesyncedIndex(session-token, band-size)` instead of index 0 —
-`scripts/policy-helpers.mjs` exports it as a pure, deterministic
-`hash(session-token) mod band-size` over the band ordered by ascending
-issue number, where `session-token` is this session's `{agent-id}` (use
-the recommended unique per-session agent-id suffix; it is available at
-selection time, unlike `{claim-id}`, which A5 only generates after
-selection). This
-proactively spreads concurrent autopilot sessions across **different**
-eligible issues to cut the claim races that A4 Step 1.5 and A5(e) only
-resolve reactively. It reorders **only within** a single score tie band —
-never across score bands — and never bypasses A4.5/A5. Same-issue branch
-convergence is preserved because the branch name derives from the issue,
-not selection order. With `off`, a single-entry band, or no applicable
-score, keep the deterministic **lowest issue number** pick.
+`selectDesyncedIndex(session-token, band-size)` instead of index 0 (a
+pure, deterministic `hash(session-token) mod band-size` from
+`scripts/policy-helpers.mjs`, over the band ordered by ascending issue
+number, `session-token` being this session's `{agent-id}`). It reorders
+**only within** a single score tie band, never across score bands, and
+never bypasses A4.5/A5. With `off`, a single-entry band, or no applicable
+score, keep the deterministic **lowest issue number** pick. See
+[rationale](../../docs/idd-design-rationale.md#a4-step-2--rationale-concurrent-selection-desync).
 
 **Author-recorded effort hint (soft tie-breaker).** When candidates remain
 tied after the score and optional desync rules, prefer the **lower-effort**
-candidate **before** the lowest-issue-number tie-break, so autopilot tends to
-clear small issues first and leave large ones for a fresh session. Read the
-authored `<!-- idd-skill-effort: S|M|L -->` footer (or the
-`discover-roadmap-graph` node's `effort`): order `S` < `M` < `L`, and a
-missing or invalid hint is treated as the **neutral middle** (as-if `M`), so a
-band with no effort hints keeps the lowest-issue-number order exactly as
-before. This is a **soft** rule: it reorders **only within** a single score
-tie band, never skips, gates, or crosses a score band, and a large (`L`) issue
-stays fully claimable when it is the only ready work. The
-`discover-roadmap-graph` union already emits this order, so it is a cheap read;
-the pick still passes A4.5/A5 unchanged.
+candidate **before** the lowest-issue-number tie-break. Read the authored
+`<!-- idd-skill-effort: S|M|L -->` footer (or the `discover-roadmap-graph`
+node's `effort`): order `S` < `M` < `L`, and a missing or invalid hint is
+treated as the **neutral middle** (as-if `M`), so a band with no effort hints
+keeps the lowest-issue-number order exactly as before. This is a **soft**
+rule: it reorders **only within** a single score tie band, never skips,
+gates, or crosses a score band; the `discover-roadmap-graph` union already
+emits this order.
 
 **High-contention shared-file overlap (advisory).** Concurrent autopilot
 sessions tend to edit the same F-phase bundle instruction files
-(`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`, so a
-colliding pick costs a later merge-from-main conflict. As a **soft**
-tie-breaker layered after the score / desync / effort / lowest-number
-rules, prefer a candidate whose `## Candidate files` do **not** overlap an
-actively-claimed or open-PR issue on one of those files; the optional
-`discover-shared-file-overlap` helper (see
+(`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`. As a
+**soft** tie-breaker layered after the score / desync / effort /
+lowest-number rules, prefer a candidate whose `## Candidate files` do
+**not** overlap an actively-claimed or open-PR issue on one of those files;
+the optional `discover-shared-file-overlap` helper (see
 [IDD helper scripts](../../docs/idd-helper-scripts.md)) reports each candidate's
-`overlapFlag` and a `recommendedOrder`. This is **never a hard gate** — overlap
-never overrides the score or crosses a score band, and a colliding candidate
-stays claimable when it is the only ready work. See the
+`overlapFlag` and a `recommendedOrder`. This is **never a hard gate** —
+overlap never overrides the score or crosses a score band. See the
 [high-contention shared-file convention](../../docs/policy-constants.md#high-contention-shared-files).
 
 After picking, proceed to **A4.5** (`idd-suitability.instructions.md`).

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -504,13 +504,13 @@ After scanning the current batch:
 
 When the entire viable candidate set is exhausted (the last row above),
 resolve the exit by scope: if the A3.5 approval-needed bucket is
-non-empty, stop with the approval-needed message (the approval hold takes
-precedence — not a true zero); otherwise, under `roadmap-first` scope
-route to the A0-O roadmap-first fallback (A0 trigger (b)) if it has not run
-this pass; under `issue-scope: roadmap`, or once that fallback is spent,
-report that all viable issues are currently claimed and stop (not an
-abort). Do not post `unclaimed-by` (no claim was made); retry later as
-claims go stale or new work appears.
+non-empty, report both the claimed-survivor exhaustion and the
+approval-needed hold, then stop (the approval hold takes precedence — not
+a true zero); otherwise, under `roadmap-first` scope route to the A0-O
+roadmap-first fallback (A0 trigger (b)) if it has not run this pass; under
+`issue-scope: roadmap`, or once that fallback is spent, report that all
+viable issues are currently claimed and stop (not an abort). Do not post
+`unclaimed-by` (no claim was made); retry later.
 
 See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
 for why this pre-scan exists.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -94,9 +94,9 @@ Read the **issue-scope** value from the Project commands table in
 - If `issue-scope` is `roadmap-first` (the default): proceed to A1 as
   normal. Fall back to **A0-O** before entering the A3 decision tree when
   the roadmap path yields **no viable, startable, unclaimed candidate** —
-  either (a) **zero candidates reach A3.5** (A2 enumerated no open
-  execution leaves, or A3 filtered them all out as blocked), or (b)
-  **candidates reach A3.5 but none is workable** (A4 Step 1 viability
+  via **trigger (a)** (zero candidates reach A3.5 — A2 enumerated no open
+  execution leaves, or A3 filtered them all out as blocked) or **trigger
+  (b)** (candidates reach A3.5 but none is workable — A4 Step 1 viability
   discards every A3.5-startable candidate, or A4 Step 1.5 eliminates the
   last one). Run A0-O **at most once** as this fallback per Discover pass;
   once spent, a later A4 exhaustion reports and stops per A4 Step 1 / Step

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -17,9 +17,9 @@ remain in the instruction files.
 ### A0-O roadmap-first fallback triggers
 
 The `roadmap-first` A0-O fallback originally fired only when **zero
-candidates reached A3.5** — A2 found no open execution leaves, or A3
-filtered them all out as blocked. But a candidate can reach A3.5 and
-still be unworkable: the workshop leaves #553 (which runs a real
+candidates reached A3.5** (trigger (a)) — A2 found no open execution
+leaves, or A3 filtered them all out as blocked. But a candidate can reach
+A3.5 and still be unworkable: the workshop leaves #553 (which runs a real
 external deployment) and #611 (a "published" convergence checkpoint)
 pass A3 readiness and A3.5 (the owner self-approves), then fail the A4
 viability gate (Autonomous completion). Because they reached A3.5, the

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -14,6 +14,48 @@ remain in the instruction files.
 
 ## Discover
 
+### A0-O roadmap-first fallback triggers
+
+The `roadmap-first` A0-O fallback originally fired only when **zero
+candidates reached A3.5** — A2 found no open execution leaves, or A3
+filtered them all out as blocked. But a candidate can reach A3.5 and
+still be unworkable: the workshop leaves #553 (which runs a real
+external deployment) and #611 (a "published" convergence checkpoint)
+pass A3 readiness and A3.5 (the owner self-approves), then fail the A4
+viability gate (Autonomous completion). Because they reached A3.5, the
+original trigger stayed suppressed, so A4 stopped with "no viable
+issue" and never fell back to A0-O even when claimable orphan issues
+existed — forcing an operator opt-in every loop. The same shadowing
+occurred when A4 Step 1.5 eliminated the last A3.5-startable candidate.
+
+Trigger (b) closes that gap: the fallback also fires when the roadmap
+path yields no viable, startable, unclaimed candidate because A4
+Step 1 viability discards them all or Step 1.5 eliminates the last.
+Three guards keep it safe:
+
+- **Approval hold precedence.** A non-empty A3.5 approval-needed
+  bucket is not a true zero; the fallback fires on viability/claim
+  exhaustion only, never on the approval hold, so it never re-scopes
+  around the approval gate.
+- **True zero only.** It fires only when no viable, startable,
+  unclaimed roadmap candidate remains — never when A4 discards some
+  candidates but keeps others.
+- **At most once per pass.** A0-O runs at most once as the
+  roadmap-first fallback per Discover pass. Once spent (via trigger
+  (a) or (b)), a later A4 Step 1 / Step 1.5 exhaustion reports and
+  stops (not an abort) without re-entering A0-O; A0-O's own
+  zero-orphan result separately routes to the A3 decision tree. This
+  prevents an A1 ↔ A0-O or A4 ↔ A0-O loop.
+
+When both the roadmap path (whether it returned zero A3.5-reaching
+candidates or exhausted at A4 viability / active-claim) and the orphan
+fallback yield nothing, discovery lands in the A3 decision tree,
+exactly as the zero-reach-A3.5 case did before.
+
+The `orphan-first` symmetric case — orphan candidates all failing A4,
+which would fall back to the roadmap path — is a separate concern and
+out of scope here.
+
 ### A3 — Diagnostic: all candidates blocked by an open roadmap
 
 When the A3 decision tree reports zero ready-to-start candidates and

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -43,14 +43,20 @@ Three guards keep it safe:
 - **At most once per pass.** A0-O runs at most once as the
   roadmap-first fallback per Discover pass. Once spent (via trigger
   (a) or (b)), a later A4 Step 1 / Step 1.5 exhaustion reports and
-  stops (not an abort) without re-entering A0-O; A0-O's own
-  zero-orphan result separately routes to the A3 decision tree. This
-  prevents an A1 ↔ A0-O or A4 ↔ A0-O loop.
+  stops (not an abort) without re-entering A0-O. A **trigger (a)**
+  A0-O run that finds no orphan routes to the A3 decision tree (both
+  paths genuinely empty); a **trigger (b)** one reports and stops
+  instead, because roadmap candidates reached A4 — an exhaustion the
+  A3 tree's A2/A3-empty cases do not describe. This prevents an
+  A1 ↔ A0-O or A4 ↔ A0-O loop.
 
-When both the roadmap path (whether it returned zero A3.5-reaching
-candidates or exhausted at A4 viability / active-claim) and the orphan
-fallback yield nothing, discovery lands in the A3 decision tree,
-exactly as the zero-reach-A3.5 case did before.
+When **trigger (a)** (zero A3.5-reaching candidates) and the orphan
+fallback both yield nothing, discovery lands in the A3 decision tree,
+exactly as the zero-reach-A3.5 case did before. **Trigger (b)** instead
+reports and stops (not an abort): roadmap candidates reached A4, so the
+A3 tree's A2/A3-empty reports would misdescribe the exhaustion. The
+fallback is also scoped to roadmap traversal (A2→A3→A4) — the A0-T
+explicit-target gate keeps its own no-fallback stop.
 
 The `orphan-first` symmetric case — orphan candidates all failing A4,
 which would fall back to the roadmap path — is a separate concern and

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -117,10 +117,11 @@ in `idd-overview-core.instructions.md` before any repo-wide orphan issue
 search.
 
 When A0-O runs as the `roadmap-first` fallback (not the `orphan-first`
-primary path), every "proceed to A1" / "skip to A1" exit below instead
-goes to the **A3 decision tree** — the roadmap path already ran and must
-not be re-entered (this prevents an A1 ↔ A0-O loop, e.g. under
-`public-disabled` on a public repo).
+primary path), every exit below that would re-enter **A1** or reach the
+**A3 decision tree** is redirected by the invoking trigger — trigger (a)
+to the A3 decision tree, trigger (b) (A4 exhaustion) to the A4 **"report
+and stop (not an abort)"** terminal — because the roadmap path already ran
+and must not be re-entered (no A1 ↔ A0-O or A4 ↔ A0-O loop).
 
 - If `orphan-first-policy` is `public-disabled`, first determine the
   repository visibility. If the repository is public, skip A0-O without
@@ -167,10 +168,8 @@ next step depends on which path invoked A0-O:
   to **A1** and continue with the normal
   A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence.
 - **`roadmap-first` fallback**: the roadmap path already ran, so do **not**
-  re-enter A1. A **trigger (a)** entry (zero-reach-A3.5) goes straight to
-  the **A3 decision tree** (per the guard atop A0-O). A **trigger (b)**
-  entry (A4 Step 1 / Step 1.5 exhaustion) instead **reports and stops (not
-  an abort)** via that invoking A4 terminal.
+  re-enter A1. This exit is redirected by the invoking trigger per the
+  guard atop A0-O.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: for
@@ -487,12 +486,13 @@ If **no issue** survives the gate:
   that only approval-needed issues remain and stop without claim in
   unattended mode. In attended mode, ask the operator whether to obtain
   approval or opt out explicitly;
-- otherwise, in the **roadmap-traversal** candidate flow (A2→A3→A4 only;
-  the A0-T explicit-target gate never reaches here — a failed target stops
-  in A0-T with no fallback), route to the **A0-O** roadmap-first fallback
-  (A0 trigger (b)) if it has not run this pass; once spent, report the
-  discarded issues with the criterion each failed, then **stop** — do not
-  post `unclaimed-by` because no claim was made. This is not an abort.
+- otherwise, under **`roadmap-first`** scope in the roadmap-traversal flow
+  (A2→A3→A4; not the A0-T gate, which stops a failed target with no
+  fallback), route to the **A0-O** roadmap-first fallback (A0 trigger (b))
+  if it has not run this pass. Once spent, or under `issue-scope: roadmap`
+  (A0-O skipped), report the discarded issues with the criterion each
+  failed, then **stop** — do not post `unclaimed-by` because no claim was
+  made. This is not an abort.
 
 ### Step 1.5 — Active-claim pre-scan
 
@@ -525,12 +525,12 @@ After scanning the current batch:
 When the entire viable candidate set is exhausted (the last row above),
 resolve the exit by scope: if the A3.5 approval-needed bucket is
 non-empty, stop with the approval-needed message (the approval hold takes
-precedence — not a true zero); otherwise, under `roadmap-first`
-discovery, route to the A0-O roadmap-first fallback (A0 trigger (b)) if it
-has not run this pass, else report that all viable issues are currently
-claimed and stop (not an abort). Do not post `unclaimed-by` (no claim was
-made); retry later when claims may have become stale or new viable
-candidates appear.
+precedence — not a true zero); otherwise, under `roadmap-first` scope
+route to the A0-O roadmap-first fallback (A0 trigger (b)) if it has not run
+this pass; under `issue-scope: roadmap`, or once that fallback is spent,
+report that all viable issues are currently claimed and stop (not an
+abort). Do not post `unclaimed-by` (no claim was made); retry later as
+claims go stale or new work appears.
 
 See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
 for why this pre-scan exists.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -101,9 +101,8 @@ Read the **issue-scope** value from the Project commands table in
   discards every A3.5-startable candidate, or A4 Step 1.5 eliminates the
   last one). Run A0-O **at most once** as this fallback per Discover pass;
   once spent, a later A4 exhaustion reports and stops per A4 Step 1 / Step
-  1.5 (not an abort) without re-entering A0-O (A0-O's own zero-orphan exit
-  still routes to the A3 decision tree). This reuses A0-O **only** as a
-  post-roadmap fallback;
+  1.5 (not an abort) without re-entering A0-O. This reuses A0-O **only** as
+  a post-roadmap fallback;
   the roadmap path stays primary (unlike `orphan-first`). If candidates
   reach A3.5 but it holds them all as approval-needed, do **not** fall
   back: the approval hold governs and a non-empty approval-needed bucket
@@ -168,8 +167,10 @@ next step depends on which path invoked A0-O:
   to **A1** and continue with the normal
   A1 → A1.5 → A2 → A3 → A3.5 → A4 sequence.
 - **`roadmap-first` fallback**: the roadmap path already ran, so do **not**
-  re-enter A1. Per the guard at the top of A0-O, this exit goes straight to
-  the **A3 decision tree**.
+  re-enter A1. A **trigger (a)** entry (zero-reach-A3.5) goes straight to
+  the **A3 decision tree** (per the guard atop A0-O). A **trigger (b)**
+  entry (A4 Step 1 / Step 1.5 exhaustion) instead **reports and stops (not
+  an abort)** via that invoking A4 terminal.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
 reached when the active discovery path(s) produce zero results: for
@@ -486,12 +487,12 @@ If **no issue** survives the gate:
   that only approval-needed issues remain and stop without claim in
   unattended mode. In attended mode, ask the operator whether to obtain
   approval or opt out explicitly;
-- otherwise, under `roadmap-first` discovery, route to the **A0-O**
-  roadmap-first fallback (A0 trigger (b)) if it has not run this pass;
-  else (already spent, or `issue-scope` is not `roadmap-first` — e.g. the
-  A0-T explicit-target gate) report the discarded issues with the
-  criterion each failed, then **stop** — do not post `unclaimed-by`
-  because no claim was made. This is not an abort.
+- otherwise, in the **roadmap-traversal** candidate flow (A2→A3→A4 only;
+  the A0-T explicit-target gate never reaches here — a failed target stops
+  in A0-T with no fallback), route to the **A0-O** roadmap-first fallback
+  (A0 trigger (b)) if it has not run this pass; once spent, report the
+  discarded issues with the criterion each failed, then **stop** — do not
+  post `unclaimed-by` because no claim was made. This is not an abort.
 
 ### Step 1.5 — Active-claim pre-scan
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -524,13 +524,13 @@ After scanning the current batch:
 
 When the entire viable candidate set is exhausted (the last row above),
 resolve the exit by scope: if the A3.5 approval-needed bucket is
-non-empty, stop with the approval-needed message (the approval hold takes
-precedence — not a true zero); otherwise, under `roadmap-first` scope
-route to the A0-O roadmap-first fallback (A0 trigger (b)) if it has not run
-this pass; under `issue-scope: roadmap`, or once that fallback is spent,
-report that all viable issues are currently claimed and stop (not an
-abort). Do not post `unclaimed-by` (no claim was made); retry later as
-claims go stale or new work appears.
+non-empty, report both the claimed-survivor exhaustion and the
+approval-needed hold, then stop (the approval hold takes precedence — not
+a true zero); otherwise, under `roadmap-first` scope route to the A0-O
+roadmap-first fallback (A0 trigger (b)) if it has not run this pass; under
+`issue-scope: roadmap`, or once that fallback is spent, report that all
+viable issues are currently claimed and stop (not an abort). Do not post
+`unclaimed-by` (no claim was made); retry later.
 
 See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
 for why this pre-scan exists.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -95,9 +95,9 @@ Read the **issue-scope** value from the Project commands table in
 - If `issue-scope` is `roadmap-first` (the default): proceed to A1 as
   normal. Fall back to **A0-O** before entering the A3 decision tree when
   the roadmap path yields **no viable, startable, unclaimed candidate** —
-  either (a) **zero candidates reach A3.5** (A2 enumerated no open
-  execution leaves, or A3 filtered them all out as blocked), or (b)
-  **candidates reach A3.5 but none is workable** (A4 Step 1 viability
+  via **trigger (a)** (zero candidates reach A3.5 — A2 enumerated no open
+  execution leaves, or A3 filtered them all out as blocked) or **trigger
+  (b)** (candidates reach A3.5 but none is workable — A4 Step 1 viability
   discards every A3.5-startable candidate, or A4 Step 1.5 eliminates the
   last one). Run A0-O **at most once** as this fallback per Discover pass;
   once spent, a later A4 exhaustion reports and stops per A4 Step 1 / Step

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -93,16 +93,22 @@ Read the **issue-scope** value from the Project commands table in
 
 - If `issue-scope` is `roadmap`: skip A0-O and proceed to A1 as normal.
 - If `issue-scope` is `roadmap-first` (the default): proceed to A1 as
-  normal. When the
-  roadmap path yields **zero candidates reaching A3.5** — i.e. A2
-  enumerated no open execution leaves, or A3 filtered them all out as
-  blocked — fall back to **A0-O** before entering the A3 decision tree.
-  This reuses the A0-O orphan search **only** as a post-roadmap fallback;
-  the roadmap path stays primary (unlike `orphan-first`, where A0-O is the
-  first path). If candidates do reach A3.5 but it holds
-  them all as
-  approval-needed, do **not** fall back: A3.5's stop/ask behavior
-  governs, so the fallback never re-scopes around the approval gate.
+  normal. Fall back to **A0-O** before entering the A3 decision tree when
+  the roadmap path yields **no viable, startable, unclaimed candidate** —
+  either (a) **zero candidates reach A3.5** (A2 enumerated no open
+  execution leaves, or A3 filtered them all out as blocked), or (b)
+  **candidates reach A3.5 but none is workable** (A4 Step 1 viability
+  discards every A3.5-startable candidate, or A4 Step 1.5 eliminates the
+  last one). Run A0-O **at most once** as this fallback per Discover pass;
+  once spent, a later A4 exhaustion reports and stops per A4 Step 1 / Step
+  1.5 (not an abort) without re-entering A0-O (A0-O's own zero-orphan exit
+  still routes to the A3 decision tree). This reuses A0-O **only** as a
+  post-roadmap fallback;
+  the roadmap path stays primary (unlike `orphan-first`). If candidates
+  reach A3.5 but it holds them all as approval-needed, do **not** fall
+  back: the approval hold governs and a non-empty approval-needed bucket
+  is not a true zero. See
+  [A0-O fallback triggers](../../docs/idd-design-rationale.md#a0-o-roadmap-first-fallback-triggers).
 - If `issue-scope` is `orphan-first`: proceed to A0-O.
 
 ## A0-O — Discover orphan issues
@@ -480,8 +486,11 @@ If **no issue** survives the gate:
   that only approval-needed issues remain and stop without claim in
   unattended mode. In attended mode, ask the operator whether to obtain
   approval or opt out explicitly;
-- otherwise report the full list of discarded issues with the criterion
-  or criteria each failed, then **stop** — do not post `unclaimed-by`
+- otherwise, under `roadmap-first` discovery, route to the **A0-O**
+  roadmap-first fallback (A0 trigger (b)) if it has not run this pass;
+  else (already spent, or `issue-scope` is not `roadmap-first` — e.g. the
+  A0-T explicit-target gate) report the discarded issues with the
+  criterion each failed, then **stop** — do not post `unclaimed-by`
   because no claim was made. This is not an abort.
 
 ### Step 1.5 — Active-claim pre-scan
@@ -506,11 +515,21 @@ in ascending issue-number order:
 
 After scanning the current batch:
 
-| Batch outcome                                                                       | Action                                                                                                                                                                                                  |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| At least one eligible candidate in the batch                                        | Proceed to Step 2 to rank and select.                                                                                                                                                                   |
-| All `N` in this batch are claimed but viable survivors remain                       | Continue with the next batch (`N+1`–`2N`, then `2N+1`–`3N`, …) until an eligible candidate is found.                                                                                                    |
-| Entire viable candidate set exhausted (all surviving viable candidates are claimed) | Report that all viable issues are currently claimed; stop. Do not post `unclaimed-by` (no claim was made). Not an abort; retry later when claims may have become stale or new viable candidates appear. |
+| Batch outcome                                                                       | Action                                                                                               |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| At least one eligible candidate in the batch                                        | Proceed to Step 2 to rank and select.                                                                |
+| All `N` in this batch are claimed but viable survivors remain                       | Continue with the next batch (`N+1`–`2N`, then `2N+1`–`3N`, …) until an eligible candidate is found. |
+| Entire viable candidate set exhausted (all surviving viable candidates are claimed) | Resolve the exit by scope (see the note below).                                                      |
+
+When the entire viable candidate set is exhausted (the last row above),
+resolve the exit by scope: if the A3.5 approval-needed bucket is
+non-empty, stop with the approval-needed message (the approval hold takes
+precedence — not a true zero); otherwise, under `roadmap-first`
+discovery, route to the A0-O roadmap-first fallback (A0 trigger (b)) if it
+has not run this pass, else report that all viable issues are currently
+claimed and stop (not an abort). Do not post `unclaimed-by` (no claim was
+made); retry later when claims may have become stale or new viable
+candidates appear.
 
 See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
 for why this pre-scan exists.
@@ -534,47 +553,36 @@ neither skip below-floor candidates nor reorder by score — and select by
 `.github/idd/config.json` `discover.selectionDesync` is `session-offset`
 (default `off`) and the chosen highest-score tie band has more than one
 eligible candidate, pick the band entry at index
-`selectDesyncedIndex(session-token, band-size)` instead of index 0 —
-`scripts/policy-helpers.mjs` exports it as a pure, deterministic
-`hash(session-token) mod band-size` over the band ordered by ascending
-issue number, where `session-token` is this session's `{agent-id}` (use
-the recommended unique per-session agent-id suffix; it is available at
-selection time, unlike `{claim-id}`, which A5 only generates after
-selection). This
-proactively spreads concurrent autopilot sessions across **different**
-eligible issues to cut the claim races that A4 Step 1.5 and A5(e) only
-resolve reactively. It reorders **only within** a single score tie band —
-never across score bands — and never bypasses A4.5/A5. Same-issue branch
-convergence is preserved because the branch name derives from the issue,
-not selection order. With `off`, a single-entry band, or no applicable
-score, keep the deterministic **lowest issue number** pick.
+`selectDesyncedIndex(session-token, band-size)` instead of index 0 (a
+pure, deterministic `hash(session-token) mod band-size` from
+`scripts/policy-helpers.mjs`, over the band ordered by ascending issue
+number, `session-token` being this session's `{agent-id}`). It reorders
+**only within** a single score tie band, never across score bands, and
+never bypasses A4.5/A5. With `off`, a single-entry band, or no applicable
+score, keep the deterministic **lowest issue number** pick. See
+[rationale](../../docs/idd-design-rationale.md#a4-step-2--rationale-concurrent-selection-desync).
 
 **Author-recorded effort hint (soft tie-breaker).** When candidates remain
 tied after the score and optional desync rules, prefer the **lower-effort**
-candidate **before** the lowest-issue-number tie-break, so autopilot tends to
-clear small issues first and leave large ones for a fresh session. Read the
-authored `<!-- {{PROJECT_MARKER_PREFIX}}-effort: S|M|L -->` footer (or the
+candidate **before** the lowest-issue-number tie-break. Read the authored
+`<!-- {{PROJECT_MARKER_PREFIX}}-effort: S|M|L -->` footer (or the
 `discover-roadmap-graph` node's `effort`): order `S` < `M` < `L`, and a
 missing or invalid hint is treated as the **neutral middle** (as-if `M`), so a
 band with no effort hints keeps the lowest-issue-number order exactly as
 before. This is a **soft** rule: it reorders **only within** a single score
-tie band, never skips, gates, or crosses a score band, and a large (`L`) issue
-stays fully claimable when it is the only ready work. The
-`discover-roadmap-graph` union already emits this order, so it is a cheap read;
-the pick still passes A4.5/A5 unchanged.
+tie band, never skips, gates, or crosses a score band; the
+`discover-roadmap-graph` union already emits this order.
 
 **High-contention shared-file overlap (advisory).** Concurrent autopilot
 sessions tend to edit the same F-phase bundle instruction files
-(`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`, so a
-colliding pick costs a later merge-from-main conflict. As a **soft**
-tie-breaker layered after the score / desync / effort / lowest-number
-rules, prefer a candidate whose `## Candidate files` do **not** overlap an
-actively-claimed or open-PR issue on one of those files; the optional
-`discover-shared-file-overlap` helper (see
+(`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`. As a
+**soft** tie-breaker layered after the score / desync / effort /
+lowest-number rules, prefer a candidate whose `## Candidate files` do
+**not** overlap an actively-claimed or open-PR issue on one of those files;
+the optional `discover-shared-file-overlap` helper (see
 [IDD helper scripts](../../docs/idd-helper-scripts.md)) reports each candidate's
-`overlapFlag` and a `recommendedOrder`. This is **never a hard gate** — overlap
-never overrides the score or crosses a score band, and a colliding candidate
-stays claimable when it is the only ready work. See the
+`overlapFlag` and a `recommendedOrder`. This is **never a hard gate** —
+overlap never overrides the score or crosses a score band. See the
 [high-contention shared-file convention](../../docs/policy-constants.md#high-contention-shared-files).
 
 After picking, continue to **A4.5** (`idd-suitability.instructions.md`).

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -17,9 +17,9 @@ remain in the instruction files.
 ### A0-O roadmap-first fallback triggers
 
 The `roadmap-first` A0-O fallback originally fired only when **zero
-candidates reached A3.5** — A2 found no open execution leaves, or A3
-filtered them all out as blocked. But a candidate can reach A3.5 and
-still be unworkable: the workshop leaves #553 (which runs a real
+candidates reached A3.5** (trigger (a)) — A2 found no open execution
+leaves, or A3 filtered them all out as blocked. But a candidate can reach
+A3.5 and still be unworkable: the workshop leaves #553 (which runs a real
 external deployment) and #611 (a "published" convergence checkpoint)
 pass A3 readiness and A3.5 (the owner self-approves), then fail the A4
 viability gate (Autonomous completion). Because they reached A3.5, the

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -19,10 +19,10 @@ remain in the instruction files.
 The `roadmap-first` A0-O fallback originally fired only when **zero
 candidates reached A3.5** (trigger (a)) — A2 found no open execution
 leaves, or A3 filtered them all out as blocked. But a candidate can reach
-A3.5 and still be unworkable: the workshop leaves #553 (which runs a real
-external deployment) and #611 (a "published" convergence checkpoint)
-pass A3 readiness and A3.5 (the owner self-approves), then fail the A4
-viability gate (Autonomous completion). Because they reached A3.5, the
+A3.5 and still be unworkable: a workshop leaf that runs a real external
+deployment, or a "published" convergence checkpoint, can pass A3 readiness
+and A3.5 (the owner self-approves), then fail the A4 viability gate
+(Autonomous completion). Because they reached A3.5, the
 original trigger stayed suppressed, so A4 stopped with "no viable
 issue" and never fell back to A0-O even when claimable orphan issues
 existed — forcing an operator opt-in every loop. The same shadowing

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -14,6 +14,48 @@ remain in the instruction files.
 
 ## Discover
 
+### A0-O roadmap-first fallback triggers
+
+The `roadmap-first` A0-O fallback originally fired only when **zero
+candidates reached A3.5** — A2 found no open execution leaves, or A3
+filtered them all out as blocked. But a candidate can reach A3.5 and
+still be unworkable: the workshop leaves #553 (which runs a real
+external deployment) and #611 (a "published" convergence checkpoint)
+pass A3 readiness and A3.5 (the owner self-approves), then fail the A4
+viability gate (Autonomous completion). Because they reached A3.5, the
+original trigger stayed suppressed, so A4 stopped with "no viable
+issue" and never fell back to A0-O even when claimable orphan issues
+existed — forcing an operator opt-in every loop. The same shadowing
+occurred when A4 Step 1.5 eliminated the last A3.5-startable candidate.
+
+Trigger (b) closes that gap: the fallback also fires when the roadmap
+path yields no viable, startable, unclaimed candidate because A4
+Step 1 viability discards them all or Step 1.5 eliminates the last.
+Three guards keep it safe:
+
+- **Approval hold precedence.** A non-empty A3.5 approval-needed
+  bucket is not a true zero; the fallback fires on viability/claim
+  exhaustion only, never on the approval hold, so it never re-scopes
+  around the approval gate.
+- **True zero only.** It fires only when no viable, startable,
+  unclaimed roadmap candidate remains — never when A4 discards some
+  candidates but keeps others.
+- **At most once per pass.** A0-O runs at most once as the
+  roadmap-first fallback per Discover pass. Once spent (via trigger
+  (a) or (b)), a later A4 Step 1 / Step 1.5 exhaustion reports and
+  stops (not an abort) without re-entering A0-O; A0-O's own
+  zero-orphan result separately routes to the A3 decision tree. This
+  prevents an A1 ↔ A0-O or A4 ↔ A0-O loop.
+
+When both the roadmap path (whether it returned zero A3.5-reaching
+candidates or exhausted at A4 viability / active-claim) and the orphan
+fallback yield nothing, discovery lands in the A3 decision tree,
+exactly as the zero-reach-A3.5 case did before.
+
+The `orphan-first` symmetric case — orphan candidates all failing A4,
+which would fall back to the roadmap path — is a separate concern and
+out of scope here.
+
 ### A3 — Diagnostic: all candidates blocked by an open roadmap
 
 When the A3 decision tree reports zero ready-to-start candidates and

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -43,14 +43,20 @@ Three guards keep it safe:
 - **At most once per pass.** A0-O runs at most once as the
   roadmap-first fallback per Discover pass. Once spent (via trigger
   (a) or (b)), a later A4 Step 1 / Step 1.5 exhaustion reports and
-  stops (not an abort) without re-entering A0-O; A0-O's own
-  zero-orphan result separately routes to the A3 decision tree. This
-  prevents an A1 ↔ A0-O or A4 ↔ A0-O loop.
+  stops (not an abort) without re-entering A0-O. A **trigger (a)**
+  A0-O run that finds no orphan routes to the A3 decision tree (both
+  paths genuinely empty); a **trigger (b)** one reports and stops
+  instead, because roadmap candidates reached A4 — an exhaustion the
+  A3 tree's A2/A3-empty cases do not describe. This prevents an
+  A1 ↔ A0-O or A4 ↔ A0-O loop.
 
-When both the roadmap path (whether it returned zero A3.5-reaching
-candidates or exhausted at A4 viability / active-claim) and the orphan
-fallback yield nothing, discovery lands in the A3 decision tree,
-exactly as the zero-reach-A3.5 case did before.
+When **trigger (a)** (zero A3.5-reaching candidates) and the orphan
+fallback both yield nothing, discovery lands in the A3 decision tree,
+exactly as the zero-reach-A3.5 case did before. **Trigger (b)** instead
+reports and stops (not an abort): roadmap candidates reached A4, so the
+A3 tree's A2/A3-empty reports would misdescribe the exhaustion. The
+fallback is also scoped to roadmap traversal (A2→A3→A4) — the A0-T
+explicit-target gate keeps its own no-fallback stop.
 
 The `orphan-first` symmetric case — orphan candidates all failing A4,
 which would fall back to the roadmap path — is a separate concern and


### PR DESCRIPTION
## Summary

Extends the Discover-phase `roadmap-first` A0-O orphan fallback so it also
fires when the roadmap path yields no viable, startable, unclaimed
candidate because **A4 Step 1 (viability)** discards every A3.5-startable
candidate or **A4 Step 1.5 (active-claim pre-scan)** eliminates the last
one — not only when zero candidates reach A3.5. Previously, workshop leaves
that reach A3.5 but fail A4 viability (e.g. #553 / #611) suppressed the
fallback, so Discover stopped with "no viable issue" and stranded claimable
orphan work behind a manual operator opt-in every loop.

## Behavior (guards preserved)

- **Approval-hold precedence** — a non-empty A3.5 approval-needed bucket is
  not a true zero; the fallback fires on viability / claim exhaustion only,
  never on the approval hold.
- **True zero only** — never fires when A4 keeps some candidates.
- **At most once per Discover pass** — once A0-O has run as the
  roadmap-first fallback, a later A4 exhaustion reports and stops (not an
  abort) without re-entering A0-O; A0-O's own zero-orphan result still
  routes to the A3 decision tree. No A1↔A0-O or A4↔A0-O loop.

## Files

- `.github/instructions/idd-discover.instructions.md` + its `idd-template/`
  source (A0 trigger, A4 Step 1 / Step 1.5 routing) — kept structurally
  consistent (`mode: structure`; heading parity enforced by `audit-docs`).
- `docs/idd-design-rationale.md` + template — new
  `### A0-O roadmap-first fallback triggers` subsection.

## Footprint note (budget callout)

The live discover file sat at ~99 % of its per-file phase budget
(`instructionSizeBudgets.phaseLimitBytes = 32200`). Per the near-ceiling
exception in `docs/policy-constants.md` (prefer trim/split over a ratchet
bump ≥95 %) and operator direction, the explanatory rationale was **split**
into the uncapped design-rationale doc and redundant WHY prose in the A4
Step 2 tie-breakers was trimmed (the desync WHY was already duplicated in
the rationale doc's existing `### A4 Step 2 — Rationale` subsection). No
budget bump: the file is now 31,988 B (was 31,898 B), ~212 B under budget.
No code or tests changed.

## Verification

`node scripts/audit-docs.mjs --check` and `pnpm run lint:minimum` (biome,
dprint, typecheck, build:check, 1498 tests, cspell, markdownlint,
workshop-integrity) pass.

## Out of scope (follow-up)

The symmetric `orphan-first` case — orphan candidates all failing A4 that
would fall back to the roadmap path — is a separate concern, deliberately
excluded here.

Closes #1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified discovery fallback behavior for roadmap-first flows.
  * Added guidance for when fallback triggers, including one-time-per-pass limits and approval-hold precedence.
  * Refined selection behavior to keep reordering within tie bands only and preserve existing tie-break hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->