### PR TITLE
docs(onboard): document the CLI onboarding path and guard it against doc drift

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -296,12 +296,14 @@ If you have a local clone of `kurone-kito/idd-skill` (Step 2 Option B
 below), the `idd-onboard` CLI shipped in that clone
 (`scripts/idd-onboard.mjs`) can automate Steps 2, 4, and 6. **The manual
 steps remain canonical**; this CLI is a mechanical, optional shortcut for
-the same three steps, and it has no remote-fetch equivalent — every mode
-requires `--source <path-to-a-cloned-idd-skill-tree>`, so it does not
-apply to the Option A remote-fetch flow. Each mode prints a JSON verdict
-and exits `0` (converged), `1` (a blocking or residue finding — nothing is
-written), or `2` (a usage error), so an agent can gate on the exit code
-without parsing prose.
+the same three steps. `--import` and `--verify` both require
+`--source <path-to-a-cloned-idd-skill-tree>` and therefore only replace
+the Option B local-clone flow, never Option A's remote fetch;
+`--substitute` takes no `--source` at all (it only rewrites an already-
+imported `--target` tree) and works the same regardless of how that tree
+was populated. Each mode prints a JSON verdict and exits `0` (converged),
+`1` (a blocking or residue finding — nothing is written), or `2` (a usage
+error), so an agent can gate on the exit code without parsing prose.
 
 - **Step 2 (fetch or copy) → `--import`**: copies the core template file
   set from `--source` into `--target`. The file set it copies is the same
@@ -354,9 +356,9 @@ every accepted argument.
 
 ## Step 2 — Fetch or copy template files
 
