### PR TITLE
feat(discover,idd): resolve labels.* config in six helpers

### DIFF
--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -24,12 +24,9 @@ import {
   isCliExecution,
 } from './gh-exec.mjs';
 import { createMarkerRegex } from './marker-regex.mjs';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
-const BLOCKED_LABELS = new Set([
-  'status:blocked-by-human',
-  'status:needs-decision',
-]);
 if (isCliExecution(import.meta.url)) {
   runCli();
 }
@@ -71,6 +68,12 @@ export function classifyIssue(issue, options) {
   const authoringLabelName = normalizeAuthoringLabelName(
     options.authoringLabelName,
   );
+  const blockedByHumanLabelName = normalizeBlockedByHumanLabelName(
+    options.blockedByHumanLabelName,
+  );
+  const needsDecisionLabelName = normalizeNeedsDecisionLabelName(
+    options.needsDecisionLabelName,
+  );
   const roadmapMarkerRegex = createMarkerRegex(markerPrefix, 'roadmap-id');
   const blockedMarkerRegex = createMarkerRegex(markerPrefix, 'blocked-by');
   if (roadmapMarkerRegex.test(body)) {
@@ -79,7 +82,11 @@ export function classifyIssue(issue, options) {
   if (blockedMarkerRegex.test(body)) {
     return { orphan: false, reason: 'blocked_by_marker' };
   }
-  const blockedLabel = [...labels].find((label) => BLOCKED_LABELS.has(label));
+  const blockedLabels = new Set([
+    blockedByHumanLabelName,
+    needsDecisionLabelName,
+  ]);
+  const blockedLabel = [...labels].find((label) => blockedLabels.has(label));
   if (blockedLabel) {
     return { orphan: false, reason: 'blocked_label', details: blockedLabel };
   }
@@ -144,6 +151,8 @@ export function filterOrphanIssues(issues, options = {}) {
       fetchIssueStateByNumber,
       markerPrefix: options.markerPrefix,
       authoringLabelName: options.authoringLabelName,
+      blockedByHumanLabelName: options.blockedByHumanLabelName,
+      needsDecisionLabelName: options.needsDecisionLabelName,
     });
     if (result.reason === 'unresolvable_reference') {
       for (const number of result.details ?? []) {
@@ -280,6 +289,8 @@ function runCli() {
     markerPrefix: policy.markerPrefix,
     authoringLabelName: policy.authoringLabelName,
     authoringStaleAgeMs: policy.authoringStaleAgeMs,
+    blockedByHumanLabelName: policy.blockedByHumanLabelName,
+    needsDecisionLabelName: policy.needsDecisionLabelName,
     autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
     autopilot: args.autopilot,
@@ -397,6 +408,7 @@ function loadPolicy(policyPath) {
   try {
     const config = JSON.parse(readFileSync(targetPath, 'utf8'));
     const authoringPolicy = resolveAuthoringGuardPolicy(config);
+    const labelsPolicy = normalizePolicyConfig(config).labels;
     return {
       source: targetPath,
       orphanFirstPolicy: getOrphanFirstPolicy(config),
@@ -404,11 +416,14 @@ function loadPolicy(policyPath) {
       authoringLabelName: authoringPolicy.labelName,
       authoringStaleAge: authoringPolicy.staleAge,
       authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+      blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+      needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
       autopilotSuitabilityFloor: resolveAutopilotSuitabilityFloor(config),
       autopilotSuitabilityEnabled: resolveAutopilotSuitabilityEnabled(config),
     };
   } catch {
     const authoringPolicy = resolveAuthoringGuardPolicy({});
+    const labelsPolicy = normalizePolicyConfig({}).labels;
     return {
       source: targetPath,
       orphanFirstPolicy: 'none',
@@ -416,6 +431,8 @@ function loadPolicy(policyPath) {
       authoringLabelName: authoringPolicy.labelName,
       authoringStaleAge: authoringPolicy.staleAge,
       authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+      blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+      needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
       autopilotSuitabilityFloor: DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
       autopilotSuitabilityEnabled: true,
     };
@@ -544,6 +561,18 @@ function normalizeAuthoringLabelName(labelName) {
   return typeof labelName === 'string' && labelName.length > 0
     ? labelName
     : 'status:authoring';
+}
+/** Resolve the configured `labels.blockedByHumanLabelName` (#1273). */
+function normalizeBlockedByHumanLabelName(labelName) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : POLICY_DEFAULTS.labels.blockedByHumanLabelName;
+}
+/** Resolve the configured `labels.needsDecisionLabelName` (#1273). */
+function normalizeNeedsDecisionLabelName(labelName) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : POLICY_DEFAULTS.labels.needsDecisionLabelName;
 }
 function fetchOpenIssues(repoRef) {
   const issues = [];

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -20,6 +20,7 @@ import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import { escapeRegex } from './marker-regex.mjs';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // Leading-anchor source shared by the `Blocked by` / `Depends on` line parsers.
@@ -61,6 +62,7 @@ if (isMainModule(import.meta.url)) {
   const policyConfig = loadPolicy(args.policy);
   const authoringPolicy = resolveAuthoringGuardPolicy(policyConfig);
   const markerPrefix = resolveMarkerPrefix(policyConfig);
+  const labelsPolicy = normalizePolicyConfig(policyConfig).labels;
   // `--swarm-floor` sweeps every open issue (orphans included); otherwise
   // evaluate exactly the issues the caller named.
   const issueNumbers =
@@ -83,6 +85,9 @@ if (isMainModule(import.meta.url)) {
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
     markerPrefix,
+    roadmapLabelName: labelsPolicy.roadmapLabelName,
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
     autopilotSuitabilityFloor:
       args.swarmFloor ?? resolveSuitabilityFloor(policyConfig),
     autopilotSuitabilityEnabled: resolveSuitabilityEnabled(policyConfig),
@@ -107,6 +112,9 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     authoringLabelName = 'status:authoring',
     authoringStaleAgeMs = 4 * 60 * 60 * 1000,
     markerPrefix,
+    roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
+    blockedByHumanLabelName = POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    needsDecisionLabelName = POLICY_DEFAULTS.labels.needsDecisionLabelName,
     autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled,
     now = new Date(),
@@ -187,11 +195,11 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     }
     const reasons = new Set();
     const labels = normalizeLabels(issue.labels);
-    if (labels.has('status:blocked-by-human')) {
-      reasons.add('label:status:blocked-by-human');
+    if (labels.has(blockedByHumanLabelName)) {
+      reasons.add(`label:${blockedByHumanLabelName}`);
     }
-    if (labels.has('status:needs-decision')) {
-      reasons.add('label:status:needs-decision');
+    if (labels.has(needsDecisionLabelName)) {
+      reasons.add(`label:${needsDecisionLabelName}`);
     }
     if (labels.has(authoringLabelName)) {
       reasons.add(`label:${authoringLabelName}`);
@@ -227,7 +235,7 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
       }
       if (
         dependencyIssue.state === 'OPEN' &&
-        !isParentEpicIssue(dependencyIssue)
+        !isParentEpicIssue(dependencyIssue, roadmapLabelName)
       ) {
         reasons.add(`open_dependency_issue:#${dependencyNumber}`);
       }
@@ -567,11 +575,17 @@ function normalizeLabels(labelsInput) {
   }
   return new Set();
 }
-function isParentEpicIssue(issue) {
+function isParentEpicIssue(
+  issue,
+  roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
+) {
+  // Title heuristic is intentionally independent of the configured roadmap
+  // label (#1273): it is a naming-convention signal on free-form title text,
+  // not a label comparison, so it is not wired to `labels.roadmapLabelName`.
   if (issue.title.toLowerCase().startsWith('roadmap')) {
     return true;
   }
-  return issue.labels.has('roadmap');
+  return issue.labels.has(roadmapLabelName);
 }
 async function getIssue(issueNumber, cache, loadIssue) {
   if (cache.has(issueNumber)) {

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -112,13 +112,26 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     authoringLabelName = 'status:authoring',
     authoringStaleAgeMs = 4 * 60 * 60 * 1000,
     markerPrefix,
-    roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
-    blockedByHumanLabelName = POLICY_DEFAULTS.labels.blockedByHumanLabelName,
-    needsDecisionLabelName = POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    roadmapLabelName: rawRoadmapLabelName,
+    blockedByHumanLabelName: rawBlockedByHumanLabelName,
+    needsDecisionLabelName: rawNeedsDecisionLabelName,
     autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled,
     now = new Date(),
   } = options ?? {};
+  // Route the three label-name options through normalizePolicyConfig rather
+  // than a bare destructure default (which only applies on `undefined`), so
+  // an invalid or empty-string input also falls back to POLICY_DEFAULTS
+  // instead of silently disabling the blocked-label / roadmap-label checks
+  // below (consistent with the other five helpers in #1273).
+  const { roadmapLabelName, blockedByHumanLabelName, needsDecisionLabelName } =
+    normalizePolicyConfig({
+      labels: {
+        roadmapLabelName: rawRoadmapLabelName,
+        blockedByHumanLabelName: rawBlockedByHumanLabelName,
+        needsDecisionLabelName: rawNeedsDecisionLabelName,
+      },
+    }).labels;
   if (typeof loadIssue !== 'function') {
     throw new Error(
       'evaluateDiscoverReadiness requires loadIssue(issueNumber)',

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -21,7 +21,11 @@ import {
 import { effortOrdinal, parseEffort } from './effort.mjs';
 import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mjs';
 import { stripMarkdownCodeRegions } from './markdown-code.mjs';
-import { parseIsoDurationToMs } from './policy-helpers.mjs';
+import {
+  normalizePolicyConfig,
+  POLICY_DEFAULTS,
+  parseIsoDurationToMs,
+} from './policy-helpers.mjs';
 import {
   isStaleAt,
   resolveActiveClaim,
@@ -157,6 +161,7 @@ if (isMainModule(import.meta.url)) {
   const report = args.allRoadmaps
     ? await enumerateAllRoadmapsGraph({
         markerPrefix: policy.markerPrefix,
+        roadmapLabelName: policy.labels?.roadmapLabelName,
         floor: policy.autopilotSuitability?.floor,
         owner,
         repo,
@@ -166,6 +171,8 @@ if (isMainModule(import.meta.url)) {
           owner,
           repo,
           policy.markerPrefix,
+          buildSearchIssuesRunner(),
+          policy.labels?.roadmapLabelName,
         ),
         claimState,
         readiness,
@@ -173,6 +180,7 @@ if (isMainModule(import.meta.url)) {
       })
     : await enumerateRoadmapGraph(args.issue, {
         markerPrefix: policy.markerPrefix,
+        roadmapLabelName: policy.labels?.roadmapLabelName,
         owner,
         repo,
         loadIssue: buildIssueLoader(owner, repo),
@@ -223,6 +231,7 @@ async function mapPool(items, limit, task) {
 }
 export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  const roadmapLabelName = normalizeRoadmapLabelName(options.roadmapLabelName);
   const loadIssueOption = options.loadIssue;
   const loadSubIssues =
     typeof options.loadSubIssues === 'function'
@@ -556,7 +565,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   }
   function recordNode(issue, path) {
     const existing = nodeRecords.get(issue.number);
-    const classification = classifyIssue(issue, markerPrefix);
+    const classification = classifyIssue(issue, markerPrefix, roadmapLabelName);
     if (issue.number === rootIssue.number) {
       classification.kind = 'roadmap';
     }
@@ -651,6 +660,7 @@ export async function enumerateAllRoadmapsGraph(options = {}) {
   for (const rootNumber of rootNumbers) {
     const graph = await enumerateRoadmapGraph(rootNumber, {
       markerPrefix,
+      roadmapLabelName: options.roadmapLabelName,
       owner: options.owner,
       repo: options.repo,
       loadIssue: options.loadIssue,
@@ -898,6 +908,9 @@ async function annotateReadiness(entries, readiness, loadIssue, markerPrefix) {
       findRoadmapsByMarker: readiness.findRoadmapsByMarker,
       authoringLabelName: readiness.authoringLabelName,
       authoringStaleAgeMs: readiness.authoringStaleAgeMs,
+      roadmapLabelName: readiness.roadmapLabelName,
+      blockedByHumanLabelName: readiness.blockedByHumanLabelName,
+      needsDecisionLabelName: readiness.needsDecisionLabelName,
       markerPrefix,
       now: readiness.nowIso,
     },
@@ -1054,10 +1067,14 @@ function buildClaimStateResolution(owner, repo, policy, currentClaimId) {
 function buildReadinessResolution(owner, repo, policy) {
   const authoringPolicy = resolveAuthoringGuardPolicy(policy);
   const markerPrefix = normalizeMarkerPrefix(policy.markerPrefix);
+  const labelsPolicy = normalizePolicyConfig(policy).labels;
   return {
     findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo, markerPrefix),
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+    roadmapLabelName: labelsPolicy.roadmapLabelName,
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
     nowIso: new Date().toISOString(),
   };
 }
@@ -1143,10 +1160,14 @@ export function extractRoadmapMarkerId(
   const match = regex.exec(stripMarkdownCodeRegions(String(body ?? '')));
   return match ? match[1] : '';
 }
-export function classifyIssue(issue, markerPrefix = DEFAULT_MARKER_PREFIX) {
+export function classifyIssue(
+  issue,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+  roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
+) {
   const roadmapMarkerId = extractRoadmapMarkerId(issue.body, markerPrefix);
   const labels = normalizeLabels(issue.labels);
-  if (roadmapMarkerId || labels.has('roadmap')) {
+  if (roadmapMarkerId || labels.has(roadmapLabelName)) {
     return {
       kind: 'roadmap',
       roadmapMarkerId,
@@ -1543,6 +1564,17 @@ function normalizeMarkerPrefix(markerPrefix) {
   const normalized = String(markerPrefix ?? '').trim();
   return normalized || DEFAULT_MARKER_PREFIX;
 }
+/**
+ * Resolve the configured `labels.roadmapLabelName` (#1273), falling back to
+ * the `policy-helpers.mts` default (`'roadmap'`) for an absent or invalid
+ * value. Routing an already-`unknown` field through `normalizePolicyConfig`
+ * (rather than hand-rolling the same non-empty-string check again) keeps the
+ * validation and the default in the single source of truth.
+ */
+function normalizeRoadmapLabelName(roadmapLabelName) {
+  return normalizePolicyConfig({ labels: { roadmapLabelName } }).labels
+    .roadmapLabelName;
+}
 async function getIssue(issueNumber, cache, loadIssue) {
   if (cache.has(issueNumber)) {
     return cache.get(issueNumber) ?? null;
@@ -1626,12 +1658,14 @@ export function buildSubIssueLoader(owner, repo) {
  * issue's `body` plus up to 100 labels just to detect a root) with two
  * cheap server-side searches whose union is the SAME open-root set:
  *
- *   1. Label roots — `gh search issues --label roadmap --state open` returns
- *      every open issue carrying the `roadmap` label. These are roots by
- *      label with NO body inspection needed; the old scan's
- *      `labels.has('roadmap')` branch is reproduced exactly (the GitHub
- *      search `--label` qualifier is a case-insensitive exact-name match, as
- *      is the `normalizeLabels`-backed `Set.has('roadmap')` it replaces).
+ *   1. Label roots — `gh search issues --label <roadmapLabelName> --state
+ *      open` (the configured `labels.roadmapLabelName`, #1273; defaults to
+ *      `roadmap`) returns every open issue carrying that label. These are
+ *      roots by label with NO body inspection needed; the old scan's
+ *      `labels.has(roadmapLabelName)` branch is reproduced exactly (the
+ *      GitHub search `--label` qualifier is a case-insensitive exact-name
+ *      match, as is the `normalizeLabels`-backed `Set.has(...)` it
+ *      replaces).
  *   2. Marker-only roots — `gh search issues --match body "<...>roadmap-id"
  *      --state open` narrows to open issues whose body text contains the
  *      `idd-skill-roadmap-id`-style marker token, then RE-CONFIRMS each
@@ -1671,15 +1705,17 @@ export function buildOpenRoadmapRootsLoader(
   repo,
   markerPrefix,
   searchIssues = buildSearchIssuesRunner(),
+  roadmapLabelName,
 ) {
   const prefix = normalizeMarkerPrefix(markerPrefix);
+  const label = normalizeRoadmapLabelName(roadmapLabelName);
   return async () => {
     const numbers = new Set();
     // 1. Label roots: roadmap-labeled open issues are roots by label.
     const labelResults = searchIssues({
       owner,
       repo,
-      label: 'roadmap',
+      label,
       fields: ['number'],
     });
     warnOnSearchResultCap(labelResults, 'label');

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1165,9 +1165,14 @@ export function classifyIssue(
   markerPrefix = DEFAULT_MARKER_PREFIX,
   roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
 ) {
+  // Re-normalize even though the parameter already has a default: a caller
+  // (direct or test) that explicitly passes an empty string would otherwise
+  // bypass the default (parameter defaults only trigger on `undefined`) and
+  // silently disable the roadmap-label check.
+  const resolvedRoadmapLabelName = normalizeRoadmapLabelName(roadmapLabelName);
   const roadmapMarkerId = extractRoadmapMarkerId(issue.body, markerPrefix);
   const labels = normalizeLabels(issue.labels);
-  if (roadmapMarkerId || labels.has(roadmapLabelName)) {
+  if (roadmapMarkerId || labels.has(resolvedRoadmapLabelName)) {
     return {
       kind: 'roadmap',
       roadmapMarkerId,

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1165,11 +1165,20 @@ export function classifyIssue(
   markerPrefix = DEFAULT_MARKER_PREFIX,
   roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
 ) {
-  // Re-normalize even though the parameter already has a default: a caller
+  // Re-validate even though the parameter already has a default: a caller
   // (direct or test) that explicitly passes an empty string would otherwise
   // bypass the default (parameter defaults only trigger on `undefined`) and
-  // silently disable the roadmap-label check.
-  const resolvedRoadmapLabelName = normalizeRoadmapLabelName(roadmapLabelName);
+  // silently disable the roadmap-label check. Use a cheap non-empty-string
+  // check rather than the full normalizeRoadmapLabelName()/
+  // normalizePolicyConfig() — classifyIssue() runs once per node during
+  // graph enumeration, so rebuilding the whole policy-defaults object here
+  // would be avoidable per-node overhead; callers that need policy-level
+  // normalization already do it once via normalizeRoadmapLabelName() before
+  // reaching this function.
+  const resolvedRoadmapLabelName =
+    typeof roadmapLabelName === 'string' && roadmapLabelName.length > 0
+      ? roadmapLabelName
+      : POLICY_DEFAULTS.labels.roadmapLabelName;
   const roadmapMarkerId = extractRoadmapMarkerId(issue.body, markerPrefix);
   const labels = normalizeLabels(issue.labels);
   if (roadmapMarkerId || labels.has(resolvedRoadmapLabelName)) {

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -14,6 +14,7 @@ import {
 } from './autopilot-suitability.mjs';
 import {
   inspectHelperRuntimeConfig,
+  POLICY_DEFAULTS,
   parseProjectCommandRows,
 } from './policy-helpers.mjs';
 
@@ -99,6 +100,11 @@ export function evaluateAutopilotSuitabilityConsistency(issues, options = {}) {
     typeof options.markerPrefix === 'string' && options.markerPrefix.length > 0
       ? options.markerPrefix
       : 'idd-skill';
+  const blockedByHumanLabelName =
+    typeof options.blockedByHumanLabelName === 'string' &&
+    options.blockedByHumanLabelName.length > 0
+      ? options.blockedByHumanLabelName
+      : POLICY_DEFAULTS.labels.blockedByHumanLabelName;
   const warnings = [];
   for (const issue of Array.isArray(issues) ? issues : []) {
     const labelNames = new Set(
@@ -106,7 +112,7 @@ export function evaluateAutopilotSuitabilityConsistency(issues, options = {}) {
         typeof label === 'string' ? label : (label?.name ?? ''),
       ),
     );
-    const blockedByHuman = labelNames.has('status:blocked-by-human');
+    const blockedByHuman = labelNames.has(blockedByHumanLabelName);
     const marker = parseAutopilotSuitabilityMarker(issue?.body, prefix);
     if (!marker.present) {
       continue;
@@ -120,7 +126,7 @@ export function evaluateAutopilotSuitabilityConsistency(issues, options = {}) {
     }
     if (marker.value === 1 && !blockedByHuman) {
       warnings.push(
-        `autopilot-suitability: issue #${number} is scored 1 (human-only) but is missing the status:blocked-by-human label`,
+        `autopilot-suitability: issue #${number} is scored 1 (human-only) but is missing the ${blockedByHumanLabelName} label`,
       );
     } else if (
       marker.value !== null &&
@@ -129,7 +135,7 @@ export function evaluateAutopilotSuitabilityConsistency(issues, options = {}) {
       blockedByHuman
     ) {
       warnings.push(
-        `autopilot-suitability: issue #${number} is scored ${marker.value} (>= floor ${floor}) but carries status:blocked-by-human; the score and label disagree`,
+        `autopilot-suitability: issue #${number} is scored ${marker.value} (>= floor ${floor}) but carries ${blockedByHumanLabelName}; the score and label disagree`,
       );
     }
   }
@@ -171,17 +177,21 @@ function checkAutopilotSuitabilityConsistency(root, options, report) {
     return;
   }
   let floor;
+  let blockedByHumanLabelName;
   try {
     const config = JSON.parse(
       readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
     );
     floor = config?.autopilotSuitability?.floor;
+    blockedByHumanLabelName = config?.labels?.blockedByHumanLabelName;
   } catch {
     floor = undefined;
+    blockedByHumanLabelName = undefined;
   }
   const { warnings } = evaluateAutopilotSuitabilityConsistency(issues, {
     floor,
     markerPrefix: options.markerPrefix,
+    blockedByHumanLabelName,
   });
   for (const warning of warnings) {
     report.warnings.push(warning);

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -28,6 +28,7 @@ import {
   parseClaimStaleAgeMs,
 } from './discover-roadmap-graph.mjs';
 import { ghText, safeGhText } from './gh-exec.mjs';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 import {
   renderUnclaimedByMarker,
   resolveTrustedMarkerActors,
@@ -39,10 +40,6 @@ const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // only as the fallback when the policy declares no (or an invalid)
 // `claimTiming.staleAge`; mirrors discover-roadmap-graph's own default.
 const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
-const BLOCKED_LABELS = new Set([
-  'status:blocked-by-human',
-  'status:needs-decision',
-]);
 // Scope caveat (A1.5): this helper gates only the MECHANICAL completion
 // preconditions. It deliberately does NOT verify the roadmap's free-form
 // success criteria or autonomy-gap items — that is agent judgment "where
@@ -74,10 +71,20 @@ export function evaluateRoadmapAuditGates(report, options = {}) {
   const pathTo = buildProvenanceLookup(report);
   const openLinkedPrIssues = new Set(options.openLinkedPrIssues ?? []);
   const reachableExecutionLeafCount = buildReachableLeafCounter(report);
+  const blockedLabels = new Set([
+    normalizeConfiguredLabelName(
+      options.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    normalizeConfiguredLabelName(
+      options.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+  ]);
   // Root carrying a human-gate label is never auto-closed.
   const rootNode = report.nodes.find((node) => node.number === rootNumber);
   const rootBlockedLabel = (rootNode?.labels ?? []).find((label) =>
-    BLOCKED_LABELS.has(label),
+    blockedLabels.has(label),
   );
   if (rootBlockedLabel) {
     blockers.push({
@@ -421,6 +428,8 @@ export async function runRoadmapAuditExecute(argv, deps) {
     openLinkedPrIssues: resolvedDeps.resolveOpenLinkedPrIssues(
       closedDescendantNumbers(report),
     ),
+    blockedByHumanLabelName: resolvedDeps.blockedByHumanLabelName,
+    needsDecisionLabelName: resolvedDeps.needsDecisionLabelName,
   });
   const ready = blockers.length === 0;
   const evidenceBody = ready ? buildRoadmapCompletionAuditBody(report) : '';
@@ -495,6 +504,8 @@ export async function runRoadmapAuditExecute(argv, deps) {
     openLinkedPrIssues: resolvedDeps.resolveOpenLinkedPrIssues(
       closedDescendantNumbers(revalidated),
     ),
+    blockedByHumanLabelName: resolvedDeps.blockedByHumanLabelName,
+    needsDecisionLabelName: resolvedDeps.needsDecisionLabelName,
   });
   if (revalidatedBlockers.length > 0) {
     verdict.blockers = revalidatedBlockers;
@@ -605,12 +616,14 @@ function createProductionDeps(args) {
   const staleAgeMs =
     parseClaimStaleAgeMs(rawConfig?.claimTiming?.staleAge) ??
     DEFAULT_CLAIM_STALE_AGE_MS;
+  const labelsPolicy = normalizePolicyConfig(rawConfig).labels;
   const loadIssue = buildIssueLoader(owner, repo);
   const loadSubIssues = buildSubIssueLoader(owner, repo);
   return {
     collect: (roadmapNumber) =>
       enumerateRoadmapGraph(roadmapNumber, {
         markerPrefix,
+        roadmapLabelName: labelsPolicy.roadmapLabelName,
         owner,
         repo,
         loadIssue,
@@ -618,6 +631,8 @@ function createProductionDeps(args) {
       }),
     resolveOpenLinkedPrIssues: (issueNumbers) =>
       resolveOpenLinkedPrIssues(owner, repo, issueNumbers),
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
     revalidateClaim: ({
       issueNumber,
       roadmapNumber,
@@ -948,6 +963,16 @@ function loadPolicy(policyPath) {
 function normalizeMarkerPrefix(markerPrefix) {
   const normalized = String(markerPrefix ?? '').trim();
   return normalized || DEFAULT_MARKER_PREFIX;
+}
+/**
+ * Resolve one configured `labels.*` name (#1273), falling back to the given
+ * `policy-helpers.mts` `POLICY_DEFAULTS.labels` default for an absent or
+ * invalid value.
+ */
+function normalizeConfiguredLabelName(labelName, fallback) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : fallback;
 }
 // ---------------------------------------------------------------------------
 // CLI

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -106,9 +106,10 @@ export const POLICY_DEFAULTS = Object.freeze({
     authoringLabelName: 'status:authoring',
     authoringStaleAge: 'PT4H',
   }),
-  // Additive only (#1272): no consuming helper reads this namespace yet.
-  // Wiring the discover/claim/roadmap-audit label lookups to it is
-  // deferred to a follow-up issue (#1273).
+  // Added in #1272; the discover-roadmap-graph, discover-orphan-filter,
+  // discover-readiness-check, idd-roadmap-audit-execute,
+  // suitability-triage, and idd-doctor label lookups were wired to this
+  // namespace in #1273.
   labels: Object.freeze({
     roadmapLabelName: 'roadmap',
     blockedByHumanLabelName: 'status:blocked-by-human',
@@ -359,11 +360,10 @@ export function normalizePolicyConfig(config) {
         POLICY_DEFAULTS.issueAuthoring.authoringStaleAge,
       ),
     },
-    // Additive only (#1272): normalized here for shape parity with the
-    // clone(POLICY_DEFAULTS) early-return branch above (non-object
-    // input), but no consuming helper reads this namespace yet. Wiring
-    // the discover/claim/roadmap-audit label lookups to it is deferred
-    // to a follow-up issue (#1273).
+    // Added in #1272 for shape parity with the clone(POLICY_DEFAULTS)
+    // early-return branch above (non-object input); wired to the
+    // consuming helpers' label lookups in #1273 (see the POLICY_DEFAULTS
+    // comment above for the exact file list).
     labels: {
       roadmapLabelName: parseNonEmptyString(
         c?.labels?.roadmapLabelName,

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -5,16 +5,15 @@
 // source named above by `pnpm run build`. Edit the .mts source, never
 // the generated .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   GH_TEXT_LOOP_TIMEOUT_OPTIONS,
   ghText,
   isCliExecution,
 } from './gh-exec.mjs';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 
-const BLOCKED_LABELS = new Set([
-  'status:blocked-by-human',
-  'status:needs-decision',
-]);
 const CHECKS = [
   {
     id: 'repository_fit',
@@ -135,6 +134,14 @@ export function evaluateSuitability(issue, options = {}) {
       options.duplicateCandidates,
     ),
     trustSafetyAmbiguous: Boolean(options.trustSafetyAmbiguous),
+    blockedByHumanLabelName: normalizeConfiguredLabelName(
+      options.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    needsDecisionLabelName: normalizeConfiguredLabelName(
+      options.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
   };
   const checks = [];
   for (const check of CHECKS) {
@@ -426,7 +433,17 @@ export function checkAutonomy(context) {
   const { issue } = context;
   const labels = new Set(issue.labels);
   const body = issue.body;
-  for (const label of BLOCKED_LABELS) {
+  const blockedLabels = new Set([
+    normalizeConfiguredLabelName(
+      context.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    normalizeConfiguredLabelName(
+      context.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+  ]);
+  for (const label of blockedLabels) {
     if (labels.has(label)) {
       return {
         pass: false,
@@ -578,9 +595,12 @@ function runCli() {
   const repoRef = `${owner}/${repo}`;
   const issue = fetchIssue(repoRef, args.issue);
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
+  const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
     duplicateCandidates,
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
   });
   const output = {
     repository: { owner, repo },
@@ -609,6 +629,7 @@ function parseArgs(argv) {
     token: '',
     owner: '',
     repo: '',
+    policy: '',
     verbose: false,
     help: false,
   };
@@ -635,6 +656,11 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (token === '--policy') {
+      parsed.policy = value ?? '';
+      index += 1;
+      continue;
+    }
     if (token === '--verbose') {
       parsed.verbose = true;
       continue;
@@ -647,9 +673,31 @@ function parseArgs(argv) {
   }
   return parsed;
 }
+/**
+ * Load and parse `.github/idd/config.json` (or `--policy <path>` when given),
+ * falling back to `{}` on a missing/invalid default path so the CLI stays
+ * usable without any policy file (#1273; mirrors the sibling helpers'
+ * `loadPolicy` pattern, e.g. `discover-orphan-filter.mts`). An explicit
+ * `--policy <path>` that fails to read/parse throws, matching the sibling
+ * helpers' fail-loud behavior for an operator-specified path.
+ */
+function loadPolicy(policyPath) {
+  const targetPath = policyPath
+    ? resolve(process.cwd(), policyPath)
+    : resolve(process.cwd(), '.github/idd/config.json');
+  try {
+    return JSON.parse(readFileSync(targetPath, 'utf8'));
+  } catch (error) {
+    if (!policyPath) {
+      return {};
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to load policy from ${targetPath}: ${detail}`);
+  }
+}
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--verbose]
+  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--verbose]
 
 Output schema:
 {
@@ -672,6 +720,16 @@ function normalizeIssue(issue) {
     labels: normalizeLabels(i.labels),
     url: String(i.url ?? i.html_url ?? ''),
   };
+}
+/**
+ * Resolve one configured `labels.*` name (#1273), falling back to the given
+ * `policy-helpers.mts` `POLICY_DEFAULTS.labels` default for an absent or
+ * invalid value.
+ */
+function normalizeConfiguredLabelName(labelName, fallback) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : fallback;
 }
 function normalizeRepository(repository) {
   if (!repository || typeof repository !== 'object') {

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -26,12 +26,9 @@ import {
   isCliExecution,
 } from './gh-exec.mts';
 import { createMarkerRegex } from './marker-regex.mts';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
-const BLOCKED_LABELS = new Set([
-  'status:blocked-by-human',
-  'status:needs-decision',
-]);
 
 /** Reasons that keep an issue out of the orphan candidate list. */
 export type OrphanFilteredReason =
@@ -77,6 +74,8 @@ interface ClassifyIssueOptions {
   fetchIssueStateByNumber: (issueNumber: number) => string;
   markerPrefix?: unknown;
   authoringLabelName?: unknown;
+  blockedByHumanLabelName?: unknown;
+  needsDecisionLabelName?: unknown;
 }
 
 interface FilterOrphanIssuesOptions {
@@ -85,6 +84,8 @@ interface FilterOrphanIssuesOptions {
   fetchLabelEventsByIssueNumber?: (issueNumber: number) => unknown[];
   markerPrefix?: unknown;
   authoringLabelName?: unknown;
+  blockedByHumanLabelName?: unknown;
+  needsDecisionLabelName?: unknown;
   authoringStaleAgeMs?: number;
   autopilotSuitabilityFloor?: number;
   autopilotSuitabilityEnabled?: boolean;
@@ -173,6 +174,12 @@ export function classifyIssue(
   const authoringLabelName = normalizeAuthoringLabelName(
     options.authoringLabelName,
   );
+  const blockedByHumanLabelName = normalizeBlockedByHumanLabelName(
+    options.blockedByHumanLabelName,
+  );
+  const needsDecisionLabelName = normalizeNeedsDecisionLabelName(
+    options.needsDecisionLabelName,
+  );
   const roadmapMarkerRegex = createMarkerRegex(markerPrefix, 'roadmap-id');
   const blockedMarkerRegex = createMarkerRegex(markerPrefix, 'blocked-by');
 
@@ -184,7 +191,11 @@ export function classifyIssue(
     return { orphan: false, reason: 'blocked_by_marker' };
   }
 
-  const blockedLabel = [...labels].find((label) => BLOCKED_LABELS.has(label));
+  const blockedLabels = new Set([
+    blockedByHumanLabelName,
+    needsDecisionLabelName,
+  ]);
+  const blockedLabel = [...labels].find((label) => blockedLabels.has(label));
   if (blockedLabel) {
     return { orphan: false, reason: 'blocked_label', details: blockedLabel };
   }
@@ -264,6 +275,8 @@ export function filterOrphanIssues(
       fetchIssueStateByNumber,
       markerPrefix: options.markerPrefix,
       authoringLabelName: options.authoringLabelName,
+      blockedByHumanLabelName: options.blockedByHumanLabelName,
+      needsDecisionLabelName: options.needsDecisionLabelName,
     });
 
     if (result.reason === 'unresolvable_reference') {
@@ -412,6 +425,8 @@ function runCli() {
     markerPrefix: policy.markerPrefix,
     authoringLabelName: policy.authoringLabelName,
     authoringStaleAgeMs: policy.authoringStaleAgeMs,
+    blockedByHumanLabelName: policy.blockedByHumanLabelName,
+    needsDecisionLabelName: policy.needsDecisionLabelName,
     autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
     autopilot: args.autopilot,
@@ -537,6 +552,7 @@ function loadPolicy(policyPath: string) {
       markerPrefix?: unknown;
     };
     const authoringPolicy = resolveAuthoringGuardPolicy(config);
+    const labelsPolicy = normalizePolicyConfig(config).labels;
     return {
       source: targetPath,
       orphanFirstPolicy: getOrphanFirstPolicy(config),
@@ -544,11 +560,14 @@ function loadPolicy(policyPath: string) {
       authoringLabelName: authoringPolicy.labelName,
       authoringStaleAge: authoringPolicy.staleAge,
       authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+      blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+      needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
       autopilotSuitabilityFloor: resolveAutopilotSuitabilityFloor(config),
       autopilotSuitabilityEnabled: resolveAutopilotSuitabilityEnabled(config),
     };
   } catch {
     const authoringPolicy = resolveAuthoringGuardPolicy({});
+    const labelsPolicy = normalizePolicyConfig({}).labels;
     return {
       source: targetPath,
       orphanFirstPolicy: 'none',
@@ -556,6 +575,8 @@ function loadPolicy(policyPath: string) {
       authoringLabelName: authoringPolicy.labelName,
       authoringStaleAge: authoringPolicy.staleAge,
       authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+      blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+      needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
       autopilotSuitabilityFloor: DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
       autopilotSuitabilityEnabled: true,
     };
@@ -718,6 +739,20 @@ function normalizeAuthoringLabelName(labelName: unknown): string {
   return typeof labelName === 'string' && labelName.length > 0
     ? labelName
     : 'status:authoring';
+}
+
+/** Resolve the configured `labels.blockedByHumanLabelName` (#1273). */
+function normalizeBlockedByHumanLabelName(labelName: unknown): string {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : POLICY_DEFAULTS.labels.blockedByHumanLabelName;
+}
+
+/** Resolve the configured `labels.needsDecisionLabelName` (#1273). */
+function normalizeNeedsDecisionLabelName(labelName: unknown): string {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : POLICY_DEFAULTS.labels.needsDecisionLabelName;
 }
 
 function fetchOpenIssues(repoRef: string) {

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -22,6 +22,7 @@ import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
 import { stripMarkdownCodeRegions } from './markdown-code.mts';
 import { escapeRegex } from './marker-regex.mts';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
@@ -118,6 +119,12 @@ interface EvaluateDiscoverReadinessOptions {
   authoringLabelName?: string;
   authoringStaleAgeMs?: number;
   markerPrefix?: string;
+  /** Configured `labels.roadmapLabelName` (#1273); defaults to `'roadmap'`. */
+  roadmapLabelName?: string;
+  /** Configured `labels.blockedByHumanLabelName` (#1273). */
+  blockedByHumanLabelName?: string;
+  /** Configured `labels.needsDecisionLabelName` (#1273). */
+  needsDecisionLabelName?: string;
   autopilotSuitabilityFloor?: number;
   autopilotSuitabilityEnabled?: boolean;
   now?: Date | string;
@@ -162,6 +169,7 @@ if (isMainModule(import.meta.url)) {
   const policyConfig = loadPolicy(args.policy);
   const authoringPolicy = resolveAuthoringGuardPolicy(policyConfig);
   const markerPrefix = resolveMarkerPrefix(policyConfig);
+  const labelsPolicy = normalizePolicyConfig(policyConfig).labels;
 
   // `--swarm-floor` sweeps every open issue (orphans included); otherwise
   // evaluate exactly the issues the caller named.
@@ -186,6 +194,9 @@ if (isMainModule(import.meta.url)) {
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
     markerPrefix,
+    roadmapLabelName: labelsPolicy.roadmapLabelName,
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
     autopilotSuitabilityFloor:
       args.swarmFloor ?? resolveSuitabilityFloor(policyConfig),
     autopilotSuitabilityEnabled: resolveSuitabilityEnabled(policyConfig),
@@ -215,6 +226,9 @@ export async function evaluateDiscoverReadiness(
     authoringLabelName = 'status:authoring',
     authoringStaleAgeMs = 4 * 60 * 60 * 1000,
     markerPrefix,
+    roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
+    blockedByHumanLabelName = POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    needsDecisionLabelName = POLICY_DEFAULTS.labels.needsDecisionLabelName,
     autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled,
     now = new Date(),
@@ -300,11 +314,11 @@ export async function evaluateDiscoverReadiness(
 
     const reasons = new Set<string>();
     const labels = normalizeLabels(issue.labels);
-    if (labels.has('status:blocked-by-human')) {
-      reasons.add('label:status:blocked-by-human');
+    if (labels.has(blockedByHumanLabelName)) {
+      reasons.add(`label:${blockedByHumanLabelName}`);
     }
-    if (labels.has('status:needs-decision')) {
-      reasons.add('label:status:needs-decision');
+    if (labels.has(needsDecisionLabelName)) {
+      reasons.add(`label:${needsDecisionLabelName}`);
     }
     if (labels.has(authoringLabelName)) {
       reasons.add(`label:${authoringLabelName}`);
@@ -341,7 +355,7 @@ export async function evaluateDiscoverReadiness(
       }
       if (
         dependencyIssue.state === 'OPEN' &&
-        !isParentEpicIssue(dependencyIssue)
+        !isParentEpicIssue(dependencyIssue, roadmapLabelName)
       ) {
         reasons.add(`open_dependency_issue:#${dependencyNumber}`);
       }
@@ -728,11 +742,17 @@ function normalizeLabels(labelsInput: unknown): Set<string> {
   return new Set();
 }
 
-function isParentEpicIssue(issue: NormalizedIssue): boolean {
+function isParentEpicIssue(
+  issue: NormalizedIssue,
+  roadmapLabelName: string = POLICY_DEFAULTS.labels.roadmapLabelName,
+): boolean {
+  // Title heuristic is intentionally independent of the configured roadmap
+  // label (#1273): it is a naming-convention signal on free-form title text,
+  // not a label comparison, so it is not wired to `labels.roadmapLabelName`.
   if (issue.title.toLowerCase().startsWith('roadmap')) {
     return true;
   }
-  return issue.labels.has('roadmap');
+  return issue.labels.has(roadmapLabelName);
 }
 
 async function getIssue(

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -226,13 +226,26 @@ export async function evaluateDiscoverReadiness(
     authoringLabelName = 'status:authoring',
     authoringStaleAgeMs = 4 * 60 * 60 * 1000,
     markerPrefix,
-    roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
-    blockedByHumanLabelName = POLICY_DEFAULTS.labels.blockedByHumanLabelName,
-    needsDecisionLabelName = POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    roadmapLabelName: rawRoadmapLabelName,
+    blockedByHumanLabelName: rawBlockedByHumanLabelName,
+    needsDecisionLabelName: rawNeedsDecisionLabelName,
     autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled,
     now = new Date(),
   } = options ?? {};
+  // Route the three label-name options through normalizePolicyConfig rather
+  // than a bare destructure default (which only applies on `undefined`), so
+  // an invalid or empty-string input also falls back to POLICY_DEFAULTS
+  // instead of silently disabling the blocked-label / roadmap-label checks
+  // below (consistent with the other five helpers in #1273).
+  const { roadmapLabelName, blockedByHumanLabelName, needsDecisionLabelName } =
+    normalizePolicyConfig({
+      labels: {
+        roadmapLabelName: rawRoadmapLabelName,
+        blockedByHumanLabelName: rawBlockedByHumanLabelName,
+        needsDecisionLabelName: rawNeedsDecisionLabelName,
+      },
+    }).labels;
   if (typeof loadIssue !== 'function') {
     throw new Error(
       'evaluateDiscoverReadiness requires loadIssue(issueNumber)',

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -23,7 +23,11 @@ import {
 import { type EffortHint, effortOrdinal, parseEffort } from './effort.mts';
 import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mts';
 import { stripMarkdownCodeRegions } from './markdown-code.mts';
-import { parseIsoDurationToMs } from './policy-helpers.mts';
+import {
+  normalizePolicyConfig,
+  POLICY_DEFAULTS,
+  parseIsoDurationToMs,
+} from './policy-helpers.mts';
 import {
   isStaleAt,
   resolveActiveClaim,
@@ -448,6 +452,12 @@ interface ReadinessResolution {
   authoringLabelName: string;
   /** Configured authoring stale age in ms (`issueAuthoring.authoringStaleAge`). */
   authoringStaleAgeMs: number;
+  /** Configured roadmap label (`labels.roadmapLabelName`, #1273). */
+  roadmapLabelName: string;
+  /** Configured blocked-by-human label (`labels.blockedByHumanLabelName`, #1273). */
+  blockedByHumanLabelName: string;
+  /** Configured needs-decision label (`labels.needsDecisionLabelName`, #1273). */
+  needsDecisionLabelName: string;
   /** Resolution "now" (ISO8601); defaults to the wall clock in the CLI. */
   nowIso: string;
 }
@@ -460,6 +470,8 @@ interface EnumerateRoadmapGraphOptions
   extends ClaimStateOptions,
     ReadinessOptions {
   markerPrefix?: unknown;
+  /** Configured `labels.roadmapLabelName` (#1273); defaults to `'roadmap'`. */
+  roadmapLabelName?: unknown;
   owner?: string;
   repo?: string;
   loadIssue?: (issueNumber: number) => unknown;
@@ -541,6 +553,7 @@ if (isMainModule(import.meta.url)) {
     autopilotSuitability?: { floor?: unknown };
     claimTiming?: { staleAge?: unknown };
     trustedMarkerActors?: unknown;
+    labels?: { roadmapLabelName?: unknown };
   };
 
   // The claim-state annotation is strictly opt-in: only when --with-claim-state
@@ -563,6 +576,7 @@ if (isMainModule(import.meta.url)) {
   const report = args.allRoadmaps
     ? await enumerateAllRoadmapsGraph({
         markerPrefix: policy.markerPrefix,
+        roadmapLabelName: policy.labels?.roadmapLabelName,
         floor: policy.autopilotSuitability?.floor,
         owner,
         repo,
@@ -572,6 +586,8 @@ if (isMainModule(import.meta.url)) {
           owner,
           repo,
           policy.markerPrefix,
+          buildSearchIssuesRunner(),
+          policy.labels?.roadmapLabelName,
         ),
         claimState,
         readiness,
@@ -579,6 +595,7 @@ if (isMainModule(import.meta.url)) {
       })
     : await enumerateRoadmapGraph(args.issue, {
         markerPrefix: policy.markerPrefix,
+        roadmapLabelName: policy.labels?.roadmapLabelName,
         owner,
         repo,
         loadIssue: buildIssueLoader(owner, repo),
@@ -640,6 +657,7 @@ export async function enumerateRoadmapGraph(
   options: EnumerateRoadmapGraphOptions = {},
 ): Promise<RoadmapGraphReport> {
   const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
+  const roadmapLabelName = normalizeRoadmapLabelName(options.roadmapLabelName);
   const loadIssueOption = options.loadIssue;
   const loadSubIssues =
     typeof options.loadSubIssues === 'function'
@@ -1000,7 +1018,7 @@ export async function enumerateRoadmapGraph(
 
   function recordNode(issue: NormalizedIssue, path: number[]) {
     const existing = nodeRecords.get(issue.number);
-    const classification = classifyIssue(issue, markerPrefix);
+    const classification = classifyIssue(issue, markerPrefix, roadmapLabelName);
     if (issue.number === rootIssue.number) {
       classification.kind = 'roadmap';
     }
@@ -1110,6 +1128,7 @@ export async function enumerateAllRoadmapsGraph(
   for (const rootNumber of rootNumbers) {
     const graph = await enumerateRoadmapGraph(rootNumber, {
       markerPrefix,
+      roadmapLabelName: options.roadmapLabelName,
       owner: options.owner,
       repo: options.repo,
       loadIssue: options.loadIssue,
@@ -1397,6 +1416,9 @@ async function annotateReadiness(
       findRoadmapsByMarker: readiness.findRoadmapsByMarker,
       authoringLabelName: readiness.authoringLabelName,
       authoringStaleAgeMs: readiness.authoringStaleAgeMs,
+      roadmapLabelName: readiness.roadmapLabelName,
+      blockedByHumanLabelName: readiness.blockedByHumanLabelName,
+      needsDecisionLabelName: readiness.needsDecisionLabelName,
       markerPrefix,
       now: readiness.nowIso,
     },
@@ -1595,10 +1617,14 @@ function buildReadinessResolution(
 ): ReadinessResolution {
   const authoringPolicy = resolveAuthoringGuardPolicy(policy);
   const markerPrefix = normalizeMarkerPrefix(policy.markerPrefix);
+  const labelsPolicy = normalizePolicyConfig(policy).labels;
   return {
     findRoadmapsByMarker: buildRoadmapMarkerResolver(owner, repo, markerPrefix),
     authoringLabelName: authoringPolicy.labelName,
     authoringStaleAgeMs: authoringPolicy.staleAgeMs,
+    roadmapLabelName: labelsPolicy.roadmapLabelName,
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
     nowIso: new Date().toISOString(),
   };
 }
@@ -1694,10 +1720,11 @@ export function extractRoadmapMarkerId(
 export function classifyIssue(
   issue: { body?: unknown; labels?: unknown },
   markerPrefix: string = DEFAULT_MARKER_PREFIX,
+  roadmapLabelName: string = POLICY_DEFAULTS.labels.roadmapLabelName,
 ): RoadmapIssueClassification {
   const roadmapMarkerId = extractRoadmapMarkerId(issue.body, markerPrefix);
   const labels = normalizeLabels(issue.labels);
-  if (roadmapMarkerId || labels.has('roadmap')) {
+  if (roadmapMarkerId || labels.has(roadmapLabelName)) {
     return {
       kind: 'roadmap',
       roadmapMarkerId,
@@ -2137,6 +2164,18 @@ function normalizeMarkerPrefix(markerPrefix: unknown): string {
   return normalized || DEFAULT_MARKER_PREFIX;
 }
 
+/**
+ * Resolve the configured `labels.roadmapLabelName` (#1273), falling back to
+ * the `policy-helpers.mts` default (`'roadmap'`) for an absent or invalid
+ * value. Routing an already-`unknown` field through `normalizePolicyConfig`
+ * (rather than hand-rolling the same non-empty-string check again) keeps the
+ * validation and the default in the single source of truth.
+ */
+function normalizeRoadmapLabelName(roadmapLabelName: unknown): string {
+  return normalizePolicyConfig({ labels: { roadmapLabelName } }).labels
+    .roadmapLabelName;
+}
+
 async function getIssue(
   issueNumber: number,
   cache: Map<number, CachedIssue>,
@@ -2241,12 +2280,14 @@ export function buildSubIssueLoader(owner: string, repo: string) {
  * issue's `body` plus up to 100 labels just to detect a root) with two
  * cheap server-side searches whose union is the SAME open-root set:
  *
- *   1. Label roots — `gh search issues --label roadmap --state open` returns
- *      every open issue carrying the `roadmap` label. These are roots by
- *      label with NO body inspection needed; the old scan's
- *      `labels.has('roadmap')` branch is reproduced exactly (the GitHub
- *      search `--label` qualifier is a case-insensitive exact-name match, as
- *      is the `normalizeLabels`-backed `Set.has('roadmap')` it replaces).
+ *   1. Label roots — `gh search issues --label <roadmapLabelName> --state
+ *      open` (the configured `labels.roadmapLabelName`, #1273; defaults to
+ *      `roadmap`) returns every open issue carrying that label. These are
+ *      roots by label with NO body inspection needed; the old scan's
+ *      `labels.has(roadmapLabelName)` branch is reproduced exactly (the
+ *      GitHub search `--label` qualifier is a case-insensitive exact-name
+ *      match, as is the `normalizeLabels`-backed `Set.has(...)` it
+ *      replaces).
  *   2. Marker-only roots — `gh search issues --match body "<...>roadmap-id"
  *      --state open` narrows to open issues whose body text contains the
  *      `idd-skill-roadmap-id`-style marker token, then RE-CONFIRMS each
@@ -2286,8 +2327,10 @@ export function buildOpenRoadmapRootsLoader(
   repo: string,
   markerPrefix: unknown,
   searchIssues: SearchIssuesFn = buildSearchIssuesRunner(),
+  roadmapLabelName?: unknown,
 ) {
   const prefix = normalizeMarkerPrefix(markerPrefix);
+  const label = normalizeRoadmapLabelName(roadmapLabelName);
   return async () => {
     const numbers = new Set<number>();
 
@@ -2295,7 +2338,7 @@ export function buildOpenRoadmapRootsLoader(
     const labelResults = searchIssues({
       owner,
       repo,
-      label: 'roadmap',
+      label,
       fields: ['number'],
     });
     warnOnSearchResultCap(labelResults, 'label');

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1722,9 +1722,14 @@ export function classifyIssue(
   markerPrefix: string = DEFAULT_MARKER_PREFIX,
   roadmapLabelName: string = POLICY_DEFAULTS.labels.roadmapLabelName,
 ): RoadmapIssueClassification {
+  // Re-normalize even though the parameter already has a default: a caller
+  // (direct or test) that explicitly passes an empty string would otherwise
+  // bypass the default (parameter defaults only trigger on `undefined`) and
+  // silently disable the roadmap-label check.
+  const resolvedRoadmapLabelName = normalizeRoadmapLabelName(roadmapLabelName);
   const roadmapMarkerId = extractRoadmapMarkerId(issue.body, markerPrefix);
   const labels = normalizeLabels(issue.labels);
-  if (roadmapMarkerId || labels.has(roadmapLabelName)) {
+  if (roadmapMarkerId || labels.has(resolvedRoadmapLabelName)) {
     return {
       kind: 'roadmap',
       roadmapMarkerId,

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1722,11 +1722,20 @@ export function classifyIssue(
   markerPrefix: string = DEFAULT_MARKER_PREFIX,
   roadmapLabelName: string = POLICY_DEFAULTS.labels.roadmapLabelName,
 ): RoadmapIssueClassification {
-  // Re-normalize even though the parameter already has a default: a caller
+  // Re-validate even though the parameter already has a default: a caller
   // (direct or test) that explicitly passes an empty string would otherwise
   // bypass the default (parameter defaults only trigger on `undefined`) and
-  // silently disable the roadmap-label check.
-  const resolvedRoadmapLabelName = normalizeRoadmapLabelName(roadmapLabelName);
+  // silently disable the roadmap-label check. Use a cheap non-empty-string
+  // check rather than the full normalizeRoadmapLabelName()/
+  // normalizePolicyConfig() — classifyIssue() runs once per node during
+  // graph enumeration, so rebuilding the whole policy-defaults object here
+  // would be avoidable per-node overhead; callers that need policy-level
+  // normalization already do it once via normalizeRoadmapLabelName() before
+  // reaching this function.
+  const resolvedRoadmapLabelName =
+    typeof roadmapLabelName === 'string' && roadmapLabelName.length > 0
+      ? roadmapLabelName
+      : POLICY_DEFAULTS.labels.roadmapLabelName;
   const roadmapMarkerId = extractRoadmapMarkerId(issue.body, markerPrefix);
   const labels = normalizeLabels(issue.labels);
   if (roadmapMarkerId || labels.has(resolvedRoadmapLabelName)) {

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -15,6 +15,7 @@ import {
 } from './autopilot-suitability.mts';
 import {
   inspectHelperRuntimeConfig,
+  POLICY_DEFAULTS,
   parseProjectCommandRows,
 } from './policy-helpers.mts';
 
@@ -170,13 +171,22 @@ export function runDoctor({
  */
 export function evaluateAutopilotSuitabilityConsistency(
   issues: unknown,
-  options: { floor?: unknown; markerPrefix?: unknown } = {},
+  options: {
+    floor?: unknown;
+    markerPrefix?: unknown;
+    blockedByHumanLabelName?: unknown;
+  } = {},
 ): { warnings: string[] } {
   const floor = normalizeAutopilotSuitabilityFloor(options.floor);
   const prefix =
     typeof options.markerPrefix === 'string' && options.markerPrefix.length > 0
       ? options.markerPrefix
       : 'idd-skill';
+  const blockedByHumanLabelName =
+    typeof options.blockedByHumanLabelName === 'string' &&
+    options.blockedByHumanLabelName.length > 0
+      ? options.blockedByHumanLabelName
+      : POLICY_DEFAULTS.labels.blockedByHumanLabelName;
   const warnings: string[] = [];
   for (const issue of (Array.isArray(issues)
     ? issues
@@ -188,7 +198,7 @@ export function evaluateAutopilotSuitabilityConsistency(
           : ((label as { name?: unknown } | null)?.name ?? ''),
       ),
     );
-    const blockedByHuman = labelNames.has('status:blocked-by-human');
+    const blockedByHuman = labelNames.has(blockedByHumanLabelName);
     const marker = parseAutopilotSuitabilityMarker(issue?.body, prefix);
     if (!marker.present) {
       continue;
@@ -202,7 +212,7 @@ export function evaluateAutopilotSuitabilityConsistency(
     }
     if (marker.value === 1 && !blockedByHuman) {
       warnings.push(
-        `autopilot-suitability: issue #${number} is scored 1 (human-only) but is missing the status:blocked-by-human label`,
+        `autopilot-suitability: issue #${number} is scored 1 (human-only) but is missing the ${blockedByHumanLabelName} label`,
       );
     } else if (
       marker.value !== null &&
@@ -211,7 +221,7 @@ export function evaluateAutopilotSuitabilityConsistency(
       blockedByHuman
     ) {
       warnings.push(
-        `autopilot-suitability: issue #${number} is scored ${marker.value} (>= floor ${floor}) but carries status:blocked-by-human; the score and label disagree`,
+        `autopilot-suitability: issue #${number} is scored ${marker.value} (>= floor ${floor}) but carries ${blockedByHumanLabelName}; the score and label disagree`,
       );
     }
   }
@@ -260,18 +270,25 @@ function checkAutopilotSuitabilityConsistency(
   }
 
   let floor: unknown;
+  let blockedByHumanLabelName: unknown;
   try {
     const config = JSON.parse(
       readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    ) as { autopilotSuitability?: { floor?: unknown } } | null;
+    ) as {
+      autopilotSuitability?: { floor?: unknown };
+      labels?: { blockedByHumanLabelName?: unknown };
+    } | null;
     floor = config?.autopilotSuitability?.floor;
+    blockedByHumanLabelName = config?.labels?.blockedByHumanLabelName;
   } catch {
     floor = undefined;
+    blockedByHumanLabelName = undefined;
   }
 
   const { warnings } = evaluateAutopilotSuitabilityConsistency(issues, {
     floor,
     markerPrefix: options.markerPrefix,
+    blockedByHumanLabelName,
   });
   for (const warning of warnings) {
     report.warnings.push(warning);

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -30,6 +30,7 @@ import {
   type RoadmapGraphReport,
 } from './discover-roadmap-graph.mts';
 import { ghText, safeGhText } from './gh-exec.mts';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 import type { ClaimValidationSummary } from './protocol-helpers.mts';
 import {
   renderUnclaimedByMarker,
@@ -42,10 +43,6 @@ const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // only as the fallback when the policy declares no (or an invalid)
 // `claimTiming.staleAge`; mirrors discover-roadmap-graph's own default.
 const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
-const BLOCKED_LABELS = new Set([
-  'status:blocked-by-human',
-  'status:needs-decision',
-]);
 
 // Scope caveat (A1.5): this helper gates only the MECHANICAL completion
 // preconditions. It deliberately does NOT verify the roadmap's free-form
@@ -147,18 +144,32 @@ interface RoadmapAuditExecuteArgs {
  */
 export function evaluateRoadmapAuditGates(
   report: RoadmapGraphReport,
-  options: { openLinkedPrIssues?: Iterable<number> } = {},
+  options: {
+    openLinkedPrIssues?: Iterable<number>;
+    blockedByHumanLabelName?: unknown;
+    needsDecisionLabelName?: unknown;
+  } = {},
 ): RoadmapAuditBlocker[] {
   const blockers: RoadmapAuditBlocker[] = [];
   const rootNumber = report.root.number;
   const pathTo = buildProvenanceLookup(report);
   const openLinkedPrIssues = new Set(options.openLinkedPrIssues ?? []);
   const reachableExecutionLeafCount = buildReachableLeafCounter(report);
+  const blockedLabels = new Set([
+    normalizeConfiguredLabelName(
+      options.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    normalizeConfiguredLabelName(
+      options.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+  ]);
 
   // Root carrying a human-gate label is never auto-closed.
   const rootNode = report.nodes.find((node) => node.number === rootNumber);
   const rootBlockedLabel = (rootNode?.labels ?? []).find((label) =>
-    BLOCKED_LABELS.has(label),
+    blockedLabels.has(label),
   );
   if (rootBlockedLabel) {
     blockers.push({
@@ -555,6 +566,10 @@ export interface RoadmapAuditExecuteDeps {
   ) => void;
   /** Resolution "now" (ISO8601); defaults to the wall clock. */
   now: () => string;
+  /** Configured `labels.blockedByHumanLabelName` (#1273). */
+  blockedByHumanLabelName?: string;
+  /** Configured `labels.needsDecisionLabelName` (#1273). */
+  needsDecisionLabelName?: string;
 }
 
 /**
@@ -583,6 +598,8 @@ export async function runRoadmapAuditExecute(
     openLinkedPrIssues: resolvedDeps.resolveOpenLinkedPrIssues(
       closedDescendantNumbers(report),
     ),
+    blockedByHumanLabelName: resolvedDeps.blockedByHumanLabelName,
+    needsDecisionLabelName: resolvedDeps.needsDecisionLabelName,
   });
   const ready = blockers.length === 0;
   const evidenceBody = ready ? buildRoadmapCompletionAuditBody(report) : '';
@@ -665,6 +682,8 @@ export async function runRoadmapAuditExecute(
     openLinkedPrIssues: resolvedDeps.resolveOpenLinkedPrIssues(
       closedDescendantNumbers(revalidated),
     ),
+    blockedByHumanLabelName: resolvedDeps.blockedByHumanLabelName,
+    needsDecisionLabelName: resolvedDeps.needsDecisionLabelName,
   });
   if (revalidatedBlockers.length > 0) {
     verdict.blockers = revalidatedBlockers;
@@ -791,6 +810,7 @@ function createProductionDeps(
       (rawConfig as { claimTiming?: { staleAge?: unknown } } | null)
         ?.claimTiming?.staleAge,
     ) ?? DEFAULT_CLAIM_STALE_AGE_MS;
+  const labelsPolicy = normalizePolicyConfig(rawConfig).labels;
   const loadIssue = buildIssueLoader(owner, repo);
   const loadSubIssues = buildSubIssueLoader(owner, repo);
 
@@ -798,6 +818,7 @@ function createProductionDeps(
     collect: (roadmapNumber) =>
       enumerateRoadmapGraph(roadmapNumber, {
         markerPrefix,
+        roadmapLabelName: labelsPolicy.roadmapLabelName,
         owner,
         repo,
         loadIssue,
@@ -805,6 +826,8 @@ function createProductionDeps(
       }),
     resolveOpenLinkedPrIssues: (issueNumbers) =>
       resolveOpenLinkedPrIssues(owner, repo, issueNumbers),
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
     revalidateClaim: ({
       issueNumber,
       roadmapNumber,
@@ -1219,6 +1242,20 @@ function loadPolicy(policyPath: string): unknown {
 function normalizeMarkerPrefix(markerPrefix: unknown): string {
   const normalized = String(markerPrefix ?? '').trim();
   return normalized || DEFAULT_MARKER_PREFIX;
+}
+
+/**
+ * Resolve one configured `labels.*` name (#1273), falling back to the given
+ * `policy-helpers.mts` `POLICY_DEFAULTS.labels` default for an absent or
+ * invalid value.
+ */
+function normalizeConfiguredLabelName(
+  labelName: unknown,
+  fallback: string,
+): string {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : fallback;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -184,9 +184,10 @@ export const POLICY_DEFAULTS = Object.freeze({
     authoringLabelName: 'status:authoring',
     authoringStaleAge: 'PT4H',
   }),
-  // Additive only (#1272): no consuming helper reads this namespace yet.
-  // Wiring the discover/claim/roadmap-audit label lookups to it is
-  // deferred to a follow-up issue (#1273).
+  // Added in #1272; the discover-roadmap-graph, discover-orphan-filter,
+  // discover-readiness-check, idd-roadmap-audit-execute,
+  // suitability-triage, and idd-doctor label lookups were wired to this
+  // namespace in #1273.
   labels: Object.freeze({
     roadmapLabelName: 'roadmap',
     blockedByHumanLabelName: 'status:blocked-by-human',
@@ -449,11 +450,10 @@ export function normalizePolicyConfig(config: unknown) {
         POLICY_DEFAULTS.issueAuthoring.authoringStaleAge,
       ),
     },
-    // Additive only (#1272): normalized here for shape parity with the
-    // clone(POLICY_DEFAULTS) early-return branch above (non-object
-    // input), but no consuming helper reads this namespace yet. Wiring
-    // the discover/claim/roadmap-audit label lookups to it is deferred
-    // to a follow-up issue (#1273).
+    // Added in #1272 for shape parity with the clone(POLICY_DEFAULTS)
+    // early-return branch above (non-object input); wired to the
+    // consuming helpers' label lookups in #1273 (see the POLICY_DEFAULTS
+    // comment above for the exact file list).
     labels: {
       roadmapLabelName: parseNonEmptyString(
         c?.labels?.roadmapLabelName,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -6,12 +6,15 @@
 // the generated .mjs. See docs/typescript-sources.md.
 
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 import {
   GH_TEXT_LOOP_TIMEOUT_OPTIONS,
   ghText,
   isCliExecution,
 } from './gh-exec.mts';
+import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 
 interface NormalizedIssue {
   number: number;
@@ -39,6 +42,10 @@ interface Context {
   repository: Repository | null;
   duplicateCandidates: DuplicateCandidate[];
   trustSafetyAmbiguous: boolean;
+  /** Configured `labels.blockedByHumanLabelName` (#1273). */
+  blockedByHumanLabelName?: string;
+  /** Configured `labels.needsDecisionLabelName` (#1273). */
+  needsDecisionLabelName?: string;
 }
 
 interface CheckOutcome {
@@ -64,12 +71,9 @@ interface SuitabilityOptions {
   repository?: unknown;
   duplicateCandidates?: unknown;
   trustSafetyAmbiguous?: unknown;
+  blockedByHumanLabelName?: unknown;
+  needsDecisionLabelName?: unknown;
 }
-
-const BLOCKED_LABELS = new Set([
-  'status:blocked-by-human',
-  'status:needs-decision',
-]);
 
 const CHECKS: {
   id: string;
@@ -204,6 +208,14 @@ export function evaluateSuitability(
       options.duplicateCandidates,
     ),
     trustSafetyAmbiguous: Boolean(options.trustSafetyAmbiguous),
+    blockedByHumanLabelName: normalizeConfiguredLabelName(
+      options.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    needsDecisionLabelName: normalizeConfiguredLabelName(
+      options.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
   };
 
   const checks: CheckResult[] = [];
@@ -520,8 +532,18 @@ export function checkAutonomy(context: Context): CheckOutcome {
   const { issue } = context;
   const labels = new Set(issue.labels);
   const body = issue.body;
+  const blockedLabels = new Set([
+    normalizeConfiguredLabelName(
+      context.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    normalizeConfiguredLabelName(
+      context.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+  ]);
 
-  for (const label of BLOCKED_LABELS) {
+  for (const label of blockedLabels) {
     if (labels.has(label)) {
       return {
         pass: false,
@@ -689,9 +711,12 @@ function runCli(): void {
 
   const issue = fetchIssue(repoRef, args.issue);
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
+  const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
     duplicateCandidates,
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
   });
 
   const output = {
@@ -722,6 +747,7 @@ function parseArgs(argv: string[]): {
   token: string;
   owner: string;
   repo: string;
+  policy: string;
   verbose: boolean;
   help: boolean;
 } {
@@ -730,6 +756,7 @@ function parseArgs(argv: string[]): {
     token: string;
     owner: string;
     repo: string;
+    policy: string;
     verbose: boolean;
     help: boolean;
   } = {
@@ -737,6 +764,7 @@ function parseArgs(argv: string[]): {
     token: '',
     owner: '',
     repo: '',
+    policy: '',
     verbose: false,
     help: false,
   };
@@ -764,6 +792,11 @@ function parseArgs(argv: string[]): {
       index += 1;
       continue;
     }
+    if (token === '--policy') {
+      parsed.policy = value ?? '';
+      index += 1;
+      continue;
+    }
     if (token === '--verbose') {
       parsed.verbose = true;
       continue;
@@ -778,9 +811,32 @@ function parseArgs(argv: string[]): {
   return parsed;
 }
 
+/**
+ * Load and parse `.github/idd/config.json` (or `--policy <path>` when given),
+ * falling back to `{}` on a missing/invalid default path so the CLI stays
+ * usable without any policy file (#1273; mirrors the sibling helpers'
+ * `loadPolicy` pattern, e.g. `discover-orphan-filter.mts`). An explicit
+ * `--policy <path>` that fails to read/parse throws, matching the sibling
+ * helpers' fail-loud behavior for an operator-specified path.
+ */
+function loadPolicy(policyPath: string): unknown {
+  const targetPath = policyPath
+    ? resolve(process.cwd(), policyPath)
+    : resolve(process.cwd(), '.github/idd/config.json');
+  try {
+    return JSON.parse(readFileSync(targetPath, 'utf8'));
+  } catch (error) {
+    if (!policyPath) {
+      return {};
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to load policy from ${targetPath}: ${detail}`);
+  }
+}
+
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--verbose]
+  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--verbose]
 
 Output schema:
 {
@@ -812,6 +868,20 @@ function normalizeIssue(issue: unknown): NormalizedIssue {
     labels: normalizeLabels(i.labels),
     url: String(i.url ?? i.html_url ?? ''),
   };
+}
+
+/**
+ * Resolve one configured `labels.*` name (#1273), falling back to the given
+ * `policy-helpers.mts` `POLICY_DEFAULTS.labels` default for an absent or
+ * invalid value.
+ */
+function normalizeConfiguredLabelName(
+  labelName: unknown,
+  fallback: string,
+): string {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : fallback;
 }
 
 function normalizeRepository(repository: unknown): Repository | null {

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -169,6 +169,41 @@ test('filterOrphanIssues excludes blocked labels and open blockers', () => {
   assert.equal(result.filtered.blocked_label.length, 1);
 });
 
+test('filterOrphanIssues resolves configured blocked-label names (#1273)', () => {
+  const issues = [
+    {
+      number: 30,
+      title: 'custom human-gate label',
+      state: 'OPEN',
+      labels: [{ name: 'triage:human-gate' }],
+      body: '',
+      url: 'https://example.com/30',
+    },
+    {
+      number: 31,
+      title: 'stock status:blocked-by-human label no longer blocks',
+      state: 'OPEN',
+      labels: [{ name: 'status:blocked-by-human' }],
+      body: '',
+      url: 'https://example.com/31',
+    },
+  ];
+
+  const result = filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    blockedByHumanLabelName: 'triage:human-gate',
+  });
+
+  // The configured label name blocks #30...
+  assert.equal(result.filtered.blocked_label.length, 1);
+  assert.equal(result.filtered.blocked_label[0].number, 30);
+  // ...while the stock default no longer matches once overridden, so #31 is
+  // an orphan (the override replaces, not adds to, the default).
+  assert.equal(result.orphans.length, 1);
+  assert.equal(result.orphans[0].number, 31);
+});
+
 test('filterOrphanIssues excludes custom authoring label and warns when stale', () => {
   const issues = [
     {

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -244,6 +244,39 @@ test('filters issue with blocked labels', async () => {
   ]);
 });
 
+test('resolves configured blocked-label names (#1273)', async () => {
+  const summary = await evaluateDiscoverReadiness([102, 103], {
+    loadIssue: async (number) =>
+      number === 102
+        ? {
+            number: 102,
+            title: 'custom human-gate label',
+            state: 'OPEN',
+            body: '',
+            labels: [{ name: 'triage:human-gate' }],
+          }
+        : {
+            number: 103,
+            title: 'stock label no longer matches',
+            state: 'OPEN',
+            body: '',
+            labels: [{ name: 'status:blocked-by-human' }],
+          },
+    findRoadmapsByMarker: async () => [],
+    blockedByHumanLabelName: 'triage:human-gate',
+  });
+
+  const byNumber = new Map(
+    summary.filteredOut.map((entry) => [entry.number, entry]),
+  );
+  assert.deepEqual(byNumber.get(102)?.reasons, ['label:triage:human-gate']);
+  // The stock default no longer matches once overridden, so #103 is ready.
+  assert.deepEqual(
+    summary.ready.map((entry) => entry.number),
+    [103],
+  );
+});
+
 test('filters authoring-labeled issue and emits stale warning', async () => {
   const summary = await evaluateDiscoverReadiness([151], {
     now: '2026-05-15T12:00:00Z',
@@ -377,6 +410,45 @@ test('open roadmap dependencies are ignored as parent epics', async () => {
       belowFloor: false,
     },
   ]);
+});
+
+test('open dependency with a configured roadmap label name is ignored as a parent epic (#1273)', async () => {
+  const issues = new Map([
+    [
+      411,
+      {
+        number: 411,
+        title: 'candidate',
+        state: 'OPEN',
+        body: 'Depends on #412',
+        labels: [],
+      },
+    ],
+    [
+      // Title deliberately does NOT start with "roadmap" so this exercises
+      // only the configured-label path, not the independent title heuristic.
+      412,
+      {
+        number: 412,
+        title: 'parent epic',
+        state: 'OPEN',
+        body: '',
+        labels: [{ name: 'epic' }],
+      },
+    ],
+  ]);
+
+  const summary = await evaluateDiscoverReadiness([411], {
+    loadIssue: async (number) => issues.get(number) ?? null,
+    findRoadmapsByMarker: async () => [],
+    roadmapLabelName: 'epic',
+  });
+
+  assert.deepEqual(summary.filteredOut, []);
+  assert.deepEqual(
+    summary.ready.map((entry) => entry.number),
+    [411],
+  );
 });
 
 test('returns empty unresolvable list when include-unresolvable is disabled', async () => {

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -277,6 +277,28 @@ test('resolves configured blocked-label names (#1273)', async () => {
   );
 });
 
+test('an empty-string label-name option falls back to the default instead of disabling the check (#1273 review fix)', async () => {
+  const summary = await evaluateDiscoverReadiness([104], {
+    loadIssue: async () => ({
+      number: 104,
+      title: 'still blocked by the stock label',
+      state: 'OPEN',
+      body: '',
+      labels: [{ name: 'status:blocked-by-human' }],
+    }),
+    findRoadmapsByMarker: async () => [],
+    // An empty string is a destructure-default-bypassing value (not
+    // `undefined`): it must still resolve to the POLICY_DEFAULTS fallback,
+    // not silently disable the blocked-label filter.
+    blockedByHumanLabelName: '',
+  });
+
+  assert.equal(summary.ready.length, 0);
+  assert.deepEqual(summary.filteredOut[0].reasons, [
+    'label:status:blocked-by-human',
+  ]);
+});
+
 test('filters authoring-labeled issue and emits stale warning', async () => {
   const summary = await evaluateDiscoverReadiness([151], {
     now: '2026-05-15T12:00:00Z',

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -76,6 +76,26 @@ Resolve #107
   );
 });
 
+test('classifyIssue resolves a configured roadmap label name (#1273)', () => {
+  // A custom `labels.roadmapLabelName` (e.g. 'epic') classifies as roadmap...
+  assert.equal(
+    classifyIssue({ body: '', labels: [{ name: 'epic' }] }, 'idd-skill', 'epic')
+      .kind,
+    'roadmap',
+  );
+  // ...and the stock 'roadmap' label alone no longer matches once a custom
+  // label name is configured (the override replaces, not adds to, the
+  // default).
+  assert.equal(
+    classifyIssue(
+      { body: '', labels: [{ name: 'roadmap' }] },
+      'idd-skill',
+      'epic',
+    ).kind,
+    'execution',
+  );
+});
+
 test('ignores roadmap-id markers quoted inside code regions (#1083)', () => {
   // The #1083 shape: an execution-leaf issue *about* the marker system that
   // quotes the marker inside inline code. It must not read as roadmap identity.
@@ -1545,6 +1565,27 @@ test('open-roadmap-roots loader honors a custom marker prefix in the body search
   );
 });
 
+test('open-roadmap-roots loader honors a configured roadmap label name (#1273)', async () => {
+  const queries: SearchIssuesQuery[] = [];
+  const searchIssues = (query: SearchIssuesQuery) => {
+    queries.push(query);
+    return [];
+  };
+
+  await buildOpenRoadmapRootsLoader(
+    'kurone-kito',
+    'idd-skill',
+    'idd-skill',
+    searchIssues,
+    'epic',
+  )();
+
+  // The configured `labels.roadmapLabelName` ('epic') is used for the
+  // `--label` search qualifier instead of the default `'roadmap'`.
+  const labelQuery = queries.find((query) => query.label);
+  assert.equal(labelQuery?.label, 'epic');
+});
+
 test('open-roadmap-roots loader warns on the 1000-result search cap', () => {
   // Below the cap: no warning is emitted (the common case stays silent).
   const belowCap = captureStderr(() => {
@@ -1972,6 +2013,9 @@ function readinessResolution() {
     loadIssueLabelEvents: async () => [],
     authoringLabelName: 'status:authoring',
     authoringStaleAgeMs: 4 * 60 * 60 * 1000,
+    roadmapLabelName: 'roadmap',
+    blockedByHumanLabelName: 'status:blocked-by-human',
+    needsDecisionLabelName: 'status:needs-decision',
     nowIso: '2026-06-26T00:00:00Z',
   };
 }

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -96,6 +96,17 @@ test('classifyIssue resolves a configured roadmap label name (#1273)', () => {
   );
 });
 
+test('classifyIssue falls back to the default roadmap label on an empty-string override (#1273 review fix)', () => {
+  // An empty string is a parameter-default-bypassing value (not
+  // `undefined`): it must still resolve to the POLICY_DEFAULTS fallback
+  // ('roadmap'), not silently disable the roadmap-label check.
+  assert.equal(
+    classifyIssue({ body: '', labels: [{ name: 'roadmap' }] }, 'idd-skill', '')
+      .kind,
+    'roadmap',
+  );
+});
+
 test('ignores roadmap-id markers quoted inside code regions (#1083)', () => {
   // The #1083 shape: an execution-leaf issue *about* the marker system that
   // quotes the marker inside inline code. It must not read as roadmap identity.

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -93,6 +93,54 @@ test('autopilot-suitability consistency: score >= floor with blocked-by-human wa
   );
 });
 
+test('autopilot-suitability consistency: resolves a configured blocked-by-human label name (#1273)', () => {
+  // The configured label name is honored for both the "missing" and
+  // "carries" warning paths...
+  const missing = evaluateAutopilotSuitabilityConsistency(
+    [{ number: 20, body: `task\n${ap(1)}`, labels: [] }],
+    { floor: 3, blockedByHumanLabelName: 'triage:human-gate' },
+  );
+  assert.equal(missing.warnings.length, 1);
+  assert.match(
+    missing.warnings[0],
+    /issue #20 is scored 1 .* missing the triage:human-gate label/,
+  );
+
+  const carries = evaluateAutopilotSuitabilityConsistency(
+    [
+      {
+        number: 21,
+        body: `task\n${ap(4)}`,
+        labels: ['triage:human-gate'],
+      },
+    ],
+    { floor: 3, blockedByHumanLabelName: 'triage:human-gate' },
+  );
+  assert.equal(carries.warnings.length, 1);
+  assert.match(
+    carries.warnings[0],
+    /issue #21 is scored 4 \(>= floor 3\) but carries triage:human-gate/,
+  );
+
+  // ...and the stock default no longer matches once overridden, so a score
+  // of 1 with only the stock label still warns as "missing".
+  const stockNoLongerMatches = evaluateAutopilotSuitabilityConsistency(
+    [
+      {
+        number: 22,
+        body: `task\n${ap(1)}`,
+        labels: ['status:blocked-by-human'],
+      },
+    ],
+    { floor: 3, blockedByHumanLabelName: 'triage:human-gate' },
+  );
+  assert.equal(stockNoLongerMatches.warnings.length, 1);
+  assert.match(
+    stockNoLongerMatches.warnings[0],
+    /issue #22 is scored 1 .* missing the triage:human-gate label/,
+  );
+});
+
 test('autopilot-suitability consistency: malformed or conflicting markers warn', () => {
   const issues = [
     { number: 9, body: `task\n${ap(6)}`, labels: [] },

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -725,6 +725,36 @@ test('a human-gate label on the roadmap root blocks the close', () => {
   );
 });
 
+test('resolves configured blocked-label names on the roadmap root (#1273)', () => {
+  const customLabeled = readyReport();
+  customLabeled.nodes = customLabeled.nodes.map((entry) =>
+    entry.number === ROADMAP
+      ? { ...entry, labels: ['roadmap', 'triage:human-gate'] }
+      : entry,
+  );
+  const blockers = evaluateRoadmapAuditGates(customLabeled, {
+    blockedByHumanLabelName: 'triage:human-gate',
+  });
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['roadmap-blocked'],
+  );
+
+  // The stock default no longer matches once overridden.
+  const stockLabeled = readyReport();
+  stockLabeled.nodes = stockLabeled.nodes.map((entry) =>
+    entry.number === ROADMAP
+      ? { ...entry, labels: ['roadmap', 'status:blocked-by-human'] }
+      : entry,
+  );
+  assert.deepEqual(
+    evaluateRoadmapAuditGates(stockLabeled, {
+      blockedByHumanLabelName: 'triage:human-gate',
+    }),
+    [],
+  );
+});
+
 // ---------------------------------------------------------------------------
 // buildRoadmapCompletionAuditBody (pure)
 // ---------------------------------------------------------------------------

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -454,6 +454,41 @@ test('check helpers expose deterministic evidence', () => {
   );
 });
 
+test('checkAutonomy resolves configured blocked-label names (#1273)', () => {
+  // A custom configured label blocks...
+  assert.equal(
+    checkAutonomy({
+      issue: { ...BASE_ISSUE, labels: ['triage:human-gate'] },
+      blockedByHumanLabelName: 'triage:human-gate',
+    } as Context).pass,
+    false,
+  );
+
+  // ...and the stock default no longer matches once overridden (the
+  // override replaces, not adds to, the default).
+  assert.equal(
+    checkAutonomy({
+      issue: { ...BASE_ISSUE, labels: ['status:blocked-by-human'] },
+      blockedByHumanLabelName: 'triage:human-gate',
+    } as Context).pass,
+    true,
+  );
+});
+
+test('evaluateSuitability threads configured blocked-label options through to Autonomy', () => {
+  const result = evaluateSuitability(
+    { ...BASE_ISSUE, labels: ['triage:needs-call'] },
+    {
+      repository: { owner: 'kurone-kito', repo: 'idd-skill' },
+      duplicateCandidates: [{ number: 1, title: BASE_ISSUE.title }],
+      needsDecisionLabelName: 'triage:needs-call',
+    },
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.outcome, 'blocked-by-human');
+  assert.equal(result.failedCheck, 'autonomy');
+});
+
 test('trust safety flags a sudo-wrapped install pipeline directive', () => {
   const result = checkTrustSafety({
     issue: {


### PR DESCRIPTION
# Summary

`labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /
`labels.needsDecisionLabelName` were added to the policy config in
#1272 (additive only — no consuming helper read them yet). This PR
wires the six helpers that previously hard-coded `'roadmap'`,
`'status:blocked-by-human'`, and `'status:needs-decision'` to resolve
these names through `normalizePolicyConfig`/`POLICY_DEFAULTS` in
`src/scripts/policy-helpers.mts` instead, so a configured override
takes effect end-to-end.

- `discover-roadmap-graph.mts`: `classifyIssue()` and
  `buildOpenRoadmapRootsLoader()`'s live `gh search --label` query now
  resolve `roadmapLabelName`; the composed `--with-readiness`
  annotation path (`ReadinessResolution`) carries all three names, so
  `idd-roadmap-audit-execute.mts`'s traversal picks them up too.
- `discover-orphan-filter.mts` / `idd-roadmap-audit-execute.mts` /
  `suitability-triage.mts`: each had a module-level `BLOCKED_LABELS`
  Set — replaced with a per-call resolved Set from config.
- `discover-readiness-check.mts`: the two blocked-label checks and
  `isParentEpicIssue()`'s roadmap-label check now resolve from config.
  Its sibling `title.startsWith('roadmap')` heuristic is left as a
  literal — it's a title-text naming convention independent of the
  configured label, not a label comparison.
- `suitability-triage.mts` had **no** `--policy` flag or config loading
  at all; added one (mirroring the sibling helpers' `loadPolicy`
  pattern) so the CLI path can actually honor an override.
- `idd-doctor.mts`: `evaluateAutopilotSuitabilityConsistency()`'s
  `status:blocked-by-human` check and warning text now resolve
  `blockedByHumanLabelName` from config.

Internal `classification: 'roadmap' | 'execution'` enum tags (in
`discover-roadmap-graph.mts` and `idd-roadmap-audit-execute.mts`) are
unchanged — they're computed union-type tags, not GitHub label string
comparisons, so they're out of scope for this issue.

Also corrected two now-stale `policy-helpers.mts` comments from #1272
("no consuming helper reads this namespace yet ... deferred to a
follow-up issue (#1273)") that this PR's own wiring makes inaccurate.

Each of the six `.mts` sources' actual current call sites was
re-verified against `main` before editing, since the issue's original
candidate-file list predated some interim changes.

## Linked issue

Closes #1273

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Design mirrors the existing `authoringLabelName` / `markerPrefix`
precedent already used in these files: resolve the raw config once at
the CLI/config-load boundary via `normalizePolicyConfig`, then thread
the resolved plain string down through existing options plumbing,
falling back to `POLICY_DEFAULTS.labels.*` at each pure-function
boundary so direct unit-test calls without config keep today's
behavior unchanged. All new parameters/options fields are additive and
optional (or positional with a trailing default), so no existing call
site needed to change to keep compiling/passing.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
