### PR TITLE
feat(ci): strip CodeRabbit-applied reserved IDD labels

### DIFF
--- a/.github/workflows/strip-untrusted-labels.yml
+++ b/.github/workflows/strip-untrusted-labels.yml
@@ -1,0 +1,61 @@
+# Trust model: this workflow triggers on `issues: labeled`, which fires once
+# per label application and carries both `label.name` and `sender.login` (the
+# actor who applied that specific label) in the event payload -- no extra API
+# call is needed to attribute the mutation to an actor.
+#   - The job runs only when BOTH hold for this one event:
+#     `github.event.sender.login` equals `coderabbitai[bot]` (the actor that
+#     applied *this* label, confirmed via the REST API `user.login` /
+#     `type: Bot` shape -- not the GraphQL-rendered login some `gh` read
+#     paths shorten), AND `github.event.label.name` is a reserved IDD
+#     operational label: the exact `roadmap` label, or any label whose name
+#     starts with `status:`.
+#   - This is fail-safe by construction against ever re-fighting a human: a
+#     human re-adding the same label afterward is a *separate* `labeled`
+#     event whose `sender.login` is the human, not `coderabbitai[bot]`, so
+#     the condition above does not match and the human's re-add is left
+#     untouched. The guard never diffs current label state against a human
+#     decision -- it only ever reacts to the one label-add event it already
+#     fail-closed-matched by actor and label name.
+#   - No repository content is checked out (this job never runs
+#     `actions/checkout`) and no code from the issue body, comments, or
+#     label metadata is executed. The job's only action is a single `gh`
+#     call that removes one already-known label from one already-known
+#     issue via the REST API; both values come from the trusted event
+#     payload and are passed through environment variables, never
+#     interpolated directly into a shell command string.
+#   - `permissions:` stays least-privilege: `issues: write` only -- no
+#     `contents`, `pull-requests`, or other elevated scopes.
+# If a future change widens the trigger, adds repository checkout, executes
+# issue-supplied content, or broadens `permissions:`, re-review this trust
+# model before merging that change.
+name: Strip untrusted reserved IDD labels
+on:
+  issues:
+    types:
+      - labeled
+permissions:
+  issues: write
+concurrency:
+  group: strip-untrusted-labels-${{ github.event.issue.number }}-${{ github.event.label.name }}
+  cancel-in-progress: true
+jobs:
+  strip-label:
+    # Reserved set: the exact `roadmap` label, or any operational `status:*`
+    # label (currently `status:authoring`, `status:needs-decision`,
+    # `status:blocked-by-human`; the prefix match also covers any future
+    # `status:*` label without needing to edit this condition).
+    if: |-
+      github.event.sender.login == 'coderabbitai[bot]' && (github.event.label.name == 'roadmap' || startsWith(github.event.label.name, 'status:'))
+    runs-on: ubuntu-slim
+    # A single `gh issue edit` REST call; observed comparable single-call
+    # jobs in this repository complete in well under a minute. 5 min bounds
+    # a pathological hang with generous headroom.
+    timeout-minutes: 5
+    steps:
+      - name: Remove reserved label applied by CodeRabbit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL_NAME"

--- a/.github/workflows/strip-untrusted-labels.yml
+++ b/.github/workflows/strip-untrusted-labels.yml
@@ -4,9 +4,10 @@
 # call is needed to attribute the mutation to an actor.
 #   - The job runs only when BOTH hold for this one event:
 #     `github.event.sender.login` equals `coderabbitai[bot]` (the actor that
-#     applied *this* label, confirmed via the REST API `user.login` /
-#     `type: Bot` shape -- not the GraphQL-rendered login some `gh` read
-#     paths shorten), AND `github.event.label.name` is a reserved IDD
+#     applied *this* label, confirmed via the REST simple-user object's
+#     `login` + `type: Bot` fields directly on `sender` -- not the
+#     GraphQL-rendered login some `gh` read paths shorten), AND
+#     `github.event.label.name` is a reserved IDD
 #     operational label: the exact `roadmap` label, or any label whose name
 #     starts with `status:`.
 #   - This is fail-safe by construction against ever re-fighting a human: a


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Add `.github/workflows/strip-untrusted-labels.yml`, a repo-side guard
that removes a reserved IDD operational label (`roadmap` or any
`status:*` label) the instant CodeRabbit's issue auto-labeler applies
it, while never touching the same label when a human applies it.

