### PR TITLE
docs(idd): reference the configurable label names in instructions

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -57,7 +57,10 @@ that issue only:
    `Issue #N is currently being authored`, run the stale-authoring
    warning check above, and stop without claiming.
 3. Apply the same readiness intent as A3 to the target:
-   - no `status:blocked-by-human` or `status:needs-decision` label;
+   - no configured blocked-by-human label from
+     `labels.blockedByHumanLabelName` (default: `status:blocked-by-human`)
+     or configured needs-decision label from
+     `labels.needsDecisionLabelName` (default: `status:needs-decision`);
    - no open dependent issues, except parent epics or aggregate issues
      that are acceptable under A3;
    - visible `Blocked by #NNN` references resolve to closed or otherwise
@@ -135,7 +138,7 @@ body satisfies **all** of the following:
 - Does NOT contain any `<!-- idd-skill-roadmap-id: … -->` marker
   (the issue is not itself a roadmap).
 - Does NOT contain any `<!-- idd-skill-blocked-by: … -->` marker.
-- Does NOT have a `status:blocked-by-human` or `status:needs-decision`
+- Does NOT have the configured blocked-by-human or needs-decision
   label.
 - Does NOT have the configured authoring label.
 - Does NOT contain visible `Blocked by #NNN` lines where the referenced
@@ -178,7 +181,8 @@ when it returns zero.
 ## A1 — Find the roadmap
 
 Use GH CLI or GH MCP to find the roadmap among open issues. Identify it
-by the `roadmap` label (project field) or by recognizing it as an
+by the configured roadmap label from `labels.roadmapLabelName`
+(default: `roadmap`, project field) or by recognizing it as an
 umbrella issue. If no roadmap issue exists, report and abort.
 
 **Autopilot cross-roadmap mode (optional, additive).** When several
@@ -236,7 +240,7 @@ referenced issues. Collect only **open** issues.
   explicit task, sub-issue, or dependency relationship
 
 Traverse referenced issues regardless of their open/closed state.
-Issues carrying the `roadmap` label or an
+Issues carrying the configured roadmap label or an
 `<!-- idd-skill-roadmap-id: ... -->` marker are **roadmap nodes**; any
 other issue is an **execution leaf**. Include only open execution leaf
 issues in the candidate set; do not advance roadmap nodes to
@@ -327,7 +331,7 @@ is cheap — run it first per candidate.
 
 From A2, keep only issues that satisfy **all** of the following:
 
-- No `status:blocked-by-human` or `status:needs-decision` label
+- No configured blocked-by-human or needs-decision label
 - No configured authoring label
 - No open dependent issues (parent epics / aggregate issues that are
   still open are acceptable)
@@ -600,8 +604,8 @@ discover phase:
 
 - **Roadmap identity** (`idd-skill-roadmap-id`): placed in the roadmap
   issue body. A3 uses this marker to resolve `blocked-by` dependency
-  lookups. A1 identifies the roadmap by its `roadmap` label or umbrella
-  structure — not by this marker.
+  lookups. A1 identifies the roadmap by its configured roadmap label
+  or umbrella structure — not by this marker.
 - **Sequential dependency** (`idd-skill-blocked-by`): placed in an
   issue body to express a hard dependency — this issue **cannot start
   until** the roadmap with the matching `roadmap-id` is closed.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -181,9 +181,9 @@ when it returns zero.
 ## A1 — Find the roadmap
 
 Use GH CLI or GH MCP to find the roadmap among open issues. Identify it
-by the configured roadmap label from `labels.roadmapLabelName`
-(default: `roadmap`, project field) or by recognizing it as an
-umbrella issue. If no roadmap issue exists, report and abort.
+by the configured roadmap label (project field) from
+`labels.roadmapLabelName` (default: `roadmap`) or by recognizing it as
+an umbrella issue. If no roadmap issue exists, report and abort.
 
 **Autopilot cross-roadmap mode (optional, additive).** When several
 roadmaps run in parallel and the active autopilot-suitable work may live

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -246,8 +246,11 @@ Roadmap-audit claims are coordination locks for roadmap-side mutations
 only. They must not be treated as global execution locks: child issue
 discovery and A5 checks remain issue-local and are gated by each child's
 own claim state, blockers, and dependencies. This does not relax
