### PR TITLE
docs(idd): document residual wait-stall and topology gate

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -53,10 +53,10 @@ then handles the request, pending, stalled, restart, and cap cases.
 
 Keep the wait itself cheap per the
 [wake-up discipline](idd-ci.instructions.md#wake-up-discipline): schedule
-a single wake at the **expected** completion, or — gated by the
-topology-safety condition — background instead only if confirmed to
-route completion back to this turn; otherwise wait synchronously. Batch
-all post-wait actions into one turn.
+a single wake at the **expected** completion, or background only if the
+topology-safety condition holds (confirmed to route completion back to
+this turn); otherwise wait synchronously. Batch all post-wait actions
+into one turn.
 
 ## 1. Canonical path (helper-first)
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -52,10 +52,11 @@ Enter the full protocol below **only** when `LAST_COPILOT_COMMIT != PR_HEAD_SHA`
 then handles the request, pending, stalled, restart, and cap cases.
 
 Keep the wait itself cheap per the
-[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): the
-topology-safety condition gates backgrounding — background only if
-confirmed to route completion back to this turn, else wait synchronously
-— and batch all post-wait actions into one turn.
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): schedule
+a single wake at the **expected** completion, or — gated by the
+topology-safety condition — background instead only if confirmed to
+route completion back to this turn; otherwise wait synchronously. Batch
+all post-wait actions into one turn.
 
 ## 1. Canonical path (helper-first)
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -52,9 +52,10 @@ Enter the full protocol below **only** when `LAST_COPILOT_COMMIT != PR_HEAD_SHA`
 then handles the request, pending, stalled, restart, and cap cases.
 
 Keep the wait itself cheap per the
-[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): background or
-schedule a single wake at the **expected** completion rather than inserting
-interim polling turns, and batch all post-wait actions into one turn.
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): the
+topology-safety condition gates backgrounding — background only if
+confirmed to route completion back to this turn, else wait synchronously
+— and batch all post-wait actions into one turn.
 
 ## 1. Canonical path (helper-first)
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -311,3 +311,7 @@ here.
 This trims only the wasteful dimensions (context re-read, CI minutes); it does
 **not** reduce review rounds, which remain valuable and run in full. This same
 discipline applies to the advisory-wait and review-fix wait points.
+
+**Known residual risk**: workers can still stall here — expected and
+budgeted, not broken. Recovery is one message citing live state first (PR
+number, check states, worktree commit state).

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -314,4 +314,4 @@ discipline applies to the advisory-wait and review-fix wait points.
 
 **Known residual risk**: workers can still stall here — expected and
 budgeted, not broken. Recovery is one message citing live state first (PR
-number, check states, worktree commit state).
+number, check states, local worktree HEAD SHA).

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -90,10 +90,12 @@ Before any mutating action in F3, apply the
    the active claim still uses your current `{claim-id}`. If it does
    not, the claim was lost — report and stop.
 
-   **Advisory state revalidation (blocking; the advisory-wait check below
-   backgrounds only if the topology-safety condition holds — confirmed to
-   route completion back to this turn — otherwise waits synchronously)**:
-   re-fetch the HEAD SHA:
+   **Advisory state revalidation (blocking)**: the AW1 check just below is
+   an instant state read, not itself a wait. If it escalates to a genuine
+   wait, return to the F2 advisory bot wait check, which backgrounds only
+   if the topology-safety condition holds (confirmed to route completion
+   back to this turn) and otherwise waits synchronously. Re-fetch the HEAD
+   SHA:
 
    ```sh
    PR_HEAD_SHA_F3=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -92,7 +92,7 @@ Before any mutating action in F3, apply the
 
    **Advisory state revalidation (blocking; the advisory-wait check below
    backgrounds only if the topology-safety condition holds — confirmed to
-   route completion back to this turn — else waits synchronously)**:
+   route completion back to this turn — otherwise waits synchronously)**:
    re-fetch the HEAD SHA:
 
    ```sh

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -90,7 +90,10 @@ Before any mutating action in F3, apply the
    the active claim still uses your current `{claim-id}`. If it does
    not, the claim was lost — report and stop.
 
