### PR TITLE
fix(review-triage): loosen the Codex usage-limit non-review-notice detection

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -928,9 +928,13 @@ const ADVISORY_NON_REVIEW_NOTICE_PATTERNS = [
   // the `summarize by coderabbit.ai` review marker) and its warning heading.
   /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
   /^[>\s]*#{1,6}\s*Review limit reached\b/im,
-  // Codex usage / quota exhaustion for code reviews.
-  /\bCodex usage limits for code reviews\b/i,
-  /\breached your Codex usage limits\b/i,
+  // Codex usage / quota exhaustion for code reviews. Token-anchored on
+  // "Codex usage limit(s)" plus a reach/exceed/hit-family verb within a
+  // bounded window, tolerant of interposed wording drift and matching
+  // either verb-before or verb-after phrasing (#1312: the two prior
+  // exact-phrase regexes broke when Codex's wording interposed "have been"
+  // between "usage limits" and "reached").
+  /\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)|\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b/i,
 ];
 export function isAdvisoryNonReviewNotice(body) {
   const text = String(body ?? '');

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -928,13 +928,16 @@ const ADVISORY_NON_REVIEW_NOTICE_PATTERNS = [
   // the `summarize by coderabbit.ai` review marker) and its warning heading.
   /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
   /^[>\s]*#{1,6}\s*Review limit reached\b/im,
-  // Codex usage / quota exhaustion for code reviews. Token-anchored on
-  // "Codex usage limit(s)" plus a reach/exceed/hit-family verb within a
-  // bounded window, tolerant of interposed wording drift and matching
-  // either verb-before or verb-after phrasing (#1312: the two prior
-  // exact-phrase regexes broke when Codex's wording interposed "have been"
-  // between "usage limits" and "reached").
-  /\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)|\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b/i,
+  // Codex usage / quota exhaustion for code reviews. Token-anchored on all
+  // three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and
+  // "for code reviews", each tolerant of interposed wording drift, in the
+  // two known real orderings (#1312: the two prior exact-phrase regexes
+  // broke when Codex's wording interposed "have been" between "usage
+  // limits" and "reached"). Requiring "for code reviews" too (not just the
+  // verb) keeps the match narrow, per the fail-closed under-match-over
+  // false-positive intent documented above: a bare "Codex usage limits
+  // exceeded" mention with no "for code reviews" nearby must not match.
+  /\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b[\s\S]{0,40}?\bfor code reviews\b|\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bfor code reviews\b/i,
 ];
 export function isAdvisoryNonReviewNotice(body) {
   const text = String(body ?? '');

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1543,13 +1543,16 @@ const ADVISORY_NON_REVIEW_NOTICE_PATTERNS: RegExp[] = [
   // the `summarize by coderabbit.ai` review marker) and its warning heading.
   /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
   /^[>\s]*#{1,6}\s*Review limit reached\b/im,
-  // Codex usage / quota exhaustion for code reviews. Token-anchored on
-  // "Codex usage limit(s)" plus a reach/exceed/hit-family verb within a
-  // bounded window, tolerant of interposed wording drift and matching
-  // either verb-before or verb-after phrasing (#1312: the two prior
-  // exact-phrase regexes broke when Codex's wording interposed "have been"
-  // between "usage limits" and "reached").
-  /\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)|\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b/i,
+  // Codex usage / quota exhaustion for code reviews. Token-anchored on all
+  // three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and
+  // "for code reviews", each tolerant of interposed wording drift, in the
+  // two known real orderings (#1312: the two prior exact-phrase regexes
+  // broke when Codex's wording interposed "have been" between "usage
+  // limits" and "reached"). Requiring "for code reviews" too (not just the
+  // verb) keeps the match narrow, per the fail-closed under-match-over
+  // false-positive intent documented above: a bare "Codex usage limits
+  // exceeded" mention with no "for code reviews" nearby must not match.
+  /\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b[\s\S]{0,40}?\bfor code reviews\b|\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bfor code reviews\b/i,
 ];
 
 export function isAdvisoryNonReviewNotice(body: unknown): boolean {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1543,9 +1543,13 @@ const ADVISORY_NON_REVIEW_NOTICE_PATTERNS: RegExp[] = [
   // the `summarize by coderabbit.ai` review marker) and its warning heading.
   /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
   /^[>\s]*#{1,6}\s*Review limit reached\b/im,
-  // Codex usage / quota exhaustion for code reviews.
-  /\bCodex usage limits for code reviews\b/i,
-  /\breached your Codex usage limits\b/i,
+  // Codex usage / quota exhaustion for code reviews. Token-anchored on
+  // "Codex usage limit(s)" plus a reach/exceed/hit-family verb within a
+  // bounded window, tolerant of interposed wording drift and matching
+  // either verb-before or verb-after phrasing (#1312: the two prior
+  // exact-phrase regexes broke when Codex's wording interposed "have been"
+  // between "usage limits" and "reached").
+  /\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)|\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b/i,
 ];
 
 export function isAdvisoryNonReviewNotice(body: unknown): boolean {

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -19,6 +19,11 @@ const CODEX = 'chatgpt-codex-connector[bot]';
 const CODERABBIT = 'coderabbitai[bot]';
 const CODEX_NOTICE =
   'You have reached your Codex usage limits for code reviews.';
+// #1312: current Codex wording interposes "have been" between "usage
+// limits" and "reached" — the two prior exact-phrase regexes missed this.
+const CODEX_NOTICE_CURRENT_WORDING =
+  'Codex usage limits have been reached for code reviews. Please check ' +
+  'with the admins of this repo to increase the limits by adding credits.';
 const CODERABBIT_NOTICE =
   '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n> ## Review limit reached';
 const CODERABBIT_SUMMARY =
@@ -87,6 +92,22 @@ test('buildDispositionPlan plans one disposition per undispositioned notice', ()
     assert.ok(entry.body.startsWith('**Rejected**'));
     assert.match(entry.body, /did not review HEAD abc1234/);
   }
+});
+
+test('buildDispositionPlan plans a rejection for the current Codex usage-limit wording', () => {
+  // #1312 regression: Codex's current wording ("...have been reached...")
+  // must still be recognized as a non-review notice and dispositioned.
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [notice(1, CODEX, CODEX_NOTICE_CURRENT_WORDING)],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 1);
+  assert.equal(plan.planned[0]?.botLogin, CODEX);
+  assert.ok(plan.planned[0]?.body.startsWith('**Rejected**'));
+  assert.match(plan.planned[0]?.body ?? '', /did not review HEAD abc1234/);
 });
 
 test('buildDispositionPlan is idempotent: a notice already dispositioned for its bot is skipped', () => {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2369,6 +2369,15 @@ test('isAdvisoryNonReviewNotice matches only machine-generated non-review notice
     ),
     true,
   );
+  // #1312: current Codex wording interposes "have been" between "usage
+  // limits" and "reached" — must still classify as a non-review notice.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'Codex usage limits have been reached for code reviews. Please check ' +
+        'with the admins of this repo to increase the limits by adding credits.',
+    ),
+    true,
+  );
   assert.equal(
     isAdvisoryNonReviewNotice(
       '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> ## Review limit reached',
@@ -2386,6 +2395,15 @@ test('isAdvisoryNonReviewNotice matches only machine-generated non-review notice
   assert.equal(
     isAdvisoryNonReviewNotice(
       'This rate limit handling looks off — please cap the retries.',
+    ),
+    false,
+  );
+  // #1312: a genuine Codex review comment that merely mentions the phrase
+  // "Codex usage limits" — with no nearby reach/exceed/hit verb — must not
+  // be misclassified as a non-review notice.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'This PR modifies the Codex usage limits configuration file; overall LGTM.',
     ),
     false,
   );

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2407,6 +2407,16 @@ test('isAdvisoryNonReviewNotice matches only machine-generated non-review notice
     ),
     false,
   );
