### PR TITLE
fix(advisory-convergence): honor forced-handoff and collaborator trust

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1161,6 +1161,17 @@ Interpretation rules:
   `summarizeClaimValidation`, and `summarizeExternalCheckWaivers` — rather
   than duplicating review- or waiver-parsing logic; only the
   Copilot-thread-authorship filter and the review-item-count read are new.
+- Claim resolution for the waiver escape hatch is forced-handoff-aware and
+  collaborator-marker-trust-aware (#1344), matching `pre-merge-readiness.mjs`
+  exactly: with `forcedHandoff.mode: "human-gated"` enabled, a verified
+  handoff on the linked claim issue transfers `activeClaimId` to the
+  successor (including the Part B (#1058) allowance for an `issue-only`
+  handoff that predates the PR); with `markerTrust.allowCollaboratorMarkers`
+  (or `IDD_TRUST_COLLABORATOR_MARKERS`) enabled, a Write/Maintain/Admin
+  collaborator's marker-shaped PR comment adds them to the trusted-marker
+  set the same way it already does for `pre-merge-readiness.mjs` /
+  `advisory-wait-state.mjs`. Both stay no-ops when the repository leaves
+  them at their (disabled) defaults.
 - Fail closed: if helper execution fails, output is invalid JSON, or
   required fields are missing, discard helper output and apply the
   written F2 advisory/disposition sub-gate check manually.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1161,6 +1161,17 @@ Interpretation rules:
   `summarizeClaimValidation`, and `summarizeExternalCheckWaivers` — rather
   than duplicating review- or waiver-parsing logic; only the
   Copilot-thread-authorship filter and the review-item-count read are new.
+- Claim resolution for the waiver escape hatch is forced-handoff-aware and
+  collaborator-marker-trust-aware (#1344), matching `pre-merge-readiness.mjs`
+  exactly: with `forcedHandoff.mode: "human-gated"` enabled, a verified
+  handoff on the linked claim issue transfers `activeClaimId` to the
+  successor (including the Part B (#1058) allowance for an `issue-only`
+  handoff that predates the PR); with `markerTrust.allowCollaboratorMarkers`
+  (or `IDD_TRUST_COLLABORATOR_MARKERS`) enabled, a Write/Maintain/Admin
+  collaborator's marker-shaped PR comment adds them to the trusted-marker
+  set the same way it already does for `pre-merge-readiness.mjs` /
+  `advisory-wait-state.mjs`. Both stay no-ops when the repository leaves
+  them at their (disabled) defaults.
 - Fail closed: if helper execution fails, output is invalid JSON, or
   required fields are missing, discard helper output and apply the
   written F2 advisory/disposition sub-gate check manually.

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -26,6 +26,13 @@
 //     PR's linked issue exactly as `external-check-waiver.mts`'s own
 //     `--apply` path already does, so no claim flag is required to call
 //     this helper (`--pr <n> --assert` is sufficient -- see docs).
+//   - `resolveCollaboratorMarkerTrust`, `isAuthorizedForcedHandoffActor`,
+//     `operationalMarkerPrefix` -- reused, matching `pre-merge-readiness.mts`
+//     exactly (#1344), to thread forced-handoff-aware claim resolution and
+//     collaborator-marker trust into the same `summarizeClaimValidation`
+//     call above, so this gate does not disagree with the sibling F2/F3
+//     helpers when a repository opts into either (both stay no-ops
+//     otherwise).
 //
 // This helper never mutates GitHub state: it only reads PR/review/thread/
 // comment data and prints a verdict.
@@ -35,13 +42,26 @@ import {
   readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
 } from './advisory-wait-policy.mjs';
-import { ghApiJson, ghText, isCliExecution, safeGhText } from './gh-exec.mjs';
+import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
+import {
+  GH_TEXT_LOOP_OPTIONS,
+  ghApiJson,
+  ghText,
+  isCliExecution,
+  safeGhText,
+} from './gh-exec.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import { isValidIsoTimestamp } from './marker-helpers.mjs';
-import { normalizePolicyConfig } from './policy-helpers.mjs';
 import {
+  normalizePolicyConfig,
+  parseIsoDurationToMs,
+  resolveCollaboratorMarkerTrust,
+} from './policy-helpers.mjs';
+import {
+  DEFAULT_STALE_AGE_MS,
   isCopilotReviewerLogin,
   normalizeTrustedMarkerLogins,
+  operationalMarkerPrefix,
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
   summarizeClaimValidation,
@@ -183,7 +203,17 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   const waiverCheckSelector =
     String(options.waiverCheckSelector ?? '').trim() ||
     ADVISORY_CONVERGENCE_CHECK_SELECTOR;
-  const claim = summarizeClaimValidation(claimEvents, { trustedMarkerLogins });
+  const claim = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins,
+    // #1344: parity with `pre-merge-readiness.mts`'s own
+    // `summarizeClaimValidation` call -- see `AdvisoryConvergenceOptions`
+    // for why each field is a no-op when the caller omits it.
+    forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+    isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
+    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
+    staleAgeMs: options.staleAgeMs,
+  });
   const activeClaimId = claim.activeClaim?.claimId ?? '';
   let validWaiverCount = 0;
   if (!converged && deadlinePassed && waiverMode === 'maintainer-authorized') {
@@ -471,6 +501,69 @@ function collectFromGitHub(args) {
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config: rawConfig,
   });
+  const pr = JSON.parse(
+    ghText([
+      'pr',
+      'view',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'headRefOid,closingIssuesReferences,author,url',
+    ]),
+  );
+  const prHeadSha = String(pr.headRefOid ?? '').toLowerCase();
+  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
+  const prUrl = String(pr.url ?? '');
+  // Fetched here (ahead of `trustedMarkerLogins` below) so a collaborator's
+  // marker-shaped PR comment can be detected before that set is used to
+  // resolve `claimEvents` -- see `resolveTrustedCollaboratorMarkerLogins`.
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    {
+      paginate: true,
+    },
+  );
+  // #1344: collaborator-marker trust, matching `pre-merge-readiness.mts`'s
+  // `readCollaboratorTrustEnabled` exactly, except reusing the already-
+  // loaded `rawConfig` instead of a second `.github/idd/config.json` read
+  // (`resolveCollaboratorMarkerTrust` and `loadIddConfig` are both already
+  // null-safe, so no extra try/catch is needed for that simplification).
+  const collaboratorTrustEnabled = resolveCollaboratorMarkerTrust(
+    rawConfig,
+    process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+  );
+  // Base set (no collaborator fold yet). Sufficient for `resolveClaimEvents`'s
+  // own internal disambiguation below, which only needs to know whether SOME
+  // active claim exists on a candidate linked issue -- a presence check, not
+  // an identity resolution. A forced-handoff transition can only ever
+  // TRANSFORM an already-active claim (rule 7 requires `oldAgentId`/
+  // `oldClaimId`/`branch` to match the currently active claim), and
+  // `resolveActiveClaim`'s stale/non-superseded fallthrough always returns
+  // the pre-transform claim unchanged (protocol-helpers.mts's
+  // `applyClaimEvent`, the `return activeClaim;` fallthrough after the
+  // `isStale` check) -- so that pre-transform claim is always still
+  // "present" here whether or not this narrower set (or forced-handoff
+  // awareness generally) recognizes the transition itself. The
+  // collaborator-augmented FINAL set below (after `claimEvents` resolves)
+  // is what the real verdict computation uses.
+  const baseTrustedMarkerLogins = normalizeTrustedMarkerLogins([
+    viewerLogin,
+    ...configuredTrustedActors,
+  ]);
+  const { reviews, headCommittedAt } = fetchReviewsAndHeadCommit(
+    owner,
+    repo,
+    Number(args.prNumber),
+  );
+  const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
+  const claimEvents = resolveClaimEvents(
+    owner,
+    repo,
+    args.claimIssueNumber,
+    pr.closingIssuesReferences,
+    baseTrustedMarkerLogins,
+  );
   // Deliberately NOT unioned with `advisoryBotLogins` here (unlike some
   // other locally-collected sets in this file that scope broader trust for
   // marker *parsing*): every sibling helper (advisory-wait-state.mts,
@@ -480,42 +573,25 @@ function collectFromGitHub(args) {
   // Waivers`, below) -- folding a configured advisory bot login in here
   // would let that bot's own comment count as a "maintainer-authorized"
   // waiver author.
+  //
+  // #1344: folds collaborator-marker trust over the UNION of PR comments
+  // and the resolved claim issue's own comments, matching
+  // `pre-merge-readiness.mts`'s `[...comments, ...claimComments]` union
+  // exactly. Scanning `comments` alone would make `collaboratorTrustEnabled`
+  // a no-op for claim and forced-handoff markers: those are always posted to
+  // the claim ISSUE, never the PR (see `forced-handoff-marker.mts`), and
+  // `applyClaimEvent`'s `isTrustedAuthor` gate runs before any forced-handoff
+  // parsing -- an untrusted-author's marker never even reaches the
+  // authorization check.
   const trustedMarkerLogins = normalizeTrustedMarkerLogins([
-    viewerLogin,
-    ...configuredTrustedActors,
+    ...baseTrustedMarkerLogins,
+    ...(collaboratorTrustEnabled
+      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
+          ...comments,
+          ...claimEvents,
+        ])
+      : []),
   ]);
-  const pr = JSON.parse(
-    ghText([
-      'pr',
-      'view',
-      String(args.prNumber),
-      '-R',
-      repoRef,
-      '--json',
-      'headRefOid,closingIssuesReferences,author',
-    ]),
-  );
-  const prHeadSha = String(pr.headRefOid ?? '').toLowerCase();
-  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
-  const { reviews, headCommittedAt } = fetchReviewsAndHeadCommit(
-    owner,
-    repo,
-    Number(args.prNumber),
-  );
-  const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
-  const comments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-    {
-      paginate: true,
-    },
-  );
-  const claimEvents = resolveClaimEvents(
-    owner,
-    repo,
-    args.claimIssueNumber,
-    pr.closingIssuesReferences,
-    trustedMarkerLogins,
-  );
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
   // No manual cast: `normalizePolicyConfig`'s inferred return type already
