### PR TITLE
docs(idd-ci): document action_required advisory-convergence recovery

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -250,7 +250,8 @@ rerun <run-id>` the _existing_ non-bot `pull_request`-triggered run that
 already executed for this HEAD, subject to `ciWait.rerunPolicy` (a `hold`
 policy inspects instead). Do **not** rerun the gated bot run: a re-run
 keeps the original actor's privileges and re-enters `action_required`
-(approve it via `POST /actions/runs/{run_id}/approve` if it must run).
+(approve it via `POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve`
+if it must run).
 The check also self-heals on the next non-bot trigger -- a push, or a
 **review-thread** disposition reply (`pull_request_review_comment`), but
 not a regular-comment (PATH B) one, since the workflow ignores

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -242,19 +242,20 @@ mechanic above -- `gh run rerun <run-id>` on the _existing_ PR-linked
 run for the current HEAD SHA -- rather than `workflow_dispatch`.
 
 A second cause leaves the same check stuck: GitHub gates a bot-triggered
-run -- for example Copilot posting its review via a `pull_request_review`
-/ `pull_request_review_comment` event -- to `action_required`, so it
-waits for approval instead of running. Subscribing to a review trigger
-is thus not the same as running on it, and the bot's review event does
-**not** by itself refresh the check for the current HEAD. Recovery does
-not approve that gated run: instead `gh run rerun <run-id>` the
-_existing_ PR-linked (`pull_request`-family) run for the current HEAD --
-the one that already executed -- so it re-evaluates now that the bot has
-reviewed; the check also self-heals on the next non-bot trigger (a push,
-or an E-phase disposition reply). So the `action_required` row in the
-Interpretation table below does not apply here: rerunning the already-run
-PR-linked run clears the rollup, with no hold or gated-run approval
-needed.
+run -- e.g. Copilot posting its review via a `pull_request_review` /
+`pull_request_review_comment` event -- to `action_required`, so it waits
+for approval instead of running, and the bot's review event does **not**
+by itself refresh the check for the current HEAD. To recover, `gh run
+rerun <run-id>` the _existing_ non-bot `pull_request`-triggered run that
+already executed for this HEAD, subject to `ciWait.rerunPolicy` (a `hold`
+policy inspects instead). Do **not** rerun the gated bot run: a re-run
+keeps the original actor's privileges and re-enters `action_required`
+(approve it via `POST /actions/runs/{run_id}/approve` if it must run).
+The check also self-heals on the next non-bot trigger -- a push, or a
+**review-thread** disposition reply (`pull_request_review_comment`), but
+not a regular-comment (PATH B) one, since the workflow ignores
+`issue_comment`. This is the exception to the `action_required` row
+below.
 
 ## Interpretation
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -241,13 +241,25 @@ When this check shows a stuck or stale rollup entry, apply the rerun
 mechanic above -- `gh run rerun <run-id>` on the _existing_ PR-linked
 run for the current HEAD SHA -- rather than `workflow_dispatch`.
 
+A second cause leaves the same check stuck: GitHub gates a bot-triggered
+run -- for example Copilot posting its review via a `pull_request_review`
+/ `pull_request_review_comment` event -- to `action_required`, so it
+never executes. Subscribing to a review trigger is thus not the same as
+running on it, and the check does **not** self-refresh after the bot
+re-reviews the current HEAD. Recovery is the same `gh run rerun
+<run-id>` on the _existing_ PR-linked run for that HEAD; it also
+self-heals on the next non-bot trigger (a push, or an E-phase
+disposition reply). The run here is merely bot-gated -- not awaiting a
+maintainer action or a code fix -- so a rerun clears it rather than a
+hold (the exception noted in the Interpretation table below).
+
 ## Interpretation
 
 <!-- dprint-ignore-start -->
 | State (required checks only, normalized) | Action |
 | --- | --- |
 | All required checks are generated and pass-equivalent | → **on-success** (caller-defined) |
-| Any required check is non-pass `failure`, `action_required`, `startup_failure`, or `stale` | Inspect the log. If infra/flaky: apply `ciWait.rerunPolicy` (default `rerun-once`). If it resolves to rerun, rerun the exact failed run once and resume polling. If it resolves to hold, post a hold comment and stop. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. `action_required`, `startup_failure`, and `stale` rarely clear on a blind rerun: inspect, and if the check needs a maintainer action or a fresh run, post a hold comment and stop rather than looping reruns. |
+| Any required check is non-pass `failure`, `action_required`, `startup_failure`, or `stale` | Inspect the log. If infra/flaky: apply `ciWait.rerunPolicy` (default `rerun-once`). If it resolves to rerun, rerun the exact failed run once and resume polling. If it resolves to hold, post a hold comment and stop. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. `action_required`, `startup_failure`, and `stale` rarely clear on a blind rerun: inspect, and if the check needs a maintainer action or a fresh run, post a hold comment and stop rather than looping reruns. Exception: `idd-advisory-convergence` stuck at `action_required` from a gated bot-triggered review run clears by rerunning the _existing_ PR-linked run, not a hold (see §Rerun mechanics). |
 | Any required check is non-pass `cancelled` or `timed_out` | Investigate cause. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. If infra-caused: apply `ciWait.rerunPolicy`; rerun or re-push only when the current rerun budget allows it, otherwise post a hold comment and stop. |
 | Any required check is running (`pending`/`requested`/`waiting`/`expected`/...) | Continue waiting. After `ciWait.runningTimeout` — measured from the check's server `startedAt` (see the Polling algorithm) — elapses with no completion (default: 30 min), apply `ciWait.rerunPolicy`. If it resolves to rerun, rerun CI once and resume polling. If the same route recurs after that rerun, or if the policy is `hold`, post a hold comment and stop. |
 | Required checks are not generated after `ciWait.generationTimeout` | Treat as running. Default: 10 min. If the corresponding workflow run does not exist at all when that window elapses, post a hold comment and escalate to a maintainer, then stop. |

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -254,7 +254,7 @@ keeps the original actor's privileges and re-enters `action_required`
 if it must run).
 The check also self-heals on the next non-bot trigger -- a push, or a
 **review-thread** disposition reply (`pull_request_review_comment`), but
-not a regular-comment (PATH B) one, since the workflow ignores
+not a regular PR comment, since the workflow does not subscribe to
 `issue_comment`. This is the exception to the `action_required` row
 below.
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -255,8 +255,7 @@ if it must run).
 The check also self-heals on the next non-bot trigger -- a push, or a
 **review-thread** disposition reply (`pull_request_review_comment`), but
 not a regular PR comment, since the workflow does not subscribe to
-`issue_comment`. This is the exception to the `action_required` row
-below.
+`issue_comment`.
 
 ## Interpretation
 
@@ -264,7 +263,7 @@ below.
 | State (required checks only, normalized) | Action |
 | --- | --- |
 | All required checks are generated and pass-equivalent | → **on-success** (caller-defined) |
-| Any required check is non-pass `failure`, `action_required`, `startup_failure`, or `stale` | Inspect the log. If infra/flaky: apply `ciWait.rerunPolicy` (default `rerun-once`). If it resolves to rerun, rerun the exact failed run once and resume polling. If it resolves to hold, post a hold comment and stop. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. `action_required`, `startup_failure`, and `stale` rarely clear on a blind rerun: inspect, and if the check needs a maintainer action or a fresh run, post a hold comment and stop rather than looping reruns. Exception: `idd-advisory-convergence` stuck at `action_required` from a gated bot-triggered review run clears by rerunning the _existing_ PR-linked run, not a hold (see §Rerun mechanics). |
+| Any required check is non-pass `failure`, `action_required`, `startup_failure`, or `stale` | Inspect the log. If infra/flaky: apply `ciWait.rerunPolicy` (default `rerun-once`). If it resolves to rerun, rerun the exact failed run once and resume polling. If it resolves to hold, post a hold comment and stop. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. `action_required`, `startup_failure`, and `stale` rarely clear on a blind rerun: inspect, and if the check needs a maintainer action or a fresh run, post a hold comment and stop rather than looping reruns. Exception: `idd-advisory-convergence` stuck at `action_required` from a gated bot-triggered review run is recovered by rerunning the _existing_ PR-linked run, subject to `ciWait.rerunPolicy` (see §Rerun mechanics). |
 | Any required check is non-pass `cancelled` or `timed_out` | Investigate cause. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. If infra-caused: apply `ciWait.rerunPolicy`; rerun or re-push only when the current rerun budget allows it, otherwise post a hold comment and stop. |
 | Any required check is running (`pending`/`requested`/`waiting`/`expected`/...) | Continue waiting. After `ciWait.runningTimeout` — measured from the check's server `startedAt` (see the Polling algorithm) — elapses with no completion (default: 30 min), apply `ciWait.rerunPolicy`. If it resolves to rerun, rerun CI once and resume polling. If the same route recurs after that rerun, or if the policy is `hold`, post a hold comment and stop. |
 | Required checks are not generated after `ciWait.generationTimeout` | Treat as running. Default: 10 min. If the corresponding workflow run does not exist at all when that window elapses, post a hold comment and escalate to a maintainer, then stop. |

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -244,14 +244,17 @@ run for the current HEAD SHA -- rather than `workflow_dispatch`.
 A second cause leaves the same check stuck: GitHub gates a bot-triggered
 run -- for example Copilot posting its review via a `pull_request_review`
 / `pull_request_review_comment` event -- to `action_required`, so it
-never executes. Subscribing to a review trigger is thus not the same as
-running on it, and the check does **not** self-refresh after the bot
-re-reviews the current HEAD. Recovery is the same `gh run rerun
-<run-id>` on the _existing_ PR-linked run for that HEAD; it also
-self-heals on the next non-bot trigger (a push, or an E-phase
-disposition reply). The run here is merely bot-gated -- not awaiting a
-maintainer action or a code fix -- so a rerun clears it rather than a
-hold (the exception noted in the Interpretation table below).
+waits for approval instead of running. Subscribing to a review trigger
+is thus not the same as running on it, and the bot's review event does
+**not** by itself refresh the check for the current HEAD. Recovery does
+not approve that gated run: instead `gh run rerun <run-id>` the
+_existing_ PR-linked (`pull_request`-family) run for the current HEAD --
+the one that already executed -- so it re-evaluates now that the bot has
+reviewed; the check also self-heals on the next non-bot trigger (a push,
+or an E-phase disposition reply). So the `action_required` row in the
+Interpretation table below does not apply here: rerunning the already-run
+PR-linked run clears the rollup, with no hold or gated-run approval
+needed.
 
 ## Interpretation
 

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -202,7 +202,7 @@
         ".github/instructions/idd-review-snapshot.instructions.md",
         ".github/instructions/idd-review-triage.instructions.md"
       ],
-      "limitBytes": 115800
+      "limitBytes": 116800
     },
     {
       "id": "bundle-merge",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -202,7 +202,7 @@
         ".github/instructions/idd-review-snapshot.instructions.md",
         ".github/instructions/idd-review-triage.instructions.md"
       ],
-      "limitBytes": 116800
+      "limitBytes": 116900
     },
     {
       "id": "bundle-merge",

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -249,7 +249,7 @@ keeps the original actor's privileges and re-enters `action_required`
 if it must run).
 The check also self-heals on the next non-bot trigger -- a push, or a
 **review-thread** disposition reply (`pull_request_review_comment`), but
-not a regular-comment (PATH B) one, since the workflow ignores
+not a regular PR comment, since the workflow does not subscribe to
 `issue_comment`. This is the exception to the `action_required` row
 below.
 

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -250,8 +250,7 @@ if it must run).
 The check also self-heals on the next non-bot trigger -- a push, or a
 **review-thread** disposition reply (`pull_request_review_comment`), but
 not a regular PR comment, since the workflow does not subscribe to
-`issue_comment`. This is the exception to the `action_required` row
-below.
+`issue_comment`.
 
 ## Interpretation
 
@@ -259,7 +258,7 @@ below.
 | State (required checks only, normalized) | Action |
 | --- | --- |
 | All required checks are generated and pass-equivalent | → **on-success** (caller-defined) |
-| Any required check is non-pass `failure`, `action_required`, `startup_failure`, or `stale` | Inspect the log. If infra/flaky: apply `ciWait.rerunPolicy` (default `rerun-once`). If it resolves to rerun, rerun the exact failed run once and resume polling. If it resolves to hold, post a hold comment and stop. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. `action_required`, `startup_failure`, and `stale` rarely clear on a blind rerun: inspect, and if the check needs a maintainer action or a fresh run, post a hold comment and stop rather than looping reruns. Exception: `idd-advisory-convergence` stuck at `action_required` from a gated bot-triggered review run clears by rerunning the _existing_ PR-linked run, not a hold (see §Rerun mechanics). |
+| Any required check is non-pass `failure`, `action_required`, `startup_failure`, or `stale` | Inspect the log. If infra/flaky: apply `ciWait.rerunPolicy` (default `rerun-once`). If it resolves to rerun, rerun the exact failed run once and resume polling. If it resolves to hold, post a hold comment and stop. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. `action_required`, `startup_failure`, and `stale` rarely clear on a blind rerun: inspect, and if the check needs a maintainer action or a fresh run, post a hold comment and stop rather than looping reruns. Exception: `idd-advisory-convergence` stuck at `action_required` from a gated bot-triggered review run is recovered by rerunning the _existing_ PR-linked run, subject to `ciWait.rerunPolicy` (see §Rerun mechanics). |
 | Any required check is non-pass `cancelled` or `timed_out` | Investigate cause. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. If infra-caused: apply `ciWait.rerunPolicy`; rerun or re-push only when the current rerun budget allows it, otherwise post a hold comment and stop. |
 | Any required check is running (`pending`/`requested`/`waiting`/`expected`/...) | Continue waiting. After `ciWait.runningTimeout` — measured from the check's server `startedAt` (see the Polling algorithm) — elapses with no completion (default: 30 min), apply `ciWait.rerunPolicy`. If it resolves to rerun, rerun CI once and resume polling. If the same route recurs after that rerun, or if the policy is `hold`, post a hold comment and stop. |
 | Required checks are not generated after `ciWait.generationTimeout` | Treat as running. Default: 10 min. If the corresponding workflow run does not exist at all when that window elapses, post a hold comment and escalate to a maintainer, then stop. |

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -245,7 +245,8 @@ rerun <run-id>` the _existing_ non-bot `pull_request`-triggered run that
 already executed for this HEAD, subject to `ciWait.rerunPolicy` (a `hold`
 policy inspects instead). Do **not** rerun the gated bot run: a re-run
 keeps the original actor's privileges and re-enters `action_required`
