### PR TITLE
docs(onboarding): add opencode guidance with config recipe

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -929,7 +929,10 @@ any copied file.
 
 By default, leave the repository with root entry files for every
 manually-routed non-Copilot agent named in `docs/idd-workflow.md`:
-`CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`.
+`CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`. `AGENTS.md` is the shared
+agents.md-standard entry for both Codex CLI and OpenCode — OpenCode
+auto-loads it natively, so no dedicated root file is needed for
+OpenCode.
 
 - If the file already exists, append or adapt an IDD section without
   replacing unrelated repository guidance.

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -69,12 +69,17 @@ Before starting IDD work, open
 phase file manually when the current step changes.
 ```
 
-### AGENTS.md (for Codex CLI)
+### AGENTS.md (for Codex CLI and OpenCode)
+
+`AGENTS.md` is the shared agents.md-standard entry file for both Codex
+CLI and OpenCode: each auto-loads `AGENTS.md` from the repository root
+natively, so this single file covers both runtimes and OpenCode needs
+no dedicated root file of its own.
 
 If `AGENTS.md` already exists, add the shared IDD workflow section and
-keep the wording explicit that Codex CLI agents should manually open
-`.github/instructions/idd-overview-core.instructions.md` and the routed
-phase file before starting IDD work.
+keep the wording explicit that Codex CLI and OpenCode agents should
+manually open `.github/instructions/idd-overview-core.instructions.md`
+and the routed phase file before starting IDD work.
 
 If `AGENTS.md` does not exist, create a minimal file such as:
 
@@ -99,6 +104,42 @@ Before starting IDD work, open
 `.github/instructions/idd-overview-core.instructions.md`. Open the routed
 phase file manually when the current step changes.
 ```
