### PR TITLE
refactor(helpers): carve marker helpers out of protocol-helpers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -39,6 +39,7 @@ scripts/idd-merge-execute.mjs linguist-generated=true
 scripts/idd-roadmap-audit-execute.mjs linguist-generated=true
 scripts/live-status-digest.mjs linguist-generated=true
 scripts/markdown-code.mjs linguist-generated=true
+scripts/marker-helpers.mjs linguist-generated=true
 scripts/marker-regex.mjs linguist-generated=true
 scripts/merged-pr-feedback-sweep.mjs linguist-generated=true
 scripts/minimize-superseded-markers.mjs linguist-generated=true

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -79,8 +79,8 @@ file drop:
    `protocol-helpers` shared-core API absent from your older snapshot, so the
    real work is a shared-core bump — budget that prerequisite before scoping the
    leaf-helper slices. The shared core is no longer always a single file: a
-   façade split (e.g. `protocol-helpers.mts` re-exporting `marker-helpers.mts`)
-   can move an API to a focused module that the entry file only re-exports, so
+   façade split (e.g. `protocol-helpers` re-exporting `marker-helpers`) can
+   move an API to a focused module that the entry file only re-exports, so
    vendor every file the shared-core entry point re-exports from, not just the
    entry file itself.
 2. **Reconcile a hardened core additively.** If you hardened that core, treat

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -78,7 +78,11 @@ file drop:
 1. **Diff the shared core first.** The new helper usually imports a newer
    `protocol-helpers` shared-core API absent from your older snapshot, so the
    real work is a shared-core bump — budget that prerequisite before scoping the
-   leaf-helper slices.
+   leaf-helper slices. The shared core is no longer always a single file: a
+   façade split (e.g. `protocol-helpers.mts` re-exporting `marker-helpers.mts`)
+   can move an API to a focused module that the entry file only re-exports, so
+   vendor every file the shared-core entry point re-exports from, not just the
+   entry file itself.
 2. **Reconcile a hardened core additively.** If you hardened that core, treat
    the bump as additive named-divergence reconciliation gated on your protected
    tests: preserve the local hardening and append only the new exports rather

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -8,15 +8,15 @@
 // split; see #1209): the render*/parse* functions for the claim, watermark,
 // baseline, advisory-wait, forced-handoff, and external-check-waiver
 // HTML-comment markers, plus the marker-field validation helpers they
-// share. protocol-helpers.mts re-exports every name below (`export * from
-// './marker-helpers.mts'`), so existing call sites are unaffected.
+// share. The protocol-helpers module re-exports every name below (a plain
+// `export * from` re-export), so existing call sites are unaffected.
 //
-// Layering: this module MUST NOT import from protocol-helpers.mts — that
-// would form an import cycle, since protocol-helpers.mts imports from here.
-// Gate-level aggregation that folds many markers together with trust/policy
-// context (summarizeExternalCheckWaivers, summarizeAdvisoryWaitMarkers,
+// Layering: this module MUST NOT import from protocol-helpers — that would
+// form an import cycle, since protocol-helpers imports from here. Gate-level
+// aggregation that folds many markers together with trust/policy context
+// (summarizeExternalCheckWaivers, summarizeAdvisoryWaitMarkers,
 // resolveLatestReviewWatermark, deriveIddAgentLogins, and friends) stays in
-// protocol-helpers.mts on purpose: those depend on the broader trusted-actor
+// protocol-helpers on purpose: those depend on the broader trusted-actor
 // resolution machinery there (normalizeTrustedMarkerLogins and friends), and
 // moving them here would force exactly that forbidden back-import. Only the
 // single-marker parse/render primitives move in this wave.

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -1,0 +1,667 @@
+// idd-generated-from: src/scripts/marker-helpers.mts
+//
+// The scripts/marker-helpers.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Operational-marker rendering and parsing (wave 1 of the protocol-helpers
+// split; see #1209): the render*/parse* functions for the claim, watermark,
+// baseline, advisory-wait, forced-handoff, and external-check-waiver
+// HTML-comment markers, plus the marker-field validation helpers they
+// share. protocol-helpers.mts re-exports every name below (`export * from
+// './marker-helpers.mts'`), so existing call sites are unaffected.
+//
+// Layering: this module MUST NOT import from protocol-helpers.mts — that
+// would form an import cycle, since protocol-helpers.mts imports from here.
+// Gate-level aggregation that folds many markers together with trust/policy
+// context (summarizeExternalCheckWaivers, summarizeAdvisoryWaitMarkers,
+// resolveLatestReviewWatermark, deriveIddAgentLogins, and friends) stays in
+// protocol-helpers.mts on purpose: those depend on the broader trusted-actor
+// resolution machinery there (normalizeTrustedMarkerLogins and friends), and
+// moving them here would force exactly that forbidden back-import. Only the
+// single-marker parse/render primitives move in this wave.
+const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
+const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
+const OPERATIONAL_MARKERS = [
+  {
+    label: '<!-- claimed-by:',
+    pattern:
+      /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+  },
+  {
+    label: '<!-- unclaimed-by:',
+    pattern:
+      /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+  },
+  {
+    label: '<!-- review-watermark:',
+    pattern:
+      /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+  },
+  {
+    label: '<!-- review-baseline:',
+    pattern:
+      /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+  },
+  {
+    label: 'advisory-wait:',
+    pattern:
+      /^advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+  },
+  {
+    label: 'advisory-wait-recovery:',
+    pattern:
+      /^advisory-wait-recovery:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+  },
+  {
+    label: '<!-- advisory-wait:',
+    pattern: /^<!--\s*advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\S+\s*-->\s*$/,
+  },
+  {
+    label: '<!-- forced-handoff:',
+    pattern: /^\s*<!--\s*forced-handoff:\s*\{[\s\S]*\}\s*-->[\s\S]*$/i,
+    startPattern: /^<!--\s*forced-handoff:/i,
+  },
+  {
+    label: '<!-- idd-external-check-waiver:',
+    pattern:
+      /^<!--\s*idd-external-check-waiver:\s+\S+\s+\S+\s+[0-9a-f]{40}\s+check:\S+\s+reason:\S+\s+expires:\S+\s*-->[\s\S]*$/i,
+    startPattern: /^<!--\s*idd-external-check-waiver:/i,
+  },
+];
+export const IDD_AGENT_DERIVED_MARKERS = new Set([
+  '<!-- claimed-by:',
+  '<!-- unclaimed-by:',
+  '<!-- review-watermark:',
+  '<!-- review-baseline:',
+  'advisory-wait:',
+  'advisory-wait-recovery:',
+  '<!-- advisory-wait:',
+]);
+const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(['issue-only', 'issue-plus-pr']);
+const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/;
+export function parseClaimComment(body, createdAt) {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match || !isValidIsoTimestamp(match[4])) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    supersedes: match[3],
+    branch: match[5],
+    createdAt,
+  };
+}
+export function parseReleaseComment(body) {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match || !isValidIsoTimestamp(match[3])) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+  };
+}
+export function parseForcedHandoffComment(body, createdAt) {
+  const trimmed = body.trimStart().trimEnd();
+  const markerMatch = trimmed.match(/^<!--\s*forced-handoff:\s*/i);
+  if (!markerMatch) {
+    return null;
+  }
+  const markerEnd = trimmed.indexOf('-->');
+  if (markerEnd < 0) {
+    return null;
+  }
+  const visibleNote = trimmed.slice(markerEnd + 3);
+  const visibleText = visibleNote
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<!--[\s\S]*$/g, ' ')
+    .trim();
+  if (!visibleText) {
+    return null;
+  }
+  const payloadText = trimmed.slice(markerMatch[0].length, markerEnd).trim();
+  let payload;
+  try {
+    payload = JSON.parse(payloadText);
+  } catch {
+    return null;
+  }
+  return normalizeForcedHandoffPayload(payload, { createdAt });
+}
+export function normalizeForcedHandoffPayload(payload, options = {}) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+  const record = payload;
+  if (
+    hasConflictingPayloadAliases(record, 'oldAgentId', 'old-agent-id') ||
+    hasConflictingPayloadAliases(record, 'oldClaimId', 'old-claim-id') ||
+    hasConflictingPayloadAliases(record, 'newAgentId', 'new-agent-id') ||
+    hasConflictingPayloadAliases(record, 'newClaimId', 'new-claim-id') ||
+    hasConflictingPayloadAliases(record, 'forcedBy', 'forced-by') ||
+    hasConflictingPayloadAliases(record, 'linkedPr', 'linked-pr') ||
+    hasConflictingPayloadAliases(record, 'contextScope', 'context-scope')
+  ) {
+    return null;
+  }
+  const oldAgentId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'oldAgentId', 'old-agent-id'),
+  );
+  const oldClaimId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'oldClaimId', 'old-claim-id'),
+  );
+  const newAgentId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'newAgentId', 'new-agent-id'),
+  );
+  const newClaimId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'newClaimId', 'new-claim-id'),
+  );
+  const branch = normalizeBranchToken(pickPayloadValue(record, 'branch'));
+  const forcedBy = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'forcedBy', 'forced-by'),
+  );
+  const reason = normalizeForcedHandoffReason(
+    pickPayloadValue(record, 'reason'),
+  );
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(
+    pickPayloadValue(record, 'timestamp'),
+  );
+  const contextScope = normalizeContextScope(
+    pickPayloadValue(record, 'contextScope', 'context-scope'),
+  );
+  const linkedPr = normalizeLinkedPr(
+    pickPayloadValue(record, 'linkedPr', 'linked-pr'),
+  );
+  const createdAt = normalizeSecondPrecisionIsoTimestamp(options.createdAt);
+  if (
+    !oldAgentId ||
+    !oldClaimId ||
+    !newAgentId ||
+    !newClaimId ||
+    !branch ||
+    !forcedBy ||
+    !reason ||
+    !timestamp ||
+    !contextScope
+  ) {
+    return null;
+  }
+  if (oldClaimId === newClaimId) {
+    return null;
+  }
+  if (contextScope === 'issue-plus-pr' && !linkedPr) {
+    return null;
+  }
+  if (contextScope === 'issue-only' && linkedPr) {
+    return null;
+  }
+  return {
+    oldAgentId,
+    oldClaimId,
+    newAgentId,
+    newClaimId,
+    branch,
+    ...(linkedPr ? { linkedPr } : {}),
+    forcedBy,
+    reason,
+    timestamp,
+    contextScope,
+    ...(createdAt ? { createdAt } : {}),
+  };
+}
+export function renderForcedHandoffConsentNote(payload) {
+  const normalized = normalizeForcedHandoffPayload(payload);
+  if (!normalized) {
+    throw new Error('invalid forced handoff payload');
+  }
+  if (normalized.contextScope === 'issue-plus-pr') {
+    const linkedPr = normalized.linkedPr ?? '';
+    const prReference = /^\d+$/.test(linkedPr) ? `#${linkedPr}` : linkedPr;
+    return [
+      `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
+      'owning session or agent is unavailable. This transfers ownership away',
+      `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\` for PR ${prReference}.`,
+      'If the prior session resumes, it must stop immediately and must not',
+      'push, comment, resolve review state, or merge until a maintainer',
+      'reassigns ownership.',
+    ].join('\n');
+  }
+  return [
+    `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
+    'owning session or agent is unavailable. This transfers ownership away',
+    `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\`.`,
+    'If the prior session resumes, it must stop immediately and must not',
+    'push, comment, resolve review state, or merge until a maintainer',
+    'reassigns ownership.',
+  ].join('\n');
+}
+export function renderForcedHandoffComment(payload) {
+  const normalized = normalizeForcedHandoffPayload(payload);
+  if (!normalized) {
+    throw new Error('invalid forced handoff payload');
+  }
+  const markerPayload = {
+    'old-agent-id': normalized.oldAgentId,
+    'old-claim-id': normalized.oldClaimId,
+    'new-agent-id': normalized.newAgentId,
+    'new-claim-id': normalized.newClaimId,
+    branch: normalized.branch,
+    ...(normalized.linkedPr ? { 'linked-pr': normalized.linkedPr } : {}),
+    'forced-by': normalized.forcedBy,
+    reason: normalized.reason,
+    timestamp: normalized.timestamp,
+    'context-scope': normalized.contextScope,
+  };
+  return `<!-- forced-handoff: ${JSON.stringify(markerPayload)} -->\n\n${renderForcedHandoffConsentNote(normalized)}`;
+}
+function normalizeExternalCheckWaiverField(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (
+    !trimmed ||
+    /[\r\n]/.test(trimmed) ||
+    trimmed.includes('<!--') ||
+    trimmed.includes('-->')
+  ) {
+    return '';
+  }
+  return trimmed;
+}
+function encodeExternalCheckWaiverField(value) {
+  return encodeURIComponent(value);
+}
+function decodeExternalCheckWaiverField(value) {
+  try {
+    return decodeURIComponent(String(value ?? '').trim());
+  } catch {
+    return '';
+  }
+}
+function renderExternalCheckWaiverNote(normalized) {
+  const actor = normalizeNonWhitespaceToken(normalized.actor) || 'idd-operator';
+  return [
+    `_${actor}: external check waiver for IDD F phase on \`${normalized.checkSelector}\``,
+    `until \`${normalized.expiresAt}\` (reason: ${normalized.reason})._`,
+  ].join(' ');
+}
+export function renderExternalCheckWaiverComment(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const checkSelector = normalizeExternalCheckWaiverField(
+    payload?.checkSelector ?? payload?.check,
+  );
+  const reason = normalizeExternalCheckWaiverField(payload?.reason);
+  const expiresAt = normalizeIsoTimestamp(
+    payload?.expiresAt ?? payload?.expires,
+  );
+  if (
+    !agentId ||
+    !claimId ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    !checkSelector ||
+    !reason ||
+    !expiresAt
+  ) {
+    throw new Error('invalid external check waiver payload');
+  }
+  const encodedCheck = encodeExternalCheckWaiverField(checkSelector);
+  const encodedReason = encodeExternalCheckWaiverField(reason);
+  return [
+    `<!-- idd-external-check-waiver: ${agentId} ${claimId} ${headSha} check:${encodedCheck} reason:${encodedReason} expires:${expiresAt} -->`,
+    '',
+    renderExternalCheckWaiverNote({
+      actor: payload?.actor,
+      checkSelector,
+      reason,
+      expiresAt,
+    }),
+  ].join('\n');
+}
+// --- Per-cycle marker body renderers (#900) ---
+//
+// Pure, network-free renderers for the three operational markers an agent
+// posts every cycle. Each returns the exact ready-to-post body (HTML marker
+// token + visible "Do not edit" note); the agent still posts it via the
+// documented HTTP path, so the read-only-by-default / instructions-only
+// fallback is unaffected. The written formats in idd-overview-core (claim)
+// and idd-review-snapshot (watermark/baseline) remain canonical.
+function normalizeMarkerCount(value) {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : null;
+  }
+  const trimmed = String(value ?? '').trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+  // The watermark parser reads the count back with Number.parseInt; reject
+  // magnitudes beyond the safe-integer range, which would not round-trip to
+  // the same value (and as a JS number would stringify to exponential form
+  // that the parser's `\d+` count pattern rejects outright).
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? trimmed : null;
+}
+// `none` or a valid ISO timestamp (matching the watermark parser's
+// none-or-ISO contract); null signals an invalid value the caller rejects.
+function normalizeMarkerIsoOrNone(value) {
+  const token = normalizeNonWhitespaceToken(value);
+  if (token === '' || token === 'none') {
+    return 'none';
+  }
+  return normalizeIsoTimestamp(token) || null;
+}
+export function renderClaimedByMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const supersedesToken = normalizeNonWhitespaceToken(payload?.supersedes);
+  // Normalize any case-variant of the sentinel to lowercase `none`. The claim
+  // parser matches case-insensitively, but the claim lifecycle
+  // (`applyClaimEvent`) accepts a fresh claim only when `supersedes === 'none'`
+  // exactly, so an emitted `None`/`NONE` would round-trip into a claim that is
+  // silently ignored. Real claim IDs (never a case-variant of `none`) pass
+  // through verbatim.
+  const supersedes =
+    supersedesToken === '' || supersedesToken.toLowerCase() === 'none'
+      ? 'none'
+      : supersedesToken;
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  const branch = normalizeBranchToken(payload?.branch);
+  if (!agentId || !claimId || !timestamp || !branch) {
+    throw new Error('invalid claimed-by marker payload');
+  }
+  return [
+    `<!-- claimed-by: ${agentId} ${claimId} supersedes: ${supersedes} ${timestamp} branch: ${branch} -->`,
+    '',
+    `_${agentId}: issue claim — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+export function renderReviewWatermarkMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const maxActivityAt = normalizeMarkerIsoOrNone(payload?.maxActivityAt);
+  const totalItemCount = normalizeMarkerCount(payload?.totalItemCount);
+  const ciCompletedAt = normalizeMarkerIsoOrNone(payload?.ciCompletedAt);
+  if (
+    !agentId ||
+    !claimId ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    maxActivityAt === null ||
+    totalItemCount === null ||
+    ciCompletedAt === null
+  ) {
+    throw new Error('invalid review-watermark marker payload');
+  }
+  return [
+    `<!-- review-watermark: ${agentId} ${claimId} ${headSha} ${maxActivityAt} ${totalItemCount} ${ciCompletedAt} -->`,
+    '',
+    `_${agentId}: review triage snapshot — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+export function renderReviewBaselineMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const sha = normalizeNonWhitespaceToken(payload?.sha).toLowerCase();
+  if (!agentId || !claimId || !/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error('invalid review-baseline marker payload');
+  }
+  return [
+    `<!-- review-baseline: ${agentId} ${claimId} ${sha} -->`,
+    '',
+    `_${agentId}: critique baseline — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+// --- Write-side companion renderers (#1047) ---
+//
+// The post-idd-marker helper POSTs the same operational markers an agent emits
+// per cycle, so it needs a renderer for every type it can post. claim /
+// watermark / baseline already have renderers above; these three cover the
+// remaining post-idd-marker types so the body formats stay single-sourced.
+export function renderUnclaimedByMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !claimId || !timestamp) {
+    throw new Error('invalid unclaimed-by marker payload');
+  }
+  return [
+    `<!-- unclaimed-by: ${agentId} ${claimId} ${timestamp} -->`,
+    '',
+    `_${agentId}: issue claim released — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+// advisory-wait / advisory-wait-recovery are PLAIN-TEXT markers (no visible
+// note): the AW2 / shell-fallback recognizers anchor on `-->$` / `\s*$`, so a
+// trailing visible note would break them. They carry the PR HEAD SHA (not a
+// claim id) per the AW3 protocol.
+export function renderAdvisoryWaitMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-wait marker payload');
+  }
+  return `advisory-wait: ${agentId} ${headSha} ${timestamp}`;
+}
+export function renderAdvisoryWaitRecoveryMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-wait-recovery marker payload');
+  }
+  return `advisory-wait-recovery: ${agentId} ${headSha} ${timestamp}`;
+}
+export function parseExternalCheckWaiverComment(body, createdAt) {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*idd-external-check-waiver:\\s+(\\S+)\\s+(\\S+)\\s+([0-9a-f]{40})\\s+check:(\\S+)\\s+reason:(\\S+)\\s+expires:(\\S+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match) {
+    return null;
+  }
+  const checkSelector = normalizeExternalCheckWaiverField(
+    decodeExternalCheckWaiverField(match[4]),
+  );
+  const reason = normalizeExternalCheckWaiverField(
+    decodeExternalCheckWaiverField(match[5]),
+  );
+  const expiresAt = normalizeIsoTimestamp(match[6]);
+  if (!checkSelector || !reason || !expiresAt) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    headSha: match[3].toLowerCase(),
+    checkSelector,
+    reason,
+    expiresAt,
+    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
+  };
+}
+export function parseReviewWatermarkComment(body, createdAt) {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*review-watermark:\\s+(\\S+)\\s+(\\S+)\\s+([0-9a-f]{40})\\s+(\\S+)\\s+(\\d+)\\s+(\\S+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match) {
+    return null;
+  }
+  const maxActivityUpdatedAt = match[4];
+  const latestCiCompletedAt = match[6];
+  if (
+    maxActivityUpdatedAt !== 'none' &&
+    !isValidIsoTimestamp(maxActivityUpdatedAt)
+  ) {
+    return null;
+  }
+  if (
+    latestCiCompletedAt !== 'none' &&
+    !isValidIsoTimestamp(latestCiCompletedAt)
+  ) {
+    return null;
+  }
+  const totalItemCount = Number.parseInt(match[5], 10);
+  if (!Number.isInteger(totalItemCount) || totalItemCount < 0) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    headSha: match[3],
+    maxActivityUpdatedAt,
+    totalItemCount,
+    latestCiCompletedAt,
+    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
+  };
+}
+export function operationalMarkerPrefix(body) {
+  const normalized = body.trimEnd();
+  const marker = OPERATIONAL_MARKERS.find((candidate) =>
+    candidate.pattern.test(normalized),
+  );
+  if (!marker) {
+    return null;
+  }
+  if (
+    marker.label === '<!-- forced-handoff:' &&
+    !isValidForcedHandoffOperationalMarker(normalized)
+  ) {
+    return null;
+  }
+  return marker.label;
+}
+export function operationalMarkerPrefixByStart(body) {
+  const normalized = body.trimStart();
+  const marker = OPERATIONAL_MARKERS.find(
+    (candidate) =>
+      candidate.startPattern?.test(normalized) ??
+      normalized.startsWith(candidate.label),
+  );
+  if (!marker) {
+    return null;
+  }
+  if (
+    marker.label === '<!-- forced-handoff:' &&
+    !isValidForcedHandoffOperationalMarker(normalized)
+  ) {
+    return null;
+  }
+  return marker.label;
+}
+function normalizeNonWhitespaceToken(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (
+    !trimmed ||
+    /\s/.test(trimmed) ||
+    trimmed.includes('<!--') ||
+    trimmed.includes('-->')
+  ) {
+    return '';
+  }
+  return trimmed;
+}
+function pickPayloadValue(payload, ...keys) {
+  for (const key of keys) {
+    if (Object.hasOwn(payload, key)) {
+      return payload[key];
+    }
+  }
+  return undefined;
+}
+function hasConflictingPayloadAliases(payload, firstKey, secondKey) {
+  if (!Object.hasOwn(payload, firstKey) || !Object.hasOwn(payload, secondKey)) {
+    return false;
+  }
+  return (
+    String(payload[firstKey] ?? '').trim() !==
+    String(payload[secondKey] ?? '').trim()
+  );
+}
+function normalizeBranchToken(value) {
+  const token = normalizeNonWhitespaceToken(value);
+  if (!token || token.includes('>')) {
+    return '';
+  }
+  return token;
+}
+function normalizeForcedHandoffReason(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed || /[\r\n]/.test(trimmed) || trimmed.includes('-->')) {
+    return '';
+  }
+  return trimmed;
+}
+function normalizeIsoTimestamp(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed || !isValidIsoTimestamp(trimmed)) {
+    return '';
+  }
+  return trimmed;
+}
+function normalizeSecondPrecisionIsoTimestamp(value) {
+  const timestamp = normalizeIsoTimestamp(value);
+  if (!timestamp || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(timestamp)) {
+    return '';
+  }
+  return timestamp;
+}
+function normalizeContextScope(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  return FORCED_HANDOFF_CONTEXT_SCOPES.has(trimmed) ? trimmed : '';
+}
+function normalizeLinkedPr(value) {
+  const token = normalizeNonWhitespaceToken(value);
+  if (!token || !FORCED_HANDOFF_LINKED_PR_PATTERN.test(token)) {
+    return '';
+  }
+  return token;
+}
+function isValidForcedHandoffOperationalMarker(body) {
+  return parseForcedHandoffComment(body, '') !== null;
+}
+export function isValidIsoTimestamp(value) {
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) return false;
+  const normalize = (ts) => ts.replace('.000Z', 'Z');
+  return normalize(new Date(time).toISOString()) === normalize(value);
+}

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -8,70 +8,31 @@ import {
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
   normalizeAdvisoryWaitRuntimeOptions,
 } from './advisory-wait-policy.mjs';
