### PR TITLE
fix(helpers): stop import-time CLI execution in 3 helpers

### DIFF
--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -6,6 +6,8 @@
 // .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   readAdvisoryPrimaryBotLogin,
   readAdvisorySecondaryBotLogin,
@@ -18,98 +20,118 @@ import {
   resolveTrustedMarkerActors,
 } from './protocol-helpers.mjs';
 
-const args = parseArgs(process.argv.slice(2));
-if (!args.prNumber) {
-  throw new Error('missing required --pr <number> argument');
+if (isCliExecution()) {
+  main();
 }
-const owner =
-  args.owner ||
-  ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-const repo =
-  args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-const repoRef = `${owner}/${repo}`;
-const viewerLogin = safeGhText(['api', 'user', '--jq', '.login']).toLowerCase();
-const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
-  resolveTrustedMarkerActors({
-    flagValue: args.trustedMarkerLogins,
-    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
-    config: loadIddConfig(),
-  });
-const prHeadSha = ghText([
-  'pr',
-  'view',
-  String(args.prNumber),
-  '-R',
-  repoRef,
-  '--json',
-  'headRefOid',
-  '--jq',
-  '.headRefOid',
-]);
-const reviews = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-  true,
-);
-const requestedReviewers = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
-  false,
-);
-const timelineEvents = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
-  true,
-  ['-H', 'Accept: application/vnd.github+json'],
-);
-const comments = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-  true,
-);
-const collaboratorTrustEnabled = isTruthy(
-  process.env.IDD_TRUST_COLLABORATOR_MARKERS,
-);
-const trustedMarkerLogins = normalizeTrustedMarkerLogins([
-  viewerLogin,
-  ...configuredTrustedActors,
-  ...(collaboratorTrustEnabled
-    ? resolveTrustedCollaboratorMarkerLogins(owner, repo, comments)
-    : []),
-]);
-const advisoryWaitPolicy = readAdvisoryWaitPolicy();
-const primaryBotLogin = readAdvisoryPrimaryBotLogin();
-const secondaryBotLogin = readAdvisorySecondaryBotLogin();
-const summary = buildAdvisoryWaitSummary(
-  {
-    prHeadSha,
-    reviews,
-    requestedReviewers: requestedReviewers.users ?? [],
-    timelineEvents,
-    comments: comments.map(normalizeComment),
-  },
-  {
-    now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
-    requestCap: advisoryWaitPolicy.requestCap,
-    pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
-    settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
-    pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
-    capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
-    primaryBotLogin,
-    secondaryBotLogin,
+// The CLI body. Guarded behind isCliExecution() so importing this module (for
+// unit tests) does not parse process.argv, fail, or make a `gh` call —
+// matching the sibling-helper convention (see isCliExecution() in
+// live-status-digest.mts).
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const viewerLogin = safeGhText([
+    'api',
+    'user',
+    '--jq',
+    '.login',
+  ]).toLowerCase();
+  const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: loadIddConfig(),
+    });
+  const prHeadSha = ghText([
+    'pr',
+    'view',
+    String(args.prNumber),
+    '-R',
+    repoRef,
+    '--json',
+    'headRefOid',
+    '--jq',
+    '.headRefOid',
+  ]);
+  const reviews = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
+    true,
+  );
+  const requestedReviewers = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
+    false,
+  );
+  const timelineEvents = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
+    true,
+    ['-H', 'Accept: application/vnd.github+json'],
+  );
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    true,
+  );
+  const collaboratorTrustEnabled = isTruthy(
+    process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+  );
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins([
     viewerLogin,
-    configuredTrustedActors,
-    collaboratorTrustEnabled,
-    trustedMarkerLogins,
-  },
-);
-process.stdout.write(
-  `${JSON.stringify(
+    ...configuredTrustedActors,
+    ...(collaboratorTrustEnabled
+      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, comments)
+      : []),
+  ]);
+  const advisoryWaitPolicy = readAdvisoryWaitPolicy();
+  const primaryBotLogin = readAdvisoryPrimaryBotLogin();
+  const secondaryBotLogin = readAdvisorySecondaryBotLogin();
+  const summary = buildAdvisoryWaitSummary(
     {
-      ...summary,
-      trustedMarkerActors: configuredTrustedActors,
-      trustedMarkerActorsSource,
+      prHeadSha,
+      reviews,
+      requestedReviewers: requestedReviewers.users ?? [],
+      timelineEvents,
+      comments: comments.map(normalizeComment),
     },
-    null,
-    2,
-  )}\n`,
-);
+    {
+      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      requestCap: advisoryWaitPolicy.requestCap,
+      pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
+      settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
+      pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
+      capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
+      primaryBotLogin,
+      secondaryBotLogin,
+      viewerLogin,
+      configuredTrustedActors,
+      collaboratorTrustEnabled,
+      trustedMarkerLogins,
+    },
+  );
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        ...summary,
+        trustedMarkerActors: configuredTrustedActors,
+        trustedMarkerActorsSource,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+function isCliExecution() {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
 function parseArgs(argv) {
   const parsed = {
     prNumber: null,

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -6,6 +6,8 @@
 // .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { computeReportSummary } from './audit-pr-cleanup-summary.mjs';
 import {
   isAuthorizedForcedHandoffActor,
@@ -32,80 +34,64 @@ const trustedMarkerAuthorCache = new Map();
 const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerActorSources = null;
 let cachedCurrentViewerLogin = null;
-const args = parseArgs(process.argv.slice(2));
-if (args.help) {
-  printUsage();
-  process.exit(0);
+if (isCliExecution()) {
+  await main();
 }
-if (!args.pr) {
-  fail('missing required --pr <number>');
-}
-if (args.apply && args.dryRun) {
-  fail('choose only one of --dry-run or --apply');
-}
-if (!args.apply) {
-  args.dryRun = true;
-}
-if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
-  fail(
-    '--skip-claim-check cannot be combined with --claim-issue or --claim-id',
-  );
-}
-if (args.apply && !args.skipClaimCheck && (!args.claimIssue || !args.claimId)) {
-  fail(
-    '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
-  );
-}
-const repository = args.repo ?? detectRepository();
-const [owner, repo] = parseRepository(repository);
-const prNumber = parsePositiveInteger(args.pr, '--pr');
-const claimContext = {
-  expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, prNumber),
-  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
-  // a legitimate issue-only handoff that predates the PR is honored even
-  // against this PR-backed claim. Resolve it once for both claim asserts.
-  prFirstCommitAt: args.apply
-    ? fetchPrFirstCommitAt(owner, repo, prNumber)
-    : null,
-};
-if (args.claimIssue) {
-  args.claimIssue = String(
-    parsePositiveInteger(args.claimIssue, '--claim-issue'),
-  );
-}
-const report = await buildReport(owner, repo, prNumber);
-if (args.apply) {
-  report.mode = 'apply';
-  for (const candidate of report.candidates) {
-    if (!args.skipClaimCheck) {
-      try {
-        assertActiveClaim(
-          owner,
-          repo,
-          args.claimIssue,
-          args.agentId,
-          args.claimId,
-          claimContext,
-        );
-      } catch (error) {
-        report.failed.push({
-          ...candidate,
-          error: error.message,
-        });
-        break;
-      }
-    }
-    try {
-      const freshCandidate = await revalidateCandidate(
-        owner,
-        repo,
-        prNumber,
-        candidate,
-        report,
-      );
-      if (!freshCandidate) {
-        continue;
-      }
+// The CLI body. Guarded behind isCliExecution() so importing this module (for
+// unit tests) does not parse process.argv, fail, or make a `gh` call —
+// matching the sibling-helper convention (see isCliExecution() in
+// live-status-digest.mts). This one stays async because it retains a
+// pre-existing await (buildReport) from before the guard was added.
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+  if (!args.pr) {
+    fail('missing required --pr <number>');
+  }
+  if (args.apply && args.dryRun) {
+    fail('choose only one of --dry-run or --apply');
+  }
+  if (!args.apply) {
+    args.dryRun = true;
+  }
+  if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
+    fail(
+      '--skip-claim-check cannot be combined with --claim-issue or --claim-id',
+    );
+  }
+  if (
+    args.apply &&
+    !args.skipClaimCheck &&
+    (!args.claimIssue || !args.claimId)
+  ) {
+    fail(
+      '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
+    );
+  }
+  const repository = args.repo ?? detectRepository();
+  const [owner, repo] = parseRepository(repository);
+  const prNumber = parsePositiveInteger(args.pr, '--pr');
+  const claimContext = {
+    expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, prNumber),
+    // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
+    // a legitimate issue-only handoff that predates the PR is honored even
+    // against this PR-backed claim. Resolve it once for both claim asserts.
+    prFirstCommitAt: args.apply
+      ? fetchPrFirstCommitAt(owner, repo, prNumber)
+      : null,
+  };
+  if (args.claimIssue) {
+    args.claimIssue = String(
+      parsePositiveInteger(args.claimIssue, '--claim-issue'),
+    );
+  }
+  const report = await buildReport(owner, repo, prNumber);
+  if (args.apply) {
+    report.mode = 'apply';
+    for (const candidate of report.candidates) {
       if (!args.skipClaimCheck) {
         try {
           assertActiveClaim(
@@ -118,36 +104,72 @@ if (args.apply) {
           );
         } catch (error) {
           report.failed.push({
-            ...freshCandidate,
+            ...candidate,
             error: error.message,
           });
           break;
         }
       }
-      const minimized = minimizeComment(
-        freshCandidate.subjectId,
-        freshCandidate.classifier,
-      );
-      report.applied.push({
-        ...freshCandidate,
-        isMinimized: minimized.isMinimized,
-        minimizedReason: minimized.minimizedReason,
-      });
-    } catch (error) {
-      report.failed.push({
-        ...candidate,
-        error: error.message,
-      });
+      try {
+        const freshCandidate = await revalidateCandidate(
+          owner,
+          repo,
+          prNumber,
+          candidate,
+          report,
+        );
+        if (!freshCandidate) {
+          continue;
+        }
+        if (!args.skipClaimCheck) {
+          try {
+            assertActiveClaim(
+              owner,
+              repo,
+              args.claimIssue,
+              args.agentId,
+              args.claimId,
+              claimContext,
+            );
+          } catch (error) {
+            report.failed.push({
+              ...freshCandidate,
+              error: error.message,
+            });
+            break;
+          }
+        }
+        const minimized = minimizeComment(
+          freshCandidate.subjectId,
+          freshCandidate.classifier,
+        );
+        report.applied.push({
+          ...freshCandidate,
+          isMinimized: minimized.isMinimized,
+          minimizedReason: minimized.minimizedReason,
+        });
+      } catch (error) {
+        report.failed.push({
+          ...candidate,
+          error: error.message,
+        });
+      }
+    }
+    computeReportSummary(report);
+    if (report.failed.length > 0) {
+      writeReport(report, args.format);
+      process.exit(1);
     }
   }
   computeReportSummary(report);
-  if (report.failed.length > 0) {
-    writeReport(report, args.format);
-    process.exit(1);
-  }
+  writeReport(report, args.format);
 }
-computeReportSummary(report);
-writeReport(report, args.format);
+function isCliExecution() {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
 // Build an IDD-scoped disposition-author predicate from the resolved
 // trusted-marker actors (the accounts the IDD agent posts dispositions under).
 // The non-gate `hasFreshDisposition` callers must use this so a human

--- a/scripts/review-activity-snapshot.mjs
+++ b/scripts/review-activity-snapshot.mjs
@@ -6,103 +6,120 @@
 // generated .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   buildActivitySnapshotSummary,
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
 } from './protocol-helpers.mjs';
 
-const args = parseArgs(process.argv.slice(2));
-if (!args.prNumber) {
-  throw new Error('missing required --pr <number> argument');
+if (isCliExecution()) {
+  main();
 }
-const owner =
-  args.owner ||
-  ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-const repo =
-  args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-const repoRef = `${owner}/${repo}`;
-const iddConfig = loadIddConfig();
-const { actors: trustedMarkerLogins, source: trustedMarkerActorsSource } =
-  resolveTrustedMarkerActors({
-    flagValue: args.trustedMarkerLogins,
-    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
-    config: iddConfig,
-  });
-const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
-  resolveAdvisoryBotLogins({
-    flagValue: args.advisoryBotLogins,
-    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
-    config: iddConfig,
-  });
-const headSha = ghText([
-  'pr',
-  'view',
-  String(args.prNumber),
-  '-R',
-  repoRef,
-  '--json',
-  'headRefOid',
-  '--jq',
-  '.headRefOid',
-]);
-const checks = ghJson(
-  [
+// The CLI body. Guarded behind isCliExecution() so importing this module (for
+// unit tests) does not parse process.argv, fail, or make a `gh` call —
+// matching the sibling-helper convention (see isCliExecution() in
+// live-status-digest.mts).
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const iddConfig = loadIddConfig();
+  const { actors: trustedMarkerLogins, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: iddConfig,
+    });
+  const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
+    resolveAdvisoryBotLogins({
+      flagValue: args.advisoryBotLogins,
+      envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+      config: iddConfig,
+    });
+  const headSha = ghText([
     'pr',
-    'checks',
+    'view',
     String(args.prNumber),
     '-R',
     repoRef,
     '--json',
-    'name,state,completedAt',
+    'headRefOid',
     '--jq',
-    '.',
-  ],
-  { allowStatuses: [1, 8] },
-);
-const reviews = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-  true,
-);
-const comments = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-  true,
-);
-const threads = fetchReviewThreads(owner, repo, args.prNumber);
-const summary = buildActivitySnapshotSummary(
-  {
-    comments: comments.map(normalizeComment),
-    reviews: reviews.map(normalizeReview),
-    threads: threads.map(normalizeThread),
-    checks,
-  },
-  {
-    trustedMarkerLogins,
-    advisoryBotLogins,
-    advisoryBotLoginsSource,
-    // Advisory bots are excluded from disposition authorship inside the
-    // summary builder, so the trusted-marker set is a safe default here.
-    dispositionAuthorLogins: trustedMarkerLogins,
-  },
-);
-process.stdout.write(
-  `${JSON.stringify(
+    '.headRefOid',
+  ]);
+  const checks = ghJson(
+    [
+      'pr',
+      'checks',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'name,state,completedAt',
+      '--jq',
+      '.',
+    ],
+    { allowStatuses: [1, 8] },
+  );
+  const reviews = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
+    true,
+  );
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    true,
+  );
+  const threads = fetchReviewThreads(owner, repo, args.prNumber);
+  const summary = buildActivitySnapshotSummary(
     {
-      headSha,
-      trustedMarkerActors: trustedMarkerLogins,
-      trustedMarkerActorsSource,
-      totalItemCount: summary.totalItemCount,
-      maxActivityUpdatedAt: summary.maxActivityUpdatedAt,
-      latestCiCompletedAt: summary.latestCiCompletedAt,
-      latestPassingCiCompletedAt: summary.latestPassingCiCompletedAt,
-      counts: summary.counts,
-      ackOnly: summary.ackOnly,
-      effective: summary.effective,
+      comments: comments.map(normalizeComment),
+      reviews: reviews.map(normalizeReview),
+      threads: threads.map(normalizeThread),
+      checks,
     },
-    null,
-    2,
-  )}\n`,
-);
+    {
+      trustedMarkerLogins,
+      advisoryBotLogins,
+      advisoryBotLoginsSource,
+      // Advisory bots are excluded from disposition authorship inside the
+      // summary builder, so the trusted-marker set is a safe default here.
+      dispositionAuthorLogins: trustedMarkerLogins,
+    },
+  );
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        headSha,
+        trustedMarkerActors: trustedMarkerLogins,
+        trustedMarkerActorsSource,
+        totalItemCount: summary.totalItemCount,
+        maxActivityUpdatedAt: summary.maxActivityUpdatedAt,
+        latestCiCompletedAt: summary.latestCiCompletedAt,
+        latestPassingCiCompletedAt: summary.latestPassingCiCompletedAt,
+        counts: summary.counts,
+        ackOnly: summary.ackOnly,
+        effective: summary.effective,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+function isCliExecution() {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
 function loadIddConfig() {
   try {
     return JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));

--- a/src/scripts/advisory-wait-state.mts
+++ b/src/scripts/advisory-wait-state.mts
@@ -7,6 +7,8 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   readAdvisoryPrimaryBotLogin,
@@ -69,104 +71,126 @@ export type AdvisoryWaitStateReport = ReturnType<
   trustedMarkerActorsSource: TrustedMarkerActorResolution['source'];
 };
 
-const args = parseArgs(process.argv.slice(2));
-if (!args.prNumber) {
-  throw new Error('missing required --pr <number> argument');
+if (isCliExecution()) {
+  main();
 }
 
-const owner =
-  args.owner ||
-  ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-const repo =
-  args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-const repoRef = `${owner}/${repo}`;
-const viewerLogin = safeGhText(['api', 'user', '--jq', '.login']).toLowerCase();
-const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
-  resolveTrustedMarkerActors({
-    flagValue: args.trustedMarkerLogins,
-    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
-    config: loadIddConfig(),
-  });
+// The CLI body. Guarded behind isCliExecution() so importing this module (for
+// unit tests) does not parse process.argv, fail, or make a `gh` call —
+// matching the sibling-helper convention (see isCliExecution() in
+// live-status-digest.mts).
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
 
-const prHeadSha = ghText([
-  'pr',
-  'view',
-  String(args.prNumber),
-  '-R',
-  repoRef,
-  '--json',
-  'headRefOid',
-  '--jq',
-  '.headRefOid',
-]);
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const viewerLogin = safeGhText([
+    'api',
+    'user',
+    '--jq',
+    '.login',
+  ]).toLowerCase();
+  const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: loadIddConfig(),
+    });
 
-const reviews = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-  true,
-) as ReviewPayload[];
-const requestedReviewers = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
-  false,
-) as { users?: GhAuthorPayload[] | null };
-const timelineEvents = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
-  true,
-  ['-H', 'Accept: application/vnd.github+json'],
-) as TimelineEventPayload[];
-const comments = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-  true,
-) as IssueCommentPayload[];
+  const prHeadSha = ghText([
+    'pr',
+    'view',
+    String(args.prNumber),
+    '-R',
+    repoRef,
+    '--json',
+    'headRefOid',
+    '--jq',
+    '.headRefOid',
+  ]);
 
