### PR TITLE
fix(discover): ignore code-quoted refs in roadmap-graph traversal

### DIFF
--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1135,18 +1135,31 @@ export function classifyIssue(issue, markerPrefix = DEFAULT_MARKER_PREFIX) {
   };
 }
 export function extractTaskListReferences(body) {
-  return String(body ?? '')
-    .split(/\r?\n/u)
-    .flatMap((line) => {
-      const match = line.match(/^\s*-\s*\[(?: |x|X)\]\s+#(\d+)\b/u);
-      if (!match) {
-        return [];
-      }
-      const target = Number.parseInt(match[1], 10);
-      return Number.isInteger(target) && target > 0
-        ? [{ target, relationship: 'task-list', evidence: line.trim() }]
-        : [];
-    });
+  // Match against a code-masked copy so a checkbox merely quoted inside inline
+  // code or a fenced block is not walked as a real task-list edge — consistent
+  // with the #1121 boundary already applied to extractRoadmapMarkerId (#1204).
+  // stripMarkdownCodeRegions preserves the line count, so the masked and raw
+  // lines share an index and evidence stays the raw line for any surviving edge
+  // (e.g. one that shares a line with unrelated inline code).
+  const rawBody = String(body ?? '');
+  const rawLines = rawBody.split(/\r?\n/u);
+  const maskedLines = stripMarkdownCodeRegions(rawBody).split(/\r?\n/u);
+  return maskedLines.flatMap((maskedLine, index) => {
+    const match = maskedLine.match(/^\s*-\s*\[(?: |x|X)\]\s+#(\d+)\b/u);
+    if (!match) {
+      return [];
+    }
+    const target = Number.parseInt(match[1], 10);
+    return Number.isInteger(target) && target > 0
+      ? [
+          {
+            target,
+            relationship: 'task-list',
+            evidence: (rawLines[index] ?? maskedLine).trim(),
+          },
+        ]
+      : [];
+  });
 }
 export function extractKeywordReferences(body, options = {}) {
   const references = [];
@@ -1158,13 +1171,25 @@ export function extractKeywordReferences(body, options = {}) {
       ? options.currentRepoRef.split('/')[1]
       : options.repo,
   );
-  for (const line of String(body ?? '').split(/\r?\n/u)) {
-    const keywordMatches = [...line.matchAll(KEYWORD_REFERENCE_REGEX)];
+  // Run the keyword match AND the trailing-segment scan against a code-masked
+  // copy of the body so a reference merely quoted inside inline code or a fenced
+  // block is not walked as a real graph edge — consistent with the #1121
+  // boundary already applied to extractRoadmapMarkerId (#1204). Only `evidence`
+  // reads the raw line; stripMarkdownCodeRegions preserves the line count, so
+  // the masked and raw lines share an index and evidence stays byte-identical
+  // for any surviving edge that is not itself inside/adjacent to code.
+  const rawBody = String(body ?? '');
+  const rawLines = rawBody.split(/\r?\n/u);
+  const maskedLines = stripMarkdownCodeRegions(rawBody).split(/\r?\n/u);
+  for (let lineIndex = 0; lineIndex < maskedLines.length; lineIndex += 1) {
+    const maskedLine = maskedLines[lineIndex];
+    const rawLine = rawLines[lineIndex] ?? maskedLine;
+    const keywordMatches = [...maskedLine.matchAll(KEYWORD_REFERENCE_REGEX)];
     for (let index = 0; index < keywordMatches.length; index += 1) {
       const match = keywordMatches[index];
       const segmentStart = (match.index ?? 0) + match[0].length;
-      const segmentEnd = keywordMatches[index + 1]?.index ?? line.length;
-      const segment = line.slice(segmentStart, segmentEnd);
+      const segmentEnd = keywordMatches[index + 1]?.index ?? maskedLine.length;
+      const segment = maskedLine.slice(segmentStart, segmentEnd);
       for (const target of extractKeywordReferenceTargets(
         segment,
         currentRepoRef,
@@ -1175,7 +1200,7 @@ export function extractKeywordReferences(body, options = {}) {
         references.push({
           target,
           relationship: classifyKeywordRelationship(match[1]),
-          evidence: line.trim(),
+          evidence: rawLine.trim(),
         });
       }
     }

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1689,18 +1689,31 @@ export function classifyIssue(
 export function extractTaskListReferences(
   body: unknown,
 ): RoadmapGraphReference[] {
-  return String(body ?? '')
-    .split(/\r?\n/u)
-    .flatMap((line) => {
-      const match = line.match(/^\s*-\s*\[(?: |x|X)\]\s+#(\d+)\b/u);
-      if (!match) {
-        return [];
-      }
-      const target = Number.parseInt(match[1], 10);
-      return Number.isInteger(target) && target > 0
-        ? [{ target, relationship: 'task-list', evidence: line.trim() }]
-        : [];
-    });
+  // Match against a code-masked copy so a checkbox merely quoted inside inline
+  // code or a fenced block is not walked as a real task-list edge — consistent
+  // with the #1121 boundary already applied to extractRoadmapMarkerId (#1204).
+  // stripMarkdownCodeRegions preserves the line count, so the masked and raw
+  // lines share an index and evidence stays the raw line for any surviving edge
+  // (e.g. one that shares a line with unrelated inline code).
+  const rawBody = String(body ?? '');
+  const rawLines = rawBody.split(/\r?\n/u);
+  const maskedLines = stripMarkdownCodeRegions(rawBody).split(/\r?\n/u);
+  return maskedLines.flatMap((maskedLine, index) => {
+    const match = maskedLine.match(/^\s*-\s*\[(?: |x|X)\]\s+#(\d+)\b/u);
+    if (!match) {
+      return [];
+    }
+    const target = Number.parseInt(match[1], 10);
+    return Number.isInteger(target) && target > 0
+      ? [
+          {
+            target,
+            relationship: 'task-list',
+            evidence: (rawLines[index] ?? maskedLine).trim(),
+          },
+        ]
+      : [];
+  });
 }
 
 export function extractKeywordReferences(
@@ -1716,13 +1729,25 @@ export function extractKeywordReferences(
       ? options.currentRepoRef.split('/')[1]
       : options.repo,
   );
-  for (const line of String(body ?? '').split(/\r?\n/u)) {
-    const keywordMatches = [...line.matchAll(KEYWORD_REFERENCE_REGEX)];
+  // Run the keyword match AND the trailing-segment scan against a code-masked
+  // copy of the body so a reference merely quoted inside inline code or a fenced
+  // block is not walked as a real graph edge — consistent with the #1121
+  // boundary already applied to extractRoadmapMarkerId (#1204). Only `evidence`
+  // reads the raw line; stripMarkdownCodeRegions preserves the line count, so
+  // the masked and raw lines share an index and evidence stays byte-identical
+  // for any surviving edge that is not itself inside/adjacent to code.
+  const rawBody = String(body ?? '');
+  const rawLines = rawBody.split(/\r?\n/u);
+  const maskedLines = stripMarkdownCodeRegions(rawBody).split(/\r?\n/u);
+  for (let lineIndex = 0; lineIndex < maskedLines.length; lineIndex += 1) {
+    const maskedLine = maskedLines[lineIndex];
+    const rawLine = rawLines[lineIndex] ?? maskedLine;
+    const keywordMatches = [...maskedLine.matchAll(KEYWORD_REFERENCE_REGEX)];
     for (let index = 0; index < keywordMatches.length; index += 1) {
       const match = keywordMatches[index];
       const segmentStart = (match.index ?? 0) + match[0].length;
-      const segmentEnd = keywordMatches[index + 1]?.index ?? line.length;
-      const segment = line.slice(segmentStart, segmentEnd);
+      const segmentEnd = keywordMatches[index + 1]?.index ?? maskedLine.length;
+      const segment = maskedLine.slice(segmentStart, segmentEnd);
       for (const target of extractKeywordReferenceTargets(
         segment,
         currentRepoRef,
@@ -1733,7 +1758,7 @@ export function extractKeywordReferences(
         references.push({
           target,
           relationship: classifyKeywordRelationship(match[1]),
-          evidence: line.trim(),
+          evidence: rawLine.trim(),
         });
       }
     }

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -239,6 +239,82 @@ Depends on #403, #404 and #405
   ]);
 });
 
+test('extractKeywordReferences ignores refs quoted inside code regions (#1204)', () => {
+  // The #1142/#1143 shape: an execution leaf *about* the dependency parser
+  // quotes example `Blocked by` / `Depends on` refs in inline code and fences.
+  // Walking them as real edges made a completed roadmap permanently
+  // un-closeable by the mechanical audit — consistent with the #1121 boundary
+  // already applied to extractRoadmapMarkerId, these must not become edges.
+  const inline = 'an inline-code `Blocked by #77` example is ignored';
+  assert.deepEqual(extractKeywordReferences(inline), []);
+
+  const fenced = [
+    'Example from the parser fix:',
+    '',
+    '```md',
+    'Blocked by #100, #200',
+    'Depends on #66',
+    '```',
+  ].join('\n');
+  assert.deepEqual(extractKeywordReferences(fenced), []);
+});
+
+test('extractKeywordReferences keeps a real ref while dropping a code-quoted one on the same line', () => {
+  // Masking replaces inline-code inner chars with spaces but keeps the real
+  // reference; evidence stays the raw line because stripMarkdownCodeRegions
+  // preserves the line count so the raw and masked splits stay index-aligned.
+  const body = 'Depends on #303 (not the `Blocked by #5` example)';
+  assert.deepEqual(extractKeywordReferences(body), [
+    {
+      target: 303,
+      relationship: 'dependency',
+      evidence: 'Depends on #303 (not the `Blocked by #5` example)',
+    },
+  ]);
+});
+
+test('extractTaskListReferences ignores a checkbox quoted inside a fence (#1204)', () => {
+  const fenced = ['```md', '- [ ] #900', '```', '- [ ] #901'].join('\n');
+  assert.deepEqual(extractTaskListReferences(fenced), [
+    { target: 901, relationship: 'task-list', evidence: '- [ ] #901' },
+  ]);
+});
+
+test('graph traversal creates no phantom edges from code-quoted refs in a child body (#1204)', async () => {
+  // Reproduces the #1142/#1143 audit false-positive at the graph level: a
+  // completed child that documents the dependency parser quotes example
+  // Blocked by / Depends on refs in inline code and a fence. None of them may
+  // become traversal edges, or the roadmap looks incomplete forever.
+  const childBody = [
+    '## Background',
+    '',
+    'The parser turns `Blocked by #66, #200` into `[66, 200]`, and a',
+    'blockquote `> Depends on #98` is matched too.',
+    '',
+    '```md',
+    'Blocked by #100',
+    '```',
+  ].join('\n');
+  const issues = new Map([
+    [700, roadmapIssue(700, '- [ ] #701', 'phantom-roadmap')],
+    [701, executionIssue(701, childBody, 'closed')],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(700, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.edges, [
+    {
+      source: 700,
+      target: 701,
+      relationship: 'task-list',
+      evidence: '- [ ] #701',
+    },
+  ]);
+  assert.deepEqual(graph.executionCandidates, []);
+});
+
 test('enumerates a flat roadmap graph and separates execution candidates', async () => {
   const issues = new Map([
     [100, roadmapIssue(100, '- [ ] #101\n- [ ] #102', 'root-roadmap')],


### PR DESCRIPTION
## Summary

`discover-roadmap-graph`'s two body-text edge extractors —
`extractKeywordReferences` and `extractTaskListReferences` — matched
`Blocked by` / `Depends on` / `Closes` / task-list references directly on
the raw issue body, unlike `extractRoadmapMarkerId`, which already masks
Markdown code regions (#1121). So a reference merely **quoted inside inline
code or a fenced block** was walked as a real outbound traversal edge.

This made a genuinely-complete roadmap **un-closeable** by the mechanical
audit: during the A1.5 completion audit of roadmap #1142, the traversal
followed #1143's illustrative `` `Blocked by #100, #200` `` / `` `> Blocked
by #66` `` / inline-code `` `Blocked by #77` `` example refs as edges,
reporting phantom `unresolved-reference #66/#77/#200` (actually merged PRs)
and `nested-roadmap #98` — and #1142 had to be closed by hand.

## Change

Both extractors now match against a `stripMarkdownCodeRegions` copy of the
body while sourcing each edge's `evidence` from the **aligned raw line**
(the helper preserves line count, so the raw/masked splits stay
index-aligned). Real, non-code edges therefore stay byte-identical —
including their dedup key and sort order, where `evidence` participates.

Mid-line closing keywords (`Closes #N`, `Fixes #N`, `Refs #N`) are
deliberately still honored — anchoring them the way
`discover-readiness-check` anchors `Blocked by`/`Depends on` (#1143) would
regress legitimate mid-line edges, and every #1142/#1143 phantom ref was
code-quoted, so code-region masking alone resolves the reported bug. A
non-code mid-sentence mention is left as a possible follow-up.

## Tests

New regression cases in `tests/discover-roadmap-graph.test.mts`: an
inline-code keyword ref ignored, a fenced-code ref ignored, a real ref kept
while a code-quoted ref on the same line is dropped (with raw evidence), a
fenced task-list checkbox ignored, and a graph-level reproduction of the
#1142/#1143 shape producing zero phantom descendant edges. Existing
real-edge assertions are unchanged. `pnpm test` (1502) and
`pnpm run lint:minimum` pass; the generated
`scripts/discover-roadmap-graph.mjs` is regenerated from the `.mts` source.

Closes #1204
