### PR TITLE
docs(policy-constants): warn about dprint table-alignment padding

### DIFF
--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -366,6 +366,34 @@ both**. Apply this to clearly append-mostly surfaces such as
 `audit/sync-manifest.json` helper / budget entries and any export / registry
 list; file a follow-up where a reorder is non-trivial.
 
+### Table-column alignment padding
+
+`dprint`'s markdown plugin **aligns table columns** by padding every cell in
+a column out to that column's widest cell, and exposes no config option to
+turn this off; `dprint check` (part of **pre-push-validate**) enforces the
+padded result. The per-file limits above measure the dprint-formatted
+bytes, so widening a single table cell in a near-ceiling instruction file
+can silently re-pad every other row in that column and add far more bytes
+than the edit itself appears to. `markdownlint`'s `table-column-style:
+false` permits a non-aligned table, but only `dprint` decides what actually
+gets written, so that setting alone does not prevent the padding.
+
+**Convention**: in a budget-guarded instruction file, keep table cells
+short. When a row would otherwise need long conditional or branching
+prose, move that prose out of the cell and into a paragraph placed after
+the table instead of widening the column.
+
+**Escape hatch**: wrap a table that genuinely needs wide cells in
+`<!-- dprint-ignore-start -->` / `<!-- dprint-ignore-end -->` to exempt it
+from alignment; `markdownlint`'s existing `table-column-style: false`
+already accepts the resulting non-aligned table.
+
+**Measure after formatting**: a byte count taken before running `dprint
+fmt` (or **fix-validate**) under-reports the size the budget check will
+actually see, because column padding is applied at format time. Re-run
+`dprint fmt` (or **fix-validate**) and re-measure before trusting a
+near-ceiling file's size against its budget.
+
 ## Changing A Default
 
 For now, this page records the defaults; it does not centralize them.

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -366,6 +366,34 @@ both**. Apply this to clearly append-mostly surfaces such as
 `audit/sync-manifest.json` helper / budget entries and any export / registry
 list; file a follow-up where a reorder is non-trivial.
 
+### Table-column alignment padding
+
+`dprint`'s markdown plugin **aligns table columns** by padding every cell in
+a column out to that column's widest cell, and exposes no config option to
+turn this off; `dprint check` (part of **pre-push-validate**) enforces the
+padded result. The per-file limits above measure the dprint-formatted
+bytes, so widening a single table cell in a near-ceiling instruction file
+can silently re-pad every other row in that column and add far more bytes
+than the edit itself appears to. `markdownlint`'s `table-column-style:
+false` permits a non-aligned table, but only `dprint` decides what actually
+gets written, so that setting alone does not prevent the padding.
+
+**Convention**: in a budget-guarded instruction file, keep table cells
+short. When a row would otherwise need long conditional or branching
+prose, move that prose out of the cell and into a paragraph placed after
+the table instead of widening the column.
+
+**Escape hatch**: wrap a table that genuinely needs wide cells in
+`<!-- dprint-ignore-start -->` / `<!-- dprint-ignore-end -->` to exempt it
+from alignment; `markdownlint`'s existing `table-column-style: false`
+already accepts the resulting non-aligned table.
+
+**Measure after formatting**: a byte count taken before running `dprint
+fmt` (or **fix-validate**) under-reports the size the budget check will
+actually see, because column padding is applied at format time. Re-run
+`dprint fmt` (or **fix-validate**) and re-measure before trusting a
+near-ceiling file's size against its budget.
+
 ## Changing A Default
 
 For now, this page records the defaults; it does not centralize them.


### PR DESCRIPTION
# Summary

Documents a `dprint` footgun: its markdown plugin pads every cell in a
table column out to that column's widest cell, with no config option to
disable it, so widening a single cell in a near-ceiling budget-guarded
instruction file can silently blow the per-file byte budget that
`audit-docs.mjs` enforces. Adds a new subsection under "Runtime
Instruction Size and Bundle Budgets" documenting the mechanism, the
short-cells-plus-prose-after convention, the `dprint-ignore-start/end`
escape hatch, and the measure-after-`dprint fmt` workflow gotcha.

## Linked issue

Closes #1206

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`docs/policy-constants.md` and `idd-template/docs/policy-constants.md`
sync in `"exact"` (byte-identical) mode per `audit/sync-manifest.json`
(`policy-constants-doc`), so the new subsection is written once in the
template source and propagated with `node scripts/sync-docs.mjs --apply`.
The wording is deliberately generic (no repo-specific issue numbers, e.g.
no reference to the motivating #1197 / PR #1201 history) because the
template copy is adopter-distributed and the sync mode requires the two
files to stay byte-for-byte identical — there is no room for the template
to generalize while the live copy keeps a concrete example. The new
subsection itself is prose-only (no table), which sidesteps the exact
padding risk it documents.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