-   **Advisory state revalidation (blocking)**: re-fetch the HEAD SHA:
+   **Advisory state revalidation (blocking; the advisory-wait check below
+   backgrounds only if the topology-safety condition holds — confirmed to
+   route completion back to this turn — else waits synchronously)**:
+   re-fetch the HEAD SHA:
 
    ```sh
    PR_HEAD_SHA_F3=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -237,8 +237,9 @@ issue, the regex check above is redundant but still safe to run.
 
 ## D4 — Wait for CI
 
-Background this wait only if the topology-safety condition holds (confirmed
-to route completion back to this turn); otherwise wait synchronously.
-Delegate polling mechanics to `idd-ci.instructions.md`.
+Schedule a wake, or background this wait only if the topology-safety
+condition holds (confirmed to route completion back to this turn);
+otherwise wait synchronously. Delegate polling mechanics to
+`idd-ci.instructions.md`.
 
 - **On success** → proceed to `idd-review-snapshot.instructions.md`

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -237,9 +237,9 @@ issue, the regex check above is redundant but still safe to run.
 
 ## D4 — Wait for CI
 
-Schedule a wake, or background this wait only if the topology-safety
-condition holds (confirmed to route completion back to this turn);
-otherwise wait synchronously. Delegate polling mechanics to
+Schedule a wake, or background this wait only if the
+topology-safety condition holds (confirmed to route completion back to
+this turn); otherwise wait synchronously. Delegate polling mechanics to
 `idd-ci.instructions.md`.
 
 - **On success** → proceed to `idd-review-snapshot.instructions.md`

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -237,6 +237,8 @@ issue, the regex check above is redundant but still safe to run.
 
 ## D4 — Wait for CI
 
-Delegate to `idd-ci.instructions.md`.
+Background this wait only if the topology-safety condition holds (confirmed
+to route completion back to this turn); otherwise wait synchronously.
+Delegate polling mechanics to `idd-ci.instructions.md`.
 
 - **On success** → proceed to `idd-review-snapshot.instructions.md`

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -155,11 +155,11 @@ returns the workflow to E1 instead of merging over it.
   re-covers them so this check passes on the refreshed watermark. If a
   return-to-E1 is triggered solely by those disposition replies, refresh
   the watermark rather than treating them as new reviewer activity.
-- **Advisory bot wait** (restart-safe enforcement): background only if the
-  topology-safety condition holds (confirmed to route completion back to
-  this turn); otherwise wait synchronously. `PR_HEAD_SHA` is already
-  available from the review-currency check above. Apply the advisory-wait
-  protocol (`idd-advisory-wait.instructions.md`):
+- **Advisory bot wait** (restart-safe enforcement): schedule a wake, or
+  background only if the topology-safety condition holds (confirmed to
+  route completion back to this turn); otherwise wait synchronously.
+  `PR_HEAD_SHA` is already available from the review-currency check above.
+  Apply the advisory-wait protocol (`idd-advisory-wait.instructions.md`):
 
   1. Run **AW1**. If **SATISFIED** → this check is **satisfied**;
      continue to the **CI** check.

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -155,9 +155,11 @@ returns the workflow to E1 instead of merging over it.
   re-covers them so this check passes on the refreshed watermark. If a
   return-to-E1 is triggered solely by those disposition replies, refresh
   the watermark rather than treating them as new reviewer activity.
-- **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
-  already available from the review-currency check above. Apply the
-  advisory-wait protocol (`idd-advisory-wait.instructions.md`):
+- **Advisory bot wait** (restart-safe enforcement): background only if the
+  topology-safety condition holds (confirmed to route completion back to
+  this turn); otherwise wait synchronously. `PR_HEAD_SHA` is already
+  available from the review-currency check above. Apply the advisory-wait
+  protocol (`idd-advisory-wait.instructions.md`):
 
   1. Run **AW1**. If **SATISFIED** → this check is **satisfied**;
      continue to the **CI** check.

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -333,8 +333,9 @@ not advisory; they remain under the hold/escalation path above.
 
 ## E15 — Wait for CI
 
-Background this wait only if the topology-safety condition holds (confirmed
-to route completion back to this turn); otherwise wait synchronously — see
+Schedule a wake, or background this wait only if the topology-safety
+condition holds (confirmed to route completion back to this turn);
+otherwise wait synchronously — see
 [wake-up discipline](idd-ci.instructions.md#wake-up-discipline).
 
 Use `idd-ci.instructions.md` for the polling mechanics and timing. E15

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -333,9 +333,9 @@ not advisory; they remain under the hold/escalation path above.
 
 ## E15 — Wait for CI
 
-Schedule a wake, or background this wait only if the topology-safety
-condition holds (confirmed to route completion back to this turn);
-otherwise wait synchronously — see
+Schedule a wake, or background this wait only if the
+topology-safety condition holds (confirmed to route completion back to
+this turn); otherwise wait synchronously — see
 [wake-up discipline](idd-ci.instructions.md#wake-up-discipline).
 
 Use `idd-ci.instructions.md` for the polling mechanics and timing. E15

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -333,16 +333,16 @@ not advisory; they remain under the hold/escalation path above.
 
 ## E15 — Wait for CI
 
+Background this wait only if the topology-safety condition holds (confirmed
+to route completion back to this turn); otherwise wait synchronously — see
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline).
+
 Use `idd-ci.instructions.md` for the polling mechanics and timing. E15
 reuses the same resolved `ciWait.runningTimeout`,
 `ciWait.generationTimeout`, and `ciWait.rerunPolicy` values; omitted
 keys preserve the distributed defaults. The outcome paths below are
 authoritative and override the shared helper's generic outcomes for this
 phase:
-
-Keep the wait cheap per the
-[wake-up discipline](idd-ci.instructions.md#wake-up-discipline) (no interim
-polling turns; batch post-wait actions into one turn).
 
 **While polling**: if new review threads or comments arrive during the
 CI wait, note them. After CI resolves (any outcome), return to E1 before

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -202,7 +202,7 @@
         ".github/instructions/idd-review-snapshot.instructions.md",
         ".github/instructions/idd-review-triage.instructions.md"
       ],
-      "limitBytes": 116900
+      "limitBytes": 117300
     },
     {
       "id": "bundle-merge",

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -47,9 +47,10 @@ Enter the full protocol below **only** when `LAST_COPILOT_COMMIT != PR_HEAD_SHA`
 then handles the request, pending, stalled, restart, and cap cases.
 
 Keep the wait itself cheap per the
-[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): background or
-schedule a single wake at the **expected** completion rather than inserting
-interim polling turns, and batch all post-wait actions into one turn.
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): the
+topology-safety condition gates backgrounding — background only if
+confirmed to route completion back to this turn, else wait synchronously
+— and batch all post-wait actions into one turn.
 
 ## 1. Canonical path (helper-first)
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -48,10 +48,10 @@ then handles the request, pending, stalled, restart, and cap cases.
 
 Keep the wait itself cheap per the
 [wake-up discipline](idd-ci.instructions.md#wake-up-discipline): schedule
-a single wake at the **expected** completion, or — gated by the
-topology-safety condition — background instead only if confirmed to
-route completion back to this turn; otherwise wait synchronously. Batch
-all post-wait actions into one turn.
+a single wake at the **expected** completion, or background only if the
+topology-safety condition holds (confirmed to route completion back to
+this turn); otherwise wait synchronously. Batch all post-wait actions
+into one turn.
 
 ## 1. Canonical path (helper-first)
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -47,10 +47,11 @@ Enter the full protocol below **only** when `LAST_COPILOT_COMMIT != PR_HEAD_SHA`
 then handles the request, pending, stalled, restart, and cap cases.
 
 Keep the wait itself cheap per the
-[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): the
-topology-safety condition gates backgrounding — background only if
-confirmed to route completion back to this turn, else wait synchronously
-— and batch all post-wait actions into one turn.
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): schedule
+a single wake at the **expected** completion, or — gated by the
+topology-safety condition — background instead only if confirmed to
+route completion back to this turn; otherwise wait synchronously. Batch
+all post-wait actions into one turn.
 
 ## 1. Canonical path (helper-first)
 

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -306,3 +306,7 @@ here.
 This trims only the wasteful dimensions (context re-read, CI minutes); it does
 **not** reduce review rounds, which remain valuable and run in full. This same
 discipline applies to the advisory-wait and review-fix wait points.
+
+**Known residual risk**: workers can still stall here — expected and
+budgeted, not broken. Recovery is one message citing live state first (PR
+number, check states, worktree commit state).

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -309,4 +309,4 @@ discipline applies to the advisory-wait and review-fix wait points.
 
 **Known residual risk**: workers can still stall here — expected and
 budgeted, not broken. Recovery is one message citing live state first (PR
-number, check states, worktree commit state).
+number, check states, local worktree HEAD SHA).

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -87,7 +87,7 @@ Before any mutating action in F3, apply the
 
    **Advisory state revalidation (blocking; the advisory-wait check below
    backgrounds only if the topology-safety condition holds — confirmed to
-   route completion back to this turn — else waits synchronously)**:
+   route completion back to this turn — otherwise waits synchronously)**:
    re-fetch the HEAD SHA:
 
    ```sh

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -85,10 +85,12 @@ Before any mutating action in F3, apply the
    the active claim still uses your current `{claim-id}`. If it does
    not, the claim was lost — report and stop.
 