+
+// Façade re-export (wave 1 of the protocol-helpers split; see #1209): every
+// marker render/parse primitive now lives in marker-helpers.mts. Re-exporting
+// it here keeps every existing call site (`from './protocol-helpers.mts'`)
+// unchanged. The named imports below are this module's own internal uses of
+// those moved names; see marker-helpers.mts for the layering rule (it must
+// never import back from this file).
+export * from './marker-helpers.mjs';
+
+import {
+  IDD_AGENT_DERIVED_MARKERS,
+  isValidIsoTimestamp,
+  operationalMarkerPrefix,
+  operationalMarkerPrefixByStart,
+  parseClaimComment,
+  parseExternalCheckWaiverComment,
+  parseForcedHandoffComment,
+  parseReleaseComment,
+  parseReviewWatermarkComment,
+} from './marker-helpers.mjs';
 import {
   getReviewEscalationChangesRequestedPolicy,
   parseIsoDurationToMs,
 } from './policy-helpers.mjs';
-
-const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
-const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
 export const LIVE_STATUS_DIGEST_MARKER = '<!-- idd-live-status: current -->';
-const OPERATIONAL_MARKERS = [
-  {
-    label: '<!-- claimed-by:',
-    pattern:
-      /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
-  },
-  {
-    label: '<!-- unclaimed-by:',
-    pattern:
-      /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
-  },
-  {
-    label: '<!-- review-watermark:',
-    pattern:
-      /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
-  },
-  {
-    label: '<!-- review-baseline:',
-    pattern:
-      /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
-  },
-  {
-    label: 'advisory-wait:',
-    pattern:
-      /^advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
-  },
-  {
-    label: 'advisory-wait-recovery:',
-    pattern:
-      /^advisory-wait-recovery:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
-  },
-  {
-    label: '<!-- advisory-wait:',
-    pattern: /^<!--\s*advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\S+\s*-->\s*$/,
-  },
-  {
-    label: '<!-- forced-handoff:',
-    pattern: /^\s*<!--\s*forced-handoff:\s*\{[\s\S]*\}\s*-->[\s\S]*$/i,
-    startPattern: /^<!--\s*forced-handoff:/i,
-  },
-  {
-    label: '<!-- idd-external-check-waiver:',
-    pattern:
-      /^<!--\s*idd-external-check-waiver:\s+\S+\s+\S+\s+[0-9a-f]{40}\s+check:\S+\s+reason:\S+\s+expires:\S+\s*-->[\s\S]*$/i,
-    startPattern: /^<!--\s*idd-external-check-waiver:/i,
-  },
-];
-const IDD_AGENT_DERIVED_MARKERS = new Set([
-  '<!-- claimed-by:',
-  '<!-- unclaimed-by:',
-  '<!-- review-watermark:',
-  '<!-- review-baseline:',
-  'advisory-wait:',
-  'advisory-wait-recovery:',
-  '<!-- advisory-wait:',
-]);
 const REVIEW_BOT_LOGINS = new Set([
   'coderabbitai',
   'coderabbitai[bot]',
@@ -94,8 +55,6 @@ const UNSAFE_TEXT_RULES = [
   },
 ];
 const AMD_MARKER_PATTERN = /^\*\*Awaiting maintainer decision\*\*/i;
-const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(['issue-only', 'issue-plus-pr']);
-const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/;
 export function parsePaginatedGhNdjson(raw) {
   const text = String(raw ?? '').trim();
   if (!text) {
@@ -108,396 +67,6 @@ export function parsePaginatedGhNdjson(raw) {
       const value = JSON.parse(line);
       return Array.isArray(value) ? value : [value];
     });
-}
-export function parseClaimComment(body, createdAt) {
-  const match = body
-    .trimEnd()
-    .match(
-      new RegExp(
-        `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
-        'i',
-      ),
-    );
-  if (!match || !isValidIsoTimestamp(match[4])) {
-    return null;
-  }
-  return {
-    agentId: match[1],
-    claimId: match[2],
-    supersedes: match[3],
-    branch: match[5],
-    createdAt,
-  };
-}
-export function parseReleaseComment(body) {
-  const match = body
-    .trimEnd()
-    .match(
-      new RegExp(
-        `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
-        'i',
-      ),
-    );
-  if (!match || !isValidIsoTimestamp(match[3])) {
-    return null;
-  }
-  return {
-    agentId: match[1],
-    claimId: match[2],
-  };
-}
-export function parseForcedHandoffComment(body, createdAt) {
-  const trimmed = body.trimStart().trimEnd();
-  const markerMatch = trimmed.match(/^<!--\s*forced-handoff:\s*/i);
-  if (!markerMatch) {
-    return null;
-  }
-  const markerEnd = trimmed.indexOf('-->');
-  if (markerEnd < 0) {
-    return null;
-  }
-  const visibleNote = trimmed.slice(markerEnd + 3);
-  const visibleText = visibleNote
-    .replace(/<!--[\s\S]*?-->/g, ' ')
-    .replace(/<!--[\s\S]*$/g, ' ')
-    .trim();
-  if (!visibleText) {
-    return null;
-  }
-  const payloadText = trimmed.slice(markerMatch[0].length, markerEnd).trim();
-  let payload;
-  try {
-    payload = JSON.parse(payloadText);
-  } catch {
-    return null;
-  }
-  return normalizeForcedHandoffPayload(payload, { createdAt });
-}
-export function normalizeForcedHandoffPayload(payload, options = {}) {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    return null;
-  }
-  const record = payload;
-  if (
-    hasConflictingPayloadAliases(record, 'oldAgentId', 'old-agent-id') ||
-    hasConflictingPayloadAliases(record, 'oldClaimId', 'old-claim-id') ||
-    hasConflictingPayloadAliases(record, 'newAgentId', 'new-agent-id') ||
-    hasConflictingPayloadAliases(record, 'newClaimId', 'new-claim-id') ||
-    hasConflictingPayloadAliases(record, 'forcedBy', 'forced-by') ||
-    hasConflictingPayloadAliases(record, 'linkedPr', 'linked-pr') ||
-    hasConflictingPayloadAliases(record, 'contextScope', 'context-scope')
-  ) {
-    return null;
-  }
-  const oldAgentId = normalizeNonWhitespaceToken(
-    pickPayloadValue(record, 'oldAgentId', 'old-agent-id'),
-  );
-  const oldClaimId = normalizeNonWhitespaceToken(
-    pickPayloadValue(record, 'oldClaimId', 'old-claim-id'),
-  );
-  const newAgentId = normalizeNonWhitespaceToken(
-    pickPayloadValue(record, 'newAgentId', 'new-agent-id'),
-  );
-  const newClaimId = normalizeNonWhitespaceToken(
-    pickPayloadValue(record, 'newClaimId', 'new-claim-id'),
-  );
-  const branch = normalizeBranchToken(pickPayloadValue(record, 'branch'));
-  const forcedBy = normalizeNonWhitespaceToken(
-    pickPayloadValue(record, 'forcedBy', 'forced-by'),
-  );
-  const reason = normalizeForcedHandoffReason(
-    pickPayloadValue(record, 'reason'),
-  );
-  const timestamp = normalizeSecondPrecisionIsoTimestamp(
-    pickPayloadValue(record, 'timestamp'),
-  );
-  const contextScope = normalizeContextScope(
-    pickPayloadValue(record, 'contextScope', 'context-scope'),
-  );
-  const linkedPr = normalizeLinkedPr(
-    pickPayloadValue(record, 'linkedPr', 'linked-pr'),
-  );
-  const createdAt = normalizeSecondPrecisionIsoTimestamp(options.createdAt);
-  if (
-    !oldAgentId ||
-    !oldClaimId ||
-    !newAgentId ||
-    !newClaimId ||
-    !branch ||
-    !forcedBy ||
-    !reason ||
-    !timestamp ||
-    !contextScope
-  ) {
-    return null;
-  }
-  if (oldClaimId === newClaimId) {
-    return null;
-  }
-  if (contextScope === 'issue-plus-pr' && !linkedPr) {
-    return null;
-  }
-  if (contextScope === 'issue-only' && linkedPr) {
-    return null;
-  }
-  return {
-    oldAgentId,
-    oldClaimId,
-    newAgentId,
-    newClaimId,
-    branch,
-    ...(linkedPr ? { linkedPr } : {}),
-    forcedBy,
-    reason,
-    timestamp,
-    contextScope,
-    ...(createdAt ? { createdAt } : {}),
-  };
-}
-export function renderForcedHandoffConsentNote(payload) {
-  const normalized = normalizeForcedHandoffPayload(payload);
-  if (!normalized) {
-    throw new Error('invalid forced handoff payload');
-  }
-  if (normalized.contextScope === 'issue-plus-pr') {
-    const linkedPr = normalized.linkedPr ?? '';
-    const prReference = /^\d+$/.test(linkedPr) ? `#${linkedPr}` : linkedPr;
-    return [
-      `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
-      'owning session or agent is unavailable. This transfers ownership away',
-      `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\` for PR ${prReference}.`,
-      'If the prior session resumes, it must stop immediately and must not',
-      'push, comment, resolve review state, or merge until a maintainer',
-      'reassigns ownership.',
-    ].join('\n');
-  }
-  return [
-    `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
-    'owning session or agent is unavailable. This transfers ownership away',
-    `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\`.`,
-    'If the prior session resumes, it must stop immediately and must not',
-    'push, comment, resolve review state, or merge until a maintainer',
-    'reassigns ownership.',
-  ].join('\n');
-}
-export function renderForcedHandoffComment(payload) {
-  const normalized = normalizeForcedHandoffPayload(payload);
-  if (!normalized) {
-    throw new Error('invalid forced handoff payload');
-  }
-  const markerPayload = {
-    'old-agent-id': normalized.oldAgentId,
-    'old-claim-id': normalized.oldClaimId,
-    'new-agent-id': normalized.newAgentId,
-    'new-claim-id': normalized.newClaimId,
-    branch: normalized.branch,
-    ...(normalized.linkedPr ? { 'linked-pr': normalized.linkedPr } : {}),
-    'forced-by': normalized.forcedBy,
-    reason: normalized.reason,
-    timestamp: normalized.timestamp,
-    'context-scope': normalized.contextScope,
-  };
-  return `<!-- forced-handoff: ${JSON.stringify(markerPayload)} -->\n\n${renderForcedHandoffConsentNote(normalized)}`;
-}
-function normalizeExternalCheckWaiverField(value) {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  const trimmed = value.trim();
-  if (
-    !trimmed ||
-    /[\r\n]/.test(trimmed) ||
-    trimmed.includes('<!--') ||
-    trimmed.includes('-->')
-  ) {
-    return '';
-  }
-  return trimmed;
-}
-function encodeExternalCheckWaiverField(value) {
-  return encodeURIComponent(value);
-}
-function decodeExternalCheckWaiverField(value) {
-  try {
-    return decodeURIComponent(String(value ?? '').trim());
-  } catch {
-    return '';
-  }
-}
-function renderExternalCheckWaiverNote(normalized) {
-  const actor = normalizeNonWhitespaceToken(normalized.actor) || 'idd-operator';
-  return [
-    `_${actor}: external check waiver for IDD F phase on \`${normalized.checkSelector}\``,
-    `until \`${normalized.expiresAt}\` (reason: ${normalized.reason})._`,
-  ].join(' ');
-}
-export function renderExternalCheckWaiverComment(payload) {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
-  const checkSelector = normalizeExternalCheckWaiverField(
-    payload?.checkSelector ?? payload?.check,
-  );
-  const reason = normalizeExternalCheckWaiverField(payload?.reason);
-  const expiresAt = normalizeIsoTimestamp(
-    payload?.expiresAt ?? payload?.expires,
-  );
-  if (
-    !agentId ||
-    !claimId ||
-    !/^[0-9a-f]{40}$/.test(headSha) ||
-    !checkSelector ||
-    !reason ||
-    !expiresAt
-  ) {
-    throw new Error('invalid external check waiver payload');
-  }
-  const encodedCheck = encodeExternalCheckWaiverField(checkSelector);
-  const encodedReason = encodeExternalCheckWaiverField(reason);
-  return [
-    `<!-- idd-external-check-waiver: ${agentId} ${claimId} ${headSha} check:${encodedCheck} reason:${encodedReason} expires:${expiresAt} -->`,
-    '',
-    renderExternalCheckWaiverNote({
-      actor: payload?.actor,
-      checkSelector,
-      reason,
-      expiresAt,
-    }),
-  ].join('\n');
-}
-// --- Per-cycle marker body renderers (#900) ---
-//
-// Pure, network-free renderers for the three operational markers an agent
-// posts every cycle. Each returns the exact ready-to-post body (HTML marker
-// token + visible "Do not edit" note); the agent still posts it via the
-// documented HTTP path, so the read-only-by-default / instructions-only
-// fallback is unaffected. The written formats in idd-overview-core (claim)
-// and idd-review-snapshot (watermark/baseline) remain canonical.
-function normalizeMarkerCount(value) {
-  if (typeof value === 'number') {
-    return Number.isSafeInteger(value) && value >= 0 ? String(value) : null;
-  }
-  const trimmed = String(value ?? '').trim();
-  if (!/^\d+$/.test(trimmed)) {
-    return null;
-  }
-  // The watermark parser reads the count back with Number.parseInt; reject
-  // magnitudes beyond the safe-integer range, which would not round-trip to
-  // the same value (and as a JS number would stringify to exponential form
-  // that the parser's `\d+` count pattern rejects outright).
-  const parsed = Number.parseInt(trimmed, 10);
-  return Number.isSafeInteger(parsed) ? trimmed : null;
-}
-// `none` or a valid ISO timestamp (matching the watermark parser's
-// none-or-ISO contract); null signals an invalid value the caller rejects.
-function normalizeMarkerIsoOrNone(value) {
-  const token = normalizeNonWhitespaceToken(value);
-  if (token === '' || token === 'none') {
-    return 'none';
-  }
-  return normalizeIsoTimestamp(token) || null;
-}
-export function renderClaimedByMarker(payload) {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const supersedesToken = normalizeNonWhitespaceToken(payload?.supersedes);
-  // Normalize any case-variant of the sentinel to lowercase `none`. The claim
-  // parser matches case-insensitively, but the claim lifecycle
-  // (`applyClaimEvent`) accepts a fresh claim only when `supersedes === 'none'`
-  // exactly, so an emitted `None`/`NONE` would round-trip into a claim that is
-  // silently ignored. Real claim IDs (never a case-variant of `none`) pass
-  // through verbatim.
-  const supersedes =
-    supersedesToken === '' || supersedesToken.toLowerCase() === 'none'
-      ? 'none'
-      : supersedesToken;
-  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  const branch = normalizeBranchToken(payload?.branch);
-  if (!agentId || !claimId || !timestamp || !branch) {
-    throw new Error('invalid claimed-by marker payload');
-  }
-  return [
-    `<!-- claimed-by: ${agentId} ${claimId} supersedes: ${supersedes} ${timestamp} branch: ${branch} -->`,
-    '',
-    `_${agentId}: issue claim — IDD automation marker. Do not edit._`,
-  ].join('\n');
-}
-export function renderReviewWatermarkMarker(payload) {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
-  const maxActivityAt = normalizeMarkerIsoOrNone(payload?.maxActivityAt);
-  const totalItemCount = normalizeMarkerCount(payload?.totalItemCount);
-  const ciCompletedAt = normalizeMarkerIsoOrNone(payload?.ciCompletedAt);
-  if (
-    !agentId ||
-    !claimId ||
-    !/^[0-9a-f]{40}$/.test(headSha) ||
-    maxActivityAt === null ||
-    totalItemCount === null ||
-    ciCompletedAt === null
-  ) {
-    throw new Error('invalid review-watermark marker payload');
-  }
-  return [
-    `<!-- review-watermark: ${agentId} ${claimId} ${headSha} ${maxActivityAt} ${totalItemCount} ${ciCompletedAt} -->`,
-    '',
-    `_${agentId}: review triage snapshot — IDD automation marker. Do not edit._`,
-  ].join('\n');
-}
-export function renderReviewBaselineMarker(payload) {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const sha = normalizeNonWhitespaceToken(payload?.sha).toLowerCase();
-  if (!agentId || !claimId || !/^[0-9a-f]{40}$/.test(sha)) {
-    throw new Error('invalid review-baseline marker payload');
-  }
-  return [
-    `<!-- review-baseline: ${agentId} ${claimId} ${sha} -->`,
-    '',
-    `_${agentId}: critique baseline — IDD automation marker. Do not edit._`,
-  ].join('\n');
-}
-// --- Write-side companion renderers (#1047) ---
-//
-// The post-idd-marker helper POSTs the same operational markers an agent emits
-// per cycle, so it needs a renderer for every type it can post. claim /
-// watermark / baseline already have renderers above; these three cover the
-// remaining post-idd-marker types so the body formats stay single-sourced.
-export function renderUnclaimedByMarker(payload) {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !claimId || !timestamp) {
-    throw new Error('invalid unclaimed-by marker payload');
-  }
-  return [
-    `<!-- unclaimed-by: ${agentId} ${claimId} ${timestamp} -->`,
-    '',
-    `_${agentId}: issue claim released — IDD automation marker. Do not edit._`,
-  ].join('\n');
-}
-// advisory-wait / advisory-wait-recovery are PLAIN-TEXT markers (no visible
-// note): the AW2 / shell-fallback recognizers anchor on `-->$` / `\s*$`, so a
-// trailing visible note would break them. They carry the PR HEAD SHA (not a
-// claim id) per the AW3 protocol.
-export function renderAdvisoryWaitMarker(payload) {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
-  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid advisory-wait marker payload');
-  }
-  return `advisory-wait: ${agentId} ${headSha} ${timestamp}`;
-}
-export function renderAdvisoryWaitRecoveryMarker(payload) {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
-  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid advisory-wait-recovery marker payload');
-  }
-  return `advisory-wait-recovery: ${agentId} ${headSha} ${timestamp}`;
 }
 function matchCheckSelectorLocal(name, selector, matchMode) {
   const n = String(name ?? '').trim();
@@ -686,112 +255,6 @@ export function summarizeExternalCheckWaivers(
     malformed,
     notConfigured,
   };
-}
-export function parseExternalCheckWaiverComment(body, createdAt) {
-  const match = body
-    .trimEnd()
-    .match(
-      new RegExp(
-        `^<!--\\s*idd-external-check-waiver:\\s+(\\S+)\\s+(\\S+)\\s+([0-9a-f]{40})\\s+check:(\\S+)\\s+reason:(\\S+)\\s+expires:(\\S+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
-        'i',
-      ),
-    );
-  if (!match) {
-    return null;
-  }
-  const checkSelector = normalizeExternalCheckWaiverField(
-    decodeExternalCheckWaiverField(match[4]),
-  );
-  const reason = normalizeExternalCheckWaiverField(
-    decodeExternalCheckWaiverField(match[5]),
-  );
-  const expiresAt = normalizeIsoTimestamp(match[6]);
-  if (!checkSelector || !reason || !expiresAt) {
-    return null;
-  }
-  return {
-    agentId: match[1],
-    claimId: match[2],
-    headSha: match[3].toLowerCase(),
-    checkSelector,
-    reason,
-    expiresAt,
-    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
-  };
-}
-export function parseReviewWatermarkComment(body, createdAt) {
-  const match = body
-    .trimEnd()
-    .match(
-      new RegExp(
-        `^<!--\\s*review-watermark:\\s+(\\S+)\\s+(\\S+)\\s+([0-9a-f]{40})\\s+(\\S+)\\s+(\\d+)\\s+(\\S+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
-        'i',
-      ),
-    );
-  if (!match) {
-    return null;
-  }
-  const maxActivityUpdatedAt = match[4];
-  const latestCiCompletedAt = match[6];
-  if (
-    maxActivityUpdatedAt !== 'none' &&
-    !isValidIsoTimestamp(maxActivityUpdatedAt)
-  ) {
-    return null;
-  }
-  if (
-    latestCiCompletedAt !== 'none' &&
-    !isValidIsoTimestamp(latestCiCompletedAt)
-  ) {
-    return null;
-  }
-  const totalItemCount = Number.parseInt(match[5], 10);
-  if (!Number.isInteger(totalItemCount) || totalItemCount < 0) {
-    return null;
-  }
-  return {
-    agentId: match[1],
-    claimId: match[2],
-    headSha: match[3],
-    maxActivityUpdatedAt,
-    totalItemCount,
-    latestCiCompletedAt,
-    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
-  };
-}
-export function operationalMarkerPrefix(body) {
-  const normalized = body.trimEnd();
-  const marker = OPERATIONAL_MARKERS.find((candidate) =>
-    candidate.pattern.test(normalized),
-  );
-  if (!marker) {
-    return null;
-  }
-  if (
-    marker.label === '<!-- forced-handoff:' &&
-    !isValidForcedHandoffOperationalMarker(normalized)
-  ) {
-    return null;
-  }
-  return marker.label;
-}
-export function operationalMarkerPrefixByStart(body) {
-  const normalized = body.trimStart();
-  const marker = OPERATIONAL_MARKERS.find(
-    (candidate) =>
-      candidate.startPattern?.test(normalized) ??
-      normalized.startsWith(candidate.label),
-  );
-  if (!marker) {
-    return null;
-  }
-  if (
-    marker.label === '<!-- forced-handoff:' &&
-    !isValidForcedHandoffOperationalMarker(normalized)
-  ) {
-    return null;
-  }
-  return marker.label;
 }
 export function findLiveStatusDigestComments(comments) {
   return comments.filter((comment) => {
@@ -4543,55 +4006,6 @@ function normalizeClaimResolutionOptions(optionsOrPredicate) {
         : () => {},
   };
 }
-function normalizeNonWhitespaceToken(value) {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  const trimmed = value.trim();
-  if (
-    !trimmed ||
-    /\s/.test(trimmed) ||
-    trimmed.includes('<!--') ||
-    trimmed.includes('-->')
-  ) {
-    return '';
-  }
-  return trimmed;
-}
-function pickPayloadValue(payload, ...keys) {
-  for (const key of keys) {
-    if (Object.hasOwn(payload, key)) {
-      return payload[key];
-    }
-  }
-  return undefined;
-}
-function hasConflictingPayloadAliases(payload, firstKey, secondKey) {
-  if (!Object.hasOwn(payload, firstKey) || !Object.hasOwn(payload, secondKey)) {
-    return false;
-  }
-  return (
-    String(payload[firstKey] ?? '').trim() !==
-    String(payload[secondKey] ?? '').trim()
-  );
-}
-function normalizeBranchToken(value) {
-  const token = normalizeNonWhitespaceToken(value);
-  if (!token || token.includes('>')) {
-    return '';
-  }
-  return token;
-}
-function normalizeForcedHandoffReason(value) {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  const trimmed = value.trim();
-  if (!trimmed || /[\r\n]/.test(trimmed) || trimmed.includes('-->')) {
-    return '';
-  }
-  return trimmed;
-}
 export function normalizeLinkedPrReference(value) {
   const token = String(value ?? '').trim();
   if (!token) {
@@ -4620,37 +4034,6 @@ export function normalizeLinkedPrReference(value) {
     // Not a URL-form linked-pr reference.
   }
   return token.toLowerCase();
-}
-function normalizeIsoTimestamp(value) {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  const trimmed = value.trim();
-  if (!trimmed || !isValidIsoTimestamp(trimmed)) {
-    return '';
-  }
-  return trimmed;
-}
-function normalizeSecondPrecisionIsoTimestamp(value) {
-  const timestamp = normalizeIsoTimestamp(value);
-  if (!timestamp || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(timestamp)) {
-    return '';
-  }
-  return timestamp;
-}
-function normalizeContextScope(value) {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  const trimmed = value.trim();
-  return FORCED_HANDOFF_CONTEXT_SCOPES.has(trimmed) ? trimmed : '';
-}
-function normalizeLinkedPr(value) {
-  const token = normalizeNonWhitespaceToken(value);
-  if (!token || !FORCED_HANDOFF_LINKED_PR_PATTERN.test(token)) {
-    return '';
-  }
-  return token;
 }
 export function classifyResumeRoutingCase(input, options = {}) {
   const staleHours = Number.isFinite(options.staleHours)
@@ -5099,9 +4482,6 @@ function isOperationalOrDigestCommentForGate(
   }
   return marker !== null || firstLine(body) === LIVE_STATUS_DIGEST_MARKER;
 }
-function isValidForcedHandoffOperationalMarker(body) {
-  return parseForcedHandoffComment(body, '') !== null;
-}
 function buildBodyPreview(body) {
   return firstLine(String(body ?? '')).slice(0, 120);
 }
@@ -5210,12 +4590,6 @@ function hasUnresolvedKnownBotThreads(threads) {
       return isKnownReviewBot(comment.author?.login ?? '');
     });
   });
-}
-function isValidIsoTimestamp(value) {
-  const time = Date.parse(value);
-  if (!Number.isFinite(time)) return false;
-  const normalize = (ts) => ts.replace('.000Z', 'Z');
-  return normalize(new Date(time).toISOString()) === normalize(value);
 }
 function isCompletedCiTimestamp(value) {
   const timestamp = String(value ?? '');

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -10,11 +10,11 @@ import {
 } from './advisory-wait-policy.mjs';
 
 // Façade re-export (wave 1 of the protocol-helpers split; see #1209): every
-// marker render/parse primitive now lives in marker-helpers.mts. Re-exporting
-// it here keeps every existing call site (`from './protocol-helpers.mts'`)
-// unchanged. The named imports below are this module's own internal uses of
-// those moved names; see marker-helpers.mts for the layering rule (it must
-// never import back from this file).
+// marker render/parse primitive now lives in the marker-helpers module.
+// Re-exporting it here keeps every existing call site importing from
+// protocol-helpers unchanged. The named imports below are this module's own
+// internal uses of those moved names; see marker-helpers for the layering
+// rule (it must never import back from this file).
 export * from './marker-helpers.mjs';
 
 import {

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1,0 +1,861 @@
+// idd-generated-from: src/scripts/marker-helpers.mts
+//
+// The scripts/marker-helpers.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Operational-marker rendering and parsing (wave 1 of the protocol-helpers
+// split; see #1209): the render*/parse* functions for the claim, watermark,
+// baseline, advisory-wait, forced-handoff, and external-check-waiver
+// HTML-comment markers, plus the marker-field validation helpers they
+// share. protocol-helpers.mts re-exports every name below (`export * from
+// './marker-helpers.mts'`), so existing call sites are unaffected.
+//
+// Layering: this module MUST NOT import from protocol-helpers.mts — that
+// would form an import cycle, since protocol-helpers.mts imports from here.
+// Gate-level aggregation that folds many markers together with trust/policy
+// context (summarizeExternalCheckWaivers, summarizeAdvisoryWaitMarkers,
+// resolveLatestReviewWatermark, deriveIddAgentLogins, and friends) stays in
+// protocol-helpers.mts on purpose: those depend on the broader trusted-actor
+// resolution machinery there (normalizeTrustedMarkerLogins and friends), and
+// moving them here would force exactly that forbidden back-import. Only the
+// single-marker parse/render primitives move in this wave.
+
+/** Operational marker matcher entry. */
+interface OperationalMarker {
+  label: string;
+  pattern: RegExp;
+  startPattern?: RegExp;
+}
+
+/** Parsed `<!-- claimed-by: ... -->` claim marker. */
+export interface ParsedClaimMarker {
+  agentId: string;
+  claimId: string;
+  supersedes: string;
+  branch: string;
+  createdAt: string;
+}
+
+/** Parsed `<!-- unclaimed-by: ... -->` release marker. */
+export interface ParsedReleaseMarker {
+  agentId: string;
+  claimId: string;
+}
+
+/** Parsed `<!-- forced-handoff: {...} -->` marker payload. */
+export interface ParsedForcedHandoffMarker {
+  oldAgentId: string;
+  oldClaimId: string;
+  newAgentId: string;
+  newClaimId: string;
+  branch: string;
+  linkedPr?: string;
+  forcedBy: string;
+  reason: string;
+  timestamp: string;
+  contextScope: string;
+  createdAt?: string;
+}
+
+/** Parsed `<!-- idd-external-check-waiver: ... -->` marker. */
+export interface ParsedExternalCheckWaiver {
+  agentId: string;
+  claimId: string;
+  headSha: string;
+  checkSelector: string;
+  reason: string;
+  expiresAt: string;
+  createdAt: string;
+}
+
+/** Parsed `<!-- review-watermark: ... -->` marker. */
+export interface ParsedReviewWatermark {
+  agentId: string;
+  claimId: string;
+  headSha: string;
+  maxActivityUpdatedAt: string;
+  totalItemCount: number;
+  latestCiCompletedAt: string;
+  createdAt: string;
+}
+
+const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
+const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
+
+const OPERATIONAL_MARKERS: OperationalMarker[] = [
+  {
+    label: '<!-- claimed-by:',
+    pattern:
+      /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+  },
+  {
+    label: '<!-- unclaimed-by:',
+    pattern:
+      /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+  },
+  {
+    label: '<!-- review-watermark:',
+    pattern:
+      /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+  },
+  {
+    label: '<!-- review-baseline:',
+    pattern:
+      /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+  },
+  {
+    label: 'advisory-wait:',
+    pattern:
+      /^advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+  },
+  {
+    label: 'advisory-wait-recovery:',
+    pattern:
+      /^advisory-wait-recovery:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+  },
+  {
+    label: '<!-- advisory-wait:',
+    pattern: /^<!--\s*advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\S+\s*-->\s*$/,
+  },
+  {
+    label: '<!-- forced-handoff:',
+    pattern: /^\s*<!--\s*forced-handoff:\s*\{[\s\S]*\}\s*-->[\s\S]*$/i,
+    startPattern: /^<!--\s*forced-handoff:/i,
+  },
+  {
+    label: '<!-- idd-external-check-waiver:',
+    pattern:
+      /^<!--\s*idd-external-check-waiver:\s+\S+\s+\S+\s+[0-9a-f]{40}\s+check:\S+\s+reason:\S+\s+expires:\S+\s*-->[\s\S]*$/i,
+    startPattern: /^<!--\s*idd-external-check-waiver:/i,
+  },
+];
+
+export const IDD_AGENT_DERIVED_MARKERS = new Set([
+  '<!-- claimed-by:',
+  '<!-- unclaimed-by:',
+  '<!-- review-watermark:',
+  '<!-- review-baseline:',
+  'advisory-wait:',
+  'advisory-wait-recovery:',
+  '<!-- advisory-wait:',
+]);
+
+const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(['issue-only', 'issue-plus-pr']);
+const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/;
+
+export function parseClaimComment(
+  body: string,
+  createdAt: string,
+): ParsedClaimMarker | null {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match || !isValidIsoTimestamp(match[4])) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    supersedes: match[3],
+    branch: match[5],
+    createdAt,
+  };
+}
+
+export function parseReleaseComment(body: string): ParsedReleaseMarker | null {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match || !isValidIsoTimestamp(match[3])) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    claimId: match[2],
+  };
+}
+
+export function parseForcedHandoffComment(
+  body: string,
+  createdAt: string,
+): ParsedForcedHandoffMarker | null {
+  const trimmed = body.trimStart().trimEnd();
+  const markerMatch = trimmed.match(/^<!--\s*forced-handoff:\s*/i);
+  if (!markerMatch) {
+    return null;
+  }
+
+  const markerEnd = trimmed.indexOf('-->');
+  if (markerEnd < 0) {
+    return null;
+  }
+
+  const visibleNote = trimmed.slice(markerEnd + 3);
+  const visibleText = visibleNote
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<!--[\s\S]*$/g, ' ')
+    .trim();
+  if (!visibleText) {
+    return null;
+  }
+
+  const payloadText = trimmed.slice(markerMatch[0].length, markerEnd).trim();
+  let payload: unknown;
+  try {
+    payload = JSON.parse(payloadText);
+  } catch {
+    return null;
+  }
+
+  return normalizeForcedHandoffPayload(payload, { createdAt });
+}
+
+export function normalizeForcedHandoffPayload(
+  payload: unknown,
+  options: { createdAt?: unknown } = {},
+): ParsedForcedHandoffMarker | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+
+  if (
+    hasConflictingPayloadAliases(record, 'oldAgentId', 'old-agent-id') ||
+    hasConflictingPayloadAliases(record, 'oldClaimId', 'old-claim-id') ||
+    hasConflictingPayloadAliases(record, 'newAgentId', 'new-agent-id') ||
+    hasConflictingPayloadAliases(record, 'newClaimId', 'new-claim-id') ||
+    hasConflictingPayloadAliases(record, 'forcedBy', 'forced-by') ||
+    hasConflictingPayloadAliases(record, 'linkedPr', 'linked-pr') ||
+    hasConflictingPayloadAliases(record, 'contextScope', 'context-scope')
+  ) {
+    return null;
+  }
+
+  const oldAgentId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'oldAgentId', 'old-agent-id'),
+  );
+  const oldClaimId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'oldClaimId', 'old-claim-id'),
+  );
+  const newAgentId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'newAgentId', 'new-agent-id'),
+  );
+  const newClaimId = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'newClaimId', 'new-claim-id'),
+  );
+  const branch = normalizeBranchToken(pickPayloadValue(record, 'branch'));
+  const forcedBy = normalizeNonWhitespaceToken(
+    pickPayloadValue(record, 'forcedBy', 'forced-by'),
+  );
+  const reason = normalizeForcedHandoffReason(
+    pickPayloadValue(record, 'reason'),
+  );
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(
+    pickPayloadValue(record, 'timestamp'),
+  );
+  const contextScope = normalizeContextScope(
+    pickPayloadValue(record, 'contextScope', 'context-scope'),
+  );
+  const linkedPr = normalizeLinkedPr(
+    pickPayloadValue(record, 'linkedPr', 'linked-pr'),
+  );
+  const createdAt = normalizeSecondPrecisionIsoTimestamp(options.createdAt);
+
+  if (
+    !oldAgentId ||
+    !oldClaimId ||
+    !newAgentId ||
+    !newClaimId ||
+    !branch ||
+    !forcedBy ||
+    !reason ||
+    !timestamp ||
+    !contextScope
+  ) {
+    return null;
+  }
+
+  if (oldClaimId === newClaimId) {
+    return null;
+  }
+
+  if (contextScope === 'issue-plus-pr' && !linkedPr) {
+    return null;
+  }
+
+  if (contextScope === 'issue-only' && linkedPr) {
+    return null;
+  }
+
+  return {
+    oldAgentId,
+    oldClaimId,
+    newAgentId,
+    newClaimId,
+    branch,
+    ...(linkedPr ? { linkedPr } : {}),
+    forcedBy,
+    reason,
+    timestamp,
+    contextScope,
+    ...(createdAt ? { createdAt } : {}),
+  };
+}
+
+export function renderForcedHandoffConsentNote(payload: unknown): string {
+  const normalized = normalizeForcedHandoffPayload(payload);
+  if (!normalized) {
+    throw new Error('invalid forced handoff payload');
+  }
+
+  if (normalized.contextScope === 'issue-plus-pr') {
+    const linkedPr = normalized.linkedPr ?? '';
+    const prReference = /^\d+$/.test(linkedPr) ? `#${linkedPr}` : linkedPr;
+    return [
+      `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
+      'owning session or agent is unavailable. This transfers ownership away',
+      `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\` for PR ${prReference}.`,
+      'If the prior session resumes, it must stop immediately and must not',
+      'push, comment, resolve review state, or merge until a maintainer',
+      'reassigns ownership.',
+    ].join('\n');
+  }
+
+  return [
+    `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
+    'owning session or agent is unavailable. This transfers ownership away',
+    `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\`.`,
+    'If the prior session resumes, it must stop immediately and must not',
+    'push, comment, resolve review state, or merge until a maintainer',
+    'reassigns ownership.',
+  ].join('\n');
+}
+
+export function renderForcedHandoffComment(payload: unknown): string {
+  const normalized = normalizeForcedHandoffPayload(payload);
+  if (!normalized) {
+    throw new Error('invalid forced handoff payload');
+  }
+
+  const markerPayload = {
+    'old-agent-id': normalized.oldAgentId,
+    'old-claim-id': normalized.oldClaimId,
+    'new-agent-id': normalized.newAgentId,
+    'new-claim-id': normalized.newClaimId,
+    branch: normalized.branch,
+    ...(normalized.linkedPr ? { 'linked-pr': normalized.linkedPr } : {}),
+    'forced-by': normalized.forcedBy,
+    reason: normalized.reason,
+    timestamp: normalized.timestamp,
+    'context-scope': normalized.contextScope,
+  };
+
+  return `<!-- forced-handoff: ${JSON.stringify(markerPayload)} -->\n\n${renderForcedHandoffConsentNote(normalized)}`;
+}
+
+function normalizeExternalCheckWaiverField(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (
+    !trimmed ||
+    /[\r\n]/.test(trimmed) ||
+    trimmed.includes('<!--') ||
+    trimmed.includes('-->')
+  ) {
+    return '';
+  }
+  return trimmed;
+}
+
+function encodeExternalCheckWaiverField(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function decodeExternalCheckWaiverField(value: unknown): string {
+  try {
+    return decodeURIComponent(String(value ?? '').trim());
+  } catch {
+    return '';
+  }
+}
+
+function renderExternalCheckWaiverNote(normalized: {
+  actor?: unknown;
+  checkSelector: string;
+  reason: string;
+  expiresAt: string;
+}): string {
+  const actor = normalizeNonWhitespaceToken(normalized.actor) || 'idd-operator';
+  return [
+    `_${actor}: external check waiver for IDD F phase on \`${normalized.checkSelector}\``,
+    `until \`${normalized.expiresAt}\` (reason: ${normalized.reason})._`,
+  ].join(' ');
+}
+
+export function renderExternalCheckWaiverComment(
+  payload:
+    | {
+        agentId?: unknown;
+        claimId?: unknown;
+        headSha?: unknown;
+        checkSelector?: unknown;
+        check?: unknown;
+        reason?: unknown;
+        expiresAt?: unknown;
+        expires?: unknown;
+        actor?: unknown;
+      }
+    | null
+    | undefined,
+): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const checkSelector = normalizeExternalCheckWaiverField(
+    payload?.checkSelector ?? payload?.check,
+  );
+  const reason = normalizeExternalCheckWaiverField(payload?.reason);
+  const expiresAt = normalizeIsoTimestamp(
+    payload?.expiresAt ?? payload?.expires,
+  );
+
+  if (
+    !agentId ||
+    !claimId ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    !checkSelector ||
+    !reason ||
+    !expiresAt
+  ) {
+    throw new Error('invalid external check waiver payload');
+  }
+
+  const encodedCheck = encodeExternalCheckWaiverField(checkSelector);
+  const encodedReason = encodeExternalCheckWaiverField(reason);
+
+  return [
+    `<!-- idd-external-check-waiver: ${agentId} ${claimId} ${headSha} check:${encodedCheck} reason:${encodedReason} expires:${expiresAt} -->`,
+    '',
+    renderExternalCheckWaiverNote({
+      actor: payload?.actor,
+      checkSelector,
+      reason,
+      expiresAt,
+    }),
+  ].join('\n');
+}
+
+// --- Per-cycle marker body renderers (#900) ---
+//
+// Pure, network-free renderers for the three operational markers an agent
+// posts every cycle. Each returns the exact ready-to-post body (HTML marker
+// token + visible "Do not edit" note); the agent still posts it via the
+// documented HTTP path, so the read-only-by-default / instructions-only
+// fallback is unaffected. The written formats in idd-overview-core (claim)
+// and idd-review-snapshot (watermark/baseline) remain canonical.
+
+function normalizeMarkerCount(value: unknown): string | null {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : null;
+  }
+  const trimmed = String(value ?? '').trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+  // The watermark parser reads the count back with Number.parseInt; reject
+  // magnitudes beyond the safe-integer range, which would not round-trip to
+  // the same value (and as a JS number would stringify to exponential form
+  // that the parser's `\d+` count pattern rejects outright).
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? trimmed : null;
+}
+
+// `none` or a valid ISO timestamp (matching the watermark parser's
+// none-or-ISO contract); null signals an invalid value the caller rejects.
+function normalizeMarkerIsoOrNone(value: unknown): string | null {
+  const token = normalizeNonWhitespaceToken(value);
+  if (token === '' || token === 'none') {
+    return 'none';
+  }
+  return normalizeIsoTimestamp(token) || null;
+}
+
+export function renderClaimedByMarker(payload: {
+  agentId?: unknown;
+  claimId?: unknown;
+  supersedes?: unknown;
+  timestamp?: unknown;
+  branch?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const supersedesToken = normalizeNonWhitespaceToken(payload?.supersedes);
+  // Normalize any case-variant of the sentinel to lowercase `none`. The claim
+  // parser matches case-insensitively, but the claim lifecycle
+  // (`applyClaimEvent`) accepts a fresh claim only when `supersedes === 'none'`
+  // exactly, so an emitted `None`/`NONE` would round-trip into a claim that is
+  // silently ignored. Real claim IDs (never a case-variant of `none`) pass
+  // through verbatim.
+  const supersedes =
+    supersedesToken === '' || supersedesToken.toLowerCase() === 'none'
+      ? 'none'
+      : supersedesToken;
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  const branch = normalizeBranchToken(payload?.branch);
+  if (!agentId || !claimId || !timestamp || !branch) {
+    throw new Error('invalid claimed-by marker payload');
+  }
+  return [
+    `<!-- claimed-by: ${agentId} ${claimId} supersedes: ${supersedes} ${timestamp} branch: ${branch} -->`,
+    '',
+    `_${agentId}: issue claim — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+
+export function renderReviewWatermarkMarker(payload: {
+  agentId?: unknown;
+  claimId?: unknown;
+  headSha?: unknown;
+  maxActivityAt?: unknown;
+  totalItemCount?: unknown;
+  ciCompletedAt?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const maxActivityAt = normalizeMarkerIsoOrNone(payload?.maxActivityAt);
+  const totalItemCount = normalizeMarkerCount(payload?.totalItemCount);
+  const ciCompletedAt = normalizeMarkerIsoOrNone(payload?.ciCompletedAt);
+  if (
+    !agentId ||
+    !claimId ||
+    !/^[0-9a-f]{40}$/.test(headSha) ||
+    maxActivityAt === null ||
+    totalItemCount === null ||
+    ciCompletedAt === null
+  ) {
+    throw new Error('invalid review-watermark marker payload');
+  }
+  return [
+    `<!-- review-watermark: ${agentId} ${claimId} ${headSha} ${maxActivityAt} ${totalItemCount} ${ciCompletedAt} -->`,
+    '',
+    `_${agentId}: review triage snapshot — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+
+export function renderReviewBaselineMarker(payload: {
+  agentId?: unknown;
+  claimId?: unknown;
+  sha?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const sha = normalizeNonWhitespaceToken(payload?.sha).toLowerCase();
+  if (!agentId || !claimId || !/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error('invalid review-baseline marker payload');
+  }
+  return [
+    `<!-- review-baseline: ${agentId} ${claimId} ${sha} -->`,
+    '',
+    `_${agentId}: critique baseline — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+
+// --- Write-side companion renderers (#1047) ---
+//
+// The post-idd-marker helper POSTs the same operational markers an agent emits
+// per cycle, so it needs a renderer for every type it can post. claim /
+// watermark / baseline already have renderers above; these three cover the
+// remaining post-idd-marker types so the body formats stay single-sourced.
+
+export function renderUnclaimedByMarker(payload: {
+  agentId?: unknown;
+  claimId?: unknown;
+  timestamp?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !claimId || !timestamp) {
+    throw new Error('invalid unclaimed-by marker payload');
+  }
+  return [
+    `<!-- unclaimed-by: ${agentId} ${claimId} ${timestamp} -->`,
+    '',
+    `_${agentId}: issue claim released — IDD automation marker. Do not edit._`,
+  ].join('\n');
+}
+
+// advisory-wait / advisory-wait-recovery are PLAIN-TEXT markers (no visible
+// note): the AW2 / shell-fallback recognizers anchor on `-->$` / `\s*$`, so a
+// trailing visible note would break them. They carry the PR HEAD SHA (not a
+// claim id) per the AW3 protocol.
+export function renderAdvisoryWaitMarker(payload: {
+  agentId?: unknown;
+  headSha?: unknown;
+  timestamp?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-wait marker payload');
+  }
+  return `advisory-wait: ${agentId} ${headSha} ${timestamp}`;
+}
+
+export function renderAdvisoryWaitRecoveryMarker(payload: {
+  agentId?: unknown;
+  headSha?: unknown;
+  timestamp?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid advisory-wait-recovery marker payload');
+  }
+  return `advisory-wait-recovery: ${agentId} ${headSha} ${timestamp}`;
+}
+
+export function parseExternalCheckWaiverComment(
+  body: string,
+  createdAt: string,
+): ParsedExternalCheckWaiver | null {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*idd-external-check-waiver:\\s+(\\S+)\\s+(\\S+)\\s+([0-9a-f]{40})\\s+check:(\\S+)\\s+reason:(\\S+)\\s+expires:(\\S+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match) {
+    return null;
+  }
+
+  const checkSelector = normalizeExternalCheckWaiverField(
+    decodeExternalCheckWaiverField(match[4]),
+  );
+  const reason = normalizeExternalCheckWaiverField(
+    decodeExternalCheckWaiverField(match[5]),
+  );
+  const expiresAt = normalizeIsoTimestamp(match[6]);
+  if (!checkSelector || !reason || !expiresAt) {
+    return null;
+  }
+
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    headSha: match[3].toLowerCase(),
+    checkSelector,
+    reason,
+    expiresAt,
+    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
+  };
+}
+
+export function parseReviewWatermarkComment(
+  body: string,
+  createdAt: string,
+): ParsedReviewWatermark | null {
+  const match = body
+    .trimEnd()
+    .match(
+      new RegExp(
+        `^<!--\\s*review-watermark:\\s+(\\S+)\\s+(\\S+)\\s+([0-9a-f]{40})\\s+(\\S+)\\s+(\\d+)\\s+(\\S+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
+        'i',
+      ),
+    );
+  if (!match) {
+    return null;
+  }
+
+  const maxActivityUpdatedAt = match[4];
+  const latestCiCompletedAt = match[6];
+  if (
+    maxActivityUpdatedAt !== 'none' &&
+    !isValidIsoTimestamp(maxActivityUpdatedAt)
+  ) {
+    return null;
+  }
+  if (
+    latestCiCompletedAt !== 'none' &&
+    !isValidIsoTimestamp(latestCiCompletedAt)
+  ) {
+    return null;
+  }
+
+  const totalItemCount = Number.parseInt(match[5], 10);
+  if (!Number.isInteger(totalItemCount) || totalItemCount < 0) {
+    return null;
+  }
+
+  return {
+    agentId: match[1],
+    claimId: match[2],
+    headSha: match[3],
+    maxActivityUpdatedAt,
+    totalItemCount,
+    latestCiCompletedAt,
+    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
+  };
+}
+
+export function operationalMarkerPrefix(body: string): string | null {
+  const normalized = body.trimEnd();
+  const marker = OPERATIONAL_MARKERS.find((candidate) =>
+    candidate.pattern.test(normalized),
+  );
+  if (!marker) {
+    return null;
+  }
+  if (
+    marker.label === '<!-- forced-handoff:' &&
+    !isValidForcedHandoffOperationalMarker(normalized)
+  ) {
+    return null;
+  }
+  return marker.label;
+}
+
+export function operationalMarkerPrefixByStart(body: string): string | null {
+  const normalized = body.trimStart();
+  const marker = OPERATIONAL_MARKERS.find(
+    (candidate) =>
+      candidate.startPattern?.test(normalized) ??
+      normalized.startsWith(candidate.label),
+  );
+  if (!marker) {
+    return null;
+  }
+  if (
+    marker.label === '<!-- forced-handoff:' &&
+    !isValidForcedHandoffOperationalMarker(normalized)
+  ) {
+    return null;
+  }
+  return marker.label;
+}
+
+function normalizeNonWhitespaceToken(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (
+    !trimmed ||
+    /\s/.test(trimmed) ||
+    trimmed.includes('<!--') ||
+    trimmed.includes('-->')
+  ) {
+    return '';
+  }
+  return trimmed;
+}
+
+function pickPayloadValue(
+  payload: Record<string, unknown>,
+  ...keys: string[]
+): unknown {
+  for (const key of keys) {
+    if (Object.hasOwn(payload, key)) {
+      return payload[key];
+    }
+  }
+  return undefined;
+}
+
+function hasConflictingPayloadAliases(
+  payload: Record<string, unknown>,
+  firstKey: string,
+  secondKey: string,
+): boolean {
+  if (!Object.hasOwn(payload, firstKey) || !Object.hasOwn(payload, secondKey)) {
+    return false;
+  }
+
+  return (
+    String(payload[firstKey] ?? '').trim() !==
+    String(payload[secondKey] ?? '').trim()
+  );
+}
+
+function normalizeBranchToken(value: unknown): string {
+  const token = normalizeNonWhitespaceToken(value);
+  if (!token || token.includes('>')) {
+    return '';
+  }
+  return token;
+}
+
+function normalizeForcedHandoffReason(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed || /[\r\n]/.test(trimmed) || trimmed.includes('-->')) {
+    return '';
+  }
+  return trimmed;
+}
+
+function normalizeIsoTimestamp(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed || !isValidIsoTimestamp(trimmed)) {
+    return '';
+  }
+  return trimmed;
+}
+
+function normalizeSecondPrecisionIsoTimestamp(value: unknown): string {
+  const timestamp = normalizeIsoTimestamp(value);
+  if (!timestamp || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(timestamp)) {
+    return '';
+  }
+  return timestamp;
+}
+
+function normalizeContextScope(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  return FORCED_HANDOFF_CONTEXT_SCOPES.has(trimmed) ? trimmed : '';
+}
+
+function normalizeLinkedPr(value: unknown): string {
+  const token = normalizeNonWhitespaceToken(value);
+  if (!token || !FORCED_HANDOFF_LINKED_PR_PATTERN.test(token)) {
+    return '';
+  }
+  return token;
+}
+
+function isValidForcedHandoffOperationalMarker(body: string): boolean {
+  return parseForcedHandoffComment(body, '') !== null;
+}
+
+export function isValidIsoTimestamp(value: unknown): value is string {
+  const time = Date.parse(value as string);
+  if (!Number.isFinite(time)) return false;
+  const normalize = (ts: string) => ts.replace('.000Z', 'Z');
+  return normalize(new Date(time).toISOString()) === normalize(value as string);
+}

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -8,15 +8,15 @@
 // split; see #1209): the render*/parse* functions for the claim, watermark,
 // baseline, advisory-wait, forced-handoff, and external-check-waiver
 // HTML-comment markers, plus the marker-field validation helpers they
-// share. protocol-helpers.mts re-exports every name below (`export * from
-// './marker-helpers.mts'`), so existing call sites are unaffected.
+// share. The protocol-helpers module re-exports every name below (a plain
+// `export * from` re-export), so existing call sites are unaffected.
 //
-// Layering: this module MUST NOT import from protocol-helpers.mts — that
-// would form an import cycle, since protocol-helpers.mts imports from here.
-// Gate-level aggregation that folds many markers together with trust/policy
-// context (summarizeExternalCheckWaivers, summarizeAdvisoryWaitMarkers,
+// Layering: this module MUST NOT import from protocol-helpers — that would
+// form an import cycle, since protocol-helpers imports from here. Gate-level
+// aggregation that folds many markers together with trust/policy context
+// (summarizeExternalCheckWaivers, summarizeAdvisoryWaitMarkers,
 // resolveLatestReviewWatermark, deriveIddAgentLogins, and friends) stays in
-// protocol-helpers.mts on purpose: those depend on the broader trusted-actor
+// protocol-helpers on purpose: those depend on the broader trusted-actor
 // resolution machinery there (normalizeTrustedMarkerLogins and friends), and
 // moving them here would force exactly that forbidden back-import. Only the
 // single-marker parse/render primitives move in this wave.

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -131,7 +131,7 @@ const OPERATIONAL_MARKERS: OperationalMarker[] = [
   },
 ];
 
-export const IDD_AGENT_DERIVED_MARKERS = new Set([
+export const IDD_AGENT_DERIVED_MARKERS: ReadonlySet<string> = new Set([
   '<!-- claimed-by:',
   '<!-- unclaimed-by:',
   '<!-- review-watermark:',

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -9,6 +9,31 @@ import {
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
   normalizeAdvisoryWaitRuntimeOptions,
 } from './advisory-wait-policy.mts';
+
+// Façade re-export (wave 1 of the protocol-helpers split; see #1209): every
+// marker render/parse primitive now lives in marker-helpers.mts. Re-exporting
+// it here keeps every existing call site (`from './protocol-helpers.mts'`)
+// unchanged. The named imports below are this module's own internal uses of
+// those moved names; see marker-helpers.mts for the layering rule (it must
+// never import back from this file).
+export * from './marker-helpers.mts';
+
+import type {
+  ParsedClaimMarker,
+  ParsedForcedHandoffMarker,
+  ParsedReviewWatermark,
+} from './marker-helpers.mts';
+import {
+  IDD_AGENT_DERIVED_MARKERS,
+  isValidIsoTimestamp,
+  operationalMarkerPrefix,
+  operationalMarkerPrefixByStart,
+  parseClaimComment,
+  parseExternalCheckWaiverComment,
+  parseForcedHandoffComment,
+  parseReleaseComment,
+  parseReviewWatermarkComment,
+} from './marker-helpers.mts';
 import {
   getReviewEscalationChangesRequestedPolicy,
   parseIsoDurationToMs,
@@ -191,13 +216,6 @@ interface CodeownersRule {
   emails: string[];
 }
 
-/** Operational marker matcher entry. */
-interface OperationalMarker {
-  label: string;
-  pattern: RegExp;
-  startPattern?: RegExp;
-}
-
 /** Live-status digest field inputs (validated at render time). */
 export interface LiveStatusDigestFields {
   phase?: unknown;
@@ -233,58 +251,6 @@ interface ReviewerRequirement {
 // ---------------------------------------------------------------------------
 // Protocol data shapes crossing module boundaries.
 // ---------------------------------------------------------------------------
-
-/** Parsed `<!-- claimed-by: ... -->` claim marker. */
-export interface ParsedClaimMarker {
-  agentId: string;
-  claimId: string;
-  supersedes: string;
-  branch: string;
-  createdAt: string;
-}
-
-/** Parsed `<!-- unclaimed-by: ... -->` release marker. */
-export interface ParsedReleaseMarker {
-  agentId: string;
-  claimId: string;
-}
-
-/** Parsed `<!-- forced-handoff: {...} -->` marker payload. */
-export interface ParsedForcedHandoffMarker {
-  oldAgentId: string;
-  oldClaimId: string;
-  newAgentId: string;
-  newClaimId: string;
-  branch: string;
-  linkedPr?: string;
-  forcedBy: string;
-  reason: string;
-  timestamp: string;
-  contextScope: string;
-  createdAt?: string;
-}
-
-/** Parsed `<!-- idd-external-check-waiver: ... -->` marker. */
-export interface ParsedExternalCheckWaiver {
-  agentId: string;
-  claimId: string;
-  headSha: string;
-  checkSelector: string;
-  reason: string;
-  expiresAt: string;
-  createdAt: string;
-}
-
-/** Parsed `<!-- review-watermark: ... -->` marker. */
-export interface ParsedReviewWatermark {
-  agentId: string;
-  claimId: string;
-  headSha: string;
-  maxActivityUpdatedAt: string;
-  totalItemCount: number;
-  latestCiCompletedAt: string;
-  createdAt: string;
-}
 
 /** Classification of a standalone advisory-bot comment. */
 export interface CommentClassification {
@@ -479,68 +445,7 @@ interface ClaimResolutionOptions {
 /** Fully-defaulted form of {@link ClaimResolutionOptions}. */
 type NormalizedClaimResolutionOptions = Required<ClaimResolutionOptions>;
 
-const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
-const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
-
 export const LIVE_STATUS_DIGEST_MARKER = '<!-- idd-live-status: current -->';
-
-const OPERATIONAL_MARKERS: OperationalMarker[] = [
-  {
-    label: '<!-- claimed-by:',
-    pattern:
-      /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
-  },
-  {
-    label: '<!-- unclaimed-by:',
-    pattern:
-      /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
-  },
-  {
-    label: '<!-- review-watermark:',
-    pattern:
-      /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
-  },
-  {
-    label: '<!-- review-baseline:',
-    pattern:
-      /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
-  },
-  {
-    label: 'advisory-wait:',
-    pattern:
-      /^advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
-  },
-  {
-    label: 'advisory-wait-recovery:',
-    pattern:
-      /^advisory-wait-recovery:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
-  },
-  {
-    label: '<!-- advisory-wait:',
-    pattern: /^<!--\s*advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\S+\s*-->\s*$/,
-  },
-  {
-    label: '<!-- forced-handoff:',
-    pattern: /^\s*<!--\s*forced-handoff:\s*\{[\s\S]*\}\s*-->[\s\S]*$/i,
-    startPattern: /^<!--\s*forced-handoff:/i,
-  },
-  {
-    label: '<!-- idd-external-check-waiver:',
-    pattern:
-      /^<!--\s*idd-external-check-waiver:\s+\S+\s+\S+\s+[0-9a-f]{40}\s+check:\S+\s+reason:\S+\s+expires:\S+\s*-->[\s\S]*$/i,
-    startPattern: /^<!--\s*idd-external-check-waiver:/i,
-  },
-];
-
-const IDD_AGENT_DERIVED_MARKERS = new Set([
-  '<!-- claimed-by:',
-  '<!-- unclaimed-by:',
-  '<!-- review-watermark:',
-  '<!-- review-baseline:',
-  'advisory-wait:',
-  'advisory-wait-recovery:',
-  '<!-- advisory-wait:',
-]);
 
 const REVIEW_BOT_LOGINS = new Set([
   'coderabbitai',
@@ -565,8 +470,6 @@ const UNSAFE_TEXT_RULES = [
   },
 ];
 const AMD_MARKER_PATTERN = /^\*\*Awaiting maintainer decision\*\*/i;
-const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(['issue-only', 'issue-plus-pr']);
-const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/;
 
 export function parsePaginatedGhNdjson(raw: unknown): unknown[] {
   const text = String(raw ?? '').trim();
@@ -580,493 +483,6 @@ export function parsePaginatedGhNdjson(raw: unknown): unknown[] {
       const value: unknown = JSON.parse(line);
       return Array.isArray(value) ? value : [value];
     });
-}
-
-export function parseClaimComment(
-  body: string,
-  createdAt: string,
-): ParsedClaimMarker | null {
-  const match = body
-    .trimEnd()
-    .match(
-      new RegExp(
-        `^<!--\\s*claimed-by:\\s+(\\S+)\\s+(\\S+)\\s+supersedes:\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s+branch:\\s+([^\\s>]+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
-        'i',
-      ),
-    );
-  if (!match || !isValidIsoTimestamp(match[4])) {
-    return null;
-  }
-  return {
-    agentId: match[1],
-    claimId: match[2],
-    supersedes: match[3],
-    branch: match[5],
-    createdAt,
-  };
-}
-
-export function parseReleaseComment(body: string): ParsedReleaseMarker | null {
-  const match = body
-    .trimEnd()
-    .match(
-      new RegExp(
-        `^<!--\\s*unclaimed-by:\\s+(\\S+)\\s+(\\S+)\\s+(${ISO8601_UTC_PATTERN.source})\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
-        'i',
-      ),
-    );
-  if (!match || !isValidIsoTimestamp(match[3])) {
-    return null;
-  }
-  return {
-    agentId: match[1],
-    claimId: match[2],
-  };
-}
-
-export function parseForcedHandoffComment(
-  body: string,
-  createdAt: string,
-): ParsedForcedHandoffMarker | null {
-  const trimmed = body.trimStart().trimEnd();
-  const markerMatch = trimmed.match(/^<!--\s*forced-handoff:\s*/i);
-  if (!markerMatch) {
-    return null;
-  }
-
-  const markerEnd = trimmed.indexOf('-->');
-  if (markerEnd < 0) {
-    return null;
-  }
-
-  const visibleNote = trimmed.slice(markerEnd + 3);
-  const visibleText = visibleNote
-    .replace(/<!--[\s\S]*?-->/g, ' ')
-    .replace(/<!--[\s\S]*$/g, ' ')
-    .trim();
-  if (!visibleText) {
-    return null;
-  }
-
-  const payloadText = trimmed.slice(markerMatch[0].length, markerEnd).trim();
-  let payload: unknown;
-  try {
-    payload = JSON.parse(payloadText);
-  } catch {
-    return null;
-  }
-
-  return normalizeForcedHandoffPayload(payload, { createdAt });
-}
-
-export function normalizeForcedHandoffPayload(
-  payload: unknown,
-  options: { createdAt?: unknown } = {},
-): ParsedForcedHandoffMarker | null {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    return null;
-  }
-  const record = payload as Record<string, unknown>;
-
-  if (
-    hasConflictingPayloadAliases(record, 'oldAgentId', 'old-agent-id') ||
-    hasConflictingPayloadAliases(record, 'oldClaimId', 'old-claim-id') ||
-    hasConflictingPayloadAliases(record, 'newAgentId', 'new-agent-id') ||
-    hasConflictingPayloadAliases(record, 'newClaimId', 'new-claim-id') ||
-    hasConflictingPayloadAliases(record, 'forcedBy', 'forced-by') ||
-    hasConflictingPayloadAliases(record, 'linkedPr', 'linked-pr') ||
-    hasConflictingPayloadAliases(record, 'contextScope', 'context-scope')
-  ) {
-    return null;
-  }
-
-  const oldAgentId = normalizeNonWhitespaceToken(
-    pickPayloadValue(record, 'oldAgentId', 'old-agent-id'),
-  );
-  const oldClaimId = normalizeNonWhitespaceToken(
-    pickPayloadValue(record, 'oldClaimId', 'old-claim-id'),
-  );
-  const newAgentId = normalizeNonWhitespaceToken(
-    pickPayloadValue(record, 'newAgentId', 'new-agent-id'),
-  );
-  const newClaimId = normalizeNonWhitespaceToken(
-    pickPayloadValue(record, 'newClaimId', 'new-claim-id'),
-  );
-  const branch = normalizeBranchToken(pickPayloadValue(record, 'branch'));
-  const forcedBy = normalizeNonWhitespaceToken(
-    pickPayloadValue(record, 'forcedBy', 'forced-by'),
-  );
-  const reason = normalizeForcedHandoffReason(
-    pickPayloadValue(record, 'reason'),
-  );
-  const timestamp = normalizeSecondPrecisionIsoTimestamp(
-    pickPayloadValue(record, 'timestamp'),
-  );
-  const contextScope = normalizeContextScope(
-    pickPayloadValue(record, 'contextScope', 'context-scope'),
-  );
-  const linkedPr = normalizeLinkedPr(
-    pickPayloadValue(record, 'linkedPr', 'linked-pr'),
-  );
-  const createdAt = normalizeSecondPrecisionIsoTimestamp(options.createdAt);
-
-  if (
-    !oldAgentId ||
-    !oldClaimId ||
-    !newAgentId ||
-    !newClaimId ||
-    !branch ||
-    !forcedBy ||
-    !reason ||
-    !timestamp ||
-    !contextScope
-  ) {
-    return null;
-  }
-
-  if (oldClaimId === newClaimId) {
-    return null;
-  }
-
-  if (contextScope === 'issue-plus-pr' && !linkedPr) {
-    return null;
-  }
-
-  if (contextScope === 'issue-only' && linkedPr) {
-    return null;
-  }
-
-  return {
-    oldAgentId,
-    oldClaimId,
-    newAgentId,
-    newClaimId,
-    branch,
-    ...(linkedPr ? { linkedPr } : {}),
-    forcedBy,
-    reason,
-    timestamp,
-    contextScope,
-    ...(createdAt ? { createdAt } : {}),
-  };
-}
-
-export function renderForcedHandoffConsentNote(payload: unknown): string {
-  const normalized = normalizeForcedHandoffPayload(payload);
-  if (!normalized) {
-    throw new Error('invalid forced handoff payload');
-  }
-
-  if (normalized.contextScope === 'issue-plus-pr') {
-    const linkedPr = normalized.linkedPr ?? '';
-    const prReference = /^\d+$/.test(linkedPr) ? `#${linkedPr}` : linkedPr;
-    return [
-      `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
-      'owning session or agent is unavailable. This transfers ownership away',
-      `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\` for PR ${prReference}.`,
-      'If the prior session resumes, it must stop immediately and must not',
-      'push, comment, resolve review state, or merge until a maintainer',
-      'reassigns ownership.',
-    ].join('\n');
-  }
-
-  return [
-    `Forced handoff approved by ${normalized.forcedBy}. I verified that the current`,
-    'owning session or agent is unavailable. This transfers ownership away',
-    `from claim \`${normalized.oldClaimId}\` on branch \`${normalized.branch}\`.`,
-    'If the prior session resumes, it must stop immediately and must not',
-    'push, comment, resolve review state, or merge until a maintainer',
-    'reassigns ownership.',
-  ].join('\n');
-}
-
-export function renderForcedHandoffComment(payload: unknown): string {
-  const normalized = normalizeForcedHandoffPayload(payload);
-  if (!normalized) {
-    throw new Error('invalid forced handoff payload');
-  }
-
-  const markerPayload = {
-    'old-agent-id': normalized.oldAgentId,
-    'old-claim-id': normalized.oldClaimId,
-    'new-agent-id': normalized.newAgentId,
-    'new-claim-id': normalized.newClaimId,
-    branch: normalized.branch,
-    ...(normalized.linkedPr ? { 'linked-pr': normalized.linkedPr } : {}),
-    'forced-by': normalized.forcedBy,
-    reason: normalized.reason,
-    timestamp: normalized.timestamp,
-    'context-scope': normalized.contextScope,
-  };
-
-  return `<!-- forced-handoff: ${JSON.stringify(markerPayload)} -->\n\n${renderForcedHandoffConsentNote(normalized)}`;
-}
-
-function normalizeExternalCheckWaiverField(value: unknown): string {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  const trimmed = value.trim();
-  if (
-    !trimmed ||
-    /[\r\n]/.test(trimmed) ||
-    trimmed.includes('<!--') ||
-    trimmed.includes('-->')
-  ) {
-    return '';
-  }
-  return trimmed;
-}
-
-function encodeExternalCheckWaiverField(value: string): string {
-  return encodeURIComponent(value);
-}
-
-function decodeExternalCheckWaiverField(value: unknown): string {
-  try {
-    return decodeURIComponent(String(value ?? '').trim());
-  } catch {
-    return '';
-  }
-}
-
-function renderExternalCheckWaiverNote(normalized: {
-  actor?: unknown;
-  checkSelector: string;
-  reason: string;
-  expiresAt: string;
-}): string {
-  const actor = normalizeNonWhitespaceToken(normalized.actor) || 'idd-operator';
-  return [
-    `_${actor}: external check waiver for IDD F phase on \`${normalized.checkSelector}\``,
-    `until \`${normalized.expiresAt}\` (reason: ${normalized.reason})._`,
-  ].join(' ');
-}
-
-export function renderExternalCheckWaiverComment(
-  payload:
-    | {
-        agentId?: unknown;
-        claimId?: unknown;
-        headSha?: unknown;
-        checkSelector?: unknown;
-        check?: unknown;
-        reason?: unknown;
-        expiresAt?: unknown;
-        expires?: unknown;
-        actor?: unknown;
-      }
-    | null
-    | undefined,
-): string {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
-  const checkSelector = normalizeExternalCheckWaiverField(
-    payload?.checkSelector ?? payload?.check,
-  );
-  const reason = normalizeExternalCheckWaiverField(payload?.reason);
-  const expiresAt = normalizeIsoTimestamp(
-    payload?.expiresAt ?? payload?.expires,
-  );
-
-  if (
-    !agentId ||
-    !claimId ||
-    !/^[0-9a-f]{40}$/.test(headSha) ||
-    !checkSelector ||
-    !reason ||
-    !expiresAt
-  ) {
-    throw new Error('invalid external check waiver payload');
-  }
-
-  const encodedCheck = encodeExternalCheckWaiverField(checkSelector);
-  const encodedReason = encodeExternalCheckWaiverField(reason);
-
-  return [
-    `<!-- idd-external-check-waiver: ${agentId} ${claimId} ${headSha} check:${encodedCheck} reason:${encodedReason} expires:${expiresAt} -->`,
-    '',
-    renderExternalCheckWaiverNote({
-      actor: payload?.actor,
-      checkSelector,
-      reason,
-      expiresAt,
-    }),
-  ].join('\n');
-}
-
-// --- Per-cycle marker body renderers (#900) ---
-//
-// Pure, network-free renderers for the three operational markers an agent
-// posts every cycle. Each returns the exact ready-to-post body (HTML marker
-// token + visible "Do not edit" note); the agent still posts it via the
-// documented HTTP path, so the read-only-by-default / instructions-only
-// fallback is unaffected. The written formats in idd-overview-core (claim)
-// and idd-review-snapshot (watermark/baseline) remain canonical.
-
-function normalizeMarkerCount(value: unknown): string | null {
-  if (typeof value === 'number') {
-    return Number.isSafeInteger(value) && value >= 0 ? String(value) : null;
-  }
-  const trimmed = String(value ?? '').trim();
-  if (!/^\d+$/.test(trimmed)) {
-    return null;
-  }
-  // The watermark parser reads the count back with Number.parseInt; reject
-  // magnitudes beyond the safe-integer range, which would not round-trip to
-  // the same value (and as a JS number would stringify to exponential form
-  // that the parser's `\d+` count pattern rejects outright).
-  const parsed = Number.parseInt(trimmed, 10);
-  return Number.isSafeInteger(parsed) ? trimmed : null;
-}
-
-// `none` or a valid ISO timestamp (matching the watermark parser's
-// none-or-ISO contract); null signals an invalid value the caller rejects.
-function normalizeMarkerIsoOrNone(value: unknown): string | null {
-  const token = normalizeNonWhitespaceToken(value);
-  if (token === '' || token === 'none') {
-    return 'none';
-  }
-  return normalizeIsoTimestamp(token) || null;
-}
-
-export function renderClaimedByMarker(payload: {
-  agentId?: unknown;
-  claimId?: unknown;
-  supersedes?: unknown;
-  timestamp?: unknown;
-  branch?: unknown;
-}): string {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const supersedesToken = normalizeNonWhitespaceToken(payload?.supersedes);
-  // Normalize any case-variant of the sentinel to lowercase `none`. The claim
-  // parser matches case-insensitively, but the claim lifecycle
-  // (`applyClaimEvent`) accepts a fresh claim only when `supersedes === 'none'`
-  // exactly, so an emitted `None`/`NONE` would round-trip into a claim that is
-  // silently ignored. Real claim IDs (never a case-variant of `none`) pass
-  // through verbatim.
-  const supersedes =
-    supersedesToken === '' || supersedesToken.toLowerCase() === 'none'
-      ? 'none'
-      : supersedesToken;
-  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  const branch = normalizeBranchToken(payload?.branch);
-  if (!agentId || !claimId || !timestamp || !branch) {
-    throw new Error('invalid claimed-by marker payload');
-  }
-  return [
-    `<!-- claimed-by: ${agentId} ${claimId} supersedes: ${supersedes} ${timestamp} branch: ${branch} -->`,
-    '',
-    `_${agentId}: issue claim — IDD automation marker. Do not edit._`,
-  ].join('\n');
-}
-
-export function renderReviewWatermarkMarker(payload: {
-  agentId?: unknown;
-  claimId?: unknown;
-  headSha?: unknown;
-  maxActivityAt?: unknown;
-  totalItemCount?: unknown;
-  ciCompletedAt?: unknown;
-}): string {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
-  const maxActivityAt = normalizeMarkerIsoOrNone(payload?.maxActivityAt);
-  const totalItemCount = normalizeMarkerCount(payload?.totalItemCount);
-  const ciCompletedAt = normalizeMarkerIsoOrNone(payload?.ciCompletedAt);
-  if (
-    !agentId ||
-    !claimId ||
-    !/^[0-9a-f]{40}$/.test(headSha) ||
-    maxActivityAt === null ||
-    totalItemCount === null ||
-    ciCompletedAt === null
-  ) {
-    throw new Error('invalid review-watermark marker payload');
-  }
-  return [
-    `<!-- review-watermark: ${agentId} ${claimId} ${headSha} ${maxActivityAt} ${totalItemCount} ${ciCompletedAt} -->`,
-    '',
-    `_${agentId}: review triage snapshot — IDD automation marker. Do not edit._`,
-  ].join('\n');
-}
-
-export function renderReviewBaselineMarker(payload: {
-  agentId?: unknown;
-  claimId?: unknown;
-  sha?: unknown;
-}): string {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const sha = normalizeNonWhitespaceToken(payload?.sha).toLowerCase();
-  if (!agentId || !claimId || !/^[0-9a-f]{40}$/.test(sha)) {
-    throw new Error('invalid review-baseline marker payload');
-  }
-  return [
-    `<!-- review-baseline: ${agentId} ${claimId} ${sha} -->`,
-    '',
-    `_${agentId}: critique baseline — IDD automation marker. Do not edit._`,
-  ].join('\n');
-}
-
-// --- Write-side companion renderers (#1047) ---
-//
-// The post-idd-marker helper POSTs the same operational markers an agent emits
-// per cycle, so it needs a renderer for every type it can post. claim /
-// watermark / baseline already have renderers above; these three cover the
-// remaining post-idd-marker types so the body formats stay single-sourced.
-
-export function renderUnclaimedByMarker(payload: {
-  agentId?: unknown;
-  claimId?: unknown;
-  timestamp?: unknown;
-}): string {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const claimId = normalizeNonWhitespaceToken(payload?.claimId);
-  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !claimId || !timestamp) {
-    throw new Error('invalid unclaimed-by marker payload');
-  }
-  return [
-    `<!-- unclaimed-by: ${agentId} ${claimId} ${timestamp} -->`,
-    '',
-    `_${agentId}: issue claim released — IDD automation marker. Do not edit._`,
-  ].join('\n');
-}
-
-// advisory-wait / advisory-wait-recovery are PLAIN-TEXT markers (no visible
-// note): the AW2 / shell-fallback recognizers anchor on `-->$` / `\s*$`, so a
-// trailing visible note would break them. They carry the PR HEAD SHA (not a
-// claim id) per the AW3 protocol.
-export function renderAdvisoryWaitMarker(payload: {
-  agentId?: unknown;
-  headSha?: unknown;
-  timestamp?: unknown;
-}): string {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
-  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid advisory-wait marker payload');
-  }
-  return `advisory-wait: ${agentId} ${headSha} ${timestamp}`;
-}
-
-export function renderAdvisoryWaitRecoveryMarker(payload: {
-  agentId?: unknown;
-  headSha?: unknown;
-  timestamp?: unknown;
-}): string {
-  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
-  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
-  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid advisory-wait-recovery marker payload');
-  }
-  return `advisory-wait-recovery: ${agentId} ${headSha} ${timestamp}`;
 }
 
 function matchCheckSelectorLocal(
@@ -1289,127 +705,6 @@ export function summarizeExternalCheckWaivers(
     malformed,
     notConfigured,
   };
-}
-
-export function parseExternalCheckWaiverComment(
-  body: string,
-  createdAt: string,
-): ParsedExternalCheckWaiver | null {
-  const match = body
-    .trimEnd()
-    .match(
-      new RegExp(
-        `^<!--\\s*idd-external-check-waiver:\\s+(\\S+)\\s+(\\S+)\\s+([0-9a-f]{40})\\s+check:(\\S+)\\s+reason:(\\S+)\\s+expires:(\\S+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
-        'i',
-      ),
-    );
-  if (!match) {
-    return null;
-  }
-
-  const checkSelector = normalizeExternalCheckWaiverField(
-    decodeExternalCheckWaiverField(match[4]),
-  );
-  const reason = normalizeExternalCheckWaiverField(
-    decodeExternalCheckWaiverField(match[5]),
-  );
-  const expiresAt = normalizeIsoTimestamp(match[6]);
-  if (!checkSelector || !reason || !expiresAt) {
-    return null;
-  }
-
-  return {
-    agentId: match[1],
-    claimId: match[2],
-    headSha: match[3].toLowerCase(),
-    checkSelector,
-    reason,
-    expiresAt,
-    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
-  };
-}
-
-export function parseReviewWatermarkComment(
-  body: string,
-  createdAt: string,
-): ParsedReviewWatermark | null {
-  const match = body
-    .trimEnd()
-    .match(
-      new RegExp(
-        `^<!--\\s*review-watermark:\\s+(\\S+)\\s+(\\S+)\\s+([0-9a-f]{40})\\s+(\\S+)\\s+(\\d+)\\s+(\\S+)\\s*-->${OPTIONAL_IDD_VISIBLE_NOTE_PATTERN}$`,
-        'i',
-      ),
-    );
-  if (!match) {
-    return null;
-  }
-
-  const maxActivityUpdatedAt = match[4];
-  const latestCiCompletedAt = match[6];
-  if (
-    maxActivityUpdatedAt !== 'none' &&
-    !isValidIsoTimestamp(maxActivityUpdatedAt)
-  ) {
-    return null;
-  }
-  if (
-    latestCiCompletedAt !== 'none' &&
-    !isValidIsoTimestamp(latestCiCompletedAt)
-  ) {
-    return null;
-  }
-
-  const totalItemCount = Number.parseInt(match[5], 10);
-  if (!Number.isInteger(totalItemCount) || totalItemCount < 0) {
-    return null;
-  }
-
-  return {
-    agentId: match[1],
-    claimId: match[2],
-    headSha: match[3],
-    maxActivityUpdatedAt,
-    totalItemCount,
-    latestCiCompletedAt,
-    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
-  };
-}
-
-export function operationalMarkerPrefix(body: string): string | null {
-  const normalized = body.trimEnd();
-  const marker = OPERATIONAL_MARKERS.find((candidate) =>
-    candidate.pattern.test(normalized),
-  );
-  if (!marker) {
-    return null;
-  }
-  if (
-    marker.label === '<!-- forced-handoff:' &&
-    !isValidForcedHandoffOperationalMarker(normalized)
-  ) {
-    return null;
-  }
-  return marker.label;
-}
-
-export function operationalMarkerPrefixByStart(body: string): string | null {
-  const normalized = body.trimStart();
-  const marker = OPERATIONAL_MARKERS.find(
-    (candidate) =>
-      candidate.startPattern?.test(normalized) ??
-      normalized.startsWith(candidate.label),
-  );
-  if (!marker) {
-    return null;
-  }
-  if (
-    marker.label === '<!-- forced-handoff:' &&
-    !isValidForcedHandoffOperationalMarker(normalized)
-  ) {
-    return null;
-  }
-  return marker.label;
 }
 
 export function findLiveStatusDigestComments(
@@ -5802,68 +5097,6 @@ function normalizeClaimResolutionOptions(
   };
 }
 
-function normalizeNonWhitespaceToken(value: unknown): string {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  const trimmed = value.trim();
-  if (
-    !trimmed ||
-    /\s/.test(trimmed) ||
-    trimmed.includes('<!--') ||
-    trimmed.includes('-->')
-  ) {
-    return '';
-  }
-  return trimmed;
-}
-
-function pickPayloadValue(
-  payload: Record<string, unknown>,
-  ...keys: string[]
-): unknown {
-  for (const key of keys) {
-    if (Object.hasOwn(payload, key)) {
-      return payload[key];
-    }
-  }
-  return undefined;
-}
-
-function hasConflictingPayloadAliases(
-  payload: Record<string, unknown>,
-  firstKey: string,
-  secondKey: string,
-): boolean {
-  if (!Object.hasOwn(payload, firstKey) || !Object.hasOwn(payload, secondKey)) {
-    return false;
-  }
-
-  return (
-    String(payload[firstKey] ?? '').trim() !==
-    String(payload[secondKey] ?? '').trim()
-  );
-}
-
-function normalizeBranchToken(value: unknown): string {
-  const token = normalizeNonWhitespaceToken(value);
-  if (!token || token.includes('>')) {
-    return '';
-  }
-  return token;
-}
-
-function normalizeForcedHandoffReason(value: unknown): string {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  const trimmed = value.trim();
-  if (!trimmed || /[\r\n]/.test(trimmed) || trimmed.includes('-->')) {
-    return '';
-  }
-  return trimmed;
-}
-
 export function normalizeLinkedPrReference(value: unknown): string {
   const token = String(value ?? '').trim();
   if (!token) {
@@ -5892,41 +5125,6 @@ export function normalizeLinkedPrReference(value: unknown): string {
     // Not a URL-form linked-pr reference.
   }
   return token.toLowerCase();
-}
-
-function normalizeIsoTimestamp(value: unknown): string {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  const trimmed = value.trim();
-  if (!trimmed || !isValidIsoTimestamp(trimmed)) {
-    return '';
-  }
-  return trimmed;
-}
-
-function normalizeSecondPrecisionIsoTimestamp(value: unknown): string {
-  const timestamp = normalizeIsoTimestamp(value);
-  if (!timestamp || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(timestamp)) {
-    return '';
-  }
-  return timestamp;
-}
-
-function normalizeContextScope(value: unknown): string {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  const trimmed = value.trim();
-  return FORCED_HANDOFF_CONTEXT_SCOPES.has(trimmed) ? trimmed : '';
-}
-
-function normalizeLinkedPr(value: unknown): string {
-  const token = normalizeNonWhitespaceToken(value);
-  if (!token || !FORCED_HANDOFF_LINKED_PR_PATTERN.test(token)) {
-    return '';
-  }
-  return token;
 }
 
 export function classifyResumeRoutingCase(
@@ -6455,10 +5653,6 @@ function isOperationalOrDigestCommentForGate(
   return marker !== null || firstLine(body) === LIVE_STATUS_DIGEST_MARKER;
 }
 
-function isValidForcedHandoffOperationalMarker(body: string): boolean {
-  return parseForcedHandoffComment(body, '') !== null;
-}
-
 function buildBodyPreview(body: unknown): string {
   return firstLine(String(body ?? '')).slice(0, 120);
 }
@@ -6587,13 +5781,6 @@ function hasUnresolvedKnownBotThreads(threads: ThreadLike[]): boolean {
       return isKnownReviewBot(comment.author?.login ?? '');
     });
   });
-}
-
-function isValidIsoTimestamp(value: unknown): value is string {
-  const time = Date.parse(value as string);
-  if (!Number.isFinite(time)) return false;
-  const normalize = (ts: string) => ts.replace('.000Z', 'Z');
-  return normalize(new Date(time).toISOString()) === normalize(value as string);
 }
 
 function isCompletedCiTimestamp(value: unknown): boolean {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -11,11 +11,11 @@ import {
 } from './advisory-wait-policy.mts';
 
 // Façade re-export (wave 1 of the protocol-helpers split; see #1209): every
-// marker render/parse primitive now lives in marker-helpers.mts. Re-exporting
-// it here keeps every existing call site (`from './protocol-helpers.mts'`)
-// unchanged. The named imports below are this module's own internal uses of
-// those moved names; see marker-helpers.mts for the layering rule (it must
-// never import back from this file).
+// marker render/parse primitive now lives in the marker-helpers module.
+// Re-exporting it here keeps every existing call site importing from
+// protocol-helpers unchanged. The named imports below are this module's own
+// internal uses of those moved names; see marker-helpers for the layering
+// rule (it must never import back from this file).
 export * from './marker-helpers.mts';
 
 import type {

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as direct from '../src/scripts/marker-helpers.mts';
+import * as facade from '../src/scripts/protocol-helpers.mts';
+
+// Wave 1 of the protocol-helpers split (#1209) moved every operational-marker
+// render/parse primitive into marker-helpers.mts and made protocol-helpers.mts
+// re-export all of it (`export * from './marker-helpers.mts'`) so existing
+// call sites keep importing from '../src/scripts/protocol-helpers.mts'
+// unchanged. This test is the facade-identity assertion the issue's
+// acceptance criteria calls for: a sample of moved names, imported from BOTH
+// paths, must resolve to the exact same binding -- proving a re-export, not a
+// duplicated copy that could drift.
+const SAMPLE_NAMES = [
+  'parseClaimComment',
+  'parseReleaseComment',
+  'renderClaimedByMarker',
+  'renderUnclaimedByMarker',
+  'renderReviewWatermarkMarker',
+  'renderReviewBaselineMarker',
+  'renderAdvisoryWaitMarker',
+  'renderAdvisoryWaitRecoveryMarker',
+  'parseForcedHandoffComment',
+  'normalizeForcedHandoffPayload',
+  'renderForcedHandoffComment',
+  'renderForcedHandoffConsentNote',
+  'renderExternalCheckWaiverComment',
+  'parseExternalCheckWaiverComment',
+  'parseReviewWatermarkComment',
+  'operationalMarkerPrefix',
+  'operationalMarkerPrefixByStart',
+  'IDD_AGENT_DERIVED_MARKERS',
+  'isValidIsoTimestamp',
+] as const;
+
+test('protocol-helpers re-exports every sampled marker-helpers name by identity', () => {
+  for (const name of SAMPLE_NAMES) {
+    const viaFacade = (facade as Record<string, unknown>)[name];
+    const viaDirect = (direct as Record<string, unknown>)[name];
+    assert.notEqual(
+      viaDirect,
+      undefined,
+      `marker-helpers.mts must export ${name}`,
+    );
+    assert.strictEqual(
+      viaFacade,
+      viaDirect,
+      `protocol-helpers.mts's ${name} must be the same binding as marker-helpers.mts's (re-export, not a copy)`,
+    );
+  }
+});

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -37,7 +37,7 @@ test('protocol-helpers re-exports every sampled marker-helpers name by identity'
   for (const name of SAMPLE_NAMES) {
     const viaFacade = (facade as Record<string, unknown>)[name];
     const viaDirect = (direct as Record<string, unknown>)[name];
-    assert.notEqual(
+    assert.notStrictEqual(
       viaDirect,
       undefined,
       `marker-helpers.mts must export ${name}`,


### PR DESCRIPTION
# Summary

Wave 1 of the protocol-helpers.mts split (roadmap #1220): move every
operational-marker render/parse primitive (claim, watermark, baseline,
advisory-wait, forced-handoff, external-check-waiver) into a new
`src/scripts/marker-helpers.mts`, and make `protocol-helpers.mts`
re-export all of it (`export * from './marker-helpers.mts'`) so every
existing call site keeps importing from `protocol-helpers.mts`
unchanged.

`protocol-helpers.mts`: 6,613 -> 5,809 lines (-804, ~12%). New
`marker-helpers.mts`: 861 lines, 24 exports, zero external imports (no
import-cycle risk in either direction).

## Linked issue

Closes #1209

## Follow-up issues (if any)

- [ ] none

## Background / rationale

- **Scope boundary.** Only the single-marker render/parse primitives
  moved. Gate-level aggregation that folds many markers together with
  trust/policy context -- `summarizeExternalCheckWaivers`,
  `summarizeAdvisoryWaitMarkers`, `resolveLatestReviewWatermark`,
  `deriveIddAgentLogins` -- stays in `protocol-helpers.mts` on purpose:
  each depends on `normalizeTrustedMarkerLogins` (and similar
  broadly-shared, non-marker actor-resolution helpers), and moving them
  would force `marker-helpers.mts` to import back from
  `protocol-helpers.mts`, creating exactly the import cycle the split
  must avoid.
- **No cycle, one direction only.** `marker-helpers.mts` has zero
  imports from any other project module (only JS builtins). Two
  originally-module-private names (`IDD_AGENT_DERIVED_MARKERS`,
  `isValidIsoTimestamp`) are now exported from `marker-helpers.mts`
  solely so `protocol-helpers.mts` can import them back for its own
  internal (staying) use -- `protocol-helpers.mts` -> `marker-helpers.mts`
  is the only allowed edge.
- **Onboarding note.** Updated the "anatomy of a helper re-import" note
  in `idd-template/ONBOARDING.md` since the `vendored-node` shared-core
  re-import set now spans two files, not one.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (1568/1568 pass, including a new
      `tests/marker-helpers-facade.test.mts` facade-identity assertion)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (N/A -- no policy/config change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none; pure internal refactor, zero
      call-site changes)
- [x] Context budget impact reviewed (no `.github/instructions/*.md`
      touched; the ONBOARDING.md prose addition is 6 lines, well within
      existing headroom)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>