### PR TITLE
docs(idd-work): add dependency-drift diagnostic note

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -216,6 +216,13 @@ site's old delegate path added options or behavior (timeouts, stdio
 handling, error translation, etc.) that the new shared function does not
 replicate — not just whether the function bodies look equivalent.
 
+**Unexpected validation failures**: a `typecheck`/`lint` failure in a
+file this diff did not touch is a signal to suspect dependency drift or
+a broken `main` baseline, not necessarily the current change — verify
+with a fresh-vs-stale `node_modules` comparison, or by rerunning
+**install-deps** in a clean worktree, before assuming the failure traces
+to this diff.
+
 If B3 or C must stop for a hold, use the shared Hold / suspend rules in
 `idd-overview-appendix.instructions.md` and update the issue digest with the
 blocking condition before stopping. Do not use the digest as the only

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -211,6 +211,13 @@ site's old delegate path added options or behavior (timeouts, stdio
 handling, error translation, etc.) that the new shared function does not
 replicate — not just whether the function bodies look equivalent.
 
+**Unexpected validation failures**: a `typecheck`/`lint` failure in a
+file this diff did not touch is a signal to suspect dependency drift or
+a broken `main` baseline, not necessarily the current change — verify
+with a fresh-vs-stale `node_modules` comparison, or by rerunning
+**install-deps** in a clean worktree, before assuming the failure traces
+to this diff.
+
 If B3 or C must stop for a hold, use the shared Hold / suspend rules in
 `idd-overview-appendix.instructions.md` and update the issue digest with the
 blocking condition before stopping. Do not use the digest as the only


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Add a short B3 ("Implement") callout to `idd-work.instructions.md`: a
`typecheck`/`lint` failure in a file the current diff did not touch is
a signal to suspect dependency drift or a broken `main` baseline, not
necessarily the current change — verify via a fresh-vs-stale
`node_modules` comparison, or by rerunning `install-deps` in a clean
worktree, before assuming the failure traces to the diff.

## Linked issue

Closes #1267

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The #1164/#1193 incident (a dev-dependency bump that broke `main`'s
fresh-install `typecheck`/`lint` baseline while masked by stale
`node_modules` in existing worktrees) cost real debugging time because
the failure symptom looked like something the working agent's own
change had caused. This is #1198's option 4: a cheap diagnostic note,
not a prevention mechanism — it complements the local `idd-doctor`
signal and a separately-drafted scheduled detector by telling an agent
what to *suspect* when it hits this exact symptom shape.

The note is placed directly after the existing "De-duplication
refactors" callout added by #1238/PR #1240, matching that note's
length and one-bolded-term-plus-sentence shape rather than introducing
a new sub-checklist.

`idd-resume.instructions.md` was also reviewed for an analogous
"diagnose an unexpected validation failure" moment (per the issue's
conditional wording). No such moment exists there: that file's Step 3
CI-state routing rows (`failure`/`cancelled`/`timed_out`) only select
the next phase (D4 vs. E15); they never diagnose whether a failure
originates in the current diff. No edit lands in that file.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
