### PR TITLE
fix(review-fix): make E14's bot review-request commands version-tolerant

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -158,10 +158,15 @@ re-review:
 gh pr edit {pr-number} --add-reviewer {reviewer-login}
 ```
 
-For an **advisory bot**, pass the bot's reviewer **login** to this
-add-reviewer command (the reliable trigger). The REST `requested_reviewers`
-endpoint called with a bot's **display name** silently no-ops and wastes a
-full advisory-wait cycle, so do not use that path to request a re-review.
+For an **advisory bot**, try the add-reviewer command with the bot's
+reviewer **login** first. On some `gh` versions this GraphQL-based
+mutation fails a bot login outright (`Could not resolve user with login
+'{login}' (requestReviewsByLogin)`) instead of succeeding; on that
+failure, fall back to REST `requested_reviewers` with the bot's actual
+account login instead — REST also silently no-ops on a bot's **display
+name** and wastes a full advisory-wait cycle. See **Primary advisory
+bot** below for the exact fallback commands and the login each path
+needs.
 
 **Primary advisory bot** (default Copilot): after every push, regardless
 of any reviewer's state, request a re-review from the configured primary
@@ -176,6 +181,12 @@ login — the default is `copilot`, so the command resolves to `@copilot`.
 The advisory-wait helpers resolve the same identity from policy. The AW
 helper output fields keep their `COPILOT_PENDING` / `LAST_COPILOT_COMMIT`
 names regardless of the configured bot.
+
+The REST fallback needs a different identity,
+`{primary-advisory-bot-rest-login}`: for the default bot this is
+`copilot-pull-request-reviewer[bot]`; for a configured non-default bot it
+equals `{primary-advisory-bot}`, since a configured login is already the
+real account login.
 
 1. Fetch `PR_HEAD_SHA`:
 
@@ -208,13 +219,25 @@ names regardless of the configured bot.
      gh pr edit {pr-number} --remove-reviewer "@{primary-advisory-bot}"
      ```
 
+     On a GraphQL login-resolution failure (see above), retry via REST
+     instead:
+
+     ```sh
+     gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
+       -X DELETE -f "reviewers[]={primary-advisory-bot-rest-login}"
+     ```
+
      If removal fails because the bot is no longer pending, re-run
      AW1–AW3. If removal fails for any other reason, post the AW4
      pending-refresh-failed hold comment and stop. After removal
-     succeeds, request the primary advisory bot's review:
+     succeeds, request the primary advisory bot's review the same
+     gh-then-REST way:
 
      ```sh
      gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"
+     # on GraphQL login-resolution failure:
+     gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
+       -X POST -f "reviewers[]={primary-advisory-bot-rest-login}"
      ```
 
      ```text
@@ -231,10 +254,15 @@ names regardless of the configured bot.
    elapsed settle/pending window while the primary never reviewed the current
    HEAD), `advisoryWait.secondaryBotLogin` is configured, and that secondary
    has **not** already been `review_requested` after the current HEAD's
-   `committed` event — request the secondary bot **once** for the current HEAD:
+   `committed` event — request the secondary bot **once** for the current
+   HEAD, using the same gh-then-REST fallback as the primary:
 
    ```sh
    gh pr edit {pr-number} --add-reviewer "@{secondary-advisory-bot}"
+   # on GraphQL login-resolution failure (rare for a configured secondary,
+   # which is already a real account login):
+   gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
+     -X POST -f "reviewers[]={secondary-advisory-bot}"
    ```
 
    Post **no** `advisory-wait:` marker for the secondary (it must never satisfy

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -153,10 +153,15 @@ re-review:
 gh pr edit {pr-number} --add-reviewer {reviewer-login}
 ```
 
-For an **advisory bot**, pass the bot's reviewer **login** to this
-add-reviewer command (the reliable trigger). The REST `requested_reviewers`
-endpoint called with a bot's **display name** silently no-ops and wastes a
-full advisory-wait cycle, so do not use that path to request a re-review.
+For an **advisory bot**, try the add-reviewer command with the bot's
+reviewer **login** first. On some `gh` versions this GraphQL-based
+mutation fails a bot login outright (`Could not resolve user with login
+'{login}' (requestReviewsByLogin)`) instead of succeeding; on that
+failure, fall back to REST `requested_reviewers` with the bot's actual
+account login instead — REST also silently no-ops on a bot's **display
+name** and wastes a full advisory-wait cycle. See **Primary advisory
+bot** below for the exact fallback commands and the login each path
+needs.
 
 **Primary advisory bot** (default Copilot): after every push, regardless
 of any reviewer's state, request a re-review from the configured primary
@@ -171,6 +176,12 @@ login — the default is `copilot`, so the command resolves to `@copilot`.
 The advisory-wait helpers resolve the same identity from policy. The AW
 helper output fields keep their `COPILOT_PENDING` / `LAST_COPILOT_COMMIT`
 names regardless of the configured bot.
