### PR TITLE
docs(idd-work): add de-dup-refactor hidden-behavior-loss note

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -202,6 +202,12 @@ Implement the plan. Before each commit, run **fix-validate**.
 
 Keep commits atomic — one logical change per commit.
 
+**De-duplication refactors**: when consolidating a wrapper function used
+at multiple call sites into one shared function, check whether any call
+site's old delegate path added options or behavior (timeouts, stdio
+handling, error translation, etc.) that the new shared function does not
+replicate — not just whether the function bodies look equivalent.
+
 If B3 or C must stop for a hold, use the shared Hold / suspend rules in
 `idd-overview-appendix.instructions.md` and update the issue digest with the
 blocking condition before stopping. Do not use the digest as the only

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -197,6 +197,12 @@ Implement the plan. Before each commit, run **fix-validate**.
 
 Keep commits atomic — one logical change per commit.
 
+**De-duplication refactors**: when consolidating a wrapper function used
+at multiple call sites into one shared function, check whether any call
+site's old delegate path added options or behavior (timeouts, stdio
+handling, error translation, etc.) that the new shared function does not
+replicate — not just whether the function bodies look equivalent.
+
 If B3 or C must stop for a hold, use the shared Hold / suspend rules in
 `idd-overview-appendix.instructions.md` and update the issue digest with the
 blocking condition before stopping. Do not use the digest as the only


### PR DESCRIPTION
# Summary

Add a short B3 ("Implement") callout to `idd-work.instructions.md`: when
de-duplicating a wrapper function used at multiple call sites, check
whether any call site's old delegate path added options or behavior
(timeouts, stdio handling, error translation, etc.) that the new shared
function does not replicate — not just whether the function bodies look
equivalent.

## Linked issue

Closes #1238

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This is drawn from a real regression class hit during #1208's
`gh-exec.mts` consolidation: 10 of 22 call sites lost `execFileSync`
`stdio` isolation / `timeout` options that a local `runGh` wrapper had
been adding. It was caught only by an ad hoc multi-agent critique pass
and, independently, by a reviewer's comment on two of the affected
files — not by anything in the written implementation guidance. This
repository has more of this exact refactor class coming (#1208's own PR
explicitly deferred a 15-file `isMainModule` cluster and several
divergent `ghApiJson` callers for later), so the note is added directly
next to the existing "keep commits atomic" guidance in B3 rather than as
a new sub-checklist, matching the length of nearby notes in the same
section.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
