### PR TITLE
docs(idd): require invariant-first resume conditions for holds

### DIFF
--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -77,6 +77,11 @@ blocking condition in `Open blockers`, and the resume condition in
 `Next action`. Long holds still need claim heartbeats; the digest does
 not reset the claim stale clock.
 
+For an externally owned blocker (sibling PR/issue, external check),
+phrase the resume condition as the checkable invariant (e.g. a named
+check passing on main), not the sibling alone — the proxy may resolve
+differently, or never.
+
 ## Roadmap markers
 
 For roadmap markers and their usage rules, see

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -77,10 +77,10 @@ blocking condition in `Open blockers`, and the resume condition in
 `Next action`. Long holds still need claim heartbeats; the digest does
 not reset the claim stale clock.
 
-For an externally owned blocker (sibling PR/issue, external check),
-phrase the resume condition as the checkable invariant (e.g. a named
-check passing on main), not the sibling alone — the proxy may resolve
-differently, or never.
+For an externally owned blocker (sibling PR/issue, maintainer-owned
+check, base-branch health), phrase the resume condition as the checkable
+invariant (e.g. a named check passing on main), not the sibling alone —
+the proxy may resolve differently, or never.
 
 ## Roadmap markers
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -358,8 +358,8 @@ proceeding to F — do not skip triage.
   if the policy is `hold`, post a hold comment on the PR documenting the
   pre-existing failure and stop. A maintainer must resolve or bypass the
   failing check; do not auto-continue or treat as passed without human
-  confirmation. See the externally-owned-blocker rule in
-  `idd-overview-appendix.instructions.md`.
+  confirmation. Phrase the resume condition per the invariant-first
+  guidance in `idd-overview-appendix.instructions.md` (Hold / suspend).
 - **On cancelled / timed_out / code-caused**: fix, run **fix-validate**,
   commit, return to E11
 - **On cancelled / timed_out / infra**: apply `ciWait.rerunPolicy`.

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -358,7 +358,8 @@ proceeding to F — do not skip triage.
   if the policy is `hold`, post a hold comment on the PR documenting the
   pre-existing failure and stop. A maintainer must resolve or bypass the
   failing check; do not auto-continue or treat as passed without human
-  confirmation.
+  confirmation. See the externally-owned-blocker rule in
+  `idd-overview-appendix.instructions.md`.
 - **On cancelled / timed_out / code-caused**: fix, run **fix-validate**,
   commit, return to E11
 - **On cancelled / timed_out / infra**: apply `ciWait.rerunPolicy`.

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -202,7 +202,7 @@
         ".github/instructions/idd-review-snapshot.instructions.md",
         ".github/instructions/idd-review-triage.instructions.md"
       ],
-      "limitBytes": 115300
+      "limitBytes": 115800
     },
     {
       "id": "bundle-merge",

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -72,6 +72,11 @@ blocking condition in `Open blockers`, and the resume condition in
 `Next action`. Long holds still need claim heartbeats; the digest does
 not reset the claim stale clock.
 
+For an externally owned blocker (sibling PR/issue, external check),
+phrase the resume condition as the checkable invariant (e.g. a named
+check passing on main), not the sibling alone — the proxy may resolve
+differently, or never.
+
 ## Roadmap markers
 
 For roadmap markers and their usage rules, see

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -72,10 +72,10 @@ blocking condition in `Open blockers`, and the resume condition in
 `Next action`. Long holds still need claim heartbeats; the digest does
 not reset the claim stale clock.
 
-For an externally owned blocker (sibling PR/issue, external check),
-phrase the resume condition as the checkable invariant (e.g. a named
-check passing on main), not the sibling alone — the proxy may resolve
-differently, or never.
+For an externally owned blocker (sibling PR/issue, maintainer-owned
+check, base-branch health), phrase the resume condition as the checkable
+invariant (e.g. a named check passing on main), not the sibling alone —
+the proxy may resolve differently, or never.
 
 ## Roadmap markers
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -353,7 +353,8 @@ proceeding to F — do not skip triage.
   if the policy is `hold`, post a hold comment on the PR documenting the
   pre-existing failure and stop. A maintainer must resolve or bypass the
   failing check; do not auto-continue or treat as passed without human
-  confirmation.
+  confirmation. See the externally-owned-blocker rule in
+  `idd-overview-appendix.instructions.md`.
 - **On cancelled / timed_out / code-caused**: fix, run **fix-validate**,
   commit, return to E11
 - **On cancelled / timed_out / infra**: apply `ciWait.rerunPolicy`.

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -353,8 +353,8 @@ proceeding to F — do not skip triage.
   if the policy is `hold`, post a hold comment on the PR documenting the
   pre-existing failure and stop. A maintainer must resolve or bypass the
   failing check; do not auto-continue or treat as passed without human
-  confirmation. See the externally-owned-blocker rule in
-  `idd-overview-appendix.instructions.md`.
+  confirmation. Phrase the resume condition per the invariant-first
+  guidance in `idd-overview-appendix.instructions.md` (Hold / suspend).
 - **On cancelled / timed_out / code-caused**: fix, run **fix-validate**,
   commit, return to E11
 - **On cancelled / timed_out / infra**: apply `ciWait.rerunPolicy`.


### PR DESCRIPTION
# Summary

Amend the hold contract so that a hold on an **externally owned**
blocker (a sibling PR/issue, a maintainer-owned check, base-branch
health) states the resume condition as the directly checkable
invariant itself, not a proxy artifact — a named sibling PR/issue can
resolve differently from, or never resolve while, the invariant it
stands in for (e.g. closed unmerged after a different PR fixes the
same regression first), which can strand an unsupervised worker
polling the wrong thing for its entire wait bound. Also cross-references
the new rule from the E15 pre-existing-failure hold in
`idd-review-fix.instructions.md`.

## Linked issue

Closes #1392

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Byte-budget ratchet callout**: this PR raises
`audit/sync-manifest.json`'s `bundle-review.limitBytes` from `115300` to
`115800` (+500 bytes, ~0.43%). `bundle-review` was already at 99.96%
utilization (115257/115300 bytes) *before* this change — a pre-existing
near-ceiling condition caused by `idd-overview-core.instructions.md`'s
`{{...}}` template-placeholder expansion (invisible when measuring the
raw `idd-template/` source directly; only visible in the generated,
banner-stripped bundle total that `audit-docs.mjs` actually checks).
Per the "Near-ceiling exception" in `docs/policy-constants.md`, the new
content was compressed to its minimal legible form first (~280 bytes,
down from an initial ~450-byte draft) rather than defaulting to a
ratchet bump. That compressed addition still overflowed the remaining
~43 bytes by ~239 bytes, so a small ratchet was required. Trimming an
unrelated existing bundle-review member instead (e.g.
`idd-review-triage.instructions.md`) was considered and declined: every
bundle-review/bundle-merge member is independently documented as a
"high-contention shared file" under concurrent autopilot load, and this
repository had several sibling sessions concurrently active on other
issues at claim time — an unrelated trim there would widen this PR's
diff beyond its stated scope and raise the odds of a real merge
conflict with a concurrent session, for the sake of avoiding an
already-tiny (0.43%) ratchet.

An independent critique subagent reviewed the diff (per the B2/C1
critique-pass protocol): it confirmed both acceptance criteria are met,
ran the full test suite (1953/1953 passing) and doc tooling
independently, flagged one wording ambiguity (missing antecedent for
"the sibling") which was fixed, and raised the ratchet-vs-trim question
addressed above.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
