### PR TITLE
chore(release): cut v0.4.0 — changelog synthesis, iddVersion bump

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.3.0",
+  "iddVersion": "0.4.0",
   "markerPrefix": "idd-skill",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,115 @@ from 0.2.0 onward is also published as an annotated `v<iddVersion>`
 git tag once its release pull request merges; 0.1.0 predates the tag
 discipline and has no tag.
 
+## [0.4.0] - 2026-07-04
+
+TypeScript helper toolchain, autopilot-discovery, and merge-gate
+hardening release. From this release on, the cadence is
+milestone-based: a release is cut after each merged roadmap.
+
+### Added
+
+- TypeScript helper toolchain: every helper script now builds from a
+  typed `.mts` source into a committed, generated `.mjs` artifact
+  (`pnpm run build`), with a `build:check` drift gate, schema-to-type
+  reconciliation tests, type-suppression budget guards, an
+  auto-maintained `.gitattributes` generated block, and generated-from
+  banners on generated instruction files; the test suite moved to
+  typed `.mts` as well (run natively, never emitted).
+- Write-side merge-flow helpers that render and post the canonical
+  bodies through the reliable JSON path: `idd-merge-execute` (F3 gate
+  plus merge commit bound to the validated head), `post-idd-marker`
+  (claim/unclaim/watermark/baseline/advisory markers, including a
+  one-step watermark derived from the live snapshot and pinned to the
+  E1 head), `resolve-review-thread` (E13 reply-and-resolve),
+  `idd-roadmap-audit-execute` (A1.5 completion audit and close), and
+  auto-disposition helpers for advisory non-review notices and the
+  CodeRabbit summary walkthrough.
+- Autopilot discovery upgrades: a cross-roadmap ranked-union mode with
+  opt-in claim-state, readiness, and startable annotations on
+  `discover-roadmap-graph`; a mechanical A5 fresh-claim gate; a B2
+  supersession re-check before implementation; an A0-O orphan fallback
+  on A4 viability/claim exhaustion; and softer selection controls —
+  author-recorded effort hints, concurrent-selection desync,
+  high-contention shared-file overlap advisories, and a
+  `--swarm-floor` eligibility sweep.
+- Advisory review generalization: the advisory-wait protocol now names
+  a configurable primary advisory bot, can request a secondary
+  advisory bot once per head, carries non-review-notice dispositions
+  across head changes, and surfaces the `ack-only-post-disposition`
+  override signal in the merge gate.
+- New repository guards: `idd-doctor` warnings for config-to-prose
+  policy drift, an inert worktree guard, main drifting far from the
+  latest release tag, and node_modules/lockfile version drift; a
+  scheduled fresh-install typecheck workflow; a CI workflow hygiene
+  pass (job timeouts, stale concurrency); an install-deps
+  verify-and-retry wrapper for under-installed worktrees; and a CI
+  strip of CodeRabbit-applied reserved IDD labels.
+- Adopter label configurability: the `labels.*` policy namespace with
+  helper support and instruction references.
+- Onboarding automation wave 1: the `idd-onboard`
+  placeholder-substitution CLI with `--dry-run`, site-aware JSON
+  escaping, and fail-closed apply.
+- Smaller evidence helpers: `branch-name` (canonical issue branch
+  slug), `emit-marker` (per-cycle marker bodies), and
+  `merged-pr-feedback-sweep` (read-only post-merge feedback detector).
+
+### Changed
+
+- Instruction-set hardening across the phase files: a D1 no-op-rebase
+  skip and detached-HEAD recovery, watermark-after-CI ordering with
+  refreshes after dispositions, a copy-paste-safe F3 head-SHA gate
+  checklist, a CI/advisory wake-up discipline, the
+  one-issue-per-session operating model with F4/F5 as the safe exit
+  boundary, E9 fix-side convergence rules, an ask-first gate for
+  dependency and CI-workflow changes, and a strict-resume versus
+  lenient-merge forced-handoff split.
+- Documentation footprint governance: bundle byte budgets are
+  de-hardcoded and guarded against the sync manifest, with recovered
+  headroom on the review and work bundles.
+- `pre-merge-readiness` now emits a ready/blockers rollup, requires
+  `waiverEvidence`, and records `trustedMarkerActors` provenance.
+- `discover-roadmap-graph` traversal parallelizes its I/O and narrows
+  `--all-roadmaps` root discovery with server-side search.
+- Helper internals consolidated: shared `gh-exec` / config-loader
+  modules, marker helpers carved out of `protocol-helpers`, CLI bodies
+  guarded behind `isCliExecution()` so imports are side-effect free,
+  and the test suites consolidated onto a shared typed test-utility
+  module.
+- Issue-authoring skill hardening: codebase-fidelity pre-publish
+  guards with a deliberate-divergence check, a required
+  autopilot-suitability footer in the draft schemas, `Blocked by`
+  encoding on finalize-track siblings, and close-not-delete draft
+  recovery.
+
+### Fixed
+
+- Merge-gate correctness: resolved AMD-rejection threads and
+  out-of-snapshot threads are recognized, disposition markers pair 1:1
+  with items, trusted-actor dispositions satisfy the
+  unreplied-comments gate, write-side helpers honor forced handoff,
+  `fully_autonomous_merge` reaches its handoff step without an active
+  claim, and asynchronous mergeability is classified as computing
+  rather than a terminal unknown.
+- Claim-phase races: A5 same-second tie-break and refs/heads
+  normalization, an A0-T race loss stops instead of silently falling
+  back to Discover, forced-handoff evidence must be PR-scoped for
+  PR-backed claims, and competing-claim searches baseline on the
+  original claim.
+- Discovery and triage read the right signals: gh lookup errors fail
+  closed instead of masquerading as missing issues, code-quoted marker
+  and reference text is ignored, every same-line blocked-by reference
+  is captured, authoring labels match case-insensitively, the
+  protocol-mandated `Refs` provenance breadcrumbs from closed leaves
+  are no longer misclassified as blocking cycles, and
+  suitability-triage pattern-matching precision was tightened twice.
+- An `idd-doctor` robustness cluster (workshop back-link scanning,
+  CRLF/null-safe worktree parsing, overview-table resolution,
+  suitability-floor contradiction checks) and assorted helper
+  hardening (fail-closed forced-handoff authorization, allowed gh
+  HTTP statuses yielding empty results, waiver-marker matching and
+  consume-side gating).
+
 ## [0.3.0] - 2026-06-11
 
 Structural ack-only review-currency evidence release.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -66,7 +66,9 @@ distributed IDD workflow a repository imported.
   `iddVersion` bump also requires a matching `CHANGELOG.md` entry in the
   same pull request, and an annotated `v<iddVersion>` git tag pushed to
   the source repository after the bump PR merges, so adopters can diff
