### PR TITLE
ci(workflows): hygiene pass — job timeouts, stale concurrency, pull_request_target trust note

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,11 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    # Observed matrix-job duration is ~70-105s (gh api .../jobs started_at/
+    # completed_at, including scheduled full-repo scans); 30 min bounds
+    # pathological hangs while leaving generous headroom as the codebase
+    # grows.
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -18,6 +18,10 @@ permissions:
 jobs:
   idd-doctor:
     runs-on: ubuntu-slim
+    # Observed run duration is ~10-105s (gh api .../jobs started_at/
+    # completed_at); 10 min bounds pathological hangs with ~6x headroom
+    # over the slowest observed run.
+    timeout-minutes: 10
     steps:
       # Check out the exact commit (detached HEAD) so idd-doctor's
       # local-only primary-worktree-HEAD check never false-positives.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,10 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-slim
+    # Observed run duration is ~35-135s (gh api .../jobs started_at/
+    # completed_at); 15 min bounds pathological hangs with ~7x headroom
+    # over the slowest observed run.
+    timeout-minutes: 15
     steps:
       # fetch-depth: 0 is required by audit-docs' changed-file diff bases.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,6 +24,12 @@ jobs:
       id-token: write
       pages: write
     runs-on: ubuntu-latest
+    # Observed deploy-job duration is ~10-410s (gh api .../jobs started_at/
+    # completed_at; the 410s case is real GitHub Pages deployment latency,
+    # not queue wait). 15 min (not the 10 min starting suggestion) keeps
+    # ~2x headroom above that observed outlier while still bounding
+    # pathological hangs.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -1,3 +1,26 @@
+# Trust model: this workflow triggers on `pull_request_target`, which runs
+# with base-repository permissions and secrets even for pull requests from
+# forks. That is safe here only because all of the following hold, and any
+# future edit to this file must preserve them:
+#   - No PR-head content is ever checked out: the sole `actions/checkout`
+#     step below carries no `ref:` override, so it resolves to the
+#     `pull_request_target` default -- the PR's base branch at the time of
+#     the event -- never the PR head SHA or a merge commit.
+#   - No PR-head code, workflow, or action is ever executed: the only
+#     script that runs is this repository's own tracked
+#     `scripts/audit-pr-cleanup.mjs`, invoked with the PR number as inert
+#     numeric data (interpolated into a single-quoted shell variable, not
+#     evaluated).
+#   - The `cleanup` job only runs when
+#     `github.event.pull_request.merged == true`, or via an explicit,
+#     human-triggered `workflow_dispatch` -- never against an open or
+#     unmerged pull request.
+#   - `permissions:` stays least-privilege: `contents: read`,
+#     `issues: write`, `pull-requests: write` -- no `contents: write` and
+#     no elevated or secret-bearing scopes.
+# If a future change adds a `ref:` override on the checkout step, downloads
+# or executes PR-head content, widens `permissions:`, or removes the
+# merged-only guard, re-review this trust model before merging that change.
 name: Post-merge cleanup
 on:
   pull_request_target:

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -2,10 +2,15 @@
 # with base-repository permissions and secrets even for pull requests from
 # forks. That is safe here only because all of the following hold, and any
 # future edit to this file must preserve them:
-#   - No PR-head content is ever checked out: the sole `actions/checkout`
-#     step below carries no `ref:` override, so it resolves to the
-#     `pull_request_target` default -- the PR's base branch at the time of
-#     the event -- never the PR head SHA or a merge commit.
+#   - No unreviewed PR-head content is ever checked out: the sole
+#     `actions/checkout` step below carries no `ref:` override, so it
+#     resolves to the `pull_request_target` default -- the base branch's
+#     tip at event time. Because the job only proceeds when
+#     `merged == true`, that tip already includes this PR's own merge
+#     (this repository merges via merge commits, so it is typically that
+#     merge commit itself) -- it is never the PR's own head SHA, and
+#     never content that has not already passed through the merge
+#     decision.
 #   - No PR-head code, workflow, or action is ever executed: the only
 #     script that runs is this repository's own tracked
 #     `scripts/audit-pr-cleanup.mjs`, invoked with the PR number as inert

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,6 @@
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 name: Mark stale issues
 on:
   schedule:
@@ -8,6 +11,10 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-slim
+    # Observed run duration is ~9-25s (gh api .../jobs started_at/
+    # completed_at); 5 min bounds pathological hangs with generous
+    # headroom over the slowest observed run.
+    timeout-minutes: 5
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

