### PR TITLE
test(infra): consolidate the duplicated test utilities into one shared tests helper module

### DIFF
--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -21,6 +21,7 @@ import {
   unsafeTextReason,
 } from '../src/scripts/protocol-helpers.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
+import { readJson } from './test-utils.mts';
 
 const ciSuccess = readJson('fixtures/ci/success.json');
 const ciPending = readJson('fixtures/ci/pending.json');
@@ -673,9 +674,3 @@ test('advisory wait summary normalizes invalid direct options to defaults', () =
   assert.equal(summary.pollIntervalMinutes, 2);
   assert.equal(summary.capExhaustedRoute, 'phase-specific');
 });
-
-function readJson(relativePath: string) {
-  return JSON.parse(
-    readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8'),
-  );
-}

--- a/tests/claim-lifecycle.test.mts
+++ b/tests/claim-lifecycle.test.mts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import { resolveActiveClaim } from '../src/scripts/protocol-helpers.mts';
+import { readJson } from './test-utils.mts';
 
 const fixtures = {
   staleTakeover: readJson('fixtures/claim-lifecycle/stale-takeover.json'),
@@ -20,9 +20,3 @@ test('golden scenario: same-second competing claims use deterministic tie-break'
   const active = resolveActiveClaim(fixtures.sameSecondTieBreak.events);
   assert.deepEqual(active, fixtures.sameSecondTieBreak.expectedActiveClaim);
 });
-
-function readJson(relativePath: string) {
-  return JSON.parse(
-    readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8'),
-  );
-}

--- a/tests/claim-parser.test.mts
+++ b/tests/claim-parser.test.mts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
@@ -8,6 +7,7 @@ import {
   parseClaimComment,
   parseReleaseComment,
 } from '../src/scripts/protocol-helpers.mts';
+import { readText } from './test-utils.mts';
 
 const fixtures = {
   active: readText('fixtures/issue-comments/active-claim.md'),
@@ -182,7 +182,3 @@ test('matching heartbeat does not invoke the onAnomalousHeartbeat callback', () 
   );
   assert.equal(seen.length, 0);
 });
-
-function readText(relativePath: string): string {
-  return readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8');
-}

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -20,8 +20,8 @@ import {
   stripGeneratedFromBanner,
 } from '../src/scripts/consistency-helpers.mts';
 import { findPlaceholders } from '../src/scripts/idd-doctor.mts';
+import { readJson, readText } from './test-utils.mts';
 