-(approve it via `POST /actions/runs/{run_id}/approve` if it must run).
+(approve it via `POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve`
+if it must run).
 The check also self-heals on the next non-bot trigger -- a push, or a
 **review-thread** disposition reply (`pull_request_review_comment`), but
 not a regular-comment (PATH B) one, since the workflow ignores

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -239,14 +239,17 @@ run for the current HEAD SHA -- rather than `workflow_dispatch`.
 A second cause leaves the same check stuck: GitHub gates a bot-triggered
 run -- for example Copilot posting its review via a `pull_request_review`
 / `pull_request_review_comment` event -- to `action_required`, so it
-never executes. Subscribing to a review trigger is thus not the same as
-running on it, and the check does **not** self-refresh after the bot
-re-reviews the current HEAD. Recovery is the same `gh run rerun
-<run-id>` on the _existing_ PR-linked run for that HEAD; it also
-self-heals on the next non-bot trigger (a push, or an E-phase
-disposition reply). The run here is merely bot-gated -- not awaiting a
-maintainer action or a code fix -- so a rerun clears it rather than a
-hold (the exception noted in the Interpretation table below).
+waits for approval instead of running. Subscribing to a review trigger
+is thus not the same as running on it, and the bot's review event does
+**not** by itself refresh the check for the current HEAD. Recovery does
+not approve that gated run: instead `gh run rerun <run-id>` the
+_existing_ PR-linked (`pull_request`-family) run for the current HEAD --
+the one that already executed -- so it re-evaluates now that the bot has
+reviewed; the check also self-heals on the next non-bot trigger (a push,
+or an E-phase disposition reply). So the `action_required` row in the
+Interpretation table below does not apply here: rerunning the already-run
+PR-linked run clears the rollup, with no hold or gated-run approval
+needed.
 
 ## Interpretation
 

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -237,19 +237,20 @@ mechanic above -- `gh run rerun <run-id>` on the _existing_ PR-linked
 run for the current HEAD SHA -- rather than `workflow_dispatch`.
 
 A second cause leaves the same check stuck: GitHub gates a bot-triggered
