### PR TITLE
fix(claim): stop instead of falling back to Discover on A0-T race loss

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -96,9 +96,9 @@ of `claimable | already-claimed | stale-reclaimable` with the winning
   competing / same-second claim raced in: **return to Discover** using the same
   selection mode that produced this target (orphan-first: continue the A0-O
   capable path; roadmap mode: continue the A3-ready path). Do not post a claim.
-  For an explicit-target A0-T run, report the lost claim race and stop
-  instead of falling back to Discover, per `idd-discover.instructions.md`'s
-  A0-T stop-don't-fallback rule.
+  For an explicit-target A0-T run, report that the issue is already claimed
+  and stop without claiming instead of falling back to Discover, per
+  `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
 
 GitHub issue comments have no compare-and-swap, so this **narrows** the
 claim→write TOCTOU window rather than closing it; the 24 h stale-takeover and
@@ -119,9 +119,9 @@ for these stale checks (distributed default: `24 h`).
   when the `agent-id` matches. Return to Discover using the same
   selection mode that produced this target (orphan-first: continue the
   A0-O capable path; roadmap mode: continue the A3-ready path). For an
-  explicit-target A0-T run, report the lost claim race and stop instead
-  of falling back to Discover, per `idd-discover.instructions.md`'s A0-T
-  stop-don't-fallback rule.
+  explicit-target A0-T run, report that the issue is already claimed and
+  stop without claiming instead of falling back to Discover, per
+  `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
 - Any other active claim whose latest valid `claimed-by` comment has
   GitHub `created_at` ≥ 24 h → stale, proceed with takeover.
 
@@ -141,9 +141,10 @@ Otherwise, use the latest trusted legacy `claimed-by` comment as a
   by another live session, even when the `agent-id` matches. Return to
   Discover using the same selection mode that produced this target
   (orphan-first: continue the A0-O capable path; roadmap mode: continue
-  the A3-ready path). For an explicit-target A0-T run, report the lost
-  claim race and stop instead of falling back to Discover, per
-  `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
+  the A3-ready path). For an explicit-target A0-T run, report that the
+  issue is already claimed and stop without claiming instead of falling
+  back to Discover, per `idd-discover.instructions.md`'s A0-T
+  stop-don't-fallback rule.
 - Latest trusted legacy claim has GitHub `created_at` ≥ 24 h → stale,
   proceed and replace it with a new-format claim.
 
@@ -262,9 +263,10 @@ catches parallel-session concurrency before a new claim comment is posted.
      A0-O capable path; roadmap mode: continue the A3-ready path), and
      select the **next eligible issue**. This is the scale-out path that
      allows multiple sessions to work on different issues when one issue
-     has concurrent claims. For an explicit-target A0-T run, report the
-     lost claim race and stop instead of falling back to Discover, per
-     `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
+     has concurrent claims. For an explicit-target A0-T run, report that
+     the issue is already claimed and stop without claiming instead of
+     falling back to Discover, per `idd-discover.instructions.md`'s A0-T
+     stop-don't-fallback rule.
 
    - **If a match is found, does NOT correspond to an inheritable claim,
      AND no active claim references that branch**:

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -96,6 +96,9 @@ of `claimable | already-claimed | stale-reclaimable` with the winning
   competing / same-second claim raced in: **return to Discover** using the same
   selection mode that produced this target (orphan-first: continue the A0-O
   capable path; roadmap mode: continue the A3-ready path). Do not post a claim.
+  For an explicit-target A0-T run, report the lost claim race and stop
+  instead of falling back to Discover, per `idd-discover.instructions.md`'s
+  A0-T stop-don't-fallback rule.
 
 GitHub issue comments have no compare-and-swap, so this **narrows** the
 claim→write TOCTOU window rather than closing it; the 24 h stale-takeover and
@@ -115,7 +118,10 @@ for these stale checks (distributed default: `24 h`).
   GitHub `created_at` < 24 h → claimed by another live session, even
   when the `agent-id` matches. Return to Discover using the same
   selection mode that produced this target (orphan-first: continue the
-  A0-O capable path; roadmap mode: continue the A3-ready path).
+  A0-O capable path; roadmap mode: continue the A3-ready path). For an
+  explicit-target A0-T run, report the lost claim race and stop instead
+  of falling back to Discover, per `idd-discover.instructions.md`'s A0-T
+  stop-don't-fallback rule.
 - Any other active claim whose latest valid `claimed-by` comment has
   GitHub `created_at` ≥ 24 h → stale, proceed with takeover.
 
