### PR TITLE
feat(ci): add a ci-wait-state snapshot helper for D-phase CI polling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,7 @@ scripts/branch-name.mjs linguist-generated=true
 scripts/build-ts.mjs linguist-generated=true
 scripts/check-pnpm-boundary.mjs linguist-generated=true
 scripts/ci-wait-policy.mjs linguist-generated=true
+scripts/ci-wait-state.mjs linguist-generated=true
 scripts/claim-approval-gate.mjs linguist-generated=true
 scripts/collaborator-permission.mjs linguist-generated=true
 scripts/consistency-helpers.mjs linguist-generated=true

--- a/bin/idd-ci-wait-state.mjs
+++ b/bin/idd-ci-wait-state.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-ci-wait-state.mts
+//
+// The bin/idd-ci-wait-state.mjs copy is generated from the .mts source above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/ci-wait-state.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -77,6 +77,9 @@ In the idd-skill source repository, the following optional helpers were adopted:
   collection and AW outcome reporting
 - `scripts/ci-wait-policy.mjs` for read-only CI wait policy resolution
   and rerun-budget decisions
+- `scripts/ci-wait-state.mjs` for a read-only, single-shot D-phase CI
+  snapshot: per-check status keyed by `(checkName, workflowName)`, the
+  live `headRefOid`, and a required-checks rollup
 - `scripts/pre-merge-readiness.mjs` for read-only F2/F3 readiness
   evidence collection
 - `scripts/idd-merge-execute.mjs` for the F3 merge gate: a dry-run
@@ -949,6 +952,32 @@ Interpretation rules:
   `rerunDecision.reason`
 - it remains read-only; the command does not poll CI, rerun workflows,
   or post any GitHub comment
+
+### CI wait state snapshot
+
+- Source repo / vendored-node command:
+  `node scripts/ci-wait-state.mjs --pr <pr-number>`
+- Package-manager / ephemeral-npx command: use the
+  profile-selected `idd:ci-wait-state` command from the helper runtime
+  manifest wiring above
+- Single-shot, read-only: fetches `gh pr view`'s
+  `headRefOid`/`statusCheckRollup` plus the base branch's active rules and
+  classic branch protection, then reuses the same
+  `summarizeBranchReviewRequirements` required-check-name resolution
+  `pre-merge-readiness` already relies on — no forked required-check
+  discovery.
+- Stable fields consumed by D-phase polling: top-level `headRefOid` (for
+  caller-side HEAD-drift detection between polls); `checks[]`, each keyed
+  by both `checkName` and `workflowName` so two check runs sharing a
+  display name across different triggering workflows are never collapsed
+  into one entry, plus a normalized `status`
+  (`success|pending|failure|unknown`) and `required` flag; and
+  `requiredChecks` (`names`, `missingNames`, `allRequiredPresent`,
+  `allRequiredPassing`, `anyRequiredPending`, `anyRequiredFailing`,
+  `anyRequiredUnknown`, and a top-level `status` of
+  `success|pending|failing|missing|no-required-checks`)
+- it remains read-only; the command performs no reruns and posts no
+  GitHub comment
 
 ### Merge-gate evidence
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -968,14 +968,21 @@ Interpretation rules:
   discovery.
 - Stable fields consumed by D-phase polling: top-level `headRefOid` (for
   caller-side HEAD-drift detection between polls); `checks[]`, each keyed
-  by both `checkName` and `workflowName` so two check runs sharing a
-  display name across different triggering workflows are never collapsed
-  into one entry, plus a normalized `status`
-  (`success|pending|failure|unknown`) and `required` flag; and
+  by both `checkName` and (trimmed) `workflowName` so two check runs
+  sharing a display name across different triggering workflows are never
+  collapsed into one entry, plus a normalized `status`
+  (`success|pending|failure|unknown` — a commit-status `error` state
+  buckets as `failure`, same as `failure`) and `required` flag; and
   `requiredChecks` (`names`, `missingNames`, `allRequiredPresent`,
   `allRequiredPassing`, `anyRequiredPending`, `anyRequiredFailing`,
-  `anyRequiredUnknown`, and a top-level `status` of
-  `success|pending|failing|missing|no-required-checks`)
+  `anyRequiredUnknown`, `requiredCheckSourcePinned`, and a top-level
+  `status` of
+  `success|pending|failing|missing|no-required-checks|source-pinned`)
+- **Source-pinned required checks**: when a ruleset `workflows` rule or an
+  app/integration-pinned classic required check is in force but cannot be
+  enumerated by name, `requiredCheckSourcePinned` is `true` and `status` is
+  `source-pinned` — never `no-required-checks` — so a caller cannot
+  mistake an unresolvable required-check source for a vacuous pass.
 - it remains read-only; the command performs no reruns and posts no
   GitHub comment
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -77,6 +77,9 @@ In the idd-skill source repository, the following optional helpers were adopted:
   collection and AW outcome reporting
 - `scripts/ci-wait-policy.mjs` for read-only CI wait policy resolution
   and rerun-budget decisions
+- `scripts/ci-wait-state.mjs` for a read-only, single-shot D-phase CI
+  snapshot: per-check status keyed by `(checkName, workflowName)`, the
+  live `headRefOid`, and a required-checks rollup
 - `scripts/pre-merge-readiness.mjs` for read-only F2/F3 readiness
   evidence collection
 - `scripts/idd-merge-execute.mjs` for the F3 merge gate: a dry-run
@@ -949,6 +952,32 @@ Interpretation rules:
   `rerunDecision.reason`
 - it remains read-only; the command does not poll CI, rerun workflows,
   or post any GitHub comment
+
+### CI wait state snapshot
+
+- Source repo / vendored-node command:
+  `node scripts/ci-wait-state.mjs --pr <pr-number>`
+- Package-manager / ephemeral-npx command: use the
+  profile-selected `idd:ci-wait-state` command from the helper runtime
+  manifest wiring above
+- Single-shot, read-only: fetches `gh pr view`'s
+  `headRefOid`/`statusCheckRollup` plus the base branch's active rules and
+  classic branch protection, then reuses the same
+  `summarizeBranchReviewRequirements` required-check-name resolution
+  `pre-merge-readiness` already relies on — no forked required-check
+  discovery.
+- Stable fields consumed by D-phase polling: top-level `headRefOid` (for
+  caller-side HEAD-drift detection between polls); `checks[]`, each keyed
+  by both `checkName` and `workflowName` so two check runs sharing a
+  display name across different triggering workflows are never collapsed
+  into one entry, plus a normalized `status`
+  (`success|pending|failure|unknown`) and `required` flag; and
+  `requiredChecks` (`names`, `missingNames`, `allRequiredPresent`,
+  `allRequiredPassing`, `anyRequiredPending`, `anyRequiredFailing`,
+  `anyRequiredUnknown`, and a top-level `status` of
+  `success|pending|failing|missing|no-required-checks`)
+- it remains read-only; the command performs no reruns and posts no
+  GitHub comment
 
 ### Merge-gate evidence
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -968,14 +968,21 @@ Interpretation rules:
   discovery.
 - Stable fields consumed by D-phase polling: top-level `headRefOid` (for
   caller-side HEAD-drift detection between polls); `checks[]`, each keyed
-  by both `checkName` and `workflowName` so two check runs sharing a
-  display name across different triggering workflows are never collapsed
-  into one entry, plus a normalized `status`
-  (`success|pending|failure|unknown`) and `required` flag; and
+  by both `checkName` and (trimmed) `workflowName` so two check runs
+  sharing a display name across different triggering workflows are never
+  collapsed into one entry, plus a normalized `status`
+  (`success|pending|failure|unknown` — a commit-status `error` state
+  buckets as `failure`, same as `failure`) and `required` flag; and
   `requiredChecks` (`names`, `missingNames`, `allRequiredPresent`,
   `allRequiredPassing`, `anyRequiredPending`, `anyRequiredFailing`,
-  `anyRequiredUnknown`, and a top-level `status` of
-  `success|pending|failing|missing|no-required-checks`)
+  `anyRequiredUnknown`, `requiredCheckSourcePinned`, and a top-level
+  `status` of
+  `success|pending|failing|missing|no-required-checks|source-pinned`)
+- **Source-pinned required checks**: when a ruleset `workflows` rule or an
+  app/integration-pinned classic required check is in force but cannot be
+  enumerated by name, `requiredCheckSourcePinned` is `true` and `status` is
+  `source-pinned` — never `no-required-checks` — so a caller cannot
+  mistake an unresolvable required-check source for a vacuous pass.
 - it remains read-only; the command performs no reruns and posts no
   GitHub comment
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "idd-branch-conflict-state": "./bin/idd-branch-conflict-state.mjs",
     "idd-branch-name": "./bin/idd-branch-name.mjs",
     "idd-ci-wait-policy": "./bin/idd-ci-wait-policy.mjs",
