### PR TITLE
feat(onboard): wave 1 placeholder-substitution CLI with --dry-run

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -38,6 +38,7 @@ scripts/helper-runtime-manifest.mjs linguist-generated=true
 scripts/idd-config.mjs linguist-generated=true
 scripts/idd-doctor.mjs linguist-generated=true
 scripts/idd-merge-execute.mjs linguist-generated=true
+scripts/idd-onboard.mjs linguist-generated=true
 scripts/idd-roadmap-audit-execute.mjs linguist-generated=true
 scripts/live-status-digest.mjs linguist-generated=true
 scripts/markdown-code.mjs linguist-generated=true

--- a/bin/idd-onboard.mjs
+++ b/bin/idd-onboard.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-onboard.mts
+//
+// The bin/idd-onboard.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/idd-onboard.mjs');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "idd-merge-execute": "./bin/idd-merge-execute.mjs",
     "idd-merged-pr-feedback-sweep": "./bin/idd-merged-pr-feedback-sweep.mjs",
     "idd-minimize-superseded-markers": "./bin/idd-minimize-superseded-markers.mjs",
+    "idd-onboard": "./bin/idd-onboard.mjs",
     "idd-phase-id-resolver": "./bin/idd-phase-id-resolver.mjs",
     "idd-post-idd-marker": "./bin/idd-post-idd-marker.mjs",
     "idd-pre-merge-readiness": "./bin/idd-pre-merge-readiness.mjs",

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -46,7 +46,7 @@ export const ONBOARDING_PLACEHOLDERS = [
   ),
   placeholder('INSTALL_DEPS_COMMAND', 'command', '--install-deps-command'),
 ];
