### PR TITLE
fix(claim): honor configured staleAge in write-gate check

### DIFF
--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -52,6 +52,13 @@ export const POLICY_DEFAULTS = Object.freeze({
   stallRecovery: Object.freeze({
     quietWindow: 'PT30M',
   }),
+  // The write-gate claim-staleness window (#1310). isStaleAt's hardcoded 24h
+  // literal remains the fallback baked into protocol-helpers.mts; this is the
+  // one canonical config parse point every write-gate caller should read
+  // instead of hand-rolling `config?.claimTiming?.staleAge` access.
+  claimTiming: Object.freeze({
+    staleAge: 'PT24H',
+  }),
   forcedHandoff: Object.freeze({
     mode: 'disabled',
     authorityPolicy: 'owners-and-maintainers-only',
@@ -214,6 +221,12 @@ export function normalizePolicyConfig(config) {
       quietWindow: parseDuration(
         c?.stallRecovery?.quietWindow,
         POLICY_DEFAULTS.stallRecovery.quietWindow,
+      ),
+    },
+    claimTiming: {
+      staleAge: parsePositiveDuration(
+        c?.claimTiming?.staleAge,
+        POLICY_DEFAULTS.claimTiming.staleAge,
       ),
     },
     forcedHandoff: {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -21,6 +21,7 @@ import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
   normalizePolicyConfig,
+  parseIsoDurationToMs,
   resolveCollaboratorMarkerTrust,
 } from './policy-helpers.mjs';
 import {
@@ -35,6 +36,13 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mjs';
+
+// Fallback claim-staleness window (#1310) used by readClaimStaleAgeMs when
+// `.github/idd/config.json` is absent, unreadable, or does not parse to a
+// valid claimTiming.staleAge. Declared above the CLI entry block (module-
+// level bindings must stay above it — see cli-entry-smoke.test.mts) even
+// though it is only read from inside a function.
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 /**
  * Fetch live GitHub state for the PR + claim issue and build the
  * read-only pre-merge readiness report. Shared by this CLI and the
@@ -212,6 +220,7 @@ export function collectPreMergeReadiness(argv) {
   const forcedHandoffPermissionCache = new Map();
   const waivableCheckSelectors = readWaivableCheckSelectors();
   const externalCheckWaiverMaxValidity = readExternalCheckWaiverMaxValidity();
+  const staleAgeMs = readClaimStaleAgeMs();
   const summary = buildPreMergeReadinessSummary(
     {
       prHeadSha,
@@ -248,6 +257,7 @@ export function collectPreMergeReadiness(argv) {
       primaryBotLogin,
       waivableCheckSelectors,
       externalCheckWaiverMaxValidity,
+      staleAgeMs,
       forcedHandoffEnabled,
       expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
       prFirstCommitAt,
@@ -861,5 +871,21 @@ function readExternalCheckWaiverMaxValidity() {
     ).ciGate.externalCheckWaivers.maxValidity;
   } catch {
     return 'PT24H';
+  }
+}
+// Configured claim-staleness window (`claimTiming.staleAge`, #1310), parsed
+// to milliseconds so the write-gate claim resolver honors it instead of the
+// hardcoded 24h `isStaleAt` default. `normalizePolicyConfig` already defaults
+// this to `PT24H`; an absent, unreadable, or unparseable config falls back to
+// the same 24h value in milliseconds so behavior is unchanged for repos on
+// the default.
+function readClaimStaleAgeMs() {
+  try {
+    const staleAge = normalizePolicyConfig(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+    ).claimTiming.staleAge;
+    return parseIsoDurationToMs(staleAge) ?? DEFAULT_CLAIM_STALE_AGE_MS;
+  } catch {
+    return DEFAULT_CLAIM_STALE_AGE_MS;
   }
 }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -869,18 +869,16 @@ function readExternalCheckWaiverMaxValidity() {
 }
 // Configured claim-staleness window (`claimTiming.staleAge`, #1310), parsed
 // to milliseconds so the write-gate claim resolver honors it instead of the
-// hardcoded 24h `isStaleAt` default. `normalizePolicyConfig` already defaults
-// this to `PT24H`; an absent, unreadable, or unparseable config falls back to
-// the shared `DEFAULT_STALE_AGE_MS` (protocol-helpers.mts) rather than a
-// second local 24h literal, so behavior is unchanged for repos on the
-// default and there is exactly one hardcoded-24h source of truth.
+// hardcoded 24h `isStaleAt` default. Reuses the shared `loadIddConfig`
+// loader (already imported by this file) instead of a per-helper
+// `readFileSync + JSON.parse` copy; `loadIddConfig` already fails safe to
+// `null` and `normalizePolicyConfig(null)` already defaults to `PT24H`, so
+// no separate try/catch is needed here. An absent, unreadable, or
+// unparseable config falls back to the shared `DEFAULT_STALE_AGE_MS`
+// (protocol-helpers.mts) rather than a second local 24h literal, so
+// behavior is unchanged for repos on the default and there is exactly one
+// hardcoded-24h source of truth.
 function readClaimStaleAgeMs() {
-  try {
-    const staleAge = normalizePolicyConfig(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-    ).claimTiming.staleAge;
-    return parseIsoDurationToMs(staleAge) ?? DEFAULT_STALE_AGE_MS;
-  } catch {
-    return DEFAULT_STALE_AGE_MS;
-  }
+  const staleAge = normalizePolicyConfig(loadIddConfig()).claimTiming.staleAge;
+  return parseIsoDurationToMs(staleAge) ?? DEFAULT_STALE_AGE_MS;
 }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -26,6 +26,7 @@ import {
 } from './policy-helpers.mjs';
 import {
   buildPreMergeReadinessSummary,
+  DEFAULT_STALE_AGE_MS,
   deriveIddAgentLogins,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
@@ -36,13 +37,6 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mjs';
-
-// Fallback claim-staleness window (#1310) used by readClaimStaleAgeMs when
-// `.github/idd/config.json` is absent, unreadable, or does not parse to a
-// valid claimTiming.staleAge. Declared above the CLI entry block (module-
-// level bindings must stay above it — see cli-entry-smoke.test.mts) even
-// though it is only read from inside a function.
-const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 /**
  * Fetch live GitHub state for the PR + claim issue and build the
  * read-only pre-merge readiness report. Shared by this CLI and the
@@ -877,15 +871,16 @@ function readExternalCheckWaiverMaxValidity() {
 // to milliseconds so the write-gate claim resolver honors it instead of the
 // hardcoded 24h `isStaleAt` default. `normalizePolicyConfig` already defaults
 // this to `PT24H`; an absent, unreadable, or unparseable config falls back to
-// the same 24h value in milliseconds so behavior is unchanged for repos on
-// the default.
+// the shared `DEFAULT_STALE_AGE_MS` (protocol-helpers.mts) rather than a
+// second local 24h literal, so behavior is unchanged for repos on the
+// default and there is exactly one hardcoded-24h source of truth.
 function readClaimStaleAgeMs() {
   try {
     const staleAge = normalizePolicyConfig(
       JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
     ).claimTiming.staleAge;
-    return parseIsoDurationToMs(staleAge) ?? DEFAULT_CLAIM_STALE_AGE_MS;
+    return parseIsoDurationToMs(staleAge) ?? DEFAULT_STALE_AGE_MS;
   } catch {
-    return DEFAULT_CLAIM_STALE_AGE_MS;
+    return DEFAULT_STALE_AGE_MS;
   }
 }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3268,6 +3268,11 @@ export function buildForcedHandoffEnableGate(options) {
  *   that forget to wire it fail closed.
  * - `requireAuthorMatchesForcedBy` defaults to `true` (the strict
  *   self-signed-hijack block used by Resume routing).
+ * - `staleAgeMs` (#1310) is an optional config-aware claim-staleness window,
+ *   in milliseconds (a parsed `claimTiming.staleAge`). When omitted, invalid
+ *   (non-numeric/non-finite), or non-positive, staleness falls back to the
+ *   hardcoded 24h `isStaleAt` default unchanged — so callers that do not
+ *   pass it keep today's exact behavior. See `isStaleByAge`.
  */
 export function resolveActiveClaimForWriteGate(events, options) {
   const expectedLinkedPrReferences = new Set(
@@ -3620,6 +3625,7 @@ export function buildPreMergeReadinessSummary(
     isForcedHandoffEnabled: options.isForcedHandoffEnabled,
     expectedClaimId: options.expectedClaimId,
     expectedAgentId: options.expectedAgentId,
+    staleAgeMs: options.staleAgeMs,
   });
   const waivableCheckSelectors = options.waivableCheckSelectors ?? null;
   const waiverEvidence = summarizeExternalCheckWaivers(comments, {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3288,6 +3288,7 @@ export function resolveActiveClaimForWriteGate(events, options) {
         ? options.isAuthorizedForcedHandoff
         : () => false,
     requireAuthorMatchesForcedBy: options.requireAuthorMatchesForcedBy ?? true,
+    isStale: resolveStalePredicate(options.staleAgeMs),
   });
 }
 export function summarizeClaimValidation(claimEvents = [], options = {}) {
@@ -3350,6 +3351,7 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
                 .toLowerCase(),
             );
           },
+    isStale: resolveStalePredicate(options.staleAgeMs),
   });
   let reason = 'match';
   if (!activeClaim) {
@@ -3758,12 +3760,61 @@ function firstLine(value) {
 function sameDigestBody(currentBody, nextBody) {
   return currentBody.trimEnd() === nextBody.trimEnd();
 }
+/**
+ * The distributed default claim-staleness window (`claimTiming.staleAge`
+ * `PT24H`), in milliseconds. Exported so config-aware callers can compare
+ * a parsed `claimTiming.staleAge` against "no override configured" and so
+ * {@link isStaleByAge} can fast-path to {@link isStaleAt} when the two
+ * agree.
+ */
+export const DEFAULT_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 export function isStaleAt(activeCreatedAt, nextCreatedAt) {
-  const staleMs = 24 * 60 * 60 * 1000;
   return (
     new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >=
-    staleMs
+    DEFAULT_STALE_AGE_MS
   );
+}
+/**
+ * Config-aware claim-staleness primitive: true when `nextCreatedAt` is at
+ * least `staleAgeMs` after `activeCreatedAt`. This is the single shared
+ * primitive promoted out of the staleness-window comparison that was
+ * independently duplicated across the resume and discover paths (each of
+ * which already reads `claimTiming.staleAge` from policy correctly) so a
+ * write-gate caller can reuse the exact same algorithm instead of adding
+ * yet another copy. Delegates to {@link isStaleAt} when `staleAgeMs` equals
+ * {@link DEFAULT_STALE_AGE_MS}, so behavior stays byte-identical for
+ * repositories on the default. Fails closed to `false` (not stale) when
+ * either timestamp is unparseable.
+ */
+export function isStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs) {
+  if (staleAgeMs === DEFAULT_STALE_AGE_MS) {
+    return isStaleAt(activeCreatedAt, nextCreatedAt);
+  }
+  const start = Date.parse(activeCreatedAt ?? '');
+  const end = Date.parse(nextCreatedAt ?? '');
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    return false;
+  }
+  return end - start >= staleAgeMs;
+}
+/**
+ * Resolve the `isStale` predicate for the write-gate resolvers below from an
+ * optional caller-supplied `staleAgeMs` (a parsed `claimTiming.staleAge` in
+ * milliseconds). A valid positive finite value routes through the
+ * config-aware {@link isStaleByAge}; an omitted, non-numeric, non-finite, or
+ * non-positive value falls back to {@link isStaleAt} unchanged, so callers
+ * that do not pass `staleAgeMs` keep today's exact 24h behavior.
+ */
+function resolveStalePredicate(staleAgeMs) {
+  if (
+    typeof staleAgeMs !== 'number' ||
+    !Number.isFinite(staleAgeMs) ||
+    staleAgeMs <= 0
+  ) {
+    return isStaleAt;
+  }
+  return (activeCreatedAt, nextCreatedAt) =>
+    isStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs);
 }
 function compareClaimIds(left, right) {
   if (left === right) {

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -16,13 +16,13 @@ import {
 import { normalizePolicyConfig } from './policy-helpers.mjs';
 import {
   buildForcedHandoffEnableGate,
-  isStaleAt,
+  DEFAULT_STALE_AGE_MS,
+  isStaleByAge,
   normalizeLinkedPrReference,
   parseClaimComment,
   resolveActiveClaim,
 } from './protocol-helpers.mjs';
 
-const DEFAULT_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 const LEGACY_CLAIM_PATTERN =
   /^<!--\s*claimed-by:\s+(\S+)\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s+branch:\s+([^\s>]+)\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i;
 const LEGACY_RELEASE_PATTERN =
@@ -736,17 +736,6 @@ function normalizeStaleAgeMs(value) {
     return DEFAULT_STALE_AGE_MS;
   }
   return Math.floor(value);
-}
-function isStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs) {
-  if (staleAgeMs === DEFAULT_STALE_AGE_MS) {
-    return isStaleAt(activeCreatedAt, nextCreatedAt);
-  }
-  const start = Date.parse(activeCreatedAt ?? '');
-  const end = Date.parse(nextCreatedAt ?? '');
-  if (!Number.isFinite(start) || !Number.isFinite(end)) {
-    return false;
-  }
-  return end - start >= staleAgeMs;
 }
 function normalizeIso(value) {
   if (!value) {

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -25,6 +25,7 @@ interface RawConfig {
   skipIssueAuthorApprovalGate?: unknown;
   maintainerApprovalActorPolicy?: unknown;
   stallRecovery?: { quietWindow?: unknown };
+  claimTiming?: { staleAge?: unknown };
   forcedHandoff?: RawForcedHandoff;
   'forced-handoff'?: RawForcedHandoff;
   forcedHandoffAuthority?: unknown;
@@ -129,6 +130,13 @@ export const POLICY_DEFAULTS = Object.freeze({
   maintainerApprovalActorPolicy: 'owners-and-maintainers-only',
   stallRecovery: Object.freeze({
     quietWindow: 'PT30M',
+  }),
+  // The write-gate claim-staleness window (#1310). isStaleAt's hardcoded 24h
+  // literal remains the fallback baked into protocol-helpers.mts; this is the
+  // one canonical config parse point every write-gate caller should read
+  // instead of hand-rolling `config?.claimTiming?.staleAge` access.
+  claimTiming: Object.freeze({
+    staleAge: 'PT24H',
   }),
   forcedHandoff: Object.freeze({
     mode: 'disabled',
@@ -304,6 +312,12 @@ export function normalizePolicyConfig(config: unknown) {
       quietWindow: parseDuration(
         c?.stallRecovery?.quietWindow,
         POLICY_DEFAULTS.stallRecovery.quietWindow,
+      ),
+    },
+    claimTiming: {
+      staleAge: parsePositiveDuration(
+        c?.claimTiming?.staleAge,
+        POLICY_DEFAULTS.claimTiming.staleAge,
       ),
     },
     forcedHandoff: {

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -30,6 +30,7 @@ import {
 import type { TrustedMarkerActorResolution } from './protocol-helpers.mts';
 import {
   buildPreMergeReadinessSummary,
+  DEFAULT_STALE_AGE_MS,
   deriveIddAgentLogins,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
@@ -40,13 +41,6 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mts';
-
-// Fallback claim-staleness window (#1310) used by readClaimStaleAgeMs when
-// `.github/idd/config.json` is absent, unreadable, or does not parse to a
-// valid claimTiming.staleAge. Declared above the CLI entry block (module-
-// level bindings must stay above it — see cli-entry-smoke.test.mts) even
-// though it is only read from inside a function.
-const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 
 /** Author reference embedded in GitHub REST/GraphQL payloads. */
 interface GhAuthorPayload {
@@ -1151,15 +1145,16 @@ function readExternalCheckWaiverMaxValidity(): string {
 // to milliseconds so the write-gate claim resolver honors it instead of the
 // hardcoded 24h `isStaleAt` default. `normalizePolicyConfig` already defaults
 // this to `PT24H`; an absent, unreadable, or unparseable config falls back to
-// the same 24h value in milliseconds so behavior is unchanged for repos on
-// the default.
+// the shared `DEFAULT_STALE_AGE_MS` (protocol-helpers.mts) rather than a
+// second local 24h literal, so behavior is unchanged for repos on the
+// default and there is exactly one hardcoded-24h source of truth.
 function readClaimStaleAgeMs(): number {
   try {
     const staleAge = normalizePolicyConfig(
       JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
     ).claimTiming.staleAge;
-    return parseIsoDurationToMs(staleAge) ?? DEFAULT_CLAIM_STALE_AGE_MS;
+    return parseIsoDurationToMs(staleAge) ?? DEFAULT_STALE_AGE_MS;
   } catch {
-    return DEFAULT_CLAIM_STALE_AGE_MS;
+    return DEFAULT_STALE_AGE_MS;
   }
 }

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -24,6 +24,7 @@ import { deriveGhHttpStatus } from './gh-http-status.mts';
 import { loadIddConfig } from './idd-config.mts';
 import {
   normalizePolicyConfig,
+  parseIsoDurationToMs,
   resolveCollaboratorMarkerTrust,
 } from './policy-helpers.mts';
 import type { TrustedMarkerActorResolution } from './protocol-helpers.mts';
@@ -39,6 +40,13 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mts';
+
+// Fallback claim-staleness window (#1310) used by readClaimStaleAgeMs when
+// `.github/idd/config.json` is absent, unreadable, or does not parse to a
+// valid claimTiming.staleAge. Declared above the CLI entry block (module-
+// level bindings must stay above it — see cli-entry-smoke.test.mts) even
+// though it is only read from inside a function.
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 
 /** Author reference embedded in GitHub REST/GraphQL payloads. */
 interface GhAuthorPayload {
@@ -391,6 +399,7 @@ export function collectPreMergeReadiness(
   const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
   const waivableCheckSelectors = readWaivableCheckSelectors();
   const externalCheckWaiverMaxValidity = readExternalCheckWaiverMaxValidity();
+  const staleAgeMs = readClaimStaleAgeMs();
 
   const summary = buildPreMergeReadinessSummary(
     {
@@ -428,6 +437,7 @@ export function collectPreMergeReadiness(
       primaryBotLogin,
       waivableCheckSelectors,
       externalCheckWaiverMaxValidity,
+      staleAgeMs,
       forcedHandoffEnabled,
       expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
       prFirstCommitAt,
@@ -1134,5 +1144,22 @@ function readExternalCheckWaiverMaxValidity(): string {
     ).ciGate.externalCheckWaivers.maxValidity;
   } catch {
     return 'PT24H';
+  }
+}
+
+// Configured claim-staleness window (`claimTiming.staleAge`, #1310), parsed
+// to milliseconds so the write-gate claim resolver honors it instead of the
+// hardcoded 24h `isStaleAt` default. `normalizePolicyConfig` already defaults
+// this to `PT24H`; an absent, unreadable, or unparseable config falls back to
+// the same 24h value in milliseconds so behavior is unchanged for repos on
+// the default.
+function readClaimStaleAgeMs(): number {
+  try {
+    const staleAge = normalizePolicyConfig(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+    ).claimTiming.staleAge;
+    return parseIsoDurationToMs(staleAge) ?? DEFAULT_CLAIM_STALE_AGE_MS;
+  } catch {
+    return DEFAULT_CLAIM_STALE_AGE_MS;
   }
 }

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -1143,18 +1143,16 @@ function readExternalCheckWaiverMaxValidity(): string {
 
 // Configured claim-staleness window (`claimTiming.staleAge`, #1310), parsed
 // to milliseconds so the write-gate claim resolver honors it instead of the
-// hardcoded 24h `isStaleAt` default. `normalizePolicyConfig` already defaults
-// this to `PT24H`; an absent, unreadable, or unparseable config falls back to
-// the shared `DEFAULT_STALE_AGE_MS` (protocol-helpers.mts) rather than a
-// second local 24h literal, so behavior is unchanged for repos on the
-// default and there is exactly one hardcoded-24h source of truth.
+// hardcoded 24h `isStaleAt` default. Reuses the shared `loadIddConfig`
+// loader (already imported by this file) instead of a per-helper
+// `readFileSync + JSON.parse` copy; `loadIddConfig` already fails safe to
+// `null` and `normalizePolicyConfig(null)` already defaults to `PT24H`, so
+// no separate try/catch is needed here. An absent, unreadable, or
+// unparseable config falls back to the shared `DEFAULT_STALE_AGE_MS`
+// (protocol-helpers.mts) rather than a second local 24h literal, so
+// behavior is unchanged for repos on the default and there is exactly one
+// hardcoded-24h source of truth.
 function readClaimStaleAgeMs(): number {
-  try {
-    const staleAge = normalizePolicyConfig(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-    ).claimTiming.staleAge;
-    return parseIsoDurationToMs(staleAge) ?? DEFAULT_STALE_AGE_MS;
-  } catch {
-    return DEFAULT_STALE_AGE_MS;
-  }
+  const staleAge = normalizePolicyConfig(loadIddConfig()).claimTiming.staleAge;
+  return parseIsoDurationToMs(staleAge) ?? DEFAULT_STALE_AGE_MS;
 }

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4545,7 +4545,7 @@ export function buildPreMergeReadinessSummary(
     // Configured `claimTiming.staleAge` (#1310), parsed to milliseconds and
     // threaded to the write-gate claim resolver below so the F2/F3 merge gate
     // honors it instead of the hardcoded 24h `isStaleAt` default. Omitted by
-    // unit callers (default 24h behavior preserved);
+    // unit callers (default 24h behavior preserved).
     // `collectPreMergeReadiness` always sources the policy value.
     staleAgeMs?: number;
   } = {},

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4162,6 +4162,11 @@ export function buildForcedHandoffEnableGate(options: {
  *   that forget to wire it fail closed.
  * - `requireAuthorMatchesForcedBy` defaults to `true` (the strict
  *   self-signed-hijack block used by Resume routing).
+ * - `staleAgeMs` (#1310) is an optional config-aware claim-staleness window,
+ *   in milliseconds (a parsed `claimTiming.staleAge`). When omitted, invalid
+ *   (non-numeric/non-finite), or non-positive, staleness falls back to the
+ *   hardcoded 24h `isStaleAt` default unchanged — so callers that do not
+ *   pass it keep today's exact behavior. See `isStaleByAge`.
  */
 export function resolveActiveClaimForWriteGate(
   events: CommentLike[],
@@ -4537,6 +4542,12 @@ export function buildPreMergeReadinessSummary(
     // (window check off); `collectPreMergeReadiness` always sources the policy
     // value (default `PT24H`).
     externalCheckWaiverMaxValidity?: string;
+    // Configured `claimTiming.staleAge` (#1310), parsed to milliseconds and
+    // threaded to the write-gate claim resolver below so the F2/F3 merge gate
+    // honors it instead of the hardcoded 24h `isStaleAt` default. Omitted by
+    // unit callers (default 24h behavior preserved);
+    // `collectPreMergeReadiness` always sources the policy value.
+    staleAgeMs?: number;
   } = {},
 ) {
   const now = String(options.now ?? '');
@@ -4655,6 +4666,7 @@ export function buildPreMergeReadinessSummary(
     isForcedHandoffEnabled: options.isForcedHandoffEnabled,
     expectedClaimId: options.expectedClaimId,
     expectedAgentId: options.expectedAgentId,
+    staleAgeMs: options.staleAgeMs,
   });
   const waivableCheckSelectors = options.waivableCheckSelectors ?? null;
   const waiverEvidence = summarizeExternalCheckWaivers(comments, {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4176,6 +4176,7 @@ export function resolveActiveClaimForWriteGate(
       event: CommentLike,
     ) => boolean;
     requireAuthorMatchesForcedBy?: boolean;
+    staleAgeMs?: number;
   },
 ): ParsedClaimMarker | null {
   const expectedLinkedPrReferences = new Set(
@@ -4196,6 +4197,7 @@ export function resolveActiveClaimForWriteGate(
         ? options.isAuthorizedForcedHandoff
         : () => false,
     requireAuthorMatchesForcedBy: options.requireAuthorMatchesForcedBy ?? true,
+    isStale: resolveStalePredicate(options.staleAgeMs),
   });
 }
 
@@ -4219,6 +4221,7 @@ export function summarizeClaimValidation(
       forcedHandoff: ParsedForcedHandoffMarker,
       event: CommentLike,
     ) => boolean;
+    staleAgeMs?: number;
   } = {},
 ): ClaimValidationSummary {
   const trustedMarkerLogins = new Set(
@@ -4281,6 +4284,7 @@ export function summarizeClaimValidation(
                 .toLowerCase(),
             );
           },
+    isStale: resolveStalePredicate(options.staleAgeMs),
   });
 
   let reason = 'match';
@@ -4807,15 +4811,73 @@ function sameDigestBody(currentBody: string, nextBody: string): boolean {
   return currentBody.trimEnd() === nextBody.trimEnd();
 }
 
+/**
+ * The distributed default claim-staleness window (`claimTiming.staleAge`
+ * `PT24H`), in milliseconds. Exported so config-aware callers can compare
+ * a parsed `claimTiming.staleAge` against "no override configured" and so
+ * {@link isStaleByAge} can fast-path to {@link isStaleAt} when the two
+ * agree.
+ */
+export const DEFAULT_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+
 export function isStaleAt(
   activeCreatedAt: string,
   nextCreatedAt: string,
 ): boolean {
-  const staleMs = 24 * 60 * 60 * 1000;
   return (
     new Date(nextCreatedAt).getTime() - new Date(activeCreatedAt).getTime() >=
-    staleMs
+    DEFAULT_STALE_AGE_MS
   );
+}
+
+/**
+ * Config-aware claim-staleness primitive: true when `nextCreatedAt` is at
+ * least `staleAgeMs` after `activeCreatedAt`. This is the single shared
+ * primitive promoted out of the staleness-window comparison that was
+ * independently duplicated across the resume and discover paths (each of
+ * which already reads `claimTiming.staleAge` from policy correctly) so a
+ * write-gate caller can reuse the exact same algorithm instead of adding
+ * yet another copy. Delegates to {@link isStaleAt} when `staleAgeMs` equals
+ * {@link DEFAULT_STALE_AGE_MS}, so behavior stays byte-identical for
+ * repositories on the default. Fails closed to `false` (not stale) when
+ * either timestamp is unparseable.
+ */
+export function isStaleByAge(
+  activeCreatedAt: string,
+  nextCreatedAt: string,
+  staleAgeMs: number,
+): boolean {
+  if (staleAgeMs === DEFAULT_STALE_AGE_MS) {
+    return isStaleAt(activeCreatedAt, nextCreatedAt);
+  }
+  const start = Date.parse(activeCreatedAt ?? '');
+  const end = Date.parse(nextCreatedAt ?? '');
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    return false;
+  }
+  return end - start >= staleAgeMs;
+}
+
+/**
+ * Resolve the `isStale` predicate for the write-gate resolvers below from an
+ * optional caller-supplied `staleAgeMs` (a parsed `claimTiming.staleAge` in
+ * milliseconds). A valid positive finite value routes through the
+ * config-aware {@link isStaleByAge}; an omitted, non-numeric, non-finite, or
+ * non-positive value falls back to {@link isStaleAt} unchanged, so callers
+ * that do not pass `staleAgeMs` keep today's exact 24h behavior.
+ */
+function resolveStalePredicate(
+  staleAgeMs: number | undefined,
+): (activeCreatedAt: string, nextCreatedAt: string) => boolean {
+  if (
+    typeof staleAgeMs !== 'number' ||
+    !Number.isFinite(staleAgeMs) ||
+    staleAgeMs <= 0
+  ) {
+    return isStaleAt;
+  }
+  return (activeCreatedAt: string, nextCreatedAt: string) =>
+    isStaleByAge(activeCreatedAt, nextCreatedAt, staleAgeMs);
 }
 
 function compareClaimIds(left: string, right: string): number {

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -22,7 +22,8 @@ import type {
 } from './protocol-helpers.mts';
 import {
   buildForcedHandoffEnableGate,
-  isStaleAt,
+  DEFAULT_STALE_AGE_MS,
+  isStaleByAge,
   normalizeLinkedPrReference,
   parseClaimComment,
   resolveActiveClaim,
@@ -107,7 +108,6 @@ interface ResumeClaimRoutingArgs {
   help: boolean;
 }
 
-const DEFAULT_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 const LEGACY_CLAIM_PATTERN =
   /^<!--\s*claimed-by:\s+(\S+)\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s+branch:\s+([^\s>]+)\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i;
 const LEGACY_RELEASE_PATTERN =
@@ -954,22 +954,6 @@ function normalizeStaleAgeMs(value: unknown): number {
     return DEFAULT_STALE_AGE_MS;
   }
   return Math.floor(value);
-}
-
-function isStaleByAge(
-  activeCreatedAt: string,
-  nextCreatedAt: string,
-  staleAgeMs: number,
-): boolean {
-  if (staleAgeMs === DEFAULT_STALE_AGE_MS) {
-    return isStaleAt(activeCreatedAt, nextCreatedAt);
-  }
-  const start = Date.parse(activeCreatedAt ?? '');
-  const end = Date.parse(nextCreatedAt ?? '');
-  if (!Number.isFinite(start) || !Number.isFinite(end)) {
-    return false;
-  }
-  return end - start >= staleAgeMs;
 }
 
 function normalizeIso(value: unknown): string | null {

--- a/tests/claim-parser.test.mts
+++ b/tests/claim-parser.test.mts
@@ -3,7 +3,9 @@ import { test } from 'node:test';
 
 import {
   applyClaimEvent,
+  DEFAULT_STALE_AGE_MS,
   isStaleAt,
+  isStaleByAge,
   parseClaimComment,
   parseReleaseComment,
 } from '../src/scripts/protocol-helpers.mts';
@@ -58,6 +60,69 @@ test('parses the release comment and stale threshold', () => {
   assert.equal(isStaleAt('2026-05-09T10:00:00Z', '2026-05-10T11:00:00Z'), true);
   assert.equal(
     isStaleAt('2026-05-09T10:00:00Z', '2026-05-09T23:59:59Z'),
+    false,
+  );
+});
+
+test('isStaleByAge honors a configured staleAge in the 18-24h gap', () => {
+  // ~20h gap: not stale under the old hardcoded 24h constant, but stale
+  // under a configured 18h staleAge (the write-gate bug in #1310).
+  const activeCreatedAt = '2026-05-09T10:00:00Z';
+  const nextCreatedAt = '2026-05-10T06:00:00Z';
+  const eighteenHoursMs = 18 * 60 * 60 * 1000;
+
+  assert.equal(
+    isStaleByAge(activeCreatedAt, nextCreatedAt, DEFAULT_STALE_AGE_MS),
+    false,
+  );
+  assert.equal(
+    isStaleByAge(activeCreatedAt, nextCreatedAt, eighteenHoursMs),
+    true,
+  );
+});
+
+test('isStaleByAge at the configured boundary is inclusive, matching isStaleAt', () => {
+  const eighteenHoursMs = 18 * 60 * 60 * 1000;
+  assert.equal(
+    isStaleByAge(
+      '2026-05-09T10:00:00Z',
+      '2026-05-10T04:00:00Z',
+      eighteenHoursMs,
+    ),
+    true, // exactly 18h
+  );
+  assert.equal(
+    isStaleByAge(
+      '2026-05-09T10:00:00Z',
+      '2026-05-10T03:59:59Z',
+      eighteenHoursMs,
+    ),
+    false, // 1s under 18h
+  );
+});
+
+test('isStaleByAge delegates to isStaleAt at the default 24h window', () => {
+  // Same fast path resume-claim-routing.mts relied on: staleAgeMs equal to
+  // the default must produce byte-identical results to isStaleAt.
+  const cases: [string, string][] = [
+    ['2026-05-09T10:00:00Z', '2026-05-10T11:00:00Z'],
+    ['2026-05-09T10:00:00Z', '2026-05-09T23:59:59Z'],
+  ];
+  for (const [activeCreatedAt, nextCreatedAt] of cases) {
+    assert.equal(
+      isStaleByAge(activeCreatedAt, nextCreatedAt, DEFAULT_STALE_AGE_MS),
+      isStaleAt(activeCreatedAt, nextCreatedAt),
+    );
+  }
+});
+
+test('isStaleByAge fails closed on unparseable timestamps', () => {
+  assert.equal(
+    isStaleByAge('not-a-date', '2026-05-10T06:00:00Z', 18 * 60 * 60 * 1000),
+    false,
+  );
+  assert.equal(
+    isStaleByAge('2026-05-09T10:00:00Z', 'not-a-date', 18 * 60 * 60 * 1000),
     false,
   );
 });

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -468,6 +468,9 @@ test('policy normalization provides default-safe values and supports aliases', (
     stallRecovery: {
       quietWindow: 'PT30M',
     },
+    claimTiming: {
+      staleAge: 'PT24H',
+    },
     forcedHandoff: {
       mode: 'disabled',
       authorityPolicy: 'owners-and-maintainers-only',
@@ -552,6 +555,9 @@ test('policy normalization provides default-safe values and supports aliases', (
       stallRecovery: {
         quietWindow: 'PT45M',
       },
+      claimTiming: {
+        staleAge: 'PT18H',
+      },
       forcedHandoffMode: 'human-gated',
       'forced-handoff-authority': 'all-write-permission-actors',
       markerTrustAllowCollaboratorMarkers: true,
@@ -615,6 +621,9 @@ test('policy normalization provides default-safe values and supports aliases', (
       maintainerApprovalActorPolicy: 'all-write-permission-actors',
       stallRecovery: {
         quietWindow: 'PT45M',
+      },
+      claimTiming: {
+        staleAge: 'PT18H',
       },
       forcedHandoff: {
         mode: 'human-gated',

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -44,6 +44,30 @@ test('POLICY_DEFAULTS.labels exposes the three reserved label name defaults', ()
   });
 });
 
+test('claimTiming.staleAge defaults to PT24H and accepts a configured override', () => {
+  // #1310: the canonical single parse point for claimTiming.staleAge, so
+  // write-gate callers read it here instead of hand-rolling
+  // `config?.claimTiming?.staleAge` access.
+  assert.equal(POLICY_DEFAULTS.claimTiming.staleAge, 'PT24H');
+  assert.equal(normalizePolicyConfig({}).claimTiming.staleAge, 'PT24H');
+  assert.equal(
+    normalizePolicyConfig({ claimTiming: { staleAge: 'PT18H' } }).claimTiming
+      .staleAge,
+    'PT18H',
+  );
+  // Malformed or non-positive values fall back to the 24h default.
+  assert.equal(
+    normalizePolicyConfig({ claimTiming: { staleAge: 'not-a-duration' } })
+      .claimTiming.staleAge,
+    'PT24H',
+  );
+  assert.equal(
+    normalizePolicyConfig({ claimTiming: { staleAge: 'PT0S' } }).claimTiming
+      .staleAge,
+    'PT24H',
+  );
+});
+
 test('parseIsoDurationToMs parses supported ISO durations', () => {
   assert.equal(parseIsoDurationToMs('PT5S'), 5000);
   assert.equal(parseIsoDurationToMs('PT2H'), 2 * 60 * 60 * 1000);

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -3912,6 +3912,85 @@ test('Part B: summarizeClaimValidation rejects an issue-only handoff after the P
   assert.equal(summary.activeClaim.claimId, 'claim-20260512T090000Z-337-old');
 });
 
+// ---------------------------------------------------------------------------
+// #1310: the write-gate resolvers must honor a configured claimTiming.staleAge
+// instead of being locked to the hardcoded 24h default. WG_OLD_CLAIM is
+// created at 2026-05-12T09:00:00Z; the takeover claim below lands 20h later
+// (2026-05-13T05:00:00Z) — squarely in the 18-24h gap the issue describes:
+// stale under an 18h configured age, not stale under the old hardcoded 24h.
+// ---------------------------------------------------------------------------
+
+const WG_TAKEOVER_CLAIM_ID = 'claim-20260513T050000Z-337-new';
+const EIGHTEEN_HOURS_MS = 18 * 60 * 60 * 1000;
+
+function wgTakeoverEvent() {
+  const body = `<!-- claimed-by: cli-new ${WG_TAKEOVER_CLAIM_ID} supersedes: claim-20260512T090000Z-337-old 2026-05-13T05:00:00Z branch: issue/337-feat -->`;
+  return {
+    body: [body, '', '_cli-new: issue claim — IDD automation marker._'].join(
+      '\n',
+    ),
+    createdAt: '2026-05-13T05:00:00Z',
+    author: { login: 'cli-new' },
+  };
+}
+
+test('resolveActiveClaimForWriteGate recognizes a takeover claim inside a configured 18h staleAge', () => {
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgTakeoverEvent()],
+    {
+      isTrustedAuthor: wgTrusted,
+      staleAgeMs: EIGHTEEN_HOURS_MS,
+    },
+  );
+  assert.equal(active?.claimId, WG_TAKEOVER_CLAIM_ID);
+  assert.equal(active?.agentId, 'cli-new');
+});
+
+test('resolveActiveClaimForWriteGate keeps the old claim active for the same 20h gap without staleAgeMs (old hardcoded 24h)', () => {
+  const active = resolveActiveClaimForWriteGate(
+    [wgClaimEvent(), wgTakeoverEvent()],
+    {
+      isTrustedAuthor: wgTrusted,
+    },
+  );
+  assert.equal(active?.claimId, 'claim-20260512T090000Z-337-old');
+  assert.equal(active?.agentId, 'cli-old');
+});
+
+test('summarizeClaimValidation reports no claimLost for a takeover inside a configured 18h staleAge', () => {
+  const summary = summarizeClaimValidation(
+    [wgClaimEvent(), wgTakeoverEvent()],
+    {
+      trustedMarkerLogins: ['cli-old', 'cli-new'],
+      expectedClaimId: WG_TAKEOVER_CLAIM_ID,
+      expectedAgentId: 'cli-new',
+      staleAgeMs: EIGHTEEN_HOURS_MS,
+    },
+  );
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, 'match');
+  assert.equal(summary.activeClaim.claimId, WG_TAKEOVER_CLAIM_ID);
+});
+
+test('summarizeClaimValidation falsely reports claimLost for the same takeover without staleAgeMs (the #1310 bug, pinned)', () => {
+  // Documents the exact production symptom from the issue: the legitimate
+  // successor's session recorded WG_TAKEOVER_CLAIM_ID as its expected claim,
+  // but the write gate — with no staleAgeMs override — still resolves the
+  // hardcoded-stale old claim as active, so a live successor reads as
+  // claimLost. Fixed by passing staleAgeMs from the resolved policy.
+  const summary = summarizeClaimValidation(
+    [wgClaimEvent(), wgTakeoverEvent()],
+    {
+      trustedMarkerLogins: ['cli-old', 'cli-new'],
+      expectedClaimId: WG_TAKEOVER_CLAIM_ID,
+      expectedAgentId: 'cli-new',
+    },
+  );
+  assert.equal(summary.claimLost, true);
+  assert.equal(summary.reason, 'claim-id-mismatch');
+  assert.equal(summary.activeClaim.claimId, 'claim-20260512T090000Z-337-old');
+});
+
 // Shape of a real execFileSync('gh', ...) failure: exit code 1 with the true
 // HTTP status carried in stderr (mirrors gh-http-status.test.mts). gh writes a
 // 404 response body to stdout, so fetchBranchRulesets must discriminate on the

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -3991,6 +3991,46 @@ test('summarizeClaimValidation falsely reports claimLost for the same takeover w
   assert.equal(summary.activeClaim.claimId, 'claim-20260512T090000Z-337-old');
 });
 
+test('buildPreMergeReadinessSummary threads staleAgeMs to the F2/F3 claim gate (#1310)', () => {
+  // End-to-end proof that the merge-gate aggregator itself (not just the
+  // underlying write-gate resolvers) honors a configured claimTiming.staleAge:
+  // the same 20h-gap takeover from the tests above, driven through the full
+  // buildPreMergeReadinessSummary entry point pre-merge-readiness.mts calls.
+  const prHeadSha = '1111111111111111111111111111111111111111';
+  const now = '2026-05-14T00:00:00Z';
+  const claimEvents = [wgClaimEvent(), wgTakeoverEvent()];
+
+  const withConfiguredStaleAge = buildPreMergeReadinessSummary(
+    { prHeadSha, claimEvents },
+    {
+      now,
+      trustedMarkerLogins: ['cli-old', 'cli-new'],
+      staleAgeMs: EIGHTEEN_HOURS_MS,
+    },
+  );
+  const claimWithConfiguredStaleAge = withConfiguredStaleAge.claim as Record<
+    string,
+    Record<string, unknown>
+  >;
+  assert.equal(
+    claimWithConfiguredStaleAge.activeClaim.claimId,
+    WG_TAKEOVER_CLAIM_ID,
+  );
+
+  const withoutStaleAgeOverride = buildPreMergeReadinessSummary(
+    { prHeadSha, claimEvents },
+    { now, trustedMarkerLogins: ['cli-old', 'cli-new'] },
+  );
+  const claimWithoutStaleAgeOverride = withoutStaleAgeOverride.claim as Record<
+    string,
+    Record<string, unknown>
+  >;
+  assert.equal(
+    claimWithoutStaleAgeOverride.activeClaim.claimId,
+    'claim-20260512T090000Z-337-old',
+  );
+});
+
 // Shape of a real execFileSync('gh', ...) failure: exit code 1 with the true
 // HTTP status carried in stderr (mirrors gh-http-status.test.mts). gh writes a
 // 404 response body to stdout, so fetchBranchRulesets must discriminate on the


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`summarizeClaimValidation` and `resolveActiveClaimForWriteGate`
(`src/scripts/protocol-helpers.mts`) always resolved claim staleness
through the hardcoded `isStaleAt` (24h) default — their option types
did not even accept an override. A repository whose
`claimTiming.staleAge` differs from 24h (e.g. `PT18H`) could hit a
false `claim-ownership` / `claimLost` blocker for a legitimate
stale-claim takeover whose age fell in the 18-24h gap.

This PR:

- Promotes a shared, config-aware `isStaleByAge(activeCreatedAt,
  nextCreatedAt, staleAgeMs)` primitive into `protocol-helpers.mts`
  (same algorithm already proven correct in
  `resume-claim-routing.mts`), alongside `isStaleAt` as the default
  fallback.
- Threads an optional `staleAgeMs` option through both write-gate
  resolvers, resolved via a small shared `resolveStalePredicate`
  helper. Omitting `staleAgeMs` keeps today's exact 24h behavior.
- De-duplicates `resume-claim-routing.mts`'s own (now redundant) local
  copy of `isStaleByAge` / `DEFAULT_STALE_AGE_MS` by importing the
  shared versions instead — zero behavior change there, confirmed by
  its existing test suite passing unchanged.
- **Wires the F2/F3 merge gate itself**: adds `claimTiming.staleAge` to
  `policy-helpers.mts`'s `normalizePolicyConfig` as the one canonical
  parse point, threads `staleAgeMs` through
  `buildPreMergeReadinessSummary`, and has
  `pre-merge-readiness.mts`'s `collectPreMergeReadiness` (the real
  F2/F3 entry point) read the configured value via a new
  `readClaimStaleAgeMs()` and pass it through — so the merge gate now
  resolves staleness from the repository's actual configured value,
  not just the underlying primitive being capable of it. (Added after
  review; see the disposition on the Codex thread below.)
- Adds direct unit coverage for the 18-24h window: `isStaleByAge`
  itself (`tests/claim-parser.test.mts`), both write-gate resolvers
  with and without `staleAgeMs`
  (`tests/pre-merge-readiness.test.mts`), `claimTiming.staleAge`
  default/override/malformed parsing
  (`tests/policy-helpers.test.mts`), and an end-to-end
  `buildPreMergeReadinessSummary` assertion proving the same scenario
  resolves correctly through the full F2/F3 aggregator.

## Linked issue

Closes #1310

## Follow-up issues (if any)

- [ ] none

This PR wires the merge gate itself (`pre-merge-readiness.mts`) but
does not wire the other write-gate **callers**
(`audit-pr-cleanup.mts`, `live-status-digest.mts`,
`idd-roadmap-audit-execute.mts`, `forced-handoff-marker.mts`,
`resolve-review-thread.mts`, `disposition-non-review-notices.mts`) to
read `claimTiming.staleAge` and pass it as `staleAgeMs` — none of them
decide mergeability the way `pre-merge-readiness` does, and the
canonical `claimTiming.staleAge` primitive now lives in
`policy-helpers.mts` for a fast, mechanical follow-up on each. See the
disposition on the Codex review thread for detail.

## Background / rationale (if material)

Original scope boundary (revised after review — see below): issue
#1310's own Candidate Files list names only `protocol-helpers.mts`
plus `tests/claim-lifecycle.test.mts` / "the pre-merge-readiness
tests", and the parent roadmap #1309's parallel-note frames #1310 as
touching one distinct function surface ("the write-gate staleness
resolver") in `protocol-helpers.mts`. I initially read the fix as
"make the write-gate resolvers *capable* of honoring a configured
`staleAge`" without also wiring a live caller. Codex review correctly
flagged that this left the advertised fix unreachable from any actual
production gate (`buildPreMergeReadinessSummary` — itself inside
`protocol-helpers.mts` — never forwarded `staleAgeMs` to
`summarizeClaimValidation`, and `pre-merge-readiness.mts` never read
the config value at all). Accepted that finding and wired the merge
gate's real entry point; see the commits and thread dispositions for
detail.

`discover-roadmap-graph.mts` (`isClaimStaleByAge`) and
`discover-shared-file-overlap.mts` (its own inline copy) remain
deliberately untouched: the issue's Background section describes the
discover (and resume) paths as already reading `claimTiming.staleAge`
correctly — only the write-gate resolvers were broken — and neither
file is in this issue's Candidate Files or the roadmap's file map for
#1310.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

**Updated after review** (an earlier version of this section claimed
no runtime behavior change; that is no longer accurate — flagged by a
Copilot review comment). `pre-merge-readiness.mts`'s
`collectPreMergeReadiness` — the CLI backing the F2/F3 merge gate —
now reads `claimTiming.staleAge` from `.github/idd/config.json` and
passes it through. A repository whose configured `staleAge` differs
from the 24h default (e.g. this issue's own `PT18H` example) will now
see a real, intended behavior change: a stale-claim takeover in the
configured-to-24h gap is recognized instead of falsely blocked. A
repository on the default 24h value (including this one —
`claimTiming.staleAge: PT24H` in `.github/idd/config.json`) sees no
behavior change.

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

All green locally (1787/1787 tests passing, including the new
coverage). `idd-doctor` reports 3 pre-existing environmental warnings
unrelated to this change (missing adopter profile READMEs,
`worktreeGuard` hooksPath note, branch protection not readable from
this environment).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