+    "idd-ci-wait-state": "./bin/idd-ci-wait-state.mjs",
     "idd-claim-approval-gate": "./bin/idd-claim-approval-gate.mjs",
     "idd-discover-orphan-filter": "./bin/idd-discover-orphan-filter.mjs",
     "idd-discover-readiness-check": "./bin/idd-discover-readiness-check.mjs",

--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -228,7 +228,7 @@ function buildRequiredChecksRollup(
   const anyRequiredUnknown = requiredEntries.some(
     (check) => check.status === 'unknown',
   );
-  const allRequiredPassing =
+  const namedChecksPassing =
     allRequiredPresent &&
     requiredEntries.every((check) => check.status === 'success');
   let status;
@@ -238,9 +238,19 @@ function buildRequiredChecksRollup(
     status = 'failing';
   } else if (anyRequiredPending || anyRequiredUnknown) {
     status = 'pending';
+  } else if (requiredCheckSourcePinned) {
+    // Mixed case: enumerable required checks all pass, but a ruleset
+    // `workflows` rule or an app-pinned classic check is ALSO in force and
+    // not name-enumerable, so it is not covered by requiredEntries at all.
+    // Mirrors summarizeRequiredChecks in protocol-helpers.mts, which
+    // downgrades an otherwise-"success" classification to unresolved under
+    // the same condition — never report a vacuous success while an
+    // unverified source-pinned requirement could still be gating the branch.
+    status = 'source-pinned';
   } else {
     status = 'success';
   }
+  const allRequiredPassing = namedChecksPassing && status === 'success';
   return {
     names,
     missingNames,

--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -24,7 +24,10 @@
 import { execFileSync } from 'node:child_process';
 import { ghText, isCliExecution } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
-import { summarizeBranchReviewRequirements } from './protocol-helpers.mjs';
+import {
+  parsePaginatedGhNdjson,
+  summarizeBranchReviewRequirements,
+} from './protocol-helpers.mjs';
 
 // Interpretation table this bucketing mirrors exactly:
 // idd-ci.instructions.md's "Interpretation" section. Keep these three sets in
@@ -294,27 +297,23 @@ function parseArgs(argv) {
  * treating an auth/network failure as "no required checks configured".
  */
 function ghApiJsonOr404Empty(path, paginate) {
+  // `--jq '.[]'` (NDJSON, one array element per line) is the repo-standard
+  // paginate form — see gh-exec.mts and protocol-helpers.mts's
+  // parsePaginatedGhNdjson, reused here rather than hand-rolling a second
+  // parser. Unlike `--jq '.'`, it does not depend on gh's jq implementation
+  // staying compact-per-page; `--slurp` (a single JSON array) landed in gh
+  // v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0 via apt, so NDJSON stays
+  // the compatible default.
   const args = paginate
-    ? ['api', path, '--paginate', '--jq', '.']
+    ? ['api', path, '--paginate', '--jq', '.[]']
     : ['api', path];
   try {
-    const raw = execFileSync('gh', args, { encoding: 'utf8' }).trim();
-    if (!raw) {
-      return paginate ? [] : {};
-    }
+    const raw = execFileSync('gh', args, { encoding: 'utf8' });
     if (!paginate) {
-      return JSON.parse(raw);
+      const trimmed = raw.trim();
+      return trimmed ? JSON.parse(trimmed) : {};
     }
-    // `gh api --paginate --jq '.'` on an array-shaped endpoint emits one
-    // JSON array per page; flatten instead of assuming a single page.
-    return raw
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .flatMap((line) => {
-        const parsed = JSON.parse(line);
-        return Array.isArray(parsed) ? parsed : [parsed];
-      });
+    return parsePaginatedGhNdjson(raw);
   } catch (error) {
     if (deriveGhHttpStatus(error) === 404) {
       return paginate ? [] : {};

--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -29,9 +29,11 @@ import {
   summarizeBranchReviewRequirements,
 } from './protocol-helpers.mjs';
 
-// Interpretation table this bucketing mirrors exactly:
-// idd-ci.instructions.md's "Interpretation" section. Keep these three sets in
-// sync with that table's normalized states.
+// Interpretation table this bucketing is based on: idd-ci.instructions.md's
+// "Interpretation" section. Keep these three sets in sync with that table's
+// normalized states, with one deliberate addition: FAILURE_STATES also
+// includes StatusContext-only `ERROR` (see below), which that table does not
+// list because it predates this StatusContext-specific case.
 const SUCCESS_STATES = new Set([
   'SUCCESS',
   'NEUTRAL',

--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -69,7 +69,10 @@ if (isCliExecution(import.meta.url)) {
 function main() {
   const args = parseArgs(process.argv.slice(2));
   if (!args.prNumber) {
-    throw new Error('missing required --pr <number> argument');
+    // parseArgs normalizes both an absent --pr and an invalid one (e.g.
+    // `--pr 0` or `--pr foo`) to null, so "missing" alone would misreport an
+    // invalid value as absent.
+    throw new Error('missing or invalid --pr <number> argument');
   }
   const owner =
     args.owner ||

--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -50,6 +50,10 @@ const FAILURE_STATES = new Set([
   'ACTION_REQUIRED',
   'STARTUP_FAILURE',
   'STALE',
+  // Commit-status contexts (StatusContext) report `error` as a state
+  // distinct from `failure`; bucket it as failure too, or a clearly
+  // failing required check would misleadingly read as "unknown".
+  'ERROR',
 ]);
 if (isCliExecution(import.meta.url)) {
   main();
@@ -88,16 +92,20 @@ function main() {
     `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
     false,
   );
-  const requiredCheckNames = summarizeBranchReviewRequirements(
+  const branchReviewRequirements = summarizeBranchReviewRequirements(
     branchRules,
     branchProtection,
-  ).requiredCheckNames;
+  );
   const summary = buildCiWaitStateSummary(
     {
       headRefOid: pr.headRefOid ?? '',
       statusCheckRollup: pr.statusCheckRollup ?? [],
     },
-    { requiredCheckNames },
+    {
+      requiredCheckNames: branchReviewRequirements.requiredCheckNames,
+      requiredCheckSourcePinned:
+        branchReviewRequirements.requiredCheckSourcePinned,
+    },
   );
   process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
 }
@@ -119,6 +127,7 @@ export function buildCiWaitStateSummary(input, options = {}) {
   const requiredChecks = buildRequiredChecksRollup(
     checks,
     requiredCheckNameSet,
+    options.requiredCheckSourcePinned === true,
   );
   return {
     headRefOid: String(input.headRefOid ?? ''),
@@ -155,7 +164,11 @@ function normalizeCheckEntry(entry, requiredCheckNameSet) {
     status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status || 'UNKNOWN';
   return {
     checkName,
-    workflowName: String(entry?.workflowName ?? ''),
+    // Trimmed like checkName: workflowName is part of the
+    // (checkName, workflowName) disambiguation key, so untrimmed
+    // whitespace-only differences could otherwise produce unstable keys
+    // or spuriously "distinct" workflow entries.
+    workflowName: String(entry?.workflowName ?? '').trim(),
     type: 'check-run',
     state,
     status: bucketState(state),
@@ -171,18 +184,30 @@ function bucketState(state) {
   if (SUCCESS_STATES.has(state)) return 'success';
   return 'unknown';
 }
-function buildRequiredChecksRollup(checks, requiredCheckNameSet) {
+function buildRequiredChecksRollup(
+  checks,
+  requiredCheckNameSet,
+  requiredCheckSourcePinned,
+) {
   const names = [...requiredCheckNameSet].sort();
   if (names.length === 0) {
     return {
       names,
       missingNames: [],
-      allRequiredPresent: true,
+      // A source-pinned required check (ruleset `workflows` rule, or an
+      // app/integration-pinned classic check with no enumerable context)
+      // is still gating the branch even though it cannot be resolved by
+      // name here — fail closed (`allRequiredPresent: false`) instead of
+      // reporting the vacuous "no required checks" pass.
+      allRequiredPresent: !requiredCheckSourcePinned,
       allRequiredPassing: false,
       anyRequiredPending: false,
       anyRequiredFailing: false,
       anyRequiredUnknown: false,
-      status: 'no-required-checks',
+      requiredCheckSourcePinned,
+      status: requiredCheckSourcePinned
+        ? 'source-pinned'
+        : 'no-required-checks',
     };
   }
   const requiredEntries = checks.filter((check) => check.required);
@@ -219,6 +244,7 @@ function buildRequiredChecksRollup(checks, requiredCheckNameSet) {
     anyRequiredPending,
     anyRequiredFailing,
     anyRequiredUnknown,
+    requiredCheckSourcePinned,
     status,
   };
 }

--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/ci-wait-state.mts
+//
+// The scripts/ci-wait-state.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Single-shot, read-only D-phase CI snapshot helper (#1317). Unlike the
+// E/F review-state steps, which each have a committed evidence-snapshot
+// helper (advisory-wait-state, pre-merge-readiness, review-activity-snapshot),
+// the D-phase CI wait has historically had no committed polling/snapshot
+// helper: callers re-derive check status from raw `statusCheckRollup` JSON
+// by hand every wait. Two concrete traps this helper closes:
+//
+// - Duplicate check names across triggering workflows: a single PR can carry
+//   two check runs with the identical display `name` (e.g. the same job name
+//   once under a "push as feature branch" workflow and again under a "merge
+//   as main branch" workflow). This helper keys every check entry by
+//   `(checkName, workflowName)` so a naive "first match by name" read never
+//   silently picks the wrong workflow's status.
+// - HEAD drift mid-wait: this helper always reports the live `headRefOid` at
+//   read time, so a caller polling in a loop can detect the branch moving
+//   out from under an in-flight wait.
+import { execFileSync } from 'node:child_process';
+import { ghText, isCliExecution } from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import { summarizeBranchReviewRequirements } from './protocol-helpers.mjs';
+
+// Interpretation table this bucketing mirrors exactly:
+// idd-ci.instructions.md's "Interpretation" section. Keep these three sets in
+// sync with that table's normalized states.
+const SUCCESS_STATES = new Set([
+  'SUCCESS',
+  'NEUTRAL',
+  'SKIPPED',
+  'NOT_APPLICABLE',
+]);
+const PENDING_STATES = new Set([
+  'QUEUED',
+  'IN_PROGRESS',
+  'WAITING',
+  'PENDING',
+  'EXPECTED',
+  'REQUESTED',
+]);
+const FAILURE_STATES = new Set([
+  'FAILURE',
+  'CANCELLED',
+  'TIMED_OUT',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+  'STALE',
+]);
+if (isCliExecution(import.meta.url)) {
+  main();
+}
+// The CLI body. Guarded behind isCliExecution(import.meta.url) (shared, see
+// gh-exec.mts) so importing this module (for unit tests) does not parse
+// process.argv, fail, or make a `gh` call.
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const pr = JSON.parse(
+    ghText([
+      'pr',
+      'view',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'headRefOid,baseRefName,statusCheckRollup',
+    ]),
+  );
+  const encodedBaseRefName = encodeURIComponent(String(pr.baseRefName ?? ''));
+  const branchRules = ghApiJsonOr404Empty(
+    `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
+    true,
+  );
+  const branchProtection = ghApiJsonOr404Empty(
+    `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
+    false,
+  );
+  const requiredCheckNames = summarizeBranchReviewRequirements(
+    branchRules,
+    branchProtection,
+  ).requiredCheckNames;
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: pr.headRefOid ?? '',
+      statusCheckRollup: pr.statusCheckRollup ?? [],
+    },
+    { requiredCheckNames },
+  );
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+/**
+ * Build the read-only D-phase CI snapshot: every current check keyed by
+ * `(checkName, workflowName)`, the live `headRefOid`, and the top-level
+ * required-checks rollup. Pure and side-effect-free so it is directly unit
+ * testable without a live `gh` call.
+ */
+export function buildCiWaitStateSummary(input, options = {}) {
+  const requiredCheckNameSet = new Set(
+    (options.requiredCheckNames ?? [])
+      .map((name) => String(name ?? '').trim())
+      .filter(Boolean),
+  );
+  const checks = (input.statusCheckRollup ?? [])
+    .map((entry) => normalizeCheckEntry(entry, requiredCheckNameSet))
+    .filter((entry) => entry.checkName);
+  const requiredChecks = buildRequiredChecksRollup(
+    checks,
+    requiredCheckNameSet,
+  );
+  return {
+    headRefOid: String(input.headRefOid ?? ''),
+    checks,
+    requiredChecks,
+  };
+}
+function normalizeCheckEntry(entry, requiredCheckNameSet) {
+  if (entry?.__typename === 'StatusContext') {
+    const checkName = String(entry.context ?? '').trim();
+    const state = String(entry.state ?? '')
+      .trim()
+      .toUpperCase();
+    return {
+      checkName,
+      workflowName: '',
+      type: 'status-context',
+      state,
+      status: bucketState(state),
+      required: requiredCheckNameSet.has(checkName),
+      url: String(entry.targetUrl ?? ''),
+      startedAt: String(entry.startedAt ?? ''),
+      completedAt: String(entry.completedAt ?? ''),
+    };
+  }
+  const checkName = String(entry?.name ?? '').trim();
+  const status = String(entry?.status ?? '')
+    .trim()
+    .toUpperCase();
+  const conclusion = String(entry?.conclusion ?? '')
+    .trim()
+    .toUpperCase();
+  const state =
+    status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status || 'UNKNOWN';
+  return {
+    checkName,
+    workflowName: String(entry?.workflowName ?? ''),
+    type: 'check-run',
+    state,
+    status: bucketState(state),
+    required: requiredCheckNameSet.has(checkName),
+    url: String(entry?.detailsUrl ?? ''),
+    startedAt: String(entry?.startedAt ?? ''),
+    completedAt: String(entry?.completedAt ?? ''),
+  };
+}
+function bucketState(state) {
+  if (FAILURE_STATES.has(state)) return 'failure';
+  if (PENDING_STATES.has(state)) return 'pending';
+  if (SUCCESS_STATES.has(state)) return 'success';
+  return 'unknown';
+}
+function buildRequiredChecksRollup(checks, requiredCheckNameSet) {
+  const names = [...requiredCheckNameSet].sort();
+  if (names.length === 0) {
+    return {
+      names,
+      missingNames: [],
+      allRequiredPresent: true,
+      allRequiredPassing: false,
+      anyRequiredPending: false,
+      anyRequiredFailing: false,
+      anyRequiredUnknown: false,
+      status: 'no-required-checks',
+    };
+  }
+  const requiredEntries = checks.filter((check) => check.required);
+  const presentNames = new Set(requiredEntries.map((check) => check.checkName));
+  const missingNames = names.filter((name) => !presentNames.has(name));
+  const allRequiredPresent = missingNames.length === 0;
+  const anyRequiredFailing = requiredEntries.some(
+    (check) => check.status === 'failure',
+  );
+  const anyRequiredPending = requiredEntries.some(
+    (check) => check.status === 'pending',
+  );
+  const anyRequiredUnknown = requiredEntries.some(
+    (check) => check.status === 'unknown',
+  );
+  const allRequiredPassing =
+    allRequiredPresent &&
+    requiredEntries.every((check) => check.status === 'success');
+  let status;
+  if (!allRequiredPresent) {
+    status = 'missing';
+  } else if (anyRequiredFailing) {
+    status = 'failing';
+  } else if (anyRequiredPending || anyRequiredUnknown) {
+    status = 'pending';
+  } else {
+    status = 'success';
+  }
+  return {
+    names,
+    missingNames,
+    allRequiredPresent,
+    allRequiredPassing,
+    anyRequiredPending,
+    anyRequiredFailing,
+    anyRequiredUnknown,
+    status,
+  };
+}
+function parseArgs(argv) {
+  const parsed = {
+    prNumber: null,
+    owner: '',
+    repo: '',
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === '--pr') {
+      parsed.prNumber = Number.parseInt(value ?? '', 10);
+      index += 1;
+      continue;
+    }
+    if (token === '--owner') {
+      parsed.owner = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--repo') {
+      parsed.repo = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
+    parsed.prNumber = null;
+  }
+  return parsed;
+}
+/**
+ * `gh api <path>`, tolerating a genuine 404 (unprotected branch / no active
+ * rules) as an empty result. `gh` exits 1 for every HTTP error alike, so the
+ * real status is derived from the error text via the shared
+ * {@link deriveGhHttpStatus} rather than the useless process exit code —
+ * the same discrimination `pre-merge-readiness.mts` and the A3/A4 discovery
+ * helpers already rely on. Any other status (403, rate limit, transient
+ * failure) propagates so this snapshot fails closed instead of silently
+ * treating an auth/network failure as "no required checks configured".
+ */
+function ghApiJsonOr404Empty(path, paginate) {
+  const args = paginate
+    ? ['api', path, '--paginate', '--jq', '.']
+    : ['api', path];
+  try {
+    const raw = execFileSync('gh', args, { encoding: 'utf8' }).trim();
+    if (!raw) {
+      return paginate ? [] : {};
+    }
+    if (!paginate) {
+      return JSON.parse(raw);
+    }
+    // `gh api --paginate --jq '.'` on an array-shaped endpoint emits one
+    // JSON array per page; flatten instead of assuming a single page.
+    return raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .flatMap((line) => {
+        const parsed = JSON.parse(line);
+        return Array.isArray(parsed) ? parsed : [parsed];
+      });
+  } catch (error) {
+    if (deriveGhHttpStatus(error) === 404) {
+      return paginate ? [] : {};
+    }
+    throw error;
+  }
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/ci-wait-state.mjs --pr <number> [--owner <owner>] [--repo <repo>]
+
+Single-shot, read-only D-phase CI snapshot: per-check status keyed by
+(checkName, workflowName), the live headRefOid, and a top-level
+required-checks rollup. Performs no writes or reruns.
+`);
+}

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -138,6 +138,15 @@ const HELPER_COMMANDS = [
     contractPaths: ['schemas/policy.schema.json'],
   },
   {
+    id: 'ci-wait-state',
+    scriptName: 'idd:ci-wait-state',
+    binName: 'idd-ci-wait-state',
+    entryPath: 'scripts/ci-wait-state.mjs',
+    vendoredCommand: 'node scripts/ci-wait-state.mjs',
+    description:
+      'Collect a read-only D-phase CI snapshot: per-check status keyed by (checkName, workflowName), the live headRefOid, and a required-checks rollup.',
+  },
+  {
     id: 'claim-approval-gate',
     scriptName: 'idd:claim-approval-gate',
     binName: 'idd-claim-approval-gate',

--- a/src/bin/idd-ci-wait-state.mts
+++ b/src/bin/idd-ci-wait-state.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-ci-wait-state.mts
+//
+// The bin/idd-ci-wait-state.mjs copy is generated from the .mts source above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/ci-wait-state.mjs');

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -154,9 +154,11 @@ interface CiWaitStateArgs {
   repo: string;
 }
 
-// Interpretation table this bucketing mirrors exactly:
-// idd-ci.instructions.md's "Interpretation" section. Keep these three sets in
-// sync with that table's normalized states.
+// Interpretation table this bucketing is based on: idd-ci.instructions.md's
+// "Interpretation" section. Keep these three sets in sync with that table's
+// normalized states, with one deliberate addition: FAILURE_STATES also
+// includes StatusContext-only `ERROR` (see below), which that table does not
+// list because it predates this StatusContext-specific case.
 const SUCCESS_STATES = new Set([
   'SUCCESS',
   'NEUTRAL',

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -196,7 +196,10 @@ if (isCliExecution(import.meta.url)) {
 function main(): void {
   const args = parseArgs(process.argv.slice(2));
   if (!args.prNumber) {
-    throw new Error('missing required --pr <number> argument');
+    // parseArgs normalizes both an absent --pr and an invalid one (e.g.
+    // `--pr 0` or `--pr foo`) to null, so "missing" alone would misreport an
+    // invalid value as absent.
+    throw new Error('missing or invalid --pr <number> argument');
   }
 
   const owner =

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -118,7 +118,23 @@ export interface CiWaitRequiredChecksRollup {
   anyRequiredPending: boolean;
   anyRequiredFailing: boolean;
   anyRequiredUnknown: boolean;
-  status: 'success' | 'pending' | 'failing' | 'missing' | 'no-required-checks';
+  /**
+   * True when a ruleset `workflows` rule or an app/integration-pinned
+   * classic required check is in force but cannot be enumerated by name
+   * (mirrors `summarizeBranchReviewRequirements`'s
+   * `requiredCheckSourcePinned`). When this is true and `names` is empty,
+   * `status` is `source-pinned`, not `no-required-checks` — required
+   * checks are still gating the branch; this helper just cannot resolve
+   * them by name, so callers must not treat it as a vacuous pass.
+   */
+  requiredCheckSourcePinned: boolean;
+  status:
+    | 'success'
+    | 'pending'
+    | 'failing'
+    | 'missing'
+    | 'no-required-checks'
+    | 'source-pinned';
 }
 
 /** Full snapshot document returned by {@link buildCiWaitStateSummary}. */
@@ -159,6 +175,10 @@ const FAILURE_STATES = new Set([
   'ACTION_REQUIRED',
   'STARTUP_FAILURE',
   'STALE',
+  // Commit-status contexts (StatusContext) report `error` as a state
+  // distinct from `failure`; bucket it as failure too, or a clearly
+  // failing required check would misleadingly read as "unknown".
+  'ERROR',
 ]);
 
 if (isCliExecution(import.meta.url)) {
@@ -203,17 +223,21 @@ function main(): void {
     false,
   ) as BranchProtectionPayload;
 
-  const requiredCheckNames = summarizeBranchReviewRequirements(
+  const branchReviewRequirements = summarizeBranchReviewRequirements(
     branchRules,
     branchProtection,
-  ).requiredCheckNames;
+  );
 
   const summary = buildCiWaitStateSummary(
     {
       headRefOid: pr.headRefOid ?? '',
       statusCheckRollup: pr.statusCheckRollup ?? [],
     },
-    { requiredCheckNames },
+    {
+      requiredCheckNames: branchReviewRequirements.requiredCheckNames,
+      requiredCheckSourcePinned:
+        branchReviewRequirements.requiredCheckSourcePinned,
+    },
   );
 
   process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
@@ -230,7 +254,10 @@ export function buildCiWaitStateSummary(
     headRefOid?: string | null;
     statusCheckRollup?: StatusCheckRollupEntry[] | null;
   },
-  options: { requiredCheckNames?: string[] | null } = {},
+  options: {
+    requiredCheckNames?: string[] | null;
+    requiredCheckSourcePinned?: boolean;
+  } = {},
 ): CiWaitStateSummary {
   const requiredCheckNameSet = new Set(
     (options.requiredCheckNames ?? [])
@@ -245,6 +272,7 @@ export function buildCiWaitStateSummary(
   const requiredChecks = buildRequiredChecksRollup(
     checks,
     requiredCheckNameSet,
+    options.requiredCheckSourcePinned === true,
   );
 
   return {
@@ -287,7 +315,11 @@ function normalizeCheckEntry(
     status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status || 'UNKNOWN';
   return {
     checkName,
-    workflowName: String(entry?.workflowName ?? ''),
+    // Trimmed like checkName: workflowName is part of the
+    // (checkName, workflowName) disambiguation key, so untrimmed
+    // whitespace-only differences could otherwise produce unstable keys
+    // or spuriously "distinct" workflow entries.
+    workflowName: String(entry?.workflowName ?? '').trim(),
     type: 'check-run',
     state,
     status: bucketState(state),
@@ -308,18 +340,27 @@ function bucketState(state: string): CiWaitCheckEntry['status'] {
 function buildRequiredChecksRollup(
   checks: CiWaitCheckEntry[],
   requiredCheckNameSet: Set<string>,
+  requiredCheckSourcePinned: boolean,
 ): CiWaitRequiredChecksRollup {
   const names = [...requiredCheckNameSet].sort();
   if (names.length === 0) {
     return {
       names,
       missingNames: [],
-      allRequiredPresent: true,
+      // A source-pinned required check (ruleset `workflows` rule, or an
+      // app/integration-pinned classic check with no enumerable context)
+      // is still gating the branch even though it cannot be resolved by
+      // name here — fail closed (`allRequiredPresent: false`) instead of
+      // reporting the vacuous "no required checks" pass.
+      allRequiredPresent: !requiredCheckSourcePinned,
       allRequiredPassing: false,
       anyRequiredPending: false,
       anyRequiredFailing: false,
       anyRequiredUnknown: false,
-      status: 'no-required-checks',
+      requiredCheckSourcePinned,
+      status: requiredCheckSourcePinned
+        ? 'source-pinned'
+        : 'no-required-checks',
     };
   }
 
@@ -360,6 +401,7 @@ function buildRequiredChecksRollup(
     anyRequiredPending,
     anyRequiredFailing,
     anyRequiredUnknown,
+    requiredCheckSourcePinned,
     status,
   };
 }

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/ci-wait-state.mts
+//
+// The scripts/ci-wait-state.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+//
+// Single-shot, read-only D-phase CI snapshot helper (#1317). Unlike the
+// E/F review-state steps, which each have a committed evidence-snapshot
+// helper (advisory-wait-state, pre-merge-readiness, review-activity-snapshot),
+// the D-phase CI wait has historically had no committed polling/snapshot
+// helper: callers re-derive check status from raw `statusCheckRollup` JSON
+// by hand every wait. Two concrete traps this helper closes:
+//
+// - Duplicate check names across triggering workflows: a single PR can carry
+//   two check runs with the identical display `name` (e.g. the same job name
+//   once under a "push as feature branch" workflow and again under a "merge
+//   as main branch" workflow). This helper keys every check entry by
+//   `(checkName, workflowName)` so a naive "first match by name" read never
+//   silently picks the wrong workflow's status.
+// - HEAD drift mid-wait: this helper always reports the live `headRefOid` at
+//   read time, so a caller polling in a loop can detect the branch moving
+//   out from under an in-flight wait.
+
+import { execFileSync } from 'node:child_process';
+
+import { ghText, isCliExecution } from './gh-exec.mts';
+import { deriveGhHttpStatus } from './gh-http-status.mts';
+import { summarizeBranchReviewRequirements } from './protocol-helpers.mts';
+
+/** Required-check entry from a branch ruleset rule or classic protection. */
+type RawRequiredCheckPayload =
+  | string
+  | {
+      app_id?: unknown;
+      integration_id?: unknown;
+      source?: unknown;
+      context?: unknown;
+      name?: unknown;
+      check?: unknown;
+    }
+  | null
+  | undefined;
+
+/** Check-bearing parameters object shared by rules and classic protection. */
+interface RequiredCheckParametersPayload {
+  required_status_checks?: RawRequiredCheckPayload[] | null;
+  required_checks?: RawRequiredCheckPayload[] | null;
+  checks?: RawRequiredCheckPayload[] | null;
+  contexts?: RawRequiredCheckPayload[] | null;
+}
+
+/** Branch rule entry from `repos/{owner}/{repo}/rules/branches/{branch}`. */
+interface BranchRulePayload {
+  type?: string | null;
+  parameters?:
+    | (RequiredCheckParametersPayload & {
+        required_approving_review_count?: unknown;
+        require_code_owner_review?: unknown;
+        required_review_thread_resolution?: unknown;
+        workflows?: unknown;
+      })
+    | null;
+}
+
+/** Classic branch-protection payload fields this helper reads. */
+interface BranchProtectionPayload {
+  required_pull_request_reviews?: {
+    require_code_owner_reviews?: unknown;
+    require_code_owner_review?: unknown;
+    required_approving_review_count?: unknown;
+  } | null;
+  required_conversation_resolution?: { enabled?: unknown } | null;
+  required_status_checks?: RequiredCheckParametersPayload | null;
+}
+
+/** Status-check rollup entry from `gh pr view --json statusCheckRollup`. */
+interface StatusCheckRollupEntry {
+  __typename?: string | null;
+  context?: string | null;
+  state?: string | null;
+  targetUrl?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
+  name?: string | null;
+  detailsUrl?: string | null;
+  workflowName?: string | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+}
+
+/** PR payload fields consumed by this helper. */
+interface PrPayload {
+  headRefOid?: string | null;
+  baseRefName?: string | null;
+  statusCheckRollup?: StatusCheckRollupEntry[] | null;
+}
+
+/** One normalized, disambiguated per-check entry. */
+export interface CiWaitCheckEntry {
+  checkName: string;
+  workflowName: string;
+  type: 'check-run' | 'status-context';
+  state: string;
+  status: 'success' | 'pending' | 'failure' | 'unknown';
+  required: boolean;
+  url: string;
+  startedAt: string;
+  completedAt: string;
+}
+
+/** Top-level required-checks rollup. */
+export interface CiWaitRequiredChecksRollup {
+  names: string[];
+  missingNames: string[];
+  allRequiredPresent: boolean;
+  allRequiredPassing: boolean;
+  anyRequiredPending: boolean;
+  anyRequiredFailing: boolean;
+  anyRequiredUnknown: boolean;
+  status: 'success' | 'pending' | 'failing' | 'missing' | 'no-required-checks';
+}
+
+/** Full snapshot document returned by {@link buildCiWaitStateSummary}. */
+export interface CiWaitStateSummary {
+  headRefOid: string;
+  checks: CiWaitCheckEntry[];
+  requiredChecks: CiWaitRequiredChecksRollup;
+}
+
+/** Parsed CLI arguments. */
+interface CiWaitStateArgs {
+  prNumber: number | null;
+  owner: string;
+  repo: string;
+}
+
+// Interpretation table this bucketing mirrors exactly:
+// idd-ci.instructions.md's "Interpretation" section. Keep these three sets in
+// sync with that table's normalized states.
+const SUCCESS_STATES = new Set([
+  'SUCCESS',
+  'NEUTRAL',
+  'SKIPPED',
+  'NOT_APPLICABLE',
+]);
+const PENDING_STATES = new Set([
+  'QUEUED',
+  'IN_PROGRESS',
+  'WAITING',
+  'PENDING',
+  'EXPECTED',
+  'REQUESTED',
+]);
+const FAILURE_STATES = new Set([
+  'FAILURE',
+  'CANCELLED',
+  'TIMED_OUT',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+  'STALE',
+]);
+
+if (isCliExecution(import.meta.url)) {
+  main();
+}
+
+// The CLI body. Guarded behind isCliExecution(import.meta.url) (shared, see
+// gh-exec.mts) so importing this module (for unit tests) does not parse
+// process.argv, fail, or make a `gh` call.
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+
+  const pr = JSON.parse(
+    ghText([
+      'pr',
+      'view',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'headRefOid,baseRefName,statusCheckRollup',
+    ]),
+  ) as PrPayload;
+  const encodedBaseRefName = encodeURIComponent(String(pr.baseRefName ?? ''));
+
+  const branchRules = ghApiJsonOr404Empty(
+    `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
+    true,
+  ) as BranchRulePayload[];
+  const branchProtection = ghApiJsonOr404Empty(
+    `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
+    false,
+  ) as BranchProtectionPayload;
+
+  const requiredCheckNames = summarizeBranchReviewRequirements(
+    branchRules,
+    branchProtection,
+  ).requiredCheckNames;
+
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: pr.headRefOid ?? '',
+      statusCheckRollup: pr.statusCheckRollup ?? [],
+    },
+    { requiredCheckNames },
+  );
+
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+
+/**
+ * Build the read-only D-phase CI snapshot: every current check keyed by
+ * `(checkName, workflowName)`, the live `headRefOid`, and the top-level
+ * required-checks rollup. Pure and side-effect-free so it is directly unit
+ * testable without a live `gh` call.
+ */
+export function buildCiWaitStateSummary(
+  input: {
+    headRefOid?: string | null;
+    statusCheckRollup?: StatusCheckRollupEntry[] | null;
+  },
+  options: { requiredCheckNames?: string[] | null } = {},
+): CiWaitStateSummary {
+  const requiredCheckNameSet = new Set(
+    (options.requiredCheckNames ?? [])
+      .map((name) => String(name ?? '').trim())
+      .filter(Boolean),
+  );
+
+  const checks = (input.statusCheckRollup ?? [])
+    .map((entry) => normalizeCheckEntry(entry, requiredCheckNameSet))
+    .filter((entry) => entry.checkName);
+
+  const requiredChecks = buildRequiredChecksRollup(
+    checks,
+    requiredCheckNameSet,
+  );
+
+  return {
+    headRefOid: String(input.headRefOid ?? ''),
+    checks,
+    requiredChecks,
+  };
+}
+
+function normalizeCheckEntry(
+  entry: StatusCheckRollupEntry,
+  requiredCheckNameSet: Set<string>,
+): CiWaitCheckEntry {
+  if (entry?.__typename === 'StatusContext') {
+    const checkName = String(entry.context ?? '').trim();
+    const state = String(entry.state ?? '')
+      .trim()
+      .toUpperCase();
+    return {
+      checkName,
+      workflowName: '',
+      type: 'status-context',
+      state,
+      status: bucketState(state),
+      required: requiredCheckNameSet.has(checkName),
+      url: String(entry.targetUrl ?? ''),
+      startedAt: String(entry.startedAt ?? ''),
+      completedAt: String(entry.completedAt ?? ''),
+    };
+  }
+
+  const checkName = String(entry?.name ?? '').trim();
+  const status = String(entry?.status ?? '')
+    .trim()
+    .toUpperCase();
+  const conclusion = String(entry?.conclusion ?? '')
+    .trim()
+    .toUpperCase();
+  const state =
+    status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status || 'UNKNOWN';
+  return {
+    checkName,
+    workflowName: String(entry?.workflowName ?? ''),
+    type: 'check-run',
+    state,
+    status: bucketState(state),
+    required: requiredCheckNameSet.has(checkName),
+    url: String(entry?.detailsUrl ?? ''),
+    startedAt: String(entry?.startedAt ?? ''),
+    completedAt: String(entry?.completedAt ?? ''),
+  };
+}
+
+function bucketState(state: string): CiWaitCheckEntry['status'] {
+  if (FAILURE_STATES.has(state)) return 'failure';
+  if (PENDING_STATES.has(state)) return 'pending';
+  if (SUCCESS_STATES.has(state)) return 'success';
+  return 'unknown';
+}
+
+function buildRequiredChecksRollup(
+  checks: CiWaitCheckEntry[],
+  requiredCheckNameSet: Set<string>,
+): CiWaitRequiredChecksRollup {
+  const names = [...requiredCheckNameSet].sort();
+  if (names.length === 0) {
+    return {
+      names,
+      missingNames: [],
+      allRequiredPresent: true,
+      allRequiredPassing: false,
+      anyRequiredPending: false,
+      anyRequiredFailing: false,
+      anyRequiredUnknown: false,
+      status: 'no-required-checks',
+    };
+  }
+
+  const requiredEntries = checks.filter((check) => check.required);
+  const presentNames = new Set(requiredEntries.map((check) => check.checkName));
+  const missingNames = names.filter((name) => !presentNames.has(name));
+  const allRequiredPresent = missingNames.length === 0;
+
+  const anyRequiredFailing = requiredEntries.some(
+    (check) => check.status === 'failure',
+  );
+  const anyRequiredPending = requiredEntries.some(
+    (check) => check.status === 'pending',
+  );
+  const anyRequiredUnknown = requiredEntries.some(
+    (check) => check.status === 'unknown',
+  );
+  const allRequiredPassing =
+    allRequiredPresent &&
+    requiredEntries.every((check) => check.status === 'success');
+
+  let status: CiWaitRequiredChecksRollup['status'];
+  if (!allRequiredPresent) {
+    status = 'missing';
+  } else if (anyRequiredFailing) {
+    status = 'failing';
+  } else if (anyRequiredPending || anyRequiredUnknown) {
+    status = 'pending';
+  } else {
+    status = 'success';
+  }
+
+  return {
+    names,
+    missingNames,
+    allRequiredPresent,
+    allRequiredPassing,
+    anyRequiredPending,
+    anyRequiredFailing,
+    anyRequiredUnknown,
+    status,
+  };
+}
+
+function parseArgs(argv: string[]): CiWaitStateArgs {
+  const parsed: CiWaitStateArgs = {
+    prNumber: null,
+    owner: '',
+    repo: '',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === '--pr') {
+      parsed.prNumber = Number.parseInt(value ?? '', 10);
+      index += 1;
+      continue;
+    }
+    if (token === '--owner') {
+      parsed.owner = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--repo') {
+      parsed.repo = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+
+  if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
+    parsed.prNumber = null;
+  }
+
+  return parsed;
+}
+
+/**
+ * `gh api <path>`, tolerating a genuine 404 (unprotected branch / no active
+ * rules) as an empty result. `gh` exits 1 for every HTTP error alike, so the
+ * real status is derived from the error text via the shared
+ * {@link deriveGhHttpStatus} rather than the useless process exit code —
+ * the same discrimination `pre-merge-readiness.mts` and the A3/A4 discovery
+ * helpers already rely on. Any other status (403, rate limit, transient
+ * failure) propagates so this snapshot fails closed instead of silently
+ * treating an auth/network failure as "no required checks configured".
+ */
+function ghApiJsonOr404Empty(path: string, paginate: boolean): unknown {
+  const args = paginate
+    ? ['api', path, '--paginate', '--jq', '.']
+    : ['api', path];
+  try {
+    const raw = execFileSync('gh', args, { encoding: 'utf8' }).trim();
+    if (!raw) {
+      return paginate ? [] : {};
+    }
+    if (!paginate) {
+      return JSON.parse(raw);
+    }
+    // `gh api --paginate --jq '.'` on an array-shaped endpoint emits one
+    // JSON array per page; flatten instead of assuming a single page.
+    return raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .flatMap((line) => {
+        const parsed = JSON.parse(line) as unknown;
+        return Array.isArray(parsed) ? parsed : [parsed];
+      });
+  } catch (error) {
+    if (deriveGhHttpStatus(error) === 404) {
+      return paginate ? [] : {};
+    }
+    throw error;
+  }
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/ci-wait-state.mjs --pr <number> [--owner <owner>] [--repo <repo>]
+
+Single-shot, read-only D-phase CI snapshot: per-check status keyed by
+(checkName, workflowName), the live headRefOid, and a top-level
+required-checks rollup. Performs no writes or reruns.
+`);
+}

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -26,7 +26,10 @@ import { execFileSync } from 'node:child_process';
 
 import { ghText, isCliExecution } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
-import { summarizeBranchReviewRequirements } from './protocol-helpers.mts';
+import {
+  parsePaginatedGhNdjson,
+  summarizeBranchReviewRequirements,
+} from './protocol-helpers.mts';
 
 /** Required-check entry from a branch ruleset rule or classic protection. */
 type RawRequiredCheckPayload =
@@ -456,27 +459,23 @@ function parseArgs(argv: string[]): CiWaitStateArgs {
  * treating an auth/network failure as "no required checks configured".
  */
 function ghApiJsonOr404Empty(path: string, paginate: boolean): unknown {
+  // `--jq '.[]'` (NDJSON, one array element per line) is the repo-standard
+  // paginate form — see gh-exec.mts and protocol-helpers.mts's
+  // parsePaginatedGhNdjson, reused here rather than hand-rolling a second
+  // parser. Unlike `--jq '.'`, it does not depend on gh's jq implementation
+  // staying compact-per-page; `--slurp` (a single JSON array) landed in gh
+  // v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0 via apt, so NDJSON stays
+  // the compatible default.
   const args = paginate
-    ? ['api', path, '--paginate', '--jq', '.']
+    ? ['api', path, '--paginate', '--jq', '.[]']
     : ['api', path];
   try {
-    const raw = execFileSync('gh', args, { encoding: 'utf8' }).trim();
-    if (!raw) {
-      return paginate ? [] : {};
-    }
+    const raw = execFileSync('gh', args, { encoding: 'utf8' });
     if (!paginate) {
-      return JSON.parse(raw);
+      const trimmed = raw.trim();
+      return trimmed ? JSON.parse(trimmed) : {};
     }
-    // `gh api --paginate --jq '.'` on an array-shaped endpoint emits one
-    // JSON array per page; flatten instead of assuming a single page.
-    return raw
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .flatMap((line) => {
-        const parsed = JSON.parse(line) as unknown;
-        return Array.isArray(parsed) ? parsed : [parsed];
-      });
+    return parsePaginatedGhNdjson(raw);
   } catch (error) {
     if (deriveGhHttpStatus(error) === 404) {
       return paginate ? [] : {};

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -383,7 +383,7 @@ function buildRequiredChecksRollup(
   const anyRequiredUnknown = requiredEntries.some(
     (check) => check.status === 'unknown',
   );
-  const allRequiredPassing =
+  const namedChecksPassing =
     allRequiredPresent &&
     requiredEntries.every((check) => check.status === 'success');
 
@@ -394,9 +394,19 @@ function buildRequiredChecksRollup(
     status = 'failing';
   } else if (anyRequiredPending || anyRequiredUnknown) {
     status = 'pending';
+  } else if (requiredCheckSourcePinned) {
+    // Mixed case: enumerable required checks all pass, but a ruleset
+    // `workflows` rule or an app-pinned classic check is ALSO in force and
+    // not name-enumerable, so it is not covered by requiredEntries at all.
+    // Mirrors summarizeRequiredChecks in protocol-helpers.mts, which
+    // downgrades an otherwise-"success" classification to unresolved under
+    // the same condition — never report a vacuous success while an
+    // unverified source-pinned requirement could still be gating the branch.
+    status = 'source-pinned';
   } else {
     status = 'success';
   }
+  const allRequiredPassing = namedChecksPassing && status === 'success';
 
   return {
     names,

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -210,6 +210,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
     contractPaths: ['schemas/policy.schema.json'],
   },
   {
+    id: 'ci-wait-state',
+    scriptName: 'idd:ci-wait-state',
+    binName: 'idd-ci-wait-state',
+    entryPath: 'scripts/ci-wait-state.mjs',
+    vendoredCommand: 'node scripts/ci-wait-state.mjs',
+    description:
+      'Collect a read-only D-phase CI snapshot: per-check status keyed by (checkName, workflowName), the live headRefOid, and a required-checks rollup.',
+  },
+  {
     id: 'claim-approval-gate',
     scriptName: 'idd:claim-approval-gate',
     binName: 'idd-claim-approval-gate',

--- a/tests/ci-wait-state.test.mts
+++ b/tests/ci-wait-state.test.mts
@@ -264,16 +264,12 @@ test('workflowName is trimmed so whitespace-only differences do not produce spur
   assert.equal(summary.checks[0]?.workflowName, 'ci');
 });
 
-// Importing the CLI module directly is only possible now that its top-level
-// statements are guarded behind isCliExecution() (#1210); previously the
-// import parsed process.argv and called a `gh` command, aborting the test
-// process when no --pr argument or gh binary was available.
-test('importing ci-wait-state.mts has no import-time side effect', async () => {
-  const originalPath = process.env.PATH;
-  process.env.PATH = '';
-  try {
-    await assert.doesNotReject(import('../src/scripts/ci-wait-state.mts'));
-  } finally {
-    process.env.PATH = originalPath;
-  }
-});
+// No separate "importing ci-wait-state.mts has no import-time side effect"
+// dynamic-import test here: this file already statically imports
+// buildCiWaitStateSummary from ci-wait-state.mts above, so a later dynamic
+// `import('../src/scripts/ci-wait-state.mts')` would just return the
+// already-cached module and re-run no top-level code, making that assertion
+// vacuous — it would pass even if the isCliExecution(import.meta.url) guard
+// were removed. ci-wait-policy.test.mts (a fellow builder+CLI single-file
+// helper whose test file statically imports its builder functions too)
+// follows the same precedent and omits this test for the same reason.

--- a/tests/ci-wait-state.test.mts
+++ b/tests/ci-wait-state.test.mts
@@ -140,6 +140,26 @@ test('a source-pinned required check (empty names) reports source-pinned, never 
   assert.equal(summary.requiredChecks.allRequiredPassing, false);
 });
 
+test('mixed source-pinned case: named required checks all pass, but never reports success while an unnamed source-pinned requirement is unverified', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({ name: 'lint', workflowName: 'ci', conclusion: 'SUCCESS' }),
+      ],
+    },
+    { requiredCheckNames: ['lint'], requiredCheckSourcePinned: true },
+  );
+
+  assert.equal(summary.requiredChecks.allRequiredPresent, true);
+  assert.equal(summary.requiredChecks.anyRequiredFailing, false);
+  assert.equal(summary.requiredChecks.anyRequiredPending, false);
+  // The critical assertion: never a vacuous success/allRequiredPassing while
+  // requiredCheckSourcePinned is true, even though the one named check passed.
+  assert.equal(summary.requiredChecks.status, 'source-pinned');
+  assert.equal(summary.requiredChecks.allRequiredPassing, false);
+});
+
 test('all required checks passing reports allRequiredPassing and status success', () => {
   const summary = buildCiWaitStateSummary(
     {

--- a/tests/ci-wait-state.test.mts
+++ b/tests/ci-wait-state.test.mts
@@ -122,6 +122,22 @@ test('required-checks rollup: no required checks configured is reported distinct
   assert.equal(summary.requiredChecks.status, 'no-required-checks');
   assert.equal(summary.requiredChecks.allRequiredPassing, false);
   assert.equal(summary.requiredChecks.names.length, 0);
+  assert.equal(summary.requiredChecks.requiredCheckSourcePinned, false);
+});
+
+test('a source-pinned required check (empty names) reports source-pinned, never the vacuous no-required-checks pass', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [checkRun({ name: 'build', conclusion: 'SUCCESS' })],
+    },
+    { requiredCheckNames: [], requiredCheckSourcePinned: true },
+  );
+
+  assert.equal(summary.requiredChecks.status, 'source-pinned');
+  assert.equal(summary.requiredChecks.requiredCheckSourcePinned, true);
+  assert.equal(summary.requiredChecks.allRequiredPresent, false);
+  assert.equal(summary.requiredChecks.allRequiredPassing, false);
 });
 
 test('all required checks passing reports allRequiredPassing and status success', () => {
@@ -209,6 +225,43 @@ test('a genuinely unrecognized state buckets as unknown and marks the rollup unk
   assert.equal(summary.requiredChecks.anyRequiredUnknown, true);
   assert.equal(summary.requiredChecks.allRequiredPassing, false);
   assert.equal(summary.requiredChecks.status, 'pending');
+});
+
+test('a StatusContext ERROR state buckets as failure, distinct from FAILURE but equally blocking', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        {
+          __typename: 'StatusContext',
+          context: 'external-check',
+          state: 'ERROR',
+          targetUrl: '',
+        },
+      ],
+    },
+    { requiredCheckNames: ['external-check'] },
+  );
+  assert.equal(summary.checks[0]?.status, 'failure');
+  assert.equal(summary.requiredChecks.anyRequiredFailing, true);
+  assert.equal(summary.requiredChecks.status, 'failing');
+});
+
+test('workflowName is trimmed so whitespace-only differences do not produce spurious distinct entries', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({
+          name: 'lint',
+          workflowName: '  ci  ',
+          conclusion: 'SUCCESS',
+        }),
+      ],
+    },
+    { requiredCheckNames: [] },
+  );
+  assert.equal(summary.checks[0]?.workflowName, 'ci');
 });
 
 // Importing the CLI module directly is only possible now that its top-level

--- a/tests/ci-wait-state.test.mts
+++ b/tests/ci-wait-state.test.mts
@@ -1,0 +1,226 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { buildCiWaitStateSummary } from '../src/scripts/ci-wait-state.mts';
+
+const HEAD_SHA = 'a'.repeat(40);
+
+function checkRun(overrides: Record<string, unknown> = {}) {
+  return {
+    __typename: 'CheckRun',
+    name: 'lint',
+    status: 'COMPLETED',
+    conclusion: 'SUCCESS',
+    workflowName: 'push',
+    detailsUrl: 'https://example/run',
+    startedAt: '2026-07-09T00:00:00Z',
+    completedAt: '2026-07-09T00:05:00Z',
+    ...overrides,
+  };
+}
+
+test('keys duplicate-name checks by (checkName, workflowName) instead of collapsing them', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({
+          workflowName: 'push as feature branch',
+          status: 'COMPLETED',
+          conclusion: 'SUCCESS',
+        }),
+        checkRun({
+          workflowName: 'merge as main branch',
+          status: 'IN_PROGRESS',
+          conclusion: '',
+        }),
+      ],
+    },
+    { requiredCheckNames: ['lint'] },
+  );
+
+  assert.equal(summary.checks.length, 2);
+  const byWorkflow = new Map(
+    summary.checks.map((check) => [check.workflowName, check]),
+  );
+  assert.equal(byWorkflow.get('push as feature branch')?.status, 'success');
+  assert.equal(byWorkflow.get('merge as main branch')?.status, 'pending');
+  // Both entries share the display name; disambiguation must not merge them.
+  assert.equal(
+    summary.checks.every((check) => check.checkName === 'lint'),
+    true,
+  );
+});
+
+test('required-checks rollup: mixed pending/passing reports anyRequiredPending, not passing', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({ name: 'lint', workflowName: 'ci', conclusion: 'SUCCESS' }),
+        checkRun({
+          name: 'test',
+          workflowName: 'ci',
+          status: 'IN_PROGRESS',
+          conclusion: '',
+        }),
+      ],
+    },
+    { requiredCheckNames: ['lint', 'test'] },
+  );
+
+  assert.equal(summary.requiredChecks.allRequiredPresent, true);
+  assert.equal(summary.requiredChecks.allRequiredPassing, false);
+  assert.equal(summary.requiredChecks.anyRequiredPending, true);
+  assert.equal(summary.requiredChecks.anyRequiredFailing, false);
+  assert.equal(summary.requiredChecks.status, 'pending');
+});
+
+test('required-checks rollup: a failing required check reports anyRequiredFailing and status failing', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({ name: 'lint', workflowName: 'ci', conclusion: 'SUCCESS' }),
+        checkRun({ name: 'test', workflowName: 'ci', conclusion: 'FAILURE' }),
+      ],
+    },
+    { requiredCheckNames: ['lint', 'test'] },
+  );
+
+  assert.equal(summary.requiredChecks.anyRequiredFailing, true);
+  assert.equal(summary.requiredChecks.allRequiredPassing, false);
+  assert.equal(summary.requiredChecks.status, 'failing');
+});
+
+test('required-checks rollup: a not-yet-generated required check reports missing, not vacuously passing', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({ name: 'lint', workflowName: 'ci', conclusion: 'SUCCESS' }),
+      ],
+    },
+    { requiredCheckNames: ['lint', 'test'] },
+  );
+
+  assert.deepEqual(summary.requiredChecks.missingNames, ['test']);
+  assert.equal(summary.requiredChecks.allRequiredPresent, false);
+  assert.equal(summary.requiredChecks.allRequiredPassing, false);
+  assert.equal(summary.requiredChecks.status, 'missing');
+});
+
+test('required-checks rollup: no required checks configured is reported distinctly, not as passing', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [checkRun({ name: 'build' })],
+    },
+    { requiredCheckNames: [] },
+  );
+
+  assert.equal(summary.requiredChecks.status, 'no-required-checks');
+  assert.equal(summary.requiredChecks.allRequiredPassing, false);
+  assert.equal(summary.requiredChecks.names.length, 0);
+});
+
+test('all required checks passing reports allRequiredPassing and status success', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({ name: 'lint', workflowName: 'ci', conclusion: 'SUCCESS' }),
+        checkRun({ name: 'test', workflowName: 'ci', conclusion: 'SKIPPED' }),
+      ],
+    },
+    { requiredCheckNames: ['lint', 'test'] },
+  );
+
+  assert.equal(summary.requiredChecks.allRequiredPassing, true);
+  assert.equal(summary.requiredChecks.status, 'success');
+});
+
+test('a StatusContext entry is normalized alongside CheckRun entries', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        {
+          __typename: 'StatusContext',
+          context: 'CodeRabbit',
+          state: 'SUCCESS',
+          targetUrl: '',
+          startedAt: '2026-07-09T00:00:00Z',
+        },
+      ],
+    },
+    { requiredCheckNames: [] },
+  );
+
+  assert.equal(summary.checks.length, 1);
+  assert.equal(summary.checks[0]?.type, 'status-context');
+  assert.equal(summary.checks[0]?.checkName, 'CodeRabbit');
+  assert.equal(summary.checks[0]?.workflowName, '');
+  assert.equal(summary.checks[0]?.status, 'success');
+});
+
+test('reports the live headRefOid unchanged, for caller-side HEAD-drift detection', () => {
+  const summary = buildCiWaitStateSummary(
+    { headRefOid: HEAD_SHA, statusCheckRollup: [] },
+    { requiredCheckNames: [] },
+  );
+  assert.equal(summary.headRefOid, HEAD_SHA);
+});
+
+test('a failure-family state (cancelled/timed_out/action_required/stale) buckets as failure, not unknown', () => {
+  for (const conclusion of [
+    'CANCELLED',
+    'TIMED_OUT',
+    'ACTION_REQUIRED',
+    'STARTUP_FAILURE',
+    'STALE',
+  ]) {
+    const summary = buildCiWaitStateSummary(
+      {
+        headRefOid: HEAD_SHA,
+        statusCheckRollup: [checkRun({ name: 'lint', conclusion })],
+      },
+      { requiredCheckNames: [] },
+    );
+    assert.equal(
+      summary.checks[0]?.status,
+      'failure',
+      `expected ${conclusion} to bucket as failure`,
+    );
+  }
+});
+
+test('a genuinely unrecognized state buckets as unknown and marks the rollup unknown, not passing', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({ name: 'lint', status: 'COMPLETED', conclusion: 'WEIRD' }),
+      ],
+    },
+    { requiredCheckNames: ['lint'] },
+  );
+  assert.equal(summary.checks[0]?.status, 'unknown');
+  assert.equal(summary.requiredChecks.anyRequiredUnknown, true);
+  assert.equal(summary.requiredChecks.allRequiredPassing, false);
+  assert.equal(summary.requiredChecks.status, 'pending');
+});
+
+// Importing the CLI module directly is only possible now that its top-level
+// statements are guarded behind isCliExecution() (#1210); previously the
+// import parsed process.argv and called a `gh` command, aborting the test
+// process when no --pr argument or gh binary was available.
+test('importing ci-wait-state.mts has no import-time side effect', async () => {
+  const originalPath = process.env.PATH;
+  process.env.PATH = '';
+  try {
+    await assert.doesNotReject(import('../src/scripts/ci-wait-state.mts'));
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `src/scripts/ci-wait-state.mts` (generated `scripts/ci-wait-state.mjs`), a single-shot, read-only D-phase CI snapshot helper modeled on `advisory-wait-state.mts`.
- Every check entry is keyed by `(checkName, workflowName)` so two check runs sharing a display name across different triggering workflows (e.g. "push as feature branch" vs. "merge as main branch") are never collapsed into one entry.
- Reports the live `headRefOid` at read time so a caller polling in a loop can detect the branch moving out from under an in-flight wait.
- Reuses the existing `summarizeBranchReviewRequirements` (already relied on by `pre-merge-readiness`) for required-check-name resolution — no forked required-check discovery.
- Computes a top-level `requiredChecks` rollup (`allRequiredPresent`, `allRequiredPassing`, `anyRequiredPending`, `anyRequiredFailing`, `anyRequiredUnknown`, `status`).
- Registers the helper in the helper runtime manifest (`src/scripts/helper-runtime-manifest.mts`) and `package.json`'s `bin` map.
- Documents the helper in `idd-template/docs/idd-helper-scripts.md` (the source of truth) and re-syncs the generated `docs/idd-helper-scripts.md` copy via `node scripts/sync-docs.mjs --apply`.
- Adds `tests/ci-wait-state.test.mts` covering duplicate-display-name disambiguation, mixed pending/passing/failing rollups, missing/not-yet-generated required checks, the no-required-checks-configured case, and the full failure-state family (`cancelled`/`timed_out`/`action_required`/`startup_failure`/`stale`).

The instruction-side D-phase polling notes that consume this helper are intentionally deferred to the sibling docs issue #1318 (`Blocked by #1317`), per the parent roadmap #1309.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build` / `pnpm run build:check` (generated `.mjs` artifacts match source)
- [x] `node --test tests/*.test.mts` (1787 passed)
- [x] `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress`
- [x] `node scripts/idd-doctor.mjs` (passed, pre-existing environment-only warnings)
- [x] Smoke-tested `node scripts/ci-wait-state.mjs --pr 1102` against a real merged PR in this repo — correctly resolved the repo's actual required checks (`idd-doctor`, `lint`, `pnpm-boundary`) via branch rules and reported `allRequiredPassing: true`.

Closes #1317

https://claude.ai/code/session_0152p38Md7FmYCPgrLwdxGjv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only CI wait-state snapshot command for pull requests.
  - Reports individual check statuses, the current commit identifier, and required-check readiness.
  - Supports direct command-line and package-level invocation with optional repository parameters.

- **Documentation**
  - Added usage guidance, output details, and read-only behavior documentation.

- **Tests**
  - Added coverage for check normalization, status handling, deduplication, and required-check rollups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->