### PR TITLE
fix(idd-discover): fast-fail A0-T on an already-claimed target

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -69,8 +69,9 @@ that issue only:
      resolve through the same scoped body-content lookup used by A3, and
      the matching roadmap work is closed or otherwise complete;
    - no external human coordination is required to start;
-   - no active, non-stale, trusted-actor claim exists on the target
-     (A4 Step 1.5 rules); a hit reports `already claimed`, same as A5.
+   - no active, non-stale claim from a trusted marker actor exists on
+     the target (A4 Step 1.5 rules); a hit reports "already claimed",
+     same as A5.
 4. Run the normal A4 viability gate against the target only.
 5. Apply the **A3.5** issue-author approval gate against the target.
    If A3.5 classifies it as not startable, report that the gate

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -68,7 +68,9 @@ that issue only:
    - hidden `<!-- idd-skill-blocked-by: {roadmap-id} -->` markers
      resolve through the same scoped body-content lookup used by A3, and
      the matching roadmap work is closed or otherwise complete;
-   - no external human coordination is required to start.
+   - no external human coordination is required to start;
+   - no active, non-stale, trusted-actor claim exists on the target
+     (A4 Step 1.5 rules); a hit reports `already claimed`, same as A5.
 4. Run the normal A4 viability gate against the target only.
 5. Apply the **A3.5** issue-author approval gate against the target.
    If A3.5 classifies it as not startable, report that the gate

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -70,7 +70,8 @@ that issue only:
      the matching roadmap work is closed or otherwise complete;
    - no external human coordination is required to start;
    - no active, non-stale claim from a trusted marker actor exists on
-     the target (A4 Step 1.5 rules); a hit reports "already claimed",
+     the target, other than a claim this session already recorded and
+     verified (A4 Step 1.5 rules); a hit reports "already claimed",
      same as A5.
 4. Run the normal A4 viability gate against the target only.
 5. Apply the **A3.5** issue-author approval gate against the target.

--- a/README.ja.md
+++ b/README.ja.md
@@ -145,7 +145,7 @@ IDD は instruction の増加を機械的に上限管理します。下表に記
 | 予算タイプ                      | 維持される値 |
 | ------------------------------- | ------------ |
 | 常時ロード instruction ファイル | 20,000 bytes |