-   **Advisory state revalidation (blocking; the advisory-wait check below
-   backgrounds only if the topology-safety condition holds — confirmed to
-   route completion back to this turn — otherwise waits synchronously)**:
-   re-fetch the HEAD SHA:
+   **Advisory state revalidation (blocking)**: the AW1 check just below is
+   an instant state read, not itself a wait. If it escalates to a genuine
+   wait, return to the F2 advisory bot wait check, which backgrounds only
+   if the topology-safety condition holds (confirmed to route completion
+   back to this turn) and otherwise waits synchronously. Re-fetch the HEAD
+   SHA:
 
    ```sh
    PR_HEAD_SHA_F3=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -85,7 +85,10 @@ Before any mutating action in F3, apply the
    the active claim still uses your current `{claim-id}`. If it does
    not, the claim was lost — report and stop.
 
-   **Advisory state revalidation (blocking)**: re-fetch the HEAD SHA:
+   **Advisory state revalidation (blocking; the advisory-wait check below
+   backgrounds only if the topology-safety condition holds — confirmed to
+   route completion back to this turn — else waits synchronously)**:
+   re-fetch the HEAD SHA:
 
    ```sh
    PR_HEAD_SHA_F3=$(gh pr view {pr-number} --json headRefOid --jq '.headRefOid')

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -232,9 +232,9 @@ issue, the regex check above is redundant but still safe to run.
 
 ## D4 — Wait for CI
 
