### PR TITLE
test(infra): migrate agent-entry-mirror-sync helpers to test-utils

### DIFF
--- a/tests/agent-entry-mirror-sync.test.mts
+++ b/tests/agent-entry-mirror-sync.test.mts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
+import {
+  extractSection,
+  extractTopLevelSection,
+  readText,
+} from './test-utils.mts';
 
 const FILES = ['CLAUDE.md', 'AGENTS.md', 'GEMINI.md'] as const;
 type EntryFile = (typeof FILES)[number];
@@ -152,39 +156,3 @@ test('canonical-reference tool naming stays per-tool and does not cross-contamin
     }
   }
 });
-
-function readText(relativePath: string): string {
-  return readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8');
-}
-
-function extractTopLevelSection(
-  text: string,
-  fileLabel: string,
-  startMarker: string,
-): string {
-  const nextSectionMarker = '\n## ';
-  const start = text.indexOf(startMarker);
-  assert.notEqual(
-    start,
-    -1,
-    `${fileLabel} is missing section marker: ${startMarker}`,
-  );
-  const nextSectionStart = text.indexOf(
-    nextSectionMarker,
-    start + startMarker.length,
-  );
-  const end = nextSectionStart === -1 ? text.length : nextSectionStart;
-  return text.slice(start, end).trim();
-}
-
-function extractSection(
-  text: string,
-  startMarker: string,
-  endMarker: string,
-): string {
-  const start = text.indexOf(startMarker);
-  assert.notEqual(start, -1, `Missing section marker: ${startMarker}`);
-  const end = text.indexOf(endMarker, start);
-  assert.notEqual(end, -1, `Missing section marker: ${endMarker}`);
-  return text.slice(start, end);
-}


### PR DESCRIPTION
# Summary

Migrate the three local test helpers in
`tests/agent-entry-mirror-sync.test.mts` (`readText`,
`extractTopLevelSection`, `extractSection`) to imports from the shared
`tests/test-utils.mts` module, and drop the now-unused `readFileSync`
import. The local copies were behavior-identical residues of a
merge-order collision: #1214 (which added this test file) merged 17
minutes before #1211 (the consolidation), so the consolidation never
saw the new file. No assertion changes.

## Linked issue

Closes #1258

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Found by the #1220 roadmap completion audit. The acceptance grep now
holds: `function readText|function extractSection|function
extractTopLevelSection` under `tests/` matches only
`tests/test-utils.mts`.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

(None — test-only change.)

## Verification

- [x] `pnpm lint` (pre-push-validate set: biome, dprint, markdownlint, cspell)
- [x] `pnpm test` (1,630 pass / 0 fail; count did not drop)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (no docs touched; covered by lint:minimum surfaces)
- [ ] `node scripts/idd-doctor.mjs` (not applicable — test-only change)

Also ran `pnpm run typecheck` (tsc pass).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (no instruction/doc bytes touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfLxdRb6ct4eZmYkGToS4a