-const FIXTURE_ROOT = new URL('./fixtures/', import.meta.url);
 const SUITABILITY_PATH = new URL(
   '../.github/instructions/idd-suitability.instructions.md',
   import.meta.url,
@@ -364,12 +364,16 @@ test('doc budget guard is a no-op without config and notices on empty budgets', 
 });
 
 test('config drift scenarios detect mismatches between config and overview defaults', () => {
-  const overview = readText('consistency/config/overview.txt');
+  const overview = readText('tests/fixtures/consistency/config/overview.txt');
   const missingRowOverview = readText(
-    'consistency/config/overview-missing-policy-row.txt',
+    'tests/fixtures/consistency/config/overview-missing-policy-row.txt',
   );
-  const aligned = readJson('consistency/config/aligned-config.json');
-  const drifted = readJson('consistency/config/drifted-config.json');
+  const aligned = readJson(
+    'tests/fixtures/consistency/config/aligned-config.json',
+  );
+  const drifted = readJson(
+    'tests/fixtures/consistency/config/drifted-config.json',
+  );
 
   assert.deepEqual(collectPolicyConfigDrift(aligned, overview), []);
   assert.deepEqual(collectPolicyConfigDrift(drifted, overview), [
@@ -795,7 +799,7 @@ test('A4.5 outcome fixtures match the documented check-to-outcome mapping', () =
   const text = readFileSync(SUITABILITY_PATH, 'utf8');
   const checks = extractCheckOutcomes(text);
   const outcomes = extractOutcomeTable(text);
-  const cases = readJson('consistency/a45-outcomes.json') as {
+  const cases = readJson('tests/fixtures/consistency/a45-outcomes.json') as {
     id: string;
     failedCheck: string;
     expectedOutcome: string;
@@ -931,14 +935,6 @@ function extractOutcomeTable(text: string): Map<string, string> {
       return [cells[0].replaceAll('`', ''), cells[2]] as [string, string];
     }),
   );
-}
-
-function readJson(relativePath: string): unknown {
-  return JSON.parse(readText(relativePath));
-}
-
-function readText(relativePath: string): string {
-  return readFileSync(new URL(relativePath, FIXTURE_ROOT), 'utf8');
 }
 
 test('package.json version stays aligned with iddVersion in the shipped and template configs', () => {

--- a/tests/idd-workflow-phase-map-sync.test.mts
+++ b/tests/idd-workflow-phase-map-sync.test.mts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
+
+import {
+  extractTopLevelSection,
+  normalizeWhitespace,
+  readText,
+} from './test-utils.mts';
 
 const CANONICAL_DOC = 'docs/idd-workflow.md';
 const TEMPLATE_DOC = 'idd-template/docs/idd-workflow.md';
@@ -56,31 +61,3 @@ test('workflow onboarding guidance stays synced between docs and template', () =
     templateText.includes('helper-backed evidence collectors first'),
   );
 });
-
-function readText(relativePath: string): string {
-  return readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8');
-}
-
-function extractTopLevelSection(
-  text: string,
-  fileLabel: string,
-  startMarker: string,
-): string {
-  const nextSectionMarker = '\n## ';
-  const start = text.indexOf(startMarker);
-  assert.notEqual(
-    start,
-    -1,
-    `${fileLabel} is missing section marker: ${startMarker}`,
-  );
-  const nextSectionStart = text.indexOf(
-    nextSectionMarker,
-    start + startMarker.length,
-  );
-  const end = nextSectionStart === -1 ? text.length : nextSectionStart;
-  return text.slice(start, end).trim();
-}
-
-function normalizeWhitespace(text: string): string {
-  return text.replace(/\s+/g, ' ').trim();
-}

--- a/tests/issue-author-approval-gate.test.mts
+++ b/tests/issue-author-approval-gate.test.mts
@@ -3,20 +3,10 @@ import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import { stripGeneratedFromBanner } from '../src/scripts/consistency-helpers.mts';
+import { extractSection } from './test-utils.mts';
 
 function read(relativePath: string) {
   return readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8');
-}
-
-function extractSection(
-  text: string,
-  startHeading: string,
-  endHeading?: string,
-) {
-  const start = text.indexOf(startHeading);
-  assert.notEqual(start, -1, `missing start heading: ${startHeading}`);
-  const end = endHeading ? text.indexOf(endHeading, start) : -1;
-  return text.slice(start, end === -1 ? undefined : end).trim();
 }
 
 test('discover instructions define approval-needed fallback routing', () => {

--- a/tests/issue-authoring-specificity.test.mts
+++ b/tests/issue-authoring-specificity.test.mts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
+
+import {
+  extractTopLevelSection,
+  normalizeWhitespace,
+  readText,
+} from './test-utils.mts';
 
 test('specificity guidance stays synced between canonical and bundled contract', () => {
   const canonicalFile = 'docs/issue-authoring-skill.md';
@@ -325,36 +330,3 @@ test('child issue validation keeps verification and dependency-marker guidance',
     }
   }
 });
-
-function readText(relativePath: string): string {
-  return readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8');
-}
-
-function extractTopLevelSection(
-  text: string,
-  fileLabel: string,
-  startMarker: string,
-): string {
-  const nextSectionMarker = '\n## ';
-
-  const start = text.indexOf(startMarker);
-  assert.notEqual(
-    start,
-    -1,
-    `${fileLabel} is missing section marker: ${startMarker}`,
-  );
-
-  // If the section is last in the file, compare through EOF instead of
-  // coupling the test to a specific following heading.
-  const nextSectionStart = text.indexOf(
-    nextSectionMarker,
-    start + startMarker.length,
-  );
-  const end = nextSectionStart === -1 ? text.length : nextSectionStart;
-
-  return text.slice(start, end).trim();
-}
-
-function normalizeWhitespace(text: string): string {
-  return text.replace(/\s+/g, ' ').trim();
-}

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -5,31 +5,13 @@ import {
   buildMergedPrFeedbackSweep,
   type MergedPrInput,
 } from '../src/scripts/merged-pr-feedback-sweep.mts';
+import { buildCommentThread } from './test-utils.mts';
 
 const OPTIONS = {
   trustedMarkerActors: ['kurone-kito'],
   advisoryBotLogins: ['coderabbitai[bot]'],
   iddAgentLogins: ['kurone-kito'],
 };
-
-function thread(
-  isResolved: boolean,
-  comments: { login: string; body: string; createdAt: string; url?: string }[],
-  path = 'src/x.mts',
-) {
-  return {
-    isResolved,
-    path,
-    comments: {
-      nodes: comments.map((c) => ({
-        body: c.body,
-        url: c.url ?? 'https://example/thread',
-        createdAt: c.createdAt,
-        author: { login: c.login },
-      })),
-    },
-  };
-}
 
 test('surfaces an unresolved reviewer thread with no disposition', () => {
   const prs: MergedPrInput[] = [
@@ -38,7 +20,7 @@ test('surfaces an unresolved reviewer thread with no disposition', () => {
       mergedAt: '2026-06-10T00:00:00Z',
       mergeCommit: 'abc',
       threads: [
-        thread(false, [
+        buildCommentThread(false, [
           {
             login: 'coderabbitai[bot]',
             body: 'This loop can deadlock.',
@@ -63,7 +45,7 @@ test('excludes a resolved thread', () => {
     {
       number: 2,
       threads: [
-        thread(true, [
+        buildCommentThread(true, [
           {
             login: 'coderabbitai[bot]',
             body: 'nit',
@@ -82,7 +64,7 @@ test('marks an unresolved thread dispositioned when the agent replied with a mar
     {
       number: 3,
       threads: [
-        thread(false, [
+        buildCommentThread(false, [
           {
             login: 'coderabbitai[bot]',
             body: 'concern',
@@ -106,7 +88,7 @@ test('marks an unresolved thread dispositioned on an IDD AMD reply', () => {
     {
       number: 3,
       threads: [
-        thread(false, [
+        buildCommentThread(false, [
           {
             login: 'coderabbitai[bot]',
             body: 'concern',
@@ -130,7 +112,7 @@ test('excludes a thread the IDD agent itself opened', () => {
     {
       number: 4,
       threads: [
-        thread(false, [
+        buildCommentThread(false, [
           {
             login: 'kurone-kito',
             body: 'self note',
@@ -204,7 +186,7 @@ test('a later thread-level IDD disposition addresses a top-level comment', () =>
       // The disposition lives inside a (resolved) review thread, not as a
       // top-level comment; it must still count as the "later disposition".
       threads: [
-        thread(true, [
+        buildCommentThread(true, [
           {
             login: 'coderabbitai[bot]',
             body: 'related concern',
@@ -404,7 +386,7 @@ test('summary aggregates across PRs and skips clean PRs', () => {
     {
       number: 11,
       threads: [
-        thread(false, [
+        buildCommentThread(false, [
           { login: 'h', body: 'x', createdAt: '2026-06-09T00:00:00Z' },
         ]),
       ],
@@ -419,7 +401,7 @@ test('summary aggregates across PRs and skips clean PRs', () => {
     {
       number: 12,
       threads: [
-        thread(true, [
+        buildCommentThread(true, [
           { login: 'h', body: 'z', createdAt: '2026-06-09T00:00:00Z' },
         ]),
       ],

--- a/tests/non-node-fallback.test.mts
+++ b/tests/non-node-fallback.test.mts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
+
+import {
+  extractSection,
+  normalizeWhitespace,
+  readText,
+} from './test-utils.mts';
 
 test('customization docs keep npx fallback wording aligned', () => {
   for (const file of [
@@ -510,23 +515,3 @@ test('ci wait helper docs route non-vendored profiles through the selected comma
     );
   }
 });
-
-function readText(relativePath: string): string {
-  return readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8');
-}
-
-function normalizeWhitespace(text: string): string {
-  return text.replace(/\s+/g, ' ').trim();
-}
-
-function extractSection(
-  text: string,
-  startMarker: string,
-  endMarker: string,
-): string {
-  const start = text.indexOf(startMarker);
-  assert.notEqual(start, -1, `Missing section marker: ${startMarker}`);
-  const end = text.indexOf(endMarker, start);
-  assert.notEqual(end, -1, `Missing section marker: ${endMarker}`);
-  return text.slice(start, end);
-}

--- a/tests/phase-id-resolver.test.mts
+++ b/tests/phase-id-resolver.test.mts
@@ -10,6 +10,7 @@ import {
   normalizePhaseIdToken,
   resolvePhaseId,
 } from '../src/scripts/phase-id-resolver.mts';
+import { readJson } from './test-utils.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
@@ -227,10 +228,6 @@ test('every resume-route-selection route resolves except the terminal stop senti
   // Bare `A` is intentionally absent from the canonical list (see above).
   assertUnknownPhaseId('A');
 });
-
-function readJson(relativePath: string): unknown {
-  return JSON.parse(readFileSync(join(REPO_ROOT, relativePath), 'utf8'));
-}
 
 function assertUnknownPhaseId(input: string): void {
   assert.throws(

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
@@ -33,6 +32,7 @@ import {
   summarizeReviewThreadsForGate,
 } from '../src/scripts/protocol-helpers.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
+import { readJson } from './test-utils.mts';
 
 const readinessSchema = loadJson('schemas/pre-merge-readiness.schema.json');
 
@@ -4081,12 +4081,6 @@ test('parseArgs: a non-positive / non-integer number throws a clear message', ()
     /invalid --claim-issue value/,
   );
 });
-
-function readJson(relativePath: string) {
-  return JSON.parse(
-    readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8'),
-  );
-}
 
 test('buildPreMergeReadinessSummary embeds a strict ready/blockers rollup', () => {
   // A clean fixture built WITHOUT dispositionEvidence fails closed on that

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -10,22 +10,9 @@ import {
   type ReviewThreadNode,
 } from '../src/scripts/resolve-review-thread.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
+import { buildReviewThreadNode } from './test-utils.mts';
 
 const resultSchema = loadJson('schemas/resolve-review-thread.schema.json');
-
-function thread(
-  id: string,
-  isResolved: boolean,
-  commentDatabaseIds: number[],
-): ReviewThreadNode {
-  return {
-    id,
-    isResolved,
-    comments: {
-      nodes: commentDatabaseIds.map((databaseId) => ({ databaseId })),
-    },
-  };
-}
 
 test('parseArgs reads the call shape and defaults to dry-run', () => {
   const args = parseArgs([
@@ -66,8 +53,8 @@ test('parseArgs reads the apply-mode claim inputs', () => {
 
 test('findThreadForComment maps a REST comment id to its owning thread and root comment', () => {
   const threads = [
-    thread('thread-a', false, [900, 901]),
-    thread('thread-b', true, [1001, 1002]),
+    buildReviewThreadNode('thread-a', false, [900, 901]),
+    buildReviewThreadNode('thread-b', true, [1001, 1002]),
   ];
   const match = findThreadForComment(threads, 1002);
   assert.deepEqual(match, {
@@ -81,7 +68,7 @@ test('findThreadForComment returns the top-level comment id when a later reply m
   // The reply must target the thread's first (top-level) comment, since GitHub
   // does not support replies to replies; matching a later reply still resolves
   // to the root comment id.
-  const threads = [thread('thread-x', false, [500, 777])];
+  const threads = [buildReviewThreadNode('thread-x', false, [500, 777])];
   assert.deepEqual(findThreadForComment(threads, 777), {
     threadId: 'thread-x',
     isResolved: false,
@@ -90,7 +77,7 @@ test('findThreadForComment returns the top-level comment id when a later reply m
 });
 
 test('findThreadForComment returns null when no thread owns the comment', () => {
-  const threads = [thread('thread-a', false, [900])];
+  const threads = [buildReviewThreadNode('thread-a', false, [900])];
   assert.equal(findThreadForComment(threads, 999), null);
 });
 
@@ -102,7 +89,7 @@ test('findThreadForComment ignores missing databaseId nodes safely', () => {
       comments: { nodes: [{ databaseId: null }] },
     },
     { id: 'thread-b', isResolved: false, comments: { nodes: null } },
-    thread('thread-c', false, [1001]),
+    buildReviewThreadNode('thread-c', false, [1001]),
   ];
   assert.deepEqual(findThreadForComment(threads, 1001), {
     threadId: 'thread-c',

--- a/tests/review-gate.test.mts
+++ b/tests/review-gate.test.mts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
@@ -8,6 +7,7 @@ import {
   routeRejectedChangesRequestedReview,
   summarizeReviewThreadsForGate,
 } from '../src/scripts/protocol-helpers.mts';
+import { readJson } from './test-utils.mts';
 
 const changesRequestedRoutes = readJson(
   'fixtures/review-gate/changes-requested-routes.json',
@@ -59,9 +59,3 @@ test('classifies unresolved threads for awaiting-reviewer and conversation-resol
     }
   }
 });
-
-function readJson(relativePath: string) {
-  return JSON.parse(
-    readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8'),
-  );
-}

--- a/tests/review-snapshot.test.mts
+++ b/tests/review-snapshot.test.mts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
@@ -8,6 +7,7 @@ import {
   indexLatestGatingReviewsByAuthor,
   indexThreadsByReview,
 } from '../src/scripts/protocol-helpers.mts';
+import { readJson } from './test-utils.mts';
 
 type ReviewLike = Parameters<
   typeof indexLatestGatingReviewsByAuthor
@@ -22,17 +22,19 @@ interface SnapshotFixture {
   comments: CommentLike[];
 }
 
-const acceptedAll = readJson('fixtures/review-snapshots/accepted-all.json');
-const changesRequested = readJson(
+const acceptedAll = readJson<SnapshotFixture>(
+  'fixtures/review-snapshots/accepted-all.json',
+);
+const changesRequested = readJson<SnapshotFixture>(
   'fixtures/review-snapshots/changes-requested.json',
 );
-const latestGatingReview = readJson(
+const latestGatingReview = readJson<SnapshotFixture>(
   'fixtures/review-snapshots/latest-gating-review.json',
 );
-const truncatedThread = readJson(
+const truncatedThread = readJson<SnapshotFixture>(
   'fixtures/review-snapshots/truncated-thread.json',
 );
-const newCommentAfterF2 = readJson(
+const newCommentAfterF2 = readJson<SnapshotFixture>(
   'fixtures/review-snapshots/new-comment-after-f2.json',
 );
 
@@ -541,9 +543,3 @@ test('activity snapshot ignores pending check sentinel timestamps', () => {
   assert.equal(summary.latestCiCompletedAt, 'none');
   assert.equal(summary.latestPassingCiCompletedAt, 'none');
 });
-
-function readJson(relativePath: string): SnapshotFixture {
-  return JSON.parse(
-    readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8'),
-  ) as SnapshotFixture;
-}

--- a/tests/review-snapshot.test.mts
+++ b/tests/review-snapshot.test.mts
@@ -22,21 +22,21 @@ interface SnapshotFixture {
   comments: CommentLike[];
 }
 
-const acceptedAll = readJson<SnapshotFixture>(
+const acceptedAll = readJson(
   'fixtures/review-snapshots/accepted-all.json',
-);
-const changesRequested = readJson<SnapshotFixture>(
+) as SnapshotFixture;
+const changesRequested = readJson(
   'fixtures/review-snapshots/changes-requested.json',
-);
-const latestGatingReview = readJson<SnapshotFixture>(
+) as SnapshotFixture;
+const latestGatingReview = readJson(
   'fixtures/review-snapshots/latest-gating-review.json',
-);
-const truncatedThread = readJson<SnapshotFixture>(
+) as SnapshotFixture;
+const truncatedThread = readJson(
   'fixtures/review-snapshots/truncated-thread.json',
-);
-const newCommentAfterF2 = readJson<SnapshotFixture>(
+) as SnapshotFixture;
+const newCommentAfterF2 = readJson(
   'fixtures/review-snapshots/new-comment-after-f2.json',
-);
+) as SnapshotFixture;
 
 test('indexes the latest gating review per author', () => {
   const index = indexLatestGatingReviewsByAuthor(acceptedAll.reviews);

--- a/tests/sync-docs.test.mts
+++ b/tests/sync-docs.test.mts
@@ -1,66 +1,15 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import {
-  cpSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { test } from 'node:test';
-import { fileURLToPath } from 'node:url';
 
-// sync-docs.mts runs at module top level and calls process.exit, exporting
-// nothing, so it can only be exercised as a subprocess. The script resolves
-// its repository root by walking up from its own location to the nearest
-// package.json (resolveRepoRoot) and reads audit/sync-manifest.json relative
-// to that root — never from cwd. So a hermetic fixture must place package.json
-// and audit/sync-manifest.json next to a copy of the committed .mjs artifact.
-const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
-const SYNC_DOCS = join(REPO_ROOT, 'scripts/sync-docs.mjs');
-// sync-docs.mjs imports the shared banner/helper module, which in turn imports
-// policy-helpers; the hermetic fixture must carry that whole import closure so
-// the copied script resolves its siblings under the temp scripts/ dir.
-const SYNC_DOCS_DEPS = ['consistency-helpers.mjs', 'policy-helpers.mjs'];
+import { makeScaffoldedSyncRepo } from './test-utils.mts';
 
 interface RunResult {
   status: number;
   stdout: string;
   stderr: string;
-}
-
-// Build a self-contained fixture repo: package.json (so resolveRepoRoot stops
-// here), a copy of the real sync-docs.mjs under scripts/, the fixture
-// manifest, and any referenced source/target files.
-function makeRepo(
-  register: (cleanup: () => void) => void,
-  manifest: unknown,
-  files: Record<string, string> = {},
-): string {
-  const dir = mkdtempSync(join(tmpdir(), 'sync-docs-'));
-  register(() => rmSync(dir, { recursive: true, force: true }));
-
-  writeFile(dir, 'package.json', '{}\n');
-  mkdirSync(join(dir, 'scripts'), { recursive: true });
-  cpSync(SYNC_DOCS, join(dir, 'scripts', 'sync-docs.mjs'));
-  for (const dep of SYNC_DOCS_DEPS) {
-    cpSync(join(REPO_ROOT, 'scripts', dep), join(dir, 'scripts', dep));
-  }
-  writeFile(dir, 'audit/sync-manifest.json', JSON.stringify(manifest, null, 2));
-
-  for (const [rel, content] of Object.entries(files)) {
-    writeFile(dir, rel, content);
-  }
-  return dir;
-}
-
-function writeFile(dir: string, rel: string, content: string): void {
-  const abs = join(dir, rel);
-  mkdirSync(dirname(abs), { recursive: true });
-  writeFileSync(abs, content, 'utf8');
 }
 
 function read(dir: string, rel: string): string {
@@ -86,7 +35,7 @@ function run(dir: string, ...args: string[]): RunResult {
 }
 
 test('exact syncPair: --check reports drift without writing, --apply writes and is idempotent', (t) => {
-  const dir = makeRepo(
+  const dir = makeScaffoldedSyncRepo(
     (cleanup) => t.after(cleanup),
     {
       syncPairs: [
@@ -126,7 +75,7 @@ test('exact syncPair: --check reports drift without writing, --apply writes and 
 });
 
 test('contains and structure syncPair modes are skipped, not generated', (t) => {
-  const dir = makeRepo((cleanup) => t.after(cleanup), {
+  const dir = makeScaffoldedSyncRepo((cleanup) => t.after(cleanup), {
     syncPairs: [
       {
         id: 'pair-contains',
@@ -153,7 +102,7 @@ test('contains and structure syncPair modes are skipped, not generated', (t) => 
 });
 
 test('generatedBlock resolves explicit paths (prefix-stripped); absent paths render an empty list', (t) => {
-  const dir = makeRepo(
+  const dir = makeScaffoldedSyncRepo(
     (cleanup) => t.after(cleanup),
     {
       generatedBlocks: [
@@ -187,7 +136,7 @@ test('generatedBlock resolves explicit paths (prefix-stripped); absent paths ren
 });
 
 test('shell-file-list rewrites the "for FILE in" block from its source generatedBlock', (t) => {
-  const dir = makeRepo(
+  const dir = makeScaffoldedSyncRepo(
     (cleanup) => t.after(cleanup),
     {
       generatedBlocks: [
@@ -217,7 +166,7 @@ test('shell-file-list rewrites the "for FILE in" block from its source generated
 test('doStripPrefix mismatch sets nonZeroExit, independent of mode, short-circuiting all writes', (t) => {
   const docOriginal = blockFixture('blk');
   const otherOriginal = blockFixture('other');
-  const dir = makeRepo(
+  const dir = makeScaffoldedSyncRepo(
     (cleanup) => t.after(cleanup),
     {
       generatedBlocks: [
@@ -256,7 +205,7 @@ test('doStripPrefix mismatch sets nonZeroExit, independent of mode, short-circui
 });
 
 test('an unrecognized syncPair mode throws and exits non-zero', (t) => {
-  const dir = makeRepo((cleanup) => t.after(cleanup), {
+  const dir = makeScaffoldedSyncRepo((cleanup) => t.after(cleanup), {
     syncPairs: [
       {
         id: 'pair-bogus',
@@ -275,7 +224,7 @@ test('an unrecognized syncPair mode throws and exits non-zero', (t) => {
 });
 
 test('shell-file-list referencing an unknown generatedBlock sets nonZeroExit', (t) => {
-  const dir = makeRepo((cleanup) => t.after(cleanup), {
+  const dir = makeScaffoldedSyncRepo((cleanup) => t.after(cleanup), {
     shellFileLists: [
       { id: 'sl', file: 'sh.md', generatedBlock: 'does-not-exist' },
     ],
@@ -287,7 +236,7 @@ test('shell-file-list referencing an unknown generatedBlock sets nonZeroExit', (
 });
 
 test('generatedBlock with a missing target file sets nonZeroExit', (t) => {
-  const dir = makeRepo((cleanup) => t.after(cleanup), {
+  const dir = makeScaffoldedSyncRepo((cleanup) => t.after(cleanup), {
     generatedBlocks: [{ id: 'blk', file: 'missing.md', paths: ['x'] }],
   });
 
@@ -297,7 +246,7 @@ test('generatedBlock with a missing target file sets nonZeroExit', (t) => {
 });
 
 test('generatedBlock whose marker is absent sets nonZeroExit', (t) => {
-  const dir = makeRepo(
+  const dir = makeScaffoldedSyncRepo(
     (cleanup) => t.after(cleanup),
     { generatedBlocks: [{ id: 'blk', file: 'doc.md', paths: ['x'] }] },
     { 'doc.md': 'no markers here\n' },

--- a/tests/test-utils.mts
+++ b/tests/test-utils.mts
@@ -93,7 +93,7 @@ export function makeRepo(): {
     cleanup: () => rmSync(root, { recursive: true, force: true }),
     write: (relPath: string, content: string) => {
       const full = join(root, relPath);
-      mkdirSync(join(full, '..'), { recursive: true });
+      mkdirSync(dirname(full), { recursive: true });
       writeFileSync(full, content);
       return full;
     },

--- a/tests/test-utils.mts
+++ b/tests/test-utils.mts
@@ -21,14 +21,13 @@ const SYNC_DOCS_SCRIPT = join(REPO_ROOT, 'scripts/sync-docs.mjs');
 const SYNC_DOCS_DEPS = ['consistency-helpers.mjs', 'policy-helpers.mjs'];
 
 /**
- * Reads and JSON-parses a repo-root-relative fixture or schema file.
- * Defaults to `any` (matching `JSON.parse`'s own declared return type, and
- * every previously-untyped local copy of this function) so most callers need
- * no change; pass an explicit `T` for the callers that already narrowed
- * their local copy's return type (e.g. `readJson<SnapshotFixture>(...)`).
+ * Reads and JSON-parses a repo-root-relative fixture or schema file. Left
+ * without a return-type annotation so it infers the same permissive type
+ * `JSON.parse` itself returns — matching every previously-untyped local
+ * copy of this function without a call-site change; callers that want a
+ * narrower shape cast the result (e.g. `readJson(path) as SnapshotFixture`).
  */
-// biome-ignore lint/suspicious/noExplicitAny: matches JSON.parse's own declared return type.
-export function readJson<T = any>(relativePath: string): T {
+export function readJson(relativePath: string) {
   return JSON.parse(readText(relativePath));
 }
 

--- a/tests/test-utils.mts
+++ b/tests/test-utils.mts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { ReviewThreadNode } from '../src/scripts/resolve-review-thread.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const SYNC_DOCS_SCRIPT = join(REPO_ROOT, 'scripts/sync-docs.mjs');
+// sync-docs.mjs imports the shared banner/helper module, which in turn imports
+// policy-helpers; the hermetic fixture must carry that whole import closure so
+// the copied script resolves its siblings under the temp scripts/ dir.
+const SYNC_DOCS_DEPS = ['consistency-helpers.mjs', 'policy-helpers.mjs'];
+
+/** Reads and JSON-parses a repo-root-relative fixture or schema file. */
+export function readJson<T = unknown>(relativePath: string): T {
+  return JSON.parse(readText(relativePath)) as T;
+}
+
+/** Reads a repo-root-relative file as UTF-8 text. */
+export function readText(relativePath: string): string {
+  return readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8');
+}
+
+/** Collapses runs of whitespace to a single space and trims the ends. */
+export function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Slices `text` between `startMarker` and `endMarker`, asserting both are
+ * present (a missing end marker is a fixture bug, not an implicit EOF slice).
+ */
+export function extractSection(
+  text: string,
+  startMarker: string,
+  endMarker: string,
+): string {
+  const start = text.indexOf(startMarker);
+  assert.notEqual(start, -1, `Missing section marker: ${startMarker}`);
+  const end = text.indexOf(endMarker, start);
+  assert.notEqual(end, -1, `Missing section marker: ${endMarker}`);
+  return text.slice(start, end);
+}
+
+/**
+ * Slices `text` from `startMarker` through the next top-level (`\n## `)
+ * heading, or through EOF when `startMarker` opens the last section.
+ */
+export function extractTopLevelSection(
+  text: string,
+  fileLabel: string,
+  startMarker: string,
+): string {
+  const nextSectionMarker = '\n## ';
+  const start = text.indexOf(startMarker);
+  assert.notEqual(
+    start,
+    -1,
+    `${fileLabel} is missing section marker: ${startMarker}`,
+  );
+  const nextSectionStart = text.indexOf(
+    nextSectionMarker,
+    start + startMarker.length,
+  );
+  const end = nextSectionStart === -1 ? text.length : nextSectionStart;
+  return text.slice(start, end).trim();
+}
+
+/** Creates a hermetic temp directory with write/cleanup helpers. */
+export function makeRepo(): {
+  root: string;
+  cleanup: () => void;
+  write: (relPath: string, content: string) => string;
+} {
+  const root = mkdtempSync(join(tmpdir(), 'workshop-integrity-'));
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    write: (relPath: string, content: string) => {
+      const full = join(root, relPath);
+      mkdirSync(join(full, '..'), { recursive: true });
+      writeFileSync(full, content);
+      return full;
+    },
+  };
+}
+
+function writeScaffoldedFile(dir: string, rel: string, content: string): void {
+  const abs = join(dir, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, content, 'utf8');
+}
+
+/**
+ * Builds a self-contained sync-docs fixture repo: `package.json` (so
+ * `resolveRepoRoot` stops here), a copy of the real `sync-docs.mjs` under
+ * `scripts/` plus its import closure, the fixture manifest, and any
+ * referenced source/target files. `register` is called with a cleanup
+ * callback (e.g. `(cleanup) => t.after(cleanup)`).
+ */
+export function makeScaffoldedSyncRepo(
+  register: (cleanup: () => void) => void,
+  manifest: unknown,
+  files: Record<string, string> = {},
+): string {
+  const dir = mkdtempSync(join(tmpdir(), 'sync-docs-'));
+  register(() => rmSync(dir, { recursive: true, force: true }));
+
+  writeScaffoldedFile(dir, 'package.json', '{}\n');
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  cpSync(SYNC_DOCS_SCRIPT, join(dir, 'scripts', 'sync-docs.mjs'));
+  for (const dep of SYNC_DOCS_DEPS) {
+    cpSync(join(REPO_ROOT, 'scripts', dep), join(dir, 'scripts', dep));
+  }
+  writeScaffoldedFile(
+    dir,
+    'audit/sync-manifest.json',
+    JSON.stringify(manifest, null, 2),
+  );
+
+  for (const [rel, content] of Object.entries(files)) {
+    writeScaffoldedFile(dir, rel, content);
+  }
+  return dir;
+}
+
+/** Builds a merged-pr-feedback-sweep review-thread fixture. */
+export function buildCommentThread(
+  isResolved: boolean,
+  comments: { login: string; body: string; createdAt: string; url?: string }[],
+  path = 'src/x.mts',
+) {
+  return {
+    isResolved,
+    path,
+    comments: {
+      nodes: comments.map((c) => ({
+        body: c.body,
+        url: c.url ?? 'https://example/thread',
+        createdAt: c.createdAt,
+        author: { login: c.login },
+      })),
+    },
+  };
+}
+
+/** Builds a resolve-review-thread GraphQL review-thread-node fixture. */
+export function buildReviewThreadNode(
+  id: string,
+  isResolved: boolean,
+  commentDatabaseIds: number[],
+): ReviewThreadNode {
+  return {
+    id,
+    isResolved,
+    comments: {
+      nodes: commentDatabaseIds.map((databaseId) => ({ databaseId })),
+    },
+  };
+}

--- a/tests/test-utils.mts
+++ b/tests/test-utils.mts
@@ -20,9 +20,16 @@ const SYNC_DOCS_SCRIPT = join(REPO_ROOT, 'scripts/sync-docs.mjs');
 // the copied script resolves its siblings under the temp scripts/ dir.
 const SYNC_DOCS_DEPS = ['consistency-helpers.mjs', 'policy-helpers.mjs'];
 
-/** Reads and JSON-parses a repo-root-relative fixture or schema file. */
-export function readJson<T = unknown>(relativePath: string): T {
-  return JSON.parse(readText(relativePath)) as T;
+/**
+ * Reads and JSON-parses a repo-root-relative fixture or schema file.
+ * Defaults to `any` (matching `JSON.parse`'s own declared return type, and
+ * every previously-untyped local copy of this function) so most callers need
+ * no change; pass an explicit `T` for the callers that already narrowed
+ * their local copy's return type (e.g. `readJson<SnapshotFixture>(...)`).
+ */
+// biome-ignore lint/suspicious/noExplicitAny: matches JSON.parse's own declared return type.
+export function readJson<T = any>(relativePath: string): T {
+  return JSON.parse(readText(relativePath));
 }
 
 /** Reads a repo-root-relative file as UTF-8 text. */

--- a/tests/verify-workshop-integrity.test.mts
+++ b/tests/verify-workshop-integrity.test.mts
@@ -1,12 +1,5 @@
 import assert from 'node:assert/strict';
-import {
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { test } from 'node:test';
 
@@ -22,20 +15,7 @@ import {
   stripHtmlComments,
   stripInlineCodeSpans,
 } from '../src/scripts/verify-workshop-integrity.mts';
-
-function makeRepo() {
-  const root = mkdtempSync(join(tmpdir(), 'workshop-integrity-'));
-  return {
-    root,
-    cleanup: () => rmSync(root, { recursive: true, force: true }),
-    write: (relPath: string, content: string) => {
-      const full = join(root, relPath);
-      mkdirSync(join(full, '..'), { recursive: true });
-      writeFileSync(full, content);
-      return full;
-    },
-  };
-}
+import { makeRepo } from './test-utils.mts';
 
 test('slugifyHeading mirrors GitHub heading slug algorithm', () => {
   assert.equal(slugifyHeading('Hello World'), 'hello-world');


### PR DESCRIPTION
## Summary

Consolidates 7 duplicated test utility functions (`readJson`, `readText`,
`normalizeWhitespace`, `extractSection`, `extractTopLevelSection`,
`makeRepo`, `thread`), previously re-defined locally across 16 test
files, into one new shared module: `tests/test-utils.mts`.

Full design rationale (4 real divergences found and how each was
resolved) is posted as the implementation-plan comment on #1211 before
this PR existed. Short version:

- `readJson`/`readText` standardize on the majority repo-root-relative
  path resolution; `consistency.test.mts`'s 5 call sites (the one file
  that resolved against a `tests/fixtures/`-relative base) get a
  `tests/fixtures/` path prefix instead.
- `extractSection` consolidates on the stricter required-end-marker,
  assert-both variant — a strict behavioral superset for every existing
  caller (verified: `issue-author-approval-gate.test.mts`'s 8 call sites
  all already passed both markers).
- `makeRepo` (sync-docs.test.mts) and `thread`
  (merged-pr-feedback-sweep.test.mts / resolve-review-thread.test.mts)
  turned out to be genuinely different implementations that happened to
  share a name, not copies of each other — split into 4 distinctly-named
  exports (`makeRepo` + `makeScaffoldedSyncRepo`;
  `buildCommentThread` + `buildReviewThreadNode`) instead of forcing one
  signature onto unrelated fixture shapes.
- `readJson`'s shared implementation is left without a return-type
  annotation (relying on `JSON.parse`'s own inferred type) rather than a
  generic defaulting to an explicit permissive type, since the repo's
  `type-suppression-budgets` audit caps that token's occurrences at 0;
  the one caller that wants a narrower shape
  (`review-snapshot.test.mts`) casts the result instead of using a
  generic argument.

No test cases were added, removed, or changed — this is utility
plumbing only.

## Test plan

- [x] `grep -rn "function readJson\|function makeRepo\|function readText" tests`
      matches only `tests/test-utils.mts` (the issue's acceptance
      criterion)
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes at the same count as before (1,502/1,502, 0
      failures)
- [x] `pnpm run lint:minimum` passes in full (audit-docs, typecheck,
      build:check, biome, dprint, tests, verify-workshop-integrity,
      cspell, markdownlint)
- [x] Independent critique pass (fresh-context review agent) found no
      correctness or behavioral-fidelity issues

Closes #1211