@@ -135,7 +141,9 @@ Otherwise, use the latest trusted legacy `claimed-by` comment as a
   by another live session, even when the `agent-id` matches. Return to
   Discover using the same selection mode that produced this target
   (orphan-first: continue the A0-O capable path; roadmap mode: continue
-  the A3-ready path).
+  the A3-ready path). For an explicit-target A0-T run, report the lost
+  claim race and stop instead of falling back to Discover, per
+  `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
 - Latest trusted legacy claim has GitHub `created_at` ≥ 24 h → stale,
   proceed and replace it with a new-format claim.
 
@@ -254,7 +262,9 @@ catches parallel-session concurrency before a new claim comment is posted.
      A0-O capable path; roadmap mode: continue the A3-ready path), and
      select the **next eligible issue**. This is the scale-out path that
      allows multiple sessions to work on different issues when one issue
-     has concurrent claims.
+     has concurrent claims. For an explicit-target A0-T run, report the
+     lost claim race and stop instead of falling back to Discover, per
+     `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
 
    - **If a match is found, does NOT correspond to an inheritable claim,
      AND no active claim references that branch**:

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -91,9 +91,9 @@ of `claimable | already-claimed | stale-reclaimable` with the winning
   competing / same-second claim raced in: **return to Discover** using the same
   selection mode that produced this target (orphan-first: continue the A0-O
   capable path; roadmap mode: continue the A3-ready path). Do not post a claim.
-  For an explicit-target A0-T run, report the lost claim race and stop
-  instead of falling back to Discover, per `idd-discover.instructions.md`'s
-  A0-T stop-don't-fallback rule.
+  For an explicit-target A0-T run, report that the issue is already claimed
+  and stop without claiming instead of falling back to Discover, per
+  `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
 
 GitHub issue comments have no compare-and-swap, so this **narrows** the
 claim→write TOCTOU window rather than closing it; the 24 h stale-takeover and
@@ -114,9 +114,9 @@ for these stale checks (distributed default: `24 h`).
   when the `agent-id` matches. Return to Discover using the same
   selection mode that produced this target (orphan-first: continue the
   A0-O capable path; roadmap mode: continue the A3-ready path). For an
-  explicit-target A0-T run, report the lost claim race and stop instead
-  of falling back to Discover, per `idd-discover.instructions.md`'s A0-T
-  stop-don't-fallback rule.
+  explicit-target A0-T run, report that the issue is already claimed and
+  stop without claiming instead of falling back to Discover, per
+  `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
 - Any other active claim whose latest valid `claimed-by` comment has
   GitHub `created_at` ≥ 24 h → stale, proceed with takeover.
 
@@ -136,9 +136,10 @@ Otherwise, use the latest trusted legacy `claimed-by` comment as a
   by another live session, even when the `agent-id` matches. Return to
   Discover using the same selection mode that produced this target
   (orphan-first: continue the A0-O capable path; roadmap mode: continue
-  the A3-ready path). For an explicit-target A0-T run, report the lost
-  claim race and stop instead of falling back to Discover, per
-  `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
+  the A3-ready path). For an explicit-target A0-T run, report that the
+  issue is already claimed and stop without claiming instead of falling
+  back to Discover, per `idd-discover.instructions.md`'s A0-T
+  stop-don't-fallback rule.
 - Latest trusted legacy claim has GitHub `created_at` ≥ 24 h → stale,
   proceed and replace it with a new-format claim.
 
@@ -257,9 +258,10 @@ catches parallel-session concurrency before a new claim comment is posted.
      A0-O capable path; roadmap mode: continue the A3-ready path), and
      select the **next eligible issue**. This is the scale-out path that
      allows multiple sessions to work on different issues when one issue
-     has concurrent claims. For an explicit-target A0-T run, report the
-     lost claim race and stop instead of falling back to Discover, per
-     `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
+     has concurrent claims. For an explicit-target A0-T run, report that
+     the issue is already claimed and stop without claiming instead of
+     falling back to Discover, per `idd-discover.instructions.md`'s A0-T
+     stop-don't-fallback rule.
 
    - **If a match is found, does NOT correspond to an inheritable claim,
      AND no active claim references that branch**:

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -91,6 +91,9 @@ of `claimable | already-claimed | stale-reclaimable` with the winning
   competing / same-second claim raced in: **return to Discover** using the same
   selection mode that produced this target (orphan-first: continue the A0-O
   capable path; roadmap mode: continue the A3-ready path). Do not post a claim.
