### PR TITLE
feat(onboard): wave 2 manifest-driven fetch/copy of distributed files

### DIFF
--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -31,7 +31,10 @@ function resolveRepoRoot(fromUrl) {
 }
 const PACKAGE_ROOT = resolveRepoRoot(import.meta.url);
 const PACKAGE_MANAGERS = ['npm', 'pnpm', 'yarn'];
-const PROFILE_NAMES = [
+// Exported so other onboarding-stage CLIs (e.g. idd-onboard.mts's --import
+// mode) can validate a --profile flag against the same canonical set
+// instead of hand-maintaining a second copy of these four names.
+export const PROFILE_NAMES = [
   'package-manager',
   'vendored-node',
   'ephemeral-npx',

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -6,20 +6,43 @@
 // generated .mjs. See docs/typescript-sources.md.
 //
 // Onboarding automation CLI — wave 1: placeholder substitution (#1263,
-// roadmap #1262).
+// roadmap #1262). Wave 2 (#1292) adds the --import fetch/copy stage.
 //
-// Given a target tree that already contains the imported template files,
-// resolve the seven onboarding placeholders (auto-derived from repository
-// evidence where `idd-template/docs/onboarding/placeholders.md` defines a
-// derivation; explicit flags override) and rewrite the files. `--dry-run`
-// prints the per-file, per-placeholder plan without writing anything.
-// That reference document is the source of truth this CLI must match; a
-// drift test in tests/idd-onboard.test.mts fails on mismatch.
+// --substitute: given a target tree that already contains the imported
+// template files, resolve the seven onboarding placeholders (auto-derived
+// from repository evidence where
+// `idd-template/docs/onboarding/placeholders.md` defines a derivation;
+// explicit flags override) and rewrite the files. `--dry-run` prints the
+// per-file, per-placeholder plan without writing anything. That reference
+// document is the source of truth this CLI must match; a drift test in
+// tests/idd-onboard.test.mts fails on mismatch.
+//
+// --import: copy the distributed core template file set (and, with
+// `--profile vendored-node`, the profile-conditional helper bundle) from a
+// local idd-skill source tree into a target repository. The file set is
+// read from `audit/sync-manifest.json`'s `idd-template-core-files`
+// generated block — the same canonical source `sync-docs.mjs` /
+// `audit-docs.mjs` render into `idd-template/ONBOARDING.md`'s Step 2 file
+// list — so the CLI and the manual doc can never carry two independently
+// hardcoded file lists. A drift test in tests/idd-onboard.test.mts fails on
+// mismatch.
 import { execFileSync } from 'node:child_process';
-import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
 import { isCliExecution } from './gh-exec.mjs';
-import { collectHelperRuntimeEvidence } from './helper-runtime-manifest.mjs';
+import {
+  collectHelperRuntimeEvidence,
+  collectVendoredFiles,
+  PROFILE_NAMES,
+} from './helper-runtime-manifest.mjs';
 
 function placeholder(name, kind, flag) {
   return { name, token: `{{${name}}}`, kind, flag };
@@ -503,6 +526,151 @@ export function applySubstitutionPlan(targetDir, plan) {
   }
   return byFile.size;
 }
+const CORE_TEMPLATE_BLOCK_ID = 'idd-template-core-files';
+/**
+ * Resolve the distributed core template file set from the same
+ * `audit/sync-manifest.json` canonical source that `sync-docs.mjs` /
+ * `audit-docs.mjs` render into `idd-template/ONBOARDING.md`'s Step 2
+ * `idd-template-core-files` block, so this CLI never carries a second,
+ * independently hardcoded file list. `sourcePath` is relative to
+ * `sourceRoot` (the manifest's recorded paths already carry the
+ * `idd-template/` prefix); `targetPath` has `stripPrefix` removed, landing
+ * at the same relative path the generated ONBOARDING.md list documents.
+ * Throws when `sourceRoot` has no readable manifest or no block with a
+ * `paths` list — that tree is not a usable idd-skill source root.
+ */
+export function resolveCoreTemplateFiles(sourceRoot) {
+  const manifestPath = join(sourceRoot, 'audit', 'sync-manifest.json');
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch (error) {
+    throw new Error(
+      `--source is not a readable idd-skill tree (missing or invalid audit/sync-manifest.json): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const block = (manifest.generatedBlocks ?? []).find(
+    (entry) => entry.id === CORE_TEMPLATE_BLOCK_ID,
+  );
+  if (!block?.paths) {
+    throw new Error(
+      `--source's audit/sync-manifest.json has no "${CORE_TEMPLATE_BLOCK_ID}" generated block with a paths list`,
+    );
+  }
+  const prefix = block.stripPrefix ?? '';
+  return block.paths.map((sourcePath) => {
+    if (prefix && !sourcePath.startsWith(prefix)) {
+      throw new Error(
+        `${CORE_TEMPLATE_BLOCK_ID}: manifest path "${sourcePath}" does not start with its stripPrefix "${prefix}"`,
+      );
+    }
+    return { sourcePath, targetPath: sourcePath.slice(prefix.length) };
+  });
+}
+/**
+ * Resolve the full import file set: the core template files, plus — only
+ * when `profile` is exactly `vendored-node` — the profile-conditional
+ * helper bundle from `helper-runtime-manifest.mts`'s `collectVendoredFiles`
+ * (mirroring ONBOARDING Step 2's profile guidance). Every other known
+ * profile name vends zero extra files, matching its own `managedFiles: []`
+ * catalog entry. `profile` is validated against the same `PROFILE_NAMES`
+ * the helper manifest CLI itself validates against — no second hardcoded
+ * profile-name list.
+ */
+export function resolveImportFiles(sourceRoot, profile) {
+  const coreFiles = resolveCoreTemplateFiles(sourceRoot);
+  if (!profile) {
+    return coreFiles;
+  }
+  if (!PROFILE_NAMES.includes(profile)) {
+    throw new Error(
+      `unknown --profile: ${profile} (expected one of ${PROFILE_NAMES.join(', ')})`,
+    );
+  }
+  if (profile !== 'vendored-node') {
+    return coreFiles;
+  }
+  const helperFiles = collectVendoredFiles(sourceRoot).map((file) => ({
+    sourcePath: file.sourcePath,
+    targetPath: file.targetPath,
+  }));
+  const merged = [...coreFiles, ...helperFiles];
+  const seenTargets = new Set();
+  for (const file of merged) {
+    if (seenTargets.has(file.targetPath)) {
+      throw new Error(
+        `manifest drift: duplicate target path "${file.targetPath}" across the core file set and the profile-conditional bundle`,
+      );
+    }
+    seenTargets.add(file.targetPath);
+  }
+  return merged;
+}
+/**
+ * Build the import plan: classify each manifest file as `new` (no target
+ * file yet), `unchanged` (target already matches byte-for-byte — a safe
+ * no-op), or `overwrite` (target exists and differs). An `overwrite` entry
+ * is also recorded in `blockedOverwrites` unless `force` is set — the
+ * fail-closed default refuses to clobber a differing target file. A
+ * missing declared source file is recorded in `missingSource` instead of
+ * a plan entry.
+ */
+export function buildImportPlan(
+  sourceRoot,
+  targetRoot,
+  { profile, force = false } = {},
+) {
+  const files = resolveImportFiles(sourceRoot, profile);
+  const entries = [];
+  const missingSource = [];
+  const blockedOverwrites = [];
+  for (const file of files) {
+    if (!fileExists(sourceRoot, file.sourcePath)) {
+      missingSource.push(file.sourcePath);
+      continue;
+    }
+    if (!fileExists(targetRoot, file.targetPath)) {
+      entries.push({ ...file, classification: 'new' });
+      continue;
+    }
+    const sourceBytes = readFileSync(join(sourceRoot, file.sourcePath));
+    const targetBytes = readFileSync(join(targetRoot, file.targetPath));
+    if (sourceBytes.equals(targetBytes)) {
+      entries.push({ ...file, classification: 'unchanged' });
+      continue;
+    }
+    entries.push({ ...file, classification: 'overwrite' });
+    if (!force) {
+      blockedOverwrites.push(file.targetPath);
+    }
+  }
+  return { entries, missingSource, blockedOverwrites };
+}
+/**
+ * Apply the plan: copy every `new` or `overwrite` entry (skipping
+ * `unchanged` entries, which already match), creating parent directories
+ * as needed. Preserves the source file's permission bits — a plain byte
+ * copy would otherwise silently drop the executable bit that
+ * `.githooks/pre-commit` / `.githooks/pre-push` require. Returns the count
+ * of files written. Callers must gate on `missingSource` /
+ * `blockedOverwrites` themselves; this function copies whatever the plan
+ * contains without re-checking blocking conditions.
+ */
+export function applyImportPlan(sourceRoot, targetRoot, plan) {
+  let filesChanged = 0;
+  for (const entry of plan.entries) {
+    if (entry.classification === 'unchanged') {
+      continue;
+    }
+    const sourceAbsolute = join(sourceRoot, entry.sourcePath);
+    const targetAbsolute = join(targetRoot, entry.targetPath);
+    mkdirSync(dirname(targetAbsolute), { recursive: true });
+    copyFileSync(sourceAbsolute, targetAbsolute);
+    chmodSync(targetAbsolute, statSync(sourceAbsolute).mode);
+    filesChanged += 1;
+  }
+  return filesChanged;
+}
 if (isCliExecution(import.meta.url)) {
   try {
     runCli();
@@ -518,8 +686,12 @@ if (isCliExecution(import.meta.url)) {
 function parseArgs(argv) {
   const parsed = {
     substitute: false,
+    importMode: false,
+    source: undefined,
     target: '.',
     dryRun: false,
+    force: false,
+    profile: undefined,
     overrides: {},
     help: false,
   };
@@ -539,6 +711,15 @@ function parseArgs(argv) {
       parsed.substitute = true;
       continue;
     }
+    if (token === '--import') {
+      parsed.importMode = true;
+      continue;
+    }
+    if (token === '--source') {
+      parsed.source = requireValue();
+      index += 1;
+      continue;
+    }
     if (token === '--target') {
       parsed.target = requireValue();
       index += 1;
@@ -546,6 +727,15 @@ function parseArgs(argv) {
     }
     if (token === '--dry-run') {
       parsed.dryRun = true;
+      continue;
+    }
+    if (token === '--force') {
+      parsed.force = true;
+      continue;
+    }
+    if (token === '--profile') {
+      parsed.profile = requireValue();
+      index += 1;
       continue;
     }
     if (token === '--help' || token === '-h') {
@@ -568,10 +758,15 @@ function runCli() {
     printHelp();
     process.exit(0);
   }
+  if (args.substitute && args.importMode) {
+    throw new Error('--substitute and --import are mutually exclusive');
+  }
+  if (args.importMode) {
+    runImportCli(args);
+    return;
+  }
   if (!args.substitute) {
-    throw new Error(
-      'wave 1 supports the substitution stage only: pass --substitute',
-    );
+    throw new Error('pass --substitute or --import to select a stage');
   }
   const targetDir = resolve(args.target);
   if (!statSync(targetDir).isDirectory()) {
@@ -604,16 +799,61 @@ function runCli() {
   // callers can gate on the exit code. Unknown tokens are informational.
   process.exit(plan.residue.length > 0 ? 1 : 0);
 }
+function runImportCli(args) {
+  if (!args.source) {
+    throw new Error('--import requires --source <idd-skill-tree>');
+  }
+  const sourceDir = resolve(args.source);
+  if (!statSync(sourceDir).isDirectory()) {
+    throw new Error(`--source is not a directory: ${args.source}`);
+  }
+  const targetDir = resolve(args.target);
+  if (!statSync(targetDir).isDirectory()) {
+    throw new Error(`--target is not a directory: ${args.target}`);
+  }
+  const plan = buildImportPlan(sourceDir, targetDir, {
+    profile: args.profile,
+    force: args.force,
+  });
+  // Fail closed: never write a partially-imported tree. Apply mode writes
+  // only when every declared source file exists and no existing target
+  // file would be silently clobbered without --force.
+  const blocking =
+    plan.missingSource.length > 0 || plan.blockedOverwrites.length > 0;
+  const canWrite = !args.dryRun && !blocking;
+  const filesChanged = canWrite
+    ? applyImportPlan(sourceDir, targetDir, plan)
+    : 0;
+  const verdict = {
+    protocolVersion: '1',
+    mode: args.dryRun ? 'dry-run' : 'apply',
+    source: sourceDir,
+    target: targetDir,
+    profile: args.profile ?? null,
+    plan: plan.entries,
+    missingSource: plan.missingSource,
+    blockedOverwrites: plan.blockedOverwrites,
+    filesChanged,
+    written: canWrite && filesChanged > 0,
+  };
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  // Blocking findings signal in dry-run and apply alike so callers can gate
+  // on the exit code without needing a separate --dry-run probe first.
+  process.exit(blocking ? 1 : 0);
+}
 function printHelp() {
   const flags = ONBOARDING_PLACEHOLDERS.map(
     (entry) =>
       `  ${entry.flag} <value>${entry.kind === 'command' ? ' (accepts the no-op "true")' : ''}`,
   ).join('\n');
   process.stdout.write(`usage: node scripts/idd-onboard.mjs --substitute [options]
+       node scripts/idd-onboard.mjs --import --source <dir> --target <dir> [options]
 
-Onboarding automation — wave 1: placeholder substitution. Resolves the
-seven template placeholders for a target tree that already contains the
-imported template files (auto-derived from repository evidence where
+Onboarding automation.
+
+--substitute (wave 1): resolves the seven template placeholders for a
+target tree that already contains the imported template files
+(auto-derived from repository evidence where
 idd-template/docs/onboarding/placeholders.md defines a derivation;
 explicit flags override; --trusted-marker-actor is always explicit) and
 rewrites the files. Prints a JSON verdict with the per-file,
@@ -623,12 +863,35 @@ placeholders), and informational unknown {{...}} tokens.
 Exit codes: 0 converged; 1 residue would remain (apply writes nothing
 in that case); 2 usage or configuration error.
 
-  --substitute         run the substitution stage (required)
+  --substitute         run the substitution stage
   --target <dir>       target tree to rewrite (default: current directory)
   --dry-run            print the plan without writing anything
   --help, -h           show this help
 
 Placeholder overrides:
 ${flags}
+
+--import (wave 2): copies the distributed core template file set from a
+local idd-skill source tree (--source) into --target, driven by
+audit/sync-manifest.json's idd-template-core-files generated block (the
+same canonical source idd-template/ONBOARDING.md's Step 2 file list
+renders from). With --profile vendored-node, also copies the
+profile-conditional helper bundle (helper-runtime-manifest.mts's
+managedFiles); every other profile value vends no extra files. Refuses to
+overwrite an existing target file whose content differs unless --force,
+and reports missing declared source files, as blocking findings. Prints a
+JSON verdict with the per-file plan (new / unchanged / overwrite
+classification) and the blocking findings.
+
+Exit codes: 0 converged; 1 a blocking finding exists (apply writes
+nothing in that case); 2 usage or configuration error.
+
+  --import                          run the import stage
+  --source <dir>                    local idd-skill source tree to copy from
+  --target <dir>                    target repository (default: current directory)
+  --profile <name>                  package-manager | vendored-node | ephemeral-npx | instructions-only
+  --force                           allow overwriting a differing target file
+  --dry-run                         print the plan without writing anything
+  --help, -h                        show this help
 `);
 }

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -166,6 +166,32 @@ function pathExists(root, name) {
     return false;
   }
 }
+/**
+ * Whether any ancestor directory segment of `root`/`relativePath` already
+ * exists as a non-directory entry (e.g. a plain file at `.github` when
+ * planning `.github/idd/config.json`). `mkdirSync`'s recursive mode cannot
+ * create a directory through such an obstruction, so this must be checked
+ * separately from the leaf path itself (see `pathExists`). `relativePath`
+ * uses `/` separators, matching every `ManifestFile.targetPath` in this
+ * module. A missing (rather than non-directory) ancestor is fine —
+ * `mkdirSync`'s recursive mode creates it — so this returns `false` as
+ * soon as an ancestor segment does not exist yet.
+ */
+function hasNonDirectoryAncestor(root, relativePath) {
+  const segments = relativePath.split('/').slice(0, -1);
+  let current = root;
+  for (const segment of segments) {
+    current = join(current, segment);
+    try {
+      if (!statSync(current).isDirectory()) {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
 function readTextIfPresent(root, name) {
   try {
     return readFileSync(join(root, name), 'utf8');
@@ -589,7 +615,7 @@ export function resolveCoreTemplateFiles(sourceRoot) {
 export function resolveImportFiles(sourceRoot, profile) {
   const coreFiles = resolveCoreTemplateFiles(sourceRoot);
   if (!profile) {
-    return coreFiles;
+    return { files: coreFiles, missingSource: [] };
   }
   if (!PROFILE_NAMES.includes(profile)) {
     throw new Error(
@@ -597,12 +623,27 @@ export function resolveImportFiles(sourceRoot, profile) {
     );
   }
   if (profile !== 'vendored-node') {
-    return coreFiles;
+    return { files: coreFiles, missingSource: [] };
   }
-  const helperFiles = collectVendoredFiles(sourceRoot).map((file) => ({
-    sourcePath: file.sourcePath,
-    targetPath: file.targetPath,
-  }));
+  let helperFiles;
+  try {
+    helperFiles = collectVendoredFiles(sourceRoot).map((file) => ({
+      sourcePath: file.sourcePath,
+      targetPath: file.targetPath,
+    }));
+  } catch (error) {
+    // collectVendoredFiles reads each helper entry's content to walk its
+    // import graph, so a missing helper file under an incomplete or
+    // version-skewed --source tree throws a raw fs error (ENOENT) instead
+    // of the missingSource reporting the core file set uses. Degrade to
+    // the core file set alone and surface the specific unreadable path
+    // (when the error exposes one) as a blocking finding, rather than
+    // letting the raw exception crash the CLI with a bare exit 2.
+    return {
+      files: coreFiles,
+      missingSource: [describeUnresolvedVendoredPath(sourceRoot, error)],
+    };
+  }
   const merged = [...coreFiles, ...helperFiles];
   const seenTargets = new Set();
   for (const file of merged) {
@@ -613,7 +654,20 @@ export function resolveImportFiles(sourceRoot, profile) {
     }
     seenTargets.add(file.targetPath);
   }
-  return merged;
+  return { files: merged, missingSource: [] };
+}
+/**
+ * Best-effort description of the source path that broke the vendored-node
+ * bundle walk, derived from the failing fs error's `path` property. Falls
+ * back to a generic label when the error does not expose one so a caller
+ * always has a non-empty `missingSource` entry to report.
+ */
+function describeUnresolvedVendoredPath(sourceRoot, error) {
+  const path = error?.path;
+  if (typeof path === 'string') {
+    return relative(sourceRoot, path).replaceAll('\\', '/');
+  }
+  return 'vendored-node helper bundle (unresolvable: unreadable helper source)';
 }
 /**
  * Build the import plan: classify each manifest file as `new` (no target
@@ -631,22 +685,28 @@ export function buildImportPlan(
   targetRoot,
   { profile, force = false } = {},
 ) {
-  const files = resolveImportFiles(sourceRoot, profile);
+  const resolved = resolveImportFiles(sourceRoot, profile);
   const entries = [];
-  const missingSource = [];
+  const missingSource = [...resolved.missingSource];
   const blockedOverwrites = [];
   const nonFileTargetCollisions = [];
-  for (const file of files) {
+  for (const file of resolved.files) {
     if (!fileExists(sourceRoot, file.sourcePath)) {
       missingSource.push(file.sourcePath);
       continue;
     }
     if (!fileExists(targetRoot, file.targetPath)) {
-      if (pathExists(targetRoot, file.targetPath)) {
-        // The target path exists but is not a regular file (e.g. a
-        // directory). Treating this as "new" would make applyImportPlan's
-        // copyFileSync throw EISDIR/ENOTDIR, possibly after already
-        // writing earlier entries — fail closed instead.
+      if (
+        pathExists(targetRoot, file.targetPath) ||
+        hasNonDirectoryAncestor(targetRoot, file.targetPath)
+      ) {
+        // Either the target path itself exists but is not a regular file
+        // (e.g. a directory), or an ancestor path segment is not a
+        // directory (e.g. a plain file at `.github` when planning
+        // `.github/idd/config.json`). Treating either case as "new" would
+        // make applyImportPlan's mkdirSync/copyFileSync throw
+        // EISDIR/ENOTDIR, possibly after already writing earlier entries
+        // — fail closed instead.
         entries.push({ ...file, classification: 'blocked-non-file' });
         nonFileTargetCollisions.push(file.targetPath);
         continue;

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -584,12 +584,27 @@ export function resolveCoreTemplateFiles(sourceRoot) {
       `--source is not a readable idd-skill tree (missing or invalid audit/sync-manifest.json): ${error instanceof Error ? error.message : String(error)}`,
     );
   }
-  const block = (manifest.generatedBlocks ?? []).find(
-    (entry) => entry.id === CORE_TEMPLATE_BLOCK_ID,
-  );
-  if (!block?.paths) {
+  // `manifest` is only type-asserted, not runtime-validated, so a corrupted
+  // manifest can carry a `generatedBlocks` / `paths` / `stripPrefix` of the
+  // wrong shape. Validate every level before using it as an array/string —
+  // otherwise a malformed manifest throws a raw, unhelpful TypeError
+  // (`.find is not a function`, `.map is not a function`) instead of the
+  // actionable error this function otherwise gives for a missing block.
+  const rawBlocks = manifest.generatedBlocks;
+  if (!Array.isArray(rawBlocks)) {
     throw new Error(
-      `--source's audit/sync-manifest.json has no "${CORE_TEMPLATE_BLOCK_ID}" generated block with a paths list`,
+      "--source's audit/sync-manifest.json has a malformed generatedBlocks (expected an array)",
+    );
+  }
+  const block = rawBlocks.find((entry) => entry?.id === CORE_TEMPLATE_BLOCK_ID);
+  if (
+    !block ||
+    !Array.isArray(block.paths) ||
+    !block.paths.every((entry) => typeof entry === 'string') ||
+    (block.stripPrefix !== undefined && typeof block.stripPrefix !== 'string')
+  ) {
+    throw new Error(
+      `--source's audit/sync-manifest.json has no "${CORE_TEMPLATE_BLOCK_ID}" generated block with a valid paths: string[] (and stripPrefix?: string)`,
     );
   }
   const prefix = block.stripPrefix ?? '';

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -779,6 +779,26 @@ function parseArgs(argv) {
   }
   return parsed;
 }
+/** Import-only flags the user explicitly passed (present regardless of mode). */
+function importOnlyFlagsPresent(args) {
+  const present = [];
+  if (args.source !== undefined) {
+    present.push('--source');
+  }
+  if (args.force) {
+    present.push('--force');
+  }
+  if (args.profile !== undefined) {
+    present.push('--profile');
+  }
+  return present;
+}
+/** Substitute-only placeholder-override flags the user explicitly passed. */
+function substituteOnlyFlagsPresent(args) {
+  return ONBOARDING_PLACEHOLDERS.filter(
+    (entry) => args.overrides[entry.name] !== undefined,
+  ).map((entry) => entry.flag);
+}
 function runCli() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -789,11 +809,26 @@ function runCli() {
     throw new Error('--substitute and --import are mutually exclusive');
   }
   if (args.importMode) {
+    // parseArgs collects every known flag regardless of the active stage,
+    // so a stage-foreign flag (e.g. a placeholder override alongside
+    // --import) would otherwise be silently ignored instead of reported.
+    const foreign = substituteOnlyFlagsPresent(args);
+    if (foreign.length > 0) {
+      throw new Error(
+        `--import does not accept substitute-only flag(s): ${foreign.join(', ')}`,
+      );
+    }
     runImportCli(args);
     return;
   }
   if (!args.substitute) {
     throw new Error('pass --substitute or --import to select a stage');
+  }
+  const foreign = importOnlyFlagsPresent(args);
+  if (foreign.length > 0) {
+    throw new Error(
+      `--substitute does not accept import-only flag(s): ${foreign.join(', ')}`,
+    );
   }
   const targetDir = resolve(args.target);
   if (!statSync(targetDir).isDirectory()) {

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -599,8 +599,50 @@ export function resolveCoreTemplateFiles(sourceRoot) {
         `${CORE_TEMPLATE_BLOCK_ID}: manifest path "${sourcePath}" does not start with its stripPrefix "${prefix}"`,
       );
     }
-    return { sourcePath, targetPath: sourcePath.slice(prefix.length) };
+    return assertSafeManifestFile(
+      { sourcePath, targetPath: sourcePath.slice(prefix.length) },
+      CORE_TEMPLATE_BLOCK_ID,
+    );
   });
+}
+/**
+ * Whether `relativePath` is safe to join onto a root directory: no
+ * absolute-path form, no parent-traversal (`..`) or empty segment, and no
+ * backslash (which `path.join` treats as a separator on Windows even
+ * though every path in this module is `/`-normalized). Defense-in-depth
+ * against a corrupted or hostile manifest / helper bundle escaping the
+ * intended `--source` / `--target` root through `join()`.
+ */
+function isSafeRelativePath(relativePath) {
+  if (!relativePath || relativePath.includes('\\')) {
+    return false;
+  }
+  if (relativePath.startsWith('/') || /^[a-zA-Z]:/.test(relativePath)) {
+    return false;
+  }
+  return relativePath
+    .split('/')
+    .every((segment) => segment !== '' && segment !== '.' && segment !== '..');
+}
+/**
+ * Validate both sides of a manifest file entry with `isSafeRelativePath`
+ * and return it unchanged, or throw a hard, fail-closed error naming
+ * `origin` (the manifest source this entry came from). A path-safety
+ * violation is manifest corruption, not an ordinary missing/blocked file,
+ * so it is reported the same way as the other manifest-integrity checks
+ * in this module (stripPrefix mismatch, duplicate target path): a thrown
+ * usage/config error, never a soft `missingSource` / blocking-plan entry.
+ */
+function assertSafeManifestFile(file, origin) {
+  if (
+    !isSafeRelativePath(file.sourcePath) ||
+    !isSafeRelativePath(file.targetPath)
+  ) {
+    throw new Error(
+      `${origin}: unsafe manifest path (absolute or parent-traversal segment): source="${file.sourcePath}" target="${file.targetPath}"`,
+    );
+  }
+  return file;
 }
 /**
  * Resolve the full import file set: the core template files, plus — only
@@ -625,12 +667,9 @@ export function resolveImportFiles(sourceRoot, profile) {
   if (profile !== 'vendored-node') {
     return { files: coreFiles, missingSource: [] };
   }
-  let helperFiles;
+  let vendoredFiles;
   try {
-    helperFiles = collectVendoredFiles(sourceRoot).map((file) => ({
-      sourcePath: file.sourcePath,
-      targetPath: file.targetPath,
-    }));
+    vendoredFiles = collectVendoredFiles(sourceRoot);
   } catch (error) {
     // collectVendoredFiles reads each helper entry's content to walk its
     // import graph, so a missing helper file under an incomplete or
@@ -644,6 +683,16 @@ export function resolveImportFiles(sourceRoot, profile) {
       missingSource: [describeUnresolvedVendoredPath(sourceRoot, error)],
     };
   }
+  // Outside the try/catch above: a path-safety violation is manifest
+  // corruption, not a missing file, so it must hard-fail (propagate as a
+  // thrown usage/config error) rather than being absorbed as a
+  // missingSource finding the same way a genuinely absent file is.
+  const helperFiles = vendoredFiles.map((file) =>
+    assertSafeManifestFile(
+      { sourcePath: file.sourcePath, targetPath: file.targetPath },
+      'vendored-node helper bundle',
+    ),
+  );
   const merged = [...coreFiles, ...helperFiles];
   const seenTargets = new Set();
   for (const file of merged) {

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -30,6 +30,7 @@ import { execFileSync } from 'node:child_process';
 import {
   chmodSync,
   copyFileSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -150,9 +151,20 @@ const PYPROJECT_TOOL_COMMANDS = [
   { pattern: /^\s*\[tool\.hatch[.\]]/mu, command: 'hatch env create' },
   { pattern: /^\s*\[tool\.uv[.\]]/mu, command: 'uv sync' },
 ];
+// lstatSync, not statSync: every existence/type check below feeds a
+// decision about whether it is safe to read from or write to a path (the
+// --import planner's fileExists / pathExists / hasNonDirectoryAncestor,
+// plus the placeholder-derivation checks below that also call
+// fileExists). statSync follows symlinks, so a symlink leaf or ancestor
+// would be silently treated as whatever it points to; a symlink inside
+// --source or --target could then let a copy read from or write outside
+// the intended root. lstatSync reports the entry itself, so any symlink
+// is classified as "not a plain file/directory" and — for the --import
+// planner — falls through to the existing blocked-non-file handling
+// instead of being followed.
 function fileExists(root, name) {
   try {
-    return statSync(join(root, name)).isFile();
+    return lstatSync(join(root, name)).isFile();
   } catch {
     return false;
   }
@@ -160,7 +172,7 @@ function fileExists(root, name) {
 /** Whether any filesystem entry exists at `root`/`name`, of any type. */
 function pathExists(root, name) {
   try {
-    statSync(join(root, name));
+    lstatSync(join(root, name));
     return true;
   } catch {
     return false;
@@ -168,14 +180,17 @@ function pathExists(root, name) {
 }
 /**
  * Whether any ancestor directory segment of `root`/`relativePath` already
- * exists as a non-directory entry (e.g. a plain file at `.github` when
- * planning `.github/idd/config.json`). `mkdirSync`'s recursive mode cannot
- * create a directory through such an obstruction, so this must be checked
- * separately from the leaf path itself (see `pathExists`). `relativePath`
- * uses `/` separators, matching every `ManifestFile.targetPath` in this
- * module. A missing (rather than non-directory) ancestor is fine —
- * `mkdirSync`'s recursive mode creates it — so this returns `false` as
- * soon as an ancestor segment does not exist yet.
+ * exists as a non-directory entry (e.g. a plain file — or a symlink,
+ * including one that points at a real directory — at `.github` when
+ * planning `.github/idd/config.json`). `mkdirSync`'s recursive mode
+ * cannot create a directory through such an obstruction (and would
+ * otherwise silently traverse a symlinked ancestor), so this must be
+ * checked separately from the leaf path itself (see `pathExists`).
+ * `relativePath` uses `/` separators, matching every
+ * `ManifestFile.targetPath` in this module. A missing (rather than
+ * non-directory) ancestor is fine — `mkdirSync`'s recursive mode creates
+ * it — so this returns `false` as soon as an ancestor segment does not
+ * exist yet.
  */
 function hasNonDirectoryAncestor(root, relativePath) {
   const segments = relativePath.split('/').slice(0, -1);
@@ -183,7 +198,7 @@ function hasNonDirectoryAncestor(root, relativePath) {
   for (const segment of segments) {
     current = join(current, segment);
     try {
-      if (!statSync(current).isDirectory()) {
+      if (!lstatSync(current).isDirectory()) {
         return true;
       }
     } catch {

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -774,18 +774,25 @@ export function buildImportPlan(
       missingSource.push(file.sourcePath);
       continue;
     }
+    // Check the ancestor chain unconditionally, before the leaf-existence
+    // check below. A symlinked ancestor directory can resolve straight to
+    // a real, already-existing leaf file (fileExists on the joined path
+    // follows every ancestor segment, symlinked or not, the same way a
+    // plain stat/lstat would) — checking hasNonDirectoryAncestor only
+    // inside the "leaf does not exist" branch would then never run,
+    // letting applyImportPlan read/write straight through the symlinked
+    // ancestor and escape --target.
+    if (hasNonDirectoryAncestor(targetRoot, file.targetPath)) {
+      entries.push({ ...file, classification: 'blocked-non-file' });
+      nonFileTargetCollisions.push(file.targetPath);
+      continue;
+    }
     if (!fileExists(targetRoot, file.targetPath)) {
-      if (
-        pathExists(targetRoot, file.targetPath) ||
-        hasNonDirectoryAncestor(targetRoot, file.targetPath)
-      ) {
-        // Either the target path itself exists but is not a regular file
-        // (e.g. a directory), or an ancestor path segment is not a
-        // directory (e.g. a plain file at `.github` when planning
-        // `.github/idd/config.json`). Treating either case as "new" would
-        // make applyImportPlan's mkdirSync/copyFileSync throw
-        // EISDIR/ENOTDIR, possibly after already writing earlier entries
-        // — fail closed instead.
+      if (pathExists(targetRoot, file.targetPath)) {
+        // The target path itself exists but is not a regular file (e.g. a
+        // directory or a symlink). Treating this as "new" would make
+        // applyImportPlan's copyFileSync throw EISDIR/ENOTDIR, possibly
+        // after already writing earlier entries — fail closed instead.
         entries.push({ ...file, classification: 'blocked-non-file' });
         nonFileTargetCollisions.push(file.targetPath);
         continue;

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -157,6 +157,15 @@ function fileExists(root, name) {
     return false;
   }
 }
+/** Whether any filesystem entry exists at `root`/`name`, of any type. */
+function pathExists(root, name) {
+  try {
+    statSync(join(root, name));
+    return true;
+  } catch {
+    return false;
+  }
+}
 function readTextIfPresent(root, name) {
   try {
     return readFileSync(join(root, name), 'utf8');
@@ -608,12 +617,14 @@ export function resolveImportFiles(sourceRoot, profile) {
 }
 /**
  * Build the import plan: classify each manifest file as `new` (no target
- * file yet), `unchanged` (target already matches byte-for-byte — a safe
- * no-op), or `overwrite` (target exists and differs). An `overwrite` entry
- * is also recorded in `blockedOverwrites` unless `force` is set — the
- * fail-closed default refuses to clobber a differing target file. A
- * missing declared source file is recorded in `missingSource` instead of
- * a plan entry.
+ * path yet), `unchanged` (target already matches byte-for-byte — a safe
+ * no-op), `overwrite` (target exists as a file and differs), or
+ * `blocked-non-file` (target path exists but is not a regular file, e.g. a
+ * directory — always blocking, see `nonFileTargetCollisions`). An
+ * `overwrite` entry is also recorded in `blockedOverwrites` unless `force`
+ * is set — the fail-closed default refuses to clobber a differing target
+ * file. A missing declared source file is recorded in `missingSource`
+ * instead of a plan entry.
  */
 export function buildImportPlan(
   sourceRoot,
@@ -624,12 +635,22 @@ export function buildImportPlan(
   const entries = [];
   const missingSource = [];
   const blockedOverwrites = [];
+  const nonFileTargetCollisions = [];
   for (const file of files) {
     if (!fileExists(sourceRoot, file.sourcePath)) {
       missingSource.push(file.sourcePath);
       continue;
     }
     if (!fileExists(targetRoot, file.targetPath)) {
+      if (pathExists(targetRoot, file.targetPath)) {
+        // The target path exists but is not a regular file (e.g. a
+        // directory). Treating this as "new" would make applyImportPlan's
+        // copyFileSync throw EISDIR/ENOTDIR, possibly after already
+        // writing earlier entries — fail closed instead.
+        entries.push({ ...file, classification: 'blocked-non-file' });
+        nonFileTargetCollisions.push(file.targetPath);
+        continue;
+      }
       entries.push({ ...file, classification: 'new' });
       continue;
     }
@@ -644,22 +665,28 @@ export function buildImportPlan(
       blockedOverwrites.push(file.targetPath);
     }
   }
-  return { entries, missingSource, blockedOverwrites };
+  return { entries, missingSource, blockedOverwrites, nonFileTargetCollisions };
 }
 /**
  * Apply the plan: copy every `new` or `overwrite` entry (skipping
- * `unchanged` entries, which already match), creating parent directories
+ * `unchanged` entries, which already match, and `blocked-non-file`
+ * entries, which can never be copied onto), creating parent directories
  * as needed. Preserves the source file's permission bits — a plain byte
  * copy would otherwise silently drop the executable bit that
  * `.githooks/pre-commit` / `.githooks/pre-push` require. Returns the count
  * of files written. Callers must gate on `missingSource` /
- * `blockedOverwrites` themselves; this function copies whatever the plan
- * contains without re-checking blocking conditions.
+ * `blockedOverwrites` / `nonFileTargetCollisions` themselves; this
+ * function copies whatever the plan contains without re-checking blocking
+ * conditions (except that it never attempts the impossible
+ * `blocked-non-file` copy, regardless of caller gating).
  */
 export function applyImportPlan(sourceRoot, targetRoot, plan) {
   let filesChanged = 0;
   for (const entry of plan.entries) {
-    if (entry.classification === 'unchanged') {
+    if (
+      entry.classification === 'unchanged' ||
+      entry.classification === 'blocked-non-file'
+    ) {
       continue;
     }
     const sourceAbsolute = join(sourceRoot, entry.sourcePath);
@@ -816,10 +843,13 @@ function runImportCli(args) {
     force: args.force,
   });
   // Fail closed: never write a partially-imported tree. Apply mode writes
-  // only when every declared source file exists and no existing target
-  // file would be silently clobbered without --force.
+  // only when every declared source file exists, no existing target file
+  // would be silently clobbered without --force, and no target path is
+  // blocked by a non-file collision (which --force cannot override).
   const blocking =
-    plan.missingSource.length > 0 || plan.blockedOverwrites.length > 0;
+    plan.missingSource.length > 0 ||
+    plan.blockedOverwrites.length > 0 ||
+    plan.nonFileTargetCollisions.length > 0;
   const canWrite = !args.dryRun && !blocking;
   const filesChanged = canWrite
     ? applyImportPlan(sourceDir, targetDir, plan)
@@ -833,6 +863,7 @@ function runImportCli(args) {
     plan: plan.entries,
     missingSource: plan.missingSource,
     blockedOverwrites: plan.blockedOverwrites,
+    nonFileTargetCollisions: plan.nonFileTargetCollisions,
     filesChanged,
     written: canWrite && filesChanged > 0,
   };
@@ -877,11 +908,13 @@ audit/sync-manifest.json's idd-template-core-files generated block (the
 same canonical source idd-template/ONBOARDING.md's Step 2 file list
 renders from). With --profile vendored-node, also copies the
 profile-conditional helper bundle (helper-runtime-manifest.mts's
-managedFiles); every other profile value vends no extra files. Refuses to
-overwrite an existing target file whose content differs unless --force,
-and reports missing declared source files, as blocking findings. Prints a
-JSON verdict with the per-file plan (new / unchanged / overwrite
-classification) and the blocking findings.
+collectVendoredFiles); every other profile value vends no extra files.
+Refuses to overwrite an existing target file whose content differs
+unless --force, and reports missing declared source files and non-file
+target collisions (e.g. an existing directory at a target path) as
+blocking findings. Prints a JSON verdict with the per-file plan
+(new / unchanged / overwrite / blocked-non-file classification) and the
+blocking findings.
 
 Exit codes: 0 converged; 1 a blocking finding exists (apply writes
 nothing in that case); 2 usage or configuration error.

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1096,7 +1096,7 @@ nothing in that case); 2 usage or configuration error.
   --import                          run the import stage
   --source <dir>                    local idd-skill source tree to copy from
   --target <dir>                    target repository (default: current directory)
-  --profile <name>                  package-manager | vendored-node | ephemeral-npx | instructions-only
+  --profile <name>                  ${PROFILE_NAMES.join(' | ')}
   --force                           allow overwriting a differing target file
   --dry-run                         print the plan without writing anything
   --help, -h                        show this help

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -102,7 +102,10 @@ interface ManifestArgs {
 }
 
 const PACKAGE_MANAGERS = ['npm', 'pnpm', 'yarn'];
-const PROFILE_NAMES = [
+// Exported so other onboarding-stage CLIs (e.g. idd-onboard.mts's --import
+// mode) can validate a --profile flag against the same canonical set
+// instead of hand-maintaining a second copy of these four names.
+export const PROFILE_NAMES = [
   'package-manager',
   'vendored-node',
   'ephemeral-npx',

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -774,8 +774,55 @@ export function resolveCoreTemplateFiles(sourceRoot: string): ManifestFile[] {
         `${CORE_TEMPLATE_BLOCK_ID}: manifest path "${sourcePath}" does not start with its stripPrefix "${prefix}"`,
       );
     }
-    return { sourcePath, targetPath: sourcePath.slice(prefix.length) };
+    return assertSafeManifestFile(
+      { sourcePath, targetPath: sourcePath.slice(prefix.length) },
+      CORE_TEMPLATE_BLOCK_ID,
+    );
   });
+}
+
+/**
+ * Whether `relativePath` is safe to join onto a root directory: no
+ * absolute-path form, no parent-traversal (`..`) or empty segment, and no
+ * backslash (which `path.join` treats as a separator on Windows even
+ * though every path in this module is `/`-normalized). Defense-in-depth
+ * against a corrupted or hostile manifest / helper bundle escaping the
+ * intended `--source` / `--target` root through `join()`.
+ */
+function isSafeRelativePath(relativePath: string): boolean {
+  if (!relativePath || relativePath.includes('\\')) {
+    return false;
+  }
+  if (relativePath.startsWith('/') || /^[a-zA-Z]:/.test(relativePath)) {
+    return false;
+  }
+  return relativePath
+    .split('/')
+    .every((segment) => segment !== '' && segment !== '.' && segment !== '..');
+}
+
+/**
+ * Validate both sides of a manifest file entry with `isSafeRelativePath`
+ * and return it unchanged, or throw a hard, fail-closed error naming
+ * `origin` (the manifest source this entry came from). A path-safety
+ * violation is manifest corruption, not an ordinary missing/blocked file,
+ * so it is reported the same way as the other manifest-integrity checks
+ * in this module (stripPrefix mismatch, duplicate target path): a thrown
+ * usage/config error, never a soft `missingSource` / blocking-plan entry.
+ */
+function assertSafeManifestFile(
+  file: ManifestFile,
+  origin: string,
+): ManifestFile {
+  if (
+    !isSafeRelativePath(file.sourcePath) ||
+    !isSafeRelativePath(file.targetPath)
+  ) {
+    throw new Error(
+      `${origin}: unsafe manifest path (absolute or parent-traversal segment): source="${file.sourcePath}" target="${file.targetPath}"`,
+    );
+  }
+  return file;
 }
 
 /** Result of resolving the import file set: files plus any unresolved paths. */
@@ -815,12 +862,9 @@ export function resolveImportFiles(
   if (profile !== 'vendored-node') {
     return { files: coreFiles, missingSource: [] };
   }
-  let helperFiles: ManifestFile[];
+  let vendoredFiles: { sourcePath: string; targetPath: string }[];
   try {
-    helperFiles = collectVendoredFiles(sourceRoot).map((file) => ({
-      sourcePath: file.sourcePath,
-      targetPath: file.targetPath,
-    }));
+    vendoredFiles = collectVendoredFiles(sourceRoot);
   } catch (error) {
     // collectVendoredFiles reads each helper entry's content to walk its
     // import graph, so a missing helper file under an incomplete or
@@ -834,6 +878,16 @@ export function resolveImportFiles(
       missingSource: [describeUnresolvedVendoredPath(sourceRoot, error)],
     };
   }
+  // Outside the try/catch above: a path-safety violation is manifest
+  // corruption, not a missing file, so it must hard-fail (propagate as a
+  // thrown usage/config error) rather than being absorbed as a
+  // missingSource finding the same way a genuinely absent file is.
+  const helperFiles = vendoredFiles.map((file) =>
+    assertSafeManifestFile(
+      { sourcePath: file.sourcePath, targetPath: file.targetPath },
+      'vendored-node helper bundle',
+    ),
+  );
   const merged = [...coreFiles, ...helperFiles];
   const seenTargets = new Set<string>();
   for (const file of merged) {

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -1353,7 +1353,7 @@ nothing in that case); 2 usage or configuration error.
   --import                          run the import stage
   --source <dir>                    local idd-skill source tree to copy from
   --target <dir>                    target repository (default: current directory)
-  --profile <name>                  package-manager | vendored-node | ephemeral-npx | instructions-only
+  --profile <name>                  ${PROFILE_NAMES.join(' | ')}
   --force                           allow overwriting a differing target file
   --dry-run                         print the plan without writing anything
   --help, -h                        show this help

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -210,6 +210,33 @@ function pathExists(root: string, name: string): boolean {
   }
 }
 
+/**
+ * Whether any ancestor directory segment of `root`/`relativePath` already
+ * exists as a non-directory entry (e.g. a plain file at `.github` when
+ * planning `.github/idd/config.json`). `mkdirSync`'s recursive mode cannot
+ * create a directory through such an obstruction, so this must be checked
+ * separately from the leaf path itself (see `pathExists`). `relativePath`
+ * uses `/` separators, matching every `ManifestFile.targetPath` in this
+ * module. A missing (rather than non-directory) ancestor is fine —
+ * `mkdirSync`'s recursive mode creates it — so this returns `false` as
+ * soon as an ancestor segment does not exist yet.
+ */
+function hasNonDirectoryAncestor(root: string, relativePath: string): boolean {
+  const segments = relativePath.split('/').slice(0, -1);
+  let current = root;
+  for (const segment of segments) {
+    current = join(current, segment);
+    try {
+      if (!statSync(current).isDirectory()) {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 function readTextIfPresent(root: string, name: string): string | null {
   try {
     return readFileSync(join(root, name), 'utf8');
@@ -751,6 +778,17 @@ export function resolveCoreTemplateFiles(sourceRoot: string): ManifestFile[] {
   });
 }
 
+/** Result of resolving the import file set: files plus any unresolved paths. */
+export interface ResolvedImportFiles {
+  files: ManifestFile[];
+  /**
+   * Declared or expected source paths that could not be resolved (e.g. a
+   * missing helper file interrupted the vendored-node bundle walk).
+   * Blocking, same as `ImportPlan.missingSource`.
+   */
+  missingSource: string[];
+}
+
 /**
  * Resolve the full import file set: the core template files, plus — only
  * when `profile` is exactly `vendored-node` — the profile-conditional
@@ -764,10 +802,10 @@ export function resolveCoreTemplateFiles(sourceRoot: string): ManifestFile[] {
 export function resolveImportFiles(
   sourceRoot: string,
   profile?: string,
-): ManifestFile[] {
+): ResolvedImportFiles {
   const coreFiles = resolveCoreTemplateFiles(sourceRoot);
   if (!profile) {
-    return coreFiles;
+    return { files: coreFiles, missingSource: [] };
   }
   if (!PROFILE_NAMES.includes(profile)) {
     throw new Error(
@@ -775,11 +813,27 @@ export function resolveImportFiles(
     );
   }
   if (profile !== 'vendored-node') {
-    return coreFiles;
+    return { files: coreFiles, missingSource: [] };
   }
-  const helperFiles: ManifestFile[] = collectVendoredFiles(sourceRoot).map(
-    (file) => ({ sourcePath: file.sourcePath, targetPath: file.targetPath }),
-  );
+  let helperFiles: ManifestFile[];
+  try {
+    helperFiles = collectVendoredFiles(sourceRoot).map((file) => ({
+      sourcePath: file.sourcePath,
+      targetPath: file.targetPath,
+    }));
+  } catch (error) {
+    // collectVendoredFiles reads each helper entry's content to walk its
+    // import graph, so a missing helper file under an incomplete or
+    // version-skewed --source tree throws a raw fs error (ENOENT) instead
+    // of the missingSource reporting the core file set uses. Degrade to
+    // the core file set alone and surface the specific unreadable path
+    // (when the error exposes one) as a blocking finding, rather than
+    // letting the raw exception crash the CLI with a bare exit 2.
+    return {
+      files: coreFiles,
+      missingSource: [describeUnresolvedVendoredPath(sourceRoot, error)],
+    };
+  }
   const merged = [...coreFiles, ...helperFiles];
   const seenTargets = new Set<string>();
   for (const file of merged) {
@@ -790,7 +844,24 @@ export function resolveImportFiles(
     }
     seenTargets.add(file.targetPath);
   }
-  return merged;
+  return { files: merged, missingSource: [] };
+}
+
+/**
+ * Best-effort description of the source path that broke the vendored-node
+ * bundle walk, derived from the failing fs error's `path` property. Falls
+ * back to a generic label when the error does not expose one so a caller
+ * always has a non-empty `missingSource` entry to report.
+ */
+function describeUnresolvedVendoredPath(
+  sourceRoot: string,
+  error: unknown,
+): string {
+  const path = (error as { path?: unknown } | null | undefined)?.path;
+  if (typeof path === 'string') {
+    return relative(sourceRoot, path).replaceAll('\\', '/');
+  }
+  return 'vendored-node helper bundle (unresolvable: unreadable helper source)';
 }
 
 /** How one planned import file relates to the current target tree. */
@@ -841,22 +912,28 @@ export function buildImportPlan(
   targetRoot: string,
   { profile, force = false }: { profile?: string; force?: boolean } = {},
 ): ImportPlan {
-  const files = resolveImportFiles(sourceRoot, profile);
+  const resolved = resolveImportFiles(sourceRoot, profile);
   const entries: ImportPlanEntry[] = [];
-  const missingSource: string[] = [];
+  const missingSource: string[] = [...resolved.missingSource];
   const blockedOverwrites: string[] = [];
   const nonFileTargetCollisions: string[] = [];
-  for (const file of files) {
+  for (const file of resolved.files) {
     if (!fileExists(sourceRoot, file.sourcePath)) {
       missingSource.push(file.sourcePath);
       continue;
     }
     if (!fileExists(targetRoot, file.targetPath)) {
-      if (pathExists(targetRoot, file.targetPath)) {
-        // The target path exists but is not a regular file (e.g. a
-        // directory). Treating this as "new" would make applyImportPlan's
-        // copyFileSync throw EISDIR/ENOTDIR, possibly after already
-        // writing earlier entries — fail closed instead.
+      if (
+        pathExists(targetRoot, file.targetPath) ||
+        hasNonDirectoryAncestor(targetRoot, file.targetPath)
+      ) {
+        // Either the target path itself exists but is not a regular file
+        // (e.g. a directory), or an ancestor path segment is not a
+        // directory (e.g. a plain file at `.github` when planning
+        // `.github/idd/config.json`). Treating either case as "new" would
+        // make applyImportPlan's mkdirSync/copyFileSync throw
+        // EISDIR/ENOTDIR, possibly after already writing earlier entries
+        // — fail closed instead.
         entries.push({ ...file, classification: 'blocked-non-file' });
         nonFileTargetCollisions.push(file.targetPath);
         continue;

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -1007,18 +1007,25 @@ export function buildImportPlan(
       missingSource.push(file.sourcePath);
       continue;
     }
+    // Check the ancestor chain unconditionally, before the leaf-existence
+    // check below. A symlinked ancestor directory can resolve straight to
+    // a real, already-existing leaf file (fileExists on the joined path
+    // follows every ancestor segment, symlinked or not, the same way a
+    // plain stat/lstat would) — checking hasNonDirectoryAncestor only
+    // inside the "leaf does not exist" branch would then never run,
+    // letting applyImportPlan read/write straight through the symlinked
+    // ancestor and escape --target.
+    if (hasNonDirectoryAncestor(targetRoot, file.targetPath)) {
+      entries.push({ ...file, classification: 'blocked-non-file' });
+      nonFileTargetCollisions.push(file.targetPath);
+      continue;
+    }
     if (!fileExists(targetRoot, file.targetPath)) {
-      if (
-        pathExists(targetRoot, file.targetPath) ||
-        hasNonDirectoryAncestor(targetRoot, file.targetPath)
-      ) {
-        // Either the target path itself exists but is not a regular file
-        // (e.g. a directory), or an ancestor path segment is not a
-        // directory (e.g. a plain file at `.github` when planning
-        // `.github/idd/config.json`). Treating either case as "new" would
-        // make applyImportPlan's mkdirSync/copyFileSync throw
-        // EISDIR/ENOTDIR, possibly after already writing earlier entries
-        // — fail closed instead.
+      if (pathExists(targetRoot, file.targetPath)) {
+        // The target path itself exists but is not a regular file (e.g. a
+        // directory or a symlink). Treating this as "new" would make
+        // applyImportPlan's copyFileSync throw EISDIR/ENOTDIR, possibly
+        // after already writing earlier entries — fail closed instead.
         entries.push({ ...file, classification: 'blocked-non-file' });
         nonFileTargetCollisions.push(file.targetPath);
         continue;

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -759,12 +759,27 @@ export function resolveCoreTemplateFiles(sourceRoot: string): ManifestFile[] {
       }`,
     );
   }
-  const block = (manifest.generatedBlocks ?? []).find(
-    (entry) => entry.id === CORE_TEMPLATE_BLOCK_ID,
-  );
-  if (!block?.paths) {
+  // `manifest` is only type-asserted, not runtime-validated, so a corrupted
+  // manifest can carry a `generatedBlocks` / `paths` / `stripPrefix` of the
+  // wrong shape. Validate every level before using it as an array/string —
+  // otherwise a malformed manifest throws a raw, unhelpful TypeError
+  // (`.find is not a function`, `.map is not a function`) instead of the
+  // actionable error this function otherwise gives for a missing block.
+  const rawBlocks = manifest.generatedBlocks;
+  if (!Array.isArray(rawBlocks)) {
     throw new Error(
-      `--source's audit/sync-manifest.json has no "${CORE_TEMPLATE_BLOCK_ID}" generated block with a paths list`,
+      "--source's audit/sync-manifest.json has a malformed generatedBlocks (expected an array)",
+    );
+  }
+  const block = rawBlocks.find((entry) => entry?.id === CORE_TEMPLATE_BLOCK_ID);
+  if (
+    !block ||
+    !Array.isArray(block.paths) ||
+    !block.paths.every((entry) => typeof entry === 'string') ||
+    (block.stripPrefix !== undefined && typeof block.stripPrefix !== 'string')
+  ) {
+    throw new Error(
+      `--source's audit/sync-manifest.json has no "${CORE_TEMPLATE_BLOCK_ID}" generated block with a valid paths: string[] (and stripPrefix?: string)`,
     );
   }
   const prefix = block.stripPrefix ?? '';

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -31,6 +31,7 @@ import { execFileSync } from 'node:child_process';
 import {
   chmodSync,
   copyFileSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -192,9 +193,21 @@ const PYPROJECT_TOOL_COMMANDS: readonly {
   { pattern: /^\s*\[tool\.uv[.\]]/mu, command: 'uv sync' },
 ];
 
+// lstatSync, not statSync: every existence/type check below feeds a
+// decision about whether it is safe to read from or write to a path (the
+// --import planner's fileExists / pathExists / hasNonDirectoryAncestor,
+// plus the placeholder-derivation checks below that also call
+// fileExists). statSync follows symlinks, so a symlink leaf or ancestor
+// would be silently treated as whatever it points to; a symlink inside
+// --source or --target could then let a copy read from or write outside
+// the intended root. lstatSync reports the entry itself, so any symlink
+// is classified as "not a plain file/directory" and — for the --import
+// planner — falls through to the existing blocked-non-file handling
+// instead of being followed.
+
 function fileExists(root: string, name: string): boolean {
   try {
-    return statSync(join(root, name)).isFile();
+    return lstatSync(join(root, name)).isFile();
   } catch {
     return false;
   }
@@ -203,7 +216,7 @@ function fileExists(root: string, name: string): boolean {
 /** Whether any filesystem entry exists at `root`/`name`, of any type. */
 function pathExists(root: string, name: string): boolean {
   try {
-    statSync(join(root, name));
+    lstatSync(join(root, name));
     return true;
   } catch {
     return false;
@@ -212,14 +225,17 @@ function pathExists(root: string, name: string): boolean {
 
 /**
  * Whether any ancestor directory segment of `root`/`relativePath` already
- * exists as a non-directory entry (e.g. a plain file at `.github` when
- * planning `.github/idd/config.json`). `mkdirSync`'s recursive mode cannot
- * create a directory through such an obstruction, so this must be checked
- * separately from the leaf path itself (see `pathExists`). `relativePath`
- * uses `/` separators, matching every `ManifestFile.targetPath` in this
- * module. A missing (rather than non-directory) ancestor is fine —
- * `mkdirSync`'s recursive mode creates it — so this returns `false` as
- * soon as an ancestor segment does not exist yet.
+ * exists as a non-directory entry (e.g. a plain file — or a symlink,
+ * including one that points at a real directory — at `.github` when
+ * planning `.github/idd/config.json`). `mkdirSync`'s recursive mode
+ * cannot create a directory through such an obstruction (and would
+ * otherwise silently traverse a symlinked ancestor), so this must be
+ * checked separately from the leaf path itself (see `pathExists`).
+ * `relativePath` uses `/` separators, matching every
+ * `ManifestFile.targetPath` in this module. A missing (rather than
+ * non-directory) ancestor is fine — `mkdirSync`'s recursive mode creates
+ * it — so this returns `false` as soon as an ancestor segment does not
+ * exist yet.
  */
 function hasNonDirectoryAncestor(root: string, relativePath: string): boolean {
   const segments = relativePath.split('/').slice(0, -1);
@@ -227,7 +243,7 @@ function hasNonDirectoryAncestor(root: string, relativePath: string): boolean {
   for (const segment of segments) {
     current = join(current, segment);
     try {
-      if (!statSync(current).isDirectory()) {
+      if (!lstatSync(current).isDirectory()) {
         return true;
       }
     } catch {

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -200,6 +200,16 @@ function fileExists(root: string, name: string): boolean {
   }
 }
 
+/** Whether any filesystem entry exists at `root`/`name`, of any type. */
+function pathExists(root: string, name: string): boolean {
+  try {
+    statSync(join(root, name));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function readTextIfPresent(root: string, name: string): string | null {
   try {
     return readFileSync(join(root, name), 'utf8');
@@ -784,7 +794,11 @@ export function resolveImportFiles(
 }
 
 /** How one planned import file relates to the current target tree. */
-export type ImportClassification = 'new' | 'unchanged' | 'overwrite';
+export type ImportClassification =
+  | 'new'
+  | 'unchanged'
+  | 'overwrite'
+  | 'blocked-non-file';
 
 /** One planned copy: a manifest file plus its target-tree classification. */
 export interface ImportPlanEntry extends ManifestFile {
@@ -801,16 +815,26 @@ export interface ImportPlan {
    * `--force`. Blocking.
    */
   blockedOverwrites: string[];
+  /**
+   * Target paths that already exist but are not a regular file (e.g. a
+   * directory). These can never be copied onto, so they are always
+   * blocking — `--force` does not override this, since it only means
+   * "allow overwriting a differing file", not "remove whatever is
+   * already there". Entries are classified `blocked-non-file`.
+   */
+  nonFileTargetCollisions: string[];
 }
 
 /**
  * Build the import plan: classify each manifest file as `new` (no target
- * file yet), `unchanged` (target already matches byte-for-byte — a safe
- * no-op), or `overwrite` (target exists and differs). An `overwrite` entry
- * is also recorded in `blockedOverwrites` unless `force` is set — the
- * fail-closed default refuses to clobber a differing target file. A
- * missing declared source file is recorded in `missingSource` instead of
- * a plan entry.
+ * path yet), `unchanged` (target already matches byte-for-byte — a safe
+ * no-op), `overwrite` (target exists as a file and differs), or
+ * `blocked-non-file` (target path exists but is not a regular file, e.g. a
+ * directory — always blocking, see `nonFileTargetCollisions`). An
+ * `overwrite` entry is also recorded in `blockedOverwrites` unless `force`
+ * is set — the fail-closed default refuses to clobber a differing target
+ * file. A missing declared source file is recorded in `missingSource`
+ * instead of a plan entry.
  */
 export function buildImportPlan(
   sourceRoot: string,
@@ -821,12 +845,22 @@ export function buildImportPlan(
   const entries: ImportPlanEntry[] = [];
   const missingSource: string[] = [];
   const blockedOverwrites: string[] = [];
+  const nonFileTargetCollisions: string[] = [];
   for (const file of files) {
     if (!fileExists(sourceRoot, file.sourcePath)) {
       missingSource.push(file.sourcePath);
       continue;
     }
     if (!fileExists(targetRoot, file.targetPath)) {
+      if (pathExists(targetRoot, file.targetPath)) {
+        // The target path exists but is not a regular file (e.g. a
+        // directory). Treating this as "new" would make applyImportPlan's
+        // copyFileSync throw EISDIR/ENOTDIR, possibly after already
+        // writing earlier entries — fail closed instead.
+        entries.push({ ...file, classification: 'blocked-non-file' });
+        nonFileTargetCollisions.push(file.targetPath);
+        continue;
+      }
       entries.push({ ...file, classification: 'new' });
       continue;
     }
@@ -841,18 +875,21 @@ export function buildImportPlan(
       blockedOverwrites.push(file.targetPath);
     }
   }
-  return { entries, missingSource, blockedOverwrites };
+  return { entries, missingSource, blockedOverwrites, nonFileTargetCollisions };
 }
 
 /**
  * Apply the plan: copy every `new` or `overwrite` entry (skipping
- * `unchanged` entries, which already match), creating parent directories
+ * `unchanged` entries, which already match, and `blocked-non-file`
+ * entries, which can never be copied onto), creating parent directories
  * as needed. Preserves the source file's permission bits — a plain byte
  * copy would otherwise silently drop the executable bit that
  * `.githooks/pre-commit` / `.githooks/pre-push` require. Returns the count
  * of files written. Callers must gate on `missingSource` /
- * `blockedOverwrites` themselves; this function copies whatever the plan
- * contains without re-checking blocking conditions.
+ * `blockedOverwrites` / `nonFileTargetCollisions` themselves; this
+ * function copies whatever the plan contains without re-checking blocking
+ * conditions (except that it never attempts the impossible
+ * `blocked-non-file` copy, regardless of caller gating).
  */
 export function applyImportPlan(
   sourceRoot: string,
@@ -861,7 +898,10 @@ export function applyImportPlan(
 ): number {
   let filesChanged = 0;
   for (const entry of plan.entries) {
-    if (entry.classification === 'unchanged') {
+    if (
+      entry.classification === 'unchanged' ||
+      entry.classification === 'blocked-non-file'
+    ) {
       continue;
     }
     const sourceAbsolute = join(sourceRoot, entry.sourcePath);
@@ -1034,10 +1074,13 @@ function runImportCli(args: ParsedArgs): void {
     force: args.force,
   });
   // Fail closed: never write a partially-imported tree. Apply mode writes
-  // only when every declared source file exists and no existing target
-  // file would be silently clobbered without --force.
+  // only when every declared source file exists, no existing target file
+  // would be silently clobbered without --force, and no target path is
+  // blocked by a non-file collision (which --force cannot override).
   const blocking =
-    plan.missingSource.length > 0 || plan.blockedOverwrites.length > 0;
+    plan.missingSource.length > 0 ||
+    plan.blockedOverwrites.length > 0 ||
+    plan.nonFileTargetCollisions.length > 0;
   const canWrite = !args.dryRun && !blocking;
   const filesChanged = canWrite
     ? applyImportPlan(sourceDir, targetDir, plan)
@@ -1051,6 +1094,7 @@ function runImportCli(args: ParsedArgs): void {
     plan: plan.entries,
     missingSource: plan.missingSource,
     blockedOverwrites: plan.blockedOverwrites,
+    nonFileTargetCollisions: plan.nonFileTargetCollisions,
     filesChanged,
     written: canWrite && filesChanged > 0,
   };
@@ -1096,11 +1140,13 @@ audit/sync-manifest.json's idd-template-core-files generated block (the
 same canonical source idd-template/ONBOARDING.md's Step 2 file list
 renders from). With --profile vendored-node, also copies the
 profile-conditional helper bundle (helper-runtime-manifest.mts's
-managedFiles); every other profile value vends no extra files. Refuses to
-overwrite an existing target file whose content differs unless --force,
-and reports missing declared source files, as blocking findings. Prints a
-JSON verdict with the per-file plan (new / unchanged / overwrite
-classification) and the blocking findings.
+collectVendoredFiles); every other profile value vends no extra files.
+Refuses to overwrite an existing target file whose content differs
+unless --force, and reports missing declared source files and non-file
+target collisions (e.g. an existing directory at a target path) as
+blocking findings. Prints a JSON verdict with the per-file plan
+(new / unchanged / overwrite / blocked-non-file classification) and the
+blocking findings.
 
 Exit codes: 0 converged; 1 a blocking finding exists (apply writes
 nothing in that case); 2 usage or configuration error.

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -1009,6 +1009,28 @@ function parseArgs(argv: string[]): ParsedArgs {
   return parsed;
 }
 
+/** Import-only flags the user explicitly passed (present regardless of mode). */
+function importOnlyFlagsPresent(args: ParsedArgs): string[] {
+  const present: string[] = [];
+  if (args.source !== undefined) {
+    present.push('--source');
+  }
+  if (args.force) {
+    present.push('--force');
+  }
+  if (args.profile !== undefined) {
+    present.push('--profile');
+  }
+  return present;
+}
+
+/** Substitute-only placeholder-override flags the user explicitly passed. */
+function substituteOnlyFlagsPresent(args: ParsedArgs): string[] {
+  return ONBOARDING_PLACEHOLDERS.filter(
+    (entry) => args.overrides[entry.name] !== undefined,
+  ).map((entry) => entry.flag);
+}
+
 function runCli(): void {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -1019,11 +1041,26 @@ function runCli(): void {
     throw new Error('--substitute and --import are mutually exclusive');
   }
   if (args.importMode) {
+    // parseArgs collects every known flag regardless of the active stage,
+    // so a stage-foreign flag (e.g. a placeholder override alongside
+    // --import) would otherwise be silently ignored instead of reported.
+    const foreign = substituteOnlyFlagsPresent(args);
+    if (foreign.length > 0) {
+      throw new Error(
+        `--import does not accept substitute-only flag(s): ${foreign.join(', ')}`,
+      );
+    }
     runImportCli(args);
     return;
   }
   if (!args.substitute) {
     throw new Error('pass --substitute or --import to select a stage');
+  }
+  const foreign = importOnlyFlagsPresent(args);
+  if (foreign.length > 0) {
+    throw new Error(
+      `--substitute does not accept import-only flag(s): ${foreign.join(', ')}`,
+    );
   }
   const targetDir = resolve(args.target);
   if (!statSync(targetDir).isDirectory()) {

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -6,22 +6,45 @@
 // generated .mjs. See docs/typescript-sources.md.
 //
 // Onboarding automation CLI — wave 1: placeholder substitution (#1263,
-// roadmap #1262).
+// roadmap #1262). Wave 2 (#1292) adds the --import fetch/copy stage.
 //
-// Given a target tree that already contains the imported template files,
-// resolve the seven onboarding placeholders (auto-derived from repository
-// evidence where `idd-template/docs/onboarding/placeholders.md` defines a
-// derivation; explicit flags override) and rewrite the files. `--dry-run`
-// prints the per-file, per-placeholder plan without writing anything.
-// That reference document is the source of truth this CLI must match; a
-// drift test in tests/idd-onboard.test.mts fails on mismatch.
+// --substitute: given a target tree that already contains the imported
+// template files, resolve the seven onboarding placeholders (auto-derived
+// from repository evidence where
+// `idd-template/docs/onboarding/placeholders.md` defines a derivation;
+// explicit flags override) and rewrite the files. `--dry-run` prints the
+// per-file, per-placeholder plan without writing anything. That reference
+// document is the source of truth this CLI must match; a drift test in
+// tests/idd-onboard.test.mts fails on mismatch.
+//
+// --import: copy the distributed core template file set (and, with
+// `--profile vendored-node`, the profile-conditional helper bundle) from a
+// local idd-skill source tree into a target repository. The file set is
+// read from `audit/sync-manifest.json`'s `idd-template-core-files`
+// generated block — the same canonical source `sync-docs.mjs` /
+// `audit-docs.mjs` render into `idd-template/ONBOARDING.md`'s Step 2 file
+// list — so the CLI and the manual doc can never carry two independently
+// hardcoded file lists. A drift test in tests/idd-onboard.test.mts fails on
+// mismatch.
 
 import { execFileSync } from 'node:child_process';
-import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
 
 import { isCliExecution } from './gh-exec.mts';
-import { collectHelperRuntimeEvidence } from './helper-runtime-manifest.mts';
+import {
+  collectHelperRuntimeEvidence,
+  collectVendoredFiles,
+  PROFILE_NAMES,
+} from './helper-runtime-manifest.mts';
 
 /** Substitution role of a placeholder: only `command` rows may be `true`. */
 export type OnboardingPlaceholderKind = 'identity' | 'command';
@@ -651,6 +674,206 @@ export function applySubstitutionPlan(
   return byFile.size;
 }
 
+// ---------------------------------------------------------------------------
+// Wave 2: --import (manifest-driven fetch/copy)
+// ---------------------------------------------------------------------------
+
+/** One file the import stage copies: paths are relative to their root. */
+export interface ManifestFile {
+  /** Path relative to the `--source` idd-skill tree. */
+  sourcePath: string;
+  /** Path relative to the `--target` repository. */
+  targetPath: string;
+}
+
+const CORE_TEMPLATE_BLOCK_ID = 'idd-template-core-files';
+
+interface SyncManifestGeneratedBlock {
+  id: string;
+  paths?: string[];
+  stripPrefix?: string;
+}
+
+interface SyncManifest {
+  generatedBlocks?: SyncManifestGeneratedBlock[];
+}
+
+/**
+ * Resolve the distributed core template file set from the same
+ * `audit/sync-manifest.json` canonical source that `sync-docs.mjs` /
+ * `audit-docs.mjs` render into `idd-template/ONBOARDING.md`'s Step 2
+ * `idd-template-core-files` block, so this CLI never carries a second,
+ * independently hardcoded file list. `sourcePath` is relative to
+ * `sourceRoot` (the manifest's recorded paths already carry the
+ * `idd-template/` prefix); `targetPath` has `stripPrefix` removed, landing
+ * at the same relative path the generated ONBOARDING.md list documents.
+ * Throws when `sourceRoot` has no readable manifest or no block with a
+ * `paths` list — that tree is not a usable idd-skill source root.
+ */
+export function resolveCoreTemplateFiles(sourceRoot: string): ManifestFile[] {
+  const manifestPath = join(sourceRoot, 'audit', 'sync-manifest.json');
+  let manifest: SyncManifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as SyncManifest;
+  } catch (error) {
+    throw new Error(
+      `--source is not a readable idd-skill tree (missing or invalid audit/sync-manifest.json): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  const block = (manifest.generatedBlocks ?? []).find(
+    (entry) => entry.id === CORE_TEMPLATE_BLOCK_ID,
+  );
+  if (!block?.paths) {
+    throw new Error(
+      `--source's audit/sync-manifest.json has no "${CORE_TEMPLATE_BLOCK_ID}" generated block with a paths list`,
+    );
+  }
+  const prefix = block.stripPrefix ?? '';
+  return block.paths.map((sourcePath) => {
+    if (prefix && !sourcePath.startsWith(prefix)) {
+      throw new Error(
+        `${CORE_TEMPLATE_BLOCK_ID}: manifest path "${sourcePath}" does not start with its stripPrefix "${prefix}"`,
+      );
+    }
+    return { sourcePath, targetPath: sourcePath.slice(prefix.length) };
+  });
+}
+
+/**
+ * Resolve the full import file set: the core template files, plus — only
+ * when `profile` is exactly `vendored-node` — the profile-conditional
+ * helper bundle from `helper-runtime-manifest.mts`'s `collectVendoredFiles`
+ * (mirroring ONBOARDING Step 2's profile guidance). Every other known
+ * profile name vends zero extra files, matching its own `managedFiles: []`
+ * catalog entry. `profile` is validated against the same `PROFILE_NAMES`
+ * the helper manifest CLI itself validates against — no second hardcoded
+ * profile-name list.
+ */
+export function resolveImportFiles(
+  sourceRoot: string,
+  profile?: string,
+): ManifestFile[] {
+  const coreFiles = resolveCoreTemplateFiles(sourceRoot);
+  if (!profile) {
+    return coreFiles;
+  }
+  if (!PROFILE_NAMES.includes(profile)) {
+    throw new Error(
+      `unknown --profile: ${profile} (expected one of ${PROFILE_NAMES.join(', ')})`,
+    );
+  }
+  if (profile !== 'vendored-node') {
+    return coreFiles;
+  }
+  const helperFiles: ManifestFile[] = collectVendoredFiles(sourceRoot).map(
+    (file) => ({ sourcePath: file.sourcePath, targetPath: file.targetPath }),
+  );
+  const merged = [...coreFiles, ...helperFiles];
+  const seenTargets = new Set<string>();
+  for (const file of merged) {
+    if (seenTargets.has(file.targetPath)) {
+      throw new Error(
+        `manifest drift: duplicate target path "${file.targetPath}" across the core file set and the profile-conditional bundle`,
+      );
+    }
+    seenTargets.add(file.targetPath);
+  }
+  return merged;
+}
+
+/** How one planned import file relates to the current target tree. */
+export type ImportClassification = 'new' | 'unchanged' | 'overwrite';
+
+/** One planned copy: a manifest file plus its target-tree classification. */
+export interface ImportPlanEntry extends ManifestFile {
+  classification: ImportClassification;
+}
+
+/** The full dry-run/apply plan for one `--import` invocation. */
+export interface ImportPlan {
+  entries: ImportPlanEntry[];
+  /** Declared source files missing under `--source`. Blocking. */
+  missingSource: string[];
+  /**
+   * Existing target files whose content differs from source, without
+   * `--force`. Blocking.
+   */
+  blockedOverwrites: string[];
+}
+
+/**
+ * Build the import plan: classify each manifest file as `new` (no target
+ * file yet), `unchanged` (target already matches byte-for-byte — a safe
+ * no-op), or `overwrite` (target exists and differs). An `overwrite` entry
+ * is also recorded in `blockedOverwrites` unless `force` is set — the
+ * fail-closed default refuses to clobber a differing target file. A
+ * missing declared source file is recorded in `missingSource` instead of
+ * a plan entry.
+ */
+export function buildImportPlan(
+  sourceRoot: string,
+  targetRoot: string,
+  { profile, force = false }: { profile?: string; force?: boolean } = {},
+): ImportPlan {
+  const files = resolveImportFiles(sourceRoot, profile);
+  const entries: ImportPlanEntry[] = [];
+  const missingSource: string[] = [];
+  const blockedOverwrites: string[] = [];
+  for (const file of files) {
+    if (!fileExists(sourceRoot, file.sourcePath)) {
+      missingSource.push(file.sourcePath);
+      continue;
+    }
+    if (!fileExists(targetRoot, file.targetPath)) {
+      entries.push({ ...file, classification: 'new' });
+      continue;
+    }
+    const sourceBytes = readFileSync(join(sourceRoot, file.sourcePath));
+    const targetBytes = readFileSync(join(targetRoot, file.targetPath));
+    if (sourceBytes.equals(targetBytes)) {
+      entries.push({ ...file, classification: 'unchanged' });
+      continue;
+    }
+    entries.push({ ...file, classification: 'overwrite' });
+    if (!force) {
+      blockedOverwrites.push(file.targetPath);
+    }
+  }
+  return { entries, missingSource, blockedOverwrites };
+}
+
+/**
+ * Apply the plan: copy every `new` or `overwrite` entry (skipping
+ * `unchanged` entries, which already match), creating parent directories
+ * as needed. Preserves the source file's permission bits — a plain byte
+ * copy would otherwise silently drop the executable bit that
+ * `.githooks/pre-commit` / `.githooks/pre-push` require. Returns the count
+ * of files written. Callers must gate on `missingSource` /
+ * `blockedOverwrites` themselves; this function copies whatever the plan
+ * contains without re-checking blocking conditions.
+ */
+export function applyImportPlan(
+  sourceRoot: string,
+  targetRoot: string,
+  plan: ImportPlan,
+): number {
+  let filesChanged = 0;
+  for (const entry of plan.entries) {
+    if (entry.classification === 'unchanged') {
+      continue;
+    }
+    const sourceAbsolute = join(sourceRoot, entry.sourcePath);
+    const targetAbsolute = join(targetRoot, entry.targetPath);
+    mkdirSync(dirname(targetAbsolute), { recursive: true });
+    copyFileSync(sourceAbsolute, targetAbsolute);
+    chmodSync(targetAbsolute, statSync(sourceAbsolute).mode);
+    filesChanged += 1;
+  }
+  return filesChanged;
+}
+
 if (isCliExecution(import.meta.url)) {
   try {
     runCli();
@@ -666,8 +889,12 @@ if (isCliExecution(import.meta.url)) {
 
 interface ParsedArgs {
   substitute: boolean;
+  importMode: boolean;
+  source: string | undefined;
   target: string;
   dryRun: boolean;
+  force: boolean;
+  profile: string | undefined;
   overrides: PlaceholderOverrides;
   help: boolean;
 }
@@ -675,8 +902,12 @@ interface ParsedArgs {
 function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = {
     substitute: false,
+    importMode: false,
+    source: undefined,
     target: '.',
     dryRun: false,
+    force: false,
+    profile: undefined,
     overrides: {},
     help: false,
   };
@@ -696,6 +927,15 @@ function parseArgs(argv: string[]): ParsedArgs {
       parsed.substitute = true;
       continue;
     }
+    if (token === '--import') {
+      parsed.importMode = true;
+      continue;
+    }
+    if (token === '--source') {
+      parsed.source = requireValue();
+      index += 1;
+      continue;
+    }
     if (token === '--target') {
       parsed.target = requireValue();
       index += 1;
@@ -703,6 +943,15 @@ function parseArgs(argv: string[]): ParsedArgs {
     }
     if (token === '--dry-run') {
       parsed.dryRun = true;
+      continue;
+    }
+    if (token === '--force') {
+      parsed.force = true;
+      continue;
+    }
+    if (token === '--profile') {
+      parsed.profile = requireValue();
+      index += 1;
       continue;
     }
     if (token === '--help' || token === '-h') {
@@ -726,10 +975,15 @@ function runCli(): void {
     printHelp();
     process.exit(0);
   }
+  if (args.substitute && args.importMode) {
+    throw new Error('--substitute and --import are mutually exclusive');
+  }
+  if (args.importMode) {
+    runImportCli(args);
+    return;
+  }
   if (!args.substitute) {
-    throw new Error(
-      'wave 1 supports the substitution stage only: pass --substitute',
-    );
+    throw new Error('pass --substitute or --import to select a stage');
   }
   const targetDir = resolve(args.target);
   if (!statSync(targetDir).isDirectory()) {
@@ -763,16 +1017,62 @@ function runCli(): void {
   process.exit(plan.residue.length > 0 ? 1 : 0);
 }
 
+function runImportCli(args: ParsedArgs): void {
+  if (!args.source) {
+    throw new Error('--import requires --source <idd-skill-tree>');
+  }
+  const sourceDir = resolve(args.source);
+  if (!statSync(sourceDir).isDirectory()) {
+    throw new Error(`--source is not a directory: ${args.source}`);
+  }
+  const targetDir = resolve(args.target);
+  if (!statSync(targetDir).isDirectory()) {
+    throw new Error(`--target is not a directory: ${args.target}`);
+  }
+  const plan = buildImportPlan(sourceDir, targetDir, {
+    profile: args.profile,
+    force: args.force,
+  });
+  // Fail closed: never write a partially-imported tree. Apply mode writes
+  // only when every declared source file exists and no existing target
+  // file would be silently clobbered without --force.
+  const blocking =
+    plan.missingSource.length > 0 || plan.blockedOverwrites.length > 0;
+  const canWrite = !args.dryRun && !blocking;
+  const filesChanged = canWrite
+    ? applyImportPlan(sourceDir, targetDir, plan)
+    : 0;
+  const verdict = {
+    protocolVersion: '1',
+    mode: args.dryRun ? 'dry-run' : 'apply',
+    source: sourceDir,
+    target: targetDir,
+    profile: args.profile ?? null,
+    plan: plan.entries,
+    missingSource: plan.missingSource,
+    blockedOverwrites: plan.blockedOverwrites,
+    filesChanged,
+    written: canWrite && filesChanged > 0,
+  };
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  // Blocking findings signal in dry-run and apply alike so callers can gate
+  // on the exit code without needing a separate --dry-run probe first.
+  process.exit(blocking ? 1 : 0);
+}
+
 function printHelp(): void {
   const flags = ONBOARDING_PLACEHOLDERS.map(
     (entry) =>
       `  ${entry.flag} <value>${entry.kind === 'command' ? ' (accepts the no-op "true")' : ''}`,
   ).join('\n');
   process.stdout.write(`usage: node scripts/idd-onboard.mjs --substitute [options]
+       node scripts/idd-onboard.mjs --import --source <dir> --target <dir> [options]
 
-Onboarding automation — wave 1: placeholder substitution. Resolves the
-seven template placeholders for a target tree that already contains the
-imported template files (auto-derived from repository evidence where
+Onboarding automation.
+
+--substitute (wave 1): resolves the seven template placeholders for a
+target tree that already contains the imported template files
+(auto-derived from repository evidence where
 idd-template/docs/onboarding/placeholders.md defines a derivation;
 explicit flags override; --trusted-marker-actor is always explicit) and
 rewrites the files. Prints a JSON verdict with the per-file,
@@ -782,12 +1082,35 @@ placeholders), and informational unknown {{...}} tokens.
 Exit codes: 0 converged; 1 residue would remain (apply writes nothing
 in that case); 2 usage or configuration error.
 
-  --substitute         run the substitution stage (required)
+  --substitute         run the substitution stage
   --target <dir>       target tree to rewrite (default: current directory)
   --dry-run            print the plan without writing anything
   --help, -h           show this help
 
 Placeholder overrides:
 ${flags}
+
+--import (wave 2): copies the distributed core template file set from a
+local idd-skill source tree (--source) into --target, driven by
+audit/sync-manifest.json's idd-template-core-files generated block (the
+same canonical source idd-template/ONBOARDING.md's Step 2 file list
+renders from). With --profile vendored-node, also copies the
+profile-conditional helper bundle (helper-runtime-manifest.mts's
+managedFiles); every other profile value vends no extra files. Refuses to
+overwrite an existing target file whose content differs unless --force,
+and reports missing declared source files, as blocking findings. Prints a
+JSON verdict with the per-file plan (new / unchanged / overwrite
+classification) and the blocking findings.
+
+Exit codes: 0 converged; 1 a blocking finding exists (apply writes
+nothing in that case); 2 usage or configuration error.
+
+  --import                          run the import stage
+  --source <dir>                    local idd-skill source tree to copy from
+  --target <dir>                    target repository (default: current directory)
+  --profile <name>                  package-manager | vendored-node | ephemeral-npx | instructions-only
+  --force                           allow overwriting a differing target file
+  --dry-run                         print the plan without writing anything
+  --help, -h                        show this help
 `);
 }

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -1118,6 +1118,57 @@ test('bin/idd-onboard.mjs exits 2 when both --substitute and --import are passed
   }
 });
 
+test('bin/idd-onboard.mjs exits 2 when --import is combined with a substitute-only placeholder override', () => {
+  const targetRoot = makeFixtureDir();
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        BIN_PATH,
+        '--import',
+        '--source',
+        REPO_ROOT,
+        '--target',
+        targetRoot,
+        '--repo-name',
+        'my-app',
+      ],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    assert.fail('expected a non-zero exit');
+  } catch (error) {
+    const failed = error as { status?: number; stderr?: string };
+    assert.equal(failed.status, 2);
+    assert.match(String(failed.stderr), /substitute-only flag/);
+    assert.match(String(failed.stderr), /--repo-name/);
+  }
+});
+
+test('bin/idd-onboard.mjs exits 2 when --substitute is combined with an import-only flag', () => {
+  const targetRoot = makeFixtureDir();
+  writeTemplateFixture(targetRoot);
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        BIN_PATH,
+        '--substitute',
+        '--target',
+        targetRoot,
+        '--force',
+        ...CLI_OVERRIDE_FLAGS,
+      ],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    assert.fail('expected a non-zero exit');
+  } catch (error) {
+    const failed = error as { status?: number; stderr?: string };
+    assert.equal(failed.status, 2);
+    assert.match(String(failed.stderr), /import-only flag/);
+    assert.match(String(failed.stderr), /--force/);
+  }
+});
+
 test('importing idd-onboard.mts has no import-time side effect', async () => {
   const originalPath = process.env.PATH;
   process.env.PATH = '';

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -4,12 +4,14 @@ import {
   chmodSync,
   cpSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -851,6 +853,55 @@ test('buildImportPlan blocks a non-directory ancestor collision, not just a leaf
   // if a caller applied the plan without checking the blocking arrays.
   assert.equal(applyImportPlan(sourceRoot, targetRoot, plan), 0);
   assert.ok(statSync(join(targetRoot, 'nested')).isFile());
+});
+
+test('buildImportPlan blocks a symlink at the leaf target path instead of following it', () => {
+  const sourceRoot = makeImportSourceFixture({ 'a.md': 'alpha\n' });
+  const targetRoot = makeFixtureDir();
+  const linkTarget = join(targetRoot, 'real.md');
+  writeFileSync(linkTarget, 'alpha\n');
+  symlinkSync(linkTarget, join(targetRoot, 'a.md'));
+
+  const plan = buildImportPlan(sourceRoot, targetRoot);
+  const entry = plan.entries.find((e) => e.targetPath === 'a.md');
+  assert.equal(entry?.classification, 'blocked-non-file');
+  assert.deepEqual(plan.nonFileTargetCollisions, ['a.md']);
+
+  // Even with --force, applyImportPlan must never write through the
+  // symlink (force overrides a differing *file*, not a type collision).
+  const forcedPlan = buildImportPlan(sourceRoot, targetRoot, { force: true });
+  assert.equal(applyImportPlan(sourceRoot, targetRoot, forcedPlan), 0);
+  assert.ok(lstatSync(join(targetRoot, 'a.md')).isSymbolicLink());
+});
+
+test('buildImportPlan blocks a symlinked ancestor directory in the target tree', () => {
+  const sourceRoot = makeImportSourceFixture({ 'nested/a.md': 'alpha\n' });
+  const targetRoot = makeFixtureDir();
+  const realDir = join(targetRoot, 'real-dir');
+  mkdirSync(realDir, { recursive: true });
+  symlinkSync(realDir, join(targetRoot, 'nested'));
+
+  const plan = buildImportPlan(sourceRoot, targetRoot);
+  assert.equal(plan.entries[0]?.classification, 'blocked-non-file');
+  assert.deepEqual(plan.nonFileTargetCollisions, ['nested/a.md']);
+  assert.equal(applyImportPlan(sourceRoot, targetRoot, plan), 0);
+  // The symlink itself must survive untouched — no write escaped through
+  // it into realDir.
+  assert.ok(lstatSync(join(targetRoot, 'nested')).isSymbolicLink());
+  assert.deepEqual(readdirSync(realDir), []);
+});
+
+test('buildImportPlan reports a symlinked source file as missing rather than reading through it', () => {
+  const sourceRoot = makeFixtureDir();
+  writeCoreFilesManifest(sourceRoot, ['idd-template/a.md']);
+  mkdirSync(join(sourceRoot, 'idd-template'), { recursive: true });
+  const realFile = join(sourceRoot, 'real.md');
+  writeFileSync(realFile, 'alpha\n');
+  symlinkSync(realFile, join(sourceRoot, 'idd-template', 'a.md'));
+
+  const plan = buildImportPlan(sourceRoot, makeFixtureDir());
+  assert.deepEqual(plan.missingSource, ['idd-template/a.md']);
+  assert.equal(plan.entries.length, 0);
 });
 
 /** A minimal idd-skill-shaped source tree: just enough for resolveImportFiles. */

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -688,6 +688,65 @@ test('resolveCoreTemplateFiles rejects an absolute manifest path', () => {
   assert.throws(() => resolveCoreTemplateFiles(root), /unsafe manifest path/u);
 });
 
+/** Write an arbitrary (possibly malformed) sync-manifest.json body. */
+function writeRawManifest(root: string, body: unknown): void {
+  mkdirSync(join(root, 'audit'), { recursive: true });
+  writeFileSync(
+    join(root, 'audit', 'sync-manifest.json'),
+    JSON.stringify(body),
+  );
+}
+
+test('resolveCoreTemplateFiles rejects a malformed generatedBlocks instead of throwing a raw TypeError', () => {
+  const root = makeFixtureDir();
+  writeRawManifest(root, { generatedBlocks: 'not-an-array' });
+  assert.throws(
+    () => resolveCoreTemplateFiles(root),
+    /malformed generatedBlocks/u,
+  );
+});
+
+test('resolveCoreTemplateFiles rejects a non-array paths field instead of throwing a raw TypeError', () => {
+  const root = makeFixtureDir();
+  writeRawManifest(root, {
+    generatedBlocks: [{ id: 'idd-template-core-files', paths: 'not-an-array' }],
+  });
+  assert.throws(
+    () => resolveCoreTemplateFiles(root),
+    /valid paths: string\[\]/u,
+  );
+});
+
+test('resolveCoreTemplateFiles rejects a paths array containing a non-string entry', () => {
+  const root = makeFixtureDir();
+  writeRawManifest(root, {
+    generatedBlocks: [
+      { id: 'idd-template-core-files', paths: ['idd-template/a.md', 42] },
+    ],
+  });
+  assert.throws(
+    () => resolveCoreTemplateFiles(root),
+    /valid paths: string\[\]/u,
+  );
+});
+
+test('resolveCoreTemplateFiles rejects a non-string stripPrefix', () => {
+  const root = makeFixtureDir();
+  writeRawManifest(root, {
+    generatedBlocks: [
+      {
+        id: 'idd-template-core-files',
+        paths: ['idd-template/a.md'],
+        stripPrefix: 42,
+      },
+    ],
+  });
+  assert.throws(
+    () => resolveCoreTemplateFiles(root),
+    /valid paths: string\[\]/u,
+  );
+});
+
 test('resolveImportFiles vends no extra files for a non-vendored-node profile', () => {
   const withoutProfile = resolveImportFiles(REPO_ROOT);
   const packageManagerProfile = resolveImportFiles(

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -894,6 +894,33 @@ test('buildImportPlan blocks a symlinked ancestor directory in the target tree',
   assert.deepEqual(readdirSync(realDir), []);
 });
 
+test('buildImportPlan blocks a symlinked ancestor even when the leaf already exists under it', () => {
+  // The more dangerous variant of the previous test: fileExists() on the
+  // joined target path would report "exists" here (the leaf resolves,
+  // through the symlinked ancestor, to a real file), so the ancestor
+  // check must run unconditionally rather than only when the leaf is
+  // absent -- otherwise this case would fall through to unchanged /
+  // overwrite and applyImportPlan would read or write straight through
+  // the symlinked ancestor.
+  const sourceRoot = makeImportSourceFixture({ 'nested/a.md': 'alpha\n' });
+  const targetRoot = makeFixtureDir();
+  const realDir = join(targetRoot, 'real-dir');
+  mkdirSync(realDir, { recursive: true });
+  writeFileSync(join(realDir, 'a.md'), 'alpha\n'); // byte-identical to source
+  symlinkSync(realDir, join(targetRoot, 'nested'));
+
+  const plan = buildImportPlan(sourceRoot, targetRoot);
+  assert.equal(plan.entries[0]?.classification, 'blocked-non-file');
+  assert.deepEqual(plan.nonFileTargetCollisions, ['nested/a.md']);
+
+  // Even with --force (which only overrides a differing *file*), the
+  // symlinked ancestor must still block.
+  const forcedPlan = buildImportPlan(sourceRoot, targetRoot, { force: true });
+  assert.equal(forcedPlan.entries[0]?.classification, 'blocked-non-file');
+  assert.equal(applyImportPlan(sourceRoot, targetRoot, forcedPlan), 0);
+  assert.ok(lstatSync(join(targetRoot, 'nested')).isSymbolicLink());
+});
+
 test('buildImportPlan reports a symlinked source file as missing rather than reading through it', () => {
   const sourceRoot = makeFixtureDir();
   writeCoreFilesManifest(sourceRoot, ['idd-template/a.md']);

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -1,22 +1,28 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import {
+  chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
+  rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
-
+import { collectVendoredFiles } from '../src/scripts/helper-runtime-manifest.mts';
 // Importing the CLI module directly is only possible because its top-level
 // statements are guarded behind isCliExecution() (#1210 pattern); an
 // import-time CLI run would parse process.argv and abort this test process.
 import {
+  applyImportPlan,
   applySubstitutionPlan,
+  buildImportPlan,
   buildSubstitutionPlan,
   deriveInstallDepsCommand,
   deriveMarkerPrefix,
@@ -25,6 +31,8 @@ import {
   MARKER_PREFIX_PATTERN,
   ONBOARDING_PLACEHOLDERS,
   parseRemoteRepoRef,
+  resolveCoreTemplateFiles,
+  resolveImportFiles,
   resolvePlaceholderValues,
   scanPlaceholderTokens,
 } from '../src/scripts/idd-onboard.mts';
@@ -607,6 +615,207 @@ test('binary files and excluded directories are not scanned', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Wave 2: --import (manifest-driven fetch/copy)
+// ---------------------------------------------------------------------------
+
+const CORE_FILES_BLOCK_MARKER =
+  '<!-- audit:generated id=idd-template-core-files -->';
+
+test('resolveCoreTemplateFiles matches the ONBOARDING.md idd-template-core-files generated block', () => {
+  const onboardingPath = join(REPO_ROOT, 'idd-template', 'ONBOARDING.md');
+  const text = readFileSync(onboardingPath, 'utf8');
+  const markerIndex = text.indexOf(CORE_FILES_BLOCK_MARKER);
+  assert.ok(markerIndex !== -1, 'core-files generated block marker not found');
+  const fenceStart = text.indexOf('```text\n', markerIndex);
+  assert.ok(fenceStart !== -1, 'core-files code fence not found');
+  const contentStart = fenceStart + '```text\n'.length;
+  const fenceEnd = text.indexOf('\n```', contentStart);
+  assert.ok(fenceEnd !== -1, 'core-files code fence not closed');
+  const documented = text
+    .slice(contentStart, fenceEnd)
+    .split('\n')
+    .filter((line) => line.length > 0);
+
+  const resolved = resolveCoreTemplateFiles(REPO_ROOT).map(
+    (file) => file.targetPath,
+  );
+  assert.deepEqual(
+    resolved,
+    documented,
+    "audit/sync-manifest.json's idd-template-core-files paths must match the rendered ONBOARDING.md block exactly",
+  );
+});
+
+test('resolveCoreTemplateFiles rejects a source tree without a readable manifest', () => {
+  assert.throws(
+    () => resolveCoreTemplateFiles(makeFixtureDir()),
+    /audit\/sync-manifest\.json/u,
+  );
+});
+
+test('resolveImportFiles vends no extra files for a non-vendored-node profile', () => {
+  const withoutProfile = resolveImportFiles(REPO_ROOT);
+  const packageManagerProfile = resolveImportFiles(
+    REPO_ROOT,
+    'package-manager',
+  );
+  const coreTargets = resolveCoreTemplateFiles(REPO_ROOT).map(
+    (f) => f.targetPath,
+  );
+  assert.deepEqual(
+    withoutProfile.map((f) => f.targetPath),
+    coreTargets,
+  );
+  assert.deepEqual(
+    packageManagerProfile.map((f) => f.targetPath),
+    coreTargets,
+  );
+});
+
+test('resolveImportFiles includes the helper bundle only for the vendored-node profile', () => {
+  const files = resolveImportFiles(REPO_ROOT, 'vendored-node');
+  const coreTargets = new Set(
+    resolveCoreTemplateFiles(REPO_ROOT).map((f) => f.targetPath),
+  );
+  const helperTargets = new Set(
+    collectVendoredFiles(REPO_ROOT).map((f) => f.targetPath),
+  );
+  const resultTargets = new Set(files.map((f) => f.targetPath));
+  assert.equal(resultTargets.size, coreTargets.size + helperTargets.size);
+  for (const target of coreTargets) {
+    assert.ok(resultTargets.has(target), `missing core file: ${target}`);
+  }
+  for (const target of helperTargets) {
+    assert.ok(resultTargets.has(target), `missing helper file: ${target}`);
+  }
+});
+
+test('resolveImportFiles rejects an unknown --profile value', () => {
+  assert.throws(
+    () => resolveImportFiles(REPO_ROOT, 'bogus-profile'),
+    /unknown --profile/u,
+  );
+});
+
+/** A minimal idd-skill-shaped source tree: just enough for resolveImportFiles. */
+function makeImportSourceFixture(files: Record<string, string>): string {
+  const root = makeFixtureDir();
+  const paths = Object.keys(files).map((rel) => `idd-template/${rel}`);
+  mkdirSync(join(root, 'audit'), { recursive: true });
+  writeFileSync(
+    join(root, 'audit', 'sync-manifest.json'),
+    JSON.stringify(
+      {
+        generatedBlocks: [
+          {
+            id: 'idd-template-core-files',
+            file: 'idd-template/ONBOARDING.md',
+            stripPrefix: 'idd-template/',
+            paths,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  for (const [rel, content] of Object.entries(files)) {
+    const absolute = join(root, 'idd-template', rel);
+    mkdirSync(dirname(absolute), { recursive: true });
+    writeFileSync(absolute, content);
+  }
+  return root;
+}
+
+test('buildImportPlan classifies new, unchanged, and blocked-overwrite target files', () => {
+  const sourceRoot = makeImportSourceFixture({
+    'a.md': 'alpha\n',
+    'b.md': 'bravo\n',
+    'c.md': 'charlie\n',
+  });
+  const targetRoot = makeFixtureDir();
+  writeFileSync(join(targetRoot, 'a.md'), 'alpha\n'); // byte-identical
+  writeFileSync(join(targetRoot, 'b.md'), 'DIFFERENT\n'); // differs
+  // c.md is absent from the target -> new
+
+  const plan = buildImportPlan(sourceRoot, targetRoot);
+  const byTarget = new Map(plan.entries.map((e) => [e.targetPath, e]));
+  assert.equal(byTarget.get('a.md')?.classification, 'unchanged');
+  assert.equal(byTarget.get('b.md')?.classification, 'overwrite');
+  assert.equal(byTarget.get('c.md')?.classification, 'new');
+  assert.deepEqual(plan.blockedOverwrites, ['b.md']);
+  assert.deepEqual(plan.missingSource, []);
+});
+
+test('buildImportPlan reports missing declared source files and plans nothing for them', () => {
+  const sourceRoot = makeImportSourceFixture({ 'a.md': 'alpha\n' });
+  // Simulate a stale/shallow --source checkout missing a declared file.
+  rmSync(join(sourceRoot, 'idd-template', 'a.md'));
+  const plan = buildImportPlan(sourceRoot, makeFixtureDir());
+  assert.deepEqual(plan.missingSource, ['idd-template/a.md']);
+  assert.equal(plan.entries.length, 0);
+});
+
+test('applyImportPlan copies new nested files byte-identically and preserves the source mode bit', () => {
+  const sourceRoot = makeImportSourceFixture({
+    'hooks/pre-commit': '#!/bin/sh\necho hook\n',
+  });
+  chmodSync(join(sourceRoot, 'idd-template', 'hooks', 'pre-commit'), 0o755);
+  const targetRoot = makeFixtureDir();
+  const plan = buildImportPlan(sourceRoot, targetRoot);
+  assert.equal(plan.entries[0]?.classification, 'new');
+  const filesChanged = applyImportPlan(sourceRoot, targetRoot, plan);
+  assert.equal(filesChanged, 1);
+  const targetHook = join(targetRoot, 'hooks', 'pre-commit');
+  assert.equal(readFileSync(targetHook, 'utf8'), '#!/bin/sh\necho hook\n');
+  assert.equal(statSync(targetHook).mode & 0o777, 0o755);
+});
+
+test('applyImportPlan skips unchanged files without rewriting them', () => {
+  const sourceRoot = makeImportSourceFixture({ 'a.md': 'same\n' });
+  const targetRoot = makeFixtureDir();
+  writeFileSync(join(targetRoot, 'a.md'), 'same\n');
+  const plan = buildImportPlan(sourceRoot, targetRoot);
+  assert.equal(plan.entries[0]?.classification, 'unchanged');
+  assert.equal(applyImportPlan(sourceRoot, targetRoot, plan), 0);
+});
+
+test('applyImportPlan only overwrites a differing target when the plan was built with force', () => {
+  const sourceRoot = makeImportSourceFixture({ 'a.md': 'new content\n' });
+  const targetRoot = makeFixtureDir();
+  writeFileSync(join(targetRoot, 'a.md'), 'old content\n');
+
+  const forcedPlan = buildImportPlan(sourceRoot, targetRoot, { force: true });
+  assert.deepEqual(forcedPlan.blockedOverwrites, []);
+  assert.equal(forcedPlan.entries[0]?.classification, 'overwrite');
+  assert.equal(applyImportPlan(sourceRoot, targetRoot, forcedPlan), 1);
+  assert.equal(readFileSync(join(targetRoot, 'a.md'), 'utf8'), 'new content\n');
+});
+
+test('a real idd-skill source tree imports the full core file set byte-identically into an empty target', () => {
+  const targetRoot = makeFixtureDir();
+  const plan = buildImportPlan(REPO_ROOT, targetRoot);
+  assert.deepEqual(plan.missingSource, []);
+  assert.deepEqual(plan.blockedOverwrites, []);
+  assert.ok(plan.entries.length > 0);
+  assert.ok(plan.entries.every((entry) => entry.classification === 'new'));
+
+  const filesChanged = applyImportPlan(REPO_ROOT, targetRoot, plan);
+  assert.equal(filesChanged, plan.entries.length);
+  for (const entry of plan.entries) {
+    const sourceBytes = readFileSync(join(REPO_ROOT, entry.sourcePath));
+    const targetBytes = readFileSync(join(targetRoot, entry.targetPath));
+    assert.ok(
+      sourceBytes.equals(targetBytes),
+      `byte mismatch: ${entry.targetPath}`,
+    );
+  }
+  // The pre-commit hook's executable bit must survive the copy.
+  const hookMode = statSync(join(targetRoot, '.githooks', 'pre-commit')).mode;
+  assert.equal(hookMode & 0o111, 0o111);
+});
+
+// ---------------------------------------------------------------------------
 // CLI (acceptance criteria) through the committed bin artifact
 // ---------------------------------------------------------------------------
 
@@ -730,6 +939,129 @@ test('bin/idd-onboard.mjs exits 2 on usage errors, distinct from residue', () =>
     const failed = error as { status?: number; stderr?: string };
     assert.equal(failed.status, 2);
     assert.match(String(failed.stderr), /unknown argument/);
+  }
+});
+
+test('bin/idd-onboard.mjs --import --dry-run prints the plan and writes nothing', () => {
+  const targetRoot = makeFixtureDir();
+  const before = snapshotTree(targetRoot);
+  const { status, verdict } = runCliBin([
+    '--import',
+    '--dry-run',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.mode, 'dry-run');
+  assert.equal(verdict.written, false);
+  assert.ok(Array.isArray(verdict.plan) && verdict.plan.length > 0);
+  assert.deepEqual(verdict.missingSource, []);
+  assert.deepEqual(verdict.blockedOverwrites, []);
+  assertTreeUnchanged(targetRoot, before);
+});
+
+test('bin/idd-onboard.mjs --import without --dry-run copies exactly the planned set', () => {
+  const targetRoot = makeFixtureDir();
+  const { status, verdict } = runCliBin([
+    '--import',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.mode, 'apply');
+  assert.equal(verdict.written, true);
+  const plan = verdict.plan as { targetPath: string }[];
+  assert.equal(verdict.filesChanged, plan.length);
+  for (const entry of plan) {
+    assert.ok(
+      existsSync(join(targetRoot, entry.targetPath)),
+      `not copied: ${entry.targetPath}`,
+    );
+  }
+});
+
+test('bin/idd-onboard.mjs --import blocks on a differing existing target file without --force', () => {
+  const targetRoot = makeFixtureDir();
+  mkdirSync(join(targetRoot, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(targetRoot, '.github', 'idd', 'config.json'),
+    '{"stale": true}\n',
+  );
+  const before = snapshotTree(targetRoot);
+  const { status, verdict } = runCliBin([
+    '--import',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.written, false);
+  assert.ok(
+    (verdict.blockedOverwrites as string[]).includes('.github/idd/config.json'),
+  );
+  assertTreeUnchanged(targetRoot, before);
+});
+
+test('bin/idd-onboard.mjs --import --force overwrites a differing existing target file', () => {
+  const targetRoot = makeFixtureDir();
+  mkdirSync(join(targetRoot, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(targetRoot, '.github', 'idd', 'config.json'),
+    '{"stale": true}\n',
+  );
+  const { status, verdict } = runCliBin([
+    '--import',
+    '--force',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.written, true);
+  assert.equal(
+    readFileSync(join(targetRoot, '.github', 'idd', 'config.json'), 'utf8'),
+    readFileSync(
+      join(REPO_ROOT, 'idd-template', '.github', 'idd', 'config.json'),
+      'utf8',
+    ),
+  );
+});
+
+test('bin/idd-onboard.mjs --import exits 2 when --source is missing', () => {
+  const targetRoot = makeFixtureDir();
+  try {
+    execFileSync(
+      process.execPath,
+      [BIN_PATH, '--import', '--target', targetRoot],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    assert.fail('expected a non-zero exit');
+  } catch (error) {
+    const failed = error as { status?: number; stderr?: string };
+    assert.equal(failed.status, 2);
+    assert.match(String(failed.stderr), /--source/);
+  }
+});
+
+test('bin/idd-onboard.mjs exits 2 when both --substitute and --import are passed', () => {
+  const targetRoot = makeFixtureDir();
+  try {
+    execFileSync(
+      process.execPath,
+      [BIN_PATH, '--substitute', '--import', '--target', targetRoot],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    assert.fail('expected a non-zero exit');
+  } catch (error) {
+    const failed = error as { status?: number; stderr?: string };
+    assert.equal(failed.status, 2);
+    assert.match(String(failed.stderr), /mutually exclusive/);
   }
 });
 

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import {
   chmodSync,
+  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -663,24 +664,27 @@ test('resolveImportFiles vends no extra files for a non-vendored-node profile', 
     (f) => f.targetPath,
   );
   assert.deepEqual(
-    withoutProfile.map((f) => f.targetPath),
+    withoutProfile.files.map((f) => f.targetPath),
     coreTargets,
   );
+  assert.deepEqual(withoutProfile.missingSource, []);
   assert.deepEqual(
-    packageManagerProfile.map((f) => f.targetPath),
+    packageManagerProfile.files.map((f) => f.targetPath),
     coreTargets,
   );
+  assert.deepEqual(packageManagerProfile.missingSource, []);
 });
 
 test('resolveImportFiles includes the helper bundle only for the vendored-node profile', () => {
-  const files = resolveImportFiles(REPO_ROOT, 'vendored-node');
+  const resolved = resolveImportFiles(REPO_ROOT, 'vendored-node');
+  assert.deepEqual(resolved.missingSource, []);
   const coreTargets = new Set(
     resolveCoreTemplateFiles(REPO_ROOT).map((f) => f.targetPath),
   );
   const helperTargets = new Set(
     collectVendoredFiles(REPO_ROOT).map((f) => f.targetPath),
   );
-  const resultTargets = new Set(files.map((f) => f.targetPath));
+  const resultTargets = new Set(resolved.files.map((f) => f.targetPath));
   assert.equal(resultTargets.size, coreTargets.size + helperTargets.size);
   for (const target of coreTargets) {
     assert.ok(resultTargets.has(target), `missing core file: ${target}`);
@@ -695,6 +699,65 @@ test('resolveImportFiles rejects an unknown --profile value', () => {
     () => resolveImportFiles(REPO_ROOT, 'bogus-profile'),
     /unknown --profile/u,
   );
+});
+
+/**
+ * A real idd-skill tree copy with one vendored helper entry deleted, so
+ * collectVendoredFiles's import-graph walk hits that missing file.
+ * Excludes node_modules and other heavy/irrelevant directories to keep
+ * the copy cheap.
+ */
+function makeIncompleteVendoredSourceFixture(
+  missingRelativePath: string,
+): string {
+  const root = makeFixtureDir();
+  for (const dir of [
+    'idd-template',
+    'audit',
+    'scripts',
+    'schemas',
+    'fixtures',
+  ]) {
+    const source = join(REPO_ROOT, dir);
+    if (existsSync(source)) {
+      cpSync(source, join(root, dir), { recursive: true });
+    }
+  }
+  rmSync(join(root, missingRelativePath), { force: true });
+  return root;
+}
+
+test('resolveImportFiles reports a missing vendored helper file via missingSource instead of crashing', () => {
+  const sourceRoot = makeIncompleteVendoredSourceFixture(
+    'scripts/branch-name.mjs',
+  );
+  const resolved = resolveImportFiles(sourceRoot, 'vendored-node');
+  assert.deepEqual(resolved.missingSource, ['scripts/branch-name.mjs']);
+  // The core file set still resolves even though the vendored bundle
+  // walk was interrupted by the missing helper file.
+  assert.ok(resolved.files.length > 0);
+  assert.ok(
+    resolved.files.every(
+      (file) => file.targetPath !== 'scripts/branch-name.mjs',
+    ),
+  );
+});
+
+test('buildImportPlan blocks a non-directory ancestor collision, not just a leaf collision', () => {
+  const sourceRoot = makeImportSourceFixture({ 'nested/a.md': 'alpha\n' });
+  const targetRoot = makeFixtureDir();
+  // A plain file occupies "nested", the ancestor directory the manifest
+  // path "nested/a.md" needs to be created under.
+  writeFileSync(join(targetRoot, 'nested'), 'not a directory\n');
+
+  const plan = buildImportPlan(sourceRoot, targetRoot);
+  assert.equal(plan.entries[0]?.classification, 'blocked-non-file');
+  assert.deepEqual(plan.nonFileTargetCollisions, ['nested/a.md']);
+
+  // applyImportPlan must never attempt the impossible mkdirSync/copy, even
+  // if a caller applied the plan without checking the blocking arrays.
+  assert.equal(applyImportPlan(sourceRoot, targetRoot, plan), 0);
+  assert.ok(statSync(join(targetRoot, 'nested')).isFile());
 });
 
 /** A minimal idd-skill-shaped source tree: just enough for resolveImportFiles. */

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -654,6 +654,40 @@ test('resolveCoreTemplateFiles rejects a source tree without a readable manifest
   );
 });
 
+/** Write a minimal sync-manifest.json declaring exactly the given paths. */
+function writeCoreFilesManifest(
+  root: string,
+  paths: string[],
+  stripPrefix = 'idd-template/',
+): void {
+  mkdirSync(join(root, 'audit'), { recursive: true });
+  writeFileSync(
+    join(root, 'audit', 'sync-manifest.json'),
+    JSON.stringify({
+      generatedBlocks: [
+        {
+          id: 'idd-template-core-files',
+          file: 'idd-template/ONBOARDING.md',
+          stripPrefix,
+          paths,
+        },
+      ],
+    }),
+  );
+}
+
+test('resolveCoreTemplateFiles rejects a manifest path that parent-traverses out of the source root', () => {
+  const root = makeFixtureDir();
+  writeCoreFilesManifest(root, ['idd-template/../../../etc/passwd']);
+  assert.throws(() => resolveCoreTemplateFiles(root), /unsafe manifest path/u);
+});
+
+test('resolveCoreTemplateFiles rejects an absolute manifest path', () => {
+  const root = makeFixtureDir();
+  writeCoreFilesManifest(root, ['/etc/passwd'], '');
+  assert.throws(() => resolveCoreTemplateFiles(root), /unsafe manifest path/u);
+});
+
 test('resolveImportFiles vends no extra files for a non-vendored-node profile', () => {
   const withoutProfile = resolveImportFiles(REPO_ROOT);
   const packageManagerProfile = resolveImportFiles(

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -756,6 +756,30 @@ test('buildImportPlan reports missing declared source files and plans nothing fo
   assert.equal(plan.entries.length, 0);
 });
 
+test('buildImportPlan blocks a non-file target collision even with --force, and applyImportPlan never attempts it', () => {
+  const sourceRoot = makeImportSourceFixture({ 'a.md': 'alpha\n' });
+  const targetRoot = makeFixtureDir();
+  // A directory already occupies the declared target path.
+  mkdirSync(join(targetRoot, 'a.md'), { recursive: true });
+
+  const plan = buildImportPlan(sourceRoot, targetRoot);
+  assert.equal(plan.entries[0]?.classification, 'blocked-non-file');
+  assert.deepEqual(plan.nonFileTargetCollisions, ['a.md']);
+  assert.deepEqual(plan.blockedOverwrites, []);
+
+  // --force overrides a differing *file*, but must not paper over a
+  // fundamental type collision it cannot copyFileSync onto.
+  const forcedPlan = buildImportPlan(sourceRoot, targetRoot, { force: true });
+  assert.equal(forcedPlan.entries[0]?.classification, 'blocked-non-file');
+  assert.deepEqual(forcedPlan.nonFileTargetCollisions, ['a.md']);
+
+  // Even if a caller applied the plan without gating on the blocking
+  // finding, applyImportPlan itself must never attempt the impossible
+  // copy (which would throw EISDIR/ENOTDIR).
+  assert.equal(applyImportPlan(sourceRoot, targetRoot, forcedPlan), 0);
+  assert.ok(statSync(join(targetRoot, 'a.md')).isDirectory());
+});
+
 test('applyImportPlan copies new nested files byte-identically and preserves the source mode bit', () => {
   const sourceRoot = makeImportSourceFixture({
     'hooks/pre-commit': '#!/bin/sh\necho hook\n',
@@ -1030,6 +1054,35 @@ test('bin/idd-onboard.mjs --import --force overwrites a differing existing targe
       join(REPO_ROOT, 'idd-template', '.github', 'idd', 'config.json'),
       'utf8',
     ),
+  );
+});
+
+test('bin/idd-onboard.mjs --import blocks a non-file target collision even with --force', () => {
+  const targetRoot = makeFixtureDir();
+  // A directory occupies a declared core-file target path.
+  mkdirSync(join(targetRoot, '.github', 'idd', 'config.json'), {
+    recursive: true,
+  });
+  const before = snapshotTree(targetRoot);
+  const { status, verdict } = runCliBin([
+    '--import',
+    '--force',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.written, false);
+  assert.ok(
+    (verdict.nonFileTargetCollisions as string[]).includes(
+      '.github/idd/config.json',
+    ),
+  );
+  assertTreeUnchanged(targetRoot, before);
+  // The directory itself must survive untouched (not replaced by a file).
+  assert.ok(
+    statSync(join(targetRoot, '.github', 'idd', 'config.json')).isDirectory(),
   );
 });
 

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -18,7 +18,10 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { collectVendoredFiles } from '../src/scripts/helper-runtime-manifest.mts';
+import {
+  collectVendoredFiles,
+  PROFILE_NAMES,
+} from '../src/scripts/helper-runtime-manifest.mts';
 // Importing the CLI module directly is only possible because its top-level
 // statements are guarded behind isCliExecution() (#1210 pattern); an
 // import-time CLI run would parse process.argv and abort this test process.
@@ -1322,6 +1325,15 @@ test('bin/idd-onboard.mjs exits 2 when both --substitute and --import are passed
     const failed = error as { status?: number; stderr?: string };
     assert.equal(failed.status, 2);
     assert.match(String(failed.stderr), /mutually exclusive/);
+  }
+});
+
+test('bin/idd-onboard.mjs --help lists --profile values sourced from PROFILE_NAMES, not a second hardcoded list', () => {
+  const help = execFileSync(process.execPath, [BIN_PATH, '--help'], {
+    encoding: 'utf8',
+  });
+  for (const profile of PROFILE_NAMES) {
+    assert.ok(help.includes(profile), `--help is missing profile: ${profile}`);
   }
 });
 


### PR DESCRIPTION
## Summary

Wave 2 of the onboarding automation CLI (roadmap #1262): adds an
`--import` mode to `src/scripts/idd-onboard.mts` that copies the
distributed core template file set from a local idd-skill source tree
into a target repository, manifest-driven so it can never drift from
the `idd-template/ONBOARDING.md` Step 2 file list.

- New `--import --source <idd-skill-tree> --target <dir>` mode,
  alongside wave 1's existing `--substitute` mode (mutually exclusive).
- The core file list is read at runtime from
  `audit/sync-manifest.json`'s `idd-template-core-files` generated
  block — the same canonical source `sync-docs.mjs` / `audit-docs.mjs`
  already render into `idd-template/ONBOARDING.md`'s file list — so
  there is never a second, independently hardcoded list. A new drift
  test asserts the two stay identical.
- `--profile vendored-node` additionally copies the profile-conditional
  helper bundle by reusing `helper-runtime-manifest.mts`'s
  `collectVendoredFiles` (now exported, along with its `PROFILE_NAMES`
  validation set); every other profile value vends no extra files.
- `--dry-run` prints the per-file plan (`new` / `unchanged` /
  `overwrite` classification) without writing. Fails closed like wave
  1: refuses to overwrite an existing target file whose content differs
  unless `--force`, and reports missing declared source files as
  blocking findings — apply mode writes nothing when any blocking
  finding exists.
- Preserves the source file's permission bits on copy (`chmodSync`
  after `copyFileSync`), so `.githooks/pre-commit` / `.githooks/pre-push`
  keep their executable bit through the import.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build` (regenerated `scripts/idd-onboard.mjs`,
      `scripts/helper-runtime-manifest.mjs`; committed)
- [x] `node --test tests/*.test.mts` (1726 pass, repo-wide)
- [x] `pnpm run lint:minimum` (audit-docs, typecheck, build:check,
      biome, dprint, tests, workshop integrity, cspell, markdownlint)
- [x] New drift test: `resolveCoreTemplateFiles(REPO_ROOT)` output
      matches `idd-template/ONBOARDING.md`'s rendered
      `idd-template-core-files` block line for line
- [x] Fixture-tree + real-tree coverage for `new` / `unchanged` /
      `overwrite` classification, missing-source blocking, `--force`
      overwrite, and byte-identical + executable-bit-preserving copy
      (both as unit tests against the `.mts` source and CLI tests
      against the committed `bin/idd-onboard.mjs` artifact)

Closes #1292

Refs #1262. Follow-up waves already tracked on the roadmap: #1293
(post-import verify mode) is blocked by this PR; #1294 (CLI onboarding
docs) is blocked by this PR and #1293.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new onboarding `--import` mode to copy manifest-driven core template files into a target project.
  * Introduced profile-based selection (including a vendored helper profile) with a `--dry-run` plan preview and updated help/flags (including stage exclusivity).
  * Added structured import verdict output and clearer exit codes for blocking findings.
* **Bug Fixes**
  * Strengthened safety checks for path validation, collision detection, and non-regular targets.
  * Preserved executable permissions when importing and improved overwrite/force behavior.
* **Tests**
  * Expanded Wave 2 coverage for import planning, execution semantics, and CLI acceptance cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->