### PR TITLE
docs(idd-claim): adopt forced-handoff new-agent-id verbatim; note sticky claim

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -387,8 +387,10 @@ a `claimed-by` whose `{claim-id}` matches the active claim but whose
 later heartbeat or F2/F3 check as `agent-id-mismatch` / `claimLost`, with no
 explaining error. Cite the trusted forced-handoff evidence in the issue
 digest or resume report's `Authoritative by` field. Do not invent ad hoc
-`claimed-by` fields, and do not reuse the displaced old `{agent-id}` /
-`{claim-id}`.
+`claimed-by` fields, and do not reuse the displaced old `{claim-id}` as your
+own — always use the marker's assigned `new-claim-id` (`{agent-id}` may
+legitimately equal the displaced claim's agent-id; only `{claim-id}` must
+always be the fresh marker-assigned value).
 
 **The successor claim is sticky**, not a one-shot unlock: forced-handoff
 re-derives the adopted pair as the active claim on every resolution pass, so

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -298,8 +298,9 @@ Determine `{branch-name}`:
   normalization algorithm from pre-check (e).
 
 Generate a fresh `{claim-id}` — **except in forced-handoff recovery**, where
-the successor adopts the marker's pre-recorded `new-claim-id` instead of
-minting one (see _Claim verification_ below). Determine `{prior-claim-id}`:
+the successor adopts the marker's pre-recorded `new-agent-id` / `new-claim-id`
+pair instead of minting a claim-id or keeping its own agent-id (see _Claim
+verification_ below). Determine `{prior-claim-id}`:
 
 - **Takeover of an active claim** (stale claim recovery) → the current
   active claim's `{claim-id}`
@@ -374,13 +375,31 @@ the rest of the workflow.
 
 When the new claim came from forced-handoff recovery, the verified
 `forced-handoff` marker has already set the active claim to its pre-recorded
-`new-claim-id` (Claim-state parsing rule 7). Adopt that `new-claim-id` as your
-own `{claim-id}` for the rest of the run — including the `--claim-id` passed to
-`pre-merge-readiness` at F2/F3 — instead of minting a fresh one; no separate
-`claimed-by supersedes: none` post is required for the transfer itself. Cite
-the trusted forced-handoff evidence in the issue digest or resume report's
-`Authoritative by` field. Do not invent ad hoc `claimed-by` fields, and do not
-reuse the displaced old `{claim-id}`.
+`new-agent-id` / `new-claim-id` pair (Claim-state parsing rule 7). Adopt
+**both fields verbatim** as your own `{agent-id}` / `{claim-id}` for the rest
+of the run — including `--agent-id` and `--claim-id` at F2/F3's
+`pre-merge-readiness` — instead of minting a fresh claim-id or keeping your
+own native agent-id; no separate `claimed-by supersedes: none` post is
+required for the transfer itself. `new-agent-id` defaults to the _displaced_
+claim's own agent-id, not the successor's: Claim-state parsing rule 6 ignores
+a `claimed-by` whose `{claim-id}` matches the active claim but whose
+`{agent-id}` differs, so an invented native agent-id silently fails every
+later heartbeat or F2/F3 check as `agent-id-mismatch` / `claimLost`, with no
+explaining error. Cite the trusted forced-handoff evidence in the issue
+digest or resume report's `Authoritative by` field. Do not invent ad hoc
+`claimed-by` fields, and do not reuse the displaced old `{agent-id}` /
+`{claim-id}`.
+
+**The successor claim is sticky**, not a one-shot unlock: forced-handoff
+re-derives the adopted pair as the active claim on every resolution pass, so
+a later `claimed-by supersedes: none` does not activate (Claim-state parsing
+rule 4 requires no active claim for `supersedes: none` to take effect) and
+instead reads as contested. Reconcile via one of two short sequences:
+**adopt-verbatim** — keep using the recorded `new-agent-id` / `new-claim-id`
+pair, as above; or **release-then-fresh** — post `unclaimed-by` for the
+sticky pair (and, to be safe, the displaced original pair too) using each
+pair's exact recorded `{agent-id}` / `{claim-id}`, then post a fresh
+`claimed-by supersedes: none` with a self-chosen pair.
 
 ### Hide displaced claim chain on takeover
 

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -385,7 +385,7 @@ claim's own agent-id, not the successor's: Claim-state parsing rule 6 ignores
 a `claimed-by` whose `{claim-id}` matches the active claim but whose
 `{agent-id}` differs, so an invented native agent-id silently fails every
 later heartbeat or F2/F3 check as `agent-id-mismatch` / `claimLost`, with no
