### PR TITLE
fix(review-triage): gate Codex notice detector on comment shape

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -977,11 +977,20 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 // Anchored to the *entire* trimmed remainder (start `^` through end `$`,
 // not a bare substring `.test()`), so "known trailer, then more unrelated
 // prose" is still correctly rejected — a substring-only match would let
-// extra content after the trailer hide behind a recognized prefix. A short
-// `[\s\S]{0,20}?` span is allowed before the core trailer tokens (the real
-// wording has ". Please " between the matched span and "check with the
-// admins"), and only trailing punctuation/whitespace is allowed after the
-// closing sentence(s).
+// extra content after the trailer hide behind a recognized prefix.
+//
+// Every connector in this pattern (lead-in, inter-sentence, and trailing)
+// is bounded to punctuation/whitespace plus, where needed, one specific
+// known word — never an arbitrary-content character budget. An earlier
+// version of this fix allowed an arbitrary `[\s\S]{0,20}?` lead-in before
+// the core trailer tokens (reasoning that the real wording's ". Please "
+// connector needed *some* tolerance), but a bounded *character count* still
+// admits arbitrary *words* within that budget — a critique pass on this PR
+// found that narrative content like "We should " fits the same budget and
+// would still reach the trailer tokens. `CODEX_NOTICE_TRAILER_LEAD_IN`
+// closes that class by allowing only punctuation/whitespace and the
+// literal word "Please" (the only lead-in word in any known real wording),
+// so no other word can occupy that position regardless of length.
 //
 // The live wording observed on this very PR's own Codex review (#1326)
 // appends a SECOND administrative sentence after the one #1312 quoted
@@ -996,12 +1005,14 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 // uses, so a comment that merely reuses those individual words near
 // SENTENCE_1's exact bot phrasing cannot piggyback a false accept (a gap
 // found and closed during this PR's own review-fix rounds).
+const CODEX_NOTICE_TRAILER_LEAD_IN =
+  '[.!,;:\\s]{0,3}(?:\\bPlease\\b[.!,;:\\s]{0,3})?';
 const CODEX_NOTICE_TRAILER_SENTENCE_1 =
   '\\bcheck with the admins\\b[\\s\\S]{0,60}?\\bincrease the limits\\b[\\s\\S]{0,60}?\\badding credits\\b';
 const CODEX_NOTICE_TRAILER_SENTENCE_2 =
   '\\bcredits must be used\\b[\\s\\S]{0,40}?\\benable\\b[\\s\\S]{0,40}?\\brepository\\b[\\s\\S]{0,40}?\\b(?:code )?reviews?\\b';
 const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN = new RegExp(
-  `^[\\s\\S]{0,20}?${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?[.!,;:\\s]*$`,
+  `^${CODEX_NOTICE_TRAILER_LEAD_IN}${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?[.!,;:\\s]*$`,
   'i',
 );
 const CODEX_NOTICE_MAX_LENGTH = 220;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -974,8 +974,16 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 // matching, which the #1312 fix deliberately avoids), but it substantially
 // narrows the matching surface in the safe direction the block comment above
 // already documents: under-match is safe, over-match risks a false merge.
+// Anchored to the *entire* trimmed remainder (start `^` through end `$`,
+// not a bare substring `.test()`), so "known trailer, then more unrelated
+// prose" is still correctly rejected — a substring-only match would let
+// extra content after the trailer hide behind a recognized prefix. A short
+// `[\s\S]{0,20}?` span is allowed before the core trailer tokens (the real
+// wording has ". Please " between the matched span and "check with the
+// admins"), and only trailing punctuation/whitespace is allowed after
+// "adding credits".
 const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN =
-  /\bcheck with the admins\b[\s\S]{0,60}?\bincrease the limits\b[\s\S]{0,60}?\badding credits\b/i;
+  /^[\s\S]{0,20}?\bcheck with the admins\b[\s\S]{0,60}?\bincrease the limits\b[\s\S]{0,60}?\badding credits\b[.!,;:\s]*$/i;
 const CODEX_NOTICE_MAX_LENGTH = 220;
 const CODEX_NOTICE_MAX_PREFIX_LENGTH = 20;
 // Anchored to the *entire* trimmed remainder (not a starts-with check), so

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -958,8 +958,8 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 //
 // 1. Whole-comment length ≤ CODEX_NOTICE_MAX_LENGTH — defends against a long
 //    structured review whose *last* sentence happens to coincidentally
