### PR TITLE
feat(doctor): warn when main has drifted far from latest release tag

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1664,12 +1664,14 @@ export function classifyReleaseTagDrift(tag, commitsSinceTag, daysSinceTag) {
   };
 }
 // Warns (never fails) when the current HEAD has drifted far from the latest
-// release tag. Skips silently -- no warning, no crash -- when the
-// repository has no tags reachable from HEAD yet (including a fresh
-// adopter clone before its first release): `git describe` failure is the
-// single, safe signal for both "no tags at all" and "no tag reachable from
-// HEAD", and either case means there is no baseline to measure drift
-// against.
+// release tag. Skips silently -- no warning, no crash -- whenever there is
+// no usable tag baseline to measure drift against: `git describe` (or the
+// follow-up `rev-list` / `log` calls) failing is treated as one single,
+// safe "no baseline" signal, covering every cause the same way -- no tags
+// at all yet (a fresh adopter clone before its first release), no tag
+// reachable from HEAD, tag history hidden by a shallow fetch (see
+// idd-skill#1286), or `git` itself being unavailable. This function never
+// tries to distinguish those causes; any of them means skip silently.
 function checkReleaseTagDrift(root, report) {
   const describeResult = runCommand(
     'git',

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1532,7 +1532,13 @@ export function classifyReleaseTagDrift(tag, commitsSinceTag, daysSinceTag) {
     parts.push(`${safeCommits} commit(s) (> ${commitThreshold})`);
   }
   if (overDays) {
-    parts.push(`${Math.floor(safeDays)} day(s) (> ${dayThreshold})`);
+    // Round up, not down: flooring a value just over the threshold (e.g.
+    // 45.1 with a 45-day threshold) would print "45 day(s) (> 45)", which
+    // reads as self-contradictory. Ceiling guarantees the printed integer
+    // is always strictly greater than dayThreshold whenever overDays is
+    // true (safeDays > dayThreshold implies ceil(safeDays) > dayThreshold
+    // for any integer dayThreshold).
+    parts.push(`${Math.ceil(safeDays)} day(s) (> ${dayThreshold})`);
   }
   return {
     warn: true,

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1471,8 +1471,9 @@ function checkPostMergeCleanupBacklog(root, options, report) {
     `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. Remediation: see docs/idd-comment-minimization.md or run \`node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check\`.`,
   );
 }
-// Default drift thresholds (idd-skill#1269): warn when `main` is more than
-// 100 commits OR more than 45 days past the latest reachable tag, whichever
+// Default drift thresholds (idd-skill#1269): warn when the checked-out HEAD
+// (typically `main` -- see the HEAD-vs-main note below) is more than 100
+// commits OR more than 45 days past the latest reachable tag, whichever
 // fires first (OR logic -- either alone is enough to warn). "Days past the
 // tag" is measured from the tagged **commit's** date (`%cI` on the
 // dereferenced commit), not an annotated tag object's own creation
@@ -1488,12 +1489,18 @@ function checkPostMergeCleanupBacklog(root, options, report) {
 // to (correctly) also fire immediately for idd-skill itself. 45 days gives
 // roughly 1.5 release cycles of slack under a monthly-ish cadence before
 // warning.
+//
+// HEAD-vs-main: the check measures drift from whatever commit is currently
+// checked out, not specifically `main` -- `.github/workflows/idd-doctor.yml`
+// runs it on every pull request against the PR's own (detached) HEAD, not
+// `main`. The warning message below says "HEAD", not "main", so it stays
+// accurate under that CI topology and any other non-main invocation.
 export const RELEASE_TAG_DRIFT_COMMIT_THRESHOLD = 100;
 export const RELEASE_TAG_DRIFT_DAY_THRESHOLD = 45;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /**
- * Classify how far `main` (or the current HEAD) has drifted from the latest
- * release tag, given the already-computed commit and day distances. Pure and
+ * Classify how far the current HEAD has drifted from the latest release
+ * tag, given the already-computed commit and day distances. Pure and
  * exported so tests can cover every threshold combination without shelling
  * out to git, using the module-level `RELEASE_TAG_DRIFT_*` thresholds (no
  * CLI override -- the issue's acceptance criteria only calls for documented
@@ -1529,15 +1536,16 @@ export function classifyReleaseTagDrift(tag, commitsSinceTag, daysSinceTag) {
   }
   return {
     warn: true,
-    message: `release-tag drift: main is ${parts.join(' and ')} past the latest tag ${tag}. Consider cutting a new release.`,
+    message: `release-tag drift: HEAD is ${parts.join(' and ')} past the latest tag ${tag}. Consider cutting a new release.`,
   };
 }
-// Warns (never fails) when `main` has drifted far from the latest release
-// tag. Skips silently -- no warning, no crash -- when the repository has no
-// tags reachable from HEAD yet (including a fresh adopter clone before its
-// first release): `git describe` failure is the single, safe signal for
-// both "no tags at all" and "no tag reachable from HEAD", and either case
-// means there is no baseline to measure drift against.
+// Warns (never fails) when the current HEAD has drifted far from the latest
+// release tag. Skips silently -- no warning, no crash -- when the
+// repository has no tags reachable from HEAD yet (including a fresh
+// adopter clone before its first release): `git describe` failure is the
+// single, safe signal for both "no tags at all" and "no tag reachable from
+// HEAD", and either case means there is no baseline to measure drift
+// against.
 function checkReleaseTagDrift(root, report) {
   const describeResult = runCommand(
     'git',

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -71,6 +71,7 @@ export function runDoctor({
     },
     report,
   );
+  checkReleaseTagDrift(root, report);
   checkWorkshopCrossReferences(
     root,
     { allowMissing: workshopCrossRefAllowMissing ?? [] },
@@ -1469,6 +1470,112 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   report.warnings.push(
     `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. Remediation: see docs/idd-comment-minimization.md or run \`node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check\`.`,
   );
+}
+// Default drift thresholds (idd-skill#1269): warn when `main` is more than
+// 100 commits OR more than 45 days past the latest reachable tag, whichever
+// fires first (OR logic -- either alone is enough to warn). "Days past the
+// tag" is measured from the tagged **commit's** date (`%cI` on the
+// dereferenced commit), not an annotated tag object's own creation
+// timestamp -- lightweight tags have no separate tagger date to read, and
+// using the commit date keeps both tag forms measured the same way.
+// Calibrated against this repository's own history rather than picked
+// arbitrarily: as of 2026-07-03, `main` was 636 commits / ~22 days past
+// `v0.3.0` under this repository's own atypically heavy dogfooding
+// velocity (~29 commits/day) -- not a representative adopter cadence, and
+// the `v0.2.0` -> `v0.3.0` gap (~10.5 hours) was too short to use as a
+// cadence sample either. 100 commits sizes the default for a *typical*
+// adopter's velocity, not idd-skill's own extreme rate -- it is expected
+// to (correctly) also fire immediately for idd-skill itself. 45 days gives
+// roughly 1.5 release cycles of slack under a monthly-ish cadence before
+// warning.
+export const RELEASE_TAG_DRIFT_COMMIT_THRESHOLD = 100;
+export const RELEASE_TAG_DRIFT_DAY_THRESHOLD = 45;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+/**
+ * Classify how far `main` (or the current HEAD) has drifted from the latest
+ * release tag, given the already-computed commit and day distances. Pure and
+ * exported so tests can cover every threshold combination without shelling
+ * out to git, using the module-level `RELEASE_TAG_DRIFT_*` thresholds (no
+ * CLI override -- the issue's acceptance criteria only calls for documented
+ * defaults). `tag === null` means no tag is reachable from HEAD yet (a
+ * fresh adopter clone before its first release) -- always non-warning. The
+ * only caller, `checkReleaseTagDrift`, already returns before ever invoking
+ * this with `tag: null` (its own `git describe` failure is the earlier exit
+ * point); the branch is kept here, mirroring
+ * `classifyWorktreeGuardActivation`'s `headDetached` handling, purely so
+ * this no-tag case is directly unit-testable without shelling out to git.
+ */
+export function classifyReleaseTagDrift(tag, commitsSinceTag, daysSinceTag) {
+  if (!tag) {
+    return { warn: false };
+  }
+  const commitThreshold = RELEASE_TAG_DRIFT_COMMIT_THRESHOLD;
+  const dayThreshold = RELEASE_TAG_DRIFT_DAY_THRESHOLD;
+  const commits = Number(commitsSinceTag);
+  const days = Number(daysSinceTag);
+  const safeCommits = Number.isFinite(commits) ? commits : 0;
+  const safeDays = Number.isFinite(days) ? days : 0;
+  const overCommits = safeCommits > commitThreshold;
+  const overDays = safeDays > dayThreshold;
+  if (!overCommits && !overDays) {
+    return { warn: false };
+  }
+  const parts = [];
+  if (overCommits) {
+    parts.push(`${safeCommits} commit(s) (> ${commitThreshold})`);
+  }
+  if (overDays) {
+    parts.push(`${Math.floor(safeDays)} day(s) (> ${dayThreshold})`);
+  }
+  return {
+    warn: true,
+    message: `release-tag drift: main is ${parts.join(' and ')} past the latest tag ${tag}. Consider cutting a new release.`,
+  };
+}
+// Warns (never fails) when `main` has drifted far from the latest release
+// tag. Skips silently -- no warning, no crash -- when the repository has no
+// tags reachable from HEAD yet (including a fresh adopter clone before its
+// first release): `git describe` failure is the single, safe signal for
+// both "no tags at all" and "no tag reachable from HEAD", and either case
+// means there is no baseline to measure drift against.
+function checkReleaseTagDrift(root, report) {
+  const describeResult = runCommand(
+    'git',
+    ['describe', '--tags', '--abbrev=0'],
+    root,
+  );
+  if (!describeResult.ok) {
+    return;
+  }
+  const tag = describeResult.stdout.trim();
+  if (!tag) {
+    return;
+  }
+  const countResult = runCommand(
+    'git',
+    ['rev-list', '--count', `${tag}..HEAD`],
+    root,
+  );
+  // `^{commit}` dereferences an annotated tag to the commit it points at, so
+  // the drift measurement uses the tagged commit's date in both tag forms.
+  const dateResult = runCommand(
+    'git',
+    ['log', '-1', '--format=%cI', `${tag}^{commit}`],
+    root,
+  );
+  if (!countResult.ok || !dateResult.ok) {
+    return;
+  }
+  const commitsSinceTag = Number(countResult.stdout.trim());
+  const tagDate = new Date(dateResult.stdout.trim());
+  if (!Number.isFinite(commitsSinceTag) || Number.isNaN(tagDate.getTime())) {
+    return;
+  }
+  const daysSinceTag = (Date.now() - tagDate.getTime()) / MS_PER_DAY;
+  const verdict = classifyReleaseTagDrift(tag, commitsSinceTag, daysSinceTag);
+  if (verdict.warn && verdict.message) {
+    report.warnings.push(verdict.message);
+  }
 }
 export function findMissingWorkshopReferences(entryFiles, allowMissing) {
   const allowSet = new Set(

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1807,7 +1807,13 @@ export function classifyReleaseTagDrift(
     parts.push(`${safeCommits} commit(s) (> ${commitThreshold})`);
   }
   if (overDays) {
-    parts.push(`${Math.floor(safeDays)} day(s) (> ${dayThreshold})`);
+    // Round up, not down: flooring a value just over the threshold (e.g.
+    // 45.1 with a 45-day threshold) would print "45 day(s) (> 45)", which
+    // reads as self-contradictory. Ceiling guarantees the printed integer
+    // is always strictly greater than dayThreshold whenever overDays is
+    // true (safeDays > dayThreshold implies ceil(safeDays) > dayThreshold
+    // for any integer dayThreshold).
+    parts.push(`${Math.ceil(safeDays)} day(s) (> ${dayThreshold})`);
   }
   return {
     warn: true,

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -144,6 +144,7 @@ export function runDoctor({
     },
     report,
   );
+  checkReleaseTagDrift(root, report);
   checkWorkshopCrossReferences(
     root,
     { allowMissing: workshopCrossRefAllowMissing ?? [] },
@@ -1732,6 +1733,125 @@ function checkPostMergeCleanupBacklog(
   report.warnings.push(
     `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. Remediation: see docs/idd-comment-minimization.md or run \`node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check\`.`,
   );
+}
+
+// Default drift thresholds (idd-skill#1269): warn when `main` is more than
+// 100 commits OR more than 45 days past the latest reachable tag, whichever
+// fires first (OR logic -- either alone is enough to warn). "Days past the
+// tag" is measured from the tagged **commit's** date (`%cI` on the
+// dereferenced commit), not an annotated tag object's own creation
+// timestamp -- lightweight tags have no separate tagger date to read, and
+// using the commit date keeps both tag forms measured the same way.
+// Calibrated against this repository's own history rather than picked
+// arbitrarily: as of 2026-07-03, `main` was 636 commits / ~22 days past
+// `v0.3.0` under this repository's own atypically heavy dogfooding
+// velocity (~29 commits/day) -- not a representative adopter cadence, and
+// the `v0.2.0` -> `v0.3.0` gap (~10.5 hours) was too short to use as a
+// cadence sample either. 100 commits sizes the default for a *typical*
+// adopter's velocity, not idd-skill's own extreme rate -- it is expected
+// to (correctly) also fire immediately for idd-skill itself. 45 days gives
+// roughly 1.5 release cycles of slack under a monthly-ish cadence before
+// warning.
+export const RELEASE_TAG_DRIFT_COMMIT_THRESHOLD = 100;
+export const RELEASE_TAG_DRIFT_DAY_THRESHOLD = 45;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Verdict for one release-tag-drift classification. */
+export interface ReleaseTagDriftVerdict {
+  warn: boolean;
+  message?: string;
+}
+
+/**
+ * Classify how far `main` (or the current HEAD) has drifted from the latest
+ * release tag, given the already-computed commit and day distances. Pure and
+ * exported so tests can cover every threshold combination without shelling
+ * out to git, using the module-level `RELEASE_TAG_DRIFT_*` thresholds (no
+ * CLI override -- the issue's acceptance criteria only calls for documented
+ * defaults). `tag === null` means no tag is reachable from HEAD yet (a
+ * fresh adopter clone before its first release) -- always non-warning. The
+ * only caller, `checkReleaseTagDrift`, already returns before ever invoking
+ * this with `tag: null` (its own `git describe` failure is the earlier exit
+ * point); the branch is kept here, mirroring
+ * `classifyWorktreeGuardActivation`'s `headDetached` handling, purely so
+ * this no-tag case is directly unit-testable without shelling out to git.
+ */
+export function classifyReleaseTagDrift(
+  tag: string | null,
+  commitsSinceTag: unknown,
+  daysSinceTag: unknown,
+): ReleaseTagDriftVerdict {
+  if (!tag) {
+    return { warn: false };
+  }
+  const commitThreshold = RELEASE_TAG_DRIFT_COMMIT_THRESHOLD;
+  const dayThreshold = RELEASE_TAG_DRIFT_DAY_THRESHOLD;
+  const commits = Number(commitsSinceTag);
+  const days = Number(daysSinceTag);
+  const safeCommits = Number.isFinite(commits) ? commits : 0;
+  const safeDays = Number.isFinite(days) ? days : 0;
+  const overCommits = safeCommits > commitThreshold;
+  const overDays = safeDays > dayThreshold;
+  if (!overCommits && !overDays) {
+    return { warn: false };
+  }
+  const parts: string[] = [];
+  if (overCommits) {
+    parts.push(`${safeCommits} commit(s) (> ${commitThreshold})`);
+  }
+  if (overDays) {
+    parts.push(`${Math.floor(safeDays)} day(s) (> ${dayThreshold})`);
+  }
+  return {
+    warn: true,
+    message: `release-tag drift: main is ${parts.join(' and ')} past the latest tag ${tag}. Consider cutting a new release.`,
+  };
+}
+
+// Warns (never fails) when `main` has drifted far from the latest release
+// tag. Skips silently -- no warning, no crash -- when the repository has no
+// tags reachable from HEAD yet (including a fresh adopter clone before its
+// first release): `git describe` failure is the single, safe signal for
+// both "no tags at all" and "no tag reachable from HEAD", and either case
+// means there is no baseline to measure drift against.
+function checkReleaseTagDrift(root: string, report: DoctorReport) {
+  const describeResult = runCommand(
+    'git',
+    ['describe', '--tags', '--abbrev=0'],
+    root,
+  );
+  if (!describeResult.ok) {
+    return;
+  }
+  const tag = describeResult.stdout.trim();
+  if (!tag) {
+    return;
+  }
+  const countResult = runCommand(
+    'git',
+    ['rev-list', '--count', `${tag}..HEAD`],
+    root,
+  );
+  // `^{commit}` dereferences an annotated tag to the commit it points at, so
+  // the drift measurement uses the tagged commit's date in both tag forms.
+  const dateResult = runCommand(
+    'git',
+    ['log', '-1', '--format=%cI', `${tag}^{commit}`],
+    root,
+  );
+  if (!countResult.ok || !dateResult.ok) {
+    return;
+  }
+  const commitsSinceTag = Number(countResult.stdout.trim());
+  const tagDate = new Date(dateResult.stdout.trim());
+  if (!Number.isFinite(commitsSinceTag) || Number.isNaN(tagDate.getTime())) {
+    return;
+  }
+  const daysSinceTag = (Date.now() - tagDate.getTime()) / MS_PER_DAY;
+  const verdict = classifyReleaseTagDrift(tag, commitsSinceTag, daysSinceTag);
+  if (verdict.warn && verdict.message) {
+    report.warnings.push(verdict.message);
+  }
 }
 
 export function findMissingWorkshopReferences(

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1968,12 +1968,14 @@ export function classifyReleaseTagDrift(
 }
 
 // Warns (never fails) when the current HEAD has drifted far from the latest
-// release tag. Skips silently -- no warning, no crash -- when the
-// repository has no tags reachable from HEAD yet (including a fresh
-// adopter clone before its first release): `git describe` failure is the
-// single, safe signal for both "no tags at all" and "no tag reachable from
-// HEAD", and either case means there is no baseline to measure drift
-// against.
+// release tag. Skips silently -- no warning, no crash -- whenever there is
+// no usable tag baseline to measure drift against: `git describe` (or the
+// follow-up `rev-list` / `log` calls) failing is treated as one single,
+// safe "no baseline" signal, covering every cause the same way -- no tags
+// at all yet (a fresh adopter clone before its first release), no tag
+// reachable from HEAD, tag history hidden by a shallow fetch (see
+// idd-skill#1286), or `git` itself being unavailable. This function never
+// tries to distinguish those causes; any of them means skip silently.
 function checkReleaseTagDrift(root: string, report: DoctorReport) {
   const describeResult = runCommand(
     'git',

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1735,8 +1735,9 @@ function checkPostMergeCleanupBacklog(
   );
 }
 
-// Default drift thresholds (idd-skill#1269): warn when `main` is more than
-// 100 commits OR more than 45 days past the latest reachable tag, whichever
+// Default drift thresholds (idd-skill#1269): warn when the checked-out HEAD
+// (typically `main` -- see the HEAD-vs-main note below) is more than 100
+// commits OR more than 45 days past the latest reachable tag, whichever
 // fires first (OR logic -- either alone is enough to warn). "Days past the
 // tag" is measured from the tagged **commit's** date (`%cI` on the
 // dereferenced commit), not an annotated tag object's own creation
@@ -1752,6 +1753,12 @@ function checkPostMergeCleanupBacklog(
 // to (correctly) also fire immediately for idd-skill itself. 45 days gives
 // roughly 1.5 release cycles of slack under a monthly-ish cadence before
 // warning.
+//
+// HEAD-vs-main: the check measures drift from whatever commit is currently
+// checked out, not specifically `main` -- `.github/workflows/idd-doctor.yml`
+// runs it on every pull request against the PR's own (detached) HEAD, not
+// `main`. The warning message below says "HEAD", not "main", so it stays
+// accurate under that CI topology and any other non-main invocation.
 export const RELEASE_TAG_DRIFT_COMMIT_THRESHOLD = 100;
 export const RELEASE_TAG_DRIFT_DAY_THRESHOLD = 45;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -1763,8 +1770,8 @@ export interface ReleaseTagDriftVerdict {
 }
 
 /**
- * Classify how far `main` (or the current HEAD) has drifted from the latest
- * release tag, given the already-computed commit and day distances. Pure and
+ * Classify how far the current HEAD has drifted from the latest release
+ * tag, given the already-computed commit and day distances. Pure and
  * exported so tests can cover every threshold combination without shelling
  * out to git, using the module-level `RELEASE_TAG_DRIFT_*` thresholds (no
  * CLI override -- the issue's acceptance criteria only calls for documented
@@ -1804,16 +1811,17 @@ export function classifyReleaseTagDrift(
   }
   return {
     warn: true,
-    message: `release-tag drift: main is ${parts.join(' and ')} past the latest tag ${tag}. Consider cutting a new release.`,
+    message: `release-tag drift: HEAD is ${parts.join(' and ')} past the latest tag ${tag}. Consider cutting a new release.`,
   };
 }
 
-// Warns (never fails) when `main` has drifted far from the latest release
-// tag. Skips silently -- no warning, no crash -- when the repository has no
-// tags reachable from HEAD yet (including a fresh adopter clone before its
-// first release): `git describe` failure is the single, safe signal for
-// both "no tags at all" and "no tag reachable from HEAD", and either case
-// means there is no baseline to measure drift against.
+// Warns (never fails) when the current HEAD has drifted far from the latest
+// release tag. Skips silently -- no warning, no crash -- when the
+// repository has no tags reachable from HEAD yet (including a fresh
+// adopter clone before its first release): `git describe` failure is the
+// single, safe signal for both "no tags at all" and "no tag reachable from
+// HEAD", and either case means there is no baseline to measure drift
+// against.
 function checkReleaseTagDrift(root: string, report: DoctorReport) {
   const describeResult = runCommand(
     'git',

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -11,6 +11,7 @@ import {
   classifyBacklog,
   classifyClaimTimingConsistency,
   classifyPrimaryHead,
+  classifyReleaseTagDrift,
   classifyWorktreeGuardActivation,
   classifyWorktreeHeadFinding,
   computeWindowStartIso,
@@ -947,6 +948,58 @@ test('computeWindowStartIso returns null for windows that overflow Date range', 
   // would historically throw RangeError before this guard landed.
   assert.equal(computeWindowStartIso(now, 1e9), null);
   assert.equal(computeWindowStartIso(now, Number.MAX_SAFE_INTEGER), null);
+});
+
+test('classifyReleaseTagDrift skips silently when no tag is reachable from HEAD', () => {
+  // A fresh adopter clone before its first release (or a repo with no
+  // tags at all) must never warn or crash.
+  const verdict = classifyReleaseTagDrift(null, 500, 200);
+  assert.equal(verdict.warn, false);
+  assert.equal(verdict.message, undefined);
+});
+
+test('classifyReleaseTagDrift does not warn when a tag is within both thresholds', () => {
+  const verdict = classifyReleaseTagDrift('v1.0.0', 50, 10);
+  assert.equal(verdict.warn, false);
+  assert.equal(verdict.message, undefined);
+});
+
+test('classifyReleaseTagDrift warns when past the commit threshold only', () => {
+  const verdict = classifyReleaseTagDrift('v1.0.0', 150, 10);
+  assert.equal(verdict.warn, true);
+  assert.match(verdict.message ?? '', /150 commit\(s\) \(> 100\)/);
+  assert.doesNotMatch(verdict.message ?? '', /day\(s\)/);
+  assert.match(verdict.message ?? '', /v1\.0\.0/);
+});
+
+test('classifyReleaseTagDrift warns when past the day threshold only', () => {
+  const verdict = classifyReleaseTagDrift('v1.0.0', 50, 60);
+  assert.equal(verdict.warn, true);
+  assert.match(verdict.message ?? '', /60 day\(s\) \(> 45\)/);
+  assert.doesNotMatch(verdict.message ?? '', /commit\(s\)/);
+});
+
+test('classifyReleaseTagDrift warns on both thresholds and names both in the message', () => {
+  const verdict = classifyReleaseTagDrift('v1.0.0', 636, 22);
+  // The 22-day figure alone is under the 45-day threshold; only the
+  // commit count crosses here -- covered separately above. Use values
+  // that exceed both to exercise the "and" join.
+  const bothOver = classifyReleaseTagDrift('v1.0.0', 636, 60);
+  assert.equal(verdict.warn, true);
+  assert.equal(bothOver.warn, true);
+  assert.match(bothOver.message ?? '', /commit\(s\).*and.*day\(s\)/);
+});
+
+test('classifyReleaseTagDrift treats the threshold boundary as non-warning ("more than", not "at least")', () => {
+  const atCommitThreshold = classifyReleaseTagDrift('v1.0.0', 100, 10);
+  const atDayThreshold = classifyReleaseTagDrift('v1.0.0', 50, 45);
+  assert.equal(atCommitThreshold.warn, false);
+  assert.equal(atDayThreshold.warn, false);
+});
+
+test('classifyReleaseTagDrift coerces non-numeric commit/day values to 0', () => {
+  const verdict = classifyReleaseTagDrift('v1.0.0', 'not a number', NaN);
+  assert.equal(verdict.warn, false);
 });
 
 test('containsWorkshopReference accepts canonical, dotted, and absolute link targets', () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -983,14 +983,9 @@ test('classifyReleaseTagDrift warns when past the day threshold only', () => {
 });
 
 test('classifyReleaseTagDrift warns on both thresholds and names both in the message', () => {
-  const verdict = classifyReleaseTagDrift('v1.0.0', 636, 22);
-  // The 22-day figure alone is under the 45-day threshold; only the
-  // commit count crosses here -- covered separately above. Use values
-  // that exceed both to exercise the "and" join.
-  const bothOver = classifyReleaseTagDrift('v1.0.0', 636, 60);
+  const verdict = classifyReleaseTagDrift('v1.0.0', 636, 60);
   assert.equal(verdict.warn, true);
-  assert.equal(bothOver.warn, true);
-  assert.match(bothOver.message ?? '', /commit\(s\).*and.*day\(s\)/);
+  assert.match(verdict.message ?? '', /commit\(s\).*and.*day\(s\)/);
 });
 
 test('classifyReleaseTagDrift treats the threshold boundary as non-warning ("more than", not "at least")', () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1002,6 +1002,15 @@ test('classifyReleaseTagDrift coerces non-numeric commit/day values to 0', () =>
   assert.equal(verdict.warn, false);
 });
 
+test('classifyReleaseTagDrift rounds the printed day count up, never down to the threshold', () => {
+  // A floor here would print "45 day(s) (> 45)", which reads as
+  // self-contradictory since 45 is not greater than 45.
+  const verdict = classifyReleaseTagDrift('v1.0.0', 50, 45.1);
+  assert.equal(verdict.warn, true);
+  assert.match(verdict.message ?? '', /46 day\(s\) \(> 45\)/);
+  assert.doesNotMatch(verdict.message ?? '', /45 day\(s\)/);
+});
+
 test('containsWorkshopReference accepts canonical, dotted, and absolute link targets', () => {
   assert.equal(
     containsWorkshopReference('see [workshop](docs/workshop/README.md)'),


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Add a new `idd-doctor` check, `checkReleaseTagDrift`, that warns (never
fails) when `main` has drifted far from the latest release tag: more
than 100 commits, or more than 45 days, past the latest tag reachable
from HEAD (OR logic, whichever fires first). Skips silently when no
tag is reachable from HEAD yet (a fresh adopter clone before its first
release).

The pure classifier `classifyReleaseTagDrift` is exported and unit
tested directly (no real git repo needed), mirroring this file's
existing `classify*`/`check*` split (e.g.
`classifyWorktreeGuardActivation`/`checkWorktreeGuardActive`,
`classifyBacklog`/`checkPostMergeCleanupBacklog`). The thresholds and
their rationale are documented in a code comment next to the
classifier, citing this repository's own history (636 commits / ~22
days past `v0.3.0` as of 2026-07-03, under this repo's own atypically
heavy dogfooding velocity -- not a representative adopter cadence).

## Linked issue

Closes #1269

## Follow-up issues (if any)

- [x] #1286 -- `.github/workflows/idd-doctor.yml` uses a shallow
      checkout, so `checkReleaseTagDrift` (and any other tag-history
      dependent check) currently has no tag data to see in that
      workflow's own CI run. Deferred to a separate issue because
      fixing it requires editing `.github/workflows/**`, which this
      repository's ask-first policy gates separately from this PR.

## Background / rationale (if material)

#1217 decision point 3 asked whether a guard should exist for `main`
drifting far from the latest release tag; a concurrent session's
resolution of #1217 (#1260) explicitly left this decision undecided.
This issue/PR implements it as an advisory-only `idd-doctor` warning,
the same shape every other `idd-doctor` check already uses.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

