### PR TITLE
docs(idd-ci): document sync-wait, billing-block hold, dup-check keying

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -186,9 +186,10 @@ infra-vs-code triage above:
 
 - **Account-level Actions billing / spend-limit block**: every job in
   every workflow fails near-instantly with an identical platform banner
-  (the run never starts, unlike a normal step failure). Non-transient — a
-  rerun reproduces it, no code change fixes it. Skip `ciWait.rerunPolicy`;
-  post a hold comment naming the block and stop for a maintainer.
+  (the run starts but no steps execute, unlike a normal step failure).
+  Non-transient — a rerun reproduces it, no code change fixes it. Skip
+  `ciWait.rerunPolicy`; post a hold comment naming the block and stop for
+  a maintainer.
 
 ## Wake-up discipline
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -113,6 +113,20 @@ that set instead of re-deriving it.
    gh pr checks {pr-number} --json name,state,bucket,startedAt,completedAt,link
    ```
 
+   **Duplicate-name-safe, HEAD-pinned reads**: `gh pr checks` can collapse
+   same-named checks across workflows. When helper support is installed,
+   read the profile-selected `ci-wait-state` snapshot instead (keyed by
+   `(checkName, workflowName)`, live `headRefOid`); see
+   `docs/idd-helper-scripts.md`.
+
+   ```sh
+   # source repo / vendored-node profile
+   node scripts/ci-wait-state.mjs --pr {pr-number}
+
+   # package-manager / ephemeral-npx profile
+   <profile-selected-ci-wait-state-command> --pr {pr-number}
+   ```
+
 2. Normalize check states:
    - treat `skipped`, `neutral`, and `not_applicable` as pass-equivalent
    - treat `pending`, `requested`, `waiting`, `queued`,
@@ -165,12 +179,30 @@ for the same run before posting a hold.
 | Required checks are not generated after `ciWait.generationTimeout` | Treat as running. Default: 10 min. If the corresponding workflow run does not exist at all when that window elapses, post a hold comment and escalate to a maintainer, then stop. |
 <!-- dprint-ignore-end -->
 
+## Hold-and-report failure shapes
+
+Recognize this shape in one pass; hold-and-report instead of the
+infra-vs-code triage above:
+
+- **Account-level Actions billing / spend-limit block**: every job in
+  every workflow fails near-instantly with an identical platform banner
+  (the run never starts, unlike a normal step failure). Non-transient — a
+  rerun reproduces it, no code change fixes it. Skip `ciWait.rerunPolicy`;
+  post a hold comment naming the block and stop for a maintainer.
+
 ## Wake-up discipline
 
 The polling mechanics above are unchanged. This advisory, tool-agnostic note
 keeps the **wait itself cheap**: the dominant cost of a wait is each
 re-invocation's context re-read (worse once it crosses the prompt-cache TTL,
 as CI/e2e waits routinely do), not the idle time.
+
+**Portability**: prefer a synchronous / blocking wait in the worker's own
+turn under supervisor/worker or multi-agent topologies — a background
+wait's completion notification often reaches only the supervisor, so the
+worker's turn ends and stalls until re-prompted (the background-wait
+resumption caveat). Background the watch (below) only when the topology
+is known to route completion back to the same turn.
 
 - **No interim polling turns** — background the watch, or schedule one wake at
   the **expected** completion interval; do not insert "is it done yet?" turns

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -195,7 +195,7 @@
         ".github/instructions/idd-review-snapshot.instructions.md",
         ".github/instructions/idd-review-triage.instructions.md"
       ],
-      "limitBytes": 108800
+      "limitBytes": 115300
     },
     {
       "id": "bundle-merge",

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -108,6 +108,20 @@ that set instead of re-deriving it.
    gh pr checks {pr-number} --json name,state,bucket,startedAt,completedAt,link
    ```
 
+   **Duplicate-name-safe, HEAD-pinned reads**: `gh pr checks` can collapse
+   same-named checks across workflows. When helper support is installed,
+   read the profile-selected `ci-wait-state` snapshot instead (keyed by
+   `(checkName, workflowName)`, live `headRefOid`); see
+   `docs/idd-helper-scripts.md`.
+
+   ```sh
+   # source repo / vendored-node profile
+   node scripts/ci-wait-state.mjs --pr {pr-number}
+
+   # package-manager / ephemeral-npx profile
+   <profile-selected-ci-wait-state-command> --pr {pr-number}
+   ```
+
 2. Normalize check states:
    - treat `skipped`, `neutral`, and `not_applicable` as pass-equivalent
    - treat `pending`, `requested`, `waiting`, `queued`,
