### PR TITLE
docs: position IDD as a loop-engineering implementation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,6 +15,25 @@ IDD Skill は、リポジトリへ移植できる Issue-Driven Development
 選択したマージポリシーに従ってマージと後片づけまで進めます。ループ全体は、
 リポジトリ内の Markdown で書かれた指示ファイルとして管理されます。
 
+## ループエンジニアリングとしての IDD
+
+この開発ループは、**loop engineering**（エージェントの trigger・topology・
+verifier・stop rules を仕組みとして設計する考え方）の具体例です。
+Anthropic は同じ考え方を **agentic loops** と呼んでいます。IDD は、
+専用ランタイムではなく issue コメントの永続状態のうえに構築された、
+移植可能で GitHub ネイティブな実装です:
+
+| ループの要素 | IDD での実装                                                                             |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| Trigger      | Discover が着手できる issue を選びます。                                                 |
+| Topology     | フェーズパイプライン、ロードマップの子 issue 分解、worktree で分離した並列エージェント。 |
+| Verifier     | CI ゲートと advisory bot（Copilot / CodeRabbit / Codex）、レビュー triage。              |
+| Stop rules   | Merge ゲート（claim・鮮度・CI・advisory・レビュー）。issue のクローズが終了条件です。    |
+
+強力な verifier と stop-gate が重要な理由は
+[Core concepts](docs/concepts.md#idd-as-loop-engineering)
+を参照してください。
+
 ## 実例で学ぶ
 
 [VRChat Event Calendar ワークショップ](docs/workshop/README.md) を読むと、

--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ branch, open a PR, handle review feedback, wait for CI, merge, and clean
 up according to the repository's selected merge policy. The whole loop
 lives in your repo as Markdown instruction files.
 
+## IDD as Loop Engineering
+
+This delivery loop is a concrete instance of **loop engineering** —
+designing an agent's trigger, topology, verifier, and stop rules as a
+system, instead of hand-prompting each step. Anthropic frames the same
+idea as **agentic loops**; IDD is a portable, GitHub-native
+implementation of it, built on durable issue-comment state rather than
+a custom runtime:
+
+| Loop element | IDD's implementation                                                                                   |
+| ------------ | ------------------------------------------------------------------------------------------------------ |
+| Trigger      | Discover picks a ready issue.                                                                          |
+| Topology     | Phase pipeline, roadmap decomposition, worktree-isolated parallel agents.                              |
+| Verifier     | CI gates plus advisory bots (Copilot / CodeRabbit / Codex) and review triage.                          |
+| Stop rules   | Merge gates (claim / freshness / CI / advisory / review); the issue closing is the terminal condition. |
+
+See [Core concepts](docs/concepts.md#idd-as-loop-engineering) for why
+strong verifiers and stop-gates matter.
+
 ## Learn by Example
 
 Follow the [VRChat Event Calendar workshop](docs/workshop/README.md) to

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ idea as **agentic loops**; IDD is a portable, GitHub-native
 implementation of it, built on durable issue-comment state rather than
 a custom runtime:
 
-| Loop element | IDD's implementation                                                                                   |
-| ------------ | ------------------------------------------------------------------------------------------------------ |
-| Trigger      | Discover picks a ready issue.                                                                          |
-| Topology     | Phase pipeline, roadmap decomposition, worktree-isolated parallel agents.                              |
-| Verifier     | CI gates plus advisory bots (Copilot / CodeRabbit / Codex) and review triage.                          |
-| Stop rules   | Merge gates (claim / freshness / CI / advisory / review); the issue closing is the terminal condition. |
+| Loop element | IDD's implementation                                                                                        |
+| ------------ | ----------------------------------------------------------------------------------------------------------- |
+| Trigger      | Discover picks a ready issue.                                                                               |
+| Topology     | Phase pipeline, roadmap decomposition, worktree-isolated parallel agents.                                   |
+| Verifier     | CI gates plus advisory bots (Copilot / CodeRabbit / Codex) and review triage.                               |
+| Stop rules   | Merge gates (claim / freshness / CI / advisory / review); the issue being closed is the terminal condition. |
 
 See [Core concepts](docs/concepts.md#idd-as-loop-engineering) for why
 strong verifiers and stop-gates matter.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -18,12 +18,12 @@ or multi-agent orchestration), its **verifier**, and its **stop
 rules**. Anthropic frames the same idea as **agentic loops**; IDD is a
 concrete, GitHub-native implementation of it.
 
-| Loop element | IDD's implementation                                                                                                  |
-| ------------ | --------------------------------------------------------------------------------------------------------------------- |
-| Trigger      | Discover picks a ready roadmap or orphan issue without silently widening scope.                                       |
-| Topology     | The phase pipeline, roadmap decomposition into sub-issues, and worktree-isolated parallel agents.                     |
-| Verifier     | CI gates plus advisory bots (Copilot / CodeRabbit / Codex), review triage, and disposition / unresolved-thread gates. |
-| Stop rules   | Merge gates recheck claim, freshness, CI, advisory, and review state; the issue closing is the terminal condition.    |
+| Loop element | IDD's implementation                                                                                                    |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Trigger      | Discover picks a ready roadmap or orphan issue without silently widening scope.                                         |
+| Topology     | The phase pipeline, roadmap decomposition into sub-issues, and worktree-isolated parallel agents.                       |
+| Verifier     | CI gates plus advisory bots (Copilot / CodeRabbit / Codex), review triage, and disposition / unresolved-thread gates.   |
+| Stop rules   | Merge gates recheck claim, freshness, CI, advisory, and review state; the issue being closed is the terminal condition. |
 
 Looping harder is not automatically looping better: assuming enough
 iterations will eventually converge on a correct result ("loopmaxxing")

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -9,6 +9,35 @@ For the shortest procedural path, start with
 [Getting started](getting-started.md). For phase routing and file
 ownership, use the [IDD workflow guide](idd-workflow.md).
 
+## IDD as Loop Engineering
+
+**Loop engineering** is the practice of designing the system that runs
+an agent through an act -> observe -> decide -> repeat cycle, instead
+of hand-prompting each step: its **trigger**, its **topology** (single-
+or multi-agent orchestration), its **verifier**, and its **stop
+rules**. Anthropic frames the same idea as **agentic loops**; IDD is a
+concrete, GitHub-native implementation of it.
+
+| Loop element | IDD's implementation                                                                                                  |
+| ------------ | --------------------------------------------------------------------------------------------------------------------- |
+| Trigger      | Discover picks a ready roadmap or orphan issue without silently widening scope.                                       |
+| Topology     | The phase pipeline, roadmap decomposition into sub-issues, and worktree-isolated parallel agents.                     |
+| Verifier     | CI gates plus advisory bots (Copilot / CodeRabbit / Codex), review triage, and disposition / unresolved-thread gates. |
+| Stop rules   | Merge gates recheck claim, freshness, CI, advisory, and review state; the issue closing is the terminal condition.    |
+
+Looping harder is not automatically looping better: assuming enough
+iterations will eventually converge on a correct result ("loopmaxxing")
+is a known failure mode, not a property that emerges for free. IDD
+avoids it by pairing every loop turn with the verifier and stop-rule
+gates above, and by recording claims, review snapshots, decisions, and
+cleanup markers as the durable issue-comment state described throughout
+this page — so progress is auditable rather than assumed.
+
+See [Discover](../.github/instructions/idd-discover.instructions.md),
+[review triage](../.github/instructions/idd-review-triage.instructions.md),
+and [merge execution](../.github/instructions/idd-merge.instructions.md)
+for the phase files behind this table.
+
 ## Claims and Heartbeats
 
 IDD agents coordinate through GitHub issue comments instead of a
@@ -106,6 +135,8 @@ status digest contract, cleanup policy, and helper notes.
 
 ## Where to Read Next
 
+- [IDD as Loop Engineering](#idd-as-loop-engineering) for the
+  trigger/topology/verifier/stop-rules framing this page opens with.
 - [Getting started](getting-started.md) for the first adoption path.
 - [IDD workflow guide](idd-workflow.md) for routing and phase ownership.
 - [Permissions and threat model](permissions.md) before granting

--- a/idd-template/docs/concepts.md
+++ b/idd-template/docs/concepts.md
@@ -18,12 +18,12 @@ or multi-agent orchestration), its **verifier**, and its **stop
 rules**. Anthropic frames the same idea as **agentic loops**; IDD is a
 concrete, GitHub-native implementation of it.
 
-| Loop element | IDD's implementation                                                                                                  |
-| ------------ | --------------------------------------------------------------------------------------------------------------------- |
-| Trigger      | Discover picks a ready roadmap or orphan issue without silently widening scope.                                       |
-| Topology     | The phase pipeline, roadmap decomposition into sub-issues, and worktree-isolated parallel agents.                     |
-| Verifier     | CI gates plus advisory bots (Copilot / CodeRabbit / Codex), review triage, and disposition / unresolved-thread gates. |
-| Stop rules   | Merge gates recheck claim, freshness, CI, advisory, and review state; the issue closing is the terminal condition.    |
+| Loop element | IDD's implementation                                                                                                    |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Trigger      | Discover picks a ready roadmap or orphan issue without silently widening scope.                                         |
+| Topology     | The phase pipeline, roadmap decomposition into sub-issues, and worktree-isolated parallel agents.                       |
+| Verifier     | CI gates plus advisory bots (Copilot / CodeRabbit / Codex), review triage, and disposition / unresolved-thread gates.   |
+| Stop rules   | Merge gates recheck claim, freshness, CI, advisory, and review state; the issue being closed is the terminal condition. |
 
 Looping harder is not automatically looping better: assuming enough
 iterations will eventually converge on a correct result ("loopmaxxing")

--- a/idd-template/docs/concepts.md
+++ b/idd-template/docs/concepts.md
@@ -9,6 +9,35 @@ For the shortest procedural path, start with
 [Getting started](getting-started.md). For phase routing and file
 ownership, use the [IDD workflow guide](idd-workflow.md).
 
+## IDD as Loop Engineering
+
+**Loop engineering** is the practice of designing the system that runs
+an agent through an act -> observe -> decide -> repeat cycle, instead
+of hand-prompting each step: its **trigger**, its **topology** (single-
+or multi-agent orchestration), its **verifier**, and its **stop
+rules**. Anthropic frames the same idea as **agentic loops**; IDD is a
+concrete, GitHub-native implementation of it.
+
+| Loop element | IDD's implementation                                                                                                  |
+| ------------ | --------------------------------------------------------------------------------------------------------------------- |
+| Trigger      | Discover picks a ready roadmap or orphan issue without silently widening scope.                                       |
+| Topology     | The phase pipeline, roadmap decomposition into sub-issues, and worktree-isolated parallel agents.                     |
+| Verifier     | CI gates plus advisory bots (Copilot / CodeRabbit / Codex), review triage, and disposition / unresolved-thread gates. |
+| Stop rules   | Merge gates recheck claim, freshness, CI, advisory, and review state; the issue closing is the terminal condition.    |
+
+Looping harder is not automatically looping better: assuming enough
+iterations will eventually converge on a correct result ("loopmaxxing")
+is a known failure mode, not a property that emerges for free. IDD
+avoids it by pairing every loop turn with the verifier and stop-rule
+gates above, and by recording claims, review snapshots, decisions, and
+cleanup markers as the durable issue-comment state described throughout
+this page — so progress is auditable rather than assumed.
+
+See [Discover](../.github/instructions/idd-discover.instructions.md),
+[review triage](../.github/instructions/idd-review-triage.instructions.md),
+and [merge execution](../.github/instructions/idd-merge.instructions.md)
+for the phase files behind this table.
+
 ## Claims and Heartbeats
 
 IDD agents coordinate through GitHub issue comments instead of a
@@ -106,6 +135,8 @@ status digest contract, cleanup policy, and helper notes.
 
 ## Where to Read Next
 
+- [IDD as Loop Engineering](#idd-as-loop-engineering) for the
+  trigger/topology/verifier/stop-rules framing this page opens with.
 - [Getting started](getting-started.md) for the first adoption path.
 - [IDD workflow guide](idd-workflow.md) for routing and phase ownership.
 - [Permissions and threat model](permissions.md) before granting


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Names "loop engineering" (Anthropic's "agentic loops") in the top
positioning copy of `README.md` / `README.ja.md` and positions IDD as
a portable, GitHub-native implementation of it, with a compact
trigger/topology/verifier/stop-rules mapping table cross-linked to a
new, deeper `docs/concepts.md` section (added at its canonical source,
`idd-template/docs/concepts.md`, and resynced).

## Linked issue

Closes #1332

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

"Loop engineering" is a currently-trending industry term for designing
the system around an agent's trigger, topology, verifier, and stop
rules instead of hand-prompting each step. IDD already maps onto this
almost exactly but never named the concept, so first-visit readers who
arrive with that mental model could not immediately recognize IDD as
an instance of it. The new copy stays grounded in IDD's existing,
already-shipped mechanics (Discover, CI/advisory gates, merge gates,
durable issue-comment state) rather than introducing new claims, and
explicitly avoids the "unbounded iteration eventually succeeds"
framing ("loopmaxxing") that the issue calls out as a misconception to
guard against.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
