### PR TITLE
fix(pre-merge): surface bot in-place edits as an advisory signal

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -296,6 +296,20 @@ returns the workflow to E1 instead of merging over it.
   any thread whose `ackOnlyPostDisposition` is `false`) keeps the backstop
   and routes to E1/E4 unchanged.
 
+  `dispositionEvidence.soleCauseInPlaceEditOnly` (and the per-thread
+  `inPlaceEditOnly`) is **informational-only**, not a second deterministic
+  override (#1313): it is a narrower sibling of `ackOnlyPostDisposition`
+  that additionally confirms the blocking comment is an edit of content
+  that already existed at-or-before its thread's disposition, rather than
+  a brand-new post-disposition comment. GitHub's API exposes no revision
+  diff for an edited comment, so neither this field nor the helper that
+  computes it can verify whether the edit only added cosmetic content
+  (e.g. an "addressed" badge) or changed the substance of the finding. An
+  agent may use it as a stronger hint when deciding whether to invoke the
+  `soleCauseAckOnlyPostDisposition` override above, but must still read
+  the comment's current body before doing so — this field alone never
+  authorizes proceeding.
+
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the PR live status digest after the blocking evidence is recorded and
 before stopping or returning. Set `Phase` to the failing F2 check,

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -512,6 +512,11 @@ override the `return-to-e1` and proceed on the current HEAD SHA (see
 non-ack blocking cause makes it `false`, so the backstop still holds for every
 other case.
 
+The narrower, informational-only `inPlaceEditOnly` /
+`soleCauseInPlaceEditOnly` sibling is documented in
+`idd-pre-merge.instructions.md` F2 (#1313) — it is not a second override
+path.
+
 ## Review item classes
 
 During E-phase review triage, classify each ReviewItems_snapshot item

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -291,6 +291,20 @@ returns the workflow to E1 instead of merging over it.
   any thread whose `ackOnlyPostDisposition` is `false`) keeps the backstop
   and routes to E1/E4 unchanged.
 
+  `dispositionEvidence.soleCauseInPlaceEditOnly` (and the per-thread
+  `inPlaceEditOnly`) is **informational-only**, not a second deterministic
+  override (#1313): it is a narrower sibling of `ackOnlyPostDisposition`
+  that additionally confirms the blocking comment is an edit of content
+  that already existed at-or-before its thread's disposition, rather than
+  a brand-new post-disposition comment. GitHub's API exposes no revision
+  diff for an edited comment, so neither this field nor the helper that
+  computes it can verify whether the edit only added cosmetic content
+  (e.g. an "addressed" badge) or changed the substance of the finding. An
+  agent may use it as a stronger hint when deciding whether to invoke the
+  `soleCauseAckOnlyPostDisposition` override above, but must still read
+  the comment's current body before doing so — this field alone never
+  authorizes proceeding.
+
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the PR live status digest after the blocking evidence is recorded and
 before stopping or returning. Set `Phase` to the failing F2 check,

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -507,6 +507,11 @@ override the `return-to-e1` and proceed on the current HEAD SHA (see
 non-ack blocking cause makes it `false`, so the backstop still holds for every
 other case.
 
+The narrower, informational-only `inPlaceEditOnly` /
+`soleCauseInPlaceEditOnly` sibling is documented in
+`idd-pre-merge.instructions.md` F2 (#1313) — it is not a second override
+path.
+
 ## Review item classes
 
 During E-phase review triage, classify each ReviewItems_snapshot item

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -853,6 +853,7 @@
         "missingRegularCommentCount",
         "missingThreadCount",
         "soleCauseAckOnlyPostDisposition",
+        "soleCauseInPlaceEditOnly",
         "missingRegularComments",
         "missingThreads"
       ],
@@ -885,6 +886,9 @@
           "minimum": 0
         },
         "soleCauseAckOnlyPostDisposition": {
+          "type": "boolean"
+        },
+        "soleCauseInPlaceEditOnly": {
           "type": "boolean"
         },
         "missingRegularComments": {
@@ -926,7 +930,8 @@
               "id",
               "isResolved",
               "reason",
-              "ackOnlyPostDisposition"
+              "ackOnlyPostDisposition",
+              "inPlaceEditOnly"
             ],
             "additionalProperties": false,
             "properties": {
@@ -946,6 +951,9 @@
                 ]
               },
               "ackOnlyPostDisposition": {
+                "type": "boolean"
+              },
+              "inPlaceEditOnly": {
                 "type": "boolean"
               }
             }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -831,6 +831,17 @@ export function hasFreshDisposition(thread, options = {}) {
     typeof options.isDispositionAuthor === 'function'
       ? options.isDispositionAuthor
       : (login) => !isKnownReviewBot(login);
+  // A cosmetic in-place edit of a bot's own thread comment (e.g. an
+  // "addressed" badge appended after a disposition) must not read as fresh
+  // non-disposition activity -- see effectiveThreadCommentActivityAt.
+  // Defaults to the same isKnownReviewBot notion of "bot" used above;
+  // callers with a configured advisory-bot set (e.g.
+  // summarizeDispositionEvidenceForGate) pass their own predicate so a
+  // custom-configured bot login is recognized too.
+  const isAdvisoryBot =
+    typeof options.isAdvisoryBot === 'function'
+      ? options.isAdvisoryBot
+      : isKnownReviewBot;
   const comments = thread.comments?.nodes ?? [];
   // A resolved thread may be terminally dispositioned with the documented
   // `**Rejection confirmed by maintainer**` marker instead of a fresh
@@ -850,7 +861,9 @@ export function hasFreshDisposition(thread, options = {}) {
           isDisposition(comment) && dispositionAuthorPredicate(authorLogin)
         );
       })