@@ -160,12 +174,30 @@ for the same run before posting a hold.
 | Required checks are not generated after `ciWait.generationTimeout` | Treat as running. Default: 10 min. If the corresponding workflow run does not exist at all when that window elapses, post a hold comment and escalate to a maintainer, then stop. |
 <!-- dprint-ignore-end -->
 
+## Hold-and-report failure shapes
+
+Recognize this shape in one pass; hold-and-report instead of the
+infra-vs-code triage above:
+
+- **Account-level Actions billing / spend-limit block**: every job in
+  every workflow fails near-instantly with an identical platform banner
+  (the run never starts, unlike a normal step failure). Non-transient — a
+  rerun reproduces it, no code change fixes it. Skip `ciWait.rerunPolicy`;
+  post a hold comment naming the block and stop for a maintainer.
+
 ## Wake-up discipline
 
 The polling mechanics above are unchanged. This advisory, tool-agnostic note
 keeps the **wait itself cheap**: the dominant cost of a wait is each
 re-invocation's context re-read (worse once it crosses the prompt-cache TTL,
 as CI/e2e waits routinely do), not the idle time.
+
+**Portability**: prefer a synchronous / blocking wait in the worker's own
+turn under supervisor/worker or multi-agent topologies — a background
+wait's completion notification often reaches only the supervisor, so the
+worker's turn ends and stalls until re-prompted (the background-wait
+resumption caveat). Background the watch (below) only when the topology
+is known to route completion back to the same turn.
 
 - **No interim polling turns** — background the watch, or schedule one wake at
   the **expected** completion interval; do not insert "is it done yet?" turns

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -181,9 +181,10 @@ infra-vs-code triage above:
 
 - **Account-level Actions billing / spend-limit block**: every job in
   every workflow fails near-instantly with an identical platform banner
-  (the run never starts, unlike a normal step failure). Non-transient — a
-  rerun reproduces it, no code change fixes it. Skip `ciWait.rerunPolicy`;
-  post a hold comment naming the block and stop for a maintainer.
+  (the run starts but no steps execute, unlike a normal step failure).
+  Non-transient — a rerun reproduces it, no code change fixes it. Skip
+  `ciWait.rerunPolicy`; post a hold comment naming the block and stop for
+  a maintainer.
 
 ## Wake-up discipline
 


### PR DESCRIPTION
## Summary

- Adds a portability note to the `## Wake-up discipline` section of `idd-ci.instructions.md` recommending a synchronous / blocking wait as the safe default under supervisor/worker or multi-agent topologies, and explains the background-wait resumption caveat (a self-started background wait's completion notification often reaches only the supervisor, not the waiting worker turn).
- Adds a new `## Hold-and-report failure shapes` section naming the account-level Actions billing/spend-limit block: every job in every triggered workflow fails near-instantly with an identical platform-generated banner, non-transient, not resolvable by any code change — route straight to a hold instead of the normal infra-vs-code triage.
- Extends the `## Polling algorithm` step 1 with a pointer to the `ci-wait-state` helper (shipped in #1317) for duplicate-name-safe, HEAD-pinned per-check reads, keyed by `(checkName, workflowName)`.

This child is sequenced after #1317 (`ci-wait-state` helper) per the roadmap (#1309), so the instruction describes shipped behavior. It is the last execution leaf under roadmap #1309.

**Byte budget**: `idd-ci.instructions.md` participates in the `bundle-review` and `bundle-merge` bundle budgets (`audit/sync-manifest.json`). `bundle-review` was already at ~99.6% utilization (108337/108800 bytes) before this change. Per the near-ceiling guidance in `docs/policy-constants.md`, the new content was trimmed as far as reasonable first (cut from an initial ~1998-byte overage down to ~965 bytes) before raising the limit. `bundle-review`'s `limitBytes` is bumped from `108800` to `115300` (~5% headroom over the new 109765-byte measured total) — an explicit ratchet-rule callout per `audit/README.md`. `bundle-merge` needed no change (still has ~6% headroom).

Closes #1318

## Test plan

- [x] `node scripts/audit-docs.mjs --check` — passes (sync mirror + bundle budgets green)
- [x] `pnpm run lint:minimum` — passes (typecheck, build:check, biome, dprint, 1825 tests, workshop-integrity, cspell, markdownlint all green)
- [x] `node scripts/idd-doctor.mjs` — passes (only pre-existing, unrelated WARNs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152p38Md7FmYCPgrLwdxGjv