CI workflow hygiene pass, scoped exactly to the issue body:

- Add job-level `timeout-minutes` to the five workflows that had none:
  `codeql.yml`, `idd-doctor.yml`, `lint.yml`, `pages.yml`, `stale.yml`.
- Add a `concurrency` group to `stale.yml`, matching the
  `codeql.yml` / `idd-doctor.yml` / `lint.yml` convention (it was the only
  workflow with none).
- Document `post-merge-cleanup.yml`'s `pull_request_target` trust model in
  a header comment (comment-only; no trigger/permission/logic change).

No workflow trigger, permission, or job-logic changes anywhere in this PR
— every change is additive (a duration bound, a concurrency group, or a
comment).

## Linked issue

Closes #1215

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Ask-first gate**: this issue requires an explicit operator confirmation
before any `.github/workflows/**` edit (`docs/permissions.md`, "Ask-First
Shared-State Actions"). The repository owner posted the scoped
confirmation on the issue before this branch was created:
<https://github.com/kurone-kito/idd-skill/issues/1215#issuecomment-4876473782>.

**`timeout-minutes` values**, justified against observed job execution
time (`gh api repos/.../actions/runs/<id>/jobs` `started_at`/
`completed_at` — job-level, not workflow-level, so concurrency-queue wait
is excluded):

| Workflow / job | Observed range | Max observed | Chosen | Headroom | Notes |
| --- | --- | --- | --- | --- | --- |
| `codeql.yml` `analyze` (×2 matrix) | 68–103s | 103s | **30 min** | ~17x | includes 3 schedule-triggered (weekly cron) samples; generous margin left for codebase growth |
| `idd-doctor.yml` `idd-doctor` | 10–103s | 103s | **10 min** | ~5.8x | |
| `lint.yml` `lint` | 34–132s | 132s | **15 min** | ~6.8x | |
| `pages.yml` `deploy` | 12–406s | 406s | **15 min** | ~2.2x | deviates from the issue's suggested 10 min — see below |
| `stale.yml` `stale` | 9–24s | 24s | **5 min** | ~12.5x | |

`pages.yml` is the one deliberate deviation from the issue's suggested
starting points. One real `deploy` job run (id `28533534694`) took 406s of
actual execution time (confirmed via job-level `started_at`/`completed_at`,
not just the workflow-level timestamp, which can include concurrency-queue
wait since `pages.yml` serializes on a fixed `pages` group). A 10-minute
timeout would leave only ~194s of margin above an already-observed case —
too tight for a bound whose purpose is to catch pathological hangs rather
than shadow typical run time. 15 minutes keeps ~2.2x headroom over the
worst observed run while still cutting off the 6-hour default runaway
case.

**`stale.yml` concurrency**: this is a weekly-cron-only workflow, so two
overlapping runs are already an edge case (e.g., a manual re-run while a
scheduled run is still in flight). Adding `cancel-in-progress: true` +
`group: ${{ github.workflow }}-${{ github.ref }}` (identical shape to
`codeql.yml` / `idd-doctor.yml` / `lint.yml`) only changes behavior in that
edge case; a normal, isolated scheduled run is unaffected.

**`post-merge-cleanup.yml` trust model** — verified directly against the
current file body before writing the comment:

- The sole `actions/checkout` step has no `ref:` override anywhere in the
  file, so it resolves to the `pull_request_target` default (the PR's
  **base** branch at event time), never PR-head content.
- The only script executed is this repository's own tracked
  `scripts/audit-pr-cleanup.mjs`, invoked with the PR number as inert
  numeric data (a single-quoted shell variable, not evaluated).
- The `cleanup` job's `if:` already required
  `github.event.pull_request.merged == true` (or an explicit,
  human-triggered `workflow_dispatch`) before this PR, and that guard is
  unchanged.
- `permissions:` was already least-privilege (`contents: read`,
  `issues: write`, `pull-requests: write`) and is unchanged.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (1630 tests pass; audit-docs, typecheck, build:check,
      biome, dprint, cspell, markdownlint all clean)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; 3 pre-existing warnings
      unrelated to this change — missing adopter profile READMEs, local
      hooksPath not wired in this environment, branch protection API not
      readable with this token)
- [ ] CI (`codeql`, `idd-doctor`, `lint`, `pnpm-boundary`) — pending on
      this PR

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed — none; no trigger/permission changes
- [x] Context budget impact reviewed — not applicable (no instruction
      files changed)
