### PR TITLE
fix(pre-merge): fail closed on a masked 404 from ruleset-detail reads

### DIFF
--- a/fixtures/pre-merge-readiness/ack-only-current.json
+++ b/fixtures/pre-merge-readiness/ack-only-current.json
@@ -265,7 +265,8 @@
         "codeownerApprovalSatisfied": true,
         "bypassDetected": false,
         "bypassMode": "none",
-        "currentUserCanBypass": "unknown"
+        "currentUserCanBypass": "unknown",
+        "rulesetBypassUnreadable": false
       },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -197,7 +197,8 @@
         "codeownerApprovalSatisfied": false,
         "bypassDetected": false,
         "bypassMode": "none",
-        "currentUserCanBypass": "unknown"
+        "currentUserCanBypass": "unknown",
+        "rulesetBypassUnreadable": false
       },
       "humanChangesRequestedCount": 1,
       "blockingChangesRequestedLogins": [

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -200,7 +200,8 @@
         "codeownerApprovalSatisfied": true,
         "bypassDetected": false,
         "bypassMode": "none",
-        "currentUserCanBypass": "unknown"
+        "currentUserCanBypass": "unknown",
+        "rulesetBypassUnreadable": false
       },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -227,7 +227,8 @@
         "codeownerApprovalSatisfied": true,
         "bypassDetected": false,
         "bypassMode": "none",
-        "currentUserCanBypass": "unknown"
+        "currentUserCanBypass": "unknown",
+        "rulesetBypassUnreadable": false
       },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -227,7 +227,8 @@
         "codeownerApprovalSatisfied": true,
         "bypassDetected": false,
         "bypassMode": "none",
-        "currentUserCanBypass": "unknown"
+        "currentUserCanBypass": "unknown",
+        "rulesetBypassUnreadable": false
       },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -227,7 +227,8 @@
         "codeownerApprovalSatisfied": true,
         "bypassDetected": false,
         "bypassMode": "none",
-        "currentUserCanBypass": "unknown"
+        "currentUserCanBypass": "unknown",
+        "rulesetBypassUnreadable": false
       },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -213,7 +213,8 @@
         "codeownerApprovalSatisfied": true,
         "bypassDetected": false,
         "bypassMode": "none",
-        "currentUserCanBypass": "unknown"
+        "currentUserCanBypass": "unknown",
+        "rulesetBypassUnreadable": false
       },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -227,7 +227,8 @@
         "codeownerApprovalSatisfied": true,
         "bypassDetected": false,
         "bypassMode": "none",
-        "currentUserCanBypass": "unknown"
+        "currentUserCanBypass": "unknown",
+        "rulesetBypassUnreadable": false
       },
       "humanChangesRequestedCount": 0,
       "blockingChangesRequestedLogins": []

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -106,7 +106,8 @@
       "codeownerApprovalSatisfied": true,
       "bypassDetected": false,
       "bypassMode": "none",
-      "currentUserCanBypass": "never"
+      "currentUserCanBypass": "never",
+      "rulesetBypassUnreadable": false
     },
     "humanChangesRequestedCount": 0,
     "blockingChangesRequestedLogins": []

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -501,7 +501,8 @@
             "codeownerApprovalSatisfied",
             "bypassDetected",
             "bypassMode",
-            "currentUserCanBypass"
+            "currentUserCanBypass",
+            "rulesetBypassUnreadable"
           ],
           "additionalProperties": false,
           "properties": {
@@ -564,6 +565,9 @@
                 "exempt",
                 "mixed"
               ]
+            },
+            "rulesetBypassUnreadable": {
+              "type": "boolean"
             }
           }
         },

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -124,7 +124,13 @@ export function collectPreMergeReadiness(argv) {
     [],
   );
   const branchRules = branchRulesRead.value;
