### PR TITLE
docs(onboarding): fix two stale file-manifest omissions

### DIFF
--- a/docs/idd-review-policy-profiles.md
+++ b/docs/idd-review-policy-profiles.md
@@ -207,6 +207,9 @@ branch protection, and any human review rules configured outside IDD.
 - `.github/instructions/idd-advisory-wait.instructions.md`: mark the
   advisory wait helper unused by this profile, or remove local
   references to it from the customized phase flow.
+- `docs/idd-advisory-wait-shell-fallback.md`: mark the doc unused by
+  this profile, or remove local references to it, matching the
+  `idd-advisory-wait.instructions.md` disposition above.
 - `.github/instructions/idd-pre-merge.instructions.md`: gate on CI,
   branch protection, unresolved conversations, freshness, and claim
   evidence without requiring an advisory reviewer.

--- a/idd-template/docs/idd-review-policy-profiles.md
+++ b/idd-template/docs/idd-review-policy-profiles.md
@@ -207,6 +207,9 @@ branch protection, and any human review rules configured outside IDD.
 - `.github/instructions/idd-advisory-wait.instructions.md`: mark the
   advisory wait helper unused by this profile, or remove local
   references to it from the customized phase flow.
+- `docs/idd-advisory-wait-shell-fallback.md`: mark the doc unused by
+  this profile, or remove local references to it, matching the
+  `idd-advisory-wait.instructions.md` disposition above.
 - `.github/instructions/idd-pre-merge.instructions.md`: gate on CI,
   branch protection, unresolved conversations, freshness, and claim
   evidence without requiring an advisory reviewer.

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -151,10 +151,13 @@ checks, confirm the detailed items below.
       file list is present in `.github/instructions/`.
 - [ ] `docs/getting-started.md`, `docs/concepts.md`,
       `docs/customization.md`, `docs/reference.md`,
-      `docs/idd-workflow.md`,
+      `docs/policy-constants.md`, `docs/idd-workflow.md`,
       `docs/idd-review-policy-profiles.md`,
       `docs/idd-helper-scripts.md`,
-      `docs/idd-comment-minimization.md`, and `docs/permissions.md`
+      `docs/idd-comment-minimization.md`,
+      `docs/idd-resume-detail.md`,
+      `docs/idd-advisory-wait-shell-fallback.md`,
+      `docs/idd-design-rationale.md`, and `docs/permissions.md`
       are present.
 - [ ] `profiles/README.md` and the non-default profile artifacts under
       `profiles/` are present.

--- a/idd-template/profiles/no-advisory/README.md
+++ b/idd-template/profiles/no-advisory/README.md
@@ -19,16 +19,17 @@ Record these values before editing phase behavior:
 
 ## Patch Surface
 
-| File                                                       | Required local edit                                                                                                            |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `.github/instructions/idd-review-fix.instructions.md`      | Remove the E14 advisory request and wait path.                                                                                 |
-| `.github/instructions/idd-advisory-wait.instructions.md`   | Mark the advisory wait helper unused by this profile, or remove local references to it from the customized phase flow.         |
-| `.github/instructions/idd-pre-merge.instructions.md`       | Gate on CI, branch protection, unresolved conversations, freshness, and claim evidence without requiring an advisory reviewer. |
-| `.github/instructions/idd-merge.instructions.md`           | Remove final advisory rechecks while keeping CI, claim, freshness, branch protection, and unresolved-thread checks.            |
-| `.github/instructions/idd-review-snapshot.instructions.md` | Keep human comments in scope and remove advisory-only PATH B requirements.                                                     |
-| `.github/instructions/idd-review-triage.instructions.md`   | Keep human review comments in the review universe and remove advisory-only disposition requirements.                           |
-| `docs/idd-review-policy-profiles.md`                       | Record the selected `no-advisory` profile and link to the local verification evidence.                                         |
-| `docs/customization.md` or another local policy document   | Record why no IDD-managed advisory reviewer is used and which outside gates still protect merges.                              |
+| File                                                       | Required local edit                                                                                                                        |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `.github/instructions/idd-review-fix.instructions.md`      | Remove the E14 advisory request and wait path.                                                                                             |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | Mark the advisory wait helper unused by this profile, or remove local references to it from the customized phase flow.                     |
+| `docs/idd-advisory-wait-shell-fallback.md`                 | Mark the doc unused by this profile, or remove local references to it, matching the `idd-advisory-wait.instructions.md` disposition above. |
+| `.github/instructions/idd-pre-merge.instructions.md`       | Gate on CI, branch protection, unresolved conversations, freshness, and claim evidence without requiring an advisory reviewer.             |
+| `.github/instructions/idd-merge.instructions.md`           | Remove final advisory rechecks while keeping CI, claim, freshness, branch protection, and unresolved-thread checks.                        |
+| `.github/instructions/idd-review-snapshot.instructions.md` | Keep human comments in scope and remove advisory-only PATH B requirements.                                                                 |
+| `.github/instructions/idd-review-triage.instructions.md`   | Keep human review comments in the review universe and remove advisory-only disposition requirements.                                       |
+| `docs/idd-review-policy-profiles.md`                       | Record the selected `no-advisory` profile and link to the local verification evidence.                                                     |
+| `docs/customization.md` or another local policy document   | Record why no IDD-managed advisory reviewer is used and which outside gates still protect merges.                                          |
 
 ## Verification Evidence
 


### PR DESCRIPTION
## Summary

Two independent stale file-manifest fixes in `idd-template/`, both pure additive completeness fixes:

1. `idd-template/docs/onboarding/agent-entry-and-verification.md`'s "Imported files and profile artifacts" checklist was missing 4 real, currently-imported files (`policy-constants.md`, `idd-resume-detail.md`, `idd-advisory-wait-shell-fallback.md`, `idd-design-rationale.md`) that `ONBOARDING.md`'s canonical Step-2 file list already includes. Added them to the checklist.
2. The no-advisory profile's Patch Surface table (`idd-template/profiles/no-advisory/README.md`, mirrored in `idd-template/docs/idd-review-policy-profiles.md`) told adopters to edit `idd-advisory-wait.instructions.md` but never mentioned `idd-advisory-wait-shell-fallback.md`, which that file links to twice — so following the table as written left the doc orphaned. Added a row/bullet for it with the same disposition as its sibling entry.

`docs/idd-review-policy-profiles.md` (root) was regenerated via `node scripts/sync-docs.mjs --apply` from the edited canonical source, with no other diff.

Closes #1251

## Test plan

- [x] `npx biome check`, `npx dprint check "**/*.md"`, `npx markdownlint-cli2 "**/*.md"`, `npx cspell lint "**" --no-progress` all pass
- [x] `node scripts/sync-docs.mjs --check` reports all mirrored artifacts up to date
- [x] `node scripts/audit-docs.mjs --check` passes
