### PR TITLE
docs(idd-ci): fold topology-safety gate into wake-up bullet itself

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -272,16 +272,20 @@ keeps the **wait itself cheap**: the dominant cost of a wait is each
 re-invocation's context re-read (worse once it crosses the prompt-cache TTL,
 as CI/e2e waits routinely do), not the idle time.
 
-**Portability**: prefer a synchronous / blocking wait in the worker's own
-turn under supervisor/worker or multi-agent topologies — a background
-wait's completion notification often reaches only the supervisor, so the
-worker's turn ends and stalls until re-prompted (the background-wait
-resumption caveat). Background the watch (below) only when the topology
-is known to route completion back to the same turn.
+**Portability**: under supervisor/worker or multi-agent topologies, a
+background wait's completion notification often reaches only the
+supervisor, so the worker's turn ends and stalls until re-prompted (the
+background-wait resumption caveat). The topology-safety condition this
+implies is folded directly into the first bullet below, not just stated
+here.
 
-- **No interim polling turns** — background the watch, or schedule one wake at
-  the **expected** completion interval; do not insert "is it done yet?" turns
-  or peek at an empty watch buffer between wakes.
+- **No interim polling turns** — schedule one wake at the **expected**
+  completion interval, or background the watch only if the topology is
+  confirmed to route completion back to this turn; otherwise default to a
+  synchronous / blocking wait here. Do not insert "is it done yet?" turns,
+  peek at an empty watch buffer, or end this turn assuming an unconfirmed
+  background/async notification resumes it — that stalls silently under
+  supervisor/worker topologies.
 - **Batch post-wait actions** into a single turn once the wait resolves
   (disposition, replies, marker, next gate together — not one round-trip each).
 - **Scope post-fix re-validation to the changed surface** when the change is

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -267,16 +267,20 @@ keeps the **wait itself cheap**: the dominant cost of a wait is each
 re-invocation's context re-read (worse once it crosses the prompt-cache TTL,
 as CI/e2e waits routinely do), not the idle time.
 
-**Portability**: prefer a synchronous / blocking wait in the worker's own
-turn under supervisor/worker or multi-agent topologies — a background
-wait's completion notification often reaches only the supervisor, so the
-worker's turn ends and stalls until re-prompted (the background-wait
-resumption caveat). Background the watch (below) only when the topology
-is known to route completion back to the same turn.
+**Portability**: under supervisor/worker or multi-agent topologies, a
+background wait's completion notification often reaches only the
+supervisor, so the worker's turn ends and stalls until re-prompted (the
+background-wait resumption caveat). The topology-safety condition this
+implies is folded directly into the first bullet below, not just stated
+here.
 
-- **No interim polling turns** — background the watch, or schedule one wake at
-  the **expected** completion interval; do not insert "is it done yet?" turns
-  or peek at an empty watch buffer between wakes.
+- **No interim polling turns** — schedule one wake at the **expected**
+  completion interval, or background the watch only if the topology is
+  confirmed to route completion back to this turn; otherwise default to a
+  synchronous / blocking wait here. Do not insert "is it done yet?" turns,
+  peek at an empty watch buffer, or end this turn assuming an unconfirmed
+  background/async notification resumes it — that stalls silently under
+  supervisor/worker topologies.
 - **Batch post-wait actions** into a single turn once the wait resolves
   (disposition, replies, marker, next gate together — not one round-trip each).
 - **Scope post-fix re-validation to the changed surface** when the change is


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Rewrites the "No interim polling turns" bullet in `idd-ci.instructions.md`'s
"Wake-up discipline" section so the topology-safety gate lives directly in
the actionable bullet, not only in the "Portability" paragraph above it. The
bullet now states the fail-safe default (synchronous/blocking wait when the
topology is not confirmed) and names the observed failure shape — an agent
ending its own turn to "wait for" a background/async notification that never
resumes it — as a recognizable anti-pattern. The Portability paragraph is
trimmed to remove the now-redundant restatement, both to avoid duplication
and to stay within the `bundle-review` byte budget after the bullet grew.
Regenerated the repo-root mirror via `node scripts/sync-docs.mjs --apply`.

## Linked issue

Closes #1384

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Three sibling subagents in one session each fell into exactly the failure
this section already named in prose but not in its bullet list: each ended
its own turn saying it would "wait for" a background/async notification and
silently stalled until a human supervisor noticed and resumed it. #1384's
body has the full empirical account. This PR is documentation-only — no
helper/script behavior changes.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`lint:minimum`: 1953/1953 tests pass, 0 lint/markdown/cspell issues)
- [x] `pnpm test` (included in `lint:minimum` above)
- [x] `node scripts/audit-docs.mjs --check` (passed, no bundle-budget drift)
- [x] `pnpm run docs:sync:check` (mirrors up to date)
- [x] `node scripts/idd-doctor.mjs` (passed; only pre-existing environment warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