-run -- for example Copilot posting its review via a `pull_request_review`
-/ `pull_request_review_comment` event -- to `action_required`, so it
-waits for approval instead of running. Subscribing to a review trigger
-is thus not the same as running on it, and the bot's review event does
-**not** by itself refresh the check for the current HEAD. Recovery does
-not approve that gated run: instead `gh run rerun <run-id>` the
-_existing_ PR-linked (`pull_request`-family) run for the current HEAD --
-the one that already executed -- so it re-evaluates now that the bot has
-reviewed; the check also self-heals on the next non-bot trigger (a push,
-or an E-phase disposition reply). So the `action_required` row in the
-Interpretation table below does not apply here: rerunning the already-run
-PR-linked run clears the rollup, with no hold or gated-run approval
-needed.
+run -- e.g. Copilot posting its review via a `pull_request_review` /
+`pull_request_review_comment` event -- to `action_required`, so it waits
+for approval instead of running, and the bot's review event does **not**
+by itself refresh the check for the current HEAD. To recover, `gh run
+rerun <run-id>` the _existing_ non-bot `pull_request`-triggered run that
+already executed for this HEAD, subject to `ciWait.rerunPolicy` (a `hold`
+policy inspects instead). Do **not** rerun the gated bot run: a re-run
+keeps the original actor's privileges and re-enters `action_required`
+(approve it via `POST /actions/runs/{run_id}/approve` if it must run).
+The check also self-heals on the next non-bot trigger -- a push, or a
+**review-thread** disposition reply (`pull_request_review_comment`), but
+not a regular-comment (PATH B) one, since the workflow ignores
+`issue_comment`. This is the exception to the `action_required` row
+below.
 
 ## Interpretation
 

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -236,13 +236,25 @@ When this check shows a stuck or stale rollup entry, apply the rerun
 mechanic above -- `gh run rerun <run-id>` on the _existing_ PR-linked
 run for the current HEAD SHA -- rather than `workflow_dispatch`.
 