-/** Validation pattern for `{{PROJECT_MARKER_PREFIX}}` from the reference. */
+/** Validation pattern for the PROJECT_MARKER_PREFIX value (reference). */
 export const MARKER_PREFIX_PATTERN = /^[a-z][a-z0-9-]{1,31}$/;
 /**
  * Parse the owner and repository short name from a git remote URL.
@@ -82,7 +82,7 @@ export function parseRemoteRepoRef(url) {
   return { owner, repo };
 }
 /**
- * Normalize a repository short name into a `{{PROJECT_MARKER_PREFIX}}`
+ * Normalize a repository short name into a PROJECT_MARKER_PREFIX
  * candidate: lowercase, non-`[a-z0-9-]` runs collapsed to `-`, leading
  * non-letter characters stripped (the prefix must start with a letter),
  * cut to 32 characters, trailing `-` stripped. Returns `null` when the
@@ -152,7 +152,7 @@ function hasAnyRecognizedTooling(targetDir) {
   );
 }
 /**
- * Derive `{{INSTALL_DEPS_COMMAND}}` from the target tree per the
+ * Derive the INSTALL_DEPS_COMMAND row from the target tree per the
  * reference table. Returns `null` when the evidence is ambiguous or
  * insufficient (bare `package.json` without package-manager signals,
  * `pyproject.toml` + `requirements.txt` together, an unrecognized Python
@@ -375,7 +375,10 @@ export function resolvePlaceholderValues(
   }
   return { values, unresolved };
 }
-/** Placeholder-shaped tokens: `{{NAME}}` with an upper-snake name. */
+// Placeholder-shaped tokens: doubled braces around an upper-snake name.
+// Comments in this module spell token names WITHOUT the doubled braces:
+// idd-doctor's unresolved-placeholder scan reads the generated artifact,
+// and a braced example would register as leftover template residue.
 const PLACEHOLDER_TOKEN_PATTERN = /\{\{[A-Z][A-Z0-9_]*\}\}/g;
 /** Directories never scanned for placeholder tokens. */
 const SCAN_EXCLUDED_DIRS = new Set(['.git', 'node_modules']);

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1,0 +1,625 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-onboard.mts
+//
+// The scripts/idd-onboard.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Onboarding automation CLI — wave 1: placeholder substitution (#1263,
+// roadmap #1262).
+//
+// Given a target tree that already contains the imported template files,
+// resolve the seven onboarding placeholders (auto-derived from repository
+// evidence where `idd-template/docs/onboarding/placeholders.md` defines a
+// derivation; explicit flags override) and rewrite the files. `--dry-run`
+// prints the per-file, per-placeholder plan without writing anything.
+// That reference document is the source of truth this CLI must match; a
+// drift test in tests/idd-onboard.test.mts fails on mismatch.
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { isCliExecution } from './gh-exec.mjs';
+import { collectHelperRuntimeEvidence } from './helper-runtime-manifest.mjs';
+
+function placeholder(name, kind, flag) {
+  return { name, token: `{{${name}}}`, kind, flag };
+}
+/**
+ * The seven placeholders, in the order of the "Final placeholder
+ * meanings" table in `idd-template/docs/onboarding/placeholders.md`. The
+ * drift test asserts this list matches that table exactly.
+ */
+export const ONBOARDING_PLACEHOLDERS = [
+  placeholder('REPO_NAME', 'identity', '--repo-name'),
+  placeholder('PROJECT_MARKER_PREFIX', 'identity', '--marker-prefix'),
+  placeholder('TRUSTED_MARKER_ACTOR', 'identity', '--trusted-marker-actor'),
+  placeholder('FIX_VALIDATE_COMMANDS', 'command', '--fix-validate-commands'),
+  placeholder(
+    'PRE_PUSH_VALIDATE_COMMANDS',
+    'command',
+    '--pre-push-validate-commands',
+  ),
+  placeholder(
+    'POST_FIX_VALIDATE_COMMANDS',
+    'command',
+    '--post-fix-validate-commands',
+  ),
+  placeholder('INSTALL_DEPS_COMMAND', 'command', '--install-deps-command'),
+];
+/** Validation pattern for `{{PROJECT_MARKER_PREFIX}}` from the reference. */
+export const MARKER_PREFIX_PATTERN = /^[a-z][a-z0-9-]{1,31}$/;
+/**
+ * Parse the owner and repository short name from a git remote URL.
+ * Supports the common `https://`, `ssh://`, and scp-like
+ * `git@host:owner/repo(.git)` forms, tolerating a trailing slash.
+ * Returns `null` when the URL does not carry a repository path —
+ * derivation then falls back to flags.
+ */
+export function parseRemoteRepoRef(url) {
+  const raw = String(url ?? '')
+    .trim()
+    .replace(/\/+$/, '');
+  if (raw === '') {
+    return null;
+  }
+  // Normalize the scp-like form (`git@host:owner/repo.git`) into a path.
+  const scpMatch = raw.match(/^[\w.-]+@([\w.-]+):(.+)$/);
+  const path = scpMatch
+    ? scpMatch[2]
+    : raw.replace(/^[a-z+]+:\/\/([^/@]+@)?[^/]+\//i, '');
+  if (path === raw && !scpMatch) {
+    return null;
+  }
+  const segments = path.split('/').filter((segment) => segment.length > 0);
+  if (segments.length < 2) {
+    return null;
+  }
+  const repo = (segments[segments.length - 1] ?? '').replace(/\.git$/, '');
+  if (repo === '') {
+    return null;
+  }
+  const owner = segments.length === 2 ? (segments[0] ?? null) : null;
+  return { owner, repo };
+}
+/**
+ * Normalize a repository short name into a `{{PROJECT_MARKER_PREFIX}}`
+ * candidate: lowercase, non-`[a-z0-9-]` runs collapsed to `-`, leading
+ * non-letter characters stripped (the prefix must start with a letter),
+ * cut to 32 characters, trailing `-` stripped. Returns `null` when the
+ * result does not satisfy `MARKER_PREFIX_PATTERN` (fail closed).
+ */
+export function deriveMarkerPrefix(repoName) {
+  const candidate = String(repoName ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[^a-z]+/, '')
+    .slice(0, 32)
+    .replace(/-+$/, '');
+  return MARKER_PREFIX_PATTERN.test(candidate) ? candidate : null;
+}
+/**
+ * JSON-escape a login for the quoted `trustedMarkerActors` array entry in
+ * `config.json`: the template already provides the surrounding quotes, so
+ * the substitution value is the escaped string *content* only.
+ */
+export function escapeJsonStringContent(value) {
+  return JSON.stringify(value).slice(1, -1);
+}
+/** Install command per detected Node.js package manager. */
+const NODE_INSTALL_COMMANDS = {
+  npm: 'npm install',
+  pnpm: 'pnpm install',
+  yarn: 'yarn install',
+};
+/**
+ * Python tool table from the reference (`pyproject.toml` tool section →
+ * command). Patterns match the bare `[tool.x]` header and its dotted
+ * sub-tables (`[tool.x.y]`), the common real-world shape.
+ */
+const PYPROJECT_TOOL_COMMANDS = [
+  { pattern: /^\s*\[tool\.poetry[.\]]/mu, command: 'poetry install' },
+  { pattern: /^\s*\[tool\.pdm[.\]]/mu, command: 'pdm install' },
+  { pattern: /^\s*\[tool\.hatch[.\]]/mu, command: 'hatch env create' },
+  { pattern: /^\s*\[tool\.uv[.\]]/mu, command: 'uv sync' },
+];
+function fileExists(root, name) {
+  try {
+    return statSync(join(root, name)).isFile();
+  } catch {
+    return false;
+  }
+}
+function readTextIfPresent(root, name) {
+  try {
+    return readFileSync(join(root, name), 'utf8');
+  } catch {
+    return null;
+  }
+}
+/** Dependency tooling recognized by the derivation table. */
+function hasAnyRecognizedTooling(targetDir) {
+  return (
+    fileExists(targetDir, 'package.json') ||
+    fileExists(targetDir, 'pnpm-lock.yaml') ||
+    fileExists(targetDir, 'package-lock.json') ||
+    fileExists(targetDir, 'yarn.lock') ||
+    fileExists(targetDir, 'requirements.txt') ||
+    fileExists(targetDir, 'pyproject.toml') ||
+    fileExists(targetDir, 'go.mod') ||
+    fileExists(targetDir, 'Gemfile') ||
+    fileExists(targetDir, 'Cargo.toml')
+  );
+}
+/**
+ * Derive `{{INSTALL_DEPS_COMMAND}}` from the target tree per the
+ * reference table. Returns `null` when the evidence is ambiguous or
+ * insufficient (bare `package.json` without package-manager signals,
+ * `pyproject.toml` + `requirements.txt` together, an unrecognized Python
+ * tool) — the reference says not to guess in those cases. Returns the
+ * no-op `true` only when no standard dependency tooling exists at all.
+ */
+export function deriveInstallDepsCommand(targetDir) {
+  const hasRequirements = fileExists(targetDir, 'requirements.txt');
+  const pyproject = readTextIfPresent(targetDir, 'pyproject.toml');
+  if (hasRequirements && pyproject !== null) {
+    // Both Python workflows present: confirm with the operator.
+    return null;
+  }
+  // The reference's Node signals — declared packageManager metadata or
+  // exactly one supported lockfile — apply with or without a
+  // package.json alongside them.
+  const evidence = collectHelperRuntimeEvidence(targetDir);
+  if (evidence.detectedPackageManager !== '') {
+    return NODE_INSTALL_COMMANDS[evidence.detectedPackageManager] ?? null;
+  }
+  if (fileExists(targetDir, 'package.json')) {
+    // A bare package.json without those signals is not enough evidence
+    // to infer `npm install`.
+    return null;
+  }
+  if (hasRequirements) {
+    return 'pip install -r requirements.txt';
+  }
+  if (pyproject !== null) {
+    const match = PYPROJECT_TOOL_COMMANDS.find(({ pattern }) =>
+      pattern.test(pyproject),
+    );
+    return match ? match.command : null;
+  }
+  if (fileExists(targetDir, 'go.mod')) {
+    return 'go mod download';
+  }
+  if (fileExists(targetDir, 'Gemfile')) {
+    return 'bundle install';
+  }
+  if (!hasAnyRecognizedTooling(targetDir)) {
+    return 'true';
+  }
+  return null;
+}
+/**
+ * Derive the three validate-command rows from the target tree per the
+ * reference patterns: Node trees read the existing `package.json` scripts;
+ * `go.mod` / `Cargo.toml` trees use the fixed rows; a tree with no
+ * recognized tooling at all takes the no-op `true` rows. Anything else
+ * stays unresolved so the operator supplies flags.
+ */
+export function deriveValidateCommands(targetDir) {
+  const packageJsonText = readTextIfPresent(targetDir, 'package.json');
+  if (packageJsonText !== null) {
+    let scripts = {};
+    try {
+      const parsed = JSON.parse(packageJsonText);
+      scripts = parsed.scripts ?? {};
+    } catch {
+      // Unparseable package.json: leave every row unresolved.
+      return {
+        fixValidate: null,
+        prePushValidate: null,
+        postFixValidate: null,
+      };
+    }
+    const evidence = collectHelperRuntimeEvidence(targetDir);
+    const pm = evidence.detectedPackageManager;
+    if (pm === '') {
+      // Package manager unknown or ambiguous: do not guess npm — the
+      // same fail-closed stance deriveInstallDepsCommand applies to the
+      // exact same evidence.
+      return {
+        fixValidate: null,
+        prePushValidate: null,
+        postFixValidate: null,
+      };
+    }
+    const fixValidate =
+      'lint:fix' in scripts && 'lint' in scripts
+        ? `${pm} run lint:fix && ${pm} run lint`
+        : null;
+    const prePushParts = ['lint', 'build', 'test'].filter(
+      (name) => name in scripts,
+    );
+    const prePushValidate =
+      prePushParts.length > 0
+        ? prePushParts.map((name) => `${pm} run ${name}`).join(' && ')
+        : null;
+    // Superset of the two rows with duplicate steps removed (a naive
+    // concatenation would run `<pm> run lint` twice back to back).
+    const postFixCommands = [
+      ...(fixValidate ? fixValidate.split(' && ') : []),
+      ...(prePushValidate ? prePushValidate.split(' && ') : []),
+    ].filter((command, index, all) => all.indexOf(command) === index);
+    const postFixValidate =
+      postFixCommands.length > 0 ? postFixCommands.join(' && ') : null;
+    return { fixValidate, prePushValidate, postFixValidate };
+  }
+  if (fileExists(targetDir, 'go.mod')) {
+    return {
+      fixValidate: 'go fmt ./...',
+      prePushValidate: 'go vet ./... && go test ./...',
+      postFixValidate: 'go fmt ./... && go vet ./... && go test ./...',
+    };
+  }
+  if (fileExists(targetDir, 'Cargo.toml')) {
+    return {
+      fixValidate: 'cargo fmt',
+      prePushValidate: 'cargo check && cargo test',
+      postFixValidate: 'cargo fmt && cargo check && cargo test',
+    };
+  }
+  if (!hasAnyRecognizedTooling(targetDir)) {
+    return {
+      fixValidate: 'true',
+      prePushValidate: 'true',
+      postFixValidate: 'true',
+    };
+  }
+  return { fixValidate: null, prePushValidate: null, postFixValidate: null };
+}
+/** Default remote-URL reader: `git -C <target> config remote.origin.url`. */
+export function readGitRemoteUrl(targetDir) {
+  try {
+    const output = execFileSync(
+      'git',
+      ['-C', targetDir, 'config', '--get', 'remote.origin.url'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim();
+    return output === '' ? null : output;
+  } catch {
+    return null;
+  }
+}
+/**
+ * Resolve the seven placeholder values: explicit flag overrides win;
+ * otherwise auto-derive from the target tree where the reference defines
+ * a derivation. Enforces the no-op rule (`true` is valid only for the
+ * command placeholders) and the marker-prefix pattern on explicit
+ * overrides (fail closed on invalid input rather than substituting a
+ * value the template contract rejects).
+ *
+ * `TRUSTED_MARKER_ACTOR` is never auto-derived: the remote owner slug is
+ * an organization name on org-owned repositories, not a login that posts
+ * markers, so silently writing it into the trust configuration would
+ * fail open. The reference's owner-derived candidate is an operator
+ * proposal, not a substitution value — the flag is required.
+ */
+export function resolvePlaceholderValues(
+  targetDir,
+  overrides = {},
+  readers = {},
+) {
+  const knownNames = new Set(
+    ONBOARDING_PLACEHOLDERS.map((entry) => entry.name),
+  );
+  for (const key of Object.keys(overrides)) {
+    if (!knownNames.has(key)) {
+      throw new Error(`unknown placeholder override: ${key}`);
+    }
+  }
+  for (const entry of ONBOARDING_PLACEHOLDERS) {
+    const override = overrides[entry.name];
+    if (override === 'true' && entry.kind !== 'command') {
+      throw new Error(
+        `the no-op value "true" is only valid for command placeholders, not ${entry.name}`,
+      );
+    }
+  }
+  const markerOverride = overrides.PROJECT_MARKER_PREFIX;
+  if (
+    markerOverride !== undefined &&
+    !MARKER_PREFIX_PATTERN.test(markerOverride)
+  ) {
+    throw new Error(
+      `--marker-prefix must match ${MARKER_PREFIX_PATTERN}: ${markerOverride}`,
+    );
+  }
+  const readRemoteUrl = readers.readRemoteUrl ?? readGitRemoteUrl;
+  const remoteRef = parseRemoteRepoRef(readRemoteUrl(targetDir));
+  const validateRows = deriveValidateCommands(targetDir);
+  // The marker prefix derives from the *finalized* repository name, so an
+  // explicit --repo-name feeds the derivation exactly as the reference
+  // ("start from the repository name") describes.
+  const repoName = overrides.REPO_NAME ?? remoteRef?.repo ?? null;
+  const derived = {
+    REPO_NAME: remoteRef?.repo ?? null,
+    PROJECT_MARKER_PREFIX:
+      repoName !== null ? deriveMarkerPrefix(repoName) : null,
+    TRUSTED_MARKER_ACTOR: null,
+    FIX_VALIDATE_COMMANDS: validateRows.fixValidate,
+    PRE_PUSH_VALIDATE_COMMANDS: validateRows.prePushValidate,
+    POST_FIX_VALIDATE_COMMANDS: validateRows.postFixValidate,
+    INSTALL_DEPS_COMMAND: deriveInstallDepsCommand(targetDir),
+  };
+  const values = {};
+  const unresolved = [];
+  for (const entry of ONBOARDING_PLACEHOLDERS) {
+    const override = overrides[entry.name];
+    let resolved = null;
+    if (override !== undefined) {
+      resolved = { value: override, source: 'flag' };
+    } else if (derived[entry.name] !== null) {
+      resolved = { value: derived[entry.name], source: 'derived' };
+    }
+    // The template's trustedMarkerActors entry is already quoted, so the
+    // substitution value is JSON-escaped string content.
+    if (resolved && entry.name === 'TRUSTED_MARKER_ACTOR') {
+      resolved = {
+        ...resolved,
+        value: escapeJsonStringContent(resolved.value),
+      };
+    }
+    values[entry.name] = resolved;
+    if (!resolved) {
+      unresolved.push(entry.name);
+    }
+  }
+  return { values, unresolved };
+}
+/** Placeholder-shaped tokens: `{{NAME}}` with an upper-snake name. */
+const PLACEHOLDER_TOKEN_PATTERN = /\{\{[A-Z][A-Z0-9_]*\}\}/g;
+/** Directories never scanned for placeholder tokens. */
+const SCAN_EXCLUDED_DIRS = new Set(['.git', 'node_modules']);
+function isProbablyBinary(content) {
+  return content.includes(0);
+}
+/**
+ * Walk the target tree (excluding `.git` and `node_modules`, skipping
+ * binary files) and collect every placeholder-shaped `{{...}}` token per
+ * file, in ascending path order. Symlinks are deliberately not followed:
+ * imported template files are regular files, and following links could
+ * escape the target tree.
+ */
+export function scanPlaceholderTokens(targetDir) {
+  const results = [];
+  const compareEntryNames = (left, right) => {
+    if (left.name < right.name) {
+      return -1;
+    }
+    return left.name > right.name ? 1 : 0;
+  };
+  const walk = (dir) => {
+    const entries = readdirSync(dir, { withFileTypes: true }).sort(
+      compareEntryNames,
+    );
+    for (const entry of entries) {
+      const absolute = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!SCAN_EXCLUDED_DIRS.has(entry.name)) {
+          walk(absolute);
+        }
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      const raw = readFileSync(absolute);
+      if (isProbablyBinary(raw)) {
+        continue;
+      }
+      const tokens = new Map();
+      for (const match of raw
+        .toString('utf8')
+        .matchAll(PLACEHOLDER_TOKEN_PATTERN)) {
+        tokens.set(match[0], (tokens.get(match[0]) ?? 0) + 1);
+      }
+      if (tokens.size > 0) {
+        results.push({
+          file: relative(targetDir, absolute).split('\\').join('/'),
+          tokens,
+        });
+      }
+    }
+  };
+  walk(targetDir);
+  return results;
+}
+/**
+ * Combine the token scan with the resolved values into the substitution
+ * plan: known tokens with resolved values become plan entries; known
+ * tokens without values become blocking residue (the reference's final
+ * "verify that no `{{...}}` strings remain" pass for the seven); other
+ * `{{...}}`-shaped tokens are reported informationally.
+ */
+export function buildSubstitutionPlan(scans, resolution) {
+  const byToken = new Map(
+    ONBOARDING_PLACEHOLDERS.map((entry) => [entry.token, entry]),
+  );
+  const entries = [];
+  const residue = [];
+  const unknownTokens = [];
+  for (const scan of scans) {
+    for (const [token, occurrences] of scan.tokens) {
+      const known = byToken.get(token);
+      if (!known) {
+        unknownTokens.push({ file: scan.file, token, occurrences });
+        continue;
+      }
+      const resolved = resolution.values[known.name];
+      if (!resolved) {
+        residue.push({ file: scan.file, token, occurrences });
+        continue;
+      }
+      entries.push({
+        file: scan.file,
+        placeholder: known.name,
+        occurrences,
+        from: token,
+        to: resolved.value,
+      });
+    }
+  }
+  return { entries, residue, unknownTokens };
+}
+/**
+ * Apply the plan: rewrite each planned file in a single replacement pass
+ * over the placeholder-token pattern, so a token injected by one
+ * substitution value is never re-substituted by a later one. Returns the
+ * count of files written.
+ */
+export function applySubstitutionPlan(targetDir, plan) {
+  const byFile = new Map();
+  for (const entry of plan.entries) {
+    const tokens = byFile.get(entry.file) ?? new Map();
+    tokens.set(entry.from, entry.to);
+    byFile.set(entry.file, tokens);
+  }
+  for (const [file, tokens] of byFile) {
+    const absolute = resolve(targetDir, file);
+    const content = readFileSync(absolute, 'utf8');
+    const rewritten = content.replace(
+      PLACEHOLDER_TOKEN_PATTERN,
+      (token) => tokens.get(token) ?? token,
+    );
+    writeFileSync(absolute, rewritten);
+  }
+  return byFile.size;
+}
+if (isCliExecution(import.meta.url)) {
+  try {
+    runCli();
+  } catch (error) {
+    // Usage/config errors exit 2, keeping exit 1 unambiguous as the
+    // residue signal (same split as audit-pr-cleanup's fail()).
+    process.stderr.write(
+      `idd-onboard: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exit(2);
+  }
+}
+function parseArgs(argv) {
+  const parsed = {
+    substitute: false,
+    target: '.',
+    dryRun: false,
+    overrides: {},
+    help: false,
+  };
+  const flagToName = new Map(
+    ONBOARDING_PLACEHOLDERS.map((entry) => [entry.flag, entry.name]),
+  );
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    const requireValue = () => {
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    if (token === '--substitute') {
+      parsed.substitute = true;
+      continue;
+    }
+    if (token === '--target') {
+      parsed.target = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--dry-run') {
+      parsed.dryRun = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    const name = flagToName.get(token);
+    if (name !== undefined) {
+      parsed.overrides[name] = requireValue();
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  return parsed;
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!args.substitute) {
+    throw new Error(
+      'wave 1 supports the substitution stage only: pass --substitute',
+    );
+  }
+  const targetDir = resolve(args.target);
+  if (!statSync(targetDir).isDirectory()) {
+    throw new Error(`--target is not a directory: ${args.target}`);
+  }
+  const resolution = resolvePlaceholderValues(targetDir, args.overrides);
+  const plan = buildSubstitutionPlan(
+    scanPlaceholderTokens(targetDir),
+    resolution,
+  );
+  // Fail closed: never write a half-substituted tree. Apply mode writes
+  // only when every scanned onboarding placeholder resolved.
+  const canWrite = !args.dryRun && plan.residue.length === 0;
+  const filesChanged = canWrite ? applySubstitutionPlan(targetDir, plan) : 0;
+  const verdict = {
+    protocolVersion: '1',
+    mode: args.dryRun ? 'dry-run' : 'apply',
+    target: targetDir,
+    values: resolution.values,
+    unresolved: resolution.unresolved,
+    plan: plan.entries,
+    residue: plan.residue,
+    unknownTokens: plan.unknownTokens,
+    filesChanged,
+    written: canWrite && filesChanged > 0,
+  };
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  // Residue means the replacement pass cannot converge (an onboarding
+  // placeholder would survive): signal it in dry-run and apply alike so
+  // callers can gate on the exit code. Unknown tokens are informational.
+  process.exit(plan.residue.length > 0 ? 1 : 0);
+}
+function printHelp() {
+  const flags = ONBOARDING_PLACEHOLDERS.map(
+    (entry) =>
+      `  ${entry.flag} <value>${entry.kind === 'command' ? ' (accepts the no-op "true")' : ''}`,
+  ).join('\n');
+  process.stdout.write(`usage: node scripts/idd-onboard.mjs --substitute [options]
+
+Onboarding automation — wave 1: placeholder substitution. Resolves the
+seven template placeholders for a target tree that already contains the
+imported template files (auto-derived from repository evidence where
+idd-template/docs/onboarding/placeholders.md defines a derivation;
+explicit flags override; --trusted-marker-actor is always explicit) and
+rewrites the files. Prints a JSON verdict with the per-file,
+per-placeholder plan, blocking residue (unresolved onboarding
+placeholders), and informational unknown {{...}} tokens.
+
+Exit codes: 0 converged; 1 residue would remain (apply writes nothing
+in that case); 2 usage or configuration error.
+
+  --substitute         run the substitution stage (required)
+  --target <dir>       target tree to rewrite (default: current directory)
+  --dry-run            print the plan without writing anything
+  --help, -h           show this help
+
+Placeholder overrides:
+${flags}
+`);
+}

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -99,9 +99,13 @@ export function deriveMarkerPrefix(repoName) {
   return MARKER_PREFIX_PATTERN.test(candidate) ? candidate : null;
 }
 /**
- * JSON-escape a login for the quoted `trustedMarkerActors` array entry in
- * `config.json`: the template already provides the surrounding quotes, so
- * the substitution value is the escaped string *content* only.
+ * JSON-escape a substitution value for a placeholder site inside a JSON
+ * string field (the template provides the surrounding quotes, so this is
+ * the escaped string *content* only). Escaping is a property of the
+ * substitution site, not the value: the same command row lands raw in
+ * the markdown command tables and escaped inside `config.json`, and the
+ * onboarding reference requires the JSON command strings to stay
+ * JSON-escaped rather than raw shell.
  */
 export function escapeJsonStringContent(value) {
   return JSON.stringify(value).slice(1, -1);
@@ -360,14 +364,9 @@ export function resolvePlaceholderValues(
     } else if (derived[entry.name] !== null) {
       resolved = { value: derived[entry.name], source: 'derived' };
     }
-    // The template's trustedMarkerActors entry is already quoted, so the
-    // substitution value is JSON-escaped string content.
-    if (resolved && entry.name === 'TRUSTED_MARKER_ACTOR') {
-      resolved = {
-        ...resolved,
-        value: escapeJsonStringContent(resolved.value),
-      };
-    }
+    // Values stay raw here; JSON escaping is applied per substitution
+    // site by buildSubstitutionPlan (the same value lands raw in the
+    // markdown tables and escaped inside config.json string fields).
     values[entry.name] = resolved;
     if (!resolved) {
       unresolved.push(entry.name);
@@ -462,12 +461,19 @@ export function buildSubstitutionPlan(scans, resolution) {
         residue.push({ file: scan.file, token, occurrences });
         continue;
       }
+      // Site-aware escaping: a placeholder inside a JSON file sits in a
+      // string field the template already quotes, so the value must be
+      // JSON-escaped there (a command row containing quotes would
+      // otherwise break config.json); every other site takes it raw.
+      const isJsonSite = scan.file.endsWith('.json');
       entries.push({
         file: scan.file,
         placeholder: known.name,
         occurrences,
         from: token,
-        to: resolved.value,
+        to: isJsonSite
+          ? escapeJsonStringContent(resolved.value)
+          : resolved.value,
       });
     }
   }

--- a/src/bin/idd-onboard.mts
+++ b/src/bin/idd-onboard.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-onboard.mts
+//
+// The bin/idd-onboard.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/idd-onboard.mjs');

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -1,0 +1,784 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-onboard.mts
+//
+// The scripts/idd-onboard.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Onboarding automation CLI — wave 1: placeholder substitution (#1263,
+// roadmap #1262).
+//
+// Given a target tree that already contains the imported template files,
+// resolve the seven onboarding placeholders (auto-derived from repository
+// evidence where `idd-template/docs/onboarding/placeholders.md` defines a
+// derivation; explicit flags override) and rewrite the files. `--dry-run`
+// prints the per-file, per-placeholder plan without writing anything.
+// That reference document is the source of truth this CLI must match; a
+// drift test in tests/idd-onboard.test.mts fails on mismatch.
+
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+import { isCliExecution } from './gh-exec.mts';
+import { collectHelperRuntimeEvidence } from './helper-runtime-manifest.mts';
+
+/** Substitution role of a placeholder: only `command` rows may be `true`. */
+export type OnboardingPlaceholderKind = 'identity' | 'command';
+
+/** One of the seven template placeholders the replacement pass rewrites. */
+export interface OnboardingPlaceholder {
+  /** Bare name as it appears between the braces, e.g. `REPO_NAME`. */
+  name: string;
+  /** Literal token to replace, e.g. `{{REPO_NAME}}`. */
+  token: string;
+  kind: OnboardingPlaceholderKind;
+  /** CLI override flag, e.g. `--repo-name`. */
+  flag: string;
+}
+
+function placeholder(
+  name: string,
+  kind: OnboardingPlaceholderKind,
+  flag: string,
+): OnboardingPlaceholder {
+  return { name, token: `{{${name}}}`, kind, flag };
+}
+
+/**
+ * The seven placeholders, in the order of the "Final placeholder
+ * meanings" table in `idd-template/docs/onboarding/placeholders.md`. The
+ * drift test asserts this list matches that table exactly.
+ */
+export const ONBOARDING_PLACEHOLDERS: readonly OnboardingPlaceholder[] = [
+  placeholder('REPO_NAME', 'identity', '--repo-name'),
+  placeholder('PROJECT_MARKER_PREFIX', 'identity', '--marker-prefix'),
+  placeholder('TRUSTED_MARKER_ACTOR', 'identity', '--trusted-marker-actor'),
+  placeholder('FIX_VALIDATE_COMMANDS', 'command', '--fix-validate-commands'),
+  placeholder(
+    'PRE_PUSH_VALIDATE_COMMANDS',
+    'command',
+    '--pre-push-validate-commands',
+  ),
+  placeholder(
+    'POST_FIX_VALIDATE_COMMANDS',
+    'command',
+    '--post-fix-validate-commands',
+  ),
+  placeholder('INSTALL_DEPS_COMMAND', 'command', '--install-deps-command'),
+];
+
+/** Validation pattern for `{{PROJECT_MARKER_PREFIX}}` from the reference. */
+export const MARKER_PREFIX_PATTERN = /^[a-z][a-z0-9-]{1,31}$/;
+
+/** Owner/repo pair parsed from a git remote URL. */
+export interface RemoteRepoRef {
+  /**
+   * Owner segment, known only for the plain two-segment `owner/repo`
+   * form; deeper paths (GitLab subgroups, Azure `_git` routes) leave it
+   * `null` rather than guessing a wrong segment.
+   */
+  owner: string | null;
+  repo: string;
+}
+
+/**
+ * Parse the owner and repository short name from a git remote URL.
+ * Supports the common `https://`, `ssh://`, and scp-like
+ * `git@host:owner/repo(.git)` forms, tolerating a trailing slash.
+ * Returns `null` when the URL does not carry a repository path —
+ * derivation then falls back to flags.
+ */
+export function parseRemoteRepoRef(url: unknown): RemoteRepoRef | null {
+  const raw = String(url ?? '')
+    .trim()
+    .replace(/\/+$/, '');
+  if (raw === '') {
+    return null;
+  }
+  // Normalize the scp-like form (`git@host:owner/repo.git`) into a path.
+  const scpMatch = raw.match(/^[\w.-]+@([\w.-]+):(.+)$/);
+  const path = scpMatch
+    ? scpMatch[2]
+    : raw.replace(/^[a-z+]+:\/\/([^/@]+@)?[^/]+\//i, '');
+  if (path === raw && !scpMatch) {
+    return null;
+  }
+  const segments = path.split('/').filter((segment) => segment.length > 0);
+  if (segments.length < 2) {
+    return null;
+  }
+  const repo = (segments[segments.length - 1] ?? '').replace(/\.git$/, '');
+  if (repo === '') {
+    return null;
+  }
+  const owner = segments.length === 2 ? (segments[0] ?? null) : null;
+  return { owner, repo };
+}
+
+/**
+ * Normalize a repository short name into a `{{PROJECT_MARKER_PREFIX}}`
+ * candidate: lowercase, non-`[a-z0-9-]` runs collapsed to `-`, leading
+ * non-letter characters stripped (the prefix must start with a letter),
+ * cut to 32 characters, trailing `-` stripped. Returns `null` when the
+ * result does not satisfy `MARKER_PREFIX_PATTERN` (fail closed).
+ */
+export function deriveMarkerPrefix(repoName: unknown): string | null {
+  const candidate = String(repoName ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[^a-z]+/, '')
+    .slice(0, 32)
+    .replace(/-+$/, '');
+  return MARKER_PREFIX_PATTERN.test(candidate) ? candidate : null;
+}
+
+/**
+ * JSON-escape a login for the quoted `trustedMarkerActors` array entry in
+ * `config.json`: the template already provides the surrounding quotes, so
+ * the substitution value is the escaped string *content* only.
+ */
+export function escapeJsonStringContent(value: string): string {
+  return JSON.stringify(value).slice(1, -1);
+}
+
+/** Install command per detected Node.js package manager. */
+const NODE_INSTALL_COMMANDS: Record<string, string> = {
+  npm: 'npm install',
+  pnpm: 'pnpm install',
+  yarn: 'yarn install',
+};
+
+/**
+ * Python tool table from the reference (`pyproject.toml` tool section →
+ * command). Patterns match the bare `[tool.x]` header and its dotted
+ * sub-tables (`[tool.x.y]`), the common real-world shape.
+ */
+const PYPROJECT_TOOL_COMMANDS: readonly {
+  pattern: RegExp;
+  command: string;
+}[] = [
+  { pattern: /^\s*\[tool\.poetry[.\]]/mu, command: 'poetry install' },
+  { pattern: /^\s*\[tool\.pdm[.\]]/mu, command: 'pdm install' },
+  { pattern: /^\s*\[tool\.hatch[.\]]/mu, command: 'hatch env create' },
+  { pattern: /^\s*\[tool\.uv[.\]]/mu, command: 'uv sync' },
+];
+
+function fileExists(root: string, name: string): boolean {
+  try {
+    return statSync(join(root, name)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function readTextIfPresent(root: string, name: string): string | null {
+  try {
+    return readFileSync(join(root, name), 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/** Dependency tooling recognized by the derivation table. */
+function hasAnyRecognizedTooling(targetDir: string): boolean {
+  return (
+    fileExists(targetDir, 'package.json') ||
+    fileExists(targetDir, 'pnpm-lock.yaml') ||
+    fileExists(targetDir, 'package-lock.json') ||
+    fileExists(targetDir, 'yarn.lock') ||
+    fileExists(targetDir, 'requirements.txt') ||
+    fileExists(targetDir, 'pyproject.toml') ||
+    fileExists(targetDir, 'go.mod') ||
+    fileExists(targetDir, 'Gemfile') ||
+    fileExists(targetDir, 'Cargo.toml')
+  );
+}
+
+/**
+ * Derive `{{INSTALL_DEPS_COMMAND}}` from the target tree per the
+ * reference table. Returns `null` when the evidence is ambiguous or
+ * insufficient (bare `package.json` without package-manager signals,
+ * `pyproject.toml` + `requirements.txt` together, an unrecognized Python
+ * tool) — the reference says not to guess in those cases. Returns the
+ * no-op `true` only when no standard dependency tooling exists at all.
+ */
+export function deriveInstallDepsCommand(targetDir: string): string | null {
+  const hasRequirements = fileExists(targetDir, 'requirements.txt');
+  const pyproject = readTextIfPresent(targetDir, 'pyproject.toml');
+  if (hasRequirements && pyproject !== null) {
+    // Both Python workflows present: confirm with the operator.
+    return null;
+  }
+  // The reference's Node signals — declared packageManager metadata or
+  // exactly one supported lockfile — apply with or without a
+  // package.json alongside them.
+  const evidence = collectHelperRuntimeEvidence(targetDir);
+  if (evidence.detectedPackageManager !== '') {
+    return NODE_INSTALL_COMMANDS[evidence.detectedPackageManager] ?? null;
+  }
+  if (fileExists(targetDir, 'package.json')) {
+    // A bare package.json without those signals is not enough evidence
+    // to infer `npm install`.
+    return null;
+  }
+  if (hasRequirements) {
+    return 'pip install -r requirements.txt';
+  }
+  if (pyproject !== null) {
+    const match = PYPROJECT_TOOL_COMMANDS.find(({ pattern }) =>
+      pattern.test(pyproject),
+    );
+    return match ? match.command : null;
+  }
+  if (fileExists(targetDir, 'go.mod')) {
+    return 'go mod download';
+  }
+  if (fileExists(targetDir, 'Gemfile')) {
+    return 'bundle install';
+  }
+  if (!hasAnyRecognizedTooling(targetDir)) {
+    return 'true';
+  }
+  return null;
+}
+
+/** The three validate-command rows derived together. */
+export interface ValidateCommandRows {
+  fixValidate: string | null;
+  prePushValidate: string | null;
+  postFixValidate: string | null;
+}
+
+/**
+ * Derive the three validate-command rows from the target tree per the
+ * reference patterns: Node trees read the existing `package.json` scripts;
+ * `go.mod` / `Cargo.toml` trees use the fixed rows; a tree with no
+ * recognized tooling at all takes the no-op `true` rows. Anything else
+ * stays unresolved so the operator supplies flags.
+ */
+export function deriveValidateCommands(targetDir: string): ValidateCommandRows {
+  const packageJsonText = readTextIfPresent(targetDir, 'package.json');
+  if (packageJsonText !== null) {
+    let scripts: Record<string, unknown> = {};
+    try {
+      const parsed = JSON.parse(packageJsonText) as {
+        scripts?: Record<string, unknown>;
+      };
+      scripts = parsed.scripts ?? {};
+    } catch {
+      // Unparseable package.json: leave every row unresolved.
+      return {
+        fixValidate: null,
+        prePushValidate: null,
+        postFixValidate: null,
+      };
+    }
+    const evidence = collectHelperRuntimeEvidence(targetDir);
+    const pm = evidence.detectedPackageManager;
+    if (pm === '') {
+      // Package manager unknown or ambiguous: do not guess npm — the
+      // same fail-closed stance deriveInstallDepsCommand applies to the
+      // exact same evidence.
+      return {
+        fixValidate: null,
+        prePushValidate: null,
+        postFixValidate: null,
+      };
+    }
+    const fixValidate =
+      'lint:fix' in scripts && 'lint' in scripts
+        ? `${pm} run lint:fix && ${pm} run lint`
+        : null;
+    const prePushParts = ['lint', 'build', 'test'].filter(
+      (name) => name in scripts,
+    );
+    const prePushValidate =
+      prePushParts.length > 0
+        ? prePushParts.map((name) => `${pm} run ${name}`).join(' && ')
+        : null;
+    // Superset of the two rows with duplicate steps removed (a naive
+    // concatenation would run `<pm> run lint` twice back to back).
+    const postFixCommands = [
+      ...(fixValidate ? fixValidate.split(' && ') : []),
+      ...(prePushValidate ? prePushValidate.split(' && ') : []),
+    ].filter((command, index, all) => all.indexOf(command) === index);
+    const postFixValidate =
+      postFixCommands.length > 0 ? postFixCommands.join(' && ') : null;
+    return { fixValidate, prePushValidate, postFixValidate };
+  }
+  if (fileExists(targetDir, 'go.mod')) {
+    return {
+      fixValidate: 'go fmt ./...',
+      prePushValidate: 'go vet ./... && go test ./...',
+      postFixValidate: 'go fmt ./... && go vet ./... && go test ./...',
+    };
+  }
+  if (fileExists(targetDir, 'Cargo.toml')) {
+    return {
+      fixValidate: 'cargo fmt',
+      prePushValidate: 'cargo check && cargo test',
+      postFixValidate: 'cargo fmt && cargo check && cargo test',
+    };
+  }
+  if (!hasAnyRecognizedTooling(targetDir)) {
+    return {
+      fixValidate: 'true',
+      prePushValidate: 'true',
+      postFixValidate: 'true',
+    };
+  }
+  return { fixValidate: null, prePushValidate: null, postFixValidate: null };
+}
+
+/** How a placeholder value was established. */
+export type PlaceholderValueSource = 'flag' | 'derived';
+
+/** A resolved placeholder value with its provenance. */
+export interface ResolvedPlaceholderValue {
+  value: string;
+  source: PlaceholderValueSource;
+}
+
+/** Explicit override values keyed by placeholder name. */
+export type PlaceholderOverrides = Partial<Record<string, string>>;
+
+/** Injectable evidence readers so resolution stays unit-testable. */
+export interface OnboardEvidenceReaders {
+  /** Returns the target tree's `remote.origin.url`, or `null`. */
+  readRemoteUrl?: (targetDir: string) => string | null;
+}
+
+/** Default remote-URL reader: `git -C <target> config remote.origin.url`. */
+export function readGitRemoteUrl(targetDir: string): string | null {
+  try {
+    const output = execFileSync(
+      'git',
+      ['-C', targetDir, 'config', '--get', 'remote.origin.url'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim();
+    return output === '' ? null : output;
+  } catch {
+    return null;
+  }
+}
+
+/** Outcome of resolving all seven placeholder values for a target tree. */
+export interface PlaceholderResolution {
+  values: Record<string, ResolvedPlaceholderValue | null>;
+  /** Placeholder names that could not be resolved. */
+  unresolved: string[];
+}
+
+/**
+ * Resolve the seven placeholder values: explicit flag overrides win;
+ * otherwise auto-derive from the target tree where the reference defines
+ * a derivation. Enforces the no-op rule (`true` is valid only for the
+ * command placeholders) and the marker-prefix pattern on explicit
+ * overrides (fail closed on invalid input rather than substituting a
+ * value the template contract rejects).
+ *
+ * `TRUSTED_MARKER_ACTOR` is never auto-derived: the remote owner slug is
+ * an organization name on org-owned repositories, not a login that posts
+ * markers, so silently writing it into the trust configuration would
+ * fail open. The reference's owner-derived candidate is an operator
+ * proposal, not a substitution value — the flag is required.
+ */
+export function resolvePlaceholderValues(
+  targetDir: string,
+  overrides: PlaceholderOverrides = {},
+  readers: OnboardEvidenceReaders = {},
+): PlaceholderResolution {
+  const knownNames = new Set(
+    ONBOARDING_PLACEHOLDERS.map((entry) => entry.name),
+  );
+  for (const key of Object.keys(overrides)) {
+    if (!knownNames.has(key)) {
+      throw new Error(`unknown placeholder override: ${key}`);
+    }
+  }
+  for (const entry of ONBOARDING_PLACEHOLDERS) {
+    const override = overrides[entry.name];
+    if (override === 'true' && entry.kind !== 'command') {
+      throw new Error(
+        `the no-op value "true" is only valid for command placeholders, not ${entry.name}`,
+      );
+    }
+  }
+  const markerOverride = overrides.PROJECT_MARKER_PREFIX;
+  if (
+    markerOverride !== undefined &&
+    !MARKER_PREFIX_PATTERN.test(markerOverride)
+  ) {
+    throw new Error(
+      `--marker-prefix must match ${MARKER_PREFIX_PATTERN}: ${markerOverride}`,
+    );
+  }
+
+  const readRemoteUrl = readers.readRemoteUrl ?? readGitRemoteUrl;
+  const remoteRef = parseRemoteRepoRef(readRemoteUrl(targetDir));
+  const validateRows = deriveValidateCommands(targetDir);
+  // The marker prefix derives from the *finalized* repository name, so an
+  // explicit --repo-name feeds the derivation exactly as the reference
+  // ("start from the repository name") describes.
+  const repoName = overrides.REPO_NAME ?? remoteRef?.repo ?? null;
+  const derived: Record<string, string | null> = {
+    REPO_NAME: remoteRef?.repo ?? null,
+    PROJECT_MARKER_PREFIX:
+      repoName !== null ? deriveMarkerPrefix(repoName) : null,
+    TRUSTED_MARKER_ACTOR: null,
+    FIX_VALIDATE_COMMANDS: validateRows.fixValidate,
+    PRE_PUSH_VALIDATE_COMMANDS: validateRows.prePushValidate,
+    POST_FIX_VALIDATE_COMMANDS: validateRows.postFixValidate,
+    INSTALL_DEPS_COMMAND: deriveInstallDepsCommand(targetDir),
+  };
+
+  const values: Record<string, ResolvedPlaceholderValue | null> = {};
+  const unresolved: string[] = [];
+  for (const entry of ONBOARDING_PLACEHOLDERS) {
+    const override = overrides[entry.name];
+    let resolved: ResolvedPlaceholderValue | null = null;
+    if (override !== undefined) {
+      resolved = { value: override, source: 'flag' };
+    } else if (derived[entry.name] !== null) {
+      resolved = { value: derived[entry.name] as string, source: 'derived' };
+    }
+    // The template's trustedMarkerActors entry is already quoted, so the
+    // substitution value is JSON-escaped string content.
+    if (resolved && entry.name === 'TRUSTED_MARKER_ACTOR') {
+      resolved = {
+        ...resolved,
+        value: escapeJsonStringContent(resolved.value),
+      };
+    }
+    values[entry.name] = resolved;
+    if (!resolved) {
+      unresolved.push(entry.name);
+    }
+  }
+  return { values, unresolved };
+}
+
+/** Placeholder-shaped tokens: `{{NAME}}` with an upper-snake name. */
+const PLACEHOLDER_TOKEN_PATTERN = /\{\{[A-Z][A-Z0-9_]*\}\}/g;
+
+/** Directories never scanned for placeholder tokens. */
+const SCAN_EXCLUDED_DIRS = new Set(['.git', 'node_modules']);
+
+/** Token occurrences found in one scanned file. */
+export interface PlaceholderFileScan {
+  /** Path relative to the scan root, `/`-separated. */
+  file: string;
+  /** Token literal → occurrence count, e.g. `{{REPO_NAME}}` → 3. */
+  tokens: Map<string, number>;
+}
+
+function isProbablyBinary(content: Buffer): boolean {
+  return content.includes(0);
+}
+
+/**
+ * Walk the target tree (excluding `.git` and `node_modules`, skipping
+ * binary files) and collect every placeholder-shaped `{{...}}` token per
+ * file, in ascending path order. Symlinks are deliberately not followed:
+ * imported template files are regular files, and following links could
+ * escape the target tree.
+ */
+export function scanPlaceholderTokens(
+  targetDir: string,
+): PlaceholderFileScan[] {
+  const results: PlaceholderFileScan[] = [];
+  const compareEntryNames = (
+    left: { name: string },
+    right: { name: string },
+  ): number => {
+    if (left.name < right.name) {
+      return -1;
+    }
+    return left.name > right.name ? 1 : 0;
+  };
+  const walk = (dir: string): void => {
+    const entries = readdirSync(dir, { withFileTypes: true }).sort(
+      compareEntryNames,
+    );
+    for (const entry of entries) {
+      const absolute = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!SCAN_EXCLUDED_DIRS.has(entry.name)) {
+          walk(absolute);
+        }
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      const raw = readFileSync(absolute);
+      if (isProbablyBinary(raw)) {
+        continue;
+      }
+      const tokens = new Map<string, number>();
+      for (const match of raw
+        .toString('utf8')
+        .matchAll(PLACEHOLDER_TOKEN_PATTERN)) {
+        tokens.set(match[0], (tokens.get(match[0]) ?? 0) + 1);
+      }
+      if (tokens.size > 0) {
+        results.push({
+          file: relative(targetDir, absolute).split('\\').join('/'),
+          tokens,
+        });
+      }
+    }
+  };
+  walk(targetDir);
+  return results;
+}
+
+/** One planned rewrite: every occurrence of a token in one file. */
+export interface SubstitutionPlanEntry {
+  file: string;
+  placeholder: string;
+  occurrences: number;
+  from: string;
+  to: string;
+}
+
+/** One residue finding: an unresolved placeholder that would survive. */
+export interface SubstitutionResidueEntry {
+  file: string;
+  token: string;
+  occurrences: number;
+}
+
+/** One informational finding: a `{{...}}`-shaped token not in the seven. */
+export interface UnknownTokenEntry {
+  file: string;
+  token: string;
+  occurrences: number;
+}
+
+/** The full dry-run/apply plan for one target tree. */
+export interface SubstitutionPlan {
+  entries: SubstitutionPlanEntry[];
+  /** Unresolved onboarding placeholders — blocking (exit 1). */
+  residue: SubstitutionResidueEntry[];
+  /**
+   * Placeholder-shaped tokens outside the seven — informational only.
+   * Wave 1 cannot tell an adopter's own template token (handlebars,
+   * mustache, …) from copied-template residue because the copy stage
+   * that records the imported file set is a later wave, so these are
+   * reported for the operator instead of failing the run.
+   */
+  unknownTokens: UnknownTokenEntry[];
+}
+
+/**
+ * Combine the token scan with the resolved values into the substitution
+ * plan: known tokens with resolved values become plan entries; known
+ * tokens without values become blocking residue (the reference's final
+ * "verify that no `{{...}}` strings remain" pass for the seven); other
+ * `{{...}}`-shaped tokens are reported informationally.
+ */
+export function buildSubstitutionPlan(
+  scans: readonly PlaceholderFileScan[],
+  resolution: PlaceholderResolution,
+): SubstitutionPlan {
+  const byToken = new Map(
+    ONBOARDING_PLACEHOLDERS.map((entry) => [entry.token, entry]),
+  );
+  const entries: SubstitutionPlanEntry[] = [];
+  const residue: SubstitutionResidueEntry[] = [];
+  const unknownTokens: UnknownTokenEntry[] = [];
+  for (const scan of scans) {
+    for (const [token, occurrences] of scan.tokens) {
+      const known = byToken.get(token);
+      if (!known) {
+        unknownTokens.push({ file: scan.file, token, occurrences });
+        continue;
+      }
+      const resolved = resolution.values[known.name];
+      if (!resolved) {
+        residue.push({ file: scan.file, token, occurrences });
+        continue;
+      }
+      entries.push({
+        file: scan.file,
+        placeholder: known.name,
+        occurrences,
+        from: token,
+        to: resolved.value,
+      });
+    }
+  }
+  return { entries, residue, unknownTokens };
+}
+
+/**
+ * Apply the plan: rewrite each planned file in a single replacement pass
+ * over the placeholder-token pattern, so a token injected by one
+ * substitution value is never re-substituted by a later one. Returns the
+ * count of files written.
+ */
+export function applySubstitutionPlan(
+  targetDir: string,
+  plan: SubstitutionPlan,
+): number {
+  const byFile = new Map<string, Map<string, string>>();
+  for (const entry of plan.entries) {
+    const tokens = byFile.get(entry.file) ?? new Map<string, string>();
+    tokens.set(entry.from, entry.to);
+    byFile.set(entry.file, tokens);
+  }
+  for (const [file, tokens] of byFile) {
+    const absolute = resolve(targetDir, file);
+    const content = readFileSync(absolute, 'utf8');
+    const rewritten = content.replace(
+      PLACEHOLDER_TOKEN_PATTERN,
+      (token) => tokens.get(token) ?? token,
+    );
+    writeFileSync(absolute, rewritten);
+  }
+  return byFile.size;
+}
+
+if (isCliExecution(import.meta.url)) {
+  try {
+    runCli();
+  } catch (error) {
+    // Usage/config errors exit 2, keeping exit 1 unambiguous as the
+    // residue signal (same split as audit-pr-cleanup's fail()).
+    process.stderr.write(
+      `idd-onboard: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exit(2);
+  }
+}
+
+interface ParsedArgs {
+  substitute: boolean;
+  target: string;
+  dryRun: boolean;
+  overrides: PlaceholderOverrides;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    substitute: false,
+    target: '.',
+    dryRun: false,
+    overrides: {},
+    help: false,
+  };
+  const flagToName = new Map(
+    ONBOARDING_PLACEHOLDERS.map((entry) => [entry.flag, entry.name]),
+  );
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    const requireValue = (): string => {
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error(`missing value for argument: ${token}`);
+      }
+      return value;
+    };
+    if (token === '--substitute') {
+      parsed.substitute = true;
+      continue;
+    }
+    if (token === '--target') {
+      parsed.target = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--dry-run') {
+      parsed.dryRun = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    const name = flagToName.get(token);
+    if (name !== undefined) {
+      parsed.overrides[name] = requireValue();
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  return parsed;
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!args.substitute) {
+    throw new Error(
+      'wave 1 supports the substitution stage only: pass --substitute',
+    );
+  }
+  const targetDir = resolve(args.target);
+  if (!statSync(targetDir).isDirectory()) {
+    throw new Error(`--target is not a directory: ${args.target}`);
+  }
+  const resolution = resolvePlaceholderValues(targetDir, args.overrides);
+  const plan = buildSubstitutionPlan(
+    scanPlaceholderTokens(targetDir),
+    resolution,
+  );
+  // Fail closed: never write a half-substituted tree. Apply mode writes
+  // only when every scanned onboarding placeholder resolved.
+  const canWrite = !args.dryRun && plan.residue.length === 0;
+  const filesChanged = canWrite ? applySubstitutionPlan(targetDir, plan) : 0;
+  const verdict = {
+    protocolVersion: '1',
+    mode: args.dryRun ? 'dry-run' : 'apply',
+    target: targetDir,
+    values: resolution.values,
+    unresolved: resolution.unresolved,
+    plan: plan.entries,
+    residue: plan.residue,
+    unknownTokens: plan.unknownTokens,
+    filesChanged,
+    written: canWrite && filesChanged > 0,
+  };
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  // Residue means the replacement pass cannot converge (an onboarding
+  // placeholder would survive): signal it in dry-run and apply alike so
+  // callers can gate on the exit code. Unknown tokens are informational.
+  process.exit(plan.residue.length > 0 ? 1 : 0);
+}
+
+function printHelp(): void {
+  const flags = ONBOARDING_PLACEHOLDERS.map(
+    (entry) =>
+      `  ${entry.flag} <value>${entry.kind === 'command' ? ' (accepts the no-op "true")' : ''}`,
+  ).join('\n');
+  process.stdout.write(`usage: node scripts/idd-onboard.mjs --substitute [options]
+
+Onboarding automation — wave 1: placeholder substitution. Resolves the
+seven template placeholders for a target tree that already contains the
+imported template files (auto-derived from repository evidence where
+idd-template/docs/onboarding/placeholders.md defines a derivation;
+explicit flags override; --trusted-marker-actor is always explicit) and
+rewrites the files. Prints a JSON verdict with the per-file,
+per-placeholder plan, blocking residue (unresolved onboarding
+placeholders), and informational unknown {{...}} tokens.
+
+Exit codes: 0 converged; 1 residue would remain (apply writes nothing
+in that case); 2 usage or configuration error.
+
+  --substitute         run the substitution stage (required)
+  --target <dir>       target tree to rewrite (default: current directory)
+  --dry-run            print the plan without writing anything
+  --help, -h           show this help
+
+Placeholder overrides:
+${flags}
+`);
+}

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -135,9 +135,13 @@ export function deriveMarkerPrefix(repoName: unknown): string | null {
 }
 
 /**
- * JSON-escape a login for the quoted `trustedMarkerActors` array entry in
- * `config.json`: the template already provides the surrounding quotes, so
- * the substitution value is the escaped string *content* only.
+ * JSON-escape a substitution value for a placeholder site inside a JSON
+ * string field (the template provides the surrounding quotes, so this is
+ * the escaped string *content* only). Escaping is a property of the
+ * substitution site, not the value: the same command row lands raw in
+ * the markdown command tables and escaped inside `config.json`, and the
+ * onboarding reference requires the JSON command strings to stay
+ * JSON-escaped rather than raw shell.
  */
 export function escapeJsonStringContent(value: string): string {
   return JSON.stringify(value).slice(1, -1);
@@ -444,14 +448,9 @@ export function resolvePlaceholderValues(
     } else if (derived[entry.name] !== null) {
       resolved = { value: derived[entry.name] as string, source: 'derived' };
     }
-    // The template's trustedMarkerActors entry is already quoted, so the
-    // substitution value is JSON-escaped string content.
-    if (resolved && entry.name === 'TRUSTED_MARKER_ACTOR') {
-      resolved = {
-        ...resolved,
-        value: escapeJsonStringContent(resolved.value),
-      };
-    }
+    // Values stay raw here; JSON escaping is applied per substitution
+    // site by buildSubstitutionPlan (the same value lands raw in the
+    // markdown tables and escaped inside config.json string fields).
     values[entry.name] = resolved;
     if (!resolved) {
       unresolved.push(entry.name);
@@ -605,12 +604,19 @@ export function buildSubstitutionPlan(
         residue.push({ file: scan.file, token, occurrences });
         continue;
       }
+      // Site-aware escaping: a placeholder inside a JSON file sits in a
+      // string field the template already quotes, so the value must be
+      // JSON-escaped there (a command row containing quotes would
+      // otherwise break config.json); every other site takes it raw.
+      const isJsonSite = scan.file.endsWith('.json');
       entries.push({
         file: scan.file,
         placeholder: known.name,
         occurrences,
         from: token,
-        to: resolved.value,
+        to: isJsonSite
+          ? escapeJsonStringContent(resolved.value)
+          : resolved.value,
       });
     }
   }

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -30,7 +30,7 @@ export type OnboardingPlaceholderKind = 'identity' | 'command';
 export interface OnboardingPlaceholder {
   /** Bare name as it appears between the braces, e.g. `REPO_NAME`. */
   name: string;
-  /** Literal token to replace, e.g. `{{REPO_NAME}}`. */
+  /** Literal doubled-brace token to replace in scanned files. */
   token: string;
   kind: OnboardingPlaceholderKind;
   /** CLI override flag, e.g. `--repo-name`. */
@@ -68,7 +68,7 @@ export const ONBOARDING_PLACEHOLDERS: readonly OnboardingPlaceholder[] = [
   placeholder('INSTALL_DEPS_COMMAND', 'command', '--install-deps-command'),
 ];
 
-/** Validation pattern for `{{PROJECT_MARKER_PREFIX}}` from the reference. */
+/** Validation pattern for the PROJECT_MARKER_PREFIX value (reference). */
 export const MARKER_PREFIX_PATTERN = /^[a-z][a-z0-9-]{1,31}$/;
 
 /** Owner/repo pair parsed from a git remote URL. */
@@ -117,7 +117,7 @@ export function parseRemoteRepoRef(url: unknown): RemoteRepoRef | null {
 }
 
 /**
- * Normalize a repository short name into a `{{PROJECT_MARKER_PREFIX}}`
+ * Normalize a repository short name into a PROJECT_MARKER_PREFIX
  * candidate: lowercase, non-`[a-z0-9-]` runs collapsed to `-`, leading
  * non-letter characters stripped (the prefix must start with a letter),
  * cut to 32 characters, trailing `-` stripped. Returns `null` when the
@@ -197,7 +197,7 @@ function hasAnyRecognizedTooling(targetDir: string): boolean {
 }
 
 /**
- * Derive `{{INSTALL_DEPS_COMMAND}}` from the target tree per the
+ * Derive the INSTALL_DEPS_COMMAND row from the target tree per the
  * reference table. Returns `null` when the evidence is ambiguous or
  * insufficient (bare `package.json` without package-manager signals,
  * `pyproject.toml` + `requirements.txt` together, an unrecognized Python
@@ -460,7 +460,10 @@ export function resolvePlaceholderValues(
   return { values, unresolved };
 }
 
-/** Placeholder-shaped tokens: `{{NAME}}` with an upper-snake name. */
+// Placeholder-shaped tokens: doubled braces around an upper-snake name.
+// Comments in this module spell token names WITHOUT the doubled braces:
+// idd-doctor's unresolved-placeholder scan reads the generated artifact,
+// and a braced example would register as leftover template residue.
 const PLACEHOLDER_TOKEN_PATTERN = /\{\{[A-Z][A-Z0-9_]*\}\}/g;
 
 /** Directories never scanned for placeholder tokens. */
@@ -470,7 +473,7 @@ const SCAN_EXCLUDED_DIRS = new Set(['.git', 'node_modules']);
 export interface PlaceholderFileScan {
   /** Path relative to the scan root, `/`-separated. */
   file: string;
-  /** Token literal → occurrence count, e.g. `{{REPO_NAME}}` → 3. */
+  /** Token literal → occurrence count within the file. */
   tokens: Map<string, number>;
 }
 

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -1,0 +1,714 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// Importing the CLI module directly is only possible because its top-level
+// statements are guarded behind isCliExecution() (#1210 pattern); an
+// import-time CLI run would parse process.argv and abort this test process.
+import {
+  applySubstitutionPlan,
+  buildSubstitutionPlan,
+  deriveInstallDepsCommand,
+  deriveMarkerPrefix,
+  deriveValidateCommands,
+  escapeJsonStringContent,
+  MARKER_PREFIX_PATTERN,
+  ONBOARDING_PLACEHOLDERS,
+  parseRemoteRepoRef,
+  resolvePlaceholderValues,
+  scanPlaceholderTokens,
+} from '../src/scripts/idd-onboard.mts';
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
+const PLACEHOLDERS_DOC = join(
+  REPO_ROOT,
+  'idd-template',
+  'docs',
+  'onboarding',
+  'placeholders.md',
+);
+
+function makeFixtureDir(): string {
+  return mkdtempSync(join(tmpdir(), 'idd-onboard-'));
+}
+
+const ALL_OVERRIDES = {
+  REPO_NAME: 'my-app',
+  PROJECT_MARKER_PREFIX: 'my-app',
+  TRUSTED_MARKER_ACTOR: 'trusted-user-a',
+  FIX_VALIDATE_COMMANDS: 'npm run lint:fix && npm run lint',
+  PRE_PUSH_VALIDATE_COMMANDS: 'npm run lint && npm run test',
+  POST_FIX_VALIDATE_COMMANDS: 'npm run lint:fix && npm run test',
+  INSTALL_DEPS_COMMAND: 'npm install',
+};
+
+/** A minimal imported-template tree exercising every placeholder site. */
+function writeTemplateFixture(root: string): void {
+  mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    [
+      '{',
+      '  "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",',
+      '  "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTOR}}"],',
+      '  "commands": {',
+      '    "install-deps": "{{INSTALL_DEPS_COMMAND}}",',
+      '    "fix-validate": "{{FIX_VALIDATE_COMMANDS}}",',
+      '    "pre-push-validate": "{{PRE_PUSH_VALIDATE_COMMANDS}}",',
+      '    "post-fix-validate": "{{POST_FIX_VALIDATE_COMMANDS}}"',
+      '  }',
+      '}',
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(
+    join(root, 'README.md'),
+    '# {{REPO_NAME}}\n\nWorktree example: ../{{REPO_NAME}}.issue-1-fix\n',
+  );
+}
+
+/** Snapshot every file's bytes so byte-identity can be asserted later. */
+function snapshotTree(root: string): Map<string, Buffer> {
+  const snapshot = new Map<string, Buffer>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const absolute = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        snapshot.set(absolute, readFileSync(absolute));
+      }
+    }
+  };
+  walk(root);
+  return snapshot;
+}
+
+function assertTreeUnchanged(root: string, before: Map<string, Buffer>): void {
+  const after = snapshotTree(root);
+  assert.deepEqual(
+    [...after.keys()].sort(),
+    [...before.keys()].sort(),
+    'file set changed',
+  );
+  for (const [file, bytes] of before) {
+    assert.ok(after.get(file)?.equals(bytes), `file changed: ${file}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Drift guard against idd-template/docs/onboarding/placeholders.md
+// ---------------------------------------------------------------------------
+
+test('the placeholder set matches the onboarding reference table exactly', () => {
+  const doc = readFileSync(PLACEHOLDERS_DOC, 'utf8');
+  const rows = [
+    ...doc.matchAll(/^\| `\{\{([A-Z0-9_]+)\}\}`\s+\| (.+?)\s+\|/gmu),
+  ];
+  const documented = rows.map((row) => row[1]);
+  assert.deepEqual(
+    ONBOARDING_PLACEHOLDERS.map((entry) => entry.name),
+    documented,
+    'ONBOARDING_PLACEHOLDERS must match the "Final placeholder meanings" table order',
+  );
+  // No-op rule drift: exactly the placeholders whose documented meaning is
+  // a command row may take the no-op value `true`.
+  for (const row of rows) {
+    const name = String(row[1] ?? '');
+    const meaning = String(row[2] ?? '');
+    const entry = ONBOARDING_PLACEHOLDERS.find((item) => item.name === name);
+    assert.ok(entry, `undocumented placeholder ${name}`);
+    assert.equal(
+      entry.kind,
+      /command/iu.test(meaning) ? 'command' : 'identity',
+      `kind for ${name} must follow the documented meaning`,
+    );
+  }
+});
+
+test('the marker-prefix pattern matches the documented constraint', () => {
+  const doc = readFileSync(PLACEHOLDERS_DOC, 'utf8');
+  assert.ok(
+    doc.includes(MARKER_PREFIX_PATTERN.source),
+    'placeholders.md must document the same validation pattern',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Derivations
+// ---------------------------------------------------------------------------
+
+test('parseRemoteRepoRef handles https, ssh, and scp-like remote forms', () => {
+  const expected = { owner: 'kurone-kito', repo: 'idd-skill' };
+  assert.deepEqual(
+    parseRemoteRepoRef('https://github.com/kurone-kito/idd-skill.git'),
+    expected,
+  );
+  assert.deepEqual(
+    parseRemoteRepoRef('https://github.com/kurone-kito/idd-skill'),
+    expected,
+  );
+  assert.deepEqual(
+    parseRemoteRepoRef('ssh://git@github.com/kurone-kito/idd-skill.git'),
+    expected,
+  );
+  assert.deepEqual(
+    parseRemoteRepoRef('git@github.com:kurone-kito/idd-skill.git'),
+    expected,
+  );
+  // A trailing slash must not defeat the `.git` strip.
+  assert.deepEqual(
+    parseRemoteRepoRef('https://github.com/kurone-kito/idd-skill.git/'),
+    expected,
+  );
+  // Deeper paths (GitLab subgroups, Azure `_git`) yield no owner rather
+  // than guessing a wrong segment.
+  assert.deepEqual(
+    parseRemoteRepoRef('https://gitlab.com/group/sub/repo.git'),
+    {
+      owner: null,
+      repo: 'repo',
+    },
+  );
+  assert.deepEqual(
+    parseRemoteRepoRef('https://dev.azure.com/org/project/_git/repo'),
+    { owner: null, repo: 'repo' },
+  );
+  assert.equal(parseRemoteRepoRef('not a url'), null);
+  assert.equal(parseRemoteRepoRef('https://github.com/idd-skill'), null);
+  assert.equal(parseRemoteRepoRef(''), null);
+  assert.equal(parseRemoteRepoRef(null), null);
+});
+
+test('deriveMarkerPrefix normalizes to the documented pattern or fails closed', () => {
+  assert.equal(deriveMarkerPrefix('My_App.2024'), 'my-app-2024');
+  assert.equal(deriveMarkerPrefix('idd-skill'), 'idd-skill');
+  assert.equal(deriveMarkerPrefix('123-repo'), 'repo');
+  assert.equal(
+    deriveMarkerPrefix('a-very-long-repository-name-that-exceeds-limits'),
+    'a-very-long-repository-name-that',
+  );
+  assert.equal(deriveMarkerPrefix('!!!'), null);
+  assert.equal(deriveMarkerPrefix('a'), null);
+  assert.equal(deriveMarkerPrefix(''), null);
+  for (const derived of ['my-app-2024', 'repo']) {
+    assert.match(derived, MARKER_PREFIX_PATTERN);
+  }
+});
+
+test('deriveInstallDepsCommand follows the documented evidence table', () => {
+  const cases: {
+    files: Record<string, string>;
+    expected: string | null;
+  }[] = [
+    {
+      files: { 'pnpm-lock.yaml': '', 'package.json': '{}' },
+      expected: 'pnpm install',
+    },
+    {
+      files: { 'package.json': '{"packageManager":"npm@10.0.0"}' },
+      expected: 'npm install',
+    },
+    // Bare package.json without signals: do not infer npm install.
+    { files: { 'package.json': '{}' }, expected: null },
+    {
+      files: { 'requirements.txt': 'requests\n' },
+      expected: 'pip install -r requirements.txt',
+    },
+    {
+      files: { 'pyproject.toml': '[tool.poetry]\nname = "x"\n' },
+      expected: 'poetry install',
+    },
+    // Dotted sub-tables are the common real-world pyproject shape.
+    {
+      files: { 'pyproject.toml': '[tool.hatch.envs.default]\ndeps = []\n' },
+      expected: 'hatch env create',
+    },
+    // Exactly one supported lockfile counts even without a package.json.
+    { files: { 'pnpm-lock.yaml': '' }, expected: 'pnpm install' },
+    // Both Python workflows: confirm with the operator, do not guess.
+    {
+      files: { 'pyproject.toml': '[tool.pdm]\n', 'requirements.txt': '' },
+      expected: null,
+    },
+    { files: { 'go.mod': 'module x\n' }, expected: 'go mod download' },
+    {
+      files: { Gemfile: 'source "https://rubygems.org"\n' },
+      expected: 'bundle install',
+    },
+    // No standard dependency tooling at all: the documented no-op.
+    { files: {}, expected: 'true' },
+  ];
+  for (const { files, expected } of cases) {
+    const root = makeFixtureDir();
+    for (const [name, content] of Object.entries(files)) {
+      writeFileSync(join(root, name), content);
+    }
+    assert.equal(
+      deriveInstallDepsCommand(root),
+      expected,
+      `files: ${Object.keys(files).join(', ') || '(none)'}`,
+    );
+  }
+});
+
+test('deriveValidateCommands reads Node project scripts with the detected pm', () => {
+  const root = makeFixtureDir();
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({
+      scripts: { 'lint:fix': 'x', lint: 'x', test: 'x' },
+    }),
+  );
+  writeFileSync(join(root, 'pnpm-lock.yaml'), '');
+  // The post-fix superset deduplicates the shared `lint` step.
+  assert.deepEqual(deriveValidateCommands(root), {
+    fixValidate: 'pnpm run lint:fix && pnpm run lint',
+    prePushValidate: 'pnpm run lint && pnpm run test',
+    postFixValidate: 'pnpm run lint:fix && pnpm run lint && pnpm run test',
+  });
+});
+
+test('deriveValidateCommands fails closed when the package manager is unknown', () => {
+  // Ambiguous evidence (two lockfiles) must not silently fall back to
+  // npm — the same rule the install-command derivation applies.
+  const root = makeFixtureDir();
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ scripts: { 'lint:fix': 'x', lint: 'x', test: 'x' } }),
+  );
+  writeFileSync(join(root, 'pnpm-lock.yaml'), '');
+  writeFileSync(join(root, 'yarn.lock'), '');
+  assert.deepEqual(deriveValidateCommands(root), {
+    fixValidate: null,
+    prePushValidate: null,
+    postFixValidate: null,
+  });
+});
+
+test('deriveValidateCommands uses fixed rows for go and the no-op for bare trees', () => {
+  const goRoot = makeFixtureDir();
+  writeFileSync(join(goRoot, 'go.mod'), 'module x\n');
+  assert.deepEqual(deriveValidateCommands(goRoot), {
+    fixValidate: 'go fmt ./...',
+    prePushValidate: 'go vet ./... && go test ./...',
+    postFixValidate: 'go fmt ./... && go vet ./... && go test ./...',
+  });
+
+  const bareRoot = makeFixtureDir();
+  assert.deepEqual(deriveValidateCommands(bareRoot), {
+    fixValidate: 'true',
+    prePushValidate: 'true',
+    postFixValidate: 'true',
+  });
+
+  // Recognized-but-unmapped tooling (plain pyproject) stays unresolved.
+  const pyRoot = makeFixtureDir();
+  writeFileSync(join(pyRoot, 'pyproject.toml'), '[project]\nname = "x"\n');
+  assert.deepEqual(deriveValidateCommands(pyRoot), {
+    fixValidate: null,
+    prePushValidate: null,
+    postFixValidate: null,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolution rules
+// ---------------------------------------------------------------------------
+
+test('resolvePlaceholderValues derives identity values from the git remote', () => {
+  const root = makeFixtureDir();
+  const resolution = resolvePlaceholderValues(
+    root,
+    {},
+    { readRemoteUrl: () => 'git@github.com:trusted-user-a/My-App.git' },
+  );
+  // TRUSTED_MARKER_ACTOR is never auto-derived: the remote owner may be
+  // an organization slug, not a login that posts markers.
+  assert.deepEqual(resolution.unresolved, ['TRUSTED_MARKER_ACTOR']);
+  assert.deepEqual(resolution.values.REPO_NAME, {
+    value: 'My-App',
+    source: 'derived',
+  });
+  assert.deepEqual(resolution.values.PROJECT_MARKER_PREFIX, {
+    value: 'my-app',
+    source: 'derived',
+  });
+  assert.equal(resolution.values.TRUSTED_MARKER_ACTOR, null);
+  // Empty tree: command rows all take the documented no-op.
+  assert.equal(resolution.values.INSTALL_DEPS_COMMAND?.value, 'true');
+});
+
+test('the marker prefix derives from an explicit --repo-name without a remote', () => {
+  const root = makeFixtureDir();
+  const resolution = resolvePlaceholderValues(
+    root,
+    { REPO_NAME: 'New_Name' },
+    { readRemoteUrl: () => null },
+  );
+  assert.deepEqual(resolution.values.PROJECT_MARKER_PREFIX, {
+    value: 'new-name',
+    source: 'derived',
+  });
+  // ...and the flag also wins over a stale remote for the derivation.
+  const renamed = resolvePlaceholderValues(
+    root,
+    { REPO_NAME: 'new-name' },
+    { readRemoteUrl: () => 'git@github.com:owner/old-name.git' },
+  );
+  assert.equal(renamed.values.PROJECT_MARKER_PREFIX?.value, 'new-name');
+});
+
+test('unknown override keys are rejected instead of silently ignored', () => {
+  const root = makeFixtureDir();
+  assert.throws(
+    () =>
+      resolvePlaceholderValues(
+        root,
+        { REPONAME: 'typo' },
+        {
+          readRemoteUrl: () => null,
+        },
+      ),
+    /unknown placeholder override: REPONAME/,
+  );
+});
+
+test('resolvePlaceholderValues reports unresolved placeholders without evidence', () => {
+  const root = makeFixtureDir();
+  writeFileSync(join(root, 'package.json'), '{}');
+  const resolution = resolvePlaceholderValues(
+    root,
+    {},
+    { readRemoteUrl: () => null },
+  );
+  assert.deepEqual(resolution.unresolved, [
+    'REPO_NAME',
+    'PROJECT_MARKER_PREFIX',
+    'TRUSTED_MARKER_ACTOR',
+    'FIX_VALIDATE_COMMANDS',
+    'PRE_PUSH_VALIDATE_COMMANDS',
+    'POST_FIX_VALIDATE_COMMANDS',
+    'INSTALL_DEPS_COMMAND',
+  ]);
+});
+
+test('flag overrides win over derivation and are marked as flag-sourced', () => {
+  const root = makeFixtureDir();
+  const resolution = resolvePlaceholderValues(
+    root,
+    { REPO_NAME: 'renamed' },
+    { readRemoteUrl: () => 'git@github.com:owner/original.git' },
+  );
+  assert.deepEqual(resolution.values.REPO_NAME, {
+    value: 'renamed',
+    source: 'flag',
+  });
+});
+
+test('the no-op value true is rejected for identity placeholders', () => {
+  const root = makeFixtureDir();
+  assert.throws(
+    () =>
+      resolvePlaceholderValues(
+        root,
+        { REPO_NAME: 'true' },
+        {
+          readRemoteUrl: () => null,
+        },
+      ),
+    /only valid for command placeholders/,
+  );
+  // ...and accepted for every command placeholder.
+  const resolution = resolvePlaceholderValues(
+    root,
+    {
+      ...ALL_OVERRIDES,
+      FIX_VALIDATE_COMMANDS: 'true',
+      PRE_PUSH_VALIDATE_COMMANDS: 'true',
+      POST_FIX_VALIDATE_COMMANDS: 'true',
+      INSTALL_DEPS_COMMAND: 'true',
+    },
+    { readRemoteUrl: () => null },
+  );
+  assert.deepEqual(resolution.unresolved, []);
+});
+
+test('an explicit marker prefix must satisfy the documented pattern', () => {
+  const root = makeFixtureDir();
+  assert.throws(
+    () =>
+      resolvePlaceholderValues(
+        root,
+        { PROJECT_MARKER_PREFIX: 'Bad_Prefix' },
+        {
+          readRemoteUrl: () => null,
+        },
+      ),
+    /--marker-prefix must match/,
+  );
+});
+
+test('the trusted-marker-actor value is JSON-escaped string content', () => {
+  assert.equal(escapeJsonStringContent('trusted-user-a'), 'trusted-user-a');
+  assert.equal(escapeJsonStringContent('a"b\\c'), 'a\\"b\\\\c');
+  const root = makeFixtureDir();
+  const resolution = resolvePlaceholderValues(
+    root,
+    { TRUSTED_MARKER_ACTOR: 'a"b' },
+    { readRemoteUrl: () => null },
+  );
+  assert.equal(resolution.values.TRUSTED_MARKER_ACTOR?.value, 'a\\"b');
+});
+
+// ---------------------------------------------------------------------------
+// Scan / plan / apply
+// ---------------------------------------------------------------------------
+
+test('substitution applies exactly the planned edits and keeps config.json valid', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  const resolution = resolvePlaceholderValues(
+    root,
+    { ...ALL_OVERRIDES },
+    {
+      readRemoteUrl: () => null,
+    },
+  );
+  const plan = buildSubstitutionPlan(scanPlaceholderTokens(root), resolution);
+  assert.deepEqual(plan.residue, []);
+  const readme = plan.entries.filter((entry) => entry.file === 'README.md');
+  assert.deepEqual(readme, [
+    {
+      file: 'README.md',
+      placeholder: 'REPO_NAME',
+      occurrences: 2,
+      from: '{{REPO_NAME}}',
+      to: 'my-app',
+    },
+  ]);
+
+  const filesChanged = applySubstitutionPlan(root, plan);
+  assert.equal(filesChanged, 2);
+  assert.equal(
+    readFileSync(join(root, 'README.md'), 'utf8'),
+    '# my-app\n\nWorktree example: ../my-app.issue-1-fix\n',
+  );
+  const config = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as {
+    markerPrefix: string;
+    trustedMarkerActors: string[];
+    commands: Record<string, string>;
+  };
+  assert.equal(config.markerPrefix, 'my-app');
+  assert.deepEqual(config.trustedMarkerActors, ['trusted-user-a']);
+  assert.equal(config.commands['install-deps'], 'npm install');
+  // The replacement pass converged: no {{...}} strings remain.
+  assert.deepEqual(scanPlaceholderTokens(root), []);
+});
+
+test('unresolved placeholders block as residue; unknown tokens stay informational', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  writeFileSync(join(root, 'NOTES.md'), 'Leftover {{UNKNOWN_TOKEN}} here\n');
+  const { REPO_NAME: _omitted, ...withoutRepoName } = ALL_OVERRIDES;
+  const resolution = resolvePlaceholderValues(root, withoutRepoName, {
+    readRemoteUrl: () => null,
+  });
+  const plan = buildSubstitutionPlan(scanPlaceholderTokens(root), resolution);
+  assert.deepEqual(
+    plan.residue.map((entry) => [entry.file, entry.token]),
+    [['README.md', '{{REPO_NAME}}']],
+  );
+  // An adopter's own {{UPPER_SNAKE}} template token must not make the
+  // run permanently non-convergent — wave 1 cannot know the copied set.
+  assert.deepEqual(
+    plan.unknownTokens.map((entry) => [entry.file, entry.token]),
+    [['NOTES.md', '{{UNKNOWN_TOKEN}}']],
+  );
+});
+
+test('a substitution value containing another token is never re-substituted', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  const resolution = resolvePlaceholderValues(
+    root,
+    {
+      ...ALL_OVERRIDES,
+      FIX_VALIDATE_COMMANDS: 'echo {{PRE_PUSH_VALIDATE_COMMANDS}}',
+    },
+    { readRemoteUrl: () => null },
+  );
+  const plan = buildSubstitutionPlan(scanPlaceholderTokens(root), resolution);
+  applySubstitutionPlan(root, plan);
+  const config = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as { commands: Record<string, string> };
+  // Single-pass replacement keeps the operator's literal flag value.
+  assert.equal(
+    config.commands['fix-validate'],
+    'echo {{PRE_PUSH_VALIDATE_COMMANDS}}',
+  );
+  assert.equal(
+    config.commands['pre-push-validate'],
+    'npm run lint && npm run test',
+  );
+});
+
+test('binary files and excluded directories are not scanned', () => {
+  const root = makeFixtureDir();
+  writeFileSync(join(root, 'blob.bin'), Buffer.from('{{REPO_NAME}}\0tail'));
+  mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true });
+  writeFileSync(join(root, 'node_modules', 'pkg', 'x.md'), '{{REPO_NAME}}');
+  mkdirSync(join(root, '.git'), { recursive: true });
+  writeFileSync(join(root, '.git', 'config'), '{{REPO_NAME}}');
+  assert.deepEqual(scanPlaceholderTokens(root), []);
+});
+
+// ---------------------------------------------------------------------------
+// CLI (acceptance criteria) through the committed bin artifact
+// ---------------------------------------------------------------------------
+
+const BIN_PATH = join(REPO_ROOT, 'bin', 'idd-onboard.mjs');
+
+function runCliBin(args: string[]): {
+  status: number;
+  verdict: Record<string, unknown>;
+} {
+  try {
+    const stdout = execFileSync(process.execPath, [BIN_PATH, ...args], {
+      encoding: 'utf8',
+    });
+    return {
+      status: 0,
+      verdict: JSON.parse(stdout) as Record<string, unknown>,
+    };
+  } catch (error) {
+    const failed = error as { status?: number; stdout?: string };
+    return {
+      status: failed.status ?? -1,
+      verdict: JSON.parse(String(failed.stdout ?? '{}')) as Record<
+        string,
+        unknown
+      >,
+    };
+  }
+}
+
+const CLI_OVERRIDE_FLAGS = [
+  '--repo-name',
+  'my-app',
+  '--marker-prefix',
+  'my-app',
+  '--trusted-marker-actor',
+  'trusted-user-a',
+  '--fix-validate-commands',
+  'npm run lint:fix && npm run lint',
+  '--pre-push-validate-commands',
+  'npm run lint && npm run test',
+  '--post-fix-validate-commands',
+  'npm run lint:fix && npm run test',
+  '--install-deps-command',
+  'npm install',
+];
+
+test('bin/idd-onboard.mjs --substitute --dry-run prints the plan and writes nothing', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  const before = snapshotTree(root);
+  const { status, verdict } = runCliBin([
+    '--substitute',
+    '--dry-run',
+    '--target',
+    root,
+    ...CLI_OVERRIDE_FLAGS,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.mode, 'dry-run');
+  assert.equal(verdict.written, false);
+  assert.ok(Array.isArray(verdict.plan) && verdict.plan.length > 0);
+  assert.deepEqual(verdict.residue, []);
+  assertTreeUnchanged(root, before);
+});
+
+test('bin/idd-onboard.mjs without --dry-run applies exactly the planned edits', () => {
+  const dryRoot = makeFixtureDir();
+  writeTemplateFixture(dryRoot);
+  const planned = runCliBin([
+    '--substitute',
+    '--dry-run',
+    '--target',
+    dryRoot,
+    ...CLI_OVERRIDE_FLAGS,
+  ]).verdict.plan;
+
+  const applyRoot = makeFixtureDir();
+  writeTemplateFixture(applyRoot);
+  const { status, verdict } = runCliBin([
+    '--substitute',
+    '--target',
+    applyRoot,
+    ...CLI_OVERRIDE_FLAGS,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.mode, 'apply');
+  assert.equal(verdict.written, true);
+  assert.deepEqual(verdict.plan, planned);
+  assert.equal(
+    readFileSync(join(applyRoot, 'README.md'), 'utf8'),
+    '# my-app\n\nWorktree example: ../my-app.issue-1-fix\n',
+  );
+});
+
+test('bin/idd-onboard.mjs exits 1, reports residue, and writes nothing when unresolved', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  const before = snapshotTree(root);
+  // Apply mode (no --dry-run): the fail-closed gate must refuse to write
+  // a half-substituted tree when any placeholder stays unresolved.
+  const { status, verdict } = runCliBin(['--substitute', '--target', root]);
+  assert.equal(status, 1);
+  assert.equal(verdict.written, false);
+  assert.equal(verdict.filesChanged, 0);
+  const residue = verdict.residue as { token: string }[];
+  assert.ok(residue.length > 0);
+  assert.ok(residue.every((entry) => entry.token.startsWith('{{')));
+  assertTreeUnchanged(root, before);
+});
+
+test('bin/idd-onboard.mjs exits 2 on usage errors, distinct from residue', () => {
+  const root = makeFixtureDir();
+  try {
+    execFileSync(
+      process.execPath,
+      [BIN_PATH, '--substitute', '--target', root, '--no-such-flag'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    assert.fail('expected a non-zero exit');
+  } catch (error) {
+    const failed = error as { status?: number; stderr?: string };
+    assert.equal(failed.status, 2);
+    assert.match(String(failed.stderr), /unknown argument/);
+  }
+});
+
+test('importing idd-onboard.mts has no import-time side effect', async () => {
+  const originalPath = process.env.PATH;
+  process.env.PATH = '';
+  try {
+    await assert.doesNotReject(import('../src/scripts/idd-onboard.mts'));
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -459,7 +459,7 @@ test('an explicit marker prefix must satisfy the documented pattern', () => {
   );
 });
 
-test('the trusted-marker-actor value is JSON-escaped string content', () => {
+test('values stay raw at resolution; JSON sites are escaped in the plan', () => {
   assert.equal(escapeJsonStringContent('trusted-user-a'), 'trusted-user-a');
   assert.equal(escapeJsonStringContent('a"b\\c'), 'a\\"b\\\\c');
   const root = makeFixtureDir();
@@ -468,7 +468,37 @@ test('the trusted-marker-actor value is JSON-escaped string content', () => {
     { TRUSTED_MARKER_ACTOR: 'a"b' },
     { readRemoteUrl: () => null },
   );
-  assert.equal(resolution.values.TRUSTED_MARKER_ACTOR?.value, 'a\\"b');
+  // Escaping is a property of the substitution site, applied per file in
+  // buildSubstitutionPlan — the resolved value itself stays raw.
+  assert.equal(resolution.values.TRUSTED_MARKER_ACTOR?.value, 'a"b');
+});
+
+test('command values containing quotes stay valid JSON and land raw in markdown', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  // A markdown command-table site next to the config.json site.
+  writeFileSync(
+    join(root, 'INSTALL.md'),
+    '| **install-deps** | `{{INSTALL_DEPS_COMMAND}}` |\n',
+  );
+  const quotedCommand = 'npx cspell lint "**" --no-progress';
+  const resolution = resolvePlaceholderValues(
+    root,
+    { ...ALL_OVERRIDES, INSTALL_DEPS_COMMAND: quotedCommand },
+    { readRemoteUrl: () => null },
+  );
+  const plan = buildSubstitutionPlan(scanPlaceholderTokens(root), resolution);
+  applySubstitutionPlan(root, plan);
+  // The JSON site parses and round-trips the raw command...
+  const config = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as { commands: Record<string, string> };
+  assert.equal(config.commands['install-deps'], quotedCommand);
+  // ...while the markdown site receives it unescaped.
+  assert.equal(
+    readFileSync(join(root, 'INSTALL.md'), 'utf8'),
+    `| **install-deps** | \`${quotedCommand}\` |\n`,
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

First track of the onboarding-automation roadmap #1262: a new `idd-onboard` helper (source `src/scripts/idd-onboard.mts`, generated `scripts/` / `bin/` artifacts, sorted `package.json` `bin` entry) whose `--substitute` mode resolves the seven template placeholders for a target tree that already contains the imported template files and rewrites them. `idd-template/docs/onboarding/placeholders.md` is the source of truth; a drift test fails on any mismatch between that table and the CLI's placeholder set or no-op rules.

- **Auto-derivation** exactly where the reference defines one: repo name and marker prefix from the git remote (marker prefix derives from the *finalized* repo name, so `--repo-name` feeds it); package-manager signals via the shared `collectHelperRuntimeEvidence` (declared `packageManager` metadata or exactly one supported lockfile — bare `package.json` and multi-lockfile trees stay unresolved rather than guessing npm); the documented pip / poetry / pdm / hatch / uv (dotted sub-tables included) / go / bundle rows; `true` no-op rows only when no dependency tooling exists at all. `TRUSTED_MARKER_ACTOR` is never auto-derived — an org-owned remote's owner slug is not a marker-posting login, so writing it into the trust configuration would fail open; the flag is required.
- **Fail-closed apply**: `--dry-run` prints the per-file, per-placeholder plan (old → new, occurrence counts) and writes nothing; apply writes only when every scanned onboarding placeholder resolved, so a half-substituted tree is never produced. Replacement is single-pass, so a substitution value containing another `{{...}}` token stays literal.
- **Exit-code contract**: 0 converged; 1 unresolved-placeholder residue (reported per file, dry-run and apply alike); 2 usage/config errors. Adopter-owned `{{UPPER_SNAKE}}` tokens outside the seven are reported informationally instead of failing the run — wave 1 has no copied-file manifest yet (that arrives with the fetch/copy stage), so unknown tokens cannot be distinguished from an adopter's own template tokens.
- CLI body is guarded by `isCliExecution()` (#1210 pattern) with an explicit PATH-stripped import-purity test; 25 fixture-driven tests cover the derivation matrix, no-op rules, byte-identical dry-run, plan-equals-apply, residue reporting, and the acceptance-criteria invocation through the committed `bin/idd-onboard.mjs`.

## Linked issue

Closes #1263

## Follow-up issues (if any)

- [x] none (the fetch/copy and drift-check stages are already tracked as later waves under roadmap #1262)

## Background / rationale (if material)

The `idd-onboard` bin is intentionally **not** registered in `HELPER_COMMANDS` / `docs/idd-helper-scripts.md`: it is a one-shot onboarding tool, not an IDD-phase evidence helper, and registering it would vendor it into adopter repos via the helper-runtime install path. Wave-2+ can revisit once the full pipeline shape exists.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`pnpm run lint:minimum`)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (covered by audit-docs in lint:minimum)
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (no gate behavior changed)
- [x] Context budget impact reviewed (no instruction/doc bundle changes)