-Schedule a wake, or background this wait only if the topology-safety
-condition holds (confirmed to route completion back to this turn);
-otherwise wait synchronously. Delegate polling mechanics to
+Schedule a wake, or background this wait only if the
+topology-safety condition holds (confirmed to route completion back to
+this turn); otherwise wait synchronously. Delegate polling mechanics to
 `idd-ci.instructions.md`.
 
 - **On success** → proceed to `idd-review-snapshot.instructions.md`

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -232,6 +232,8 @@ issue, the regex check above is redundant but still safe to run.
 
 ## D4 — Wait for CI
 
-Delegate to `idd-ci.instructions.md`.
+Background this wait only if the topology-safety condition holds (confirmed
+to route completion back to this turn); otherwise wait synchronously.
+Delegate polling mechanics to `idd-ci.instructions.md`.
 
 - **On success** → proceed to `idd-review-snapshot.instructions.md`

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -232,8 +232,9 @@ issue, the regex check above is redundant but still safe to run.
 
 ## D4 — Wait for CI
 
-Background this wait only if the topology-safety condition holds (confirmed
-to route completion back to this turn); otherwise wait synchronously.
-Delegate polling mechanics to `idd-ci.instructions.md`.
+Schedule a wake, or background this wait only if the topology-safety
+condition holds (confirmed to route completion back to this turn);
+otherwise wait synchronously. Delegate polling mechanics to
+`idd-ci.instructions.md`.
 
 - **On success** → proceed to `idd-review-snapshot.instructions.md`

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -150,9 +150,11 @@ returns the workflow to E1 instead of merging over it.
   re-covers them so this check passes on the refreshed watermark. If a
   return-to-E1 is triggered solely by those disposition replies, refresh
   the watermark rather than treating them as new reviewer activity.