-//    match (the longest known real wording, current wording + trailer, is
-//    138 characters).
+//    match (the longest known real wording — current wording plus its
+//    two-sentence trailer, see below — is 199 characters).
 // 2. Text before the matched span ≤ CODEX_NOTICE_MAX_PREFIX_LENGTH once
 //    trimmed — defends against a narrative lead-in preceding an otherwise
 //    bare match (known real prefixes are 0 and 9 characters).
@@ -980,10 +980,30 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 // extra content after the trailer hide behind a recognized prefix. A short
 // `[\s\S]{0,20}?` span is allowed before the core trailer tokens (the real
 // wording has ". Please " between the matched span and "check with the
-// admins"), and only trailing punctuation/whitespace is allowed after
-// "adding credits".
-const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN =
-  /^[\s\S]{0,20}?\bcheck with the admins\b[\s\S]{0,60}?\bincrease the limits\b[\s\S]{0,60}?\badding credits\b[.!,;:\s]*$/i;
+// admins"), and only trailing punctuation/whitespace is allowed after the
+// closing sentence(s).
+//
+// The live wording observed on this very PR's own Codex review (#1326)
+// appends a SECOND administrative sentence after the one #1312 quoted
+// ("Credits must be used to enable repository wide code reviews."), so the
+// accepted closing shape is two sentences, each independently
+// token-anchored and gap-tolerant (not exact-phrase — the same #1312
+// wording-drift tolerance applies within each sentence), with the second
+// sentence optional so the shorter single-sentence wording still matches.
+// SENTENCE_2 anchors the distinctive multi-word phrases "credits must be
+// used" and "enable" (not the single generic words "credits" / "repository"
+// / "reviews" alone) — matching the same specificity SENTENCE_1 already
+// uses, so a comment that merely reuses those individual words near
+// SENTENCE_1's exact bot phrasing cannot piggyback a false accept (a gap
+// found and closed during this PR's own review-fix rounds).
+const CODEX_NOTICE_TRAILER_SENTENCE_1 =
+  '\\bcheck with the admins\\b[\\s\\S]{0,60}?\\bincrease the limits\\b[\\s\\S]{0,60}?\\badding credits\\b';
+const CODEX_NOTICE_TRAILER_SENTENCE_2 =
+  '\\bcredits must be used\\b[\\s\\S]{0,40}?\\benable\\b[\\s\\S]{0,40}?\\brepository\\b[\\s\\S]{0,40}?\\b(?:code )?reviews?\\b';
+const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN = new RegExp(
+  `^[\\s\\S]{0,20}?${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?[.!,;:\\s]*$`,
+  'i',
+);
 const CODEX_NOTICE_MAX_LENGTH = 220;
 const CODEX_NOTICE_MAX_PREFIX_LENGTH = 20;
 // Anchored to the *entire* trimmed remainder (not a starts-with check), so

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -928,24 +928,87 @@ const ADVISORY_NON_REVIEW_NOTICE_PATTERNS = [
   // the `summarize by coderabbit.ai` review marker) and its warning heading.
   /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
   /^[>\s]*#{1,6}\s*Review limit reached\b/im,
-  // Codex usage / quota exhaustion for code reviews. Token-anchored on all
-  // three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and
-  // "for code reviews", each tolerant of interposed wording drift, in the
-  // two known real orderings (#1312: the two prior exact-phrase regexes
-  // broke when Codex's wording interposed "have been" between "usage
-  // limits" and "reached"). Requiring "for code reviews" too (not just the
-  // verb) keeps the match narrow, per the fail-closed under-match-over
-  // false-positive intent documented above: a bare "Codex usage limits
-  // exceeded" mention with no "for code reviews" nearby must not match.
-  /\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b[\s\S]{0,40}?\bfor code reviews\b|\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bfor code reviews\b/i,
 ];