-const collaboratorTrustEnabled = isTruthy(
-  process.env.IDD_TRUST_COLLABORATOR_MARKERS,
-);
-const trustedMarkerLogins = normalizeTrustedMarkerLogins([
-  viewerLogin,
-  ...configuredTrustedActors,
-  ...(collaboratorTrustEnabled
-    ? resolveTrustedCollaboratorMarkerLogins(owner, repo, comments)
-    : []),
-]);
-const advisoryWaitPolicy = readAdvisoryWaitPolicy();
-const primaryBotLogin = readAdvisoryPrimaryBotLogin();
-const secondaryBotLogin = readAdvisorySecondaryBotLogin();
+  const reviews = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
+    true,
+  ) as ReviewPayload[];
+  const requestedReviewers = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
+    false,
+  ) as { users?: GhAuthorPayload[] | null };
+  const timelineEvents = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
+    true,
+    ['-H', 'Accept: application/vnd.github+json'],
+  ) as TimelineEventPayload[];
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    true,
+  ) as IssueCommentPayload[];
 
-const summary = buildAdvisoryWaitSummary(
-  {
-    prHeadSha,
-    reviews,
-    requestedReviewers: requestedReviewers.users ?? [],
-    timelineEvents,
-    comments: comments.map(normalizeComment),
-  },
-  {
-    now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
-    requestCap: advisoryWaitPolicy.requestCap,
-    pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
-    settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
-    pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
-    capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
-    primaryBotLogin,
-    secondaryBotLogin,
+  const collaboratorTrustEnabled = isTruthy(
+    process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+  );
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins([
     viewerLogin,
-    configuredTrustedActors,
-    collaboratorTrustEnabled,
-    trustedMarkerLogins,
-  },
-);
+    ...configuredTrustedActors,
+    ...(collaboratorTrustEnabled
+      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, comments)
+      : []),
+  ]);
+  const advisoryWaitPolicy = readAdvisoryWaitPolicy();
+  const primaryBotLogin = readAdvisoryPrimaryBotLogin();
+  const secondaryBotLogin = readAdvisorySecondaryBotLogin();
 