-  against a concrete release ref instead of a raw commit SHA.
+  against a concrete release ref instead of a raw commit SHA. The
+  release cadence is milestone-based: cut a release after each merged
+  roadmap.
 - **Adopters** can compare their `iddVersion` against the source release
   to see whether a re-sync is worthwhile. Because the value only moves
   when maintainers bump it, it is a coarse signal — so `idd-doctor` also

--- a/idd-template/.github/idd/config.json
+++ b/idd-template/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.3.0",
+  "iddVersion": "0.4.0",
   "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -66,7 +66,9 @@ distributed IDD workflow a repository imported.
   `iddVersion` bump also requires a matching `CHANGELOG.md` entry in the
   same pull request, and an annotated `v<iddVersion>` git tag pushed to
   the source repository after the bump PR merges, so adopters can diff
-  against a concrete release ref instead of a raw commit SHA.
+  against a concrete release ref instead of a raw commit SHA. The
+  release cadence is milestone-based: cut a release after each merged
+  roadmap.
 - **Adopters** can compare their `iddVersion` against the source release
   to see whether a re-sync is worthwhile. Because the value only moves
   when maintainers bump it, it is a coarse signal — so `idd-doctor` also

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/idd-skill",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Issue-Driven Development workflow assets",
   "license": "MIT",


### PR DESCRIPTION
# Summary

Cuts **v0.4.0** per the operator decision recorded on #1217 during the #1220 roadmap completion audit, and adopts the milestone-based release cadence (cut a release after each merged roadmap) going forward.

- **CHANGELOG**: a `## [0.4.0] - 2026-07-04` section synthesizing the 199 pull requests merged since the `v0.3.0` tag (`v0.3.0..main` first-parent ancestry, #863–#1289) as user-facing highlights under Added/Changed/Fixed at the 0.3.0 entry's editorial granularity — thematic clusters (TypeScript helper toolchain, write-side merge-flow helpers, autopilot discovery, advisory generalization, doctor/CI guards, labels.* configurability, onboarding wave 1, instruction hardening, fail-closed discovery fixes), not a raw PR list. Accuracy was adversarially cross-checked against the full PR title list (each bullet clause traced to concrete PRs; overstatements and a misattributed predicate corrected).
- **Version bump**: `iddVersion` → `0.4.0` in `.github/idd/config.json` and `idd-template/.github/idd/config.json`, plus `package.json` `version` (the consistency test pins these in lockstep). A repo-wide grep confirms no live `0.3.0` reference remains — historical CHANGELOG entries and a dated calibration comment in `idd-doctor` (the out-of-scope drift-guard question of #1217) excepted; the other documented surfaces reference `iddVersion` generically and carry no literal.
- **Cadence rule**: recorded once on the canonical release-discipline surface (`idd-template/docs/customization.md` § Template Version and Staleness) and mirrored to `docs/customization.md` via sync-docs. The 0.4.0 release-notes theme line announces the same policy as narrative, not a second maintained surface.

## Linked issue

Closes #1260

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Post-merge step (operator-authorized by the #1217 decision record):** after this PR merges, create the annotated tag on the merge commit and push it:

    git tag -a v0.4.0 -m "IDD workflow template v0.4.0" <merge-commit-sha>
    git push origin v0.4.0

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`pnpm run lint:minimum`)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (covered by audit-docs in lint:minimum)
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (no gate behavior changed; tag push is the documented, operator-authorized post-merge step)
- [x] Context budget impact reviewed (one cadence sentence on the customization pair; CHANGELOG is not a budgeted bundle surface)
