### PR TITLE
feat(marker): surface malformed claim/watermark markers instead of silently dropping them

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -330,12 +330,14 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 
 **Nothing appended after the note.** A `claimed-by` / `unclaimed-by` marker
 comment body must be exactly the HTML comment token followed by, at most,
-the single italic note shown above — never more. Appending anything else
-(a rationale, a follow-up sentence, extra formatting) after the note fails
-the parser's whole-body anchor: the comment is not recognized as a live
-claim event, matching every other malformed body. Unlike an ordinary
-unrecognized comment, though, this specific shape — a structurally valid
-token plus note with content appended — is a **detectable** malformed
+the single italic note shown above — never more. Any deviation from that
+exact shape — content appended after the note, content appended directly
+after the token with no note, a note that does not satisfy the required
+note grammar, or any other departure — fails the parser's whole-body
+anchor: the comment is not recognized as a live claim event, matching
+every other malformed body. Unlike an ordinary unrecognized comment,
+though, a body that starts with a structurally valid token but deviates
+from the exact shape in any of those ways is a **detectable** malformed
 marker (`detectMalformedOperationalMarker` in `marker-helpers.mts`), so
 tooling can flag it instead of the claim silently reading as unremarkable
 "other" content. Detection is diagnostic only: never salvage a malformed

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -328,6 +328,28 @@ HTTP `POST` with a JSON body when the helper runtime is unavailable:
 _{agent-id}: issue claim — IDD automation marker. Do not edit._
 ```
 
+**Nothing appended after the note.** A `claimed-by` / `unclaimed-by` marker
+comment body must be exactly the HTML comment token followed by, at most,
+the single italic note shown above — never more. Appending anything else
+(a rationale, a follow-up sentence, extra formatting) after the note fails
+the parser's whole-body anchor: the comment is not recognized as a live
+claim event, matching every other malformed body. Unlike an ordinary
+unrecognized comment, though, this specific shape — a structurally valid
+token plus note with content appended — is a **detectable** malformed
+marker (`detectMalformedOperationalMarker` in `marker-helpers.mts`), so
+tooling can flag it instead of the claim silently reading as unremarkable
+"other" content. Detection is diagnostic only: never salvage a malformed
+post as if it were valid, always re-post a clean marker with nothing
+appended. A marker merely quoted or embedded mid-prose (not the literal
+first bytes of the body) is still never treated as live or flagged —
+anti-spoofing is unaffected.
+
+Related: a disposition marker (`**Accepted**` / `**Rejected**`, posted
+during review triage — see `idd-review-triage.instructions.md`) is governed
+by the same no-wrapping principle: it must not be wrapped in a code fence
+or other block-level markdown either, or the disposition-evidence gate
+will not recognize it.
+
 ## Heartbeat posting
 
 When posting a heartbeat (i.e., when the issue is already claimed by this current

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -124,14 +124,16 @@ ambiguous). Example Japanese note:
 **Nothing appended after the note.** As with the `claimed-by` /
 `unclaimed-by` markers in `idd-claim.instructions.md`, a `review-watermark`
 (and `review-baseline`, below) comment body must be exactly the HTML
-comment token plus the single italic note, with nothing appended —
-appending anything else after the note fails the parser's whole-body
-anchor and the comment is not recognized as a live watermark. That
-specific shape (valid token + note plus appended content) is a detectable
-malformed marker (`detectMalformedOperationalMarker` in
-`marker-helpers.mts`); see `idd-claim.instructions.md` for the full rule,
-including the related disposition-marker (`**Accepted**` / `**Rejected**`)
-no-code-fence note.
+comment token plus the single italic note, with nothing appended — any
+deviation (content appended after the note, content appended directly
+after the token with no note, a note that does not satisfy the required
+note grammar, or any other departure) fails the parser's whole-body anchor
+and the comment is not recognized as a live watermark. A body that starts
+with a structurally valid token but deviates from the exact shape in any
+of those ways is a detectable malformed marker
+(`detectMalformedOperationalMarker` in `marker-helpers.mts`); see
+`idd-claim.instructions.md` for the full rule, including the related
+disposition-marker (`**Accepted**` / `**Rejected**`) no-code-fence note.
 
 - **`{head-SHA}`**: the value read at the very start of Step 1, before
   any fetching. F2 uses this to detect pushes that occurred between E1's

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -121,6 +121,18 @@ write the visible note in that language (default to English if
 ambiguous). Example Japanese note:
 `_{agent-id}: レビュートリアージのスナップショット — IDD 自動化マーカー。編集しないでください。_`
 
+**Nothing appended after the note.** As with the `claimed-by` /
+`unclaimed-by` markers in `idd-claim.instructions.md`, a `review-watermark`
+(and `review-baseline`, below) comment body must be exactly the HTML
+comment token plus the single italic note, with nothing appended —
+appending anything else after the note fails the parser's whole-body
+anchor and the comment is not recognized as a live watermark. That
+specific shape (valid token + note plus appended content) is a detectable
+malformed marker (`detectMalformedOperationalMarker` in
+`marker-helpers.mts`); see `idd-claim.instructions.md` for the full rule,
+including the related disposition-marker (`**Accepted**` / `**Rejected**`)
+no-code-fence note.
+
 - **`{head-SHA}`**: the value read at the very start of Step 1, before
   any fetching. F2 uses this to detect pushes that occurred between E1's
   snapshot and the watermark comment post.
@@ -272,6 +284,8 @@ watermark). Example Japanese note:
 Post using the GitHub REST API directly (the body begins with an HTML
 comment token; use the HTTP `POST` path for reliability) — or the
 post-idd-marker `--apply` helper above, which performs that JSON `POST`.
+The same "nothing appended after the note" rule stated above for
+`review-watermark` applies here too.
 
 ## E3 — Empty list check
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -236,8 +236,12 @@ marker is a separate PATH A thread signal, not part of this predicate or
 count pairing):
 
 - The marker must be the **first bytes of the comment body** — no heading,
-  block quote, or preamble before it, or the gate counts zero dispositions for
-  that comment.
+  block quote, code fence, or preamble before it, or the gate counts zero
+  dispositions for that comment. A code-fenced marker (e.g. wrapping
+  `**Accepted** — {reason}` in a fenced block for emphasis) already fails
+  this rule on its own — the fence delimiters, not the marker, would be the
+  first bytes — call it out explicitly rather than leaving it merely
+  implied.
 - Post **one disposition reply per advisory item**. Do **not** combine several
   markers into one comment: the 1:1 count pairing clears only one item per
   comment, so a combined reply leaves the rest flagged

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -323,6 +323,28 @@ HTTP `POST` with a JSON body when the helper runtime is unavailable:
 _{agent-id}: issue claim — IDD automation marker. Do not edit._
 ```
 
