### PR TITLE
fix(review-snapshot): pin --from-pr watermark posting to the Step 1 HEAD

### DIFF
--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -86,18 +86,28 @@ empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
 PR comment with this format (when helper runtime is enabled, prefer the
 **one-command** profile-selected post-idd-marker watermark path —
-`--type watermark --from-pr <pr-number> --agent-id <id> --claim-id <id> --apply`
-— which derives `{head-SHA}` / `{max-activity-updatedAt}` /
-`{total-item-count}` / `{latest-ci-completed-at}` from a fresh
-`review-activity-snapshot` of the PR and POSTs the marker in one step, so a
-hand-typed head SHA cannot mis-route the F2 review-currency check (forward
-`--trusted-marker-logins` here too when you pass it to the snapshot). The
-manual six-field form — `--type watermark --target pr <pr-number>
-<watermark-fields> --apply`, passing the same six values shown below as
-`--agent-id` / `--claim-id` / `--head-sha` / `--max-activity-at` /
-`--total-item-count` / `--ci-completed-at` — stays the fallback, as do
-`emit-marker --type review-watermark` for emit-only rendering and the manual
-HTTP `POST` below; see `docs/idd-helper-scripts.md`):
+`--type watermark --from-pr <pr-number> --expected-head-sha {head-SHA}
+--agent-id <id> --claim-id <id> --apply`
+— which derives `{max-activity-updatedAt}` / `{total-item-count}` /
+`{latest-ci-completed-at}` (and, subject to the pin below, `{head-SHA}`) from
+a fresh `review-activity-snapshot` of the PR and POSTs the marker in one
+step, so a hand-typed head SHA cannot mis-route the F2 review-currency check
+(forward `--trusted-marker-logins` here too when you pass it to the
+snapshot). **Always pass `--expected-head-sha` with the exact `{head-SHA}`
+value stored at the start of Step 1.** The helper compares it against the
+fresh snapshot's live HEAD and fails closed — posting nothing — when they
+differ, instead of silently posting a watermark keyed to a HEAD newer than
+the one Step 1 actually snapshotted; this is what keeps the one-command path
+honoring the single-stored-value invariant from Step 1 above. On that
+failure, do not retry Step 2 as-is — return to Step 1 and re-snapshot the
+moved branch. The manual six-field form — `--type watermark --target pr
+<pr-number> <watermark-fields> --apply`, passing the same six values shown
+below as `--agent-id` / `--claim-id` / `--head-sha` / `--max-activity-at` /
+`--total-item-count` / `--ci-completed-at` — stays the fallback (it already
+posts the exact Step-1 stored `{head-SHA}` value since the agent supplies it
+directly), as do `emit-marker --type review-watermark` for emit-only
+rendering and the manual HTTP `POST` below; see
+`docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-watermark: {agent-id} {claim-id} {head-SHA} {max-activity-updatedAt|none} {total-item-count} {latest-ci-completed-at|none} -->

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -885,6 +885,16 @@ Interpretation rules:
   child so its counts match the manual path, and rejects the four manual
   snapshot fields as ambiguous. Unlike the manual dry-run it reads from GitHub
   (it spawns the snapshot), but still posts nothing without `--apply`.
+- `--from-pr` HEAD pin (`--expected-head-sha <sha>`): optional, `--from-pr`
+  only. Pass the E1 Step 1 stored `{head-SHA}` here to guard against the
+  branch moving between Step 1 and the Step 2 post: if the fresh snapshot's
+  live HEAD no longer matches (case-insensitive compare), the CLI fails
+  closed — it writes a `refusing to post watermark` message to stderr and
+  exits non-zero **before** any POST, rather than silently posting a
+  watermark keyed to a HEAD newer than Step 1 actually snapshotted. Rejected
+  (exits non-zero, no `gh` call) when passed without `--from-pr`, since manual
+  mode already supplies `--head-sha` directly with nothing to compare it
+  against.
 - **No claim/state gating** (the `emit-marker` philosophy): this is a
   single-marker render+POST primitive, so the calling phase must run its
   claim-revalidation gate before `--apply`, exactly as the manual POST path it

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -81,18 +81,28 @@ empty. Compute `{total-item-count}` as the total number of items in the
 snapshot (0 if empty). Persist all six values immediately by posting a
 PR comment with this format (when helper runtime is enabled, prefer the
 **one-command** profile-selected post-idd-marker watermark path —
-`--type watermark --from-pr <pr-number> --agent-id <id> --claim-id <id> --apply`
-— which derives `{head-SHA}` / `{max-activity-updatedAt}` /
-`{total-item-count}` / `{latest-ci-completed-at}` from a fresh
-`review-activity-snapshot` of the PR and POSTs the marker in one step, so a
-hand-typed head SHA cannot mis-route the F2 review-currency check (forward
-`--trusted-marker-logins` here too when you pass it to the snapshot). The
-manual six-field form — `--type watermark --target pr <pr-number>
-<watermark-fields> --apply`, passing the same six values shown below as
-`--agent-id` / `--claim-id` / `--head-sha` / `--max-activity-at` /
-`--total-item-count` / `--ci-completed-at` — stays the fallback, as do
-`emit-marker --type review-watermark` for emit-only rendering and the manual
-HTTP `POST` below; see `docs/idd-helper-scripts.md`):
+`--type watermark --from-pr <pr-number> --expected-head-sha {head-SHA}
+--agent-id <id> --claim-id <id> --apply`
+— which derives `{max-activity-updatedAt}` / `{total-item-count}` /
+`{latest-ci-completed-at}` (and, subject to the pin below, `{head-SHA}`) from
+a fresh `review-activity-snapshot` of the PR and POSTs the marker in one
+step, so a hand-typed head SHA cannot mis-route the F2 review-currency check
+(forward `--trusted-marker-logins` here too when you pass it to the
+snapshot). **Always pass `--expected-head-sha` with the exact `{head-SHA}`
+value stored at the start of Step 1.** The helper compares it against the
+fresh snapshot's live HEAD and fails closed — posting nothing — when they
+differ, instead of silently posting a watermark keyed to a HEAD newer than
+the one Step 1 actually snapshotted; this is what keeps the one-command path
+honoring the single-stored-value invariant from Step 1 above. On that
+failure, do not retry Step 2 as-is — return to Step 1 and re-snapshot the
+moved branch. The manual six-field form — `--type watermark --target pr
+<pr-number> <watermark-fields> --apply`, passing the same six values shown
+below as `--agent-id` / `--claim-id` / `--head-sha` / `--max-activity-at` /
+`--total-item-count` / `--ci-completed-at` — stays the fallback (it already
+posts the exact Step-1 stored `{head-SHA}` value since the agent supplies it
+directly), as do `emit-marker --type review-watermark` for emit-only
+rendering and the manual HTTP `POST` below; see
+`docs/idd-helper-scripts.md`):
 
 ```markdown
 <!-- review-watermark: {agent-id} {claim-id} {head-SHA} {max-activity-updatedAt|none} {total-item-count} {latest-ci-completed-at|none} -->

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -885,6 +885,16 @@ Interpretation rules:
   child so its counts match the manual path, and rejects the four manual
   snapshot fields as ambiguous. Unlike the manual dry-run it reads from GitHub
   (it spawns the snapshot), but still posts nothing without `--apply`.
