### PR TITLE
feat(pre-merge): add advisory-convergence policy-engine helper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 # their diffs collapse in review. Listed per file during the TypeScript
 # migration so hand-written .mjs are never mis-marked; see
 # docs/typescript-sources.md.
+scripts/advisory-convergence.mjs linguist-generated=true
 scripts/advisory-wait-policy.mjs linguist-generated=true
 scripts/advisory-wait-state.mjs linguist-generated=true
 scripts/audit-docs.mjs linguist-generated=true

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -277,38 +277,19 @@ returns the workflow to E1 instead of merging over it.
   E1's regular-comment filter for non-advisory discussion. Copilot and
   CI advisory bot comments are handled earlier in the PATH B triage flow
   (E4-E7) and are excluded from this gate.
-- **E7 disposition evidence complete**: If helper evidence includes a
-  `dispositionEvidence` section, require
-  `dispositionEvidence.route == "proceed"` and
-  `dispositionEvidence.blockingCount == 0`. If either check fails, route
-  to E1/E4 with the missing-thread or missing-comment evidence reported
-  from that section. This gate consumes the `pre-merge-readiness`
-  `dispositionEvidence` shape only; do not substitute E7 verifier fields
-  (`passed`, `items[]`) here.
-
-  Deterministic override (advisory-only): if `dispositionEvidence.route`
-  is `return-to-e1` but `dispositionEvidence.soleCauseAckOnlyPostDisposition`
-  is `true` — every blocking item is an `ackOnlyPostDisposition` resolved
-  thread, with no missing regular comments — autopilot **may** treat this
-  gate as satisfied and proceed on the current HEAD SHA, mirroring the
-  review-currency ack-only carve-out. The override applies to that signal
-  **only**; any other `return-to-e1` cause (a missing regular comment, or
-  any thread whose `ackOnlyPostDisposition` is `false`) keeps the backstop
-  and routes to E1/E4 unchanged.
-
-  `dispositionEvidence.soleCauseInPlaceEditOnly` (and the per-thread
-  `inPlaceEditOnly`) is **informational-only**, not a second deterministic
-  override (#1313): it is a narrower sibling of `ackOnlyPostDisposition`
-  that additionally confirms the blocking comment is an edit of content
-  that already existed at-or-before its thread's disposition, rather than
-  a brand-new post-disposition comment. GitHub's API exposes no revision
-  diff for an edited comment, so neither this field nor the helper that
-  computes it can verify whether the edit only added cosmetic content
-  (e.g. an "addressed" badge) or changed the substance of the finding. An
-  agent may use it as a stronger hint when deciding whether to invoke the
-  `soleCauseAckOnlyPostDisposition` override above, but must still read
-  the comment's current body before doing so — this field alone never
-  authorizes proceeding.
+- **Advisory convergence** (exit-code obligation for Copilot-authored
+  review threads, not a judgment call): run `node
+  scripts/advisory-convergence.mjs --pr {pr-number} --assert` (or the
+  profile-selected `idd-advisory-convergence` command). A non-zero exit
+  is a hard merge block — route to E1/E4 using the printed `reasons`; a
+  zero exit (`ready: true`) satisfies this condition.
+  Separately, if helper evidence includes `dispositionEvidence`, require
+  `dispositionEvidence.missingRegularComments.length == 0` (ad hoc
+  advisory-bot or reviewer comments outside a review thread, which the
+  helper above does not cover). A non-empty list routes to E1/E4 with
+  that evidence.
+  Fails closed per the shared default: if either check cannot run or its
+  output is unusable, treat this condition as unmet.
 
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the PR live status digest after the blocking evidence is recorded and

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -283,11 +283,12 @@ returns the workflow to E1 instead of merging over it.
   profile-selected `idd-advisory-convergence` command). A non-zero exit
   is a hard merge block — route to E1/E4 using the printed `reasons`; a
   zero exit (`ready: true`) satisfies this condition.
-  Separately, if helper evidence includes `dispositionEvidence`, require
-  `dispositionEvidence.missingRegularComments.length == 0` (ad hoc
-  advisory-bot or reviewer comments outside a review thread, which the
-  helper above does not cover). A non-empty list routes to E1/E4 with
-  that evidence.
+  Separately, require `dispositionEvidence.missingRegularComments.length
+  == 0` (ad hoc advisory-bot or reviewer comments outside a review
+  thread, which the helper above does not cover); treat absent,
+  malformed, or non-list `dispositionEvidence`/`missingRegularComments`
+  as unmet, not as vacuously satisfied. A non-empty (or unusable) result
+  routes to E1/E4 with that evidence.
   Fails closed per the shared default: if either check cannot run or its
   output is unusable, treat this condition as unmet.
 

