### PR TITLE
docs(idd-workflow): name the orchestrator fan-out variant

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -319,6 +319,48 @@ config, and forge state. This guidance is **advisory** — a recommended
 practice with its rationale, not a hard requirement — and
 **runner-agnostic**, since this repository ships no runner.
 
+### Orchestrator fan-out variant
+
+A long-lived orchestrating session may run Discover and Claim itself and
+delegate each claimed issue's B-through-F execution to an isolated
+subagent, instead of a thin external runner re-entering a fresh session
+per issue. This is an **explicitly supported alternative** to the
+one-issue-one-session model above, not a replacement for it — the
+monolithic-loop anti-pattern is about a single session accumulating every
+issue's diff, CI log, and review-thread noise in its own context, and
+the orchestrator avoids exactly that: its own context holds only claim
+tokens, branch names, and each worker's final report, while the
+per-issue noise stays inside each short-lived worker's own throwaway
+context. Cross-issue bookkeeping (the claimed set, a concurrency budget,
+one desync token reused across the run) is also cheaper to keep in one
+orchestrating session than to reconstruct per invocation of a stateless
+external scheduler.
+
+Running this variant safely requires:
+
+- **A small concurrency cap**, sized against CI-minute cost and
+  shared-file contention rather than raised without bound. The optional
+  `discover-shared-file-overlap` helper (see
+  [IDD helper script evaluation](idd-helper-scripts.md#discover-shared-file-overlap-contract))
+  reports high-contention shared-file overlap evidence to inform both
+  the cap and the delegation order.
+- **Full per-issue gating before every delegation.** The orchestrator
+  runs the complete A4.5/A5 suitability and claim gates (and the A4
+  viability gate that precedes them) for each issue before handing it to
+  a worker; claiming several issues concurrently is never a shortcut
+  around those gates.
+- **A delegation brief that restates the background-wait topology
+  warning.** Each worker's brief must carry the
+  [wake-up discipline](../.github/instructions/idd-ci.instructions.md#wake-up-discipline)
+  topology-safety condition, so a worker never assumes an unconfirmed
+  background wait resumes its own turn.
+- **Resume-specific recovery when a worker dies mid-turn.** Re-verify
+  claim ownership and worktree state before continuing; treat any
+  uncommitted work found in the worktree as unverified input to check,
+  never as something to trust or silently discard; then delegate a fresh
+  subagent with a resume-specific briefing rather than resuming the dead
+  worker's own context.
+
 ## Live Status Digests
 
 Use the live status digest contract in

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -350,10 +350,21 @@ Running this variant safely requires:
   a worker; claiming several issues concurrently is never a shortcut
   around those gates.
 - **A delegation brief that restates the background-wait topology
-  warning.** Each worker's brief must carry the
+  warning and the worker's exit boundary.** Each worker's brief must
+  carry the
   [wake-up discipline](../.github/instructions/idd-ci.instructions.md#wake-up-discipline)
   topology-safety condition, so a worker never assumes an unconfirmed
-  background wait resumes its own turn.
+  background wait resumes its own turn. The brief must also state that
+  the worker's B-through-F execution ends at F4-complete: the worker
+  reports its final result back to the orchestrator instead of
+  independently entering F5's Discover step, so Discover/Claim ownership
+  stays with the orchestrator alone.
+- **Serialized worktree/clone lifecycle operations when workers share
+  one clone.** Concurrent `git fetch` / `git worktree add` / `git
+  worktree remove` / local-`main` updates from the same primary clone
+  can collide; serialize these specific operations behind a per-clone
+  lock, or give concurrent workers separate clones, once the
+  concurrency cap allows more than one worker at a time.
 - **Resume-specific recovery when a worker dies mid-turn.** Re-verify
   claim ownership and worktree state before continuing; treat any
   uncommitted work found in the worktree as unverified input to check,

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -328,10 +328,21 @@ Running this variant safely requires:
   a worker; claiming several issues concurrently is never a shortcut
   around those gates.
 - **A delegation brief that restates the background-wait topology
-  warning.** Each worker's brief must carry the
+  warning and the worker's exit boundary.** Each worker's brief must
+  carry the
   [wake-up discipline](../.github/instructions/idd-ci.instructions.md#wake-up-discipline)
   topology-safety condition, so a worker never assumes an unconfirmed
-  background wait resumes its own turn.
+  background wait resumes its own turn. The brief must also state that
+  the worker's B-through-F execution ends at F4-complete: the worker
+  reports its final result back to the orchestrator instead of
+  independently entering F5's Discover step, so Discover/Claim ownership
+  stays with the orchestrator alone.
+- **Serialized worktree/clone lifecycle operations when workers share
+  one clone.** Concurrent `git fetch` / `git worktree add` / `git
+  worktree remove` / local-`main` updates from the same primary clone
+  can collide; serialize these specific operations behind a per-clone
+  lock, or give concurrent workers separate clones, once the
+  concurrency cap allows more than one worker at a time.
 - **Resume-specific recovery when a worker dies mid-turn.** Re-verify
   claim ownership and worktree state before continuing; treat any
   uncommitted work found in the worktree as unverified input to check,

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -297,6 +297,48 @@ config, and forge state. This guidance is **advisory** — a recommended
 practice with its rationale, not a hard requirement — and
 **runner-agnostic**, since this repository ships no runner.
 
+### Orchestrator fan-out variant
+
+A long-lived orchestrating session may run Discover and Claim itself and
+delegate each claimed issue's B-through-F execution to an isolated
+subagent, instead of a thin external runner re-entering a fresh session
+per issue. This is an **explicitly supported alternative** to the
+one-issue-one-session model above, not a replacement for it — the
+monolithic-loop anti-pattern is about a single session accumulating every
+issue's diff, CI log, and review-thread noise in its own context, and
+the orchestrator avoids exactly that: its own context holds only claim
+tokens, branch names, and each worker's final report, while the
+per-issue noise stays inside each short-lived worker's own throwaway
+context. Cross-issue bookkeeping (the claimed set, a concurrency budget,
+one desync token reused across the run) is also cheaper to keep in one
+orchestrating session than to reconstruct per invocation of a stateless
+external scheduler.
+
+Running this variant safely requires:
+
+- **A small concurrency cap**, sized against CI-minute cost and
+  shared-file contention rather than raised without bound. The optional
+  `discover-shared-file-overlap` helper (see
+  [IDD helper script evaluation](idd-helper-scripts.md#discover-shared-file-overlap-contract))
+  reports high-contention shared-file overlap evidence to inform both
+  the cap and the delegation order.
+- **Full per-issue gating before every delegation.** The orchestrator
+  runs the complete A4.5/A5 suitability and claim gates (and the A4
+  viability gate that precedes them) for each issue before handing it to
+  a worker; claiming several issues concurrently is never a shortcut
+  around those gates.
+- **A delegation brief that restates the background-wait topology
+  warning.** Each worker's brief must carry the
+  [wake-up discipline](../.github/instructions/idd-ci.instructions.md#wake-up-discipline)
+  topology-safety condition, so a worker never assumes an unconfirmed
+  background wait resumes its own turn.
+- **Resume-specific recovery when a worker dies mid-turn.** Re-verify
+  claim ownership and worktree state before continuing; treat any
+  uncommitted work found in the worktree as unverified input to check,
+  never as something to trust or silently discard; then delegate a fresh
+  subagent with a resume-specific briefing rather than resuming the dead
+  worker's own context.
+
 ## Live Status Digests
 
 Use the live status digest contract in


### PR DESCRIPTION
# Summary

Adds a `### Orchestrator fan-out variant` subsection to the "Autopilot
operating model" section of `docs/idd-workflow.md` (and its
`idd-template/` mirror), documenting a long-lived orchestrating session
that runs Discover/Claim itself and delegates each claimed issue's B-F
execution to an isolated subagent — an explicitly supported alternative
to the one-issue-one-session model, not a replacement for it. The
existing one-issue-one-session prose and the monolithic-loop
anti-pattern text are untouched.

## Linked issue

Closes #1389

## Follow-up issues (if any)

- [x] #1439 — a Codex review on this PR flagged a genuine, unresolved
  claim-protocol design question: how a delegated worker satisfies the
  session-scoped claim-ownership proof rule without itself having
  posted and verified the claim. Two doc-only wording attempts to close
  this in-place were each independently checked against the literal
  protocol text and refuted, so it is tracked as a separate design
  question for a maintainer decision rather than asserted away here.
  The other two Codex findings from the same review round (worker exit
  boundary at F4/F5, concurrent worktree/clone serialization) were
  fixed directly in this PR.

A post-handoff issue comment suggested broadening the concurrency-cap
bullet with a second rationale (bounding claim-blast-radius on an
orchestrator crash) and a coupling sub-rule (claim only when actively
delegating, not as a batch reservation). That comment explicitly scoped
itself out of this issue ("a suggestion for whoever drafts the
acceptance criteria next ... the issue's active claim/body are
unaffected by this comment") and pointed at #1433, so it is
intentionally not folded into this PR.

## Background / rationale (if material)

Part of the field-report batch-6 roadmap (#1386). A downstream adopter's
field report documented this variant used successfully across six-plus
runs (7-16 delegations per run, up to 5 concurrent), with resilience
field-confirmed across two crash incidents (2 and 4 workers killed
mid-turn by an infrastructure auth failure) — all workers resumed
cleanly with no lost work or claim corruption, including one worker that
had to verify genuine uncommitted work as correct rather than trust or
discard it on resume. This PR itself was produced by exactly that
recovery path: a forced-handoff resume of a stalled orchestrator-pattern
claim on this same issue.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