+  For an explicit-target A0-T run, report the lost claim race and stop
+  instead of falling back to Discover, per `idd-discover.instructions.md`'s
+  A0-T stop-don't-fallback rule.
 
 GitHub issue comments have no compare-and-swap, so this **narrows** the
 claim→write TOCTOU window rather than closing it; the 24 h stale-takeover and
@@ -110,7 +113,10 @@ for these stale checks (distributed default: `24 h`).
   GitHub `created_at` < 24 h → claimed by another live session, even
   when the `agent-id` matches. Return to Discover using the same
   selection mode that produced this target (orphan-first: continue the
-  A0-O capable path; roadmap mode: continue the A3-ready path).
+  A0-O capable path; roadmap mode: continue the A3-ready path). For an
+  explicit-target A0-T run, report the lost claim race and stop instead
+  of falling back to Discover, per `idd-discover.instructions.md`'s A0-T
+  stop-don't-fallback rule.
 - Any other active claim whose latest valid `claimed-by` comment has
   GitHub `created_at` ≥ 24 h → stale, proceed with takeover.
 
@@ -130,7 +136,9 @@ Otherwise, use the latest trusted legacy `claimed-by` comment as a
   by another live session, even when the `agent-id` matches. Return to
   Discover using the same selection mode that produced this target
   (orphan-first: continue the A0-O capable path; roadmap mode: continue
-  the A3-ready path).
+  the A3-ready path). For an explicit-target A0-T run, report the lost
+  claim race and stop instead of falling back to Discover, per
+  `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
 - Latest trusted legacy claim has GitHub `created_at` ≥ 24 h → stale,
   proceed and replace it with a new-format claim.
 
@@ -249,7 +257,9 @@ catches parallel-session concurrency before a new claim comment is posted.
      A0-O capable path; roadmap mode: continue the A3-ready path), and
      select the **next eligible issue**. This is the scale-out path that
      allows multiple sessions to work on different issues when one issue
-     has concurrent claims.
+     has concurrent claims. For an explicit-target A0-T run, report the
+     lost claim race and stop instead of falling back to Discover, per
+     `idd-discover.instructions.md`'s A0-T stop-don't-fallback rule.
 
    - **If a match is found, does NOT correspond to an inheritable claim,
      AND no active claim references that branch**:


### PR DESCRIPTION
# Summary

`idd-claim.instructions.md`'s already-claimed / claim-race-lost bullets
unconditionally said to return to Discover, which silently conflicted with
`idd-discover.instructions.md`'s A0-T (explicit-target) section: A0-T says a
failed targeted check must stop and report, never fall back to another
issue unless the operator explicitly asks for normal discovery in the same
run. This adds an explicit A0-T carve-out to the four affected spots (A5(c)
helper-first `fresh_claim_gate` bullet, A5(c) written-rule bullet, A5(c)
legacy-migration bullet, A5(e) branch-collision bullet), each
cross-referencing `idd-discover.instructions.md`'s A0-T rule. The
`## Claim verification` section already had the correct carve-out — it was
the model this PR matches, not something this PR needed to fix.

## Linked issue

Closes #1247

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The non-A0-T "return to Discover" behavior is preserved unchanged for every
other selection path (roadmap traversal, A0-O orphan discovery, cross-roadmap
union) — each edit only appends a new sentence after the existing text, never
replaces it. Edited the canonical source
(`idd-template/.github/instructions/idd-claim.instructions.md`) and
regenerated the mirrored `.github/instructions/idd-claim.instructions.md` via
`node scripts/sync-docs.mjs --apply`; the mirror is byte-identical to the
source apart from the generated-from banner.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (verified piecewise: `audit-docs --check`, `typecheck`,
  `build:check`, `biome check`, `dprint check`, `node --test tests/*.test.mts`
  [1626/1626 pass], `verify-workshop-integrity`, `cspell lint`,
  `markdownlint-cli2` — all clean)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; 3 pre-existing warnings unrelated
  to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — documentation-only change)
- [x] Context budget impact reviewed (4 short sentences added across 2
  mirrored files; negligible)