--- a/bin/idd-advisory-convergence.mjs
+++ b/bin/idd-advisory-convergence.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-advisory-convergence.mts
+//
+// The bin/idd-advisory-convergence.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/advisory-convergence.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1137,9 +1137,10 @@ Interpretation rules:
   verdict (the intended shape for #1341's workflow).
 - Stable contract:
   [`advisory-convergence.schema.json`][advisory-convergence-schema]
-- Always prints the JSON verdict. Without `--assert` it always exits `0`
-  (report-only). With `--assert` it exits non-zero unless `ready` is
-  `true` (`ready = converged || (deadline passed && validly waived)`).
+- Every invocation other than `--help`/`-h` prints the JSON verdict.
+  Without `--assert` it always exits `0` (report-only). With `--assert` it
+  exits non-zero unless `ready` is `true` (`ready = converged || (deadline
+  passed && validly waived)`).
 - **Deadlock / deadline policy**: while the primary bot has not reviewed
   the current HEAD, `pending` is `true` and the gate is not ready. After
   `advisoryWait.convergenceDeadline` (default 24h; see

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1148,8 +1148,12 @@ Interpretation rules:
   path is a valid maintainer external-check waiver for that HEAD under the
   selector `idd-advisory-convergence` (reusing the same
   `<!-- idd-external-check-waiver: ... -->` marker format and validity
-  rules as `external-check-waiver.mjs`, gated the same way by
-  `ciGate.externalCheckWaivers.mode == "maintainer-authorized"`).
+  rules as `external-check-waiver.mjs`). Gated by the same two-dimensional
+  opt-in every other external-check waiver already requires:
+  `ciGate.externalCheckWaivers.mode == "maintainer-authorized"` **and**
+  `idd-advisory-convergence` registered under
+  `ciGate.externalChecks.waivable` — enabling waiver mode for some other
+  external check never silently makes this gate waivable too.
 - Reuses the existing evidence modules — `isCopilotReviewerLogin` /
   `readAdvisoryPrimaryBotLogin`, `resolveAdvisoryBotLogins`,
   `resolveTrustedMarkerActors`, `summarizeDispositionEvidenceForGate`,

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -85,6 +85,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/idd-merge-execute.mjs` for the F3 merge gate: a dry-run
   verdict by default and, with `--apply`, the bound merge execution; it
   wraps `pre-merge-readiness` and adds no new decision authority
+- `scripts/advisory-convergence.mjs` for the F2 advisory/disposition
+  sub-gate (#1340): a deterministic `converged`/`ready` verdict with an
+  exit-code contract via `--assert`, claim-independent so it also works
+  as a required-check-able CI verdict
 - `scripts/live-status-digest.mjs` for issue or PR live status digest
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
@@ -1113,6 +1117,49 @@ Interpretation rules:
   merge steps in `idd-merge.instructions.md`. The written F3 decision
   table and gate checklist remain canonical.
 
+### Advisory convergence (F2)
+
+- Read-only policy-engine helper (#1340) that deterministically asserts
+  whether the primary advisory bot's ("Copilot's") review has _converged_
+  on the current PR HEAD: `converged` = (the latest primary-bot review's
+  `commit_id` equals the current HEAD **and** that review carries zero
+  actionable items) **and** (every current-HEAD primary-bot-authored review
+  thread is resolved **or** carries a valid disposition marker).
+- Command: `node scripts/advisory-convergence.mjs --pr <pr-number>
+  [--claim-issue <issue-number>] [--owner <owner>] [--repo <repo>]
+  [--trusted-marker-logins "<login1,login2>"]
+  [--advisory-bot-logins "<bot1,bot2>"] [--now <ISO8601>] [--assert]`.
+  Unlike `pre-merge-readiness`, no claim flags are required: the linked
+  issue (and its active claim, needed only for the waiver check below) is
+  auto-discovered from the PR's closing references, the same way
+  `external-check-waiver.mjs`'s `--apply` path already resolves it — so
+  this helper also works as a claim-independent, required-check-able CI
+  verdict (the intended shape for #1341's workflow).
+- Stable contract:
+  [`advisory-convergence.schema.json`][advisory-convergence-schema]
+- Always prints the JSON verdict. Without `--assert` it always exits `0`
+  (report-only). With `--assert` it exits non-zero unless `ready` is
+  `true` (`ready = converged || (deadline passed && validly waived)`).
+- **Deadlock / deadline policy**: while the primary bot has not reviewed
+  the current HEAD, `pending` is `true` and the gate is not ready. After
+  `advisoryWait.convergenceDeadline` (default 24h; see
+  [policy constants](policy-constants.md#advisory-review-defaults)) has
+  elapsed since the current HEAD commit's own timestamp, the only pass
+  path is a valid maintainer external-check waiver for that HEAD under the
+  selector `idd-advisory-convergence` (reusing the same
+  `<!-- idd-external-check-waiver: ... -->` marker format and validity
+  rules as `external-check-waiver.mjs`, gated the same way by
+  `ciGate.externalCheckWaivers.mode == "maintainer-authorized"`).
+- Reuses the existing evidence modules — `isCopilotReviewerLogin` /
+  `readAdvisoryPrimaryBotLogin`, `resolveAdvisoryBotLogins`,
+  `resolveTrustedMarkerActors`, `summarizeDispositionEvidenceForGate`,
+  `summarizeClaimValidation`, and `summarizeExternalCheckWaivers` — rather
+  than duplicating review- or waiver-parsing logic; only the
+  Copilot-thread-authorship filter and the review-item-count read are new.
+- Fail closed: if helper execution fails, output is invalid JSON, or
+  required fields are missing, discard helper output and apply the
+  written F2 advisory/disposition sub-gate check manually.
+
 ### E7 disposition verification
 
 - Preferred command when helper runtime is enabled:
@@ -1376,6 +1423,7 @@ Good future candidates remain read-only evidence collectors for
 pre-merge readiness or later claim-state inspection. They should not
 replace the written decision tables.
 
+[advisory-convergence-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-convergence.schema.json
 [advisory-wait-state-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-wait-state.schema.json
 [disposition-non-review-notices-schema]: https://kurone-kito.github.io/idd-skill/schemas/disposition-non-review-notices.schema.json
 [idd-merge-execute-schema]: https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -170,12 +170,19 @@ The current policy schema and helper runtime now support
 `.github/idd/config.json` `advisoryWait.requestCap`,
 `advisoryWait.pendingWindow`, `advisoryWait.settledWindow`,
 `advisoryWait.pollInterval`, `advisoryWait.capExhaustedRoute`,
-`advisoryWait.primaryBotLogin`, and `advisoryWait.secondaryBotLogin`.
-Omitted keys keep the distributed defaults below. The three duration keys
+`advisoryWait.primaryBotLogin`, `advisoryWait.secondaryBotLogin`, and
+`advisoryWait.convergenceDeadline`.
+Omitted keys keep the distributed defaults below. The four duration keys
 accept positive whole-minute ISO 8601 durations only.
 `advisoryWait.primaryBotLogin` selects the advisory bot whose review the
 advisory-wait gate tracks; it defaults to Copilot, so omitting it
 preserves the Copilot-advisory behavior exactly.
+`advisoryWait.convergenceDeadline` is the `advisory-convergence.mjs` helper's
+(#1340) deadlock deadline: while the primary bot has not posted a zero-item
+review on the current PR HEAD, the gate reports pending; once this deadline
+elapses (measured from the current HEAD commit's own timestamp, not an IDD
+marker), the only pass path is a valid maintainer external-check waiver for
+that HEAD under the selector `idd-advisory-convergence`.
 `advisoryWait.secondaryBotLogin` is an **optional, non-gating** supplement:
 when set, the secondary bot is requested once per HEAD only while the
 primary is cap-exhausted or stalled / rate-limited. It never satisfies the
@@ -196,6 +203,7 @@ install without a requestable-reviewer event cannot be tracked once per HEAD.
 | Primary advisory bot login              | `copilot` (via `advisoryWait.primaryBotLogin`)                               | [Review fix](../.github/instructions/idd-review-fix.instructions.md), [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)                                                                     | Keep Copilot unless the repository routes the advisory-wait gate to a different primary bot.          |
 | Secondary advisory bot supplement       | unset (optional `advisoryWait.secondaryBotLogin`; non-gating, once per HEAD) | [Review fix](../.github/instructions/idd-review-fix.instructions.md), [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)                                                                     | Leave unset unless the repository wants a non-gating fallback reviewer when the primary is throttled. |
 | Human re-review response wait           | 30 min after addressed `CHANGES_REQUESTED` feedback has a re-review request  | [Pre-merge](../.github/instructions/idd-pre-merge.instructions.md)                                                                                                                                                   | Keep unless the repository has a different required-reviewer response window.                         |
+| Advisory-convergence deadline           | 24 h (`advisoryWait.convergenceDeadline`)                                    | [Pre-merge](../.github/instructions/idd-pre-merge.instructions.md), [Helper scripts](idd-helper-scripts.md)                                                                                                          | Keep unless the repository needs a different bound before the maintainer waiver escape hatch applies. |
 
 ## CI Wait Defaults
 

--- a/fixtures/schemas/advisory-convergence.invalid.json
+++ b/fixtures/schemas/advisory-convergence.invalid.json
@@ -1,0 +1,38 @@
+{
+  "protocolVersion": "1",
+  "decisionAuthority": "instructions",
+  "prNumber": 1340,
+  "prHeadSha": "",
+  "now": "2026-07-11T12:00:00Z",
+  "primaryBotLogin": "copilot",
+  "review": {
+    "found": false,
+    "commitId": "",
+    "matchesHead": false,
+    "itemCount": null,
+    "submittedAt": "",
+    "satisfied": false
+  },
+  "threads": {
+    "copilotThreadCount": 0,
+    "blockingIds": [],
+    "blockingCount": 0,
+    "satisfied": true
+  },
+  "pending": true,
+  "deadline": {
+    "minutes": 1440,
+    "headCommittedAt": "",
+    "elapsedMinutes": null,
+    "passed": false
+  },
+  "waiver": {
+    "mode": "disabled",
+    "checkSelector": "idd-advisory-convergence",
+    "activeClaimId": "",
+    "validCount": 0
+  },
+  "converged": false,
+  "waived": false,
+  "ready": true
+}

--- a/fixtures/schemas/advisory-convergence.valid.json
+++ b/fixtures/schemas/advisory-convergence.valid.json
@@ -1,0 +1,39 @@
+{
+  "protocolVersion": "1",
+  "decisionAuthority": "instructions",
+  "prNumber": 1340,
+  "prHeadSha": "0123456789abcdef0123456789abcdef01234567",
+  "now": "2026-07-11T12:00:00Z",
+  "primaryBotLogin": "copilot",
+  "review": {
+    "found": true,
+    "commitId": "0123456789abcdef0123456789abcdef01234567",
+    "matchesHead": true,
+    "itemCount": 0,
+    "submittedAt": "2026-07-11T10:00:00Z",
+    "satisfied": true
+  },
+  "threads": {
+    "copilotThreadCount": 0,
+    "blockingIds": [],
+    "blockingCount": 0,
+    "satisfied": true
+  },
+  "pending": false,
+  "deadline": {
+    "minutes": 1440,
+    "headCommittedAt": "2026-07-11T09:00:00Z",
+    "elapsedMinutes": 180,
+    "passed": false
+  },
+  "waiver": {
+    "mode": "disabled",
+    "checkSelector": "idd-advisory-convergence",
+    "activeClaimId": "",
+    "validCount": 0
+  },
+  "converged": true,
+  "waived": false,
+  "ready": true,
+  "reasons": []
+}

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -272,38 +272,19 @@ returns the workflow to E1 instead of merging over it.
   E1's regular-comment filter for non-advisory discussion. Copilot and
   CI advisory bot comments are handled earlier in the PATH B triage flow
   (E4-E7) and are excluded from this gate.
-- **E7 disposition evidence complete**: If helper evidence includes a
-  `dispositionEvidence` section, require
-  `dispositionEvidence.route == "proceed"` and
-  `dispositionEvidence.blockingCount == 0`. If either check fails, route
-  to E1/E4 with the missing-thread or missing-comment evidence reported
-  from that section. This gate consumes the `pre-merge-readiness`
-  `dispositionEvidence` shape only; do not substitute E7 verifier fields
-  (`passed`, `items[]`) here.
-
-  Deterministic override (advisory-only): if `dispositionEvidence.route`
-  is `return-to-e1` but `dispositionEvidence.soleCauseAckOnlyPostDisposition`
-  is `true` — every blocking item is an `ackOnlyPostDisposition` resolved
-  thread, with no missing regular comments — autopilot **may** treat this
-  gate as satisfied and proceed on the current HEAD SHA, mirroring the
-  review-currency ack-only carve-out. The override applies to that signal
-  **only**; any other `return-to-e1` cause (a missing regular comment, or
-  any thread whose `ackOnlyPostDisposition` is `false`) keeps the backstop
-  and routes to E1/E4 unchanged.
-
-  `dispositionEvidence.soleCauseInPlaceEditOnly` (and the per-thread
-  `inPlaceEditOnly`) is **informational-only**, not a second deterministic
-  override (#1313): it is a narrower sibling of `ackOnlyPostDisposition`
-  that additionally confirms the blocking comment is an edit of content
-  that already existed at-or-before its thread's disposition, rather than
-  a brand-new post-disposition comment. GitHub's API exposes no revision
-  diff for an edited comment, so neither this field nor the helper that
-  computes it can verify whether the edit only added cosmetic content
-  (e.g. an "addressed" badge) or changed the substance of the finding. An
-  agent may use it as a stronger hint when deciding whether to invoke the
-  `soleCauseAckOnlyPostDisposition` override above, but must still read
-  the comment's current body before doing so — this field alone never
-  authorizes proceeding.
+- **Advisory convergence** (exit-code obligation for Copilot-authored
+  review threads, not a judgment call): run `node
+  scripts/advisory-convergence.mjs --pr {pr-number} --assert` (or the
+  profile-selected `idd-advisory-convergence` command). A non-zero exit
+  is a hard merge block — route to E1/E4 using the printed `reasons`; a
+  zero exit (`ready: true`) satisfies this condition.
+  Separately, if helper evidence includes `dispositionEvidence`, require
+  `dispositionEvidence.missingRegularComments.length == 0` (ad hoc
+  advisory-bot or reviewer comments outside a review thread, which the
+  helper above does not cover). A non-empty list routes to E1/E4 with
+  that evidence.
+  Fails closed per the shared default: if either check cannot run or its
+  output is unusable, treat this condition as unmet.
 
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the PR live status digest after the blocking evidence is recorded and

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -278,11 +278,12 @@ returns the workflow to E1 instead of merging over it.
   profile-selected `idd-advisory-convergence` command). A non-zero exit
   is a hard merge block — route to E1/E4 using the printed `reasons`; a
   zero exit (`ready: true`) satisfies this condition.
-  Separately, if helper evidence includes `dispositionEvidence`, require
-  `dispositionEvidence.missingRegularComments.length == 0` (ad hoc
-  advisory-bot or reviewer comments outside a review thread, which the
-  helper above does not cover). A non-empty list routes to E1/E4 with
-  that evidence.
+  Separately, require `dispositionEvidence.missingRegularComments.length
+  == 0` (ad hoc advisory-bot or reviewer comments outside a review
+  thread, which the helper above does not cover); treat absent,
+  malformed, or non-list `dispositionEvidence`/`missingRegularComments`
+  as unmet, not as vacuously satisfied. A non-empty (or unusable) result
+  routes to E1/E4 with that evidence.
   Fails closed per the shared default: if either check cannot run or its
   output is unusable, treat this condition as unmet.
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1137,9 +1137,10 @@ Interpretation rules:
   verdict (the intended shape for #1341's workflow).
 - Stable contract:
   [`advisory-convergence.schema.json`][advisory-convergence-schema]
-- Always prints the JSON verdict. Without `--assert` it always exits `0`
-  (report-only). With `--assert` it exits non-zero unless `ready` is
-  `true` (`ready = converged || (deadline passed && validly waived)`).
+- Every invocation other than `--help`/`-h` prints the JSON verdict.
+  Without `--assert` it always exits `0` (report-only). With `--assert` it
+  exits non-zero unless `ready` is `true` (`ready = converged || (deadline
+  passed && validly waived)`).
 - **Deadlock / deadline policy**: while the primary bot has not reviewed
   the current HEAD, `pending` is `true` and the gate is not ready. After
   `advisoryWait.convergenceDeadline` (default 24h; see

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1148,8 +1148,12 @@ Interpretation rules:
   path is a valid maintainer external-check waiver for that HEAD under the
   selector `idd-advisory-convergence` (reusing the same
   `<!-- idd-external-check-waiver: ... -->` marker format and validity
-  rules as `external-check-waiver.mjs`, gated the same way by
-  `ciGate.externalCheckWaivers.mode == "maintainer-authorized"`).
+  rules as `external-check-waiver.mjs`). Gated by the same two-dimensional
+  opt-in every other external-check waiver already requires:
+  `ciGate.externalCheckWaivers.mode == "maintainer-authorized"` **and**
+  `idd-advisory-convergence` registered under
+  `ciGate.externalChecks.waivable` — enabling waiver mode for some other
+  external check never silently makes this gate waivable too.
 - Reuses the existing evidence modules — `isCopilotReviewerLogin` /
   `readAdvisoryPrimaryBotLogin`, `resolveAdvisoryBotLogins`,
   `resolveTrustedMarkerActors`, `summarizeDispositionEvidenceForGate`,

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -85,6 +85,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/idd-merge-execute.mjs` for the F3 merge gate: a dry-run
   verdict by default and, with `--apply`, the bound merge execution; it
   wraps `pre-merge-readiness` and adds no new decision authority
+- `scripts/advisory-convergence.mjs` for the F2 advisory/disposition
+  sub-gate (#1340): a deterministic `converged`/`ready` verdict with an
+  exit-code contract via `--assert`, claim-independent so it also works
+  as a required-check-able CI verdict
 - `scripts/live-status-digest.mjs` for issue or PR live status digest
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
@@ -1113,6 +1117,49 @@ Interpretation rules:
   merge steps in `idd-merge.instructions.md`. The written F3 decision
   table and gate checklist remain canonical.
 
+### Advisory convergence (F2)
+
+- Read-only policy-engine helper (#1340) that deterministically asserts
+  whether the primary advisory bot's ("Copilot's") review has _converged_
+  on the current PR HEAD: `converged` = (the latest primary-bot review's
+  `commit_id` equals the current HEAD **and** that review carries zero
+  actionable items) **and** (every current-HEAD primary-bot-authored review
+  thread is resolved **or** carries a valid disposition marker).
+- Command: `node scripts/advisory-convergence.mjs --pr <pr-number>
+  [--claim-issue <issue-number>] [--owner <owner>] [--repo <repo>]
+  [--trusted-marker-logins "<login1,login2>"]
+  [--advisory-bot-logins "<bot1,bot2>"] [--now <ISO8601>] [--assert]`.
+  Unlike `pre-merge-readiness`, no claim flags are required: the linked
+  issue (and its active claim, needed only for the waiver check below) is
+  auto-discovered from the PR's closing references, the same way
+  `external-check-waiver.mjs`'s `--apply` path already resolves it — so
+  this helper also works as a claim-independent, required-check-able CI
+  verdict (the intended shape for #1341's workflow).
+- Stable contract:
+  [`advisory-convergence.schema.json`][advisory-convergence-schema]
+- Always prints the JSON verdict. Without `--assert` it always exits `0`
+  (report-only). With `--assert` it exits non-zero unless `ready` is
+  `true` (`ready = converged || (deadline passed && validly waived)`).
+- **Deadlock / deadline policy**: while the primary bot has not reviewed
+  the current HEAD, `pending` is `true` and the gate is not ready. After
+  `advisoryWait.convergenceDeadline` (default 24h; see
+  [policy constants](policy-constants.md#advisory-review-defaults)) has
+  elapsed since the current HEAD commit's own timestamp, the only pass
+  path is a valid maintainer external-check waiver for that HEAD under the
+  selector `idd-advisory-convergence` (reusing the same
+  `<!-- idd-external-check-waiver: ... -->` marker format and validity
+  rules as `external-check-waiver.mjs`, gated the same way by
+  `ciGate.externalCheckWaivers.mode == "maintainer-authorized"`).
+- Reuses the existing evidence modules — `isCopilotReviewerLogin` /
+  `readAdvisoryPrimaryBotLogin`, `resolveAdvisoryBotLogins`,
+  `resolveTrustedMarkerActors`, `summarizeDispositionEvidenceForGate`,
+  `summarizeClaimValidation`, and `summarizeExternalCheckWaivers` — rather
+  than duplicating review- or waiver-parsing logic; only the
+  Copilot-thread-authorship filter and the review-item-count read are new.
+- Fail closed: if helper execution fails, output is invalid JSON, or
+  required fields are missing, discard helper output and apply the
+  written F2 advisory/disposition sub-gate check manually.
+
 ### E7 disposition verification
 
 - Preferred command when helper runtime is enabled:
@@ -1376,6 +1423,7 @@ Good future candidates remain read-only evidence collectors for
 pre-merge readiness or later claim-state inspection. They should not
 replace the written decision tables.
 
+[advisory-convergence-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-convergence.schema.json
 [advisory-wait-state-schema]: https://kurone-kito.github.io/idd-skill/schemas/advisory-wait-state.schema.json
 [disposition-non-review-notices-schema]: https://kurone-kito.github.io/idd-skill/schemas/disposition-non-review-notices.schema.json
 [idd-merge-execute-schema]: https://kurone-kito.github.io/idd-skill/schemas/idd-merge-execute.schema.json

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -170,12 +170,19 @@ The current policy schema and helper runtime now support
 `.github/idd/config.json` `advisoryWait.requestCap`,
 `advisoryWait.pendingWindow`, `advisoryWait.settledWindow`,
 `advisoryWait.pollInterval`, `advisoryWait.capExhaustedRoute`,
-`advisoryWait.primaryBotLogin`, and `advisoryWait.secondaryBotLogin`.
-Omitted keys keep the distributed defaults below. The three duration keys
+`advisoryWait.primaryBotLogin`, `advisoryWait.secondaryBotLogin`, and
+`advisoryWait.convergenceDeadline`.
+Omitted keys keep the distributed defaults below. The four duration keys
 accept positive whole-minute ISO 8601 durations only.
 `advisoryWait.primaryBotLogin` selects the advisory bot whose review the
 advisory-wait gate tracks; it defaults to Copilot, so omitting it
 preserves the Copilot-advisory behavior exactly.
+`advisoryWait.convergenceDeadline` is the `advisory-convergence.mjs` helper's
+(#1340) deadlock deadline: while the primary bot has not posted a zero-item
+review on the current PR HEAD, the gate reports pending; once this deadline
+elapses (measured from the current HEAD commit's own timestamp, not an IDD
+marker), the only pass path is a valid maintainer external-check waiver for
+that HEAD under the selector `idd-advisory-convergence`.
 `advisoryWait.secondaryBotLogin` is an **optional, non-gating** supplement:
 when set, the secondary bot is requested once per HEAD only while the
 primary is cap-exhausted or stalled / rate-limited. It never satisfies the
@@ -196,6 +203,7 @@ install without a requestable-reviewer event cannot be tracked once per HEAD.
 | Primary advisory bot login              | `copilot` (via `advisoryWait.primaryBotLogin`)                               | [Review fix](../.github/instructions/idd-review-fix.instructions.md), [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)                                                                     | Keep Copilot unless the repository routes the advisory-wait gate to a different primary bot.          |
 | Secondary advisory bot supplement       | unset (optional `advisoryWait.secondaryBotLogin`; non-gating, once per HEAD) | [Review fix](../.github/instructions/idd-review-fix.instructions.md), [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)                                                                     | Leave unset unless the repository wants a non-gating fallback reviewer when the primary is throttled. |
 | Human re-review response wait           | 30 min after addressed `CHANGES_REQUESTED` feedback has a re-review request  | [Pre-merge](../.github/instructions/idd-pre-merge.instructions.md)                                                                                                                                                   | Keep unless the repository has a different required-reviewer response window.                         |
+| Advisory-convergence deadline           | 24 h (`advisoryWait.convergenceDeadline`)                                    | [Pre-merge](../.github/instructions/idd-pre-merge.instructions.md), [Helper scripts](idd-helper-scripts.md)                                                                                                          | Keep unless the repository needs a different bound before the maintainer waiver escape hatch applies. |
 
 ## CI Wait Defaults
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "github:kurone-kito/idd-skill",
   "type": "module",
   "bin": {
+    "idd-advisory-convergence": "./bin/idd-advisory-convergence.mjs",
     "idd-advisory-wait-state": "./bin/idd-advisory-wait-state.mjs",
     "idd-audit-pr-cleanup": "./bin/idd-audit-pr-cleanup.mjs",
     "idd-branch-conflict-state": "./bin/idd-branch-conflict-state.mjs",

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/advisory-convergence.schema.json",
+  "title": "Advisory Convergence",
+  "description": "Read-only deterministic verdict for whether the primary advisory bot's review has converged on the current PR HEAD (issue #1340).",
+  "type": "object",
+  "required": [
+    "protocolVersion",
+    "decisionAuthority",
+    "prNumber",
+    "prHeadSha",
+    "now",
+    "primaryBotLogin",
+    "review",
+    "threads",
+    "pending",
+    "deadline",
+    "waiver",
+    "converged",
+    "waived",
+    "ready",
+    "reasons"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "protocolVersion": {
+      "type": "string",
+      "enum": ["1"]
+    },
+    "decisionAuthority": {
+      "type": "string",
+      "enum": ["instructions"]
+    },
+    "prNumber": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "prHeadSha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "now": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+    },
+    "primaryBotLogin": {
+      "type": "string",
+      "minLength": 1
+    },
+    "review": {
+      "type": "object",
+      "required": ["found", "commitId", "matchesHead", "itemCount", "submittedAt", "satisfied"],
+      "additionalProperties": false,
+      "properties": {
+        "found": { "type": "boolean" },
+        "commitId": { "type": "string" },
+        "matchesHead": { "type": "boolean" },
+        "itemCount": { "type": ["integer", "null"] },
+        "submittedAt": { "type": "string" },
+        "satisfied": { "type": "boolean" }
+      }
+    },
+    "threads": {
+      "type": "object",
+      "required": [
+        "copilotThreadCount",
+        "blockingIds",
+        "blockingCount",
+        "satisfied"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "copilotThreadCount": { "type": "integer", "minimum": 0 },
+        "blockingIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "blockingCount": { "type": "integer", "minimum": 0 },
+        "satisfied": { "type": "boolean" }
+      }
+    },
+    "pending": {
+      "type": "boolean"
+    },
+    "deadline": {
+      "type": "object",
+      "required": ["minutes", "headCommittedAt", "elapsedMinutes", "passed"],
+      "additionalProperties": false,
+      "properties": {
+        "minutes": { "type": "number", "minimum": 0 },
+        "headCommittedAt": { "type": "string" },
+        "elapsedMinutes": { "type": ["number", "null"] },
+        "passed": { "type": "boolean" }
+      }
+    },
+    "waiver": {
+      "type": "object",
+      "required": ["mode", "checkSelector", "activeClaimId", "validCount"],
+      "additionalProperties": false,
+      "properties": {
+        "mode": { "type": "string" },
+        "checkSelector": { "type": "string" },
+        "activeClaimId": { "type": "string" },
+        "validCount": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "converged": {
+      "type": "boolean"
+    },
+    "waived": {
+      "type": "boolean"
+    },
+    "ready": {
+      "type": "boolean"
+    },
+    "reasons": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -266,6 +266,10 @@
         "secondaryBotLogin": {
           "type": "string",
           "minLength": 1
+        },
+        "convergenceDeadline": {
+          "type": "string",
+          "pattern": "^P(?=(?:\\d+D|T\\d+[HM]))(?=.*(?:[1-9]\\d*[DHM]))(?:\\d+D)?(?:T(?=\\d+[HM])(?:\\d+H)?(?:\\d+M)?)?$"
         }
       }
     },

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -30,6 +30,7 @@
 // This helper never mutates GitHub state: it only reads PR/review/thread/
 // comment data and prints a verdict.
 import {
+  DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
   readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
@@ -160,7 +161,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // --- timestamp (not an IDD marker -- see module header for why) -------
   const deadlineMinutes = Number.isFinite(options.deadlineMinutes)
     ? Number(options.deadlineMinutes)
-    : 1440;
+    : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
   const headCommittedAt = String(options.headCommittedAt ?? '');
   const elapsedMinutes = isValidIsoTimestamp(headCommittedAt)
     ? minutesBetween(headCommittedAt, now)
@@ -215,7 +216,9 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   const waived = validWaiverCount > 0;
   if (!converged && deadlinePassed && !waived) {
     reasons.push(
-      `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`,
+      waiverMode === 'maintainer-authorized'
+        ? `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`
+        : `deadline (${deadlineMinutes}m) passed and no waiver is available (ciGate.externalCheckWaivers.mode is "${waiverMode}", not "maintainer-authorized")`,
     );
   }
   const ready = converged || (deadlinePassed && waived);
@@ -237,30 +240,31 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     reasons,
   };
 }
-/** Evaluate Clause 1 (the latest-review clause) against every Copilot
- * review that targets the current HEAD, and evaluate Clause 1 against
- * *that* review only. Re-requesting a review without a new push is a real,
- * supported flow in this repo's own advisory-wait protocol (AW3
- * `REQUEST_NEEDED`), so two reviews can legitimately share one `commitId`
- * with the later one superseding the earlier one (e.g. addressed via
- * thread replies, then re-reviewed) -- requiring every on-HEAD review to
- * be clean would wrongly keep a genuinely-converged PR blocked forever
- * (see PR #1343 review). The latest on-HEAD review is simply the last
- * on-HEAD entry in fetch order: GitHub's GraphQL `reviews` connection
- * returns reviews in submission order (the same assumption
- * `findLastCopilotReviewCommit` already relies on elsewhere in this
- * codebase), so this deliberately does NOT re-sort by `submittedAt` --
- * which can be missing/invalid on a real payload (the field is nullable)
- * and would otherwise let an earlier, differently-ordered review win by
- * comparator accident, hiding a genuinely later dirty review. */
+/** Evaluate Clause 1 against the single, absolute-latest Copilot review --
+ * per the issue's literal wording ("the latest Copilot review's commit_id
+ * equals current HEAD"), not "the latest review among those that happen to
+ * target current HEAD". Those two differ when Copilot's most recent
+ * activity targets a commit other than the current HEAD (e.g. an unusual
+ * force-push/revert ordering, see PR #1343 review): only looking within
+ * on-HEAD reviews could report `matchesHead: true` off a stale earlier
+ * review while ignoring what Copilot's true latest signal actually says.
+ * This simpler form still correctly handles a legitimate re-request
+ * without a new push (this repo's own AW3 `REQUEST_NEEDED` flow, where a
+ * later review supersedes an earlier dirty one on the *same* commit): the
+ * absolute latest naturally IS that later, superseding review when both
+ * target the current HEAD. "Latest" is fetch order, not `submittedAt`:
+ * GitHub's GraphQL `reviews` connection returns reviews in submission
+ * order (the same assumption `findLastCopilotReviewCommit` already relies
+ * on elsewhere in this codebase), so this deliberately does not re-sort by
+ * `submittedAt` -- which can be missing/invalid on a real payload (the
+ * field is nullable) and would otherwise let an earlier, differently-
+ * ordered review win by comparator accident. */
 function resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin) {
-  const copilotReviews = reviews.filter((review) =>
-    isCopilotReviewerLogin(review.author?.login ?? '', primaryBotLogin),
-  );
-  const onHead = copilotReviews.filter(
-    (review) => String(review.commitId ?? '').toLowerCase() === prHeadSha,
-  );
-  const latest = onHead.length > 0 ? onHead.at(-1) : copilotReviews.at(-1);
+  const latest = reviews
+    .filter((review) =>
+      isCopilotReviewerLogin(review.author?.login ?? '', primaryBotLogin),
+    )
+    .at(-1);
   if (!latest) {
     return {
       found: false,
@@ -271,7 +275,8 @@ function resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin) {
       satisfied: false,
     };
   }
-  const matchesHead = onHead.length > 0;
+  const commitId = String(latest.commitId ?? '').toLowerCase();
+  const matchesHead = commitId === prHeadSha;
   const itemCount = matchesHead
     ? Number.isFinite(latest.itemCount)
       ? Number(latest.itemCount)
@@ -279,7 +284,7 @@ function resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin) {
     : null;
   return {
     found: true,
-    commitId: String(latest.commitId ?? '').toLowerCase(),
+    commitId,
     matchesHead,
     itemCount,
     submittedAt: String(latest.submittedAt ?? ''),

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -254,11 +254,14 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
  * absolute latest naturally IS that later, superseding review when both
  * target the current HEAD. "Latest" is fetch order, not `submittedAt`:
  * GitHub's GraphQL `reviews` connection returns reviews in submission
- * order (the same assumption `findLastCopilotReviewCommit` already relies
- * on elsewhere in this codebase), so this deliberately does not re-sort by
- * `submittedAt` -- which can be missing/invalid on a real payload (the
- * field is nullable) and would otherwise let an earlier, differently-
- * ordered review win by comparator accident. */
+ * order, the same assumption this file's own `fetchThreadCommentPages` /
+ * `fetchReviewThreads` already rely on (they append paginated results
+ * without ever re-sorting). This deliberately does NOT sort by
+ * `submittedAt` the way `findLastCopilotReviewCommit` does elsewhere in
+ * this codebase (protocol-helpers.mts) -- that timestamp-sort approach is
+ * exactly the footgun being avoided here: `submittedAt` can be missing or
+ * invalid on a real payload (the field is nullable) and would otherwise
+ * let an earlier, differently-ordered review win by comparator accident. */
 function resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin) {
   const latest = reviews
     .filter((review) =>
@@ -324,8 +327,18 @@ export function classifyCopilotAuthoredThreadIds(threads, primaryBotLogin) {
   });
   return ids;
 }
+/** Whole minutes elapsed from `start` to `end`, clamped to 0 and floored --
+ * matching `minutesBetweenIso` (protocol-helpers.mts) exactly, so a clock-
+ * skew or malformed-timestamp edge case can never make `deadline.elapsed-
+ * Minutes` negative or fractional. Not reused directly since that helper is
+ * not exported. */
 function minutesBetween(start, end) {
-  return (new Date(end).getTime() - new Date(start).getTime()) / 60000;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return 0;
+  }
+  return Math.floor((endMs - startMs) / 60000);
 }
 export function parseArgs(argv) {
   const parsed = {

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -1,0 +1,677 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/advisory-convergence.mts
+//
+// The scripts/advisory-convergence.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Read-only policy-engine helper (#1340): deterministically asserts whether
+// the primary advisory bot's ("Copilot's") review has *converged* on the
+// current PR HEAD -- see issue #1340 and roadmap #1342. This closes a gap
+// where the existing evidence collectors (`pre-merge-readiness.mjs`,
+// `review-disposition-verify.mjs`, `advisory-wait-state.mjs`) report JSON
+// for the model to interpret, but no single helper asserts the invariant
+// with a hard exit code.
+//
+// Reuse map (no duplicated review-parsing logic):
+//   - `isCopilotReviewerLogin` / `readAdvisoryPrimaryBotLogin` /
+//     `resolveAdvisoryPrimaryBotLogin` -- Copilot identity resolution.
+//   - `resolveAdvisoryBotLogins`, `resolveTrustedMarkerActors` -- the same
+//     trust/identity resolution every other helper uses.
+//   - `summarizeDispositionEvidenceForGate` -- reused UNFILTERED for
+//     per-thread disposition-marker validity; this file only adds a thin
+//     Copilot-authorship filter on top of its `missingThreads` output.
+//   - `summarizeClaimValidation`, `summarizeExternalCheckWaivers` -- reused
+//     verbatim for the deadline/waiver escape hatch, auto-discovering the
+//     PR's linked issue exactly as `external-check-waiver.mts`'s own
+//     `--apply` path already does, so no claim flag is required to call
+//     this helper (`--pr <n> --assert` is sufficient -- see docs).
+//
+// This helper never mutates GitHub state: it only reads PR/review/thread/
+// comment data and prints a verdict.
+import {
+  DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+  readAdvisoryConvergenceDeadlineMinutes,
+  readAdvisoryPrimaryBotLogin,
+} from './advisory-wait-policy.mjs';
+import { ghApiJson, ghText, isCliExecution, safeGhText } from './gh-exec.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import { isValidIsoTimestamp } from './marker-helpers.mjs';
+import { normalizePolicyConfig } from './policy-helpers.mjs';
+import {
+  isCopilotReviewerLogin,
+  normalizeTrustedMarkerLogins,
+  resolveAdvisoryBotLogins,
+  resolveTrustedMarkerActors,
+  summarizeClaimValidation,
+  summarizeDispositionEvidenceForGate,
+  summarizeExternalCheckWaivers,
+} from './protocol-helpers.mjs';
+/** The external-check-waiver selector this gate recognizes (documented in
+ * docs/idd-helper-scripts.md and docs/policy-constants.md; #1341's required
+ * check is expected to register under the same name). */
+export const ADVISORY_CONVERGENCE_CHECK_SELECTOR = 'idd-advisory-convergence';
+/**
+ * Compute the deterministic advisory-convergence verdict from already-
+ * fetched PR evidence. Pure (no I/O), so it is directly unit-testable with
+ * fixtures -- mirrors `buildPreMergeReadinessSummary` /
+ * `buildAdvisoryWaitSummary` in `protocol-helpers.mts`.
+ */
+export function computeAdvisoryConvergenceVerdict(inputs, options) {
+  const now = String(options.now ?? '');
+  if (!isValidIsoTimestamp(now)) {
+    throw new Error('now must be an ISO 8601 UTC timestamp');
+  }
+  const prHeadSha = String(inputs.prHeadSha ?? '').toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    throw new Error('prHeadSha must be a 40-character lowercase commit SHA');
+  }
+  const primaryBotLogin =
+    String(options.primaryBotLogin ?? '')
+      .trim()
+      .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins(
+    options.trustedMarkerLogins ?? [],
+  );
+  const reviews = inputs.reviews ?? [];
+  const threads = inputs.threads ?? [];
+  const comments = inputs.comments ?? [];
+  const claimEvents = inputs.claimEvents ?? [];
+  const reasons = [];
+  // --- Clause 1: latest Copilot review is clean on the current HEAD -----
+  const review = resolveLatestCopilotReviewClause(
+    reviews,
+    prHeadSha,
+    primaryBotLogin,
+  );
+  const pending = !review.matchesHead;
+  if (pending) {
+    reasons.push(
+      review.found
+        ? `latest ${primaryBotLogin} review (commit ${review.commitId || '<unknown>'}) does not cover current HEAD ${prHeadSha}`
+        : `${primaryBotLogin} has not reviewed this pull request yet`,
+    );
+  } else if (!review.satisfied) {
+    reasons.push(
+      `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`,
+    );
+  }
+  // --- Clause 2: every current Copilot-authored thread is resolved or ---
+  // --- validly dispositioned (reusing summarizeDispositionEvidenceForGate)
+  const copilotThreadIds = classifyCopilotAuthoredThreadIds(
+    threads,
+    primaryBotLogin,
+  );
+  const dispositionEvidence = summarizeDispositionEvidenceForGate(
+    { comments, threads },
+    {
+      // `summarizeDispositionEvidenceForGate` requires a recognized
+      // "IDD agent" login to accept an Accept/Reject/AMD marker as a fresh
+      // disposition (see `hasFreshDisposition`). This gate has no separate
+      // notion of "IDD agent" from "trusted marker actor" -- both mean the
+      // same thing here (whoever is authorized to post operational markers
+      // on this repo) -- so the trusted set is reused for both, avoiding an
+      // extra CLI flag / config surface the issue does not ask for.
+      iddAgentLogins: trustedMarkerLogins,
+      trustedMarkerLogins,
+      advisoryBotLogins: normalizeTrustedMarkerLogins(
+        options.advisoryBotLogins ?? [],
+      ),
+      prAuthorLogin: String(options.prAuthorLogin ?? '')
+        .trim()
+        .toLowerCase(),
+      // Deliberately no `snapshotBoundaryAt`: this claim-independent gate has
+      // no F2 review-watermark to anchor one to, and threading a sentinel
+      // (e.g. `now`) through would make every resolved thread's feedback
+      // trivially predate it -- silently turning the boundary-gated
+      // ack-only-post-disposition classification (`classifyThreadAckOnly-
+      // PostDisposition`, protocol-helpers.mts) into permanent dead code
+      // instead of the deliberate carve-out it looks like. "Resolved is
+      // sufficient" (below) is handled directly, without relying on that
+      // classification at all.
+    },
+  );
+  // Clause 2 per the issue: "resolved OR carries a valid disposition
+  // marker." `missingThreads` (computed without a boundary, above) flags
+  // BOTH an unresolved thread lacking a fresh marker AND a resolved thread
+  // lacking one (`reason: 'missing-fresh-disposition'`) -- the latter is not
+  // a Clause-2 blocker here, since resolution alone already satisfies it, so
+  // only the genuinely unresolved entries count.
+  const copilotBlocking = dispositionEvidence.missingThreads.filter(
+    (thread) =>
+      copilotThreadIds.has(String(thread.id ?? '')) &&
+      thread.isResolved === false,
+  );
+  const threadClause = {
+    copilotThreadCount: copilotThreadIds.size,
+    blockingIds: copilotBlocking.map((thread) => String(thread.id ?? '')),
+    blockingCount: copilotBlocking.length,
+    satisfied: copilotBlocking.length === 0,
+  };
+  if (!threadClause.satisfied) {
+    reasons.push(
+      `${threadClause.blockingCount} ${primaryBotLogin}-authored review thread(s) are neither resolved nor validly dispositioned: ${threadClause.blockingIds.join(', ')}`,
+    );
+  }
+  const converged = !pending && review.satisfied && threadClause.satisfied;
+  // --- Deadline clock, anchored on the current HEAD commit's own --------
+  // --- timestamp (not an IDD marker -- see module header for why) -------
+  const deadlineMinutes = Number.isFinite(options.deadlineMinutes)
+    ? Number(options.deadlineMinutes)
+    : 1440;
+  const headCommittedAt = String(options.headCommittedAt ?? '');
+  const elapsedMinutes = isValidIsoTimestamp(headCommittedAt)
+    ? minutesBetween(headCommittedAt, now)
+    : null;
+  const deadlinePassed =
+    elapsedMinutes !== null && elapsedMinutes >= deadlineMinutes;
+  const deadline = {
+    minutes: deadlineMinutes,
+    headCommittedAt,
+    elapsedMinutes,
+    passed: deadlinePassed,
+  };
+  // --- Waiver escape hatch (only reachable once the deadline has passed) -
+  const waiverMode = String(options.waiverMode ?? 'disabled');
+  const waiverCheckSelector =
+    String(options.waiverCheckSelector ?? '').trim() ||
+    ADVISORY_CONVERGENCE_CHECK_SELECTOR;
+  const claim = summarizeClaimValidation(claimEvents, { trustedMarkerLogins });
+  const activeClaimId = claim.activeClaim?.claimId ?? '';
+  let validWaiverCount = 0;
+  if (!converged && deadlinePassed && waiverMode === 'maintainer-authorized') {
+    const waiverEvidence = summarizeExternalCheckWaivers(comments, {
+      prHeadSha,
+      activeClaimId,
+      trustedMarkerLogins,
+      now,
+      waivableSelectors: [
+        { selector: waiverCheckSelector, matchMode: 'exact' },
+      ],
+      maxValidity: String(options.waiverMaxValidity ?? 'PT24H'),
+    });
+    validWaiverCount = waiverEvidence.valid.length;
+  }
+  const waiver = {
+    mode: waiverMode,
+    checkSelector: waiverCheckSelector,
+    activeClaimId,
+    validCount: validWaiverCount,
+  };
+  const waived = validWaiverCount > 0;
+  if (!converged && deadlinePassed && !waived) {
+    reasons.push(
+      `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`,
+    );
+  }
+  const ready = converged || (deadlinePassed && waived);
+  return {
+    protocolVersion: '1',
+    decisionAuthority: 'instructions',
+    prNumber: inputs.prNumber,
+    prHeadSha,
+    now,
+    primaryBotLogin,
+    review,
+    threads: threadClause,
+    pending,
+    deadline,
+    waiver,
+    converged,
+    waived,
+    ready,
+    reasons,
+  };
+}
+/** Evaluate Clause 1 (the latest-review clause) against every Copilot
+ * review that targets the current HEAD. Deliberately does not pick "the
+ * single latest review by `submittedAt`" and check only that one: a fresh
+ * push never reuses a commit SHA, so multiple same-HEAD Copilot reviews are
+ * retries or duplicates of the same content, not a legitimate
+ * "re-reviewed after a fix" sequence. Requiring every on-HEAD review to be
+ * clean is the fail-closed choice, and it never depends on `submittedAt`
+ * ordering -- which can be missing/invalid on a real GraphQL payload (the
+ * field is nullable) -- to decide which single review "counts". A
+ * timestamp-sort-based pick would let a later, dirty, timestamp-less review
+ * be silently out-ranked by an earlier clean one; filtering by `commitId`
+ * first sidesteps that ordering question entirely. */
+function resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin) {
+  const copilotReviews = reviews.filter((review) =>
+    isCopilotReviewerLogin(review.author?.login ?? '', primaryBotLogin),
+  );
+  const onHead = copilotReviews.filter(
+    (review) => String(review.commitId ?? '').toLowerCase() === prHeadSha,
+  );
+  if (onHead.length === 0) {
+    const last = copilotReviews.at(-1);
+    return {
+      found: copilotReviews.length > 0,
+      commitId: String(last?.commitId ?? '').toLowerCase(),
+      matchesHead: false,
+      itemCount: null,
+      submittedAt: String(last?.submittedAt ?? ''),
+      satisfied: false,
+    };
+  }
+  const itemCounts = onHead.map((review) =>
+    Number.isFinite(review.itemCount) ? Number(review.itemCount) : null,
+  );
+  const worstItemCount = itemCounts.every((count) => count !== null)
+    ? Math.max(...itemCounts)
+    : null;
+  return {
+    found: true,
+    commitId: prHeadSha,
+    matchesHead: true,
+    itemCount: worstItemCount,
+    submittedAt: String(onHead.at(-1)?.submittedAt ?? ''),
+    satisfied: worstItemCount === 0,
+  };
+}
+/** Thread IDs whose *originating* (first) comment is Copilot-authored.
+ * `summarizeReviewThreadsForGate` classifies by latest-commenter identity
+ * for a different purpose (backlog gating) and is not bot-scoped, so this
+ * is new, narrow logic -- the disposition-marker validity it feeds into
+ * still comes entirely from the reused `summarizeDispositionEvidenceForGate`
+ * output. */
+export function classifyCopilotAuthoredThreadIds(threads, primaryBotLogin) {
+  const ids = new Set();
+  threads.forEach((thread, index) => {
+    // GitHub's GraphQL `comments` connection on a review thread returns
+    // comments in creation order -- the same assumption `fetchReviewThreads`
+    // / `fetchThreadCommentPages` already rely on when appending paginated
+    // results without re-sorting -- so the thread-opening comment is always
+    // `nodes[0]`. Deliberately not timestamp-sorted: `compareIsoTimestamps`
+    // sorts a missing/invalid `createdAt` BEFORE any valid one (by design,
+    // for existing "pick the latest, ignore garbage" call sites elsewhere),
+    // which would let a later reply with a bad timestamp silently usurp
+    // "originating" status and make a genuinely Copilot-opened thread
+    // invisible to this gate.
+    const originating = (thread.comments?.nodes ?? [])[0];
+    if (
+      originating &&
+      isCopilotReviewerLogin(originating.author?.login ?? '', primaryBotLogin)
+    ) {
+      // Match `summarizeDispositionEvidenceForGate`'s own
+      // `missingThreads[].id` fallback exactly (protocol-helpers.mts) so a
+      // thread with an empty/missing GraphQL id still round-trips through
+      // the `.has()` lookup in the caller instead of silently diverging.
+      ids.add(String(thread.id ?? '') || `thread-${index + 1}`);
+    }
+  });
+  return ids;
+}
+function minutesBetween(start, end) {
+  return (new Date(end).getTime() - new Date(start).getTime()) / 60000;
+}
+export function parseArgs(argv) {
+  const parsed = {
+    prNumber: null,
+    owner: '',
+    repo: '',
+    claimIssueNumber: null,
+    trustedMarkerLogins: '',
+    advisoryBotLogins: '',
+    now: '',
+    assert: false,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === '--pr') {
+      parsed.prNumber = Number.parseInt(value ?? '', 10);
+      index += 1;
+      continue;
+    }
+    if (token === '--owner') {
+      parsed.owner = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--repo') {
+      parsed.repo = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--claim-issue') {
+      parsed.claimIssueNumber = Number.parseInt(value ?? '', 10);
+      index += 1;
+      continue;
+    }
+    if (token === '--trusted-marker-logins') {
+      parsed.trustedMarkerLogins = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--advisory-bot-logins') {
+      parsed.advisoryBotLogins = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--now') {
+      parsed.now = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--assert') {
+      parsed.assert = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+  if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
+    parsed.prNumber = null;
+  }
+  if (
+    !Number.isInteger(parsed.claimIssueNumber) ||
+    (parsed.claimIssueNumber ?? 0) < 1
+  ) {
+    parsed.claimIssueNumber = null;
+  }
+  return parsed;
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/advisory-convergence.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--claim-issue <number>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--now <ISO8601>] [--assert]
+
+Read-only: asserts whether the primary advisory bot's review has converged
+on the current PR HEAD. Always prints the JSON verdict. Without --assert,
+always exits 0 (report-only). With --assert, exits non-zero unless the
+verdict is "ready" (converged, or validly waived past the configured
+deadline).
+`);
+}
+const defaultDeps = { collect: collectFromGitHub };
+/**
+ * Parse argv, collect evidence (via `deps.collect`, real `gh` calls by
+ * default), compute the verdict, and derive the `--assert` exit code.
+ * Mirrors `idd-merge-execute.mts`'s `runMergeExecute` DI pattern so tests
+ * can substitute a fake `collect` instead of shelling out to `gh`.
+ */
+export function runAdvisoryConvergence(argv, deps = defaultDeps) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    return { verdict: null, exitCode: 0, help: true };
+  }
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+  const { inputs, options } = deps.collect(args);
+  const verdict = computeAdvisoryConvergenceVerdict(inputs, options);
+  const exitCode = args.assert ? (verdict.ready ? 0 : 1) : 0;
+  return { verdict, exitCode, help: false };
+}
+// --- Production I/O: fetch PR/review/thread/comment evidence via `gh` ----
+function collectFromGitHub(args) {
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const viewerLogin = safeGhText([
+    'api',
+    'user',
+    '--jq',
+    '.login',
+  ]).toLowerCase();
+  const rawConfig = loadIddConfig();
+  const { actors: configuredTrustedActors } = resolveTrustedMarkerActors({
+    flagValue: args.trustedMarkerLogins,
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: rawConfig,
+  });
+  const { logins: advisoryBotLogins } = resolveAdvisoryBotLogins({
+    flagValue: args.advisoryBotLogins,
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+    config: rawConfig,
+  });
+  // Deliberately NOT unioned with `advisoryBotLogins` here (unlike some
+  // other locally-collected sets in this file that scope broader trust for
+  // marker *parsing*): every sibling helper (advisory-wait-state.mts,
+  // pre-merge-readiness.mts) keeps `trustedMarkerLogins` and
+  // `advisoryBotLogins` disjoint, and this specific set also authorizes
+  // `--assert`-gating external-check waivers (via `summarizeExternalCheck-
+  // Waivers`, below) -- folding a configured advisory bot login in here
+  // would let that bot's own comment count as a "maintainer-authorized"
+  // waiver author.
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins([
+    viewerLogin,
+    ...configuredTrustedActors,
+  ]);
+  const pr = JSON.parse(
+    ghText([
+      'pr',
+      'view',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'headRefOid,closingIssuesReferences,author',
+    ]),
+  );
+  const prHeadSha = String(pr.headRefOid ?? '').toLowerCase();
+  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
+  const { reviews, headCommittedAt } = fetchReviewsAndHeadCommit(
+    owner,
+    repo,
+    Number(args.prNumber),
+  );
+  const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    {
+      paginate: true,
+    },
+  );
+  const claimIssueNumber =
+    args.claimIssueNumber ??
+    resolveSoleClosingIssueNumber(pr.closingIssuesReferences);
+  const claimEvents = claimIssueNumber
+    ? ghApiJson(`repos/${owner}/${repo}/issues/${claimIssueNumber}/comments`, {
+        paginate: true,
+      })
+    : [];
+  const primaryBotLogin = readAdvisoryPrimaryBotLogin();
+  const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
+  // No manual cast: `normalizePolicyConfig`'s inferred return type already
+  // carries `ciGate.externalCheckWaivers.{mode,maxValidity}` precisely (see
+  // `external-check-waiver.mts`'s `NormalizedPolicy` alias for the same
+  // pattern) -- re-declaring the shape here would silently stop tracking
+  // that source of truth on drift.
+  const policy = normalizePolicyConfig(rawConfig);
+  return {
+    inputs: {
+      prNumber: Number(args.prNumber),
+      prHeadSha,
+      reviews,
+      threads,
+      comments,
+      claimEvents,
+    },
+    options: {
+      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      primaryBotLogin,
+      trustedMarkerLogins,
+      advisoryBotLogins,
+      prAuthorLogin,
+      headCommittedAt,
+      deadlineMinutes,
+      waiverMode: String(
+        policy?.ciGate?.externalCheckWaivers?.mode ?? 'disabled',
+      ),
+      waiverMaxValidity: String(
+        policy?.ciGate?.externalCheckWaivers?.maxValidity ?? 'PT24H',
+      ),
+      waiverCheckSelector: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+    },
+  };
+}
+function resolveSoleClosingIssueNumber(refs) {
+  const numbers = [
+    ...new Set(
+      (refs ?? []).map((ref) => ref?.number).filter((n) => Number.isInteger(n)),
+    ),
+  ];
+  return numbers.length === 1 ? numbers[0] : null;
+}
+function ghGraphql(query, variables) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'number') {
+      args.push('-F', `${key}=${value}`);
+      continue;
+    }
+    args.push('-f', `${key}=${value}`);
+  }
+  return JSON.parse(ghText(args).trim() || '{}');
+}
+function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
+  const payload = ghGraphql(
+    `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviews(first: 100) {
+              nodes {
+                commit { oid }
+                submittedAt
+                author { login }
+                comments { totalCount }
+              }
+            }
+            commits(last: 1) {
+              nodes { commit { committedDate } }
+            }
+          }
+        }
+      }`,
+    { owner, repo, number: prNumber },
+  );
+  const reviews = (
+    payload?.data?.repository?.pullRequest?.reviews?.nodes ?? []
+  ).map((node) => ({
+    author: node.author ?? null,
+    submittedAt: node.submittedAt ?? null,
+    commitId: node.commit?.oid ?? null,
+    itemCount: node.comments?.totalCount ?? null,
+  }));
+  const headCommittedAt = String(
+    payload?.data?.repository?.pullRequest?.commits?.nodes?.[0]?.commit
+      ?.committedDate ?? '',
+  );
+  return { reviews, headCommittedAt };
+}
+function fetchReviewThreads(owner, repo, prNumber) {
+  const nodes = [];
+  let cursor = null;
+  while (true) {
+    const payload = ghGraphql(
+      `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  isResolved
+                  comments(first: 100) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      body
+                      createdAt
+                      updatedAt
+                      author { login }
+                      pullRequestReview { id }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }`,
+      { owner, repo, number: prNumber, cursor },
+    );
+    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
+    for (const thread of reviewThreads?.nodes ?? []) {
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        if (!thread.id || !thread.comments.pageInfo.endCursor) {
+          throw new Error(
+            'review thread pagination payload is missing id or endCursor',
+          );
+        }
+        thread.comments.nodes.push(
+          ...fetchThreadCommentPages(
+            thread.id,
+            thread.comments.pageInfo.endCursor,
+          ),
+        );
+        thread.comments.pageInfo.hasNextPage = false;
+      }
+    }
+    nodes.push(...(reviewThreads?.nodes ?? []));
+    if (!reviewThreads?.pageInfo?.hasNextPage) break;
+    if (!reviewThreads.pageInfo.endCursor) {
+      throw new Error('review thread pagination payload is missing endCursor');
+    }
+    cursor = reviewThreads.pageInfo.endCursor;
+  }
+  return nodes;
+}
+function fetchThreadCommentPages(threadId, afterCursor) {
+  const nodes = [];
+  let cursor = afterCursor;
+  while (cursor) {
+    const payload = ghGraphql(
+      `
+        query($id: ID!, $cursor: String) {
+          node(id: $id) {
+            ... on PullRequestReviewThread {
+              comments(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  body
+                  createdAt
+                  updatedAt
+                  author { login }
+                  pullRequestReview { id }
+                }
+              }
+            }
+          }
+        }`,
+      { id: threadId, cursor },
+    );
+    const comments = payload?.data?.node?.comments;
+    nodes.push(...(comments?.nodes ?? []));
+    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
+      throw new Error('thread comment pagination payload is missing endCursor');
+    }
+    cursor = comments?.pageInfo?.hasNextPage
+      ? comments.pageInfo.endCursor
+      : null;
+  }
+  return nodes;
+}
+// CLI: emit the verdict as JSON and set the exit code when invoked directly.
+// Guarded behind isCliExecution(import.meta.url) (shared, see gh-exec.mts)
+// so importing this module (for unit tests) never parses process.argv,
+// prints usage, or makes a `gh` call.
+if (isCliExecution(import.meta.url)) {
+  const { verdict, exitCode, help } = runAdvisoryConvergence(
+    process.argv.slice(2),
+  );
+  if (help) {
+    printHelp();
+  } else if (verdict) {
+    process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  }
+  process.exit(exitCode);
+}

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -531,6 +531,32 @@ function collectFromGitHub(args) {
   };
 }
 /**
+ * Fetch one issue's comments and normalize them to the `author.login` /
+ * `createdAt` shape `resolveActiveClaim`/`applyClaimEvent`
+ * (`protocol-helpers.mts`) require. Unlike `summarizeDispositionEvidence-
+ * ForGate` / `summarizeExternalCheckWaivers`, the claim resolver has NO
+ * `user.login` / `created_at` REST fallback (`event.author?.login ?? ''`,
+ * `event.createdAt ?? ''`, verbatim) -- passing raw `gh api` REST comments
+ * through unnormalized silently resolves `activeClaimPresent: false` for
+ * every real claim, breaking the entire waiver escape hatch without any
+ * error. `pre-merge-readiness.mts`'s own `normalizeClaimComment` does the
+ * same normalization for the identical reason; mirrored here rather than
+ * imported since it is not exported.
+ */
+function fetchClaimComments(owner, repo, issueNumber) {
+  const raw = ghApiJson(
+    `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+    {
+      paginate: true,
+    },
+  );
+  return raw.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.createdAt ?? comment.created_at ?? '',
+    author: { login: comment.author?.login ?? comment.user?.login ?? '' },
+  }));
+}
+/**
  * Resolve the linked (claim) issue's comment stream for waiver-claim
  * binding. When `explicitIssueNumber` (`--claim-issue`) is given, use it
  * directly -- no ambiguity to resolve. Otherwise a PR can close more than
@@ -550,10 +576,7 @@ function resolveClaimEvents(
   trustedMarkerLogins,
 ) {
   if (explicitIssueNumber) {
-    return ghApiJson(
-      `repos/${owner}/${repo}/issues/${explicitIssueNumber}/comments`,
-      { paginate: true },
-    );
+    return fetchClaimComments(owner, repo, explicitIssueNumber);
   }
   const candidateNumbers = [
     ...new Set(
@@ -562,10 +585,7 @@ function resolveClaimEvents(
   ];
   const resolving = candidateNumbers
     .map((issueNumber) => {
-      const comments = ghApiJson(
-        `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
-        { paginate: true },
-      );
+      const comments = fetchClaimComments(owner, repo, issueNumber);
       return {
         comments,
         hasActiveClaim: Boolean(

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -417,13 +417,13 @@ export function parseArgs(argv) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/advisory-convergence.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--claim-issue <number>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--now <ISO8601>] [--assert]
+  node scripts/advisory-convergence.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--claim-issue <number>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--now <ISO8601>] [--assert] [--help]
 
 Read-only: asserts whether the primary advisory bot's review has converged
-on the current PR HEAD. Always prints the JSON verdict. Without --assert,
-always exits 0 (report-only). With --assert, exits non-zero unless the
-verdict is "ready" (converged, or validly waived past the configured
-deadline).
+on the current PR HEAD. Every invocation other than --help/-h prints the
+JSON verdict to stdout. Without --assert, always exits 0 (report-only).
+With --assert, exits non-zero unless the verdict is "ready" (converged, or
+validly waived past the configured deadline).
 `);
 }
 const defaultDeps = { collect: collectFromGitHub };

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -63,9 +63,13 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   if (!isValidIsoTimestamp(now)) {
     throw new Error('now must be an ISO 8601 UTC timestamp');
   }
+  // Lowercased before validating, so a mixed-/upper-case 40-hex SHA is
+  // accepted (normalized), not rejected -- the error message below
+  // describes the post-normalization shape, not a case restriction on the
+  // input.
   const prHeadSha = String(inputs.prHeadSha ?? '').toLowerCase();
   if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
-    throw new Error('prHeadSha must be a 40-character lowercase commit SHA');
+    throw new Error('prHeadSha must be a 40-character hexadecimal commit SHA');
   }
   const primaryBotLogin =
     String(options.primaryBotLogin ?? '')

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -93,7 +93,9 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     );
   } else if (!review.satisfied) {
     reasons.push(
-      `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`,
+      review.itemCount === null
+        ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
+        : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`,
     );
   }
   // --- Clause 2: every current Copilot-authored thread is resolved or ---
