### PR TITLE
docs(ci): document gh run rerun recovery for advisory-convergence rollups

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -52,3 +52,4 @@ words:
   - Esync
   - minimizable
   - waivable
+  - rollup

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -225,6 +225,19 @@ check name.
 If GH CLI cannot resolve a run ID, use Actions REST endpoints directly
 for the same run before posting a hold.
 
+**`idd-advisory-convergence` specifically** (when a repository hosts it
+as a required check): its own `workflow_dispatch` trigger does NOT
+reliably refresh the PR's required-check rollup for the current HEAD
+SHA, even though the workflow's own header comment frames it as a
+one-click re-check affordance -- a manually dispatched run has no
+`pull_request` context of its own, so it is not reliably associated
+with the PR's HEAD SHA the way a `pull_request` / `pull_request_review`
+/ `pull_request_review_comment`-triggered run is (see that workflow
+file's header comment for the full finding). When this check shows a
+stuck or stale rollup entry, apply the rerun mechanic above -- `gh run
+rerun <run-id>` on the _existing_ PR-linked run for the current HEAD
+SHA -- rather than `workflow_dispatch`.
+
 ## Interpretation
 
 <!-- dprint-ignore-start -->

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -236,7 +236,7 @@ with the PR's HEAD SHA the way a `pull_request` / `pull_request_review`
 [kurone-kito/idd-skill's own dogfooded copy of `.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
 header comment for the full finding -- the investigation prose lives
 only in that upstream file, not in the portable stub this template
-mirrors at `idd-template/.github/workflows/idd-advisory-convergence.yml`.
+ships as your `.github/workflows/idd-advisory-convergence.yml`.
 When this check shows a stuck or stale rollup entry, apply the rerun
 mechanic above -- `gh run rerun <run-id>` on the _existing_ PR-linked
 run for the current HEAD SHA -- rather than `workflow_dispatch`.

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -232,11 +232,14 @@ SHA, even though the workflow's own header comment frames it as a
 one-click re-check affordance -- a manually dispatched run has no
 `pull_request` context of its own, so it is not reliably associated
 with the PR's HEAD SHA the way a `pull_request` / `pull_request_review`
-/ `pull_request_review_comment`-triggered run is (see that workflow
-file's header comment for the full finding). When this check shows a
-stuck or stale rollup entry, apply the rerun mechanic above -- `gh run
-rerun <run-id>` on the _existing_ PR-linked run for the current HEAD
-SHA -- rather than `workflow_dispatch`.
+/ `pull_request_review_comment`-triggered run is. See
+[kurone-kito/idd-skill's own dogfooded copy of `.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
+header comment for the full finding -- the investigation prose lives
+only in that upstream file, not in the portable stub this template
+mirrors at `idd-template/.github/workflows/idd-advisory-convergence.yml`.
+When this check shows a stuck or stale rollup entry, apply the rerun
+mechanic above -- `gh run rerun <run-id>` on the _existing_ PR-linked
+run for the current HEAD SHA -- rather than `workflow_dispatch`.
 
 ## Interpretation
 

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -91,6 +91,51 @@ name: IDD advisory-convergence gate
 # run's conclusion never changes on its own -- a new run has to
 # execute. workflow_dispatch gives that a one-click affordance instead
 # of relying solely on the Actions UI's generic "re-run failed jobs".
+#
+# Correction (kurone-kito/idd-skill#1381): in practice, workflow_dispatch
+# does NOT reliably flip the PR's required-check rollup for its own HEAD
+# SHA, despite the "one-click affordance" framing above -- roughly a
+# dozen PRs in one session each independently hit this and had to
+# rediscover the real fix. Most likely cause: a manually dispatched run
+# has no `pull_request` context of its own, so GitHub associates it with
+# whatever ref the dispatch targets (the default branch, absent an
+# explicit `--ref <pr-branch>`) rather than the PR's HEAD SHA -- this
+# matches GitHub's own documented/reported behavior that a
+# workflow_dispatch (or repository_dispatch) run's check-run can end up
+# associated with the default branch instead of the intended branch, so
+# it never surfaces in that PR's required-check rollup at all even when
+# the run itself succeeds. The verified recovery is `gh run rerun
+# <run-id>` (or `gh run rerun --failed <run-id>`) on the *existing*
+# PR-linked run for the current HEAD SHA -- found via `gh run list
+# --workflow=idd-advisory-convergence.yml --json databaseId,headSha,url`
+# filtered to the PR's HEAD SHA, or the Checks API -- because re-running
+# that run object preserves its original pull_request-family
+# association, so its fresh conclusion does update the rollup. Prefer
+# this whenever an existing run for the current HEAD SHA is available to
+# rerun; fall back to workflow_dispatch only when no such run exists yet
+# for this HEAD (e.g. the check never triggered for it).
+#
+# Concurrency-hardening investigation (kurone-kito/idd-skill#1381): the
+# cancel-in-progress group above can cancel a legitimately in-flight run
+# when a near-simultaneous review event (Copilot/CodeRabbit/Codex
+# posting review comments in quick succession) fires another trigger for
+# the same PR, leaving a stale CANCELLED entry that can race a later
+# genuine SUCCESS in the rollup display. No safe mechanical fix was
+# identified: `cancel-in-progress: false` does not close this gap -- a
+# concurrency group's queue slot still holds only one pending run, so a
+# newer trigger unconditionally evicts (silently drops) whatever was
+# already queued, reproducing the same class of stale-entry race through
+# a different code path rather than eliminating it (a documented,
+# still-open GitHub Actions platform limitation, not something this
+# workflow's own config controls). Narrowing the concurrency group (for
+# example splitting it per trigger type) would defeat the deliberate
+# cross-trigger debouncing already explained in the CI-topology comment
+# above, without addressing the underlying rollup-ordering race, which
+# is orthogonal to how the group happens to be keyed. The operational
+# recovery documented above (`gh run rerun <run-id>`) fully resolves the
+# resulting stale display without a config change, so this workflow
+# keeps its current concurrency configuration rather than trading it for
+# an equally-racy alternative.
 on:
   pull_request:
     types:

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -122,13 +122,35 @@ name: IDD advisory-convergence gate
 # rerun; fall back to workflow_dispatch only when no such run exists yet
 # for this HEAD (e.g. the check never triggered for it).
 #
+# When more than one run exists for the same HEAD SHA (the concurrency
+# race below), do NOT assume the most-recently-completed run is the one
+# the rollup is stuck on -- confirmed empirically (kurone-kito/idd-skill#1381,
+# live during that issue's own PR #1383): the rollup can stay pinned to
+# an *earlier* CANCELLED run's check-run object even after a genuinely
+# later run for the identical SHA completes with SUCCESS. Identify the
+# specific stuck run by matching `gh pr checks <pr-number>`'s reported
+# `completedAt` for this check against `gh run list
+# --workflow=idd-advisory-convergence.yml --json
+# databaseId,headSha,event,conclusion,createdAt` (or the per-check-run
+# `completed_at` from the Checks API) for that same HEAD SHA, then rerun
+# that exact run. If the match is unclear, rerun every run for that HEAD
+# SHA rather than guessing -- rerunning an already-successful run is a
+# harmless no-op, but rerunning the wrong one leaves the rollup stuck.
+#
 # Concurrency-hardening investigation (kurone-kito/idd-skill#1381): the
 # cancel-in-progress group above can cancel a legitimately in-flight run
 # when a near-simultaneous review event (Copilot/CodeRabbit/Codex
 # posting review comments in quick succession) fires another trigger for
 # the same PR, leaving a stale CANCELLED entry that can race a later
-# genuine SUCCESS in the rollup display. No safe mechanical fix was
-# identified: `cancel-in-progress: false` does not close this gap -- a
+# genuine SUCCESS in the rollup display -- directly reproduced during
+# this same issue's own PR #1383: several review-triage replies fired
+# five pull_request_review / pull_request_review_comment runs for one
+# HEAD SHA in quick succession, and the rollup stayed on the *earliest*
+# CANCELLED one even after two later runs for that identical SHA
+# completed with SUCCESS, until that specific earliest run was
+# individually rerun (see the recovery guidance above). No safe
+# mechanical fix was identified: `cancel-in-progress: false` does not
+# close this gap -- a
 # concurrency group's queue slot still holds only one pending run, so a
 # newer trigger unconditionally evicts (silently drops) whatever was
 # already queued, reproducing the same class of stale-entry race through

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -105,12 +105,19 @@ name: IDD advisory-convergence gate
 # associated with the default branch instead of the intended branch, so
 # it never surfaces in that PR's required-check rollup at all even when
 # the run itself succeeds. The verified recovery is `gh run rerun
-# <run-id>` (or `gh run rerun --failed <run-id>`) on the *existing*
-# PR-linked run for the current HEAD SHA -- found via `gh run list
-# --workflow=idd-advisory-convergence.yml --json databaseId,headSha,url`
-# filtered to the PR's HEAD SHA, or the Checks API -- because re-running
-# that run object preserves its original pull_request-family
-# association, so its fresh conclusion does update the rollup. Prefer
+# <run-id>` on the *existing* pull_request / pull_request_review /
+# pull_request_review_comment-triggered run for the current HEAD SHA --
+# found via `gh run list --workflow=idd-advisory-convergence.yml --json
+# databaseId,headSha,event,url` filtered to that exact SHA (not merely
+# a run that happens to share it, and not an older run for an earlier
+# HEAD on the same PR), or the Checks API -- because re-running that
+# run object preserves its original pull_request-family association, so
+# its fresh conclusion does update the rollup. Use the plain whole-run
+# form here, not `gh run rerun --failed <run-id>`: a stale CANCELLED run
+# (see the concurrency-hardening note below) has no job with a `failure`
+# conclusion for `--failed` to retry, so it would silently do nothing
+# and leave the stale entry in place; `--failed` stays appropriate only
+# when the run has genuinely failed jobs to retry. Prefer
 # this whenever an existing run for the current HEAD SHA is available to
 # rerun; fall back to workflow_dispatch only when no such run exists yet
 # for this HEAD (e.g. the check never triggered for it).

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -347,9 +347,9 @@ required-check rollup. See
 header comment for the full finding — this deliberately links the
 upstream source repository's copy, not a relative path to your own
 vendored workflow file, because the fuller investigation prose lives
-only in that dogfooded original; the portable stub this template
-mirrors at `idd-template/.github/workflows/idd-advisory-convergence.yml`
-does not carry it.
+only in that dogfooded original; the portable stub this template ships
+as your `.github/workflows/idd-advisory-convergence.yml` is
+intentionally shorter and does not carry it.
 
 ## Phase ID Compatibility Contract
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -335,8 +335,15 @@ regular PR comment, which is not one of the workflow's triggers
 (`pull_request` push, `pull_request_review` submission, or
 `pull_request_review_comment` created/edited/deleted on a review
 thread), so after posting a waiver a maintainer must also trigger a new
-run explicitly — the Actions UI "Re-run jobs" button, or
-`workflow_dispatch` — for the required check to actually reflect it.
+run on the _existing_ PR-linked check run — the Actions UI "Re-run
+jobs" button, or `gh run rerun <run-id>` — for the required check to
+actually reflect it. `workflow_dispatch` does **not** reliably do this:
+a dispatched run has no `pull_request` context of its own, so GitHub
+associates it with the dispatch ref rather than the PR's HEAD SHA, and
+the resulting run's conclusion can be invisible to that PR's
+required-check rollup (see
+[`.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
+header comment for the full finding).
 
 ## Phase ID Compatibility Contract
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -335,9 +335,10 @@ regular PR comment, which is not one of the workflow's triggers
 (`pull_request` push, `pull_request_review` submission, or
 `pull_request_review_comment` created/edited/deleted on a review
 thread), so after posting a waiver a maintainer must also **re-run the
-existing** PR-linked check run — the Actions UI "Re-run jobs" button,
-or `gh run rerun <run-id>` — for the required check to actually
-reflect it. `workflow_dispatch` does **not** reliably do this:
+existing** PR-linked check run **for the current HEAD SHA** — the
+Actions UI "Re-run jobs" button, or `gh run rerun <run-id>` — for the
+required check to actually reflect it. `workflow_dispatch` does
+**not** reliably do this:
 a dispatched run has no `pull_request` context of its own, so GitHub
 associates it with the dispatch ref rather than the PR's HEAD SHA, and
 the resulting run's conclusion can be invisible to that PR's

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -334,10 +334,10 @@ waiver comment does not by itself turn the check green**: a waiver is a
 regular PR comment, which is not one of the workflow's triggers
 (`pull_request` push, `pull_request_review` submission, or
 `pull_request_review_comment` created/edited/deleted on a review
-thread), so after posting a waiver a maintainer must also trigger a new
-run on the _existing_ PR-linked check run — the Actions UI "Re-run
-jobs" button, or `gh run rerun <run-id>` — for the required check to
-actually reflect it. `workflow_dispatch` does **not** reliably do this:
+thread), so after posting a waiver a maintainer must also **re-run the
+existing** PR-linked check run — the Actions UI "Re-run jobs" button,
+or `gh run rerun <run-id>` — for the required check to actually
+reflect it. `workflow_dispatch` does **not** reliably do this:
 a dispatched run has no `pull_request` context of its own, so GitHub
 associates it with the dispatch ref rather than the PR's HEAD SHA, and
 the resulting run's conclusion can be invisible to that PR's

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -341,9 +341,14 @@ reflect it. `workflow_dispatch` does **not** reliably do this:
 a dispatched run has no `pull_request` context of its own, so GitHub
 associates it with the dispatch ref rather than the PR's HEAD SHA, and
 the resulting run's conclusion can be invisible to that PR's
-required-check rollup (see
-[`.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
-header comment for the full finding).
+required-check rollup. See
+[kurone-kito/idd-skill's own dogfooded copy of `.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
+header comment for the full finding — this deliberately links the
+upstream source repository's copy, not a relative path to your own
+vendored workflow file, because the fuller investigation prose lives
+only in that dogfooded original; the portable stub this template
+mirrors at `idd-template/.github/workflows/idd-advisory-convergence.yml`
+does not carry it.
 
 ## Phase ID Compatibility Contract
 

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -227,11 +227,14 @@ SHA, even though the workflow's own header comment frames it as a
 one-click re-check affordance -- a manually dispatched run has no
 `pull_request` context of its own, so it is not reliably associated
 with the PR's HEAD SHA the way a `pull_request` / `pull_request_review`
-/ `pull_request_review_comment`-triggered run is (see that workflow
-file's header comment for the full finding). When this check shows a
-stuck or stale rollup entry, apply the rerun mechanic above -- `gh run
-rerun <run-id>` on the _existing_ PR-linked run for the current HEAD
-SHA -- rather than `workflow_dispatch`.
+/ `pull_request_review_comment`-triggered run is. See
+[kurone-kito/idd-skill's own dogfooded copy of `.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
+header comment for the full finding -- the investigation prose lives
+only in that upstream file, not in the portable stub this template
+mirrors at `idd-template/.github/workflows/idd-advisory-convergence.yml`.
+When this check shows a stuck or stale rollup entry, apply the rerun
+mechanic above -- `gh run rerun <run-id>` on the _existing_ PR-linked
+run for the current HEAD SHA -- rather than `workflow_dispatch`.
 
 ## Interpretation
 

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -220,6 +220,19 @@ check name.
 If GH CLI cannot resolve a run ID, use Actions REST endpoints directly
 for the same run before posting a hold.
 
+**`idd-advisory-convergence` specifically** (when a repository hosts it
+as a required check): its own `workflow_dispatch` trigger does NOT
+reliably refresh the PR's required-check rollup for the current HEAD
+SHA, even though the workflow's own header comment frames it as a
+one-click re-check affordance -- a manually dispatched run has no
+`pull_request` context of its own, so it is not reliably associated
+with the PR's HEAD SHA the way a `pull_request` / `pull_request_review`
+/ `pull_request_review_comment`-triggered run is (see that workflow
+file's header comment for the full finding). When this check shows a
+stuck or stale rollup entry, apply the rerun mechanic above -- `gh run
+rerun <run-id>` on the _existing_ PR-linked run for the current HEAD
+SHA -- rather than `workflow_dispatch`.
+
 ## Interpretation
 
 <!-- dprint-ignore-start -->

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -231,7 +231,7 @@ with the PR's HEAD SHA the way a `pull_request` / `pull_request_review`
 [kurone-kito/idd-skill's own dogfooded copy of `.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
 header comment for the full finding -- the investigation prose lives
 only in that upstream file, not in the portable stub this template
-mirrors at `idd-template/.github/workflows/idd-advisory-convergence.yml`.
+ships as your `.github/workflows/idd-advisory-convergence.yml`.
 When this check shows a stuck or stale rollup entry, apply the rerun
 mechanic above -- `gh run rerun <run-id>` on the _existing_ PR-linked
 run for the current HEAD SHA -- rather than `workflow_dispatch`.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -848,14 +848,19 @@ green**: a PR comment is not one of this workflow's trigger events and
 a completed run's conclusion never changes on its own, so after
 posting the waiver a maintainer must also trigger a new run — push, a
 fresh review, the Actions UI "Re-run jobs" button on the _existing_
-PR-linked run, or `gh run rerun <run-id>` — for the required check to
-actually reflect it. `workflow_dispatch` does **not** reliably do
-this: a dispatched run has no `pull_request` context of its own, so
-GitHub associates it with the dispatch ref rather than the PR's HEAD
-SHA, and the resulting run's conclusion can be invisible to that PR's
-required-check rollup (see this source repository's own
-`.github/workflows/idd-advisory-convergence.yml` header comment for
-the full finding).
+PR-linked run for the **current HEAD SHA**, or `gh run rerun <run-id>`
+on that same run — for the required check to actually reflect it.
+`workflow_dispatch` does **not** reliably do this: a dispatched run has
+no `pull_request` context of its own, so GitHub associates it with the
+dispatch ref rather than the PR's HEAD SHA, and the resulting run's
+conclusion can be invisible to that PR's required-check rollup. See
+[kurone-kito/idd-skill's own dogfooded copy of `.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
+header comment for the full finding — this deliberately links the
+upstream source repository's copy, not your own vendored workflow
+file: the fuller investigation prose lives only in that dogfooded
+original, and the portable stub this template mirrors at
+`.github/workflows/idd-advisory-convergence.yml` in your own
+repository does not carry it.
 
 ### Optional — mark the vendored helper bundle `linguist-vendored`
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -846,9 +846,16 @@ for some other external check never silently makes this one waivable
 too. **Posting the waiver comment does not by itself turn the check
 green**: a PR comment is not one of this workflow's trigger events and
 a completed run's conclusion never changes on its own, so after
-posting the waiver a maintainer must also trigger a new run — push,
-a fresh review, the Actions UI "Re-run jobs" button, or
-`workflow_dispatch` — for the required check to actually reflect it.
+posting the waiver a maintainer must also trigger a new run — push, a
+fresh review, the Actions UI "Re-run jobs" button on the _existing_
+PR-linked run, or `gh run rerun <run-id>` — for the required check to
+actually reflect it. `workflow_dispatch` does **not** reliably do
+this: a dispatched run has no `pull_request` context of its own, so
+GitHub associates it with the dispatch ref rather than the PR's HEAD
+SHA, and the resulting run's conclusion can be invisible to that PR's
+required-check rollup (see this source repository's own
+`.github/workflows/idd-advisory-convergence.yml` header comment for
+the full finding).
 
 ### Optional — mark the vendored helper bundle `linguist-vendored`
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -347,9 +347,9 @@ required-check rollup. See
 header comment for the full finding — this deliberately links the
 upstream source repository's copy, not a relative path to your own
 vendored workflow file, because the fuller investigation prose lives
-only in that dogfooded original; the portable stub this template
-mirrors at `idd-template/.github/workflows/idd-advisory-convergence.yml`
-does not carry it.
+only in that dogfooded original; the portable stub this template ships
+as your `.github/workflows/idd-advisory-convergence.yml` is
+intentionally shorter and does not carry it.
 
 ## Phase ID Compatibility Contract
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -335,8 +335,15 @@ regular PR comment, which is not one of the workflow's triggers
 (`pull_request` push, `pull_request_review` submission, or
 `pull_request_review_comment` created/edited/deleted on a review
 thread), so after posting a waiver a maintainer must also trigger a new
-run explicitly — the Actions UI "Re-run jobs" button, or
-`workflow_dispatch` — for the required check to actually reflect it.
+run on the _existing_ PR-linked check run — the Actions UI "Re-run
+jobs" button, or `gh run rerun <run-id>` — for the required check to
+actually reflect it. `workflow_dispatch` does **not** reliably do this:
+a dispatched run has no `pull_request` context of its own, so GitHub
+associates it with the dispatch ref rather than the PR's HEAD SHA, and
+the resulting run's conclusion can be invisible to that PR's
+required-check rollup (see
+[`.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
+header comment for the full finding).
 
 ## Phase ID Compatibility Contract
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -335,9 +335,10 @@ regular PR comment, which is not one of the workflow's triggers
 (`pull_request` push, `pull_request_review` submission, or
 `pull_request_review_comment` created/edited/deleted on a review
 thread), so after posting a waiver a maintainer must also **re-run the
-existing** PR-linked check run — the Actions UI "Re-run jobs" button,
-or `gh run rerun <run-id>` — for the required check to actually
-reflect it. `workflow_dispatch` does **not** reliably do this:
+existing** PR-linked check run **for the current HEAD SHA** — the
+Actions UI "Re-run jobs" button, or `gh run rerun <run-id>` — for the
+required check to actually reflect it. `workflow_dispatch` does
+**not** reliably do this:
 a dispatched run has no `pull_request` context of its own, so GitHub
 associates it with the dispatch ref rather than the PR's HEAD SHA, and
 the resulting run's conclusion can be invisible to that PR's

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -334,10 +334,10 @@ waiver comment does not by itself turn the check green**: a waiver is a
 regular PR comment, which is not one of the workflow's triggers
 (`pull_request` push, `pull_request_review` submission, or
 `pull_request_review_comment` created/edited/deleted on a review
-thread), so after posting a waiver a maintainer must also trigger a new
-run on the _existing_ PR-linked check run — the Actions UI "Re-run
-jobs" button, or `gh run rerun <run-id>` — for the required check to
-actually reflect it. `workflow_dispatch` does **not** reliably do this:
+thread), so after posting a waiver a maintainer must also **re-run the
+existing** PR-linked check run — the Actions UI "Re-run jobs" button,
+or `gh run rerun <run-id>` — for the required check to actually
+reflect it. `workflow_dispatch` does **not** reliably do this:
 a dispatched run has no `pull_request` context of its own, so GitHub
 associates it with the dispatch ref rather than the PR's HEAD SHA, and
 the resulting run's conclusion can be invisible to that PR's

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -341,9 +341,14 @@ reflect it. `workflow_dispatch` does **not** reliably do this:
 a dispatched run has no `pull_request` context of its own, so GitHub
 associates it with the dispatch ref rather than the PR's HEAD SHA, and
 the resulting run's conclusion can be invisible to that PR's
-required-check rollup (see
-[`.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
-header comment for the full finding).
+required-check rollup. See
+[kurone-kito/idd-skill's own dogfooded copy of `.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)'s
+header comment for the full finding — this deliberately links the
+upstream source repository's copy, not a relative path to your own
+vendored workflow file, because the fuller investigation prose lives
+only in that dogfooded original; the portable stub this template
+mirrors at `idd-template/.github/workflows/idd-advisory-convergence.yml`
+does not carry it.
 
 ## Phase ID Compatibility Contract
 


### PR DESCRIPTION
# Summary

Documents the verified `gh run rerun <run-id>` recovery for a stuck or
stale `idd-advisory-convergence` required-check rollup, correcting the
workflow's own claim that `workflow_dispatch` is a reliable "one-click"
re-check affordance. Also records the concurrency/trigger-hardening
investigation this issue asked for: no safe mechanical fix was
identified for the `cancel-in-progress` stale-vs-fresh-result race, so
the finding is documented in the workflow's header comment in place of
a config change, per the issue's explicit bias toward the
safe/document-only outcome for this security-relevant CI workflow.

- `.github/workflows/idd-advisory-convergence.yml`: extends the
  existing "workflow_dispatch (manual re-run)" header comment with the
  corrected recovery procedure and the concurrency-hardening
  investigation finding.
- `idd-template/docs/customization.md` / `idd-template/ONBOARDING.md`
  (+ regenerated `docs/customization.md` mirror): the same
  `workflow_dispatch`-vs-`gh run rerun` misconception appeared in the
  maintainer-facing waiver-recovery guidance; corrected there too.
- `idd-template/.github/instructions/idd-ci.instructions.md` (+
  regenerated `.github/instructions/idd-ci.instructions.md` mirror):
  cross-links the existing generic "Rerun mechanics" section so a
  future agent debugging this specific check is steered toward `gh run
  rerun`, not `workflow_dispatch`.
- `.cspell.config.yml`: adds "rollup" to the word list (passes in
  markdown-scoped content elsewhere in this repo, but not the
  yaml-scoped dictionary).

## Linked issue

Closes #1381

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

At least a dozen PRs in one autonomous-loop session on 2026-07-15 each
independently hit the same friction and had to rediscover the fix from
the Checks API. The root-cause explanation in the workflow header
(a `workflow_dispatch` run has no `pull_request` context, so GitHub
associates it with the dispatch ref rather than the PR's HEAD SHA) is
corroborated by GitHub's own documented/reported behavior for
`workflow_dispatch`/`repository_dispatch` runs and required status
checks (see GitHub Community Discussions #53506, #8336, #26127, #5435
for the concurrency/cancellation research behind the investigation
finding).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how to refresh the required advisory-convergence check after applying a waiver.
  * Added guidance to rerun the existing pull-request-linked workflow through the Actions UI or CLI.
  * Documented limitations of manually dispatched workflow runs and expanded troubleshooting guidance.
* **Chores**
  * Added `rollup` to the approved spelling dictionary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->