+A second cause leaves the same check stuck: GitHub gates a bot-triggered
+run -- for example Copilot posting its review via a `pull_request_review`
+/ `pull_request_review_comment` event -- to `action_required`, so it
+never executes. Subscribing to a review trigger is thus not the same as
+running on it, and the check does **not** self-refresh after the bot
+re-reviews the current HEAD. Recovery is the same `gh run rerun
+<run-id>` on the _existing_ PR-linked run for that HEAD; it also
+self-heals on the next non-bot trigger (a push, or an E-phase
+disposition reply). The run here is merely bot-gated -- not awaiting a
+maintainer action or a code fix -- so a rerun clears it rather than a
+hold (the exception noted in the Interpretation table below).
+
 ## Interpretation
 
 <!-- dprint-ignore-start -->
 | State (required checks only, normalized) | Action |
 | --- | --- |
 | All required checks are generated and pass-equivalent | → **on-success** (caller-defined) |
-| Any required check is non-pass `failure`, `action_required`, `startup_failure`, or `stale` | Inspect the log. If infra/flaky: apply `ciWait.rerunPolicy` (default `rerun-once`). If it resolves to rerun, rerun the exact failed run once and resume polling. If it resolves to hold, post a hold comment and stop. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. `action_required`, `startup_failure`, and `stale` rarely clear on a blind rerun: inspect, and if the check needs a maintainer action or a fresh run, post a hold comment and stop rather than looping reruns. |
+| Any required check is non-pass `failure`, `action_required`, `startup_failure`, or `stale` | Inspect the log. If infra/flaky: apply `ciWait.rerunPolicy` (default `rerun-once`). If it resolves to rerun, rerun the exact failed run once and resume polling. If it resolves to hold, post a hold comment and stop. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. `action_required`, `startup_failure`, and `stale` rarely clear on a blind rerun: inspect, and if the check needs a maintainer action or a fresh run, post a hold comment and stop rather than looping reruns. Exception: `idd-advisory-convergence` stuck at `action_required` from a gated bot-triggered review run clears by rerunning the _existing_ PR-linked run, not a hold (see §Rerun mechanics). |
 | Any required check is non-pass `cancelled` or `timed_out` | Investigate cause. If code-caused: fix, run **fix-validate**, commit atomically, then return to caller's pre-push step. If infra-caused: apply `ciWait.rerunPolicy`; rerun or re-push only when the current rerun budget allows it, otherwise post a hold comment and stop. |
 | Any required check is running (`pending`/`requested`/`waiting`/`expected`/...) | Continue waiting. After `ciWait.runningTimeout` — measured from the check's server `startedAt` (see the Polling algorithm) — elapses with no completion (default: 30 min), apply `ciWait.rerunPolicy`. If it resolves to rerun, rerun CI once and resume polling. If the same route recurs after that rerun, or if the policy is `hold`, post a hold comment and stop. |
 | Required checks are not generated after `ciWait.generationTimeout` | Treat as running. Default: 10 min. If the corresponding workflow run does not exist at all when that window elapses, post a hold comment and escalate to a maintainer, then stop. |


