### PR TITLE
fix(idd-pr-submit): check for pull request template before D3 PR body

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -113,8 +113,19 @@ head before merge.
 
 ## D3 — Create PR
 
+Before drafting the PR body, check whether the repository defines
+`.github/pull_request_template.md`. If it exists, shape the PR body to
+follow that template's section structure from the start, rather than
+drafting free-form text and reconciling it against the template
+afterward — repository review tooling (for example, CodeRabbit's
+default description check) can compare the PR description against
+that template when present, and a mismatched body can trigger an
+avoidable advisory finding. If no template file exists, use the
+structure below directly.
+
 Use GH CLI or GH MCP to create the pull request. The PR body must
-include:
+include the following content, mapped onto the template's sections
+when one exists:
 
 - A concise summary of the branch's changes
 - A closing keyword on its own line linking the claimed issue (see

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -108,8 +108,19 @@ head before merge.
 
 ## D3 — Create PR
 
+Before drafting the PR body, check whether the repository defines
+`.github/pull_request_template.md`. If it exists, shape the PR body to
+follow that template's section structure from the start, rather than
+drafting free-form text and reconciling it against the template
+afterward — repository review tooling (for example, CodeRabbit's
+default description check) can compare the PR description against
+that template when present, and a mismatched body can trigger an
+avoidable advisory finding. If no template file exists, use the
+structure below directly.
+
 Use GH CLI or GH MCP to create the pull request. The PR body must
-include:
+include the following content, mapped onto the template's sections
+when one exists:
 
 - A concise summary of the branch's changes
 - A closing keyword on its own line linking the claimed issue (see


### PR DESCRIPTION
# Summary

D3 of `idd-pr-submit.instructions.md` listed the required PR body
content (summary, closing keyword, follow-up issues,
background/rationale) but never checked whether the repository defines
`.github/pull_request_template.md`. This repository has one, and
CodeRabbit's default review behavior compares the PR description
against that template's sections when present — this surfaced as a
genuine advisory finding in a recent session (PR for issue #1214),
forcing a mid-flight PR-body rewrite. This PR adds a D3 step
instructing the agent to check for the template before drafting the
body and shape it to the template's section structure from the start
when one exists.

## Linked issue

Closes #1234

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The added guidance intentionally stays generic (no hardcoded section
names) since `idd-template/.github/instructions/idd-pr-submit.instructions.md`
is a portable file distributed to other repositories that may define a
differently structured template, or none at all. The existing
required-content bullet list is kept and reframed as content that maps
onto the template's sections when one exists, rather than being
replaced.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (1610/1610 passing; no test-relevant code changed —
      documentation-only change)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed with 3 pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