+- `--from-pr` HEAD pin (`--expected-head-sha <sha>`): optional, `--from-pr`
+  only. Pass the E1 Step 1 stored `{head-SHA}` here to guard against the
+  branch moving between Step 1 and the Step 2 post: if the fresh snapshot's
+  live HEAD no longer matches (case-insensitive compare), the CLI fails
+  closed — it writes a `refusing to post watermark` message to stderr and
+  exits non-zero **before** any POST, rather than silently posting a
+  watermark keyed to a HEAD newer than Step 1 actually snapshotted. Rejected
+  (exits non-zero, no `gh` call) when passed without `--from-pr`, since manual
+  mode already supplies `--head-sha` directly with nothing to compare it
+  against.
 - **No claim/state gating** (the `emit-marker` philosophy): this is a
   single-marker render+POST primitive, so the calling phase must run its
   claim-revalidation gate before `--apply`, exactly as the manual POST path it

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -156,6 +156,7 @@ export function parseArgs(argv) {
     target: '',
     number: null,
     fromPr: null,
+    expectedHeadSha: '',
     apply: false,
     owner: '',
     repo: '',
@@ -196,6 +197,8 @@ export function parseArgs(argv) {
       args.target = value;
     } else if (token === '--from-pr') {
       args.fromPr = parsePositiveIntToken(value, 'invalid --from-pr number');
+    } else if (token === '--expected-head-sha') {
+      args.expectedHeadSha = value;
     } else if (token === '--owner') {
       args.owner = value;
     } else if (token === '--repo') {
@@ -229,6 +232,10 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
                        to PR <n>, so only --agent-id / --claim-id (and --apply)
                        are still needed (always targets the PR; an explicit
                        non-pr --target is rejected). Not network-free.
+  --expected-head-sha <sha>  --from-pr only: the E1 Step 1 stored {head-SHA}.
+                       Fails closed (posts nothing) if the fresh snapshot's live
+                       HEAD no longer matches it, i.e. the branch moved between
+                       E1 Step 1 and this Step 2 call.
   --apply              POST the marker (default: dry-run prints it in a JSON envelope)
   --owner <owner>      repo owner (default: gh repo view)
   --repo <repo>        repo name (default: gh repo view)
@@ -238,13 +245,15 @@ Per-type field flags:
   claim              --agent-id --claim-id --supersedes --timestamp --branch
   unclaim            --agent-id --claim-id --timestamp
   watermark          --agent-id --claim-id --head-sha --max-activity-at --total-item-count --ci-completed-at
-                     (or --agent-id --claim-id --from-pr <n>)
+                     (or --agent-id --claim-id --from-pr <n> [--expected-head-sha <sha>])
   baseline           --agent-id --claim-id --sha
   advisory           --agent-id --head-sha --timestamp
   advisory-recovery  --agent-id --head-sha --timestamp
 
 --from-pr forwards optional --trusted-marker-logins / --advisory-bot-logins to
 the snapshot child so its counts match the manual review-activity-snapshot path.
+--expected-head-sha pins --from-pr to the Step 1 stored HEAD and fails closed
+(no post) on drift instead of silently posting a newer HEAD than Step 1 saw.
 `;
 /**
  * POST the marker body as a JSON document (`{"body": …}`) read from stdin via
@@ -343,6 +352,15 @@ if (isMainModule(import.meta.url)) {
     );
     process.exit(1);
   }
+  // --expected-head-sha only guards the --from-pr derivation below; in manual
+  // mode the caller already supplies --head-sha directly, so there is nothing
+  // to compare it against.
+  if (args.expectedHeadSha && args.fromPr === null) {
+    process.stderr.write(
+      '--expected-head-sha is only valid together with --from-pr\n',
+    );
+    process.exit(1);
+  }
   // `--from-pr <n>` snapshot-derivation mode (watermark only): default the post
   // target to PR <n>, reject the manual snapshot fields as ambiguous, then
   // derive head-sha / max-activity-at / total-item-count / ci-completed-at from
@@ -410,6 +428,22 @@ if (isMainModule(import.meta.url)) {
     } catch (error) {
       process.stderr.write(
         `failed to derive watermark fields from PR ${args.fromPr}: ${error.message}\n`,
+      );
+      process.exit(1);
+    }
+    // Fail closed (this repository's fail-closed default) when the branch
+    // moved between E1 Step 1 (which stored {head-SHA} and must not re-read
+    // HEAD through Step 3) and this Step 2 call: posting a watermark keyed to
+    // a HEAD newer than the one E1 Step 1 actually snapshotted would silently
+    // violate that single-stored-value invariant. Refuse to post; the caller
+    // reruns E1 from Step 1 against the moved branch instead.
+    const liveHeadSha = args.fields['head-sha'];
+    if (
+      args.expectedHeadSha &&
+      liveHeadSha.toLowerCase() !== args.expectedHeadSha.toLowerCase()
+    ) {
+      process.stderr.write(
+        `refusing to post watermark: PR ${args.fromPr}'s live HEAD (${liveHeadSha}) no longer matches the Step 1 stored --expected-head-sha (${args.expectedHeadSha}); the branch moved between E1 Step 1 and Step 2. Re-run E1 from Step 1 against the new HEAD.\n`,
       );
       process.exit(1);
     }

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -175,6 +175,13 @@ interface CliArgs {
   number: number | null;
   /** `--from-pr <n>`: derive the watermark snapshot fields from PR <n>. */
   fromPr: number | null;
+  /**
+   * `--expected-head-sha <sha>`: `--from-pr` only. The E1 Step 1 stored
+   * `{head-SHA}`. When set, fail closed (no post) if the fresh
+   * `--from-pr` snapshot's live HEAD no longer matches it — the branch
+   * moved between E1 Step 1 and this Step 2 call.
+   */
+  expectedHeadSha: string;
   apply: boolean;
   owner: string;
   repo: string;
@@ -205,6 +212,7 @@ export function parseArgs(argv: string[]): CliArgs {
     target: '',
     number: null,
     fromPr: null,
+    expectedHeadSha: '',
     apply: false,
     owner: '',
     repo: '',
@@ -245,6 +253,8 @@ export function parseArgs(argv: string[]): CliArgs {
       args.target = value;
     } else if (token === '--from-pr') {
       args.fromPr = parsePositiveIntToken(value, 'invalid --from-pr number');
+    } else if (token === '--expected-head-sha') {
+      args.expectedHeadSha = value;
     } else if (token === '--owner') {
       args.owner = value;
     } else if (token === '--repo') {
@@ -279,6 +289,10 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
                        to PR <n>, so only --agent-id / --claim-id (and --apply)
                        are still needed (always targets the PR; an explicit
                        non-pr --target is rejected). Not network-free.
+  --expected-head-sha <sha>  --from-pr only: the E1 Step 1 stored {head-SHA}.
+                       Fails closed (posts nothing) if the fresh snapshot's live
+                       HEAD no longer matches it, i.e. the branch moved between
+                       E1 Step 1 and this Step 2 call.
   --apply              POST the marker (default: dry-run prints it in a JSON envelope)
   --owner <owner>      repo owner (default: gh repo view)
   --repo <repo>        repo name (default: gh repo view)
@@ -288,13 +302,15 @@ Per-type field flags:
   claim              --agent-id --claim-id --supersedes --timestamp --branch
   unclaim            --agent-id --claim-id --timestamp
   watermark          --agent-id --claim-id --head-sha --max-activity-at --total-item-count --ci-completed-at
-                     (or --agent-id --claim-id --from-pr <n>)
+                     (or --agent-id --claim-id --from-pr <n> [--expected-head-sha <sha>])
   baseline           --agent-id --claim-id --sha
   advisory           --agent-id --head-sha --timestamp
   advisory-recovery  --agent-id --head-sha --timestamp
 
 --from-pr forwards optional --trusted-marker-logins / --advisory-bot-logins to
 the snapshot child so its counts match the manual review-activity-snapshot path.
+--expected-head-sha pins --from-pr to the Step 1 stored HEAD and fails closed
+(no post) on drift instead of silently posting a newer HEAD than Step 1 saw.
 `;
 
 /**
@@ -403,6 +419,15 @@ if (isMainModule(import.meta.url)) {
     );
     process.exit(1);
   }
+  // --expected-head-sha only guards the --from-pr derivation below; in manual
+  // mode the caller already supplies --head-sha directly, so there is nothing
+  // to compare it against.
+  if (args.expectedHeadSha && args.fromPr === null) {
+    process.stderr.write(
+      '--expected-head-sha is only valid together with --from-pr\n',
+    );
+    process.exit(1);
+  }
 
   // `--from-pr <n>` snapshot-derivation mode (watermark only): default the post
   // target to PR <n>, reject the manual snapshot fields as ambiguous, then
@@ -471,6 +496,22 @@ if (isMainModule(import.meta.url)) {
     } catch (error) {
       process.stderr.write(
         `failed to derive watermark fields from PR ${args.fromPr}: ${(error as Error).message}\n`,
+      );
+      process.exit(1);
+    }
+    // Fail closed (this repository's fail-closed default) when the branch
+    // moved between E1 Step 1 (which stored {head-SHA} and must not re-read
+    // HEAD through Step 3) and this Step 2 call: posting a watermark keyed to
+    // a HEAD newer than the one E1 Step 1 actually snapshotted would silently
+    // violate that single-stored-value invariant. Refuse to post; the caller
+    // reruns E1 from Step 1 against the moved branch instead.
+    const liveHeadSha = args.fields['head-sha'];
+    if (
+      args.expectedHeadSha &&
+      liveHeadSha.toLowerCase() !== args.expectedHeadSha.toLowerCase()
+    ) {
+      process.stderr.write(
+        `refusing to post watermark: PR ${args.fromPr}'s live HEAD (${liveHeadSha}) no longer matches the Step 1 stored --expected-head-sha (${args.expectedHeadSha}); the branch moved between E1 Step 1 and Step 2. Re-run E1 from Step 1 against the new HEAD.\n`,
       );
       process.exit(1);
     }

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -525,6 +525,25 @@ test('parseArgs rejects a non-numeric / suffixed --from-pr', () => {
   );
 });
 
