### PR TITLE
fix(discover): apply scored-vs-unscored floor tie-break to orphan ranker

### DIFF
--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -159,6 +159,16 @@ export function rankAndRouteBySuitability(items, options = {}) {
     .sort(
       (left, right) =>
         (right.score ?? floor) - (left.score ?? floor) ||
+        // Scored-before-unscored at a tie (written A4 Step 2 rule): a
+        // genuinely-scored candidate never ranks below an unscored one
+        // defaulted to the floor. `entry.score` is already normalized to
+        // "coherent 1-5 or null" above, so `!== null` is the same
+        // "genuinely scored" notion `compareUnionLeaves` derives from
+        // `isAutopilotSuitabilityScore`, reused rather than reimplemented.
+        // Applied before the caller's pre-sorted index order (which
+        // carries the effort-hint / issue-number tie-breakers), so those
+        // softer tie-breakers never outrank a real score.
+        Number(right.score !== null) - Number(left.score !== null) ||
         left.index - right.index,
     )
     .map((entry) => entry.item);

--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -113,8 +113,13 @@ export function normalizeAutopilotSuitabilityFloor(floor) {
  * - Ranking always runs (when enabled): items are stable-sorted by
  *   effective score descending, where a missing score uses the floor as
  *   a neutral baseline so unscored (e.g. pre-existing) issues are never
- *   buried. Ties keep input order, so callers that need a domain
- *   tie-break (e.g. lowest issue number) pre-sort the input by that key.
+ *   buried. At a tied effective score, a genuinely-scored candidate
+ *   always ranks above an unscored one defaulted to the floor (the
+ *   written A4 Step 2 "scored-vs-unscored floor tie-breaker" rule,
+ *   matching `compareUnionLeaves` in discover-roadmap-graph.mts). Beyond
+ *   that scored-vs-unscored split, ties keep input order, so callers
+ *   that need a domain tie-break (e.g. effort hint, lowest issue number)
+ *   pre-sort the input by that key.
  * - Routing is **opt-in** via `routeBelowFloor` (the autopilot-run
  *   behavior). When true, candidates whose score is present and
  *   `< floor` are moved to `routedToHuman` (kept visible, never

--- a/src/scripts/autopilot-suitability.mts
+++ b/src/scripts/autopilot-suitability.mts
@@ -136,8 +136,13 @@ export function normalizeAutopilotSuitabilityFloor(floor: unknown): number {
  * - Ranking always runs (when enabled): items are stable-sorted by
  *   effective score descending, where a missing score uses the floor as
  *   a neutral baseline so unscored (e.g. pre-existing) issues are never
- *   buried. Ties keep input order, so callers that need a domain
- *   tie-break (e.g. lowest issue number) pre-sort the input by that key.
+ *   buried. At a tied effective score, a genuinely-scored candidate
+ *   always ranks above an unscored one defaulted to the floor (the
+ *   written A4 Step 2 "scored-vs-unscored floor tie-breaker" rule,
+ *   matching `compareUnionLeaves` in discover-roadmap-graph.mts). Beyond
+ *   that scored-vs-unscored split, ties keep input order, so callers
+ *   that need a domain tie-break (e.g. effort hint, lowest issue number)
+ *   pre-sort the input by that key.
  * - Routing is **opt-in** via `routeBelowFloor` (the autopilot-run
  *   behavior). When true, candidates whose score is present and
  *   `< floor` are moved to `routedToHuman` (kept visible, never

--- a/src/scripts/autopilot-suitability.mts
+++ b/src/scripts/autopilot-suitability.mts
@@ -190,6 +190,16 @@ export function rankAndRouteBySuitability<T>(
     .sort(
       (left, right) =>
         (right.score ?? floor) - (left.score ?? floor) ||
+        // Scored-before-unscored at a tie (written A4 Step 2 rule): a
+        // genuinely-scored candidate never ranks below an unscored one
+        // defaulted to the floor. `entry.score` is already normalized to
+        // "coherent 1-5 or null" above, so `!== null` is the same
+        // "genuinely scored" notion `compareUnionLeaves` derives from
+        // `isAutopilotSuitabilityScore`, reused rather than reimplemented.
+        // Applied before the caller's pre-sorted index order (which
+        // carries the effort-hint / issue-number tie-breakers), so those
+        // softer tie-breakers never outrank a real score.
+        Number(right.score !== null) - Number(left.score !== null) ||
         left.index - right.index,
     )
     .map((entry) => entry.item);

--- a/tests/autopilot-suitability.test.mts
+++ b/tests/autopilot-suitability.test.mts
@@ -249,6 +249,47 @@ test('rankAndRouteBySuitability never routes or buries unscored items (fail-safe
   );
 });
 
+test('rankAndRouteBySuitability ranks a genuinely floor-scored candidate above an unscored one at a tie', () => {
+  // Mirrors the written A4 Step 2 rule and compareUnionLeaves in
+  // discover-roadmap-graph.mts: a genuinely-scored candidate never ranks
+  // below an unscored candidate defaulted to the floor, even though the
+  // unscored candidate has a lower input index.
+  const items = [
+    { id: '#10', score: null },
+    { id: '#20', score: 3 },
+  ];
+  const { ranked } = rankAndRouteBySuitability(items, {
+    floor: 3,
+    getScore: (item) => item.score,
+  });
+  assert.deepEqual(
+    ranked.map((item) => item.id),
+    ['#20', '#10'],
+  );
+});
+
+test('rankAndRouteBySuitability applies the scored-vs-unscored term before the effort-hint tie-break', () => {
+  // discover-orphan-filter.mts pre-sorts candidates by effort-then-number
+  // before calling rankAndRouteBySuitability (ties keep input order). This
+  // reproduces that pre-sorted input: an unscored `S`-effort candidate
+  // would sort first by the soft effort tie-break alone, but a genuinely
+  // floor-scored `M`-effort candidate must still win the tie, per the
+  // written rule ordering (score band -> scored-before-unscored ->
+  // effort/number).
+  const items = [
+    { id: 'unscored-S', score: null },
+    { id: 'scored-M', score: 3 },
+  ];
+  const { ranked } = rankAndRouteBySuitability(items, {
+    floor: 3,
+    getScore: (item) => item.score,
+  });
+  assert.deepEqual(
+    ranked.map((item) => item.id),
+    ['scored-M', 'unscored-S'],
+  );
+});
+
 test('rankAndRouteBySuitability honors the enabled kill-switch', () => {
   const items = [
     { id: 'a', score: 1 },


### PR DESCRIPTION
# Summary

`rankAndRouteBySuitability` (`src/scripts/autopilot-suitability.mts`) ranked
candidates by effective score only, so its stable sort silently preserved
the caller's pre-sorted (effort/number) input order on a tie. That let an
unscored orphan outrank one its author genuinely scored at the floor,
contrary to the written A4 Step 2 "scored-vs-unscored floor tie-breaker"
rule and inconsistent with the roadmap-traversal comparator
(`compareUnionLeaves` in `discover-roadmap-graph.mts`), which already
applies this tie-break correctly.

This PR adds the same scored-before-unscored comparator term to
`rankAndRouteBySuitability`, positioned between the score-band comparison
and the index fallback (which carries the caller's effort-hint / issue-
number pre-sort) — matching the written rule's ordering and reusing the
already-normalized `score` field (`!== null`) instead of reimplementing
`isAutopilotSuitabilityScore`.

Advisory-only change: no A4.5/A5 gate behavior changes, no routing
behavior changes beyond the tie order itself.

## Linked issue

Closes #1360

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Empirical repro from the issue:
`rankAndRouteBySuitability([{#10, null}, {#20, 3}], {floor: 3})` returned
`[10, 20]` before this fix; the written rule and `compareUnionLeaves` both
require `[20, 10]`. Verified via the new test cases that this now matches.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ranking consistency when candidates have equal effective scores.
  * Candidates with an explicit score now rank above otherwise equivalent unscored candidates, including when both use the minimum score.

* **Tests**
  * Added coverage for scored versus unscored tie-breaking scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->