+
+The REST fallback needs a different identity,
+`{primary-advisory-bot-rest-login}`: for the default bot this is
+`copilot-pull-request-reviewer[bot]`; for a configured non-default bot it
+equals `{primary-advisory-bot}`, since a configured login is already the
+real account login.
 
 1. Fetch `PR_HEAD_SHA`:
 
@@ -203,13 +214,25 @@ names regardless of the configured bot.
      gh pr edit {pr-number} --remove-reviewer "@{primary-advisory-bot}"
      ```
 
+     On a GraphQL login-resolution failure (see above), retry via REST
+     instead:
+
+     ```sh
+     gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
+       -X DELETE -f "reviewers[]={primary-advisory-bot-rest-login}"
+     ```
+
      If removal fails because the bot is no longer pending, re-run
      AW1–AW3. If removal fails for any other reason, post the AW4
      pending-refresh-failed hold comment and stop. After removal
-     succeeds, request the primary advisory bot's review:
+     succeeds, request the primary advisory bot's review the same
+     gh-then-REST way:
 
      ```sh
      gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"
+     # on GraphQL login-resolution failure:
+     gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
+       -X POST -f "reviewers[]={primary-advisory-bot-rest-login}"
      ```
 
      ```text
@@ -226,10 +249,15 @@ names regardless of the configured bot.
    elapsed settle/pending window while the primary never reviewed the current
    HEAD), `advisoryWait.secondaryBotLogin` is configured, and that secondary
    has **not** already been `review_requested` after the current HEAD's
-   `committed` event — request the secondary bot **once** for the current HEAD:
+   `committed` event — request the secondary bot **once** for the current
+   HEAD, using the same gh-then-REST fallback as the primary:
 
    ```sh
    gh pr edit {pr-number} --add-reviewer "@{secondary-advisory-bot}"
+   # on GraphQL login-resolution failure (rare for a configured secondary,
+   # which is already a real account login):
+   gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
+     -X POST -f "reviewers[]={secondary-advisory-bot}"
    ```
 
    Post **no** `advisory-wait:` marker for the secondary (it must never satisfy


### PR DESCRIPTION
# Summary

E14's primary-bot request step documented `gh pr edit --add-reviewer
"@copilot"` as "the reliable trigger" and warned only that the REST
`requested_reviewers` endpoint silently no-ops on a display name. On
current `gh` (observed on PR #1285, gh 2.95.0), the gh-edit form itself
fails outright for the bot login with a GraphQL
`Could not resolve user with login 'copilot' (requestReviewsByLogin)`
error, while REST called with the bot's actual `[bot]`-suffixed account
login (`copilot-pull-request-reviewer[bot]`) succeeds.

This PR makes E14's bot review-request steps version-tolerant: try the
gh form first, and on a GraphQL login-resolution failure fall back to
REST with the bot's real account login (never the bare alias or the
display name). The same fallback is applied to the `--remove-reviewer`
pending-removal step and the optional secondary-bot request, since all
three share the same gh reviewer-resolution code path.

`docs/idd-advisory-wait-shell-fallback.md` was checked and does not
repeat the affected commands (it only has read-only pending/review-state
`GET` checks), so it needs no change.

## Linked issue

Closes #1296

## Follow-up issues (if any)

- [ ] none tracked yet, but noting for visibility: `bundle-review` (per
      `audit/sync-manifest.json` `bundleBudgets`) is now at
      108,328 / 108,800 bytes (~99.6%, only 472 bytes headroom) after
      this change rebased onto current `main` — up from ~98.0% before
      it, and pushed further by a concurrent sibling PR (#1301) that
      also touched a `bundle-review` member
      (`idd-review-snapshot.instructions.md`). Still under budget here,
      no ratchet bump needed for this PR, but the next change to any of
      that bundle's 7 member files will very likely need to trim or
      bump `bundle-review`'s `limitBytes`.

## Background / rationale (if material)

The gh-vs-REST identity split is specific to the **default** Copilot
reviewer: `gh pr edit --add-reviewer` needs the bare `copilot` alias,
while REST needs the real GitHub App account login,
`copilot-pull-request-reviewer[bot]`. For a **non-default** configured
`advisoryWait.primaryBotLogin` (e.g. a CodeRabbit-style bot), the
configured value is already the bot's real account login and works
unchanged for both paths — confirmed against `isCopilotReviewerLogin`'s
dual-match-only-for-the-default-bot semantics in
`scripts/protocol-helpers.mjs` / `src/scripts/protocol-helpers.mts`.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed with 3 pre-existing,
      unrelated warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — this only changes how a
      re-review request is issued, not merge gating)
- [x] Context budget impact reviewed (see Follow-up issues note above)
