### PR TITLE
ci(idd-doctor): fetch full history so tag checks stop skipping

### DIFF
--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -30,6 +30,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
+          # Fetch full history and tags: the default fetch-depth: 1
+          # shallow checkout hides tag refs, so checkReleaseTagDrift's
+          # `git describe --tags` (and the follow-up `rev-list` / `log`
+          # calls) silently skip every run (#1286).
+          fetch-depth: 0
           # Read-only health check: no need to persist the token in git config.
           persist-credentials: false
       - name: Run idd-doctor repository-health check


### PR DESCRIPTION
# Summary

Add `fetch-depth: 0` to `idd-doctor.yml`'s `actions/checkout` step so
`checkReleaseTagDrift` can see real tag history during CI, instead of
silently skipping under the default shallow single-commit fetch.

## Linked issue

Closes #1286

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

PR #1281 added `checkReleaseTagDrift` to `idd-doctor`, which needs
`git describe --tags --abbrev=0` (plus `git rev-list --count` and
`git log`) to find the latest release tag and measure drift.
`actions/checkout`'s default `fetch-depth: 1` fetches only a single
commit with no tag refs, so those git calls fail and the check's
fail-safe treats that identically to a fresh clone with no tags at
all -- silently skipping on every ordinary CI run in this repository.

This was out of scope for #1269/#1281 under this repository's
ask-first policy for `.github/workflows/**`
([`docs/permissions.md`](../blob/main/docs/permissions.md#ask-first-shared-state-actions));
the maintainer posted the required ask-first confirmation directly on
issue #1286 before this change was made.

`fetch-depth: 0` fetches "all history for all branches and tags" per
`actions/checkout`'s own documented contract (verified against the
pinned `v7.0.0` `action.yml`), so a single field is guaranteed to
reach the tag -- no separate `fetch-tags: true` is needed once depth
is unlimited. The repository is small (1,999 commits, 2 tags, ~14 MB
`.git`), so the added fetch cost is negligible against the documented
~10-105s job runtime; recent runs on `main` complete in ~10-20s.

Verified locally: running `node scripts/idd-doctor.mjs` with full
history correctly surfaces
`WARN release-tag drift: HEAD is 665 commit(s) (> 100) past the latest
tag v0.3.0` -- direct proof the check now fires instead of silently
skipping. I will also confirm this PR's own CI run stays within the
documented runtime range.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of the automated validation workflow by ensuring it has access to full repository history and tags.
  - This helps prevent failures in tag-based checks and makes the workflow more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->