-explaining error. Cite the trusted forced-handoff evidence in the issue
+error explaining why. Cite the trusted forced-handoff evidence in the issue
 digest or resume report's `Authoritative by` field. Do not invent ad hoc
 `claimed-by` fields, and do not reuse the displaced old `{claim-id}` as your
 own — always use the marker's assigned `new-claim-id` (`{agent-id}` may

--- a/docs/idd-resume-detail.md
+++ b/docs/idd-resume-detail.md
@@ -40,10 +40,16 @@ active, stop and wait rather than inventing a local superseding claim.
 Once GitHub state reflects the handoff outcome, continue via
 `idd-claim.instructions.md` on the branch named in the forced-handoff evidence.
 The verified `forced-handoff` marker has already set the active claim to its
-pre-recorded `new-claim-id` (rule 7), so the successor **adopts that
-`new-claim-id`** as its own `{claim-id}` for the rest of the run — including the
-`--claim-id` passed to `pre-merge-readiness` at F2/F3 — rather than minting a
-fresh one. No separate `claimed-by` post is required for the transfer itself.
+pre-recorded `new-agent-id` / `new-claim-id` pair (rule 7), so the successor
+**adopts both verbatim** as its own `{agent-id}` / `{claim-id}` for the rest
+of the run — including `--agent-id` and `--claim-id` at F2/F3's
+`pre-merge-readiness` — rather than minting a claim-id or keeping its own
+agent-id (an invented agent-id silently fails later checks as
+`agent-id-mismatch`; see `idd-claim.instructions.md`'s Claim verification
+section). No separate `claimed-by` post is required for the transfer itself.
+This adopted claim is **sticky** (re-derived on every resolution pass); see
+the same section for the adopt-verbatim vs. release-then-fresh reconciliation
+paths if a fresh claim appears not to take effect.
 
 **Displaced-session guard** — If the forced-handoff evidence names a
 `{claim-id}` that this current session had already verified before this
@@ -52,8 +58,9 @@ Do not push, comment, reply, resolve threads, request reviewers, or merge
 until a maintainer reassigns ownership.
 
 The successor must cite the forced-handoff evidence in its resume report or
-digest `Authoritative by`. It must not reuse the displaced old `{claim-id}`,
-which is distinct from the adopted `new-claim-id`.
+digest `Authoritative by`. It must not reuse the displaced old `{agent-id}` /
+`{claim-id}`, which are distinct from the adopted `new-agent-id` /
+`new-claim-id`.
 
 ## §W1 — PR exists (1 match), no worktree
 

--- a/docs/idd-resume-detail.md
+++ b/docs/idd-resume-detail.md
@@ -58,9 +58,10 @@ Do not push, comment, reply, resolve threads, request reviewers, or merge
 until a maintainer reassigns ownership.
 
 The successor must cite the forced-handoff evidence in its resume report or
-digest `Authoritative by`. It must not reuse the displaced old `{agent-id}` /
-`{claim-id}`, which are distinct from the adopted `new-agent-id` /
-`new-claim-id`.
+digest `Authoritative by`. It must not reuse the displaced old `{claim-id}` as
+its own — always use the marker's assigned `new-claim-id`. (`{agent-id}` may
+legitimately equal the displaced claim's agent-id; only `{claim-id}` must
+always be the fresh marker-assigned value.)
 
 ## §W1 — PR exists (1 match), no worktree
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -380,7 +380,7 @@ claim's own agent-id, not the successor's: Claim-state parsing rule 6 ignores
 a `claimed-by` whose `{claim-id}` matches the active claim but whose
 `{agent-id}` differs, so an invented native agent-id silently fails every
 later heartbeat or F2/F3 check as `agent-id-mismatch` / `claimLost`, with no
-explaining error. Cite the trusted forced-handoff evidence in the issue
+error explaining why. Cite the trusted forced-handoff evidence in the issue
 digest or resume report's `Authoritative by` field. Do not invent ad hoc
 `claimed-by` fields, and do not reuse the displaced old `{claim-id}` as your
 own — always use the marker's assigned `new-claim-id` (`{agent-id}` may

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -382,8 +382,10 @@ a `claimed-by` whose `{claim-id}` matches the active claim but whose
 later heartbeat or F2/F3 check as `agent-id-mismatch` / `claimLost`, with no
 explaining error. Cite the trusted forced-handoff evidence in the issue
 digest or resume report's `Authoritative by` field. Do not invent ad hoc
