### PR TITLE
test(helpers): add dedicated unit suites for the untested pure helper modules

### DIFF
--- a/tests/advisory-wait-policy.test.mts
+++ b/tests/advisory-wait-policy.test.mts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { normalizeAdvisoryWaitRuntimeOptions } from '../src/scripts/advisory-wait-policy.mts';
+
+// normalizeAdvisoryWaitRuntimeOptions is the only export of this module
+// without direct dedicated coverage: readAdvisoryWaitPolicy,
+// resolveAdvisoryWaitPolicy, resolveAdvisoryPrimaryBotLogin,
+// readAdvisoryPrimaryBotLogin, resolveAdvisorySecondaryBotLogin, and
+// readAdvisorySecondaryBotLogin already have direct, named test() blocks in
+// tests/advisory-wait.test.mts.
+
+test('normalizeAdvisoryWaitRuntimeOptions applies every default on empty input', () => {
+  assert.deepEqual(normalizeAdvisoryWaitRuntimeOptions({}), {
+    requestCap: 30,
+    pendingWindowMinutes: 30,
+    settledWindowMinutes: 10,
+    pollIntervalMinutes: 2,
+    capExhaustedRoute: 'phase-specific',
+  });
+});
+
+test('normalizeAdvisoryWaitRuntimeOptions applies every default on absent input', () => {
+  assert.deepEqual(normalizeAdvisoryWaitRuntimeOptions(), {
+    requestCap: 30,
+    pendingWindowMinutes: 30,
+    settledWindowMinutes: 10,
+    pollIntervalMinutes: 2,
+    capExhaustedRoute: 'phase-specific',
+  });
+});
+
+test('normalizeAdvisoryWaitRuntimeOptions accepts explicit valid values', () => {
+  assert.deepEqual(
+    normalizeAdvisoryWaitRuntimeOptions({
+      requestCap: 12,
+      pendingWindowMinutes: 45,
+      settledWindowMinutes: 15,
+      pollIntervalMinutes: 3,
+      capExhaustedRoute: 'hold',
+    }),
+    {
+      requestCap: 12,
+      pendingWindowMinutes: 45,
+      settledWindowMinutes: 15,
+      pollIntervalMinutes: 3,
+      capExhaustedRoute: 'hold',
+    },
+  );
+});
+
+test('normalizeAdvisoryWaitRuntimeOptions coerces a numeric string, unlike the config-file path', () => {
+  // resolveAdvisoryWaitPolicy's config-path sibling requires
+  // `typeof value === 'number'` and would reject a string to the default;
+  // this runtime-options variant uses `Number(value)` coercion instead,
+  // so a numeric string is accepted. This distinction is the reason this
+  // function needs its own dedicated coverage.
+  assert.deepEqual(
+    normalizeAdvisoryWaitRuntimeOptions({
+      requestCap: '5',
+      pendingWindowMinutes: '20',
+    }),
+    {
+      requestCap: 5,
+      pendingWindowMinutes: 20,
+      settledWindowMinutes: 10,
+      pollIntervalMinutes: 2,
+      capExhaustedRoute: 'phase-specific',
+    },
+  );
+});
+
+test('normalizeAdvisoryWaitRuntimeOptions falls back on a non-positive requestCap', () => {
+  assert.equal(
+    normalizeAdvisoryWaitRuntimeOptions({ requestCap: 0 }).requestCap,
+    30,
+  );
+  assert.equal(
+    normalizeAdvisoryWaitRuntimeOptions({ requestCap: -1 }).requestCap,
+    30,
+  );
+});
+
+test('normalizeAdvisoryWaitRuntimeOptions falls back on a non-integer requestCap', () => {
+  assert.equal(
+    normalizeAdvisoryWaitRuntimeOptions({ requestCap: 1.5 }).requestCap,
+    30,
+  );
+});
+
+test('normalizeAdvisoryWaitRuntimeOptions accepts a non-integer positive window minutes value', () => {
+  // The window/interval fields use normalizePositiveNumber (Number.isFinite),
+  // not normalizePositiveInteger, so a fractional value is accepted.
+  assert.equal(
+    normalizeAdvisoryWaitRuntimeOptions({ pendingWindowMinutes: 2.5 })
+      .pendingWindowMinutes,
+    2.5,
+  );
+});
+
+test('normalizeAdvisoryWaitRuntimeOptions falls back on a non-positive window minutes value', () => {
+  assert.equal(
+    normalizeAdvisoryWaitRuntimeOptions({ settledWindowMinutes: 0 })
+      .settledWindowMinutes,
+    10,
+  );
+  assert.equal(
+    normalizeAdvisoryWaitRuntimeOptions({ pollIntervalMinutes: -3 })
+      .pollIntervalMinutes,
+    2,
+  );
+});
+
+test('normalizeAdvisoryWaitRuntimeOptions falls back on a non-numeric window minutes value', () => {
+  assert.equal(
+    normalizeAdvisoryWaitRuntimeOptions({ settledWindowMinutes: 'soon' })
+      .settledWindowMinutes,
+    10,
+  );
+});
+
+test('normalizeAdvisoryWaitRuntimeOptions accepts only a recognized capExhaustedRoute', () => {
+  assert.equal(
+    normalizeAdvisoryWaitRuntimeOptions({ capExhaustedRoute: 'hold' })
+      .capExhaustedRoute,
+    'hold',
+  );
+  assert.equal(
+    normalizeAdvisoryWaitRuntimeOptions({ capExhaustedRoute: 'unknown-route' })
+      .capExhaustedRoute,
+    'phase-specific',
+  );
+});

