### PR TITLE
docs(idd-review-triage): require follow-ups to cross-reference origin

### DIFF
--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -219,10 +219,14 @@ For each Rejected PATH A item whose source is reviewer feedback:
     and proceed through the fix flow.
   - If the reviewer responds: restart from E1.
 - If you decide "Reject now but should do eventually": open a new issue.
-  The new issue's body must include a structural cross-reference (for
-  example `Refs #NNN` on its own line, not narrative prose) back to the
-  PR and/or the issue it originated from, mirroring the A1.5 rule in
-  `idd-roadmap-audit.instructions.md`.
+  The new issue's body must include a `Refs #NNN` line on its own
+  line (not narrative prose) back to the originating issue — use
+  `Refs` specifically and reference the issue, never the PR: a
+  referenced PR is recorded as an unresolved reference by
+  `discover-roadmap-graph`, and only the `Refs` relationship is
+  cycle-exempt for a closed leaf, so a different keyword (e.g.
+  `Closes`) or a PR target can permanently block a later A1.5
+  closure. Mirrors the A1.5 rule in `idd-roadmap-audit.instructions.md`.
 
 Use these prefixes so that disposition is always unambiguous:
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -219,6 +219,10 @@ For each Rejected PATH A item whose source is reviewer feedback:
     and proceed through the fix flow.
   - If the reviewer responds: restart from E1.
 - If you decide "Reject now but should do eventually": open a new issue.
+  The new issue's body must include a structural cross-reference (for
+  example `Refs #NNN` on its own line, not narrative prose) back to the
+  PR and/or the issue it originated from, mirroring the A1.5 rule in
+  `idd-roadmap-audit.instructions.md`.
 
 Use these prefixes so that disposition is always unambiguous:
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -225,8 +225,9 @@ For each Rejected PATH A item whose source is reviewer feedback:
   referenced PR is recorded as an unresolved reference by
   `discover-roadmap-graph`, and only the `Refs` relationship is
   cycle-exempt for a closed leaf, so a different keyword (e.g.
-  `Closes`) or a PR target can permanently block a later A1.5
-  closure. Mirrors the A1.5 rule in `idd-roadmap-audit.instructions.md`.
+  `Closes`) or a PR target leaves the reference unresolved until
+  the issue body is corrected. Mention the originating PR in prose
+  if useful. Mirrors the A1.5 rule in `idd-roadmap-audit.instructions.md`.
 
 Use these prefixes so that disposition is always unambiguous:
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -214,6 +214,10 @@ For each Rejected PATH A item whose source is reviewer feedback:
     and proceed through the fix flow.
   - If the reviewer responds: restart from E1.
 - If you decide "Reject now but should do eventually": open a new issue.
+  The new issue's body must include a structural cross-reference (for
+  example `Refs #NNN` on its own line, not narrative prose) back to the
+  PR and/or the issue it originated from, mirroring the A1.5 rule in
+  `idd-roadmap-audit.instructions.md`.
 
 Use these prefixes so that disposition is always unambiguous:
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -214,10 +214,14 @@ For each Rejected PATH A item whose source is reviewer feedback:
     and proceed through the fix flow.
   - If the reviewer responds: restart from E1.
 - If you decide "Reject now but should do eventually": open a new issue.
-  The new issue's body must include a structural cross-reference (for
-  example `Refs #NNN` on its own line, not narrative prose) back to the
-  PR and/or the issue it originated from, mirroring the A1.5 rule in
-  `idd-roadmap-audit.instructions.md`.
+  The new issue's body must include a `Refs #NNN` line on its own
+  line (not narrative prose) back to the originating issue — use
+  `Refs` specifically and reference the issue, never the PR: a
+  referenced PR is recorded as an unresolved reference by
+  `discover-roadmap-graph`, and only the `Refs` relationship is
+  cycle-exempt for a closed leaf, so a different keyword (e.g.
+  `Closes`) or a PR target can permanently block a later A1.5
+  closure. Mirrors the A1.5 rule in `idd-roadmap-audit.instructions.md`.
 
 Use these prefixes so that disposition is always unambiguous:
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -220,8 +220,9 @@ For each Rejected PATH A item whose source is reviewer feedback:
   referenced PR is recorded as an unresolved reference by
   `discover-roadmap-graph`, and only the `Refs` relationship is
   cycle-exempt for a closed leaf, so a different keyword (e.g.
-  `Closes`) or a PR target can permanently block a later A1.5
-  closure. Mirrors the A1.5 rule in `idd-roadmap-audit.instructions.md`.
+  `Closes`) or a PR target leaves the reference unresolved until
+  the issue body is corrected. Mention the originating PR in prose
+  if useful. Mirrors the A1.5 rule in `idd-roadmap-audit.instructions.md`.
 
 Use these prefixes so that disposition is always unambiguous:
 


### PR DESCRIPTION
# Summary

- When review-triage (E5/E6) decides "Reject now but should do eventually"
  and opens a new follow-up issue, `idd-review-triage.instructions.md` now
  requires that issue's body to include a structural cross-reference (for
  example `Refs #NNN` on its own line, not narrative prose) back to the PR
  and/or the issue it originated from — mirroring the existing A1.5 rule in
  `idd-roadmap-audit.instructions.md`.
- Regenerated the mirrored copy at
  `.github/instructions/idd-review-triage.instructions.md` via
  `node scripts/sync-docs.mjs --apply`; `node scripts/audit-docs.mjs --check`
  reports zero drift.

## Linked issue

Closes #1330

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This surfaced when #1326 (a review-triage follow-up spun off from PR #1319,
itself linked to #1312, a child of roadmap #1309) mentioned `#1312` and
`#1319` only as narrative prose ("Follow-up from PR #1319 (#1312)
review...") — never as a structural cross-reference. Per A2's traversal
rules, only structural references (`Closes`/`Refs`/explicit sub-issue lines)
count as traversal sources, so #1326 was unreachable from the roadmap graph
despite having a clear conceptual origin.

**Scope note**: this documents provenance for humans and future audits
reading the follow-up issue directly; it does not, by itself, make the
follow-up automatically forward-reachable via A2's outbound graph traversal
(that still requires an already-visited node — e.g. a task list entry — to
link forward to the new issue). The existing A1.5 rule this change mirrors
has the same characteristic; A1.5 additionally updates the roadmap task list
at creation time as the real graph-wiring step. Fully closing that gap for
E5/E6 follow-ups (which don't always have a roadmap task list to update) is
out of scope for this issue's literal acceptance criteria and is left as
possible future follow-up.

**Byte budget**: `idd-review-triage.instructions.md` participates in the
`bundle-review` bundle budget (`audit/sync-manifest.json`,
`limitBytes: 115300`). Before this change the bundle measured ~111,279 bytes
(~96.5% utilized) — inside the "near-ceiling" band from
`docs/policy-constants.md`, where policy prefers a small/trimmed addition
over a ratchet bump. The added text is a single ~250-byte sentence; the
bundle now measures ~111,529 bytes (~96.73%, ~3,771 bytes headroom). No
`limitBytes` change was needed.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable) — passed, only
      pre-existing unrelated warnings (missing adopter profile READMEs,
      worktree-guard hook path, release-tag drift, branch protection
      readability)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
