### PR TITLE
fix(build): mark gh-http-status as a generated helper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -36,6 +36,7 @@ scripts/external-check-waiver.mjs linguist-generated=true
 scripts/force-handoff.mjs linguist-generated=true
 scripts/forced-handoff-marker.mjs linguist-generated=true
 scripts/gh-exec.mjs linguist-generated=true
+scripts/gh-http-status.mjs linguist-generated=true
 scripts/helper-runtime-manifest.mjs linguist-generated=true
 scripts/idd-config.mjs linguist-generated=true
 scripts/idd-doctor.mjs linguist-generated=true

--- a/scripts/build-ts.mjs
+++ b/scripts/build-ts.mjs
@@ -33,8 +33,8 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const EMITTED_PREFIX = 'TSFILE: ';
-// The provenance header every emitted artifact carries; a hand-written helper
-// (e.g. scripts/gh-http-status.mjs) does not. Kept identical to the
+// The provenance header every emitted artifact carries; a helper with no
+// `.mts` source of its own would not. Kept identical to the
 // `idd-generated-from` scan in tests/inventory-ordering.test.mts so the build
 // and that test always agree on the generated set.
 const GENERATED_MARKER = 'idd-generated-from';

--- a/scripts/gh-http-status.mjs
+++ b/scripts/gh-http-status.mjs
@@ -1,3 +1,9 @@
+// idd-generated-from: src/scripts/gh-http-status.mts
+//
+// The scripts/gh-http-status.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
 // Shared HTTP-status derivation for failed `gh api` invocations.
 //
 // `gh` exits with process code 1 for 401, 403, and 404 alike, so the

--- a/src/scripts/build-ts.mts
+++ b/src/scripts/build-ts.mts
@@ -35,8 +35,8 @@ import { fileURLToPath } from 'node:url';
 
 const EMITTED_PREFIX = 'TSFILE: ';
 
-// The provenance header every emitted artifact carries; a hand-written helper
-// (e.g. scripts/gh-http-status.mjs) does not. Kept identical to the
+// The provenance header every emitted artifact carries; a helper with no
+// `.mts` source of its own would not. Kept identical to the
 // `idd-generated-from` scan in tests/inventory-ordering.test.mts so the build
 // and that test always agree on the generated set.
 const GENERATED_MARKER = 'idd-generated-from';

--- a/src/scripts/gh-http-status.mts
+++ b/src/scripts/gh-http-status.mts
@@ -1,3 +1,9 @@
+// idd-generated-from: src/scripts/gh-http-status.mts
+//
+// The scripts/gh-http-status.mjs copy is generated from the .mts source named
+// above by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+//
 // Shared HTTP-status derivation for failed `gh api` invocations.
 //
 // `gh` exits with process code 1 for 401, 403, and 404 alike, so the


### PR DESCRIPTION
# Summary

`src/scripts/gh-http-status.mts` was the one converted helper missing
the `idd-generated-from` provenance banner that every other converted
source carries, so its generated `scripts/gh-http-status.mjs` artifact
was absent from the `.gitattributes` `linguist-generated=true` block
and `src/scripts/build-ts.mts` still cited it as a "hand-written"
example (no longer true — every `scripts`/`bin` `.mjs` has an `.mts`
source).

- Added the `idd-generated-from` banner as the first lines of
  `src/scripts/gh-http-status.mts`, matching the `marker-regex.mts`
  peer convention.
- Ran `pnpm run build` so the banner propagates into
  `scripts/gh-http-status.mjs`, and the build's own `.gitattributes`
  sync added `scripts/gh-http-status.mjs linguist-generated=true`.
- Reworded the now-inaccurate "hand-written helper" comment in
  `src/scripts/build-ts.mts` so it no longer names
  `scripts/gh-http-status.mjs` as an example.
- Confirmed `tests/inventory-ordering.test.mts` had no stale
  `gh-http-status` reference to begin with (verified by grep), so no
  change was needed there.

No content drift — `deriveGhHttpStatus` behavior is unchanged, this is
a provenance/marking + doc-accuracy fix only.

## Linked issue

Closes #1358

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`tests/inventory-ordering.test.mts`'s banner-scan completeness guard
could not flag this file as generated, because the banner was exactly
what was missing — the guard stayed green while the file was
mis-marked. This PR closes that gap for `gh-http-status.mjs`
specifically; the guard now covers it going forward via the
`.gitattributes` sync in `pnpm run build`.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed API requests by identifying HTTP status codes more reliably, including statuses reported in structured error responses.

* **Documentation**
  * Added clearer provenance information to generated command-line artifacts, making it easier to identify their source and update them correctly.

* **Chores**
  * Updated repository metadata so generated scripts are excluded from language statistics and their generated diffs are condensed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->