### PR TITLE
fix(helpers): clarify node-id error in minimize-superseded-markers

### DIFF
--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -29,6 +29,17 @@ const MINIMIZABLE_TYPENAMES = new Set([
   'PullRequestReview',
   'PullRequestReviewComment',
 ]);
+// GitHub's GraphQL node(id:) query returns this message (independent of
+// subject type) when the id cannot be resolved — including the common case
+// of a REST numeric id passed where a GraphQL global node id is required.
+// Shared by probeSubject's error path and --help so the guidance never
+// drifts between the two surfaces.
+const UNRESOLVABLE_NODE_ID_PATTERN = /could not resolve to a node/i;
+const NODE_ID_CONVERSION_COMMANDS = [
+  "  issue comment:     gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q '.node_id'",
+  "  PR review:         gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} -q '.node_id'",
+  "  PR review comment: gh api repos/{owner}/{repo}/pulls/comments/{comment_id} -q '.node_id'",
+].join('\n');
 if (isMainModule(import.meta.url)) {
   let args;
   try {
@@ -196,6 +207,23 @@ export function runMinimize({
   }
   return report;
 }
+// cspell:ignore Wpaqs
+// probeSubject requires a GraphQL global node id (e.g.
+// IC_kwDOSWpaqs8AAAABIk9VAg) — REST responses instead surface a numeric id
+// (e.g. 4870591746). A bare integer is never auto-converted here: it could
+// belong to an issue comment, a PR review, or a PR review comment, each
+// served by a different REST endpoint, so guessing which one risks querying
+// the wrong resource. Point the caller at the exact conversion command
+// instead.
+function unresolvableNodeIdReason(subjectId) {
+  return (
+    `unresolvable-node-id: "${subjectId}" is not a GraphQL node ID. ` +
+    "probeSubject queries GitHub's GraphQL node(id: $id) API, which " +
+    'requires a GraphQL global node ID (e.g. IC_kwDOSWpaqs8AAAABIk9VAg), ' +
+    'not a REST numeric ID (e.g. 4870591746). Convert the REST ID to its ' +
+    `node ID first, using the command for the subject type:\n${NODE_ID_CONVERSION_COMMANDS}`
+  );
+}
 export function probeSubject(subjectId) {
   const result = runGh([
     'api',
@@ -213,6 +241,9 @@ export function probeSubject(subjectId) {
     `id=${subjectId}`,
   ]);
   if (!result.ok) {
+    if (UNRESOLVABLE_NODE_ID_PATTERN.test(result.stderr)) {
+      return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
+    }
     return {
       ok: false,
       reason: `gh-graphql-error: ${result.stderr.slice(0, 200)}`,
@@ -228,13 +259,16 @@ export function probeSubject(subjectId) {
     };
   }
   if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    const joinedErrors = parsed.errors
+      .map((e) => String(e.message ?? ''))
+      .filter(Boolean)
+      .join('; ');
+    if (UNRESOLVABLE_NODE_ID_PATTERN.test(joinedErrors)) {
+      return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
+    }
     return {
       ok: false,
-      reason: `gh-graphql-errors: ${parsed.errors
-        .map((e) => String(e.message ?? ''))
-        .filter(Boolean)
-        .join('; ')
-        .slice(0, 200)}`,
+      reason: `gh-graphql-errors: ${joinedErrors.slice(0, 200)}`,
     };
   }
   const node = parsed?.data?.node;
@@ -463,7 +497,13 @@ trustedMarkerActors list in .github/idd/config.json (flag > env >
 config precedence) so the helper rejects markers from untrusted GitHub
 actors. Use --allow-untrusted only when you intentionally want to
 minimize markers regardless of author, and the caller has already
-verified the subject IDs are operationally safe to hide.`);
+verified the subject IDs are operationally safe to hide.
+
+--subject-ids must be GraphQL global node IDs (e.g.
+IC_kwDOSWpaqs8AAAABIk9VAg), not REST numeric IDs (e.g. 4870591746).
+Convert a REST ID to its node ID first, using the command for the
+subject type:
+${NODE_ID_CONVERSION_COMMANDS}`);
 }
 function isMainModule(metaUrl) {
   const entry = process.argv[1];

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -40,11 +40,13 @@ const MINIMIZABLE_TYPENAMES = new Set([
 // the two surfaces.
 const UNRESOLVABLE_NODE_ID_PATTERN = /could not resolve to a node/i;
 // REST numeric ids (issue comment / PR review / PR review comment) are
-// always bare positive integers; GraphQL global node ids never are. Gating
-// the enhanced guidance on this shape keeps it from misfiring on a
-// GraphQL-shaped id that legitimately failed to resolve (deleted or
-// inaccessible), where the raw gh error remains the accurate reason.
-const REST_SHAPED_SUBJECT_ID_PATTERN = /^\d+$/;
+// always bare positive integers with no leading zero; GraphQL global node
+// ids never are. Gating the enhanced guidance on this shape keeps it from
+// misfiring on a GraphQL-shaped id that legitimately failed to resolve
+// (deleted or inaccessible), where the raw gh error remains the accurate
+// reason. `[1-9]\d*` (rather than `\d+`) excludes "0" and leading-zero forms
+// like "0001", which no real REST id ever takes.
+const REST_SHAPED_SUBJECT_ID_PATTERN = /^[1-9]\d*$/;
 const NODE_ID_CONVERSION_COMMANDS = [
   "  issue comment:     gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q '.node_id'",
   "  PR review:         gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} -q '.node_id'",

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -30,11 +30,21 @@ const MINIMIZABLE_TYPENAMES = new Set([
   'PullRequestReviewComment',
 ]);
 // GitHub's GraphQL node(id:) query returns this message (independent of
-// subject type) when the id cannot be resolved — including the common case
-// of a REST numeric id passed where a GraphQL global node id is required.
-// Shared by probeSubject's error path and --help so the guidance never
-// drifts between the two surfaces.
+// subject type) whenever an id cannot be resolved — including, but NOT
+// limited to, a REST numeric id passed where a GraphQL global node id is
+// required. The same text also covers a syntactically valid node id whose
+// object was deleted or is inaccessible, so this pattern alone cannot
+// distinguish "wrong id shape" from "right shape, gone object": pair it with
+// REST_SHAPED_SUBJECT_ID_PATTERN below before assuming the former. Shared by
+// probeSubject's error path and --help so the guidance never drifts between
+// the two surfaces.
 const UNRESOLVABLE_NODE_ID_PATTERN = /could not resolve to a node/i;
+// REST numeric ids (issue comment / PR review / PR review comment) are
+// always bare positive integers; GraphQL global node ids never are. Gating
+// the enhanced guidance on this shape keeps it from misfiring on a
+// GraphQL-shaped id that legitimately failed to resolve (deleted or
+// inaccessible), where the raw gh error remains the accurate reason.
+const REST_SHAPED_SUBJECT_ID_PATTERN = /^\d+$/;
 const NODE_ID_CONVERSION_COMMANDS = [
   "  issue comment:     gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q '.node_id'",
   "  PR review:         gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} -q '.node_id'",
@@ -224,6 +234,16 @@ function unresolvableNodeIdReason(subjectId) {
     `node ID first, using the command for the subject type:\n${NODE_ID_CONVERSION_COMMANDS}`
   );
 }
+// Both conditions must hold: the subject id must itself look REST-shaped
+// (see REST_SHAPED_SUBJECT_ID_PATTERN above), not just the error text —
+// otherwise a valid-but-deleted/inaccessible GraphQL node id would be
+// misreported as "not a GraphQL node ID".
+function isUnresolvableRestShapedId(subjectId, errorText) {
+  return (
+    REST_SHAPED_SUBJECT_ID_PATTERN.test(subjectId) &&
+    UNRESOLVABLE_NODE_ID_PATTERN.test(errorText)
+  );
+}
 export function probeSubject(subjectId) {
   const result = runGh([
     'api',
@@ -241,7 +261,7 @@ export function probeSubject(subjectId) {
     `id=${subjectId}`,
   ]);
   if (!result.ok) {
-    if (UNRESOLVABLE_NODE_ID_PATTERN.test(result.stderr)) {
+    if (isUnresolvableRestShapedId(subjectId, result.stderr)) {
       return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
     }
     return {
@@ -263,7 +283,7 @@ export function probeSubject(subjectId) {
       .map((e) => String(e.message ?? ''))
       .filter(Boolean)
       .join('; ');
-    if (UNRESOLVABLE_NODE_ID_PATTERN.test(joinedErrors)) {
+    if (isUnresolvableRestShapedId(subjectId, joinedErrors)) {
       return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
     }
     return {

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -29,6 +29,17 @@ const MINIMIZABLE_TYPENAMES = new Set([
   'PullRequestReview',
   'PullRequestReviewComment',
 ]);
+// GitHub's GraphQL node(id:) query returns this message (independent of
+// subject type) when the id cannot be resolved — including the common case
+// of a REST numeric id passed where a GraphQL global node id is required.
+// Shared by probeSubject's error path and --help so the guidance never
+// drifts between the two surfaces.
+const UNRESOLVABLE_NODE_ID_PATTERN = /could not resolve to a node/i;
+const NODE_ID_CONVERSION_COMMANDS = [
+  "  issue comment:     gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q '.node_id'",
+  "  PR review:         gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} -q '.node_id'",
+  "  PR review comment: gh api repos/{owner}/{repo}/pulls/comments/{comment_id} -q '.node_id'",
+].join('\n');
 if (isMainModule(import.meta.url)) {
   let args;
   try {
@@ -196,6 +207,23 @@ export function runMinimize({
   }
   return report;
 }
+// cspell:ignore Wpaqs
+// probeSubject requires a GraphQL global node id (e.g.
+// IC_kwDOSWpaqs8AAAABIk9VAg) — REST responses instead surface a numeric id
+// (e.g. 4870591746). A bare integer is never auto-converted here: it could
+// belong to an issue comment, a PR review, or a PR review comment, each
+// served by a different REST endpoint, so guessing which one risks querying
+// the wrong resource. Point the caller at the exact conversion command
+// instead.
+function unresolvableNodeIdReason(subjectId) {
+  return (
+    `unresolvable-node-id: "${subjectId}" is not a GraphQL node ID. ` +
+    "probeSubject queries GitHub's GraphQL node(id: $id) API, which " +
+    'requires a GraphQL global node ID (e.g. IC_kwDOSWpaqs8AAAABIk9VAg), ' +
+    'not a REST numeric ID (e.g. 4870591746). Convert the REST ID to its ' +
+    `node ID first, using the command for the subject type:\n${NODE_ID_CONVERSION_COMMANDS}`
+  );
+}
 export function probeSubject(subjectId) {
   const result = runGh([
     'api',
@@ -213,6 +241,9 @@ export function probeSubject(subjectId) {
     `id=${subjectId}`,
   ]);
   if (!result.ok) {
+    if (UNRESOLVABLE_NODE_ID_PATTERN.test(result.stderr)) {
+      return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
+    }
     return {
       ok: false,
       reason: `gh-graphql-error: ${result.stderr.slice(0, 200)}`,
@@ -228,13 +259,16 @@ export function probeSubject(subjectId) {
     };
   }
   if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    const joinedErrors = parsed.errors
+      .map((e) => String(e.message ?? ''))
+      .filter(Boolean)
+      .join('; ');
+    if (UNRESOLVABLE_NODE_ID_PATTERN.test(joinedErrors)) {
+      return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
+    }
     return {
       ok: false,
-      reason: `gh-graphql-errors: ${parsed.errors
-        .map((e) => String(e.message ?? ''))
-        .filter(Boolean)
-        .join('; ')
-        .slice(0, 200)}`,
+      reason: `gh-graphql-errors: ${joinedErrors.slice(0, 200)}`,
     };
   }
   const node = parsed?.data?.node;
@@ -463,7 +497,13 @@ trustedMarkerActors list in .github/idd/config.json (flag > env >
 config precedence) so the helper rejects markers from untrusted GitHub
 actors. Use --allow-untrusted only when you intentionally want to
 minimize markers regardless of author, and the caller has already
-verified the subject IDs are operationally safe to hide.`);
+verified the subject IDs are operationally safe to hide.
+
+--subject-ids must be GraphQL global node IDs (e.g.
+IC_kwDOSWpaqs8AAAABIk9VAg), not REST numeric IDs (e.g. 4870591746).
+Convert a REST ID to its node ID first, using the command for the
+subject type:
+${NODE_ID_CONVERSION_COMMANDS}`);
 }
 function isMainModule(metaUrl) {
   const entry = process.argv[1];

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -40,11 +40,13 @@ const MINIMIZABLE_TYPENAMES = new Set([
 // the two surfaces.
 const UNRESOLVABLE_NODE_ID_PATTERN = /could not resolve to a node/i;
 // REST numeric ids (issue comment / PR review / PR review comment) are
-// always bare positive integers; GraphQL global node ids never are. Gating
-// the enhanced guidance on this shape keeps it from misfiring on a
-// GraphQL-shaped id that legitimately failed to resolve (deleted or
-// inaccessible), where the raw gh error remains the accurate reason.
-const REST_SHAPED_SUBJECT_ID_PATTERN = /^\d+$/;
+// always bare positive integers with no leading zero; GraphQL global node
+// ids never are. Gating the enhanced guidance on this shape keeps it from
+// misfiring on a GraphQL-shaped id that legitimately failed to resolve
+// (deleted or inaccessible), where the raw gh error remains the accurate
+// reason. `[1-9]\d*` (rather than `\d+`) excludes "0" and leading-zero forms
+// like "0001", which no real REST id ever takes.
+const REST_SHAPED_SUBJECT_ID_PATTERN = /^[1-9]\d*$/;
 const NODE_ID_CONVERSION_COMMANDS = [
   "  issue comment:     gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q '.node_id'",
   "  PR review:         gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} -q '.node_id'",

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -30,11 +30,21 @@ const MINIMIZABLE_TYPENAMES = new Set([
   'PullRequestReviewComment',
 ]);
 // GitHub's GraphQL node(id:) query returns this message (independent of
-// subject type) when the id cannot be resolved — including the common case
-// of a REST numeric id passed where a GraphQL global node id is required.
-// Shared by probeSubject's error path and --help so the guidance never
-// drifts between the two surfaces.
+// subject type) whenever an id cannot be resolved — including, but NOT
+// limited to, a REST numeric id passed where a GraphQL global node id is
+// required. The same text also covers a syntactically valid node id whose
+// object was deleted or is inaccessible, so this pattern alone cannot
+// distinguish "wrong id shape" from "right shape, gone object": pair it with
+// REST_SHAPED_SUBJECT_ID_PATTERN below before assuming the former. Shared by
+// probeSubject's error path and --help so the guidance never drifts between
+// the two surfaces.
 const UNRESOLVABLE_NODE_ID_PATTERN = /could not resolve to a node/i;
+// REST numeric ids (issue comment / PR review / PR review comment) are
+// always bare positive integers; GraphQL global node ids never are. Gating
+// the enhanced guidance on this shape keeps it from misfiring on a
+// GraphQL-shaped id that legitimately failed to resolve (deleted or
+// inaccessible), where the raw gh error remains the accurate reason.
+const REST_SHAPED_SUBJECT_ID_PATTERN = /^\d+$/;
 const NODE_ID_CONVERSION_COMMANDS = [
   "  issue comment:     gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q '.node_id'",
   "  PR review:         gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} -q '.node_id'",
@@ -224,6 +234,16 @@ function unresolvableNodeIdReason(subjectId) {
     `node ID first, using the command for the subject type:\n${NODE_ID_CONVERSION_COMMANDS}`
   );
 }
+// Both conditions must hold: the subject id must itself look REST-shaped
+// (see REST_SHAPED_SUBJECT_ID_PATTERN above), not just the error text —
+// otherwise a valid-but-deleted/inaccessible GraphQL node id would be
+// misreported as "not a GraphQL node ID".
+function isUnresolvableRestShapedId(subjectId, errorText) {
+  return (
+    REST_SHAPED_SUBJECT_ID_PATTERN.test(subjectId) &&
+    UNRESOLVABLE_NODE_ID_PATTERN.test(errorText)
+  );
+}
 export function probeSubject(subjectId) {
   const result = runGh([
     'api',
@@ -241,7 +261,7 @@ export function probeSubject(subjectId) {
     `id=${subjectId}`,
   ]);
   if (!result.ok) {
-    if (UNRESOLVABLE_NODE_ID_PATTERN.test(result.stderr)) {
+    if (isUnresolvableRestShapedId(subjectId, result.stderr)) {
       return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
     }
     return {
@@ -263,7 +283,7 @@ export function probeSubject(subjectId) {
       .map((e) => String(e.message ?? ''))
       .filter(Boolean)
       .join('; ');
-    if (UNRESOLVABLE_NODE_ID_PATTERN.test(joinedErrors)) {
+    if (isUnresolvableRestShapedId(subjectId, joinedErrors)) {
       return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
     }
     return {

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -43,11 +43,13 @@ const MINIMIZABLE_TYPENAMES = new Set([
 // the two surfaces.
 const UNRESOLVABLE_NODE_ID_PATTERN = /could not resolve to a node/i;
 // REST numeric ids (issue comment / PR review / PR review comment) are
-// always bare positive integers; GraphQL global node ids never are. Gating
-// the enhanced guidance on this shape keeps it from misfiring on a
-// GraphQL-shaped id that legitimately failed to resolve (deleted or
-// inaccessible), where the raw gh error remains the accurate reason.
-const REST_SHAPED_SUBJECT_ID_PATTERN = /^\d+$/;
+// always bare positive integers with no leading zero; GraphQL global node
+// ids never are. Gating the enhanced guidance on this shape keeps it from
+// misfiring on a GraphQL-shaped id that legitimately failed to resolve
+// (deleted or inaccessible), where the raw gh error remains the accurate
+// reason. `[1-9]\d*` (rather than `\d+`) excludes "0" and leading-zero forms
+// like "0001", which no real REST id ever takes.
+const REST_SHAPED_SUBJECT_ID_PATTERN = /^[1-9]\d*$/;
 const NODE_ID_CONVERSION_COMMANDS = [
   "  issue comment:     gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q '.node_id'",
   "  PR review:         gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} -q '.node_id'",

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -33,11 +33,21 @@ const MINIMIZABLE_TYPENAMES = new Set([
 ]);
 
 // GitHub's GraphQL node(id:) query returns this message (independent of
-// subject type) when the id cannot be resolved — including the common case
-// of a REST numeric id passed where a GraphQL global node id is required.
-// Shared by probeSubject's error path and --help so the guidance never
-// drifts between the two surfaces.
+// subject type) whenever an id cannot be resolved — including, but NOT
+// limited to, a REST numeric id passed where a GraphQL global node id is
+// required. The same text also covers a syntactically valid node id whose
+// object was deleted or is inaccessible, so this pattern alone cannot
+// distinguish "wrong id shape" from "right shape, gone object": pair it with
+// REST_SHAPED_SUBJECT_ID_PATTERN below before assuming the former. Shared by
+// probeSubject's error path and --help so the guidance never drifts between
+// the two surfaces.
 const UNRESOLVABLE_NODE_ID_PATTERN = /could not resolve to a node/i;
+// REST numeric ids (issue comment / PR review / PR review comment) are
+// always bare positive integers; GraphQL global node ids never are. Gating
+// the enhanced guidance on this shape keeps it from misfiring on a
+// GraphQL-shaped id that legitimately failed to resolve (deleted or
+// inaccessible), where the raw gh error remains the accurate reason.
+const REST_SHAPED_SUBJECT_ID_PATTERN = /^\d+$/;
 const NODE_ID_CONVERSION_COMMANDS = [
   "  issue comment:     gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q '.node_id'",
   "  PR review:         gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} -q '.node_id'",
@@ -305,6 +315,20 @@ function unresolvableNodeIdReason(subjectId: string): string {
   );
 }
 
+// Both conditions must hold: the subject id must itself look REST-shaped
+// (see REST_SHAPED_SUBJECT_ID_PATTERN above), not just the error text —
+// otherwise a valid-but-deleted/inaccessible GraphQL node id would be
+// misreported as "not a GraphQL node ID".
+function isUnresolvableRestShapedId(
+  subjectId: string,
+  errorText: string,
+): boolean {
+  return (
+    REST_SHAPED_SUBJECT_ID_PATTERN.test(subjectId) &&
+    UNRESOLVABLE_NODE_ID_PATTERN.test(errorText)
+  );
+}
+
 export function probeSubject(subjectId: string): ProbeResult {
   const result = runGh([
     'api',
@@ -322,7 +346,7 @@ export function probeSubject(subjectId: string): ProbeResult {
     `id=${subjectId}`,
   ]);
   if (!result.ok) {
-    if (UNRESOLVABLE_NODE_ID_PATTERN.test(result.stderr)) {
+    if (isUnresolvableRestShapedId(subjectId, result.stderr)) {
       return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
     }
     return {
@@ -355,7 +379,7 @@ export function probeSubject(subjectId: string): ProbeResult {
       .map((e) => String(e.message ?? ''))
       .filter(Boolean)
       .join('; ');
-    if (UNRESOLVABLE_NODE_ID_PATTERN.test(joinedErrors)) {
+    if (isUnresolvableRestShapedId(subjectId, joinedErrors)) {
       return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
     }
     return {

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -32,6 +32,18 @@ const MINIMIZABLE_TYPENAMES = new Set([
   'PullRequestReviewComment',
 ]);
 
+// GitHub's GraphQL node(id:) query returns this message (independent of
+// subject type) when the id cannot be resolved — including the common case
+// of a REST numeric id passed where a GraphQL global node id is required.
+// Shared by probeSubject's error path and --help so the guidance never
+// drifts between the two surfaces.
+const UNRESOLVABLE_NODE_ID_PATTERN = /could not resolve to a node/i;
+const NODE_ID_CONVERSION_COMMANDS = [
+  "  issue comment:     gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q '.node_id'",
+  "  PR review:         gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} -q '.node_id'",
+  "  PR review comment: gh api repos/{owner}/{repo}/pulls/comments/{comment_id} -q '.node_id'",
+].join('\n');
+
 interface ProbeNode {
   typename: unknown;
   url: unknown;
@@ -275,6 +287,24 @@ export function runMinimize({
   return report;
 }
 
+// cspell:ignore Wpaqs
+// probeSubject requires a GraphQL global node id (e.g.
+// IC_kwDOSWpaqs8AAAABIk9VAg) — REST responses instead surface a numeric id
+// (e.g. 4870591746). A bare integer is never auto-converted here: it could
+// belong to an issue comment, a PR review, or a PR review comment, each
+// served by a different REST endpoint, so guessing which one risks querying
+// the wrong resource. Point the caller at the exact conversion command
+// instead.
+function unresolvableNodeIdReason(subjectId: string): string {
+  return (
+    `unresolvable-node-id: "${subjectId}" is not a GraphQL node ID. ` +
+    "probeSubject queries GitHub's GraphQL node(id: $id) API, which " +
+    'requires a GraphQL global node ID (e.g. IC_kwDOSWpaqs8AAAABIk9VAg), ' +
+    'not a REST numeric ID (e.g. 4870591746). Convert the REST ID to its ' +
+    `node ID first, using the command for the subject type:\n${NODE_ID_CONVERSION_COMMANDS}`
+  );
+}
+
 export function probeSubject(subjectId: string): ProbeResult {
   const result = runGh([
     'api',
@@ -292,6 +322,9 @@ export function probeSubject(subjectId: string): ProbeResult {
     `id=${subjectId}`,
   ]);
   if (!result.ok) {
+    if (UNRESOLVABLE_NODE_ID_PATTERN.test(result.stderr)) {
+      return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
+    }
     return {
       ok: false,
       reason: `gh-graphql-error: ${result.stderr.slice(0, 200)}`,
@@ -318,13 +351,16 @@ export function probeSubject(subjectId: string): ProbeResult {
     };
   }
   if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    const joinedErrors = parsed.errors
+      .map((e) => String(e.message ?? ''))
+      .filter(Boolean)
+      .join('; ');
+    if (UNRESOLVABLE_NODE_ID_PATTERN.test(joinedErrors)) {
+      return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
+    }
     return {
       ok: false,
-      reason: `gh-graphql-errors: ${parsed.errors
-        .map((e) => String(e.message ?? ''))
-        .filter(Boolean)
-        .join('; ')
-        .slice(0, 200)}`,
+      reason: `gh-graphql-errors: ${joinedErrors.slice(0, 200)}`,
     };
   }
   const node = parsed?.data?.node;
@@ -585,7 +621,13 @@ trustedMarkerActors list in .github/idd/config.json (flag > env >
 config precedence) so the helper rejects markers from untrusted GitHub
 actors. Use --allow-untrusted only when you intentionally want to
 minimize markers regardless of author, and the caller has already
-verified the subject IDs are operationally safe to hide.`,
+verified the subject IDs are operationally safe to hide.
+
+--subject-ids must be GraphQL global node IDs (e.g.
+IC_kwDOSWpaqs8AAAABIk9VAg), not REST numeric IDs (e.g. 4870591746).
+Convert a REST ID to its node ID first, using the command for the
+subject type:
+${NODE_ID_CONVERSION_COMMANDS}`,
   );
 }
 

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -160,9 +160,10 @@ test('config-only resolution passes the author gate end to end', () => {
 });
 
 // cspell:ignore Wpaqs
-// Shared by the three "unresolvable node id" tests below (CodeRabbit review
-// on PR #1242: extract the repeated gh-stub + spawn boilerplate). Stubs gh to
-// reproduce the exact stdout/stderr/exit-code shape observed from a live
+// Shared by the three "unresolvable node id" tests below, so each test only
+// supplies its --subject-ids value and assertions instead of repeating the
+// sandbox/gh-stub/spawnSync setup. Stubs gh to reproduce the exact
+// stdout/stderr/exit-code shape observed from a live
 // `gh api graphql -f id=<value>` call when the id cannot be resolved: gh
 // exits non-zero and writes "Could not resolve to a node with the global id
 // of '<id>'" to stderr, mirroring the response body in stdout.

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -206,10 +206,11 @@ process.exit(1);
         cwd: sandbox,
         env: {
           ...process.env,
-          // The gh stub's #!/usr/bin/env node shebang needs `node` on PATH
-          // too, alongside the stub directory (which must come first so the
-          // bare `gh` lookup resolves to the stub, not a real gh binary).
-          PATH: `${binDir}:${dirname(process.execPath)}`,
+          // Prepend the stub dir so the bare `gh` lookup resolves to the
+          // stub, not a real gh binary, while keeping the rest of PATH
+          // (matching the other CLI-stub tests in this repo) so the gh
+          // stub's #!/usr/bin/env node shebang can still find `node`.
+          PATH: `${binDir}:${process.env.PATH ?? ''}`,
           IDD_TRUSTED_MARKER_ACTORS: '',
         },
         encoding: 'utf8',

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -158,3 +158,81 @@ test('config-only resolution passes the author gate end to end', () => {
     rmSync(sandbox, { recursive: true, force: true });
   }
 });
+
+// cspell:ignore Wpaqs
+test('a REST-shaped --subject-ids value gets a GraphQL-node-ID explanation, not a raw gh passthrough', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-minimize-'));
+  try {
+    // Stub gh to reproduce the exact stdout/stderr/exit-code shape observed
+    // from a live `gh api graphql -f id=<REST numeric id>` call: gh exits
+    // non-zero and writes "Could not resolve to a node with the global id
+    // of '<id>'" to stderr, mirroring the response body in stdout.
+    const binDir = join(sandbox, 'bin');
+    mkdirSync(binDir);
+    writeFileSync(
+      join(binDir, 'gh'),
+      `#!/usr/bin/env node
+const value = (process.argv.find((a) => a.startsWith('id=')) ?? '').slice(3);
+const message = \`Could not resolve to a node with the global id of '\${value}'\`;
+process.stdout.write(JSON.stringify({ data: { node: null }, errors: [{ type: 'NOT_FOUND', message }] }));
+process.stderr.write(\`gh: \${message}\\n\`);
+process.exit(1);
+`,
+    );
+    chmodSync(join(binDir, 'gh'), 0o755);
+
+    const script = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'scripts',
+      'minimize-superseded-markers.mjs',
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        '--subject-ids',
+        '4870591746',
+        '--allow-untrusted',
+        '--format',
+        'json',
+      ],
+      {
+        cwd: sandbox,
+        env: {
+          ...process.env,
+          // The gh stub's #!/usr/bin/env node shebang needs `node` on PATH
+          // too, alongside the stub directory (which must come first so the
+          // bare `gh` lookup resolves to the stub, not a real gh binary).
+          PATH: `${binDir}:${dirname(process.execPath)}`,
+          IDD_TRUSTED_MARKER_ACTORS: '',
+        },
+        encoding: 'utf8',
+      },
+    );
+
+    assert.equal(result.status, 1, result.stderr);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.items.length, 1);
+    const [item] = report.items;
+    assert.equal(item.subjectId, '4870591746');
+    assert.equal(item.status, 'failed');
+    assert.match(item.reason, /^unresolvable-node-id:/);
+    assert.match(item.reason, /GraphQL global node ID/);
+    assert.match(item.reason, /IC_kwDOSWpaqs8AAAABIk9VAg/);
+    assert.match(
+      item.reason,
+      /repos\/\{owner\}\/\{repo\}\/issues\/comments\/\{comment_id\} -q '\.node_id'/,
+    );
+    assert.match(
+      item.reason,
+      /repos\/\{owner\}\/\{repo\}\/pulls\/\{pull_number\}\/reviews\/\{review_id\} -q '\.node_id'/,
+    );
+    assert.match(
+      item.reason,
+      /repos\/\{owner\}\/\{repo\}\/pulls\/comments\/\{comment_id\} -q '\.node_id'/,
+    );
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -236,3 +236,68 @@ process.exit(1);
     rmSync(sandbox, { recursive: true, force: true });
   }
 });
+
+// cspell:ignore Wpaqs
+test('a GraphQL-shaped --subject-ids value that fails to resolve keeps the raw gh passthrough', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-minimize-'));
+  try {
+    // Same "could not resolve to a node" gh signature as the REST-shaped
+    // case above, but for a syntactically valid (deleted/inaccessible)
+    // GraphQL node id — the enhanced guidance must NOT fire here, since the
+    // id is not a REST id in disguise; the raw gh error is still accurate.
+    const binDir = join(sandbox, 'bin');
+    mkdirSync(binDir);
+    writeFileSync(
+      join(binDir, 'gh'),
+      `#!/usr/bin/env node
+const value = (process.argv.find((a) => a.startsWith('id=')) ?? '').slice(3);
+const message = \`Could not resolve to a node with the global id of '\${value}'\`;
+process.stdout.write(JSON.stringify({ data: { node: null }, errors: [{ type: 'NOT_FOUND', message }] }));
+process.stderr.write(\`gh: \${message}\\n\`);
+process.exit(1);
+`,
+    );
+    chmodSync(join(binDir, 'gh'), 0o755);
+
+    const script = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'scripts',
+      'minimize-superseded-markers.mjs',
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        '--subject-ids',
+        'IC_kwDOSWpaqs8AAAABDeadBeef',
+        '--allow-untrusted',
+        '--format',
+        'json',
+      ],
+      {
+        cwd: sandbox,
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${dirname(process.execPath)}`,
+          IDD_TRUSTED_MARKER_ACTORS: '',
+        },
+        encoding: 'utf8',
+      },
+    );
+
+    assert.equal(result.status, 1, result.stderr);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.items.length, 1);
+    const [item] = report.items;
+    assert.equal(item.subjectId, 'IC_kwDOSWpaqs8AAAABDeadBeef');
+    assert.equal(item.status, 'failed');
+    assert.match(item.reason, /^gh-graphql-error:/);
+    assert.match(
+      item.reason,
+      /Could not resolve to a node with the global id of 'IC_kwDOSWpaqs8AAAABDeadBeef'/,
+    );
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -210,7 +210,10 @@ process.exit(1);
           // stub, not a real gh binary, while keeping the rest of PATH
           // (matching the other CLI-stub tests in this repo) so the gh
           // stub's #!/usr/bin/env node shebang can still find `node`.
-          PATH: `${binDir}:${process.env.PATH ?? ''}`,
+          // Conditional concatenation avoids a trailing `:` (and the
+          // implicit current-directory PATH entry it creates on POSIX)
+          // when PATH is unset.
+          PATH: process.env.PATH ? `${binDir}:${process.env.PATH}` : binDir,
           IDD_TRUSTED_MARKER_ACTORS: '',
         },
         encoding: 'utf8',

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -301,3 +301,62 @@ process.exit(1);
     rmSync(sandbox, { recursive: true, force: true });
   }
 });
+
+test('a zero / leading-zero --subject-ids value keeps the raw gh passthrough (not REST-shaped)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-minimize-'));
+  try {
+    // "0" and "0001" are digit strings but not real REST id shapes (GitHub
+    // REST ids are always positive integers with no leading zero), so
+    // REST_SHAPED_SUBJECT_ID_PATTERN (/^[1-9]\d*$/) must reject them too.
+    const binDir = join(sandbox, 'bin');
+    mkdirSync(binDir);
+    writeFileSync(
+      join(binDir, 'gh'),
+      `#!/usr/bin/env node
+const value = (process.argv.find((a) => a.startsWith('id=')) ?? '').slice(3);
+const message = \`Could not resolve to a node with the global id of '\${value}'\`;
+process.stdout.write(JSON.stringify({ data: { node: null }, errors: [{ type: 'NOT_FOUND', message }] }));
+process.stderr.write(\`gh: \${message}\\n\`);
+process.exit(1);
+`,
+    );
+    chmodSync(join(binDir, 'gh'), 0o755);
+
+    const script = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'scripts',
+      'minimize-superseded-markers.mjs',
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        '--subject-ids',
+        '0,0001',
+        '--allow-untrusted',
+        '--format',
+        'json',
+      ],
+      {
+        cwd: sandbox,
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${dirname(process.execPath)}`,
+          IDD_TRUSTED_MARKER_ACTORS: '',
+        },
+        encoding: 'utf8',
+      },
+    );
+
+    assert.equal(result.status, 1, result.stderr);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.items.length, 2);
+    for (const item of report.items) {
+      assert.equal(item.status, 'failed');
+      assert.match(item.reason, /^gh-graphql-error:/);
+    }
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { type SpawnSyncReturns, spawnSync } from 'node:child_process';
 import {
   chmodSync,
   mkdirSync,
@@ -160,13 +160,17 @@ test('config-only resolution passes the author gate end to end', () => {
 });
 
 // cspell:ignore Wpaqs
-test('a REST-shaped --subject-ids value gets a GraphQL-node-ID explanation, not a raw gh passthrough', () => {
+// Shared by the three "unresolvable node id" tests below (CodeRabbit review
+// on PR #1242: extract the repeated gh-stub + spawn boilerplate). Stubs gh to
+// reproduce the exact stdout/stderr/exit-code shape observed from a live
+// `gh api graphql -f id=<value>` call when the id cannot be resolved: gh
+// exits non-zero and writes "Could not resolve to a node with the global id
+// of '<id>'" to stderr, mirroring the response body in stdout.
+function runMinimizeAgainstUnresolvableId(
+  subjectIds: string,
+): SpawnSyncReturns<string> {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-minimize-'));
   try {
-    // Stub gh to reproduce the exact stdout/stderr/exit-code shape observed
-    // from a live `gh api graphql -f id=<REST numeric id>` call: gh exits
-    // non-zero and writes "Could not resolve to a node with the global id
-    // of '<id>'" to stderr, mirroring the response body in stdout.
     const binDir = join(sandbox, 'bin');
     mkdirSync(binDir);
     writeFileSync(
@@ -187,12 +191,12 @@ process.exit(1);
       'scripts',
       'minimize-superseded-markers.mjs',
     );
-    const result = spawnSync(
+    return spawnSync(
       process.execPath,
       [
         script,
         '--subject-ids',
-        '4870591746',
+        subjectIds,
         '--allow-untrusted',
         '--format',
         'json',
@@ -210,153 +214,70 @@ process.exit(1);
         encoding: 'utf8',
       },
     );
-
-    assert.equal(result.status, 1, result.stderr);
-    const report = JSON.parse(result.stdout);
-    assert.equal(report.items.length, 1);
-    const [item] = report.items;
-    assert.equal(item.subjectId, '4870591746');
-    assert.equal(item.status, 'failed');
-    assert.match(item.reason, /^unresolvable-node-id:/);
-    assert.match(item.reason, /GraphQL global node ID/);
-    assert.match(item.reason, /IC_kwDOSWpaqs8AAAABIk9VAg/);
-    assert.match(
-      item.reason,
-      /repos\/\{owner\}\/\{repo\}\/issues\/comments\/\{comment_id\} -q '\.node_id'/,
-    );
-    assert.match(
-      item.reason,
-      /repos\/\{owner\}\/\{repo\}\/pulls\/\{pull_number\}\/reviews\/\{review_id\} -q '\.node_id'/,
-    );
-    assert.match(
-      item.reason,
-      /repos\/\{owner\}\/\{repo\}\/pulls\/comments\/\{comment_id\} -q '\.node_id'/,
-    );
   } finally {
     rmSync(sandbox, { recursive: true, force: true });
   }
+}
+
+test('a REST-shaped --subject-ids value gets a GraphQL-node-ID explanation, not a raw gh passthrough', () => {
+  const result = runMinimizeAgainstUnresolvableId('4870591746');
+
+  assert.equal(result.status, 1, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.items.length, 1);
+  const [item] = report.items;
+  assert.equal(item.subjectId, '4870591746');
+  assert.equal(item.status, 'failed');
+  assert.match(item.reason, /^unresolvable-node-id:/);
+  assert.match(item.reason, /GraphQL global node ID/);
+  assert.match(item.reason, /IC_kwDOSWpaqs8AAAABIk9VAg/);
+  assert.match(
+    item.reason,
+    /repos\/\{owner\}\/\{repo\}\/issues\/comments\/\{comment_id\} -q '\.node_id'/,
+  );
+  assert.match(
+    item.reason,
+    /repos\/\{owner\}\/\{repo\}\/pulls\/\{pull_number\}\/reviews\/\{review_id\} -q '\.node_id'/,
+  );
+  assert.match(
+    item.reason,
+    /repos\/\{owner\}\/\{repo\}\/pulls\/comments\/\{comment_id\} -q '\.node_id'/,
+  );
 });
 
-// cspell:ignore Wpaqs
 test('a GraphQL-shaped --subject-ids value that fails to resolve keeps the raw gh passthrough', () => {
-  const sandbox = mkdtempSync(join(tmpdir(), 'idd-minimize-'));
-  try {
-    // Same "could not resolve to a node" gh signature as the REST-shaped
-    // case above, but for a syntactically valid (deleted/inaccessible)
-    // GraphQL node id — the enhanced guidance must NOT fire here, since the
-    // id is not a REST id in disguise; the raw gh error is still accurate.
-    const binDir = join(sandbox, 'bin');
-    mkdirSync(binDir);
-    writeFileSync(
-      join(binDir, 'gh'),
-      `#!/usr/bin/env node
-const value = (process.argv.find((a) => a.startsWith('id=')) ?? '').slice(3);
-const message = \`Could not resolve to a node with the global id of '\${value}'\`;
-process.stdout.write(JSON.stringify({ data: { node: null }, errors: [{ type: 'NOT_FOUND', message }] }));
-process.stderr.write(\`gh: \${message}\\n\`);
-process.exit(1);
-`,
-    );
-    chmodSync(join(binDir, 'gh'), 0o755);
+  // Same "could not resolve to a node" gh signature as the REST-shaped case
+  // above, but for a syntactically valid (deleted/inaccessible) GraphQL node
+  // id — the enhanced guidance must NOT fire here, since the id is not a
+  // REST id in disguise; the raw gh error is still accurate.
+  const result = runMinimizeAgainstUnresolvableId(
+    'IC_kwDOSWpaqs8AAAABDeadBeef',
+  );
 
-    const script = join(
-      dirname(fileURLToPath(import.meta.url)),
-      '..',
-      'scripts',
-      'minimize-superseded-markers.mjs',
-    );
-    const result = spawnSync(
-      process.execPath,
-      [
-        script,
-        '--subject-ids',
-        'IC_kwDOSWpaqs8AAAABDeadBeef',
-        '--allow-untrusted',
-        '--format',
-        'json',
-      ],
-      {
-        cwd: sandbox,
-        env: {
-          ...process.env,
-          PATH: `${binDir}:${dirname(process.execPath)}`,
-          IDD_TRUSTED_MARKER_ACTORS: '',
-        },
-        encoding: 'utf8',
-      },
-    );
-
-    assert.equal(result.status, 1, result.stderr);
-    const report = JSON.parse(result.stdout);
-    assert.equal(report.items.length, 1);
-    const [item] = report.items;
-    assert.equal(item.subjectId, 'IC_kwDOSWpaqs8AAAABDeadBeef');
-    assert.equal(item.status, 'failed');
-    assert.match(item.reason, /^gh-graphql-error:/);
-    assert.match(
-      item.reason,
-      /Could not resolve to a node with the global id of 'IC_kwDOSWpaqs8AAAABDeadBeef'/,
-    );
-  } finally {
-    rmSync(sandbox, { recursive: true, force: true });
-  }
+  assert.equal(result.status, 1, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.items.length, 1);
+  const [item] = report.items;
+  assert.equal(item.subjectId, 'IC_kwDOSWpaqs8AAAABDeadBeef');
+  assert.equal(item.status, 'failed');
+  assert.match(item.reason, /^gh-graphql-error:/);
+  assert.match(
+    item.reason,
+    /Could not resolve to a node with the global id of 'IC_kwDOSWpaqs8AAAABDeadBeef'/,
+  );
 });
 
 test('a zero / leading-zero --subject-ids value keeps the raw gh passthrough (not REST-shaped)', () => {
-  const sandbox = mkdtempSync(join(tmpdir(), 'idd-minimize-'));
-  try {
-    // "0" and "0001" are digit strings but not real REST id shapes (GitHub
-    // REST ids are always positive integers with no leading zero), so
-    // REST_SHAPED_SUBJECT_ID_PATTERN (/^[1-9]\d*$/) must reject them too.
-    const binDir = join(sandbox, 'bin');
-    mkdirSync(binDir);
-    writeFileSync(
-      join(binDir, 'gh'),
-      `#!/usr/bin/env node
-const value = (process.argv.find((a) => a.startsWith('id=')) ?? '').slice(3);
-const message = \`Could not resolve to a node with the global id of '\${value}'\`;
-process.stdout.write(JSON.stringify({ data: { node: null }, errors: [{ type: 'NOT_FOUND', message }] }));
-process.stderr.write(\`gh: \${message}\\n\`);
-process.exit(1);
-`,
-    );
-    chmodSync(join(binDir, 'gh'), 0o755);
+  // "0" and "0001" are digit strings but not real REST id shapes (GitHub
+  // REST ids are always positive integers with no leading zero), so
+  // REST_SHAPED_SUBJECT_ID_PATTERN (/^[1-9]\d*$/) must reject them too.
+  const result = runMinimizeAgainstUnresolvableId('0,0001');
 
-    const script = join(
-      dirname(fileURLToPath(import.meta.url)),
-      '..',
-      'scripts',
-      'minimize-superseded-markers.mjs',
-    );
-    const result = spawnSync(
-      process.execPath,
-      [
-        script,
-        '--subject-ids',
-        '0,0001',
-        '--allow-untrusted',
-        '--format',
-        'json',
-      ],
-      {
-        cwd: sandbox,
-        env: {
-          ...process.env,
-          PATH: `${binDir}:${dirname(process.execPath)}`,
-          IDD_TRUSTED_MARKER_ACTORS: '',
-        },
-        encoding: 'utf8',
-      },
-    );
-
-    assert.equal(result.status, 1, result.stderr);
-    const report = JSON.parse(result.stdout);
-    assert.equal(report.items.length, 2);
-    for (const item of report.items) {
-      assert.equal(item.status, 'failed');
-      assert.match(item.reason, /^gh-graphql-error:/);
-    }
-  } finally {
-    rmSync(sandbox, { recursive: true, force: true });
+  assert.equal(result.status, 1, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.items.length, 2);
+  for (const item of report.items) {
+    assert.equal(item.status, 'failed');
+    assert.match(item.reason, /^gh-graphql-error:/);
   }
 });


### PR DESCRIPTION
# Summary

`minimize-superseded-markers --subject-ids` resolves each subject through
`probeSubject`, which queries GitHub's GraphQL `node(id: $id)` API. That
requires a GraphQL global node ID (e.g. `IC_kwDOSWpaqs8AAAABIk9VAg`), not the
REST numeric ID (e.g. `4870591746`) that `gh issue view` / `gh api
.../comments` normally surface. Passing the numeric form failed with gh's raw
`Could not resolve to a node with the global id of '...'` text, which didn't
explain what went wrong or how to fix it — multiple sessions independently
hit this and had to manually discover the `gh api .../{id} -q '.node_id'`
conversion.

When `probeSubject` detects that specific GraphQL failure signature, it now
returns a `reason` that explains a GraphQL node ID is required and prints the
exact conversion command for each of the three subject types (issue comment,
PR review, PR review comment). `--help` carries the same guidance via a
shared constant so the two surfaces can't drift. Unrelated `gh` failures
(auth, network, rate limit) are untouched — they keep the existing raw
passthrough reason.

This is scoped to clearer error messaging only, per the issue: automatically
guessing/resolving a bare integer is unsafe because it could belong to any of
the three REST endpoints above, and guessing wrong risks querying the wrong
resource.

## Linked issue

Closes #1235

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Root cause confirmed by a live probe:
`gh api graphql -f query='query($id:ID!){node(id:$id){__typename}}' -f
id=4870591746` exits `1` and writes `gh: Could not resolve to a node with the
global id of '4870591746'` to stderr — that's the exact signature the new
`UNRESOLVABLE_NODE_ID_PATTERN` regex matches (case-insensitively, independent
of gh version wording around the id itself). A second, defensive check
handles the same signature if it ever arrives as a zero-exit `errors[]` body
instead.

`idd-template/scripts/minimize-superseded-markers.mjs` is tracked in
`audit/sync-manifest.json` as an **exact** mirror of the generated
`scripts/minimize-superseded-markers.mjs` (not a hand-maintained fork), so
`node scripts/sync-docs.mjs --apply` alone keeps it byte-identical — no
separate manual edit needed, and no cross-file import was introduced (the
helper stays self-contained per the existing `loadIddConfig` comment).

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when subject IDs can’t be resolved, showing clearer guidance for converting REST-style numeric IDs into GraphQL global node IDs.
  * Preserved the original GraphQL error message when the ID is already in the correct format.

* **Documentation**
  * Updated CLI help text to clearly require GraphQL global node IDs and point to conversion steps.

* **Tests**
  * Added end-to-end coverage for REST-style IDs, valid GraphQL IDs, and mixed/edge-case ID lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->