### PR DESCRIPTION
# Summary

Documents the second cause of a stuck `idd-advisory-convergence` required
check in the shared rerun-recovery guidance (`idd-ci.instructions.md`
§Rerun mechanics): a Copilot(bot)-triggered `pull_request_review` /
`pull_request_review_comment` run is gated by GitHub to `action_required`
and never executes, so the check does **not** self-refresh after the bot
re-reviews the current HEAD. Explains the shared `gh run rerun` recovery on
the existing PR-linked run and the self-heal on the next non-bot trigger,
and adds a carve-out pointer in the §Interpretation table's
`action_required` row so a top-down reader finds the exception instead of
stopping at "post a hold".

## Linked issue

Closes #1424

## Follow-up issues (if any)

- [ ] none required. Note (out of scope here): the
  `idd-advisory-convergence.yml` module-header frames the
  `pull_request_review*` triggers as refreshing the check on Copilot's
  review; that framing is partly defeated by the bot-gating documented
  here. Left untouched deliberately to keep this diff minimal; worth a
  separate header-coherence pass if desired.

## Background / rationale (if material)

- **Premise is empirically grounded**, not inferred: this session's
  investigation observed 21+ recent `idd-advisory-convergence` runs
  concluding `action_required`, **all** with `triggering_actor: Copilot`
  (verified via the Actions runs API). advisory-convergence is the only
  workflow subscribed to `pull_request_review*` events.