-- **Advisory bot wait** (restart-safe enforcement): `PR_HEAD_SHA` is
-  already available from the review-currency check above. Apply the
-  advisory-wait protocol (`idd-advisory-wait.instructions.md`):
+- **Advisory bot wait** (restart-safe enforcement): background only if the
+  topology-safety condition holds (confirmed to route completion back to
+  this turn); otherwise wait synchronously. `PR_HEAD_SHA` is already
+  available from the review-currency check above. Apply the advisory-wait
+  protocol (`idd-advisory-wait.instructions.md`):
 
   1. Run **AW1**. If **SATISFIED** → this check is **satisfied**;
      continue to the **CI** check.

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -150,11 +150,11 @@ returns the workflow to E1 instead of merging over it.
   re-covers them so this check passes on the refreshed watermark. If a
   return-to-E1 is triggered solely by those disposition replies, refresh
   the watermark rather than treating them as new reviewer activity.
-- **Advisory bot wait** (restart-safe enforcement): background only if the
-  topology-safety condition holds (confirmed to route completion back to
-  this turn); otherwise wait synchronously. `PR_HEAD_SHA` is already
-  available from the review-currency check above. Apply the advisory-wait
-  protocol (`idd-advisory-wait.instructions.md`):
+- **Advisory bot wait** (restart-safe enforcement): schedule a wake, or
+  background only if the topology-safety condition holds (confirmed to
+  route completion back to this turn); otherwise wait synchronously.
+  `PR_HEAD_SHA` is already available from the review-currency check above.
+  Apply the advisory-wait protocol (`idd-advisory-wait.instructions.md`):
 
   1. Run **AW1**. If **SATISFIED** → this check is **satisfied**;
      continue to the **CI** check.

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -328,9 +328,9 @@ not advisory; they remain under the hold/escalation path above.
 
 ## E15 — Wait for CI
 