-| フェーズ instruction ファイル   | 32,200 bytes |
+| フェーズ instruction ファイル   | 35,500 bytes |
 
 正規の値と所有箇所は
 [Policy constants: Runtime Instruction Size and Bundle Budgets](docs/policy-constants.md#runtime-instruction-size-and-bundle-budgets)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ here, so those bundle values cannot drift in the docs:
 | Budget type                    | Maintained value |
 | ------------------------------ | ---------------- |
 | Always-loaded instruction file | 20,000 bytes     |
-| Phase instruction file         | 32,200 bytes     |
+| Phase instruction file         | 35,500 bytes     |
 
 See [Policy constants: Runtime Instruction Size and Bundle
 Budgets](docs/policy-constants.md#runtime-instruction-size-and-bundle-budgets)

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -148,7 +148,7 @@
     "glob": ".github/instructions/idd-*.instructions.md",
     "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
     "alwaysLoadedLimitBytes": 20000,
-    "phaseLimitBytes": 32200
+    "phaseLimitBytes": 35500
   },
   "bundleBudgets": [
     {

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -281,7 +281,7 @@ files, or express it without the `bytes` suffix.
 | Limit type    | Value        | Applies to                                                                 | Rationale                                                                                                                                                                                               |
 | ------------- | ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Always-loaded | 20,000 bytes | Files with `applyTo: "**"` in `.github/instructions/idd-*.instructions.md` | These files load on every phase regardless of which is active, so this is the strictest ceiling — it bounds the fixed floor cost every session pays before any phase-specific content is even selected. |
-| Phase         | 32,200 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
+| Phase         | 35,500 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
 
 ### Bundle limits
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -69,7 +69,10 @@ that issue only:
      `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: {roadmap-id} -->`
      markers resolve through the same scoped body-content lookup used by
      A3, and the matching roadmap work is closed or otherwise complete;
-   - no external human coordination is required to start.
+   - no external human coordination is required to start;
+   - no active, non-stale, trusted-actor claim already exists on the
+     target, per the same parse rules as A4 Step 1.5 (the early
+     "already claimed" outcome A5 would otherwise reach).
 4. Run the normal A4 viability gate against the target only.
 5. Apply the **A3.5** issue-author approval gate against the target.
    If A3.5 classifies it as not startable, report that the gate

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -70,9 +70,10 @@ that issue only:
      markers resolve through the same scoped body-content lookup used by
      A3, and the matching roadmap work is closed or otherwise complete;
    - no external human coordination is required to start;
-   - no active, non-stale claim from a trusted marker actor already
-     exists on the target, per the same parse rules as A4 Step 1.5 (the
-     early "already claimed" outcome A5 would otherwise reach).
+   - no active, non-stale claim from a trusted marker actor, other than
+     a claim this session already recorded and verified, already exists
+     on the target — per the same parse rules as A4 Step 1.5 (the early
+     "already claimed" outcome A5 would otherwise reach).
 4. Run the normal A4 viability gate against the target only.
 5. Apply the **A3.5** issue-author approval gate against the target.
    If A3.5 classifies it as not startable, report that the gate

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -70,10 +70,10 @@ that issue only:
      markers resolve through the same scoped body-content lookup used by
      A3, and the matching roadmap work is closed or otherwise complete;
    - no external human coordination is required to start;
-   - no active, non-stale claim from a trusted marker actor, other than
-     a claim this session already recorded and verified, already exists
-     on the target — per the same parse rules as A4 Step 1.5 (the early
-     "already claimed" outcome A5 would otherwise reach).
+   - no active, non-stale claim from a trusted marker actor exists on
+     the target, other than a claim this session itself already
+     recorded and verified — per the same parse rules as A4 Step 1.5
+     (the early "already claimed" outcome A5 would otherwise reach).
 4. Run the normal A4 viability gate against the target only.
 5. Apply the **A3.5** issue-author approval gate against the target.
    If A3.5 classifies it as not startable, report that the gate

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -70,9 +70,9 @@ that issue only:
      markers resolve through the same scoped body-content lookup used by
      A3, and the matching roadmap work is closed or otherwise complete;
    - no external human coordination is required to start;
-   - no active, non-stale, trusted-actor claim already exists on the
-     target, per the same parse rules as A4 Step 1.5 (the early
-     "already claimed" outcome A5 would otherwise reach).
+   - no active, non-stale claim from a trusted marker actor already
+     exists on the target, per the same parse rules as A4 Step 1.5 (the
+     early "already claimed" outcome A5 would otherwise reach).
 4. Run the normal A4 viability gate against the target only.
 5. Apply the **A3.5** issue-author approval gate against the target.
    If A3.5 classifies it as not startable, report that the gate

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -281,7 +281,7 @@ files, or express it without the `bytes` suffix.
 | Limit type    | Value        | Applies to                                                                 | Rationale                                                                                                                                                                                               |
 | ------------- | ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Always-loaded | 20,000 bytes | Files with `applyTo: "**"` in `.github/instructions/idd-*.instructions.md` | These files load on every phase regardless of which is active, so this is the strictest ceiling — it bounds the fixed floor cost every session pays before any phase-specific content is even selected. |
-| Phase         | 32,200 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
+| Phase         | 35,500 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
 
 ### Bundle limits
 


### PR DESCRIPTION
# Summary

Add an early active-claim check to A0-T's targeted readiness checks (step
3) so an explicit-target Discover run against an already-claimed issue
fails fast, before paying the full A4 (viability) / A3.5 (approval) /
A4.5 (suitability) gate pass. The check reuses A4 Step 1.5's exact
claim-state parse rules (trusted marker actor, documented `claimed-by`
format, 24h staleness) — it is purely additive and does not change A5's
own claim-state, takeover, or verification logic.

## Linked issue

Closes #1337

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

`idd-discover.instructions.md` was already at 32163/32200 bytes (99.9%
of its phase limit) and `bundle-discovery` at 97.2% of its bundle limit
— both past the near-ceiling threshold documented in
`docs/policy-constants.md`, where policy prefers trimming over a ratchet
bump. The generated instruction file uses a `structure`-mode sync pair
(only heading signature is cross-checked against the
`idd-template/` source, so the two may diverge in wording) and its prose
is already hand-compressed relative to the template, so no low-risk
non-normative trim was available without touching normative content.

Ratcheted `phaseLimitBytes` 32200 → 35500 (~10% headroom over the new
32302-byte file), following the same pattern as commit `b6c496a`
(precedent: ratchet `phaseLimitBytes` + update doc mirrors when a
legitimate addition pushes past budget). `bundle-discovery`'s own limit
(100400) did not need to move — the new bundle total (97689) still fits
under it. Updated the four doc mirrors the `doc-budget-drift` guard
cross-checks: `README.md`, `README.ja.md`, `docs/policy-constants.md`,
and its `idd-template` source.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (1826/1826 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