@@ -185,12 +187,24 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
       activeClaimId,
       trustedMarkerLogins,
       now,
-      waivableSelectors: [
-        { selector: waiverCheckSelector, matchMode: 'exact' },
-      ],
+      // The REAL configured `ciGate.externalChecks.waivable` list (not a
+      // hardcoded single-entry override for this gate's own selector):
+      // respects the existing two-dimensional waiver opt-in
+      // (`externalCheckWaivers.mode` AND a per-check `waivable`
+      // registration) instead of silently making this gate waivable the
+      // moment ANY external check is opted into waiver mode (see PR #1343
+      // review). An absent/empty list waives nothing, matching
+      // `summarizeExternalCheckWaivers`'s own "empty list waives nothing"
+      // contract.
+      waivableSelectors: [...(options.waivableSelectors ?? [])],
       maxValidity: String(options.waiverMaxValidity ?? 'PT24H'),
     });
-    validWaiverCount = waiverEvidence.valid.length;
+    // Even when the configured list makes SOME check waivable, only count a
+    // waiver whose own marker selector is THIS gate's selector -- a valid
+    // waiver for an unrelated external check must never satisfy this one.
+    validWaiverCount = waiverEvidence.valid.filter(
+      (entry) => entry.checkSelector === waiverCheckSelector,
+    ).length;
   }
   const waiver = {
     mode: waiverMode,
@@ -224,17 +238,21 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   };
 }
 /** Evaluate Clause 1 (the latest-review clause) against every Copilot
- * review that targets the current HEAD. Deliberately does not pick "the
- * single latest review by `submittedAt`" and check only that one: a fresh
- * push never reuses a commit SHA, so multiple same-HEAD Copilot reviews are
- * retries or duplicates of the same content, not a legitimate
- * "re-reviewed after a fix" sequence. Requiring every on-HEAD review to be
- * clean is the fail-closed choice, and it never depends on `submittedAt`
- * ordering -- which can be missing/invalid on a real GraphQL payload (the
- * field is nullable) -- to decide which single review "counts". A
- * timestamp-sort-based pick would let a later, dirty, timestamp-less review
- * be silently out-ranked by an earlier clean one; filtering by `commitId`
- * first sidesteps that ordering question entirely. */
+ * review that targets the current HEAD, and evaluate Clause 1 against
+ * *that* review only. Re-requesting a review without a new push is a real,
+ * supported flow in this repo's own advisory-wait protocol (AW3
+ * `REQUEST_NEEDED`), so two reviews can legitimately share one `commitId`
+ * with the later one superseding the earlier one (e.g. addressed via
+ * thread replies, then re-reviewed) -- requiring every on-HEAD review to
+ * be clean would wrongly keep a genuinely-converged PR blocked forever
+ * (see PR #1343 review). The latest on-HEAD review is simply the last
+ * on-HEAD entry in fetch order: GitHub's GraphQL `reviews` connection
+ * returns reviews in submission order (the same assumption
+ * `findLastCopilotReviewCommit` already relies on elsewhere in this
+ * codebase), so this deliberately does NOT re-sort by `submittedAt` --
+ * which can be missing/invalid on a real payload (the field is nullable)
+ * and would otherwise let an earlier, differently-ordered review win by
+ * comparator accident, hiding a genuinely later dirty review. */
 function resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin) {
   const copilotReviews = reviews.filter((review) =>
     isCopilotReviewerLogin(review.author?.login ?? '', primaryBotLogin),
@@ -242,30 +260,30 @@ function resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin) {
   const onHead = copilotReviews.filter(
     (review) => String(review.commitId ?? '').toLowerCase() === prHeadSha,
   );
-  if (onHead.length === 0) {
-    const last = copilotReviews.at(-1);
+  const latest = onHead.length > 0 ? onHead.at(-1) : copilotReviews.at(-1);
+  if (!latest) {
     return {
-      found: copilotReviews.length > 0,
-      commitId: String(last?.commitId ?? '').toLowerCase(),
+      found: false,
+      commitId: '',
       matchesHead: false,
       itemCount: null,
-      submittedAt: String(last?.submittedAt ?? ''),
+      submittedAt: '',
       satisfied: false,
     };
   }
-  const itemCounts = onHead.map((review) =>
-    Number.isFinite(review.itemCount) ? Number(review.itemCount) : null,
-  );
-  const worstItemCount = itemCounts.every((count) => count !== null)
-    ? Math.max(...itemCounts)
+  const matchesHead = onHead.length > 0;
+  const itemCount = matchesHead
+    ? Number.isFinite(latest.itemCount)
+      ? Number(latest.itemCount)
+      : null
     : null;
   return {
     found: true,
-    commitId: prHeadSha,
-    matchesHead: true,
-    itemCount: worstItemCount,
-    submittedAt: String(onHead.at(-1)?.submittedAt ?? ''),
-    satisfied: worstItemCount === 0,
+    commitId: String(latest.commitId ?? '').toLowerCase(),
+    matchesHead,
+    itemCount,
+    submittedAt: String(latest.submittedAt ?? ''),
+    satisfied: matchesHead && itemCount === 0,
   };
 }
 /** Thread IDs whose *originating* (first) comment is Copilot-authored.
@@ -469,14 +487,13 @@ function collectFromGitHub(args) {
       paginate: true,
     },
   );
-  const claimIssueNumber =
-    args.claimIssueNumber ??
-    resolveSoleClosingIssueNumber(pr.closingIssuesReferences);
-  const claimEvents = claimIssueNumber
-    ? ghApiJson(`repos/${owner}/${repo}/issues/${claimIssueNumber}/comments`, {
-        paginate: true,
-      })
-    : [];
+  const claimEvents = resolveClaimEvents(
+    owner,
+    repo,
+    args.claimIssueNumber,
+    pr.closingIssuesReferences,
+    trustedMarkerLogins,
+  );
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
   // No manual cast: `normalizePolicyConfig`'s inferred return type already
@@ -509,16 +526,56 @@ function collectFromGitHub(args) {
         policy?.ciGate?.externalCheckWaivers?.maxValidity ?? 'PT24H',
       ),
       waiverCheckSelector: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      waivableSelectors: policy?.ciGate?.externalChecks?.waivable ?? [],
     },
   };
 }
-function resolveSoleClosingIssueNumber(refs) {
-  const numbers = [
+/**
+ * Resolve the linked (claim) issue's comment stream for waiver-claim
+ * binding. When `explicitIssueNumber` (`--claim-issue`) is given, use it
+ * directly -- no ambiguity to resolve. Otherwise a PR can close more than
+ * one issue (`pr.closingIssuesReferences`), so fetch every candidate's
+ * comments and keep only the one whose *active claim* actually resolves
+ * (`summarizeClaimValidation`), mirroring how `external-check-waiver.mts`'s
+ * own `selectLinkedIssueCandidate` disambiguates multiple linked issues by
+ * active-claim presence rather than requiring a single closing reference.
+ * Zero or multiple resolving candidates fail closed to `[]` (no waiver
+ * claim can bind unambiguously), same as before.
+ */
+function resolveClaimEvents(
+  owner,
+  repo,
+  explicitIssueNumber,
+  refs,
+  trustedMarkerLogins,
+) {
+  if (explicitIssueNumber) {
+    return ghApiJson(
+      `repos/${owner}/${repo}/issues/${explicitIssueNumber}/comments`,
+      { paginate: true },
+    );
+  }
+  const candidateNumbers = [
     ...new Set(
       (refs ?? []).map((ref) => ref?.number).filter((n) => Number.isInteger(n)),
     ),
   ];
-  return numbers.length === 1 ? numbers[0] : null;
+  const resolving = candidateNumbers
+    .map((issueNumber) => {
+      const comments = ghApiJson(
+        `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+        { paginate: true },
+      );
+      return {
+        comments,
+        hasActiveClaim: Boolean(
+          summarizeClaimValidation(comments, { trustedMarkerLogins })
+            .activeClaimPresent,
+        ),
+      };
+    })
+    .filter((candidate) => candidate.hasActiveClaim);
+  return resolving.length === 1 ? resolving[0].comments : [];
 }
 function ghGraphql(query, variables) {
   const args = ['api', 'graphql', '-f', `query=${query}`];
@@ -533,39 +590,57 @@ function ghGraphql(query, variables) {
   return JSON.parse(ghText(args).trim() || '{}');
 }
 function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
-  const payload = ghGraphql(
-    `
-      query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            reviews(first: 100) {
-              nodes {
-                commit { oid }
-                submittedAt
-                author { login }
-                comments { totalCount }
+  const nodes = [];
+  let headCommittedAt = '';
+  let cursor = null;
+  // Paginate `reviews` the same way `fetchReviewThreads` paginates
+  // `reviewThreads` below: a PR with more than one page of reviews would
+  // otherwise silently evaluate Clause 1 against only the first 100,
+  // potentially missing a later, dirty, current-HEAD review (see PR #1343
+  // review). `commits(last: 1)` is fetched once, on the first page, since
+  // it never changes across pages.
+  while (true) {
+    const payload = ghGraphql(
+      `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviews(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  commit { oid }
+                  submittedAt
+                  author { login }
+                  comments { totalCount }
+                }
+              }
+              commits(last: 1) {
+                nodes { commit { committedDate } }
               }
             }
-            commits(last: 1) {
-              nodes { commit { committedDate } }
-            }
           }
-        }
-      }`,
-    { owner, repo, number: prNumber },
-  );
-  const reviews = (
-    payload?.data?.repository?.pullRequest?.reviews?.nodes ?? []
-  ).map((node) => ({
+        }`,
+      { owner, repo, number: prNumber, cursor },
+    );
+    const pullRequest = payload?.data?.repository?.pullRequest;
+    nodes.push(...(pullRequest?.reviews?.nodes ?? []));
+    if (!headCommittedAt) {
+      headCommittedAt = String(
+        pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
+      );
+    }
+    if (!pullRequest?.reviews?.pageInfo?.hasNextPage) break;
+    if (!pullRequest.reviews.pageInfo.endCursor) {
+      throw new Error('review pagination payload is missing endCursor');
+    }
+    cursor = pullRequest.reviews.pageInfo.endCursor;
+  }
+  const reviews = nodes.map((node) => ({
     author: node.author ?? null,
     submittedAt: node.submittedAt ?? null,
     commitId: node.commit?.oid ?? null,
     itemCount: node.comments?.totalCount ?? null,
   }));
-  const headCommittedAt = String(
-    payload?.data?.repository?.pullRequest?.commits?.nodes?.[0]?.commit
-      ?.committedDate ?? '',
-  );
   return { reviews, headCommittedAt };
 }
 function fetchReviewThreads(owner, repo, prNumber) {

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -10,6 +10,9 @@ export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
 export const DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES = 10;
 export const DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES = 2;
 export const DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN = 'copilot';
+// 24h, matching the `claim-stale-age` and external-check-waiver
+// `maxValidity` defaults so this gate uses a familiar timescale.
+export const DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES = 1440;
 export const ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT = 'phase-specific';
 export const ADVISORY_CAP_EXHAUSTED_ROUTES = new Set([
   'phase-specific',
@@ -120,6 +123,40 @@ export function readAdvisorySecondaryBotLogin(
     return resolveAdvisorySecondaryBotLogin(config);
   } catch {
     return '';
+  }
+}
+/**
+ * Resolve the configured advisory-convergence deadline (in minutes) from a
+ * parsed policy object. Once a PR HEAD has gone this long without a
+ * zero-item Copilot review, `advisory-convergence.mts`'s only pass path is a
+ * valid maintainer external-check waiver for that HEAD. Kept separate from
+ * {@link resolveAdvisoryWaitPolicy} for the same reason the bot-login
+ * resolvers are separate: it is not part of the five-key active-wait timing
+ * shape, and defaults to Copilot-advisory-preserving behavior when absent.
+ */
+export function resolveAdvisoryConvergenceDeadlineMinutes(config = {}) {
+  const advisoryWait = config?.advisoryWait ?? {};
+  return normalizeConfiguredDurationMinutes(
+    advisoryWait.convergenceDeadline,
+    DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
+  );
+}
+/**
+ * Read the configured advisory-convergence deadline from a policy file,
+ * failing closed to the 24h default when the file is missing, unreadable, or
+ * schema-invalid.
+ */
+export function readAdvisoryConvergenceDeadlineMinutes(
+  path = '.github/idd/config.json',
+) {
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    if (validate(config, POLICY_SCHEMA).length > 0) {
+      return DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
+    }
+    return resolveAdvisoryConvergenceDeadlineMinutes(config);
+  } catch {
+    return DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
   }
 }
 export function normalizeAdvisoryWaitRuntimeOptions(options = {}) {

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -91,6 +91,16 @@ const EXTRA_RUNTIME_FILES = new Map([
 ]);
 const HELPER_COMMANDS = [
   {
+    id: 'advisory-convergence',
+    scriptName: 'idd:advisory-convergence',
+    binName: 'idd-advisory-convergence',
+    entryPath: 'scripts/advisory-convergence.mjs',
+    vendoredCommand: 'node scripts/advisory-convergence.mjs',
+    description:
+      'Assert whether the primary advisory bot has converged on the current PR HEAD, with an exit-code contract via --assert.',
+    contractPaths: ['schemas/advisory-convergence.schema.json'],
+  },
+  {
     id: 'advisory-wait-state',
     scriptName: 'idd:advisory-wait-state',
     binName: 'idd-advisory-wait-state',

--- a/src/bin/idd-advisory-convergence.mts
+++ b/src/bin/idd-advisory-convergence.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-advisory-convergence.mts
+//
+// The bin/idd-advisory-convergence.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/advisory-convergence.mjs');

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -765,6 +765,37 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
 }
 
 /**
+ * Fetch one issue's comments and normalize them to the `author.login` /
+ * `createdAt` shape `resolveActiveClaim`/`applyClaimEvent`
+ * (`protocol-helpers.mts`) require. Unlike `summarizeDispositionEvidence-
+ * ForGate` / `summarizeExternalCheckWaivers`, the claim resolver has NO
+ * `user.login` / `created_at` REST fallback (`event.author?.login ?? ''`,
+ * `event.createdAt ?? ''`, verbatim) -- passing raw `gh api` REST comments
+ * through unnormalized silently resolves `activeClaimPresent: false` for
+ * every real claim, breaking the entire waiver escape hatch without any
+ * error. `pre-merge-readiness.mts`'s own `normalizeClaimComment` does the
+ * same normalization for the identical reason; mirrored here rather than
+ * imported since it is not exported.
+ */
+function fetchClaimComments(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): IssueCommentPayload[] {
+  const raw = ghApiJson(
+    `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+    {
+      paginate: true,
+    },
+  ) as IssueCommentPayload[];
+  return raw.map((comment) => ({
+    body: comment.body ?? '',
+    createdAt: comment.createdAt ?? comment.created_at ?? '',
+    author: { login: comment.author?.login ?? comment.user?.login ?? '' },
+  }));
+}
+
+/**
  * Resolve the linked (claim) issue's comment stream for waiver-claim
  * binding. When `explicitIssueNumber` (`--claim-issue`) is given, use it
  * directly -- no ambiguity to resolve. Otherwise a PR can close more than
@@ -784,10 +815,7 @@ function resolveClaimEvents(
   trustedMarkerLogins: string[],
 ): IssueCommentPayload[] {
   if (explicitIssueNumber) {
-    return ghApiJson(
-      `repos/${owner}/${repo}/issues/${explicitIssueNumber}/comments`,
-      { paginate: true },
-    ) as IssueCommentPayload[];
+    return fetchClaimComments(owner, repo, explicitIssueNumber);
   }
   const candidateNumbers = [
     ...new Set(
@@ -798,10 +826,7 @@ function resolveClaimEvents(
   ];
   const resolving = candidateNumbers
     .map((issueNumber) => {
-      const comments = ghApiJson(
-        `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
-        { paginate: true },
-      ) as IssueCommentPayload[];
+      const comments = fetchClaimComments(owner, repo, issueNumber);
       return {
         comments,
         hasActiveClaim: Boolean(

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -1,0 +1,973 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/advisory-convergence.mts
+//
+// The scripts/advisory-convergence.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Read-only policy-engine helper (#1340): deterministically asserts whether
+// the primary advisory bot's ("Copilot's") review has *converged* on the
+// current PR HEAD -- see issue #1340 and roadmap #1342. This closes a gap
+// where the existing evidence collectors (`pre-merge-readiness.mjs`,
+// `review-disposition-verify.mjs`, `advisory-wait-state.mjs`) report JSON
+// for the model to interpret, but no single helper asserts the invariant
+// with a hard exit code.
+//
+// Reuse map (no duplicated review-parsing logic):
+//   - `isCopilotReviewerLogin` / `readAdvisoryPrimaryBotLogin` /
+//     `resolveAdvisoryPrimaryBotLogin` -- Copilot identity resolution.
+//   - `resolveAdvisoryBotLogins`, `resolveTrustedMarkerActors` -- the same
+//     trust/identity resolution every other helper uses.
+//   - `summarizeDispositionEvidenceForGate` -- reused UNFILTERED for
+//     per-thread disposition-marker validity; this file only adds a thin
+//     Copilot-authorship filter on top of its `missingThreads` output.
+//   - `summarizeClaimValidation`, `summarizeExternalCheckWaivers` -- reused
+//     verbatim for the deadline/waiver escape hatch, auto-discovering the
+//     PR's linked issue exactly as `external-check-waiver.mts`'s own
+//     `--apply` path already does, so no claim flag is required to call
+//     this helper (`--pr <n> --assert` is sufficient -- see docs).
+//
+// This helper never mutates GitHub state: it only reads PR/review/thread/
+// comment data and prints a verdict.
+
+import {
+  DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+  readAdvisoryConvergenceDeadlineMinutes,
+  readAdvisoryPrimaryBotLogin,
+} from './advisory-wait-policy.mts';
+import { ghApiJson, ghText, isCliExecution, safeGhText } from './gh-exec.mts';
+import { loadIddConfig } from './idd-config.mts';
+import { isValidIsoTimestamp } from './marker-helpers.mts';
+import { normalizePolicyConfig } from './policy-helpers.mts';
+import {
+  isCopilotReviewerLogin,
+  normalizeTrustedMarkerLogins,
+  resolveAdvisoryBotLogins,
+  resolveTrustedMarkerActors,
+  summarizeClaimValidation,
+  summarizeDispositionEvidenceForGate,
+  summarizeExternalCheckWaivers,
+} from './protocol-helpers.mts';
+
+/** The external-check-waiver selector this gate recognizes (documented in
+ * docs/idd-helper-scripts.md and docs/policy-constants.md; #1341's required
+ * check is expected to register under the same name). */
+export const ADVISORY_CONVERGENCE_CHECK_SELECTOR = 'idd-advisory-convergence';
+
+/** Author reference embedded in GitHub REST/GraphQL payloads. */
+interface GhAuthorPayload {
+  login?: string | null;
+}
+
+/** Issue/PR comment payload fields consumed by this helper. */
+interface IssueCommentPayload {
+  id?: string | number | null;
+  body?: string | null;
+  author?: GhAuthorPayload | null;
+  user?: GhAuthorPayload | null;
+  createdAt?: string | null;
+  created_at?: string | null;
+  updatedAt?: string | null;
+  updated_at?: string | null;
+}
+
+/** PR review payload, normalized from the GraphQL `reviews` connection. */
+interface ReviewPayload {
+  author?: GhAuthorPayload | null;
+  submittedAt?: string | null;
+  commitId?: string | null;
+  itemCount?: number | null;
+}
+
+/** Review-thread reply node (GraphQL `reviewThreads` comment). */
+interface ThreadCommentPayload {
+  body?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  author?: GhAuthorPayload | null;
+  pullRequestReview?: { id?: string | null } | null;
+}
+
+/** Review thread (GraphQL `reviewThreads` node). */
+interface ReviewThreadPayload {
+  id?: string | null;
+  isResolved?: boolean | null;
+  comments?: {
+    pageInfo?: {
+      hasNextPage?: boolean | null;
+      endCursor?: string | null;
+    } | null;
+    nodes: ThreadCommentPayload[];
+  } | null;
+}
+
+/** GraphQL pagination cursor block. */
+interface PageInfoPayload {
+  hasNextPage?: boolean | null;
+  endCursor?: string | null;
+}
+
+/** GraphQL `reviewThreads` connection payload. */
+interface ReviewThreadsConnectionPayload {
+  pageInfo?: PageInfoPayload | null;
+  nodes?: ReviewThreadPayload[] | null;
+}
+
+/** `gh pr view --json closingIssuesReferences` entry. */
+interface ClosingIssueRefPayload {
+  number?: number | null;
+}
+
+/** Latest-review clause evidence (Clause 1 of the `converged` definition). */
+export interface AdvisoryConvergenceReviewClause {
+  found: boolean;
+  commitId: string;
+  matchesHead: boolean;
+  itemCount: number | null;
+  submittedAt: string;
+  satisfied: boolean;
+}
+
+/** Thread clause evidence (Clause 2 of the `converged` definition). A
+ * Copilot-authored thread satisfies this clause when it is resolved
+ * (regardless of marker) or, if unresolved, carries a fresh disposition
+ * marker -- see the `converged` computation for the exact rule. */
+export interface AdvisoryConvergenceThreadClause {
+  copilotThreadCount: number;
+  blockingIds: string[];
+  blockingCount: number;
+  satisfied: boolean;
+}
+
+/** Deadline-clock evidence. */
+export interface AdvisoryConvergenceDeadline {
+  minutes: number;
+  headCommittedAt: string;
+  elapsedMinutes: number | null;
+  passed: boolean;
+}
+
+/** Waiver escape-hatch evidence. */
+export interface AdvisoryConvergenceWaiver {
+  mode: string;
+  checkSelector: string;
+  activeClaimId: string;
+  validCount: number;
+}
+
+/** Full JSON verdict document printed by this CLI. */
+export interface AdvisoryConvergenceVerdict {
+  protocolVersion: '1';
+  decisionAuthority: 'instructions';
+  prNumber: number;
+  prHeadSha: string;
+  now: string;
+  primaryBotLogin: string;
+  review: AdvisoryConvergenceReviewClause;
+  threads: AdvisoryConvergenceThreadClause;
+  pending: boolean;
+  deadline: AdvisoryConvergenceDeadline;
+  waiver: AdvisoryConvergenceWaiver;
+  converged: boolean;
+  waived: boolean;
+  ready: boolean;
+  reasons: string[];
+}
+
+/** Pure inputs to {@link computeAdvisoryConvergenceVerdict} (already fetched;
+ * this function performs no I/O). */
+export interface AdvisoryConvergenceInputs {
+  prNumber: number;
+  prHeadSha: string;
+  reviews?: ReviewPayload[];
+  threads?: ReviewThreadPayload[];
+  comments?: IssueCommentPayload[];
+  /** The linked (claim) issue's own comment stream, or `[]` when no linked
+   * issue could be resolved -- see module header. Used only to resolve the
+   * active claim for waiver validation; the `converged` computation itself
+   * never depends on a claim. */
+  claimEvents?: IssueCommentPayload[];
+}
+
+/** Pure options accepted by {@link computeAdvisoryConvergenceVerdict}. */
+export interface AdvisoryConvergenceOptions {
+  now: string;
+  primaryBotLogin?: string;
+  trustedMarkerLogins?: unknown[] | null;
+  advisoryBotLogins?: unknown[] | null;
+  /** The PR author's login, excluded from "external feedback" the same way
+   * `summarizeDispositionEvidenceForGate` excludes it elsewhere. */
+  prAuthorLogin?: string | null;
+  /** ISO-8601 timestamp for the current HEAD commit; anchors the deadline
+   * clock independent of any IDD-specific marker (see module header). */
+  headCommittedAt?: string | null;
+  deadlineMinutes?: number;
+  waiverMode?: string;
+  waiverMaxValidity?: string;
+  waiverCheckSelector?: string;
+}
+
+/**
+ * Compute the deterministic advisory-convergence verdict from already-
+ * fetched PR evidence. Pure (no I/O), so it is directly unit-testable with
+ * fixtures -- mirrors `buildPreMergeReadinessSummary` /
+ * `buildAdvisoryWaitSummary` in `protocol-helpers.mts`.
+ */
+export function computeAdvisoryConvergenceVerdict(
+  inputs: AdvisoryConvergenceInputs,
+  options: AdvisoryConvergenceOptions,
+): AdvisoryConvergenceVerdict {
+  const now = String(options.now ?? '');
+  if (!isValidIsoTimestamp(now)) {
+    throw new Error('now must be an ISO 8601 UTC timestamp');
+  }
+  const prHeadSha = String(inputs.prHeadSha ?? '').toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    throw new Error('prHeadSha must be a 40-character lowercase commit SHA');
+  }
+
+  const primaryBotLogin =
+    String(options.primaryBotLogin ?? '')
+      .trim()
+      .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins(
+    options.trustedMarkerLogins ?? [],
+  );
+  const reviews = inputs.reviews ?? [];
+  const threads = inputs.threads ?? [];
+  const comments = inputs.comments ?? [];
+  const claimEvents = inputs.claimEvents ?? [];
+  const reasons: string[] = [];
+
+  // --- Clause 1: latest Copilot review is clean on the current HEAD -----
+  const review = resolveLatestCopilotReviewClause(
+    reviews,
+    prHeadSha,
+    primaryBotLogin,
+  );
+  const pending = !review.matchesHead;
+  if (pending) {
+    reasons.push(
+      review.found
+        ? `latest ${primaryBotLogin} review (commit ${review.commitId || '<unknown>'}) does not cover current HEAD ${prHeadSha}`
+        : `${primaryBotLogin} has not reviewed this pull request yet`,
+    );
+  } else if (!review.satisfied) {
+    reasons.push(
+      `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`,
+    );
+  }
+
+  // --- Clause 2: every current Copilot-authored thread is resolved or ---
+  // --- validly dispositioned (reusing summarizeDispositionEvidenceForGate)
+  const copilotThreadIds = classifyCopilotAuthoredThreadIds(
+    threads,
+    primaryBotLogin,
+  );
+  const dispositionEvidence = summarizeDispositionEvidenceForGate(
+    { comments, threads },
+    {
+      // `summarizeDispositionEvidenceForGate` requires a recognized
+      // "IDD agent" login to accept an Accept/Reject/AMD marker as a fresh
+      // disposition (see `hasFreshDisposition`). This gate has no separate
+      // notion of "IDD agent" from "trusted marker actor" -- both mean the
+      // same thing here (whoever is authorized to post operational markers
+      // on this repo) -- so the trusted set is reused for both, avoiding an
+      // extra CLI flag / config surface the issue does not ask for.
+      iddAgentLogins: trustedMarkerLogins,
+      trustedMarkerLogins,
+      advisoryBotLogins: normalizeTrustedMarkerLogins(
+        options.advisoryBotLogins ?? [],
+      ),
+      prAuthorLogin: String(options.prAuthorLogin ?? '')
+        .trim()
+        .toLowerCase(),
+      // Deliberately no `snapshotBoundaryAt`: this claim-independent gate has
+      // no F2 review-watermark to anchor one to, and threading a sentinel
+      // (e.g. `now`) through would make every resolved thread's feedback
+      // trivially predate it -- silently turning the boundary-gated
+      // ack-only-post-disposition classification (`classifyThreadAckOnly-
+      // PostDisposition`, protocol-helpers.mts) into permanent dead code
+      // instead of the deliberate carve-out it looks like. "Resolved is
+      // sufficient" (below) is handled directly, without relying on that
+      // classification at all.
+    },
+  );
+  // Clause 2 per the issue: "resolved OR carries a valid disposition
+  // marker." `missingThreads` (computed without a boundary, above) flags
+  // BOTH an unresolved thread lacking a fresh marker AND a resolved thread
+  // lacking one (`reason: 'missing-fresh-disposition'`) -- the latter is not
+  // a Clause-2 blocker here, since resolution alone already satisfies it, so
+  // only the genuinely unresolved entries count.
+  const copilotBlocking = dispositionEvidence.missingThreads.filter(
+    (thread) =>
+      copilotThreadIds.has(String(thread.id ?? '')) &&
+      thread.isResolved === false,
+  );
+  const threadClause: AdvisoryConvergenceThreadClause = {
+    copilotThreadCount: copilotThreadIds.size,
+    blockingIds: copilotBlocking.map((thread) => String(thread.id ?? '')),
+    blockingCount: copilotBlocking.length,
+    satisfied: copilotBlocking.length === 0,
+  };
+  if (!threadClause.satisfied) {
+    reasons.push(
+      `${threadClause.blockingCount} ${primaryBotLogin}-authored review thread(s) are neither resolved nor validly dispositioned: ${threadClause.blockingIds.join(', ')}`,
+    );
+  }
+
+  const converged = !pending && review.satisfied && threadClause.satisfied;
+
+  // --- Deadline clock, anchored on the current HEAD commit's own --------
+  // --- timestamp (not an IDD marker -- see module header for why) -------
+  const deadlineMinutes = Number.isFinite(options.deadlineMinutes)
+    ? Number(options.deadlineMinutes)
+    : 1440;
+  const headCommittedAt = String(options.headCommittedAt ?? '');
+  const elapsedMinutes = isValidIsoTimestamp(headCommittedAt)
+    ? minutesBetween(headCommittedAt, now)
+    : null;
+  const deadlinePassed =
+    elapsedMinutes !== null && elapsedMinutes >= deadlineMinutes;
+  const deadline: AdvisoryConvergenceDeadline = {
+    minutes: deadlineMinutes,
+    headCommittedAt,
+    elapsedMinutes,
+    passed: deadlinePassed,
+  };
+
+  // --- Waiver escape hatch (only reachable once the deadline has passed) -
+  const waiverMode = String(options.waiverMode ?? 'disabled');
+  const waiverCheckSelector =
+    String(options.waiverCheckSelector ?? '').trim() ||
+    ADVISORY_CONVERGENCE_CHECK_SELECTOR;
+  const claim = summarizeClaimValidation(claimEvents, { trustedMarkerLogins });
+  const activeClaimId = claim.activeClaim?.claimId ?? '';
+  let validWaiverCount = 0;
+  if (!converged && deadlinePassed && waiverMode === 'maintainer-authorized') {
+    const waiverEvidence = summarizeExternalCheckWaivers(comments, {
+      prHeadSha,
+      activeClaimId,
+      trustedMarkerLogins,
+      now,
+      waivableSelectors: [
+        { selector: waiverCheckSelector, matchMode: 'exact' },
+      ],
+      maxValidity: String(options.waiverMaxValidity ?? 'PT24H'),
+    });
+    validWaiverCount = waiverEvidence.valid.length;
+  }
+  const waiver: AdvisoryConvergenceWaiver = {
+    mode: waiverMode,
+    checkSelector: waiverCheckSelector,
+    activeClaimId,
+    validCount: validWaiverCount,
+  };
+  const waived = validWaiverCount > 0;
+  if (!converged && deadlinePassed && !waived) {
+    reasons.push(
+      `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`,
+    );
+  }
+
+  const ready = converged || (deadlinePassed && waived);
+
+  return {
+    protocolVersion: '1',
+    decisionAuthority: 'instructions',
+    prNumber: inputs.prNumber,
+    prHeadSha,
+    now,
+    primaryBotLogin,
+    review,
+    threads: threadClause,
+    pending,
+    deadline,
+    waiver,
+    converged,
+    waived,
+    ready,
+    reasons,
+  };
+}
+
+/** Evaluate Clause 1 (the latest-review clause) against every Copilot
+ * review that targets the current HEAD. Deliberately does not pick "the
+ * single latest review by `submittedAt`" and check only that one: a fresh
+ * push never reuses a commit SHA, so multiple same-HEAD Copilot reviews are
+ * retries or duplicates of the same content, not a legitimate
+ * "re-reviewed after a fix" sequence. Requiring every on-HEAD review to be
+ * clean is the fail-closed choice, and it never depends on `submittedAt`
+ * ordering -- which can be missing/invalid on a real GraphQL payload (the
+ * field is nullable) -- to decide which single review "counts". A
+ * timestamp-sort-based pick would let a later, dirty, timestamp-less review
+ * be silently out-ranked by an earlier clean one; filtering by `commitId`
+ * first sidesteps that ordering question entirely. */
+function resolveLatestCopilotReviewClause(
+  reviews: ReviewPayload[],
+  prHeadSha: string,
+  primaryBotLogin: string,
+): AdvisoryConvergenceReviewClause {
+  const copilotReviews = reviews.filter((review) =>
+    isCopilotReviewerLogin(review.author?.login ?? '', primaryBotLogin),
+  );
+  const onHead = copilotReviews.filter(
+    (review) => String(review.commitId ?? '').toLowerCase() === prHeadSha,
+  );
+  if (onHead.length === 0) {
+    const last = copilotReviews.at(-1);
+    return {
+      found: copilotReviews.length > 0,
+      commitId: String(last?.commitId ?? '').toLowerCase(),
+      matchesHead: false,
+      itemCount: null,
+      submittedAt: String(last?.submittedAt ?? ''),
+      satisfied: false,
+    };
+  }
+  const itemCounts = onHead.map((review) =>
+    Number.isFinite(review.itemCount) ? Number(review.itemCount) : null,
+  );
+  const worstItemCount = itemCounts.every(
+    (count): count is number => count !== null,
+  )
+    ? Math.max(...itemCounts)
+    : null;
+  return {
+    found: true,
+    commitId: prHeadSha,
+    matchesHead: true,
+    itemCount: worstItemCount,
+    submittedAt: String(onHead.at(-1)?.submittedAt ?? ''),
+    satisfied: worstItemCount === 0,
+  };
+}
+
+/** Thread IDs whose *originating* (first) comment is Copilot-authored.
+ * `summarizeReviewThreadsForGate` classifies by latest-commenter identity
+ * for a different purpose (backlog gating) and is not bot-scoped, so this
+ * is new, narrow logic -- the disposition-marker validity it feeds into
+ * still comes entirely from the reused `summarizeDispositionEvidenceForGate`
+ * output. */
+export function classifyCopilotAuthoredThreadIds(
+  threads: ReviewThreadPayload[],
+  primaryBotLogin: string,
+): Set<string> {
+  const ids = new Set<string>();
+  threads.forEach((thread, index) => {
+    // GitHub's GraphQL `comments` connection on a review thread returns
+    // comments in creation order -- the same assumption `fetchReviewThreads`
+    // / `fetchThreadCommentPages` already rely on when appending paginated
+    // results without re-sorting -- so the thread-opening comment is always
+    // `nodes[0]`. Deliberately not timestamp-sorted: `compareIsoTimestamps`
+    // sorts a missing/invalid `createdAt` BEFORE any valid one (by design,
+    // for existing "pick the latest, ignore garbage" call sites elsewhere),
+    // which would let a later reply with a bad timestamp silently usurp
+    // "originating" status and make a genuinely Copilot-opened thread
+    // invisible to this gate.
+    const originating = (thread.comments?.nodes ?? [])[0];
+    if (
+      originating &&
+      isCopilotReviewerLogin(originating.author?.login ?? '', primaryBotLogin)
+    ) {
+      // Match `summarizeDispositionEvidenceForGate`'s own
+      // `missingThreads[].id` fallback exactly (protocol-helpers.mts) so a
+      // thread with an empty/missing GraphQL id still round-trips through
+      // the `.has()` lookup in the caller instead of silently diverging.
+      ids.add(String(thread.id ?? '') || `thread-${index + 1}`);
+    }
+  });
+  return ids;
+}
+
+function minutesBetween(start: string, end: string): number {
+  return (new Date(end).getTime() - new Date(start).getTime()) / 60000;
+}
+
+/** Parsed CLI arguments. */
+interface AdvisoryConvergenceArgs {
+  prNumber: number | null;
+  owner: string;
+  repo: string;
+  claimIssueNumber: number | null;
+  trustedMarkerLogins: string;
+  advisoryBotLogins: string;
+  now: string;
+  assert: boolean;
+  help: boolean;
+}
+
+export function parseArgs(argv: string[]): AdvisoryConvergenceArgs {
+  const parsed: AdvisoryConvergenceArgs = {
+    prNumber: null,
+    owner: '',
+    repo: '',
+    claimIssueNumber: null,
+    trustedMarkerLogins: '',
+    advisoryBotLogins: '',
+    now: '',
+    assert: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === '--pr') {
+      parsed.prNumber = Number.parseInt(value ?? '', 10);
+      index += 1;
+      continue;
+    }
+    if (token === '--owner') {
+      parsed.owner = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--repo') {
+      parsed.repo = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--claim-issue') {
+      parsed.claimIssueNumber = Number.parseInt(value ?? '', 10);
+      index += 1;
+      continue;
+    }
+    if (token === '--trusted-marker-logins') {
+      parsed.trustedMarkerLogins = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--advisory-bot-logins') {
+      parsed.advisoryBotLogins = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--now') {
+      parsed.now = value ?? '';
+      index += 1;
+      continue;
+    }
+    if (token === '--assert') {
+      parsed.assert = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${token}`);
+  }
+
+  if (!Number.isInteger(parsed.prNumber) || (parsed.prNumber ?? 0) < 1) {
+    parsed.prNumber = null;
+  }
+  if (
+    !Number.isInteger(parsed.claimIssueNumber) ||
+    (parsed.claimIssueNumber ?? 0) < 1
+  ) {
+    parsed.claimIssueNumber = null;
+  }
+
+  return parsed;
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/advisory-convergence.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--claim-issue <number>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--now <ISO8601>] [--assert]
+
+Read-only: asserts whether the primary advisory bot's review has converged
+on the current PR HEAD. Always prints the JSON verdict. Without --assert,
+always exits 0 (report-only). With --assert, exits non-zero unless the
+verdict is "ready" (converged, or validly waived past the configured
+deadline).
+`);
+}
+
+/** Dependencies injected by tests; production defaults perform real I/O. */
+export interface AdvisoryConvergenceDeps {
+  collect: (args: AdvisoryConvergenceArgs) => {
+    inputs: AdvisoryConvergenceInputs;
+    options: AdvisoryConvergenceOptions;
+  };
+}
+
+const defaultDeps: AdvisoryConvergenceDeps = { collect: collectFromGitHub };
+
+/**
+ * Parse argv, collect evidence (via `deps.collect`, real `gh` calls by
+ * default), compute the verdict, and derive the `--assert` exit code.
+ * Mirrors `idd-merge-execute.mts`'s `runMergeExecute` DI pattern so tests
+ * can substitute a fake `collect` instead of shelling out to `gh`.
+ */
+export function runAdvisoryConvergence(
+  argv: string[],
+  deps: AdvisoryConvergenceDeps = defaultDeps,
+): {
+  verdict: AdvisoryConvergenceVerdict | null;
+  exitCode: number;
+  help: boolean;
+} {
+  const args = parseArgs(argv);
+  if (args.help) {
+    return { verdict: null, exitCode: 0, help: true };
+  }
+  if (!args.prNumber) {
+    throw new Error('missing required --pr <number> argument');
+  }
+
+  const { inputs, options } = deps.collect(args);
+  const verdict = computeAdvisoryConvergenceVerdict(inputs, options);
+  const exitCode = args.assert ? (verdict.ready ? 0 : 1) : 0;
+  return { verdict, exitCode, help: false };
+}
+
+// --- Production I/O: fetch PR/review/thread/comment evidence via `gh` ----
+
+function collectFromGitHub(args: AdvisoryConvergenceArgs): {
+  inputs: AdvisoryConvergenceInputs;
+  options: AdvisoryConvergenceOptions;
+} {
+  const owner =
+    args.owner ||
+    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+  const repo =
+    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const repoRef = `${owner}/${repo}`;
+  const viewerLogin = safeGhText([
+    'api',
+    'user',
+    '--jq',
+    '.login',
+  ]).toLowerCase();
+  const rawConfig = loadIddConfig();
+  const { actors: configuredTrustedActors } = resolveTrustedMarkerActors({
+    flagValue: args.trustedMarkerLogins,
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: rawConfig,
+  });
+  const { logins: advisoryBotLogins } = resolveAdvisoryBotLogins({
+    flagValue: args.advisoryBotLogins,
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+    config: rawConfig,
+  });
+  // Deliberately NOT unioned with `advisoryBotLogins` here (unlike some
+  // other locally-collected sets in this file that scope broader trust for
+  // marker *parsing*): every sibling helper (advisory-wait-state.mts,
+  // pre-merge-readiness.mts) keeps `trustedMarkerLogins` and
+  // `advisoryBotLogins` disjoint, and this specific set also authorizes
+  // `--assert`-gating external-check waivers (via `summarizeExternalCheck-
+  // Waivers`, below) -- folding a configured advisory bot login in here
+  // would let that bot's own comment count as a "maintainer-authorized"
+  // waiver author.
+  const trustedMarkerLogins = normalizeTrustedMarkerLogins([
+    viewerLogin,
+    ...configuredTrustedActors,
+  ]);
+
+  const pr = JSON.parse(
+    ghText([
+      'pr',
+      'view',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'headRefOid,closingIssuesReferences,author',
+    ]),
+  ) as {
+    headRefOid?: unknown;
+    closingIssuesReferences?: ClosingIssueRefPayload[] | null;
+    author?: GhAuthorPayload | null;
+  };
+  const prHeadSha = String(pr.headRefOid ?? '').toLowerCase();
+  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
+
+  const { reviews, headCommittedAt } = fetchReviewsAndHeadCommit(
+    owner,
+    repo,
+    Number(args.prNumber),
+  );
+  const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    {
+      paginate: true,
+    },
+  ) as IssueCommentPayload[];
+
+  const claimIssueNumber =
+    args.claimIssueNumber ??
+    resolveSoleClosingIssueNumber(pr.closingIssuesReferences);
+  const claimEvents = claimIssueNumber
+    ? (ghApiJson(`repos/${owner}/${repo}/issues/${claimIssueNumber}/comments`, {
+        paginate: true,
+      }) as IssueCommentPayload[])
+    : [];
+
+  const primaryBotLogin = readAdvisoryPrimaryBotLogin();
+  const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
+  // No manual cast: `normalizePolicyConfig`'s inferred return type already
+  // carries `ciGate.externalCheckWaivers.{mode,maxValidity}` precisely (see
+  // `external-check-waiver.mts`'s `NormalizedPolicy` alias for the same
+  // pattern) -- re-declaring the shape here would silently stop tracking
+  // that source of truth on drift.
+  const policy = normalizePolicyConfig(rawConfig);
+
+  return {
+    inputs: {
+      prNumber: Number(args.prNumber),
+      prHeadSha,
+      reviews,
+      threads,
+      comments,
+      claimEvents,
+    },
+    options: {
+      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      primaryBotLogin,
+      trustedMarkerLogins,
+      advisoryBotLogins,
+      prAuthorLogin,
+      headCommittedAt,
+      deadlineMinutes,
+      waiverMode: String(
+        policy?.ciGate?.externalCheckWaivers?.mode ?? 'disabled',
+      ),
+      waiverMaxValidity: String(
+        policy?.ciGate?.externalCheckWaivers?.maxValidity ?? 'PT24H',
+      ),
+      waiverCheckSelector: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+    },
+  };
+}
+
+function resolveSoleClosingIssueNumber(
+  refs: ClosingIssueRefPayload[] | null | undefined,
+): number | null {
+  const numbers = [
+    ...new Set(
+      (refs ?? [])
+        .map((ref) => ref?.number)
+        .filter((n): n is number => Number.isInteger(n)),
+    ),
+  ];
+  return numbers.length === 1 ? numbers[0] : null;
+}
+
+function ghGraphql(
+  query: string,
+  variables: Record<string, string | number | null | undefined>,
+): unknown {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'number') {
+      args.push('-F', `${key}=${value}`);
+      continue;
+    }
+    args.push('-f', `${key}=${value}`);
+  }
+  return JSON.parse(ghText(args).trim() || '{}');
+}
+
+function fetchReviewsAndHeadCommit(
+  owner: string,
+  repo: string,
+  prNumber: number,
+): { reviews: ReviewPayload[]; headCommittedAt: string } {
+  const payload = ghGraphql(
+    `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviews(first: 100) {
+              nodes {
+                commit { oid }
+                submittedAt
+                author { login }
+                comments { totalCount }
+              }
+            }
+            commits(last: 1) {
+              nodes { commit { committedDate } }
+            }
+          }
+        }
+      }`,
+    { owner, repo, number: prNumber },
+  ) as {
+    data?: {
+      repository?: {
+        pullRequest?: {
+          reviews?: {
+            nodes?: {
+              commit?: { oid?: string | null } | null;
+              submittedAt?: string | null;
+              author?: GhAuthorPayload | null;
+              comments?: { totalCount?: number | null } | null;
+            }[];
+          } | null;
+          commits?: {
+            nodes?: { commit?: { committedDate?: string | null } | null }[];
+          } | null;
+        } | null;
+      } | null;
+    } | null;
+  };
+
+  const reviews = (
+    payload?.data?.repository?.pullRequest?.reviews?.nodes ?? []
+  ).map((node) => ({
+    author: node.author ?? null,
+    submittedAt: node.submittedAt ?? null,
+    commitId: node.commit?.oid ?? null,
+    itemCount: node.comments?.totalCount ?? null,
+  }));
+  const headCommittedAt = String(
+    payload?.data?.repository?.pullRequest?.commits?.nodes?.[0]?.commit
+      ?.committedDate ?? '',
+  );
+  return { reviews, headCommittedAt };
+}
+
+function fetchReviewThreads(
+  owner: string,
+  repo: string,
+  prNumber: number,
+): ReviewThreadPayload[] {
+  const nodes: ReviewThreadPayload[] = [];
+  let cursor: string | null | undefined = null;
+
+  while (true) {
+    const payload = ghGraphql(
+      `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  isResolved
+                  comments(first: 100) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      body
+                      createdAt
+                      updatedAt
+                      author { login }
+                      pullRequestReview { id }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }`,
+      { owner, repo, number: prNumber, cursor },
+    ) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviewThreads?: ReviewThreadsConnectionPayload | null;
+          } | null;
+        } | null;
+      } | null;
+    };
+
+    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
+    for (const thread of reviewThreads?.nodes ?? []) {
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        if (!thread.id || !thread.comments.pageInfo.endCursor) {
+          throw new Error(
+            'review thread pagination payload is missing id or endCursor',
+          );
+        }
+        thread.comments.nodes.push(
+          ...fetchThreadCommentPages(
+            thread.id,
+            thread.comments.pageInfo.endCursor,
+          ),
+        );
+        thread.comments.pageInfo.hasNextPage = false;
+      }
+    }
+    nodes.push(...(reviewThreads?.nodes ?? []));
+
+    if (!reviewThreads?.pageInfo?.hasNextPage) break;
+    if (!reviewThreads.pageInfo.endCursor) {
+      throw new Error('review thread pagination payload is missing endCursor');
+    }
+    cursor = reviewThreads.pageInfo.endCursor;
+  }
+
+  return nodes;
+}
+
+function fetchThreadCommentPages(
+  threadId: string,
+  afterCursor: string,
+): ThreadCommentPayload[] {
+  const nodes: ThreadCommentPayload[] = [];
+  let cursor: string | null | undefined = afterCursor;
+
+  while (cursor) {
+    const payload = ghGraphql(
+      `
+        query($id: ID!, $cursor: String) {
+          node(id: $id) {
+            ... on PullRequestReviewThread {
+              comments(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  body
+                  createdAt
+                  updatedAt
+                  author { login }
+                  pullRequestReview { id }
+                }
+              }
+            }
+          }
+        }`,
+      { id: threadId, cursor },
+    ) as {
+      data?: {
+        node?: {
+          comments?: {
+            pageInfo?: PageInfoPayload | null;
+            nodes?: ThreadCommentPayload[] | null;
+          } | null;
+        } | null;
+      } | null;
+    };
+
+    const comments = payload?.data?.node?.comments;
+    nodes.push(...(comments?.nodes ?? []));
+    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
+      throw new Error('thread comment pagination payload is missing endCursor');
+    }
+    cursor = comments?.pageInfo?.hasNextPage
+      ? comments.pageInfo.endCursor
+      : null;
+  }
+
+  return nodes;
+}
+
+// CLI: emit the verdict as JSON and set the exit code when invoked directly.
+// Guarded behind isCliExecution(import.meta.url) (shared, see gh-exec.mts)
+// so importing this module (for unit tests) never parses process.argv,
+// prints usage, or makes a `gh` call.
+if (isCliExecution(import.meta.url)) {
+  const { verdict, exitCode, help } = runAdvisoryConvergence(
+    process.argv.slice(2),
+  );
+  if (help) {
+    printHelp();
+  } else if (verdict) {
+    process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  }
+  process.exit(exitCode);
+}

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -228,9 +228,13 @@ export function computeAdvisoryConvergenceVerdict(
   if (!isValidIsoTimestamp(now)) {
     throw new Error('now must be an ISO 8601 UTC timestamp');
   }
+  // Lowercased before validating, so a mixed-/upper-case 40-hex SHA is
+  // accepted (normalized), not rejected -- the error message below
+  // describes the post-normalization shape, not a case restriction on the
+  // input.
   const prHeadSha = String(inputs.prHeadSha ?? '').toLowerCase();
   if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
-    throw new Error('prHeadSha must be a 40-character lowercase commit SHA');
+    throw new Error('prHeadSha must be a 40-character hexadecimal commit SHA');
   }
 
   const primaryBotLogin =

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -205,6 +205,12 @@ export interface AdvisoryConvergenceOptions {
   waiverMode?: string;
   waiverMaxValidity?: string;
   waiverCheckSelector?: string;
+  /** The configured `ciGate.externalChecks.waivable` selector list. A
+   * waiver only counts when its own selector overlaps one of these
+   * entries -- see the waiver escape-hatch computation below. */
+  waivableSelectors?:
+    | readonly { selector: string; matchMode?: string }[]
+    | null;
 }
 
 /**
@@ -254,7 +260,9 @@ export function computeAdvisoryConvergenceVerdict(
     );
   } else if (!review.satisfied) {
     reasons.push(
-      `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`,
+      review.itemCount === null
+        ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
+        : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`,
     );
   }
 
@@ -350,12 +358,24 @@ export function computeAdvisoryConvergenceVerdict(
       activeClaimId,
       trustedMarkerLogins,
       now,
-      waivableSelectors: [
-        { selector: waiverCheckSelector, matchMode: 'exact' },
-      ],
+      // The REAL configured `ciGate.externalChecks.waivable` list (not a
+      // hardcoded single-entry override for this gate's own selector):
+      // respects the existing two-dimensional waiver opt-in
+      // (`externalCheckWaivers.mode` AND a per-check `waivable`
+      // registration) instead of silently making this gate waivable the
+      // moment ANY external check is opted into waiver mode (see PR #1343
+      // review). An absent/empty list waives nothing, matching
+      // `summarizeExternalCheckWaivers`'s own "empty list waives nothing"
+      // contract.
+      waivableSelectors: [...(options.waivableSelectors ?? [])],
       maxValidity: String(options.waiverMaxValidity ?? 'PT24H'),
     });
-    validWaiverCount = waiverEvidence.valid.length;
+    // Even when the configured list makes SOME check waivable, only count a
+    // waiver whose own marker selector is THIS gate's selector -- a valid
+    // waiver for an unrelated external check must never satisfy this one.
+    validWaiverCount = waiverEvidence.valid.filter(
+      (entry) => entry.checkSelector === waiverCheckSelector,
+    ).length;
   }
   const waiver: AdvisoryConvergenceWaiver = {
     mode: waiverMode,
@@ -392,17 +412,21 @@ export function computeAdvisoryConvergenceVerdict(
 }
 
 /** Evaluate Clause 1 (the latest-review clause) against every Copilot
- * review that targets the current HEAD. Deliberately does not pick "the
- * single latest review by `submittedAt`" and check only that one: a fresh
- * push never reuses a commit SHA, so multiple same-HEAD Copilot reviews are
- * retries or duplicates of the same content, not a legitimate
- * "re-reviewed after a fix" sequence. Requiring every on-HEAD review to be
- * clean is the fail-closed choice, and it never depends on `submittedAt`
- * ordering -- which can be missing/invalid on a real GraphQL payload (the
- * field is nullable) -- to decide which single review "counts". A
- * timestamp-sort-based pick would let a later, dirty, timestamp-less review
- * be silently out-ranked by an earlier clean one; filtering by `commitId`
- * first sidesteps that ordering question entirely. */
+ * review that targets the current HEAD, and evaluate Clause 1 against
+ * *that* review only. Re-requesting a review without a new push is a real,
+ * supported flow in this repo's own advisory-wait protocol (AW3
+ * `REQUEST_NEEDED`), so two reviews can legitimately share one `commitId`
+ * with the later one superseding the earlier one (e.g. addressed via
+ * thread replies, then re-reviewed) -- requiring every on-HEAD review to
+ * be clean would wrongly keep a genuinely-converged PR blocked forever
+ * (see PR #1343 review). The latest on-HEAD review is simply the last
+ * on-HEAD entry in fetch order: GitHub's GraphQL `reviews` connection
+ * returns reviews in submission order (the same assumption
+ * `findLastCopilotReviewCommit` already relies on elsewhere in this
+ * codebase), so this deliberately does NOT re-sort by `submittedAt` --
+ * which can be missing/invalid on a real payload (the field is nullable)
+ * and would otherwise let an earlier, differently-ordered review win by
+ * comparator accident, hiding a genuinely later dirty review. */
 function resolveLatestCopilotReviewClause(
   reviews: ReviewPayload[],
   prHeadSha: string,
@@ -414,32 +438,30 @@ function resolveLatestCopilotReviewClause(
   const onHead = copilotReviews.filter(
     (review) => String(review.commitId ?? '').toLowerCase() === prHeadSha,
   );
-  if (onHead.length === 0) {
-    const last = copilotReviews.at(-1);
+  const latest = onHead.length > 0 ? onHead.at(-1) : copilotReviews.at(-1);
+  if (!latest) {
     return {
-      found: copilotReviews.length > 0,
-      commitId: String(last?.commitId ?? '').toLowerCase(),
+      found: false,
+      commitId: '',
       matchesHead: false,
       itemCount: null,
-      submittedAt: String(last?.submittedAt ?? ''),
+      submittedAt: '',
       satisfied: false,
     };
   }
-  const itemCounts = onHead.map((review) =>
-    Number.isFinite(review.itemCount) ? Number(review.itemCount) : null,
-  );
-  const worstItemCount = itemCounts.every(
-    (count): count is number => count !== null,
-  )
-    ? Math.max(...itemCounts)
+  const matchesHead = onHead.length > 0;
+  const itemCount = matchesHead
+    ? Number.isFinite(latest.itemCount)
+      ? Number(latest.itemCount)
+      : null
     : null;
   return {
     found: true,
-    commitId: prHeadSha,
-    matchesHead: true,
-    itemCount: worstItemCount,
-    submittedAt: String(onHead.at(-1)?.submittedAt ?? ''),
-    satisfied: worstItemCount === 0,
+    commitId: String(latest.commitId ?? '').toLowerCase(),
+    matchesHead,
+    itemCount,
+    submittedAt: String(latest.submittedAt ?? ''),
+    satisfied: matchesHead && itemCount === 0,
   };
 }
 
@@ -696,14 +718,13 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
     },
   ) as IssueCommentPayload[];
 
-  const claimIssueNumber =
-    args.claimIssueNumber ??
-    resolveSoleClosingIssueNumber(pr.closingIssuesReferences);
-  const claimEvents = claimIssueNumber
-    ? (ghApiJson(`repos/${owner}/${repo}/issues/${claimIssueNumber}/comments`, {
-        paginate: true,
-      }) as IssueCommentPayload[])
-    : [];
+  const claimEvents = resolveClaimEvents(
+    owner,
+    repo,
+    args.claimIssueNumber,
+    pr.closingIssuesReferences,
+    trustedMarkerLogins,
+  );
 
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
@@ -738,21 +759,59 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
         policy?.ciGate?.externalCheckWaivers?.maxValidity ?? 'PT24H',
       ),
       waiverCheckSelector: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      waivableSelectors: policy?.ciGate?.externalChecks?.waivable ?? [],
     },
   };
 }
 