-process.stdout.write(
-  `${JSON.stringify(
+  const summary = buildAdvisoryWaitSummary(
     {
-      ...summary,
-      trustedMarkerActors: configuredTrustedActors,
-      trustedMarkerActorsSource,
+      prHeadSha,
+      reviews,
+      requestedReviewers: requestedReviewers.users ?? [],
+      timelineEvents,
+      comments: comments.map(normalizeComment),
     },
-    null,
-    2,
-  )}\n`,
-);
+    {
+      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      requestCap: advisoryWaitPolicy.requestCap,
+      pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
+      settledWindowMinutes: advisoryWaitPolicy.settledWindowMinutes,
+      pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
+      capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
+      primaryBotLogin,
+      secondaryBotLogin,
+      viewerLogin,
+      configuredTrustedActors,
+      collaboratorTrustEnabled,
+      trustedMarkerLogins,
+    },
+  );
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        ...summary,
+        trustedMarkerActors: configuredTrustedActors,
+        trustedMarkerActorsSource,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function isCliExecution(): boolean {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
 
 function parseArgs(argv: string[]): AdvisoryWaitStateArgs {
   const parsed: AdvisoryWaitStateArgs = {

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -7,6 +7,8 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { CleanupReport } from './audit-pr-cleanup-summary.mts';
 import { computeReportSummary } from './audit-pr-cleanup-summary.mts';
 import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
@@ -188,91 +190,76 @@ let cachedConfiguredTrustedMarkerActorSources: {
 } | null = null;
 let cachedCurrentViewerLogin: string | null = null;
 
-const args = parseArgs(process.argv.slice(2));
-
-if (args.help) {
-  printUsage();
-  process.exit(0);
+if (isCliExecution()) {
+  await main();
 }
 
-if (!args.pr) {
-  fail('missing required --pr <number>');
-}
+// The CLI body. Guarded behind isCliExecution() so importing this module (for
+// unit tests) does not parse process.argv, fail, or make a `gh` call —
+// matching the sibling-helper convention (see isCliExecution() in
+// live-status-digest.mts). This one stays async because it retains a
+// pre-existing await (buildReport) from before the guard was added.
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
 
-if (args.apply && args.dryRun) {
-  fail('choose only one of --dry-run or --apply');
-}
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
 
-if (!args.apply) {
-  args.dryRun = true;
-}
+  if (!args.pr) {
+    fail('missing required --pr <number>');
+  }
 
-if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
-  fail(
-    '--skip-claim-check cannot be combined with --claim-issue or --claim-id',
-  );
-}
+  if (args.apply && args.dryRun) {
+    fail('choose only one of --dry-run or --apply');
+  }
 
-if (args.apply && !args.skipClaimCheck && (!args.claimIssue || !args.claimId)) {
-  fail(
-    '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
-  );
-}
+  if (!args.apply) {
+    args.dryRun = true;
+  }
 
-const repository = args.repo ?? detectRepository();
-const [owner, repo] = parseRepository(repository);
+  if (args.apply && args.skipClaimCheck && (args.claimIssue || args.claimId)) {
+    fail(
+      '--skip-claim-check cannot be combined with --claim-issue or --claim-id',
+    );
+  }
 
-const prNumber = parsePositiveInteger(args.pr, '--pr');
-const claimContext = {
-  expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, prNumber),
-  // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
-  // a legitimate issue-only handoff that predates the PR is honored even
-  // against this PR-backed claim. Resolve it once for both claim asserts.
-  prFirstCommitAt: args.apply
-    ? fetchPrFirstCommitAt(owner, repo, prNumber)
-    : null,
-};
+  if (
+    args.apply &&
+    !args.skipClaimCheck &&
+    (!args.claimIssue || !args.claimId)
+  ) {
+    fail(
+      '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
+    );
+  }
 
-if (args.claimIssue) {
-  args.claimIssue = String(
-    parsePositiveInteger(args.claimIssue, '--claim-issue'),
-  );
-}
+  const repository = args.repo ?? detectRepository();
+  const [owner, repo] = parseRepository(repository);
 
-const report = await buildReport(owner, repo, prNumber);
+  const prNumber = parsePositiveInteger(args.pr, '--pr');
+  const claimContext = {
+    expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, prNumber),
+    // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
+    // a legitimate issue-only handoff that predates the PR is honored even
+    // against this PR-backed claim. Resolve it once for both claim asserts.
+    prFirstCommitAt: args.apply
+      ? fetchPrFirstCommitAt(owner, repo, prNumber)
+      : null,
+  };
 
-if (args.apply) {
-  report.mode = 'apply';
-  for (const candidate of report.candidates) {
-    if (!args.skipClaimCheck) {
-      try {
-        assertActiveClaim(
-          owner,
-          repo,
-          args.claimIssue,
-          args.agentId,
-          args.claimId,
-          claimContext,
-        );
-      } catch (error) {
-        report.failed.push({
-          ...candidate,
-          error: (error as Error).message,
-        });
-        break;
-      }
-    }
-    try {
-      const freshCandidate = await revalidateCandidate(
-        owner,
-        repo,
-        prNumber,
-        candidate,
-        report,
-      );
-      if (!freshCandidate) {
-        continue;
-      }
+  if (args.claimIssue) {
+    args.claimIssue = String(
+      parsePositiveInteger(args.claimIssue, '--claim-issue'),
+    );
+  }
+
+  const report = await buildReport(owner, repo, prNumber);
+
+  if (args.apply) {
+    report.mode = 'apply';
+    for (const candidate of report.candidates) {
       if (!args.skipClaimCheck) {
         try {
           assertActiveClaim(
@@ -285,38 +272,75 @@ if (args.apply) {
           );
         } catch (error) {
           report.failed.push({
-            ...freshCandidate,
+            ...candidate,
             error: (error as Error).message,
           });
           break;
         }
       }
-      const minimized = minimizeComment(
-        freshCandidate.subjectId,
-        freshCandidate.classifier,
-      );
-      report.applied.push({
-        ...freshCandidate,
-        isMinimized: minimized.isMinimized,
-        minimizedReason: minimized.minimizedReason,
-      });
-    } catch (error) {
-      report.failed.push({
-        ...candidate,
-        error: (error as Error).message,
-      });
+      try {
+        const freshCandidate = await revalidateCandidate(
+          owner,
+          repo,
+          prNumber,
+          candidate,
+          report,
+        );
+        if (!freshCandidate) {
+          continue;
+        }
+        if (!args.skipClaimCheck) {
+          try {
+            assertActiveClaim(
+              owner,
+              repo,
+              args.claimIssue,
+              args.agentId,
+              args.claimId,
+              claimContext,
+            );
+          } catch (error) {
+            report.failed.push({
+              ...freshCandidate,
+              error: (error as Error).message,
+            });
+            break;
+          }
+        }
+        const minimized = minimizeComment(
+          freshCandidate.subjectId,
+          freshCandidate.classifier,
+        );
+        report.applied.push({
+          ...freshCandidate,
+          isMinimized: minimized.isMinimized,
+          minimizedReason: minimized.minimizedReason,
+        });
+      } catch (error) {
+        report.failed.push({
+          ...candidate,
+          error: (error as Error).message,
+        });
+      }
+    }
+
+    computeReportSummary(report);
+    if (report.failed.length > 0) {
+      writeReport(report, args.format);
+      process.exit(1);
     }
   }
 
   computeReportSummary(report);
-  if (report.failed.length > 0) {
-    writeReport(report, args.format);
-    process.exit(1);
-  }
+  writeReport(report, args.format);
 }
 
-computeReportSummary(report);
-writeReport(report, args.format);
+function isCliExecution(): boolean {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
 
 // Build an IDD-scoped disposition-author predicate from the resolved
 // trusted-marker actors (the accounts the IDD agent posts dispositions under).

--- a/src/scripts/review-activity-snapshot.mts
+++ b/src/scripts/review-activity-snapshot.mts
@@ -7,6 +7,8 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   buildActivitySnapshotSummary,
@@ -82,101 +84,118 @@ interface ReviewActivitySnapshotArgs {
   advisoryBotLogins: string;
 }
 
-const args = parseArgs(process.argv.slice(2));
-if (!args.prNumber) {
-  throw new Error('missing required --pr <number> argument');
+if (isCliExecution()) {
+  main();
 }
 
-const owner =
-  args.owner ||
-  ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-const repo =
-  args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-const repoRef = `${owner}/${repo}`;
-const iddConfig = loadIddConfig();
-const { actors: trustedMarkerLogins, source: trustedMarkerActorsSource } =
-  resolveTrustedMarkerActors({
-    flagValue: args.trustedMarkerLogins,
-    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
-    config: iddConfig,
-  });
-const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
-  resolveAdvisoryBotLogins({
-    flagValue: args.advisoryBotLogins,
-    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
-    config: iddConfig,
-  });
+// The CLI body. Guarded behind isCliExecution() so importing this module (for
+// unit tests) does not parse process.argv, fail, or make a `gh` call —
+// matching the sibling-helper convention (see isCliExecution() in
+// live-status-digest.mts).
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
 
-const headSha = ghText([
-  'pr',
-  'view',
-  String(args.prNumber),
-  '-R',
-  repoRef,
-  '--json',
-  'headRefOid',
-  '--jq',
-  '.headRefOid',
-]);
-const checks = ghJson(
-  [
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const iddConfig = loadIddConfig();
+  const { actors: trustedMarkerLogins, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: iddConfig,
+    });
+  const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
+    resolveAdvisoryBotLogins({
+      flagValue: args.advisoryBotLogins,
+      envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+      config: iddConfig,
+    });
+
+  const headSha = ghText([
     'pr',
-    'checks',
+    'view',
     String(args.prNumber),
     '-R',
     repoRef,
     '--json',
-    'name,state,completedAt',
+    'headRefOid',
     '--jq',
-    '.',
-  ],
-  { allowStatuses: [1, 8] },
-) as CheckPayload[];
-const reviews = ghApiJson(
-  `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-  true,
-) as ReviewPayload[];
-const comments = ghApiJson(
-  `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-  true,
-) as IssueCommentPayload[];
-const threads = fetchReviewThreads(owner, repo, args.prNumber);
+    '.headRefOid',
+  ]);
+  const checks = ghJson(
+    [
+      'pr',
+      'checks',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'name,state,completedAt',
+      '--jq',
+      '.',
+    ],
+    { allowStatuses: [1, 8] },
+  ) as CheckPayload[];
+  const reviews = ghApiJson(
+    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
+    true,
+  ) as ReviewPayload[];
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    true,
+  ) as IssueCommentPayload[];
+  const threads = fetchReviewThreads(owner, repo, args.prNumber);
 
-const summary = buildActivitySnapshotSummary(
-  {
-    comments: comments.map(normalizeComment),
-    reviews: reviews.map(normalizeReview),
-    threads: threads.map(normalizeThread),
-    checks,
-  },
-  {
-    trustedMarkerLogins,
-    advisoryBotLogins,
-    advisoryBotLoginsSource,
-    // Advisory bots are excluded from disposition authorship inside the
-    // summary builder, so the trusted-marker set is a safe default here.
-    dispositionAuthorLogins: trustedMarkerLogins,
-  },
-);
-
-process.stdout.write(
-  `${JSON.stringify(
+  const summary = buildActivitySnapshotSummary(
     {
-      headSha,
-      trustedMarkerActors: trustedMarkerLogins,
-      trustedMarkerActorsSource,
-      totalItemCount: summary.totalItemCount,
-      maxActivityUpdatedAt: summary.maxActivityUpdatedAt,
-      latestCiCompletedAt: summary.latestCiCompletedAt,
-      latestPassingCiCompletedAt: summary.latestPassingCiCompletedAt,
-      counts: summary.counts,
-      ackOnly: summary.ackOnly,
-      effective: summary.effective,
+      comments: comments.map(normalizeComment),
+      reviews: reviews.map(normalizeReview),
+      threads: threads.map(normalizeThread),
+      checks,
     },
-    null,
-    2,
-  )}\n`,
-);
+    {
+      trustedMarkerLogins,
+      advisoryBotLogins,
+      advisoryBotLoginsSource,
+      // Advisory bots are excluded from disposition authorship inside the
+      // summary builder, so the trusted-marker set is a safe default here.
+      dispositionAuthorLogins: trustedMarkerLogins,
+    },
+  );
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        headSha,
+        trustedMarkerActors: trustedMarkerLogins,
+        trustedMarkerActorsSource,
+        totalItemCount: summary.totalItemCount,
+        maxActivityUpdatedAt: summary.maxActivityUpdatedAt,
+        latestCiCompletedAt: summary.latestCiCompletedAt,
+        latestPassingCiCompletedAt: summary.latestPassingCiCompletedAt,
+        counts: summary.counts,
+        ackOnly: summary.ackOnly,
+        effective: summary.effective,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function isCliExecution(): boolean {
+  return (
+    Boolean(process.argv[1]) &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
 
 function loadIddConfig(): {
   trustedMarkerActors?: unknown;

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -674,3 +674,19 @@ test('advisory wait summary normalizes invalid direct options to defaults', () =
   assert.equal(summary.pollIntervalMinutes, 2);
   assert.equal(summary.capExhaustedRoute, 'phase-specific');
 });
+
+// Importing the CLI module directly is only possible now that its top-level
+// statements are guarded behind isCliExecution() (#1210); previously the
+// import parsed process.argv and called a `gh` command, aborting the test
+// process when no --pr argument or gh binary was available.
+test('importing advisory-wait-state.mts has no import-time side effect', async () => {
+  const originalPath = process.env.PATH;
+  process.env.PATH = '';
+  try {
+    await assert.doesNotReject(
+      import('../src/scripts/advisory-wait-state.mts'),
+    );
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+// Importing the CLI module directly is only possible now that its top-level
+// statements are guarded behind isCliExecution() (#1210); previously the
+// import parsed process.argv, called `fail()` (process.exit), or made a
+// `gh` call, aborting the test process. tests/audit-pr-cleanup-summary.test.mts
+// covers the pure summary logic in the sibling `-summary` module; this file
+// covers only the CLI module's import purity.
+test('importing audit-pr-cleanup.mts has no import-time side effect', async () => {
+  const originalPath = process.env.PATH;
+  process.env.PATH = '';
+  try {
+    await assert.doesNotReject(import('../src/scripts/audit-pr-cleanup.mts'));
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});

--- a/tests/cli-entry-smoke.test.mts
+++ b/tests/cli-entry-smoke.test.mts
@@ -365,3 +365,83 @@ process.exit(1);
   assert.equal(parsed.summary.viableCount, 1);
   assert.equal(parsed.viable[0].number, 901);
 });
+
+// ---------------------------------------------------------------------------
+// #1210 — CLI-subprocess smoke tests for the three isCliExecution()-guarded
+// helpers (advisory-wait-state, review-activity-snapshot, audit-pr-cleanup).
+//
+// Unlike the two smoke tests above, --help and the missing-required-arg path
+// in all three binaries return before any `gh` invocation (verified by
+// reading the source), so no stubbed `gh` on PATH is needed here. These pin
+// the exact pre-existing stdout/stderr/exit-code behavior byte-for-byte
+// across the isCliExecution() refactor.
+// ---------------------------------------------------------------------------
+
+for (const [binary, helpText] of [
+  [
+    'advisory-wait-state.mjs',
+    'Usage:\n  node scripts/advisory-wait-state.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--now <ISO8601>]\n',
+  ],
+  [
+    'review-activity-snapshot.mjs',
+    'Usage:\n  node scripts/review-activity-snapshot.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <login1,login2>]\n',
+  ],
+] as const) {
+  test(`${binary} --help prints usage and exits 0`, () => {
+    const output = execFileSync(
+      process.execPath,
+      [join(REPO_ROOT, 'scripts', binary), '--help'],
+      { encoding: 'utf8', timeout: 60_000 },
+    );
+    assert.equal(output, helpText);
+  });
+
+  test(`${binary} without --pr fails before any gh invocation`, () => {
+    assert.throws(
+      () => {
+        execFileSync(process.execPath, [join(REPO_ROOT, 'scripts', binary)], {
+          encoding: 'utf8',
+          timeout: 60_000,
+        });
+      },
+      (error: unknown) => {
+        const status = (error as { status?: unknown }).status;
+        const stderr = String((error as { stderr?: unknown }).stderr ?? '');
+        assert.equal(status, 1);
+        assert.match(stderr, /Error: missing required --pr <number> argument/);
+        assert.doesNotMatch(stderr, /ReferenceError|before initialization/);
+        return true;
+      },
+    );
+  });
+}
+
+test('audit-pr-cleanup.mjs --help prints usage and exits 0', () => {
+  const output = execFileSync(
+    process.execPath,
+    [join(REPO_ROOT, 'scripts/audit-pr-cleanup.mjs'), '--help'],
+    { encoding: 'utf8', timeout: 60_000 },
+  );
+  assert.match(output, /^usage: node scripts\/audit-pr-cleanup\.mjs/);
+  assert.match(output, /--claim-issue <number>/);
+});
+
+test('audit-pr-cleanup.mjs without --pr fails before any gh invocation', () => {
+  assert.throws(
+    () => {
+      execFileSync(
+        process.execPath,
+        [join(REPO_ROOT, 'scripts/audit-pr-cleanup.mjs')],
+        { encoding: 'utf8', timeout: 60_000 },
+      );
+    },
+    (error: unknown) => {
+      const status = (error as { status?: unknown }).status;
+      const stderr = String((error as { stderr?: unknown }).stderr ?? '');
+      assert.equal(status, 2);
+      assert.match(stderr, /^error: missing required --pr <number>/);
+      assert.doesNotMatch(stderr, /ReferenceError|before initialization/);
+      return true;
+    },
+  );
+});

--- a/tests/review-activity-snapshot.test.mts
+++ b/tests/review-activity-snapshot.test.mts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+// Importing the CLI module directly is only possible now that its top-level
+// statements are guarded behind isCliExecution() (#1210); previously the
+// import parsed process.argv and called a `gh` command, aborting the test
+// process when no --pr argument or gh binary was available.
+test('importing review-activity-snapshot.mts has no import-time side effect', async () => {
+  const originalPath = process.env.PATH;
+  process.env.PATH = '';
+  try {
+    await assert.doesNotReject(
+      import('../src/scripts/review-activity-snapshot.mts'),
+    );
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});


### PR DESCRIPTION
# Summary

Guards `advisory-wait-state.mts`, `review-activity-snapshot.mts`, and
`audit-pr-cleanup.mts` behind a local `isCliExecution()` check
(mirroring the merged #1120 fix for `live-status-digest.mts`), so
importing any of the three no longer parses `process.argv`, throws a
missing-argument error, or makes a live `gh` call at module scope.

## Linked issue

Closes #1210

## Follow-up issues (if any)

- [ ] #1223 — `tests/cli-entry-smoke.test.mts`'s `ENTRY_GUARD` regex
  only recognizes the `isMainModule(` / `process.argv[1]` entry
  shapes, so it silently has no coverage for the `isCliExecution()`
  shape used by this PR's three files (and `live-status-digest.mts`
  since #1120, and several older helpers). Pre-existing gap, not
  introduced here; filed separately to keep this PR scoped to the
  three named files.

## Background / rationale

- Each file's top-level executing statements (argv parsing through
  the final `stdout` write / report write) move into a `main()`
  function invoked as `if (isCliExecution()) { main(); }`. Verified
  (by reading every function declared after the moved block in all
  three files) that none of them close over a moved top-level
  `const`/`let` — they all take the needed values as parameters — so
  the transform is a pure mechanical move.
- `audit-pr-cleanup.mts` keeps **two** pre-existing internal `await`
  calls inside the moved block (`await buildReport(...)` and, inside
  the `--apply` loop, `await revalidateCandidate(...)`), so its
  `main()` becomes `async function main(): Promise<void>` and the
  guard runs `await main()` — both awaits are safely inside the same
  moved block.
- `--help` and the missing-required-`--pr` failure path in all three
  binaries return before any `gh` invocation (confirmed by reading the
  source and by running the built `.mjs` binaries directly before and
  after this change), so the new CLI-subprocess smoke tests need no
  stubbed `gh` on `PATH`.
- Pinned the pre-existing `--help` / missing-`--pr` stdout, stderr
  text, and exit codes byte-for-byte before making any change, then
  re-verified them unchanged after (only the internal JS stack-trace
  line number shifts, which is not part of the pinned contract).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
