### PR TITLE
fix(merge-handoff): let claim-less fully_autonomous_merge reach step 6

### DIFF
--- a/.github/instructions/idd-merge-handoff.instructions.md
+++ b/.github/instructions/idd-merge-handoff.instructions.md
@@ -12,8 +12,9 @@ to merge execution or must stop and hand off.
 Before any mutating action in this phase, apply the claim revalidation
 gate. If an active claim exists, it must still use your current
 `{claim-id}`. If no active claim exists, continue only for the
-designated `separate_merge_agent` actor path (see Step 1); all other
-paths must stop and report.
+designated `separate_merge_agent` actor path or the
+`fully_autonomous_merge` policy path (see Step 1); all other paths must
+stop and report.
 
 ## F2.5 — Resolve merge policy route
 
@@ -22,7 +23,9 @@ paths must stop and report.
      `{claim-id}`. If it is held by a different `{claim-id}` (even under
      the same agent ID), the claim was lost — report this and stop.
    - If no active claim exists, continue only for the designated
-     `separate_merge_agent` actor path in step 5. Other paths must stop.
+     `separate_merge_agent` actor path in step 5, or the
+     `fully_autonomous_merge` policy path in step 6. Other paths must
+     stop.
 2. Read the repository's recorded merge policy from repository
    documentation that future IDD sessions read. If no policy is
    recorded, treat it as `fully_autonomous_merge` (distributed default).

--- a/idd-template/.github/instructions/idd-merge-handoff.instructions.md
+++ b/idd-template/.github/instructions/idd-merge-handoff.instructions.md
@@ -7,8 +7,9 @@ to merge execution or must stop and hand off.
 Before any mutating action in this phase, apply the claim revalidation
 gate. If an active claim exists, it must still use your current
 `{claim-id}`. If no active claim exists, continue only for the
-designated `separate_merge_agent` actor path (see Step 1); all other
-paths must stop and report.
+designated `separate_merge_agent` actor path or the
+`fully_autonomous_merge` policy path (see Step 1); all other paths must
+stop and report.
 
 ## F2.5 — Resolve merge policy route
 
@@ -17,7 +18,9 @@ paths must stop and report.
      `{claim-id}`. If it is held by a different `{claim-id}` (even under
      the same agent ID), the claim was lost — report this and stop.
    - If no active claim exists, continue only for the designated
-     `separate_merge_agent` actor path in step 5. Other paths must stop.
+     `separate_merge_agent` actor path in step 5, or the
+     `fully_autonomous_merge` policy path in step 6. Other paths must
+     stop.
 2. Read the repository's recorded merge policy from repository
    documentation that future IDD sessions read. If no policy is
    recorded, treat it as `fully_autonomous_merge` (distributed default).


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`idd-merge-handoff.instructions.md` (F2.5) Step 1's claim-existence gate
named only `separate_merge_agent` as a policy allowed to continue without
an active claim; every other path had to stop. Step 6 of the same file
already documents `fully_autonomous_merge` continuing straight to
`idd-merge.instructions.md`, with no matching no-claim exception recorded
in Step 1 — so a claim-less `fully_autonomous_merge` session could never
reach the Step 6 behavior documented for that exact policy.

This adds `fully_autonomous_merge` alongside `separate_merge_agent` in
Step 1's claim-existence check (intro summary and the numbered step), so
both no-claim-tolerant policies can actually reach their documented
terminal behavior. No other policy's stop-on-no-claim behavior changes.

Edited only the canonical source
(`idd-template/.github/instructions/idd-merge-handoff.instructions.md`)
and regenerated the mirrored copy with `node scripts/sync-docs.mjs --apply`.

## Linked issue

Closes #1249

## Follow-up issues (if any)

- [ ] none
- Worth a follow-up: `idd-merge.instructions.md` (F3) Step 1 has its own
  unconditional "active claim missing → stop" check with no
  `fully_autonomous_merge` (or `separate_merge_agent`) exception. The
  `separate_merge_agent` path never hits this because F2.5 Step 5
  explicitly re-establishes a claim via A5 before continuing to F3; the
  `fully_autonomous_merge` path (Step 6) has no equivalent
  claim-establishment step. In practice a continuously-running
  `fully_autonomous_merge` session still holds its claim throughout, so
  this is unlikely to bite — but a genuinely claim-less session reaching
  F2.5 Step 6 by this fix would still stop at F3 Step 1. Out of scope
  here (not in this issue's candidate files / acceptance criteria, which
  are scoped to F2.5 Step 1 vs. Step 6 only); flagging for a maintainer
  decision on whether F3 needs a symmetric exception or is an intentional
  independent safety backstop.

## Background / rationale (if material)

This repository's own `.github/idd/config.json` records
`mergePolicy: fully_autonomous_merge` as its own dogfooding merge policy,
so this contradiction was directly load-bearing here, not a hypothetical
adopter-only concern.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