@@ -524,6 +600,36 @@ function collectFromGitHub(args) {
   // pattern) -- re-declaring the shape here would silently stop tracking
   // that source of truth on drift.
   const policy = normalizePolicyConfig(rawConfig);
+  // #1344: forced-handoff-aware claim resolution, matching
+  // `pre-merge-readiness.mts` exactly, except reading `forcedHandoff.mode`/
+  // `authorityPolicy` off the already-loaded/normalized `policy` above
+  // instead of `readForcedHandoffMode()`/`readForcedHandoffAuthorityPolicy()`
+  // (each of which independently re-reads and re-parses
+  // `.github/idd/config.json`) -- `readForcedHandoffPolicy`
+  // (collaborator-permission.mts) computes those two fields via the exact
+  // same `normalizePolicyConfig` call, so `policy.forcedHandoff.*` is
+  // identical, not an approximation.
+  const forcedHandoffAuthorityPolicy = policy.forcedHandoff.authorityPolicy;
+  const forcedHandoffEnabled = policy.forcedHandoff.mode === 'human-gated';
+  const forcedHandoffPermissionCache = new Map();
+  // Part B (#1058): an issue-only handoff that predates the PR is honored
+  // even against a PR-backed claim. Resolved only when forced handoffs are
+  // enabled, and fails closed to `null` (reject) on any lookup/parse error
+  // so a transient commits-API failure never widens what this gate accepts.
+  let prFirstCommitAt = null;
+  if (forcedHandoffEnabled) {
+    try {
+      const prCommits = ghApiJson(
+        `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
+        { paginate: true },
+      );
+      prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
+    } catch {
+      prFirstCommitAt = null;
+    }
+  }
+  const staleAgeMs =
+    parseIsoDurationToMs(policy.claimTiming.staleAge) ?? DEFAULT_STALE_AGE_MS;
   return {
     inputs: {
       prNumber: Number(args.prNumber),
@@ -549,6 +655,18 @@ function collectFromGitHub(args) {
       ),
       waiverCheckSelector: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
       waivableSelectors: policy?.ciGate?.externalChecks?.waivable ?? [],
+      forcedHandoffEnabled,
+      isAuthorizedForcedHandoff: (forcedBy) =>
+        isAuthorizedForcedHandoffActor(
+          owner,
+          repo,
+          forcedBy,
+          forcedHandoffAuthorityPolicy,
+          forcedHandoffPermissionCache,
+        ),
+      expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
+      prFirstCommitAt,
+      staleAgeMs,
     },
   };
 }
@@ -618,6 +736,81 @@ function resolveClaimEvents(
     })
     .filter((candidate) => candidate.hasActiveClaim);
   return resolving.length === 1 ? resolving[0].comments : [];
+}
+/**
+ * Candidate collaborator-marker-trust logins: comment authors whose comment
+ * matches a recognized operational-marker prefix (claim, waiver,
+ * forced-handoff, etc. -- `operationalMarkerPrefix`), permission-checked
+ * and kept only when Write/Maintain/Admin. Mirrors
+ * `pre-merge-readiness.mts`'s function of the same name exactly. The
+ * `collectFromGitHub` call site passes the UNION of PR comments and the
+ * resolved claim issue's own comments (matching `pre-merge-readiness.mts`'s
+ * `[...comments, ...claimComments]` union) -- PR comments alone are not
+ * enough, since forced-handoff and claim markers are always posted to the
+ * claim issue, never the PR (see `forced-handoff-marker.mts`). Only called
+ * when `markerTrust.allowCollaboratorMarkers` / `IDD_TRUST_COLLABORATOR_MARKERS`
+ * is enabled -- a no-op repository never pays for these lookups.
+ */
+function resolveTrustedCollaboratorMarkerLogins(
+  owner,
+  repo,
+  commentLikeEvents,
+) {
+  const markerAuthors = [
+    ...new Set(
+      commentLikeEvents
+        .filter(
+          (comment) => operationalMarkerPrefix(comment.body ?? '') !== null,
+        )
+        .map((comment) => comment.author?.login ?? comment.user?.login ?? '')
+        .filter(Boolean),
+    ),
+  ];
+  return markerAuthors.filter((login) => {
+    const permission = safeGhText(
+      [
+        'api',
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        '--jq',
+        '.permission',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    ).toLowerCase();
+    return (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    );
+  });
+}
+/**
+ * Resolve the PR's first-commit time as an ISO string -- mirrors
+ * `pre-merge-readiness.mts`'s `resolvePrFirstCommitAt` verbatim (the
+ * minimum across all commits of each commit's committer date, falling
+ * back to author date). Returns `null` when no commit carries a
+ * parseable date, which fails the Part B (#1058) allowance closed
+ * (an `issue-only` handoff against a PR-backed claim stays rejected).
+ */
+function resolvePrFirstCommitAt(commits) {
+  let earliestMs = null;
+  let earliestIso = null;
+  for (const commit of commits) {
+    const date =
+      String(commit?.commit?.committer?.date ?? '').trim() ||
+      String(commit?.commit?.author?.date ?? '').trim();
+    if (!date) {
+      continue;
+    }
+    const ms = Date.parse(date);
+    if (!Number.isFinite(ms)) {
+      continue;
+    }
+    if (earliestMs === null || ms < earliestMs) {
+      earliestMs = ms;
+      earliestIso = date;
+    }
+  }
+  return earliestIso;
 }
 function ghGraphql(query, variables) {
   const args = ['api', 'graphql', '-f', `query=${query}`];

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -26,6 +26,13 @@
 //     PR's linked issue exactly as `external-check-waiver.mts`'s own
 //     `--apply` path already does, so no claim flag is required to call
 //     this helper (`--pr <n> --assert` is sufficient -- see docs).
+//   - `resolveCollaboratorMarkerTrust`, `isAuthorizedForcedHandoffActor`,
+//     `operationalMarkerPrefix` -- reused, matching `pre-merge-readiness.mts`
+//     exactly (#1344), to thread forced-handoff-aware claim resolution and
+//     collaborator-marker trust into the same `summarizeClaimValidation`
+//     call above, so this gate does not disagree with the sibling F2/F3
+//     helpers when a repository opts into either (both stay no-ops
+//     otherwise).
 //
 // This helper never mutates GitHub state: it only reads PR/review/thread/
 // comment data and prints a verdict.
@@ -36,13 +43,27 @@ import {
   readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
 } from './advisory-wait-policy.mts';
-import { ghApiJson, ghText, isCliExecution, safeGhText } from './gh-exec.mts';
+import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
+import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mts';
+import {
+  GH_TEXT_LOOP_OPTIONS,
+  ghApiJson,
+  ghText,
+  isCliExecution,
+  safeGhText,
+} from './gh-exec.mts';
 import { loadIddConfig } from './idd-config.mts';
 import { isValidIsoTimestamp } from './marker-helpers.mts';
-import { normalizePolicyConfig } from './policy-helpers.mts';
 import {
+  normalizePolicyConfig,
+  parseIsoDurationToMs,
+  resolveCollaboratorMarkerTrust,
+} from './policy-helpers.mts';
+import {
+  DEFAULT_STALE_AGE_MS,
   isCopilotReviewerLogin,
   normalizeTrustedMarkerLogins,
+  operationalMarkerPrefix,
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
   summarizeClaimValidation,
@@ -117,6 +138,16 @@ interface ReviewThreadsConnectionPayload {
 /** `gh pr view --json closingIssuesReferences` entry. */
 interface ClosingIssueRefPayload {
   number?: number | null;
+}
+
+/** Commit payload fields consumed by the Part B (#1058) first-commit-time
+ * resolver -- mirrors `pre-merge-readiness.mts`'s `PrCommitPayload`
+ * verbatim. */
+interface PrCommitPayload {
+  commit?: {
+    author?: { date?: string | null } | null;
+    committer?: { date?: string | null } | null;
+  } | null;
 }
 
 /** Latest-review clause evidence (Clause 1 of the `converged` definition). */
@@ -212,6 +243,42 @@ export interface AdvisoryConvergenceOptions {
   waivableSelectors?:
     | readonly { selector: string; matchMode?: string }[]
     | null;
+  // --- Forced-handoff / collaborator-marker-trust claim-resolution
+  // parity (#1344) -- threaded straight into the `summarizeClaimValidation`
+  // call below, matching `pre-merge-readiness.mts`'s own options exactly.
+  // The first four gate an opt-in, off-by-default repository feature: each
+  // is a no-op (today's exact behavior) when the caller omits it.
+  /** `forcedHandoff.mode === "human-gated"` (default `disabled`, i.e.
+   * `false`). Off by default; when on, a trusted forced-handoff marker on
+   * the claim issue can transfer `activeClaim` to its successor. */
+  forcedHandoffEnabled?: boolean;
+  /** Authorizes a forced-handoff marker's `forced-by` actor -- mirrors
+   * `pre-merge-readiness.mts`'s `isAuthorizedForcedHandoffActor`-backed
+   * callback. Omitted/absent means every handoff is treated as
+   * unauthorized (fail closed), same as `summarizeClaimValidation`'s own
+   * default. */
+  isAuthorizedForcedHandoff?: (forcedBy: string) => boolean;
+  /** The current PR's own reference forms (`["1234", prUrl]`, typically),
+   * so an `issue-plus-pr`-scoped handoff marker must name *this* PR to
+   * transfer the claim. An empty/omitted list accepts any linked-PR
+   * reference. */
+  expectedLinkedPrs?: unknown[] | null;
+  /** ISO timestamp of the PR's earliest commit -- the Part B (#1058)
+   * allowance that still honors an `issue-only`-scoped handoff (no
+   * `linked-pr` field) predating the PR, matching
+   * `pre-merge-readiness.mts` exactly. `null`/omitted rejects every
+   * `issue-only` handoff once `expectedLinkedPrs` is non-empty (fail
+   * closed), same as `buildForcedHandoffEnableGate`'s own default. */
+  prFirstCommitAt?: string | null;
+  /** Configured `claimTiming.staleAge` (#1310), pre-parsed to milliseconds.
+   * Unlike the four fields above, this is not gated behind an opt-in
+   * feature flag -- it is an unconditional parity fix for an already-live,
+   * orthogonal config value `pre-merge-readiness.mts` already applies.
+   * Omitted keeps `summarizeClaimValidation`'s hardcoded 24h default,
+   * which is also what a repository on the (also 24h) configured default
+   * observes -- so this is only a behavior change for a repository that
+   * has configured a non-default `claimTiming.staleAge`. */
+  staleAgeMs?: number;
 }
 
 /**
@@ -354,7 +421,17 @@ export function computeAdvisoryConvergenceVerdict(
   const waiverCheckSelector =
     String(options.waiverCheckSelector ?? '').trim() ||
     ADVISORY_CONVERGENCE_CHECK_SELECTOR;
-  const claim = summarizeClaimValidation(claimEvents, { trustedMarkerLogins });
+  const claim = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins,
+    // #1344: parity with `pre-merge-readiness.mts`'s own
+    // `summarizeClaimValidation` call -- see `AdvisoryConvergenceOptions`
+    // for why each field is a no-op when the caller omits it.
+    forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+    isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
+    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
+    staleAgeMs: options.staleAgeMs,
+  });
   const activeClaimId = claim.activeClaim?.claimId ?? '';
   let validWaiverCount = 0;
   if (!converged && deadlinePassed && waiverMode === 'maintainer-authorized') {
@@ -695,6 +772,79 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config: rawConfig,
   });
+  const pr = JSON.parse(
+    ghText([
+      'pr',
+      'view',
+      String(args.prNumber),
+      '-R',
+      repoRef,
+      '--json',
+      'headRefOid,closingIssuesReferences,author,url',
+    ]),
+  ) as {
+    headRefOid?: unknown;
+    closingIssuesReferences?: ClosingIssueRefPayload[] | null;
+    author?: GhAuthorPayload | null;
+    url?: unknown;
+  };
+  const prHeadSha = String(pr.headRefOid ?? '').toLowerCase();
+  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
+  const prUrl = String(pr.url ?? '');
+
+  // Fetched here (ahead of `trustedMarkerLogins` below) so a collaborator's
+  // marker-shaped PR comment can be detected before that set is used to
+  // resolve `claimEvents` -- see `resolveTrustedCollaboratorMarkerLogins`.
+  const comments = ghApiJson(
+    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
+    {
+      paginate: true,
+    },
+  ) as IssueCommentPayload[];
+
+  // #1344: collaborator-marker trust, matching `pre-merge-readiness.mts`'s
+  // `readCollaboratorTrustEnabled` exactly, except reusing the already-
+  // loaded `rawConfig` instead of a second `.github/idd/config.json` read
+  // (`resolveCollaboratorMarkerTrust` and `loadIddConfig` are both already
+  // null-safe, so no extra try/catch is needed for that simplification).
+  const collaboratorTrustEnabled = resolveCollaboratorMarkerTrust(
+    rawConfig,
+    process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+  );
+  // Base set (no collaborator fold yet). Sufficient for `resolveClaimEvents`'s
+  // own internal disambiguation below, which only needs to know whether SOME
+  // active claim exists on a candidate linked issue -- a presence check, not
+  // an identity resolution. A forced-handoff transition can only ever
+  // TRANSFORM an already-active claim (rule 7 requires `oldAgentId`/
+  // `oldClaimId`/`branch` to match the currently active claim), and
+  // `resolveActiveClaim`'s stale/non-superseded fallthrough always returns
+  // the pre-transform claim unchanged (protocol-helpers.mts's
+  // `applyClaimEvent`, the `return activeClaim;` fallthrough after the
+  // `isStale` check) -- so that pre-transform claim is always still
+  // "present" here whether or not this narrower set (or forced-handoff
+  // awareness generally) recognizes the transition itself. The
+  // collaborator-augmented FINAL set below (after `claimEvents` resolves)
+  // is what the real verdict computation uses.
+  const baseTrustedMarkerLogins = normalizeTrustedMarkerLogins([
+    viewerLogin,
+    ...configuredTrustedActors,
+  ]);
+
+  const { reviews, headCommittedAt } = fetchReviewsAndHeadCommit(
+    owner,
+    repo,
+    Number(args.prNumber),
+  );
+  const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
+
+  const claimEvents = resolveClaimEvents(
+    owner,
+    repo,
+    args.claimIssueNumber,
+    pr.closingIssuesReferences,
+    baseTrustedMarkerLogins,
+  );
+
   // Deliberately NOT unioned with `advisoryBotLogins` here (unlike some
   // other locally-collected sets in this file that scope broader trust for
   // marker *parsing*): every sibling helper (advisory-wait-state.mts,
@@ -704,49 +854,25 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   // Waivers`, below) -- folding a configured advisory bot login in here
   // would let that bot's own comment count as a "maintainer-authorized"
   // waiver author.
+  //
+  // #1344: folds collaborator-marker trust over the UNION of PR comments
+  // and the resolved claim issue's own comments, matching
+  // `pre-merge-readiness.mts`'s `[...comments, ...claimComments]` union
+  // exactly. Scanning `comments` alone would make `collaboratorTrustEnabled`
+  // a no-op for claim and forced-handoff markers: those are always posted to
+  // the claim ISSUE, never the PR (see `forced-handoff-marker.mts`), and
+  // `applyClaimEvent`'s `isTrustedAuthor` gate runs before any forced-handoff
+  // parsing -- an untrusted-author's marker never even reaches the
+  // authorization check.
   const trustedMarkerLogins = normalizeTrustedMarkerLogins([
-    viewerLogin,
-    ...configuredTrustedActors,
+    ...baseTrustedMarkerLogins,
+    ...(collaboratorTrustEnabled
+      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
+          ...comments,
+          ...claimEvents,
+        ])
+      : []),
   ]);
-
-  const pr = JSON.parse(
-    ghText([
-      'pr',
-      'view',
-      String(args.prNumber),
-      '-R',
-      repoRef,
-      '--json',
-      'headRefOid,closingIssuesReferences,author',
-    ]),
-  ) as {
-    headRefOid?: unknown;
-    closingIssuesReferences?: ClosingIssueRefPayload[] | null;
-    author?: GhAuthorPayload | null;
-  };
-  const prHeadSha = String(pr.headRefOid ?? '').toLowerCase();
-  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
-
-  const { reviews, headCommittedAt } = fetchReviewsAndHeadCommit(
-    owner,
-    repo,
-    Number(args.prNumber),
-  );
-  const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
-  const comments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-    {
-      paginate: true,
-    },
-  ) as IssueCommentPayload[];
-
-  const claimEvents = resolveClaimEvents(
-    owner,
-    repo,
-    args.claimIssueNumber,
-    pr.closingIssuesReferences,
-    trustedMarkerLogins,
-  );
 
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
@@ -756,6 +882,37 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   // pattern) -- re-declaring the shape here would silently stop tracking
   // that source of truth on drift.
   const policy = normalizePolicyConfig(rawConfig);
