### PR TITLE
chore(config): dogfood discover.selectionDesync=session-offset

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,18 @@ normal claim, freshness, CI, advisory, review, and unresolved-thread
 gates pass. Repositories without a recorded `fully_autonomous_merge`
 policy still stop at the F3 handoff gate.
 
+## Local discover policy
+
+This source repository also records `discover.selectionDesync:
+session-offset` as a local IDD dogfooding policy. The setting applies
+only to `kurone-kito/idd-skill` and does not change the exported
+template default for adopter repositories.
+
+Concurrent-session A4 Step 2 candidate selection spreads across a
+same-score tie band by a per-session offset instead of every session
+converging on the same lowest-numbered issue, cutting claim races
+under this repository's heavy concurrent-session load.
+
 ## Commit rules
 
 This project follows

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,10 +100,10 @@ policy still stop at the F3 handoff gate.
 
 ## Local discover policy
 
-This source repository also records `discover.selectionDesync:
-session-offset` as a local IDD dogfooding policy. The setting applies
-only to `kurone-kito/idd-skill` and does not change the exported
-template default for adopter repositories.
+This source repository also records a local IDD dogfooding policy:
+`discover.selectionDesync: session-offset`. The setting applies only
+to `kurone-kito/idd-skill` and does not change the exported template
+default for adopter repositories.
 
 Concurrent-session A4 Step 2 candidate selection spreads across a
 same-score tie band by a per-session offset instead of every session

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -30,6 +30,9 @@
   },
   "issueScope": "roadmap-first",
   "orphanFirstPolicy": "none",
+  "discover": {
+    "selectionDesync": "session-offset"
+  },
   "forcedHandoff": {
     "mode": "human-gated",
     "authorityPolicy": "owners-and-maintainers-only"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,13 @@ terms literally.
   continue through F3 merge execution only after normal claim,
   freshness, CI, advisory, review, and unresolved-thread gates
   pass.
+- **Discover concurrency**: This source repository also records
+  `discover.selectionDesync: session-offset` as a local IDD
+  dogfooding policy (applies only to `kurone-kito/idd-skill`),
+  spreading concurrent-session A4 Step 2 candidate selection across
+  a same-score tie band instead of every session converging on the
+  same lowest-numbered issue, to cut claim races under this
+  repository's heavy concurrent-session load.
 
 ## For IDD work
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,13 @@ terms literally.
   continue through F3 merge execution only after normal claim,
   freshness, CI, advisory, review, and unresolved-thread gates
   pass.
+- **Discover concurrency**: This source repository also records
+  `discover.selectionDesync: session-offset` as a local IDD
+  dogfooding policy (applies only to `kurone-kito/idd-skill`),
+  spreading concurrent-session A4 Step 2 candidate selection across
+  a same-score tie band instead of every session converging on the
+  same lowest-numbered issue, to cut claim races under this
+  repository's heavy concurrent-session load.
 
 ## For IDD work
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -66,6 +66,13 @@ terms literally.
   continue through F3 merge execution only after normal claim,
   freshness, CI, advisory, review, and unresolved-thread gates
   pass.
+- **Discover concurrency**: This source repository also records
+  `discover.selectionDesync: session-offset` as a local IDD
+  dogfooding policy (applies only to `kurone-kito/idd-skill`),
+  spreading concurrent-session A4 Step 2 candidate selection across
+  a same-score tie band instead of every session converging on the
+  same lowest-numbered issue, to cut claim races under this
+  repository's heavy concurrent-session load.
 
 ## For IDD work
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Turns on `discover.selectionDesync: session-offset` in
`.github/idd/config.json` and records the dogfooding rationale across
this repository's four agent entry files (`CLAUDE.md`, `AGENTS.md`,
`GEMINI.md`, `.github/copilot-instructions.md`), mirroring how the
existing `mergePolicy: fully_autonomous_merge` dogfooding note is
already kept in sync across the same file set.

## Linked issue

Closes #1331

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Under the default `off` setting, concurrent A4 Step 2 candidate
selection deterministically converges on the same lowest-issue-number
tie-break across every session, so independent sessions racing the
same same-score tie band collide on the same target issue. This
repository hit exactly that scenario on 2026-07-10: two independent
orchestrator sessions running the IDD loop concurrently each dispatched
parallel subagents across roadmap #1309's 8 immediately-ready,
same-score Tracks, and 4-5 of the 8 claim attempts collided with
another live session's claim within seconds-to-minutes. Every collision
was caught cleanly by the pre-claim `resume-claim-routing.mjs
--fresh-claim-gate` check with zero mutations made, but each losing
subagent had already spent real orientation work before discovering the
race.

`selectionDesync: session-offset` (`selectDesyncedIndex` in
`scripts/policy-helpers.mjs`) has been implemented, documented, and
tested since #965 — this repository had simply never turned it on for
its own dogfooding.

**Scope note**: the issue's `## Candidate files` list named only
`.github/idd/config.json` and `CLAUDE.md`. During B2 planning I found
that `docs/idd-workflow.md` documents `AGENTS.md`, `CLAUDE.md`,
`GEMINI.md`, and `.github/copilot-instructions.md` as a maintained
"Agent entry files" mirror set, and the first three are currently
byte-identical (modulo agent-name substitution) for the exact `Merge
policy` bullet this issue extends. Precedent commit `446df1f` ("docs:
dogfood fully autonomous merge policy", closing #203) touched all four
files together when the `mergePolicy` dogfooding fact was first
recorded, so this PR follows the same pattern rather than
re-introducing the drift that commit fixed. No other files change, and
no runtime/script behavior changes — `selectionDesync` is read only by
the already-implemented A4 Step 2 tie-break logic.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

`.github/idd/config.json` gains a value the schema already supports
(`discover.selectionDesync` enum `[off, session-offset]`); the schema
file itself, `.github/instructions/*.instructions.md`, `idd-template/`,
and helper scripts are all untouched.

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Also ran `node scripts/validate-schemas.mjs` and the targeted
`.github/idd/config.json validates against policy schema` test
(`tests/schema-validation.test.mts`) directly — both green.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

No merge-policy change (this is a Discover-phase setting only); the
doc additions are ~7 lines per file across 4 already-small agent entry
files, a negligible context-budget increase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional session-offset selection policy that distributes concurrent candidate selection across equally ranked items, helping reduce claim collisions during heavy activity.

* **Documentation**
  * Documented the new selection policy and its concurrency behavior in repository guidance and configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->