-roadmap-level blocker gates such as `status:blocked-by-human` or
-`status:needs-decision`, which still stop child selection in Discover.
+roadmap-level blocker gates such as the configured blocked-by-human
+label from `labels.blockedByHumanLabelName` (default:
+`status:blocked-by-human`) or configured needs-decision label from
+`labels.needsDecisionLabelName` (default: `status:needs-decision`),
+which still stop child selection in Discover.
 
 ## Project commands
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -197,9 +197,11 @@ For each Rejected PATH A item whose source is reviewer feedback:
     (distributed default: `PT24H`) of no response: escalate to a
     maintainer via issue or PR comment.
   - After `reviewEscalation.changesRequestedSecondEscalation`
-    (distributed default: `PT48H`) of no escalation response: consider adding a
-    `status:needs-decision` label and releasing the claim. The label may
-    be removed and the issue re-claimed once the blocker is resolved.
+    (distributed default: `PT48H`) of no escalation response: consider
+    adding the configured needs-decision label from
+    `labels.needsDecisionLabelName` (default: `status:needs-decision`)
+    and releasing the claim. The label may be removed and the issue
+    re-claimed once the blocker is resolved.
   - If a maintainer or admin (other than the original reviewer) agrees
     with your rejection: that agreement is **not sufficient on its own**
     to clear F2's `CHANGES_REQUESTED` gate. Ask them to either obtain

--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -36,17 +36,21 @@ results only to link existing gap work or avoid creating a duplicate,
 not to widen A2 candidates.
 
 When the selected roadmap graph includes descendant issues that are
-themselves roadmap nodes, such as descendants carrying the `roadmap`
-label or a `idd-skill-roadmap-id` marker, treat those
+themselves roadmap nodes, such as descendants carrying the configured
+roadmap label from `labels.roadmapLabelName` (default: `roadmap`) or a
+`idd-skill-roadmap-id` marker, treat those
 descendants as **nested roadmaps** rather than as normal execution
 leaves. A nested roadmap is a coordination/audit node in the recursive
 hierarchy: it may remain open while its own leaf descendants are still
 executing, and its presence does not by itself widen A2 candidates
 outside the selected roadmap graph.
 
-- If the roadmap itself has `status:blocked-by-human` or
-  `status:needs-decision`, report the blocker and stop before A2. Do
-  not continue selecting child issues under a blocked roadmap.
+- If the roadmap itself carries the configured blocked-by-human label
+  from `labels.blockedByHumanLabelName` (default:
+  `status:blocked-by-human`) or configured needs-decision label from
+  `labels.needsDecisionLabelName` (default: `status:needs-decision`),
+  report the blocker and stop before A2. Do not continue selecting
+  child issues under a blocked roadmap.
 - If any referenced child or descendant issue is open, inaccessible, or
   unresolved, report the provenance path and reason, then continue to
   A2, unless the open descendant is a nested roadmap with at least one
@@ -57,12 +61,11 @@ outside the selected roadmap graph.
 - If any referenced child or descendant has an open linked or closing
   PR that is not merged or otherwise obsolete, treat that child work as
   unresolved, report the PR, and continue to A2.
-- If any open or unresolved child or descendant has
-  `status:blocked-by-human` or `status:needs-decision`, report the
-  blocker and continue to A2 or stop according to the normal
-  ready-to-start rules. Do not treat stale blocker labels on closed
-  children as audit blockers when their referenced descendants are
-  resolved.
+- If any open or unresolved child or descendant has the configured
+  blocked-by-human or needs-decision label, report the blocker and
+  continue to A2 or stop according to the normal ready-to-start
+  rules. Do not treat stale blocker labels on closed children as
+  audit blockers when their referenced descendants are resolved.
 - If an open leaf issue sits under an open nested roadmap, treat the
   nested roadmap and every ancestor roadmap on that provenance path as
   unresolved. Report the deepest blocking path and continue to A2.