+**Nothing appended after the note.** A `claimed-by` / `unclaimed-by` marker
+comment body must be exactly the HTML comment token followed by, at most,
+the single italic note shown above — never more. Appending anything else
+(a rationale, a follow-up sentence, extra formatting) after the note fails
+the parser's whole-body anchor: the comment is not recognized as a live
+claim event, matching every other malformed body. Unlike an ordinary
+unrecognized comment, though, this specific shape — a structurally valid
+token plus note with content appended — is a **detectable** malformed
+marker (`detectMalformedOperationalMarker` in `marker-helpers.mts`), so
+tooling can flag it instead of the claim silently reading as unremarkable
+"other" content. Detection is diagnostic only: never salvage a malformed
+post as if it were valid, always re-post a clean marker with nothing
+appended. A marker merely quoted or embedded mid-prose (not the literal
+first bytes of the body) is still never treated as live or flagged —
+anti-spoofing is unaffected.
+
+Related: a disposition marker (`**Accepted**` / `**Rejected**`, posted
+during review triage — see `idd-review-triage.instructions.md`) is governed
+by the same no-wrapping principle: it must not be wrapped in a code fence
+or other block-level markdown either, or the disposition-evidence gate
+will not recognize it.
+
 ## Heartbeat posting
 
 When posting a heartbeat (i.e., when the issue is already claimed by this current

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -325,12 +325,14 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 
 **Nothing appended after the note.** A `claimed-by` / `unclaimed-by` marker
 comment body must be exactly the HTML comment token followed by, at most,
-the single italic note shown above — never more. Appending anything else
-(a rationale, a follow-up sentence, extra formatting) after the note fails
-the parser's whole-body anchor: the comment is not recognized as a live
-claim event, matching every other malformed body. Unlike an ordinary
-unrecognized comment, though, this specific shape — a structurally valid
-token plus note with content appended — is a **detectable** malformed
+the single italic note shown above — never more. Any deviation from that
+exact shape — content appended after the note, content appended directly
+after the token with no note, a note that does not satisfy the required
+note grammar, or any other departure — fails the parser's whole-body
+anchor: the comment is not recognized as a live claim event, matching
+every other malformed body. Unlike an ordinary unrecognized comment,
+though, a body that starts with a structurally valid token but deviates
+from the exact shape in any of those ways is a **detectable** malformed
 marker (`detectMalformedOperationalMarker` in `marker-helpers.mts`), so
 tooling can flag it instead of the claim silently reading as unremarkable
 "other" content. Detection is diagnostic only: never salvage a malformed

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -119,14 +119,16 @@ ambiguous). Example Japanese note:
 **Nothing appended after the note.** As with the `claimed-by` /
 `unclaimed-by` markers in `idd-claim.instructions.md`, a `review-watermark`
 (and `review-baseline`, below) comment body must be exactly the HTML