-`claimed-by` fields, and do not reuse the displaced old `{agent-id}` /
-`{claim-id}`.
+`claimed-by` fields, and do not reuse the displaced old `{claim-id}` as your
+own — always use the marker's assigned `new-claim-id` (`{agent-id}` may
+legitimately equal the displaced claim's agent-id; only `{claim-id}` must
+always be the fresh marker-assigned value).
 
 **The successor claim is sticky**, not a one-shot unlock: forced-handoff
 re-derives the adopted pair as the active claim on every resolution pass, so

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -293,8 +293,9 @@ Determine `{branch-name}`:
   normalization algorithm from pre-check (e).
 
 Generate a fresh `{claim-id}` — **except in forced-handoff recovery**, where
-the successor adopts the marker's pre-recorded `new-claim-id` instead of
-minting one (see _Claim verification_ below). Determine `{prior-claim-id}`:
+the successor adopts the marker's pre-recorded `new-agent-id` / `new-claim-id`
+pair instead of minting a claim-id or keeping its own agent-id (see _Claim
+verification_ below). Determine `{prior-claim-id}`:
 
 - **Takeover of an active claim** (stale claim recovery) → the current
   active claim's `{claim-id}`
@@ -369,13 +370,31 @@ the rest of the workflow.
 
 When the new claim came from forced-handoff recovery, the verified
 `forced-handoff` marker has already set the active claim to its pre-recorded
-`new-claim-id` (Claim-state parsing rule 7). Adopt that `new-claim-id` as your
-own `{claim-id}` for the rest of the run — including the `--claim-id` passed to
-`pre-merge-readiness` at F2/F3 — instead of minting a fresh one; no separate
-`claimed-by supersedes: none` post is required for the transfer itself. Cite
-the trusted forced-handoff evidence in the issue digest or resume report's
-`Authoritative by` field. Do not invent ad hoc `claimed-by` fields, and do not
-reuse the displaced old `{claim-id}`.
+`new-agent-id` / `new-claim-id` pair (Claim-state parsing rule 7). Adopt
+**both fields verbatim** as your own `{agent-id}` / `{claim-id}` for the rest
+of the run — including `--agent-id` and `--claim-id` at F2/F3's
+`pre-merge-readiness` — instead of minting a fresh claim-id or keeping your
+own native agent-id; no separate `claimed-by supersedes: none` post is
+required for the transfer itself. `new-agent-id` defaults to the _displaced_
+claim's own agent-id, not the successor's: Claim-state parsing rule 6 ignores
+a `claimed-by` whose `{claim-id}` matches the active claim but whose
+`{agent-id}` differs, so an invented native agent-id silently fails every
+later heartbeat or F2/F3 check as `agent-id-mismatch` / `claimLost`, with no
+explaining error. Cite the trusted forced-handoff evidence in the issue
+digest or resume report's `Authoritative by` field. Do not invent ad hoc
+`claimed-by` fields, and do not reuse the displaced old `{agent-id}` /
+`{claim-id}`.
+
+**The successor claim is sticky**, not a one-shot unlock: forced-handoff
+re-derives the adopted pair as the active claim on every resolution pass, so
+a later `claimed-by supersedes: none` does not activate (Claim-state parsing
+rule 4 requires no active claim for `supersedes: none` to take effect) and
+instead reads as contested. Reconcile via one of two short sequences:
+**adopt-verbatim** — keep using the recorded `new-agent-id` / `new-claim-id`
+pair, as above; or **release-then-fresh** — post `unclaimed-by` for the
+sticky pair (and, to be safe, the displaced original pair too) using each
+pair's exact recorded `{agent-id}` / `{claim-id}`, then post a fresh
+`claimed-by supersedes: none` with a self-chosen pair.
 
 ### Hide displaced claim chain on takeover
 

--- a/idd-template/docs/idd-resume-detail.md
+++ b/idd-template/docs/idd-resume-detail.md
@@ -40,10 +40,16 @@ active, stop and wait rather than inventing a local superseding claim.
 Once GitHub state reflects the handoff outcome, continue via
 `idd-claim.instructions.md` on the branch named in the forced-handoff evidence.
 The verified `forced-handoff` marker has already set the active claim to its
-pre-recorded `new-claim-id` (rule 7), so the successor **adopts that
-`new-claim-id`** as its own `{claim-id}` for the rest of the run — including the
-`--claim-id` passed to `pre-merge-readiness` at F2/F3 — rather than minting a
-fresh one. No separate `claimed-by` post is required for the transfer itself.
+pre-recorded `new-agent-id` / `new-claim-id` pair (rule 7), so the successor
+**adopts both verbatim** as its own `{agent-id}` / `{claim-id}` for the rest
+of the run — including `--agent-id` and `--claim-id` at F2/F3's
+`pre-merge-readiness` — rather than minting a claim-id or keeping its own
+agent-id (an invented agent-id silently fails later checks as
+`agent-id-mismatch`; see `idd-claim.instructions.md`'s Claim verification
+section). No separate `claimed-by` post is required for the transfer itself.
+This adopted claim is **sticky** (re-derived on every resolution pass); see
+the same section for the adopt-verbatim vs. release-then-fresh reconciliation
+paths if a fresh claim appears not to take effect.
 
 **Displaced-session guard** — If the forced-handoff evidence names a
 `{claim-id}` that this current session had already verified before this