+// --- #1250: --expected-head-sha pins --from-pr to the Step 1 stored HEAD ---
+
+test('parseArgs reads --expected-head-sha as a structural flag, not a renderer field', () => {
+  const args = parseArgs([
+    '--type',
+    'watermark',
+    '--from-pr',
+    '1200',
+    '--expected-head-sha',
+    SHA,
+    '--agent-id',
+    'a',
+    '--claim-id',
+    'c',
+  ]);
+  assert.equal(args.expectedHeadSha, SHA);
+  assert.deepEqual(args.fields, { 'agent-id': 'a', 'claim-id': 'c' });
+});
+
 test('--from-pr CLI composes review-activity-snapshot and prints the derived watermark (dry-run)', () => {
   // Stub `gh` on PATH so the real subprocess composition runs offline: the
   // post-idd-marker.mjs CLI resolves its sibling review-activity-snapshot.mjs,
@@ -594,6 +613,147 @@ process.exit(1);
   });
 });
 
+/**
+ * Build the same offline `gh` stub as the "--from-pr CLI composes..." test
+ * above (PR HEAD = `headSha`, one CI pass, no threads, no reviews, one plain
+ * comment), so the --expected-head-sha match/mismatch tests below can reuse
+ * it without duplicating the stub script.
+ */
+function writeReviewActivitySnapshotGhStub(
+  tempRoot: string,
+  headSha: string,
+): void {
+  const ghPath = join(tempRoot, 'gh');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const out = (s) => { fs.writeSync(1, s); process.exit(0); };
+if (args[0] === 'pr' && args[1] === 'view') out('${headSha}\\n');
+if (args[0] === 'pr' && args[1] === 'checks') {
+  out(JSON.stringify([{ name: 'ci', state: 'SUCCESS', completedAt: '2026-06-25T11:00:00Z' }]));
+}
+if (args[0] === 'api' && args[1] === 'graphql') {
+  out(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false }, nodes: [] } } } } }));
+}
+if (args[0] === 'api' && /\\/reviews$/.test(args[1])) out('[]');
+if (args[0] === 'api' && /\\/comments$/.test(args[1])) {
+  out(JSON.stringify([{ body: 'hi', created_at: '2026-06-25T10:00:00Z', updated_at: '2026-06-25T10:30:00Z', user: { login: 'someone' } }]));
+}
+fs.writeSync(2, 'unexpected gh invocation: ' + args.join(' '));
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+}
+
+test('--expected-head-sha lets a matching (even differently-cased) --from-pr snapshot proceed', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-pinned-'));
+  writeReviewActivitySnapshotGhStub(tempRoot, SHA);
+
+  const runDryRun = (expectedHeadSha: string) =>
+    JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+          '--type',
+          'watermark',
+          '--from-pr',
+          '1200',
+          '--expected-head-sha',
+          expectedHeadSha,
+          '--owner',
+          'o',
+          '--repo',
+          'r',
+          '--agent-id',
+          'claude-02f8159e',
+          '--claim-id',
+          'claim-1134-02f8159e',
+        ],
+        {
+          cwd: REPO_ROOT,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${tempRoot}:${process.env.PATH ?? ''}`,
+          },
+        },
+      ),
+    );
+
+  const expected = {
+    mode: 'dry-run',
+    type: 'watermark',
+    target: 'pr',
+    number: 1200,
+    body: buildMarkerBody('watermark', {
+      'agent-id': 'claude-02f8159e',
+      'claim-id': 'claim-1134-02f8159e',
+      'head-sha': SHA,
+      'max-activity-at': '2026-06-25T10:30:00Z',
+      'total-item-count': '1',
+      'ci-completed-at': '2026-06-25T11:00:00Z',
+    }),
+  };
+
+  assert.deepEqual(runDryRun(SHA), expected);
+  // Case-insensitive: the Step 1 stored value and the live snapshot value
+  // must match regardless of hex-digit casing.
+  assert.deepEqual(runDryRun(SHA.toUpperCase()), expected);
+});
+
+test('--expected-head-sha fails closed (no post) when the live snapshot HEAD has moved', () => {
+  // The branch moved between E1 Step 1 (which stored `staleSha`) and this
+  // Step 2 call: the live snapshot now reports SHA. Even with --apply, the
+  // CLI must refuse to post rather than silently posting a watermark keyed to
+  // a HEAD newer than Step 1 actually snapshotted. If the guard regressed,
+  // this would fall through to the stub's POST-call fallback branch, whose
+  // "unexpected gh invocation" stderr would fail the message assertion below.
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-drift-'));
+  writeReviewActivitySnapshotGhStub(tempRoot, SHA);
+  const staleSha = 'fedcba9876543210fedcba9876543210fedcba98';
+
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'watermark',
+        '--from-pr',
+        '1200',
+        '--expected-head-sha',
+        staleSha,
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--claim-id',
+        'c',
+        '--apply',
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${tempRoot}:${process.env.PATH ?? ''}` },
+      },
+    );
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    assert.equal(failure.status, 1);
+    assert.match(failure.stderr ?? '', /refusing to post watermark/);
+    assert.match(failure.stderr ?? '', new RegExp(staleSha));
+    assert.match(failure.stderr ?? '', new RegExp(SHA));
+    return;
+  }
+  throw new Error('expected the CLI to exit non-zero');
+});
+
 // Run the CLI expecting a non-zero exit; return its stderr. These guards fire
 // before any `gh` call, so no stub is needed (and `gh` is removed from PATH to
 // prove the rejection is argument-only, never a network side effect).
