### PR TITLE
feat(roadmap-audit): report already-complete when --apply retries after a finished close

### DIFF
--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -407,6 +407,24 @@ export function evaluateRoadmapClaim(comments, options) {
   };
 }
 /**
+ * Detect the helper's own canonical `IDD roadmap completion audit` evidence
+ * comment (the exact heading `buildRoadmapCompletionAuditBody` emits) among
+ * `comments`, posted by an author for which `isTrustedAuthor` is true. Used
+ * only to recognize the idempotent "already complete" retry case (#1299)
+ * when the `--apply` early claim re-validation finds no owned claim but the
+ * live roadmap is already CLOSED — never to gate the primary close itself,
+ * which always requires a freshly re-validated claim. Pure and network-free
+ * so it is unit-testable apart from live GitHub.
+ */
+export function hasTrustedCompletionEvidenceComment(comments, isTrustedAuthor) {
+  return (comments ?? []).some(
+    (comment) =>
+      String(comment.body ?? '').startsWith(
+        '**IDD roadmap completion audit**',
+      ) && isTrustedAuthor(String(comment.author?.login ?? '')),
+  );
+}
+/**
  * Build the A1.5 verdict and, under `--apply`, execute the audit. The dry-run
  * path performs NO mutation. The apply path fails closed: if the roadmap is
  * not ready it exits without mutating; if it is ready it RE-VALIDATES the
@@ -415,6 +433,16 @@ export function evaluateRoadmapClaim(comments, options) {
  * owned claim or any newly-discovered blocker. Only after both re-validations
  * pass does it post the evidence comment, close the roadmap, and release the
  * claim — in that order.
+ *
+ * One claim-loss shape at the EARLY re-validation is recognized as a distinct
+ * idempotent no-op instead of a bare failure (#1299): a retry after a prior
+ * `--apply` already fully completed (e.g. its stdout was lost) finds no owned
+ * claim because that prior run already released it. When the live roadmap is
+ * already CLOSED and carries this helper's own canonical evidence comment
+ * from a trusted marker actor, report `already-complete` (exit 0) rather than
+ * the generic claim-not-owned error. Every other claim-loss shape — roadmap
+ * still open, closed without trusted evidence — keeps the unchanged
+ * fail-closed behavior.
  */
 export async function runRoadmapAuditExecute(argv, deps) {
   const args = parseArgs(argv);
@@ -492,6 +520,23 @@ export async function runRoadmapAuditExecute(argv, deps) {
     nowIso,
   });
   if (!earlyClaim.owned) {
+    // #1299: a lost/missing claim here is indistinguishable from a race or
+    // hijack UNLESS the live roadmap independently proves the audit already
+    // completed — already CLOSED, carrying this helper's own canonical
+    // evidence comment from a trusted marker actor (`report` is the graph
+    // already fetched at the top of this invocation, so this reuses that
+    // read rather than a fresh one). Recognize that one positively-provable
+    // state as an idempotent no-op success instead of the fail-closed
+    // claim-not-owned error; every other claim-loss shape (roadmap still
+    // open, closed without trusted evidence) is unchanged.
+    if (
+      report.root.state === 'CLOSED' &&
+      resolvedDeps.hasTrustedCompletionEvidence(roadmapNumber)
+    ) {
+      verdict.closed = true;
+      verdict.result = `already-complete: roadmap #${roadmapNumber} is already closed with a trusted IDD roadmap completion audit evidence comment (claim reason="${earlyClaim.reason}"); idempotent no-op, no mutation performed`;
+      return { verdict, exitCode: 0 };
+    }
     verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}"); no mutation`;
     return { verdict, exitCode: 1 };
   }
@@ -648,6 +693,11 @@ function createProductionDeps(args) {
         nowIso,
         staleAgeMs,
       }),