-function resolveSoleClosingIssueNumber(
+/**
+ * Resolve the linked (claim) issue's comment stream for waiver-claim
+ * binding. When `explicitIssueNumber` (`--claim-issue`) is given, use it
+ * directly -- no ambiguity to resolve. Otherwise a PR can close more than
+ * one issue (`pr.closingIssuesReferences`), so fetch every candidate's
+ * comments and keep only the one whose *active claim* actually resolves
+ * (`summarizeClaimValidation`), mirroring how `external-check-waiver.mts`'s
+ * own `selectLinkedIssueCandidate` disambiguates multiple linked issues by
+ * active-claim presence rather than requiring a single closing reference.
+ * Zero or multiple resolving candidates fail closed to `[]` (no waiver
+ * claim can bind unambiguously), same as before.
+ */
+function resolveClaimEvents(
+  owner: string,
+  repo: string,
+  explicitIssueNumber: number | null,
   refs: ClosingIssueRefPayload[] | null | undefined,
-): number | null {
-  const numbers = [
+  trustedMarkerLogins: string[],
+): IssueCommentPayload[] {
+  if (explicitIssueNumber) {
+    return ghApiJson(
+      `repos/${owner}/${repo}/issues/${explicitIssueNumber}/comments`,
+      { paginate: true },
+    ) as IssueCommentPayload[];
+  }
+  const candidateNumbers = [
     ...new Set(
       (refs ?? [])
         .map((ref) => ref?.number)
         .filter((n): n is number => Number.isInteger(n)),
     ),
   ];
-  return numbers.length === 1 ? numbers[0] : null;
+  const resolving = candidateNumbers
+    .map((issueNumber) => {
+      const comments = ghApiJson(
+        `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+        { paginate: true },
+      ) as IssueCommentPayload[];
+      return {
+        comments,
+        hasActiveClaim: Boolean(
+          summarizeClaimValidation(comments, { trustedMarkerLogins })
+            .activeClaimPresent,
+        ),
+      };
+    })
+    .filter((candidate) => candidate.hasActiveClaim);
+  return resolving.length === 1 ? resolving[0].comments : [];
 }
 
 function ghGraphql(
@@ -771,63 +830,87 @@ function ghGraphql(
   return JSON.parse(ghText(args).trim() || '{}');
 }
 
+interface RawReviewNode {
+  commit?: { oid?: string | null } | null;
+  submittedAt?: string | null;
+  author?: GhAuthorPayload | null;
+  comments?: { totalCount?: number | null } | null;
+}
+
 function fetchReviewsAndHeadCommit(
   owner: string,
   repo: string,
   prNumber: number,
 ): { reviews: ReviewPayload[]; headCommittedAt: string } {
-  const payload = ghGraphql(
-    `
-      query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            reviews(first: 100) {
-              nodes {
-                commit { oid }
-                submittedAt
-                author { login }
-                comments { totalCount }
+  const nodes: RawReviewNode[] = [];
+  let headCommittedAt = '';
+  let cursor: string | null | undefined = null;
+
+  // Paginate `reviews` the same way `fetchReviewThreads` paginates
+  // `reviewThreads` below: a PR with more than one page of reviews would
+  // otherwise silently evaluate Clause 1 against only the first 100,
+  // potentially missing a later, dirty, current-HEAD review (see PR #1343
+  // review). `commits(last: 1)` is fetched once, on the first page, since
+  // it never changes across pages.
+  while (true) {
+    const payload = ghGraphql(
+      `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviews(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  commit { oid }
+                  submittedAt
+                  author { login }
+                  comments { totalCount }
+                }
+              }
+              commits(last: 1) {
+                nodes { commit { committedDate } }
               }
             }
-            commits(last: 1) {
-              nodes { commit { committedDate } }
-            }
           }
-        }
-      }`,
-    { owner, repo, number: prNumber },
-  ) as {
-    data?: {
-      repository?: {
-        pullRequest?: {
-          reviews?: {
-            nodes?: {
-              commit?: { oid?: string | null } | null;
-              submittedAt?: string | null;
-              author?: GhAuthorPayload | null;
-              comments?: { totalCount?: number | null } | null;
-            }[];
-          } | null;
-          commits?: {
-            nodes?: { commit?: { committedDate?: string | null } | null }[];
+        }`,
+      { owner, repo, number: prNumber, cursor },
+    ) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviews?: {
+              pageInfo?: PageInfoPayload | null;
+              nodes?: RawReviewNode[] | null;
+            } | null;
+            commits?: {
+              nodes?: { commit?: { committedDate?: string | null } | null }[];
+            } | null;
           } | null;
         } | null;
       } | null;
-    } | null;
-  };
+    };
 
-  const reviews = (
-    payload?.data?.repository?.pullRequest?.reviews?.nodes ?? []
-  ).map((node) => ({
+    const pullRequest = payload?.data?.repository?.pullRequest;
+    nodes.push(...(pullRequest?.reviews?.nodes ?? []));
+    if (!headCommittedAt) {
+      headCommittedAt = String(
+        pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
+      );
+    }
+
+    if (!pullRequest?.reviews?.pageInfo?.hasNextPage) break;
+    if (!pullRequest.reviews.pageInfo.endCursor) {
+      throw new Error('review pagination payload is missing endCursor');
+    }
+    cursor = pullRequest.reviews.pageInfo.endCursor;
+  }
+
+  const reviews = nodes.map((node) => ({
     author: node.author ?? null,
     submittedAt: node.submittedAt ?? null,
     commitId: node.commit?.oid ?? null,
     itemCount: node.comments?.totalCount ?? null,
   }));
-  const headCommittedAt = String(
-    payload?.data?.repository?.pullRequest?.commits?.nodes?.[0]?.commit
-      ?.committedDate ?? '',
-  );
   return { reviews, headCommittedAt };
 }
 

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -618,13 +618,13 @@ export function parseArgs(argv: string[]): AdvisoryConvergenceArgs {
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/advisory-convergence.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--claim-issue <number>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--now <ISO8601>] [--assert]
+  node scripts/advisory-convergence.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--claim-issue <number>] [--trusted-marker-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--now <ISO8601>] [--assert] [--help]
 
 Read-only: asserts whether the primary advisory bot's review has converged
-on the current PR HEAD. Always prints the JSON verdict. Without --assert,
-always exits 0 (report-only). With --assert, exits non-zero unless the
-verdict is "ready" (converged, or validly waived past the configured
-deadline).
+on the current PR HEAD. Every invocation other than --help/-h prints the
+JSON verdict to stdout. Without --assert, always exits 0 (report-only).
+With --assert, exits non-zero unless the verdict is "ready" (converged, or
+validly waived past the configured deadline).
 `);
 }
 

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -31,6 +31,7 @@
 // comment data and prints a verdict.
 
 import {
+  DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
   readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
@@ -330,7 +331,7 @@ export function computeAdvisoryConvergenceVerdict(
   // --- timestamp (not an IDD marker -- see module header for why) -------
   const deadlineMinutes = Number.isFinite(options.deadlineMinutes)
     ? Number(options.deadlineMinutes)
-    : 1440;
+    : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
   const headCommittedAt = String(options.headCommittedAt ?? '');
   const elapsedMinutes = isValidIsoTimestamp(headCommittedAt)
     ? minutesBetween(headCommittedAt, now)
@@ -386,7 +387,9 @@ export function computeAdvisoryConvergenceVerdict(
   const waived = validWaiverCount > 0;
   if (!converged && deadlinePassed && !waived) {
     reasons.push(
-      `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`,
+      waiverMode === 'maintainer-authorized'
+        ? `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`
+        : `deadline (${deadlineMinutes}m) passed and no waiver is available (ciGate.externalCheckWaivers.mode is "${waiverMode}", not "maintainer-authorized")`,
     );
   }
 
@@ -411,34 +414,35 @@ export function computeAdvisoryConvergenceVerdict(
   };
 }
 
-/** Evaluate Clause 1 (the latest-review clause) against every Copilot
- * review that targets the current HEAD, and evaluate Clause 1 against
- * *that* review only. Re-requesting a review without a new push is a real,
- * supported flow in this repo's own advisory-wait protocol (AW3
- * `REQUEST_NEEDED`), so two reviews can legitimately share one `commitId`
- * with the later one superseding the earlier one (e.g. addressed via
- * thread replies, then re-reviewed) -- requiring every on-HEAD review to
- * be clean would wrongly keep a genuinely-converged PR blocked forever
- * (see PR #1343 review). The latest on-HEAD review is simply the last
- * on-HEAD entry in fetch order: GitHub's GraphQL `reviews` connection
- * returns reviews in submission order (the same assumption
- * `findLastCopilotReviewCommit` already relies on elsewhere in this
- * codebase), so this deliberately does NOT re-sort by `submittedAt` --
- * which can be missing/invalid on a real payload (the field is nullable)
- * and would otherwise let an earlier, differently-ordered review win by
- * comparator accident, hiding a genuinely later dirty review. */
+/** Evaluate Clause 1 against the single, absolute-latest Copilot review --
+ * per the issue's literal wording ("the latest Copilot review's commit_id
+ * equals current HEAD"), not "the latest review among those that happen to
+ * target current HEAD". Those two differ when Copilot's most recent
+ * activity targets a commit other than the current HEAD (e.g. an unusual
+ * force-push/revert ordering, see PR #1343 review): only looking within
+ * on-HEAD reviews could report `matchesHead: true` off a stale earlier
+ * review while ignoring what Copilot's true latest signal actually says.
+ * This simpler form still correctly handles a legitimate re-request
+ * without a new push (this repo's own AW3 `REQUEST_NEEDED` flow, where a
+ * later review supersedes an earlier dirty one on the *same* commit): the
+ * absolute latest naturally IS that later, superseding review when both
+ * target the current HEAD. "Latest" is fetch order, not `submittedAt`:
+ * GitHub's GraphQL `reviews` connection returns reviews in submission
+ * order (the same assumption `findLastCopilotReviewCommit` already relies
+ * on elsewhere in this codebase), so this deliberately does not re-sort by
+ * `submittedAt` -- which can be missing/invalid on a real payload (the
+ * field is nullable) and would otherwise let an earlier, differently-
+ * ordered review win by comparator accident. */
 function resolveLatestCopilotReviewClause(
   reviews: ReviewPayload[],
   prHeadSha: string,
   primaryBotLogin: string,
 ): AdvisoryConvergenceReviewClause {
-  const copilotReviews = reviews.filter((review) =>
-    isCopilotReviewerLogin(review.author?.login ?? '', primaryBotLogin),
-  );
-  const onHead = copilotReviews.filter(
-    (review) => String(review.commitId ?? '').toLowerCase() === prHeadSha,
-  );
-  const latest = onHead.length > 0 ? onHead.at(-1) : copilotReviews.at(-1);
+  const latest = reviews
+    .filter((review) =>
+      isCopilotReviewerLogin(review.author?.login ?? '', primaryBotLogin),
+    )
+    .at(-1);
   if (!latest) {
     return {
       found: false,
@@ -449,7 +453,8 @@ function resolveLatestCopilotReviewClause(
       satisfied: false,
     };
   }
-  const matchesHead = onHead.length > 0;
+  const commitId = String(latest.commitId ?? '').toLowerCase();
+  const matchesHead = commitId === prHeadSha;
   const itemCount = matchesHead
     ? Number.isFinite(latest.itemCount)
       ? Number(latest.itemCount)
@@ -457,7 +462,7 @@ function resolveLatestCopilotReviewClause(
     : null;
   return {
     found: true,
-    commitId: String(latest.commitId ?? '').toLowerCase(),
+    commitId,
     matchesHead,
     itemCount,
     submittedAt: String(latest.submittedAt ?? ''),

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -428,11 +428,14 @@ export function computeAdvisoryConvergenceVerdict(
  * absolute latest naturally IS that later, superseding review when both
  * target the current HEAD. "Latest" is fetch order, not `submittedAt`:
  * GitHub's GraphQL `reviews` connection returns reviews in submission
- * order (the same assumption `findLastCopilotReviewCommit` already relies
- * on elsewhere in this codebase), so this deliberately does not re-sort by
- * `submittedAt` -- which can be missing/invalid on a real payload (the
- * field is nullable) and would otherwise let an earlier, differently-
- * ordered review win by comparator accident. */
+ * order, the same assumption this file's own `fetchThreadCommentPages` /
+ * `fetchReviewThreads` already rely on (they append paginated results
+ * without ever re-sorting). This deliberately does NOT sort by
+ * `submittedAt` the way `findLastCopilotReviewCommit` does elsewhere in
+ * this codebase (protocol-helpers.mts) -- that timestamp-sort approach is
+ * exactly the footgun being avoided here: `submittedAt` can be missing or
+ * invalid on a real payload (the field is nullable) and would otherwise
+ * let an earlier, differently-ordered review win by comparator accident. */
 function resolveLatestCopilotReviewClause(
   reviews: ReviewPayload[],
   prHeadSha: string,
@@ -507,8 +510,18 @@ export function classifyCopilotAuthoredThreadIds(
   return ids;
 }
 
+/** Whole minutes elapsed from `start` to `end`, clamped to 0 and floored --
+ * matching `minutesBetweenIso` (protocol-helpers.mts) exactly, so a clock-
+ * skew or malformed-timestamp edge case can never make `deadline.elapsed-
+ * Minutes` negative or fractional. Not reused directly since that helper is
+ * not exported. */
 function minutesBetween(start: string, end: string): number {
-  return (new Date(end).getTime() - new Date(start).getTime()) / 60000;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return 0;
+  }
+  return Math.floor((endMs - startMs) / 60000);
 }
 
 /** Parsed CLI arguments. */

--- a/src/scripts/advisory-wait-policy.mts
+++ b/src/scripts/advisory-wait-policy.mts
@@ -13,6 +13,9 @@ export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
 export const DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES = 10;
 export const DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES = 2;
 export const DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN = 'copilot';
+// 24h, matching the `claim-stale-age` and external-check-waiver
+// `maxValidity` defaults so this gate uses a familiar timescale.
+export const DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES = 1440;
 export const ADVISORY_CAP_EXHAUSTED_ROUTE_DEFAULT = 'phase-specific';
 export const ADVISORY_CAP_EXHAUSTED_ROUTES = new Set([
   'phase-specific',
@@ -149,6 +152,45 @@ export function readAdvisorySecondaryBotLogin(
     return resolveAdvisorySecondaryBotLogin(config);
   } catch {
     return '';
+  }
+}
+
+/**
+ * Resolve the configured advisory-convergence deadline (in minutes) from a
+ * parsed policy object. Once a PR HEAD has gone this long without a
+ * zero-item Copilot review, `advisory-convergence.mts`'s only pass path is a
+ * valid maintainer external-check waiver for that HEAD. Kept separate from
+ * {@link resolveAdvisoryWaitPolicy} for the same reason the bot-login
+ * resolvers are separate: it is not part of the five-key active-wait timing
+ * shape, and defaults to Copilot-advisory-preserving behavior when absent.
+ */
+export function resolveAdvisoryConvergenceDeadlineMinutes(
+  config: unknown = {},
+): number {
+  const advisoryWait = ((config as { advisoryWait?: unknown } | null)
+    ?.advisoryWait ?? {}) as Record<string, unknown>;
+  return normalizeConfiguredDurationMinutes(
+    advisoryWait.convergenceDeadline,
+    DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
+  );
+}
+
+/**
+ * Read the configured advisory-convergence deadline from a policy file,
+ * failing closed to the 24h default when the file is missing, unreadable, or
+ * schema-invalid.
+ */
+export function readAdvisoryConvergenceDeadlineMinutes(
+  path: string = '.github/idd/config.json',
+): number {
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    if (validate(config, POLICY_SCHEMA).length > 0) {
+      return DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
+    }
+    return resolveAdvisoryConvergenceDeadlineMinutes(config);
+  } catch {
+    return DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
   }
 }
 

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -163,6 +163,16 @@ const EXTRA_RUNTIME_FILES = new Map<string, string[]>([
 
 const HELPER_COMMANDS: HelperCommand[] = [
   {
+    id: 'advisory-convergence',
+    scriptName: 'idd:advisory-convergence',
+    binName: 'idd-advisory-convergence',
+    entryPath: 'scripts/advisory-convergence.mjs',
+    vendoredCommand: 'node scripts/advisory-convergence.mjs',
+    description:
+      'Assert whether the primary advisory bot has converged on the current PR HEAD, with an exit-code contract via --assert.',
+    contractPaths: ['schemas/advisory-convergence.schema.json'],
+  },
+  {
     id: 'advisory-wait-state',
     scriptName: 'idd:advisory-wait-state',
     binName: 'idd-advisory-wait-state',

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -485,6 +485,25 @@ test('regression: the default deadline minutes come from the shared advisory-wai
   assert.equal(verdict.deadline.minutes, 1440);
 });
 
+test('regression: elapsedMinutes is floored to a non-negative whole number', () => {
+  // headCommittedAt 90 seconds before `now` -- a fractional 1.5 minutes
+  // must floor to 1, not report a fractional value.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview()] }),
+    baseOptions({ headCommittedAt: '2026-07-11T11:58:30Z' }),
+  );
+  assert.equal(verdict.deadline.elapsedMinutes, 1);
+  assert.equal(Number.isInteger(verdict.deadline.elapsedMinutes), true);
+});
+
+test('regression: elapsedMinutes clamps to 0 instead of going negative when headCommittedAt is after now', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview()] }),
+    baseOptions({ headCommittedAt: '2026-07-11T13:00:00Z' }), // after NOW
+  );
+  assert.equal(verdict.deadline.elapsedMinutes, 0);
+});
+
 // --- classifyCopilotAuthoredThreadIds (pure helper) -------------------------
 
 test('classifyCopilotAuthoredThreadIds: a thread counts only when its ORIGINATING comment is bot-authored', () => {

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -1,0 +1,501 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  type AdvisoryConvergenceDeps,
+  type AdvisoryConvergenceInputs,
+  type AdvisoryConvergenceOptions,
+  classifyCopilotAuthoredThreadIds,
+  computeAdvisoryConvergenceVerdict,
+  parseArgs,
+  runAdvisoryConvergence,
+} from '../src/scripts/advisory-convergence.mts';
+import { renderExternalCheckWaiverComment } from '../src/scripts/marker-helpers.mts';
+import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
+
+const SCHEMA = loadJson('schemas/advisory-convergence.schema.json');
+
+const HEAD = '1111111111111111111111111111111111111111';
+const OTHER_SHA = '2222222222222222222222222222222222222222';
+const NOW = '2026-07-11T12:00:00Z';
+const RECENT = '2026-07-11T10:00:00Z';
+const OLD = '2026-06-01T00:00:00Z'; // >24h before NOW -- deadline passed
+const TRUSTED = 'kurone-kito';
+const COPILOT_LOGIN = 'copilot-pull-request-reviewer';
+const CLAIM_ID = 'claim-abc123';
+const AGENT_ID = 'claude-test';
+
+function baseInputs(
+  overrides: Partial<AdvisoryConvergenceInputs> = {},
+): AdvisoryConvergenceInputs {
+  return {
+    prNumber: 1234,
+    prHeadSha: HEAD,
+    reviews: [],
+    threads: [],
+    comments: [],
+    claimEvents: [],
+    ...overrides,
+  };
+}
+
+function baseOptions(
+  overrides: Partial<AdvisoryConvergenceOptions> = {},
+): AdvisoryConvergenceOptions {
+  return {
+    now: NOW,
+    primaryBotLogin: 'copilot',
+    trustedMarkerLogins: [TRUSTED],
+    advisoryBotLogins: [],
+    prAuthorLogin: '',
+    headCommittedAt: RECENT,
+    deadlineMinutes: 1440,
+    waiverMode: 'disabled',
+    waiverMaxValidity: 'PT24H',
+    waiverCheckSelector: 'idd-advisory-convergence',
+    ...overrides,
+  };
+}
+
+function copilotReview(overrides: Record<string, unknown> = {}) {
+  return {
+    author: { login: COPILOT_LOGIN },
+    submittedAt: RECENT,
+    commitId: HEAD,
+    itemCount: 0,
+    ...overrides,
+  };
+}
+
+function claimComment(claimId: string = CLAIM_ID) {
+  return {
+    author: { login: TRUSTED },
+    body: `<!-- claimed-by: ${AGENT_ID} ${claimId} supersedes: none ${OLD} branch: issue/1234-test -->\n\n_${AGENT_ID}: issue claim — IDD automation marker. Do not edit._`,
+    createdAt: OLD,
+  };
+}
+
+function assertValidVerdict(verdict: unknown): void {
+  assert.deepEqual(validate(verdict, SCHEMA), []);
+}
+
+// --- 1. converged --------------------------------------------------------
+
+test('converged: clean primary-bot review on HEAD, no blocking threads', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview()] }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.review.satisfied, true);
+  assert.equal(verdict.threads.satisfied, true);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.waived, false);
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.reasons, []);
+});
+
+// --- 2. zero-review-but-open-thread ---------------------------------------
+
+test('zero-review-but-open-thread: clean HEAD review but an older bot thread is still open', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview()],
+      threads: [
+        {
+          id: 'PRT_1',
+          isResolved: false,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'nit: consider extracting this into a helper',
+                createdAt: OLD,
+                updatedAt: OLD,
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.satisfied, true);
+  assert.equal(verdict.threads.blockingCount, 1);
+  assert.deepEqual(verdict.threads.blockingIds, ['PRT_1']);
+  assert.equal(verdict.threads.satisfied, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.ready, false);
+});
+
+// --- 3. non-zero-review ----------------------------------------------------
+
+test('non-zero-review: latest bot review on HEAD carries actionable items', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview({ itemCount: 2 })] }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.review.matchesHead, true);
+  assert.equal(verdict.review.itemCount, 2);
+  assert.equal(verdict.review.satisfied, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
+  assert.match(verdict.reasons.join('\n'), /2 actionable item/);
+});
+
+// --- 4. HEAD-not-yet-reviewed (pending) -------------------------------------
+
+test('pending: the primary bot has not reviewed this pull request yet', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [] }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.review.found, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('pending: the latest bot review targets an older commit than current HEAD', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview({ commitId: OTHER_SHA })] }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.review.found, true);
+  assert.equal(verdict.review.matchesHead, false);
+  assert.equal(verdict.converged, false);
+});
+
+test('regression: a dirty on-HEAD review is never silently ignored just because its own submittedAt is missing', () => {
+  // Both reviews target the current HEAD. The earlier one is clean and has a
+  // valid timestamp; the later one carries actionable items but its
+  // `submittedAt` is missing (a real, if unlikely, GraphQL possibility).
+  // Clause 1 must fail closed here rather than silently trusting the clean
+  // review just because it happens to sort more confidently.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ submittedAt: OLD, itemCount: 0 }),
+        copilotReview({ submittedAt: null, itemCount: 3 }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.review.matchesHead, true);
+  assert.equal(verdict.review.satisfied, false);
+  assert.equal(verdict.review.itemCount, 3);
+  assert.equal(verdict.converged, false);
+});
+
+test('regression: resolved bot thread with no disposition marker at all satisfies the thread clause', () => {
+  // The issue's Clause 2 is "resolved OR carries a valid disposition
+  // marker" -- resolution alone must be sufficient, independent of whether
+  // any marker was ever posted.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview()],
+      threads: [
+        {
+          id: 'PRT_3',
+          isResolved: true,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'nit: consider extracting this into a helper',
+                createdAt: OLD,
+                updatedAt: OLD,
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.threads.blockingCount, 0);
+  assert.equal(verdict.threads.satisfied, true);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('regression: classifyCopilotAuthoredThreadIds keeps nodes[0] as the originating comment even when a later reply has an invalid createdAt', () => {
+  const ids = classifyCopilotAuthoredThreadIds(
+    [
+      {
+        id: 'D',
+        comments: {
+          nodes: [
+            { author: { login: COPILOT_LOGIN }, createdAt: OLD },
+            { author: { login: TRUSTED }, createdAt: null },
+          ],
+        },
+      },
+    ],
+    'copilot',
+  );
+  assert.deepEqual([...ids], ['D']);
+});
+
+// --- 5. valid Reject-disposition ---------------------------------------------
+
+test('valid Reject-disposition: an unresolved bot thread with a fresh Rejected marker satisfies the thread clause', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview()],
+      threads: [
+        {
+          id: 'PRT_2',
+          isResolved: false,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'nit: consider extracting this into a helper',
+                createdAt: OLD,
+                updatedAt: OLD,
+              },
+              {
+                author: { login: TRUSTED },
+                body: '**Rejected** — not applicable to this change.',
+                createdAt: RECENT,
+                updatedAt: RECENT,
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.threads.blockingCount, 0);
+  assert.equal(verdict.threads.satisfied, true);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.ready, true);
+});
+
+// --- 6. deadline-passed-with-waiver -------------------------------------------
+
+test('deadline-passed-with-waiver: a valid maintainer waiver flips a stale-pending PR ready', () => {
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: AGENT_ID,
+    claimId: CLAIM_ID,
+    headSha: HEAD,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'Copilot review API outage, maintainer verified the diff manually',
+    expiresAt: '2026-07-12T00:00:00Z',
+    actor: TRUSTED,
+  });
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [], // still pending -- the primary bot never reviewed
+      claimEvents: [claimComment()],
+      comments: [
+        { author: { login: TRUSTED }, body: waiverBody, createdAt: RECENT },
+      ],
+    }),
+    baseOptions({ headCommittedAt: OLD, waiverMode: 'maintainer-authorized' }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.deadline.passed, true);
+  assert.equal(verdict.waiver.activeClaimId, CLAIM_ID);
+  assert.equal(verdict.waiver.validCount, 1);
+  assert.equal(verdict.waived, true);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, true);
+});
+
+// --- 7. deadline-passed-no-waiver -----------------------------------------
+
+test('deadline-passed-no-waiver: no waiver comment leaves a stale-pending PR blocked', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents: [claimComment()] }),
+    baseOptions({ headCommittedAt: OLD, waiverMode: 'maintainer-authorized' }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.deadline.passed, true);
+  assert.equal(verdict.waiver.validCount, 0);
+  assert.equal(verdict.waived, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('deadline-passed-no-waiver: waiver mode disabled never waives, even with an otherwise-valid marker', () => {
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: AGENT_ID,
+    claimId: CLAIM_ID,
+    headSha: HEAD,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'attempted waiver while waivers are disabled',
+    expiresAt: '2026-07-12T00:00:00Z',
+    actor: TRUSTED,
+  });
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        { author: { login: TRUSTED }, body: waiverBody, createdAt: RECENT },
+      ],
+    }),
+    baseOptions({ headCommittedAt: OLD, waiverMode: 'disabled' }),
+  );
+  assert.equal(verdict.waiver.validCount, 0);
+  assert.equal(verdict.waived, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('deadline not yet passed: no waiver path is consulted even in maintainer-authorized mode', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents: [claimComment()] }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'maintainer-authorized',
+    }),
+  );
+  assert.equal(verdict.deadline.passed, false);
+  assert.equal(verdict.waiver.validCount, 0);
+  assert.equal(verdict.ready, false);
+});
+
+// --- classifyCopilotAuthoredThreadIds (pure helper) -------------------------
+
+test('classifyCopilotAuthoredThreadIds: a thread counts only when its ORIGINATING comment is bot-authored', () => {
+  const ids = classifyCopilotAuthoredThreadIds(
+    [
+      {
+        id: 'A',
+        comments: {
+          nodes: [
+            { author: { login: COPILOT_LOGIN }, createdAt: OLD },
+            { author: { login: TRUSTED }, createdAt: RECENT },
+          ],
+        },
+      },
+      {
+        id: 'B',
+        comments: {
+          nodes: [
+            { author: { login: TRUSTED }, createdAt: OLD },
+            { author: { login: COPILOT_LOGIN }, createdAt: RECENT },
+          ],
+        },
+      },
+      { id: 'C', comments: { nodes: [] } },
+    ],
+    'copilot',
+  );
+  assert.deepEqual([...ids].sort(), ['A']);
+});
+
+// --- parseArgs ---------------------------------------------------------------
+
+test('parseArgs: parses --pr, --assert, and --claim-issue', () => {
+  const args = parseArgs([
+    '--pr',
+    '42',
+    '--claim-issue',
+    '7',
+    '--assert',
+    '--trusted-marker-logins',
+    'a,b',
+  ]);
+  assert.equal(args.prNumber, 42);
+  assert.equal(args.claimIssueNumber, 7);
+  assert.equal(args.assert, true);
+  assert.equal(args.trustedMarkerLogins, 'a,b');
+  assert.equal(args.help, false);
+});
+
+test('parseArgs: an invalid --pr resolves to null (fails closed at the caller)', () => {
+  const args = parseArgs(['--pr', 'not-a-number']);
+  assert.equal(args.prNumber, null);
+});
+
+test('parseArgs: --help is recognized without requiring --pr', () => {
+  const args = parseArgs(['--help']);
+  assert.equal(args.help, true);
+});
+
+test('parseArgs: rejects an unknown flag', () => {
+  assert.throws(() => parseArgs(['--bogus']));
+});
+
+// --- runAdvisoryConvergence (--assert exit-code contract, DI pattern) -------
+
+function depsFor(
+  inputs: AdvisoryConvergenceInputs,
+  options: AdvisoryConvergenceOptions,
+): AdvisoryConvergenceDeps {
+  return { collect: () => ({ inputs, options }) };
+}
+
+test('runAdvisoryConvergence: --assert exits 0 when the verdict is ready', () => {
+  const deps = depsFor(
+    baseInputs({ reviews: [copilotReview()] }),
+    baseOptions(),
+  );
+  const { verdict, exitCode, help } = runAdvisoryConvergence(
+    ['--pr', '1234', '--assert'],
+    deps,
+  );
+  assert.equal(help, false);
+  assert.equal(verdict?.ready, true);
+  assert.equal(exitCode, 0);
+});
+
+test('runAdvisoryConvergence: --assert exits non-zero when the verdict is not ready', () => {
+  const deps = depsFor(baseInputs({ reviews: [] }), baseOptions());
+  const { verdict, exitCode } = runAdvisoryConvergence(
+    ['--pr', '1234', '--assert'],
+    deps,
+  );
+  assert.equal(verdict?.ready, false);
+  assert.equal(exitCode, 1);
+});
+
+test('runAdvisoryConvergence: without --assert always exits 0 regardless of the verdict', () => {
+  const deps = depsFor(baseInputs({ reviews: [] }), baseOptions());
+  const { verdict, exitCode } = runAdvisoryConvergence(['--pr', '1234'], deps);
+  assert.equal(verdict?.ready, false);
+  assert.equal(exitCode, 0);
+});
+
+test('runAdvisoryConvergence: --help short-circuits before collecting any evidence', () => {
+  let called = false;
+  const deps: AdvisoryConvergenceDeps = {
+    collect: () => {
+      called = true;
+      return { inputs: baseInputs(), options: baseOptions() };
+    },
+  };
+  const { help, exitCode } = runAdvisoryConvergence(['--help'], deps);
+  assert.equal(help, true);
+  assert.equal(exitCode, 0);
+  assert.equal(called, false);
+});
+
+test('runAdvisoryConvergence: missing --pr throws before any collection happens', () => {
+  let called = false;
+  const deps: AdvisoryConvergenceDeps = {
+    collect: () => {
+      called = true;
+      return { inputs: baseInputs(), options: baseOptions() };
+    },
+  };
+  assert.throws(() => runAdvisoryConvergence([], deps));
+  assert.equal(called, false);
+});

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -205,6 +205,31 @@ test('regression: a re-request without a new push supersedes an earlier dirty on
   assert.equal(verdict.ready, true);
 });
 
