### PR TITLE
fix(policy): surface live config schema errors and scope helper validation

### DIFF
--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -4,7 +4,7 @@
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
 import { readFileSync } from 'node:fs';
-import { loadJson, validate } from './validate-schemas.mjs';
+import { loadJson, validateConfigSection } from './validate-schemas.mjs';
 export const DEFAULT_ADVISORY_REQUEST_CAP = 30;
 export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
 export const DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES = 10;
@@ -22,7 +22,12 @@ const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
 export function readAdvisoryWaitPolicy(path = '.github/idd/config.json') {
   try {
     const config = JSON.parse(readFileSync(path, 'utf8'));
-    if (validate(config, POLICY_SCHEMA).length > 0) {
+    // Scoped to the advisoryWait subtree (#1359): an unrelated invalid
+    // field elsewhere in the document must not zero out an otherwise-valid
+    // advisoryWait section.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
       return resolveAdvisoryWaitPolicy({});
     }
     return resolveAdvisoryWaitPolicy(config);
@@ -77,7 +82,10 @@ export function resolveAdvisoryPrimaryBotLogin(config = {}) {
 export function readAdvisoryPrimaryBotLogin(path = '.github/idd/config.json') {
   try {
     const config = JSON.parse(readFileSync(path, 'utf8'));
-    if (validate(config, POLICY_SCHEMA).length > 0) {
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
       return DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
     }
     return resolveAdvisoryPrimaryBotLogin(config);
@@ -117,7 +125,10 @@ export function readAdvisorySecondaryBotLogin(
 ) {
   try {
     const config = JSON.parse(readFileSync(path, 'utf8'));
-    if (validate(config, POLICY_SCHEMA).length > 0) {
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
       return '';
     }
     return resolveAdvisorySecondaryBotLogin(config);
@@ -151,7 +162,10 @@ export function readAdvisoryConvergenceDeadlineMinutes(
 ) {
   try {
     const config = JSON.parse(readFileSync(path, 'utf8'));
-    if (validate(config, POLICY_SCHEMA).length > 0) {
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
       return DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
     }
     return resolveAdvisoryConvergenceDeadlineMinutes(config);

--- a/scripts/ci-wait-policy.mjs
+++ b/scripts/ci-wait-policy.mjs
@@ -7,7 +7,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { isCliExecution } from './gh-exec.mjs';
-import { loadJson, validate } from './validate-schemas.mjs';
+import { loadJson, validateConfigSection } from './validate-schemas.mjs';
 
 const DEFAULT_RUNNING_TIMEOUT = 'PT30M';
 const DEFAULT_GENERATION_TIMEOUT = 'PT10M';
@@ -63,7 +63,11 @@ export function readCiWaitPolicy(policyPath = DEFAULT_POLICY_PATH) {
     : resolve(process.cwd(), DEFAULT_POLICY_PATH);
   try {
     const config = JSON.parse(readFileSync(source, 'utf8'));
-    if (validate(config, POLICY_SCHEMA).length > 0) {
+    // Scoped to the ciWait subtree (#1359): an unrelated invalid field
+    // elsewhere in the document (an unknown top-level key, a typo'd enum in
+    // a sibling section, ...) must not zero out an otherwise-valid ciWait
+    // section.
+    if (validateConfigSection(config, POLICY_SCHEMA, 'ciWait').length > 0) {
       return { ...DEFAULT_CI_WAIT_POLICY };
     }
     return normalizeCiWaitPolicy(config?.ciWait);

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -17,6 +17,7 @@ import {
   POLICY_DEFAULTS,
   parseProjectCommandRows,
 } from './policy-helpers.mjs';
+import { loadJson, validate } from './validate-schemas.mjs';
 
 const WORKSHOP_ENTRY_POINTS = ['README.md', 'README.ja.md', 'docs/index.md'];
 const WORKSHOP_REL_PATH = 'docs/workshop';
@@ -55,6 +56,7 @@ export function runDoctor({
   );
   checkPolicySignals(root, report);
   checkHelperRuntimeConfig(root, report);
+  checkLiveConfigSchema(root, report);
   checkClaimTimingConsistency(root, report);
   checkDependencyVersionDrift(root, report);
   checkAgentEntryFiles(root, report);
@@ -761,6 +763,67 @@ function checkHelperRuntimeConfig(root, report) {
       `${file} declares helper runtime profile "${helperRuntime.profile}"`,
     );
   }
+}
+/**
+ * Decide whether a parsed `.github/idd/config.json` document is a schema
+ * finding, given the canonical policy schema. Pure (no I/O) so it can be
+ * unit-tested directly. Returns `null` when `config` validates cleanly.
+ *
+ * This is the live-config counterpart to the `ciWait`/`advisoryWait`
+ * readers' own subtree-scoped validation (#1359): those readers only
+ * revert their own section on their own section's error, so a malformed
+ * config (an unknown top-level key, `additionalProperties: false`
+ * rejecting an adopter typo, a typo'd enum anywhere in the document, ...)
+ * would otherwise pass through with no diagnostic at all. This check
+ * surfaces every schema error against the whole document instead, so a
+ * malformed live config no longer passes idd-doctor silently.
+ */
+export function classifyLiveConfigSchemaFinding(config, schema) {
+  const errors = validate(config, schema);
+  if (errors.length === 0) {
+    return null;
+  }
+  return {
+    level: 'error',
+    message: `.github/idd/config.json fails schema validation against policy.schema.json: ${errors.slice(0, 10).join('; ')}`,
+  };
+}
+/**
+ * Validate the live `.github/idd/config.json` (when present) against the
+ * canonical policy schema and report any errors as a doctor finding. Skips
+ * silently when the config file is absent (nothing to validate) or is not
+ * valid JSON (already reported by checkHelperRuntimeConfig above) or when
+ * the bundled schema itself cannot be loaded (a bootstrap edge case, not a
+ * live-config problem).
+ */
+export function checkLiveConfigSchema(root, report) {
+  const configPath = join(root, '.github/idd/config.json');
+  if (!exists(configPath)) {
+    return;
+  }
+  let config;
+  try {
+    config = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch {
+    return;
+  }
+  let schema;
+  try {
+    schema = loadJson('schemas/policy.schema.json');
+  } catch {
+    report.warnings.push(
+      'live-config schema check skipped: schemas/policy.schema.json could not be loaded',
+    );
+    return;
+  }
+  const finding = classifyLiveConfigSchemaFinding(config, schema);
+  if (!finding) {
+    report.passes.push(
+      '.github/idd/config.json validates against policy.schema.json',
+    );
+    return;
+  }
+  report.errors.push(finding.message);
 }
 // Adding a future anchor is a one-line addition here — no new branching
 // logic — as long as its prose lives in the same Thresholds section

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -764,10 +764,21 @@ function checkHelperRuntimeConfig(root, report) {
     );
   }
 }
+// The two live-config filenames idd-doctor already recognizes elsewhere in
+// this file (checkHelperRuntimeConfig's and checkTemplateVersionSignal's own
+// candidate lists): `.github/idd/config.json` is canonical, `idd-policy.json`
+// is the legacy top-level name. Both get the same schema check so an adopter
+// still on the legacy filename gets the same #1359 coverage.
+const LIVE_CONFIG_CANDIDATE_FILES = [
+  '.github/idd/config.json',
+  'idd-policy.json',
+];
+const LIVE_CONFIG_ERRORS_SHOWN = 10;
 /**
- * Decide whether a parsed `.github/idd/config.json` document is a schema
- * finding, given the canonical policy schema. Pure (no I/O) so it can be
- * unit-tested directly. Returns `null` when `config` validates cleanly.
+ * Decide whether a parsed live-config document is a schema finding, given
+ * the canonical policy schema and the file it was read from (for the
+ * message). Pure (no I/O) so it can be unit-tested directly. Returns `null`
+ * when `config` validates cleanly.
  *
  * This is the live-config counterpart to the `ciWait`/`advisoryWait`
  * readers' own subtree-scoped validation (#1359): those readers only
@@ -778,35 +789,33 @@ function checkHelperRuntimeConfig(root, report) {
  * surfaces every schema error against the whole document instead, so a
  * malformed live config no longer passes idd-doctor silently.
  */
-export function classifyLiveConfigSchemaFinding(config, schema) {
+export function classifyLiveConfigSchemaFinding(
+  config,
+  schema,
+  file = '.github/idd/config.json',
+) {
   const errors = validate(config, schema);
   if (errors.length === 0) {
     return null;
   }
+  const shown = errors.slice(0, LIVE_CONFIG_ERRORS_SHOWN);
+  const remainder = errors.length - shown.length;
+  const suffix = remainder > 0 ? ` (and ${remainder} more)` : '';
   return {
     level: 'error',
-    message: `.github/idd/config.json fails schema validation against policy.schema.json: ${errors.slice(0, 10).join('; ')}`,
+    message: `${file} fails schema validation against policy.schema.json: ${shown.join('; ')}${suffix}`,
   };
 }
 /**
- * Validate the live `.github/idd/config.json` (when present) against the
- * canonical policy schema and report any errors as a doctor finding. Skips
- * silently when the config file is absent (nothing to validate) or is not
- * valid JSON (already reported by checkHelperRuntimeConfig above) or when
- * the bundled schema itself cannot be loaded (a bootstrap edge case, not a
- * live-config problem).
+ * Validate each present live-config file (`.github/idd/config.json` and the
+ * legacy `idd-policy.json`) against the canonical policy schema and report
+ * any errors as a doctor finding. Skips a candidate silently when it is
+ * absent (nothing to validate) or is not valid JSON (already reported by
+ * checkHelperRuntimeConfig above); skips the whole check when the bundled
+ * schema itself cannot be loaded (a bootstrap edge case, not a live-config
+ * problem).
  */
 export function checkLiveConfigSchema(root, report) {
-  const configPath = join(root, '.github/idd/config.json');
-  if (!exists(configPath)) {
-    return;
-  }
-  let config;
-  try {
-    config = JSON.parse(readFileSync(configPath, 'utf8'));
-  } catch {
-    return;
-  }
   let schema;
   try {
     schema = loadJson('schemas/policy.schema.json');
@@ -816,14 +825,24 @@ export function checkLiveConfigSchema(root, report) {
     );
     return;
   }
-  const finding = classifyLiveConfigSchemaFinding(config, schema);
-  if (!finding) {
-    report.passes.push(
-      '.github/idd/config.json validates against policy.schema.json',
-    );
-    return;
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const configPath = join(root, file);
+    if (!exists(configPath)) {
+      continue;
+    }
+    let config;
+    try {
+      config = JSON.parse(readFileSync(configPath, 'utf8'));
+    } catch {
+      continue;
+    }
+    const finding = classifyLiveConfigSchemaFinding(config, schema, file);
+    if (!finding) {
+      report.passes.push(`${file} validates against policy.schema.json`);
+      continue;
+    }
+    report.errors.push(finding.message);
   }
-  report.errors.push(finding.message);
 }
 // Adding a future anchor is a one-line addition here — no new branching
 // logic — as long as its prose lives in the same Thresholds section

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -32,7 +32,11 @@ const LEGACY_ADVISORY_CAP_ROUTE_ALIASES = new Map([
   ['phase-default', 'phase-specific'],
   ['strict-hold', 'hold'],
 ]);
-const CI_RERUN_POLICIES = new Set(['rerun-once']);
+// Matches the schema enum and ci-wait-policy.mts's own RERUN_POLICIES set
+// (both accept `hold`); this set previously omitted it, silently
+// downgrading a configured `hold` to `rerun-once` for any future consumer
+// of normalizePolicyConfig(...).ciWait (see #1359).
+const CI_RERUN_POLICIES = new Set(['rerun-once', 'hold']);
 const LABEL_FRESHNESS_MODES = new Set(['presence-only', 'event-freshness']);
 const ISO_DURATION_RE =
   /^P(?=\d|T\d)(?:\d+D)?(?:T(?=\d)(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$/;

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -255,6 +255,36 @@ export function validate(data, schema, path = '$') {
   return errors;
 }
 /**
+ * Validate one top-level section of a config document against its own
+ * schema node (`schema.properties[sectionKey]`), ignoring errors anywhere
+ * else in `config` or `schema`. This is the scoped counterpart to calling
+ * `validate(config, schema)` on the whole document: a config-section reader
+ * (e.g. `ciWait`, `advisoryWait`) that reverts only its own values to
+ * defaults on its own section's error must not be zeroed out by an
+ * unrelated top-level key — an unknown property, a missing required field,
+ * or a typo'd enum in a sibling section — because that section's own values
+ * were never invalid (see #1359).
+ *
+ * Returns no errors (treats the section as valid) when `config` is not a
+ * plain object, `schema` declares no schema for `sectionKey`, or
+ * `sectionKey` is absent from `config` — an absent section is valid on its
+ * own terms; the caller's own defaults apply.
+ */
+export function validateConfigSection(config, schema, sectionKey) {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return [];
+  }
+  const sectionSchema = schema?.properties?.[sectionKey];
+  if (sectionSchema === undefined) {
+    return [];
+  }
+  const obj = config;
+  if (!Object.hasOwn(obj, sectionKey)) {
+    return [];
+  }
+  return validate(obj[sectionKey], sectionSchema, `$.${sectionKey}`);
+}
+/**
  * Load and parse a JSON file by path relative to repository root.
  */
 export function loadJson(relPath) {

--- a/src/scripts/advisory-wait-policy.mts
+++ b/src/scripts/advisory-wait-policy.mts
@@ -6,7 +6,7 @@
 
 import { readFileSync } from 'node:fs';
 
-import { loadJson, validate } from './validate-schemas.mts';
+import { loadJson, validateConfigSection } from './validate-schemas.mts';
 
 export const DEFAULT_ADVISORY_REQUEST_CAP = 30;
 export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
@@ -36,7 +36,12 @@ export function readAdvisoryWaitPolicy(
 ): AdvisoryWaitPolicy {
   try {
     const config = JSON.parse(readFileSync(path, 'utf8'));
-    if (validate(config, POLICY_SCHEMA).length > 0) {
+    // Scoped to the advisoryWait subtree (#1359): an unrelated invalid
+    // field elsewhere in the document must not zero out an otherwise-valid
+    // advisoryWait section.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
       return resolveAdvisoryWaitPolicy({});
     }
     return resolveAdvisoryWaitPolicy(config);
@@ -102,7 +107,10 @@ export function readAdvisoryPrimaryBotLogin(
 ): string {
   try {
     const config = JSON.parse(readFileSync(path, 'utf8'));
-    if (validate(config, POLICY_SCHEMA).length > 0) {
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
       return DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
     }
     return resolveAdvisoryPrimaryBotLogin(config);
@@ -146,7 +154,10 @@ export function readAdvisorySecondaryBotLogin(
 ): string {
   try {
     const config = JSON.parse(readFileSync(path, 'utf8'));
-    if (validate(config, POLICY_SCHEMA).length > 0) {
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
       return '';
     }
     return resolveAdvisorySecondaryBotLogin(config);
@@ -185,7 +196,10 @@ export function readAdvisoryConvergenceDeadlineMinutes(
 ): number {
   try {
     const config = JSON.parse(readFileSync(path, 'utf8'));
-    if (validate(config, POLICY_SCHEMA).length > 0) {
+    // Scoped to the advisoryWait subtree (#1359); see readAdvisoryWaitPolicy.
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length > 0
+    ) {
       return DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
     }
     return resolveAdvisoryConvergenceDeadlineMinutes(config);

--- a/src/scripts/ci-wait-policy.mts
+++ b/src/scripts/ci-wait-policy.mts
@@ -9,7 +9,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { isCliExecution } from './gh-exec.mts';
-import { loadJson, validate } from './validate-schemas.mts';
+import { loadJson, validateConfigSection } from './validate-schemas.mts';
 
 const DEFAULT_RUNNING_TIMEOUT = 'PT30M';
 const DEFAULT_GENERATION_TIMEOUT = 'PT10M';
@@ -93,7 +93,11 @@ export function readCiWaitPolicy(
 
   try {
     const config = JSON.parse(readFileSync(source, 'utf8'));
-    if (validate(config, POLICY_SCHEMA).length > 0) {
+    // Scoped to the ciWait subtree (#1359): an unrelated invalid field
+    // elsewhere in the document (an unknown top-level key, a typo'd enum in
+    // a sibling section, ...) must not zero out an otherwise-valid ciWait
+    // section.
+    if (validateConfigSection(config, POLICY_SCHEMA, 'ciWait').length > 0) {
       return { ...DEFAULT_CI_WAIT_POLICY };
     }
     return normalizeCiWaitPolicy(

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -18,6 +18,7 @@ import {
   POLICY_DEFAULTS,
   parseProjectCommandRows,
 } from './policy-helpers.mts';
+import { loadJson, validate } from './validate-schemas.mts';
 
 const WORKSHOP_ENTRY_POINTS = ['README.md', 'README.ja.md', 'docs/index.md'];
 const WORKSHOP_REL_PATH = 'docs/workshop';
@@ -128,6 +129,7 @@ export function runDoctor({
   );
   checkPolicySignals(root, report);
   checkHelperRuntimeConfig(root, report);
+  checkLiveConfigSchema(root, report);
   checkClaimTimingConsistency(root, report);
   checkDependencyVersionDrift(root, report);
   checkAgentEntryFiles(root, report);
@@ -911,6 +913,75 @@ function checkHelperRuntimeConfig(root: string, report: DoctorReport) {
       `${file} declares helper runtime profile "${helperRuntime.profile}"`,
     );
   }
+}
+
+/**
+ * Decide whether a parsed `.github/idd/config.json` document is a schema
+ * finding, given the canonical policy schema. Pure (no I/O) so it can be
+ * unit-tested directly. Returns `null` when `config` validates cleanly.
+ *
+ * This is the live-config counterpart to the `ciWait`/`advisoryWait`
+ * readers' own subtree-scoped validation (#1359): those readers only
+ * revert their own section on their own section's error, so a malformed
+ * config (an unknown top-level key, `additionalProperties: false`
+ * rejecting an adopter typo, a typo'd enum anywhere in the document, ...)
+ * would otherwise pass through with no diagnostic at all. This check
+ * surfaces every schema error against the whole document instead, so a
+ * malformed live config no longer passes idd-doctor silently.
+ */
+export function classifyLiveConfigSchemaFinding(
+  config: unknown,
+  schema: unknown,
+): { level: 'error'; message: string } | null {
+  const errors = validate(config, schema);
+  if (errors.length === 0) {
+    return null;
+  }
+  return {
+    level: 'error',
+    message: `.github/idd/config.json fails schema validation against policy.schema.json: ${errors.slice(0, 10).join('; ')}`,
+  };
+}
+
+/**
+ * Validate the live `.github/idd/config.json` (when present) against the
+ * canonical policy schema and report any errors as a doctor finding. Skips
+ * silently when the config file is absent (nothing to validate) or is not
+ * valid JSON (already reported by checkHelperRuntimeConfig above) or when
+ * the bundled schema itself cannot be loaded (a bootstrap edge case, not a
+ * live-config problem).
+ */
+export function checkLiveConfigSchema(root: string, report: DoctorReport) {
+  const configPath = join(root, '.github/idd/config.json');
+  if (!exists(configPath)) {
+    return;
+  }
+
+  let config: unknown;
+  try {
+    config = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch {
+    return;
+  }
+
+  let schema: unknown;
+  try {
+    schema = loadJson('schemas/policy.schema.json');
+  } catch {
+    report.warnings.push(
+      'live-config schema check skipped: schemas/policy.schema.json could not be loaded',
+    );
+    return;
+  }
+
+  const finding = classifyLiveConfigSchemaFinding(config, schema);
+  if (!finding) {
+    report.passes.push(
+      '.github/idd/config.json validates against policy.schema.json',
+    );
+    return;
+  }
+  report.errors.push(finding.message);
 }
 
 /** One reportable finding from the claimTiming config↔prose check. */

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -915,10 +915,22 @@ function checkHelperRuntimeConfig(root: string, report: DoctorReport) {
   }
 }
 
+// The two live-config filenames idd-doctor already recognizes elsewhere in
+// this file (checkHelperRuntimeConfig's and checkTemplateVersionSignal's own
+// candidate lists): `.github/idd/config.json` is canonical, `idd-policy.json`
+// is the legacy top-level name. Both get the same schema check so an adopter
+// still on the legacy filename gets the same #1359 coverage.
+const LIVE_CONFIG_CANDIDATE_FILES = [
+  '.github/idd/config.json',
+  'idd-policy.json',
+];
+const LIVE_CONFIG_ERRORS_SHOWN = 10;
+
 /**
- * Decide whether a parsed `.github/idd/config.json` document is a schema
- * finding, given the canonical policy schema. Pure (no I/O) so it can be
- * unit-tested directly. Returns `null` when `config` validates cleanly.
+ * Decide whether a parsed live-config document is a schema finding, given
+ * the canonical policy schema and the file it was read from (for the
+ * message). Pure (no I/O) so it can be unit-tested directly. Returns `null`
+ * when `config` validates cleanly.
  *
  * This is the live-config counterpart to the `ciWait`/`advisoryWait`
  * readers' own subtree-scoped validation (#1359): those readers only
@@ -932,38 +944,31 @@ function checkHelperRuntimeConfig(root: string, report: DoctorReport) {
 export function classifyLiveConfigSchemaFinding(
   config: unknown,
   schema: unknown,
+  file: string = '.github/idd/config.json',
 ): { level: 'error'; message: string } | null {
   const errors = validate(config, schema);
   if (errors.length === 0) {
     return null;
   }
+  const shown = errors.slice(0, LIVE_CONFIG_ERRORS_SHOWN);
+  const remainder = errors.length - shown.length;
+  const suffix = remainder > 0 ? ` (and ${remainder} more)` : '';
   return {
     level: 'error',
-    message: `.github/idd/config.json fails schema validation against policy.schema.json: ${errors.slice(0, 10).join('; ')}`,
+    message: `${file} fails schema validation against policy.schema.json: ${shown.join('; ')}${suffix}`,
   };
 }
 
 /**
- * Validate the live `.github/idd/config.json` (when present) against the
- * canonical policy schema and report any errors as a doctor finding. Skips
- * silently when the config file is absent (nothing to validate) or is not
- * valid JSON (already reported by checkHelperRuntimeConfig above) or when
- * the bundled schema itself cannot be loaded (a bootstrap edge case, not a
- * live-config problem).
+ * Validate each present live-config file (`.github/idd/config.json` and the
+ * legacy `idd-policy.json`) against the canonical policy schema and report
+ * any errors as a doctor finding. Skips a candidate silently when it is
+ * absent (nothing to validate) or is not valid JSON (already reported by
+ * checkHelperRuntimeConfig above); skips the whole check when the bundled
+ * schema itself cannot be loaded (a bootstrap edge case, not a live-config
+ * problem).
  */
 export function checkLiveConfigSchema(root: string, report: DoctorReport) {
-  const configPath = join(root, '.github/idd/config.json');
-  if (!exists(configPath)) {
-    return;
-  }
-
-  let config: unknown;
-  try {
-    config = JSON.parse(readFileSync(configPath, 'utf8'));
-  } catch {
-    return;
-  }
-
   let schema: unknown;
   try {
     schema = loadJson('schemas/policy.schema.json');
@@ -974,14 +979,26 @@ export function checkLiveConfigSchema(root: string, report: DoctorReport) {
     return;
   }
 
-  const finding = classifyLiveConfigSchemaFinding(config, schema);
-  if (!finding) {
-    report.passes.push(
-      '.github/idd/config.json validates against policy.schema.json',
-    );
-    return;
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const configPath = join(root, file);
+    if (!exists(configPath)) {
+      continue;
+    }
+
+    let config: unknown;
+    try {
+      config = JSON.parse(readFileSync(configPath, 'utf8'));
+    } catch {
+      continue;
+    }
+
+    const finding = classifyLiveConfigSchemaFinding(config, schema, file);
+    if (!finding) {
+      report.passes.push(`${file} validates against policy.schema.json`);
+      continue;
+    }
+    report.errors.push(finding.message);
   }
-  report.errors.push(finding.message);
 }
 
 /** One reportable finding from the claimTiming config↔prose check. */

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -111,7 +111,11 @@ const LEGACY_ADVISORY_CAP_ROUTE_ALIASES = new Map([
   ['phase-default', 'phase-specific'],
   ['strict-hold', 'hold'],
 ]);
-const CI_RERUN_POLICIES = new Set(['rerun-once']);
+// Matches the schema enum and ci-wait-policy.mts's own RERUN_POLICIES set
+// (both accept `hold`); this set previously omitted it, silently
+// downgrading a configured `hold` to `rerun-once` for any future consumer
+// of normalizePolicyConfig(...).ciWait (see #1359).
+const CI_RERUN_POLICIES = new Set(['rerun-once', 'hold']);
 const LABEL_FRESHNESS_MODES = new Set(['presence-only', 'event-freshness']);
 const ISO_DURATION_RE =
   /^P(?=\d|T\d)(?:\d+D)?(?:T(?=\d)(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$/;

--- a/src/scripts/validate-schemas.mts
+++ b/src/scripts/validate-schemas.mts
@@ -296,6 +296,42 @@ export function validate(data: unknown, schema: unknown, path = '$'): string[] {
 }
 
 /**
+ * Validate one top-level section of a config document against its own
+ * schema node (`schema.properties[sectionKey]`), ignoring errors anywhere
+ * else in `config` or `schema`. This is the scoped counterpart to calling
+ * `validate(config, schema)` on the whole document: a config-section reader
+ * (e.g. `ciWait`, `advisoryWait`) that reverts only its own values to
+ * defaults on its own section's error must not be zeroed out by an
+ * unrelated top-level key — an unknown property, a missing required field,
+ * or a typo'd enum in a sibling section — because that section's own values
+ * were never invalid (see #1359).
+ *
+ * Returns no errors (treats the section as valid) when `config` is not a
+ * plain object, `schema` declares no schema for `sectionKey`, or
+ * `sectionKey` is absent from `config` — an absent section is valid on its
+ * own terms; the caller's own defaults apply.
+ */
+export function validateConfigSection(
+  config: unknown,
+  schema: unknown,
+  sectionKey: string,
+): string[] {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return [];
+  }
+  const sectionSchema = (schema as { properties?: Record<string, unknown> })
+    ?.properties?.[sectionKey];
+  if (sectionSchema === undefined) {
+    return [];
+  }
+  const obj = config as Record<string, unknown>;
+  if (!Object.hasOwn(obj, sectionKey)) {
+    return [];
+  }
+  return validate(obj[sectionKey], sectionSchema, `$.${sectionKey}`);
+}
+
+/**
  * Load and parse a JSON file by path relative to repository root.
  */
 export function loadJson(relPath: string): unknown {

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -4,7 +4,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import {
+  DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+  readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
   readAdvisorySecondaryBotLogin,
   readAdvisoryWaitPolicy,
@@ -254,7 +256,7 @@ test('advisory wait policy resolves defaults, explicit values, and fail-safe fal
   );
 });
 
-test('advisory wait policy only applies file overrides from schema-valid policy config', () => {
+test('advisory wait policy only applies file overrides from a schema-valid advisoryWait section', () => {
   const root = mkdtempSync(join(tmpdir(), 'idd-advisory-policy-'));
   const validPath = join(root, 'policy.valid.json');
   const invalidPath = join(root, 'policy.invalid.json');
@@ -271,11 +273,14 @@ test('advisory wait policy only applies file overrides from schema-valid policy 
   };
 
   writeFileSync(validPath, JSON.stringify(validConfig), 'utf8');
+  // The pendingWindow value itself is a genuine advisoryWait schema
+  // violation (fails the whole-minute-duration pattern), so the
+  // advisoryWait subtree is invalid on its own terms and still reverts.
   writeFileSync(
     invalidPath,
     JSON.stringify({
       advisoryWait: {
-        pendingWindow: 'PT1M',
+        pendingWindow: 'not-a-duration',
       },
     }),
     'utf8',
@@ -295,6 +300,37 @@ test('advisory wait policy only applies file overrides from schema-valid policy 
     settledWindowMinutes: 10,
     pollIntervalMinutes: 2,
     capExhaustedRoute: 'phase-specific',
+  });
+});
+
+test('advisory wait policy still honors advisoryWait when an unrelated top-level field is schema-invalid', () => {
+  // #1359 regression: an unknown top-level key trips `additionalProperties:
+  // false` at the whole-document level, but must not zero out an otherwise
+  // schema-valid advisoryWait section — validation is scoped to
+  // advisoryWait's own subtree.
+  const root = mkdtempSync(join(tmpdir(), 'idd-advisory-policy-scoped-'));
+  const configPath = join(root, 'policy.json');
+  const config = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+
+  config.advisoryWait = {
+    requestCap: 12,
+    pendingWindow: 'PT45M',
+    settledWindow: 'PT15M',
+    pollInterval: 'PT3M',
+    capExhaustedRoute: 'hold',
+  };
+  config.unsupportedTopLevelKey = true;
+
+  writeFileSync(configPath, JSON.stringify(config), 'utf8');
+
+  assert.deepEqual(readAdvisoryWaitPolicy(configPath), {
+    requestCap: 12,
+    pendingWindowMinutes: 45,
+    settledWindowMinutes: 15,
+    pollIntervalMinutes: 3,
+    capExhaustedRoute: 'hold',
   });
 });
 
@@ -465,6 +501,36 @@ test('readAdvisorySecondaryBotLogin only applies a schema-valid file override, e
   assert.equal(readAdvisorySecondaryBotLogin(validPath), 'coderabbitai[bot]');
   assert.equal(readAdvisorySecondaryBotLogin(invalidPath), '');
   assert.equal(readAdvisorySecondaryBotLogin(join(root, 'missing.json')), '');
+});
+
+test('readAdvisoryConvergenceDeadlineMinutes applies a schema-valid override and is scoped to advisoryWait', () => {
+  const root = mkdtempSync(
+    join(tmpdir(), 'idd-advisory-convergence-deadline-'),
+  );
+  const validPath = join(root, 'policy.valid.json');
+  const invalidPath = join(root, 'policy.invalid.json');
+  const validConfig = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  validConfig.advisoryWait = { convergenceDeadline: 'PT6H' };
+  writeFileSync(validPath, JSON.stringify(validConfig), 'utf8');
+  // A non-string convergenceDeadline violates the advisoryWait schema, so
+  // the reader fails closed to the default.
+  writeFileSync(
+    invalidPath,
+    JSON.stringify({ advisoryWait: { convergenceDeadline: 5 } }),
+    'utf8',
+  );
+
+  assert.equal(readAdvisoryConvergenceDeadlineMinutes(validPath), 6 * 60);
+  assert.equal(
+    readAdvisoryConvergenceDeadlineMinutes(invalidPath),
+    DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
+  );
+  assert.equal(
+    readAdvisoryConvergenceDeadlineMinutes(join(root, 'missing.json')),
+    DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
+  );
 });
 
 test('computeSecondaryRequestedForHead detects a same-HEAD secondary request and resets per HEAD', () => {

--- a/tests/ci-wait-policy.test.mts
+++ b/tests/ci-wait-policy.test.mts
@@ -181,7 +181,11 @@ test('readCiWaitPolicy reads nested ciWait config and CLI emits the same resolut
   });
 });
 
-test('readCiWaitPolicy falls back when the policy config is schema-invalid', (t) => {
+test('readCiWaitPolicy still honors ciWait when an unrelated top-level field is schema-invalid', (t) => {
+  // #1359 regression: an unknown top-level key like `unsupportedTopLevelKey`
+  // trips `additionalProperties: false` at the whole-document level, but
+  // must not zero out an otherwise schema-valid ciWait section — validation
+  // is scoped to ciWait's own subtree.
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-ci-wait-policy-invalid-'));
   t.after(() => rmSync(sandbox, { recursive: true, force: true }));
 
@@ -213,6 +217,56 @@ test('readCiWaitPolicy falls back when the policy config is schema-invalid', (t)
           rerunPolicy: 'hold',
         },
         unsupportedTopLevelKey: true,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  assert.deepEqual(readCiWaitPolicy(configPath), {
+    runningTimeout: 'PT40M',
+    runningTimeoutMs: 40 * 60 * 1000,
+    generationTimeout: 'PT15M',
+    generationTimeoutMs: 15 * 60 * 1000,
+    rerunPolicy: 'hold',
+  });
+});
+
+test('readCiWaitPolicy falls back to defaults when its own ciWait section is schema-invalid', (t) => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-ci-wait-policy-own-invalid-'),
+  );
+  t.after(() => rmSync(sandbox, { recursive: true, force: true }));
+
+  const configPath = join(sandbox, '.github', 'idd', 'config.json');
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(
+    configPath,
+    `${JSON.stringify(
+      {
+        iddVersion: '0.1.0',
+        markerPrefix: 'idd-skill',
+        mergePolicy: 'fully_autonomous_merge',
+        reviewPolicy: 'copilot-advisory',
+        threadResolutionPolicy: 'fast-agent-resolve',
+        claimTiming: {
+          staleAge: 'PT24H',
+          heartbeatInterval: 'PT12H',
+        },
+        trustedMarkerActors: ['kurone-kito'],
+        commands: {
+          'install-deps': 'true',
+          'fix-validate': 'true',
+          'pre-push-validate': 'true',
+          'post-fix-validate': 'true',
+        },
+        // Not in the ciWait.rerunPolicy schema enum (rerun-once | hold):
+        // the ciWait subtree is itself invalid, so this still reverts.
+        ciWait: {
+          runningTimeout: 'PT40M',
+          generationTimeout: 'PT15M',
+          rerunPolicy: 'rerun-forever',
+        },
       },
       null,
       2,

--- a/tests/fixtures/helper-runtime-config/absent.json
+++ b/tests/fixtures/helper-runtime-config/absent.json
@@ -1,5 +1,6 @@
 {
   "iddVersion": "0.1.0",
+  "markerPrefix": "helper-runtime-fixture",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",
   "threadResolutionPolicy": "fast-agent-resolve",
@@ -7,6 +8,9 @@
     "staleAge": "PT24H",
     "heartbeatInterval": "PT12H"
   },
+  "trustedMarkerActors": [
+    "fixture-actor"
+  ],
   "commands": {
     "install-deps": "true",
     "fix-validate": "node --test tests/*.mjs",

--- a/tests/fixtures/helper-runtime-config/instructions-only.json
+++ b/tests/fixtures/helper-runtime-config/instructions-only.json
@@ -1,5 +1,6 @@
 {
   "iddVersion": "0.1.0",
+  "markerPrefix": "helper-runtime-fixture",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",
   "threadResolutionPolicy": "fast-agent-resolve",
@@ -7,6 +8,9 @@
     "staleAge": "PT24H",
     "heartbeatInterval": "PT12H"
   },
+  "trustedMarkerActors": [
+    "fixture-actor"
+  ],
   "commands": {
     "install-deps": "true",
     "fix-validate": "node --test tests/*.mjs",

--- a/tests/fixtures/helper-runtime-config/invalid-extra-key.json
+++ b/tests/fixtures/helper-runtime-config/invalid-extra-key.json
@@ -1,5 +1,6 @@
 {
   "iddVersion": "0.1.0",
+  "markerPrefix": "helper-runtime-fixture",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",
   "threadResolutionPolicy": "fast-agent-resolve",
@@ -7,6 +8,9 @@
     "staleAge": "PT24H",
     "heartbeatInterval": "PT12H"
   },
+  "trustedMarkerActors": [
+    "fixture-actor"
+  ],
   "commands": {
     "install-deps": "true",
     "fix-validate": "node --test tests/*.mjs",

--- a/tests/fixtures/helper-runtime-config/invalid-profile.json
+++ b/tests/fixtures/helper-runtime-config/invalid-profile.json
@@ -1,5 +1,6 @@
 {
   "iddVersion": "0.1.0",
+  "markerPrefix": "helper-runtime-fixture",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",
   "threadResolutionPolicy": "fast-agent-resolve",
@@ -7,6 +8,9 @@
     "staleAge": "PT24H",
     "heartbeatInterval": "PT12H"
   },
+  "trustedMarkerActors": [
+    "fixture-actor"
+  ],
   "commands": {
     "install-deps": "true",
     "fix-validate": "node --test tests/*.mjs",

--- a/tests/fixtures/helper-runtime-config/package-manager.json
+++ b/tests/fixtures/helper-runtime-config/package-manager.json
@@ -1,5 +1,6 @@
 {
   "iddVersion": "0.1.0",
+  "markerPrefix": "helper-runtime-fixture",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",
   "threadResolutionPolicy": "fast-agent-resolve",
@@ -7,6 +8,9 @@
     "staleAge": "PT24H",
     "heartbeatInterval": "PT12H"
   },
+  "trustedMarkerActors": [
+    "fixture-actor"
+  ],
   "commands": {
     "install-deps": "true",
     "fix-validate": "node --test tests/*.mjs",

--- a/tests/helper-runtime-profiles.test.mts
+++ b/tests/helper-runtime-profiles.test.mts
@@ -57,6 +57,23 @@ const PROFILE_FIXTURE_FILES = [
   'profiles/external-bot/README.md',
 ];
 const DEFAULT_MARKER_PREFIX = 'helper-runtime-fixture';
+// The eight fields policy.schema.json's top-level `required` array
+// demands. Inline test configs below only set the fields their own
+// scenario cares about (commands, helperRuntime, ...); this base keeps
+// every inline fixture schema-valid so checkLiveConfigSchema (#1359) does
+// not add an unrelated finding to tests exercising other doctor checks.
+const REQUIRED_CONFIG_BASE = {
+  iddVersion: '0.1.0',
+  markerPrefix: DEFAULT_MARKER_PREFIX,
+  mergePolicy: 'fully_autonomous_merge',
+  reviewPolicy: 'copilot-advisory',
+  threadResolutionPolicy: 'fast-agent-resolve',
+  claimTiming: {
+    staleAge: 'PT24H',
+    heartbeatInterval: 'PT12H',
+  },
+  trustedMarkerActors: ['fixture-actor'],
+};
 
 test('idd-doctor accepts missing helperRuntime as instructions-only fallback fixture', (t) => {
   const root = createDoctorFixtureRepo('absent.json');
@@ -148,6 +165,7 @@ test('idd-doctor fixture rejects unsupported helperRuntime keys', (t) => {
 test('idd-doctor warns when adopter marker prefix keeps source-repo lint toolchain commands', (t) => {
   const root = createDoctorFixtureRepoFromConfig(
     {
+      ...REQUIRED_CONFIG_BASE,
       commands: {
         'fix-validate': 'npx dprint check "**/*.md"',
         'pre-push-validate': 'npm run lint',
@@ -199,6 +217,7 @@ test('idd-doctor still checks overview residue when policy config is missing', (
 test('idd-doctor skips residue warnings for idd-skill marker prefix', (t) => {
   const root = createDoctorFixtureRepoFromConfig(
     {
+      ...REQUIRED_CONFIG_BASE,
       commands: {
         'fix-validate': 'npx dprint check "**/*.md"',
         'pre-push-validate': 'npx markdownlint-cli2 "**/*.md"',
@@ -224,6 +243,7 @@ test('idd-doctor skips residue warnings for idd-skill marker prefix', (t) => {
 test('idd-doctor does not warn when config and overview concrete commands agree', (t) => {
   const root = createDoctorFixtureRepoFromConfig(
     {
+      ...REQUIRED_CONFIG_BASE,
       commands: {
         'fix-validate': 'npm run fix',
         'pre-push-validate': 'npm run lint',
@@ -258,6 +278,7 @@ test('idd-doctor does not warn when config and overview concrete commands agree'
 test('idd-doctor warns when config and overview concrete commands differ', (t) => {
   const root = createDoctorFixtureRepoFromConfig(
     {
+      ...REQUIRED_CONFIG_BASE,
       commands: {
         'fix-validate': 'npm run fix && npm test',
         'pre-push-validate': 'npm run lint',

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -8,9 +8,11 @@ import {
   backLinkPatternFor,
   checkClaimTimingConsistency,
   checkDependencyVersionDrift,
+  checkLiveConfigSchema,
   checkProjectCommands,
   classifyBacklog,
   classifyClaimTimingConsistency,
+  classifyLiveConfigSchemaFinding,
   classifyPrimaryHead,
   classifyReleaseTagDrift,
   classifyWorktreeGuardActivation,
@@ -42,6 +44,7 @@ import {
   scanFileForPlaceholders,
   stripMarkdownNonText,
 } from '../src/scripts/idd-doctor.mts';
+import { loadJson } from '../src/scripts/validate-schemas.mts';
 
 const ap = (n: number | string) =>
   `<!-- idd-skill-autopilot-suitability: ${n} -->`;
@@ -2009,6 +2012,102 @@ test('checkClaimTimingConsistency pushes no warning when config and prose agree,
     checkClaimTimingConsistency(dir, missingConfigReport);
     assert.equal(missingConfigReport.warnings.length, 0);
     assert.equal(missingConfigReport.errors.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
+const VALID_POLICY_CONFIG = loadJson(
+  'fixtures/schemas/policy.valid.json',
+) as Record<string, unknown>;
+
+test('classifyLiveConfigSchemaFinding returns null for a schema-valid config', () => {
+  assert.equal(
+    classifyLiveConfigSchemaFinding(VALID_POLICY_CONFIG, POLICY_SCHEMA),
+    null,
+  );
+});
+
+test('classifyLiveConfigSchemaFinding reports an unknown top-level key', () => {
+  const config = { ...VALID_POLICY_CONFIG, _note: 'adopter comment' };
+  const finding = classifyLiveConfigSchemaFinding(config, POLICY_SCHEMA);
+  assert.ok(finding);
+  assert.equal(finding?.level, 'error');
+  assert.match(finding?.message ?? '', /fails schema validation/);
+  assert.match(
+    finding?.message ?? '',
+    /additional property "_note" not allowed/,
+  );
+});
+
+test('classifyLiveConfigSchemaFinding reports every error, not just the first', () => {
+  const config = {
+    ...VALID_POLICY_CONFIG,
+    mergePolicy: 'not-a-real-policy',
+    reviewPolicy: 'not-a-real-review-policy',
+  };
+  const finding = classifyLiveConfigSchemaFinding(config, POLICY_SCHEMA);
+  assert.ok(finding);
+  assert.match(finding?.message ?? '', /mergePolicy/);
+  assert.match(finding?.message ?? '', /reviewPolicy/);
+});
+
+test('checkLiveConfigSchema reports a finding for an unknown-key live config (fixture)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-live-config-schema-'));
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({ ...VALID_POLICY_CONFIG, _note: 'adopter comment' }),
+    );
+
+    const report = emptyReport(dir);
+    checkLiveConfigSchema(dir, report);
+    assert.equal(report.errors.length, 1);
+    assert.match(
+      report.errors[0],
+      /\.github\/idd\/config\.json fails schema validation/,
+    );
+    assert.match(report.errors[0], /additional property "_note" not allowed/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkLiveConfigSchema passes for a schema-valid live config and skips when absent or malformed', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-live-config-schema-ok-'));
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify(VALID_POLICY_CONFIG),
+    );
+
+    const validReport = emptyReport(dir);
+    checkLiveConfigSchema(dir, validReport);
+    assert.equal(validReport.errors.length, 0);
+    assert.ok(
+      validReport.passes.some((line) =>
+        line.includes('validates against policy.schema.json'),
+      ),
+    );
+
+    // Malformed JSON: already reported by checkHelperRuntimeConfig, so this
+    // check skips silently rather than double-reporting.
+    writeFileSync(join(dir, '.github/idd/config.json'), '{ not json');
+    const malformedReport = emptyReport(dir);
+    checkLiveConfigSchema(dir, malformedReport);
+    assert.equal(malformedReport.errors.length, 0);
+    assert.equal(malformedReport.warnings.length, 0);
+
+    // No config.json at all: nothing to validate.
+    rmSync(join(dir, '.github/idd/config.json'));
+    const missingReport = emptyReport(dir);
+    checkLiveConfigSchema(dir, missingReport);
+    assert.equal(missingReport.errors.length, 0);
+    assert.equal(missingReport.warnings.length, 0);
+    assert.equal(missingReport.passes.length, 0);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -2053,6 +2053,65 @@ test('classifyLiveConfigSchemaFinding reports every error, not just the first', 
   assert.match(finding?.message ?? '', /reviewPolicy/);
 });
 
+test('classifyLiveConfigSchemaFinding truncates past 10 errors with an "and N more" suffix', () => {
+  const config = {
+    ...VALID_POLICY_CONFIG,
+    // 12 unrelated unknown top-level keys, each its own additionalProperties
+    // error, so the total exceeds the 10-error display cap.
+    ...Object.fromEntries(
+      Array.from({ length: 12 }, (_, i) => [`_extra${i}`, true]),
+    ),
+  };
+  const finding = classifyLiveConfigSchemaFinding(config, POLICY_SCHEMA);
+  assert.ok(finding);
+  assert.match(finding?.message ?? '', /\(and 2 more\)$/);
+});
+
+test('checkLiveConfigSchema also validates the legacy idd-policy.json path', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-live-config-schema-legacy-'));
+  try {
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ ...VALID_POLICY_CONFIG, _note: 'adopter comment' }),
+    );
+
+    const report = emptyReport(dir);
+    checkLiveConfigSchema(dir, report);
+    assert.equal(report.errors.length, 1);
+    assert.match(report.errors[0], /^idd-policy\.json fails schema validation/);
+    assert.match(report.errors[0], /additional property "_note" not allowed/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkLiveConfigSchema checks both live-config filenames independently when both are present', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-live-config-schema-both-'));
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify(VALID_POLICY_CONFIG),
+    );
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ ...VALID_POLICY_CONFIG, _note: 'adopter comment' }),
+    );
+
+    const report = emptyReport(dir);
+    checkLiveConfigSchema(dir, report);
+    assert.equal(report.errors.length, 1);
+    assert.match(report.errors[0], /^idd-policy\.json fails schema validation/);
+    assert.ok(
+      report.passes.some((line) =>
+        line.startsWith('.github/idd/config.json validates'),
+      ),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('checkLiveConfigSchema reports a finding for an unknown-key live config (fixture)', () => {
   const dir = mkdtempSync(join(tmpdir(), 'idd-live-config-schema-'));
   try {

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -68,6 +68,30 @@ test('claimTiming.staleAge defaults to PT24H and accepts a configured override',
   );
 });
 
+test('ciWait.rerunPolicy defaults to rerun-once and accepts hold', () => {
+  // #1359: CI_RERUN_POLICIES previously only accepted 'rerun-once',
+  // silently downgrading a configured 'hold' — the schema and
+  // ci-wait-policy.mts's own RERUN_POLICIES both accept 'hold'.
+  assert.equal(POLICY_DEFAULTS.ciWait.rerunPolicy, 'rerun-once');
+  assert.equal(normalizePolicyConfig({}).ciWait.rerunPolicy, 'rerun-once');
+  assert.equal(
+    normalizePolicyConfig({ ciWait: { rerunPolicy: 'hold' } }).ciWait
+      .rerunPolicy,
+    'hold',
+  );
+  assert.equal(
+    normalizePolicyConfig({ ciWait: { rerunPolicy: 'rerun-once' } }).ciWait
+      .rerunPolicy,
+    'rerun-once',
+  );
+  // An unrecognized value still falls back to the default.
+  assert.equal(
+    normalizePolicyConfig({ ciWait: { rerunPolicy: 'rerun-forever' } }).ciWait
+      .rerunPolicy,
+    'rerun-once',
+  );
+});
+
 test('parseIsoDurationToMs parses supported ISO durations', () => {
   assert.equal(parseIsoDurationToMs('PT5S'), 5000);
   assert.equal(parseIsoDurationToMs('PT2H'), 2 * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary

- `idd-doctor` now validates the live `.github/idd/config.json` against
  the canonical `policy.schema.json` and reports every schema error as a
  doctor finding — a malformed config (unknown top-level key, typo'd
  enum, ...) no longer passes silently.
- `ci-wait-policy.mts` and `advisory-wait-policy.mts`'s config readers
  now validate only their own `ciWait`/`advisoryWait` subtree
  (`validateConfigSection`, new export in `validate-schemas.mts`)
  instead of the whole document, so an unrelated invalid field
  elsewhere in the file no longer zeroes out an otherwise-valid
  section.
- `normalizePolicyConfig(...).ciWait.rerunPolicy` now accepts `hold`,
  matching the schema, `ci-wait-policy.mts`'s own `RERUN_POLICIES`, and
  the docs.

Closes #1359. Parent roadmap: #1357.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build` then verified the diff is Biome-formatted
      (2-space/single-quote), not raw `tsc` output
- [x] `pnpm run build:check`
- [x] `node --test tests/*.test.mts` (1880/1880 pass)
- [x] `pnpm run lint:minimum` (full gate, passes)
- [x] Dogfooded `node scripts/idd-doctor.mjs` against this repo's own
      live config — `PASS .github/idd/config.json validates against
      policy.schema.json`
- [x] New/updated unit tests cover: an unknown-key config surfacing an
      `idd-doctor` finding; a valid `ciWait`/`advisoryWait` section
      still resolving to its configured values despite an unrelated
      invalid field elsewhere in the document; `ciWait.rerunPolicy`
      accepting `hold`