--- a/tests/check-pnpm-boundary.test.mts
+++ b/tests/check-pnpm-boundary.test.mts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { checkPnpmBoundary } from '../src/scripts/check-pnpm-boundary.mts';
+
+// findPnpmCommandLeaks already has direct, dedicated coverage in
+// tests/pnpm-boundary.test.mts (happy path, multi-row failures,
+// case-folding, non-pnpm package managers). This file covers only
+// checkPnpmBoundary itself — the root-resolution + file-read +
+// {ok, errors} aggregation wrapper — which had no coverage anywhere.
+
+const TEMPLATE_OVERVIEW_REL_PATH =
+  'idd-template/.github/instructions/idd-overview-core.instructions.md';
+
+function makeRootWithOverview(overviewMarkdown: string): {
+  root: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), 'pnpm-boundary-'));
+  const overviewPath = join(root, TEMPLATE_OVERVIEW_REL_PATH);
+  mkdirSync(join(overviewPath, '..'), { recursive: true });
+  writeFileSync(overviewPath, overviewMarkdown, 'utf8');
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+const CLEAN_OVERVIEW = [
+  '| Name                    | Commands                |',
+  '| ----------------------- | ------------------------ |',
+  '| **fix-validate**        | `npx biome check --write` |',
+  '| **pre-push-validate**   | `npx biome check`         |',
+  '| **post-fix-validate**   | `npx biome check --write` |',
+  '| **install-deps**        | `npm install`              |',
+].join('\n');
+
+const LEAKING_OVERVIEW = [
+  '| Name                    | Commands                |',
+  '| ----------------------- | ------------------------ |',
+  '| **fix-validate**        | `pnpm run lint:fix`       |',
+  '| **pre-push-validate**   | `npx biome check`         |',
+  '| **post-fix-validate**   | `npx biome check --write` |',
+  '| **install-deps**        | `npm install`              |',
+].join('\n');
+
+test('checkPnpmBoundary reports ok:true and no errors on a clean template overview', (t) => {
+  const { root, cleanup } = makeRootWithOverview(CLEAN_OVERVIEW);
+  t.after(cleanup);
+
+  assert.deepEqual(checkPnpmBoundary(root), { ok: true, errors: [] });
+});
+
+test('checkPnpmBoundary reports ok:false with the leaking row when pnpm appears', (t) => {
+  const { root, cleanup } = makeRootWithOverview(LEAKING_OVERVIEW);
+  t.after(cleanup);
+
+  const result = checkPnpmBoundary(root);
+  assert.equal(result.ok, false);
+  assert.equal(result.errors.length, 1);
+  assert.match(result.errors[0], /fix-validate.*pnpm/);
+});
+
+test('checkPnpmBoundary reads the template overview relative to the given root, not the default ROOT', (t) => {
+  const { root: cleanRoot, cleanup: cleanupClean } =
+    makeRootWithOverview(CLEAN_OVERVIEW);
+  const { root: leakingRoot, cleanup: cleanupLeaking } =
+    makeRootWithOverview(LEAKING_OVERVIEW);
+  t.after(cleanupClean);
+  t.after(cleanupLeaking);
+
+  assert.equal(checkPnpmBoundary(cleanRoot).ok, true);
+  assert.equal(checkPnpmBoundary(leakingRoot).ok, false);
+});
+
+test('checkPnpmBoundary throws when the template overview file is missing at the given root', (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'pnpm-boundary-empty-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  assert.throws(() => checkPnpmBoundary(root));
+});