+test('regression: matchesHead reflects the absolute-latest review, not merely any on-HEAD review', () => {
+  // Copilot reviewed the current HEAD first (clean), then its most recent
+  // activity overall is a review of a DIFFERENT commit (an unusual
+  // force-push/revert-style ordering). The absolute-latest review is the
+  // one that must be evaluated, so this must NOT report matchesHead: true
+  // off the earlier, now-stale on-HEAD review.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ submittedAt: OLD, commitId: HEAD, itemCount: 0 }),
+        copilotReview({
+          submittedAt: RECENT,
+          commitId: OTHER_SHA,
+          itemCount: 0,
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.matchesHead, false);
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.converged, false);
+});
+
 test('regression: a dirty on-HEAD review is never silently ignored just because its own submittedAt is missing', () => {
   // Both reviews target the current HEAD. The earlier one is clean and has a
   // valid timestamp; the later one carries actionable items but its
@@ -437,6 +462,27 @@ test('deadline not yet passed: no waiver path is consulted even in maintainer-au
   assert.equal(verdict.deadline.passed, false);
   assert.equal(verdict.waiver.validCount, 0);
   assert.equal(verdict.ready, false);
+});
+
+test('regression: the deadline-passed reason names the waiver mode instead of implying a waiver would work when waivers are disabled', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents: [claimComment()] }),
+    baseOptions({ headCommittedAt: OLD, waiverMode: 'disabled' }),
+  );
+  assert.equal(verdict.ready, false);
+  assert.match(verdict.reasons.join('\n'), /no waiver is available/);
+  assert.doesNotMatch(
+    verdict.reasons.join('\n'),
+    /no valid maintainer external-check waiver/,
+  );
+});
+
+test('regression: the default deadline minutes come from the shared advisory-wait-policy constant', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview()] }),
+    baseOptions({ deadlineMinutes: undefined }),
+  );
+  assert.equal(verdict.deadline.minutes, 1440);
 });
 
 // --- classifyCopilotAuthoredThreadIds (pure helper) -------------------------

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -24,6 +24,14 @@ const TRUSTED = 'kurone-kito';
 const COPILOT_LOGIN = 'copilot-pull-request-reviewer';
 const CLAIM_ID = 'claim-abc123';
 const AGENT_ID = 'claude-test';