-Schedule a wake, or background this wait only if the topology-safety
-condition holds (confirmed to route completion back to this turn);
-otherwise wait synchronously — see
+Schedule a wake, or background this wait only if the
+topology-safety condition holds (confirmed to route completion back to
+this turn); otherwise wait synchronously — see
 [wake-up discipline](idd-ci.instructions.md#wake-up-discipline).
 
 Use `idd-ci.instructions.md` for the polling mechanics and timing. E15

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -328,8 +328,9 @@ not advisory; they remain under the hold/escalation path above.
 
 ## E15 — Wait for CI
 
-Background this wait only if the topology-safety condition holds (confirmed
-to route completion back to this turn); otherwise wait synchronously — see
+Schedule a wake, or background this wait only if the topology-safety
+condition holds (confirmed to route completion back to this turn);
+otherwise wait synchronously — see
 [wake-up discipline](idd-ci.instructions.md#wake-up-discipline).
 
 Use `idd-ci.instructions.md` for the polling mechanics and timing. E15

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -328,16 +328,16 @@ not advisory; they remain under the hold/escalation path above.
 
 ## E15 — Wait for CI
 
+Background this wait only if the topology-safety condition holds (confirmed
+to route completion back to this turn); otherwise wait synchronously — see
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline).
+
 Use `idd-ci.instructions.md` for the polling mechanics and timing. E15
 reuses the same resolved `ciWait.runningTimeout`,
 `ciWait.generationTimeout`, and `ciWait.rerunPolicy` values; omitted
 keys preserve the distributed defaults. The outcome paths below are
 authoritative and override the shared helper's generic outcomes for this
 phase:
-
-Keep the wait cheap per the
-[wake-up discipline](idd-ci.instructions.md#wake-up-discipline) (no interim
-polling turns; batch post-wait actions into one turn).
 
 **While polling**: if new review threads or comments arrive during the
 CI wait, note them. After CI resolves (any outcome), return to E1 before


### PR DESCRIPTION
# Summary

Documents the residual background-wait stall that survives the existing
wake-up-discipline "Portability" fix, and restates the topology-safety
condition inline at each wait-heavy phase instead of leaving it as a bare
cross-reference.

## Linked issue

Closes #1387

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

A downstream adopter's field report (multiple autonomous multi-issue runs
under a supervisor/worker topology) showed that even with the wake-up-
discipline Portability fix landed and every delegation brief repeating the
warning, roughly a third of delegated workers per run still background a
long-running wait and end their turn expecting a completion notification
that never arrives for a subagent. The rate stayed in the same range
before and after that fix landed, suggesting textual guidance alone has a
ceiling on correcting a training-distribution default. Every occurrence
resolved with a single follow-up message, and corrections that carried
the worker's actual live state (PR number, check states, worktree commit
state) unstuck workers in one round-trip instead of two.

Changes (all in `idd-template/.github/instructions/*.instructions.md`
sources, mirrored into `.github/instructions/` via
`node scripts/sync-docs.mjs --apply`):

1. `idd-ci.instructions.md` (`## Wake-up discipline`): adds a "Known
   residual risk" note documenting the stall as expected/budgeted (not
   broken delegation) and prescribing live-state-first recovery.
2. `idd-pr-submit.instructions.md` (D4), `idd-review-fix.instructions.md`
   (E15), `idd-pre-merge.instructions.md` (F2, "Advisory bot wait"), and
   `idd-merge.instructions.md` (F3, "Advisory state revalidation") each
   now open their wait guidance with the topology-safety condition
   inline, grep-verifiable via the literal phrase `topology-safety
   condition` (6 matches total: 1 pre-existing canonical mention in
   `idd-ci` + 5 new restatements).
3. `idd-advisory-wait.instructions.md`'s "Fast path — common case"
   summary — the passage the issue specifically flagged as presenting
   "background" as an unconditioned first option — is reworded so
   backgrounding is explicitly gated by the topology-safety condition.

**Budget ratchet**: `audit/sync-manifest.json`'s `bundle-review`
`limitBytes` moves from 116900 to 117300 (+400 bytes). The bundle already
sat at ~99.96% utilization before this change (116851/116900), inside the
"near-ceiling exception" documented in `docs/policy-constants.md`, which
prefers trimming or splitting a net addition over another ratchet bump
once a bundle is this full. The new content was trimmed through several
passes to the acceptance-criteria minimum first; no split target exists
for genuinely new review-path safety content, so the small remaining gap
is covered by a ratchet sized just above the trimmed measured total
(117139/117300, 161 bytes headroom) rather than the usual ~10%.
`bundle-merge` absorbs its share of the same edits within existing
headroom (95900 limit, ~95153 measured) and needs no ratchet.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified when advisory and CI checks may run in the background versus synchronously, based on a topology-safety condition.
  * Updated guidance to batch all post-wait actions into a single subsequent turn.
  * Added “Known residual risk” notes for possible worker stalling and improved live-state recovery instructions.
  * Refined merge, pre-merge, review-fix, and CI wait procedures to match the updated wake-up discipline.
* **Chores**
  * Increased the review bundle budget limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->