@@ -165,8 +168,8 @@ Apply one outcome:
   issue link so the next audit can link it before considering
   duplicates.
 - **Non-autonomous gaps found**: comment with the decision or human
-  blocker, apply `status:needs-decision` or `status:blocked-by-human`
-  when those labels exist, and do not close the roadmap. Stop before A2
-  after reporting a non-autonomous gap, even if the repository does not
-  have the blocker labels, so the same unattended run cannot select
-  child work under a roadmap that needs human input.
+  blocker, apply the configured needs-decision or blocked-by-human
+  label when those labels exist, and do not close the roadmap. Stop
+  before A2 after reporting a non-autonomous gap, even if the
+  repository does not have the blocker labels, so the same unattended
+  run cannot select child work under a roadmap that needs human input.

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -85,7 +85,10 @@ trust or safety risk?
 
 Is this work a duplicate of an existing open issue, closed issue,
 merged PR, or draft PR? Is it superseded by paused work marked with
-`status:blocked-by-human` or `status:needs-decision`?
+the configured blocked-by-human label from
+`labels.blockedByHumanLabelName` (default: `status:blocked-by-human`)
+or configured needs-decision label from `labels.needsDecisionLabelName`
+(default: `status:needs-decision`)?
 
 - **Pass**: No duplicate or superseded work detected; this issue
   represents novel work

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -57,7 +57,10 @@ that issue only:
    `Issue #N is currently being authored`, run the stale-authoring
    warning check above, and stop without claiming.
 3. Apply the same readiness intent as A3 to the target:
-   - no `status:blocked-by-human` or `status:needs-decision` label;
+   - no configured blocked-by-human label from
+     `labels.blockedByHumanLabelName` (default: `status:blocked-by-human`)
+     or configured needs-decision label from
+     `labels.needsDecisionLabelName` (default: `status:needs-decision`);
    - no open dependent issues, except parent epics or aggregate issues
      that are acceptable under A3;
    - visible `Blocked by #NNN` references resolve to closed or otherwise
@@ -138,7 +141,7 @@ body satisfies **all** of the following:
   is not itself a roadmap).
 - Does NOT contain any
   `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: … -->` marker.
-- Does NOT have a `status:blocked-by-human` or `status:needs-decision`
+- Does NOT have the configured blocked-by-human or needs-decision
   label.
 - Does NOT have the configured authoring label.
 - Does NOT contain visible `Blocked by #NNN` lines where the referenced
@@ -181,7 +184,8 @@ when it returns zero.
 ## A1 — Find the roadmap
 
 Use GH CLI or GH MCP to find the roadmap among open issues. Identify it
-by the `roadmap` label (project field) or by recognizing it as an
+by the configured roadmap label from `labels.roadmapLabelName`
+(default: `roadmap`, project field) or by recognizing it as an
 umbrella issue. If no roadmap issue exists, report and abort.
 
 **Autopilot cross-roadmap mode (optional, additive).** When several
@@ -243,8 +247,8 @@ referenced issues. Collect only **open** issues.
 
 Traverse referenced issues regardless of their open/closed state.
 
-**Roadmap node classification**: any issue carrying the `roadmap` label
-or containing an
+**Roadmap node classification**: any issue carrying the configured
+roadmap label or containing an
 `<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: ... -->` marker is a
 **roadmap node**, not an execution leaf. Roadmap nodes are
 traversal-only coordination nodes:
@@ -346,7 +350,7 @@ is cheap — run it first per candidate.
 
 From A2, keep only issues that satisfy **all** of the following:
 
-- No `status:blocked-by-human` or `status:needs-decision` label
+- No configured blocked-by-human or needs-decision label
 - No configured authoring label
 - No open dependent issues (parent epics / aggregate issues that are
   still open are acceptable)
@@ -620,8 +624,8 @@ discover phase:
 
 - **Roadmap identity** (`{{PROJECT_MARKER_PREFIX}}-roadmap-id`): placed
   in the roadmap issue body. A3 uses this marker to resolve `blocked-by`