@@ -52,8 +58,9 @@ Do not push, comment, reply, resolve threads, request reviewers, or merge
 until a maintainer reassigns ownership.
 
 The successor must cite the forced-handoff evidence in its resume report or
-digest `Authoritative by`. It must not reuse the displaced old `{claim-id}`,
-which is distinct from the adopted `new-claim-id`.
+digest `Authoritative by`. It must not reuse the displaced old `{agent-id}` /
+`{claim-id}`, which are distinct from the adopted `new-agent-id` /
+`new-claim-id`.
 
 ## §W1 — PR exists (1 match), no worktree
 

--- a/idd-template/docs/idd-resume-detail.md
+++ b/idd-template/docs/idd-resume-detail.md
@@ -58,9 +58,10 @@ Do not push, comment, reply, resolve threads, request reviewers, or merge
 until a maintainer reassigns ownership.
 
 The successor must cite the forced-handoff evidence in its resume report or
-digest `Authoritative by`. It must not reuse the displaced old `{agent-id}` /
-`{claim-id}`, which are distinct from the adopted `new-agent-id` /
-`new-claim-id`.
+digest `Authoritative by`. It must not reuse the displaced old `{claim-id}` as
+its own — always use the marker's assigned `new-claim-id`. (`{agent-id}` may
+legitimately equal the displaced claim's agent-id; only `{claim-id}` must
+always be the fresh marker-assigned value.)
 
 ## §W1 — PR exists (1 match), no worktree
 


### PR DESCRIPTION
# Summary

The forced-handoff adoption guidance in `idd-claim.instructions.md` already
told the successor to adopt the marker's recorded `new-claim-id` verbatim,
but left two load-bearing gaps:

1. It never said to also adopt `new-agent-id` verbatim. `new-agent-id`
   defaults to the *displaced* claim's own agent-id, not the successor's
   native id. `applyClaimEvent`'s claim-id-match-but-agent-id-mismatch rule
   (Claim-state parsing rule 6) silently ignores a `claimed-by` in that
   shape, so a successor that keeps its own agent-id loses the claim with no
   explaining error — surfacing later at F2/F3 as `agent-id-mismatch` /
   `claimLost`.
2. It never stated that the adopted successor claim is **sticky**:
   `applyClaimEvent` re-derives it as the active claim on every resolution
   pass (rule 7), so a plain fresh `claimed-by supersedes: none` posted
   afterward does not activate (rule 4 requires no active claim) and reads
   as contested instead.

This PR documents both gaps and names the two valid reconciliation shapes:
**adopt-verbatim** (reuse the recorded `new-agent-id` + `new-claim-id`) and
**release-then-fresh** (release the sticky successor — and, to be safe, the
displaced original — via `unclaimed-by`, then post a fresh claim).

Both technical claims (rule 6 agent-id-mismatch → ignored event; rule 4
sticky re-derivation) were verified against `applyClaimEvent` in
`src/scripts/protocol-helpers.mts`, and the `agent-id-mismatch` /
`claimLost` strings were confirmed as literal identifiers used by
`pre-merge-readiness`'s claim-match check. No code or behavior change —
docs only.

## Linked issue

Closes #1314

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Changed files:

- `idd-template/.github/instructions/idd-claim.instructions.md` (canonical
  source): extend the forced-handoff adoption prose in "Claim execution" and
  "Claim verification" per the two points above.
- `idd-template/docs/idd-resume-detail.md` §FH (canonical source): same
  clarification, since its forced-handoff recovery narrative independently
  restated the old claim-id-only adoption text.
- Regenerated mirrors via `node scripts/sync-docs.mjs --apply`:
  `.github/instructions/idd-claim.instructions.md`,
  `docs/idd-resume-detail.md`.

`idd-claim.instructions.md` participates in the `bundle-discovery` byte
budget (limit 100,400 bytes). After this change the bundle totals 95,575
bytes (4,825 bytes of headroom remaining); `idd-claim.instructions.md`
itself is 27,805 bytes against its own 32,200-byte phase-file cap.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
