### PR TITLE
feat(policy): add the labels.* config namespace

### DIFF
--- a/fixtures/schemas/policy.valid.json
+++ b/fixtures/schemas/policy.valid.json
@@ -88,5 +88,10 @@
   "worktreeGuard": {
     "enabled": true,
     "branchPatterns": ["issue/*", "roadmap-audit/*"]
+  },
+  "labels": {
+    "roadmapLabelName": "roadmap",
+    "blockedByHumanLabelName": "status:blocked-by-human",
+    "needsDecisionLabelName": "status:needs-decision"
   }
 }

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -475,6 +475,24 @@
           "description": "Branch globs the guard treats as implementation branches that must not live in the primary worktree (default [\"issue/*\", \"roadmap-audit/*\"] when absent)."
         }
       }
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "roadmapLabelName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "blockedByHumanLabelName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "needsDecisionLabelName": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
     }
   },
   "patternProperties": {

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -106,6 +106,14 @@ export const POLICY_DEFAULTS = Object.freeze({
     authoringLabelName: 'status:authoring',
     authoringStaleAge: 'PT4H',
   }),
+  // Additive only (#1272): no consuming helper reads this namespace yet.
+  // Wiring the discover/claim/roadmap-audit label lookups to it is
+  // deferred to a follow-up issue (#1273).
+  labels: Object.freeze({
+    roadmapLabelName: 'roadmap',
+    blockedByHumanLabelName: 'status:blocked-by-human',
+    needsDecisionLabelName: 'status:needs-decision',
+  }),
 });
 export function parseProjectCommandRows(text) {
   const commands = new Map();
@@ -349,6 +357,25 @@ export function normalizePolicyConfig(config) {
       authoringStaleAge: parseDuration(
         c?.issueAuthoring?.authoringStaleAge,
         POLICY_DEFAULTS.issueAuthoring.authoringStaleAge,
+      ),
+    },
+    // Additive only (#1272): normalized here for shape parity with the
+    // clone(POLICY_DEFAULTS) early-return branch above (non-object
+    // input), but no consuming helper reads this namespace yet. Wiring
+    // the discover/claim/roadmap-audit label lookups to it is deferred
+    // to a follow-up issue (#1273).
+    labels: {
+      roadmapLabelName: parseNonEmptyString(
+        c?.labels?.roadmapLabelName,
+        POLICY_DEFAULTS.labels.roadmapLabelName,
+      ),
+      blockedByHumanLabelName: parseNonEmptyString(
+        c?.labels?.blockedByHumanLabelName,
+        POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+      ),
+      needsDecisionLabelName: parseNonEmptyString(
+        c?.labels?.needsDecisionLabelName,
+        POLICY_DEFAULTS.labels.needsDecisionLabelName,
       ),
     },
   };

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -73,6 +73,11 @@ interface RawConfig {
     authoringLabelName?: unknown;
     authoringStaleAge?: unknown;
   };
+  labels?: {
+    roadmapLabelName?: unknown;
+    blockedByHumanLabelName?: unknown;
+    needsDecisionLabelName?: unknown;
+  };
 }
 
 const HELPER_RUNTIME_PROFILES = new Set([
@@ -178,6 +183,14 @@ export const POLICY_DEFAULTS = Object.freeze({
     maxClarificationRounds: 3,
     authoringLabelName: 'status:authoring',
     authoringStaleAge: 'PT4H',
+  }),
+  // Additive only (#1272): no consuming helper reads this namespace yet.
+  // Wiring the discover/claim/roadmap-audit label lookups to it is
+  // deferred to a follow-up issue (#1273).
+  labels: Object.freeze({
+    roadmapLabelName: 'roadmap',
+    blockedByHumanLabelName: 'status:blocked-by-human',
+    needsDecisionLabelName: 'status:needs-decision',
   }),
 });
 
@@ -434,6 +447,25 @@ export function normalizePolicyConfig(config: unknown) {
       authoringStaleAge: parseDuration(
         c?.issueAuthoring?.authoringStaleAge,
         POLICY_DEFAULTS.issueAuthoring.authoringStaleAge,
+      ),
+    },
+    // Additive only (#1272): normalized here for shape parity with the
+    // clone(POLICY_DEFAULTS) early-return branch above (non-object
+    // input), but no consuming helper reads this namespace yet. Wiring
+    // the discover/claim/roadmap-audit label lookups to it is deferred
+    // to a follow-up issue (#1273).
+    labels: {
+      roadmapLabelName: parseNonEmptyString(
+        c?.labels?.roadmapLabelName,
+        POLICY_DEFAULTS.labels.roadmapLabelName,
+      ),
+      blockedByHumanLabelName: parseNonEmptyString(
+        c?.labels?.blockedByHumanLabelName,
+        POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+      ),
+      needsDecisionLabelName: parseNonEmptyString(
+        c?.labels?.needsDecisionLabelName,
+        POLICY_DEFAULTS.labels.needsDecisionLabelName,
       ),
     },
   };

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -522,6 +522,11 @@ test('policy normalization provides default-safe values and supports aliases', (
       authoringLabelName: 'status:authoring',
       authoringStaleAge: 'PT4H',
     },
+    labels: {
+      roadmapLabelName: 'roadmap',
+      blockedByHumanLabelName: 'status:blocked-by-human',
+      needsDecisionLabelName: 'status:needs-decision',
+    },
   });
 
   const defaultPolicy = normalizePolicyConfig(null);
