### PR TITLE
docs(resume): cross-reference the FH authorization gate from §FH

### DIFF
--- a/docs/idd-resume-detail.md
+++ b/docs/idd-resume-detail.md
@@ -32,12 +32,10 @@ forced-handoff if:
 - The evidence `{claim-id}`, branch, or linked PR does not match the live
   active claim or inheritable released branch/PR state — stop and report
   the mismatch; do not claim, push, or mutate review state.
-- The forced-handoff **authorization gate** does not hold: the comment
-  author is not a trusted marker actor, does not equal `forcedBy`, is not
-  authorized under `forcedHandoff.authorityPolicy`, or `mode != human-gated`.
-  This gate is defined once in
+- The forced-handoff **authorization gate** does not hold. See
   [`idd-claim.instructions.md` rule 7](../.github/instructions/idd-claim.instructions.md#claim-state-parsing)
-  and is not restated here — apply it in addition to the checks above.
+  for the full criteria — apply it in addition to the checks above; it
+  is not restated here.
 
 **Re-claim rule** — Re-claim only after the human-gated handoff mechanism
 has already updated the GitHub claim stream to a released or

--- a/docs/idd-resume-detail.md
+++ b/docs/idd-resume-detail.md
@@ -32,6 +32,12 @@ forced-handoff if:
 - The evidence `{claim-id}`, branch, or linked PR does not match the live
   active claim or inheritable released branch/PR state — stop and report
   the mismatch; do not claim, push, or mutate review state.
+- The forced-handoff **authorization gate** does not hold: the comment
+  author is not a trusted marker actor, does not equal `forcedBy`, is not
+  authorized under `forcedHandoff.authorityPolicy`, or `mode != human-gated`.
+  This gate is defined once in
+  [`idd-claim.instructions.md` rule 7](../.github/instructions/idd-claim.instructions.md#claim-state-parsing)
+  and is not restated here — apply it in addition to the checks above.
 
 **Re-claim rule** — Re-claim only after the human-gated handoff mechanism
 has already updated the GitHub claim stream to a released or

--- a/idd-template/docs/idd-resume-detail.md
+++ b/idd-template/docs/idd-resume-detail.md
@@ -32,12 +32,10 @@ forced-handoff if:
 - The evidence `{claim-id}`, branch, or linked PR does not match the live
   active claim or inheritable released branch/PR state — stop and report
   the mismatch; do not claim, push, or mutate review state.
-- The forced-handoff **authorization gate** does not hold: the comment
-  author is not a trusted marker actor, does not equal `forcedBy`, is not
-  authorized under `forcedHandoff.authorityPolicy`, or `mode != human-gated`.
-  This gate is defined once in
+- The forced-handoff **authorization gate** does not hold. See
   [`idd-claim.instructions.md` rule 7](../.github/instructions/idd-claim.instructions.md#claim-state-parsing)
-  and is not restated here — apply it in addition to the checks above.
+  for the full criteria — apply it in addition to the checks above; it
+  is not restated here.
 
 **Re-claim rule** — Re-claim only after the human-gated handoff mechanism
 has already updated the GitHub claim stream to a released or

--- a/idd-template/docs/idd-resume-detail.md
+++ b/idd-template/docs/idd-resume-detail.md
@@ -32,6 +32,12 @@ forced-handoff if:
 - The evidence `{claim-id}`, branch, or linked PR does not match the live
   active claim or inheritable released branch/PR state — stop and report
   the mismatch; do not claim, push, or mutate review state.
+- The forced-handoff **authorization gate** does not hold: the comment
+  author is not a trusted marker actor, does not equal `forcedBy`, is not
+  authorized under `forcedHandoff.authorityPolicy`, or `mode != human-gated`.
+  This gate is defined once in
+  [`idd-claim.instructions.md` rule 7](../.github/instructions/idd-claim.instructions.md#claim-state-parsing)
+  and is not restated here — apply it in addition to the checks above.
 
 **Re-claim rule** — Re-claim only after the human-gated handoff mechanism
 has already updated the GitHub claim stream to a released or


### PR DESCRIPTION
# Summary

Adds a one-line cross-reference to the §FH "Validity checks" list in
`docs/idd-resume-detail.md` (and its canonical `idd-template/` source),
pointing to the forced-handoff **authorization gate** defined in
`idd-claim.instructions.md` rule 7 (Claim-state parsing): trusted-actor
author, author equals `forcedBy`, author authorized under
`forcedHandoff.authorityPolicy`, and `mode == human-gated`.

The existing §FH list covered field-completeness, PR-naming, and
live-state matching only, so a literal-minded reader could treat it as
the complete gate and miss the separate author/authority binding that
blocks a same-identity self-signed hijack. The rule itself already
exists and is enforced elsewhere; this change only makes it
discoverable from §FH — it does not duplicate the rule text.

## Linked issue

Closes #1364

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

None beyond the issue body — this is a discoverability fix for an
already-enforced rule, not a live fail-open.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified forced-handoff recovery requirements.
  * Added an authorization gate requiring a trusted approver, matching identity, valid authority policy, and human-gated mode.
  * Specified that authorization checks apply alongside existing evidence and eligibility validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->