--- a/tests/collaborator-permission.test.mts
+++ b/tests/collaborator-permission.test.mts
@@ -156,6 +156,9 @@ test('isAuthorizedForcedHandoffActor rejects an empty or blank login without tou
 // collapses maintain to write).
 const DEFAULT_POLICY_CASES: [string, string, boolean][] = [
   ['admin', 'admin', true],
+  // Isolates roleName === 'admin' as the sole cause: permission is 'write'
+  // here, so this only passes if the roleName clause is actually checked.
+  ['write', 'admin', true],
   ['write', 'maintain', true],
   ['admin', '', true],
   ['write', 'write', false],
@@ -184,7 +187,10 @@ for (const [permission, roleName, expected] of DEFAULT_POLICY_CASES) {
 // legacy permission write (so a custom write-base role_name still
 // satisfies the loose policy via the legacy field).
 const LOOSE_POLICY_CASES: [string, string, boolean][] = [
-  ['admin', 'admin', true],
+  // Isolates permission === 'admin' as the sole cause: roleName matches
+  // none of the roleName clauses, so this only passes if the legacy
+  // permission field is actually checked.
+  ['admin', 'custom-role', true],
   ['write', 'maintain', true],
   ['write', 'write', true],
   ['write', 'custom-role', true],

--- a/tests/collaborator-permission.test.mts
+++ b/tests/collaborator-permission.test.mts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { test } from 'node:test';
+import { after, test } from 'node:test';
 
 import {
   type CollaboratorPermissionCache,
@@ -19,8 +19,17 @@ import {
 // stays untested here — it is exercised instead via the cache-seeding seam
 // below, which is the pure surface these functions actually expose.
 
+const configFileDirs: string[] = [];
+
+after(() => {
+  for (const dir of configFileDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function makeConfigFile(content: string): string {
   const dir = mkdtempSync(join(tmpdir(), 'forced-handoff-policy-'));
+  configFileDirs.push(dir);
   const path = join(dir, 'config.json');
   writeFileSync(path, content, 'utf8');
   return path;

--- a/tests/collaborator-permission.test.mts
+++ b/tests/collaborator-permission.test.mts
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import {
+  type CollaboratorPermissionCache,
+  collaboratorPermission,
+  isAuthorizedForcedHandoffActor,
+  readForcedHandoffAuthorityPolicy,
+  readForcedHandoffMode,
+  readForcedHandoffPolicy,
+} from '../src/scripts/collaborator-permission.mts';
+
+// collaboratorPermission and isAuthorizedForcedHandoffActor's UNCACHED path
+// shells out to `gh api repos/{owner}/{repo}/collaborators/{login}/permission`.
+// Per #1212's scope note ("do NOT mock `gh` subprocess calls"), that path
+// stays untested here — it is exercised instead via the cache-seeding seam
+// below, which is the pure surface these functions actually expose.
+
+function makeConfigFile(content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'forced-handoff-policy-'));
+  const path = join(dir, 'config.json');
+  writeFileSync(path, content, 'utf8');
+  return path;
+}
+
+test('readForcedHandoffPolicy falls back to defaults when the file is missing', () => {
+  assert.deepEqual(
+    readForcedHandoffPolicy('/nonexistent/path/does-not-exist.json'),
+    { mode: 'disabled', authorityPolicy: 'owners-and-maintainers-only' },
+  );
+});
+
+test('readForcedHandoffPolicy falls back to defaults on malformed JSON', () => {
+  const path = makeConfigFile('{ not valid json');
+  assert.deepEqual(readForcedHandoffPolicy(path), {
+    mode: 'disabled',
+    authorityPolicy: 'owners-and-maintainers-only',
+  });
+});
+
+test('readForcedHandoffPolicy reads explicit values from a valid file', () => {
+  const path = makeConfigFile(
+    JSON.stringify({
+      forcedHandoff: {
+        mode: 'human-gated',
+        authorityPolicy: 'all-write-permission-actors',
+      },
+    }),
+  );
+  assert.deepEqual(readForcedHandoffPolicy(path), {
+    mode: 'human-gated',
+    authorityPolicy: 'all-write-permission-actors',
+  });
+});
+
+test('readForcedHandoffPolicy falls back per-field on an unrecognized value', () => {
+  const path = makeConfigFile(
+    JSON.stringify({ forcedHandoff: { mode: 'sometimes' } }),
+  );
+  assert.deepEqual(readForcedHandoffPolicy(path), {
+    mode: 'disabled',
+    authorityPolicy: 'owners-and-maintainers-only',
+  });
+});
+
+test('readForcedHandoffMode and readForcedHandoffAuthorityPolicy are convenience accessors', () => {
+  const path = makeConfigFile(
+    JSON.stringify({
+      forcedHandoff: {
+        mode: 'human-gated',
+        authorityPolicy: 'all-write-permission-actors',
+      },
+    }),
+  );
+  assert.equal(readForcedHandoffMode(path), 'human-gated');
+  assert.equal(
+    readForcedHandoffAuthorityPolicy(path),
+    'all-write-permission-actors',
+  );
+});
+
+function seededCache(
+  owner: string,
+  repo: string,
+  login: string,
+  permission: string,
+  roleName: string,
+): CollaboratorPermissionCache {
+  const cache: CollaboratorPermissionCache = new Map();
+  cache.set(`${owner}/${repo}:${login}`, { permission, roleName });
+  return cache;
+}
+
+test('collaboratorPermission returns the seeded cache entry without shelling out', () => {
+  // A real (uncached) call for this owner/repo/login would fail closed to
+  // empty strings (nonexistent repo/user); getting the seeded sentinel
+  // back instead is the proof the cache short-circuited before
+  // execFileSync('gh', ...) would ever run.
+  const cache = seededCache(
+    'nonexistent-owner-xyz',
+    'nonexistent-repo-xyz',
+    'nonexistent-user-xyz',
+    'admin',
+    'admin',
+  );
+  assert.deepEqual(
+    collaboratorPermission(
+      'nonexistent-owner-xyz',
+      'nonexistent-repo-xyz',
+      'nonexistent-user-xyz',
+      cache,
+    ),
+    { permission: 'admin', roleName: 'admin' },
+  );
+});
+
+test('collaboratorPermission normalizes the login before the cache lookup', () => {
+  const cache = seededCache('o', 'r', 'someuser', 'write', 'write');
+  assert.deepEqual(collaboratorPermission('o', 'r', ' SomeUser ', cache), {
+    permission: 'write',
+    roleName: 'write',
+  });
+});
+
+test('isAuthorizedForcedHandoffActor rejects an empty or blank login without touching the cache', () => {
+  const cache: CollaboratorPermissionCache = new Map();
+  assert.equal(
+    isAuthorizedForcedHandoffActor(
+      'o',
+      'r',
+      '',
+      'owners-and-maintainers-only',
+      cache,
+    ),
+    false,
+  );
+  assert.equal(
+    isAuthorizedForcedHandoffActor(
+      'o',
+      'r',
+      '   ',
+      'owners-and-maintainers-only',
+      cache,
+    ),
+    false,
+  );
+  assert.equal(cache.size, 0);
+});
+
+// owners-and-maintainers-only: role_name admin/maintain, or legacy
+// permission admin as a backstop. write/read/none are all rejected, and
+// maintain specifically requires role_name (the legacy permission field
+// collapses maintain to write).
+const DEFAULT_POLICY_CASES: [string, string, boolean][] = [
+  ['admin', 'admin', true],
+  ['write', 'maintain', true],
+  ['admin', '', true],
+  ['write', 'write', false],
+  ['read', 'read', false],
+  ['none', 'none', false],
+  ['write', '', false],
+];
+
+for (const [permission, roleName, expected] of DEFAULT_POLICY_CASES) {
+  test(`isAuthorizedForcedHandoffActor under owners-and-maintainers-only: permission=${permission} roleName=${roleName || '(empty)'} -> ${expected}`, () => {
+    const cache = seededCache('o', 'r', 'actor', permission, roleName);
+    assert.equal(
+      isAuthorizedForcedHandoffActor(
+        'o',
+        'r',
+        'actor',
+        'owners-and-maintainers-only',
+        cache,
+      ),
+      expected,
+    );
+  });
+}
+
+// all-write-permission-actors: everything above, plus role_name write or
+// legacy permission write (so a custom write-base role_name still
+// satisfies the loose policy via the legacy field).
+const LOOSE_POLICY_CASES: [string, string, boolean][] = [
+  ['admin', 'admin', true],
+  ['write', 'maintain', true],
+  ['write', 'write', true],
+  ['write', 'custom-role', true],
+  ['read', 'read', false],
+  ['none', 'none', false],
+];
+
+for (const [permission, roleName, expected] of LOOSE_POLICY_CASES) {
+  test(`isAuthorizedForcedHandoffActor under all-write-permission-actors: permission=${permission} roleName=${roleName} -> ${expected}`, () => {
+    const cache = seededCache('o', 'r', 'actor', permission, roleName);
+    assert.equal(
+      isAuthorizedForcedHandoffActor(
+        'o',
+        'r',
+        'actor',
+        'all-write-permission-actors',
+        cache,
+      ),
+      expected,
+    );
+  });
+}

--- a/tests/consistency-helpers.test.mts
+++ b/tests/consistency-helpers.test.mts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  extractGeneratedFromBanner,
+  generatedFromBanner,
+} from '../src/scripts/consistency-helpers.mts';
+
+// extractGeneratedFromBanner is the only export of this module without
+// direct dedicated coverage: it is only ever called internally by
+// stripGeneratedFromBanner/parseGeneratedFromBannerSource, never asserted
+// on directly. The other 12 exports already have direct, named test()
+// blocks in tests/consistency.test.mts, plus
+// collectRootMarkdownAllowlistViolations (tests/root-markdown-allowlist.test.mts)
+// and collectTypeSuppressionViolations (tests/type-suppression-budgets.test.mts).
+// The 3 re-exported policy-helpers.mts functions have their own
+// tests/policy-helpers.test.mts.
+
+const BANNER = generatedFromBanner('src/example.mts');
+
+test('extractGeneratedFromBanner returns the banner at the top when there is no frontmatter', () => {
+  const body = `${BANNER}\n\n# Heading\n\nBody.\n`;
+  assert.equal(extractGeneratedFromBanner(body), BANNER);
+});
+
+test('extractGeneratedFromBanner returns the banner immediately after a frontmatter block', () => {
+  const body = `---\napplyTo: "**"\n---\n\n${BANNER}\n\n# Heading\n\nBody.\n`;
+  assert.equal(extractGeneratedFromBanner(body), BANNER);
+});
+
+test('extractGeneratedFromBanner returns null when no banner is present', () => {
+  assert.equal(extractGeneratedFromBanner('# Heading\n\nBody.\n'), null);
+});
+
+test('extractGeneratedFromBanner returns null when frontmatter is present but no banner follows', () => {
+  const body = '---\napplyTo: "**"\n---\n\n# Heading\n\nBody.\n';
+  assert.equal(extractGeneratedFromBanner(body), null);
+});
+
+test('extractGeneratedFromBanner does not match a banner-shaped comment out of position', () => {
+  // The function deliberately only matches at the very top or immediately
+  // after frontmatter; a banner-shaped block elsewhere in the body must be
+  // reported as missing rather than silently accepted.
+  const body = `# Heading\n\nBody.\n\n${BANNER}\n`;
+  assert.equal(extractGeneratedFromBanner(body), null);
+});

--- a/tests/marker-regex.test.mts
+++ b/tests/marker-regex.test.mts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  createMarkerRegex,
+  escapeRegex,
+} from '../src/scripts/marker-regex.mts';
+
+test('escapeRegex escapes every RegExp metacharacter', () => {
+  assert.equal(
+    escapeRegex('.*+?^${}()|[]\\'),
+    '\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\',
+  );
+});
+
+test('escapeRegex leaves a string with no metacharacters unchanged', () => {
+  assert.equal(escapeRegex('roadmap-id'), 'roadmap-id');
+});
+
+test('escapeRegex leaves an empty string unchanged', () => {
+  assert.equal(escapeRegex(''), '');
+});
+
+test('escapeRegex makes a namespaced prefix safe to interpolate', () => {
+  const escaped = escapeRegex('org.project');
+  const regex = new RegExp(escaped);
+  assert.ok(regex.test('org.project'));
+  // Without escaping, `.` would also match "orgXproject"; the escaped form must not.
+  assert.ok(!regex.test('orgXproject'));
+});
+
+test('createMarkerRegex detects a well-formed marker case-insensitively', () => {
+  const regex = createMarkerRegex('idd-skill', 'roadmap-id');
+  assert.ok(regex.test('<!-- idd-skill-roadmap-id: my-roadmap -->'));
+  assert.ok(regex.test('<!-- IDD-SKILL-ROADMAP-ID: my-roadmap -->'));
+});
+
+test('createMarkerRegex matches mid-string, not just at position 0', () => {
+  const regex = createMarkerRegex('idd-skill', 'roadmap-id');
+  const text = 'Some prose before.\n<!-- idd-skill-roadmap-id: x -->\nAfter.';
+  assert.ok(regex.test(text));
+});
+
+test('createMarkerRegex escapes a prefix containing regex metacharacters', () => {
+  const regex = createMarkerRegex('org.project', 'roadmap-id');
+  assert.ok(regex.test('<!-- org.project-roadmap-id: x -->'));
+  // A literal dot must not act as a wildcard for an unrelated character.
+  assert.ok(!regex.test('<!-- orgXproject-roadmap-id: x -->'));
+});
+
+test('createMarkerRegex requires a word boundary after the suffix', () => {
+  const regex = createMarkerRegex('idd-skill', 'roadmap-id');
+  // `\b` blocks a word-character extension of the suffix (no transition
+  // between two word characters), e.g. "roadmap-id" gluing onto "x".
+  assert.ok(!regex.test('<!-- idd-skill-roadmap-idx: x -->'));
+  // A hyphen is not a word character, so it already forms a boundary on
+  // its own; `\b` does not additionally block a hyphen-separated suffix.
+  assert.ok(regex.test('<!-- idd-skill-roadmap-id-2: x -->'));
+});
+
+test('createMarkerRegex does not match a wrong prefix or suffix', () => {
+  const regex = createMarkerRegex('idd-skill', 'roadmap-id');
+  assert.ok(!regex.test('<!-- other-roadmap-id: x -->'));
+  assert.ok(!regex.test('<!-- idd-skill-blocked-by: x -->'));
+});
+
+test('createMarkerRegex has no capture group and is not global', () => {
+  const regex = createMarkerRegex('idd-skill', 'roadmap-id');
+  const match = regex.exec('<!-- idd-skill-roadmap-id: x -->');
+  assert.ok(match);
+  assert.equal(match.length, 1);
+  assert.equal(regex.global, false);
+});

--- a/tests/marker-regex.test.mts
+++ b/tests/marker-regex.test.mts
@@ -8,6 +8,7 @@ import {
 
 test('escapeRegex escapes every RegExp metacharacter', () => {
   assert.equal(
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${} chars under test, not a forgotten template placeholder.
     escapeRegex('.*+?^${}()|[]\\'),
     '\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\',
   );


### PR DESCRIPTION
## Summary

Adds dedicated unit-test coverage for the pure logic in 5 previously
under-tested helper modules: `marker-regex.mts`,
`advisory-wait-policy.mts`, `consistency-helpers.mts`,
`collaborator-permission.mts`, and `check-pnpm-boundary.mts`.

Before writing anything, I audited how much of each module's surface
already had *direct, dedicated* coverage under a differently-named
existing file (not just the issue's literal "no
`tests/<module-name>*.test.mts` file" check). 3 of the 5 modules
turned out to already have deep, direct, named `test()` coverage for
most of their exports:

- `advisory-wait-policy.mts`: 6 of 7 exports already covered by
  `tests/advisory-wait.test.mts`.
- `consistency-helpers.mts`: 12 of 13 exports already covered across
  `tests/consistency.test.mts`, `tests/root-markdown-allowlist.test.mts`,
  `tests/type-suppression-budgets.test.mts`, and
  `tests/policy-helpers.test.mts` (the 3 re-exported
  `policy-helpers.mts` functions).
- `check-pnpm-boundary.mts`: I initially believed both exports were
  covered by `tests/pnpm-boundary.test.mts`, but a fresh-context
  critique pass caught that only `findPnpmCommandLeaks` is — the
  wrapper function `checkPnpmBoundary` itself (root resolution +
  file read + `{ok, errors}` aggregation) had zero coverage. Fixed
  before this PR.

So `tests/advisory-wait-policy.test.mts` and
`tests/consistency-helpers.test.mts` are scoped to the one real gap
each (documented inline in the file), rather than re-asserting
behavior another file already asserts.

`marker-regex.mts` and `collaborator-permission.mts` had zero prior
direct coverage and get full new suites.
`collaboratorPermission`/`isAuthorizedForcedHandoffActor`'s uncached
path shells out to `gh api .../collaborators/.../permission`; per the
issue's scope note that path stays untested here (no `execFileSync`
mock), but their tier-mapping logic is fully testable by pre-seeding
the `CollaboratorPermissionCache` the functions already accept —
`collaboratorPermission` checks the cache before ever reaching
`execFileSync`.

## Test plan

- [x] `node --test tests/*.test.mts` — 5 new files run in the normal
      glob; full suite green (1567/1567, 0 failures)
- [x] `pnpm run lint:minimum` passes in full (audit-docs, typecheck,
      build:check, biome, dprint, verify-workshop-integrity, cspell,
      markdownlint)
- [x] No `gh`/network calls in any new file (the one function that
      needs `gh` — `collaboratorPermission`'s uncached path — is
      exercised only through its pre-seeded-cache pure seam)
- [x] Independent critique pass (fresh-context review agent) verified
      every coverage-audit claim against the actual test files (not
      just the plan's prose) and caught the `check-pnpm-boundary.mts`
      gap described above before merge, plus 2 branch-isolating test
      cases now added to the `collaborator-permission.mts` tier-mapping
      tables

Closes #1212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for advisory wait option normalization, including defaults, numeric coercion, and invalid value handling.
  * Added checks for boundary validation and missing-file behavior in project overview scanning.
  * Added collaborator permission and forced-handoff policy tests, including cache usage and authorization rules.
  * Added consistency-helper tests for generated-banner detection with and without frontmatter.
  * Added marker-regex tests to ensure literal matching, safe escaping, and correct comment-marker detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->