### PR TITLE
fix(advisory): silence expected gh api user 403 in CI only

### DIFF
--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -477,6 +477,27 @@ export function runAdvisoryConvergence(argv, deps = defaultDeps) {
   return { verdict, exitCode, help: false };
 }
 // --- Production I/O: fetch PR/review/thread/comment evidence via `gh` ----
+/**
+ * `gh` options for the viewer-login probe (`gh api user`).
+ *
+ * Under GitHub Actions the workflow token is a GitHub App installation token
+ * with no authenticated user, so `gh api user` always returns 403 ("Resource
+ * not accessible by integration"). That is expected and harmless here:
+ * {@link safeGhText} swallows it and `viewerLogin === ''` is the correct value
+ * in CI (there is no runner "self" whose markers should be trusted). Only the
+ * inherited stderr leaks the confusing 403 line into the run log, so under
+ * Actions we capture that run's stderr (`stdio` pipe) to keep the log clean.
+ *
+ * Outside Actions (a local/interactive run) the probe normally succeeds; if it
+ * genuinely fails we deliberately keep stderr **inherited** so the failure
+ * stays visible — a silently-empty `viewerLogin` narrows self-marker trust,
+ * the same fail-noisy concern #1396 hardens for the roadmap-audit helper.
+ */
+export function viewerProbeGhOptions(env = process.env) {
+  return env.GITHUB_ACTIONS === 'true'
+    ? { stdio: ['ignore', 'pipe', 'pipe'] }
+    : {};
+}
 function collectFromGitHub(args) {
   const owner =
     args.owner ||
@@ -484,12 +505,10 @@ function collectFromGitHub(args) {
   const repo =
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
   const repoRef = `${owner}/${repo}`;
-  const viewerLogin = safeGhText([
-    'api',
-    'user',
-    '--jq',
-    '.login',
-  ]).toLowerCase();
+  const viewerLogin = safeGhText(
+    ['api', 'user', '--jq', '.login'],
+    viewerProbeGhOptions(),
+  ).toLowerCase();
   const rawConfig = loadIddConfig();
   const { actors: configuredTrustedActors } = resolveTrustedMarkerActors({
     flagValue: args.trustedMarkerLogins,

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -489,14 +489,24 @@ export function runAdvisoryConvergence(argv, deps = defaultDeps) {
  * Actions we capture that run's stderr (`stdio` pipe) to keep the log clean.
  *
  * Outside Actions (a local/interactive run) the probe normally succeeds; if it
- * genuinely fails we deliberately keep stderr **inherited** so the failure
- * stays visible — a silently-empty `viewerLogin` narrows self-marker trust,
- * the same fail-noisy concern #1396 hardens for the roadmap-audit helper.
+ * genuinely fails we deliberately **inherit** stderr so the failure stays
+ * visible — a silently-empty `viewerLogin` narrows self-marker trust, the same
+ * fail-noisy concern #1396 hardens for the roadmap-audit helper.
+ *
+ * Both branches set `stdio` **explicitly** rather than leaning on
+ * `execFileSync`'s default: that default already writes the child's stderr to
+ * the parent (so a bare call would leak the 403), but relying on it is
+ * non-obvious. `pipe` captures stderr (silent); `inherit` forwards it to the
+ * parent (visible). stdin is `ignore` on both, matching `GH_TEXT_LOOP_OPTIONS`'
+ * stdin-safety.
  */
 export function viewerProbeGhOptions(env = process.env) {
-  return env.GITHUB_ACTIONS === 'true'
-    ? { stdio: ['ignore', 'pipe', 'pipe'] }
-    : {};
+  return {
+    stdio:
+      env.GITHUB_ACTIONS === 'true'
+        ? ['ignore', 'pipe', 'pipe']
+        : ['ignore', 'pipe', 'inherit'],
+  };
 }
 function collectFromGitHub(args) {
   const owner =

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -758,16 +758,26 @@ export function runAdvisoryConvergence(
  * Actions we capture that run's stderr (`stdio` pipe) to keep the log clean.
  *
  * Outside Actions (a local/interactive run) the probe normally succeeds; if it
- * genuinely fails we deliberately keep stderr **inherited** so the failure
- * stays visible — a silently-empty `viewerLogin` narrows self-marker trust,
- * the same fail-noisy concern #1396 hardens for the roadmap-audit helper.
+ * genuinely fails we deliberately **inherit** stderr so the failure stays
+ * visible — a silently-empty `viewerLogin` narrows self-marker trust, the same
+ * fail-noisy concern #1396 hardens for the roadmap-audit helper.
+ *
+ * Both branches set `stdio` **explicitly** rather than leaning on
+ * `execFileSync`'s default: that default already writes the child's stderr to
+ * the parent (so a bare call would leak the 403), but relying on it is
+ * non-obvious. `pipe` captures stderr (silent); `inherit` forwards it to the
+ * parent (visible). stdin is `ignore` on both, matching `GH_TEXT_LOOP_OPTIONS`'
+ * stdin-safety.
  */
 export function viewerProbeGhOptions(
   env: NodeJS.ProcessEnv = process.env,
 ): GhTextOptions {
-  return env.GITHUB_ACTIONS === 'true'
-    ? { stdio: ['ignore', 'pipe', 'pipe'] }
-    : {};
+  return {
+    stdio:
+      env.GITHUB_ACTIONS === 'true'
+        ? ['ignore', 'pipe', 'pipe']
+        : ['ignore', 'pipe', 'inherit'],
+  };
 }
 
 function collectFromGitHub(args: AdvisoryConvergenceArgs): {

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -47,6 +47,7 @@ import type { CollaboratorPermissionCache } from './collaborator-permission.mts'
 import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mts';
 import {
   GH_TEXT_LOOP_OPTIONS,
+  type GhTextOptions,
   ghApiJson,
   ghText,
   isCliExecution,
@@ -745,6 +746,30 @@ export function runAdvisoryConvergence(
 
 // --- Production I/O: fetch PR/review/thread/comment evidence via `gh` ----
 
+/**
+ * `gh` options for the viewer-login probe (`gh api user`).
+ *
+ * Under GitHub Actions the workflow token is a GitHub App installation token
+ * with no authenticated user, so `gh api user` always returns 403 ("Resource
+ * not accessible by integration"). That is expected and harmless here:
+ * {@link safeGhText} swallows it and `viewerLogin === ''` is the correct value
+ * in CI (there is no runner "self" whose markers should be trusted). Only the
+ * inherited stderr leaks the confusing 403 line into the run log, so under
+ * Actions we capture that run's stderr (`stdio` pipe) to keep the log clean.
+ *
+ * Outside Actions (a local/interactive run) the probe normally succeeds; if it
+ * genuinely fails we deliberately keep stderr **inherited** so the failure
+ * stays visible — a silently-empty `viewerLogin` narrows self-marker trust,
+ * the same fail-noisy concern #1396 hardens for the roadmap-audit helper.
+ */
+export function viewerProbeGhOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): GhTextOptions {
+  return env.GITHUB_ACTIONS === 'true'
+    ? { stdio: ['ignore', 'pipe', 'pipe'] }
+    : {};
+}
+
 function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   inputs: AdvisoryConvergenceInputs;
   options: AdvisoryConvergenceOptions;
@@ -755,12 +780,10 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   const repo =
     args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
   const repoRef = `${owner}/${repo}`;
-  const viewerLogin = safeGhText([
-    'api',
-    'user',
-    '--jq',
-    '.login',
-  ]).toLowerCase();
+  const viewerLogin = safeGhText(
+    ['api', 'user', '--jq', '.login'],
+    viewerProbeGhOptions(),
+  ).toLowerCase();
   const rawConfig = loadIddConfig();
   const { actors: configuredTrustedActors } = resolveTrustedMarkerActors({
     flagValue: args.trustedMarkerLogins,

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -1068,19 +1068,20 @@ test('runAdvisoryConvergence: missing --pr throws before any collection happens'
   assert.equal(called, false);
 });
 
-test('viewerProbeGhOptions suppresses gh stderr only under GitHub Actions', () => {
-  // Under Actions: capture the probe's stdout AND stderr (stdio pipe) so the
-  // expected `gh api user` 403 does not leak into the run log.
+test('viewerProbeGhOptions captures gh stderr only under GitHub Actions', () => {
+  // Under Actions: capture stderr (pipe) so the expected `gh api user` 403 does
+  // not leak into the run log; stdout is still piped so viewerLogin is read.
   const ci = viewerProbeGhOptions({ GITHUB_ACTIONS: 'true' });
   assert.deepEqual(ci.stdio, ['ignore', 'pipe', 'pipe']);
 
-  // Outside Actions: no stdio override, so stderr stays inherited and a real
-  // local viewer-lookup failure stays visible (the #1396 fail-noisy concern).
-  assert.equal(viewerProbeGhOptions({}).stdio, undefined);
-  assert.equal(
+  // Outside Actions: inherit stderr so a real local viewer-lookup failure
+  // stays visible (the #1396 fail-noisy concern). Both are set explicitly.
+  const local = ['ignore', 'pipe', 'inherit'];
+  assert.deepEqual(viewerProbeGhOptions({}).stdio, local);
+  assert.deepEqual(
     viewerProbeGhOptions({ GITHUB_ACTIONS: 'false' }).stdio,
-    undefined,
+    local,
   );
   // Only the literal string 'true' opts in (matches GitHub's own value).
-  assert.equal(viewerProbeGhOptions({ GITHUB_ACTIONS: '1' }).stdio, undefined);
+  assert.deepEqual(viewerProbeGhOptions({ GITHUB_ACTIONS: '1' }).stdio, local);
 });

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -10,6 +10,7 @@ import {
   parseArgs,
   pickResolvingClaimEvents,
   runAdvisoryConvergence,
+  viewerProbeGhOptions,
 } from '../src/scripts/advisory-convergence.mts';
 import { renderExternalCheckWaiverComment } from '../src/scripts/marker-helpers.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
@@ -1065,4 +1066,21 @@ test('runAdvisoryConvergence: missing --pr throws before any collection happens'
   };
   assert.throws(() => runAdvisoryConvergence([], deps));
   assert.equal(called, false);
+});
+
+test('viewerProbeGhOptions suppresses gh stderr only under GitHub Actions', () => {
+  // Under Actions: capture the probe's stdout AND stderr (stdio pipe) so the
+  // expected `gh api user` 403 does not leak into the run log.
+  const ci = viewerProbeGhOptions({ GITHUB_ACTIONS: 'true' });
+  assert.deepEqual(ci.stdio, ['ignore', 'pipe', 'pipe']);
+
+  // Outside Actions: no stdio override, so stderr stays inherited and a real
+  // local viewer-lookup failure stays visible (the #1396 fail-noisy concern).
+  assert.equal(viewerProbeGhOptions({}).stdio, undefined);
+  assert.equal(
+    viewerProbeGhOptions({ GITHUB_ACTIONS: 'false' }).stdio,
+    undefined,
+  );
+  // Only the literal string 'true' opts in (matches GitHub's own value).
+  assert.equal(viewerProbeGhOptions({ GITHUB_ACTIONS: '1' }).stdio, undefined);
 });


### PR DESCRIPTION
# Summary

The `idd-advisory-convergence` viewer probe (`gh api user`) always returns
403 under the GitHub Actions token — a GitHub App installation token has no
authenticated user. `safeGhText` already swallows it and `viewerLogin === ''`
is the correct value in CI, but the inherited stderr leaks a confusing
`Resource not accessible by integration` line into every advisory-convergence
run log (the noise that prompted the investigation behind #1424).

`viewerProbeGhOptions()` now passes a stderr-capturing `stdio`
(`['ignore','pipe','pipe']`) to the probe **only under `GITHUB_ACTIONS`**, so
the expected 403 no longer prints. Outside Actions it passes no override, so
stderr stays inherited and a genuine local viewer-lookup failure remains
visible — the fail-noisy concern #1396 hardens for the `roadmap-audit`
helper (a silently-empty `viewerLogin` only narrows self-marker trust here,
but should not be hidden locally).

## Linked issue

Closes #1425

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

- **CI-conditional on purpose.** `advisory-convergence.mjs` is dual-use (the
  required CI check *and* a helper an agent can run locally). Suppressing
  stderr unconditionally would be the reverse of #1396; gating on
  `GITHUB_ACTIONS === 'true'` (GitHub's own value) keeps the local diagnostic.
- **Verdict unaffected.** Only the probe's `stdio` changes, never its result
  handling. Verified byte-identical verdict JSON with and without
  `GITHUB_ACTIONS` on a real PR. The in-CI 403-suppression itself only
  manifests once merged, because the advisory-convergence workflow checks out
  trusted `main`, not the PR head (see #1424).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (pre-push-validate: biome + dprint + markdownlint + cspell all clean)
- [x] `pnpm test` (full suite green; new `viewerProbeGhOptions` unit test included)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (no docs change)
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing warnings only)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (CI-only cosmetic; no gate/verdict change)
- [x] Context budget impact reviewed (no instruction-bundle change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced expected authentication warning noise during GitHub Actions checks while preserving error visibility in other environments.
  * Improved handling of GitHub viewer detection when workflow tokens lack user authentication.

* **Tests**
  * Added coverage for GitHub Actions environment detection and command output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->