@@ -661,4 +821,35 @@ test('--from-pr fails closed on an explicit non-pr --target', () => {
     'c',
   ]);
   assert.match(stderr, /--from-pr always targets the PR/);
+});
+
+test('--expected-head-sha is rejected without --from-pr (before any gh call)', () => {
+  // In manual mode the caller already supplies --head-sha directly; there is
+  // nothing for --expected-head-sha to compare it against.
+  const stderr = runCliExpectingFailure([
+    join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+    '--type',
+    'watermark',
+    '--target',
+    'pr',
+    '1200',
+    '--expected-head-sha',
+    SHA,
+    '--agent-id',
+    'a',
+    '--claim-id',
+    'c',
+    '--head-sha',
+    SHA,
+    '--max-activity-at',
+    'none',
+    '--total-item-count',
+    '0',
+    '--ci-completed-at',
+    'none',
+  ]);
+  assert.match(
+    stderr,
+    /--expected-head-sha is only valid together with --from-pr/,
+  );
 });


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`idd-review-snapshot.instructions.md` E1 Step 1 stores `{head-SHA}` and
says not to re-read HEAD through Step 3, but the documented one-command
`post-idd-marker --from-pr` helper path re-derived `{head-SHA}` from a
**fresh** `review-activity-snapshot` call at Step 2 — silently posting a
newer HEAD than Step 1 actually snapshotted if the branch moved in
between.