+
+#### OpenCode: optional `opencode.json` recipe
+
+OpenCode's native `AGENTS.md` auto-load already delivers the IDD
+workflow stub above to every session; the steps below are an
+**optional** Copilot-parity recipe, not a requirement.
+
+- OpenCode's `opencode.json` `instructions` array can point at
+  additional rule files, but every listed file loads
+  **unconditionally** into every session — unlike GitHub Copilot's
+  `applyTo` frontmatter, which OpenCode does not read (frontmatter in
+  a loaded file is inert there). Skip this recipe for weak or local
+  models (see
+  [Weak-model guardrails](../idd-workflow.md#weak-model-guardrails)):
+  the extra context can crowd out task-relevant content instead of
+  helping.
+- When an operator does opt in, list only the shared entry file, not
+  the whole `.github/instructions/` directory, to approximate the
+  Copilot `applyTo` scoping without flooding every session:
+
+  ```json
+  {
+    "$schema": "https://opencode.ai/config.json",
+    "instructions": [".github/instructions/idd-overview-core.instructions.md"]
+  }
+  ```
+
+- OpenCode discovers Claude-compatible skill bundles from
+  `.claude/skills/` (and `.opencode/skills/`), so the `issue-authoring`
+  skill installed under `.claude/skills/issue-authoring/` in Step 2 is
+  already available to OpenCode without extra configuration.
+- If a target repository runs OpenCode as an autonomous worker under
+  its own GitHub identity (not just an interactive assistant), add
+  that login to `trustedMarkerActors` (and the advisory-bot lists if
+  it also reviews) in `.github/idd/config.json` — a config-values edit
+  only; `schemas/policy.schema.json` stays agent-agnostic.
 
 ### GEMINI.md
 
@@ -221,8 +262,15 @@ checks, confirm the detailed items below.
 - [ ] `CLAUDE.md` exists and references `docs/idd-workflow.md`, unless
       the operator explicitly opted out of creating it.
 - [ ] `AGENTS.md` exists and references `docs/idd-workflow.md`, unless
-      the operator explicitly opted out of creating it.
+      the operator explicitly opted out of creating it; this single
+      file covers both Codex CLI and OpenCode.
 - [ ] `GEMINI.md` exists and references `docs/idd-workflow.md`, unless
       the operator explicitly opted out of creating it.
 - [ ] If `.github/copilot-instructions.md` existed before onboarding,
       it now includes the IDD workflow reference as well.
+- [ ] If the operator opted into the optional `opencode.json`
+      Copilot-parity recipe, the target repository's `opencode.json`
+      lists only
+      `.github/instructions/idd-overview-core.instructions.md`, and no
+      `opencode.json` file was added to the target repository unless
+      the operator explicitly requested one.

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -275,6 +275,6 @@ checks, confirm the detailed items below.
 - [ ] If the operator opted into the optional `opencode.json`
       Copilot-parity recipe, the target repository's `opencode.json`
       lists only
-      `.github/instructions/idd-overview-core.instructions.md`, and no
-      `opencode.json` file was added to the target repository unless
-      the operator explicitly requested one.
+      `.github/instructions/idd-overview-core.instructions.md`.
+- [ ] If the operator did not opt into that recipe, no `opencode.json`
+      file was added to the target repository as part of onboarding.

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -131,10 +131,14 @@ workflow stub above to every session; the steps below are an
   }
   ```
 
-- OpenCode discovers Claude-compatible skill bundles from
-  `.claude/skills/` (and `.opencode/skills/`), so the `issue-authoring`
-  skill installed under `.claude/skills/issue-authoring/` in Step 2 is
-  already available to OpenCode without extra configuration.
+- If the operator installs the optional `issue-authoring` companion
+  from Step 2 under a directory OpenCode reads natively —
+  `.claude/skills/` or `.opencode/skills/` — it is already available to
+  OpenCode without extra configuration. Step 2 also allows other
+  runtime-specific locations (for example `.github/skills/`); OpenCode
+  does not discover a bundle placed only in one of those, so copy or
+  symlink it into `.claude/skills/` or `.opencode/skills/` as well when
+  OpenCode also needs it.
 - If a target repository runs OpenCode as an autonomous worker under
   its own GitHub identity (not just an interactive assistant), add
   that login to `trustedMarkerActors` (and the advisory-bot lists if

--- a/tests/non-node-fallback.test.mts
+++ b/tests/non-node-fallback.test.mts
@@ -391,7 +391,7 @@ test('onboarding links extracted agent-entry and verification guidance', () => {
   );
   assert.match(
     reference,
-    /### AGENTS\.md \(for Codex CLI\)/,
+    /### AGENTS\.md \(for Codex CLI and OpenCode\)/,
     'agent-entry reference must keep the AGENTS.md example outside ONBOARDING',
   );
   assert.match(


### PR DESCRIPTION
# Summary

Add OpenCode onboarding guidance to the onboarding materials, per the
OpenCode support roadmap (#1413). `AGENTS.md` is documented as the
shared agents.md-standard entry for both Codex CLI and OpenCode (no
new root file needed), and the onboarding companion doc gains an
optional `opencode.json` Copilot-parity recipe with explicit guardrails
(unconditional-load warning + weak-model skip note, skills-discovery
note, `trustedMarkerActors` note for autonomous OpenCode workers).

## Linked issue

Closes #1418

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Operator decisions recorded on the parent roadmap (#1413): documentation
and example snippets only — no `opencode.json` template file enters
`idd-template/` or the `idd-onboard` core file set. This PR follows
that constraint: the `opencode.json` example appears exactly once, as a
fenced snippet inside the onboarding companion doc, and no actual
`opencode.json` file exists anywhere in the repository (verified by
`find`/`grep`).

A B2 critique pass caught that retitling the `### AGENTS.md (for Codex
CLI)` heading to include OpenCode breaks a pinned-regex test in
`tests/non-node-fallback.test.mts` (asserted against verbatim heading
text, run by CI via `node --test tests/*.test.mts`); that test's regex
is updated in the same commit.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
