### PR TITLE
docs(discover): clarify floor tie-break for unscored candidates

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -542,8 +542,8 @@ neither skip below-floor candidates nor reorder by score — and select by
 
 **Scored-vs-unscored floor tie-break.** When the highest-score tie band
 pairs an unscored candidate (missing or out-of-range score, defaulted to
-the floor above) against a candidate genuinely scored exactly at the
-floor value, the genuinely-scored candidate wins the tie: an explicit
+the floor as defined above) against a candidate genuinely scored exactly
+at the floor value, the genuinely-scored candidate wins the tie: an explicit
 author judgment outranks a default fallback. Apply this rule first,
 before the concurrent-selection desync, effort-hint, and
 lowest-issue-number tie-breakers below, which still apply in unchanged

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -533,14 +533,14 @@ Among the surviving viable and unclaimed issues (after Step 1.5), pick the
 `autopilotSuitability.floor` (default `3`) as human-oriented; a missing or
 out-of-range score is treated as no score — ranked at the floor and never
 skipped, so the unscored backlog flows as before, subject to the
-scored-vs-unscored tie-break below when it ties against a
+scored-vs-unscored tie-breaker below when it ties against a
 genuinely-scored candidate at the same value. Advisory only: the pick
 still passes A4.5/A5 unchanged and the score never bypasses a gate. When
 `autopilotSuitability.enabled` is `false`, ignore the score entirely —
 neither skip below-floor candidates nor reorder by score — and select by
 **lowest issue number**.
 
-**Scored-vs-unscored floor tie-break.** When the highest-score tie band
+**Scored-vs-unscored floor tie-breaker.** When the highest-score tie band
 pairs an unscored candidate (missing or out-of-range score, defaulted to
 the floor as defined above) against a candidate genuinely scored exactly
 at the floor value, the genuinely-scored candidate wins the tie: an explicit

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -532,11 +532,24 @@ Among the surviving viable and unclaimed issues (after Step 1.5), pick the
 **lowest issue number**. In autopilot runs, skip scores below
 `autopilotSuitability.floor` (default `3`) as human-oriented; a missing or
 out-of-range score is treated as no score — ranked at the floor and never
-skipped, so the unscored backlog flows as before. Advisory only: the pick
+skipped, so the unscored backlog flows as before, subject to the
+scored-vs-unscored tie-break below when it ties against a
+genuinely-scored candidate at the same value. Advisory only: the pick
 still passes A4.5/A5 unchanged and the score never bypasses a gate. When
 `autopilotSuitability.enabled` is `false`, ignore the score entirely —
 neither skip below-floor candidates nor reorder by score — and select by
 **lowest issue number**.
+
+**Scored-vs-unscored floor tie-break.** When the highest-score tie band
+pairs an unscored candidate (missing or out-of-range score, defaulted to
+the floor above) against a candidate genuinely scored exactly at the
+floor value, the genuinely-scored candidate wins the tie: an explicit
+author judgment outranks a default fallback. Apply this rule first,
+before the concurrent-selection desync, effort-hint, and
+lowest-issue-number tie-breakers below, which still apply in unchanged
+relative order to any tie that remains afterward (for example, between
+two genuinely-scored candidates, or between two unscored candidates when
+no genuinely-scored one is present at that value).
 
 **Concurrent-selection desync (opt-in, off by default).** When
 `.github/idd/config.json` `discover.selectionDesync` is `session-offset`

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -552,11 +552,24 @@ Among the surviving viable and unclaimed issues (after Step 1.5), pick the
 **lowest issue number**. In autopilot runs, skip scores below
 `autopilotSuitability.floor` (default `3`) as human-oriented; a missing or
 out-of-range score is treated as no score — ranked at the floor and never
-skipped, so the unscored backlog flows as before. Advisory only: the pick
+skipped, so the unscored backlog flows as before, subject to the
+scored-vs-unscored tie-break below when it ties against a
+genuinely-scored candidate at the same value. Advisory only: the pick
 still passes A4.5/A5 unchanged and the score never bypasses a gate. When
 `autopilotSuitability.enabled` is `false`, ignore the score entirely —
 neither skip below-floor candidates nor reorder by score — and select by
 **lowest issue number**.