-  const branchRulesets = fetchBranchRulesets(owner, repo, branchRules);
+  const branchRulesetsRead = fetchBranchRulesets(
+    owner,
+    repo,
+    branchRules,
+    trustEmptyProtectionReads,
+  );
+  const branchRulesets = branchRulesetsRead.value;
   const branchProtectionRead = fetchGovernanceJson(
     `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
     false,
@@ -138,6 +144,14 @@ export function collectPreMergeReadiness(argv) {
   // `summarizeRequiredChecks` in protocol-helpers.mts).
   const protectionReadsUnreadable =
     branchRulesRead.unreadable || branchProtectionRead.unreadable;
+  // #1380: a masked-403-as-404 on a ruleset's *detail* read is a distinct
+  // surface from the required-check reads above -- `branchRulesets` only
+  // feeds `summarizeReviewerStates`'s ruleset-bypass/CODEOWNER detection,
+  // never `summarizeRequiredChecks` (see `summarizeBranchReviewRequirements`
+  // in protocol-helpers.mts, which reads only `branchRules` /
+  // `branchProtection`) -- so it is threaded separately rather than folded
+  // into `protectionReadsUnreadable`.
+  const branchRulesetsUnreadable = branchRulesetsRead.unreadable;
   const reviews = ghApiJson(
     `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
     true,
@@ -235,6 +249,7 @@ export function collectPreMergeReadiness(argv) {
       branchRulesets,
       branchProtection,
       protectionReadsUnreadable,
+      branchRulesetsUnreadable,
       requestedReviewers: requestedReviewers.users ?? [],
       timelineEvents,
       claimEvents: claimComments.map(normalizeClaimComment),
@@ -514,13 +529,33 @@ function fetchCodeownersText(owner, repo, ref) {
   return selectCodeownersText(payloads);
 }
 /**
- * Fetch each referenced ruleset's detail, skipping ones that no longer exist.
+ * Fetch each referenced ruleset's detail, discriminating a masked `404`
+ * (unreadable) from a genuine deletion race.
  *
- * A 404 means the ruleset is gone, so it is mapped to `{}` and dropped by the
- * trailing empty-object filter. Any other status (403, rate limit, transient
- * failure) is re-thrown so the F2/F3 merge gate fails closed and falls back to
- * the written-rules path, instead of fabricating a "no ruleset" result that
- * would silently over-block a legitimately configured bypass.
+ * Every `ruleset_id` passed in via `branchRules` was already confirmed to
+ * exist moments earlier by the `rules/branches/{base}` list read in the same
+ * call (see `collectPreMergeReadiness`), so a `404` on its own detail read
+ * here is not a plausible independent deletion race. GitHub's "Get a
+ * repository ruleset" reference documents only `200`/`404`/`500` for this
+ * endpoint -- no `403` --
+ * (<https://docs.github.com/en/rest/repos/rules#get-a-repository-ruleset>),
+ * the same masked-403-as-404 pattern `#1377` documented for the other two
+ * governance reads (see `fetchGovernanceJson`'s doc comment for the full
+ * citation set, including GitHub's REST troubleshooting guide). A `404`
+ * here is therefore **unreadable** by default: the ruleset is still dropped
+ * from the returned array (the caller has no usable detail either way, so
+ * `#1380` cannot invent one), but `unreadable` is set so
+ * `summarizeReviewerStates` can distinguish "no bypass configured" from
+ * "could not determine" instead of asserting an unjustified certain
+ * `deadlock`. `trustEmptyReads` (`ciGate.trustEmptyProtectionReads`, the
+ * same policy key `fetchGovernanceJson` reads) restores the pre-`#1380`
+ * trusting behavior.
+ *
+ * Any other thrown status (`403`, rate limit, transient failure, …) is
+ * still re-thrown unchanged, preserving the existing fail-closed behavior
+ * for an explicit permission error (`#1371`) instead of fabricating a "no
+ * ruleset" result that would silently over-block a legitimately configured
+ * bypass.
  *
  * The 404 must be discriminated on the *thrown* status: `gh api` writes a 404
  * response body to stdout, so `allowHttpStatuses: [404]` would return that
@@ -535,6 +570,7 @@ export function fetchBranchRulesets(
   owner,
   repo,
   branchRules,
+  trustEmptyReads = false,
   fetchRulesetDetail = (path) =>
     ghApiJson(path, false, ['-H', 'Accept: application/vnd.github+json']),
 ) {
@@ -552,18 +588,23 @@ export function fetchBranchRulesets(
     seenPaths.add(path);
     rulesetPaths.push(path);
   }
-  return rulesetPaths
+  let unreadable = false;
+  const value = rulesetPaths
     .map((path) => {
       try {
         return fetchRulesetDetail(path);
       } catch (error) {
         if (deriveGhHttpStatus(error) === 404) {
+          if (!trustEmptyReads) {
+            unreadable = true;
+          }
           return {};
         }
         throw error;
       }
     })
     .filter((ruleset) => Object.keys(ruleset).length > 0);
+  return { value, unreadable };
 }
 function resolveViewerClassicBypassTeamSlugs(
   owner,

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -534,8 +534,10 @@ function fetchCodeownersText(owner, repo, ref) {
  *
  * Every `ruleset_id` passed in via `branchRules` was already confirmed to
  * exist moments earlier by the `rules/branches/{base}` list read in the same
- * call (see `collectPreMergeReadiness`), so a `404` on its own detail read
- * here is not a plausible independent deletion race. GitHub's "Get a
+ * call (see `collectPreMergeReadiness`), so a genuine deletion between that
+ * read and this one is possible but unlikely. That timing alone would not
+ * justify treating every `404` as unreadable -- the real justification is
+ * that the response itself cannot distinguish the two cases. GitHub's "Get a
  * repository ruleset" reference documents only `200`/`404`/`500` for this
  * endpoint -- no `403` --
  * (<https://docs.github.com/en/rest/repos/rules#get-a-repository-ruleset>),

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3679,11 +3679,20 @@ export function computePreMergeReadinessBlockers(report) {
   if (!isPreMergeReviewSatisfied(reviewerStates)) {
     const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
     // #1380: name the masked-403-as-404 ruleset-detail cause explicitly when
-    // that is why the required-reviews gate is unmet, mirroring the CI
+    // that is *why* the required-reviews gate is unmet, mirroring the CI
     // gate's `protectionReadsUnreadable`-specific detail above, instead of
-    // the generic status detail below.
+    // the generic status detail below. Gate on the specific `reason` (set
+    // only by the one branch in `summarizeCodeownerSelfApproval` that
+    // actually resolved to this cause), not the bare
+    // `rulesetBypassUnreadable` boolean: that flag is present on every
+    // returned branch (it lives on `base`), so an unrelated resolution --
+    // e.g. `possible_deadlock`/`team-codeowner-ambiguous` -- could also
+    // carry `rulesetBypassUnreadable: true` (the same fetch that flagged
+    // the ruleset unreadable) while the real blocking cause is the
+    // ambiguous team, not the unreadable ruleset. Naming the wrong cause
+    // would misdirect an operator's remediation.
     const detail =
-      selfApproval.rulesetBypassUnreadable === true
+      selfApproval.reason === 'ruleset-bypass-unreadable'
         ? 'cannot determine CODEOWNER ruleset bypass: ruleset detail unreadable'
         : `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(reviewerStates.requiredApprovalsSatisfied)}, codeownerApprovalSatisfied=${Boolean(reviewerStates.codeownerApprovalSatisfied)}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`;
     blockers.push({ gate: 'required-reviews', detail });

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2954,6 +2954,7 @@ export function summarizeReviewerStates(
     branchRules = [],
     branchRulesets = [],
     branchProtection = {},
+    branchRulesetsUnreadable = false,
     codeownersText = '',
     changedFiles = [],
     eligibleCodeownerUserLogins = null,
@@ -3073,6 +3074,7 @@ export function summarizeReviewerStates(
     viewerAppSlug,
     branchRules,
     branchRulesets,
+    branchRulesetsUnreadable,
     classicRequireCodeOwnerReview:
       branchReviewRequirements.classicRequireCodeOwnerReview,
     classicBypassPullRequestUserLogins:
@@ -3127,6 +3129,7 @@ function summarizeCodeownerSelfApproval({
   viewerAppSlug = '',
   branchRules = [],
   branchRulesets = [],
+  branchRulesetsUnreadable = false,
   classicRequireCodeOwnerReview = false,
   classicBypassPullRequestUserLogins = [],
   classicBypassPullRequestTeamSlugs = [],
@@ -3172,7 +3175,11 @@ function summarizeCodeownerSelfApproval({
             classicBypassPullRequestAppSlugs,
           ).includes(normalizedViewerAppSlug))),
   );
-  const bypass = summarizeRulesetPullRequestBypass(branchRulesets, branchRules);
+  const bypass = summarizeRulesetPullRequestBypass(
+    branchRulesets,
+    branchRules,
+    branchRulesetsUnreadable,
+  );
   const rulesetGateSatisfiedByBypass =
     bypass.relevantRulesetCount === 0 || bypass.detected;
   const classicGateSatisfiedByBypass =
@@ -3197,6 +3204,12 @@ function summarizeCodeownerSelfApproval({
     bypassDetected: applicableBypassDetected,
     bypassMode: applicableBypassMode,
     currentUserCanBypass: bypass.currentUserCanBypass,
+    // #1380: true when a codeowner-requiring ruleset's *detail* read was
+    // masked-404 unreadable, so `bypass.detected` could not rule out an
+    // actual configured bypass. Diagnostic only -- never flips a `status`
+    // to `clear` on its own -- but downgrades a would-be certain `deadlock`
+    // below to the already-documented `possible_deadlock`.
+    rulesetBypassUnreadable: bypass.unreadable,
   };
   if (!requireCodeOwnerReview) {
     return base;
@@ -3260,6 +3273,20 @@ function summarizeCodeownerSelfApproval({
     };
   }
   if (allDirectUsersAreAuthor) {
+    // #1380: a masked-404 on a relevant ruleset's detail read means
+    // `bypass.detected` could not rule out an actual configured bypass for
+    // this PR author -- asserting a *certain* `deadlock` here would be an
+    // unjustified false-certainty diagnostic. Downgrade to the
+    // already-documented `possible_deadlock` (idd-pre-merge.instructions.md:
+    // "could not prove ... applicable pull-request bypass, so fail closed")
+    // instead of inventing a new status value.
+    if (bypass.unreadable) {
+      return {
+        ...base,
+        status: 'possible_deadlock',
+        reason: 'ruleset-bypass-unreadable',
+      };
+    }
     return {
       ...base,
       status: 'deadlock',
@@ -3278,6 +3305,7 @@ function summarizeCodeownerSelfApproval({
 function summarizeRulesetPullRequestBypass(
   branchRulesets = [],
   branchRules = [],
+  branchRulesetsUnreadable = false,
 ) {
   const codeownerRulesetIds = new Set(
     (branchRules ?? [])
@@ -3336,11 +3364,26 @@ function summarizeRulesetPullRequestBypass(
       mode = 'exempt';
     }
   }
+  // #1380: only report `unreadable` when a *relevant* (codeowner-requiring)
+  // ruleset is actually missing from `relevantRulesets` -- not merely
+  // whenever `detected` is `false`, since a fully-read ruleset can
+  // legitimately report a real, non-bypass value (e.g. `never`) that also
+  // makes `detected` false. That is genuine data, not a masked-404 gap, and
+  // must not be relabeled as "could not determine". A masked-404 on a
+  // relevant ruleset's detail read only ever *prevents* `detected` from
+  // becoming `true` (the count check above requires every expected
+  // ruleset's detail to be present), so this can never cause a false
+  // `detected: true`.
+  const unreadable =
+    branchRulesetsUnreadable &&
+    expectedRulesetCount > 0 &&
+    relevantRulesets.length < expectedRulesetCount;
   return {
     detected,
     mode,
     currentUserCanBypass,
     relevantRulesetCount: expectedRulesetCount,
+    unreadable,
   };
 }
 export function resolveRulesetDetailPath(owner, repo, rule, rulesetId) {
@@ -3635,10 +3678,15 @@ export function computePreMergeReadinessBlockers(report) {
   const reviewerStates = preMergeAsRecord(report.reviewerStates);
   if (!isPreMergeReviewSatisfied(reviewerStates)) {
     const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
-    blockers.push({
-      gate: 'required-reviews',
-      detail: `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(reviewerStates.requiredApprovalsSatisfied)}, codeownerApprovalSatisfied=${Boolean(reviewerStates.codeownerApprovalSatisfied)}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`,
-    });
+    // #1380: name the masked-403-as-404 ruleset-detail cause explicitly when
+    // that is why the required-reviews gate is unmet, mirroring the CI
+    // gate's `protectionReadsUnreadable`-specific detail above, instead of
+    // the generic status detail below.
+    const detail =
+      selfApproval.rulesetBypassUnreadable === true
+        ? 'cannot determine CODEOWNER ruleset bypass: ruleset detail unreadable'
+        : `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(reviewerStates.requiredApprovalsSatisfied)}, codeownerApprovalSatisfied=${Boolean(reviewerStates.codeownerApprovalSatisfied)}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`;
+    blockers.push({ gate: 'required-reviews', detail });
   }
   const claim = preMergeAsRecord(report.claim);
   if (claim.matchesExpectedClaim !== true) {
@@ -3674,6 +3722,7 @@ export function buildPreMergeReadinessSummary(
     branchRulesets = [],
     branchProtection = {},
     protectionReadsUnreadable = false,
+    branchRulesetsUnreadable = false,
     requestedReviewers = [],
     timelineEvents = [],
     claimEvents = [],
@@ -3761,6 +3810,7 @@ export function buildPreMergeReadinessSummary(
     branchRules,
     branchRulesets,
     branchProtection,
+    branchRulesetsUnreadable,
     codeownersText,
     changedFiles,
     eligibleCodeownerUserLogins,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -741,8 +741,10 @@ function fetchCodeownersText(owner: string, repo: string, ref: string): string {
  *
  * Every `ruleset_id` passed in via `branchRules` was already confirmed to
  * exist moments earlier by the `rules/branches/{base}` list read in the same
- * call (see `collectPreMergeReadiness`), so a `404` on its own detail read
- * here is not a plausible independent deletion race. GitHub's "Get a
+ * call (see `collectPreMergeReadiness`), so a genuine deletion between that
+ * read and this one is possible but unlikely. That timing alone would not
+ * justify treating every `404` as unreadable -- the real justification is
+ * that the response itself cannot distinguish the two cases. GitHub's "Get a
  * repository ruleset" reference documents only `200`/`404`/`500` for this
  * endpoint -- no `403` --
  * (<https://docs.github.com/en/rest/repos/rules#get-a-repository-ruleset>),

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -301,7 +301,13 @@ export function collectPreMergeReadiness(
     [],
   );
   const branchRules = branchRulesRead.value;
-  const branchRulesets = fetchBranchRulesets(owner, repo, branchRules);
+  const branchRulesetsRead = fetchBranchRulesets(
+    owner,
+    repo,
+    branchRules,
+    trustEmptyProtectionReads,
+  );
+  const branchRulesets = branchRulesetsRead.value;
   const branchProtectionRead = fetchGovernanceJson<BranchProtectionPayload>(
     `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
     false,
@@ -315,6 +321,14 @@ export function collectPreMergeReadiness(
   // `summarizeRequiredChecks` in protocol-helpers.mts).
   const protectionReadsUnreadable =
     branchRulesRead.unreadable || branchProtectionRead.unreadable;
+  // #1380: a masked-403-as-404 on a ruleset's *detail* read is a distinct
+  // surface from the required-check reads above -- `branchRulesets` only
+  // feeds `summarizeReviewerStates`'s ruleset-bypass/CODEOWNER detection,
+  // never `summarizeRequiredChecks` (see `summarizeBranchReviewRequirements`
+  // in protocol-helpers.mts, which reads only `branchRules` /
+  // `branchProtection`) -- so it is threaded separately rather than folded
+  // into `protectionReadsUnreadable`.
+  const branchRulesetsUnreadable = branchRulesetsRead.unreadable;
   const reviews = ghApiJson(
     `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
     true,
@@ -415,6 +429,7 @@ export function collectPreMergeReadiness(
       branchRulesets,
       branchProtection,
       protectionReadsUnreadable,
+      branchRulesetsUnreadable,
       requestedReviewers: requestedReviewers.users ?? [],
       timelineEvents,
       claimEvents: claimComments.map(normalizeClaimComment),
@@ -721,13 +736,33 @@ function fetchCodeownersText(owner: string, repo: string, ref: string): string {
 }
 
 /**
- * Fetch each referenced ruleset's detail, skipping ones that no longer exist.
+ * Fetch each referenced ruleset's detail, discriminating a masked `404`
+ * (unreadable) from a genuine deletion race.
  *
- * A 404 means the ruleset is gone, so it is mapped to `{}` and dropped by the
- * trailing empty-object filter. Any other status (403, rate limit, transient
- * failure) is re-thrown so the F2/F3 merge gate fails closed and falls back to
- * the written-rules path, instead of fabricating a "no ruleset" result that
- * would silently over-block a legitimately configured bypass.
+ * Every `ruleset_id` passed in via `branchRules` was already confirmed to
+ * exist moments earlier by the `rules/branches/{base}` list read in the same
+ * call (see `collectPreMergeReadiness`), so a `404` on its own detail read
+ * here is not a plausible independent deletion race. GitHub's "Get a
+ * repository ruleset" reference documents only `200`/`404`/`500` for this
+ * endpoint -- no `403` --
+ * (<https://docs.github.com/en/rest/repos/rules#get-a-repository-ruleset>),
+ * the same masked-403-as-404 pattern `#1377` documented for the other two
+ * governance reads (see `fetchGovernanceJson`'s doc comment for the full
+ * citation set, including GitHub's REST troubleshooting guide). A `404`
+ * here is therefore **unreadable** by default: the ruleset is still dropped
+ * from the returned array (the caller has no usable detail either way, so
+ * `#1380` cannot invent one), but `unreadable` is set so
+ * `summarizeReviewerStates` can distinguish "no bypass configured" from
+ * "could not determine" instead of asserting an unjustified certain
+ * `deadlock`. `trustEmptyReads` (`ciGate.trustEmptyProtectionReads`, the
+ * same policy key `fetchGovernanceJson` reads) restores the pre-`#1380`
+ * trusting behavior.
+ *
+ * Any other thrown status (`403`, rate limit, transient failure, …) is
+ * still re-thrown unchanged, preserving the existing fail-closed behavior
+ * for an explicit permission error (`#1371`) instead of fabricating a "no
+ * ruleset" result that would silently over-block a legitimately configured
+ * bypass.
  *
  * The 404 must be discriminated on the *thrown* status: `gh api` writes a 404
  * response body to stdout, so `allowHttpStatuses: [404]` would return that
@@ -742,12 +777,13 @@ export function fetchBranchRulesets(
   owner: string,
   repo: string,
   branchRules: BranchRulePayload[],
+  trustEmptyReads = false,
   fetchRulesetDetail: (path: string) => Record<string, unknown> = (path) =>
     ghApiJson(path, false, [
       '-H',
       'Accept: application/vnd.github+json',
     ]) as Record<string, unknown>,
-) {
+): GovernanceReadResult<Record<string, unknown>[]> {
   const rulesetPaths: string[] = [];
   const seenPaths = new Set<string>();
   for (const rule of branchRules ?? []) {
@@ -763,18 +799,23 @@ export function fetchBranchRulesets(
     rulesetPaths.push(path);
   }
 
-  return rulesetPaths
+  let unreadable = false;
+  const value = rulesetPaths
     .map((path) => {
       try {
         return fetchRulesetDetail(path);
       } catch (error) {
         if (deriveGhHttpStatus(error) === 404) {
+          if (!trustEmptyReads) {
+            unreadable = true;
+          }
           return {};
         }
         throw error;
       }
     })
     .filter((ruleset) => Object.keys(ruleset).length > 0);
+  return { value, unreadable };
 }
 
 function resolveViewerClassicBypassTeamSlugs(

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4672,11 +4672,20 @@ export function computePreMergeReadinessBlockers(
   if (!isPreMergeReviewSatisfied(reviewerStates)) {
     const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
     // #1380: name the masked-403-as-404 ruleset-detail cause explicitly when
-    // that is why the required-reviews gate is unmet, mirroring the CI
+    // that is *why* the required-reviews gate is unmet, mirroring the CI
     // gate's `protectionReadsUnreadable`-specific detail above, instead of
-    // the generic status detail below.
+    // the generic status detail below. Gate on the specific `reason` (set
+    // only by the one branch in `summarizeCodeownerSelfApproval` that
+    // actually resolved to this cause), not the bare
+    // `rulesetBypassUnreadable` boolean: that flag is present on every
+    // returned branch (it lives on `base`), so an unrelated resolution --
+    // e.g. `possible_deadlock`/`team-codeowner-ambiguous` -- could also
+    // carry `rulesetBypassUnreadable: true` (the same fetch that flagged
+    // the ruleset unreadable) while the real blocking cause is the
+    // ambiguous team, not the unreadable ruleset. Naming the wrong cause
+    // would misdirect an operator's remediation.
     const detail =
-      selfApproval.rulesetBypassUnreadable === true
+      selfApproval.reason === 'ruleset-bypass-unreadable'
         ? 'cannot determine CODEOWNER ruleset bypass: ruleset detail unreadable'
         : `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(
             reviewerStates.requiredApprovalsSatisfied,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -3821,6 +3821,7 @@ export function summarizeReviewerStates(
     branchRules = [],
     branchRulesets = [],
     branchProtection = {},
+    branchRulesetsUnreadable = false,
     codeownersText = '',
     changedFiles = [],
     eligibleCodeownerUserLogins = null,
@@ -3834,6 +3835,8 @@ export function summarizeReviewerStates(
     branchRules?: BranchRuleLike[];
     branchRulesets?: BranchRulesetLike[];
     branchProtection?: BranchProtectionLike;
+    // #1380: see `buildPreMergeReadinessSummary`'s option of the same name.
+    branchRulesetsUnreadable?: boolean;
     codeownersText?: string;
     changedFiles?: unknown[];
     eligibleCodeownerUserLogins?: unknown[] | null;
@@ -3956,6 +3959,7 @@ export function summarizeReviewerStates(
     viewerAppSlug,
     branchRules,
     branchRulesets,
+    branchRulesetsUnreadable,
     classicRequireCodeOwnerReview:
       branchReviewRequirements.classicRequireCodeOwnerReview,
     classicBypassPullRequestUserLogins:
@@ -4012,6 +4016,7 @@ function summarizeCodeownerSelfApproval({
   viewerAppSlug = '',
   branchRules = [],
   branchRulesets = [],
+  branchRulesetsUnreadable = false,
   classicRequireCodeOwnerReview = false,
   classicBypassPullRequestUserLogins = [],
   classicBypassPullRequestTeamSlugs = [],
@@ -4030,6 +4035,8 @@ function summarizeCodeownerSelfApproval({
   viewerAppSlug?: string | null;
   branchRules?: BranchRuleLike[];
   branchRulesets?: BranchRulesetLike[];
+  // #1380: see `buildPreMergeReadinessSummary`'s option of the same name.
+  branchRulesetsUnreadable?: boolean;
   classicRequireCodeOwnerReview?: boolean;
   classicBypassPullRequestUserLogins?: unknown[];
   classicBypassPullRequestTeamSlugs?: unknown[];
@@ -4075,7 +4082,11 @@ function summarizeCodeownerSelfApproval({
             classicBypassPullRequestAppSlugs,
           ).includes(normalizedViewerAppSlug))),
   );
-  const bypass = summarizeRulesetPullRequestBypass(branchRulesets, branchRules);
+  const bypass = summarizeRulesetPullRequestBypass(
+    branchRulesets,
+    branchRules,
+    branchRulesetsUnreadable,
+  );
   const rulesetGateSatisfiedByBypass =
     bypass.relevantRulesetCount === 0 || bypass.detected;
   const classicGateSatisfiedByBypass =
@@ -4100,6 +4111,12 @@ function summarizeCodeownerSelfApproval({
     bypassDetected: applicableBypassDetected,
     bypassMode: applicableBypassMode,
     currentUserCanBypass: bypass.currentUserCanBypass,
+    // #1380: true when a codeowner-requiring ruleset's *detail* read was
+    // masked-404 unreadable, so `bypass.detected` could not rule out an
+    // actual configured bypass. Diagnostic only -- never flips a `status`
+    // to `clear` on its own -- but downgrades a would-be certain `deadlock`
+    // below to the already-documented `possible_deadlock`.
+    rulesetBypassUnreadable: bypass.unreadable,
   };
 
   if (!requireCodeOwnerReview) {
@@ -4166,6 +4183,20 @@ function summarizeCodeownerSelfApproval({
     };
   }
   if (allDirectUsersAreAuthor) {
+    // #1380: a masked-404 on a relevant ruleset's detail read means
+    // `bypass.detected` could not rule out an actual configured bypass for
+    // this PR author -- asserting a *certain* `deadlock` here would be an
+    // unjustified false-certainty diagnostic. Downgrade to the
+    // already-documented `possible_deadlock` (idd-pre-merge.instructions.md:
+    // "could not prove ... applicable pull-request bypass, so fail closed")
+    // instead of inventing a new status value.
+    if (bypass.unreadable) {
+      return {
+        ...base,
+        status: 'possible_deadlock',
+        reason: 'ruleset-bypass-unreadable',
+      };
+    }
     return {
       ...base,
       status: 'deadlock',
@@ -4186,6 +4217,7 @@ function summarizeCodeownerSelfApproval({
 function summarizeRulesetPullRequestBypass(
   branchRulesets: BranchRulesetLike[] = [],
   branchRules: BranchRuleLike[] = [],
+  branchRulesetsUnreadable = false,
 ) {
   const codeownerRulesetIds = new Set(
     (branchRules ?? [])
@@ -4244,11 +4276,26 @@ function summarizeRulesetPullRequestBypass(
       mode = 'exempt';
     }
   }
+  // #1380: only report `unreadable` when a *relevant* (codeowner-requiring)
+  // ruleset is actually missing from `relevantRulesets` -- not merely
+  // whenever `detected` is `false`, since a fully-read ruleset can
+  // legitimately report a real, non-bypass value (e.g. `never`) that also
+  // makes `detected` false. That is genuine data, not a masked-404 gap, and
+  // must not be relabeled as "could not determine". A masked-404 on a
+  // relevant ruleset's detail read only ever *prevents* `detected` from
+  // becoming `true` (the count check above requires every expected
+  // ruleset's detail to be present), so this can never cause a false
+  // `detected: true`.
+  const unreadable =
+    branchRulesetsUnreadable &&
+    expectedRulesetCount > 0 &&
+    relevantRulesets.length < expectedRulesetCount;
   return {
     detected,
     mode,
     currentUserCanBypass,
     relevantRulesetCount: expectedRulesetCount,
+    unreadable,
   };
 }
 
@@ -4624,14 +4671,19 @@ export function computePreMergeReadinessBlockers(
   const reviewerStates = preMergeAsRecord(report.reviewerStates);
   if (!isPreMergeReviewSatisfied(reviewerStates)) {
     const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
-    blockers.push({
-      gate: 'required-reviews',
-      detail: `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(
-        reviewerStates.requiredApprovalsSatisfied,
-      )}, codeownerApprovalSatisfied=${Boolean(
-        reviewerStates.codeownerApprovalSatisfied,
-      )}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`,
-    });
+    // #1380: name the masked-403-as-404 ruleset-detail cause explicitly when
+    // that is why the required-reviews gate is unmet, mirroring the CI
+    // gate's `protectionReadsUnreadable`-specific detail above, instead of
+    // the generic status detail below.
+    const detail =
+      selfApproval.rulesetBypassUnreadable === true
+        ? 'cannot determine CODEOWNER ruleset bypass: ruleset detail unreadable'
+        : `required/CODEOWNER reviews not satisfied (requiredApprovalsSatisfied=${Boolean(
+            reviewerStates.requiredApprovalsSatisfied,
+          )}, codeownerApprovalSatisfied=${Boolean(
+            reviewerStates.codeownerApprovalSatisfied,
+          )}, codeownerSelfApproval.status="${String(selfApproval.status ?? '')}")`;
+    blockers.push({ gate: 'required-reviews', detail });
   }
 
   const claim = preMergeAsRecord(report.claim);
@@ -4675,6 +4727,7 @@ export function buildPreMergeReadinessSummary(
     branchRulesets = [],
     branchProtection = {},
     protectionReadsUnreadable = false,
+    branchRulesetsUnreadable = false,
     requestedReviewers = [],
     timelineEvents = [],
     claimEvents = [],
@@ -4699,6 +4752,14 @@ export function buildPreMergeReadinessSummary(
     // state. Omitted by unit callers (default `false`, unchanged
     // pre-`#1377` behavior).
     protectionReadsUnreadable?: boolean;
+    // #1380: true when a ruleset-*detail* read threw a `404` that was not
+    // trusted as genuinely empty (see `fetchBranchRulesets` in
+    // pre-merge-readiness.mts). Distinct from `protectionReadsUnreadable`
+    // above: `branchRulesets` never feeds `summarizeRequiredChecks`, only
+    // `summarizeReviewerStates`'s ruleset-bypass/CODEOWNER detection below.
+    // Omitted by unit callers (default `false`, unchanged pre-`#1380`
+    // behavior).
+    branchRulesetsUnreadable?: boolean;
     requestedReviewers?: RequestedReviewerLike[];
     timelineEvents?: TimelineEventLike[];
     claimEvents?: CommentLike[];
@@ -4836,6 +4897,7 @@ export function buildPreMergeReadinessSummary(
     branchRules,
     branchRulesets,
     branchProtection,
+    branchRulesetsUnreadable,
     codeownersText,
     changedFiles,
     eligibleCodeownerUserLogins,

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -538,7 +538,98 @@ test('self-CODEOWNER diagnostic reports deadlock without bypass', () => {
     bypassDetected: false,
     bypassMode: 'none',
     currentUserCanBypass: 'never',
+    rulesetBypassUnreadable: false,
   });
+});
+
+// #1380: when the sole-direct-codeowner-is-the-author ruleset's own detail
+// read was masked-404 (unreadable), `bypass.detected` could not rule out an
+// actual configured bypass -- asserting a *certain* `deadlock` would be an
+// unjustified false-certainty diagnostic. Downgrade to the
+// already-documented `possible_deadlock` instead.
+test('self-CODEOWNER diagnostic downgrades a certain deadlock to possible_deadlock when the ruleset bypass detail is unreadable', () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [
+      {
+        type: 'pull_request',
+        ruleset_id: 1,
+        parameters: { require_code_owner_review: true },
+      },
+    ],
+    // The one codeowner-requiring ruleset's own detail 404'd and was
+    // dropped, so `branchRulesets` is empty even though a ruleset is
+    // referenced by `branchRules`.
+    branchRulesets: [],
+    branchRulesetsUnreadable: true,
+    codeownersText: '* @author\n',
+    changedFiles: ['README.md'],
+    prAuthorLogin: 'author',
+  });
+
+  assert.deepEqual(summary.codeownerSelfApproval, {
+    status: 'possible_deadlock',
+    reason: 'ruleset-bypass-unreadable',
+    prAuthorLogin: 'author',
+    directCodeownerUserLogins: ['author'],
+    codeownerTeamSlugs: [],
+    requireCodeOwnerReview: true,
+    codeownerApprovalSatisfied: false,
+    bypassDetected: false,
+    bypassMode: 'none',
+    currentUserCanBypass: 'unknown',
+    rulesetBypassUnreadable: true,
+  });
+});
+
+// A globally unreadable ruleset detail that is *irrelevant* to this PR (no
+// codeowner-requiring ruleset referenced at all) must not manufacture a
+// diagnostic -- `rulesetBypassUnreadable` stays `false` and the existing
+// deadlock-free `not_applicable` outcome is unaffected.
+test('self-CODEOWNER diagnostic ignores an unreadable ruleset detail when no codeowner-requiring ruleset applies', () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [],
+    branchRulesets: [],
+    branchRulesetsUnreadable: true,
+    codeownersText: '* @author\n',
+    changedFiles: ['README.md'],
+    prAuthorLogin: 'author',
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, 'not_applicable');
+  assert.equal(summary.codeownerSelfApproval.rulesetBypassUnreadable, false);
+});
+
+// A relevant ruleset detail that *was* successfully read (bypass genuinely
+// not detected, e.g. `current_user_can_bypass: 'never'`) must not be
+// downgraded just because some *other*, unrelated ruleset in the same fetch
+// was unreadable -- `detected` already ruling out this ruleset is real data,
+// not an artifact of the drop.
+test('self-CODEOWNER diagnostic keeps a certain deadlock when the relevant ruleset detail was actually read', () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [
+      {
+        type: 'pull_request',
+        ruleset_id: 1,
+        parameters: { require_code_owner_review: true },
+      },
+    ],
+    branchRulesets: [
+      { id: 1, current_user_can_bypass: 'never', bypass_actors: [] },
+    ],
+    // Some other, unrelated ruleset in the same fetch was unreadable, but
+    // ruleset 1 (the only codeowner-requiring one) was fully read.
+    branchRulesetsUnreadable: true,
+    codeownersText: '* @author\n',
+    changedFiles: ['README.md'],
+    prAuthorLogin: 'author',
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, 'deadlock');
+  assert.equal(
+    summary.codeownerSelfApproval.reason,
+    'pr-author-is-only-direct-codeowner',
+  );
+  assert.equal(summary.codeownerSelfApproval.rulesetBypassUnreadable, false);
 });
 
 test('self-CODEOWNER diagnostic clears when another direct owner exists', () => {
@@ -4394,34 +4485,62 @@ const oneRulesetRule = [{ ruleset_id: 1 }] as Parameters<
 
 test('fetchBranchRulesets skips a 404 ruleset detail without throwing', () => {
   const seen: string[] = [];
-  const result = fetchBranchRulesets('o', 'r', oneRulesetRule, (path) => {
-    seen.push(path);
-    throw ghHttpError(404, 'Not Found');
-  });
+  const result = fetchBranchRulesets(
+    'o',
+    'r',
+    oneRulesetRule,
+    false,
+    (path) => {
+      seen.push(path);
+      throw ghHttpError(404, 'Not Found');
+    },
+  );
   assert.equal(seen.length, 1);
   assert.match(seen[0] ?? '', /\/rulesets\/1$/);
-  assert.deepEqual(result, []);
+  assert.deepEqual(result.value, []);
 });
 
 test('fetchBranchRulesets keeps real rulesets and drops empty results', () => {
   const rules = [{ ruleset_id: 1 }, { ruleset_id: 2 }] as Parameters<
     typeof fetchBranchRulesets
   >[2];
-  const result = fetchBranchRulesets('o', 'r', rules, (path) =>
+  const result = fetchBranchRulesets('o', 'r', rules, false, (path) =>
     path.endsWith('/1') ? { id: 1, current_user_can_bypass: 'always' } : {},
   );
-  assert.deepEqual(result, [{ id: 1, current_user_can_bypass: 'always' }]);
+  assert.deepEqual(result.value, [
+    { id: 1, current_user_can_bypass: 'always' },
+  ]);
+  assert.equal(result.unreadable, false);
 });
 
 test('fetchBranchRulesets propagates a non-404 fetch error instead of coercing to "no ruleset"', () => {
   const boom = ghHttpError(403, 'API rate limit exceeded');
   assert.throws(
     () =>
-      fetchBranchRulesets('o', 'r', oneRulesetRule, () => {
+      fetchBranchRulesets('o', 'r', oneRulesetRule, false, () => {
         throw boom;
       }),
     (error: unknown) => error === boom,
   );
+});
+
+// #1380: GitHub's "Get a repository ruleset" reference documents only
+// `200`/`404`/`500` for this endpoint -- no `403` -- so a `404` here is
+// structurally ambiguous the same way #1377 established for the other two
+// governance reads (see `fetchGovernanceJson`'s doc comment for the full
+// citation set).
+test('fetchBranchRulesets marks a masked-404 ruleset detail as unreadable by default (fail closed)', () => {
+  const result = fetchBranchRulesets('o', 'r', oneRulesetRule, false, () => {
+    throw ghHttpError(404, 'Not Found');
+  });
+  assert.deepEqual(result, { value: [], unreadable: true });
+});
+
+test('fetchBranchRulesets trusts a masked-404 ruleset detail as genuinely empty when ciGate.trustEmptyProtectionReads opts in', () => {
+  const result = fetchBranchRulesets('o', 'r', oneRulesetRule, true, () => {
+    throw ghHttpError(404, 'Not Found');
+  });
+  assert.deepEqual(result, { value: [], unreadable: false });
 });
 
 // #1377: neither `branches/{branch}/protection` nor `rules/branches/{branch}`
@@ -4688,6 +4807,68 @@ test('buildPreMergeReadinessSummary blocks on the ci gate with a specific detail
   assert.equal(
     ciBlocker?.detail,
     'cannot determine required checks: protection/ruleset unreadable',
+  );
+  assert.equal(unreadable.ready, false);
+});
+
+// #1380: a masked-403-as-404 on a codeowner-requiring ruleset's *detail*
+// read must block the required-reviews gate with a specific, actionable
+// detail (mirroring #1377's ci-gate detail above) instead of the generic
+// status dump, when that unreadable ruleset is why the gate cannot resolve.
+test('buildPreMergeReadinessSummary blocks on the required-reviews gate with a specific detail when the ruleset bypass detail is unreadable', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  // The PR author is the sole codeowner (no non-author eligible codeowner,
+  // no actual codeowner approval yet, and the aggregate reviewDecision is
+  // not APPROVED), and the one codeowner-requiring rule references a
+  // ruleset whose detail read was masked-404 and dropped.
+  const branchRules = (
+    fixture.input.branchRules as Record<string, unknown>[]
+  ).map((rule) =>
+    rule.type === 'pull_request' ? { ...rule, ruleset_id: 1 } : rule,
+  );
+  const baseInput = {
+    ...fixture.input,
+    branchRules,
+    branchRulesets: [],
+    reviewDecision: '',
+    codeownersText: '* @contributor\n',
+    reviews: [],
+  };
+
+  const withoutOverride = buildPreMergeReadinessSummary(baseInput, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+  });
+  const reviewerStatesWithout = withoutOverride.reviewerStates as Record<
+    string,
+    unknown
+  >;
+  const selfApprovalWithout =
+    reviewerStatesWithout.codeownerSelfApproval as Record<string, unknown>;
+  assert.equal(selfApprovalWithout.status, 'deadlock');
+  assert.equal(selfApprovalWithout.rulesetBypassUnreadable, false);
+
+  const unreadable = buildPreMergeReadinessSummary(
+    { ...baseInput, branchRulesetsUnreadable: true },
+    { ...fixture.options, includeDispositionEvidence: true },
+  );
+  const reviewerStates = unreadable.reviewerStates as Record<string, unknown>;
+  const selfApproval = reviewerStates.codeownerSelfApproval as Record<
+    string,
+    unknown
+  >;
+  assert.equal(selfApproval.status, 'possible_deadlock');
+  assert.equal(selfApproval.rulesetBypassUnreadable, true);
+  assert.deepEqual(
+    unreadable.blockers,
+    computePreMergeReadinessBlockers(unreadable),
+  );
+  const reviewBlocker = (
+    unreadable.blockers as { gate: string; detail: string }[]
+  ).find((blocker) => blocker.gate === 'required-reviews');
+  assert.equal(
+    reviewBlocker?.detail,
+    'cannot determine CODEOWNER ruleset bypass: ruleset detail unreadable',
   );
   assert.equal(unreadable.ready, false);
 });

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -632,6 +632,43 @@ test('self-CODEOWNER diagnostic keeps a certain deadlock when the relevant rules
   assert.equal(summary.codeownerSelfApproval.rulesetBypassUnreadable, false);
 });
 
+// #1380: two codeowner-requiring rulesets, only one of which 404'd on its
+// detail read. `relevantRulesets.length` (1) falls short of
+// `expectedRulesetCount` (2) -- the exact partial-drop shape the
+// `relevantRulesets.length < expectedRulesetCount` formula (as opposed to a
+// coarser `!detected` check) exists to detect.
+test('self-CODEOWNER diagnostic reports unreadable when only one of several codeowner-requiring rulesets is missing', () => {
+  const summary = summarizeReviewerStates([], {
+    branchRules: [
+      {
+        type: 'pull_request',
+        ruleset_id: 1,
+        parameters: { require_code_owner_review: true },
+      },
+      {
+        type: 'pull_request',
+        ruleset_id: 2,
+        parameters: { require_code_owner_review: true },
+      },
+    ],
+    // Ruleset 2's detail 404'd and was dropped; ruleset 1 was fully read.
+    branchRulesets: [
+      { id: 1, current_user_can_bypass: 'never', bypass_actors: [] },
+    ],
+    branchRulesetsUnreadable: true,
+    codeownersText: '* @author\n',
+    changedFiles: ['README.md'],
+    prAuthorLogin: 'author',
+  });
+
+  assert.equal(summary.codeownerSelfApproval.status, 'possible_deadlock');
+  assert.equal(
+    summary.codeownerSelfApproval.reason,
+    'ruleset-bypass-unreadable',
+  );
+  assert.equal(summary.codeownerSelfApproval.rulesetBypassUnreadable, true);
+});
+
 test('self-CODEOWNER diagnostic clears when another direct owner exists', () => {
   const summary = summarizeReviewerStates([], {
     branchRules: [
@@ -4871,6 +4908,59 @@ test('buildPreMergeReadinessSummary blocks on the required-reviews gate with a s
     'cannot determine CODEOWNER ruleset bypass: ruleset detail unreadable',
   );
   assert.equal(unreadable.ready, false);
+});
+
+// #1380: `rulesetBypassUnreadable` lives on `base` in
+// `summarizeCodeownerSelfApproval` and is therefore present on *every*
+// returned branch, not just the one that names it as the reason. When some
+// other escape path resolves first (here: an ambiguous team-only CODEOWNERS
+// entry, unrelated to ruleset bypass), the required-reviews blocker detail
+// must report the *actual* blocking cause instead of the unreadable-ruleset
+// message, even though the ruleset detail genuinely was unreadable too.
+test('buildPreMergeReadinessSummary reports the real blocking cause, not the unreadable-ruleset message, when a different codeowner escape path resolves first', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const branchRules = (
+    fixture.input.branchRules as Record<string, unknown>[]
+  ).map((rule) =>
+    rule.type === 'pull_request' ? { ...rule, ruleset_id: 1 } : rule,
+  );
+  const unreadable = buildPreMergeReadinessSummary(
+    {
+      ...fixture.input,
+      branchRules,
+      branchRulesets: [],
+      branchRulesetsUnreadable: true,
+      reviewDecision: '',
+      // Team-only CODEOWNERS entry: no direct codeowner user at all, so the
+      // team-ambiguous escape path resolves before the sole-direct-codeowner
+      // (ruleset-bypass-unreadable) branch is ever reached.
+      codeownersText: '* @org/team\n',
+      reviews: [],
+    },
+    { ...fixture.options, includeDispositionEvidence: true },
+  );
+  const reviewerStates = unreadable.reviewerStates as Record<string, unknown>;
+  const selfApproval = reviewerStates.codeownerSelfApproval as Record<
+    string,
+    unknown
+  >;
+  assert.equal(selfApproval.status, 'possible_deadlock');
+  assert.equal(selfApproval.reason, 'team-codeowner-ambiguous');
+  // The underlying fetch genuinely was unreadable -- this field must still
+  // reflect that -- but it must not drive the blocker message below.
+  assert.equal(selfApproval.rulesetBypassUnreadable, true);
+  assert.deepEqual(
+    unreadable.blockers,
+    computePreMergeReadinessBlockers(unreadable),
+  );
+  const reviewBlocker = (
+    unreadable.blockers as { gate: string; detail: string }[]
+  ).find((blocker) => blocker.gate === 'required-reviews');
+  assert.match(
+    reviewBlocker?.detail ?? '',
+    /codeownerSelfApproval\.status="possible_deadlock"/,
+  );
+  assert.doesNotMatch(reviewBlocker?.detail ?? '', /ruleset detail unreadable/);
 });
 
 test('a trusted machine-disposition clears the notice/summary in both merge gates without promoting the author to a global IDD agent (#1182)', () => {

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -928,6 +928,7 @@ const preMergeReadinessFixture = {
       bypassDetected: false,
       bypassMode: 'none',
       currentUserCanBypass: 'never',
+      rulesetBypassUnreadable: false,
     },
     humanChangesRequestedCount: 0,
     blockingChangesRequestedLogins: [],


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

PR #1379 (closing #1377) made the branch-protection and ruleset-list
reads that feed required-check discovery fail closed on a masked
`404`, but intentionally left `fetchBranchRulesets`'s per-ruleset
**detail** read (`GET /repos/{owner}/{repo}/rulesets/{ruleset_id}`)
unchanged, since that read doesn't feed required-check discovery at
all. This PR extends the same masked-404 fail-closed pattern to that
read.

**Research finding (path (a), confirmed):** GitHub's "Get a repository
ruleset" reference documents only `200`/`404`/`500` for this endpoint
— no `403` —
(<https://docs.github.com/en/rest/repos/rules#get-a-repository-ruleset>),
confirmed live, the same masked-403-as-404 pattern `#1377` documented
for the other two reads (GitHub's REST troubleshooting guide's general
404-masks-403 behavior applies here too).

**Scope correction:** tracing every consumer of `branchRulesets`
confirmed `requireCodeOwnerReview` (the CODEOWNER-*requirement* flag)
is computed only from `branchRules` — already fail-closed since
`#1377` — never from `branchRulesets`, so it does not need this fix,
the same way `#1379` found the required-check-discovery claim didn't
apply to `summarizeRequiredChecks`. The real, narrower consumer is
`summarizeRulesetPullRequestBypass`'s ruleset-**bypass** detection
(feeding `summarizeCodeownerSelfApproval`). Its count-matching formula
already prevents a masked-404 drop from producing a false *positive*
(the merge gate never fails open on this gap); the actual defect is a
false-*certainty* diagnostic: `summarizeCodeownerSelfApproval` could
assert a definite `'deadlock'` (no possible escape) when the PR author
is the ruleset's only direct codeowner, even when the ruleset's own
bypass detail could not be read.

**Design:** `fetchBranchRulesets` now returns `{ value, unreadable }`
(mirroring `fetchGovernanceJson`), reusing the existing
`ciGate.trustEmptyProtectionReads` opt-in rather than adding a new
config key. The `unreadable` signal threads through
`summarizeReviewerStates` and `summarizeRulesetPullRequestBypass` into
`summarizeCodeownerSelfApproval`, which downgrades a would-be certain
`'deadlock'` to the already-documented `'possible_deadlock'` status
(new reason `'ruleset-bypass-unreadable'`) instead of inventing a new
status value, and `computePreMergeReadinessBlockers` names the cause
explicitly in the required-reviews blocker detail — gated on the
specific `reason`, not the bare `rulesetBypassUnreadable` boolean
(caught in self-review: that flag lives on the shared `base` object
and is present on every returned branch, so gating on the boolean
alone could misreport an unrelated escape path, e.g. an ambiguous
team-only CODEOWNERS entry, as "ruleset detail unreadable").

## Linked issue

Closes #1380

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`docs/customization.md` / `docs/policy-constants.md` already describe
`ciGate.trustEmptyProtectionReads` generically as covering "the
branch-protection or ruleset reads," and `idd-pre-merge.instructions.md`
already defines `possible_deadlock` as "could not prove ... applicable
pull-request bypass, so fail closed" — both are broad enough to cover
this extension without wording changes.

`idd-ci.instructions.md`'s Required-check discovery step 4 separately
documents the ruleset-**detail** read for its own scope: the *manual*
written-rules fallback algorithm an agent uses when no helper is
available derives required-check names directly from ruleset-detail
payload rules (step 2's "Use detail payload rules only from enforcing
rulesets"), so a masked 404 there genuinely does affect that fallback
path's required-check computation. That is unrelated to this PR's
`fetchBranchRulesets` (the TS helper's implementation, which never
derives required-check names from ruleset detail) and pre-dates this
change, so it was left as-is.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (1953/1953 passing, including new coverage for
      `fetchBranchRulesets`'s unreadable/trusted-empty cases, the
      `possible_deadlock` downgrade and its false-positive-avoidance
      cases, the partial-ruleset-drop case, and an end-to-end
      `buildPreMergeReadinessSummary` / `computePreMergeReadinessBlockers`
      case for the new blocker detail)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-merge readiness checks when ruleset details cannot be read.
  * Prevented unreadable ruleset information from being treated as confirmed bypass availability.
  * Added clearer required-review blocker details for unresolved ruleset bypass checks.

* **Tests**
  * Expanded coverage for partial, irrelevant, and masked ruleset-read scenarios.
  * Updated readiness fixtures and schema validation for the new diagnostic state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->