### PR TITLE
feat(onboard): add --verify post-import check mode

### DIFF
--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -857,17 +857,31 @@ export function applyImportPlan(sourceRoot, targetRoot, plan) {
   return filesChanged;
 }
 /**
- * Check that every file the manifest declares for `profile` exists in the
- * target tree, reusing wave 2's own `resolveImportFiles` resolution (the
- * same source `--import` copies from) instead of a second hardcoded file
- * list.
+ * Check that every file the manifest declares for `profile` exists on both
+ * sides, reusing wave 2's own `resolveImportFiles` resolution (the same
+ * source `--import` copies from) instead of a second hardcoded file list.
+ *
+ * `resolveImportFiles`'s own `missingSource` only ever reports a
+ * vendored-node bundle resolution failure (see `resolveImportFiles`'s doc
+ * comment) — it does not check the core/profile file set's declared
+ * `sourcePath` entries against `sourceRoot`, unlike `buildImportPlan`, which
+ * performs that `fileExists(sourceRoot, file.sourcePath)` check itself. This
+ * check mirrors that same existence check here so a corrupt or incomplete
+ * `--source` tree is caught, not just a target that failed to receive a
+ * file `--import` did manage to copy from a complete source.
  */
 export function checkManifestCompleteness(sourceRoot, targetRoot, profile) {
   const resolved = resolveImportFiles(sourceRoot, profile);
+  const missingSource = [
+    ...resolved.missingSource,
+    ...resolved.files
+      .filter((file) => !fileExists(sourceRoot, file.sourcePath))
+      .map((file) => file.sourcePath),
+  ];
   const missingTarget = resolved.files
     .filter((file) => !fileExists(targetRoot, file.targetPath))
     .map((file) => file.targetPath);
-  return { missingSource: resolved.missingSource, missingTarget };
+  return { missingSource, missingTarget };
 }
 /**
  * Scan the target tree for leftover `{{...}}` tokens after onboarding.

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -6,7 +6,8 @@
 // generated .mjs. See docs/typescript-sources.md.
 //
 // Onboarding automation CLI — wave 1: placeholder substitution (#1263,
-// roadmap #1262). Wave 2 (#1292) adds the --import fetch/copy stage.
+// roadmap #1262). Wave 2 (#1292) adds the --import fetch/copy stage. Wave 3
+// (#1293) adds the --verify post-import check stage.
 //
 // --substitute: given a target tree that already contains the imported
 // template files, resolve the seven onboarding placeholders (auto-derived
@@ -26,6 +27,16 @@
 // list — so the CLI and the manual doc can never carry two independently
 // hardcoded file lists. A drift test in tests/idd-onboard.test.mts fails on
 // mismatch.
+//
+// --verify: mechanical pass/fail for a target tree after --import and
+// --substitute have run, replacing a manual walkthrough of
+// `idd-template/ONBOARDING.md` Step 6 with three check groups: manifest
+// completeness (reuses --import's own manifest resolution — no second file
+// list), placeholder residue (reuses --substitute's scanner — no second
+// scan), and a stale-import signal (re-runs idd-doctor's content-based
+// drift detector against the target's imported files instead of forking its
+// logic, the #1208 shared-module convention `check-pnpm-boundary.mts`
+// already uses).
 import { execFileSync } from 'node:child_process';
 import {
   chmodSync,
@@ -44,6 +55,7 @@ import {
   collectVendoredFiles,
   PROFILE_NAMES,
 } from './helper-runtime-manifest.mjs';
+import { findMissingWorktreeHardening } from './idd-doctor.mjs';
 
 function placeholder(name, kind, flag) {
   return { name, token: `{{${name}}}`, kind, flag };
@@ -844,6 +856,86 @@ export function applyImportPlan(sourceRoot, targetRoot, plan) {
   }
   return filesChanged;
 }
+/**
+ * Check that every file the manifest declares for `profile` exists in the
+ * target tree, reusing wave 2's own `resolveImportFiles` resolution (the
+ * same source `--import` copies from) instead of a second hardcoded file
+ * list.
+ */
+export function checkManifestCompleteness(sourceRoot, targetRoot, profile) {
+  const resolved = resolveImportFiles(sourceRoot, profile);
+  const missingTarget = resolved.files
+    .filter((file) => !fileExists(targetRoot, file.targetPath))
+    .map((file) => file.targetPath);
+  return { missingSource: resolved.missingSource, missingTarget };
+}
+/**
+ * Scan the target tree for leftover `{{...}}` tokens after onboarding.
+ * Reuses wave 1's `scanPlaceholderTokens` / `buildSubstitutionPlan` scanner
+ * rather than a new scan: verify mode has no resolved substitution values to
+ * consult (an empty resolution), so `buildSubstitutionPlan` puts every
+ * occurrence of one of the seven onboarding placeholder tokens into
+ * `residue` — the correct outcome here, since a converged onboarding run
+ * should have already replaced them. Other `{{...}}`-shaped tokens land in
+ * `unknownTokens`, informational just as they are for `--substitute`.
+ */
+export function checkPlaceholderResidue(targetRoot) {
+  const plan = buildSubstitutionPlan(scanPlaceholderTokens(targetRoot), {
+    values: {},
+    unresolved: [],
+  });
+  return { residue: plan.residue, unknownTokens: plan.unknownTokens };
+}
+/**
+ * Re-run idd-doctor's content-based stale-import detector
+ * (`findMissingWorktreeHardening`) against the target tree's imported
+ * files, instead of forking its logic — the same #1208 shared-module
+ * convention `check-pnpm-boundary.mts` already uses for
+ * `parseProjectCommandRows`. Matches `checkWorktreeHardeningPresence`'s own
+ * severity in idd-doctor: these are warning-level drift signals, not
+ * blocking findings, so a target that is merely behind on the latest
+ * hardening guidance does not fail verify on its own.
+ */
+export function checkStaleImportSignal(targetRoot) {
+  const missing = findMissingWorktreeHardening({
+    work: readTextIfPresent(
+      targetRoot,
+      '.github/instructions/idd-work.instructions.md',
+    ),
+    core: readTextIfPresent(
+      targetRoot,
+      '.github/instructions/idd-overview-core.instructions.md',
+    ),
+    doctor: readTextIfPresent(targetRoot, 'scripts/idd-doctor.mjs'),
+  });
+  return { missing };
+}
+/**
+ * Run all three wave-3 check groups against one target tree. The
+ * stale-import signal never contributes to `blocking` (see
+ * `checkStaleImportSignal`'s doc comment); only a manifest gap or
+ * placeholder residue can fail verify, matching the exit contract in
+ * `runVerifyCli`.
+ */
+export function runVerify(sourceRoot, targetRoot, profile) {
+  const manifestCompleteness = checkManifestCompleteness(
+    sourceRoot,
+    targetRoot,
+    profile,
+  );
+  const placeholderResidue = checkPlaceholderResidue(targetRoot);
+  const staleImportSignal = checkStaleImportSignal(targetRoot);
+  const blocking =
+    manifestCompleteness.missingSource.length > 0 ||
+    manifestCompleteness.missingTarget.length > 0 ||
+    placeholderResidue.residue.length > 0;
+  return {
+    manifestCompleteness,
+    placeholderResidue,
+    staleImportSignal,
+    blocking,
+  };
+}
 if (isCliExecution(import.meta.url)) {
   try {
     runCli();
@@ -860,6 +952,7 @@ function parseArgs(argv) {
   const parsed = {
     substitute: false,
     importMode: false,
+    verify: false,
     source: undefined,
     target: '.',
     dryRun: false,
@@ -886,6 +979,10 @@ function parseArgs(argv) {
     }
     if (token === '--import') {
       parsed.importMode = true;
+      continue;
+    }
+    if (token === '--verify') {
+      parsed.verify = true;
       continue;
     }
     if (token === '--source') {
@@ -945,14 +1042,35 @@ function substituteOnlyFlagsPresent(args) {
     (entry) => args.overrides[entry.name] !== undefined,
   ).map((entry) => entry.flag);
 }
+/**
+ * Flags --verify does not accept: every substitute-only override flag (verify
+ * never substitutes), plus `--force` and `--dry-run` (verify never writes, so
+ * "allow overwriting" and "print the plan without writing" are both
+ * meaningless for it).
+ */
+function verifyForeignFlagsPresent(args) {
+  const present = substituteOnlyFlagsPresent(args);
+  if (args.force) {
+    present.push('--force');
+  }
+  if (args.dryRun) {
+    present.push('--dry-run');
+  }
+  return present;
+}
 function runCli() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
     printHelp();
     process.exit(0);
   }
-  if (args.substitute && args.importMode) {
-    throw new Error('--substitute and --import are mutually exclusive');
+  const modeCount = [args.substitute, args.importMode, args.verify].filter(
+    Boolean,
+  ).length;
+  if (modeCount > 1) {
+    throw new Error(
+      '--substitute, --import, and --verify are mutually exclusive',
+    );
   }
   if (args.importMode) {
     // parseArgs collects every known flag regardless of the active stage,
@@ -967,8 +1085,20 @@ function runCli() {
     runImportCli(args);
     return;
   }
+  if (args.verify) {
+    const foreign = verifyForeignFlagsPresent(args);
+    if (foreign.length > 0) {
+      throw new Error(
+        `--verify does not accept flag(s) it never uses: ${foreign.join(', ')}`,
+      );
+    }
+    runVerifyCli(args);
+    return;
+  }
   if (!args.substitute) {
-    throw new Error('pass --substitute or --import to select a stage');
+    throw new Error(
+      'pass --substitute, --import, or --verify to select a stage',
+    );
   }
   const foreign = importOnlyFlagsPresent(args);
   if (foreign.length > 0) {
@@ -1053,6 +1183,37 @@ function runImportCli(args) {
   // on the exit code without needing a separate --dry-run probe first.
   process.exit(blocking ? 1 : 0);
 }
+function runVerifyCli(args) {
+  if (!args.source) {
+    throw new Error('--verify requires --source <idd-skill-tree>');
+  }
+  const sourceDir = resolve(args.source);
+  if (!statSync(sourceDir).isDirectory()) {
+    throw new Error(`--source is not a directory: ${args.source}`);
+  }
+  const targetDir = resolve(args.target);
+  if (!statSync(targetDir).isDirectory()) {
+    throw new Error(`--target is not a directory: ${args.target}`);
+  }
+  const result = runVerify(sourceDir, targetDir, args.profile);
+  const verdict = {
+    protocolVersion: '1',
+    mode: 'verify',
+    source: sourceDir,
+    target: targetDir,
+    profile: args.profile ?? null,
+    manifestCompleteness: result.manifestCompleteness,
+    placeholderResidue: result.placeholderResidue,
+    staleImportSignal: result.staleImportSignal,
+    blocking: result.blocking,
+  };
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  // Blocking findings (manifest gap or placeholder residue) signal via exit
+  // 1, matching --substitute / --import's contract; the stale-import signal
+  // is informational only and never flips this exit code (see
+  // checkStaleImportSignal / runVerify).
+  process.exit(result.blocking ? 1 : 0);
+}
 function printHelp() {
   const flags = ONBOARDING_PLACEHOLDERS.map(
     (entry) =>
@@ -1060,6 +1221,7 @@ function printHelp() {
   ).join('\n');
   process.stdout.write(`usage: node scripts/idd-onboard.mjs --substitute [options]
        node scripts/idd-onboard.mjs --import --source <dir> --target <dir> [options]
+       node scripts/idd-onboard.mjs --verify --source <dir> --target <dir> [options]
 
 Onboarding automation.
 
@@ -1107,5 +1269,25 @@ nothing in that case); 2 usage or configuration error.
   --force                           allow overwriting a differing target file
   --dry-run                         print the plan without writing anything
   --help, -h                        show this help
+
+--verify (wave 3): mechanical pass/fail for a target tree after --import and
+--substitute have run, in place of a manual walkthrough of
+idd-template/ONBOARDING.md Step 6. Reports three check groups:
+manifestCompleteness (every file --import would copy for --source /
+--profile exists under --target, reusing that same manifest resolution —
+missing files are blocking), placeholderResidue (leftover {{...}} tokens via
+--substitute's own scanner — a remaining onboarding placeholder is blocking
+residue, any other {{...}}-shaped token stays informational), and
+staleImportSignal (idd-doctor's content-based stale-import detector re-run
+against the target's imported files — informational only, never blocking).
+
+Exit codes: 0 no blocking finding; 1 a blocking finding exists (manifest gap
+or placeholder residue); 2 usage or configuration error.
+
+  --verify                           run the verify stage
+  --source <dir>                     local idd-skill source tree the target was imported from
+  --target <dir>                     target repository to verify (default: current directory)
+  --profile <name>                   ${PROFILE_NAMES.join(' | ')}
+  --help, -h                         show this help
 `);
 }

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -1116,10 +1116,18 @@ export interface ManifestCompletenessResult {
 }
 
 /**
- * Check that every file the manifest declares for `profile` exists in the
- * target tree, reusing wave 2's own `resolveImportFiles` resolution (the
- * same source `--import` copies from) instead of a second hardcoded file
- * list.
+ * Check that every file the manifest declares for `profile` exists on both
+ * sides, reusing wave 2's own `resolveImportFiles` resolution (the same
+ * source `--import` copies from) instead of a second hardcoded file list.
+ *
+ * `resolveImportFiles`'s own `missingSource` only ever reports a
+ * vendored-node bundle resolution failure (see `resolveImportFiles`'s doc
+ * comment) — it does not check the core/profile file set's declared
+ * `sourcePath` entries against `sourceRoot`, unlike `buildImportPlan`, which
+ * performs that `fileExists(sourceRoot, file.sourcePath)` check itself. This
+ * check mirrors that same existence check here so a corrupt or incomplete
+ * `--source` tree is caught, not just a target that failed to receive a
+ * file `--import` did manage to copy from a complete source.
  */
 export function checkManifestCompleteness(
   sourceRoot: string,
@@ -1127,10 +1135,16 @@ export function checkManifestCompleteness(
   profile?: string,
 ): ManifestCompletenessResult {
   const resolved = resolveImportFiles(sourceRoot, profile);
+  const missingSource = [
+    ...resolved.missingSource,
+    ...resolved.files
+      .filter((file) => !fileExists(sourceRoot, file.sourcePath))
+      .map((file) => file.sourcePath),
+  ];
   const missingTarget = resolved.files
     .filter((file) => !fileExists(targetRoot, file.targetPath))
     .map((file) => file.targetPath);
-  return { missingSource: resolved.missingSource, missingTarget };
+  return { missingSource, missingTarget };
 }
 
 /** Placeholder-residue result: blocking residue plus informational tokens. */

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -6,7 +6,8 @@
 // generated .mjs. See docs/typescript-sources.md.
 //
 // Onboarding automation CLI — wave 1: placeholder substitution (#1263,
-// roadmap #1262). Wave 2 (#1292) adds the --import fetch/copy stage.
+// roadmap #1262). Wave 2 (#1292) adds the --import fetch/copy stage. Wave 3
+// (#1293) adds the --verify post-import check stage.
 //
 // --substitute: given a target tree that already contains the imported
 // template files, resolve the seven onboarding placeholders (auto-derived
@@ -26,6 +27,16 @@
 // list — so the CLI and the manual doc can never carry two independently
 // hardcoded file lists. A drift test in tests/idd-onboard.test.mts fails on
 // mismatch.
+//
+// --verify: mechanical pass/fail for a target tree after --import and
+// --substitute have run, replacing a manual walkthrough of
+// `idd-template/ONBOARDING.md` Step 6 with three check groups: manifest
+// completeness (reuses --import's own manifest resolution — no second file
+// list), placeholder residue (reuses --substitute's scanner — no second
+// scan), and a stale-import signal (re-runs idd-doctor's content-based
+// drift detector against the target's imported files instead of forking its
+// logic, the #1208 shared-module convention `check-pnpm-boundary.mts`
+// already uses).
 
 import { execFileSync } from 'node:child_process';
 import {
@@ -46,6 +57,7 @@ import {
   collectVendoredFiles,
   PROFILE_NAMES,
 } from './helper-runtime-manifest.mts';
+import { findMissingWorktreeHardening } from './idd-doctor.mts';
 
 /** Substitution role of a placeholder: only `command` rows may be `true`. */
 export type OnboardingPlaceholderKind = 'identity' | 'command';
@@ -1083,6 +1095,142 @@ export function applyImportPlan(
   return filesChanged;
 }
 
+// ---------------------------------------------------------------------------
+// Wave 3: --verify (post-import verification, reusing doctor drift checks)
+// ---------------------------------------------------------------------------
+
+/** Manifest-completeness result: declared files missing from either side. */
+export interface ManifestCompletenessResult {
+  /**
+   * Declared source paths missing under `--source` — a corrupt or
+   * incomplete idd-skill source tree, not a target-side gap. Mirrors
+   * `ImportPlan.missingSource`.
+   */
+  missingSource: string[];
+  /**
+   * Manifest target paths declared for `--source` / `--profile` that are
+   * absent under `--target` — the post-import completeness gap this check
+   * exists to catch.
+   */
+  missingTarget: string[];
+}
+
+/**
+ * Check that every file the manifest declares for `profile` exists in the
+ * target tree, reusing wave 2's own `resolveImportFiles` resolution (the
+ * same source `--import` copies from) instead of a second hardcoded file
+ * list.
+ */
+export function checkManifestCompleteness(
+  sourceRoot: string,
+  targetRoot: string,
+  profile?: string,
+): ManifestCompletenessResult {
+  const resolved = resolveImportFiles(sourceRoot, profile);
+  const missingTarget = resolved.files
+    .filter((file) => !fileExists(targetRoot, file.targetPath))
+    .map((file) => file.targetPath);
+  return { missingSource: resolved.missingSource, missingTarget };
+}
+
+/** Placeholder-residue result: blocking residue plus informational tokens. */
+export interface PlaceholderResidueResult {
+  residue: SubstitutionResidueEntry[];
+  unknownTokens: UnknownTokenEntry[];
+}
+
+/**
+ * Scan the target tree for leftover `{{...}}` tokens after onboarding.
+ * Reuses wave 1's `scanPlaceholderTokens` / `buildSubstitutionPlan` scanner
+ * rather than a new scan: verify mode has no resolved substitution values to
+ * consult (an empty resolution), so `buildSubstitutionPlan` puts every
+ * occurrence of one of the seven onboarding placeholder tokens into
+ * `residue` — the correct outcome here, since a converged onboarding run
+ * should have already replaced them. Other `{{...}}`-shaped tokens land in
+ * `unknownTokens`, informational just as they are for `--substitute`.
+ */
+export function checkPlaceholderResidue(
+  targetRoot: string,
+): PlaceholderResidueResult {
+  const plan = buildSubstitutionPlan(scanPlaceholderTokens(targetRoot), {
+    values: {},
+    unresolved: [],
+  });
+  return { residue: plan.residue, unknownTokens: plan.unknownTokens };
+}
+
+/** Stale-import-signal result: informational drift findings, never blocking. */
+export interface StaleImportSignalResult {
+  missing: string[];
+}
+
+/**
+ * Re-run idd-doctor's content-based stale-import detector
+ * (`findMissingWorktreeHardening`) against the target tree's imported
+ * files, instead of forking its logic — the same #1208 shared-module
+ * convention `check-pnpm-boundary.mts` already uses for
+ * `parseProjectCommandRows`. Matches `checkWorktreeHardeningPresence`'s own
+ * severity in idd-doctor: these are warning-level drift signals, not
+ * blocking findings, so a target that is merely behind on the latest
+ * hardening guidance does not fail verify on its own.
+ */
+export function checkStaleImportSignal(
+  targetRoot: string,
+): StaleImportSignalResult {
+  const missing = findMissingWorktreeHardening({
+    work: readTextIfPresent(
+      targetRoot,
+      '.github/instructions/idd-work.instructions.md',
+    ),
+    core: readTextIfPresent(
+      targetRoot,
+      '.github/instructions/idd-overview-core.instructions.md',
+    ),
+    doctor: readTextIfPresent(targetRoot, 'scripts/idd-doctor.mjs'),
+  });
+  return { missing };
+}
+
+/** The combined wave-3 verify verdict for one target tree. */
+export interface VerifyResult {
+  manifestCompleteness: ManifestCompletenessResult;
+  placeholderResidue: PlaceholderResidueResult;
+  staleImportSignal: StaleImportSignalResult;
+  /** True when a blocking finding exists (manifest gap or placeholder residue). */
+  blocking: boolean;
+}
+
+/**
+ * Run all three wave-3 check groups against one target tree. The
+ * stale-import signal never contributes to `blocking` (see
+ * `checkStaleImportSignal`'s doc comment); only a manifest gap or
+ * placeholder residue can fail verify, matching the exit contract in
+ * `runVerifyCli`.
+ */
+export function runVerify(
+  sourceRoot: string,
+  targetRoot: string,
+  profile?: string,
+): VerifyResult {
+  const manifestCompleteness = checkManifestCompleteness(
+    sourceRoot,
+    targetRoot,
+    profile,
+  );
+  const placeholderResidue = checkPlaceholderResidue(targetRoot);
+  const staleImportSignal = checkStaleImportSignal(targetRoot);
+  const blocking =
+    manifestCompleteness.missingSource.length > 0 ||
+    manifestCompleteness.missingTarget.length > 0 ||
+    placeholderResidue.residue.length > 0;
+  return {
+    manifestCompleteness,
+    placeholderResidue,
+    staleImportSignal,
+    blocking,
+  };
+}
+
 if (isCliExecution(import.meta.url)) {
   try {
     runCli();
@@ -1099,6 +1247,7 @@ if (isCliExecution(import.meta.url)) {
 interface ParsedArgs {
   substitute: boolean;
   importMode: boolean;
+  verify: boolean;
   source: string | undefined;
   target: string;
   dryRun: boolean;
@@ -1112,6 +1261,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = {
     substitute: false,
     importMode: false,
+    verify: false,
     source: undefined,
     target: '.',
     dryRun: false,
@@ -1138,6 +1288,10 @@ function parseArgs(argv: string[]): ParsedArgs {
     }
     if (token === '--import') {
       parsed.importMode = true;
+      continue;
+    }
+    if (token === '--verify') {
+      parsed.verify = true;
       continue;
     }
     if (token === '--source') {
@@ -1200,14 +1354,36 @@ function substituteOnlyFlagsPresent(args: ParsedArgs): string[] {
   ).map((entry) => entry.flag);
 }
 
+/**
+ * Flags --verify does not accept: every substitute-only override flag (verify
+ * never substitutes), plus `--force` and `--dry-run` (verify never writes, so
+ * "allow overwriting" and "print the plan without writing" are both
+ * meaningless for it).
+ */
+function verifyForeignFlagsPresent(args: ParsedArgs): string[] {
+  const present = substituteOnlyFlagsPresent(args);
+  if (args.force) {
+    present.push('--force');
+  }
+  if (args.dryRun) {
+    present.push('--dry-run');
+  }
+  return present;
+}
+
 function runCli(): void {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
     printHelp();
     process.exit(0);
   }
-  if (args.substitute && args.importMode) {
-    throw new Error('--substitute and --import are mutually exclusive');
+  const modeCount = [args.substitute, args.importMode, args.verify].filter(
+    Boolean,
+  ).length;
+  if (modeCount > 1) {
+    throw new Error(
+      '--substitute, --import, and --verify are mutually exclusive',
+    );
   }
   if (args.importMode) {
     // parseArgs collects every known flag regardless of the active stage,
@@ -1222,8 +1398,20 @@ function runCli(): void {
     runImportCli(args);
     return;
   }
+  if (args.verify) {
+    const foreign = verifyForeignFlagsPresent(args);
+    if (foreign.length > 0) {
+      throw new Error(
+        `--verify does not accept flag(s) it never uses: ${foreign.join(', ')}`,
+      );
+    }
+    runVerifyCli(args);
+    return;
+  }
   if (!args.substitute) {
-    throw new Error('pass --substitute or --import to select a stage');
+    throw new Error(
+      'pass --substitute, --import, or --verify to select a stage',
+    );
   }
   const foreign = importOnlyFlagsPresent(args);
   if (foreign.length > 0) {
@@ -1310,6 +1498,38 @@ function runImportCli(args: ParsedArgs): void {
   process.exit(blocking ? 1 : 0);
 }
 
+function runVerifyCli(args: ParsedArgs): void {
+  if (!args.source) {
+    throw new Error('--verify requires --source <idd-skill-tree>');
+  }
+  const sourceDir = resolve(args.source);
+  if (!statSync(sourceDir).isDirectory()) {
+    throw new Error(`--source is not a directory: ${args.source}`);
+  }
+  const targetDir = resolve(args.target);
+  if (!statSync(targetDir).isDirectory()) {
+    throw new Error(`--target is not a directory: ${args.target}`);
+  }
+  const result = runVerify(sourceDir, targetDir, args.profile);
+  const verdict = {
+    protocolVersion: '1',
+    mode: 'verify',
+    source: sourceDir,
+    target: targetDir,
+    profile: args.profile ?? null,
+    manifestCompleteness: result.manifestCompleteness,
+    placeholderResidue: result.placeholderResidue,
+    staleImportSignal: result.staleImportSignal,
+    blocking: result.blocking,
+  };
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  // Blocking findings (manifest gap or placeholder residue) signal via exit
+  // 1, matching --substitute / --import's contract; the stale-import signal
+  // is informational only and never flips this exit code (see
+  // checkStaleImportSignal / runVerify).
+  process.exit(result.blocking ? 1 : 0);
+}
+
 function printHelp(): void {
   const flags = ONBOARDING_PLACEHOLDERS.map(
     (entry) =>
@@ -1317,6 +1537,7 @@ function printHelp(): void {
   ).join('\n');
   process.stdout.write(`usage: node scripts/idd-onboard.mjs --substitute [options]
        node scripts/idd-onboard.mjs --import --source <dir> --target <dir> [options]
+       node scripts/idd-onboard.mjs --verify --source <dir> --target <dir> [options]
 
 Onboarding automation.
 
@@ -1364,5 +1585,25 @@ nothing in that case); 2 usage or configuration error.
   --force                           allow overwriting a differing target file
   --dry-run                         print the plan without writing anything
   --help, -h                        show this help
+
+--verify (wave 3): mechanical pass/fail for a target tree after --import and
+--substitute have run, in place of a manual walkthrough of
+idd-template/ONBOARDING.md Step 6. Reports three check groups:
+manifestCompleteness (every file --import would copy for --source /
+--profile exists under --target, reusing that same manifest resolution —
+missing files are blocking), placeholderResidue (leftover {{...}} tokens via
+--substitute's own scanner — a remaining onboarding placeholder is blocking
+residue, any other {{...}}-shaped token stays informational), and
+staleImportSignal (idd-doctor's content-based stale-import detector re-run
+against the target's imported files — informational only, never blocking).
+
+Exit codes: 0 no blocking finding; 1 a blocking finding exists (manifest gap
+or placeholder residue); 2 usage or configuration error.
+
+  --verify                           run the verify stage
+  --source <dir>                     local idd-skill source tree the target was imported from
+  --target <dir>                     target repository to verify (default: current directory)
+  --profile <name>                   ${PROFILE_NAMES.join(' | ')}
+  --help, -h                         show this help
 `);
 }

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -30,6 +30,9 @@ import {
   applySubstitutionPlan,
   buildImportPlan,
   buildSubstitutionPlan,
+  checkManifestCompleteness,
+  checkPlaceholderResidue,
+  checkStaleImportSignal,
   deriveInstallDepsCommand,
   deriveMarkerPrefix,
   deriveValidateCommands,
@@ -40,6 +43,7 @@ import {
   resolveCoreTemplateFiles,
   resolveImportFiles,
   resolvePlaceholderValues,
+  runVerify,
   scanPlaceholderTokens,
 } from '../src/scripts/idd-onboard.mts';
 
@@ -1413,6 +1417,317 @@ test('bin/idd-onboard.mjs exits 2 when --substitute is combined with an import-o
     assert.match(String(failed.stderr), /import-only flag/);
     assert.match(String(failed.stderr), /--force/);
   }
+});
+
+// ---------------------------------------------------------------------------
+// Wave 3: --verify (post-import verification, reusing doctor drift checks)
+// ---------------------------------------------------------------------------
+
+/**
+ * Import the real core file set from REPO_ROOT into `targetRoot`, then
+ * substitute every placeholder with `ALL_OVERRIDES`, producing a target
+ * tree that should pass `--verify` cleanly (the same two-stage flow
+ * `idd-template/ONBOARDING.md` documents).
+ */
+function importAndSubstitute(targetRoot: string): void {
+  const importPlan = buildImportPlan(REPO_ROOT, targetRoot);
+  applyImportPlan(REPO_ROOT, targetRoot, importPlan);
+  const resolution = resolvePlaceholderValues(targetRoot, ALL_OVERRIDES);
+  const subPlan = buildSubstitutionPlan(
+    scanPlaceholderTokens(targetRoot),
+    resolution,
+  );
+  applySubstitutionPlan(targetRoot, subPlan);
+}
+
+test('checkManifestCompleteness reports no gap for a fully imported target', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  const result = checkManifestCompleteness(REPO_ROOT, targetRoot);
+  assert.deepEqual(result.missingSource, []);
+  assert.deepEqual(result.missingTarget, []);
+});
+
+test('checkManifestCompleteness reports a deleted manifest file as missingTarget', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  rmSync(
+    join(targetRoot, '.github', 'instructions', 'idd-work.instructions.md'),
+  );
+  const result = checkManifestCompleteness(REPO_ROOT, targetRoot);
+  assert.deepEqual(result.missingSource, []);
+  assert.ok(
+    result.missingTarget.includes(
+      '.github/instructions/idd-work.instructions.md',
+    ),
+  );
+});
+
+test('checkManifestCompleteness checks every file resolveImportFiles declares, not a forked subset', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  const resolved = resolveImportFiles(REPO_ROOT);
+  // Delete every declared file's target one at a time is too slow; instead
+  // assert the check surfaces a real declared file as missing (proving it
+  // is drawn from the same list resolveImportFiles produces, not a second,
+  // possibly incomplete, hardcoded one).
+  const sample = resolved.files[0];
+  assert.ok(sample, 'resolveImportFiles must declare at least one file');
+  rmSync(join(targetRoot, sample.targetPath));
+  const result = checkManifestCompleteness(REPO_ROOT, targetRoot);
+  assert.ok(result.missingTarget.includes(sample.targetPath));
+});
+
+test('checkPlaceholderResidue classifies a leftover onboarding placeholder as blocking residue', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  writeFileSync(
+    join(targetRoot, 'LEFTOVER.md'),
+    '{{REPO_NAME}} and {{SOME_ADOPTER_TOKEN}} remain\n',
+  );
+  const result = checkPlaceholderResidue(targetRoot);
+  assert.ok(
+    result.residue.some(
+      (entry) =>
+        entry.file === 'LEFTOVER.md' && entry.token === '{{REPO_NAME}}',
+    ),
+  );
+  assert.ok(
+    result.unknownTokens.some(
+      (entry) =>
+        entry.file === 'LEFTOVER.md' &&
+        entry.token === '{{SOME_ADOPTER_TOKEN}}',
+    ),
+  );
+});
+
+test('checkPlaceholderResidue reports nothing for a fully substituted target', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  const result = checkPlaceholderResidue(targetRoot);
+  assert.deepEqual(result.residue, []);
+});
+
+test('checkStaleImportSignal reuses idd-doctor findMissingWorktreeHardening and reports nothing for an up-to-date import', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  const result = checkStaleImportSignal(targetRoot);
+  assert.deepEqual(result.missing, []);
+});
+
+test('checkStaleImportSignal reports a missing B1 self-check section without blocking manifest/residue', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  const workPath = join(
+    targetRoot,
+    '.github',
+    'instructions',
+    'idd-work.instructions.md',
+  );
+  const withoutSelfCheck = readFileSync(workPath, 'utf8').replace(
+    /^### B1 self-check\b[\s\S]*?(?=\n## )/m,
+    '',
+  );
+  assert.notEqual(withoutSelfCheck, readFileSync(workPath, 'utf8'));
+  writeFileSync(workPath, withoutSelfCheck);
+  const result = checkStaleImportSignal(targetRoot);
+  assert.ok(
+    result.missing.includes('idd-work B1 self-check section'),
+    `expected the missing self-check section to be reported, got: ${JSON.stringify(result.missing)}`,
+  );
+});
+
+test('runVerify never lets the stale-import signal contribute to blocking', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  const workPath = join(
+    targetRoot,
+    '.github',
+    'instructions',
+    'idd-work.instructions.md',
+  );
+  writeFileSync(workPath, 'stale content with no recognized sections\n');
+  const result = runVerify(REPO_ROOT, targetRoot);
+  assert.ok(result.staleImportSignal.missing.length > 0);
+  assert.equal(result.blocking, false);
+});
+
+test('runVerify blocks when manifest completeness or placeholder residue fails', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  rmSync(join(targetRoot, '.github', 'idd', 'config.json'));
+  const missingManifestFile = runVerify(REPO_ROOT, targetRoot);
+  assert.equal(missingManifestFile.blocking, true);
+
+  const residueRoot = makeFixtureDir();
+  importAndSubstitute(residueRoot);
+  writeFileSync(join(residueRoot, 'LEFTOVER.md'), '{{REPO_NAME}}\n');
+  const residueResult = runVerify(REPO_ROOT, residueRoot);
+  assert.equal(residueResult.blocking, true);
+});
+
+// ---------------------------------------------------------------------------
+// CLI (acceptance criteria) — --verify
+// ---------------------------------------------------------------------------
+
+test('bin/idd-onboard.mjs --verify exits 0 with no blocking finding for a fully onboarded target', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  const { status, verdict } = runCliBin([
+    '--verify',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.mode, 'verify');
+  assert.equal(verdict.blocking, false);
+  assert.deepEqual(
+    (verdict.manifestCompleteness as { missingTarget: string[] }).missingTarget,
+    [],
+  );
+  assert.deepEqual(
+    (verdict.placeholderResidue as { residue: unknown[] }).residue,
+    [],
+  );
+});
+
+test('bin/idd-onboard.mjs --verify exits 1 and names the missing file when the manifest is incomplete', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  rmSync(join(targetRoot, '.github', 'idd', 'config.json'));
+  const { status, verdict } = runCliBin([
+    '--verify',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.blocking, true);
+  assert.ok(
+    (
+      verdict.manifestCompleteness as { missingTarget: string[] }
+    ).missingTarget.includes('.github/idd/config.json'),
+  );
+});
+
+test('bin/idd-onboard.mjs --verify exits 1 and names the file when an onboarding placeholder is unresolved', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  writeFileSync(join(targetRoot, 'LEFTOVER.md'), '{{REPO_NAME}}\n');
+  const { status, verdict } = runCliBin([
+    '--verify',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.blocking, true);
+  const residue = (
+    verdict.placeholderResidue as { residue: { file: string }[] }
+  ).residue;
+  assert.ok(residue.some((entry) => entry.file === 'LEFTOVER.md'));
+});
+
+test('bin/idd-onboard.mjs --verify exits 0 even when the stale-import signal fires (informational only)', () => {
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  writeFileSync(
+    join(targetRoot, '.github', 'instructions', 'idd-work.instructions.md'),
+    'stale content with no recognized sections\n',
+  );
+  const { status, verdict } = runCliBin([
+    '--verify',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.blocking, false);
+  assert.ok(
+    (verdict.staleImportSignal as { missing: string[] }).missing.length > 0,
+  );
+});
+
+test('bin/idd-onboard.mjs --verify exits 2 when --source is missing', () => {
+  const targetRoot = makeFixtureDir();
+  try {
+    execFileSync(
+      process.execPath,
+      [BIN_PATH, '--verify', '--target', targetRoot],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    assert.fail('expected a non-zero exit');
+  } catch (error) {
+    const failed = error as { status?: number; stderr?: string };
+    assert.equal(failed.status, 2);
+    assert.match(String(failed.stderr), /--source/);
+  }
+});
+
+test('bin/idd-onboard.mjs exits 2 when --verify is combined with --import or --substitute', () => {
+  const targetRoot = makeFixtureDir();
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        BIN_PATH,
+        '--verify',
+        '--import',
+        '--source',
+        REPO_ROOT,
+        '--target',
+        targetRoot,
+      ],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    assert.fail('expected a non-zero exit');
+  } catch (error) {
+    const failed = error as { status?: number; stderr?: string };
+    assert.equal(failed.status, 2);
+    assert.match(String(failed.stderr), /mutually exclusive/);
+  }
+});
+
+test('bin/idd-onboard.mjs --verify exits 2 when combined with --force or --dry-run', () => {
+  const targetRoot = makeFixtureDir();
+  for (const foreignFlag of ['--force', '--dry-run']) {
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          BIN_PATH,
+          '--verify',
+          '--source',
+          REPO_ROOT,
+          '--target',
+          targetRoot,
+          foreignFlag,
+        ],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+      assert.fail(`expected a non-zero exit for ${foreignFlag}`);
+    } catch (error) {
+      const failed = error as { status?: number; stderr?: string };
+      assert.equal(failed.status, 2);
+      assert.match(String(failed.stderr), /does not accept flag\(s\)/);
+      assert.match(String(failed.stderr), new RegExp(`\\${foreignFlag}`));
+    }
+  }
+});
+
+test('bin/idd-onboard.mjs --help documents --verify and lists --profile values sourced from PROFILE_NAMES', () => {
+  const help = execFileSync(process.execPath, [BIN_PATH, '--help'], {
+    encoding: 'utf8',
+  });
+  assert.match(help, /--verify/);
+  assert.match(help, /manifestCompleteness/);
+  assert.match(help, /placeholderResidue/);
+  assert.match(help, /staleImportSignal/);
 });
 
 test('importing idd-onboard.mts has no import-time side effect', async () => {

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -1463,6 +1463,35 @@ test('checkManifestCompleteness reports a deleted manifest file as missingTarget
   );
 });
 
+test('checkManifestCompleteness reports a manifest file missing from a corrupt --source tree', () => {
+  // A `--source` idd-skill tree that is itself incomplete: resolveImportFiles's
+  // own missingSource only ever surfaces a vendored-node bundle resolution
+  // failure, so this must check every declared sourcePath directly against
+  // sourceRoot (the same fileExists check buildImportPlan already performs)
+  // rather than trusting resolveImportFiles's missingSource alone. Build a
+  // minimal source tree (the manifest plus every declared file, not a full
+  // repo copy) so the test stays fast.
+  const corruptSourceRoot = makeFixtureDir();
+  mkdirSync(join(corruptSourceRoot, 'audit'), { recursive: true });
+  cpSync(
+    join(REPO_ROOT, 'audit', 'sync-manifest.json'),
+    join(corruptSourceRoot, 'audit', 'sync-manifest.json'),
+  );
+  const resolved = resolveImportFiles(REPO_ROOT);
+  for (const file of resolved.files) {
+    const dest = join(corruptSourceRoot, file.sourcePath);
+    mkdirSync(dirname(dest), { recursive: true });
+    cpSync(join(REPO_ROOT, file.sourcePath), dest);
+  }
+  const missingFile = resolved.files[0];
+  assert.ok(missingFile, 'resolveImportFiles must declare at least one file');
+  rmSync(join(corruptSourceRoot, missingFile.sourcePath));
+
+  const targetRoot = makeFixtureDir();
+  const result = checkManifestCompleteness(corruptSourceRoot, targetRoot);
+  assert.ok(result.missingSource.includes(missingFile.sourcePath));
+});
+
 test('checkManifestCompleteness checks every file resolveImportFiles declares, not a forked subset', () => {
   const targetRoot = makeFixtureDir();
   importAndSubstitute(targetRoot);

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -1507,6 +1507,37 @@ test('checkManifestCompleteness checks every file resolveImportFiles declares, n
   assert.ok(result.missingTarget.includes(sample.targetPath));
 });
 
+test('checkManifestCompleteness forwards --profile to resolveImportFiles, covering the larger vendored-node file set', () => {
+  const targetRoot = makeFixtureDir();
+  const importPlan = buildImportPlan(REPO_ROOT, targetRoot, {
+    profile: 'vendored-node',
+  });
+  applyImportPlan(REPO_ROOT, targetRoot, importPlan);
+  const resolution = resolvePlaceholderValues(targetRoot, ALL_OVERRIDES);
+  const subPlan = buildSubstitutionPlan(
+    scanPlaceholderTokens(targetRoot),
+    resolution,
+  );
+  applySubstitutionPlan(targetRoot, subPlan);
+
+  const defaultFileCount = resolveImportFiles(REPO_ROOT).files.length;
+  const vendoredFileCount = resolveImportFiles(REPO_ROOT, 'vendored-node').files
+    .length;
+  assert.ok(
+    vendoredFileCount > defaultFileCount,
+    'the vendored-node profile must declare more files than the default profile',
+  );
+
+  // Passing the same --profile the target was actually imported with must
+  // check the larger declared set, not silently fall back to the default.
+  const result = checkManifestCompleteness(
+    REPO_ROOT,
+    targetRoot,
+    'vendored-node',
+  );
+  assert.deepEqual(result.missingTarget, []);
+});
+
 test('checkPlaceholderResidue classifies a leftover onboarding placeholder as blocking residue', () => {
   const targetRoot = makeFixtureDir();
   importAndSubstitute(targetRoot);
@@ -1544,7 +1575,7 @@ test('checkStaleImportSignal reuses idd-doctor findMissingWorktreeHardening and 
   assert.deepEqual(result.missing, []);
 });
 
-test('checkStaleImportSignal reports a missing B1 self-check section without blocking manifest/residue', () => {
+test('checkStaleImportSignal reports a missing B1 self-check section', () => {
   const targetRoot = makeFixtureDir();
   importAndSubstitute(targetRoot);
   const workPath = join(
@@ -1698,7 +1729,34 @@ test('bin/idd-onboard.mjs --verify exits 2 when --source is missing', () => {
   }
 });
 
-test('bin/idd-onboard.mjs exits 2 when --verify is combined with --import or --substitute', () => {
+test('bin/idd-onboard.mjs --verify --profile vendored-node passes for a target imported with that profile', () => {
+  const targetRoot = makeFixtureDir();
+  const { status: importStatus } = runCliBin([
+    '--import',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+    '--profile',
+    'vendored-node',
+  ]);
+  assert.equal(importStatus, 0);
+  runCliBin(['--substitute', '--target', targetRoot, ...CLI_OVERRIDE_FLAGS]);
+
+  const { status, verdict } = runCliBin([
+    '--verify',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+    '--profile',
+    'vendored-node',
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.blocking, false);
+});
+
+test('bin/idd-onboard.mjs --verify exits 2 on an unknown --profile value', () => {
   const targetRoot = makeFixtureDir();
   try {
     execFileSync(
@@ -1706,11 +1764,12 @@ test('bin/idd-onboard.mjs exits 2 when --verify is combined with --import or --s
       [
         BIN_PATH,
         '--verify',
-        '--import',
         '--source',
         REPO_ROOT,
         '--target',
         targetRoot,
+        '--profile',
+        'not-a-real-profile',
       ],
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
     );
@@ -1718,7 +1777,28 @@ test('bin/idd-onboard.mjs exits 2 when --verify is combined with --import or --s
   } catch (error) {
     const failed = error as { status?: number; stderr?: string };
     assert.equal(failed.status, 2);
-    assert.match(String(failed.stderr), /mutually exclusive/);
+    assert.match(String(failed.stderr), /unknown --profile/);
+  }
+});
+
+test('bin/idd-onboard.mjs exits 2 when --verify is combined with --import or --substitute', () => {
+  const targetRoot = makeFixtureDir();
+  const combos = [
+    ['--verify', '--import', '--source', REPO_ROOT, '--target', targetRoot],
+    ['--verify', '--substitute', '--target', targetRoot],
+  ];
+  for (const args of combos) {
+    try {
+      execFileSync(process.execPath, [BIN_PATH, ...args], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      assert.fail(`expected a non-zero exit for ${args.join(' ')}`);
+    } catch (error) {
+      const failed = error as { status?: number; stderr?: string };
+      assert.equal(failed.status, 2);
+      assert.match(String(failed.stderr), /mutually exclusive/);
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

Wave 3 of the onboarding automation roadmap (#1262). Adds a
`--verify --source <idd-skill-tree> --target <dir> [--profile <name>]`
stage to `src/scripts/idd-onboard.mts` so an onboarding run ends with a
mechanical pass/fail instead of a manual walkthrough of
`idd-template/ONBOARDING.md` Step 6.

`--verify` reports three check groups, each reusing existing
implementation instead of forking logic:

- **`manifestCompleteness`** — every file wave 2's `resolveImportFiles`
  declares for `--source` / `--profile` exists under `--target`; missing
  files are blocking.
- **`placeholderResidue`** — wave 1's own `scanPlaceholderTokens` +
  `buildSubstitutionPlan` scanner, called with an empty resolution: any
  remaining onboarding-placeholder token is blocking residue, any other
  `{{...}}`-shaped token stays informational.
- **`staleImportSignal`** — re-runs idd-doctor's existing content-based
  stale-import detector (`findMissingWorktreeHardening`, imported directly
  from `idd-doctor.mts` per the #1208 shared-module convention
  `check-pnpm-boundary.mts` already uses for `parseProjectCommandRows`).
  This is informational only, matching idd-doctor's own warning-level
  severity for the same check — only a manifest gap or placeholder
  residue can fail `--verify`.

`--verify` never writes; `--force` and `--dry-run` are rejected as
foreign flags for it. Exit contract matches wave 1/2: `0` no blocking
finding, `1` a blocking finding exists, `2` usage/configuration error.

## Design notes

- `--source` is required (mirroring `--import`), even though the issue's
  invocation sketch abbreviated it to `--verify --target <dir>`: the
  canonical manifest file list lives in `audit/sync-manifest.json`, which
  is intentionally **not** among the distributed core files, so
  `--target` alone can never answer "is the manifest complete." Explained
  in `--help` and the issue's plan comment.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build` (generated `scripts/idd-onboard.mjs` committed)
- [x] `pnpm run build:check` (no drift)
- [x] `pnpm test` (1769 tests, including new unit + CLI acceptance tests
      for `--verify`: pass, each blocking finding, the non-blocking
      stale-import signal, usage errors, mode-conflict / foreign-flag
      rejection, and `--help` content)
- [x] `pnpm run lint:minimum`

Closes #1293.
