### PR TITLE
fix(discover): tolerate a colon in "Blocked by: #N" across both dependency matchers

### DIFF
--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -17,6 +17,7 @@ import {
   parseAutopilotSuitability,
   rankAndRouteBySuitability,
 } from './autopilot-suitability.mjs';
+import { extractBlockedByIssueNumbers } from './discover-readiness-check.mjs';
 import { effortOrdinal, parseEffort } from './effort.mjs';
 import {
   GH_TEXT_LOOP_TIMEOUT_OPTIONS,
@@ -30,18 +31,16 @@ const DEFAULT_MARKER_PREFIX = 'idd-skill';
 if (isCliExecution(import.meta.url)) {
   runCli();
 }
+/**
+ * Collect the visible `Blocked by #N` references in `body`. Delegates to the
+ * readiness composer's `extractBlockedByIssueNumbers` (#1311) instead of a
+ * second inline "Blocked by" regex, so this filter and the readiness gate
+ * share one dependency-line primitive — including its colon tolerance
+ * (`Blocked by: #123`), blockquote/list-bullet prefix tolerance, and
+ * code-region stripping.
+ */
 export function extractBlockedByReferences(body) {
-  const references = [];
-  const regex = /^\s*Blocked by #(\d+)\b.*$/gim;
-  let match = regex.exec(String(body ?? ''));
-  while (match) {
-    const number = Number.parseInt(match[1], 10);
-    if (Number.isInteger(number) && number > 0) {
-      references.push(number);
-    }
-    match = regex.exec(String(body ?? ''));
-  }
-  return references;
+  return extractBlockedByIssueNumbers(String(body ?? ''));
 }
 export function getOrphanFirstPolicy(config) {
   if (!config || typeof config !== 'object') {

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -361,18 +361,22 @@ export function parseSwarmFloorArg(value) {
  *
  * A line is a dependency declaration when, after the shared
  * `DEPENDENCY_LINE_PREFIX` (indentation, blockquote, and/or a list bullet), it
- * begins with `keyword` followed by horizontal whitespace and at least one
- * `#N`. From there `consumeDependencyRefList` collects the contiguous
- * dependency-ref list, so `Blocked by #A, #B, #C` (comma- or space-separated)
- * yields `[A, B, C]`. The keyword-to-ref gap is `[ \t]+` (not `\s+`) so it
- * cannot span a newline and swallow a bare `#N` on the following line, and the
- * `.*$` capture plus the `m` flag (no `s` flag) keeps the match on the single
- * keyword line. Callers pass a code-region-stripped body, so a quoted example
- * line is already masked (see `DEPENDENCY_LINE_PREFIX`).
+ * begins with `keyword`, an optional `:` (#1311 — a natural bulleted phrasing
+ * such as `- Blocked by: #123` is tolerated the same as `- Blocked by #123`,
+ * aligned with the colon-tolerant `extractKeywordReferenceTargets` edge
+ * extractor in `discover-roadmap-graph.mts`), then horizontal whitespace and
+ * at least one `#N`. From there `consumeDependencyRefList` collects the
+ * contiguous dependency-ref list, so `Blocked by #A, #B, #C` (comma- or
+ * space-separated) yields `[A, B, C]`. The keyword-to-ref gap is `[ \t]+`
+ * (not `\s+`) so it cannot span a newline and swallow a bare `#N` on the
+ * following line, and the `.*$` capture plus the `m` flag (no `s` flag)
+ * keeps the match on the single keyword line. Callers pass a
+ * code-region-stripped body, so a quoted example line is already masked (see
+ * `DEPENDENCY_LINE_PREFIX`).
  */
 function extractKeywordLineRefs(body, keyword) {
   const linePattern = new RegExp(
-    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}[ \\t]+(#\\d+.*)$`,
+    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}:?[ \\t]+(#\\d+.*)$`,
     'gim',
   );
   const numbers = [];

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -19,6 +19,7 @@ import {
   parseAutopilotSuitability,
   rankAndRouteBySuitability,
 } from './autopilot-suitability.mts';
+import { extractBlockedByIssueNumbers } from './discover-readiness-check.mts';
 import { type EffortHint, effortOrdinal, parseEffort } from './effort.mts';
 import {
   GH_TEXT_LOOP_TIMEOUT_OPTIONS,
@@ -126,18 +127,16 @@ if (isCliExecution(import.meta.url)) {
   runCli();
 }
 
+/**
+ * Collect the visible `Blocked by #N` references in `body`. Delegates to the
+ * readiness composer's `extractBlockedByIssueNumbers` (#1311) instead of a
+ * second inline "Blocked by" regex, so this filter and the readiness gate
+ * share one dependency-line primitive — including its colon tolerance
+ * (`Blocked by: #123`), blockquote/list-bullet prefix tolerance, and
+ * code-region stripping.
+ */
 export function extractBlockedByReferences(body: unknown): number[] {
-  const references: number[] = [];
-  const regex = /^\s*Blocked by #(\d+)\b.*$/gim;
-  let match = regex.exec(String(body ?? ''));
-  while (match) {
-    const number = Number.parseInt(match[1], 10);
-    if (Number.isInteger(number) && number > 0) {
-      references.push(number);
-    }
-    match = regex.exec(String(body ?? ''));
-  }
-  return references;
+  return extractBlockedByIssueNumbers(String(body ?? ''));
 }
 
 export function getOrphanFirstPolicy(config: unknown): string {

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -497,18 +497,22 @@ export function parseSwarmFloorArg(value: string): number {
  *
  * A line is a dependency declaration when, after the shared
  * `DEPENDENCY_LINE_PREFIX` (indentation, blockquote, and/or a list bullet), it
- * begins with `keyword` followed by horizontal whitespace and at least one
- * `#N`. From there `consumeDependencyRefList` collects the contiguous
- * dependency-ref list, so `Blocked by #A, #B, #C` (comma- or space-separated)
- * yields `[A, B, C]`. The keyword-to-ref gap is `[ \t]+` (not `\s+`) so it
- * cannot span a newline and swallow a bare `#N` on the following line, and the
- * `.*$` capture plus the `m` flag (no `s` flag) keeps the match on the single
- * keyword line. Callers pass a code-region-stripped body, so a quoted example
- * line is already masked (see `DEPENDENCY_LINE_PREFIX`).
+ * begins with `keyword`, an optional `:` (#1311 — a natural bulleted phrasing
+ * such as `- Blocked by: #123` is tolerated the same as `- Blocked by #123`,
+ * aligned with the colon-tolerant `extractKeywordReferenceTargets` edge
+ * extractor in `discover-roadmap-graph.mts`), then horizontal whitespace and
+ * at least one `#N`. From there `consumeDependencyRefList` collects the
+ * contiguous dependency-ref list, so `Blocked by #A, #B, #C` (comma- or
+ * space-separated) yields `[A, B, C]`. The keyword-to-ref gap is `[ \t]+`
+ * (not `\s+`) so it cannot span a newline and swallow a bare `#N` on the
+ * following line, and the `.*$` capture plus the `m` flag (no `s` flag)
+ * keeps the match on the single keyword line. Callers pass a
+ * code-region-stripped body, so a quoted example line is already masked (see
+ * `DEPENDENCY_LINE_PREFIX`).
  */
 function extractKeywordLineRefs(body: string, keyword: string): number[] {
   const linePattern = new RegExp(
-    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}[ \\t]+(#\\d+.*)$`,
+    `${DEPENDENCY_LINE_PREFIX}${escapeRegex(keyword)}:?[ \\t]+(#\\d+.*)$`,
     'gim',
   );
   const numbers: number[] = [];

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -18,6 +18,11 @@ blocked by #56
   assert.deepEqual(extractBlockedByReferences(body), [12, 34, 56]);
 });
 
+test('extractBlockedByReferences tolerates a colon between the keyword and the ref (#1311)', () => {
+  const body = '- Blocked by: #123 (context) — more text';
+  assert.deepEqual(extractBlockedByReferences(body), [123]);
+});
+
 test('getOrphanFirstPolicy reads commands row and falls back to none', () => {
   assert.equal(
     getOrphanFirstPolicy({

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -51,6 +51,13 @@ test('extractBlockedByIssueNumbers captures every same-line ref and tolerates li
   // List-bullet and blockquote prefixes are matched.
   assert.deepEqual(extractBlockedByIssueNumbers('- Blocked by #55'), [55]);
   assert.deepEqual(extractBlockedByIssueNumbers('> Blocked by #66'), [66]);
+  // #1311: an optional colon between the keyword and the ref is tolerated,
+  // aligned with the already colon-tolerant graph edge extractor.
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('- Blocked by: #123 (context) — more text'),
+    [123],
+  );
+  assert.deepEqual(extractBlockedByIssueNumbers('Blocked by: #99'), [99]);
   // Mid-sentence prose is not a dependency declaration.
   assert.deepEqual(
     extractBlockedByIssueNumbers('this is not blocked by #5'),
@@ -85,6 +92,9 @@ test('extractDependencyIssueNumbers captures every same-line Depends on ref and 
   );
   assert.deepEqual(extractDependencyIssueNumbers('- Depends on #55'), [55]);
   assert.deepEqual(extractDependencyIssueNumbers('> Depends on #66'), [66]);
+  // #1311: the colon tolerance is a property of the shared
+  // `extractKeywordLineRefs` primitive, not a "Blocked by"-only special case.
+  assert.deepEqual(extractDependencyIssueNumbers('Depends on: #55'), [55]);
   assert.deepEqual(
     extractDependencyIssueNumbers('this does not depend on #5'),
     [],


### PR DESCRIPTION
# Summary

Both "Blocked by" dependency-**gating** matchers required a plain space
directly after the keyword, so a natural bulleted phrasing like
`- Blocked by: #123` (colon form) was silently missed by **both** the
readiness composer and the orphan filter — an agent trusting either
helper's output could claim work that was actually still blocked. The
graph edge extractor already tolerated a colon; this consolidates the two
gating matchers onto that same tolerance via one shared primitive.

- `src/scripts/discover-readiness-check.mts`: `extractKeywordLineRefs`'s
  line regex now accepts an optional `:` between the keyword and the
  required whitespace before `#`. This is the single building block
  behind both exported `extractBlockedByIssueNumbers` and
  `extractDependencyIssueNumbers`, so "Blocked by" and "Depends on" both
  gain colon tolerance from one change; the blockquote/list-bullet prefix
  tolerance is untouched.
- `src/scripts/discover-orphan-filter.mts`: removed the duplicated inline
  `/^\s*Blocked by #(\d+)\b.*$/gim` regex. `extractBlockedByReferences`
  now delegates to the shared `extractBlockedByIssueNumbers`, keeping its
  exported name/signature (no call-site changes in `classifyIssue`). As a
  side benefit (not a regression — no test asserted the old behavior),
  the orphan filter now also strips markdown code regions and de-dupes,
  matching the readiness composer's existing #1121 boundary.
- New colon-form fixtures in both unit-test files (none existed:
  `grep "Blocked by:" tests/` was empty), plus one `Depends on:` case
  confirming the tolerance lives in the shared primitive rather than
  being "Blocked by"-specific.
- `pnpm run build` regenerated `scripts/discover-readiness-check.mjs` /
  `scripts/discover-orphan-filter.mjs` from the edited `.mts` sources.

Deliberately out of scope: the issue's "ideally" em/en-dash separator
tolerance is not implemented — it is a soft stretch, not an acceptance
criterion, and no fixture requests it, so this keeps the diff minimal and
precisely testable.

## Linked issue

Closes #1311

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Parent roadmap: #1309. The third existing parser,
`extractKeywordReferenceTargets` in `discover-roadmap-graph.mts`, already
strips a leading colon from the post-keyword segment — that pre-existing
behavior is the reference this change aligns the two gating matchers to.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