+
+**Scored-vs-unscored floor tie-break.** When the highest-score tie band
+pairs an unscored candidate (missing or out-of-range score, defaulted to
+the floor above) against a candidate genuinely scored exactly at the
+floor value, the genuinely-scored candidate wins the tie: an explicit
+author judgment outranks a default fallback. Apply this rule first,
+before the concurrent-selection desync, effort-hint, and
+lowest-issue-number tie-breakers below, which still apply in unchanged
+relative order to any tie that remains afterward (for example, between
+two genuinely-scored candidates, or between two unscored candidates when
+no genuinely-scored one is present at that value).
 
 **Concurrent-selection desync (opt-in, off by default).** When
 `.github/idd/config.json` `discover.selectionDesync` is `session-offset`

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -553,14 +553,14 @@ Among the surviving viable and unclaimed issues (after Step 1.5), pick the
 `autopilotSuitability.floor` (default `3`) as human-oriented; a missing or
 out-of-range score is treated as no score — ranked at the floor and never
 skipped, so the unscored backlog flows as before, subject to the
-scored-vs-unscored tie-break below when it ties against a
+scored-vs-unscored tie-breaker below when it ties against a
 genuinely-scored candidate at the same value. Advisory only: the pick
 still passes A4.5/A5 unchanged and the score never bypasses a gate. When
 `autopilotSuitability.enabled` is `false`, ignore the score entirely —
 neither skip below-floor candidates nor reorder by score — and select by
 **lowest issue number**.
 
-**Scored-vs-unscored floor tie-break.** When the highest-score tie band
+**Scored-vs-unscored floor tie-breaker.** When the highest-score tie band
 pairs an unscored candidate (missing or out-of-range score, defaulted to
 the floor as defined above) against a candidate genuinely scored exactly
 at the floor value, the genuinely-scored candidate wins the tie: an explicit

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -562,8 +562,8 @@ neither skip below-floor candidates nor reorder by score — and select by
 
 **Scored-vs-unscored floor tie-break.** When the highest-score tie band
 pairs an unscored candidate (missing or out-of-range score, defaulted to
-the floor above) against a candidate genuinely scored exactly at the
-floor value, the genuinely-scored candidate wins the tie: an explicit
+the floor as defined above) against a candidate genuinely scored exactly
+at the floor value, the genuinely-scored candidate wins the tie: an explicit
 author judgment outranks a default fallback. Apply this rule first,
 before the concurrent-selection desync, effort-hint, and
 lowest-issue-number tie-breakers below, which still apply in unchanged


### PR DESCRIPTION
# Summary

`idd-discover.instructions.md` A4 Step 2 said a missing or out-of-range
autopilot-suitability score is "treated as no score — ranked at the
floor and never skipped," but never stated who wins when such an
unscored candidate ties against a candidate genuinely scored exactly at
the floor value. CodeRabbit flagged this as a real ambiguity in the
ranking contract during a kit.black#116 template review (roadmap #1207).

This PR adds an explicit tie-break rule: the genuinely-scored candidate
wins, since an explicit author judgment should outrank a default
fallback. The rule is placed before the existing concurrent-selection
desync, effort-hint, and lowest-issue-number tie-breakers, which still
apply afterward in unchanged relative order. The wording mirrors the
equivalent rule already stated for the cross-roadmap union ranking in A2
("never rank an unscored leaf above genuinely scored work at the same
effective value").

## Linked issue

Closes #1248

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`idd-template/.github/instructions/idd-discover.instructions.md` is the
source of truth; `.github/instructions/idd-discover.instructions.md` is
its mirror. Per `audit/sync-manifest.json`, this specific file pair is
sync mode `"structure"` (heading-structure check only, no mechanical
content copy) rather than the byte-identical `"content"` mirroring used
by most other instruction files — this is why the mirror carries no
`idd-generated-from` banner. `node scripts/sync-docs.mjs --apply`
reports "up to date" for this pair either way, so both copies were
edited by hand in the same commit and verified via
`node scripts/audit-docs.mjs --check`.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified autopilot score selection behavior when a candidate is missing or out of range.
  * Added a rule for floor-value ties: a genuinely scored candidate now wins over an unscored one.
  * Confirmed that scoring is still ignored when autopilot suitability is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->