### PR TITLE
docs(review-snapshot): sequence watermark after advisory re-review

### DIFF
--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -137,11 +137,16 @@ Use server-reported timestamps, not the local wall clock.
 **CI-completion precondition.** Post the `review-watermark` only **after**
 every CI run that will count toward the merge gate has completed — including
 any opt-in / label-triggered job enabled at the quiescent pre-merge point.
-Operationally: enable the late job, await its completion, **then** take the
-Step 1 snapshot and post the watermark. A merge-gate-counting run
-completing _after_ the watermark advances HEAD's latest CI time and forces a
-wasted E1↔F2 round-trip (F2's `ci-pass-drift` return-to-E1) even though no new
-review activity occurred.
+The same precondition covers an expected advisory-bot re-review: when the
+primary advisory bot already reviewed an earlier head of this PR, an
+automatic same-head re-review is expected — check the AW1 fast-path signal in
+`idd-advisory-wait.instructions.md` (`LAST_COPILOT_COMMIT == PR_HEAD_SHA`) and
+post the watermark after that review lands, bounded by the advisory-wait
+windows when it never does. Operationally: enable the late job, await its
+completion, **then** take the Step 1 snapshot and post the watermark. A
+merge-gate-counting run completing _after_ the watermark advances HEAD's
+latest CI time and forces a wasted E1↔F2 round-trip (F2's `ci-pass-drift`
+return-to-E1) even though no new review activity occurred.
 
 Note: the comment body begins with an HTML comment token. Some GitHub
 client tools (e.g., `gh issue comment`, `gh api -f body=`) silently

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -132,11 +132,16 @@ Use server-reported timestamps, not the local wall clock.
 **CI-completion precondition.** Post the `review-watermark` only **after**
 every CI run that will count toward the merge gate has completed — including
 any opt-in / label-triggered job enabled at the quiescent pre-merge point.
-Operationally: enable the late job, await its completion, **then** take the
-Step 1 snapshot and post the watermark. A merge-gate-counting run
-completing _after_ the watermark advances HEAD's latest CI time and forces a
-wasted E1↔F2 round-trip (F2's `ci-pass-drift` return-to-E1) even though no new
-review activity occurred.
+The same precondition covers an expected advisory-bot re-review: when the
+primary advisory bot already reviewed an earlier head of this PR, an
+automatic same-head re-review is expected — check the AW1 fast-path signal in
+`idd-advisory-wait.instructions.md` (`LAST_COPILOT_COMMIT == PR_HEAD_SHA`) and
+post the watermark after that review lands, bounded by the advisory-wait
+windows when it never does. Operationally: enable the late job, await its
+completion, **then** take the Step 1 snapshot and post the watermark. A
+merge-gate-counting run completing _after_ the watermark advances HEAD's
+latest CI time and forces a wasted E1↔F2 round-trip (F2's `ci-pass-drift`
+return-to-E1) even though no new review activity occurred.
 
 Note: the comment body begins with an HTML comment token. Some GitHub
 client tools (e.g., `gh issue comment`, `gh api -f body=`) silently


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

E1 Step 2's CI-completion precondition already sequences the
`review-watermark` after every merge-gate-counting CI run, because a
later completion invalidates the watermark and forces a wasted
E1<->F2 round-trip. The same mechanism fires for the primary advisory
bot's automatic re-review: a push to a PR the bot already reviewed
triggers a re-review with no new request, and it can land a few
minutes after CI goes green, invalidating a watermark posted at
CI-green.

This extends the CI-completion precondition in
`idd-template/.github/instructions/idd-review-snapshot.instructions.md`
(and its generated mirror) with a sibling sentence: when the primary
advisory bot already reviewed an earlier head of this PR, an
automatic same-head re-review is expected — check the AW1 fast-path
signal (`LAST_COPILOT_COMMIT == PR_HEAD_SHA`) and post the watermark
after that review lands, still bounded by the advisory-wait windows
when it never does. No gate semantics change.

## Linked issue

Closes #1297

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`bundle-review` was already at ~98% of its byte budget
(106,611 / 108,800 bytes). The added sentence (~400 bytes) keeps the
bundle at 107,014 / 108,800 bytes (1,786 bytes headroom) without
needing the bump-with-margin `limitBytes` path.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