+// Codex usage / quota exhaustion for code reviews. Token-anchored on all
+// three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and "for
+// code reviews", each tolerant of interposed wording drift, in the two known
+// real orderings (#1312: the two prior exact-phrase regexes broke when
+// Codex's wording interposed "have been" between "usage limits" and
+// "reached"). Requiring "for code reviews" too (not just the verb) keeps the
+// match narrow: a bare "Codex usage limits exceeded" mention with no "for
+// code reviews" nearby must not match.
+const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
+  /\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b[\s\S]{0,40}?\bfor code reviews\b|\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bfor code reviews\b/i;
+// #1326: the token pattern above, by itself, is a structural false positive —
+// a genuine review comment that discusses "Codex", a reach/exceed/hit verb,
+// and "for code reviews" in ordinary prose (a live risk specifically on PRs
+// that touch this detector, as #1319's own review demonstrated) matches it
+// too. Tightening the interposed-word gap cannot separate the two cases: the
+// words sit just as close together in a real sentence as in the generated
+// notice, and no gap bound keeps both known real wordings matching while
+// rejecting the false positive (verified empirically while fixing #1326).
+//
+// Instead, gate the token match on the notice's known SHAPE: a genuine
+// Codex/CodeRabbit quota notice is short and is effectively the *entire*
+// comment — nothing of substance precedes or follows it (the current wording
+// adds one recognizable generated trailer sentence). A genuine review embeds
+// the phrase mid-document, with a narrative lead-in, trailing prose, or both.
+// Three structural checks apply together, only once the token pattern above
+// already matched:
+//
+// 1. Whole-comment length ≤ CODEX_NOTICE_MAX_LENGTH — defends against a long
+//    structured review whose *last* sentence happens to coincidentally
+//    match (the longest known real wording, current wording + trailer, is
+//    138 characters).
+// 2. Text before the matched span ≤ CODEX_NOTICE_MAX_PREFIX_LENGTH once
+//    trimmed — defends against a narrative lead-in preceding an otherwise
+//    bare match (known real prefixes are 0 and 9 characters).
+// 3. Text after the matched span is empty/punctuation-only, or matches the
+//    tolerant (bounded-gap, token-anchored — not exact-phrase, so a future
+//    trailer reword does not reintroduce the #1312 brittleness) generated
+//    trailer-continuation pattern below.
+//
+// This does not achieve perfect semantic disambiguation (a sufficiently
+// short human sentence with a trivial lead-in and nothing trailing is
+// inherently indistinguishable from the real notice without exact-phrase
+// matching, which the #1312 fix deliberately avoids), but it substantially
+// narrows the matching surface in the safe direction the block comment above
+// already documents: under-match is safe, over-match risks a false merge.
+const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN =
+  /\bcheck with the admins\b[\s\S]{0,60}?\bincrease the limits\b[\s\S]{0,60}?\badding credits\b/i;
+const CODEX_NOTICE_MAX_LENGTH = 220;
+const CODEX_NOTICE_MAX_PREFIX_LENGTH = 20;
+// Anchored to the *entire* trimmed remainder (not a starts-with check), so
+// trailing prose that happens to begin with a comma or period is still
+// correctly rejected.
+const CODEX_NOTICE_SUFFIX_PUNCTUATION_ONLY_RE = /^[.!,;:]*$/;
+function isCodexUsageLimitNotice(text) {
+  if (!text.trim() || text.trim().length > CODEX_NOTICE_MAX_LENGTH) {
+    return false;
+  }
+  const match = CODEX_USAGE_LIMIT_TOKEN_PATTERN.exec(text);
+  if (!match) {
+    return false;
+  }
+  const prefix = text.slice(0, match.index).trim();
+  if (prefix.length > CODEX_NOTICE_MAX_PREFIX_LENGTH) {
+    return false;
+  }
+  const remainder = text.slice(match.index + match[0].length).trim();
+  return (
+    remainder === '' ||
+    CODEX_NOTICE_SUFFIX_PUNCTUATION_ONLY_RE.test(remainder) ||
+    CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN.test(remainder)
+  );
+}
 export function isAdvisoryNonReviewNotice(body) {
   const text = String(body ?? '');
   if (!text) {
     return false;
   }
-  return ADVISORY_NON_REVIEW_NOTICE_PATTERNS.some((pattern) =>
-    pattern.test(text),
+  return (
+    ADVISORY_NON_REVIEW_NOTICE_PATTERNS.some((pattern) => pattern.test(text)) ||
+    isCodexUsageLimitNotice(text)
   );
 }
 // A trusted IDD disposition of a non-review notice: the canonical

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1613,8 +1613,16 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 // matching, which the #1312 fix deliberately avoids), but it substantially
 // narrows the matching surface in the safe direction the block comment above
 // already documents: under-match is safe, over-match risks a false merge.
+// Anchored to the *entire* trimmed remainder (start `^` through end `$`,
+// not a bare substring `.test()`), so "known trailer, then more unrelated
+// prose" is still correctly rejected — a substring-only match would let
+// extra content after the trailer hide behind a recognized prefix. A short
+// `[\s\S]{0,20}?` span is allowed before the core trailer tokens (the real
+// wording has ". Please " between the matched span and "check with the
+// admins"), and only trailing punctuation/whitespace is allowed after
+// "adding credits".
 const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN =
-  /\bcheck with the admins\b[\s\S]{0,60}?\bincrease the limits\b[\s\S]{0,60}?\badding credits\b/i;
+  /^[\s\S]{0,20}?\bcheck with the admins\b[\s\S]{0,60}?\bincrease the limits\b[\s\S]{0,60}?\badding credits\b[.!,;:\s]*$/i;
 const CODEX_NOTICE_MAX_LENGTH = 220;
 const CODEX_NOTICE_MAX_PREFIX_LENGTH = 20;
 // Anchored to the *entire* trimmed remainder (not a starts-with check), so

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1616,11 +1616,20 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 // Anchored to the *entire* trimmed remainder (start `^` through end `$`,
 // not a bare substring `.test()`), so "known trailer, then more unrelated
 // prose" is still correctly rejected — a substring-only match would let
-// extra content after the trailer hide behind a recognized prefix. A short
-// `[\s\S]{0,20}?` span is allowed before the core trailer tokens (the real
-// wording has ". Please " between the matched span and "check with the
-// admins"), and only trailing punctuation/whitespace is allowed after the
-// closing sentence(s).
+// extra content after the trailer hide behind a recognized prefix.
+//
+// Every connector in this pattern (lead-in, inter-sentence, and trailing)
+// is bounded to punctuation/whitespace plus, where needed, one specific
+// known word — never an arbitrary-content character budget. An earlier
+// version of this fix allowed an arbitrary `[\s\S]{0,20}?` lead-in before
+// the core trailer tokens (reasoning that the real wording's ". Please "
+// connector needed *some* tolerance), but a bounded *character count* still
+// admits arbitrary *words* within that budget — a critique pass on this PR
+// found that narrative content like "We should " fits the same budget and
+// would still reach the trailer tokens. `CODEX_NOTICE_TRAILER_LEAD_IN`
+// closes that class by allowing only punctuation/whitespace and the
+// literal word "Please" (the only lead-in word in any known real wording),
+// so no other word can occupy that position regardless of length.
 //
 // The live wording observed on this very PR's own Codex review (#1326)
 // appends a SECOND administrative sentence after the one #1312 quoted
@@ -1635,12 +1644,14 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 // uses, so a comment that merely reuses those individual words near
 // SENTENCE_1's exact bot phrasing cannot piggyback a false accept (a gap
 // found and closed during this PR's own review-fix rounds).
+const CODEX_NOTICE_TRAILER_LEAD_IN =
+  '[.!,;:\\s]{0,3}(?:\\bPlease\\b[.!,;:\\s]{0,3})?';
 const CODEX_NOTICE_TRAILER_SENTENCE_1 =
   '\\bcheck with the admins\\b[\\s\\S]{0,60}?\\bincrease the limits\\b[\\s\\S]{0,60}?\\badding credits\\b';
 const CODEX_NOTICE_TRAILER_SENTENCE_2 =
   '\\bcredits must be used\\b[\\s\\S]{0,40}?\\benable\\b[\\s\\S]{0,40}?\\brepository\\b[\\s\\S]{0,40}?\\b(?:code )?reviews?\\b';
 const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN = new RegExp(
-  `^[\\s\\S]{0,20}?${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?[.!,;:\\s]*$`,
+  `^${CODEX_NOTICE_TRAILER_LEAD_IN}${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?[.!,;:\\s]*$`,
   'i',
 );
 const CODEX_NOTICE_MAX_LENGTH = 220;

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1565,25 +1565,91 @@ const ADVISORY_NON_REVIEW_NOTICE_PATTERNS: RegExp[] = [
   // the `summarize by coderabbit.ai` review marker) and its warning heading.
   /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
   /^[>\s]*#{1,6}\s*Review limit reached\b/im,
-  // Codex usage / quota exhaustion for code reviews. Token-anchored on all
-  // three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and
-  // "for code reviews", each tolerant of interposed wording drift, in the
-  // two known real orderings (#1312: the two prior exact-phrase regexes
-  // broke when Codex's wording interposed "have been" between "usage
-  // limits" and "reached"). Requiring "for code reviews" too (not just the
-  // verb) keeps the match narrow, per the fail-closed under-match-over
-  // false-positive intent documented above: a bare "Codex usage limits
-  // exceeded" mention with no "for code reviews" nearby must not match.
-  /\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b[\s\S]{0,40}?\bfor code reviews\b|\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bfor code reviews\b/i,
 ];
+
+// Codex usage / quota exhaustion for code reviews. Token-anchored on all
+// three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and "for
+// code reviews", each tolerant of interposed wording drift, in the two known
+// real orderings (#1312: the two prior exact-phrase regexes broke when
+// Codex's wording interposed "have been" between "usage limits" and
+// "reached"). Requiring "for code reviews" too (not just the verb) keeps the
+// match narrow: a bare "Codex usage limits exceeded" mention with no "for
+// code reviews" nearby must not match.
+const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
+  /\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bCodex usage limits?\b[\s\S]{0,40}?\bfor code reviews\b|\bCodex usage limits?\b[\s\S]{0,40}?\b(?:reach|exceed|hit)\w*[\s\S]{0,40}?\bfor code reviews\b/i;
+
+// #1326: the token pattern above, by itself, is a structural false positive —
+// a genuine review comment that discusses "Codex", a reach/exceed/hit verb,
+// and "for code reviews" in ordinary prose (a live risk specifically on PRs
+// that touch this detector, as #1319's own review demonstrated) matches it
+// too. Tightening the interposed-word gap cannot separate the two cases: the
+// words sit just as close together in a real sentence as in the generated
+// notice, and no gap bound keeps both known real wordings matching while
+// rejecting the false positive (verified empirically while fixing #1326).
+//
+// Instead, gate the token match on the notice's known SHAPE: a genuine
+// Codex/CodeRabbit quota notice is short and is effectively the *entire*
+// comment — nothing of substance precedes or follows it (the current wording
+// adds one recognizable generated trailer sentence). A genuine review embeds
+// the phrase mid-document, with a narrative lead-in, trailing prose, or both.
+// Three structural checks apply together, only once the token pattern above
+// already matched:
+//
+// 1. Whole-comment length ≤ CODEX_NOTICE_MAX_LENGTH — defends against a long
+//    structured review whose *last* sentence happens to coincidentally
+//    match (the longest known real wording, current wording + trailer, is
+//    138 characters).
+// 2. Text before the matched span ≤ CODEX_NOTICE_MAX_PREFIX_LENGTH once
+//    trimmed — defends against a narrative lead-in preceding an otherwise
+//    bare match (known real prefixes are 0 and 9 characters).
+// 3. Text after the matched span is empty/punctuation-only, or matches the
+//    tolerant (bounded-gap, token-anchored — not exact-phrase, so a future
+//    trailer reword does not reintroduce the #1312 brittleness) generated
+//    trailer-continuation pattern below.
+//
+// This does not achieve perfect semantic disambiguation (a sufficiently
+// short human sentence with a trivial lead-in and nothing trailing is
+// inherently indistinguishable from the real notice without exact-phrase
+// matching, which the #1312 fix deliberately avoids), but it substantially
+// narrows the matching surface in the safe direction the block comment above
+// already documents: under-match is safe, over-match risks a false merge.
+const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN =
+  /\bcheck with the admins\b[\s\S]{0,60}?\bincrease the limits\b[\s\S]{0,60}?\badding credits\b/i;
+const CODEX_NOTICE_MAX_LENGTH = 220;
+const CODEX_NOTICE_MAX_PREFIX_LENGTH = 20;
+// Anchored to the *entire* trimmed remainder (not a starts-with check), so
+// trailing prose that happens to begin with a comma or period is still
+// correctly rejected.
+const CODEX_NOTICE_SUFFIX_PUNCTUATION_ONLY_RE = /^[.!,;:]*$/;
+
+function isCodexUsageLimitNotice(text: string): boolean {
+  if (!text.trim() || text.trim().length > CODEX_NOTICE_MAX_LENGTH) {
+    return false;
+  }
+  const match = CODEX_USAGE_LIMIT_TOKEN_PATTERN.exec(text);
+  if (!match) {
+    return false;
+  }
+  const prefix = text.slice(0, match.index).trim();
+  if (prefix.length > CODEX_NOTICE_MAX_PREFIX_LENGTH) {
+    return false;
+  }
+  const remainder = text.slice(match.index + match[0].length).trim();
+  return (
+    remainder === '' ||
+    CODEX_NOTICE_SUFFIX_PUNCTUATION_ONLY_RE.test(remainder) ||
+    CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN.test(remainder)
+  );
+}
 
 export function isAdvisoryNonReviewNotice(body: unknown): boolean {
   const text = String(body ?? '');
   if (!text) {
     return false;
   }
-  return ADVISORY_NON_REVIEW_NOTICE_PATTERNS.some((pattern) =>
-    pattern.test(text),
+  return (
+    ADVISORY_NON_REVIEW_NOTICE_PATTERNS.some((pattern) => pattern.test(text)) ||
+    isCodexUsageLimitNotice(text)
   );
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1597,8 +1597,8 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 //
 // 1. Whole-comment length ≤ CODEX_NOTICE_MAX_LENGTH — defends against a long
 //    structured review whose *last* sentence happens to coincidentally
-//    match (the longest known real wording, current wording + trailer, is
-//    138 characters).
+//    match (the longest known real wording — current wording plus its
+//    two-sentence trailer, see below — is 199 characters).
 // 2. Text before the matched span ≤ CODEX_NOTICE_MAX_PREFIX_LENGTH once
 //    trimmed — defends against a narrative lead-in preceding an otherwise
 //    bare match (known real prefixes are 0 and 9 characters).
@@ -1619,10 +1619,30 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 // extra content after the trailer hide behind a recognized prefix. A short
 // `[\s\S]{0,20}?` span is allowed before the core trailer tokens (the real
 // wording has ". Please " between the matched span and "check with the
-// admins"), and only trailing punctuation/whitespace is allowed after
-// "adding credits".
-const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN =
-  /^[\s\S]{0,20}?\bcheck with the admins\b[\s\S]{0,60}?\bincrease the limits\b[\s\S]{0,60}?\badding credits\b[.!,;:\s]*$/i;
+// admins"), and only trailing punctuation/whitespace is allowed after the
+// closing sentence(s).
+//
+// The live wording observed on this very PR's own Codex review (#1326)
+// appends a SECOND administrative sentence after the one #1312 quoted
+// ("Credits must be used to enable repository wide code reviews."), so the
+// accepted closing shape is two sentences, each independently
+// token-anchored and gap-tolerant (not exact-phrase — the same #1312
+// wording-drift tolerance applies within each sentence), with the second
+// sentence optional so the shorter single-sentence wording still matches.
+// SENTENCE_2 anchors the distinctive multi-word phrases "credits must be
+// used" and "enable" (not the single generic words "credits" / "repository"
+// / "reviews" alone) — matching the same specificity SENTENCE_1 already
+// uses, so a comment that merely reuses those individual words near
+// SENTENCE_1's exact bot phrasing cannot piggyback a false accept (a gap
+// found and closed during this PR's own review-fix rounds).
+const CODEX_NOTICE_TRAILER_SENTENCE_1 =
+  '\\bcheck with the admins\\b[\\s\\S]{0,60}?\\bincrease the limits\\b[\\s\\S]{0,60}?\\badding credits\\b';
+const CODEX_NOTICE_TRAILER_SENTENCE_2 =
+  '\\bcredits must be used\\b[\\s\\S]{0,40}?\\benable\\b[\\s\\S]{0,40}?\\brepository\\b[\\s\\S]{0,40}?\\b(?:code )?reviews?\\b';
+const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN = new RegExp(
+  `^[\\s\\S]{0,20}?${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?[.!,;:\\s]*$`,
+  'i',
+);
 const CODEX_NOTICE_MAX_LENGTH = 220;
 const CODEX_NOTICE_MAX_PREFIX_LENGTH = 20;
 // Anchored to the *entire* trimmed remainder (not a starts-with check), so

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -110,6 +110,28 @@ test('buildDispositionPlan plans a rejection for the current Codex usage-limit w
   assert.match(plan.planned[0]?.body ?? '', /did not review HEAD abc1234/);
 });
 
+test('buildDispositionPlan does not disposition the #1326 false-positive review comment', () => {
+  // #1326: a genuine Codex review comment that combines "Codex", a
+  // reach/exceed/hit verb, and "for code reviews" in ordinary prose (the
+  // concrete example flagged in PR #1319's own review of the #1312 fix)
+  // must not be misclassified as a non-review notice and dispositioned.
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(
+          1,
+          CODEX,
+          'This code hits the Codex usage limits for code reviews configured for the repo.',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 0);
+  assert.equal(plan.skipped.length, 0);
+});
+
 test('buildDispositionPlan is idempotent: a notice already dispositioned for its bot is skipped', () => {
   const plan = buildDispositionPlan(
     {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2712,6 +2712,20 @@ test('isAdvisoryNonReviewNotice matches only machine-generated non-review notice
     ),
     false,
   );
+  // #1326 (review-fix round 4): narrative content between the base match
+  // and the trailer's core tokens must not match, even though it fits
+  // within a short character budget — the lead-in before "check with the
+  // admins" must be punctuation/whitespace plus the one known lead-in word
+  // ("Please"), not an arbitrary-content character count (flagged by
+  // Copilot on this PR's own merge-sync-triggered re-review).
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'This code exceeds the Codex usage limits for code reviews. We ' +
+        'should check with the admins of this repo to increase the ' +
+        'limits by adding credits.',
+    ),
+    false,
+  );
   // #1326: trailing whitespace after a real notice must not defeat the
   // empty-suffix check (no regression from the added structural gate).
   assert.equal(

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2569,6 +2569,18 @@ test('isAdvisoryNonReviewNotice matches only machine-generated non-review notice
     ),
     true,
   );
+  // #1326: the live current wording observed on this PR's own Codex review
+  // appends a second administrative sentence beyond the one #1312 quoted —
+  // must still classify as a non-review notice (verified against the exact
+  // text Codex posted on PR #1329 while this fix was under review).
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'Codex usage limits have been reached for code reviews. Please check ' +
+        'with the admins of this repo to increase the limits by adding ' +
+        'credits.\nCredits must be used to enable repository wide code reviews.',
+    ),
+    true,
+  );
   assert.equal(
     isAdvisoryNonReviewNotice(
       '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> ## Review limit reached',
@@ -2649,6 +2661,54 @@ test('isAdvisoryNonReviewNotice matches only machine-generated non-review notice
       'Codex usage limits have been reached for code reviews. Please check ' +
         'with the admins of this repo to increase the limits by adding ' +
         'credits. And by the way, I also noticed a bug in the retry logic.',
+    ),
+    false,
+  );
+  // #1326: the two-sentence live trailer followed by further unrelated
+  // prose must still not match — extending the accepted closing shape to a
+  // second sentence must not reopen the same substring-anchoring gap for
+  // content past that second sentence either.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'Codex usage limits have been reached for code reviews. Please check ' +
+        'with the admins of this repo to increase the limits by adding ' +
+        'credits.\nCredits must be used to enable repository wide code ' +
+        'reviews. By the way I also noticed a bug in the retry logic.',
+    ),
+    false,
+  );
+  // #1326: a human sentence that deliberately reuses the second trailer
+  // sentence's own vocabulary ("repository", "credits", "reviews") must
+  // still not match — the trailer pattern's fixed token order and gap
+  // bounds are shape-specific, not a bag-of-words check.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'This code hits the Codex usage limits for code reviews. The ' +
+        'repository credits check has a bug in the retry logic for reviews.',
+    ),
+    false,
+  );
+  // #1326 (review-fix round 3): even when the full SENTENCE_1 bot phrasing
+  // is present (an unlikely but possible coincidence), loosely-worded
+  // content that merely reuses SENTENCE_2's individual words ("credits",
+  // "repository", "review") without its distinctive "credits must be used
+  // ... enable" phrase must not match — closes a gap a critique pass found
+  // in an earlier version of this same fix that anchored SENTENCE_2 on
+  // single generic words instead of a distinctive multi-word phrase.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'Codex usage limits have been reached for code reviews. Please check ' +
+        'with the admins of this repo to increase the limits by adding ' +
+        'credits. Credits are precious, track per repository, avoid ' +
+        'wasting review!',
+    ),
+    false,
+  );
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'Codex usage limits have been reached for code reviews. Please check ' +
+        'with the admins of this repo to increase the limits by adding ' +
+        'credits. credits repository reviews',
     ),
     false,
   );

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2638,6 +2638,20 @@ test('isAdvisoryNonReviewNotice matches only machine-generated non-review notice
     ),
     false,
   );
