### PR TITLE
docs(idd-work): add B3-entry checkpoint for the B2 plan comment

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -206,6 +206,13 @@ plan comment and verified claim.
 
 ## B3 — Implement
 
+**Plan-comment checkpoint**: before writing any implementation code,
+confirm the B2 plan comment already exists on the issue. If it does
+not, stop and return to B2. If code was already written before this
+checkpoint is noticed, disclose the ordering deviation on the issue,
+post the plan retroactively with an explicit note about the
+reordering, and run the C1 critique pass against the completed diff.
+
 Implement the plan. Before each commit, run **fix-validate**.
 
 Keep commits atomic — one logical change per commit.

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -201,6 +201,13 @@ plan comment and verified claim.
 
 ## B3 — Implement
 
+**Plan-comment checkpoint**: before writing any implementation code,
+confirm the B2 plan comment already exists on the issue. If it does
+not, stop and return to B2. If code was already written before this
+checkpoint is noticed, disclose the ordering deviation on the issue,
+post the plan retroactively with an explicit note about the
+reordering, and run the C1 critique pass against the completed diff.
+
 Implement the plan. Before each commit, run **fix-validate**.
 
 Keep commits atomic — one logical change per commit.


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Adds a B3-entry checkpoint to `idd-work.instructions.md` that requires
confirming the B2 plan comment already exists on the issue before any
implementation code is written, with a late-discovery remediation
sentence for when code was already written first.

## Linked issue

Closes #1388

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

A downstream adopter's field run had a worker implement a change first
and only reconstruct and post the B2 plan comment afterward
(self-caught and disclosed before publication) — evidence that "plan
before code" ordering yields to implementation pressure without an
explicit gate. B3 previously opened straight into "Implement the
plan." with no self-check that the plan comment exists.

An independent critique pass (per B2) flagged that a new `### B3.0 —`
heading (mirroring `### B2.0 — Supersession re-check`) would
structurally nest all of B3's unrelated content (commit atomicity,
de-duplication-refactor guidance, validation-failure guidance, hold
rules) under "Plan-comment checkpoint" until the next heading. Revised
to a `**Plan-comment checkpoint**:` bold-labeled paragraph instead,
matching the guidance-block style B3 already uses later in the same
section (`**De-duplication refactors**`, `**Unexpected validation
failures**`), placed first so B3 still opens with the checkpoint.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a planning checkpoint to the development workflow before implementation begins.
  * Clarified the required actions when a plan is missing or implementation starts out of order.
  * Added guidance to document deviations and complete a critique pass when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->