-> **CLI shortcut**: `idd-onboard --import` automates this step from a
-> local idd-skill clone — see [CLI-assisted onboarding](#cli-assisted-onboarding)
-> above.
+> **CLI shortcut**: `node scripts/idd-onboard.mjs --import` automates this
+> step from a local idd-skill clone — see
+> [CLI-assisted onboarding](#cli-assisted-onboarding) above.
 
 You need the following core execution and profile artifact files in the
 target repository. Use whichever method applies to your situation.
@@ -794,8 +796,9 @@ that mention IDD workflow.
 
 ## Step 4 — Replace placeholders
 
-> **CLI shortcut**: `idd-onboard --substitute` automates this step — see
-> [CLI-assisted onboarding](#cli-assisted-onboarding) above.
+> **CLI shortcut**: `node scripts/idd-onboard.mjs --substitute` automates
+> this step — see [CLI-assisted onboarding](#cli-assisted-onboarding)
+> above.
 
 In the copied files, perform a global replacement for:
 `{{REPO_NAME}}`, `{{PROJECT_MARKER_PREFIX}}`,
@@ -863,8 +866,9 @@ Copilot guidance may still apply to reviews.
 
 ## Step 6 — Verification checklist
 
-> **CLI shortcut**: `idd-onboard --verify` automates this checklist — see
-> [CLI-assisted onboarding](#cli-assisted-onboarding) above.
+> **CLI shortcut**: `node scripts/idd-onboard.mjs --verify` automates this
+> checklist — see [CLI-assisted onboarding](#cli-assisted-onboarding)
+> above.
 
 Use
 [Onboarding Reference — Agent Entry and Verification](docs/onboarding/agent-entry-and-verification.md)

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -290,7 +290,73 @@ notes, and `blocked-by` guidance, see
 
 ---
 
+## CLI-assisted onboarding
+
+If you have a local clone of `kurone-kito/idd-skill` (Step 2 Option B
+below), the `idd-onboard` CLI shipped in that clone
+(`scripts/idd-onboard.mjs`) can automate Steps 2, 4, and 6. **The manual
+steps remain canonical**; this CLI is a mechanical, optional shortcut for
+the same three steps, and it has no remote-fetch equivalent — every mode
+requires `--source <path-to-a-cloned-idd-skill-tree>`, so it does not
+apply to the Option A remote-fetch flow. Each mode prints a JSON verdict
+and exits `0` (converged), `1` (a blocking or residue finding — nothing is
+written), or `2` (a usage error), so an agent can gate on the exit code
+without parsing prose.
+
+- **Step 2 (fetch or copy) → `--import`**: copies the core template file
+  set from `--source` into `--target`. The file set it copies is the same
+  `idd-template-core-files` generated block Step 2's file list below
+  renders from, so this command and that list can never drift apart into
+  two independently hand-copied file sets. Add `--profile vendored-node`
+  to also copy the profile-conditional helper bundle (every other
+  `--profile` value copies no extra files); add `--force` to allow
+  overwriting an existing target file whose content differs (refused by
+  default); add `--dry-run` to print the plan without writing.
+
+  ```sh
+  node scripts/idd-onboard.mjs --import --source <idd-skill-clone> \
+    --target <target-repo> [--profile <name>] [--force] [--dry-run]
+  ```
+
+- **Step 4 (replace placeholders) → `--substitute`**: resolves the seven
+  placeholders using Step 1A's auto-derivation rules, or explicit
+  overrides (`--repo-name`, `--marker-prefix`, `--trusted-marker-actor`,
+  `--fix-validate-commands`, `--pre-push-validate-commands`,
+  `--post-fix-validate-commands`, `--install-deps-command`), then rewrites
+  the target tree in place. Add `--dry-run` to print the plan without
+  writing; apply mode refuses to write anything while any placeholder
+  would remain unresolved.
+
+  ```sh
+  node scripts/idd-onboard.mjs --substitute --target <target-repo> \
+    [--dry-run] [--repo-name <value> ...]
+  ```
+
+- **Step 6 (verification checklist) → `--verify`**: a mechanical pass/fail
+  check for a target tree after `--import` and `--substitute` have run,
+  replacing a manual walkthrough of the checklist below with three check
+  groups: manifest completeness (reusing `--import`'s own file-set
+  resolution), placeholder residue (reusing `--substitute`'s scanner), and
+  an informational stale-import signal. A missing manifest file or a
+  leftover onboarding placeholder is blocking; the stale-import signal
+  never is.
+
+  ```sh
+  node scripts/idd-onboard.mjs --verify --source <idd-skill-clone> \
+    --target <target-repo> [--profile <name>]
+  ```
+
+Run `node scripts/idd-onboard.mjs --help` for the full flag reference —
+this section documents only the flags relevant to Steps 2, 4, and 6, not
+every accepted argument.
+
+---
+
 ## Step 2 — Fetch or copy template files
+
+> **CLI shortcut**: `idd-onboard --import` automates this step from a
+> local idd-skill clone — see [CLI-assisted onboarding](#cli-assisted-onboarding)
+> above.
 
 You need the following core execution and profile artifact files in the
 target repository. Use whichever method applies to your situation.
@@ -728,6 +794,9 @@ that mention IDD workflow.
 
 ## Step 4 — Replace placeholders
 
+> **CLI shortcut**: `idd-onboard --substitute` automates this step — see
+> [CLI-assisted onboarding](#cli-assisted-onboarding) above.
+
 In the copied files, perform a global replacement for:
 `{{REPO_NAME}}`, `{{PROJECT_MARKER_PREFIX}}`,
 `{{TRUSTED_MARKER_ACTOR}}`, `{{FIX_VALIDATE_COMMANDS}}`,
@@ -793,6 +862,9 @@ Copilot guidance may still apply to reviews.
 ---
 
 ## Step 6 — Verification checklist
+
+> **CLI shortcut**: `idd-onboard --verify` automates this checklist — see
+> [CLI-assisted onboarding](#cli-assisted-onboarding) above.
 
 Use
 [Onboarding Reference — Agent Entry and Verification](docs/onboarding/agent-entry-and-verification.md)

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -55,6 +55,7 @@ const PLACEHOLDERS_DOC = join(
   'onboarding',
   'placeholders.md',
 );
+const ONBOARDING_DOC = join(REPO_ROOT, 'idd-template', 'ONBOARDING.md');
 
 function makeFixtureDir(): string {
   return mkdtempSync(join(tmpdir(), 'idd-onboard-'));
@@ -1847,4 +1848,92 @@ test('importing idd-onboard.mts has no import-time side effect', async () => {
   } finally {
     process.env.PATH = originalPath;
   }
+});
+
+// ---------------------------------------------------------------------------
+// #1294: ONBOARDING.md "CLI-assisted onboarding" section drift guard
+// ---------------------------------------------------------------------------
+//
+// The section documents idd-onboard as the automated alternative for Steps
+// 2, 4, and 6. Two mechanical properties must hold so the doc cannot drift
+// from the shipped CLI: every flag it mentions must actually exist in the
+// CLI's own --help surface, and its description of what --import copies
+// must anchor to the shared idd-template-core-files generated block
+// (Step 2's own file list) rather than hand-copying a second file list.
+
+const CLI_SECTION_HEADING = '## CLI-assisted onboarding';
+
+/** Slice out the named section: from its heading up to the next `## `. */
+function extractSection(doc: string, heading: string): string {
+  const start = doc.indexOf(heading);
+  assert.notEqual(start, -1, `ONBOARDING.md is missing heading: ${heading}`);
+  const nextHeading = doc.indexOf('\n## ', start + heading.length);
+  return nextHeading === -1 ? doc.slice(start) : doc.slice(start, nextHeading);
+}
+
+/** Every long-form `--flag` token in `text`, deduped, in first-seen order. */
+function extractFlagTokens(text: string): string[] {
+  return [...new Set(text.match(/--[a-z][a-z-]*/gu) ?? [])];
+}
+
+/**
+ * Assert every flag token in `section` appears in `helpText`. Shared by the
+ * real-section pass test and the seeded-mismatch fail test below so both
+ * exercise the identical guard logic.
+ */
+function assertFlagsDocumentedInHelp(section: string, helpText: string): void {
+  for (const flag of extractFlagTokens(section)) {
+    assert.ok(
+      helpText.includes(flag),
+      `ONBOARDING.md's CLI-assisted onboarding section documents ${flag}, which idd-onboard --help does not list`,
+    );
+  }
+}
+
+test('the ONBOARDING.md CLI-assisted onboarding section documents only flags idd-onboard --help actually lists', () => {
+  const doc = readFileSync(ONBOARDING_DOC, 'utf8');
+  const section = extractSection(doc, CLI_SECTION_HEADING);
+  const help = execFileSync(process.execPath, [BIN_PATH, '--help'], {
+    encoding: 'utf8',
+  });
+  // Sanity check: the section documents a non-trivial number of real flags,
+  // so this guard is not vacuously satisfied by an empty or flag-free section.
+  assert.ok(
+    extractFlagTokens(section).length >= 10,
+    'expected the CLI-assisted onboarding section to document at least 10 distinct flags',
+  );
+  assertFlagsDocumentedInHelp(section, help);
+});
+
+test('a seeded unknown flag in the CLI-assisted onboarding section is caught by the drift guard', () => {
+  const help = execFileSync(process.execPath, [BIN_PATH, '--help'], {
+    encoding: 'utf8',
+  });
+  const seededSection = `${CLI_SECTION_HEADING}\n\nRun \`idd-onboard --nonexistent-flag\`.\n`;
+  assert.throws(
+    () => assertFlagsDocumentedInHelp(seededSection, help),
+    /--nonexistent-flag/,
+    'a flag not in --help must fail the guard, proving it does not vacuously pass',
+  );
+});
+
+test('the ONBOARDING.md CLI-assisted onboarding section anchors its --import file set to the shared generated block, not a hand-copied list', () => {
+  const doc = readFileSync(ONBOARDING_DOC, 'utf8');
+  const section = extractSection(doc, CLI_SECTION_HEADING);
+  // The section must name the same generated block Step 2's file list
+  // renders from, rather than re-deriving or re-describing the file set on
+  // its own terms.
+  assert.match(section, /idd-template-core-files/u);
+  // The generated-block start marker must still appear exactly once in the
+  // whole document: sync-docs.mjs / audit-docs.mjs locate it with a single
+  // indexOf, so a second copy of the marker would silently go stale forever
+  // (never regenerated, never checked) instead of failing loudly.
+  const markerCount = (
+    doc.match(/<!-- audit:generated id=idd-template-core-files -->/gu) ?? []
+  ).length;
+  assert.equal(
+    markerCount,
+    1,
+    'the idd-template-core-files generated block must appear exactly once in ONBOARDING.md',
+  );
 });

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -1890,18 +1890,40 @@ function assertFlagsDocumentedInHelp(section: string, helpText: string): void {
   }
 }
 
+/**
+ * The stage-selector and shared-argument flags every mode of the section
+ * discusses. Used as the "guard is not vacuous" sanity check below: rather
+ * than an arbitrary flag-count threshold (which would make the guard fragile
+ * to a legitimate future simplification of the section's prose), assert the
+ * section still names the specific flags the guard exists to keep honest.
+ */
+const CLI_SECTION_CORE_FLAGS = [
+  '--import',
+  '--substitute',
+  '--verify',
+  '--source',
+  '--target',
+  '--profile',
+  '--dry-run',
+  '--force',
+];
+
 test('the ONBOARDING.md CLI-assisted onboarding section documents only flags idd-onboard --help actually lists', () => {
   const doc = readFileSync(ONBOARDING_DOC, 'utf8');
   const section = extractSection(doc, CLI_SECTION_HEADING);
   const help = execFileSync(process.execPath, [BIN_PATH, '--help'], {
     encoding: 'utf8',
   });
-  // Sanity check: the section documents a non-trivial number of real flags,
-  // so this guard is not vacuously satisfied by an empty or flag-free section.
-  assert.ok(
-    extractFlagTokens(section).length >= 10,
-    'expected the CLI-assisted onboarding section to document at least 10 distinct flags',
-  );
+  // Sanity check: the section still names the core stage/argument flags it
+  // exists to document, so this guard is not vacuously satisfied by an
+  // empty or flag-free section.
+  const documented = extractFlagTokens(section);
+  for (const flag of CLI_SECTION_CORE_FLAGS) {
+    assert.ok(
+      documented.includes(flag),
+      `expected the CLI-assisted onboarding section to document ${flag}`,
+    );
+  }
   assertFlagsDocumentedInHelp(section, help);
 });
 


### PR DESCRIPTION
# Summary

Adds a "CLI-assisted onboarding" section to `idd-template/ONBOARDING.md`
presenting `idd-onboard --import` / `--substitute` / `--verify` as the
automated alternative for Steps 2, 4, and 6 respectively. The manual path
stays explicitly canonical, and the section calls out that the CLI has no
remote-fetch equivalent (`--import` / `--verify` always require
`--source <cloned-idd-skill-tree>`, so it only replaces the Option B
local-clone flow). Short "CLI shortcut" pointers were added at the top of
Steps 2, 4, and 6 linking back to the new section.

The section names the `--import` file set as the same
`idd-template-core-files` generated block Step 2's own file list renders
from, rather than hand-copying a second file list.

Adds a mechanical drift guard in `tests/idd-onboard.test.mts` (the
existing lane the CLI module's own doc comments already point to for its
`--substitute` / `--import` drift tests):

- Every `--flag` token the new section documents must appear in
  `idd-onboard --help`'s live output.
- A seeded-mismatch test proves the guard actually fails on drift (an
  invented `--nonexistent-flag` is asserted to throw), not just trivially
  pass today.
- The generated-block marker (`<!-- audit:generated
  id=idd-template-core-files -->`) the section refers to must still occur
  exactly once in the document — `sync-docs.mjs` / `audit-docs.mjs` both
  locate it via a single `indexOf`, so a second copy would silently go
  stale instead of failing loudly.

## Linked issue

Closes #1294

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This is the final wave (wave 4 / docs) of roadmap #1262. Both blocking
waves are merged: #1292 (wave 2, `--import`, PR #1305) and #1293 (wave 3,
`--verify`, PR #1306). The CLI's actual flags/behavior were read from
current `main` (`src/scripts/idd-onboard.mts`) rather than assumed from
the original issue text, since both prior waves' review cycles could have
changed the shipped surface.

No new file was added under `idd-template/docs/onboarding/` — that
directory's four reference docs (`placeholders.md`, `policy-decisions.md`,
etc.) have no top-level mirror in this repo, and a same-pattern new file
would have been unnecessary surface for a 3-step CLI summary that fits
inline in `ONBOARDING.md`.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new CLI-assisted onboarding section covering supported onboarding modes, required flags, placeholder handling, verification output, and exit codes.
  - Added shortcut callouts in the onboarding steps to help users find the CLI guidance faster.

- **Tests**
  - Added checks to keep the onboarding documentation aligned with the available CLI options.
  - Added coverage to verify documented flags, generated file references, and detection of invalid documentation drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->