### PR TITLE
docs(idd-work): introduce C1 before C2/C4 skip conditions

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -233,15 +233,6 @@ or commits.
 
 ## C — Self-Review Loop
 
-**Skip condition C2**: if the critique pass finds zero issues, skip to
-`idd-pr-submit.instructions.md`.
-
-**Skip condition C4**: if Accept count is zero, or if the loop has run
-more than `critiqueLoop.cPhaseLowSeveritySkipAfter` times (distributed
-default: `3`) and all remaining Accepts are severity Low (minor
-improvements unrelated to PR intent), skip to
-`idd-pr-submit.instructions.md`.
-
 ### C1 — Critique pass
 
 Run a critique pass on this branch's diff. Ask it to check whether the

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -228,15 +228,6 @@ or commits.
 
 ## C — Self-Review Loop
 
-**Skip condition C2**: if the critique pass finds zero issues, skip to
-`idd-pr-submit.instructions.md`.
-
-**Skip condition C4**: if Accept count is zero, or if the loop has run
-more than `critiqueLoop.cPhaseLowSeveritySkipAfter` times (distributed
-default: `3`) and all remaining Accepts are severity Low (minor
-improvements unrelated to PR intent), skip to
-`idd-pr-submit.instructions.md`.
-
 ### C1 — Critique pass
 
 Run a critique pass on this branch's diff. Ask it to check whether the


### PR DESCRIPTION
# Summary

`idd-work.instructions.md`'s `## C — Self-Review Loop` section opened
with the C2/C4 "Skip condition" bullets before `### C1 — Critique pass`
was ever introduced. Both bullets already restate their conditions
inline within their own `### C2` and `### C4` subsections, so this PR
removes the redundant top-of-section preview instead of just reordering
it — nothing is lost, and `### C1 — Critique pass` is now the first
content a reader encounters after the section heading.

## Linked issue

Closes #1336

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

An executing agent went straight from B3 to D without running the C1-C6
self-review loop, and #1336's own analysis traced part of that to the
structure of this section: two consecutive "Skip condition" bullets sit
before the reader ever learns what C1 (the critique pass) actually asks
for, priming a skimming read toward "this phase is skippable."

Both options #1336 offered for the fix are equivalent here because the
skip-condition text is already duplicated verbatim inside C2/C4:

- C2's top bullet: "if the critique pass finds zero issues, skip to
  `idd-pr-submit.instructions.md`." — C2 itself already says: "If the
  critique pass reports zero issues → skip to
  `idd-pr-submit.instructions.md`."
- C4's top bullet restates the same Accept-count-zero /
  `critiqueLoop.cPhaseLowSeveritySkipAfter` loop-count logic that C4
  itself already lists as bullets, including the `critiqueLoop.cPhaseLowSeveritySkipAfter`
  default. C3 (which precedes C4 both before and after this edit)
  already defines "Low" severity, so C4's inline wording stays fully
  self-contained.

So "move the skip conditions to follow C1, inline within C2/C4's own
subsections, where they already conceptually belong" reduces to: delete
the duplicate preview. No behavioral or semantic change — same
`critiqueLoop.cPhaseLowSeveritySkipAfter` semantics, same C2/C4
outcomes, just stated once instead of twice.

This also improves the `bundle-work` byte budget margin
(`idd-overview-core` + `idd-overview-appendix` + `idd-work`): 36808 →
36417 bytes against a 37400-byte limit (margin 592 → 983 bytes).

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (ran `pnpm run lint:minimum` directly, per #1336's
  acceptance criteria: audit-docs, typecheck, build:check, biome,
  dprint, the `.mts` test suite (1826 tests), verify-workshop-integrity,
  cspell, markdownlint — all pass)
- [x] `pnpm test` (included in `lint:minimum` above — 1826/1826 pass)
- [x] `node scripts/audit-docs.mjs --check` (zero drift)
- [x] `pnpm run docs:sync:check` (mirror up to date)
- [x] `node scripts/idd-doctor.mjs` (passed, 4 pre-existing
  environment-only warnings unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — docs-only wording reorder)
- [x] Context budget impact reviewed (`bundle-work` byte budget
  improved, see Background above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated self-review workflow guidance by removing the documented skip conditions for specific review-loop outcomes.
  * The remaining self-review process steps are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->