### PR TITLE
docs(customization): scope release cadence to top-level roadmaps

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -69,10 +69,10 @@ distributed IDD workflow a repository imported.
   the source repository after the bump PR merges, so adopters can diff
   against a concrete release ref instead of a raw commit SHA. The
   release cadence is milestone-based: cut a release after each merged
-  roadmap. This cadence is triggered by top-level roadmap closures
-  only; a nested roadmap's closure does not independently trigger a
-  release, and its changes ship with the parent roadmap's release (or
-  the next top-level trigger).
+  roadmap. This trigger fires for a merged top-level roadmap only; a
+  merged nested roadmap does not independently trigger a release, and
+  its changes ship with the parent roadmap's release (or the next
+  top-level trigger).
 - **Adopters** can compare their `iddVersion` against the source release
   to see whether a re-sync is worthwhile. Because the value only moves
   when maintainers bump it, it is a coarse signal — so `idd-doctor` also

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -69,7 +69,10 @@ distributed IDD workflow a repository imported.
   the source repository after the bump PR merges, so adopters can diff
   against a concrete release ref instead of a raw commit SHA. The
   release cadence is milestone-based: cut a release after each merged
-  roadmap.
+  roadmap. This cadence is triggered by top-level roadmap closures
+  only; a nested roadmap's closure does not independently trigger a
+  release, and its changes ship with the parent roadmap's release (or
+  the next top-level trigger).
 - **Adopters** can compare their `iddVersion` against the source release
   to see whether a re-sync is worthwhile. Because the value only moves
   when maintainers bump it, it is a coarse signal — so `idd-doctor` also

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -69,10 +69,10 @@ distributed IDD workflow a repository imported.
   the source repository after the bump PR merges, so adopters can diff
   against a concrete release ref instead of a raw commit SHA. The
   release cadence is milestone-based: cut a release after each merged
-  roadmap. This cadence is triggered by top-level roadmap closures
-  only; a nested roadmap's closure does not independently trigger a
-  release, and its changes ship with the parent roadmap's release (or
-  the next top-level trigger).
+  roadmap. This trigger fires for a merged top-level roadmap only; a
+  merged nested roadmap does not independently trigger a release, and
+  its changes ship with the parent roadmap's release (or the next
+  top-level trigger).
 - **Adopters** can compare their `iddVersion` against the source release
   to see whether a re-sync is worthwhile. Because the value only moves
   when maintainers bump it, it is a coarse signal — so `idd-doctor` also

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -69,7 +69,10 @@ distributed IDD workflow a repository imported.
   the source repository after the bump PR merges, so adopters can diff
   against a concrete release ref instead of a raw commit SHA. The
   release cadence is milestone-based: cut a release after each merged
-  roadmap.
+  roadmap. This cadence is triggered by top-level roadmap closures
+  only; a nested roadmap's closure does not independently trigger a
+  release, and its changes ship with the parent roadmap's release (or
+  the next top-level trigger).
 - **Adopters** can compare their `iddVersion` against the source release
   to see whether a re-sync is worthwhile. Because the value only moves
   when maintainers bump it, it is a coarse signal — so `idd-doctor` also


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Add one clarifying sentence to the release-cadence rule in
`idd-template/docs/customization.md` (canonical), naming the trigger
scope explicitly, and sync the generated mirror (`docs/customization.md`)
via `scripts/sync-docs.mjs`.

## Linked issue

Closes #1300

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Nested roadmap #1270 closed hours after the v0.4.0 tag with exactly
one post-tag merge (#1275, PR #1295) under it, while its parent #1264
stayed open. The existing cadence sentence ("cut a release after each
merged roadmap") read literally would demand a v0.5.0 cut for that
single docs PR — the ambiguity #1300 was filed to resolve.

The operator decided **option 1** (the issue's own recommended
option, recorded on #1300): top-level roadmap closures trigger the
release cadence; nested roadmap closures do not trigger one
independently — their changes ship with the parent roadmap's release,
or the next top-level trigger. This PR only records that scope in
prose. No release is cut here (option 2, which would have required an
immediate v0.5.0, was not chosen).

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed