### PR TITLE
feat(doctor): detect config.json to instruction-prose policy-value drift

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -766,11 +766,14 @@ const CLAIM_TIMING_ANCHORS = [
   },
 ];
 /**
- * Parse an ISO 8601 duration to whole hours. Returns null for a
- * non-string, an unparseable value, a zero/negative duration (an
- * operationally meaningless stale-age/heartbeat), or sub-hour precision
- * (minutes/seconds) — the Thresholds prose only ever states whole hours,
- * so a sub-hour config value has no prose counterpart to compare against.
+ * Parse an ISO 8601 duration to whole hours. Returns null when the input
+ * is not a string, does not match the ISO 8601 duration grammar, carries
+ * sub-hour precision (minutes/seconds) — the Thresholds prose only ever
+ * states whole hours, so a sub-hour config value has no prose counterpart
+ * to compare against — or resolves to zero hours (`P`, `PT`, `PT0H`, ...),
+ * which matches the grammar but is operationally meaningless as a
+ * stale-age/heartbeat value. A negative duration cannot occur: the
+ * grammar has no sign, so a leading `-` fails the `^P` anchor outright.
  */
 export function parseIsoDurationToHours(value) {
   if (typeof value !== 'string') {
@@ -790,13 +793,32 @@ export function parseIsoDurationToHours(value) {
   return totalHours > 0 ? totalHours : null;
 }
 /**
+ * Slice `section` down to just the bullet introduced by `bulletLabel`
+ * (e.g. `**Stale**:`), stopping before the next `- ` list item or at the
+ * end of `section`. Returns null when `bulletLabel` is not found. Bounding
+ * the slice to one bullet is what stops the anchor regexes in
+ * {@link parseThresholdsProseHours} from crossing into an unrelated
+ * number that happens to appear in a *different* bullet.
+ */
+function extractBulletText(section, bulletLabel) {
+  const start = section.indexOf(bulletLabel);
+  if (start === -1) {
+    return null;
+  }
+  const nextBullet = section.indexOf('\n- ', start + 1);
+  return section.slice(start, nextBullet === -1 ? undefined : nextBullet);
+}
+/**
  * Extract the stale-age and heartbeat-interval hour values the
  * `## Thresholds` section of overview-core prose states. Returns null for
  * the whole result when the section heading itself is not found (the
  * section was renamed or removed); returns null for an individual field
- * when that field's anchor phrase is not found within an otherwise-present
- * section (the bullet was reworded past recognition). Neither case is an
- * error — the caller skips the comparison for what it cannot parse.
+ * when that field's own bullet, or its anchor phrase within that bullet,
+ * is not found (the bullet was reworded past recognition or removed).
+ * Neither case is an error — the caller skips the comparison for what it
+ * cannot parse. Each anchor regex is matched only within its own
+ * bullet's text (see {@link extractBulletText}), so a number in an
+ * unrelated bullet is never misattributed to this field.
  */
 export function parseThresholdsProseHours(overviewCoreText) {
   const sectionStart = overviewCoreText.indexOf('## Thresholds');
@@ -808,10 +830,12 @@ export function parseThresholdsProseHours(overviewCoreText) {
     sectionStart,
     nextHeading === -1 ? undefined : nextHeading,
   );
-  const staleMatch = /\*\*Stale\*\*:[\s\S]*?≥\s*(\d+)\s*h\b/.exec(section);
-  const heartbeatMatch = /\*\*Heartbeat\*\*:[\s\S]*?every\s+(\d+)\s*h\b/.exec(
-    section,
-  );
+  const staleBullet = extractBulletText(section, '**Stale**:');
+  const heartbeatBullet = extractBulletText(section, '**Heartbeat**:');
+  const staleMatch = staleBullet ? /≥\s*(\d+)\s*h\b/.exec(staleBullet) : null;
+  const heartbeatMatch = heartbeatBullet
+    ? /every\s+(\d+)\s*h\b/.exec(heartbeatBullet)
+    : null;
   return {
     staleAgeHours: staleMatch ? Number(staleMatch[1]) : null,
     heartbeatIntervalHours: heartbeatMatch ? Number(heartbeatMatch[1]) : null,
@@ -858,7 +882,7 @@ export function classifyClaimTimingConsistency(claimTiming, overviewCoreText) {
     message: `config↔instruction-prose policy-value drift: ${mismatches.join('; ')}.`,
   };
 }
-function checkClaimTimingConsistency(root, report) {
+export function checkClaimTimingConsistency(root, report) {
   const read = (relativePath) => {
     try {
       return readFileSync(join(root, relativePath), 'utf8');

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -54,6 +54,7 @@ export function runDoctor({
   );
   checkPolicySignals(root, report);
   checkHelperRuntimeConfig(root, report);
+  checkClaimTimingConsistency(root, report);
   checkAgentEntryFiles(root, report);
   checkTemplateVersionSignal(root, report);
   const worktreeGuardEnforced =
@@ -747,6 +748,141 @@ function checkHelperRuntimeConfig(root, report) {
     report.passes.push(
       `${file} declares helper runtime profile "${helperRuntime.profile}"`,
     );
+  }
+}
+// Adding a future anchor is a one-line addition here — no new branching
+// logic — as long as its prose lives in the same Thresholds section
+// parsed by parseThresholdsProseHours.
+const CLAIM_TIMING_ANCHORS = [
+  {
+    configKey: 'staleAge',
+    label: 'claimTiming.staleAge',
+    proseHoursKey: 'staleAgeHours',
+  },
+  {
+    configKey: 'heartbeatInterval',
+    label: 'claimTiming.heartbeatInterval',
+    proseHoursKey: 'heartbeatIntervalHours',
+  },
+];
+/**
+ * Parse an ISO 8601 duration to whole hours. Returns null for a
+ * non-string, an unparseable value, a zero/negative duration (an
+ * operationally meaningless stale-age/heartbeat), or sub-hour precision
+ * (minutes/seconds) — the Thresholds prose only ever states whole hours,
+ * so a sub-hour config value has no prose counterpart to compare against.
+ */
+export function parseIsoDurationToHours(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(
+    value,
+  );
+  if (!match) {
+    return null;
+  }
+  const [, days, hours, minutes, seconds] = match;
+  if (Number(minutes ?? 0) !== 0 || Number(seconds ?? 0) !== 0) {
+    return null;
+  }
+  const totalHours = Number(days ?? 0) * 24 + Number(hours ?? 0);
+  return totalHours > 0 ? totalHours : null;
+}
+/**
+ * Extract the stale-age and heartbeat-interval hour values the
+ * `## Thresholds` section of overview-core prose states. Returns null for
+ * the whole result when the section heading itself is not found (the
+ * section was renamed or removed); returns null for an individual field
+ * when that field's anchor phrase is not found within an otherwise-present
+ * section (the bullet was reworded past recognition). Neither case is an
+ * error — the caller skips the comparison for what it cannot parse.
+ */
+export function parseThresholdsProseHours(overviewCoreText) {
+  const sectionStart = overviewCoreText.indexOf('## Thresholds');
+  if (sectionStart === -1) {
+    return null;
+  }
+  const nextHeading = overviewCoreText.indexOf('\n## ', sectionStart + 1);
+  const section = overviewCoreText.slice(
+    sectionStart,
+    nextHeading === -1 ? undefined : nextHeading,
+  );
+  const staleMatch = /\*\*Stale\*\*:[\s\S]*?≥\s*(\d+)\s*h\b/.exec(section);
+  const heartbeatMatch = /\*\*Heartbeat\*\*:[\s\S]*?every\s+(\d+)\s*h\b/.exec(
+    section,
+  );
+  return {
+    staleAgeHours: staleMatch ? Number(staleMatch[1]) : null,
+    heartbeatIntervalHours: heartbeatMatch ? Number(heartbeatMatch[1]) : null,
+  };
+}
+/**
+ * Compare `.github/idd/config.json`'s claimTiming values against the
+ * overview-core Thresholds prose. Returns a warning-level finding naming
+ * both locations and both values only when a config value and its
+ * matching prose value are both parseable AND numerically differ. Returns
+ * null (no finding) when the section/bullet cannot be parsed, when either
+ * side is unparseable, or when the values agree — this check never
+ * produces an error, per its acceptance criteria, and degrades silently
+ * on a customized adopter repo rather than false-failing it.
+ */
+export function classifyClaimTimingConsistency(claimTiming, overviewCoreText) {
+  if (!claimTiming) {
+    return null;
+  }
+  const prose = parseThresholdsProseHours(overviewCoreText);
+  if (!prose) {
+    return null;
+  }
+  const mismatches = [];
+  for (const anchor of CLAIM_TIMING_ANCHORS) {
+    const configHours = parseIsoDurationToHours(claimTiming[anchor.configKey]);
+    const proseHours = prose[anchor.proseHoursKey];
+    if (configHours === null || proseHours === null) {
+      continue;
+    }
+    if (configHours !== proseHours) {
+      mismatches.push(
+        `${anchor.label} is ${configHours} h in .github/idd/config.json but ` +
+          `${proseHours} h in the Thresholds section of ` +
+          '.github/instructions/idd-overview-core.instructions.md',
+      );
+    }
+  }
+  if (mismatches.length === 0) {
+    return null;
+  }
+  return {
+    level: 'warning',
+    message: `config↔instruction-prose policy-value drift: ${mismatches.join('; ')}.`,
+  };
+}
+function checkClaimTimingConsistency(root, report) {
+  const read = (relativePath) => {
+    try {
+      return readFileSync(join(root, relativePath), 'utf8');
+    } catch {
+      return null;
+    }
+  };
+  const configText = read('.github/idd/config.json');
+  const overviewCoreText = read(
+    '.github/instructions/idd-overview-core.instructions.md',
+  );
+  if (configText === null || overviewCoreText === null) {
+    return;
+  }
+  let config;
+  try {
+    config = JSON.parse(configText);
+  } catch {
+    return;
+  }
+  const claimTiming = config?.claimTiming;
+  const finding = classifyClaimTimingConsistency(claimTiming, overviewCoreText);
+  if (finding) {
+    report.warnings.push(finding.message);
   }
 }
 function checkAgentEntryFiles(root, report) {

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -770,18 +770,27 @@ const CLAIM_TIMING_ANCHORS = [
  * is not a string, does not match the ISO 8601 duration grammar, carries
  * sub-hour precision (minutes/seconds) — the Thresholds prose only ever
  * states whole hours, so a sub-hour config value has no prose counterpart
- * to compare against — or resolves to zero hours (`P`, `PT`, `PT0H`, ...),
- * which matches the grammar but is operationally meaningless as a
+ * to compare against — or resolves to zero hours (`PT0H`, ...), which
+ * matches the grammar but is operationally meaningless as a
  * stale-age/heartbeat value. A negative duration cannot occur: the
  * grammar has no sign, so a leading `-` fails the `^P` anchor outright.
+ *
+ * The lookaheads (`(?=\d|T\d)` after `P`, `(?=\d)` after `T`) mirror
+ * `schemas/policy.schema.json`'s `claimTiming.staleAge`/
+ * `heartbeatInterval` pattern exactly, so this rejects the same
+ * dangling-designator strings the schema does (bare `P`, bare `PT`,
+ * `P1DT` with no time components after `T`) at the match stage, instead
+ * of accepting them as a syntactically-valid zero/malformed duration
+ * that a looser grammar would silently normalize.
  */
 export function parseIsoDurationToHours(value) {
   if (typeof value !== 'string') {
     return null;
   }
-  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(
-    value,
-  );
+  const match =
+    /^P(?=\d|T\d)(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(
+      value,
+    );
   if (!match) {
     return null;
   }
@@ -792,21 +801,29 @@ export function parseIsoDurationToHours(value) {
   const totalHours = Number(days ?? 0) * 24 + Number(hours ?? 0);
   return totalHours > 0 ? totalHours : null;
 }
+// Matches the start of the next Markdown list item: a newline, optional
+// leading indentation (nested/indented lists), then one of the three
+// common bullet markers and at least one space. Whitespace-tolerant so
+// an indented or differently-marked list still bounds correctly instead
+// of letting the slice run past the intended bullet.
+const NEXT_BULLET_PATTERN = /\n[ \t]*[-*+]\s+/;
 /**
  * Slice `section` down to just the bullet introduced by `bulletLabel`
- * (e.g. `**Stale**:`), stopping before the next `- ` list item or at the
- * end of `section`. Returns null when `bulletLabel` is not found. Bounding
- * the slice to one bullet is what stops the anchor regexes in
- * {@link parseThresholdsProseHours} from crossing into an unrelated
- * number that happens to appear in a *different* bullet.
+ * (e.g. `**Stale**:`), stopping before the next list item (see
+ * {@link NEXT_BULLET_PATTERN}) or at the end of `section`. Returns null
+ * when `bulletLabel` is not found. Bounding the slice to one bullet is
+ * what stops the anchor regexes in {@link parseThresholdsProseHours}
+ * from crossing into an unrelated number that happens to appear in a
+ * *different* bullet.
  */
 function extractBulletText(section, bulletLabel) {
   const start = section.indexOf(bulletLabel);
   if (start === -1) {
     return null;
   }
-  const nextBullet = section.indexOf('\n- ', start + 1);
-  return section.slice(start, nextBullet === -1 ? undefined : nextBullet);
+  const rest = section.slice(start);
+  const nextBulletMatch = NEXT_BULLET_PATTERN.exec(rest);
+  return nextBulletMatch ? rest.slice(0, nextBulletMatch.index) : rest;
 }
 /**
  * Extract the stale-age and heartbeat-interval hour values the

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -127,6 +127,7 @@ export function runDoctor({
   );
   checkPolicySignals(root, report);
   checkHelperRuntimeConfig(root, report);
+  checkClaimTimingConsistency(root, report);
   checkAgentEntryFiles(root, report);
   checkTemplateVersionSignal(root, report);
   const worktreeGuardEnforced =
@@ -890,6 +891,168 @@ function checkHelperRuntimeConfig(root: string, report: DoctorReport) {
     report.passes.push(
       `${file} declares helper runtime profile "${helperRuntime.profile}"`,
     );
+  }
+}
+
+/** One config↔prose value pair this doctor cross-checks. */
+interface ClaimTimingAnchor {
+  configKey: 'staleAge' | 'heartbeatInterval';
+  label: string;
+  proseHoursKey: 'staleAgeHours' | 'heartbeatIntervalHours';
+}
+
+// Adding a future anchor is a one-line addition here — no new branching
+// logic — as long as its prose lives in the same Thresholds section
+// parsed by parseThresholdsProseHours.
+const CLAIM_TIMING_ANCHORS: readonly ClaimTimingAnchor[] = [
+  {
+    configKey: 'staleAge',
+    label: 'claimTiming.staleAge',
+    proseHoursKey: 'staleAgeHours',
+  },
+  {
+    configKey: 'heartbeatInterval',
+    label: 'claimTiming.heartbeatInterval',
+    proseHoursKey: 'heartbeatIntervalHours',
+  },
+];
+
+/**
+ * Parse an ISO 8601 duration to whole hours. Returns null for a
+ * non-string, an unparseable value, a zero/negative duration (an
+ * operationally meaningless stale-age/heartbeat), or sub-hour precision
+ * (minutes/seconds) — the Thresholds prose only ever states whole hours,
+ * so a sub-hour config value has no prose counterpart to compare against.
+ */
+export function parseIsoDurationToHours(value: unknown): number | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(
+    value,
+  );
+  if (!match) {
+    return null;
+  }
+  const [, days, hours, minutes, seconds] = match;
+  if (Number(minutes ?? 0) !== 0 || Number(seconds ?? 0) !== 0) {
+    return null;
+  }
+  const totalHours = Number(days ?? 0) * 24 + Number(hours ?? 0);
+  return totalHours > 0 ? totalHours : null;
+}
+
+/**
+ * Extract the stale-age and heartbeat-interval hour values the
+ * `## Thresholds` section of overview-core prose states. Returns null for
+ * the whole result when the section heading itself is not found (the
+ * section was renamed or removed); returns null for an individual field
+ * when that field's anchor phrase is not found within an otherwise-present
+ * section (the bullet was reworded past recognition). Neither case is an
+ * error — the caller skips the comparison for what it cannot parse.
+ */
+export function parseThresholdsProseHours(overviewCoreText: string): {
+  staleAgeHours: number | null;
+  heartbeatIntervalHours: number | null;
+} | null {
+  const sectionStart = overviewCoreText.indexOf('## Thresholds');
+  if (sectionStart === -1) {
+    return null;
+  }
+  const nextHeading = overviewCoreText.indexOf('\n## ', sectionStart + 1);
+  const section = overviewCoreText.slice(
+    sectionStart,
+    nextHeading === -1 ? undefined : nextHeading,
+  );
+
+  const staleMatch = /\*\*Stale\*\*:[\s\S]*?≥\s*(\d+)\s*h\b/.exec(section);
+  const heartbeatMatch = /\*\*Heartbeat\*\*:[\s\S]*?every\s+(\d+)\s*h\b/.exec(
+    section,
+  );
+
+  return {
+    staleAgeHours: staleMatch ? Number(staleMatch[1]) : null,
+    heartbeatIntervalHours: heartbeatMatch ? Number(heartbeatMatch[1]) : null,
+  };
+}
+
+/**
+ * Compare `.github/idd/config.json`'s claimTiming values against the
+ * overview-core Thresholds prose. Returns a warning-level finding naming
+ * both locations and both values only when a config value and its
+ * matching prose value are both parseable AND numerically differ. Returns
+ * null (no finding) when the section/bullet cannot be parsed, when either
+ * side is unparseable, or when the values agree — this check never
+ * produces an error, per its acceptance criteria, and degrades silently
+ * on a customized adopter repo rather than false-failing it.
+ */
+export function classifyClaimTimingConsistency(
+  claimTiming: { staleAge?: unknown; heartbeatInterval?: unknown } | undefined,
+  overviewCoreText: string,
+): WorktreeHeadFinding | null {
+  if (!claimTiming) {
+    return null;
+  }
+  const prose = parseThresholdsProseHours(overviewCoreText);
+  if (!prose) {
+    return null;
+  }
+
+  const mismatches: string[] = [];
+  for (const anchor of CLAIM_TIMING_ANCHORS) {
+    const configHours = parseIsoDurationToHours(claimTiming[anchor.configKey]);
+    const proseHours = prose[anchor.proseHoursKey];
+    if (configHours === null || proseHours === null) {
+      continue;
+    }
+    if (configHours !== proseHours) {
+      mismatches.push(
+        `${anchor.label} is ${configHours} h in .github/idd/config.json but ` +
+          `${proseHours} h in the Thresholds section of ` +
+          '.github/instructions/idd-overview-core.instructions.md',
+      );
+    }
+  }
+
+  if (mismatches.length === 0) {
+    return null;
+  }
+  return {
+    level: 'warning',
+    message: `config↔instruction-prose policy-value drift: ${mismatches.join('; ')}.`,
+  };
+}
+
+function checkClaimTimingConsistency(root: string, report: DoctorReport) {
+  const read = (relativePath: string) => {
+    try {
+      return readFileSync(join(root, relativePath), 'utf8');
+    } catch {
+      return null;
+    }
+  };
+  const configText = read('.github/idd/config.json');
+  const overviewCoreText = read(
+    '.github/instructions/idd-overview-core.instructions.md',
+  );
+  if (configText === null || overviewCoreText === null) {
+    return;
+  }
+
+  let config: unknown;
+  try {
+    config = JSON.parse(configText);
+  } catch {
+    return;
+  }
+  const claimTiming = (config as { claimTiming?: unknown } | null)
+    ?.claimTiming as
+    | { staleAge?: unknown; heartbeatInterval?: unknown }
+    | undefined;
+
+  const finding = classifyClaimTimingConsistency(claimTiming, overviewCoreText);
+  if (finding) {
+    report.warnings.push(finding.message);
   }
 }
 

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -928,18 +928,27 @@ const CLAIM_TIMING_ANCHORS: readonly ClaimTimingAnchor[] = [
  * is not a string, does not match the ISO 8601 duration grammar, carries
  * sub-hour precision (minutes/seconds) — the Thresholds prose only ever
  * states whole hours, so a sub-hour config value has no prose counterpart
- * to compare against — or resolves to zero hours (`P`, `PT`, `PT0H`, ...),
- * which matches the grammar but is operationally meaningless as a
+ * to compare against — or resolves to zero hours (`PT0H`, ...), which
+ * matches the grammar but is operationally meaningless as a
  * stale-age/heartbeat value. A negative duration cannot occur: the
  * grammar has no sign, so a leading `-` fails the `^P` anchor outright.
+ *
+ * The lookaheads (`(?=\d|T\d)` after `P`, `(?=\d)` after `T`) mirror
+ * `schemas/policy.schema.json`'s `claimTiming.staleAge`/
+ * `heartbeatInterval` pattern exactly, so this rejects the same
+ * dangling-designator strings the schema does (bare `P`, bare `PT`,
+ * `P1DT` with no time components after `T`) at the match stage, instead
+ * of accepting them as a syntactically-valid zero/malformed duration
+ * that a looser grammar would silently normalize.
  */
 export function parseIsoDurationToHours(value: unknown): number | null {
   if (typeof value !== 'string') {
     return null;
   }
-  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(
-    value,
-  );
+  const match =
+    /^P(?=\d|T\d)(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(
+      value,
+    );
   if (!match) {
     return null;
   }
@@ -951,13 +960,21 @@ export function parseIsoDurationToHours(value: unknown): number | null {
   return totalHours > 0 ? totalHours : null;
 }
 
+// Matches the start of the next Markdown list item: a newline, optional
+// leading indentation (nested/indented lists), then one of the three
+// common bullet markers and at least one space. Whitespace-tolerant so
+// an indented or differently-marked list still bounds correctly instead
+// of letting the slice run past the intended bullet.
+const NEXT_BULLET_PATTERN = /\n[ \t]*[-*+]\s+/;
+
 /**
  * Slice `section` down to just the bullet introduced by `bulletLabel`
- * (e.g. `**Stale**:`), stopping before the next `- ` list item or at the
- * end of `section`. Returns null when `bulletLabel` is not found. Bounding
- * the slice to one bullet is what stops the anchor regexes in
- * {@link parseThresholdsProseHours} from crossing into an unrelated
- * number that happens to appear in a *different* bullet.
+ * (e.g. `**Stale**:`), stopping before the next list item (see
+ * {@link NEXT_BULLET_PATTERN}) or at the end of `section`. Returns null
+ * when `bulletLabel` is not found. Bounding the slice to one bullet is
+ * what stops the anchor regexes in {@link parseThresholdsProseHours}
+ * from crossing into an unrelated number that happens to appear in a
+ * *different* bullet.
  */
 function extractBulletText(
   section: string,
@@ -967,8 +984,9 @@ function extractBulletText(
   if (start === -1) {
     return null;
   }
-  const nextBullet = section.indexOf('\n- ', start + 1);
-  return section.slice(start, nextBullet === -1 ? undefined : nextBullet);
+  const rest = section.slice(start);
+  const nextBulletMatch = NEXT_BULLET_PATTERN.exec(rest);
+  return nextBulletMatch ? rest.slice(0, nextBulletMatch.index) : rest;
 }
 
 /**

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -918,11 +918,14 @@ const CLAIM_TIMING_ANCHORS: readonly ClaimTimingAnchor[] = [
 ];
 
 /**
- * Parse an ISO 8601 duration to whole hours. Returns null for a
- * non-string, an unparseable value, a zero/negative duration (an
- * operationally meaningless stale-age/heartbeat), or sub-hour precision
- * (minutes/seconds) — the Thresholds prose only ever states whole hours,
- * so a sub-hour config value has no prose counterpart to compare against.
+ * Parse an ISO 8601 duration to whole hours. Returns null when the input
+ * is not a string, does not match the ISO 8601 duration grammar, carries
+ * sub-hour precision (minutes/seconds) — the Thresholds prose only ever
+ * states whole hours, so a sub-hour config value has no prose counterpart
+ * to compare against — or resolves to zero hours (`P`, `PT`, `PT0H`, ...),
+ * which matches the grammar but is operationally meaningless as a
+ * stale-age/heartbeat value. A negative duration cannot occur: the
+ * grammar has no sign, so a leading `-` fails the `^P` anchor outright.
  */
 export function parseIsoDurationToHours(value: unknown): number | null {
   if (typeof value !== 'string') {
@@ -943,13 +946,36 @@ export function parseIsoDurationToHours(value: unknown): number | null {
 }
 
 /**
+ * Slice `section` down to just the bullet introduced by `bulletLabel`
+ * (e.g. `**Stale**:`), stopping before the next `- ` list item or at the
+ * end of `section`. Returns null when `bulletLabel` is not found. Bounding
+ * the slice to one bullet is what stops the anchor regexes in
+ * {@link parseThresholdsProseHours} from crossing into an unrelated
+ * number that happens to appear in a *different* bullet.
+ */
+function extractBulletText(
+  section: string,
+  bulletLabel: string,
+): string | null {
+  const start = section.indexOf(bulletLabel);
+  if (start === -1) {
+    return null;
+  }
+  const nextBullet = section.indexOf('\n- ', start + 1);
+  return section.slice(start, nextBullet === -1 ? undefined : nextBullet);
+}
+
+/**
  * Extract the stale-age and heartbeat-interval hour values the
  * `## Thresholds` section of overview-core prose states. Returns null for
  * the whole result when the section heading itself is not found (the
  * section was renamed or removed); returns null for an individual field
- * when that field's anchor phrase is not found within an otherwise-present
- * section (the bullet was reworded past recognition). Neither case is an
- * error — the caller skips the comparison for what it cannot parse.
+ * when that field's own bullet, or its anchor phrase within that bullet,
+ * is not found (the bullet was reworded past recognition or removed).
+ * Neither case is an error — the caller skips the comparison for what it
+ * cannot parse. Each anchor regex is matched only within its own
+ * bullet's text (see {@link extractBulletText}), so a number in an
+ * unrelated bullet is never misattributed to this field.
  */
 export function parseThresholdsProseHours(overviewCoreText: string): {
   staleAgeHours: number | null;
@@ -965,10 +991,12 @@ export function parseThresholdsProseHours(overviewCoreText: string): {
     nextHeading === -1 ? undefined : nextHeading,
   );
 
-  const staleMatch = /\*\*Stale\*\*:[\s\S]*?≥\s*(\d+)\s*h\b/.exec(section);
-  const heartbeatMatch = /\*\*Heartbeat\*\*:[\s\S]*?every\s+(\d+)\s*h\b/.exec(
-    section,
-  );
+  const staleBullet = extractBulletText(section, '**Stale**:');
+  const heartbeatBullet = extractBulletText(section, '**Heartbeat**:');
+  const staleMatch = staleBullet ? /≥\s*(\d+)\s*h\b/.exec(staleBullet) : null;
+  const heartbeatMatch = heartbeatBullet
+    ? /every\s+(\d+)\s*h\b/.exec(heartbeatBullet)
+    : null;
 
   return {
     staleAgeHours: staleMatch ? Number(staleMatch[1]) : null,
@@ -1023,7 +1051,10 @@ export function classifyClaimTimingConsistency(
   };
 }
 
-function checkClaimTimingConsistency(root: string, report: DoctorReport) {
+export function checkClaimTimingConsistency(
+  root: string,
+  report: DoctorReport,
+) {
   const read = (relativePath: string) => {
     try {
       return readFileSync(join(root, relativePath), 'utf8');

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -896,7 +896,7 @@ function checkHelperRuntimeConfig(root: string, report: DoctorReport) {
 
 /** One reportable finding from the claimTiming config↔prose check. */
 export interface ClaimTimingFinding {
-  level: 'error' | 'warning';
+  level: 'warning';
   message: string;
 }
 

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -894,6 +894,12 @@ function checkHelperRuntimeConfig(root: string, report: DoctorReport) {
   }
 }
 
+/** One reportable finding from the claimTiming config↔prose check. */
+export interface ClaimTimingFinding {
+  level: 'error' | 'warning';
+  message: string;
+}
+
 /** One config↔prose value pair this doctor cross-checks. */
 interface ClaimTimingAnchor {
   configKey: 'staleAge' | 'heartbeatInterval';
@@ -1017,7 +1023,7 @@ export function parseThresholdsProseHours(overviewCoreText: string): {
 export function classifyClaimTimingConsistency(
   claimTiming: { staleAge?: unknown; heartbeatInterval?: unknown } | undefined,
   overviewCoreText: string,
-): WorktreeHeadFinding | null {
+): ClaimTimingFinding | null {
   if (!claimTiming) {
     return null;
   }

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1692,6 +1692,16 @@ test('parseIsoDurationToHours returns null for non-string, malformed, zero, and 
   assert.equal(parseIsoDurationToHours('PT30M'), null);
 });
 
+test('parseIsoDurationToHours rejects dangling designators the policy schema also rejects', () => {
+  // Regression test: the original regex had no lookaheads, so `P1DT`
+  // (a "D" component followed by a dangling "T" with no H/M/S after it)
+  // matched and silently resolved to 24h — a schema-invalid value that
+  // should be treated as unparseable, not silently normalized.
+  assert.equal(parseIsoDurationToHours('P1DT'), null);
+  assert.equal(parseIsoDurationToHours('P'), null);
+  assert.equal(parseIsoDurationToHours('PT'), null);
+});
+
 test('parseThresholdsProseHours extracts the current stale-age and heartbeat-interval hours', () => {
   assert.deepEqual(parseThresholdsProseHours(THRESHOLDS_SECTION), {
     staleAgeHours: 24,
@@ -1815,6 +1825,25 @@ test('parseThresholdsProseHours does not let a later bullet leak into an earlier
   assert.deepEqual(parseThresholdsProseHours(rewordedWithUnrelatedNumber), {
     staleAgeHours: 24,
     heartbeatIntervalHours: null,
+  });
+});
+
+test('parseThresholdsProseHours still bounds bullets correctly when the list is indented', () => {
+  // Regression test: the bullet-boundary search originally looked only
+  // for the literal "\n- " substring, so an indented sub-list (or a
+  // "*"/"+" marker) would not be recognized as a boundary and the slice
+  // could run past the intended bullet, re-enabling the cross-bullet
+  // leak this file's other regression tests guard against.
+  const indented = `## Thresholds
+
+  - **Stale**: claims expire after a while, no number stated here.
+  - **Heartbeat**: re-post the claim comment every 12 h while holding.
+
+## Fail-closed default
+`;
+  assert.deepEqual(parseThresholdsProseHours(indented), {
+    staleAgeHours: null,
+    heartbeatIntervalHours: 12,
   });
 });
 

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 
 import {
   backLinkPatternFor,
+  checkClaimTimingConsistency,
   checkProjectCommands,
   classifyBacklog,
   classifyClaimTimingConsistency,
@@ -1781,4 +1782,97 @@ test('classifyClaimTimingConsistency skips when the config value itself is unpar
     ),
     null,
   );
+});
+
+test("parseThresholdsProseHours does not let one bullet's number leak into the other", () => {
+  // Regression test: the anchor regexes must be bounded to their OWN
+  // bullet's text. Before the extractBulletText fix, an unbounded
+  // [\s\S]*? could cross from a Stale bullet with no "≥ N h" of its own
+  // into the Heartbeat bullet's unrelated "≥ 48 h" text, silently
+  // misattributing that number as the stale-age value.
+  const rewordedWithUnrelatedNumber = `## Thresholds
+
+- **Stale**: claims expire after a while, see policy docs for specifics.
+- **Heartbeat**: re-post the claim comment every 12 h while holding;
+  note a hard SLA ceiling of ≥ 48 h before escalation applies.
+
+## Fail-closed default
+`;
+  assert.deepEqual(parseThresholdsProseHours(rewordedWithUnrelatedNumber), {
+    staleAgeHours: null,
+    heartbeatIntervalHours: 12,
+  });
+});
+
+test('parseThresholdsProseHours does not let a later bullet leak into an earlier one either', () => {
+  const rewordedWithUnrelatedNumber = `## Thresholds
+
+- **Stale**: an active claim is stale ≥ 24 h ago.
+- **Heartbeat**: re-post while holding; no fixed cadence stated here.
+
+## Fail-closed default
+`;
+  assert.deepEqual(parseThresholdsProseHours(rewordedWithUnrelatedNumber), {
+    staleAgeHours: 24,
+    heartbeatIntervalHours: null,
+  });
+});
+
+test('checkClaimTimingConsistency pushes a warning when config and prose disagree', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-claim-timing-'));
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({
+        claimTiming: { staleAge: 'PT48H', heartbeatInterval: 'PT12H' },
+      }),
+    );
+    mkdirSync(join(dir, '.github/instructions'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/instructions/idd-overview-core.instructions.md'),
+      THRESHOLDS_SECTION,
+    );
+
+    const report = emptyReport(dir);
+    checkClaimTimingConsistency(dir, report);
+    assert.equal(report.errors.length, 0);
+    assert.equal(report.warnings.length, 1);
+    assert.match(report.warnings[0], /claimTiming\.staleAge is 48 h/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkClaimTimingConsistency pushes no warning when config and prose agree, or when a file is missing', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-claim-timing-'));
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({
+        claimTiming: { staleAge: 'PT24H', heartbeatInterval: 'PT12H' },
+      }),
+    );
+    mkdirSync(join(dir, '.github/instructions'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/instructions/idd-overview-core.instructions.md'),
+      THRESHOLDS_SECTION,
+    );
+
+    const agreeingReport = emptyReport(dir);
+    checkClaimTimingConsistency(dir, agreeingReport);
+    assert.equal(agreeingReport.warnings.length, 0);
+    assert.equal(agreeingReport.errors.length, 0);
+
+    // No config.json at all: this check is not the file-presence gate —
+    // it skips rather than erroring.
+    rmSync(join(dir, '.github/idd/config.json'));
+    const missingConfigReport = emptyReport(dir);
+    checkClaimTimingConsistency(dir, missingConfigReport);
+    assert.equal(missingConfigReport.warnings.length, 0);
+    assert.equal(missingConfigReport.errors.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -8,6 +8,7 @@ import {
   backLinkPatternFor,
   checkProjectCommands,
   classifyBacklog,
+  classifyClaimTimingConsistency,
   classifyPrimaryHead,
   classifyWorktreeGuardActivation,
   classifyWorktreeHeadFinding,
@@ -27,8 +28,10 @@ import {
   formatCleanupBacklogScanProgress,
   hookWiresWorktreeGuard,
   isGithubBackLinkHost,
+  parseIsoDurationToHours,
   parsePrimaryWorktreePath,
   parseProjectCommandRows,
+  parseThresholdsProseHours,
   readWorktreeGuardBranchPatterns,
   readWorktreeGuardEnabled,
   scanFileForPlaceholders,
@@ -1651,4 +1654,131 @@ test('checkProjectCommands errors when no overview file carries the table', () =
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+const THRESHOLDS_SECTION = `## Thresholds
+
+Ownership timing in this workflow uses the policy defaults
+\`claim-stale-age\` and \`claim-heartbeat-interval\` listed in
+\`docs/policy-constants.md\`.
+
+- **Stale**: an active claim whose latest **valid** \`claimed-by\`
+  comment's GitHub \`created_at\` is ≥ 24 h ago. Another session may take
+  it over by posting a fresh \`{claim-id}\` whose \`supersedes:\` value is
+  that active claim's \`{claim-id}\`.
+- **Heartbeat**: after re-validating ownership, re-post the claim
+  comment every 12 h while holding or when any phase is expected to
+  exceed 12 h. The latest **valid** \`claimed-by\` comment for the same
+  \`{claim-id}\` resets the stale clock. Embed timestamps are ignored;
+  only the GitHub \`created_at\` of the comment itself counts.
+
+## Fail-closed default
+
+Some other section.
+`;
+
+test('parseIsoDurationToHours parses whole-hour and whole-day ISO 8601 durations', () => {
+  assert.equal(parseIsoDurationToHours('PT24H'), 24);
+  assert.equal(parseIsoDurationToHours('P1D'), 24);
+  assert.equal(parseIsoDurationToHours('PT12H'), 12);
+});
+
+test('parseIsoDurationToHours returns null for non-string, malformed, zero, and sub-hour values', () => {
+  assert.equal(parseIsoDurationToHours(24), null);
+  assert.equal(parseIsoDurationToHours(undefined), null);
+  assert.equal(parseIsoDurationToHours('not a duration'), null);
+  assert.equal(parseIsoDurationToHours('PT0H'), null);
+  assert.equal(parseIsoDurationToHours('PT30M'), null);
+});
+
+test('parseThresholdsProseHours extracts the current stale-age and heartbeat-interval hours', () => {
+  assert.deepEqual(parseThresholdsProseHours(THRESHOLDS_SECTION), {
+    staleAgeHours: 24,
+    heartbeatIntervalHours: 12,
+  });
+});
+
+test('parseThresholdsProseHours returns null when the Thresholds heading is missing', () => {
+  assert.equal(
+    parseThresholdsProseHours('## Some Other Section\n\nNo thresholds here.\n'),
+    null,
+  );
+});
+
+test('parseThresholdsProseHours degrades per-field when a bullet is reworded past recognition', () => {
+  const reworded = `## Thresholds
+
+- **Stale**: claims expire after a while.
+- **Heartbeat**: after re-validating ownership, re-post the claim
+  comment every 12 h while holding.
+
+## Fail-closed default
+`;
+  assert.deepEqual(parseThresholdsProseHours(reworded), {
+    staleAgeHours: null,
+    heartbeatIntervalHours: 12,
+  });
+});
+
+test('classifyClaimTimingConsistency returns null when config and prose agree (this repo today)', () => {
+  assert.equal(
+    classifyClaimTimingConsistency(
+      { staleAge: 'PT24H', heartbeatInterval: 'PT12H' },
+      THRESHOLDS_SECTION,
+    ),
+    null,
+  );
+});
+
+test('classifyClaimTimingConsistency warns naming both locations and both values on a seeded mismatch', () => {
+  const finding = classifyClaimTimingConsistency(
+    { staleAge: 'PT48H', heartbeatInterval: 'PT12H' },
+    THRESHOLDS_SECTION,
+  );
+  assert.equal(finding?.level, 'warning');
+  assert.match(finding?.message ?? '', /claimTiming\.staleAge is 48 h/);
+  assert.match(finding?.message ?? '', /24 h in the Thresholds section/);
+  assert.match(finding?.message ?? '', /\.github\/idd\/config\.json/);
+  assert.match(
+    finding?.message ?? '',
+    /\.github\/instructions\/idd-overview-core\.instructions\.md/,
+  );
+  // heartbeatInterval agrees (12 h both sides), so only staleAge is named.
+  assert.doesNotMatch(finding?.message ?? '', /heartbeatInterval/);
+});
+
+test('classifyClaimTimingConsistency reports every mismatching anchor, not just the first', () => {
+  const finding = classifyClaimTimingConsistency(
+    { staleAge: 'PT48H', heartbeatInterval: 'PT6H' },
+    THRESHOLDS_SECTION,
+  );
+  assert.match(finding?.message ?? '', /claimTiming\.staleAge is 48 h/);
+  assert.match(finding?.message ?? '', /claimTiming\.heartbeatInterval is 6 h/);
+});
+
+test('classifyClaimTimingConsistency skips (no warning, no error) when the section is unparseable', () => {
+  assert.equal(
+    classifyClaimTimingConsistency(
+      { staleAge: 'PT48H', heartbeatInterval: 'PT6H' },
+      '# A repo with no Thresholds section at all.\n',
+    ),
+    null,
+  );
+});
+
+test('classifyClaimTimingConsistency skips when claimTiming is absent from config', () => {
+  assert.equal(
+    classifyClaimTimingConsistency(undefined, THRESHOLDS_SECTION),
+    null,
+  );
+});
+
+test('classifyClaimTimingConsistency skips when the config value itself is unparseable', () => {
+  assert.equal(
+    classifyClaimTimingConsistency(
+      { staleAge: 'not-a-duration', heartbeatInterval: 'PT12H' },
+      THRESHOLDS_SECTION,
+    ),
+    null,
+  );
 });


### PR DESCRIPTION
## Summary

Adds an `idd-doctor` check that cross-validates
`claimTiming.staleAge` / `claimTiming.heartbeatInterval` between
`.github/idd/config.json` (machine-readable, authoritative for
helpers) and the `## Thresholds` prose section of
`.github/instructions/idd-overview-core.instructions.md`
(authoritative for instructions-only adopters).

Mirrors the #1157 enabled-but-inert pattern: a pure classifier
(`classifyClaimTimingConsistency`) plus a `read()`-based wrapper
(`checkClaimTimingConsistency`), warning-level only, never a hard
error. The anchor set (`staleAge`/`heartbeatInterval`) is a small
data-driven table so a future value can be added without new
branching logic.

Parsing degrades gracefully — skip, no warning — when the Thresholds
heading is missing/renamed or an individual bullet is reworded past
recognition, so a customized adopter repo is never false-failed.

An independent critique pass on the first implementation found a real
bug (fixed before this PR): the anchor regexes were bounded only by
section end, not by bullet end, so a reworded bullet with no number of
its own could silently pick up an unrelated number from the *other*
bullet's text. Fixed by slicing each bullet's own text before matching
(`extractBulletText`); 2 regression tests reproduce the exact
cross-bullet-leak fixtures that exposed it.

## Test plan

- [x] `pnpm test` and `pnpm run lint:minimum` pass (1582/1582, 0
      failures)
- [x] `pnpm run build` committed alongside the `.mts` source
- [x] `node bin/idd-doctor.mjs` on this repo today produces no new
      warning (config and prose currently agree at 24h/12h) — verified
      directly, and independently re-verified by the critique agent
      via a full repo copy with a seeded real mismatch, confirming the
      check fires correctly through the actual `runDoctor()` path (not
      just in isolated unit tests)
- [x] Fixture-driven tests cover: match (no warning), seeded mismatch
      (warning names both file paths and both values), unparseable/
      rewritten section or bullet (skip, no warning, no error), and
      the cross-bullet-leak regression above

Closes #1216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a check that warns when timing values in project guidance and configuration drift out of sync.
  * Made the check fail safely when required content is missing or values can’t be read, avoiding noisy errors.
* **Tests**
  * Expanded coverage for timing parsing, threshold extraction, mismatch detection, and skip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->