### PR TITLE
test(helpers): guard the idd-template/scripts exact-mirror self-containment constraint

### DIFF
--- a/tests/standalone-mirror-imports.test.mts
+++ b/tests/standalone-mirror-imports.test.mts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { readJson, readText } from './test-utils.mts';
+
+/** A minimal view of an `audit/sync-manifest.json` `syncPairs[]` entry. */
+interface SyncPair {
+  id?: string;
+  mode?: string;
+  source?: string;
+  target?: string;
+}
+
+/**
+ * Extracts the module specifier of every static `import` / `export … from`
+ * declaration in `source` — including side-effect `import 'x'` and
+ * `export * from 'x'` / `export { a } from 'x'` re-exports — while ignoring
+ * anything that appears only inside a `//` or `/* … *\/`-style comment.
+ * Dynamic `import()` calls are intentionally excluded: they are runtime
+ * expressions rather than static declarations, and the self-containment
+ * constraint this test enforces (see `docs/idd-helper-scripts.md`) is about
+ * a file's static dependency closure.
+ *
+ * The clause between the keyword and the specifier is restricted to the
+ * characters an import/export clause can actually contain (identifiers,
+ * commas, `*`, braces, whitespace). This is deliberately a *positive* class
+ * rather than "anything but a quote or semicolon": a plain `export function
+ * f(x) {` or `export const x = 'literal';` contains a `(` or `=` before any
+ * quote, which this class excludes, so scanning stops there instead of
+ * misreading an unrelated string literal deeper in the function body as an
+ * import specifier.
+ */
+function extractStaticImportSpecifiers(source: string): string[] {
+  const withoutComments = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+  const clause = '[A-Za-z0-9_$,\\s*{}]*?';
+  const declaration = new RegExp(
+    `^[ \\t]*(?:import\\b${clause}(?:\\bfrom\\s+)?|export\\b${clause}\\bfrom\\s+)['"]([^'"]+)['"]`,
+    'gm',
+  );
+  return [...withoutComments.matchAll(declaration)].map((match) => match[1]);
+}
+
+/**
+ * Derives the exact-mode `idd-template/scripts/` mirror set from
+ * `audit/sync-manifest.json` at test-run time instead of hardcoding a file
+ * name, so any future addition to this mirror pattern is automatically
+ * covered.
+ */
+function findExactTemplateScriptMirrors(): { id: string; source: string }[] {
+  const manifest = readJson('audit/sync-manifest.json') as {
+    syncPairs?: SyncPair[];
+  };
+  return (manifest.syncPairs ?? []).flatMap((pair) =>
+    pair.mode === 'exact' &&
+    typeof pair.source === 'string' &&
+    typeof pair.target === 'string' &&
+    pair.target.startsWith('idd-template/scripts/')
+      ? [{ id: pair.id ?? pair.target, source: pair.source }]
+      : [],
+  );
+}
+
+test('extractStaticImportSpecifiers finds import/export-from specifiers and ignores comments', () => {
+  const sample = `
+// import { fake } from 'ignored-line-comment';
+/* export * from 'ignored-block-comment'; */
+import { readFileSync } from 'node:fs';
+import 'node:process';
+export * from 'node:util';
+export const noSpecifierHere = 1;
+`;
+  assert.deepEqual(extractStaticImportSpecifiers(sample), [
+    'node:fs',
+    'node:process',
+    'node:util',
+  ]);
+});
+
+test('audit/sync-manifest.json has at least one exact-mode idd-template/scripts/ mirror to guard', () => {
+  // Guards the derivation itself: if this set ever drops to zero, the test
+  // below would pass vacuously without checking anything.
+  assert.ok(findExactTemplateScriptMirrors().length > 0);
+});
+
+test('exact-mode idd-template/scripts/ mirror sources import only Node built-ins', () => {
+  for (const { id, source } of findExactTemplateScriptMirrors()) {
+    const specifiers = extractStaticImportSpecifiers(readText(source));
+    const nonNodeImports = specifiers.filter(
+      (specifier) => !specifier.startsWith('node:'),
+    );
+    assert.deepEqual(
+      nonNodeImports,
+      [],
+      `sync pair "${id}" (${source}) must stay self-contained (Node ` +
+        `built-ins only) so the idd-template/scripts/ mirror runs ` +
+        `standalone; found: ${nonNodeImports.join(', ')}`,
+    );
+  }
+});


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Adds `tests/standalone-mirror-imports.test.mts`, which mechanically
guards the `idd-template/scripts/` exact-mirror self-containment
constraint that was previously documented only as prose in
`docs/idd-helper-scripts.md`.

- Derives the exact-mode `idd-template/scripts/` mirror set from
  `audit/sync-manifest.json`'s `syncPairs` at test-run time (filtering
  `mode === "exact"` and `target` starting with
  `idd-template/scripts/`), rather than hardcoding a file name, so any
  future addition to this mirror pattern is automatically covered.
- Asserts every corresponding `source` file's static `import` /
  `export … from` specifiers are Node built-ins (`node:*`) only.
- Includes a focused unit test on the specifier-extraction helper
  itself (comment-stripping, side-effect imports, re-exports) so the
  guard's own correctness is independently verifiable.

## Linked issue

Closes #1236

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

During a recent large refactor (#1208) a cross-file import nearly
leaked into this self-containment constraint and was only caught by a
reviewer's comment, not by any repository check. This test closes that
gap mechanically.

Dynamic `import()` calls are intentionally out of scope: they are
runtime expressions rather than static declarations, and the
constraint this test enforces is about a file's static dependency
closure (the whole reason a cross-file `import` breaks the
`idd-template/scripts/` mirror is that the mirror ships without the
rest of the repo, so only statically-resolved specifiers matter here).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `node scripts/audit-docs.mjs --check` (covered by `pnpm lint`)
- [ ] `pnpm run docs:sync:check` (no doc-mirrored file touched)
- [ ] `node scripts/idd-doctor.mjs` (not applicable; no claim/workflow-state file touched)

Also manually verified the negative case (acceptance criterion):
injected a non-`node:` import (`./protocol-helpers.mjs`) into
`scripts/minimize-superseded-markers.mjs`, confirmed the new test
failed with a message identifying the offending sync pair and
specifier, then reverted the injection before committing (`git diff`
empty afterward).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
