### PR TITLE
test(idd): extend ENTRY_GUARD to recognize isCliExecution() entries

### DIFF
--- a/tests/cli-entry-smoke.test.mts
+++ b/tests/cli-entry-smoke.test.mts
@@ -18,8 +18,9 @@ const SRC_SCRIPTS = fileURLToPath(new URL('../src/scripts/', import.meta.url));
 // ---------------------------------------------------------------------------
 // Module-eval-order guard
 //
-// A helper whose `if (isMainModule(import.meta.url)) { … }` CLI entry block runs
-// before a module-level `const`/`let`/`var` it (transitively) reads throws a TDZ
+// A helper whose `if (isMainModule(import.meta.url)) { … }` or
+// `if (isCliExecution(import.meta.url)) { … }` CLI entry block runs before a
+// module-level `const`/`let`/`var` it (transitively) reads throws a TDZ
 // `ReferenceError: Cannot access 'X' before initialization` on the CLI path
 // only — a top-level `await` inside the block parks module evaluation there, so
 // a later lexical binding is still in its temporal dead zone. Import-only tests
@@ -33,12 +34,14 @@ const SRC_SCRIPTS = fileURLToPath(new URL('../src/scripts/', import.meta.url));
 // ---------------------------------------------------------------------------
 
 /**
- * Matches a top-level CLI entry-guard opener at column 0. Anchored to the two
- * real signatures — an `isMainModule(` call or a `process.argv[1]` reference —
- * rather than any `import.meta.url` mention, so an unrelated top-level `if` that
- * merely references `import.meta.url` is not mistaken for the entry block.
+ * Matches a top-level CLI entry-guard opener at column 0. Anchored to the
+ * three real signatures — an `isMainModule(` call, an `isCliExecution(` call,
+ * or a `process.argv[1]` reference — rather than any `import.meta.url`
+ * mention, so an unrelated top-level `if` that merely references
+ * `import.meta.url` is not mistaken for the entry block.
  */
-const ENTRY_GUARD = /^if \(.*(?:isMainModule\(|process\.argv\[1\]).*\)\s*\{/;
+const ENTRY_GUARD =
+  /^if \(.*(?:isMainModule\(|isCliExecution\(|process\.argv\[1\]).*\)\s*\{/;
 
 /**
  * Matches a module-level (column 0) `const`/`let`/`var` binding opener,
@@ -95,6 +98,24 @@ test('module-eval-order guard flags an initialized const after the entry block',
       [
         "import { isMainModule } from './x.mts';",
         'if (isMainModule(import.meta.url)) {',
+        '  await run(LATE);',
+        '}',
+        'const LATE = new Set([1, 2, 3]);',
+        '',
+      ].join('\n'),
+    ),
+  ]);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /sample\.mts:5:.*after the CLI entry block/);
+});
+
+test('module-eval-order guard flags an initialized const after an isCliExecution() entry block', () => {
+  const violations = findModuleEvalOrderViolations([
+    readModule(
+      'src/scripts/sample.mts',
+      [
+        "import { isCliExecution } from './gh-exec.mts';",
+        'if (isCliExecution(import.meta.url)) {',
         '  await run(LATE);',
         '}',
         'const LATE = new Set([1, 2, 3]);',

--- a/tests/cli-entry-smoke.test.mts
+++ b/tests/cli-entry-smoke.test.mts
@@ -20,7 +20,7 @@ const SRC_SCRIPTS = fileURLToPath(new URL('../src/scripts/', import.meta.url));
 //
 // A helper whose `if (isMainModule(import.meta.url)) { … }` or
 // `if (isCliExecution(import.meta.url)) { … }` CLI entry block runs before a
-// module-level `const`/`let`/`var` it (transitively) reads throws a TDZ
+// module-level `const`/`let`/`var` that it (transitively) reads throws a TDZ
 // `ReferenceError: Cannot access 'X' before initialization` on the CLI path
 // only — a top-level `await` inside the block parks module evaluation there, so
 // a later lexical binding is still in its temporal dead zone. Import-only tests

--- a/tests/cli-entry-smoke.test.mts
+++ b/tests/cli-entry-smoke.test.mts
@@ -109,7 +109,7 @@ test('module-eval-order guard flags an initialized const after the entry block',
   assert.match(violations[0], /sample\.mts:5:.*after the CLI entry block/);
 });
 
-test('module-eval-order guard flags an initialized const after an isCliExecution() entry block', () => {
+test('module-eval-order guard flags an initialized const after an isCliExecution(import.meta.url) entry block', () => {
   const violations = findModuleEvalOrderViolations([
     readModule(
       'src/scripts/sample.mts',


### PR DESCRIPTION
# Summary

Broadens the `cli-entry-smoke.test.mts` module-eval-order guard
(`ENTRY_GUARD`) to also recognize the `isCliExecution(import.meta.url)`
CLI-entry shape, alongside the existing `isMainModule(` /
`process.argv[1]` shapes it already matched.

## Linked issue

Closes #1223

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The issue's premise needed a correction against current `HEAD` (as the
issue itself anticipated, since #1208/#1209/#1210 landed recently):
`isCliExecution` is not a zero-arg call. Its actual signature
(`src/scripts/gh-exec.mts:159`) is `isCliExecution(moduleUrl: string):
boolean`, and every one of its 15 current call sites uses
`if (isCliExecution(import.meta.url)) {` — the same one-argument shape
as `isMainModule`. Verified via `grep -rln "isCliExecution(" src/scripts/`
against current `HEAD` rather than trusting the issue body's snapshot.

Because the old `ENTRY_GUARD` regex only matched `isMainModule(` or
`process.argv[1]`, it silently never scanned any of those 15 files —
`entryIndex` was always `-1`, so the per-file loop `continue`d without
ever checking their bodies for the TDZ risk the guard exists to catch.

The fix broadens `ENTRY_GUARD` to also match `isCliExecution(`, with no
change to the existing column-0 `if (...) {` anchoring or the exemption
for an unrelated `if` that merely references `import.meta.url` (verified
directly: `if (someOtherThing(import.meta.url))` still does not match,
old or new).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (1610/1610, including the whole-repo scan test, which
  now genuinely scans all 30 current CLI-entry helpers of both shapes
  and still reports zero violations)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing, unrelated
  warnings only)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