+// A repo that has opted this gate into the waiver escape hatch: `mode`
+// alone (set per-test via `waiverMode`) is not sufficient -- the check
+// must also be registered here, matching the two-dimensional
+// `ciGate.externalCheckWaivers` / `ciGate.externalChecks.waivable`
+// contract every other F2/F3 waiver already follows.
+const ADVISORY_CONVERGENCE_WAIVABLE = [
+  { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+];
 
 function baseInputs(
   overrides: Partial<AdvisoryConvergenceInputs> = {},
@@ -174,6 +182,29 @@ test('pending: the latest bot review targets an older commit than current HEAD',
   assert.equal(verdict.converged, false);
 });
 
+test('regression: a re-request without a new push supersedes an earlier dirty on-HEAD review', () => {
+  // Same commit reviewed twice (a legitimate re-request per this repo's own
+  // advisory-wait protocol, AW3 REQUEST_NEEDED, without a new push): the
+  // FIRST review found issues; the SECOND (later, superseding) review is
+  // clean. Requiring every on-HEAD review to be clean would wrongly block
+  // this genuinely-converged PR forever.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ submittedAt: OLD, itemCount: 4 }),
+        copilotReview({ submittedAt: RECENT, itemCount: 0 }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.matchesHead, true);
+  assert.equal(verdict.review.itemCount, 0);
+  assert.equal(verdict.review.satisfied, true);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.ready, true);
+});
+
 test('regression: a dirty on-HEAD review is never silently ignored just because its own submittedAt is missing', () => {
   // Both reviews target the current HEAD. The earlier one is clean and has a
   // valid timestamp; the later one carries actionable items but its
@@ -306,7 +337,11 @@ test('deadline-passed-with-waiver: a valid maintainer waiver flips a stale-pendi
         { author: { login: TRUSTED }, body: waiverBody, createdAt: RECENT },
       ],
     }),
