### PR TITLE
docs(issue-authoring): update roadmap tracks when splitting a child

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -162,7 +162,13 @@ Then apply these checks in order:
    refine task-list entries there instead of creating a competing
    umbrella.
 3. If an existing issue is close but too broad, split follow-up work
-   out of it rather than widening the original issue further.
+   out of it rather than widening the original issue further. When the
+   split issue is a roadmap child, update the parent roadmap's
+   `## Tracks` list in the same authoring action — add the new issue's
+   link and adjust any sequencing notes (a short dated note is the
+   observed good pattern) — subject to the claim-state precondition
+   above applied to the roadmap issue's own claim/PR state, and record
+   the provenance in the new issue's body (e.g., `Split out of #<n>`).
 4. If an existing issue has an **active claim**, an open PR, or is
    otherwise being actively executed, do **not** edit its body or
    repurpose it (see the claim-state precondition, which exempts

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -163,12 +163,13 @@ Then apply these checks in order:
    umbrella.
 3. If an existing issue is close but too broad, split follow-up work
    out of it rather than widening the original issue further. When the
-   split issue is a roadmap child, update the parent roadmap's
-   `## Tracks` list in the same authoring action — add the new issue's
-   link and adjust any sequencing notes (a short dated note is the
-   observed good pattern) — subject to the claim-state precondition
-   above applied to the roadmap issue's own claim/PR state, and record
-   the provenance in the new issue's body (e.g., `Split out of #<n>`).
+   issue being split is itself a roadmap child, update the parent
+   roadmap's `## Tracks` list in the same authoring action — add the
+   new issue's link and adjust any sequencing notes (a short dated note
+   is the observed good pattern) — subject to the claim-state
+   precondition above applied to the roadmap issue's own claim/PR
+   state, and record the provenance in the new issue's body (e.g.,
+   `Split out of #<n>`).
 4. If an existing issue has an **active claim**, an open PR, or is
    otherwise being actively executed, do **not** edit its body or
    repurpose it (see the claim-state precondition, which exempts

--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -173,3 +173,9 @@ Apply one outcome:
   before A2 after reporting a non-autonomous gap, even if the
   repository does not have the blocker labels, so the same unattended
   run cannot select child work under a roadmap that needs human input.
+
+**Child issue split.** A further roadmap-currency trigger, orthogonal to
+the three outcomes above: when a child issue is split into two or more
+issues, bring the roadmap task list and sequencing notes current in the
+same action, per the issue-authoring contract's same-action rule
+(`skills/issue-authoring/references/contract.md`).

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -521,7 +521,14 @@ Then apply these checks in order:
    refine task-list entries there instead of creating a competing
    umbrella.
 3. If an existing issue is close but too broad, split follow-up work out
-   of it rather than widening the original issue further.
+   of it rather than widening the original issue further. When the
+   split issue is a roadmap child, the skill should update the parent
+   roadmap's `## Tracks` list in the same authoring action — add the
+   new issue's link and adjust any sequencing notes (a short dated note
+   is the observed good pattern) — subject to the claim-state
+   precondition above applied to the roadmap issue's own claim/PR
+   state, and record the provenance in the new issue's body (e.g.,
+   `Split out of #<n>`).
 4. If an existing issue has an active claim, an open PR, or is
    otherwise being actively executed, do not edit its body or repurpose
    it (see the claim-state precondition, which exempts stale/reclaimable

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -522,13 +522,13 @@ Then apply these checks in order:
    umbrella.
 3. If an existing issue is close but too broad, split follow-up work out
    of it rather than widening the original issue further. When the
-   split issue is a roadmap child, the skill should update the parent
-   roadmap's `## Tracks` list in the same authoring action — add the
-   new issue's link and adjust any sequencing notes (a short dated note
-   is the observed good pattern) — subject to the claim-state
-   precondition above applied to the roadmap issue's own claim/PR
-   state, and record the provenance in the new issue's body (e.g.,
-   `Split out of #<n>`).
+   issue being split is itself a roadmap child, the skill should update
+   the parent roadmap's `## Tracks` list in the same authoring action —
+   add the new issue's link and adjust any sequencing notes (a short
+   dated note is the observed good pattern) — subject to the
+   claim-state precondition above applied to the roadmap issue's own
+   claim/PR state, and record the provenance in the new issue's body
+   (e.g., `Split out of #<n>`).
 4. If an existing issue has an active claim, an open PR, or is
    otherwise being actively executed, do not edit its body or repurpose
    it (see the claim-state precondition, which exempts stale/reclaimable

--- a/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
@@ -168,3 +168,9 @@ Apply one outcome:
   before A2 after reporting a non-autonomous gap, even if the
   repository does not have the blocker labels, so the same unattended
   run cannot select child work under a roadmap that needs human input.
+
+**Child issue split.** A further roadmap-currency trigger, orthogonal to
+the three outcomes above: when a child issue is split into two or more
+issues, bring the roadmap task list and sequencing notes current in the
+same action, per the issue-authoring contract's same-action rule
+(`skills/issue-authoring/references/contract.md`).

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -162,7 +162,13 @@ Then apply these checks in order:
    refine task-list entries there instead of creating a competing
    umbrella.
 3. If an existing issue is close but too broad, split follow-up work
-   out of it rather than widening the original issue further.
+   out of it rather than widening the original issue further. When the
+   split issue is a roadmap child, update the parent roadmap's
+   `## Tracks` list in the same authoring action — add the new issue's
+   link and adjust any sequencing notes (a short dated note is the
+   observed good pattern) — subject to the claim-state precondition
+   above applied to the roadmap issue's own claim/PR state, and record
+   the provenance in the new issue's body (e.g., `Split out of #<n>`).
 4. If an existing issue has an **active claim**, an open PR, or is
    otherwise being actively executed, do **not** edit its body or
    repurpose it (see the claim-state precondition, which exempts

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -163,12 +163,13 @@ Then apply these checks in order:
    umbrella.
 3. If an existing issue is close but too broad, split follow-up work
    out of it rather than widening the original issue further. When the
-   split issue is a roadmap child, update the parent roadmap's
-   `## Tracks` list in the same authoring action — add the new issue's
-   link and adjust any sequencing notes (a short dated note is the
-   observed good pattern) — subject to the claim-state precondition
-   above applied to the roadmap issue's own claim/PR state, and record
-   the provenance in the new issue's body (e.g., `Split out of #<n>`).
+   issue being split is itself a roadmap child, update the parent
+   roadmap's `## Tracks` list in the same authoring action — add the
+   new issue's link and adjust any sequencing notes (a short dated note
+   is the observed good pattern) — subject to the claim-state
+   precondition above applied to the roadmap issue's own claim/PR
+   state, and record the provenance in the new issue's body (e.g.,
+   `Split out of #<n>`).
 4. If an existing issue has an **active claim**, an open PR, or is
    otherwise being actively executed, do **not** edit its body or
    repurpose it (see the claim-state precondition, which exempts


### PR DESCRIPTION
# Summary

Names "a child issue was split into two or more issues" as an explicit
same-action trigger for keeping a parent roadmap's `## Tracks` list and
sequencing notes current, in both the issue-authoring contract and the
roadmap-audit instructions. Previously only a downstream repository's
local precedent covered this case, invisible to any agent that had not
seen that repository's history.

## Linked issue

Closes #1403

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`docs/issue-authoring-skill.md` mirrors `skills/issue-authoring/references/contract.md`
in prose, but is not auto-generated by `sync-docs.mjs` for this section
(the sync manifest only does a fixed-anchor presence check between them,
not a full-content diff) -- so it needed its own matching manual edit,
written in that file's existing third-person voice, or it would have
silently drifted from the canonical contract on exactly the kind of
staleness this issue is about preventing.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
