### PR TITLE
fix(advisory-convergence): resolve trust before claim disambiguation

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1162,15 +1162,21 @@ Interpretation rules:
   than duplicating review- or waiver-parsing logic; only the
   Copilot-thread-authorship filter and the review-item-count read are new.
 - Claim resolution for the waiver escape hatch is forced-handoff-aware and
-  collaborator-marker-trust-aware (#1344), matching `pre-merge-readiness.mjs`
-  exactly: with `forcedHandoff.mode: "human-gated"` enabled, a verified
-  handoff on the linked claim issue transfers `activeClaimId` to the
-  successor (including the Part B (#1058) allowance for an `issue-only`
-  handoff that predates the PR); with `markerTrust.allowCollaboratorMarkers`
-  (or `IDD_TRUST_COLLABORATOR_MARKERS`) enabled, a Write/Maintain/Admin
-  collaborator's marker-shaped PR comment adds them to the trusted-marker
-  set the same way it already does for `pre-merge-readiness.mjs` /
-  `advisory-wait-state.mjs`. Both stay no-ops when the repository leaves
+  collaborator-marker-trust-aware (#1344, #1347), matching
+  `pre-merge-readiness.mjs` in spirit: with `forcedHandoff.mode:
+  "human-gated"` enabled, a verified handoff on the linked claim issue
+  transfers `activeClaimId` to the successor (including the Part B (#1058)
+  allowance for an `issue-only` handoff that predates the PR); with
+  `markerTrust.allowCollaboratorMarkers` (or
+  `IDD_TRUST_COLLABORATOR_MARKERS`) enabled, a Write/Maintain/Admin
+  collaborator's marker-shaped comment on the PR **or on the linked claim
+  issue** adds them to the trusted-marker set — claim and forced-handoff
+  markers are always posted to the claim issue, never the PR, so the
+  claim-issue side is not optional coverage. This gate auto-discovers
+  among every issue the PR closes (unlike `pre-merge-readiness.mjs`'s
+  single required `--claim-issue`), so the collaborator scan and the
+  active-claim disambiguation both cover every candidate issue's comments,
+  not just the one ultimately picked. Both stay no-ops when the repository leaves
   them at their (disabled) defaults.
 - Fail closed: if helper execution fails, output is invalid JSON, or
   required fields are missing, discard helper output and apply the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1162,15 +1162,21 @@ Interpretation rules:
   than duplicating review- or waiver-parsing logic; only the
   Copilot-thread-authorship filter and the review-item-count read are new.
 - Claim resolution for the waiver escape hatch is forced-handoff-aware and
-  collaborator-marker-trust-aware (#1344), matching `pre-merge-readiness.mjs`
-  exactly: with `forcedHandoff.mode: "human-gated"` enabled, a verified
-  handoff on the linked claim issue transfers `activeClaimId` to the
-  successor (including the Part B (#1058) allowance for an `issue-only`
-  handoff that predates the PR); with `markerTrust.allowCollaboratorMarkers`
-  (or `IDD_TRUST_COLLABORATOR_MARKERS`) enabled, a Write/Maintain/Admin
-  collaborator's marker-shaped PR comment adds them to the trusted-marker
-  set the same way it already does for `pre-merge-readiness.mjs` /
-  `advisory-wait-state.mjs`. Both stay no-ops when the repository leaves
+  collaborator-marker-trust-aware (#1344, #1347), matching
+  `pre-merge-readiness.mjs` in spirit: with `forcedHandoff.mode:
+  "human-gated"` enabled, a verified handoff on the linked claim issue
+  transfers `activeClaimId` to the successor (including the Part B (#1058)
+  allowance for an `issue-only` handoff that predates the PR); with
+  `markerTrust.allowCollaboratorMarkers` (or
+  `IDD_TRUST_COLLABORATOR_MARKERS`) enabled, a Write/Maintain/Admin
+  collaborator's marker-shaped comment on the PR **or on the linked claim
+  issue** adds them to the trusted-marker set — claim and forced-handoff
+  markers are always posted to the claim issue, never the PR, so the
+  claim-issue side is not optional coverage. This gate auto-discovers
+  among every issue the PR closes (unlike `pre-merge-readiness.mjs`'s
+  single required `--claim-issue`), so the collaborator scan and the
+  active-claim disambiguation both cover every candidate issue's comments,
+  not just the one ultimately picked. Both stay no-ops when the repository leaves
   them at their (disabled) defaults.
 - Fail closed: if helper execution fails, output is invalid JSON, or
   required fields are missing, discard helper output and apply the

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -533,36 +533,27 @@ function collectFromGitHub(args) {
     rawConfig,
     process.env.IDD_TRUST_COLLABORATOR_MARKERS,
   );
-  // Base set (no collaborator fold yet). Sufficient for `resolveClaimEvents`'s
-  // own internal disambiguation below, which only needs to know whether SOME
-  // active claim exists on a candidate linked issue -- a presence check, not
-  // an identity resolution. A forced-handoff transition can only ever
-  // TRANSFORM an already-active claim (rule 7 requires `oldAgentId`/
-  // `oldClaimId`/`branch` to match the currently active claim), and
-  // `resolveActiveClaim`'s stale/non-superseded fallthrough always returns
-  // the pre-transform claim unchanged (protocol-helpers.mts's
-  // `applyClaimEvent`, the `return activeClaim;` fallthrough after the
-  // `isStale` check) -- so that pre-transform claim is always still
-  // "present" here whether or not this narrower set (or forced-handoff
-  // awareness generally) recognizes the transition itself. The
-  // collaborator-augmented FINAL set below (after `claimEvents` resolves)
-  // is what the real verdict computation uses.
-  const baseTrustedMarkerLogins = normalizeTrustedMarkerLogins([
-    viewerLogin,
-    ...configuredTrustedActors,
-  ]);
   const { reviews, headCommittedAt } = fetchReviewsAndHeadCommit(
     owner,
     repo,
     Number(args.prNumber),
   );
   const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
-  const claimEvents = resolveClaimEvents(
+  // #1347: fetch every claim-issue candidate's raw comments (pure I/O)
+  // BEFORE computing `trustedMarkerLogins`, so collaborator-marker trust
+  // can be resolved from ALL candidates' comments -- not just whichever
+  // one the presence-check below eventually picks. Folding trust only
+  // from the already-picked candidate is circular: a lone candidate's
+  // claim-establishing marker, authored by a login trusted only via
+  // collaborator-marker trust, would never register as "active" for the
+  // presence check to pick it in the first place, discarding the real
+  // claim data before that trust is ever computed. See
+  // `pickResolvingClaimEvents`'s doc comment for the full history.
+  const claimCandidates = fetchClaimEventCandidates(
     owner,
     repo,
     args.claimIssueNumber,
     pr.closingIssuesReferences,
-    baseTrustedMarkerLogins,
   );
   // Deliberately NOT unioned with `advisoryBotLogins` here (unlike some
   // other locally-collected sets in this file that scope broader trust for
@@ -574,24 +565,33 @@ function collectFromGitHub(args) {
   // would let that bot's own comment count as a "maintainer-authorized"
   // waiver author.
   //
-  // #1344: folds collaborator-marker trust over the UNION of PR comments
-  // and the resolved claim issue's own comments, matching
-  // `pre-merge-readiness.mts`'s `[...comments, ...claimComments]` union
-  // exactly. Scanning `comments` alone would make `collaboratorTrustEnabled`
-  // a no-op for claim and forced-handoff markers: those are always posted to
-  // the claim ISSUE, never the PR (see `forced-handoff-marker.mts`), and
-  // `applyClaimEvent`'s `isTrustedAuthor` gate runs before any forced-handoff
-  // parsing -- an untrusted-author's marker never even reaches the
-  // authorization check.
+  // #1344/#1347: folds collaborator-marker trust over the UNION of PR
+  // comments and EVERY claim-issue candidate's comments, matching
+  // `pre-merge-readiness.mts`'s `[...comments, ...claimComments]` union in
+  // spirit (extended here to all candidates, since this gate -- unlike
+  // pre-merge-readiness.mts -- auto-discovers among several linked issues
+  // rather than requiring a single explicit one). Scanning `comments`
+  // alone would make `collaboratorTrustEnabled` a no-op for claim and
+  // forced-handoff markers: those are always posted to the claim ISSUE,
+  // never the PR (see `forced-handoff-marker.mts`), and
+  // `applyClaimEvent`'s `isTrustedAuthor` gate runs before any
+  // claim/forced-handoff parsing -- an untrusted-author's marker never
+  // even reaches the authorization check.
   const trustedMarkerLogins = normalizeTrustedMarkerLogins([
-    ...baseTrustedMarkerLogins,
+    viewerLogin,
+    ...configuredTrustedActors,
     ...(collaboratorTrustEnabled
       ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
           ...comments,
-          ...claimEvents,
+          ...claimCandidates.flat(),
         ])
       : []),
   ]);
+  const claimEvents = pickResolvingClaimEvents(
+    claimCandidates,
+    trustedMarkerLogins,
+    Boolean(args.claimIssueNumber),
+  );
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
   // No manual cast: `normalizePolicyConfig`'s inferred return type already
@@ -697,45 +697,67 @@ function fetchClaimComments(owner, repo, issueNumber) {
   }));
 }
 /**
- * Resolve the linked (claim) issue's comment stream for waiver-claim
- * binding. When `explicitIssueNumber` (`--claim-issue`) is given, use it
- * directly -- no ambiguity to resolve. Otherwise a PR can close more than
- * one issue (`pr.closingIssuesReferences`), so fetch every candidate's
- * comments and keep only the one whose *active claim* actually resolves
- * (`summarizeClaimValidation`), mirroring how `external-check-waiver.mts`'s
- * own `selectLinkedIssueCandidate` disambiguates multiple linked issues by
- * active-claim presence rather than requiring a single closing reference.
- * Zero or multiple resolving candidates fail closed to `[]` (no waiver
- * claim can bind unambiguously), same as before.
+ * Fetch the claim-issue candidate(s)' raw comment streams -- pure I/O, no
+ * trust judgment. When `explicitIssueNumber` (`--claim-issue`) is given,
+ * fetch it alone -- no ambiguity to resolve. Otherwise a PR can close more
+ * than one issue (`pr.closingIssuesReferences`), so fetch every candidate's
+ * comments; {@link pickResolvingClaimEvents} disambiguates them afterward.
+ *
+ * Split out from a single `resolveClaimEvents` (#1344) so the
+ * `trustedMarkerLogins` used for disambiguation can be computed from ALL
+ * candidates' comments first (see the `collectFromGitHub` call site) --
+ * #1347 found that resolving trust from only the eventually-picked
+ * candidate is circular: a lone candidate's claim-establishing marker,
+ * authored by a login trusted only via collaborator-marker trust, would
+ * never be recognized as "active" long enough to be picked in the first
+ * place, discarding the real claim data before that trust is ever folded
+ * in.
  */
-function resolveClaimEvents(
-  owner,
-  repo,
-  explicitIssueNumber,
-  refs,
-  trustedMarkerLogins,
-) {
+function fetchClaimEventCandidates(owner, repo, explicitIssueNumber, refs) {
   if (explicitIssueNumber) {
-    return fetchClaimComments(owner, repo, explicitIssueNumber);
+    return [fetchClaimComments(owner, repo, explicitIssueNumber)];
   }
   const candidateNumbers = [
     ...new Set(
       (refs ?? []).map((ref) => ref?.number).filter((n) => Number.isInteger(n)),
     ),
   ];
-  const resolving = candidateNumbers
-    .map((issueNumber) => {
-      const comments = fetchClaimComments(owner, repo, issueNumber);
-      return {
-        comments,
-        hasActiveClaim: Boolean(
-          summarizeClaimValidation(comments, { trustedMarkerLogins })
-            .activeClaimPresent,
-        ),
-      };
-    })
-    .filter((candidate) => candidate.hasActiveClaim);
-  return resolving.length === 1 ? resolving[0].comments : [];
+  return candidateNumbers.map((issueNumber) =>
+    fetchClaimComments(owner, repo, issueNumber),
+  );
+}
+/**
+ * Resolve the linked (claim) issue's comment stream for waiver-claim
+ * binding, given already-fetched candidate comment streams
+ * ({@link fetchClaimEventCandidates}) and a `trustedMarkerLogins` already
+ * fully resolved (including any collaborator-marker-trust fold) over ALL
+ * candidates' comments. Pure -- no I/O -- so it is directly unit-testable.
+ *
+ * `isExplicit` mirrors `fetchClaimEventCandidates`'s own
+ * `explicitIssueNumber` check: an explicit `--claim-issue` candidate is
+ * returned unconditionally, no ambiguity to resolve. Otherwise, keep only
+ * the candidate whose *active claim* actually resolves
+ * (`summarizeClaimValidation`), mirroring how `external-check-waiver.mts`'s
+ * own `selectLinkedIssueCandidate` disambiguates multiple linked issues by
+ * active-claim presence rather than requiring a single closing reference.
+ * Zero or multiple resolving candidates fail closed to `[]` (no waiver
+ * claim can bind unambiguously), same as before #1344/#1347.
+ */
+export function pickResolvingClaimEvents(
+  candidates,
+  trustedMarkerLogins,
+  isExplicit,
+) {
+  if (isExplicit) {
+    return candidates[0] ?? [];
+  }
+  const resolving = candidates.filter((comments) =>
+    Boolean(
+      summarizeClaimValidation(comments, { trustedMarkerLogins })
+        .activeClaimPresent,
+    ),
+  );
+  return resolving.length === 1 ? resolving[0] : [];
 }
 /**
  * Candidate collaborator-marker-trust logins: comment authors whose comment

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -811,24 +811,6 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
     rawConfig,
     process.env.IDD_TRUST_COLLABORATOR_MARKERS,
   );
-  // Base set (no collaborator fold yet). Sufficient for `resolveClaimEvents`'s
-  // own internal disambiguation below, which only needs to know whether SOME
-  // active claim exists on a candidate linked issue -- a presence check, not
-  // an identity resolution. A forced-handoff transition can only ever
-  // TRANSFORM an already-active claim (rule 7 requires `oldAgentId`/
-  // `oldClaimId`/`branch` to match the currently active claim), and
-  // `resolveActiveClaim`'s stale/non-superseded fallthrough always returns
-  // the pre-transform claim unchanged (protocol-helpers.mts's
-  // `applyClaimEvent`, the `return activeClaim;` fallthrough after the
-  // `isStale` check) -- so that pre-transform claim is always still
-  // "present" here whether or not this narrower set (or forced-handoff
-  // awareness generally) recognizes the transition itself. The
-  // collaborator-augmented FINAL set below (after `claimEvents` resolves)
-  // is what the real verdict computation uses.
-  const baseTrustedMarkerLogins = normalizeTrustedMarkerLogins([
-    viewerLogin,
-    ...configuredTrustedActors,
-  ]);
 
   const { reviews, headCommittedAt } = fetchReviewsAndHeadCommit(
     owner,
@@ -837,12 +819,21 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   );
   const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
 
-  const claimEvents = resolveClaimEvents(
+  // #1347: fetch every claim-issue candidate's raw comments (pure I/O)
+  // BEFORE computing `trustedMarkerLogins`, so collaborator-marker trust
+  // can be resolved from ALL candidates' comments -- not just whichever
+  // one the presence-check below eventually picks. Folding trust only
+  // from the already-picked candidate is circular: a lone candidate's
+  // claim-establishing marker, authored by a login trusted only via
+  // collaborator-marker trust, would never register as "active" for the
+  // presence check to pick it in the first place, discarding the real
+  // claim data before that trust is ever computed. See
+  // `pickResolvingClaimEvents`'s doc comment for the full history.
+  const claimCandidates = fetchClaimEventCandidates(
     owner,
     repo,
     args.claimIssueNumber,
     pr.closingIssuesReferences,
-    baseTrustedMarkerLogins,
   );
 
   // Deliberately NOT unioned with `advisoryBotLogins` here (unlike some
@@ -855,24 +846,34 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   // would let that bot's own comment count as a "maintainer-authorized"
   // waiver author.
   //
-  // #1344: folds collaborator-marker trust over the UNION of PR comments
-  // and the resolved claim issue's own comments, matching
-  // `pre-merge-readiness.mts`'s `[...comments, ...claimComments]` union
-  // exactly. Scanning `comments` alone would make `collaboratorTrustEnabled`
-  // a no-op for claim and forced-handoff markers: those are always posted to
-  // the claim ISSUE, never the PR (see `forced-handoff-marker.mts`), and
-  // `applyClaimEvent`'s `isTrustedAuthor` gate runs before any forced-handoff
-  // parsing -- an untrusted-author's marker never even reaches the
-  // authorization check.
+  // #1344/#1347: folds collaborator-marker trust over the UNION of PR
+  // comments and EVERY claim-issue candidate's comments, matching
+  // `pre-merge-readiness.mts`'s `[...comments, ...claimComments]` union in
+  // spirit (extended here to all candidates, since this gate -- unlike
+  // pre-merge-readiness.mts -- auto-discovers among several linked issues
+  // rather than requiring a single explicit one). Scanning `comments`
+  // alone would make `collaboratorTrustEnabled` a no-op for claim and
+  // forced-handoff markers: those are always posted to the claim ISSUE,
+  // never the PR (see `forced-handoff-marker.mts`), and
+  // `applyClaimEvent`'s `isTrustedAuthor` gate runs before any
+  // claim/forced-handoff parsing -- an untrusted-author's marker never
+  // even reaches the authorization check.
   const trustedMarkerLogins = normalizeTrustedMarkerLogins([
-    ...baseTrustedMarkerLogins,
+    viewerLogin,
+    ...configuredTrustedActors,
     ...(collaboratorTrustEnabled
       ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
           ...comments,
-          ...claimEvents,
+          ...claimCandidates.flat(),
         ])
       : []),
   ]);
+
+  const claimEvents = pickResolvingClaimEvents(
+    claimCandidates,
+    trustedMarkerLogins,
+    Boolean(args.claimIssueNumber),
+  );
 
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
@@ -987,26 +988,30 @@ function fetchClaimComments(
 }
 
 /**
- * Resolve the linked (claim) issue's comment stream for waiver-claim
- * binding. When `explicitIssueNumber` (`--claim-issue`) is given, use it
- * directly -- no ambiguity to resolve. Otherwise a PR can close more than
- * one issue (`pr.closingIssuesReferences`), so fetch every candidate's
- * comments and keep only the one whose *active claim* actually resolves
- * (`summarizeClaimValidation`), mirroring how `external-check-waiver.mts`'s
- * own `selectLinkedIssueCandidate` disambiguates multiple linked issues by
- * active-claim presence rather than requiring a single closing reference.
- * Zero or multiple resolving candidates fail closed to `[]` (no waiver
- * claim can bind unambiguously), same as before.
+ * Fetch the claim-issue candidate(s)' raw comment streams -- pure I/O, no
+ * trust judgment. When `explicitIssueNumber` (`--claim-issue`) is given,
+ * fetch it alone -- no ambiguity to resolve. Otherwise a PR can close more
+ * than one issue (`pr.closingIssuesReferences`), so fetch every candidate's
+ * comments; {@link pickResolvingClaimEvents} disambiguates them afterward.
+ *
+ * Split out from a single `resolveClaimEvents` (#1344) so the
+ * `trustedMarkerLogins` used for disambiguation can be computed from ALL
+ * candidates' comments first (see the `collectFromGitHub` call site) --
+ * #1347 found that resolving trust from only the eventually-picked
+ * candidate is circular: a lone candidate's claim-establishing marker,
+ * authored by a login trusted only via collaborator-marker trust, would
+ * never be recognized as "active" long enough to be picked in the first
+ * place, discarding the real claim data before that trust is ever folded
+ * in.
  */
-function resolveClaimEvents(
+function fetchClaimEventCandidates(
   owner: string,
   repo: string,
   explicitIssueNumber: number | null,
   refs: ClosingIssueRefPayload[] | null | undefined,
-  trustedMarkerLogins: string[],
-): IssueCommentPayload[] {
+): IssueCommentPayload[][] {
   if (explicitIssueNumber) {
-    return fetchClaimComments(owner, repo, explicitIssueNumber);
+    return [fetchClaimComments(owner, repo, explicitIssueNumber)];
   }
   const candidateNumbers = [
     ...new Set(
@@ -1015,19 +1020,43 @@ function resolveClaimEvents(
         .filter((n): n is number => Number.isInteger(n)),
     ),
   ];
-  const resolving = candidateNumbers
-    .map((issueNumber) => {
-      const comments = fetchClaimComments(owner, repo, issueNumber);
-      return {
-        comments,
-        hasActiveClaim: Boolean(
-          summarizeClaimValidation(comments, { trustedMarkerLogins })
-            .activeClaimPresent,
-        ),
-      };
-    })
-    .filter((candidate) => candidate.hasActiveClaim);
-  return resolving.length === 1 ? resolving[0].comments : [];
+  return candidateNumbers.map((issueNumber) =>
+    fetchClaimComments(owner, repo, issueNumber),
+  );
+}
+
+/**
+ * Resolve the linked (claim) issue's comment stream for waiver-claim
+ * binding, given already-fetched candidate comment streams
+ * ({@link fetchClaimEventCandidates}) and a `trustedMarkerLogins` already
+ * fully resolved (including any collaborator-marker-trust fold) over ALL
+ * candidates' comments. Pure -- no I/O -- so it is directly unit-testable.
+ *
+ * `isExplicit` mirrors `fetchClaimEventCandidates`'s own
+ * `explicitIssueNumber` check: an explicit `--claim-issue` candidate is
+ * returned unconditionally, no ambiguity to resolve. Otherwise, keep only
+ * the candidate whose *active claim* actually resolves
+ * (`summarizeClaimValidation`), mirroring how `external-check-waiver.mts`'s
+ * own `selectLinkedIssueCandidate` disambiguates multiple linked issues by
+ * active-claim presence rather than requiring a single closing reference.
+ * Zero or multiple resolving candidates fail closed to `[]` (no waiver
+ * claim can bind unambiguously), same as before #1344/#1347.
+ */
+export function pickResolvingClaimEvents(
+  candidates: IssueCommentPayload[][],
+  trustedMarkerLogins: string[],
+  isExplicit: boolean,
+): IssueCommentPayload[] {
+  if (isExplicit) {
+    return candidates[0] ?? [];
+  }
+  const resolving = candidates.filter((comments) =>
+    Boolean(
+      summarizeClaimValidation(comments, { trustedMarkerLogins })
+        .activeClaimPresent,
+    ),
+  );
+  return resolving.length === 1 ? resolving[0] : [];
 }
 
 /**

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -8,6 +8,7 @@ import {
   classifyCopilotAuthoredThreadIds,
   computeAdvisoryConvergenceVerdict,
   parseArgs,
+  pickResolvingClaimEvents,
   runAdvisoryConvergence,
 } from '../src/scripts/advisory-convergence.mts';
 import { renderExternalCheckWaiverComment } from '../src/scripts/marker-helpers.mts';
@@ -840,6 +841,7 @@ test('staleAgeMs: a configured shorter stale window allows a takeover the hardco
       // staleAgeMs omitted -- hardcoded 24h default; the 2h gap is not stale.
     }),
   );
+  assertValidVerdict(underDefault);
   assert.equal(underDefault.waiver.activeClaimId, CLAIM_ID);
 
   const underConfiguredWindow = computeAdvisoryConvergenceVerdict(
@@ -853,6 +855,87 @@ test('staleAgeMs: a configured shorter stale window allows a takeover the hardco
   );
   assertValidVerdict(underConfiguredWindow);
   assert.equal(underConfiguredWindow.waiver.activeClaimId, SUCCESSOR_CLAIM_ID);
+});
+
+// --- pickResolvingClaimEvents (pure helper; #1347 regression) ---------------
+// --- #1347: the collaborator-marker-trust fix in #1344 threaded
+// --- `trustedMarkerLogins` into claim-issue disambiguation using a set
+// --- resolved from ONLY the already-picked candidate's comments -- circular,
+// --- since a lone candidate whose claim-establishing marker is authored by a
+// --- collaborator-only-trusted login would never register as "active" for
+// --- the presence check to pick it in the first place. This section proves
+// --- the fix: `collectFromGitHub` now resolves `trustedMarkerLogins` from
+// --- ALL candidates' comments before calling this function, so the
+// --- disambiguation itself sees the fully-resolved set.
+
+test('pickResolvingClaimEvents: a lone candidate trusted only via collaborator-marker trust resolves correctly (the #1347 regression)', () => {
+  const COLLABORATOR = 'collab-write-user';
+  const collaboratorClaim = [
+    {
+      author: { login: COLLABORATOR },
+      body: `<!-- claimed-by: ${AGENT_ID} ${CLAIM_ID} supersedes: none ${OLD} branch: issue/1234-test -->\n\n_${AGENT_ID}: issue claim — IDD automation marker. Do not edit._`,
+      createdAt: OLD,
+    },
+  ];
+
+  // Without COLLABORATOR in trustedMarkerLogins: the claim-establishing
+  // marker's author fails idd-claim rule 2 (untrusted author), so
+  // activeClaimPresent is false and the sole candidate is discarded.
+  assert.deepEqual(
+    pickResolvingClaimEvents([collaboratorClaim], [TRUSTED], false),
+    [],
+  );
+
+  // With COLLABORATOR folded in (what collectFromGitHub's fixed ordering
+  // now guarantees -- resolved from ALL candidates' comments before this
+  // call, not just the one this call ends up picking): the same candidate
+  // now resolves correctly.
+  assert.deepEqual(
+    pickResolvingClaimEvents(
+      [collaboratorClaim],
+      [TRUSTED, COLLABORATOR],
+      false,
+    ),
+    collaboratorClaim,
+  );
+});
+
+test('pickResolvingClaimEvents: an explicit candidate (--claim-issue) is returned unconditionally, bypassing disambiguation', () => {
+  const untrustedOnlyClaim = [
+    {
+      author: { login: 'nobody-trusted' },
+      body: `<!-- claimed-by: ${AGENT_ID} ${CLAIM_ID} supersedes: none ${OLD} branch: issue/1234-test -->\n\n_${AGENT_ID}: issue claim — IDD automation marker. Do not edit._`,
+      createdAt: OLD,
+    },
+  ];
+  // isExplicit: true skips the presence check entirely -- matches the
+  // pre-#1344 behavior of the original resolveClaimEvents's `if
+  // (explicitIssueNumber) { return fetchClaimComments(...); }` early return.
+  assert.deepEqual(
+    pickResolvingClaimEvents([untrustedOnlyClaim], [TRUSTED], true),
+    untrustedOnlyClaim,
+  );
+});
+
+test('pickResolvingClaimEvents: zero or multiple resolving candidates still fail closed to [] (unchanged from pre-#1344/#1347 behavior)', () => {
+  const claimA = [claimComment('claim-a')];
+  const claimB = [claimComment('claim-b')];
+  const noClaim = [
+    { author: { login: TRUSTED }, body: 'just a comment', createdAt: OLD },
+  ];
+
+  // Zero resolving candidates.
+  assert.deepEqual(pickResolvingClaimEvents([noClaim], [TRUSTED], false), []);
+  // Multiple resolving candidates -- ambiguous, fails closed.
+  assert.deepEqual(
+    pickResolvingClaimEvents([claimA, claimB], [TRUSTED], false),
+    [],
+  );
+  // Exactly one resolving candidate among several -- picks it.
+  assert.deepEqual(
+    pickResolvingClaimEvents([noClaim, claimA], [TRUSTED], false),
+    claimA,
+  );
 });
 
 // --- classifyCopilotAuthoredThreadIds (pure helper) -------------------------


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Fixes a regression #1344 (merged as PR #1346) introduced while fixing an
earlier bug in the same PR: `collectFromGitHub`'s claim-issue
disambiguation used a trust set computed **before** collaborator-marker
trust was folded in, so a lone linked issue whose claim-establishing
marker is authored by a collaborator trusted only via
`markerTrust.allowCollaboratorMarkers` was discarded before that trust
was ever applied — silently defeating the feature #1344 shipped, for the
primary documented invocation pattern (`--pr <n> --assert`, no
`--claim-issue`).

- Splits `resolveClaimEvents` into `fetchClaimEventCandidates` (pure
  I/O) and a new exported `pickResolvingClaimEvents` (pure,
  disambiguation given an already-resolved trust set).
- `collectFromGitHub` now fetches all claim-issue candidates first,
  computes `trustedMarkerLogins` once from the union of PR comments and
  **all** candidates' comments, then disambiguates with that
  fully-resolved set. This removes the two-tier
  `baseTrustedMarkerLogins`/`trustedMarkerLogins` split #1344
  introduced entirely — there is exactly one trust value now.
- Three new tests exercise `pickResolvingClaimEvents` directly against
  the exact regression scenario.
- Also fixes two smaller findings from the same review pass: docs
  wording that undersold the claim-issue-side scope (in both
  `idd-template/docs/idd-helper-scripts.md`, the canonical source, and
  its generated `docs/` mirror), and a missing `assertValidVerdict()`
  call in one `staleAgeMs` test branch.

## Linked issue

Closes #1347

## Follow-up issues (if any)

- [x] none

## Background / rationale

This was found by a review pass dispatched during #1344/PR #1346's own
E2 triage; the report arrived after that PR had already merged (all
other signals — CI, a genuine Copilot review with zero findings, this
gate's own dogfooded `--assert` run, and `pre-merge-readiness.mjs` —
were clean at merge time, since none of them exercise the collect-layer
wiring this bug lived in).

**Why this specific bug wasn't caught earlier**: `resolveClaimEvents`'s
`hasActiveClaim` presence-check calls `applyClaimEvent`'s
`isTrustedAuthor` gate, which rejects an untrusted marker's author
**including the claim-establishing `claimed-by` event itself** — not
only forced-handoff transitions. #1344's own reasoning (still correct,
just incomplete) was that a forced-handoff transition always leaves a
still-present pre-transform claim behind regardless of trust-set
narrowness; it didn't account for the case where the claim-establishing
event itself needs collaborator trust to be recognized at all, which
`resolveTrustedCollaboratorMarkerLogins`'s own doc comment already
listed as in-scope ("claim, waiver, forced-handoff, etc.").

**Why `pre-merge-readiness.mjs` never had this bug**: that sibling
requires `--claim-issue` unconditionally (no auto-discovery /
multi-candidate disambiguation), so it never runs the presence-check
code path this bug lives in. This is a correctness gap specific to
`advisory-convergence.mts`'s own auto-discovery feature, with no
mirrored-sibling precedent to fall back on — the fix was designed from
first principles (see `pickResolvingClaimEvents`'s doc comment for the
full trace).

**Test-design note**: the new tests call the real exported
`pickResolvingClaimEvents` directly (not a reimplementation), with
inputs constructed to reproduce the exact `hasActiveClaim: false`
failure mode reported. I confirmed by direct code trace (not just test
output) that the pre-fix code path would produce `[]` for these same
inputs: `applyClaimEvent`'s `isTrustedAuthor` check rejects the
collaborator-authored `claimed-by` event under a trust set that omits
the collaborator, so `activeClaimPresent` is `false`, the sole candidate
fails the `.filter((candidate) => candidate.hasActiveClaim)` step, and
`resolving.length === 1 ? ... : []` returns `[]`.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed (`idd-template/docs/idd-helper-scripts.md`,
      mirrored to `docs/idd-helper-scripts.md`)
- [x] Helper scripts changed (`src/scripts/advisory-convergence.mts` +
      generated `.mjs`)
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed (claim-resolution
      trust logic feeding the `idd-advisory-convergence` F2 gate; no new
      credentials, no new write access — this helper stays read-only)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; same 4 pre-existing
      warnings as PR #1346, unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (this gate is advisory/read-only; it
      never mutates GitHub state or executes a merge itself, only
      informs the `idd-advisory-convergence` required-check verdict)
- [x] Context budget impact reviewed (helper-script + test + one doc
      paragraph only; no instruction-file changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved waiver and claim resolution when trusted collaborator markers appear on pull requests or linked claim issues.
  * Claim discovery now considers every issue closed by a pull request, reducing missed or ambiguous claim matches.
  * Added safer handling for zero or multiple resolving claim candidates.

* **Documentation**
  * Clarified forced-handoff behavior, collaborator trust coverage, marker placement, and disabled-default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->