-comment token plus the single italic note, with nothing appended —
-appending anything else after the note fails the parser's whole-body
-anchor and the comment is not recognized as a live watermark. That
-specific shape (valid token + note plus appended content) is a detectable
-malformed marker (`detectMalformedOperationalMarker` in
-`marker-helpers.mts`); see `idd-claim.instructions.md` for the full rule,
-including the related disposition-marker (`**Accepted**` / `**Rejected**`)
-no-code-fence note.
+comment token plus the single italic note, with nothing appended — any
+deviation (content appended after the note, content appended directly
+after the token with no note, a note that does not satisfy the required
+note grammar, or any other departure) fails the parser's whole-body anchor
+and the comment is not recognized as a live watermark. A body that starts
+with a structurally valid token but deviates from the exact shape in any
+of those ways is a detectable malformed marker
+(`detectMalformedOperationalMarker` in `marker-helpers.mts`); see
+`idd-claim.instructions.md` for the full rule, including the related
+disposition-marker (`**Accepted**` / `**Rejected**`) no-code-fence note.
 
 - **`{head-SHA}`**: the value read at the very start of Step 1, before
   any fetching. F2 uses this to detect pushes that occurred between E1's

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -116,6 +116,18 @@ write the visible note in that language (default to English if
 ambiguous). Example Japanese note:
 `_{agent-id}: レビュートリアージのスナップショット — IDD 自動化マーカー。編集しないでください。_`
 
+**Nothing appended after the note.** As with the `claimed-by` /
+`unclaimed-by` markers in `idd-claim.instructions.md`, a `review-watermark`
+(and `review-baseline`, below) comment body must be exactly the HTML
+comment token plus the single italic note, with nothing appended —
+appending anything else after the note fails the parser's whole-body
+anchor and the comment is not recognized as a live watermark. That
+specific shape (valid token + note plus appended content) is a detectable
+malformed marker (`detectMalformedOperationalMarker` in
+`marker-helpers.mts`); see `idd-claim.instructions.md` for the full rule,
+including the related disposition-marker (`**Accepted**` / `**Rejected**`)
+no-code-fence note.
+
 - **`{head-SHA}`**: the value read at the very start of Step 1, before
   any fetching. F2 uses this to detect pushes that occurred between E1's
   snapshot and the watermark comment post.
@@ -267,6 +279,8 @@ watermark). Example Japanese note:
 Post using the GitHub REST API directly (the body begins with an HTML
 comment token; use the HTTP `POST` path for reliability) — or the
 post-idd-marker `--apply` helper above, which performs that JSON `POST`.
+The same "nothing appended after the note" rule stated above for
+`review-watermark` applies here too.
 
 ## E3 — Empty list check
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -231,8 +231,12 @@ marker is a separate PATH A thread signal, not part of this predicate or
 count pairing):
 
 - The marker must be the **first bytes of the comment body** — no heading,
