### PR TITLE
ci(workflows): add scheduled fresh-install typecheck guard

### DIFF
--- a/.github/workflows/scheduled-typecheck.yml
+++ b/.github/workflows/scheduled-typecheck.yml
@@ -1,0 +1,70 @@
+name: Scheduled fresh-install typecheck
+# Background (#1266): this repository's CI is deliberately
+# `pull_request`-only (#832), so each check runs exactly once per change
+# and the pre-PR push window is covered by the local pre-push contract.
+# That design has one gap, concretely demonstrated by the #1164/#1193
+# incident: two individually-green PRs can combine into a broken `main`
+# when one of them (typically a dependency bump) merges on a base that
+# predates a semantically-conflicting change on the other. Nothing else
+# re-runs a full fresh-install check against the *merged* result of
+# `main`, so a break would otherwise surface only when the next
+# unrelated PR's own lint job goes red for a reason it did not
+# introduce. This workflow is an additive daily guard for that gap; it
+# does not change the intentional `pull_request`-only trigger topology
+# of lint.yml / idd-doctor.yml / pnpm-boundary.yml.
+#
+# Deliberately does not restore a cached pnpm store (no `cache: pnpm` on
+# actions/setup-node below) -- a stale restored cache could mask a
+# genuinely broken fresh install, which is exactly the failure mode this
+# guard exists to catch.
+on:
+  schedule:
+    # Daily, offset from the top of the hour to avoid GitHub's documented
+    # scheduling delays around busy :00/:30 minutes. The exact time is
+    # otherwise arbitrary; it only needs to avoid colliding with this
+    # repository's other scheduled workflows (stale.yml: Mon 00:00 UTC;
+    # codeql.yml: Mon 03:30 UTC).
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  typecheck:
+    runs-on: ubuntu-slim
+    # schedule/workflow_dispatch triggers only activate once this file
+    # lands on the default branch, so no real scheduled or dispatched run
+    # exists yet to observe. This bound is estimated from a local B1
+    # dry run in a fresh worktree (warm local pnpm store: install
+    # ~2.5s + typecheck ~5.5s; see the PR description for the raw
+    # numbers) plus generous headroom for cold-cache package download and
+    # Actions runner setup on a genuinely fresh runner. Revisit this
+    # value against the real observed duration after the first scheduled
+    # or workflow_dispatch run.
+    timeout-minutes: 10
+    steps:
+      # Pin to `main` explicitly: this guard's entire purpose is
+      # verifying main's merged result, regardless of which ref a manual
+      # workflow_dispatch happens to be invoked against.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          run_install: false
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          check-latest: true
+          node-version: 24.x
+      - name: Install dependencies (fresh, no restored cache)
+        env:
+          HUSKY: 0
+        run: pnpm install --frozen-lockfile
+      - name: Run typecheck
+        run: pnpm run typecheck


### PR DESCRIPTION
# Summary

Adds `.github/workflows/scheduled-typecheck.yml`: a daily `schedule` +
`workflow_dispatch` guard that checks out `main` fresh, runs `pnpm
install --frozen-lockfile` (no restored pnpm cache), and runs `pnpm run
typecheck`. It fails loudly (non-zero exit, red run in the Actions tab)
if `main`'s merged state fails to typecheck from a genuinely fresh
install.

## Linked issue

Closes #1266

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

This repository's CI is deliberately `pull_request`-only (#832): each
check runs exactly once per change, and the pre-PR push window is
covered by the local pre-push contract. That design has one gap,
concretely demonstrated by the #1164/#1193 incident: two individually-
green PRs can combine into a broken `main` when one of them (typically
a dependency bump) merges on a base that predates a semantically-
conflicting change on the other. Nothing else re-runs a full
fresh-install check against the *merged* result of `main`, so the
break would otherwise surface only when the next unrelated PR's own
`lint` job goes red for a reason it did not introduce. This is #1198's
option 3.

**Ask-first gate**: `docs/permissions.md` ("Ask-First Shared-State
Actions") requires explicit human confirmation before any
`.github/workflows/**` change. The operator posted the scoped
confirmation on #1266 before this branch was claimed:
["confirmed: the workflow edits specified in this issue body are
approved"](https://github.com/kurone-kito/idd-skill/issues/1266#issuecomment-4880408896).

**Design choices**:

- Triggers are `schedule` + `workflow_dispatch` only (no `pull_request`)
  — this does not change the intentional `pull_request`-only trigger
  topology of `lint.yml` / `idd-doctor.yml` / `pnpm-boundary.yml`.
- The install/setup steps reuse `pnpm-boundary.yml`'s pattern
  (`pnpm/action-setup` + `actions/setup-node`), but deliberately omit
  `cache: pnpm` on `actions/setup-node` so a restored dependency cache
  can never mask a genuinely broken fresh install.
- `timeout-minutes: 10` and a `concurrency` group
  (`${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress:
  true`) follow the `stale.yml` / `post-merge-cleanup.yml` hygiene
  convention established in #1215.
- Checkout pins `ref: main` explicitly, since this guard's entire
  purpose is verifying `main`'s merged result regardless of which ref a
  manual `workflow_dispatch` happens to be invoked against.

**Dry-run outcome (pre-merge verification)**: `schedule` and
`workflow_dispatch` triggers only activate once a workflow file lands
on the default branch, so neither can be exercised before this PR
merges. As an equivalent local dry run, B1 worktree setup measured the
same two commands this workflow runs, in a fresh sibling worktree:

- `pnpm install --frozen-lockfile`: **~2.5s** (warm local pnpm store —
  a genuinely cold Actions runner with no store cache will take
  longer, primarily on package download)
- `pnpm run typecheck`: **~5.5s**

`timeout-minutes: 10` leaves generous headroom over this local
baseline for Actions runner setup overhead and a cold package-registry
fetch. The workflow file's own inline comment documents this estimate
and flags it for revisit against the real observed duration once the
first scheduled or dispatched run exists.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

  New `.github/workflows/**` file, called out here for transparency per
  the Ask-First gate. Scope is minimal: `permissions: contents: read`
  only (no write scopes), it does not touch branch protection,
  rulesets, or required-check configuration, and it is purely additive
  alongside the existing `pull_request`-only workflows.

## Verification

- [x] `pnpm lint` (full `lint:minimum`, including `typecheck`,
      `build:check`, `node --test tests/*.test.mts` — 1630 tests pass,
      cspell, markdownlint)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable) — passed (3
      pre-existing warnings unrelated to this change: missing
      non-default profile READMEs, local `worktreeGuard` hook not
      wired in this environment, branch protection not readable by
      this token)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
