### PR TITLE
fix(idd-ci): document the no-required-checks fallback in Required-check discovery

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -94,7 +94,7 @@ interpreting `gh pr checks` output.
    true` state `idd-pre-merge.instructions.md` F2's CI gate already
    interprets. When `pre-merge-readiness` output is available, reuse
    its `ci.presentRunConclusion` value directly. Otherwise, derive the
-   equivalent from the current HEAD's actual runs: `all-passing`
+   equivalent from the current PR head SHA's actual runs: `all-passing`
    (every present run completed green) may proceed; `pending` → wait
    per the polling algorithm below, then re-check; `some-failing`, or
    `none` (no runs exist at all) → **hold**, do not treat an empty

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -89,8 +89,18 @@ interpreting `gh pr checks` output.
    and branch-protection checks. Keep expected check source metadata
    (GitHub App/integration) when configured.
 
-5. If neither source yields a required-check set, stop and post a hold
-   comment (missing merge-gate policy evidence).
+5. If neither source yields a required-check set, this is **not**
+   automatically a hold — it is the same `noRequiredChecksConfigured:
+   true` state `idd-pre-merge.instructions.md` F2's CI gate already
+   interprets. When `pre-merge-readiness` output is available, reuse
+   its `ci.presentRunConclusion` value directly. Otherwise, derive the
+   equivalent from the current HEAD's actual runs: `all-passing`
+   (every present run completed green) may proceed; `pending` → wait
+   per the polling algorithm below, then re-check; `some-failing`, or
+   `none` (no runs exist at all) → **hold**, do not treat an empty
+   required-check set as a vacuous pass. See
+   [F2 — Pre-merge condition check](idd-pre-merge.instructions.md#f2--pre-merge-condition-check)
+   for the full routing table; do not duplicate it here.
 
 When caller phases already provide a trusted required-check set, reuse
 that set instead of re-deriving it.

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -84,8 +84,18 @@ interpreting `gh pr checks` output.
    and branch-protection checks. Keep expected check source metadata
    (GitHub App/integration) when configured.
 
-5. If neither source yields a required-check set, stop and post a hold
-   comment (missing merge-gate policy evidence).
+5. If neither source yields a required-check set, this is **not**
+   automatically a hold — it is the same `noRequiredChecksConfigured:
+   true` state `idd-pre-merge.instructions.md` F2's CI gate already
+   interprets. When `pre-merge-readiness` output is available, reuse
+   its `ci.presentRunConclusion` value directly. Otherwise, derive the
+   equivalent from the current HEAD's actual runs: `all-passing`
+   (every present run completed green) may proceed; `pending` → wait
+   per the polling algorithm below, then re-check; `some-failing`, or
+   `none` (no runs exist at all) → **hold**, do not treat an empty
+   required-check set as a vacuous pass. See
+   [F2 — Pre-merge condition check](idd-pre-merge.instructions.md#f2--pre-merge-condition-check)
+   for the full routing table; do not duplicate it here.
 
 When caller phases already provide a trusted required-check set, reuse
 that set instead of re-deriving it.

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -89,7 +89,7 @@ interpreting `gh pr checks` output.
    true` state `idd-pre-merge.instructions.md` F2's CI gate already
    interprets. When `pre-merge-readiness` output is available, reuse
    its `ci.presentRunConclusion` value directly. Otherwise, derive the
-   equivalent from the current HEAD's actual runs: `all-passing`
+   equivalent from the current PR head SHA's actual runs: `all-passing`
    (every present run completed green) may proceed; `pending` → wait
    per the polling algorithm below, then re-check; `some-failing`, or
    `none` (no runs exist at all) → **hold**, do not treat an empty


### PR DESCRIPTION
## Summary

- `idd-ci.instructions.md`'s Required-check discovery step 5 treated an
  empty required-check set (no enforcing ruleset, no branch protection)
  as an unconditional hold, even though `idd-pre-merge.instructions.md`
  F2 already defines the correct interpretation for that exact state.
- Any D-phase or E-phase CI wait — both share `idd-ci.instructions.md`
  per its own description — hit step 5 before ever reaching F2, so it
  read as an immediate hold even when CI was running fine. This repo's
  own `main`/`features` rulesets currently have no
  `required_status_checks` rule and classic branch protection 404s, so
  this was live friction, not a hypothetical.

## Change

Step 5 now cross-references F2's `noRequiredChecksConfigured` /
`presentRunConclusion` routing instead of duplicating its table:

- When `pre-merge-readiness` output is available, reuse
  `ci.presentRunConclusion` directly.
- Otherwise (a shell-fallback CI wait with no helper output), derive
  the equivalent from the current HEAD's actual runs: `all-passing` may
  proceed, `pending` waits and re-checks, `some-failing`/`none` holds —
  an empty required-check set is never treated as a vacuous pass.

Edited `idd-template/.github/instructions/idd-ci.instructions.md` (the
`exact`-mode sync source) and regenerated the live copy via
`node scripts/sync-docs.mjs --apply`.

## Verification

- `node scripts/audit-docs.mjs --check` passes.
- `pnpm run lint:minimum` passes (1610/1610 tests, 0 markdownlint
  errors, 0 cspell issues).
- The new cross-reference anchor
  (`idd-pre-merge.instructions.md#f2--pre-merge-condition-check`) was
  hand-verified against GitHub's actual heading-slug algorithm (an
  em-dash with surrounding spaces collapses to a double hyphen) and
  cross-checked against this repo's own existing double-hyphen
  em-dash-heading anchors (e.g.
  `idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan`).
  Note: this repo's `verify-workshop-integrity.mjs` `extractHeadingSlugs`
  helper is scoped to `docs/workshop/` only and produces single-hyphen
  slugs for the same heading, so it is not a reliable oracle for this
  cross-reference — the established double-hyphen convention already in
  use elsewhere in this repo is what real GitHub rendering produces.

Closes #1233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how missing required checks are handled, so the workflow now makes a clearer decision instead of stopping too early.
  * When no checks are defined, it now uses available CI results to decide whether to continue, wait, or hold.
  * Empty required-check lists are no longer treated as an automatic pass.

* **Documentation**
  * Clarified the pre-merge decision flow and pointed to the full routing reference for check outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->