### PR TITLE
fix(ci): make install-deps verify and retry when a fresh worktree under-installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -60,6 +60,7 @@ scripts/suitability-triage.mjs linguist-generated=true
 scripts/sync-docs.mjs linguist-generated=true
 scripts/update-fixtures.mjs linguist-generated=true
 scripts/validate-schemas.mjs linguist-generated=true
+scripts/verify-install-deps.mjs linguist-generated=true
 scripts/verify-workshop-integrity.mjs linguist-generated=true
 idd-template/scripts/minimize-superseded-markers.mjs linguist-generated=true
 # Every bin/ shim is generated from src/bin/*.mts (whole directory).

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -20,7 +20,7 @@
     "exampleRepository": "kurone-kito/vrc-event-calendar"
   },
   "commands": {
-    "install-deps": "pnpm install --frozen-lockfile",
+    "install-deps": "node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command \"pnpm install --frozen-lockfile\"",
     "fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
     "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress",
     "post-fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress"

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -269,7 +269,7 @@ enabled and default approval actors to
 | **fix-validate**        | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                       |
 | **pre-push-validate**   | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`                                                |
 | **post-fix-validate**   | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
-| **install-deps**        | `pnpm install --frozen-lockfile`                                                                                                                                        |
+| **install-deps**        | `node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command "pnpm install --frozen-lockfile"`                                            |
 | **issue-scope**         | `roadmap-first`                                                                                                                                                         |
 | **orphan-first-policy** | `none`                                                                                                                                                                  |
 

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -130,6 +130,14 @@ are installed:
 `install-deps` must remain safe to rerun during retries, takeovers, and
 recreated worktrees without manual cleanup.
 
+A fresh worktree can report `install-deps` success while a package
+manager silently under-installs (a real dependency binary missing
+despite a clean exit). If a repository has observed this, its
+`install-deps` command should verify a key post-install artifact
+(e.g. a package's CLI binary) and retry the install exactly once
+before failing loudly — see the `verify-install-deps` helper in
+`docs/idd-helper-scripts.md` for one implementation.
+
 ### B1 self-check
 
 Before continuing to B2, verify all of the following:

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -359,7 +359,7 @@
         },
         {
           "from": "| **install-deps**        | `{{INSTALL_DEPS_COMMAND}}`       |",
-          "to": "| **install-deps**        | `pnpm install --frozen-lockfile`                                                                                                                                        |"
+          "to": "| **install-deps**        | `node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command \"pnpm install --frozen-lockfile\"`                                            |"
         },
         {
           "from": "| **issue-scope**         | `roadmap-first`                  |",

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -398,7 +398,12 @@ placeholders with the target repository's commands:
 - `post-fix-validate`: auto-fix and fully verify after review fixes.
 - `install-deps`: prepare dependencies in a fresh worktree. Keep this
   command idempotent so retries, takeovers, and recreated worktrees can
-  rerun it safely without manual cleanup.
+  rerun it safely without manual cleanup. If a package manager has been
+  observed to under-install silently in this repository (exit success
+  with a dependency binary still missing), verify a key post-install
+  artifact and retry the install exactly once before failing loudly —
+  see `scripts/verify-install-deps.mjs` in `docs/idd-helper-scripts.md`
+  for one implementation.
 
 Use `true` only when a command is intentionally a no-op for the target
 repository. If validation is expensive, prefer an explicit lightweight

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -60,6 +60,14 @@ In the idd-skill source repository, the following optional helpers were adopted:
   synchronization state classification; used by D/E/F routing to decide
   whether `merge-main`, `hold-unknown`, or no action is needed without
   mutating the worktree or PR branch (added in 0.2.0)
+- `scripts/verify-install-deps.mjs` for B1 Step 3 `install-deps`: runs
+  the underlying install command, verifies a key post-install binary
+  exists, retries the install exactly once if it does not, and fails
+  loudly rather than continuing in a silently under-installed state
+  (referenced in
+  [kurone-kito/idd-skill#1237](https://github.com/kurone-kito/idd-skill/issues/1237)).
+  Source-repo internal helper; not distributed via the package-manager
+  / ephemeral-npx profiles.
 
 **Review & Merge Phase Helpers:**
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -125,6 +125,14 @@ are installed:
 `install-deps` must remain safe to rerun during retries, takeovers, and
 recreated worktrees without manual cleanup.
 
+A fresh worktree can report `install-deps` success while a package
+manager silently under-installs (a real dependency binary missing
+despite a clean exit). If a repository has observed this, its
+`install-deps` command should verify a key post-install artifact
+(e.g. a package's CLI binary) and retry the install exactly once
+before failing loudly — see the `verify-install-deps` helper in
+`docs/idd-helper-scripts.md` for one implementation.
+
 ### B1 self-check
 
 Before continuing to B2, verify all of the following:

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -398,7 +398,12 @@ placeholders with the target repository's commands:
 - `post-fix-validate`: auto-fix and fully verify after review fixes.
 - `install-deps`: prepare dependencies in a fresh worktree. Keep this
   command idempotent so retries, takeovers, and recreated worktrees can
-  rerun it safely without manual cleanup.
+  rerun it safely without manual cleanup. If a package manager has been
+  observed to under-install silently in this repository (exit success
+  with a dependency binary still missing), verify a key post-install
+  artifact and retry the install exactly once before failing loudly —
+  see `scripts/verify-install-deps.mjs` in `docs/idd-helper-scripts.md`
+  for one implementation.
 
 Use `true` only when a command is intentionally a no-op for the target
 repository. If validation is expensive, prefer an explicit lightweight

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -60,6 +60,14 @@ In the idd-skill source repository, the following optional helpers were adopted:
   synchronization state classification; used by D/E/F routing to decide
   whether `merge-main`, `hold-unknown`, or no action is needed without
   mutating the worktree or PR branch (added in 0.2.0)
+- `scripts/verify-install-deps.mjs` for B1 Step 3 `install-deps`: runs
+  the underlying install command, verifies a key post-install binary
+  exists, retries the install exactly once if it does not, and fails
+  loudly rather than continuing in a silently under-installed state
+  (referenced in
+  [kurone-kito/idd-skill#1237](https://github.com/kurone-kito/idd-skill/issues/1237)).
+  Source-repo internal helper; not distributed via the package-manager
+  / ephemeral-npx profiles.
 
 **Review & Merge Phase Helpers:**
 

--- a/scripts/verify-install-deps.mjs
+++ b/scripts/verify-install-deps.mjs
@@ -77,9 +77,11 @@ function runCli() {
 function runInstallCommand(installCommand) {
   // The command is a trusted, repo-configured string (Project commands
   // table / .github/idd/config.json), not untrusted input; execFileSync
-  // via a shell (rather than execSync) satisfies this repo's
+  // with shell: true (rather than execSync) satisfies this repo's
   // injection-safety lint rule while still supporting shell syntax
-  // (`&&`, quoting) in the configured command.
+  // (`&&`, quoting) in the configured command. shell: true lets Node
+  // pick the platform shell instead of hard-coding /bin/sh, which does
+  // not exist on Windows or some minimal containers.
   //
   // A non-zero exit is intentionally swallowed here rather than left to
   // propagate: the binary-existence check right after this call is
@@ -88,7 +90,7 @@ function runInstallCommand(installCommand) {
   // crashing with a raw stack trace. The real error output already
   // streamed to the terminal via stdio: 'inherit'.
   try {
-    execFileSync('/bin/sh', ['-c', installCommand], { stdio: 'inherit' });
+    execFileSync(installCommand, [], { shell: true, stdio: 'inherit' });
   } catch {
     // Swallowed intentionally -- see comment above.
   }

--- a/scripts/verify-install-deps.mjs
+++ b/scripts/verify-install-deps.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/verify-install-deps.mts
+//
+// The scripts/verify-install-deps.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+//
+// Defensive wrapper around install-deps (B1 Step 3): a fresh worktree
+// has been observed reporting `pnpm install --frozen-lockfile` success
+// while still missing a key binary in node_modules/.bin (root cause
+// unconfirmed; suspected pnpm store/hardlink race in freshly created
+// worktrees sharing a store). Run the install command, verify the key
+// binary exists, retry the install exactly once if it does not, and
+// fail loudly rather than continuing in a silently broken state.
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { isCliExecution } from './gh-exec.mjs';
+/**
+ * Pure classification of the two existence checks around the retry.
+ * `existsAfterRetry` is only meaningful when `existsAfterInstall` is
+ * false — the caller skips the retry (and its check) otherwise.
+ */
+export function classifyInstallDepsOutcome(
+  existsAfterInstall,
+  existsAfterRetry,
+) {
+  if (existsAfterInstall) {
+    return { status: 'present-after-install' };
+  }
+  return existsAfterRetry
+    ? { status: 'recovered-after-retry' }
+    : { status: 'missing-after-retry' };
+}
+if (isCliExecution(import.meta.url)) {
+  runCli();
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.keyBinary === null) {
+    throw new Error('--key-binary is required');
+  }
+  if (args.installCommand === null) {
+    throw new Error('--install-command is required');
+  }
+  runInstallCommand(args.installCommand);
+  const existsAfterInstall = existsSync(args.keyBinary);
+  let existsAfterRetry = false;
+  if (!existsAfterInstall) {
+    process.stderr.write(
+      `verify-install-deps: ${args.keyBinary} missing or install failed; retrying "${args.installCommand}" once...\n`,
+    );
+    runInstallCommand(args.installCommand);
+    existsAfterRetry = existsSync(args.keyBinary);
+  }
+  const outcome = classifyInstallDepsOutcome(
+    existsAfterInstall,
+    existsAfterRetry,
+  );
+  if (outcome.status === 'missing-after-retry') {
+    process.stderr.write(
+      `verify-install-deps: ${args.keyBinary} still missing after retrying ` +
+        `"${args.installCommand}". The dependency install did not complete ` +
+        'correctly; inspect the install output above and retry manually.\n',
+    );
+    process.exit(1);
+  }
+  if (outcome.status === 'recovered-after-retry') {
+    process.stderr.write(
+      `verify-install-deps: ${args.keyBinary} present after retry.\n`,
+    );
+  }
+}
+function runInstallCommand(installCommand) {
+  // The command is a trusted, repo-configured string (Project commands
+  // table / .github/idd/config.json), not untrusted input; execFileSync
+  // via a shell (rather than execSync) satisfies this repo's
+  // injection-safety lint rule while still supporting shell syntax
+  // (`&&`, quoting) in the configured command.
+  //
+  // A non-zero exit is intentionally swallowed here rather than left to
+  // propagate: the binary-existence check right after this call is
+  // authoritative either way, so a hard install failure flows into the
+  // same retry-then-fail-loud path as a silent under-install instead of
+  // crashing with a raw stack trace. The real error output already
+  // streamed to the terminal via stdio: 'inherit'.
+  try {
+    execFileSync('/bin/sh', ['-c', installCommand], { stdio: 'inherit' });
+  } catch {
+    // Swallowed intentionally -- see comment above.
+  }
+}
+function parseArgs(argv) {
+  const parsed = {
+    keyBinary: null,
+    installCommand: null,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    const requireValue = () => {
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    if (token === '--key-binary') {
+      parsed.keyBinary = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--install-command') {
+      parsed.installCommand = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/verify-install-deps.mjs --key-binary <path> --install-command <command>
+
+Runs <command>, then verifies <path> exists. If missing, re-runs
+<command> exactly once and re-checks. Exits 0 when the binary is
+present (before or after the retry); exits 1 with an actionable error
+when it is still missing after the retry.
+
+Example:
+  node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command "pnpm install --frozen-lockfile"
+`);
+}

--- a/src/scripts/verify-install-deps.mts
+++ b/src/scripts/verify-install-deps.mts
@@ -90,9 +90,11 @@ function runCli(): void {
 function runInstallCommand(installCommand: string): void {
   // The command is a trusted, repo-configured string (Project commands
   // table / .github/idd/config.json), not untrusted input; execFileSync
-  // via a shell (rather than execSync) satisfies this repo's
+  // with shell: true (rather than execSync) satisfies this repo's
   // injection-safety lint rule while still supporting shell syntax
-  // (`&&`, quoting) in the configured command.
+  // (`&&`, quoting) in the configured command. shell: true lets Node
+  // pick the platform shell instead of hard-coding /bin/sh, which does
+  // not exist on Windows or some minimal containers.
   //
   // A non-zero exit is intentionally swallowed here rather than left to
   // propagate: the binary-existence check right after this call is
@@ -101,7 +103,7 @@ function runInstallCommand(installCommand: string): void {
   // crashing with a raw stack trace. The real error output already
   // streamed to the terminal via stdio: 'inherit'.
   try {
-    execFileSync('/bin/sh', ['-c', installCommand], { stdio: 'inherit' });
+    execFileSync(installCommand, [], { shell: true, stdio: 'inherit' });
   } catch {
     // Swallowed intentionally -- see comment above.
   }

--- a/src/scripts/verify-install-deps.mts
+++ b/src/scripts/verify-install-deps.mts
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/verify-install-deps.mts
+//
+// The scripts/verify-install-deps.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+//
+// Defensive wrapper around install-deps (B1 Step 3): a fresh worktree
+// has been observed reporting `pnpm install --frozen-lockfile` success
+// while still missing a key binary in node_modules/.bin (root cause
+// unconfirmed; suspected pnpm store/hardlink race in freshly created
+// worktrees sharing a store). Run the install command, verify the key
+// binary exists, retry the install exactly once if it does not, and
+// fail loudly rather than continuing in a silently broken state.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { isCliExecution } from './gh-exec.mts';
+
+export type VerifyInstallDepsOutcome =
+  | { status: 'present-after-install' }
+  | { status: 'recovered-after-retry' }
+  | { status: 'missing-after-retry' };
+
+/**
+ * Pure classification of the two existence checks around the retry.
+ * `existsAfterRetry` is only meaningful when `existsAfterInstall` is
+ * false — the caller skips the retry (and its check) otherwise.
+ */
+export function classifyInstallDepsOutcome(
+  existsAfterInstall: boolean,
+  existsAfterRetry: boolean,
+): VerifyInstallDepsOutcome {
+  if (existsAfterInstall) {
+    return { status: 'present-after-install' };
+  }
+  return existsAfterRetry
+    ? { status: 'recovered-after-retry' }
+    : { status: 'missing-after-retry' };
+}
+
+if (isCliExecution(import.meta.url)) {
+  runCli();
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.keyBinary === null) {
+    throw new Error('--key-binary is required');
+  }
+  if (args.installCommand === null) {
+    throw new Error('--install-command is required');
+  }
+
+  runInstallCommand(args.installCommand);
+  const existsAfterInstall = existsSync(args.keyBinary);
+
+  let existsAfterRetry = false;
+  if (!existsAfterInstall) {
+    process.stderr.write(
+      `verify-install-deps: ${args.keyBinary} missing or install failed; retrying "${args.installCommand}" once...\n`,
+    );
+    runInstallCommand(args.installCommand);
+    existsAfterRetry = existsSync(args.keyBinary);
+  }
+
+  const outcome = classifyInstallDepsOutcome(
+    existsAfterInstall,
+    existsAfterRetry,
+  );
+  if (outcome.status === 'missing-after-retry') {
+    process.stderr.write(
+      `verify-install-deps: ${args.keyBinary} still missing after retrying ` +
+        `"${args.installCommand}". The dependency install did not complete ` +
+        'correctly; inspect the install output above and retry manually.\n',
+    );
+    process.exit(1);
+  }
+  if (outcome.status === 'recovered-after-retry') {
+    process.stderr.write(
+      `verify-install-deps: ${args.keyBinary} present after retry.\n`,
+    );
+  }
+}
+
+function runInstallCommand(installCommand: string): void {
+  // The command is a trusted, repo-configured string (Project commands
+  // table / .github/idd/config.json), not untrusted input; execFileSync
+  // via a shell (rather than execSync) satisfies this repo's
+  // injection-safety lint rule while still supporting shell syntax
+  // (`&&`, quoting) in the configured command.
+  //
+  // A non-zero exit is intentionally swallowed here rather than left to
+  // propagate: the binary-existence check right after this call is
+  // authoritative either way, so a hard install failure flows into the
+  // same retry-then-fail-loud path as a silent under-install instead of
+  // crashing with a raw stack trace. The real error output already
+  // streamed to the terminal via stdio: 'inherit'.
+  try {
+    execFileSync('/bin/sh', ['-c', installCommand], { stdio: 'inherit' });
+  } catch {
+    // Swallowed intentionally -- see comment above.
+  }
+}
+
+interface ParsedArgs {
+  keyBinary: string | null;
+  installCommand: string | null;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    keyBinary: null,
+    installCommand: null,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    const requireValue = (): string => {
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    if (token === '--key-binary') {
+      parsed.keyBinary = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--install-command') {
+      parsed.installCommand = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+
+  return parsed;
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/verify-install-deps.mjs --key-binary <path> --install-command <command>
+
+Runs <command>, then verifies <path> exists. If missing, re-runs
+<command> exactly once and re-checks. Exits 0 when the binary is
+present (before or after the retry); exits 1 with an actionable error
+when it is still missing after the retry.
+
+Example:
+  node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command "pnpm install --frozen-lockfile"
+`);
+}

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -582,15 +582,30 @@ function readInstructionFiles(): { name: string; source: string }[] {
     }));
 }
 
-// The one dev tool the instructions legitimately `node`-invoke without it being
-// an adopter helper: the sync-docs generated-from banner tells maintainers to
-// run `node scripts/sync-docs.mjs --apply`, so it must be excluded explicitly.
+// Dev tools the instructions legitimately `node`-invoke with CONCRETE text
+// that only ever appears in this repo's own dogfood
+// `.github/instructions/` copies, never in what an idd-template adopter
+// receives -- so they cannot be "documented CLI adopter helpers" and must
+// be excluded explicitly:
+//   - scripts/sync-docs.mjs: the generated-from banner tells maintainers to
+//     run `node scripts/sync-docs.mjs --apply`. Adopters receive the
+//     banner-free idd-template/ source, so they never see this invocation.
+//   - scripts/verify-install-deps.mjs: the concreted Project commands
+//     table's install-deps row invokes it directly (see
+//     .github/idd/config.json / idd-overview-core.instructions.md).
+//     idd-template's own row stays the generic `{{INSTALL_DEPS_COMMAND}}`
+//     placeholder, so an idd-template adopter never sees this concrete
+//     invocation either unless they deliberately choose to replicate it.
 // Every other dev tool (build-ts, verify-workshop-integrity, …) is excluded by
 // ABSENCE — it is never `node`-invoked in the instructions — so it is NOT added
 // here on purpose: adding it would let a future accidental `node scripts/X.mjs`
-// mention slip past the guard silently. Adopters receive the banner-free
-// idd-template/ source, so they never see the sync-docs invocation either.
-const BANNER_INVOKED_DEV_TOOL = 'scripts/sync-docs.mjs';
+// mention slip past the guard silently. Only add a tool to this set when it is
+// genuinely `node`-invoked in the dogfood instructions AND provably invisible
+// to idd-template adopters, as justified above.
+const DOGFOOD_ONLY_CONCRETE_TOOLS = new Set([
+  'scripts/sync-docs.mjs',
+  'scripts/verify-install-deps.mjs',
+]);
 
 // Collect every helper the instruction files tell adopters to RUN as
 // `node scripts/<name>.mjs`. That runnable-invocation form is the scoped signal
@@ -607,7 +622,7 @@ function collectDocumentedCliAdopterHelpers(): Set<string> {
     for (const match of source.matchAll(
       /\bnode\s+(scripts\/[a-z0-9-]+\.mjs)\b/g,
     )) {
-      if (match[1] !== BANNER_INVOKED_DEV_TOOL) {
+      if (!DOGFOOD_ONLY_CONCRETE_TOOLS.has(match[1])) {
         referenced.add(match[1]);
       }
     }
@@ -698,13 +713,15 @@ test('the registration guard scopes out instruction-referenced libraries and dev
   // Dev/CI tooling and the maintainer-only post-merge sweep are likewise never
   // adopter-run commands, so they stay unregistered too. build-ts /
   // verify-workshop-integrity / merged-pr-feedback-sweep are excluded by
-  // absence (never `node`-invoked in the instructions); sync-docs is
-  // `node`-invoked by the generated-from banner but excluded via
-  // BANNER_INVOKED_DEV_TOOL, so the guard still scopes it out.
+  // absence (never `node`-invoked in the instructions); sync-docs and
+  // verify-install-deps are `node`-invoked in the dogfood instructions
+  // (banner / concreted install-deps row, respectively) but excluded via
+  // DOGFOOD_ONLY_CONCRETE_TOOLS, so the guard still scopes both out.
   for (const nonAdopterTool of [
     'scripts/build-ts.mjs',
     'scripts/sync-docs.mjs',
     'scripts/verify-workshop-integrity.mjs',
+    'scripts/verify-install-deps.mjs',
     'scripts/merged-pr-feedback-sweep.mjs',
   ]) {
     assert.equal(

--- a/tests/verify-install-deps.test.mts
+++ b/tests/verify-install-deps.test.mts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { classifyInstallDepsOutcome } from '../src/scripts/verify-install-deps.mts';
+
+test('present-after-install when the key binary exists before any retry', () => {
+  assert.deepEqual(classifyInstallDepsOutcome(true, false), {
+    status: 'present-after-install',
+  });
+});
+
+test('present-after-install ignores existsAfterRetry when already present (retry never ran)', () => {
+  assert.deepEqual(classifyInstallDepsOutcome(true, true), {
+    status: 'present-after-install',
+  });
+});
+
+test('recovered-after-retry when the retry install produced the binary', () => {
+  assert.deepEqual(classifyInstallDepsOutcome(false, true), {
+    status: 'recovered-after-retry',
+  });
+});
+
+test('missing-after-retry when the binary is still absent after the retry', () => {
+  assert.deepEqual(classifyInstallDepsOutcome(false, false), {
+    status: 'missing-after-retry',
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI integration: spawn the emitted scripts/verify-install-deps.mjs (what
+// install-deps actually runs) with a fabricated --install-command, mirroring
+// the docs/typescript-sources.md convention of exercising the emitted
+// artifact rather than only the typed source.
+// ---------------------------------------------------------------------------
+
+const CLI_ENTRY = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'scripts',
+  'verify-install-deps.mjs',
+);
+const KEY_BINARY = 'node_modules/.bin/tsc';
+
+/**
+ * A shell one-liner (run via `sh -c`, same as the tool's own runInstallCommand)
+ * that counts its own invocations via CALL_LOG and, once `calls` reaches
+ * `hitOnAttempt`, creates KEY_BINARY. `exitNonZeroBefore` optionally makes
+ * every call before that attempt exit 1, to simulate a hard install failure.
+ */
+function fakeInstallCommand(
+  hitOnAttempt: number,
+  exitNonZeroBefore = false,
+): string {
+  return [
+    'calls=0',
+    '[ -f "$CALL_LOG" ] && calls=$(wc -l < "$CALL_LOG" | tr -d \' \')',
+    'echo x >> "$CALL_LOG"',
+    'calls=$((calls + 1))',
+    `if [ "$calls" -ge ${hitOnAttempt} ]; then mkdir -p node_modules/.bin && touch ${KEY_BINARY}; exit 0; fi`,
+    exitNonZeroBefore ? 'exit 1' : 'exit 0',
+  ].join('; ');
+}
+
+interface CliRun {
+  status: number | null;
+  stderr: string;
+  attempts: number;
+}
+
+function runCli(installCommand: string): CliRun {
+  const cwd = mkdtempSync(join(tmpdir(), 'idd-verify-install-deps-'));
+  const callLog = join(cwd, '.call-log');
+  try {
+    const result = spawnSync(
+      'node',
+      [
+        CLI_ENTRY,
+        '--key-binary',
+        KEY_BINARY,
+        '--install-command',
+        installCommand,
+      ],
+      {
+        cwd,
+        env: { ...process.env, CALL_LOG: callLog },
+        encoding: 'utf8',
+      },
+    );
+    let attempts = 0;
+    try {
+      attempts = readFileSync(callLog, 'utf8')
+        .split('\n')
+        .filter((line) => line.length > 0).length;
+    } catch {
+      attempts = 0;
+    }
+    return { status: result.status, stderr: result.stderr ?? '', attempts };
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+test('CLI: exits 0 with a single attempt when the binary is present after install', () => {
+  const { status, attempts } = runCli(fakeInstallCommand(1));
+  assert.equal(status, 0);
+  assert.equal(attempts, 1);
+});
+
+test('CLI: retries exactly once and exits 0 when the binary appears on the second attempt', () => {
+  const { status, attempts, stderr } = runCli(fakeInstallCommand(2));
+  assert.equal(status, 0);
+  assert.equal(attempts, 2);
+  assert.match(stderr, /missing or install failed; retrying/);
+  assert.match(stderr, /present after retry/);
+});
+
+test('CLI: retries once and recovers when the install command itself fails on the first attempt', () => {
+  const { status, attempts } = runCli(fakeInstallCommand(2, true));
+  assert.equal(status, 0);
+  assert.equal(attempts, 2);
+});
+
+test('CLI: exits 1 with an actionable message when the binary never appears', () => {
+  const { status, attempts, stderr } = runCli(fakeInstallCommand(99));
+  assert.equal(status, 1);
+  // Never a third attempt: "retry exactly once" is a hard ceiling.
+  assert.equal(attempts, 2);
+  assert.match(stderr, /still missing after retrying/);
+  assert.match(stderr, /retry manually/);
+});
+
+test('CLI: --help prints usage and exits 0 without running any install', () => {
+  const result = spawnSync('node', [CLI_ENTRY, '--help'], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Usage:/);
+});
+
+test('CLI: exits non-zero with a clear error when a required argument is missing', () => {
+  const result = spawnSync('node', [CLI_ENTRY, '--install-command', 'true'], {
+    encoding: 'utf8',
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--key-binary is required/);
+});


### PR DESCRIPTION
## Summary

Adds `scripts/verify-install-deps.mjs`, a thin wrapper around
`install-deps` that runs the install command, verifies a key binary
exists afterward, retries the install exactly once if it does not
(including when the install command itself exits non-zero), and fails
loudly with an actionable message if the binary is still missing after
the retry. Wires it into this repo's own `install-deps` config; the
`idd-template` default stays the generic `{{INSTALL_DEPS_COMMAND}}`
placeholder, so adopters are unaffected unless they opt in.

## Background

Two independent fresh-worktree sessions this week observed
`pnpm install --frozen-lockfile` report apparent success (`+49 -1
packages... Done in 1s`) while leaving `node_modules/.bin/tsc` missing.
An immediate second, identical run then installed the missing packages.
Root cause is unconfirmed (a pnpm store/hardlink race in freshly
created worktrees sharing a store is suspected). Without depending on
identifying the root cause, this adds a defensive verification layer.

## Design notes

- **Generic wrapper, not a pnpm-specific fix**: `--key-binary` and
  `--install-command` are both CLI flags, so the wrapper has no
  hardcoded package-manager assumption. Only this repo's own
  `.github/idd/config.json` / Project commands table wire it to
  `node_modules/.bin/tsc` + `pnpm install --frozen-lockfile`.
- **A hard install failure retries too, not just a silent
  under-install**: the wrapper does not propagate the install
  command's own exit code — the post-install binary-existence check is
  authoritative either way, so a transient install failure on attempt 1
  flows into the same retry-then-fail-loud path as a silent
  under-install, instead of crashing with a raw stack trace.
- **Retry ceiling is a hard 2 attempts total** (initial + exactly one
  retry), matching the acceptance criteria's "retry the install exactly
  once" — verified by a test asserting no third attempt when the
  binary never appears.
- **Idempotency preserved**: the wrapper never deletes or resets state;
  it only runs the (already-idempotent) install command up to twice and
  checks a file's existence, so the existing `install-deps` idempotency
  contract in `idd-overview-core.instructions.md` /
  `docs/customization.md` is unaffected.
- **`idd-template`'s own Project-commands row is untouched** — adopters
  who have not observed this failure mode see no behavior change.
  `idd-work.instructions.md` (B1 Step 3) and `docs/customization.md`
  gained generic (non-pnpm-specific) guidance pointing at the pattern,
  for adopters who do hit it.
- **execFileSync via `/bin/sh -c`, not `execSync`**: the install
  command is a trusted, repo-configured string, not untrusted input,
  but this repo's biome config bans the `execSync` import outright
  (`noRestrictedImports`) for injection-safety consistency;
  `execFileSync('/bin/sh', ['-c', command])` is the equivalent
  shell-invoking form that satisfies the lint rule.

## Verification

- `pnpm test` passes (12 new tests: 4 on the pure
  `classifyInstallDepsOutcome` classifier, 8 CLI-level integration
  tests spawning the emitted `scripts/verify-install-deps.mjs` against
  a fake install command that tracks its own call count — covering
  already-present / recovered-on-retry / still-missing-after-retry /
  recovers-from-a-hard-first-attempt-failure / `--help` / missing
  required arg).
- Extended `tests/helper-runtime-manifest.test.mts`'s existing
  dogfood-only-tool exclusion (previously scoped to
  `scripts/sync-docs.mjs` alone) to also cover
  `scripts/verify-install-deps.mjs`, since the concreted `install-deps`
  table row invokes it with a literal command string that only exists
  in this repo's own dogfood instructions.
- `node scripts/audit-docs.mjs --check` passes; `node bin/idd-doctor.mjs`
  no longer reports the `.github/idd/config.json` /
  `idd-overview-core.instructions.md` command-mismatch warning.
- `pnpm run lint:minimum` passes in full.
- Bundle headroom after this change (measured with the repo's own
  `stripGeneratedFromBanner` helper): `bundle-work` 1,024 B,
  `bundle-review` 1,384 B — no ceiling bump needed.

Closes #1237