-  dependency lookups. A1 identifies the roadmap by its `roadmap` label
-  or umbrella structure — not by this marker.
+  dependency lookups. A1 identifies the roadmap by its configured
+  roadmap label or umbrella structure — not by this marker.
 - **Sequential dependency** (`{{PROJECT_MARKER_PREFIX}}-blocked-by`):
   placed in an issue body to express a hard dependency — this issue
   **cannot start until** the roadmap with the matching `roadmap-id` is

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -184,9 +184,9 @@ when it returns zero.
 ## A1 — Find the roadmap
 
 Use GH CLI or GH MCP to find the roadmap among open issues. Identify it
-by the configured roadmap label from `labels.roadmapLabelName`
-(default: `roadmap`, project field) or by recognizing it as an
-umbrella issue. If no roadmap issue exists, report and abort.
+by the configured roadmap label (project field) from
+`labels.roadmapLabelName` (default: `roadmap`) or by recognizing it as
+an umbrella issue. If no roadmap issue exists, report and abort.
 
 **Autopilot cross-roadmap mode (optional, additive).** When several
 roadmaps run in parallel and the active autopilot-suitable work may live

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -241,8 +241,11 @@ Roadmap-audit claims are coordination locks for roadmap-side mutations
 only. They must not be treated as global execution locks: child issue
 discovery and A5 checks remain issue-local and are gated by each child's
 own claim state, blockers, and dependencies. This does not relax
-roadmap-level blocker gates such as `status:blocked-by-human` or
-`status:needs-decision`, which still stop child selection in Discover.
+roadmap-level blocker gates such as the configured blocked-by-human
+label from `labels.blockedByHumanLabelName` (default:
+`status:blocked-by-human`) or configured needs-decision label from
+`labels.needsDecisionLabelName` (default: `status:needs-decision`),
+which still stop child selection in Discover.
 
 ## Project commands
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -192,9 +192,11 @@ For each Rejected PATH A item whose source is reviewer feedback:
     (distributed default: `PT24H`) of no response: escalate to a
     maintainer via issue or PR comment.
   - After `reviewEscalation.changesRequestedSecondEscalation`
-    (distributed default: `PT48H`) of no escalation response: consider adding a
-    `status:needs-decision` label and releasing the claim. The label may
-    be removed and the issue re-claimed once the blocker is resolved.
+    (distributed default: `PT48H`) of no escalation response: consider
+    adding the configured needs-decision label from
+    `labels.needsDecisionLabelName` (default: `status:needs-decision`)
+    and releasing the claim. The label may be removed and the issue
+    re-claimed once the blocker is resolved.
   - If a maintainer or admin (other than the original reviewer) agrees
     with your rejection: that agreement is **not sufficient on its own**
     to clear F2's `CHANGES_REQUESTED` gate. Ask them to either obtain

--- a/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
@@ -31,17 +31,21 @@ results only to link existing gap work or avoid creating a duplicate,
 not to widen A2 candidates.
 
 When the selected roadmap graph includes descendant issues that are
