### PR TITLE
chore(cli): reject non-integer-looking --number/--band-size values

### DIFF
--- a/scripts/branch-name.mjs
+++ b/scripts/branch-name.mjs
@@ -89,13 +89,25 @@ function runCli() {
     printHelp();
     process.exit(0);
   }
-  if (!Number.isInteger(args.number) || (args.number ?? 0) <= 0) {
+  if (args.number === null) {
     throw new Error('--number is required and must be a positive integer');
   }
   if (args.title === null) {
     throw new Error('--title is required');
   }
   process.stdout.write(`${computeBranchName(args.number, args.title)}\n`);
+}
+/**
+ * Parse a canonical positive-integer command-line token (whole-token
+ * `^[1-9]\d*$`, e.g. `"42"`) and return the parsed value, or `null` when the
+ * token is not a canonical positive integer. `Number.parseInt` alone is too
+ * lenient for CLI validation: it silently truncates `"3.5"` to `3` and
+ * `"5abc"` to `5` before any positivity check ever runs, so the check must
+ * run against the raw string, not the already-parsed (and already-lossy)
+ * number.
+ */
+function parsePositiveInteger(token) {
+  return /^[1-9]\d*$/.test(token) ? Number.parseInt(token, 10) : null;
 }
 function parseArgs(argv) {
   const parsed = { number: null, title: null, help: false };
@@ -109,7 +121,7 @@ function parseArgs(argv) {
       return value;
     };
     if (token === '--number') {
-      parsed.number = Number.parseInt(String(requireValue()), 10);
+      parsed.number = parsePositiveInteger(requireValue());
       index += 1;
       continue;
     }

--- a/scripts/select-desynced-index.mjs
+++ b/scripts/select-desynced-index.mjs
@@ -37,10 +37,22 @@ function runCli() {
   if (args.token === null || args.token === '') {
     throw new Error('--token is required');
   }
-  if (!Number.isInteger(args.bandSize) || (args.bandSize ?? 0) <= 0) {
+  if (args.bandSize === null) {
     throw new Error('--band-size is required and must be a positive integer');
   }
   process.stdout.write(`${selectDesyncedIndex(args.token, args.bandSize)}\n`);
+}
+/**
+ * Parse a canonical positive-integer command-line token (whole-token
+ * `^[1-9]\d*$`, e.g. `"42"`) and return the parsed value, or `null` when the
+ * token is not a canonical positive integer. `Number.parseInt` alone is too
+ * lenient for CLI validation: it silently truncates `"3.5"` to `3` and
+ * `"5abc"` to `5` before any positivity check ever runs, so the check must
+ * run against the raw string, not the already-parsed (and already-lossy)
+ * number.
+ */
+function parsePositiveInteger(token) {
+  return /^[1-9]\d*$/.test(token) ? Number.parseInt(token, 10) : null;
 }
 function parseArgs(argv) {
   const parsed = { token: null, bandSize: null, help: false };
@@ -59,7 +71,7 @@ function parseArgs(argv) {
       continue;
     }
     if (flag === '--band-size') {
-      parsed.bandSize = Number.parseInt(String(requireValue()), 10);
+      parsed.bandSize = parsePositiveInteger(requireValue());
       index += 1;
       continue;
     }

--- a/src/scripts/branch-name.mts
+++ b/src/scripts/branch-name.mts
@@ -103,7 +103,7 @@ function runCli(): void {
     printHelp();
     process.exit(0);
   }
-  if (!Number.isInteger(args.number) || (args.number ?? 0) <= 0) {
+  if (args.number === null) {
     throw new Error('--number is required and must be a positive integer');
   }
   if (args.title === null) {
@@ -112,6 +112,19 @@ function runCli(): void {
   process.stdout.write(
     `${computeBranchName(args.number as number, args.title)}\n`,
   );
+}
+
+/**
+ * Parse a canonical positive-integer command-line token (whole-token
+ * `^[1-9]\d*$`, e.g. `"42"`) and return the parsed value, or `null` when the
+ * token is not a canonical positive integer. `Number.parseInt` alone is too
+ * lenient for CLI validation: it silently truncates `"3.5"` to `3` and
+ * `"5abc"` to `5` before any positivity check ever runs, so the check must
+ * run against the raw string, not the already-parsed (and already-lossy)
+ * number.
+ */
+function parsePositiveInteger(token: string): number | null {
+  return /^[1-9]\d*$/.test(token) ? Number.parseInt(token, 10) : null;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -127,7 +140,7 @@ function parseArgs(argv: string[]): ParsedArgs {
       return value;
     };
     if (token === '--number') {
-      parsed.number = Number.parseInt(String(requireValue()), 10);
+      parsed.number = parsePositiveInteger(requireValue());
       index += 1;
       continue;
     }

--- a/src/scripts/select-desynced-index.mts
+++ b/src/scripts/select-desynced-index.mts
@@ -45,12 +45,25 @@ function runCli(): void {
   if (args.token === null || args.token === '') {
     throw new Error('--token is required');
   }
-  if (!Number.isInteger(args.bandSize) || (args.bandSize ?? 0) <= 0) {
+  if (args.bandSize === null) {
     throw new Error('--band-size is required and must be a positive integer');
   }
   process.stdout.write(
     `${selectDesyncedIndex(args.token, args.bandSize as number)}\n`,
   );
+}
+
+/**
+ * Parse a canonical positive-integer command-line token (whole-token
+ * `^[1-9]\d*$`, e.g. `"42"`) and return the parsed value, or `null` when the
+ * token is not a canonical positive integer. `Number.parseInt` alone is too
+ * lenient for CLI validation: it silently truncates `"3.5"` to `3` and
+ * `"5abc"` to `5` before any positivity check ever runs, so the check must
+ * run against the raw string, not the already-parsed (and already-lossy)
+ * number.
+ */
+function parsePositiveInteger(token: string): number | null {
+  return /^[1-9]\d*$/.test(token) ? Number.parseInt(token, 10) : null;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -71,7 +84,7 @@ function parseArgs(argv: string[]): ParsedArgs {
       continue;
     }
     if (flag === '--band-size') {
-      parsed.bandSize = Number.parseInt(String(requireValue()), 10);
+      parsed.bandSize = parsePositiveInteger(requireValue());
       index += 1;
       continue;
     }

--- a/tests/branch-name.test.mts
+++ b/tests/branch-name.test.mts
@@ -1,10 +1,46 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   computeBranchName,
   computeBranchSlug,
 } from '../src/scripts/branch-name.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const CLI_PATH = join(REPO_ROOT, 'scripts/branch-name.mjs');
+
+/** Run the built CLI and return its trimmed stdout. */
+function runCli(args: string[]): string {
+  return execFileSync(process.execPath, [CLI_PATH, ...args], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  }).trim();
+}
+
+/** Run the built CLI expecting a non-zero exit, and return its stderr. */
+function runCliExpectFailure(args: string[]): {
+  status: number;
+  stderr: string;
+} {
+  try {
+    execFileSync(process.execPath, [CLI_PATH, ...args], {
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+    throw new Error('expected the CLI to exit non-zero, but it succeeded');
+  } catch (error) {
+    const status = (error as { status?: number }).status;
+    const stderr = String((error as { stderr?: unknown }).stderr ?? '');
+    assert.ok(
+      typeof status === 'number' && status !== 0,
+      `expected a non-zero exit status, got ${String(status)}`,
+    );
+    return { status: status as number, stderr };
+  }
+}
 
 // Worked examples shared verbatim with the "Worked examples" block in
 // `.github/instructions/idd-claim.instructions.md` pre-check (e). This is
@@ -115,4 +151,68 @@ test('handles nullish and non-string titles defensively', () => {
   assert.equal(computeBranchSlug(true), 'task');
   assert.equal(computeBranchName(8, null), 'issue/8-task');
   assert.equal(computeBranchName(9, 123), 'issue/9-task');
+});
+
+// ---------------------------------------------------------------------------
+// CLI: drift guard plus invalid-input rejection. `parseArgs`/`runCli` are not
+// exported (only the pure `computeBranchName`/`computeBranchSlug` are), so
+// these cases run against the built CLI, mirroring the CLI test structure in
+// `tests/select-desynced-index.test.mts`.
+// ---------------------------------------------------------------------------
+
+test('drift: CLI output equals computeBranchName for an ordinary number and title', () => {
+  const number = 42;
+  const title = 'Add the OAuth login flow';
+  assert.equal(
+    runCli(['--number', String(number), '--title', title]),
+    computeBranchName(number, title),
+  );
+});
+
+test('missing --number exits non-zero with a clear message', () => {
+  const { stderr } = runCliExpectFailure(['--title', 'x']);
+  assert.match(stderr, /--number is required and must be a positive integer/);
+});
+
+test('non-positive --number exits non-zero with a clear message', () => {
+  for (const number of ['0', '-3']) {
+    const { stderr } = runCliExpectFailure([
+      '--number',
+      number,
+      '--title',
+      'x',
+    ]);
+    assert.match(stderr, /--number is required and must be a positive integer/);
+  }
+});
+
+test('non-integer --number exits non-zero with a clear message', () => {
+  // Includes non-integer-*looking* values (`3.5`, `5abc`) that
+  // `Number.parseInt` alone would silently truncate to a valid integer
+  // (`3`, `5`) before any positivity check ever ran.
+  for (const number of ['not-a-number', '3.5', '5abc']) {
+    const { stderr } = runCliExpectFailure([
+      '--number',
+      number,
+      '--title',
+      'x',
+    ]);
+    assert.match(stderr, /--number is required and must be a positive integer/);
+  }
+});
+
+test('missing --title exits non-zero with a clear message', () => {
+  const { stderr } = runCliExpectFailure(['--number', '5']);
+  assert.match(stderr, /--title is required/);
+});
+
+test('--help prints usage and exits 0', () => {
+  const output = execFileSync(process.execPath, [CLI_PATH, '--help'], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  assert.match(output, /^Usage:/);
+  assert.match(output, /--number <issue-number> --title <issue-title>/);
+  // The worked example in the help text must itself be correct.
+  assert.match(output, /=> issue\/42-add-oauth-login-flow\n/);
 });

--- a/tests/select-desynced-index.test.mts
+++ b/tests/select-desynced-index.test.mts
@@ -128,16 +128,21 @@ test('non-positive --band-size exits non-zero with a clear message', () => {
 });
 
 test('non-integer --band-size exits non-zero with a clear message', () => {
-  const { stderr } = runCliExpectFailure([
-    '--token',
-    'x',
-    '--band-size',
-    'not-a-number',
-  ]);
-  assert.match(
-    stderr,
-    /--band-size is required and must be a positive integer/,
-  );
+  // Includes non-integer-*looking* values (`3.5`, `5abc`) that
+  // `Number.parseInt` alone would silently truncate to a valid integer
+  // (`3`, `5`) before any positivity check ever ran.
+  for (const bandSize of ['not-a-number', '3.5', '5abc']) {
+    const { stderr } = runCliExpectFailure([
+      '--token',
+      'x',
+      '--band-size',
+      bandSize,
+    ]);
+    assert.match(
+      stderr,
+      /--band-size is required and must be a positive integer/,
+    );
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

Tighten `--number` (`src/scripts/branch-name.mts`) and `--band-size`
(`src/scripts/select-desynced-index.mts`) argument parsing so both
reject non-integer-looking strings such as `3.5` and `5abc`, not just
non-positive values.

Root cause: `Number.parseInt(value, 10)` truncates a partially numeric
string before any validation runs, so `"3.5"` -> `3` and `"5abc"` -> `5`
both silently passed the existing `Number.isInteger(...) > 0` post-parse
check, even though each CLI's own error message already claimed to
reject non-integers. The fix validates the raw CLI token against
`^[1-9]\d*$` inside `parseArgs`, before `Number.parseInt` ever runs —
not the already-parsed (and already-lossy) number — mirroring the
existing `parsePositiveIntToken` precedent in
`src/scripts/post-idd-marker.mts`. The pattern subsumes the prior
non-positive check, so both `runCli` functions now collapse to a single
`=== null` guard, and the unchanged error message is accurate for every
input it rejects.

Both files are fixed identically (same `parsePositiveInteger` helper,
duplicated verbatim per this repo's existing wrapper-script convention)
so the two intentionally-mirrored CLIs do not drift in validation
strictness.

**Behavior note**: `^[1-9]\d*$` also rejects zero-padded (`"007"`),
signed (`"+5"`), and whitespace-padded tokens that the old
`Number.parseInt` silently accepted. This is a natural consequence of
"reject non-integer-looking strings" and no real caller (GitHub issue
numbers, session band sizes) produces such tokens, but it is a
behavior change beyond the issue's literal `3.5`/`5abc` examples,
called out here for reviewer visibility.

## Linked issue

Closes #1412

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`select-desynced-index.mts` (added by #1397 / PR #1411, merged just
before this issue's claim) deliberately mirrors `branch-name.mts`'s
existing `--number` argument, which has had the identical
`Number.parseInt` leniency since it shipped (#901). Neither CLI's
original acceptance criteria required rejecting non-integer-*looking*
strings, only non-positive ones — the gap this issue closes is the
error message overclaiming relative to what was actually validated.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (1970/1970 passing, including new `3.5`/`5abc` cases
      for both CLIs)
- [ ] `node scripts/audit-docs.mjs --check` (no docs changed)
- [ ] `pnpm run docs:sync:check` (no docs changed)
- [x] `node scripts/idd-doctor.mjs` (pre-existing warnings only, no new
      findings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