@@ -597,6 +602,11 @@ test('policy normalization provides default-safe values and supports aliases', (
         authoringLabelName: 'status:drafting',
         authoringStaleAge: 'PT3H',
       },
+      labels: {
+        roadmapLabelName: 'epic',
+        blockedByHumanLabelName: 'blocked:human',
+        needsDecisionLabelName: 'needs:decision',
+      },
     }),
     {
       issueScope: 'orphan-first',
@@ -659,6 +669,11 @@ test('policy normalization provides default-safe values and supports aliases', (
         maxClarificationRounds: 4,
         authoringLabelName: 'status:drafting',
         authoringStaleAge: 'PT3H',
+      },
+      labels: {
+        roadmapLabelName: 'epic',
+        blockedByHumanLabelName: 'blocked:human',
+        needsDecisionLabelName: 'needs:decision',
       },
     },
   );

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -32,8 +32,11 @@ test('issueScope defaults to roadmap-first and accepts all values', () => {
 
 test('POLICY_DEFAULTS.labels exposes the three reserved label name defaults', () => {
   // Additive only (#1272): POLICY_DEFAULTS carries the literal defaults,
-  // but normalizePolicyConfig does not parse this namespace yet — no
-  // consuming helper reads it until the follow-up (#1273) wires it up.
+  // and normalizePolicyConfig normalizes this namespace too (for shape
+  // parity — see its labels branch), but no consuming helper outside
+  // policy-helpers.mts reads it yet. Wiring the discover/claim/
+  // roadmap-audit label lookups to it is deferred to the follow-up
+  // (#1273).
   assert.deepEqual(POLICY_DEFAULTS.labels, {
     roadmapLabelName: 'roadmap',
     blockedByHumanLabelName: 'status:blocked-by-human',

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -30,6 +30,17 @@ test('issueScope defaults to roadmap-first and accepts all values', () => {
   );
 });
 
+test('POLICY_DEFAULTS.labels exposes the three reserved label name defaults', () => {
+  // Additive only (#1272): POLICY_DEFAULTS carries the literal defaults,
+  // but normalizePolicyConfig does not parse this namespace yet — no
+  // consuming helper reads it until the follow-up (#1273) wires it up.
+  assert.deepEqual(POLICY_DEFAULTS.labels, {
+    roadmapLabelName: 'roadmap',
+    blockedByHumanLabelName: 'status:blocked-by-human',
+    needsDecisionLabelName: 'status:needs-decision',
+  });
+});
+
 test('parseIsoDurationToMs parses supported ISO durations', () => {
   assert.equal(parseIsoDurationToMs('PT5S'), 5000);
   assert.equal(parseIsoDurationToMs('PT2H'), 2 * 60 * 60 * 1000);

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -224,6 +224,11 @@ interface PolicyConfigFile {
   };
   autopilotSuitability?: { floor?: 1 | 2 | 3 | 4 | 5; enabled?: boolean };
   worktreeGuard?: { enabled?: boolean; branchPatterns?: readonly string[] };
+  labels?: {
+    roadmapLabelName?: string;
+    blockedByHumanLabelName?: string;
+    needsDecisionLabelName?: string;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -384,6 +389,7 @@ export const policyConfigKeys = [
   'issueAuthoring',
   'autopilotSuitability',
   'worktreeGuard',
+  'labels',
 ] as const satisfies readonly (keyof PolicyConfigFile)[];
 
 // PreMergeReadinessReport is index-signature typed (its summary builder
@@ -755,6 +761,11 @@ const policyConfigFixture = {
   worktreeGuard: {
     enabled: true,
     branchPatterns: ['issue/*', 'roadmap-audit/*'],
+  },
+  labels: {
+    roadmapLabelName: 'roadmap',
+    blockedByHumanLabelName: 'status:blocked-by-human',
+    needsDecisionLabelName: 'status:needs-decision',
   },
 } satisfies PolicyConfigFile;
 

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -1508,6 +1508,124 @@ test('policy schema rejects issueAuthoring unexpected extra keys', () => {
   );
 });
 
+test('policy schema accepts labels with all three fields', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = {
+    roadmapLabelName: 'roadmap',
+    blockedByHumanLabelName: 'status:blocked-by-human',
+    needsDecisionLabelName: 'status:needs-decision',
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test('policy schema accepts missing labels object', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  delete instance.labels;
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test('policy schema accepts labels without roadmapLabelName', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = {
+    blockedByHumanLabelName: 'status:blocked-by-human',
+    needsDecisionLabelName: 'status:needs-decision',
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test('policy schema accepts labels without blockedByHumanLabelName', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = {
+    roadmapLabelName: 'roadmap',
+    needsDecisionLabelName: 'status:needs-decision',
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test('policy schema accepts labels without needsDecisionLabelName', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = {
+    roadmapLabelName: 'roadmap',
+    blockedByHumanLabelName: 'status:blocked-by-human',
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test('policy schema rejects labels roadmapLabelName empty string', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = { roadmapLabelName: '' };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((e) => e.includes('labels.roadmapLabelName')),
+    errors.join('\n'),
+  );
+});
+
+test('policy schema rejects labels blockedByHumanLabelName empty string', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = { blockedByHumanLabelName: '' };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((e) => e.includes('labels.blockedByHumanLabelName')),
+    errors.join('\n'),
+  );
+});
+
+test('policy schema rejects labels needsDecisionLabelName empty string', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = { needsDecisionLabelName: '' };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((e) => e.includes('labels.needsDecisionLabelName')),
+    errors.join('\n'),
+  );
+});
+
+test('policy schema rejects labels unexpected extra keys', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = {
+    roadmapLabelName: 'roadmap',
+    unexpectedKey: true,
+  };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((e) => e.includes('$.labels') && e.includes('"unexpectedKey"')),
+    errors.join('\n'),
+  );
+});
+
 test('policy schema accepts forcedHandoff.mode human-gated', () => {
   const schema = loadJson('schemas/policy.schema.json');
   const instance = JSON.parse(


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Add a `labels` policy namespace so adopters with an existing label
taxonomy can eventually reconfigure the three reserved IDD label names
(`roadmap`, `status:blocked-by-human`, `status:needs-decision`) instead
of hand-editing every instruction file and helper that hard-codes them.
This PR is additive only: schema + defaults, no consuming helper wired
yet.

- `schemas/policy.schema.json`: new top-level `labels` object, shaped
  exactly like the existing `approvalSignals` block (`type: object`,
  `additionalProperties: false`, three optional `minLength: 1` string
  fields: `roadmapLabelName`, `blockedByHumanLabelName`,
  `needsDecisionLabelName`).
- `src/scripts/policy-helpers.mts`: matching frozen
  `POLICY_DEFAULTS.labels` sub-object with the current hard-coded
  values as defaults, plus a `normalizePolicyConfig` parsing branch for
  the same three fields (see Background below for why the parsing
  branch needed to be added too).
- `scripts/policy-helpers.mjs`: regenerated build artifact.
- Test coverage: `tests/schema-type-reconciliation.test.mts` (schema
  ⇄ type key-parity), `tests/schema-validation.test.mts` (accepts/
  rejects cases mirroring the `issueAuthoring` block), and
  `tests/policy-helpers.test.mts` / `tests/consistency.test.mts`
  (`POLICY_DEFAULTS.labels` defaults and `normalizePolicyConfig`
  aliasing/override behavior).

## Linked issue

Closes #1272

## Follow-up issues (if any)

- [ ] none (#1273, #1274, #1275 are pre-existing siblings already filed
      under the parent roadmap and are unblocked by this merge, not new
      follow-ups created by this PR)

## Background / rationale (if material)

The issue's acceptance criteria named only `POLICY_DEFAULTS.labels`,
and I initially planned to leave `normalizePolicyConfig` untouched
(its `RawConfig` view is documented as intentionally covering only
"the namespaces that helper consumes"). Running the test suite
surfaced a real shape inconsistency instead of a simple stale fixture:
`normalizePolicyConfig(null)` (and any non-object input) early-returns
a full `clone(POLICY_DEFAULTS)`, which now includes `labels` for free,
while `normalizePolicyConfig({})` goes through the explicit
field-by-field construction branch, which would omit `labels` entirely
if left alone. Left as-is, the two branches would disagree on
`normalizePolicyConfig(...).labels` depending purely on whether the
input was `null`-ish vs. a real object — a latent bug for the #1273
follow-up to trip over. I completed the parsing branch (same
`parseNonEmptyString` pattern as `issueAuthoring.authoringLabelName`)
so both paths agree; no consuming helper outside `policy-helpers.mts`
reads `.labels` yet, so this stays additive in effect.

Per the issue text, `issueAuthoring.authoringLabelName` was left
untouched (different label, out of this roadmap's scope per #1218).
`docs/policy-constants.md`'s namespace-listing prose was left
unchanged too — it is not mechanically enforced (verified: no
consistency/audit-docs check references it), and the issue's
`## Candidate files` list names only the three files in Summary above.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable; no
      `.github/instructions/` or template sources changed)
- [ ] `node scripts/idd-doctor.mjs` (not applicable; no claim/worktree/
      CI-gate behavior changed)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
