### PR TITLE
docs(resume): warn chat approval never replaces forced-handoff helper

### DIFF
--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -58,14 +58,16 @@ If stalled-session routing returns hold/inconclusive, stop.
   confirmation — this holds even when the operator explicitly says to
   proceed.
 - When an operator asks the agent to proceed with forced handoff, the
-  agent's correct action is to report the stalled-claim evidence back
-  and hand the operator the profile-selected `force-handoff` invocation
-  to run themselves in their own interactive terminal — resolved for
-  the repository's configured helper profile rather than one hardcoded
-  form (for example, `node scripts/force-handoff.mjs` under
-  `vendored-node`, or the `idd:force-handoff` package script under
-  `package-manager`; see `docs/idd-helper-scripts.md`) — not to author
-  or post the `forced-handoff` marker itself.
+  agent's correct action is to report the stalled-claim evidence back,
+  never to author or post the `forced-handoff` marker itself. Where the
+  repository vends a force-handoff helper, hand the operator a
+  concrete, runnable invocation resolved for its configured profile
+  from `docs/idd-helper-scripts.md` (for example
+  `node scripts/force-handoff.mjs` under `vendored-node`, or
+  `npm run idd:force-handoff` under `package-manager`); under
+  `instructions-only` (no helper runtime vended), the operator instead
+  posts the manual consent text and marker documented in
+  `docs/customization.md` themselves.
 
 ## Step 1 — Identify claim state
 

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -60,10 +60,11 @@ If stalled-session routing returns hold/inconclusive, stop.
 - When an operator asks the agent to proceed with forced handoff, the
   agent's correct action is to report the stalled-claim evidence back
   and hand the operator the exact helper invocation to run themselves in
-  their own interactive terminal (the repository's packaged
-  `idd-force-handoff` bin command, or `node ./bin/idd-force-handoff.mjs`
-  from the repository root for an uninstalled checkout) — not to author
-  or post the `forced-handoff` marker itself.
+  their own interactive terminal — the repository's packaged
+  `idd-force-handoff` bin command where that facade is vended, or
+  `node scripts/force-handoff.mjs` from the repository root under
+  profiles (such as `vendored-node`) that vend only the `scripts/` form
+  — not to author or post the `forced-handoff` marker itself.
 
 ## Step 1 — Identify claim state
 

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -53,6 +53,18 @@ timestamps.
 Quiet-window evidence does not bypass the shared stale threshold.
 If stalled-session routing returns hold/inconclusive, stop.
 
+- Conversational or chat-based operator approval given mid-session never
+  substitutes for the TTY-gated `idd-force-handoff` helper's own `y/N`
+  confirmation — this holds even when the operator explicitly says to
+  proceed.
+- When an operator asks the agent to proceed with forced handoff, the
+  agent's correct action is to report the stalled-claim evidence back
+  and hand the operator the exact helper invocation to run themselves in
+  their own interactive terminal (the repository's packaged
+  `idd-force-handoff` bin command, or `node ./bin/idd-force-handoff.mjs`
+  from the repository root for an uninstalled checkout) — not to author
+  or post the `forced-handoff` marker itself.
+
 ## Step 1 — Identify claim state
 
 When helper runtime is enabled, you may collect Step 1 evidence with:

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -59,12 +59,13 @@ If stalled-session routing returns hold/inconclusive, stop.
   proceed.
 - When an operator asks the agent to proceed with forced handoff, the
   agent's correct action is to report the stalled-claim evidence back
-  and hand the operator the exact helper invocation to run themselves in
-  their own interactive terminal — the repository's packaged
-  `idd-force-handoff` bin command where that facade is vended, or
-  `node scripts/force-handoff.mjs` from the repository root under
-  profiles (such as `vendored-node`) that vend only the `scripts/` form
-  — not to author or post the `forced-handoff` marker itself.
+  and hand the operator the profile-selected `force-handoff` invocation
+  to run themselves in their own interactive terminal — resolved for
+  the repository's configured helper profile rather than one hardcoded
+  form (for example, `node scripts/force-handoff.mjs` under
+  `vendored-node`, or the `idd:force-handoff` package script under
+  `package-manager`; see `docs/idd-helper-scripts.md`) — not to author
+  or post the `forced-handoff` marker itself.
 
 ## Step 1 — Identify claim state
 

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -53,14 +53,16 @@ If stalled-session routing returns hold/inconclusive, stop.
   confirmation — this holds even when the operator explicitly says to
   proceed.
 - When an operator asks the agent to proceed with forced handoff, the
-  agent's correct action is to report the stalled-claim evidence back
-  and hand the operator the profile-selected `force-handoff` invocation
-  to run themselves in their own interactive terminal — resolved for
-  the repository's configured helper profile rather than one hardcoded
-  form (for example, `node scripts/force-handoff.mjs` under
-  `vendored-node`, or the `idd:force-handoff` package script under
-  `package-manager`; see `docs/idd-helper-scripts.md`) — not to author
-  or post the `forced-handoff` marker itself.
+  agent's correct action is to report the stalled-claim evidence back,
+  never to author or post the `forced-handoff` marker itself. Where the
+  repository vends a force-handoff helper, hand the operator a
+  concrete, runnable invocation resolved for its configured profile
+  from `docs/idd-helper-scripts.md` (for example
+  `node scripts/force-handoff.mjs` under `vendored-node`, or
+  `npm run idd:force-handoff` under `package-manager`); under
+  `instructions-only` (no helper runtime vended), the operator instead
+  posts the manual consent text and marker documented in
+  `docs/customization.md` themselves.
 
 ## Step 1 — Identify claim state
 

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -54,12 +54,13 @@ If stalled-session routing returns hold/inconclusive, stop.
   proceed.
 - When an operator asks the agent to proceed with forced handoff, the
   agent's correct action is to report the stalled-claim evidence back