+  // #1326 (review-fix): the known generated trailer itself followed by
+  // MORE unrelated prose must still not match — the trailer-continuation
+  // pattern must anchor the entire remainder, not just find the trailer as
+  // a substring somewhere within it (flagged in this PR's own Copilot
+  // review: a substring-only check would let extra content hide behind a
+  // recognized trailer prefix).
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'Codex usage limits have been reached for code reviews. Please check ' +
+        'with the admins of this repo to increase the limits by adding ' +
+        'credits. And by the way, I also noticed a bug in the retry logic.',
+    ),
+    false,
+  );
   // #1326: trailing whitespace after a real notice must not defeat the
   // empty-suffix check (no regression from the added structural gate).
   assert.equal(

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2608,6 +2608,44 @@ test('isAdvisoryNonReviewNotice matches only machine-generated non-review notice
     ),
     false,
   );
+  // #1326: a genuine review comment that combines all three tokens
+  // (verb + "Codex usage limits" + "for code reviews") close together in
+  // ordinary prose must not match, even though the token-anchored pattern
+  // alone finds a candidate span — this is the concrete false positive
+  // flagged in PR #1319's own review of the #1312 fix.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'This code hits the Codex usage limits for code reviews configured for the repo.',
+    ),
+    false,
+  );
+  // #1326: a narrative lead-in before an otherwise-bare match (empty
+  // suffix) must also not match — the suffix alone is not a sufficient
+  // signal; the prefix must be checked too.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'This is what happens when you hit the Codex usage limits for code reviews.',
+    ),
+    false,
+  );
+  // #1326: a real notice immediately followed by unrelated prose (not the
+  // known generated trailer) must not match — a false positive could hide
+  // inside a longer bot comment that happens to lead with the notice text.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'You have reached your Codex usage limits for code reviews. We should ' +
+        'review our approach for code reviews going forward.',
+    ),
+    false,
+  );
+  // #1326: trailing whitespace after a real notice must not defeat the
+  // empty-suffix check (no regression from the added structural gate).
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'You have reached your Codex usage limits for code reviews.\n\n',
+    ),
+    true,
+  );
   assert.equal(isAdvisoryNonReviewNotice(''), false);
   assert.equal(isAdvisoryNonReviewNotice(null), false);
 });