-  block quote, or preamble before it, or the gate counts zero dispositions for
-  that comment.
+  block quote, code fence, or preamble before it, or the gate counts zero
+  dispositions for that comment. A code-fenced marker (e.g. wrapping
+  `**Accepted** — {reason}` in a fenced block for emphasis) already fails
+  this rule on its own — the fence delimiters, not the marker, would be the
+  first bytes — call it out explicitly rather than leaving it merely
+  implied.
 - Post **one disposition reply per advisory item**. Do **not** combine several
   markers into one comment: the 1:1 count pairing clears only one item per
   comment, so a combined reply leaves the rest flagged

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -587,16 +587,18 @@ export function operationalMarkerPrefixByStart(body) {
  * Detects a `claimed-by` / `unclaimed-by` / `review-watermark` /
  * `review-baseline` comment whose body starts with a structurally valid
  * marker token but whose whole body does not match the canonical, strict
- * `pattern` -- for example (the motivating case) a well-intentioned human
- * rationale appended after an otherwise-canonical token + note, but also a
- * note that does not satisfy the required note grammar (e.g. missing the
- * required `IDD` word) or is otherwise missing/malformed. Such a body
- * already fails `operationalMarkerPrefix`'s whole-body anchor and is
- * therefore never treated as a live marker for state resolution
- * (`parseClaimComment`, `resolveActiveClaim`, and friends keep returning
- * `null` / ignoring it, unchanged by this function's existence); this gives
- * a caller that wants one a **distinct** "malformed marker" signal instead
- * of the comment silently reading as ordinary, unremarkable content (#1316).
+ * `pattern` -- for **any** reason: content appended directly after the
+ * token with no note, a well-intentioned human rationale appended after an
+ * otherwise-canonical token + note (the motivating case), a note that does
+ * not satisfy the required note grammar (e.g. missing the required `IDD`
+ * word), or any other departure from the canonical token-then-optional-
+ * single-note shape. Such a body already fails `operationalMarkerPrefix`'s
+ * whole-body anchor and is therefore never treated as a live marker for
+ * state resolution (`parseClaimComment`, `resolveActiveClaim`, and friends
+ * keep returning `null` / ignoring it, unchanged by this function's
+ * existence); this gives a caller that wants one a **distinct** "malformed
+ * marker" signal instead of the comment silently reading as ordinary,
+ * unremarkable content (#1316).
  *
  * Returns the matching marker's `label` (e.g. `'<!-- claimed-by:'`) when the
  * body is malformed in that specific way, or `null` when the body is either

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -27,21 +27,28 @@ const OPERATIONAL_MARKERS = [
     label: '<!-- claimed-by:',
     pattern:
       /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    malformedPrefixPattern:
+      /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->/i,
   },
   {
     label: '<!-- unclaimed-by:',
     pattern:
       /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    malformedPrefixPattern:
+      /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->/i,
   },
   {
     label: '<!-- review-watermark:',
     pattern:
       /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    malformedPrefixPattern:
+      /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->/i,
   },
   {
     label: '<!-- review-baseline:',
     pattern:
       /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    malformedPrefixPattern: /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->/i,
   },
   {
     label: 'advisory-wait:',
@@ -575,6 +582,40 @@ export function operationalMarkerPrefixByStart(body) {
     return null;
   }
   return marker.label;
+}
+/**
+ * Detects a `claimed-by` / `unclaimed-by` / `review-watermark` /
+ * `review-baseline` comment whose body starts with a structurally valid
+ * marker token (and, when present, a well-formed note) but carries content
+ * appended after that -- for example a well-intentioned human rationale
+ * tacked onto an otherwise-canonical claim comment. Such a body already
+ * fails `operationalMarkerPrefix`'s whole-body anchor and is therefore
+ * never treated as a live marker for state resolution (`parseClaimComment`,
+ * `resolveActiveClaim`, and friends keep returning `null` / ignoring it,
+ * unchanged by this function's existence); this gives a caller that wants
+ * one a **distinct** "malformed marker" signal instead of the comment
+ * silently reading as ordinary, unremarkable content (#1316).
+ *
+ * Returns the matching marker's `label` (e.g. `'<!-- claimed-by:'`) when the
+ * body is malformed in that specific way, or `null` when the body is either
+ * a well-formed marker (not malformed) or not marker-shaped at all.
+ *
+ * Anti-spoofing is preserved: like `pattern`, `malformedPrefixPattern`
+ * anchors `^` at byte 0 with no leading-whitespace tolerance, so a marker
+ * merely quoted or embedded mid-prose -- i.e. not literally the first bytes
+ * of the body -- matches neither pattern and is never flagged here.
+ */
+export function detectMalformedOperationalMarker(body) {
+  if (operationalMarkerPrefix(body) !== null) {
+    // Already a well-formed marker (or otherwise-recognized marker type) --
+    // not malformed. Checking this first avoids double-classifying the
+    // happy path that `parseClaimComment` and friends already handle.
+    return null;
+  }
+  const marker = OPERATIONAL_MARKERS.find((candidate) =>
+    candidate.malformedPrefixPattern?.test(body),
+  );
+  return marker ? marker.label : null;
 }
 function normalizeNonWhitespaceToken(value) {
   if (typeof value !== 'string') {

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -586,15 +586,17 @@ export function operationalMarkerPrefixByStart(body) {
 /**
  * Detects a `claimed-by` / `unclaimed-by` / `review-watermark` /
  * `review-baseline` comment whose body starts with a structurally valid
- * marker token (and, when present, a well-formed note) but carries content
- * appended after that -- for example a well-intentioned human rationale
- * tacked onto an otherwise-canonical claim comment. Such a body already
- * fails `operationalMarkerPrefix`'s whole-body anchor and is therefore
- * never treated as a live marker for state resolution (`parseClaimComment`,
- * `resolveActiveClaim`, and friends keep returning `null` / ignoring it,
- * unchanged by this function's existence); this gives a caller that wants
- * one a **distinct** "malformed marker" signal instead of the comment
- * silently reading as ordinary, unremarkable content (#1316).
+ * marker token but whose whole body does not match the canonical, strict
+ * `pattern` -- for example (the motivating case) a well-intentioned human
+ * rationale appended after an otherwise-canonical token + note, but also a
+ * note that does not satisfy the required note grammar (e.g. missing the
+ * required `IDD` word) or is otherwise missing/malformed. Such a body
+ * already fails `operationalMarkerPrefix`'s whole-body anchor and is
+ * therefore never treated as a live marker for state resolution
+ * (`parseClaimComment`, `resolveActiveClaim`, and friends keep returning
+ * `null` / ignoring it, unchanged by this function's existence); this gives
+ * a caller that wants one a **distinct** "malformed marker" signal instead
+ * of the comment silently reading as ordinary, unremarkable content (#1316).
  *
  * Returns the matching marker's `label` (e.g. `'<!-- claimed-by:'`) when the
  * body is malformed in that specific way, or `null` when the body is either

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -35,13 +35,16 @@ interface OperationalMarker {
    * between this and `pattern` to tell three cases apart:
    *   - `pattern` matches -> well-formed marker: token, then either nothing
    *     more or exactly one well-formed single-line note, and nothing else.
-   *   - `pattern` fails but this matches -> marker-shaped prefix whose
-   *     token is valid but whose body does not match `pattern` to the end
-   *     for any reason -- content appended after an otherwise-valid note,
-   *     a note that does not satisfy the required note grammar (e.g.
-   *     missing the required `IDD` word), or more than one note. This is
-   *     the malformed case this issue surfaces; it is deliberately broader
-   *     than "appended content after a valid note" alone.
+   *   - `pattern` fails but this matches -> marker-shaped prefix: the token
+   *     itself is valid, but the body does not match `pattern` all the way
+   *     to the end, for **any** reason -- content appended directly after
+   *     the token with no note at all, content appended after an otherwise-
+   *     valid note, a note that does not satisfy the required note grammar
+   *     (e.g. missing the required `IDD` word), more than one note, or any
+   *     other departure from the canonical token-then-optional-single-note
+   *     shape. This is the malformed case this issue surfaces; it is
+   *     deliberately broader than any single illustrative example (such as
+   *     "appended content after a valid note") might suggest.
    *   - Neither matches -> not marker-shaped at all, including a marker
    *     merely quoted or embedded mid-prose (anti-spoofing: both patterns
    *     require the token to be the literal first bytes of the body, so a
@@ -789,16 +792,18 @@ export function operationalMarkerPrefixByStart(body: string): string | null {
  * Detects a `claimed-by` / `unclaimed-by` / `review-watermark` /
  * `review-baseline` comment whose body starts with a structurally valid
  * marker token but whose whole body does not match the canonical, strict
- * `pattern` -- for example (the motivating case) a well-intentioned human
- * rationale appended after an otherwise-canonical token + note, but also a
- * note that does not satisfy the required note grammar (e.g. missing the
- * required `IDD` word) or is otherwise missing/malformed. Such a body
- * already fails `operationalMarkerPrefix`'s whole-body anchor and is
- * therefore never treated as a live marker for state resolution
- * (`parseClaimComment`, `resolveActiveClaim`, and friends keep returning
- * `null` / ignoring it, unchanged by this function's existence); this gives
- * a caller that wants one a **distinct** "malformed marker" signal instead
- * of the comment silently reading as ordinary, unremarkable content (#1316).
+ * `pattern` -- for **any** reason: content appended directly after the
+ * token with no note, a well-intentioned human rationale appended after an
+ * otherwise-canonical token + note (the motivating case), a note that does
+ * not satisfy the required note grammar (e.g. missing the required `IDD`
+ * word), or any other departure from the canonical token-then-optional-
+ * single-note shape. Such a body already fails `operationalMarkerPrefix`'s
+ * whole-body anchor and is therefore never treated as a live marker for
+ * state resolution (`parseClaimComment`, `resolveActiveClaim`, and friends
+ * keep returning `null` / ignoring it, unchanged by this function's
+ * existence); this gives a caller that wants one a **distinct** "malformed
+ * marker" signal instead of the comment silently reading as ordinary,
+ * unremarkable content (#1316).
  *
  * Returns the matching marker's `label` (e.g. `'<!-- claimed-by:'`) when the
  * body is malformed in that specific way, or `null` when the body is either

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -26,6 +26,28 @@ interface OperationalMarker {
   label: string;
   pattern: RegExp;
   startPattern?: RegExp;
+  /**
+   * Anchored at the same `^` position as `pattern`, with the same field
+   * validation, but without the trailing `OPTIONAL_IDD_VISIBLE_NOTE_PATTERN`
+   * group and `$` end anchor: matches whenever the body's first bytes are a
+   * structurally valid marker token (see #1316), regardless of what -- if
+   * anything -- follows. `detectMalformedOperationalMarker` uses the gap
+   * between this and `pattern` to tell three cases apart:
+   *   - `pattern` matches -> well-formed marker (token + optional single
+   *     note, nothing more).
+   *   - `pattern` fails but this matches -> marker-shaped prefix with
+   *     content appended after the note (the malformed case this issue
+   *     surfaces).
+   *   - Neither matches -> not marker-shaped at all, including a marker
+   *     merely quoted or embedded mid-prose (anti-spoofing: both patterns
+   *     require the token to be the literal first bytes of the body, so a
+   *     preamble before it defeats both).
+   * Only defined for the note-bearing markers (`claimed-by`, `unclaimed-by`,
+   * `review-watermark`, `review-baseline`); `advisory-wait`,
+   * `forced-handoff`, and `idd-external-check-waiver` do not use the shared
+   * note-optional grammar this field targets.
+   */
+  malformedPrefixPattern?: RegExp;
 }
 
 /** Parsed `<!-- claimed-by: ... -->` claim marker. */
@@ -88,21 +110,28 @@ const OPERATIONAL_MARKERS: OperationalMarker[] = [
     label: '<!-- claimed-by:',
     pattern:
       /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    malformedPrefixPattern:
+      /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->/i,
   },
   {
     label: '<!-- unclaimed-by:',
     pattern:
       /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    malformedPrefixPattern:
+      /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->/i,
   },
   {
     label: '<!-- review-watermark:',
     pattern:
       /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    malformedPrefixPattern:
+      /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->/i,
   },
   {
     label: '<!-- review-baseline:',
     pattern:
       /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    malformedPrefixPattern: /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->/i,
   },
   {
     label: 'advisory-wait:',
@@ -750,6 +779,41 @@ export function operationalMarkerPrefixByStart(body: string): string | null {
     return null;
   }
   return marker.label;
+}
+
+/**
+ * Detects a `claimed-by` / `unclaimed-by` / `review-watermark` /
+ * `review-baseline` comment whose body starts with a structurally valid
+ * marker token (and, when present, a well-formed note) but carries content
+ * appended after that -- for example a well-intentioned human rationale
+ * tacked onto an otherwise-canonical claim comment. Such a body already
+ * fails `operationalMarkerPrefix`'s whole-body anchor and is therefore
+ * never treated as a live marker for state resolution (`parseClaimComment`,
+ * `resolveActiveClaim`, and friends keep returning `null` / ignoring it,
+ * unchanged by this function's existence); this gives a caller that wants
+ * one a **distinct** "malformed marker" signal instead of the comment
+ * silently reading as ordinary, unremarkable content (#1316).
+ *
+ * Returns the matching marker's `label` (e.g. `'<!-- claimed-by:'`) when the
+ * body is malformed in that specific way, or `null` when the body is either
+ * a well-formed marker (not malformed) or not marker-shaped at all.
+ *
+ * Anti-spoofing is preserved: like `pattern`, `malformedPrefixPattern`
+ * anchors `^` at byte 0 with no leading-whitespace tolerance, so a marker
+ * merely quoted or embedded mid-prose -- i.e. not literally the first bytes
+ * of the body -- matches neither pattern and is never flagged here.
+ */
+export function detectMalformedOperationalMarker(body: string): string | null {
+  if (operationalMarkerPrefix(body) !== null) {
+    // Already a well-formed marker (or otherwise-recognized marker type) --
+    // not malformed. Checking this first avoids double-classifying the
+    // happy path that `parseClaimComment` and friends already handle.
+    return null;
+  }
+  const marker = OPERATIONAL_MARKERS.find((candidate) =>
+    candidate.malformedPrefixPattern?.test(body),
+  );
+  return marker ? marker.label : null;
 }
 
 function normalizeNonWhitespaceToken(value: unknown): string {

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -31,13 +31,17 @@ interface OperationalMarker {
    * validation, but without the trailing `OPTIONAL_IDD_VISIBLE_NOTE_PATTERN`
    * group and `$` end anchor: matches whenever the body's first bytes are a
    * structurally valid marker token (see #1316), regardless of what -- if
-   * anything -- follows. `detectMalformedOperationalMarker` uses the gap
+   * anything -- follows it. `detectMalformedOperationalMarker` uses the gap
    * between this and `pattern` to tell three cases apart:
-   *   - `pattern` matches -> well-formed marker (token + optional single
-   *     note, nothing more).
-   *   - `pattern` fails but this matches -> marker-shaped prefix with
-   *     content appended after the note (the malformed case this issue
-   *     surfaces).
+   *   - `pattern` matches -> well-formed marker: token, then either nothing
+   *     more or exactly one well-formed single-line note, and nothing else.
+   *   - `pattern` fails but this matches -> marker-shaped prefix whose
+   *     token is valid but whose body does not match `pattern` to the end
+   *     for any reason -- content appended after an otherwise-valid note,
+   *     a note that does not satisfy the required note grammar (e.g.
+   *     missing the required `IDD` word), or more than one note. This is
+   *     the malformed case this issue surfaces; it is deliberately broader
+   *     than "appended content after a valid note" alone.
    *   - Neither matches -> not marker-shaped at all, including a marker
    *     merely quoted or embedded mid-prose (anti-spoofing: both patterns
    *     require the token to be the literal first bytes of the body, so a
@@ -784,15 +788,17 @@ export function operationalMarkerPrefixByStart(body: string): string | null {
 /**
  * Detects a `claimed-by` / `unclaimed-by` / `review-watermark` /
  * `review-baseline` comment whose body starts with a structurally valid
- * marker token (and, when present, a well-formed note) but carries content
- * appended after that -- for example a well-intentioned human rationale
- * tacked onto an otherwise-canonical claim comment. Such a body already
- * fails `operationalMarkerPrefix`'s whole-body anchor and is therefore
- * never treated as a live marker for state resolution (`parseClaimComment`,
- * `resolveActiveClaim`, and friends keep returning `null` / ignoring it,
- * unchanged by this function's existence); this gives a caller that wants
- * one a **distinct** "malformed marker" signal instead of the comment
- * silently reading as ordinary, unremarkable content (#1316).
+ * marker token but whose whole body does not match the canonical, strict
+ * `pattern` -- for example (the motivating case) a well-intentioned human
+ * rationale appended after an otherwise-canonical token + note, but also a
+ * note that does not satisfy the required note grammar (e.g. missing the
+ * required `IDD` word) or is otherwise missing/malformed. Such a body
+ * already fails `operationalMarkerPrefix`'s whole-body anchor and is
+ * therefore never treated as a live marker for state resolution
+ * (`parseClaimComment`, `resolveActiveClaim`, and friends keep returning
+ * `null` / ignoring it, unchanged by this function's existence); this gives
+ * a caller that wants one a **distinct** "malformed marker" signal instead
+ * of the comment silently reading as ordinary, unremarkable content (#1316).
  *
  * Returns the matching marker's `label` (e.g. `'<!-- claimed-by:'`) when the
  * body is malformed in that specific way, or `null` when the body is either

--- a/tests/claim-parser.test.mts
+++ b/tests/claim-parser.test.mts
@@ -5,6 +5,7 @@ import {
   applyClaimEvent,
   detectMalformedOperationalMarker,
   isStaleAt,
+  operationalMarkerPrefix,
   parseClaimComment,
   parseReleaseComment,
   parseReviewWatermarkComment,
@@ -219,6 +220,25 @@ test('review-watermark with appended prose stays null in parseReviewWatermarkCom
     detectMalformedOperationalMarker(body),
     '<!-- review-watermark:',
   );
+});
+
+test('review-baseline with appended prose is flagged malformed', () => {
+  const sha = 'b'.repeat(40);
+  const body =
+    `<!-- review-baseline: copilot claim-A ${sha} -->\n\n` +
+    '_copilot: critique baseline — IDD automation marker. Do not edit._\n\n' +
+    'This baseline covers the E2 pass that started after the last rebase.';
+  assert.equal(operationalMarkerPrefix(body), null);
+  assert.equal(detectMalformedOperationalMarker(body), '<!-- review-baseline:');
+});
+
+test('a well-formed review-baseline marker is not flagged malformed (no regression to the happy path)', () => {
+  const sha = 'b'.repeat(40);
+  const body =
+    `<!-- review-baseline: copilot claim-A ${sha} -->\n\n` +
+    '_copilot: critique baseline — IDD automation marker. Do not edit._';
+  assert.equal(operationalMarkerPrefix(body), '<!-- review-baseline:');
+  assert.equal(detectMalformedOperationalMarker(body), null);
 });
 
 test('a well-formed claimed-by marker is not flagged malformed (no regression to the happy path)', () => {

--- a/tests/claim-parser.test.mts
+++ b/tests/claim-parser.test.mts
@@ -3,9 +3,11 @@ import { test } from 'node:test';
 
 import {
   applyClaimEvent,
+  detectMalformedOperationalMarker,
   isStaleAt,
   parseClaimComment,
   parseReleaseComment,
+  parseReviewWatermarkComment,
 } from '../src/scripts/protocol-helpers.mts';
 import { readText } from './test-utils.mts';
 
@@ -181,4 +183,64 @@ test('matching heartbeat does not invoke the onAnomalousHeartbeat callback', () 
     },
   );
   assert.equal(seen.length, 0);
+});
+
+// #1316: a marker comment whose body starts with a correct token + note but
+// has extra content appended after the note must not be silently dropped as
+// indistinguishable "other" content -- it should be surfaced as a distinct
+// malformed-marker signal, while the security-critical parse functions
+// keep failing closed (still `null`, exactly as before this issue).
+test('claimed-by with appended prose stays null in parseClaimComment but is flagged malformed', () => {
+  const body =
+    '<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->\n\n' +
+    '_copilot: issue claim — IDD automation marker. Do not edit._\n\n' +
+    'Note: superseding the prior claim because the original session stalled.';
+  assert.equal(parseClaimComment(body, '2026-05-23T10:00:00Z'), null);
+  assert.equal(detectMalformedOperationalMarker(body), '<!-- claimed-by:');
+});
+
+test('unclaimed-by with appended prose stays null in parseReleaseComment but is flagged malformed', () => {
+  const body =
+    '<!-- unclaimed-by: copilot claim-A 2026-05-23T10:00:00Z -->\n\n' +
+    '_copilot: issue claim released — IDD automation marker. Do not edit._\n\n' +
+    'Releasing early: blocked on a decision from the maintainer.';
+  assert.equal(parseReleaseComment(body), null);
+  assert.equal(detectMalformedOperationalMarker(body), '<!-- unclaimed-by:');
+});
+
+test('review-watermark with appended prose stays null in parseReviewWatermarkComment but is flagged malformed', () => {
+  const sha = 'a'.repeat(40);
+  const body =
+    `<!-- review-watermark: copilot claim-A ${sha} none 0 none -->\n\n` +
+    '_copilot: review triage snapshot — IDD automation marker. Do not edit._\n\n' +
+    'No CI has run yet, so both freshness fields are none for now.';
+  assert.equal(parseReviewWatermarkComment(body, '2026-05-23T10:00:00Z'), null);
+  assert.equal(
+    detectMalformedOperationalMarker(body),
+    '<!-- review-watermark:',
+  );
+});
+
+test('a well-formed claimed-by marker is not flagged malformed (no regression to the happy path)', () => {
+  const body =
+    '<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->\n\n' +
+    '_copilot: issue claim — IDD automation marker. Do not edit._';
+  assert.notEqual(parseClaimComment(body, '2026-05-23T10:00:00Z'), null);
+  assert.equal(detectMalformedOperationalMarker(body), null);
+});
+
+test('a marker quoted mid-prose is neither a live marker nor flagged malformed (anti-spoofing)', () => {
+  const body =
+    'For reference, a claim comment looks like this:\n' +
+    '<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->\n\n' +
+    '_copilot: issue claim — IDD automation marker. Do not edit._';
+  assert.equal(parseClaimComment(body, '2026-05-23T10:00:00Z'), null);
+  assert.equal(detectMalformedOperationalMarker(body), null);
+});
+
+test('a code-fenced marker is neither a live marker nor flagged malformed (anti-spoofing)', () => {
+  const body =
+    '```\n<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->\n```';
+  assert.equal(parseClaimComment(body, '2026-05-23T10:00:00Z'), null);
+  assert.equal(detectMalformedOperationalMarker(body), null);
 });

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -29,6 +29,7 @@ const SAMPLE_NAMES = [
   'parseReviewWatermarkComment',
   'operationalMarkerPrefix',
   'operationalMarkerPrefixByStart',
+  'detectMalformedOperationalMarker',
   'IDD_AGENT_DERIVED_MARKERS',
   'isValidIsoTimestamp',
 ] as const;


### PR DESCRIPTION
# Summary

The claim / release / watermark marker parser (`parseClaimComment`,
`parseReleaseComment`, `parseReviewWatermarkComment`, and the
`OPERATIONAL_MARKERS` table in `src/scripts/marker-helpers.mts`) anchors a
whole-body regex: a `claimed-by` / `unclaimed-by` / `review-watermark` /
`review-baseline` comment must be exactly the HTML token plus, at most, one
single-line italic note — nothing appended. A comment that starts with a
structurally valid token and note but has extra content appended after the
note (for example a well-intentioned human rationale) fails that anchor and
was silently indistinguishable from ordinary "other" content, with no
diagnostic surfaced anywhere. A silently-ignored `claimed-by` is a
claim-ownership race, a larger blast radius than a disposition-bookkeeping
miss.

Per the maintainer decision recorded on the issue — **surface, do not
silently drop**:

- Added `detectMalformedOperationalMarker` to `marker-helpers.mts`. It flags
  that specific "valid token + note, plus appended content" shape as a
  distinct malformed-marker signal a caller can act on.
- `parseClaimComment` / `parseReleaseComment` / `parseReviewWatermarkComment`
  / `operationalMarkerPrefix` are unchanged for every input — they keep
  returning `null` / not-a-live-marker for a malformed body exactly as
  before. This is a pure, additive primitive; nothing currently calls it, so
  no other behavior changes as a side effect of this PR.
- Anti-spoofing is preserved: a marker merely quoted or embedded mid-prose,
  or wrapped in a code fence, is still never treated as live or flagged,
  because both the existing whole-body pattern and the new
  `malformedPrefixPattern` anchor `^` at byte 0 (the literal first-bytes
  contract already used throughout the marker format).
- Documented the "nothing appended after the note" rule next to the
  `claimed-by`/`unclaimed-by` template in `idd-claim.instructions.md` and
  the `review-watermark`/`review-baseline` templates in
  `idd-review-snapshot.instructions.md`. Folded in the small Gap-6a note in
  `idd-review-triage.instructions.md`: the existing "first bytes of the
  comment body" rule already fail-safes a code-fenced `**Accepted**` /
  `**Rejected**` disposition marker, but didn't say so explicitly — now it
  does.

## Linked issue

Closes #1316

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The strict anchor is partly intentional (it blocks note-injection and
quoted-marker spoofing); the fix preserves that property exactly and only
adds a diagnostic signal for the one specific malformed shape the issue
describes. Wiring an actual consumer (e.g. a doctor/audit pass that posts a
warning when it sees this signal) is out of scope for this issue's candidate
files and is left as possible future follow-up.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