-  and hand the operator the exact helper invocation to run themselves in
-  their own interactive terminal — the repository's packaged
-  `idd-force-handoff` bin command where that facade is vended, or
-  `node scripts/force-handoff.mjs` from the repository root under
-  profiles (such as `vendored-node`) that vend only the `scripts/` form
-  — not to author or post the `forced-handoff` marker itself.
+  and hand the operator the profile-selected `force-handoff` invocation
+  to run themselves in their own interactive terminal — resolved for
+  the repository's configured helper profile rather than one hardcoded
+  form (for example, `node scripts/force-handoff.mjs` under
+  `vendored-node`, or the `idd:force-handoff` package script under
+  `package-manager`; see `docs/idd-helper-scripts.md`) — not to author
+  or post the `forced-handoff` marker itself.
 
 ## Step 1 — Identify claim state
 

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -48,6 +48,18 @@ timestamps.
 Quiet-window evidence does not bypass the shared stale threshold.
 If stalled-session routing returns hold/inconclusive, stop.
 
+- Conversational or chat-based operator approval given mid-session never
+  substitutes for the TTY-gated `idd-force-handoff` helper's own `y/N`
+  confirmation — this holds even when the operator explicitly says to
+  proceed.
+- When an operator asks the agent to proceed with forced handoff, the
+  agent's correct action is to report the stalled-claim evidence back
+  and hand the operator the exact helper invocation to run themselves in
+  their own interactive terminal (the repository's packaged
+  `idd-force-handoff` bin command, or `node ./bin/idd-force-handoff.mjs`
+  from the repository root for an uninstalled checkout) — not to author
+  or post the `forced-handoff` marker itself.
+
 ## Step 1 — Identify claim state
 
 When helper runtime is enabled, you may collect Step 1 evidence with:

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -55,10 +55,11 @@ If stalled-session routing returns hold/inconclusive, stop.
 - When an operator asks the agent to proceed with forced handoff, the
   agent's correct action is to report the stalled-claim evidence back
   and hand the operator the exact helper invocation to run themselves in
-  their own interactive terminal (the repository's packaged
-  `idd-force-handoff` bin command, or `node ./bin/idd-force-handoff.mjs`
-  from the repository root for an uninstalled checkout) — not to author
-  or post the `forced-handoff` marker itself.
+  their own interactive terminal — the repository's packaged
+  `idd-force-handoff` bin command where that facade is vended, or
+  `node scripts/force-handoff.mjs` from the repository root under
+  profiles (such as `vendored-node`) that vend only the `scripts/` form
+  — not to author or post the `forced-handoff` marker itself.
 
 ## Step 1 — Identify claim state
 


### PR DESCRIPTION
# Summary

`docs/customization.md` already warns that autopilot/unattended agents
must never initiate forced handoff, and describes the `idd-force-handoff`
helper as intentionally TTY-only. But the execution-time
`idd-resume.instructions.md` file — the one agents actually read while
resuming a session — never said that conversational/chat-based operator
approval given mid-session does not substitute for the helper's own
TTY-gated `y/N` confirmation, and never redirected the agent to hand the
operator the exact helper invocation instead of authoring/posting the
`forced-handoff` marker itself.

This PR adds two bullets to the existing forced-handoff directive at the
end of `idd-resume.instructions.md` Step 0 (right after "If
stalled-session routing returns hold/inconclusive, stop."), closing that
coverage gap with the issue's own proposed wording.

## Linked issue

Closes #1430

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Caught as a near-miss during a live session: an agent found several
issues with claims that looked stalled, asked the operator via chat
whether it could proceed with forced handoff, received an affirmative
chat answer, and was about to construct and post a `forced-handoff`
marker directly on the operator's behalf. Reading only the
execution-time instruction files, this looked like a defensible reading
of "must never invent, request, or broaden" (the agent was relaying an
operator request, not inventing one). The agent only stopped because it
happened to read `docs/customization.md` directly. Nothing in the
execution-time reading path would have stopped a session that skipped
that extra step.

Verified `bin/idd-force-handoff.mjs` exists and `package.json` maps the
`idd-force-handoff` bin command to it, so both invocation forms named in
the new text are accurate.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

All green. `audit-docs.mjs --check` reports zero drift; the
`bundle-resume` byte budget is unaffected (40524/43300 bytes, comfortably
under the 43300 limit). `idd-claim.instructions.md`'s marker-parsing/
anti-hijack rules and `docs/customization.md`'s existing text are left
unchanged, and `audit/sync-manifest.json` was not touched (no ratchet
needed).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