CodeRabbit's issue auto-labeler has repeatedly applied reserved IDD
labels it should never touch: `status:authoring` was re-applied to
#1155 roughly 12 seconds after a session removed it, and `roadmap` has
previously been auto-applied to a non-roadmap child issue. CodeRabbit
has no true label-allowlist capability, so a `.coderabbit.yaml` change
cannot fix this (confirmed in #1268's background research) — only a
repo-side guard can.

## Linked issue

Closes #1268

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Design**: triggers on `issues: types: [labeled]`. The job's `if:`
gate requires **both**, evaluated against the single triggering event
only:

- `github.event.sender.login == 'coderabbitai[bot]'`
- `github.event.label.name == 'roadmap'` OR
  `startsWith(github.event.label.name, 'status:')`

**Why this can never re-fight a human**: the guard reacts to one
`labeled` event at a time. A human re-adding the same label afterward
is a *separate* event whose `sender.login` is the human, not
`coderabbitai[bot]`, so the condition does not match and the human's
re-add is left untouched. The guard never diffs current label state
against a past human decision — it only ever reacts to the one
label-add event it already matched by actor and label name.

**Trust model / least privilege**: no `actions/checkout` step (the job
never checks out repository code or executes issue-supplied content);
`permissions: issues: write` only; the label name and issue number come
from the event payload via environment variables, never interpolated
directly into the shell command string. A full inline trust-model
comment sits at the top of the file, mirroring the convention already
established in `post-merge-cleanup.yml`.

**Prefix match covers future labels**: `status:*` currently covers
`status:authoring`, `status:needs-decision`, and
`status:blocked-by-human` without listing them individually, so a
future `status:*` label needs no edit to this file.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed — new workflow
  under `.github/workflows/**`; operator confirmation was obtained on
  the issue before this PR was opened (ask-first gate in
  `docs/permissions.md`).

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

**Workflow-specific verification** (a real `issues.labeled` event can't
be safely triggered pre-merge without mutating a live issue, so this
was verified with `act`'s dry-run mode — GitHub's own expression
evaluator, no containers executed and no network calls made — against
six fixture event payloads covering the full actor × label matrix):

| sender                | label                   | expected | result |
| ---------------------- | ----------------------- | -------- | ------ |
| `coderabbitai[bot]`   | `roadmap`               | fires    | fires  |
| `coderabbitai[bot]`   | `status:authoring`      | fires    | fires  |
| `coderabbitai[bot]`   | `status:needs-decision` | fires (prefix match) | fires |
| `coderabbitai[bot]`   | `bug`                   | no-op    | no-op  |
| `kurone-kito` (human) | `status:authoring`      | no-op    | no-op  |
| `kurone-kito` (human) | `roadmap`               | no-op    | no-op  |

`act -v` confirmed the exact expression evaluation for each case, e.g.
for the human-relabel case (the safety-critical one):

```text
[DEBUG] evaluating expression 'github.event.sender.login == '\''coderabbitai[bot]'\'' && (github.event.label.name == '\''roadmap'\'' || startsWith(github.event.label.name, '\''status:'\''))'
[DEBUG] expression '...' evaluated to 'false'
[DEBUG] Skipping job 'strip-label' due to '...'
```

and for a prefix-matched positive case:

```text
[DEBUG] expression '...' evaluated to 'true'
✅  Success - Main Remove reserved label applied by CodeRabbit
```

All six cases matched the expected outcome. Separately confirmed via
the REST API (`gh api repos/.../issues/1268/comments` /
`.../timeline`) that a `Bot`-typed actor's `login` is rendered with the
`[bot]` suffix (`coderabbitai[bot]`) in the shape the webhook payload
actually uses — the same convention this repo's
`.github/idd/config.json` `advisoryBotLogins` already relies on — so
the `if:` condition's literal string match is correct.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