+  // #1312 (review-fix): a genuine review comment with a reach/exceed/hit
+  // verb near "Codex usage limits" but no "for code reviews" nearby must
+  // not match either — this is the concrete false-positive scenario a
+  // verb-only anchor would have caught (flagged in PR #1319 review).
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'This code exceeds the Codex usage limits configured for the repo.',
+    ),
+    false,
+  );
   assert.equal(isAdvisoryNonReviewNotice(''), false);
   assert.equal(isAdvisoryNonReviewNotice(null), false);
 });


### PR DESCRIPTION
# Summary

`isAdvisoryNonReviewNotice` (`src/scripts/protocol-helpers.mts`) used two
exact-phrase regexes to classify Codex's quota-exhaustion notice. Codex's
current wording interposes "have been" between "usage limits" and
"reached" ("Codex usage limits **have been reached** for code
reviews..."), which matched neither regex — so the notice slipped past
auto-disposition and could block or churn the merge gate.

Replaces the two brittle regexes with one token-anchored pattern that
requires "Codex usage limit(s)" plus a reach/exceed/hit-family verb
within a bounded window, tolerant of interposed wording and matching
either verb-before or verb-after phrasing (covering both the current
wording and the two prior exact-phrase wordings). Adds regression
fixtures for the current wording plus a negative fixture proving a
genuine Codex comment that merely mentions "Codex usage limits" (no
nearby verb) is not misclassified.

## Linked issue

Closes #1312

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`noticeReason` in `src/scripts/disposition-non-review-notices.mts` already
uses its own looser `/Codex usage limits/i` check and is gated upstream by
`isAdvisoryNonReviewNotice`, so it needed no change.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed (affects merge-gate
      non-review-notice auto-disposition evidence)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs drift introduced by this change;
      not run standalone, covered by `pnpm lint`'s `audit-docs.mjs --check`)
- [x] `node scripts/idd-doctor.mjs` (passed with 3 pre-existing
      environment warnings unrelated to this diff)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