-    baseOptions({ headCommittedAt: OLD, waiverMode: 'maintainer-authorized' }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+    }),
   );
   assertValidVerdict(verdict);
   assert.equal(verdict.pending, true);
@@ -316,6 +351,39 @@ test('deadline-passed-with-waiver: a valid maintainer waiver flips a stale-pendi
   assert.equal(verdict.waived, true);
   assert.equal(verdict.converged, false);
   assert.equal(verdict.ready, true);
+});
+
+test('deadline-passed-with-waiver: an otherwise-valid marker does not waive unless this gate is in the configured waivable list', () => {
+  // Same valid marker as above, but the repo never opted `idd-advisory-
+  // convergence` into `ciGate.externalChecks.waivable` -- only `mode` is
+  // "maintainer-authorized". The existing two-dimensional waiver contract
+  // (mode AND a per-check registration) must still hold for this gate.
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: AGENT_ID,
+    claimId: CLAIM_ID,
+    headSha: HEAD,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'Copilot review API outage, maintainer verified the diff manually',
+    expiresAt: '2026-07-12T00:00:00Z',
+    actor: TRUSTED,
+  });
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        { author: { login: TRUSTED }, body: waiverBody, createdAt: RECENT },
+      ],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: [], // not registered
+    }),
+  );
+  assert.equal(verdict.waiver.validCount, 0);
+  assert.equal(verdict.waived, false);
+  assert.equal(verdict.ready, false);
 });
 
 // --- 7. deadline-passed-no-waiver -----------------------------------------

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -3,6 +3,7 @@ import { readdirSync } from 'node:fs';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
+import type { AdvisoryConvergenceVerdict } from '../src/scripts/advisory-convergence.mts';
 import type { AdvisoryWaitStateReport } from '../src/scripts/advisory-wait-state.mts';
 import type { BranchConflictResult } from '../src/scripts/branch-conflict-state.mts';
 import type { RoadmapGraphUnionReport } from '../src/scripts/discover-roadmap-graph.mts';
