### PR TITLE
ci(commands): add idd-doctor to this repository's pre-push-validate lane

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -22,7 +22,7 @@
   "commands": {
     "install-deps": "node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command \"pnpm install --frozen-lockfile\"",
     "fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
-    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress",
+    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/idd-doctor.mjs",
     "post-fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress"
   },
   "helperRuntime": {

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -271,7 +271,7 @@ enabled and default approval actors to
 | Name | Commands |
 | --- | --- |
 | **fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"` |
-| **pre-push-validate** | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
+| **pre-push-validate** | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/idd-doctor.mjs` |
 | **post-fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
 | **install-deps** | `node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command "pnpm install --frozen-lockfile"` |
 | **issue-scope** | `roadmap-first` |

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -343,7 +343,7 @@
         },
         {
           "from": "| **pre-push-validate** | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |",
-          "to": "| **pre-push-validate** | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress` |"
+          "to": "| **pre-push-validate** | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/idd-doctor.mjs` |"
         },
         {
           "from": "| **post-fix-validate** | `{{POST_FIX_VALIDATE_COMMANDS}}` |",


### PR DESCRIPTION
# Summary

Add `node scripts/idd-doctor.mjs` to this repository's own
`pre-push-validate` lane so a doctor-only failure (e.g. an unresolved
`{{...}}` placeholder, observed on PR #1288) is caught locally before a
push plus a full CI round-trip, since idd-doctor already runs as a CI
gate but was absent from local validation.

## Linked issue

Closes #1298

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

- **Multi-surface edit, matching the biome precedent** (#1031 / PR
  #1034): `.github/idd/config.json` `commands.pre-push-validate`, the
  matching `audit/sync-manifest.json` `idd-overview-core-instructions`
  replacement that generates the overview-core Project-commands table
  row, then `node scripts/sync-docs.mjs --apply` to regenerate
  `.github/instructions/idd-overview-core.instructions.md` (never
  hand-edited). `node scripts/audit-docs.mjs --check` confirms the
  config.json ↔ overview-core drift check (added in #1227) passes.
- **Byte-budget impact**: the ~31-byte addition keeps every
  `bundleBudgets` total (`bundle-discovery`, `bundle-resume`,
  `bundle-work`, `bundle-review`, `bundle-merge`) under its current
  `limitBytes` ceiling, so **no ratchet bump is needed**. For
  transparency: `bundle-work` (98.4%) and `bundle-review` (98.0%) are
  already in the near-ceiling band from prior unrelated additions, not
  from this change.
- **Explicitly out of scope** (per the issue body): the distributed
  template's `{{PRE_PUSH_VALIDATE_COMMANDS}}` placeholder default in
  `idd-template/.github/idd/config.json` /
  `idd-template/.github/instructions/idd-overview-core.instructions.md`
  is untouched. `docs/customization.md`'s "Project commands reference"
  table is a generic illustrative example (`exact`-synced with
  `idd-template/docs/customization.md`) that already predates the
  `biome` addition too, so it is not a live-value mirror for this
  repository and was intentionally left alone.
- **Exit-code semantics confirmed by reading source**:
  `src/scripts/idd-doctor.mts` calls
  `process.exit(report.errors.length > 0 ? 1 : 0)` — warnings never
  block, only errors do.
- **Live smoke test performed** (not just source reading): seeded an
  unresolved `{{SMOKE_TEST_PLACEHOLDER}}` token in an untracked scratch
  file and confirmed `node scripts/idd-doctor.mjs` exits `1` with an
  `ERROR unresolved placeholders found: ...` line, alongside its
  existing 3 pre-existing `WARN` lines that do **not** affect the exit
  code. Ran the full new `pre-push-validate` chain end-to-end on a
  clean tree (exit `0`) both before and after rebasing onto `main`.
- **Sibling-worktree parity confirmed**: ran `node scripts/idd-doctor.mjs`
  from both this issue's sibling worktree and the primary worktree (on
  `main`) — identical outcome (exit `0`, the same 3 warnings, same
  report shape).
- **Timing note for the maintainer (corrected after checking this PR's
  own CI run)**: locally, with `gh` authenticated, the doctor's
  post-merge cleanup-backlog GitHub scan walks every merged PR
  (~149 currently) and took roughly **2 minutes** wall-clock here
  (measured directly: `2m11s` and `2m15s` across two runs) — not
  "seconds" as the issue's background section estimated. This is
  **not** comparable to the CI `idd-doctor` job's own timing: this PR's
  CI run shows `idd-doctor` finishing in ~8s specifically *because* it
  logs `WARN github checks skipped: gh repo view unavailable` and skips
  the network-dependent scans entirely in that job's environment, per
  the documented degrade-to-warning behavior — CI has never paid this
  cost and does not start doing so from this change. The ~2 minute cost
  is only paid by a contributor with `gh` authenticated locally (the
  realistic common case for whoever actually runs `pre-push-validate`).
  Flagging the measured number in case the maintainer wants a follow-up
  to scope, cache, or cap that specific check for local invocations.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pre-push validation checks to include an additional diagnostic step before pushes proceed.
  * Kept the documented validation command in sync with the new check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