-themselves roadmap nodes, such as descendants carrying the `roadmap`
-label or a `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker, treat those
+themselves roadmap nodes, such as descendants carrying the configured
+roadmap label from `labels.roadmapLabelName` (default: `roadmap`) or a
+`{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker, treat those
 descendants as **nested roadmaps** rather than as normal execution
 leaves. A nested roadmap is a coordination/audit node in the recursive
 hierarchy: it may remain open while its own leaf descendants are still
 executing, and its presence does not by itself widen A2 candidates
 outside the selected roadmap graph.
 
-- If the roadmap itself has `status:blocked-by-human` or
-  `status:needs-decision`, report the blocker and stop before A2. Do
-  not continue selecting child issues under a blocked roadmap.
+- If the roadmap itself carries the configured blocked-by-human label
+  from `labels.blockedByHumanLabelName` (default:
+  `status:blocked-by-human`) or configured needs-decision label from
+  `labels.needsDecisionLabelName` (default: `status:needs-decision`),
+  report the blocker and stop before A2. Do not continue selecting
+  child issues under a blocked roadmap.
 - If any referenced child or descendant issue is open, inaccessible, or
   unresolved, report the provenance path and reason, then continue to
   A2, unless the open descendant is a nested roadmap with at least one
@@ -52,12 +56,11 @@ outside the selected roadmap graph.
 - If any referenced child or descendant has an open linked or closing
   PR that is not merged or otherwise obsolete, treat that child work as
   unresolved, report the PR, and continue to A2.
-- If any open or unresolved child or descendant has
-  `status:blocked-by-human` or `status:needs-decision`, report the
-  blocker and continue to A2 or stop according to the normal
-  ready-to-start rules. Do not treat stale blocker labels on closed
-  children as audit blockers when their referenced descendants are
-  resolved.
+- If any open or unresolved child or descendant has the configured
+  blocked-by-human or needs-decision label, report the blocker and
+  continue to A2 or stop according to the normal ready-to-start
+  rules. Do not treat stale blocker labels on closed children as
+  audit blockers when their referenced descendants are resolved.
 - If an open leaf issue sits under an open nested roadmap, treat the
   nested roadmap and every ancestor roadmap on that provenance path as
   unresolved. Report the deepest blocking path and continue to A2.
@@ -160,8 +163,8 @@ Apply one outcome:
   issue link so the next audit can link it before considering
   duplicates.
 - **Non-autonomous gaps found**: comment with the decision or human
-  blocker, apply `status:needs-decision` or `status:blocked-by-human`
-  when those labels exist, and do not close the roadmap. Stop before A2
-  after reporting a non-autonomous gap, even if the repository does not
-  have the blocker labels, so the same unattended run cannot select
-  child work under a roadmap that needs human input.
+  blocker, apply the configured needs-decision or blocked-by-human
+  label when those labels exist, and do not close the roadmap. Stop
+  before A2 after reporting a non-autonomous gap, even if the
+  repository does not have the blocker labels, so the same unattended
+  run cannot select child work under a roadmap that needs human input.

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -80,7 +80,10 @@ trust or safety risk?
 
 Is this work a duplicate of an existing open issue, closed issue,
 merged PR, or draft PR? Is it superseded by paused work marked with
-`status:blocked-by-human` or `status:needs-decision`?
+the configured blocked-by-human label from
+`labels.blockedByHumanLabelName` (default: `status:blocked-by-human`)
+or configured needs-decision label from `labels.needsDecisionLabelName`
+(default: `status:needs-decision`)?
 
 - **Pass**: No duplicate or superseded work detected; this issue
   represents novel work


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

- Name the `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /
  `labels.needsDecisionLabelName` config fields (added by #1272) alongside
  their defaults wherever `idd-discover`, `idd-overview-core`,
  `idd-review-triage`, `idd-roadmap-audit`, and `idd-suitability`
  instructions previously stated the `roadmap` / `status:blocked-by-human`
  / `status:needs-decision` labels as bare literals.
- Follows the existing `approvalSignals.readyLabelName` /
  `issueAuthoring.authoringLabelName` convention already used in these
  files: the first bare-literal mention of a given label per file spells
  out the field name and default in full, and later same-file mentions
  use the established shorthand already used for the authoring label
  (e.g. "the configured authoring label").
- Both `idd-template/.github/instructions/` sources and their
  `.github/instructions/` mirrors are updated in this commit.
  `idd-discover.instructions.md` is a structure-only sync pair (not
  auto-generated per `audit/sync-manifest.json`), so both copies were
  hand-edited in parallel; the other four files were regenerated via
  `node scripts/sync-docs.mjs --apply`.

## Linked issue

Closes #1274

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

No helper or schema changes here — this issue is docs-prose only.
#1272 (schema + `POLICY_DEFAULTS.labels`) is already merged, and #1273
(wiring the fields into `src/scripts/*.mts` consumers) is a disjoint
sibling issue.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (not applicable; no claim/worktree/
      CI-gate behavior changed)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
