### PR TITLE
feat(idd-doctor): warn on node_modules/lockfile version drift

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -55,6 +55,7 @@ export function runDoctor({
   checkPolicySignals(root, report);
   checkHelperRuntimeConfig(root, report);
   checkClaimTimingConsistency(root, report);
+  checkDependencyVersionDrift(root, report);
   checkAgentEntryFiles(root, report);
   checkTemplateVersionSignal(root, report);
   const worktreeGuardEnforced =
@@ -924,6 +925,123 @@ export function checkClaimTimingConsistency(root, report) {
   const finding = classifyClaimTimingConsistency(claimTiming, overviewCoreText);
   if (finding) {
     report.warnings.push(finding.message);
+  }
+}
+// The two packages implicated in the #1164 incident: a stale node_modules
+// install silently masked a real `pnpm run typecheck` break on fresh
+// installs, because the break only surfaced once `@types/node` was
+// actually installed at its lockfile-resolved version. Kept as a single
+// array literal so extending coverage to another package is a one-line
+// change, not a redesign.
+const DEPENDENCY_VERSION_DRIFT_PACKAGES = ['typescript', '@types/node'];
+/**
+ * Extract the resolved `version:` pinned for `packageName` under the root
+ * `.` importer's `dependencies`/`devDependencies` maps in a `pnpm-lock.yaml`
+ * text (lockfileVersion 9's nested `specifier:`/`version:` shape). Pure (no
+ * I/O) so it can be unit-tested directly. Returns `null` when the
+ * `importers:` section, the root `.` importer, or the named package's own
+ * entry cannot be found — a miss here is a staleness signal, not a
+ * required-file check, so the caller must skip silently rather than treat
+ * `null` as an error. A version resolved with a trailing peer-dependency
+ * annotation (e.g. `21.2.0(@types/node@26.1.0)`) is stripped down to the
+ * bare version so it compares cleanly against an installed package's plain
+ * `package.json` `version` field.
+ */
+export function parseLockfileImporterVersion(lockfileText, packageName) {
+  if (typeof lockfileText !== 'string' || lockfileText.length === 0) {
+    return null;
+  }
+  const normalized = lockfileText.replace(/\r\n/g, '\n');
+  const importersIndex = normalized.indexOf('\nimporters:');
+  if (importersIndex === -1) {
+    return null;
+  }
+  const rootMarker = '\n  .:\n';
+  const rootIndex = normalized.indexOf(rootMarker, importersIndex);
+  if (rootIndex === -1) {
+    return null;
+  }
+  const blockStart = rootIndex + rootMarker.length;
+  // The root importer's own block ends at the next line indented 2
+  // columns or fewer: either a sibling importer entry (workspace repos)
+  // or a top-level key such as `packages:`.
+  const boundaryMatch = /\n {0,2}\S/.exec(normalized.slice(blockStart));
+  const blockEnd = boundaryMatch
+    ? blockStart + (boundaryMatch.index ?? 0)
+    : normalized.length;
+  const block = normalized.slice(blockStart, blockEnd);
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const entryPattern = new RegExp(
+    `\\n {6}'?${escaped}'?:\\n(?:.*\\n)*? {8}version: *([^\\n]+)`,
+  );
+  const match = entryPattern.exec(block);
+  if (!match) {
+    return null;
+  }
+  const bare = match[1]
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .split('(')[0]
+    .trim();
+  return bare.length > 0 ? bare : null;
+}
+/**
+ * Compare each package's installed `node_modules` version against what
+ * `pnpm-lock.yaml` resolves for it, and produce one warning string for
+ * every entry where both sides are known and differ. Pure (no I/O) so it
+ * can be unit-tested directly. An entry with either side unknown (package
+ * not installed, or not found in the lockfile) is a staleness signal only
+ * — skipped without a warning, per this check's acceptance criteria.
+ */
+export function evaluateDependencyVersionDrift(entries) {
+  const warnings = [];
+  for (const { name, installed, resolved } of entries) {
+    if (!installed || !resolved || installed === resolved) {
+      continue;
+    }
+    warnings.push(
+      `dependency version drift: node_modules/${name} is installed at ${installed}, but pnpm-lock.yaml resolves ${resolved}. Run pnpm install to sync node_modules with the lockfile.`,
+    );
+  }
+  return warnings;
+}
+function readInstalledPackageVersion(root, name) {
+  const packageJsonPath = join(root, 'node_modules', name, 'package.json');
+  if (!exists(packageJsonPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    return typeof parsed.version === 'string' ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+/**
+ * Warn (never fail) when the installed `node_modules/typescript` or
+ * `node_modules/@types/node` version drifts from what `pnpm-lock.yaml`
+ * resolves for this project's own root dependency. This is the local
+ * diagnostic half of the #1198 fix: it surfaces a stale local install
+ * *before* an agent chases a phantom typecheck failure caused by it — see
+ * the #1164 incident, where a stale `@types/node` install masked a real
+ * break for fresh installs. Skips silently (no warning, no error) when
+ * `pnpm-lock.yaml`, `node_modules`, or a package's matching lockfile entry
+ * is absent; this is a staleness signal, not a required-file check.
+ */
+export function checkDependencyVersionDrift(root, report) {
+  let lockfileText;
+  try {
+    lockfileText = readFileSync(join(root, 'pnpm-lock.yaml'), 'utf8');
+  } catch {
+    return;
+  }
+  const entries = DEPENDENCY_VERSION_DRIFT_PACKAGES.map((name) => ({
+    name,
+    installed: readInstalledPackageVersion(root, name),
+    resolved: parseLockfileImporterVersion(lockfileText, name),
+  }));
+  for (const warning of evaluateDependencyVersionDrift(entries)) {
+    report.warnings.push(warning);
   }
 }
 function checkAgentEntryFiles(root, report) {

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -128,6 +128,7 @@ export function runDoctor({
   checkPolicySignals(root, report);
   checkHelperRuntimeConfig(root, report);
   checkClaimTimingConsistency(root, report);
+  checkDependencyVersionDrift(root, report);
   checkAgentEntryFiles(root, report);
   checkTemplateVersionSignal(root, report);
   const worktreeGuardEnforced =
@@ -1108,6 +1109,151 @@ export function checkClaimTimingConsistency(
   const finding = classifyClaimTimingConsistency(claimTiming, overviewCoreText);
   if (finding) {
     report.warnings.push(finding.message);
+  }
+}
+
+/** One package's installed-vs-lockfile version comparison input. */
+export interface DependencyVersionDriftEntry {
+  name: string;
+  installed: string | null;
+  resolved: string | null;
+}
+
+// The two packages implicated in the #1164 incident: a stale node_modules
+// install silently masked a real `pnpm run typecheck` break on fresh
+// installs, because the break only surfaced once `@types/node` was
+// actually installed at its lockfile-resolved version. Kept as a single
+// array literal so extending coverage to another package is a one-line
+// change, not a redesign.
+const DEPENDENCY_VERSION_DRIFT_PACKAGES = ['typescript', '@types/node'];
+
+/**
+ * Extract the resolved `version:` pinned for `packageName` under the root
+ * `.` importer's `dependencies`/`devDependencies` maps in a `pnpm-lock.yaml`
+ * text (lockfileVersion 9's nested `specifier:`/`version:` shape). Pure (no
+ * I/O) so it can be unit-tested directly. Returns `null` when the
+ * `importers:` section, the root `.` importer, or the named package's own
+ * entry cannot be found — a miss here is a staleness signal, not a
+ * required-file check, so the caller must skip silently rather than treat
+ * `null` as an error. A version resolved with a trailing peer-dependency
+ * annotation (e.g. `21.2.0(@types/node@26.1.0)`) is stripped down to the
+ * bare version so it compares cleanly against an installed package's plain
+ * `package.json` `version` field.
+ */
+export function parseLockfileImporterVersion(
+  lockfileText: string,
+  packageName: string,
+): string | null {
+  if (typeof lockfileText !== 'string' || lockfileText.length === 0) {
+    return null;
+  }
+  const normalized = lockfileText.replace(/\r\n/g, '\n');
+  const importersIndex = normalized.indexOf('\nimporters:');
+  if (importersIndex === -1) {
+    return null;
+  }
+  const rootMarker = '\n  .:\n';
+  const rootIndex = normalized.indexOf(rootMarker, importersIndex);
+  if (rootIndex === -1) {
+    return null;
+  }
+  const blockStart = rootIndex + rootMarker.length;
+  // The root importer's own block ends at the next line indented 2
+  // columns or fewer: either a sibling importer entry (workspace repos)
+  // or a top-level key such as `packages:`.
+  const boundaryMatch = /\n {0,2}\S/.exec(normalized.slice(blockStart));
+  const blockEnd = boundaryMatch
+    ? blockStart + (boundaryMatch.index ?? 0)
+    : normalized.length;
+  const block = normalized.slice(blockStart, blockEnd);
+
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const entryPattern = new RegExp(
+    `\\n {6}'?${escaped}'?:\\n(?:.*\\n)*? {8}version: *([^\\n]+)`,
+  );
+  const match = entryPattern.exec(block);
+  if (!match) {
+    return null;
+  }
+  const bare = match[1]
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .split('(')[0]
+    .trim();
+  return bare.length > 0 ? bare : null;
+}
+
+/**
+ * Compare each package's installed `node_modules` version against what
+ * `pnpm-lock.yaml` resolves for it, and produce one warning string for
+ * every entry where both sides are known and differ. Pure (no I/O) so it
+ * can be unit-tested directly. An entry with either side unknown (package
+ * not installed, or not found in the lockfile) is a staleness signal only
+ * — skipped without a warning, per this check's acceptance criteria.
+ */
+export function evaluateDependencyVersionDrift(
+  entries: DependencyVersionDriftEntry[],
+): string[] {
+  const warnings: string[] = [];
+  for (const { name, installed, resolved } of entries) {
+    if (!installed || !resolved || installed === resolved) {
+      continue;
+    }
+    warnings.push(
+      `dependency version drift: node_modules/${name} is installed at ${installed}, but pnpm-lock.yaml resolves ${resolved}. Run pnpm install to sync node_modules with the lockfile.`,
+    );
+  }
+  return warnings;
+}
+
+function readInstalledPackageVersion(
+  root: string,
+  name: string,
+): string | null {
+  const packageJsonPath = join(root, 'node_modules', name, 'package.json');
+  if (!exists(packageJsonPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      version?: unknown;
+    };
+    return typeof parsed.version === 'string' ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Warn (never fail) when the installed `node_modules/typescript` or
+ * `node_modules/@types/node` version drifts from what `pnpm-lock.yaml`
+ * resolves for this project's own root dependency. This is the local
+ * diagnostic half of the #1198 fix: it surfaces a stale local install
+ * *before* an agent chases a phantom typecheck failure caused by it — see
+ * the #1164 incident, where a stale `@types/node` install masked a real
+ * break for fresh installs. Skips silently (no warning, no error) when
+ * `pnpm-lock.yaml`, `node_modules`, or a package's matching lockfile entry
+ * is absent; this is a staleness signal, not a required-file check.
+ */
+export function checkDependencyVersionDrift(
+  root: string,
+  report: DoctorReport,
+) {
+  let lockfileText: string;
+  try {
+    lockfileText = readFileSync(join(root, 'pnpm-lock.yaml'), 'utf8');
+  } catch {
+    return;
+  }
+
+  const entries: DependencyVersionDriftEntry[] =
+    DEPENDENCY_VERSION_DRIFT_PACKAGES.map((name) => ({
+      name,
+      installed: readInstalledPackageVersion(root, name),
+      resolved: parseLockfileImporterVersion(lockfileText, name),
+    }));
+  for (const warning of evaluateDependencyVersionDrift(entries)) {
+    report.warnings.push(warning);
   }
 }
 

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -7,6 +7,7 @@ import { test } from 'node:test';
 import {
   backLinkPatternFor,
   checkClaimTimingConsistency,
+  checkDependencyVersionDrift,
   checkProjectCommands,
   classifyBacklog,
   classifyClaimTimingConsistency,
@@ -20,6 +21,7 @@ import {
   decodeGithubReadmeBase64,
   emitCleanupBacklogProgress,
   evaluateAutopilotSuitabilityConsistency,
+  evaluateDependencyVersionDrift,
   evaluateMarkerPrefixConsistency,
   extractMarkerPrefixes,
   findMissingWorkshopReferences,
@@ -30,6 +32,7 @@ import {
   hookWiresWorktreeGuard,
   isGithubBackLinkHost,
   parseIsoDurationToHours,
+  parseLockfileImporterVersion,
   parsePrimaryWorktreePath,
   parseProjectCommandRows,
   parseThresholdsProseHours,
@@ -1901,6 +1904,203 @@ test('checkClaimTimingConsistency pushes no warning when config and prose agree,
     checkClaimTimingConsistency(dir, missingConfigReport);
     assert.equal(missingConfigReport.warnings.length, 0);
     assert.equal(missingConfigReport.errors.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const MINIMAL_LOCKFILE_WITH_DEPS = `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@commitlint/cli':
+        specifier: ^21.0.2
+        version: 21.2.0(@types/node@26.1.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
+      '@types/node':
+        specifier: 26.1.0
+        version: 26.1.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+packages:
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-fake==}
+    hasBin: true
+`;
+
+test('parseLockfileImporterVersion resolves a quoted scoped package under the root importer', () => {
+  assert.equal(
+    parseLockfileImporterVersion(MINIMAL_LOCKFILE_WITH_DEPS, '@types/node'),
+    '26.1.0',
+  );
+});
+
+test('parseLockfileImporterVersion resolves an unquoted package under the root importer', () => {
+  assert.equal(
+    parseLockfileImporterVersion(MINIMAL_LOCKFILE_WITH_DEPS, 'typescript'),
+    '6.0.3',
+  );
+});
+
+test('parseLockfileImporterVersion strips a trailing peer-dependency annotation', () => {
+  assert.equal(
+    parseLockfileImporterVersion(MINIMAL_LOCKFILE_WITH_DEPS, '@commitlint/cli'),
+    '21.2.0',
+  );
+});
+
+test('parseLockfileImporterVersion returns null for a package absent from the root importer', () => {
+  assert.equal(
+    parseLockfileImporterVersion(
+      MINIMAL_LOCKFILE_WITH_DEPS,
+      'not-a-real-package',
+    ),
+    null,
+  );
+});
+
+test('parseLockfileImporterVersion returns null when the lockfile has no importers section', () => {
+  assert.equal(
+    parseLockfileImporterVersion("lockfileVersion: '9.0'\n", 'typescript'),
+    null,
+  );
+});
+
+test('parseLockfileImporterVersion returns null when the root "." importer is absent (workspace-only lockfile)', () => {
+  const workspaceOnly = `lockfileVersion: '9.0'
+
+importers:
+
+  packages/foo:
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+packages:
+`;
+  assert.equal(parseLockfileImporterVersion(workspaceOnly, 'typescript'), null);
+});
+
+test('parseLockfileImporterVersion returns null for empty or non-string input', () => {
+  assert.equal(parseLockfileImporterVersion('', 'typescript'), null);
+});
+
+test('evaluateDependencyVersionDrift warns when installed and resolved versions differ', () => {
+  const warnings = evaluateDependencyVersionDrift([
+    { name: 'typescript', installed: '5.9.0', resolved: '6.0.3' },
+  ]);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /node_modules\/typescript is installed at 5\.9\.0/);
+  assert.match(warnings[0], /pnpm-lock\.yaml resolves 6\.0\.3/);
+});
+
+test('evaluateDependencyVersionDrift is silent when versions match', () => {
+  assert.deepEqual(
+    evaluateDependencyVersionDrift([
+      { name: 'typescript', installed: '6.0.3', resolved: '6.0.3' },
+    ]),
+    [],
+  );
+});
+
+test('evaluateDependencyVersionDrift skips (no warning) when either side is unknown', () => {
+  assert.deepEqual(
+    evaluateDependencyVersionDrift([
+      { name: 'typescript', installed: null, resolved: '6.0.3' },
+      { name: '@types/node', installed: '26.1.0', resolved: null },
+    ]),
+    [],
+  );
+});
+
+test('evaluateDependencyVersionDrift reports only the mismatching entries out of several', () => {
+  const warnings = evaluateDependencyVersionDrift([
+    { name: 'typescript', installed: '6.0.3', resolved: '6.0.3' },
+    { name: '@types/node', installed: '22.19.21', resolved: '26.1.0' },
+  ]);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /@types\/node/);
+});
+
+function makeDependencyDriftFixture(options: {
+  withLockfile?: boolean;
+  installed?: Record<string, string>;
+}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-dep-drift-'));
+  if (options.withLockfile !== false) {
+    writeFileSync(join(dir, 'pnpm-lock.yaml'), MINIMAL_LOCKFILE_WITH_DEPS);
+  }
+  for (const [name, version] of Object.entries(options.installed ?? {})) {
+    const pkgDir = join(dir, 'node_modules', name);
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name, version }),
+    );
+  }
+  return dir;
+}
+
+test('checkDependencyVersionDrift warns on a genuine installed-vs-lockfile mismatch', () => {
+  const dir = makeDependencyDriftFixture({
+    installed: { typescript: '5.9.0', '@types/node': '26.1.0' },
+  });
+  try {
+    const report = emptyReport(dir);
+    checkDependencyVersionDrift(dir, report);
+    assert.equal(report.errors.length, 0);
+    assert.equal(report.warnings.length, 1);
+    assert.match(report.warnings[0], /typescript is installed at 5\.9\.0/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkDependencyVersionDrift is silent when installed versions match the lockfile', () => {
+  const dir = makeDependencyDriftFixture({
+    installed: { typescript: '6.0.3', '@types/node': '26.1.0' },
+  });
+  try {
+    const report = emptyReport(dir);
+    checkDependencyVersionDrift(dir, report);
+    assert.equal(report.errors.length, 0);
+    assert.equal(report.warnings.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkDependencyVersionDrift skips silently when pnpm-lock.yaml is absent', () => {
+  const dir = makeDependencyDriftFixture({
+    withLockfile: false,
+    installed: { typescript: '5.9.0', '@types/node': '22.19.21' },
+  });
+  try {
+    const report = emptyReport(dir);
+    checkDependencyVersionDrift(dir, report);
+    assert.equal(report.errors.length, 0);
+    assert.equal(report.warnings.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkDependencyVersionDrift skips silently when node_modules packages are absent', () => {
+  const dir = makeDependencyDriftFixture({ installed: {} });
+  try {
+    const report = emptyReport(dir);
+    checkDependencyVersionDrift(dir, report);
+    assert.equal(report.errors.length, 0);
+    assert.equal(report.warnings.length, 0);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
# Summary

Add `checkDependencyVersionDrift` to `runDoctor()` in
`src/scripts/idd-doctor.mts`: it warns (never fails) when the installed
`node_modules/typescript` or `node_modules/@types/node` version drifts
from what `pnpm-lock.yaml` resolves for this project's own root
dependency.

## Linked issue

Closes #1265

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

On 2026-06-?? (#1164) a Dependabot bump of `@types/node` (22.19.21 →
26.1.0) narrowed `assert.ok`'s `message` parameter typing and broke
`pnpm run typecheck` on any fresh `pnpm install --frozen-lockfile`. The
break stayed invisible on the primary worktree because it still had a
stale `@types/node` 22.x installed, and diagnosing it required manually
diffing `node_modules/@types/node/package.json` between a stale
worktree and a fresh sibling worktree. This is the local diagnostic
half of the fix decided in #1198 (option 1) — a signal an agent or
maintainer can see *before* chasing a phantom error caused by a stale
local install.

Two new pure, unit-tested helpers do the work:

- `parseLockfileImporterVersion(lockfileText, packageName)` — extracts
  the resolved `version:` pinned for `packageName` under the root `.`
  importer's `dependencies`/`devDependencies` maps in `pnpm-lock.yaml`
  (lockfileVersion 9's nested `specifier:`/`version:` shape). Returns
  `null` on any parse miss (absent importer, absent package) rather
  than throwing, since a miss is a staleness signal, not an error.
- `evaluateDependencyVersionDrift(entries)` — compares each
  `{ name, installed, resolved }` entry and emits a warning only when
  both sides are known and differ.

`checkDependencyVersionDrift` wires these to `node_modules/*/package.json`
reads and only ever pushes to `report.warnings` (never `report.errors`),
so `idd-doctor`'s exit code is unaffected. It skips silently when
`pnpm-lock.yaml`, `node_modules`, or a package's matching lockfile entry
is absent.

No new dependency was added for YAML parsing — the extraction is a
regex scoped to the root importer's block, matching this file's
existing convention of lightweight text extraction for this class of
check (e.g. `parseThresholdsProseHours`, `extractMarkerPrefixes`).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