+    hasTrustedCompletionEvidence: (roadmapNumber) =>
+      hasTrustedCompletionEvidenceComment(
+        loadIssueComments(owner, repo, roadmapNumber),
+        isTrustedAuthor,
+      ),
     postEvidenceComment: (issueNumber, body) =>
       postIssueComment(owner, repo, issueNumber, body),
     closeRoadmap: (issueNumber) =>

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -40,6 +40,11 @@ const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // only as the fallback when the policy declares no (or an invalid)
 // `claimTiming.staleAge`; mirrors discover-roadmap-graph's own default.
 const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+// The canonical evidence comment's literal leading heading. Shared by the
+// body composer (`buildRoadmapCompletionAuditBody`) and the evidence
+// detector (`hasTrustedCompletionEvidenceComment`, #1299) so the two never
+// drift out of sync.
+const COMPLETION_AUDIT_HEADING = '**IDD roadmap completion audit**';
 // Scope caveat (A1.5): this helper gates only the MECHANICAL completion
 // preconditions. It deliberately does NOT verify the roadmap's free-form
 // success criteria or autonomy-gap items — that is agent judgment "where
@@ -289,7 +294,7 @@ export function buildRoadmapCompletionAuditBody(report) {
     .map((node) => `#${node.number}`)
     .join(', ');
   return [
-    '**IDD roadmap completion audit**',
+    COMPLETION_AUDIT_HEADING,
     '',
     `Roadmap #${rootNumber} "${report.root.title}" audited as complete: every referenced child and descendant issue is closed or otherwise complete.`,
     '',
@@ -419,9 +424,8 @@ export function evaluateRoadmapClaim(comments, options) {
 export function hasTrustedCompletionEvidenceComment(comments, isTrustedAuthor) {
   return (comments ?? []).some(
     (comment) =>
-      String(comment.body ?? '').startsWith(
-        '**IDD roadmap completion audit**',
-      ) && isTrustedAuthor(String(comment.author?.login ?? '')),
+      String(comment.body ?? '').startsWith(COMPLETION_AUDIT_HEADING) &&
+      isTrustedAuthor(String(comment.author?.login ?? '')),
   );
 }
 /**

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -429,6 +429,27 @@ export function hasTrustedCompletionEvidenceComment(comments, isTrustedAuthor) {
   );
 }
 /**
+ * Run `check` and treat any thrown error as "no evidence" (`false`) rather
+ * than letting it propagate. The #1299 already-complete recognition is only
+ * ever meant to convert one already-provable claim-loss shape into a nicer
+ * idempotent success — it must never leave the helper worse off than the
+ * pre-existing fail-closed `claim not owned …; no mutation` exit it sits in
+ * front of. Production wires this around the live `gh` comment fetch, whose
+ * `ghText` throws on any non-zero exit (transient network blip, rate limit,
+ * auth hiccup): without this wrapper such a failure would crash the whole
+ * helper instead of falling through to that already-correct fail-closed
+ * message (flagged by Copilot review on PR #1303). Pure given a
+ * non-throwing `check`, so the catch behavior itself is unit-testable
+ * without live `gh`.
+ */
+export function safeHasTrustedCompletionEvidence(check) {
+  try {
+    return check();
+  } catch {
+    return false;
+  }
+}
+/**
  * Build the A1.5 verdict and, under `--apply`, execute the audit. The dry-run
  * path performs NO mutation. The apply path fails closed: if the roadmap is
  * not ready it exits without mutating; if it is ready it RE-VALIDATES the
@@ -698,9 +719,11 @@ function createProductionDeps(args) {
         staleAgeMs,
       }),
     hasTrustedCompletionEvidence: (roadmapNumber) =>
-      hasTrustedCompletionEvidenceComment(
-        loadIssueComments(owner, repo, roadmapNumber),
-        isTrustedAuthor,
+      safeHasTrustedCompletionEvidence(() =>
+        hasTrustedCompletionEvidenceComment(
+          loadIssueComments(owner, repo, roadmapNumber),
+          isTrustedAuthor,
+        ),
       ),
     postEvidenceComment: (issueNumber, body) =>
       postIssueComment(owner, repo, issueNumber, body),

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -534,6 +534,28 @@ export function evaluateRoadmapClaim(
 }
 
 /**
+ * Detect the helper's own canonical `IDD roadmap completion audit` evidence
+ * comment (the exact heading `buildRoadmapCompletionAuditBody` emits) among
+ * `comments`, posted by an author for which `isTrustedAuthor` is true. Used
+ * only to recognize the idempotent "already complete" retry case (#1299)
+ * when the `--apply` early claim re-validation finds no owned claim but the
+ * live roadmap is already CLOSED — never to gate the primary close itself,
+ * which always requires a freshly re-validated claim. Pure and network-free
+ * so it is unit-testable apart from live GitHub.
+ */
+export function hasTrustedCompletionEvidenceComment(
+  comments: Parameters<typeof summarizeClaimValidation>[0],
+  isTrustedAuthor: (login: string) => boolean,
+): boolean {
+  return (comments ?? []).some(
+    (comment) =>
+      String(comment.body ?? '').startsWith(
+        '**IDD roadmap completion audit**',
+      ) && isTrustedAuthor(String(comment.author?.login ?? '')),
+  );
+}
+
+/**
  * Injectable side-effecting dependencies. Tests substitute these to drive the
  * dry-run / apply / fail-closed paths without faking live GitHub state;
  * production uses the real roadmap-graph traversal, claim stream, and `gh`.
@@ -555,6 +577,14 @@ export interface RoadmapAuditExecuteDeps {
     expectedAgentId: string;
     nowIso: string;
   }) => RoadmapClaimVerdict;
+  /**
+   * Detect the helper's own canonical completion-audit evidence comment,
+   * posted by a trusted marker actor, on the live roadmap issue. Consulted
+   * only when the early claim re-validation above is lost AND the live
+   * roadmap is already CLOSED, to recognize an idempotent already-complete
+   * retry (#1299) instead of reporting a misleading claim-loss error.
+   */
+  hasTrustedCompletionEvidence: (roadmapNumber: number) => boolean;
   /** POST the canonical `IDD roadmap completion audit` evidence comment. */
   postEvidenceComment: (issueNumber: number, body: string) => void;
   /** Close the roadmap issue as completed. */
@@ -581,6 +611,16 @@ export interface RoadmapAuditExecuteDeps {
  * owned claim or any newly-discovered blocker. Only after both re-validations
  * pass does it post the evidence comment, close the roadmap, and release the
  * claim — in that order.
+ *
+ * One claim-loss shape at the EARLY re-validation is recognized as a distinct
+ * idempotent no-op instead of a bare failure (#1299): a retry after a prior
+ * `--apply` already fully completed (e.g. its stdout was lost) finds no owned
+ * claim because that prior run already released it. When the live roadmap is
+ * already CLOSED and carries this helper's own canonical evidence comment
+ * from a trusted marker actor, report `already-complete` (exit 0) rather than
+ * the generic claim-not-owned error. Every other claim-loss shape — roadmap
+ * still open, closed without trusted evidence — keeps the unchanged
+ * fail-closed behavior.
  */
 export async function runRoadmapAuditExecute(
   argv: string[],
@@ -669,6 +709,23 @@ export async function runRoadmapAuditExecute(
     nowIso,
   });
   if (!earlyClaim.owned) {
+    // #1299: a lost/missing claim here is indistinguishable from a race or
+    // hijack UNLESS the live roadmap independently proves the audit already
+    // completed — already CLOSED, carrying this helper's own canonical
+    // evidence comment from a trusted marker actor (`report` is the graph
+    // already fetched at the top of this invocation, so this reuses that
+    // read rather than a fresh one). Recognize that one positively-provable
+    // state as an idempotent no-op success instead of the fail-closed
+    // claim-not-owned error; every other claim-loss shape (roadmap still
+    // open, closed without trusted evidence) is unchanged.
+    if (
+      report.root.state === 'CLOSED' &&
+      resolvedDeps.hasTrustedCompletionEvidence(roadmapNumber)
+    ) {
+      verdict.closed = true;
+      verdict.result = `already-complete: roadmap #${roadmapNumber} is already closed with a trusted IDD roadmap completion audit evidence comment (claim reason="${earlyClaim.reason}"); idempotent no-op, no mutation performed`;
+      return { verdict, exitCode: 0 };
+    }
     verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}"); no mutation`;
     return { verdict, exitCode: 1 };
   }
@@ -843,6 +900,11 @@ function createProductionDeps(
         nowIso,
         staleAgeMs,
       }),
+    hasTrustedCompletionEvidence: (roadmapNumber) =>
+      hasTrustedCompletionEvidenceComment(
+        loadIssueComments(owner, repo, roadmapNumber),
+        isTrustedAuthor,
+      ),
     postEvidenceComment: (issueNumber, body) =>
       postIssueComment(owner, repo, issueNumber, body),
     closeRoadmap: (issueNumber) =>

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -43,6 +43,11 @@ const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // only as the fallback when the policy declares no (or an invalid)
 // `claimTiming.staleAge`; mirrors discover-roadmap-graph's own default.
 const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+// The canonical evidence comment's literal leading heading. Shared by the
+// body composer (`buildRoadmapCompletionAuditBody`) and the evidence
+// detector (`hasTrustedCompletionEvidenceComment`, #1299) so the two never
+// drift out of sync.
+const COMPLETION_AUDIT_HEADING = '**IDD roadmap completion audit**';
 
 // Scope caveat (A1.5): this helper gates only the MECHANICAL completion
 // preconditions. It deliberately does NOT verify the roadmap's free-form
@@ -393,7 +398,7 @@ export function buildRoadmapCompletionAuditBody(
     .join(', ');
 
   return [
-    '**IDD roadmap completion audit**',
+    COMPLETION_AUDIT_HEADING,
     '',
     `Roadmap #${rootNumber} "${report.root.title}" audited as complete: every referenced child and descendant issue is closed or otherwise complete.`,
     '',
@@ -549,9 +554,8 @@ export function hasTrustedCompletionEvidenceComment(
 ): boolean {
   return (comments ?? []).some(
     (comment) =>
-      String(comment.body ?? '').startsWith(
-        '**IDD roadmap completion audit**',
-      ) && isTrustedAuthor(String(comment.author?.login ?? '')),
+      String(comment.body ?? '').startsWith(COMPLETION_AUDIT_HEADING) &&
+      isTrustedAuthor(String(comment.author?.login ?? '')),
   );
 }
 

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -560,6 +560,30 @@ export function hasTrustedCompletionEvidenceComment(
 }
 
 /**
+ * Run `check` and treat any thrown error as "no evidence" (`false`) rather
+ * than letting it propagate. The #1299 already-complete recognition is only
+ * ever meant to convert one already-provable claim-loss shape into a nicer
+ * idempotent success — it must never leave the helper worse off than the
+ * pre-existing fail-closed `claim not owned …; no mutation` exit it sits in
+ * front of. Production wires this around the live `gh` comment fetch, whose
+ * `ghText` throws on any non-zero exit (transient network blip, rate limit,
+ * auth hiccup): without this wrapper such a failure would crash the whole
+ * helper instead of falling through to that already-correct fail-closed
+ * message (flagged by Copilot review on PR #1303). Pure given a
+ * non-throwing `check`, so the catch behavior itself is unit-testable
+ * without live `gh`.
+ */
+export function safeHasTrustedCompletionEvidence(
+  check: () => boolean,
+): boolean {
+  try {
+    return check();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Injectable side-effecting dependencies. Tests substitute these to drive the
  * dry-run / apply / fail-closed paths without faking live GitHub state;
  * production uses the real roadmap-graph traversal, claim stream, and `gh`.
@@ -587,6 +611,11 @@ export interface RoadmapAuditExecuteDeps {
    * only when the early claim re-validation above is lost AND the live
    * roadmap is already CLOSED, to recognize an idempotent already-complete
    * retry (#1299) instead of reporting a misleading claim-loss error.
+   * MUST fail closed (return `false`, never throw) on any lookup error —
+   * this check only recognizes an already-provable success, so an error
+   * here must fall through to the pre-existing claim-not-owned exit rather
+   * than crash the helper. Production wires this through
+   * {@link safeHasTrustedCompletionEvidence}.
    */
   hasTrustedCompletionEvidence: (roadmapNumber: number) => boolean;
   /** POST the canonical `IDD roadmap completion audit` evidence comment. */
@@ -905,9 +934,11 @@ function createProductionDeps(
         staleAgeMs,
       }),
     hasTrustedCompletionEvidence: (roadmapNumber) =>
-      hasTrustedCompletionEvidenceComment(
-        loadIssueComments(owner, repo, roadmapNumber),
-        isTrustedAuthor,
+      safeHasTrustedCompletionEvidence(() =>
+        hasTrustedCompletionEvidenceComment(
+          loadIssueComments(owner, repo, roadmapNumber),
+          isTrustedAuthor,
+        ),
       ),
     postEvidenceComment: (issueNumber, body) =>
       postIssueComment(owner, repo, issueNumber, body),

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -15,6 +15,7 @@ import {
   reconcileConnectedOpenPrs,
   resolveOpenLinkedPrIssues,
   runRoadmapAuditExecute,
+  safeHasTrustedCompletionEvidence,
 } from '../src/scripts/idd-roadmap-audit-execute.mts';
 import { renderClaimedByMarker } from '../src/scripts/protocol-helpers.mts';
 
@@ -1126,6 +1127,30 @@ test('a trusted comment without the canonical heading is not recognized', () => 
 test('an empty comment stream is not recognized', () => {
   assert.equal(
     hasTrustedCompletionEvidenceComment([], () => true),
+    false,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// safeHasTrustedCompletionEvidence (pure) — #1299 fail-closed-on-error wrapper
+// ---------------------------------------------------------------------------
+
+test('a non-throwing check returns its own boolean result unchanged', () => {
+  assert.equal(
+    safeHasTrustedCompletionEvidence(() => true),
+    true,
+  );
+  assert.equal(
+    safeHasTrustedCompletionEvidence(() => false),
+    false,
+  );
+});
+
+test('a throwing check (e.g. a live gh/network failure) is treated as no evidence', () => {
+  assert.equal(
+    safeHasTrustedCompletionEvidence(() => {
+      throw new Error('gh: command failed (transient network error)');
+    }),
     false,
   );
 });

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -10,6 +10,7 @@ import {
   type ConnectedPrEvent,
   evaluateRoadmapAuditGates,
   evaluateRoadmapClaim,
+  hasTrustedCompletionEvidenceComment,
   type RoadmapAuditExecuteDeps,
   reconcileConnectedOpenPrs,
   resolveOpenLinkedPrIssues,
@@ -124,6 +125,7 @@ function makeDeps(
   calls: {
     collects: number;
     claimChecks: number;
+    completionEvidenceChecks: number;
     comments: { issue: number; body: string }[];
     closed: number[];
     released: {
@@ -137,6 +139,7 @@ function makeDeps(
   const calls = {
     collects: 0,
     claimChecks: 0,
+    completionEvidenceChecks: 0,
     comments: [] as { issue: number; body: string }[],
     closed: [] as number[],
     released: [] as {
@@ -166,6 +169,10 @@ function makeDeps(
           createdAt: '2026-06-26T00:00:00Z',
         },
       };
+    },
+    hasTrustedCompletionEvidence: () => {
+      calls.completionEvidenceChecks += 1;
+      return false;
     },
     postEvidenceComment: (issue, body) => calls.comments.push({ issue, body }),
     closeRoadmap: (issue) => calls.closed.push(issue),
@@ -992,6 +999,125 @@ test('--apply fails closed (no close) when the claim is lost / not owned', async
   assert.equal(exitCode, 1);
   assert.deepEqual(calls.closed, []);
   assert.deepEqual(calls.comments, []);
+});
+
+// ---------------------------------------------------------------------------
+// #1299 — already-complete recognition on the early claim-loss path
+// ---------------------------------------------------------------------------
+
+function lostClaimDeps(
+  report: RoadmapGraphReport,
+  hasTrustedCompletionEvidence: () => boolean,
+) {
+  return makeDeps(report, {
+    revalidateClaim: () => ({
+      owned: false,
+      reason: 'missing-active-claim',
+      stale: false,
+      activeClaim: {
+        agentId: '',
+        claimId: '',
+        supersedes: '',
+        branch: '',
+        createdAt: '',
+      },
+    }),
+    hasTrustedCompletionEvidence,
+  });
+}
+
+test('(a) --apply reports already-complete: closed roadmap + trusted evidence + no owned claim', async () => {
+  const closedReport = readyReport();
+  closedReport.root = { ...closedReport.root, state: 'CLOSED' };
+  const { deps, calls } = lostClaimDeps(closedReport, () => true);
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.closed, true);
+  assert.match(verdict.result, /already-complete/);
+  assert.equal(exitCode, 0);
+  // Idempotent no-op: none of the mutating deps ran.
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.released, []);
+});
+
+test('(b) --apply keeps claim-not-owned when the roadmap is still open, even with trusted evidence', async () => {
+  const openReport = readyReport(); // root.state defaults to 'OPEN'
+  const { deps, calls } = lostClaimDeps(openReport, () => true);
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /claim not owned on re-validation/);
+  assert.equal(exitCode, 1);
+  assert.deepEqual(calls.closed, []);
+  // The OPEN-state short-circuit means the evidence check is never consulted.
+  assert.equal(calls.completionEvidenceChecks, 0);
+});
+
+test('(c) --apply keeps claim-not-owned when the roadmap is closed but lacks trusted evidence', async () => {
+  const closedReport = readyReport();
+  closedReport.root = { ...closedReport.root, state: 'CLOSED' };
+  const { deps, calls } = lostClaimDeps(closedReport, () => false);
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /claim not owned on re-validation/);
+  assert.equal(exitCode, 1);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+});
+
+// ---------------------------------------------------------------------------
+// hasTrustedCompletionEvidenceComment (pure)
+// ---------------------------------------------------------------------------
+
+test('a trusted canonical evidence comment is detected', () => {
+  const comments = [
+    {
+      body: '**IDD roadmap completion audit**\n\nRoadmap #995 audited as complete.',
+      createdAt: '2026-06-26T00:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+  ];
+  assert.equal(
+    hasTrustedCompletionEvidenceComment(comments, () => true),
+    true,
+  );
+});
+
+test('an untrusted author is not recognized even with the canonical body', () => {
+  const comments = [
+    {
+      body: '**IDD roadmap completion audit**\n\nRoadmap #995 audited as complete.',
+      createdAt: '2026-06-26T00:00:00Z',
+      author: { login: 'random-actor' },
+    },
+  ];
+  assert.equal(
+    hasTrustedCompletionEvidenceComment(comments, () => false),
+    false,
+  );
+});
+
+test('a trusted comment without the canonical heading is not recognized', () => {
+  const comments = [
+    {
+      body: 'Looks good to me!',
+      createdAt: '2026-06-26T00:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+  ];
+  assert.equal(
+    hasTrustedCompletionEvidenceComment(comments, () => true),
+    false,
+  );
+});
+
+test('an empty comment stream is not recognized', () => {
+  assert.equal(
+    hasTrustedCompletionEvidenceComment([], () => true),
+    false,
+  );
 });
 
 test('--apply fails closed when re-validation finds a new blocker before close', async () => {

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -1042,8 +1042,18 @@ test('(a) --apply reports already-complete: closed roadmap + trusted evidence + 
 });
 
 test('(b) --apply keeps claim-not-owned when the roadmap is still open, even with trusted evidence', async () => {
+  // Track calls locally: overriding `hasTrustedCompletionEvidence` (like any
+  // makeDeps override) replaces its counting default, so `calls
+  // .completionEvidenceChecks` would stay 0 regardless of whether this test's
+  // own override actually ran. A local counter inside the override itself
+  // (the same pattern the claim-re-validation-order test below uses for
+  // `claimChecks`) is the only way this assertion is not vacuous (#1299).
+  let completionEvidenceChecks = 0;
   const openReport = readyReport(); // root.state defaults to 'OPEN'
-  const { deps, calls } = lostClaimDeps(openReport, () => true);
+  const { deps, calls } = lostClaimDeps(openReport, () => {
+    completionEvidenceChecks += 1;
+    return true;
+  });
   const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
 
   assert.equal(verdict.closed, false);
@@ -1051,7 +1061,7 @@ test('(b) --apply keeps claim-not-owned when the roadmap is still open, even wit
   assert.equal(exitCode, 1);
   assert.deepEqual(calls.closed, []);
   // The OPEN-state short-circuit means the evidence check is never consulted.
-  assert.equal(calls.completionEvidenceChecks, 0);
+  assert.equal(completionEvidenceChecks, 0);
 });
 
 test('(c) --apply keeps claim-not-owned when the roadmap is closed but lacks trusted evidence', async () => {


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md
-->

# Summary

`idd-roadmap-audit-execute --apply`'s early claim re-validation failure
was indistinguishable from a race or hijack even when the roadmap had
already been fully closed by a prior `--apply` run whose stdout was lost
(observed on #1270's close). This adds a distinct `already-complete`
idempotent-success result (exit 0) for exactly that recognizable case,
leaving every other claim-loss shape fail-closed and unchanged.

- Added a pure `hasTrustedCompletionEvidenceComment(comments, isTrustedAuthor)`
  helper that detects the helper's own canonical `**IDD roadmap completion
  audit**` evidence comment posted by a trusted marker actor.
- Wired a new `hasTrustedCompletionEvidence` dependency (production: reuses
  the existing `loadIssueComments` + `isTrustedAuthor` already built for
  claim re-validation).
- In the EARLY claim-revalidation failure branch only (the one the issue
  cites), when the claim is not owned AND the live roadmap (from the report
  already fetched at the top of the invocation) is already `CLOSED` AND it
  carries the trusted evidence comment, report `already-complete` (exit 0,
  `closed: true`, no mutation calls) instead of the bare claim-not-owned
  error. The two later `revalidateClaim` call sites (after the graph
  re-fetch, and immediately before the close) are intentionally untouched —
  in the scenario this issue describes, a retry always fails at the first
  check, and at the later checkpoints the roadmap cannot yet read `CLOSED`
  within the same invocation, so extending the recognition there would be
  unreachable dead code.

## Linked issue

Closes #1299

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

See the issue background for the observed #1270 retrospective. The fix
intentionally reuses the already-fetched top-of-function `report` for the
`CLOSED` check (no extra network round trip) and only calls the new
`hasTrustedCompletionEvidence` dependency when that cheap check already
indicates `CLOSED`, so the common (open-roadmap) `--apply` path incurs zero
extra cost.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (not applicable — no instruction/doc/config changes)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
