### PR TITLE
fix(discover): stop flagging closed-leaf Refs back-edges as cycles

### DIFF
--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -431,6 +431,21 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
         }
       }
       if (path.includes(edge.target)) {
+        // #1278: a plain `Refs` back-reference from a CLOSED non-roadmap leaf
+        // to an ancestor is the provenance breadcrumb the A1.5 follow-up rule
+        // requires in follow-up issue bodies, not closure-order ambiguity.
+        // Keep the edge itself as informational provenance and record no
+        // cycle diagnostic. Back-edges from OPEN nodes, from roadmap nodes,
+        // and via any stronger relationship (task-list, dependency,
+        // closing-keyword, sub-issue) still record a cycle (fail closed).
+        const sourceRecord = nodeRecords.get(edge.source);
+        if (
+          edge.relationship === 'reference' &&
+          sourceRecord?.classification === 'execution' &&
+          sourceRecord.state === 'CLOSED'
+        ) {
+          continue;
+        }
         const cyclePath = [...path, edge.target];
         const cycleKey = cyclePath.join('>');
         if (!cycleKeys.has(cycleKey)) {

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -61,7 +61,11 @@ function roadmapAuditBranchPattern(roadmapNumber) {
  * roadmap descendant, every traversal cycle, a blocked roadmap root, and a
  * childless/malformed roadmap is collected as a blocker; `ready` is true only
  * when no blocker is collected. The rules mirror the written A1.5 completion
- * criteria exactly — this helper adds no stricter sub-condition. Pure and
+ * criteria exactly — this helper adds no stricter sub-condition. One shape is
+ * interpreted as safe rather than ambiguous (#1278): a `reference` back-edge
+ * from a non-roadmap execution leaf is the provenance breadcrumb the A1.5
+ * follow-up rule itself requires, so it never blocks as a cycle (an open
+ * leaf still blocks as `open-child`). Pure and
  * network-free so it is unit-testable apart from live GitHub.
  */
 export function evaluateRoadmapAuditGates(report, options = {}) {
@@ -171,8 +175,26 @@ export function evaluateRoadmapAuditGates(report, options = {}) {
       detail: `reference #${diagnostic.source} → #${diagnostic.target} (${diagnostic.relationship}) is inaccessible: ${diagnostic.reason}`,
     });
   }
-  // Cycles / ambiguous graph: do not guess a closure order.
+  // Cycles / ambiguous graph: do not guess a closure order. A `reference`
+  // back-edge whose source is a non-roadmap execution leaf is exempt (#1278):
+  // a closed leaf's `Refs #<roadmap>` breadcrumb is the provenance the A1.5
+  // follow-up rule requires, and an open leaf is already blocked above as
+  // `open-child`, so the audit still fails closed while reporting the true
+  // cause. Roadmap-source cycles, unknown-source cycles, stronger
+  // relationships (task-list / dependency / closing-keyword / sub-issue),
+  // and execution sources in any other state keep blocking.
+  const openExecutionLeaves = new Set(report.executionCandidates);
   for (const cycle of report.diagnostics.cycles) {
+    const sourceNode = report.nodes.find(
+      (entry) => entry.number === cycle.source,
+    );
+    if (
+      cycle.relationship === 'reference' &&
+      sourceNode?.classification === 'execution' &&
+      (sourceNode.state === 'CLOSED' || openExecutionLeaves.has(cycle.source))
+    ) {
+      continue;
+    }
     blockers.push({
       kind: 'cycle',
       target: cycle.target,

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -864,6 +864,21 @@ export async function enumerateRoadmapGraph(
       }
 
       if (path.includes(edge.target)) {
+        // #1278: a plain `Refs` back-reference from a CLOSED non-roadmap leaf
+        // to an ancestor is the provenance breadcrumb the A1.5 follow-up rule
+        // requires in follow-up issue bodies, not closure-order ambiguity.
+        // Keep the edge itself as informational provenance and record no
+        // cycle diagnostic. Back-edges from OPEN nodes, from roadmap nodes,
+        // and via any stronger relationship (task-list, dependency,
+        // closing-keyword, sub-issue) still record a cycle (fail closed).
+        const sourceRecord = nodeRecords.get(edge.source);
+        if (
+          edge.relationship === 'reference' &&
+          sourceRecord?.classification === 'execution' &&
+          sourceRecord.state === 'CLOSED'
+        ) {
+          continue;
+        }
         const cyclePath = [...path, edge.target];
         const cycleKey = cyclePath.join('>');
         if (!cycleKeys.has(cycleKey)) {

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -138,7 +138,11 @@ interface RoadmapAuditExecuteArgs {
  * roadmap descendant, every traversal cycle, a blocked roadmap root, and a
  * childless/malformed roadmap is collected as a blocker; `ready` is true only
  * when no blocker is collected. The rules mirror the written A1.5 completion
- * criteria exactly — this helper adds no stricter sub-condition. Pure and
+ * criteria exactly — this helper adds no stricter sub-condition. One shape is
+ * interpreted as safe rather than ambiguous (#1278): a `reference` back-edge
+ * from a non-roadmap execution leaf is the provenance breadcrumb the A1.5
+ * follow-up rule itself requires, so it never blocks as a cycle (an open
+ * leaf still blocks as `open-child`). Pure and
  * network-free so it is unit-testable apart from live GitHub.
  */
 export function evaluateRoadmapAuditGates(
@@ -259,8 +263,26 @@ export function evaluateRoadmapAuditGates(
     });
   }
 
-  // Cycles / ambiguous graph: do not guess a closure order.
+  // Cycles / ambiguous graph: do not guess a closure order. A `reference`
+  // back-edge whose source is a non-roadmap execution leaf is exempt (#1278):
+  // a closed leaf's `Refs #<roadmap>` breadcrumb is the provenance the A1.5
+  // follow-up rule requires, and an open leaf is already blocked above as
+  // `open-child`, so the audit still fails closed while reporting the true
+  // cause. Roadmap-source cycles, unknown-source cycles, stronger
+  // relationships (task-list / dependency / closing-keyword / sub-issue),
+  // and execution sources in any other state keep blocking.
+  const openExecutionLeaves = new Set(report.executionCandidates);
   for (const cycle of report.diagnostics.cycles) {
+    const sourceNode = report.nodes.find(
+      (entry) => entry.number === cycle.source,
+    );
+    if (
+      cycle.relationship === 'reference' &&
+      sourceNode?.classification === 'execution' &&
+      (sourceNode.state === 'CLOSED' || openExecutionLeaves.has(cycle.source))
+    ) {
+      continue;
+    }
     blockers.push({
       kind: 'cycle',
       target: cycle.target,

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -457,6 +457,69 @@ test('records duplicate references and cycles without recursing forever', async 
   ]);
 });
 
+test('downgrades a Refs back-edge from a CLOSED leaf to provenance, not a cycle', async () => {
+  // #1278: the A1.5 follow-up rule requires `Refs #<roadmap>` provenance
+  // breadcrumbs in follow-up issue bodies; once the leaf is closed, the
+  // back-edge must not surface as a blocking cycle diagnostic.
+  const issues = new Map([
+    [310, roadmapIssue(310, '- [x] #311', 'breadcrumb-roadmap')],
+    [311, executionIssue(311, 'Refs #310', 'closed')],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(310, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.diagnostics.cycles, []);
+  assert.equal(graph.summary.cycleCount, 0);
+  // The back-edge itself is kept as informational provenance.
+  assert.ok(
+    graph.edges.some((edge) => edge.source === 311 && edge.target === 310),
+  );
+});
+
+test('keeps a stronger back-edge (Blocked by) from a CLOSED leaf as a cycle', async () => {
+  // Only the plain `Refs` provenance relationship is exempt; a closed leaf
+  // declaring itself `Blocked by` its ancestor is a closure-order anomaly.
+  const issues = new Map([
+    [312, roadmapIssue(312, '- [x] #313', 'anomaly-roadmap')],
+    [313, executionIssue(313, 'Blocked by #312', 'closed')],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(312, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.diagnostics.cycles, [
+    {
+      source: 313,
+      target: 312,
+      relationship: 'dependency',
+      path: [312, 313, 312],
+    },
+  ]);
+});
+
+test('keeps a back-edge from a closed ROADMAP node as a blocking cycle', async () => {
+  const issues = new Map([
+    [315, roadmapIssue(315, '- [x] #316', 'outer-roadmap')],
+    [316, roadmapIssue(316, 'Refs #315', 'inner-roadmap', 'closed')],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(315, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.diagnostics.cycles, [
+    {
+      source: 316,
+      target: 315,
+      relationship: 'reference',
+      path: [315, 316, 315],
+    },
+  ]);
+});
+
 test('counts exact duplicate references from the same issue body', async () => {
   const issues = new Map([
     [320, roadmapIssue(320, '- [ ] #321\n- [ ] #321', 'root-roadmap')],

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import type { RoadmapGraphReport } from '../src/scripts/discover-roadmap-graph.mts';
+import {
+  enumerateRoadmapGraph,
+  type RoadmapGraphReport,
+} from '../src/scripts/discover-roadmap-graph.mts';
 import {
   buildRoadmapCompletionAuditBody,
   type ConnectedPrEvent,
@@ -528,12 +531,15 @@ test('unresolved, inaccessible, and cycle diagnostics each surface a blocker', (
       reason: 'issue_inaccessible',
     },
   ];
+  // The cycle source is deliberately absent from `nodes`: an unknown-source
+  // cycle must keep blocking (fail closed), unlike the execution-leaf
+  // provenance back-edges exempted below (#1278).
   report.diagnostics.cycles = [
     {
-      source: 1047,
+      source: 4444,
       target: ROADMAP,
       relationship: 'dependency',
-      path: [ROADMAP, 1047, ROADMAP],
+      path: [ROADMAP, 4444, ROADMAP],
     },
   ];
   const kinds = evaluateRoadmapAuditGates(report)
@@ -544,6 +550,130 @@ test('unresolved, inaccessible, and cycle diagnostics each surface a blocker', (
     'inaccessible-reference',
     'unresolved-reference',
   ]);
+});
+
+// ---------------------------------------------------------------------------
+// #1278 — Refs provenance breadcrumbs from non-roadmap leaves are not cycles
+// ---------------------------------------------------------------------------
+
+/** Raw roadmap issue as the enumeration's `loadIssue` returns it. */
+function rawRoadmapIssue(number: number, body: string, state = 'open') {
+  return {
+    number,
+    title: `roadmap ${number}`,
+    state,
+    body: `<!-- idd-skill-roadmap-id: roadmap-${number} -->\n${body}`,
+    labels: [{ name: 'roadmap' }],
+  };
+}
+
+/** Raw execution-leaf issue as the enumeration's `loadIssue` returns it. */
+function rawExecutionIssue(number: number, body: string, state = 'open') {
+  return { number, title: `issue ${number}`, state, body, labels: [] };
+}
+
+/**
+ * Build the graph through the real traversal so the fixtures match exactly
+ * what discover-roadmap-graph emits for the A1.5 follow-up breadcrumb shape:
+ * the roadmap task-lists the leaf and the leaf's body carries the required
+ * `Refs #<roadmap>` back-reference (or a stronger relationship on demand).
+ */
+function breadcrumbGraph(
+  leafState: 'open' | 'closed',
+  backReference = `Refs #${ROADMAP}`,
+) {
+  const issues = new Map<number, unknown>([
+    [ROADMAP, rawRoadmapIssue(ROADMAP, '- [x] #1047')],
+    [
+      1047,
+      rawExecutionIssue(1047, `Follow-up work.\n\n${backReference}`, leafState),
+    ],
+  ]);
+  return enumerateRoadmapGraph(ROADMAP, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+}
+
+test('a Refs breadcrumb from a CLOSED leaf does not block: dry-run is ready (#1278)', async () => {
+  const graph = await breadcrumbGraph('closed');
+  const { deps, calls } = makeDeps(graph);
+  const { verdict, exitCode } = await runRoadmapAuditExecute(
+    ['--roadmap', String(ROADMAP)],
+    deps,
+  );
+
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.blockers, []);
+  assert.equal(exitCode, 0);
+  assert.deepEqual(calls.closed, []);
+});
+
+test('an OPEN leaf with a Refs breadcrumb blocks as open-child, not as a cycle (#1278)', async () => {
+  const graph = await breadcrumbGraph('open');
+  const blockers = evaluateRoadmapAuditGates(graph);
+
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['open-child'],
+  );
+  assert.equal(blockers[0]?.target, 1047);
+});
+
+test('mutually-referencing roadmap nodes still surface a blocking cycle (#1278)', async () => {
+  const issues = new Map<number, unknown>([
+    [ROADMAP, rawRoadmapIssue(ROADMAP, '- [x] #1100')],
+    [1100, rawRoadmapIssue(1100, `- [x] #1101\n\nRefs #${ROADMAP}`, 'closed')],
+    [1101, rawExecutionIssue(1101, 'done', 'closed')],
+  ]);
+  const graph = await enumerateRoadmapGraph(ROADMAP, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+  const blockers = evaluateRoadmapAuditGates(graph);
+
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['cycle'],
+  );
+  assert.equal(blockers[0]?.target, ROADMAP);
+});
+
+test('a stronger back-edge (Blocked by) from a CLOSED leaf still blocks as a cycle (#1278)', async () => {
+  // A closed leaf that declares itself `Blocked by` its still-open ancestor
+  // is a genuine closure-order anomaly, not a provenance breadcrumb — only
+  // the `reference` relationship is exempt.
+  const graph = await breadcrumbGraph('closed', `Blocked by #${ROADMAP}`);
+  const blockers = evaluateRoadmapAuditGates(graph);
+
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['cycle'],
+  );
+  assert.match(blockers[0]?.detail ?? '', /dependency/);
+});
+
+test('an execution-source cycle in a non-OPEN/CLOSED state still blocks (#1278)', () => {
+  // Fail-closed parity with the traversal: the builder records a cycle for
+  // an execution source whose state is neither OPEN nor CLOSED, and such a
+  // node is absent from executionCandidates, so no open-child blocker
+  // compensates — the evaluator must keep the cycle blocking.
+  const report = readyReport();
+  report.nodes = report.nodes.map((entry) =>
+    entry.number === 1047 ? { ...entry, state: '' } : entry,
+  );
+  report.diagnostics.cycles = [
+    {
+      source: 1047,
+      target: ROADMAP,
+      relationship: 'reference',
+      path: [ROADMAP, 1047, ROADMAP],
+    },
+  ];
+  const blockers = evaluateRoadmapAuditGates(report);
+
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['cycle'],
+  );
 });
 
 test('a childless roadmap (no edges) is reported, never closed', () => {

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -676,6 +676,27 @@ test('an execution-source cycle in a non-OPEN/CLOSED state still blocks (#1278)'
   );
 });
 
+test('an unknown-source reference cycle still blocks (fail closed) (#1278)', () => {
+  // The exemption requires a source node present in `nodes` with execution
+  // classification; a `reference` cycle whose source is absent from the
+  // graph must keep blocking even though the relationship alone matches.
+  const report = readyReport();
+  report.diagnostics.cycles = [
+    {
+      source: 4444,
+      target: ROADMAP,
+      relationship: 'reference',
+      path: [ROADMAP, 4444, ROADMAP],
+    },
+  ];
+  const blockers = evaluateRoadmapAuditGates(report);
+
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['cycle'],
+  );
+});
+
 test('a childless roadmap (no edges) is reported, never closed', () => {
   const report = readyReport();
   report.nodes = [


### PR DESCRIPTION
# Summary

The A1.5 follow-up rule requires new follow-up issues to carry a `Refs #<roadmap>` provenance breadcrumb, but the roadmap-graph traversal classified that back-edge as a blocking `cycle`, so `idd-roadmap-audit-execute` failed closed on every roadmap with an audit-created follow-up (observed on #1220: `1220 → 1258 → 1220`).

- **`discover-roadmap-graph`**: a plain `reference` (`Refs`) back-edge from a **CLOSED non-roadmap leaf** to an ancestor keeps the edge as informational provenance and records no cycle diagnostic. Back-edges from OPEN nodes, from roadmap nodes, and via stronger relationships (`task-list` / `dependency` / `closing-keyword` / `sub-issue`) still record cycles (fail closed).
- **`idd-roadmap-audit-execute`**: `evaluateRoadmapAuditGates` skips a cycle blocker only when it is a `reference` back-edge from an execution leaf that is either CLOSED or present in `executionCandidates` (an open leaf is already blocked as `open-child`, so the audit still fails closed while reporting the true cause). Roadmap-source, unknown-source, other-state, and stronger-relationship cycles keep blocking.
- Fixture-driven tests cover all three acceptance criteria end-to-end through the real traversal, plus the fail-closed edges (dependency back-edge from a closed leaf, non-OPEN/CLOSED source state, unknown-source cycle).

## Linked issue

Closes #1278

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The written A1.5 rule scopes cycle blocking to graphs that cannot "be interpreted safely"; this change makes the helper interpret the protocol-mandated breadcrumb shape safely instead of failing closed on it, so no instruction-file change is needed. `docs/idd-helper-scripts.md` documents only the `cycles` array shape, which is unchanged.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`pnpm run lint:minimum`)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (covered by audit-docs in lint:minimum)
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (audit-close gate loosened only for the protocol-mandated provenance shape; all other cycle blocking unchanged)
- [x] Context budget impact reviewed (no instruction/doc bundle changes)