### PR DESCRIPTION
# Summary

`isAdvisoryNonReviewNotice`'s Codex clause (`src/scripts/protocol-helpers.mts`)
required "Codex usage limit(s)", a reach/exceed/hit-family verb, and "for code
reviews" within a bounded gap, in either order. This correctly recognizes
Codex's generated quota-exhaustion notice, but a genuine review comment that
happens to combine those same three tokens in ordinary prose matches too —
flagged concretely on PR #1319's own review of the #1312 fix: `This code
hits the Codex usage limits for code reviews configured for the repo.`

I independently re-verified the false positive against current `main` before
changing anything, and re-ran the issue's claim that shrinking the
interposed-word gap bound (40 → 15 → 5) can't fix it: empirically, no bound
value keeps both known real Codex wordings matching while also rejecting the
false positive (bound ≤ 3 rejects the false positive but also breaks both
real wordings).

Adds a structural post-check (`isCodexUsageLimitNotice`), applied only after
the existing token-anchored pattern already found a candidate span, that
gates on the notice's known **shape**: a genuine notice is short and
effectively *is* the entire comment, while a genuine review embeds the
phrase mid-document with narrative content around it. Three checks apply
together:

1. Whole-comment length ≤ 220 characters (longest known real wording is 138).
2. Text before the matched span ≤ 20 characters once trimmed (known real
   prefixes are 0 and 9 characters) — rejects a narrative lead-in before an
   otherwise-bare match.
3. Text after the matched span is empty/punctuation-only, or matches a new
   tolerant (bounded-gap, token-anchored — not exact-phrase) pattern for the
   known generated trailer continuation ("check with the admins" … "increase
   the limits" … "adding credits").

An initial single-check design (length + suffix only, no prefix check) was
caught by a critique pass during planning: it still misclassified `This is
what happens when you hit the Codex usage limits for code reviews.` (empty
suffix, but a 30-character narrative prefix). The prefix check closes that
gap; see the issue thread for the full plan history and empirical
verification.

This remains a token-anchored (not exact-phrase) design, so it does not
reintroduce the #1312 brittleness — a future rewording of either the core
notice or its trailer still matches as long as the tokens stay recognizable.
It does not achieve perfect semantic disambiguation (a sufficiently short
human sentence with a trivial lead-in and nothing trailing is inherently
indistinguishable from the real notice without exact-phrase matching), but it
substantially narrows the false-positive surface while making the classifier
strictly *more* conservative in the direction the code's own comments already
document as safe (under-match is safe; over-match risks a false merge).

## Linked issue

Closes #1326

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Traced all five call sites of `isAdvisoryNonReviewNotice` (two in
`protocol-helpers.mts`, three in `disposition-non-review-notices.mts`,
including the production path that auto-posts the `**Rejected**`
disposition) — a stricter classifier only reduces false-notice
classifications, which is the safe direction every call site already
documents; no other call site needed a source change. `noticeReason` in
`disposition-non-review-notices.mts` needs no change (confirmed gated
upstream by this predicate, same as PR #1319's own observation).
`docs/idd-helper-scripts.md` describes the classifier only at the category
level, so it needs no update either.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed (affects merge-gate
      non-review-notice auto-disposition evidence — makes it strictly more
      conservative, not looser)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs drift introduced; not run
      standalone, covered by `pnpm lint`'s `audit-docs.mjs --check`)
- [x] `node scripts/idd-doctor.mjs` (passed with 4 pre-existing environment
      warnings unrelated to this diff — profile READMEs, hooksPath wiring,
      release-tag drift, branch protection readability)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