- **Self-contained on purpose.** The new text does not defer to the
  workflow header for the `action_required` detail (the header documents
  the `workflow_dispatch` / stale-rollup findings, not this mechanism).
  The apparent "the review trigger should refresh it" expectation is
  reconciled with an explicit *subscribed ≠ executed* sentence.
- **Distinct from the existing cause.** The paragraph already covered
  `workflow_dispatch` having no `pull_request` context; this adds a
  separate bot-gated-run cause that shares the same `gh run rerun`
  recovery.
- **Byte-budget ratchet.** `idd-ci` sits at the shared `bundle-review`
  budget edge, so the added portable guidance raises `limitBytes`
  115800 → 116900 in `audit/sync-manifest.json` — the minimum round bump
  to fit, matching the established byte-budget-ratchet precedent (#1337).
  The prose was tightened first to keep the bump small.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (pre-push-validate: biome + dprint + markdownlint + cspell all clean)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check` (documentation audit passed)
- [x] `pnpm run docs:sync:check` (sync-docs --apply left the tree clean; only the two `idd-ci` copies regenerate)
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing release-tag/branch-protection warnings only)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (documentation-only; no workflow trigger, permission, or helper-logic change)
- [x] Context budget impact reviewed (bundle-review ratcheted by the minimum amount; prose tightened to minimize growth)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to recover required checks stuck in `action_required` after bot-triggered review runs.
  * Added guidance to rerun the existing pull request-linked check for the current commit.
  * Updated the CI interpretation guidance to distinguish this case from situations requiring a hold.

* **Chores**
  * Increased the allowed review bundle size budget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->