-      .map((comment) => effectiveThreadCommentActivityAt(comment))
+      .map((comment) =>
+        effectiveThreadCommentActivityAt(comment, { isAdvisoryBot }),
+      )
       .filter(isValidIsoTimestamp),
   );
   return comments.some((comment) => {
@@ -860,7 +873,9 @@ export function hasFreshDisposition(thread, options = {}) {
     if (!(isDisposition(comment) && dispositionAuthorPredicate(authorLogin))) {
       return false;
     }
-    const dispositionActivityAt = effectiveThreadCommentActivityAt(comment);
+    const dispositionActivityAt = effectiveThreadCommentActivityAt(comment, {
+      isAdvisoryBot,
+    });
     if (!isValidIsoTimestamp(dispositionActivityAt)) {
       return false;
     }
@@ -2437,6 +2452,8 @@ export function summarizeDispositionEvidenceForGate(
                 .trim()
                 .toLowerCase(),
             ),
+          isAdvisoryBot: (login) =>
+            isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),
         })
       ) {
         return null;
@@ -4541,12 +4558,37 @@ function threadActivityAt(thread) {
     .filter(isValidIsoTimestamp);
   return maxIsoTimestamp(commentTimes);
 }
-function effectiveThreadCommentActivityAt(comment) {
+function effectiveThreadCommentActivityAt(comment, options = {}) {
   const updatedAt = String(comment?.updatedAt ?? '');
+  const createdAt = String(comment?.createdAt ?? '');
   if (isValidIsoTimestamp(updatedAt)) {
+    // A known/configured advisory bot that edits its own thread comment in
+    // place (e.g. appending an "addressed" badge after a disposition) must
+    // not read as fresh non-disposition activity -- date it by createdAt
+    // instead, mirroring effectiveRegularCommentActivityAt's createdAt-based
+    // approach (#1186) for the analogous regular-comment path. Only a
+    // genuine in-place edit (updatedAt strictly after createdAt) is
+    // affected; a fresh comment's updatedAt equals its createdAt and falls
+    // through unchanged. Opt-in via options.isAdvisoryBot: callers that do
+    // not pass it (most call sites of this shared helper) keep the exact
+    // unconditional updatedAt-preferring behavior this function has always
+    // had -- some of those callers rely on today's behavior to recognize
+    // post-disposition bot activity for their own (unrelated) ack-only
+    // reclassification, so this must never become a global default.
+    if (
+      typeof options.isAdvisoryBot === 'function' &&
+      isValidIsoTimestamp(createdAt) &&
+      compareIsoTimestamps(updatedAt, createdAt) > 0 &&
+      options.isAdvisoryBot(
+        String(comment?.author?.login ?? '')
+          .trim()
+          .toLowerCase(),
+      )
+    ) {
+      return createdAt;
+    }
     return updatedAt;
   }
-  const createdAt = String(comment?.createdAt ?? '');
   if (isValidIsoTimestamp(createdAt)) {
     return createdAt;
   }
@@ -4571,6 +4613,14 @@ function hasCompletedBotThreadDispositions(
       return (
         thread.isResolved &&
         !thread.comments?.pageInfo?.hasNextPage &&
+        // Deliberately does NOT pass isAdvisoryBot: loginPredicate here.
+        // loginPredicate (e.g. isCodeRabbitLogin) only scopes which threads
+        // count as "bot threads" above; a thread can carry non-disposition
+        // findings from other known bots too (e.g. Codex), and those must
+        // also get the in-place-edit dating fix. hasFreshDisposition's own
+        // isKnownReviewBot default is a strict superset of any single-bot
+        // loginPredicate this function is called with, so the default
+        // already covers this call site correctly and more broadly.
         hasFreshDisposition(thread, {
           isDispositionAuthor: options.isDispositionAuthor,
         })

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -831,17 +831,6 @@ export function hasFreshDisposition(thread, options = {}) {
     typeof options.isDispositionAuthor === 'function'
       ? options.isDispositionAuthor
       : (login) => !isKnownReviewBot(login);
-  // A cosmetic in-place edit of a bot's own thread comment (e.g. an
-  // "addressed" badge appended after a disposition) must not read as fresh
-  // non-disposition activity -- see effectiveThreadCommentActivityAt.
-  // Defaults to the same isKnownReviewBot notion of "bot" used above;
-  // callers with a configured advisory-bot set (e.g.
-  // summarizeDispositionEvidenceForGate) pass their own predicate so a
-  // custom-configured bot login is recognized too.
-  const isAdvisoryBot =
-    typeof options.isAdvisoryBot === 'function'
-      ? options.isAdvisoryBot
-      : isKnownReviewBot;
   const comments = thread.comments?.nodes ?? [];
   // A resolved thread may be terminally dispositioned with the documented
   // `**Rejection confirmed by maintainer**` marker instead of a fresh
@@ -861,9 +850,7 @@ export function hasFreshDisposition(thread, options = {}) {
           isDisposition(comment) && dispositionAuthorPredicate(authorLogin)
         );
       })
-      .map((comment) =>
-        effectiveThreadCommentActivityAt(comment, { isAdvisoryBot }),
-      )
+      .map((comment) => effectiveThreadCommentActivityAt(comment))
       .filter(isValidIsoTimestamp),
   );
   return comments.some((comment) => {
@@ -873,9 +860,7 @@ export function hasFreshDisposition(thread, options = {}) {
     if (!(isDisposition(comment) && dispositionAuthorPredicate(authorLogin))) {
       return false;
     }
-    const dispositionActivityAt = effectiveThreadCommentActivityAt(comment, {
-      isAdvisoryBot,
-    });
+    const dispositionActivityAt = effectiveThreadCommentActivityAt(comment);
     if (!isValidIsoTimestamp(dispositionActivityAt)) {
       return false;
     }
@@ -2350,9 +2335,26 @@ export function summarizeDispositionEvidenceForGate(
   // post-disposition ack). Fails closed (false) without a snapshot boundary,
   // without a thread-local disposition, or for unresolved threads, and never
   // changes the gate route.
-  const isThreadAckOnlyPostDisposition = (thread) => {
+  //
+  // #1313: also computes the narrower `inPlaceEditOnly` sibling signal in the
+  // same pass (it needs the identical `threadDispositionAt` /
+  // `postDispositionBlockingFeedback` groundwork, so folding it into one
+  // function avoids recomputing that twice). `inPlaceEditOnly` additionally
+  // requires every qualifying comment to be an in-place edit of content that
+  // already existed at-or-before the disposition (its own `createdAt` is not
+  // newer than the disposition, and its `updatedAt` is strictly newer than
+  // its own `createdAt`) rather than a brand-new post-disposition comment --
+  // the #1313 report's exact scenario (a bot editing its own
+  // already-dispositioned finding in place, e.g. to append a cosmetic
+  // "addressed" badge). Deliberately advisory-only, like its sibling:
+  // GitHub's API exposes no revision diff for an edited comment, so this
+  // helper cannot tell a cosmetic append from a substantive change to the
+  // finding -- an agent that wants to act on this signal must still read the
+  // comment's current body before treating the block as safe to override.
+  const classifyThreadAckOnlyPostDisposition = (thread) => {
+    const none = { ackOnlyPostDisposition: false, inPlaceEditOnly: false };
     if (!thread.isResolved || !snapshotBoundaryAt) {
-      return false;
+      return none;
     }
     const nodes = thread.comments?.nodes ?? [];
     // Recognize the same dispositions `hasFreshDisposition` accepts on a
@@ -2379,7 +2381,7 @@ export function summarizeDispositionEvidenceForGate(
         .filter(isValidIsoTimestamp),
     );
     if (!threadDispositionAt) {
-      return false;
+      return none;
     }
     // The blocking activity is external feedback newer than BOTH the snapshot
     // boundary (so it actually re-blocks the gate) AND the thread disposition
@@ -2405,12 +2407,12 @@ export function summarizeDispositionEvidenceForGate(
       );
     });
     if (postDispositionBlockingFeedback.length === 0) {
-      return false;
+      return none;
     }
     // Each remaining item must be a pure advisory-bot courtesy ack: an
     // advisory-bot author whose body is neither a `**Accepted**`/`**Rejected**`
     // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
-    return postDispositionBlockingFeedback.every(
+    const ackOnlyPostDisposition = postDispositionBlockingFeedback.every(
       (comment) =>
         isConfiguredAdvisoryBotLogin(
           comment.author?.login,
@@ -2419,6 +2421,20 @@ export function summarizeDispositionEvidenceForGate(
         !isDispositionComment({ body: String(comment.body ?? '') }) &&
         !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
     );
+    if (!ackOnlyPostDisposition) {
+      return none;
+    }
+    const inPlaceEditOnly = postDispositionBlockingFeedback.every((comment) => {
+      const createdAt = String(comment.createdAt ?? '');
+      const updatedAt = String(comment.updatedAt ?? '');
+      return (
+        isValidIsoTimestamp(createdAt) &&
+        compareIsoTimestamps(createdAt, threadDispositionAt) <= 0 &&
+        isValidIsoTimestamp(updatedAt) &&
+        compareIsoTimestamps(updatedAt, createdAt) > 0
+      );
+    });
+    return { ackOnlyPostDisposition, inPlaceEditOnly };
   };
   const missingThreads = (threads ?? [])
     .map((thread, index) => {
@@ -2442,6 +2458,7 @@ export function summarizeDispositionEvidenceForGate(
           isResolved: Boolean(thread.isResolved),
           reason: 'incomplete-thread-comments',
           ackOnlyPostDisposition: false,
+          inPlaceEditOnly: false,
         };
       }
       if (
@@ -2452,8 +2469,6 @@ export function summarizeDispositionEvidenceForGate(
                 .trim()
                 .toLowerCase(),
             ),
-          isAdvisoryBot: (login) =>
-            isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),
         })
       ) {
         return null;
@@ -2487,13 +2502,15 @@ export function summarizeDispositionEvidenceForGate(
           return null;
         }
       }
+      const classification = classifyThreadAckOnlyPostDisposition(thread);
       return {
         id: String(thread.id ?? '') || `thread-${index + 1}`,
         isResolved: Boolean(thread.isResolved),
         reason: thread.isResolved
           ? 'missing-fresh-disposition'
           : 'unresolved-without-fresh-disposition',
-        ackOnlyPostDisposition: isThreadAckOnlyPostDisposition(thread),
+        ackOnlyPostDisposition: classification.ackOnlyPostDisposition,
+        inPlaceEditOnly: classification.inPlaceEditOnly,
       };
     })
     .filter(Boolean);
@@ -2507,6 +2524,13 @@ export function summarizeDispositionEvidenceForGate(
     blockingCount > 0 &&
     missingRegularComments.length === 0 &&
     missingThreads.every((entry) => entry.ackOnlyPostDisposition === true);
+  // #1313: narrower sibling -- true only when every blocking item is ALSO an
+  // in-place edit of pre-existing content (see `inPlaceEditOnly` above). A
+  // strict subset of `soleCauseAckOnlyPostDisposition`.
+  const soleCauseInPlaceEditOnly =
+    blockingCount > 0 &&
+    missingRegularComments.length === 0 &&
+    missingThreads.every((entry) => entry.inPlaceEditOnly === true);
   return {
     route: blockingCount > 0 ? 'return-to-e1' : 'proceed',
     reason: blockingCount > 0 ? 'missing-disposition-evidence' : 'complete',
@@ -2514,6 +2538,7 @@ export function summarizeDispositionEvidenceForGate(
     missingRegularCommentCount: missingRegularComments.length,
     missingThreadCount: missingThreads.length,
     soleCauseAckOnlyPostDisposition,
+    soleCauseInPlaceEditOnly,
     missingRegularComments,
     missingThreads,
   };
@@ -4558,37 +4583,12 @@ function threadActivityAt(thread) {
     .filter(isValidIsoTimestamp);
   return maxIsoTimestamp(commentTimes);
 }
-function effectiveThreadCommentActivityAt(comment, options = {}) {
+function effectiveThreadCommentActivityAt(comment) {
   const updatedAt = String(comment?.updatedAt ?? '');
-  const createdAt = String(comment?.createdAt ?? '');
   if (isValidIsoTimestamp(updatedAt)) {
-    // A known/configured advisory bot that edits its own thread comment in
-    // place (e.g. appending an "addressed" badge after a disposition) must
-    // not read as fresh non-disposition activity -- date it by createdAt
-    // instead, mirroring effectiveRegularCommentActivityAt's createdAt-based
-    // approach (#1186) for the analogous regular-comment path. Only a
-    // genuine in-place edit (updatedAt strictly after createdAt) is
-    // affected; a fresh comment's updatedAt equals its createdAt and falls
-    // through unchanged. Opt-in via options.isAdvisoryBot: callers that do
-    // not pass it (most call sites of this shared helper) keep the exact
-    // unconditional updatedAt-preferring behavior this function has always
-    // had -- some of those callers rely on today's behavior to recognize
-    // post-disposition bot activity for their own (unrelated) ack-only
-    // reclassification, so this must never become a global default.
-    if (
-      typeof options.isAdvisoryBot === 'function' &&
-      isValidIsoTimestamp(createdAt) &&
-      compareIsoTimestamps(updatedAt, createdAt) > 0 &&
-      options.isAdvisoryBot(
-        String(comment?.author?.login ?? '')
-          .trim()
-          .toLowerCase(),
-      )
-    ) {
-      return createdAt;
-    }
     return updatedAt;
   }
+  const createdAt = String(comment?.createdAt ?? '');
   if (isValidIsoTimestamp(createdAt)) {
     return createdAt;
   }
@@ -4613,14 +4613,6 @@ function hasCompletedBotThreadDispositions(
       return (
         thread.isResolved &&
         !thread.comments?.pageInfo?.hasNextPage &&
-        // Deliberately does NOT pass isAdvisoryBot: loginPredicate here.
-        // loginPredicate (e.g. isCodeRabbitLogin) only scopes which threads
-        // count as "bot threads" above; a thread can carry non-disposition
-        // findings from other known bots too (e.g. Codex), and those must
-        // also get the in-place-edit dating fix. hasFreshDisposition's own
-        // isKnownReviewBot default is a strict superset of any single-bot
-        // loginPredicate this function is called with, so the default
-        // already covers this call site correctly and more broadly.
         hasFreshDisposition(thread, {
           isDispositionAuthor: options.isDispositionAuthor,
         })

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -367,6 +367,19 @@ export interface DispositionEvidenceSummary {
   // override a `return-to-e1` whose sole cause is post-disposition advisory-bot
   // acks. Never changes `route`; never relaxes the backstop for any other cause.
   soleCauseAckOnlyPostDisposition: boolean;
+  // Advisory-only, narrower sibling of `soleCauseAckOnlyPostDisposition`
+  // (#1313): true only when every blocking item is ALSO an in-place edit of
+  // content that already existed at-or-before its thread's disposition (an
+  // edited pre-existing comment, not a brand-new post-disposition comment).
+  // This is a strict subset of the ack-only signal -- see
+  // `missingThreads[].inPlaceEditOnly` for the per-thread detail and why this
+  // still never changes `route` by itself: GitHub's API exposes no revision
+  // diff for an edited comment, so neither this helper nor its caller can
+  // mechanically verify that an in-place edit only added cosmetic content
+  // (e.g. an "addressed" badge) rather than changing the substance of the
+  // finding. An agent that wants to trust this signal must still read the
+  // comment's current body before overriding.
+  soleCauseInPlaceEditOnly: boolean;
   missingRegularComments: {
     id: string;
     authorLogin: string;
@@ -382,6 +395,15 @@ export interface DispositionEvidenceSummary {
     isResolved: boolean;
     reason: string;
     ackOnlyPostDisposition: boolean;
+    // Advisory-only (#1313): true when `ackOnlyPostDisposition` is true AND
+    // every qualifying comment is an in-place edit of a comment that already
+    // existed at-or-before the thread's disposition (its own `createdAt` is
+    // not newer than the disposition, and its `updatedAt` is strictly newer
+    // than its own `createdAt`) -- distinguishing "the bot edited its own
+    // already-dispositioned finding in place" from a generically ack-shaped
+    // but genuinely new post-disposition comment. Still advisory-only: it
+    // never changes `reason` or the summary `route` by itself.
+    inPlaceEditOnly: boolean;
   }[];
 }
 
@@ -1423,10 +1445,7 @@ function inferReviewerReopenedAt(thread: ThreadLike): string {
 
 export function hasFreshDisposition(
   thread: ThreadLike,
-  options: {
-    isDispositionAuthor?: (login: string) => boolean;
-    isAdvisoryBot?: (login: string) => boolean;
-  } = {},
+  options: { isDispositionAuthor?: (login: string) => boolean } = {},
 ): boolean {
   // IMPORTANT: The default disposition-author predicate rejects known bots but accepts any human.
   // For F2/F3 merge-gate contexts (E7 disposition evidence), callers MUST pass
@@ -1438,17 +1457,6 @@ export function hasFreshDisposition(
     typeof options.isDispositionAuthor === 'function'
       ? options.isDispositionAuthor
       : (login: string) => !isKnownReviewBot(login);
-  // A cosmetic in-place edit of a bot's own thread comment (e.g. an
-  // "addressed" badge appended after a disposition) must not read as fresh
-  // non-disposition activity -- see effectiveThreadCommentActivityAt.
-  // Defaults to the same isKnownReviewBot notion of "bot" used above;
-  // callers with a configured advisory-bot set (e.g.
-  // summarizeDispositionEvidenceForGate) pass their own predicate so a
-  // custom-configured bot login is recognized too.
-  const isAdvisoryBot =
-    typeof options.isAdvisoryBot === 'function'
-      ? options.isAdvisoryBot
-      : isKnownReviewBot;
   const comments = thread.comments?.nodes ?? [];
   // A resolved thread may be terminally dispositioned with the documented
   // `**Rejection confirmed by maintainer**` marker instead of a fresh
@@ -1468,9 +1476,7 @@ export function hasFreshDisposition(
           isDisposition(comment) && dispositionAuthorPredicate(authorLogin)
         );
       })
-      .map((comment) =>
-        effectiveThreadCommentActivityAt(comment, { isAdvisoryBot }),
-      )
+      .map((comment) => effectiveThreadCommentActivityAt(comment))
       .filter(isValidIsoTimestamp),
   );
 
@@ -1481,9 +1487,7 @@ export function hasFreshDisposition(
     if (!(isDisposition(comment) && dispositionAuthorPredicate(authorLogin))) {
       return false;
     }
-    const dispositionActivityAt = effectiveThreadCommentActivityAt(comment, {
-      isAdvisoryBot,
-    });
+    const dispositionActivityAt = effectiveThreadCommentActivityAt(comment);
     if (!isValidIsoTimestamp(dispositionActivityAt)) {
       return false;
     }
@@ -3148,9 +3152,28 @@ export function summarizeDispositionEvidenceForGate(
   // post-disposition ack). Fails closed (false) without a snapshot boundary,
   // without a thread-local disposition, or for unresolved threads, and never
   // changes the gate route.
-  const isThreadAckOnlyPostDisposition = (thread: ThreadLike): boolean => {
+  //
+  // #1313: also computes the narrower `inPlaceEditOnly` sibling signal in the
+  // same pass (it needs the identical `threadDispositionAt` /
+  // `postDispositionBlockingFeedback` groundwork, so folding it into one
+  // function avoids recomputing that twice). `inPlaceEditOnly` additionally
+  // requires every qualifying comment to be an in-place edit of content that
+  // already existed at-or-before the disposition (its own `createdAt` is not
+  // newer than the disposition, and its `updatedAt` is strictly newer than
+  // its own `createdAt`) rather than a brand-new post-disposition comment --
+  // the #1313 report's exact scenario (a bot editing its own
+  // already-dispositioned finding in place, e.g. to append a cosmetic
+  // "addressed" badge). Deliberately advisory-only, like its sibling:
+  // GitHub's API exposes no revision diff for an edited comment, so this
+  // helper cannot tell a cosmetic append from a substantive change to the
+  // finding -- an agent that wants to act on this signal must still read the
+  // comment's current body before treating the block as safe to override.
+  const classifyThreadAckOnlyPostDisposition = (
+    thread: ThreadLike,
+  ): { ackOnlyPostDisposition: boolean; inPlaceEditOnly: boolean } => {
+    const none = { ackOnlyPostDisposition: false, inPlaceEditOnly: false };
     if (!thread.isResolved || !snapshotBoundaryAt) {
-      return false;
+      return none;
     }
     const nodes = thread.comments?.nodes ?? [];
     // Recognize the same dispositions `hasFreshDisposition` accepts on a
@@ -3177,7 +3200,7 @@ export function summarizeDispositionEvidenceForGate(
         .filter(isValidIsoTimestamp),
     );
     if (!threadDispositionAt) {
-      return false;
+      return none;
     }
     // The blocking activity is external feedback newer than BOTH the snapshot
     // boundary (so it actually re-blocks the gate) AND the thread disposition
@@ -3203,12 +3226,12 @@ export function summarizeDispositionEvidenceForGate(
       );
     });
     if (postDispositionBlockingFeedback.length === 0) {
-      return false;
+      return none;
     }
     // Each remaining item must be a pure advisory-bot courtesy ack: an
     // advisory-bot author whose body is neither a `**Accepted**`/`**Rejected**`
     // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
-    return postDispositionBlockingFeedback.every(
+    const ackOnlyPostDisposition = postDispositionBlockingFeedback.every(
       (comment) =>
         isConfiguredAdvisoryBotLogin(
           comment.author?.login,
@@ -3217,6 +3240,20 @@ export function summarizeDispositionEvidenceForGate(
         !isDispositionComment({ body: String(comment.body ?? '') }) &&
         !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
     );
+    if (!ackOnlyPostDisposition) {
+      return none;
+    }
+    const inPlaceEditOnly = postDispositionBlockingFeedback.every((comment) => {
+      const createdAt = String(comment.createdAt ?? '');
+      const updatedAt = String(comment.updatedAt ?? '');
+      return (
+        isValidIsoTimestamp(createdAt) &&
+        compareIsoTimestamps(createdAt, threadDispositionAt) <= 0 &&
+        isValidIsoTimestamp(updatedAt) &&
+        compareIsoTimestamps(updatedAt, createdAt) > 0
+      );
+    });
+    return { ackOnlyPostDisposition, inPlaceEditOnly };
   };
 
   const missingThreads = (threads ?? [])
@@ -3241,6 +3278,7 @@ export function summarizeDispositionEvidenceForGate(
           isResolved: Boolean(thread.isResolved),
           reason: 'incomplete-thread-comments',
           ackOnlyPostDisposition: false,
+          inPlaceEditOnly: false,
         };
       }
       if (
@@ -3251,8 +3289,6 @@ export function summarizeDispositionEvidenceForGate(
                 .trim()
                 .toLowerCase(),
             ),
-          isAdvisoryBot: (login) =>
-            isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),
         })
       ) {
         return null;
@@ -3286,13 +3322,15 @@ export function summarizeDispositionEvidenceForGate(
           return null;
         }
       }
+      const classification = classifyThreadAckOnlyPostDisposition(thread);
       return {
         id: String(thread.id ?? '') || `thread-${index + 1}`,
         isResolved: Boolean(thread.isResolved),
         reason: thread.isResolved
           ? 'missing-fresh-disposition'
           : 'unresolved-without-fresh-disposition',
-        ackOnlyPostDisposition: isThreadAckOnlyPostDisposition(thread),
+        ackOnlyPostDisposition: classification.ackOnlyPostDisposition,
+        inPlaceEditOnly: classification.inPlaceEditOnly,
       };
     })
     .filter(Boolean) as DispositionEvidenceSummary['missingThreads'];
@@ -3307,6 +3345,13 @@ export function summarizeDispositionEvidenceForGate(
     blockingCount > 0 &&
     missingRegularComments.length === 0 &&
     missingThreads.every((entry) => entry.ackOnlyPostDisposition === true);
+  // #1313: narrower sibling -- true only when every blocking item is ALSO an
+  // in-place edit of pre-existing content (see `inPlaceEditOnly` above). A
+  // strict subset of `soleCauseAckOnlyPostDisposition`.
+  const soleCauseInPlaceEditOnly =
+    blockingCount > 0 &&
+    missingRegularComments.length === 0 &&
+    missingThreads.every((entry) => entry.inPlaceEditOnly === true);
   return {
     route: blockingCount > 0 ? 'return-to-e1' : 'proceed',
     reason: blockingCount > 0 ? 'missing-disposition-evidence' : 'complete',
@@ -3314,6 +3359,7 @@ export function summarizeDispositionEvidenceForGate(
     missingRegularCommentCount: missingRegularComments.length,
     missingThreadCount: missingThreads.length,
     soleCauseAckOnlyPostDisposition,
+    soleCauseInPlaceEditOnly,
     missingRegularComments,
     missingThreads,
   };
@@ -5746,45 +5792,15 @@ function threadActivityAt(thread: ThreadLike): string | null | undefined {
 
 function effectiveThreadCommentActivityAt(
   comment:
-    | {
-        updatedAt?: string | null;
-        createdAt?: string | null;
-        author?: { login?: string | null } | null;
-      }
+    | { updatedAt?: string | null; createdAt?: string | null }
     | null
     | undefined,
-  options: { isAdvisoryBot?: (login: string) => boolean } = {},
 ): string {
   const updatedAt = String(comment?.updatedAt ?? '');
-  const createdAt = String(comment?.createdAt ?? '');
   if (isValidIsoTimestamp(updatedAt)) {
-    // A known/configured advisory bot that edits its own thread comment in
-    // place (e.g. appending an "addressed" badge after a disposition) must
-    // not read as fresh non-disposition activity -- date it by createdAt
-    // instead, mirroring effectiveRegularCommentActivityAt's createdAt-based
-    // approach (#1186) for the analogous regular-comment path. Only a
-    // genuine in-place edit (updatedAt strictly after createdAt) is
-    // affected; a fresh comment's updatedAt equals its createdAt and falls
-    // through unchanged. Opt-in via options.isAdvisoryBot: callers that do
-    // not pass it (most call sites of this shared helper) keep the exact
-    // unconditional updatedAt-preferring behavior this function has always
-    // had -- some of those callers rely on today's behavior to recognize
-    // post-disposition bot activity for their own (unrelated) ack-only
-    // reclassification, so this must never become a global default.
-    if (
-      typeof options.isAdvisoryBot === 'function' &&
-      isValidIsoTimestamp(createdAt) &&
-      compareIsoTimestamps(updatedAt, createdAt) > 0 &&
-      options.isAdvisoryBot(
-        String(comment?.author?.login ?? '')
-          .trim()
-          .toLowerCase(),
-      )
-    ) {
-      return createdAt;
-    }
     return updatedAt;
   }
+  const createdAt = String(comment?.createdAt ?? '');
   if (isValidIsoTimestamp(createdAt)) {
     return createdAt;
   }
@@ -5811,14 +5827,6 @@ function hasCompletedBotThreadDispositions(
       return (
         thread.isResolved &&
         !thread.comments?.pageInfo?.hasNextPage &&
-        // Deliberately does NOT pass isAdvisoryBot: loginPredicate here.
-        // loginPredicate (e.g. isCodeRabbitLogin) only scopes which threads
-        // count as "bot threads" above; a thread can carry non-disposition
-        // findings from other known bots too (e.g. Codex), and those must
-        // also get the in-place-edit dating fix. hasFreshDisposition's own
-        // isKnownReviewBot default is a strict superset of any single-bot
-        // loginPredicate this function is called with, so the default
-        // already covers this call site correctly and more broadly.
         hasFreshDisposition(thread, {
           isDispositionAuthor: options.isDispositionAuthor,
         })

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1423,7 +1423,10 @@ function inferReviewerReopenedAt(thread: ThreadLike): string {
 
 export function hasFreshDisposition(
   thread: ThreadLike,
-  options: { isDispositionAuthor?: (login: string) => boolean } = {},
+  options: {
+    isDispositionAuthor?: (login: string) => boolean;
+    isAdvisoryBot?: (login: string) => boolean;
+  } = {},
 ): boolean {
   // IMPORTANT: The default disposition-author predicate rejects known bots but accepts any human.
   // For F2/F3 merge-gate contexts (E7 disposition evidence), callers MUST pass
@@ -1435,6 +1438,17 @@ export function hasFreshDisposition(
     typeof options.isDispositionAuthor === 'function'
       ? options.isDispositionAuthor
       : (login: string) => !isKnownReviewBot(login);
+  // A cosmetic in-place edit of a bot's own thread comment (e.g. an
+  // "addressed" badge appended after a disposition) must not read as fresh
+  // non-disposition activity -- see effectiveThreadCommentActivityAt.
+  // Defaults to the same isKnownReviewBot notion of "bot" used above;
+  // callers with a configured advisory-bot set (e.g.
+  // summarizeDispositionEvidenceForGate) pass their own predicate so a
+  // custom-configured bot login is recognized too.
+  const isAdvisoryBot =
+    typeof options.isAdvisoryBot === 'function'
+      ? options.isAdvisoryBot
+      : isKnownReviewBot;
   const comments = thread.comments?.nodes ?? [];
   // A resolved thread may be terminally dispositioned with the documented
   // `**Rejection confirmed by maintainer**` marker instead of a fresh
@@ -1454,7 +1468,9 @@ export function hasFreshDisposition(
           isDisposition(comment) && dispositionAuthorPredicate(authorLogin)
         );
       })
-      .map((comment) => effectiveThreadCommentActivityAt(comment))
+      .map((comment) =>
+        effectiveThreadCommentActivityAt(comment, { isAdvisoryBot }),
+      )
       .filter(isValidIsoTimestamp),
   );
 
@@ -1465,7 +1481,9 @@ export function hasFreshDisposition(
     if (!(isDisposition(comment) && dispositionAuthorPredicate(authorLogin))) {
       return false;
     }
-    const dispositionActivityAt = effectiveThreadCommentActivityAt(comment);
+    const dispositionActivityAt = effectiveThreadCommentActivityAt(comment, {
+      isAdvisoryBot,
+    });
     if (!isValidIsoTimestamp(dispositionActivityAt)) {
       return false;
     }
@@ -3233,6 +3251,8 @@ export function summarizeDispositionEvidenceForGate(
                 .trim()
                 .toLowerCase(),
             ),
+          isAdvisoryBot: (login) =>
+            isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),
         })
       ) {
         return null;
@@ -5726,15 +5746,45 @@ function threadActivityAt(thread: ThreadLike): string | null | undefined {
 
 function effectiveThreadCommentActivityAt(
   comment:
-    | { updatedAt?: string | null; createdAt?: string | null }
+    | {
+        updatedAt?: string | null;
+        createdAt?: string | null;
+        author?: { login?: string | null } | null;
+      }
     | null
     | undefined,
+  options: { isAdvisoryBot?: (login: string) => boolean } = {},
 ): string {
   const updatedAt = String(comment?.updatedAt ?? '');
+  const createdAt = String(comment?.createdAt ?? '');
   if (isValidIsoTimestamp(updatedAt)) {
+    // A known/configured advisory bot that edits its own thread comment in
+    // place (e.g. appending an "addressed" badge after a disposition) must
+    // not read as fresh non-disposition activity -- date it by createdAt
+    // instead, mirroring effectiveRegularCommentActivityAt's createdAt-based
+    // approach (#1186) for the analogous regular-comment path. Only a
+    // genuine in-place edit (updatedAt strictly after createdAt) is
+    // affected; a fresh comment's updatedAt equals its createdAt and falls
+    // through unchanged. Opt-in via options.isAdvisoryBot: callers that do
+    // not pass it (most call sites of this shared helper) keep the exact
+    // unconditional updatedAt-preferring behavior this function has always
+    // had -- some of those callers rely on today's behavior to recognize
+    // post-disposition bot activity for their own (unrelated) ack-only
+    // reclassification, so this must never become a global default.
+    if (
+      typeof options.isAdvisoryBot === 'function' &&
+      isValidIsoTimestamp(createdAt) &&
+      compareIsoTimestamps(updatedAt, createdAt) > 0 &&
+      options.isAdvisoryBot(
+        String(comment?.author?.login ?? '')
+          .trim()
+          .toLowerCase(),
+      )
+    ) {
+      return createdAt;
+    }
     return updatedAt;
   }
-  const createdAt = String(comment?.createdAt ?? '');
   if (isValidIsoTimestamp(createdAt)) {
     return createdAt;
   }
@@ -5761,6 +5811,14 @@ function hasCompletedBotThreadDispositions(
       return (
         thread.isResolved &&
         !thread.comments?.pageInfo?.hasNextPage &&
+        // Deliberately does NOT pass isAdvisoryBot: loginPredicate here.
+        // loginPredicate (e.g. isCodeRabbitLogin) only scopes which threads
+        // count as "bot threads" above; a thread can carry non-disposition
+        // findings from other known bots too (e.g. Codex), and those must
+        // also get the in-place-edit dating fix. hasFreshDisposition's own
+        // isKnownReviewBot default is a strict superset of any single-bot
+        // loginPredicate this function is called with, so the default
+        // already covers this call site correctly and more broadly.
         hasFreshDisposition(thread, {
           isDispositionAuthor: options.isDispositionAuthor,
         })

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1966,7 +1966,24 @@ test('disposition evidence does not flag a resolved thread with substantive post
   assert.equal(summary.soleCauseAckOnlyPostDisposition, false);
 });
 
-test('hasFreshDisposition stays fresh when an advisory bot edits its own thread finding in place after disposition (#1313)', () => {
+// #1313 background: an advisory bot editing its own already-dispositioned
+// thread finding in place (e.g. appending a cosmetic "addressed" badge)
+// used to spuriously re-block `missing-fresh-disposition`. A first attempt
+// taught `hasFreshDisposition` to date such edits by `createdAt`, but a
+// maintainer-reviewed finding showed that mechanism cannot distinguish a
+// cosmetic edit from the bot silently changing the substance of the
+// finding (GitHub's API exposes no revision diff), which would let a
+// genuinely new finding bypass the merge gate. The maintainer decision was
+// to revert `hasFreshDisposition`/`effectiveThreadCommentActivityAt` to
+// their original fail-closed, `updatedAt`-preferring behavior (any bot
+// edit -- cosmetic or substantive -- still re-blocks mechanically), and
+// instead surface "in-place-edit-only, no distinguishable new content" as
+// a NARROWER advisory-only diagnostic alongside the existing #978
+// `ackOnlyPostDisposition` / `soleCauseAckOnlyPostDisposition` signal, so
+// an agent can verify the current comment body and deterministically
+// override per-instance rather than the mechanism silently trusting it.
+
+test('hasFreshDisposition still re-blocks when a bot edits its own thread finding in place after disposition (#1313)', () => {
   const thread = {
     id: 'thread-bot-edit',
     isResolved: true,
@@ -1990,83 +2007,16 @@ test('hasFreshDisposition stays fresh when an advisory bot edits its own thread 
     },
   };
 
+  // No isAdvisoryBot option exists anymore: hasFreshDisposition always dates
+  // by updatedAt (the original, fail-closed behavior), so this still blocks.
   const fresh = hasFreshDisposition(thread, {
     isDispositionAuthor: (login) => login === 'idd-bot',
-    isAdvisoryBot: (login) => login === 'coderabbitai[bot]',
-  });
-
-  assert.equal(fresh, true);
-});
-
-test('hasFreshDisposition still requires a fresh disposition after a genuinely new bot comment (#1313)', () => {
-  const thread = {
-    id: 'thread-bot-new',
-    isResolved: true,
-    comments: {
-      pageInfo: { hasNextPage: false },
-      nodes: [
-        {
-          author: { login: 'coderabbitai[bot]' },
-          createdAt: '2026-05-12T00:00:00Z',
-          body: '**Potential issue**: this needs a null check.',
-        },
-        {
-          author: { login: 'idd-bot' },
-          createdAt: '2026-05-12T00:30:00Z',
-          body: '**Rejected** — verified: not applicable here',
-        },
-        {
-          // A genuinely new reply (its own fresh createdAt, not an edit of
-          // the original finding) must still require a fresh disposition.
-          author: { login: 'coderabbitai[bot]' },
-          createdAt: '2026-05-12T02:00:00Z',
-          body: 'Actually, see also this related spot.',
-        },
-      ],
-    },
-  };
-
-  const fresh = hasFreshDisposition(thread, {
-    isDispositionAuthor: (login) => login === 'idd-bot',
-    isAdvisoryBot: (login) => login === 'coderabbitai[bot]',
   });
 
   assert.equal(fresh, false);
 });
 
-test('hasFreshDisposition still dates a non-advisory-bot in-place edit by updatedAt (#1313)', () => {
-  const thread = {
-    id: 'thread-human-edit',
-    isResolved: true,
-    comments: {
-      pageInfo: { hasNextPage: false },
-      nodes: [
-        {
-          // A human reviewer's in-place edit is unaffected: it keeps dating
-          // by updatedAt (current/pre-#1313 behavior), so it still blocks.
-          author: { login: 'reviewer-a' },
-          createdAt: '2026-05-12T00:00:00Z',
-          updatedAt: '2026-05-12T02:00:00Z',
-          body: 'please reconsider this',
-        },
-        {
-          author: { login: 'idd-bot' },
-          createdAt: '2026-05-12T00:30:00Z',
-          body: '**Rejected** — verified: not applicable here',
-        },
-      ],
-    },
-  };
-
-  const fresh = hasFreshDisposition(thread, {
-    isDispositionAuthor: (login) => login === 'idd-bot',
-    isAdvisoryBot: (login) => login === 'coderabbitai[bot]',
-  });
-
-  assert.equal(fresh, false);
-});
-
-test('disposition evidence stays fresh end-to-end when a bot thread finding is edited in place after disposition (#1313)', () => {
+test('disposition evidence still blocks but flags in-place-edit-only when a bot thread finding is edited after disposition (#1313)', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {
       comments: [],
@@ -2093,11 +2043,117 @@ test('disposition evidence stays fresh end-to-end when a bot thread finding is e
         },
       ],
     },
-    { iddAgentLogins: ['idd-bot'], advisoryBotLogins: ['coderabbitai[bot]'] },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
   );
 
-  assert.equal(summary.route, 'proceed');
-  assert.equal(summary.missingThreadCount, 0);
+  // The mechanical gate still blocks -- no silent override.
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.blockingCount, 1);
+  assert.equal(summary.missingThreads[0].reason, 'missing-fresh-disposition');
+  // The advisory-only diagnostics recognize the specific pattern: a pure
+  // advisory-bot ack (#978) that is ALSO an edit of pre-existing content.
+  assert.equal(summary.missingThreads[0].ackOnlyPostDisposition, true);
+  assert.equal(summary.missingThreads[0].inPlaceEditOnly, true);
+  assert.equal(summary.soleCauseAckOnlyPostDisposition, true);
+  assert.equal(summary.soleCauseInPlaceEditOnly, true);
+});
+
+test('disposition evidence does not flag in-place-edit-only for a genuinely new bot comment (#1313)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-bot-new',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'coderabbitai[bot]' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: '**Potential issue**: this needs a null check.',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:30:00Z',
+                body: '**Rejected** — verified: not applicable here',
+              },
+              {
+                // A genuinely new reply (its own fresh createdAt, not an
+                // edit of the original finding) is still recognized as a
+                // broad #978 ack-only courtesy comment, but must NOT be
+                // classified as an in-place edit of pre-existing content.
+                author: { login: 'coderabbitai[bot]' },
+                createdAt: '2026-05-12T02:00:00Z',
+                body: 'Actually, see also this related spot.',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingThreads[0].ackOnlyPostDisposition, true);
+  assert.equal(summary.missingThreads[0].inPlaceEditOnly, false);
+  assert.equal(summary.soleCauseAckOnlyPostDisposition, true);
+  assert.equal(summary.soleCauseInPlaceEditOnly, false);
+});
+
+test('disposition evidence does not flag ack-only or in-place-edit-only for a non-advisory-bot edit (#1313)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-human-edit',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                // A human reviewer's in-place edit is unaffected: still
+                // dated by updatedAt (unchanged behavior), and never
+                // eligible for either advisory-only diagnostic since the
+                // author is not a configured advisory bot.
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                updatedAt: '2026-05-12T02:00:00Z',
+                body: 'please reconsider this',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:30:00Z',
+                body: '**Rejected** — verified: not applicable here',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingThreads[0].ackOnlyPostDisposition, false);
+  assert.equal(summary.missingThreads[0].inPlaceEditOnly, false);
+  assert.equal(summary.soleCauseAckOnlyPostDisposition, false);
+  assert.equal(summary.soleCauseInPlaceEditOnly, false);
 });
 
 test('disposition evidence reports sole-cause false when a regular comment also blocks (#978)', () => {
@@ -4486,15 +4542,15 @@ test('a trusted machine-disposition clears the notice/summary in both merge gate
 }
 
 // #1313: classifyRegularBotComment -> hasCompletedBotThreadDispositions ->
-// hasFreshDisposition must also recognize a CodeRabbit thread finding that
-// was edited in place after its disposition (updatedAt bumped past
-// createdAt), not just a freshly re-posted one, when it decides whether
-// every bot thread is completely dispositioned. hasCompletedBotThreadDispositions
-// does not override hasFreshDisposition's isAdvisoryBot (its own loginPredicate
-// is scoped to one bot for its "which threads count as bot threads" filter,
-// narrower than hasFreshDisposition's isKnownReviewBot default), so this
-// exercises the shared default end to end.
-test('#1313: a CodeRabbit summary sticky resolves when its own thread finding was edited in place after disposition', () => {
+// hasFreshDisposition still requires a fresh disposition for a CodeRabbit
+// thread finding that was edited in place after its disposition (updatedAt
+// bumped past createdAt) -- the mechanical gate stays fail-closed (see the
+// #1313 background comment above): it cannot tell a cosmetic edit from a
+// substantive one, so it must not silently resolve the summary sticky. The
+// advisory-only in-place-edit diagnostic (summarizeDispositionEvidenceForGate)
+// is the intended place for an agent to recognize and verify this pattern,
+// not this mechanical completion check.
+test('#1313: a CodeRabbit summary sticky stays unresolved when its own thread finding was edited in place after disposition', () => {
   const summarySticky = {
     id: 1,
     createdAt: '2026-07-01T00:00:00Z',
@@ -4530,5 +4586,5 @@ test('#1313: a CodeRabbit summary sticky resolves when its own thread finding wa
     { isDispositionAuthor: (login: string) => login === 'kurone-kito' },
   );
 
-  assert.equal(result?.classifier, 'RESOLVED');
+  assert.equal(result, null);
 });

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -15,6 +15,7 @@ import {
   computePreMergeReadinessBlockers,
   deriveIddAgentLogins,
   findLastCopilotReviewCommit,
+  hasFreshDisposition,
   indexLatestGatingReviewsByAuthor,
   isAdvisoryNonReviewNotice,
   isNonReviewNoticeDisposition,
@@ -1963,6 +1964,140 @@ test('disposition evidence does not flag a resolved thread with substantive post
   assert.equal(summary.route, 'return-to-e1');
   assert.equal(summary.missingThreads[0].ackOnlyPostDisposition, false);
   assert.equal(summary.soleCauseAckOnlyPostDisposition, false);
+});
+
+test('hasFreshDisposition stays fresh when an advisory bot edits its own thread finding in place after disposition (#1313)', () => {
+  const thread = {
+    id: 'thread-bot-edit',
+    isResolved: true,
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          author: { login: 'coderabbitai[bot]' },
+          createdAt: '2026-05-12T00:00:00Z',
+          // In-place edit: updatedAt bumped past the disposition below by a
+          // cosmetic self-edit (e.g. an "addressed" badge), createdAt unchanged.
+          updatedAt: '2026-05-12T02:00:00Z',
+          body: '**Potential issue**: this needs a null check.',
+        },
+        {
+          author: { login: 'idd-bot' },
+          createdAt: '2026-05-12T00:30:00Z',
+          body: '**Rejected** — verified: not applicable here',
+        },
+      ],
+    },
+  };
+
+  const fresh = hasFreshDisposition(thread, {
+    isDispositionAuthor: (login) => login === 'idd-bot',
+    isAdvisoryBot: (login) => login === 'coderabbitai[bot]',
+  });
+
+  assert.equal(fresh, true);
+});
+
+test('hasFreshDisposition still requires a fresh disposition after a genuinely new bot comment (#1313)', () => {
+  const thread = {
+    id: 'thread-bot-new',
+    isResolved: true,
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          author: { login: 'coderabbitai[bot]' },
+          createdAt: '2026-05-12T00:00:00Z',
+          body: '**Potential issue**: this needs a null check.',
+        },
+        {
+          author: { login: 'idd-bot' },
+          createdAt: '2026-05-12T00:30:00Z',
+          body: '**Rejected** — verified: not applicable here',
+        },
+        {
+          // A genuinely new reply (its own fresh createdAt, not an edit of
+          // the original finding) must still require a fresh disposition.
+          author: { login: 'coderabbitai[bot]' },
+          createdAt: '2026-05-12T02:00:00Z',
+          body: 'Actually, see also this related spot.',
+        },
+      ],
+    },
+  };
+
+  const fresh = hasFreshDisposition(thread, {
+    isDispositionAuthor: (login) => login === 'idd-bot',
+    isAdvisoryBot: (login) => login === 'coderabbitai[bot]',
+  });
+
+  assert.equal(fresh, false);
+});
+
+test('hasFreshDisposition still dates a non-advisory-bot in-place edit by updatedAt (#1313)', () => {
+  const thread = {
+    id: 'thread-human-edit',
+    isResolved: true,
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          // A human reviewer's in-place edit is unaffected: it keeps dating
+          // by updatedAt (current/pre-#1313 behavior), so it still blocks.
+          author: { login: 'reviewer-a' },
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+          body: 'please reconsider this',
+        },
+        {
+          author: { login: 'idd-bot' },
+          createdAt: '2026-05-12T00:30:00Z',
+          body: '**Rejected** — verified: not applicable here',
+        },
+      ],
+    },
+  };
+
+  const fresh = hasFreshDisposition(thread, {
+    isDispositionAuthor: (login) => login === 'idd-bot',
+    isAdvisoryBot: (login) => login === 'coderabbitai[bot]',
+  });
+
+  assert.equal(fresh, false);
+});
+
+test('disposition evidence stays fresh end-to-end when a bot thread finding is edited in place after disposition (#1313)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-edit',
+          isResolved: true,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'coderabbitai[bot]' },
+                createdAt: '2026-05-12T00:00:00Z',
+                updatedAt: '2026-05-12T02:00:00Z',
+                body: '**Potential issue**: this needs a null check.',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:30:00Z',
+                body: '**Rejected** — verified: not applicable here',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'], advisoryBotLogins: ['coderabbitai[bot]'] },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.missingThreadCount, 0);
 });
 
 test('disposition evidence reports sole-cause false when a regular comment also blocks (#978)', () => {
@@ -4349,3 +4484,51 @@ test('a trusted machine-disposition clears the notice/summary in both merge gate
     assert.equal(result, null);
   });
 }
+
+// #1313: classifyRegularBotComment -> hasCompletedBotThreadDispositions ->
+// hasFreshDisposition must also recognize a CodeRabbit thread finding that
+// was edited in place after its disposition (updatedAt bumped past
+// createdAt), not just a freshly re-posted one, when it decides whether
+// every bot thread is completely dispositioned. hasCompletedBotThreadDispositions
+// does not override hasFreshDisposition's isAdvisoryBot (its own loginPredicate
+// is scoped to one bot for its "which threads count as bot threads" filter,
+// narrower than hasFreshDisposition's isKnownReviewBot default), so this
+// exercises the shared default end to end.
+test('#1313: a CodeRabbit summary sticky resolves when its own thread finding was edited in place after disposition', () => {
+  const summarySticky = {
+    id: 1,
+    createdAt: '2026-07-01T00:00:00Z',
+    body: `${CODERABBIT_SUMMARY_MARKER}\n\nSummary of changes.`,
+    author: { login: 'coderabbitai[bot]' },
+  };
+
+  const result = classifyRegularBotComment(
+    summarySticky,
+    [summarySticky],
+    [
+      {
+        id: 'thread-1',
+        isResolved: true,
+        comments: {
+          pageInfo: { hasNextPage: false },
+          nodes: [
+            {
+              author: { login: 'coderabbitai[bot]' },
+              createdAt: '2026-07-01T00:00:00Z',
+              updatedAt: '2026-07-01T02:00:00Z',
+              body: '**Potential issue**: this needs a null check.',
+            },
+            {
+              author: { login: 'kurone-kito' },
+              createdAt: '2026-07-01T00:30:00Z',
+              body: '**Rejected** — verified: not applicable here',
+            },
+          ],
+        },
+      },
+    ],
+    { isDispositionAuthor: (login: string) => login === 'kurone-kito' },
+  );
+
+  assert.equal(result?.classifier, 'RESOLVED');
+});


### PR DESCRIPTION
# Summary

**Note (redesigned per maintainer decision):** an earlier version of this PR
taught `hasFreshDisposition` to date an advisory bot's in-place thread-comment
edit by `createdAt`, treating it as non-fresh. Review turned up a real fail-open
risk: GitHub's API exposes no revision diff for an edited comment, so there was
no way to distinguish a cosmetic edit (e.g. appending an "addressed" badge) from
the bot silently changing the substance of an already-dispositioned finding —
see the discussion at
<https://github.com/kurone-kito/idd-skill/pull/1325#discussion_r3555525349>. The
maintainer decided to keep the mechanical gate fail-closed and instead surface
this pattern as an advisory-only diagnostic. This description reflects that
corrected design.

---

`hasFreshDisposition` / `effectiveThreadCommentActivityAt`
(`src/scripts/protocol-helpers.mts`) date a review-thread comment's activity by
`updatedAt` whenever it is set. When an advisory bot (e.g. `coderabbitai[bot]`)
edits its own thread finding in place *after* a disposition was posted — for
example appending an "addressed" badge — the bumped `updatedAt` reads as fresh
non-disposition activity newer than the (unedited) disposition, so the thread
blocks with `missing-fresh-disposition` even when the edit added no new
actionable content. That mechanical behavior is **unchanged by this PR** — it's
also the only structurally safe default, since a bot's edit could just as
plausibly change the substance of the finding as merely decorate it, and this
gate has no way to tell which happened.

What this PR actually adds: `summarizeDispositionEvidenceForGate`'s existing
`ackOnlyPostDisposition` / `soleCauseAckOnlyPostDisposition` advisory-only
diagnostic (from #978, recognizing a bot's post-disposition courtesy
ack/non-review reply) gains a narrower sibling signal,
`inPlaceEditOnly` / `soleCauseInPlaceEditOnly`: true only when every blocking
comment is *also* an in-place edit of content that already existed at-or-before
its thread's disposition (`createdAt <= disposition time`, `updatedAt >
createdAt`) — the #1313 report's exact pattern — rather than a brand-new
post-disposition comment. Like its sibling, this **never changes `route` by
itself**: it's a more specific, actionable hint for an agent, who still has to
read the comment's current body before deciding an override is safe, rather
than the mechanism silently trusting an unverifiable assumption.

`schemas/pre-merge-readiness.schema.json` gained the two new required
boolean fields (`dispositionEvidence.soleCauseInPlaceEditOnly` and
`dispositionEvidence.missingThreads[].inPlaceEditOnly`).

## Linked issue

Closes #1313

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

- **Why not the original mechanical approach?** `effectiveThreadCommentActivityAt`
  is shared by 5 other call sites that rely on the current `updatedAt`-preferring
  behavior to detect post-disposition bot activity for their own (unrelated but
  structurally similar) purposes; more importantly, dating a bot's in-place edit
  by `createdAt` removes an existing fail-closed protection with no way to
  mechanically verify the edit was cosmetic. A maintainer-reviewed finding on the
  first version of this PR caught exactly this regression before merge.
- **Why extend the #978 diagnostic instead of inventing a new mechanism?** This
  codebase already has an established, deliberate pattern for "a post-disposition
  bot signal looks inconsequential, but we can't mechanically prove it": surface
  it as an advisory-only field an agent can act on, never bake the assumption
  into the gate itself. `inPlaceEditOnly` is a strict subset of
  `ackOnlyPostDisposition` (both must hold for a comment to qualify), computed in
  the same pass to avoid recomputing `threadDispositionAt` /
  `postDispositionBlockingFeedback` twice.
- The regression tests in `tests/pre-merge-readiness.test.mts` were rewritten
  around this shape: a direct `hasFreshDisposition` test proves the mechanical
  gate still re-blocks a bot's in-place edit, and the disposition-evidence tests
  assert on `ackOnlyPostDisposition` / `inPlaceEditOnly` (still blocking, `route:
  'return-to-e1'`) rather than the route flipping to `'proceed'`.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`pnpm run lint:minimum`, includes typecheck/build:check/tests/cspell/markdownlint)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed)
- [x] `node scripts/idd-doctor.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