@@ -235,6 +236,24 @@ interface PolicyConfigFile {
 // ---------------------------------------------------------------------------
 // Top-level key lists (exported per the reconciliation contract).
 // ---------------------------------------------------------------------------
+
+export const advisoryConvergenceKeys = [
+  'protocolVersion',
+  'decisionAuthority',
+  'prNumber',
+  'prHeadSha',
+  'now',
+  'primaryBotLogin',
+  'review',
+  'threads',
+  'pending',
+  'deadline',
+  'waiver',
+  'converged',
+  'waived',
+  'ready',
+  'reasons',
+] as const satisfies readonly (keyof AdvisoryConvergenceVerdict)[];
 
 export const advisoryWaitStateKeys = [
   'protocolVersion',
@@ -507,6 +526,46 @@ const exhaustivenessWitnesses: {
 // ---------------------------------------------------------------------------
 // Canonical fixtures (compile-time side of the reconciliation).
 // ---------------------------------------------------------------------------
+
+const advisoryConvergenceFixture = {
+  protocolVersion: '1',
+  decisionAuthority: 'instructions',
+  prNumber: 1340,
+  prHeadSha: '0123456789abcdef0123456789abcdef01234567',
+  now: '2026-07-11T12:00:00Z',
+  primaryBotLogin: 'copilot',
+  review: {
+    found: true,
+    commitId: '0123456789abcdef0123456789abcdef01234567',
+    matchesHead: true,
+    itemCount: 0,
+    submittedAt: '2026-07-11T10:00:00Z',
+    satisfied: true,
+  },
+  threads: {
+    copilotThreadCount: 0,
+    blockingIds: [],
+    blockingCount: 0,
+    satisfied: true,
+  },
+  pending: false,
+  deadline: {
+    minutes: 1440,
+    headCommittedAt: '2026-07-11T09:00:00Z',
+    elapsedMinutes: 180,
+    passed: false,
+  },
+  waiver: {
+    mode: 'disabled',
+    checkSelector: 'idd-advisory-convergence',
+    activeClaimId: '',
+    validCount: 0,
+  },
+  converged: true,
+  waived: false,
+  ready: true,
+  reasons: [],
+} satisfies AdvisoryConvergenceVerdict;
 
 const advisoryWaitStateFixture = {
   protocolVersion: '1',
@@ -1063,6 +1122,13 @@ const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
     owningModule: 'src/scripts/post-idd-marker.mts',
     keys: postIddMarkerKeys,
     fixture: postIddMarkerFixture,
+  },
+  {
+    schemaFile: 'advisory-convergence.schema.json',
+    exportedType: 'AdvisoryConvergenceVerdict',
+    owningModule: 'src/scripts/advisory-convergence.mts',
+    keys: advisoryConvergenceKeys,
+    fixture: advisoryConvergenceFixture,
   },
   {
     schemaFile: 'advisory-wait-state.schema.json',


### PR DESCRIPTION
# Summary

Adds a read-only, claim-independent policy-engine helper,
`advisory-convergence.mjs`, that deterministically asserts whether the
primary advisory bot's ("Copilot's") review has *converged* on the
current PR HEAD, and re-anchors the F2 advisory/disposition sub-gate in
`idd-pre-merge.instructions.md` onto its `--assert` exit-code contract
instead of model-interpreted `dispositionEvidence` fields.

`converged` = (the latest primary-bot review targets the current HEAD
with zero actionable items) **and** (every current-HEAD bot-authored
review thread is resolved **or** carries a fresh disposition marker).
While the bot has not yet reviewed current HEAD the helper reports
`pending`; after a configurable deadline (`advisoryWait.convergenceDeadline`,
default 24h) the only pass path is a valid maintainer external-check
waiver for that HEAD, reusing the existing
`<!-- idd-external-check-waiver: ... -->` marker format and validity
rules.

No claim flags are required to call the helper: the linked issue (used
only for waiver-claim binding) auto-discovers from the PR's closing
references, the same way `external-check-waiver.mjs`'s `--apply` path
already resolves it — so this also works as a claim-independent,
required-check-able CI verdict (the shape #1341's workflow needs).

## Linked issue

Closes #1340

## Follow-up issues (if any)

- [ ] none — #1341 (already filed, blocked by this issue) will host this
      helper as a required-check CI workflow.

## Background / rationale (if material)

**Reuse, not duplication**: the helper imports and reuses
`isCopilotReviewerLogin`/`readAdvisoryPrimaryBotLogin`,
`resolveAdvisoryBotLogins`, `resolveTrustedMarkerActors`,
`summarizeDispositionEvidenceForGate`, `summarizeClaimValidation`, and
`summarizeExternalCheckWaivers` from `protocol-helpers.mts`. Only two
things are genuinely new: a thin Copilot-thread-authorship filter (the
existing thread-classification helper is opener-agnostic) and a
review-item-count read (a new GraphQL field, not existing logic).

**F2 re-anchor is byte-neutral-or-smaller** (explicit issue requirement,
verified, not defaulted-to-ratchet): both the generated copy
(20,302 → 19,117 bytes) and the `idd-template/` source
(20,091 → 18,906 bytes) shrank. `bundle-merge`'s combined total also
dropped, staying well under its `audit/sync-manifest.json` limit.

**Scope decision on `dispositionEvidence.missingRegularComments`**: the
new helper is scoped to Copilot-authored *review threads* only (per the
issue's `converged` definition), which does not cover ad hoc regular
comments from other configured advisory bots (e.g. CodeRabbit, Codex).
The re-anchored F2 bullet keeps a short, separate check for
`dispositionEvidence.missingRegularComments.length == 0` so that
coverage isn't silently dropped.

**Design correction found during self-review** (see review history on
this PR/issue for detail): an earlier draft anchored the "resolved
threads don't need a marker" rule on `snapshotBoundaryAt: now` passed
into the reused `summarizeDispositionEvidenceForGate`. That made the
shared ack-only-post-disposition classification permanently dead code
and was the wrong mechanism regardless. The current implementation
filters `missingThreads` to unresolved entries only — resolution alone
satisfies the issue's "resolved OR marker" clause directly, without
relying on that classification at all. A parallel review pass also
caught and fixed: a sort-direction footgun in `compareIsoTimestamps`
that could let a missing/invalid timestamp silently win
"latest review"/"originating comment" selection (now resolved by
filtering-then-requiring-all-clean, and by relying on GraphQL fetch
order instead of re-sorting); an ID-fallback mismatch against
`missingThreads`; and a trust-set bug that would have let a configured
advisory bot's own comment count as a "maintainer-authorized" waiver
author.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “Advisory convergence” pre-merge gate (F2) that validates current-head primary-bot reviews and that related Copilot-authored review threads are resolved/dispositioned.
  - Introduced an accompanying CLI helper supporting report-only and merge-enforcing modes.
  - Added configurable convergence deadlines (24h default) with maintainer waiver support after the deadline.

- **Bug Fixes**
  - Pre-merge now fails closed when required convergence evidence is missing, invalid, or incomplete.

- **Documentation**
  - Updated helper and policy docs to describe the contract, deadline/waiver behavior, and verdict format.

- **Tests**
  - Added schema and scenario coverage for convergence, waivers, deadlines, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->