+
+  // #1344: forced-handoff-aware claim resolution, matching
+  // `pre-merge-readiness.mts` exactly, except reading `forcedHandoff.mode`/
+  // `authorityPolicy` off the already-loaded/normalized `policy` above
+  // instead of `readForcedHandoffMode()`/`readForcedHandoffAuthorityPolicy()`
+  // (each of which independently re-reads and re-parses
+  // `.github/idd/config.json`) -- `readForcedHandoffPolicy`
+  // (collaborator-permission.mts) computes those two fields via the exact
+  // same `normalizePolicyConfig` call, so `policy.forcedHandoff.*` is
+  // identical, not an approximation.
+  const forcedHandoffAuthorityPolicy = policy.forcedHandoff.authorityPolicy;
+  const forcedHandoffEnabled = policy.forcedHandoff.mode === 'human-gated';
+  const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
+  // Part B (#1058): an issue-only handoff that predates the PR is honored
+  // even against a PR-backed claim. Resolved only when forced handoffs are
+  // enabled, and fails closed to `null` (reject) on any lookup/parse error
+  // so a transient commits-API failure never widens what this gate accepts.
+  let prFirstCommitAt: string | null = null;
+  if (forcedHandoffEnabled) {
+    try {
+      const prCommits = ghApiJson(
+        `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
+        { paginate: true },
+      ) as PrCommitPayload[];
+      prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
+    } catch {
+      prFirstCommitAt = null;
+    }
+  }
+  const staleAgeMs =
+    parseIsoDurationToMs(policy.claimTiming.staleAge) ?? DEFAULT_STALE_AGE_MS;
 
   return {
     inputs: {
@@ -782,6 +939,18 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
       ),
       waiverCheckSelector: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
       waivableSelectors: policy?.ciGate?.externalChecks?.waivable ?? [],
+      forcedHandoffEnabled,
+      isAuthorizedForcedHandoff: (forcedBy: string) =>
+        isAuthorizedForcedHandoffActor(
+          owner,
+          repo,
+          forcedBy,
+          forcedHandoffAuthorityPolicy,
+          forcedHandoffPermissionCache,
+        ),
+      expectedLinkedPrs: [String(args.prNumber), prUrl].filter(Boolean),
+      prFirstCommitAt,
+      staleAgeMs,
     },
   };
 }
@@ -859,6 +1028,85 @@ function resolveClaimEvents(
     })
     .filter((candidate) => candidate.hasActiveClaim);
   return resolving.length === 1 ? resolving[0].comments : [];
+}
+
+/**
+ * Candidate collaborator-marker-trust logins: comment authors whose comment
+ * matches a recognized operational-marker prefix (claim, waiver,
+ * forced-handoff, etc. -- `operationalMarkerPrefix`), permission-checked
+ * and kept only when Write/Maintain/Admin. Mirrors
+ * `pre-merge-readiness.mts`'s function of the same name exactly. The
+ * `collectFromGitHub` call site passes the UNION of PR comments and the
+ * resolved claim issue's own comments (matching `pre-merge-readiness.mts`'s
+ * `[...comments, ...claimComments]` union) -- PR comments alone are not
+ * enough, since forced-handoff and claim markers are always posted to the
+ * claim issue, never the PR (see `forced-handoff-marker.mts`). Only called
+ * when `markerTrust.allowCollaboratorMarkers` / `IDD_TRUST_COLLABORATOR_MARKERS`
+ * is enabled -- a no-op repository never pays for these lookups.
+ */
+function resolveTrustedCollaboratorMarkerLogins(
+  owner: string,
+  repo: string,
+  commentLikeEvents: IssueCommentPayload[],
+): string[] {
+  const markerAuthors = [
+    ...new Set(
+      commentLikeEvents
+        .filter(
+          (comment) => operationalMarkerPrefix(comment.body ?? '') !== null,
+        )
+        .map((comment) => comment.author?.login ?? comment.user?.login ?? '')
+        .filter(Boolean),
+    ),
+  ];
+
+  return markerAuthors.filter((login) => {
+    const permission = safeGhText(
+      [
+        'api',
+        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
+        '--jq',
+        '.permission',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    ).toLowerCase();
+
+    return (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    );
+  });
+}
+
+/**
+ * Resolve the PR's first-commit time as an ISO string -- mirrors
+ * `pre-merge-readiness.mts`'s `resolvePrFirstCommitAt` verbatim (the
+ * minimum across all commits of each commit's committer date, falling
+ * back to author date). Returns `null` when no commit carries a
+ * parseable date, which fails the Part B (#1058) allowance closed
+ * (an `issue-only` handoff against a PR-backed claim stays rejected).
+ */
+function resolvePrFirstCommitAt(commits: PrCommitPayload[]): string | null {
+  let earliestMs: number | null = null;
+  let earliestIso: string | null = null;
+  for (const commit of commits) {
+    const date =
+      String(commit?.commit?.committer?.date ?? '').trim() ||
+      String(commit?.commit?.author?.date ?? '').trim();
+    if (!date) {
+      continue;
+    }
+    const ms = Date.parse(date);
+    if (!Number.isFinite(ms)) {
+      continue;
+    }
+    if (earliestMs === null || ms < earliestMs) {
+      earliestMs = ms;
+      earliestIso = date;
+    }
+  }
+  return earliestIso;
 }
 
 function ghGraphql(

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -504,6 +504,357 @@ test('regression: elapsedMinutes clamps to 0 instead of going negative when head
   assert.equal(verdict.deadline.elapsedMinutes, 0);
 });
 
+// --- 8. forced-handoff / collaborator-marker-trust claim-resolution parity
+// --- (#1344) -- both are opt-in, off-by-default repository features;
+// --- `pre-merge-readiness.mts` already threads them into its own
+// --- `summarizeClaimValidation` call, this section proves
+// --- `advisory-convergence.mts` now agrees with it instead of silently
+// --- rejecting a waiver the sibling gate would accept.
+
+const SUCCESSOR_AGENT_ID = 'claude-test-2';
+const SUCCESSOR_CLAIM_ID = 'claim-successor';
+const HANDOFF_AT = '2026-06-05T00:00:00Z'; // after OLD, before PR_FIRST_COMMIT_AT
+const PR_FIRST_COMMIT_AT = '2026-06-10T00:00:00Z';
+
+function forcedHandoffComment({
+  newAgentId = SUCCESSOR_AGENT_ID,
+  newClaimId = SUCCESSOR_CLAIM_ID,
+  contextScope = 'issue-plus-pr',
+  linkedPr = '1234',
+  createdAt = RECENT,
+  author = TRUSTED,
+} = {}) {
+  const payload = {
+    'old-agent-id': AGENT_ID,
+    'old-claim-id': CLAIM_ID,
+    'new-agent-id': newAgentId,
+    'new-claim-id': newClaimId,
+    branch: 'issue/1234-test',
+    'forced-by': TRUSTED,
+    reason: 'operator-approved-recovery',
+    timestamp: createdAt,
+    'context-scope': contextScope,
+    ...(linkedPr ? { 'linked-pr': linkedPr } : {}),
+  };
+  return {
+    author: { login: author },
+    // `forced-by` stays TRUSTED regardless of `author` -- a non-default
+    // `author` models a collaborator RELAYING a separately-authorized
+    // maintainer's approval (`requireAuthorMatchesForcedBy` defaults to
+    // `false` for this gate's lenient merge-side resolution, matching
+    // `pre-merge-readiness.mts`; see `summarizeClaimValidation`'s own
+    // doc comment in protocol-helpers.mts). The comment AUTHOR still must
+    // independently pass the trusted-marker-actor gate (idd-claim rule 2)
+    // for this marker to be considered at all.
+    body: `<!-- forced-handoff: ${JSON.stringify(payload)} -->\n\nForced handoff approved by ${TRUSTED}.`,
+    createdAt,
+  };
+}
+
+/** Defaults to a maintainer-authorized waiver bound to the SUCCESSOR claim
+ * (`SUCCESSOR_AGENT_ID`/`SUCCESSOR_CLAIM_ID`), posted by `TRUSTED`. Pass
+ * `agentId`/`claimId: AGENT_ID/CLAIM_ID` to bind to the original claim
+ * instead (the collaborator-marker-trust tests below, which exercise
+ * waiver-author trust in isolation from any forced-handoff transition). */
+function waiverComment({
+  agentId = SUCCESSOR_AGENT_ID,
+  claimId = SUCCESSOR_CLAIM_ID,
+  reason = 'maintainer approved after forced-handoff takeover',
+  actor = TRUSTED,
+}: {
+  agentId?: string;
+  claimId?: string;
+  reason?: string;
+  actor?: string;
+} = {}) {
+  return {
+    author: { login: actor },
+    body: renderExternalCheckWaiverComment({
+      agentId,
+      claimId,
+      headSha: HEAD,
+      checkSelector: 'idd-advisory-convergence',
+      reason,
+      expiresAt: '2026-07-12T00:00:00Z',
+      actor,
+    }),
+    createdAt: RECENT,
+  };
+}
+
+test('forced-handoff takeover (issue-plus-pr): a waiver bound to the successor claim-id validates', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment(), forcedHandoffComment()],
+      comments: [waiverComment()],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      forcedHandoffEnabled: true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === TRUSTED,
+      expectedLinkedPrs: ['1234'],
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.deadline.passed, true);
+  assert.equal(verdict.waiver.activeClaimId, SUCCESSOR_CLAIM_ID);
+  assert.equal(verdict.waiver.validCount, 1);
+  assert.equal(verdict.waived, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('forced-handoff takeover (issue-only, predates the PR): honored via prFirstCommitAt, matching pre-merge-readiness.mts Part B (#1058)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [
+        claimComment(),
+        forcedHandoffComment({
+          contextScope: 'issue-only',
+          linkedPr: '',
+          createdAt: HANDOFF_AT,
+        }),
+      ],
+      comments: [waiverComment()],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      forcedHandoffEnabled: true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === TRUSTED,
+      // Non-empty even for an issue-only marker -- always true in
+      // production (`--pr` is required), which is exactly why
+      // `prFirstCommitAt` (not just an empty `expectedLinkedPrs`) is
+      // required to reach this branch at all.
+      expectedLinkedPrs: ['1234'],
+      prFirstCommitAt: PR_FIRST_COMMIT_AT,
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.waiver.activeClaimId, SUCCESSOR_CLAIM_ID);
+  assert.equal(verdict.waived, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('forced-handoff (issue-only) is rejected once it no longer predates the PR (prFirstCommitAt fails closed)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [
+        claimComment(),
+        forcedHandoffComment({
+          contextScope: 'issue-only',
+          linkedPr: '',
+          createdAt: HANDOFF_AT,
+        }),
+      ],
+      comments: [waiverComment()],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      forcedHandoffEnabled: true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === TRUSTED,
+      expectedLinkedPrs: ['1234'],
+      // The handoff (HANDOFF_AT) no longer predates this -- Part B denies
+      // the issue-only allowance, so the claim stays with the ORIGINAL
+      // agent and the successor-bound waiver must not validate.
+      prFirstCommitAt: '2026-06-01T00:00:01Z',
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.waiver.activeClaimId, CLAIM_ID);
+  assert.equal(verdict.waiver.validCount, 0);
+  assert.equal(verdict.waived, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('regression: forced-handoff options default OFF -- the marker is inert and a successor-bound waiver never validates', () => {
+  // Identical fixture to the first forced-handoff test above, but through
+  // `baseOptions()` alone (no forcedHandoffEnabled / isAuthorizedForced-
+  // Handoff / expectedLinkedPrs) -- proves the four new options are a
+  // true no-op when a caller never sets them, matching today's exact
+  // behavior before #1344.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment(), forcedHandoffComment()],
+      comments: [waiverComment()],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.waiver.activeClaimId, CLAIM_ID);
+  assert.equal(verdict.waiver.validCount, 0);
+  assert.equal(verdict.waived, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('collaborator-marker trust (PR side): a waiver from a login outside trustedMarkerActors is honored once it is folded into trustedMarkerLogins', () => {
+  // `collectFromGitHub` (I/O layer, not under test here) folds a
+  // Write/Maintain/Admin collaborator's login into `trustedMarkerLogins`
+  // only when `markerTrust.allowCollaboratorMarkers` /
+  // `IDD_TRUST_COLLABORATOR_MARKERS` is enabled -- see
+  // `resolveTrustedCollaboratorMarkerLogins`. This test supplies the
+  // resolved set directly (the pure-function half of that feature) the
+  // same way every other test in this file supplies pre-resolved
+  // evidence; the I/O permission lookup itself is not mocked here,
+  // matching this codebase's own convention (see
+  // `tests/collaborator-permission.test.mts`'s documented #1212 scope
+  // note: the `gh api .../permission` subprocess path is deliberately
+  // left untested, exercised only via its cache-seeding seam).
+  const COLLABORATOR = 'collab-write-user';
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        waiverComment({
+          agentId: AGENT_ID,
+          claimId: CLAIM_ID,
+          actor: COLLABORATOR,
+        }),
+      ],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      trustedMarkerLogins: [TRUSTED, COLLABORATOR],
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.waiver.activeClaimId, CLAIM_ID);
+  assert.equal(verdict.waiver.validCount, 1);
+  assert.equal(verdict.waived, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('collaborator-marker trust (claim-issue side): a forced-handoff marker AUTHORED by a login outside trustedMarkerActors is honored once folded into trustedMarkerLogins', () => {
+  // Regression coverage added during #1344's own review loop: forced-
+  // handoff markers are always posted to the claim ISSUE, never the PR
+  // (see `forced-handoff-marker.mts`), so `collectFromGitHub` must fold
+  // collaborator-marker-trust logins from the resolved claim issue's
+  // comments too, not just PR `comments` -- see
+  // `resolveTrustedCollaboratorMarkerLogins`'s call site (the union of
+  // `comments` and `claimEvents`, matching `pre-merge-readiness.mts`'s
+  // `[...comments, ...claimComments]` exactly). As above, this test
+  // supplies the already-resolved `trustedMarkerLogins` directly and
+  // proves the CONSEQUENCE: once a Write-permission collaborator's login
+  // is trusted, a forced-handoff marker they AUTHORED (relaying a
+  // separately-authorized maintainer's approval; see
+  // `forcedHandoffComment`'s `author` parameter) is honored the same way
+  // a `trustedMarkerActors`-listed author's marker already is.
+  const COLLABORATOR = 'collab-write-user';
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [
+        claimComment(),
+        forcedHandoffComment({ author: COLLABORATOR }),
+      ],
+      comments: [waiverComment()],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      forcedHandoffEnabled: true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === TRUSTED,
+      expectedLinkedPrs: ['1234'],
+      trustedMarkerLogins: [TRUSTED, COLLABORATOR],
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.waiver.activeClaimId, SUCCESSOR_CLAIM_ID);
+  assert.equal(verdict.waived, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('regression: collaborator-marker trust defaults OFF -- an untrusted marker author cannot force a handoff even with a valid forced-by maintainer', () => {
+  // Companion to both collaborator-marker-trust tests above: identical
+  // claim-issue-side fixture, but COLLABORATOR is never added to
+  // trustedMarkerLogins (baseOptions()'s default, [TRUSTED]) -- the
+  // marker's author fails the trusted-actor gate (idd-claim rule 2)
+  // before forced-handoff authorization is even evaluated, so the claim
+  // never transfers, regardless of markerTrust being the reason
+  // COLLABORATOR was omitted or simply not configured.
+  const COLLABORATOR = 'collab-write-user';
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [
+        claimComment(),
+        forcedHandoffComment({ author: COLLABORATOR }),
+      ],
+      comments: [waiverComment()],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      forcedHandoffEnabled: true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === TRUSTED,
+      expectedLinkedPrs: ['1234'],
+      // trustedMarkerLogins left at baseOptions()'s default ([TRUSTED]) --
+      // COLLABORATOR is never folded in.
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.waiver.activeClaimId, CLAIM_ID);
+  assert.equal(verdict.waiver.validCount, 0);
+  assert.equal(verdict.waived, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('staleAgeMs: a configured shorter stale window allows a takeover the hardcoded 24h default would reject', () => {
+  // claimComment() is dated OLD (2026-06-01T00:00:00Z). TAKEOVER_AT is only
+  // 2h later -- fresh under the hardcoded 24h default (takeover rejected,
+  // active claim stays CLAIM_ID) but stale under a configured 1h window
+  // (takeover accepted, active claim becomes SUCCESSOR_CLAIM_ID). Proves
+  // `staleAgeMs` actually reaches `summarizeClaimValidation`, not just that
+  // it type-checks.
+  const TAKEOVER_AT = '2026-06-01T02:00:00Z';
+  const takeoverClaim = {
+    author: { login: TRUSTED },
+    body: `<!-- claimed-by: ${SUCCESSOR_AGENT_ID} ${SUCCESSOR_CLAIM_ID} supersedes: ${CLAIM_ID} ${TAKEOVER_AT} branch: issue/1234-test -->\n\n_${SUCCESSOR_AGENT_ID}: issue claim — IDD automation marker. Do not edit._`,
+    createdAt: TAKEOVER_AT,
+  };
+  const claimEvents = [claimComment(), takeoverClaim];
+
+  const underDefault = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents, comments: [waiverComment()] }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      // staleAgeMs omitted -- hardcoded 24h default; the 2h gap is not stale.
+    }),
+  );
+  assert.equal(underDefault.waiver.activeClaimId, CLAIM_ID);
+
+  const underConfiguredWindow = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents, comments: [waiverComment()] }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      staleAgeMs: 60 * 60 * 1000, // 1h -- the 2h gap now counts as stale.
+    }),
+  );
+  assertValidVerdict(underConfiguredWindow);
+  assert.equal(underConfiguredWindow.waiver.activeClaimId, SUCCESSOR_CLAIM_ID);
+});
+
 // --- classifyCopilotAuthoredThreadIds (pure helper) -------------------------
 
 test('classifyCopilotAuthoredThreadIds: a thread counts only when its ORIGINATING comment is bot-authored', () => {


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Threads forced-handoff-aware and collaborator-marker-trust-aware claim
resolution into `advisory-convergence.mts`, matching the sibling
`pre-merge-readiness.mts` exactly, so the two F2/F3 gates no longer
disagree on `activeClaimId` when a repository opts into either feature.
Both stay no-ops on their disabled defaults.

- `AdvisoryConvergenceOptions` gains `forcedHandoffEnabled`,
  `isAuthorizedForcedHandoff`, `expectedLinkedPrs`, `prFirstCommitAt`
  (Part B, #1058), and `staleAgeMs`, all threaded into the existing
  `summarizeClaimValidation` call.
- `collectFromGitHub` folds collaborator-marker trust
  (`markerTrust.allowCollaboratorMarkers` /
  `IDD_TRUST_COLLABORATOR_MARKERS`) into `trustedMarkerLogins` over the
  union of PR comments and the resolved claim issue's own comments —
  see "Background" below for why PR comments alone are not enough.
- `docs/idd-helper-scripts.md` (and its `idd-template/` canonical
  source) documents the parity.

## Linked issue

Closes #1344

## Follow-up issues (if any)

- [ ] none

Two small, deliberately-deferred cleanup items surfaced during review,
not filed as issues (both are narrow enough to fold into a future
`/simplify` pass rather than warranting a standalone issue):

- `resolveTrustedCollaboratorMarkerLogins` / `resolvePrFirstCommitAt`
  are now duplicated a third time (`pre-merge-readiness.mts`,
  `advisory-wait-state.mts`, this file) — intentional, since the issue
  asks this file to mirror the existing pattern rather than refactor
  three files' shared logic in a narrowly-scoped parity fix.
- The mirrored `permission === 'maintain'` branch in
  `resolveTrustedCollaboratorMarkerLogins` is dead code (GitHub's
  legacy `permission` field collapses `maintain` to `write`; only
  `role_name` reports it) — pre-existing in both sibling copies too,
  left as-is for this PR rather than fixing one of three copies.

## Background / rationale

**The issue's "both gaps are inert today" premise only holds for one of
the two.** `git blame .github/idd/config.json` shows
`forcedHandoff.mode: "human-gated"` has been live in this repository
since #984 (2026-05-17) — over a month before #1344 was filed. Only
`markerTrust.allowCollaboratorMarkers` is actually off by default. This
promoted `prFirstCommitAt` from "not named in the issue's 4-field list"
to "needed for true parity": without it, `expectedLinkedPrs` is always
non-empty here (`--pr` is required), so an `issue-only`-scoped
handoff — the scope this repository's own
`forced-handoff-marker.mts` picks whenever the superseded agent had not
yet opened a PR at handoff time, arguably the most common real
trigger — would never be honored, reproducing narrowly the exact
cross-gate disagreement this issue exists to close.

**Five parallel self-review passes (C1) converged on a real scoping bug
in the first draft**, independently confirmed from four different
angles: `resolveTrustedCollaboratorMarkerLogins` initially scanned only
PR-level comments. Forced-handoff and claim markers are always posted
to the **claim issue**, never the PR (`forced-handoff-marker.mts` posts
to `issues/{issueNumber}/comments` unconditionally), and
`applyClaimEvent`'s trusted-author gate runs before any forced-handoff
parsing — so a collaborator trusted only via
`markerTrust.allowCollaboratorMarkers` could never have their
claim-issue-side marker recognized, making the feature a no-op for
exactly the scenario it exists to cover. Fixed by folding
collaborator-marker trust over `[...comments, ...claimEvents]` (the
resolved claim issue's own comments), matching
`pre-merge-readiness.mts`'s `[...comments, ...claimComments]` union
exactly. `resolveClaimEvents`'s own internal disambiguation call
(auto-discovery among several PR-linked issues) intentionally still
uses the narrower pre-fold set — traced through `applyClaimEvent`: a
forced-handoff marker can only ever *transform* an already-active
claim, and a stale-but-unsuperseded claim still falls through to
`return activeClaim`, so that inner call's `activeClaimPresent` boolean
is provably invariant to every option this PR adds (verified
independently by two of the five review passes).

Both are covered by regression tests proving the default-off no-op
behavior explicitly, alongside the positive cases (including the
newly-fixed claim-issue-side collaborator scenario).

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed (`idd-template/docs/idd-helper-scripts.md`,
      mirrored to `docs/idd-helper-scripts.md`)
- [x] Helper scripts changed (`src/scripts/advisory-convergence.mts` +
      generated `.mjs`)
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed (claim-resolution
      trust logic feeding the `idd-advisory-convergence` F2 gate; no
      new credentials, no new write access — this helper stays
      read-only)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; 4 pre-existing warnings
      unrelated to this change — missing adopter-profile READMEs,
      local `core.hooksPath` not wired to the worktree guard,
      release-tag drift, branch protection unreadable from this
      session)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (this gate is advisory/read-only;
      it never mutates GitHub state or executes a merge itself, only
      informs the `idd-advisory-convergence` required-check verdict)
- [x] Context budget impact reviewed (helper-script + one doc
      paragraph only; no instruction-file changes)