This PR adds an optional `--expected-head-sha <sha>` flag to
`post-idd-marker.mjs`'s `--from-pr` mode: pass the Step-1 stored
`{head-SHA}` and the helper fails closed (posts nothing, exits non-zero)
if the fresh snapshot's live HEAD no longer matches it. A pure "override
the field" approach was rejected because the other three derived fields
(`max-activity-at`, `total-item-count`, `ci-completed-at`) still reflect
current PR state, so forcing just `head-sha` back to the old value would
produce an internally inconsistent marker; failing closed and asking the
caller to re-run E1 Step 1 is the safer, semantically-correct fix.

The Step 2 instructions now always pass `--expected-head-sha` with the
Step-1 stored value, and `docs/idd-helper-scripts.md` documents the new
flag and its fail-closed behavior.

## Linked issue

Closes #1250

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

- The manual six-field `--head-sha` form was never affected — the agent
  already supplies the Step-1 value directly there. The bug was scoped
  to the one-command `--from-pr` shortcut only.
- `review-activity-snapshot.mjs` itself is unchanged: it is a
  general-purpose "read current activity" helper also used directly in
  E1 Step 1 and elsewhere, where reading the live HEAD fresh is correct
  by design. The pin/verify logic lives in `post-idd-marker.mjs`'s
  `--from-pr` composition layer instead, which is the one-shot
  "derive-and-post" path the instructions reference.
- `--expected-head-sha` is rejected when passed without `--from-pr`
  (manual mode already supplies `--head-sha` directly, so there is
  nothing to compare it against), and the comparison is case-insensitive.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
