### PR TITLE
feat(discover): retry transient gh failures in roadmap-graph loaders

### DIFF
--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -19,7 +19,7 @@ import {
   evaluateDiscoverReadiness,
 } from './discover-readiness-check.mjs';
 import { effortOrdinal, parseEffort } from './effort.mjs';
-import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mjs';
+import { GH_TEXT_LOOP_OPTIONS, ghText, withBoundedRetry } from './gh-exec.mjs';
 import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import {
   normalizePolicyConfig,
@@ -1173,19 +1173,28 @@ export function buildTrustedAuthorPredicate(policy) {
  *
  * Exported (#1395) so `discover-orphan-filter.mts` can reuse the identical
  * loader instead of duplicating this pagination/`gh` wiring.
+ *
+ * Async (#1394) so each page's `runGh(...) + JSON.parse(...)` fetch can be
+ * bounded-retried on a transient failure (e.g. truncated captured stdout
+ * under heavy concurrent load). Behavior-preserving: the sole caller
+ * (`annotateLeafClaimState`) already `await`s the returned value, and
+ * `ClaimStateResolution.loadComments` is typed as `Awaitable<...>` (#1395)
+ * to accommodate exactly this.
  */
 export function buildCommentLoader(owner, repo) {
-  return (issueNumber) => {
+  return async (issueNumber) => {
     const comments = [];
     const pageSize = 100;
     for (let page = 1; ; page += 1) {
-      const raw = runGh([
-        'api',
-        `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
-        '--jq',
-        '.',
-      ]).trim();
-      const pageItems = raw && raw !== 'null' ? JSON.parse(raw) : [];
+      const pageItems = await withBoundedRetry(async () => {
+        const raw = runGh([
+          'api',
+          `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+          '--jq',
+          '.',
+        ]).trim();
+        return raw && raw !== 'null' ? JSON.parse(raw) : [];
+      });
       if (!Array.isArray(pageItems) || pageItems.length === 0) {
         break;
       }
@@ -1678,6 +1687,19 @@ async function getIssue(issueNumber, cache, loadIssue) {
   cache.set(issueNumber, issue);
   return issue;
 }
+/**
+ * Live per-issue loader for the traversal hot path.
+ *
+ * Bounded-retried (#1394): the `runGhAsync(...) + JSON.parse(...)` body runs
+ * inside {@link withBoundedRetry} so a transient hiccup — including a
+ * truncated-stdout JSON parse failure — gets up to 2 additional fresh `gh`
+ * round-trips before this loader gives up. `isRetryable` reuses the same
+ * `isNotFoundIssueLookupError` / `isInaccessibleIssueLookupError` pair the
+ * outer `catch` already classifies with, so a genuine 404 or access-style
+ * failure is still recognized on the FIRST attempt (retried zero times,
+ * exactly like before this change) and still reaches the outer `catch`
+ * below unchanged.
+ */
 export function buildIssueLoader(owner, repo) {
   return async (issueNumber) => {
     const args = [
@@ -1687,11 +1709,22 @@ export function buildIssueLoader(owner, repo) {
       '.',
     ];
     try {
-      const result = (await runGhAsync(args, { allowStatuses: [404] })).trim();
-      if (!result || result === 'null') {
-        return null;
-      }
-      return JSON.parse(result);
+      return await withBoundedRetry(
+        async () => {
+          const result = (
+            await runGhAsync(args, { allowStatuses: [404] })
+          ).trim();
+          if (!result || result === 'null') {
+            return null;
+          }
+          return JSON.parse(result);
+        },
+        {
+          isRetryable: (error) =>
+            !isNotFoundIssueLookupError(error) &&
+            !isInaccessibleIssueLookupError(error),
+        },
+      );
     } catch (error) {
       if (isNotFoundIssueLookupError(error)) {
         return null;
@@ -1703,6 +1736,23 @@ export function buildIssueLoader(owner, repo) {
     }
   };
 }
+/**
+ * Live sub-issue loader for the traversal hot path.
+ *
+ * Bounded-retried (#1394): each page's `runGraphqlQuery(...)` call runs
+ * inside {@link withBoundedRetry} with the default retry-everything
+ * classifier — unlike {@link buildIssueLoader}, this loader has no
+ * pre-existing REST-status-based classification to preserve, and every
+ * failure `runGraphqlQuery` can produce today (a transient truncated-stdout
+ * parse failure, a reported GraphQL `errors[]` entry, or a process-exec
+ * failure) already rethrows unclassified. A genuinely persistent failure
+ * (e.g. an inaccessible parent issue) still rethrows, just after up to 2
+ * extra bounded round-trips instead of 0 — a small, deliberate latency cost,
+ * not a fail-closed regression. The connection/cursor-shape checks below
+ * stay un-retried on purpose: they only fire once `runGraphqlQuery` already
+ * resolved without a transport/parse error, so retrying them would not
+ * change the outcome.
+ */
 export function buildSubIssueLoader(owner, repo) {
   return async (issueNumber) => {
     const numbers = [];
@@ -1716,7 +1766,9 @@ export function buildSubIssueLoader(owner, repo) {
       if (after) {
         variables.after = after;
       }
-      const result = await runGraphqlQuery(SUB_ISSUES_QUERY, variables);
+      const result = await withBoundedRetry(() =>
+        runGraphqlQuery(SUB_ISSUES_QUERY, variables),
+      );
       const connection = result?.data?.repository?.issue?.subIssues;
       if (
         !connection ||

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -95,6 +95,45 @@ export function ghApiJson(path, options = {}) {
   // decide whether the output was empty.
   return JSON.parse(raw.trim() || '{}');
 }
+const DEFAULT_BOUNDED_RETRY_ATTEMPTS = 3;
+const DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS = 200;
+/** `await`-able delay, used only for the backoff between retry attempts. */
+function delay(ms) {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
+}
+/**
+ * Run `task`, retrying a bounded number of times on a retryable failure
+ * (#1394): a transient `gh`/API hiccup (e.g. truncated captured stdout under
+ * heavy concurrent load) no longer has to abort a whole caller-side
+ * traversal when an immediate retry would have succeeded in isolation.
+ *
+ * Fail-closed is preserved: once the bounded attempts are exhausted, the
+ * final attempt's error is rethrown unchanged — the exact same error
+ * instance, never re-wrapped — so an existing caller-side classifier (e.g.
+ * this module's own `allowStatuses` consumers, or a 404/access-style
+ * predicate) still reads the identical shape it read before this wrapper
+ * existed.
+ */
+export async function withBoundedRetry(task, options = {}) {
+  const {
+    attempts = DEFAULT_BOUNDED_RETRY_ATTEMPTS,
+    baseDelayMs = DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS,
+    isRetryable = () => true,
+  } = options;
+  const totalAttempts = Math.max(1, Math.trunc(attempts));
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await task();
+    } catch (error) {
+      if (attempt >= totalAttempts || !isRetryable(error)) {
+        throw error;
+      }
+      await delay(baseDelayMs * attempt + Math.random() * baseDelayMs);
+    }
+  }
+}
 /**
  * True when this module is executing as the invoked CLI entry point
  * (`node <this-file>.mjs ...`), false when it is only imported (e.g. from

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -122,7 +122,21 @@ export async function withBoundedRetry(task, options = {}) {
     baseDelayMs = DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS,
     isRetryable = () => true,
   } = options;
-  const totalAttempts = Math.max(1, Math.trunc(attempts));
+  // A non-finite `attempts` (`NaN` from a failed parse, or `Infinity`)
+  // would otherwise survive `Math.max`/`Math.trunc` unchanged (both are
+  // no-ops on non-finite input) and make `attempt >= totalAttempts` never
+  // true, defeating the whole bounded-attempt contract with an unbounded
+  // retry loop (Copilot + Codex review, #1394). Fall back to the default
+  // whenever the caller-supplied value is not a finite number. The same
+  // guard applies to `baseDelayMs` for consistency: a non-finite backoff
+  // would not break the bound (attempts still caps the loop), but would
+  // silently skip the intended backoff/jitter delay between attempts.
+  const totalAttempts = Number.isFinite(attempts)
+    ? Math.max(1, Math.trunc(attempts))
+    : DEFAULT_BOUNDED_RETRY_ATTEMPTS;
+  const effectiveBaseDelayMs = Number.isFinite(baseDelayMs)
+    ? baseDelayMs
+    : DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS;
   for (let attempt = 1; ; attempt += 1) {
     try {
       return await task();
@@ -130,7 +144,9 @@ export async function withBoundedRetry(task, options = {}) {
       if (attempt >= totalAttempts || !isRetryable(error)) {
         throw error;
       }
-      await delay(baseDelayMs * attempt + Math.random() * baseDelayMs);
+      await delay(
+        effectiveBaseDelayMs * attempt + Math.random() * effectiveBaseDelayMs,
+      );
     }
   }
 }

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -21,7 +21,7 @@ import {
   evaluateDiscoverReadiness,
 } from './discover-readiness-check.mts';
 import { type EffortHint, effortOrdinal, parseEffort } from './effort.mts';
-import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mts';
+import { GH_TEXT_LOOP_OPTIONS, ghText, withBoundedRetry } from './gh-exec.mts';
 import { stripMarkdownCodeRegions } from './markdown-code.mts';
 import {
   normalizePolicyConfig,
@@ -1749,19 +1749,28 @@ export function buildTrustedAuthorPredicate(policy: {
  *
  * Exported (#1395) so `discover-orphan-filter.mts` can reuse the identical
  * loader instead of duplicating this pagination/`gh` wiring.
+ *
+ * Async (#1394) so each page's `runGh(...) + JSON.parse(...)` fetch can be
+ * bounded-retried on a transient failure (e.g. truncated captured stdout
+ * under heavy concurrent load). Behavior-preserving: the sole caller
+ * (`annotateLeafClaimState`) already `await`s the returned value, and
+ * `ClaimStateResolution.loadComments` is typed as `Awaitable<...>` (#1395)
+ * to accommodate exactly this.
  */
 export function buildCommentLoader(owner: string, repo: string) {
-  return (issueNumber: number) => {
+  return async (issueNumber: number) => {
     const comments: unknown[] = [];
     const pageSize = 100;
     for (let page = 1; ; page += 1) {
-      const raw = runGh([
-        'api',
-        `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
-        '--jq',
-        '.',
-      ]).trim();
-      const pageItems = raw && raw !== 'null' ? JSON.parse(raw) : [];
+      const pageItems = await withBoundedRetry(async () => {
+        const raw = runGh([
+          'api',
+          `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+          '--jq',
+          '.',
+        ]).trim();
+        return raw && raw !== 'null' ? JSON.parse(raw) : [];
+      });
       if (!Array.isArray(pageItems) || pageItems.length === 0) {
         break;
       }
@@ -2307,6 +2316,19 @@ async function getIssue(
   return issue;
 }
 
+/**
+ * Live per-issue loader for the traversal hot path.
+ *
+ * Bounded-retried (#1394): the `runGhAsync(...) + JSON.parse(...)` body runs
+ * inside {@link withBoundedRetry} so a transient hiccup — including a
+ * truncated-stdout JSON parse failure — gets up to 2 additional fresh `gh`
+ * round-trips before this loader gives up. `isRetryable` reuses the same
+ * `isNotFoundIssueLookupError` / `isInaccessibleIssueLookupError` pair the
+ * outer `catch` already classifies with, so a genuine 404 or access-style
+ * failure is still recognized on the FIRST attempt (retried zero times,
+ * exactly like before this change) and still reaches the outer `catch`
+ * below unchanged.
+ */
 export function buildIssueLoader(owner: string, repo: string) {
   return async (issueNumber: number) => {
     const args = [
@@ -2316,11 +2338,22 @@ export function buildIssueLoader(owner: string, repo: string) {
       '.',
     ];
     try {
-      const result = (await runGhAsync(args, { allowStatuses: [404] })).trim();
-      if (!result || result === 'null') {
-        return null;
-      }
-      return JSON.parse(result);
+      return await withBoundedRetry(
+        async () => {
+          const result = (
+            await runGhAsync(args, { allowStatuses: [404] })
+          ).trim();
+          if (!result || result === 'null') {
+            return null;
+          }
+          return JSON.parse(result);
+        },
+        {
+          isRetryable: (error) =>
+            !isNotFoundIssueLookupError(error) &&
+            !isInaccessibleIssueLookupError(error),
+        },
+      );
     } catch (error) {
       if (isNotFoundIssueLookupError(error)) {
         return null;
@@ -2333,6 +2366,23 @@ export function buildIssueLoader(owner: string, repo: string) {
   };
 }
 
+/**
+ * Live sub-issue loader for the traversal hot path.
+ *
+ * Bounded-retried (#1394): each page's `runGraphqlQuery(...)` call runs
+ * inside {@link withBoundedRetry} with the default retry-everything
+ * classifier — unlike {@link buildIssueLoader}, this loader has no
+ * pre-existing REST-status-based classification to preserve, and every
+ * failure `runGraphqlQuery` can produce today (a transient truncated-stdout
+ * parse failure, a reported GraphQL `errors[]` entry, or a process-exec
+ * failure) already rethrows unclassified. A genuinely persistent failure
+ * (e.g. an inaccessible parent issue) still rethrows, just after up to 2
+ * extra bounded round-trips instead of 0 — a small, deliberate latency cost,
+ * not a fail-closed regression. The connection/cursor-shape checks below
+ * stay un-retried on purpose: they only fire once `runGraphqlQuery` already
+ * resolved without a transport/parse error, so retrying them would not
+ * change the outcome.
+ */
 export function buildSubIssueLoader(owner: string, repo: string) {
   return async (issueNumber: number) => {
     const numbers: number[] = [];
@@ -2347,7 +2397,9 @@ export function buildSubIssueLoader(owner: string, repo: string) {
       if (after) {
         variables.after = after;
       }
-      const result = (await runGraphqlQuery(SUB_ISSUES_QUERY, variables)) as {
+      const result = (await withBoundedRetry(() =>
+        runGraphqlQuery(SUB_ISSUES_QUERY, variables),
+      )) as {
         data?: {
           repository?: {
             issue?: {

--- a/src/scripts/gh-exec.mts
+++ b/src/scripts/gh-exec.mts
@@ -149,6 +149,72 @@ export function ghApiJson(
   return JSON.parse(raw.trim() || '{}');
 }
 
+/** Options accepted by {@link withBoundedRetry}. */
+export interface BoundedRetryOptions {
+  /** Total attempts including the first. Default 3. */
+  attempts?: number;
+  /**
+   * Base delay (ms) for the linear-ish backoff + jitter between attempts.
+   * Default 200.
+   */
+  baseDelayMs?: number;
+  /**
+   * Retryable predicate, checked BEFORE consuming an extra attempt.
+   * Returning `false` rethrows immediately, without waiting or re-invoking
+   * `task` — this is how a caller keeps an already-classified non-transient
+   * failure (e.g. a 404) short-circuiting to exactly one `task` invocation,
+   * byte-identical to having no retry wrapper at all. Default: retry every
+   * failure.
+   */
+  isRetryable?: (error: unknown) => boolean;
+}
+
+const DEFAULT_BOUNDED_RETRY_ATTEMPTS = 3;
+const DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS = 200;
+
+/** `await`-able delay, used only for the backoff between retry attempts. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
+}
+
+/**
+ * Run `task`, retrying a bounded number of times on a retryable failure
+ * (#1394): a transient `gh`/API hiccup (e.g. truncated captured stdout under
+ * heavy concurrent load) no longer has to abort a whole caller-side
+ * traversal when an immediate retry would have succeeded in isolation.
+ *
+ * Fail-closed is preserved: once the bounded attempts are exhausted, the
+ * final attempt's error is rethrown unchanged — the exact same error
+ * instance, never re-wrapped — so an existing caller-side classifier (e.g.
+ * this module's own `allowStatuses` consumers, or a 404/access-style
+ * predicate) still reads the identical shape it read before this wrapper
+ * existed.
+ */
+export async function withBoundedRetry<T>(
+  task: () => Promise<T>,
+  options: BoundedRetryOptions = {},
+): Promise<T> {
+  const {
+    attempts = DEFAULT_BOUNDED_RETRY_ATTEMPTS,
+    baseDelayMs = DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS,
+    isRetryable = () => true,
+  } = options;
+  const totalAttempts = Math.max(1, Math.trunc(attempts));
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await task();
+    } catch (error) {
+      if (attempt >= totalAttempts || !isRetryable(error)) {
+        throw error;
+      }
+      await delay(baseDelayMs * attempt + Math.random() * baseDelayMs);
+    }
+  }
+}
+
 /**
  * True when this module is executing as the invoked CLI entry point
  * (`node <this-file>.mjs ...`), false when it is only imported (e.g. from

--- a/src/scripts/gh-exec.mts
+++ b/src/scripts/gh-exec.mts
@@ -201,7 +201,21 @@ export async function withBoundedRetry<T>(
     baseDelayMs = DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS,
     isRetryable = () => true,
   } = options;
-  const totalAttempts = Math.max(1, Math.trunc(attempts));
+  // A non-finite `attempts` (`NaN` from a failed parse, or `Infinity`)
+  // would otherwise survive `Math.max`/`Math.trunc` unchanged (both are
+  // no-ops on non-finite input) and make `attempt >= totalAttempts` never
+  // true, defeating the whole bounded-attempt contract with an unbounded
+  // retry loop (Copilot + Codex review, #1394). Fall back to the default
+  // whenever the caller-supplied value is not a finite number. The same
+  // guard applies to `baseDelayMs` for consistency: a non-finite backoff
+  // would not break the bound (attempts still caps the loop), but would
+  // silently skip the intended backoff/jitter delay between attempts.
+  const totalAttempts = Number.isFinite(attempts)
+    ? Math.max(1, Math.trunc(attempts))
+    : DEFAULT_BOUNDED_RETRY_ATTEMPTS;
+  const effectiveBaseDelayMs = Number.isFinite(baseDelayMs)
+    ? baseDelayMs
+    : DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS;
 
   for (let attempt = 1; ; attempt += 1) {
     try {
@@ -210,7 +224,9 @@ export async function withBoundedRetry<T>(
       if (attempt >= totalAttempts || !isRetryable(error)) {
         throw error;
       }
-      await delay(baseDelayMs * attempt + Math.random() * baseDelayMs);
+      await delay(
+        effectiveBaseDelayMs * attempt + Math.random() * effectiveBaseDelayMs,
+      );
     }
   }
 }

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -1,13 +1,16 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  buildCommentLoader,
+  buildIssueLoader,
   buildOpenRoadmapRootsLoader,
+  buildSubIssueLoader,
   buildTrustedAuthorPredicate,
   classifyIssue,
   enumerateAllRoadmapsGraph,
@@ -20,6 +23,53 @@ import {
   type SearchIssuesQuery,
   warnOnSearchResultCap,
 } from '../src/scripts/discover-roadmap-graph.mts';
+
+/**
+ * Stub `gh` on PATH with a script that counts its own invocations via a
+ * counter file on disk (#1394): each retry attempt in the tests below is a
+ * genuine new `gh` subprocess, so an in-memory JS counter in the test
+ * process cannot observe it — the count must persist across process
+ * boundaries. `scriptBody` receives `count` (this invocation's 1-based
+ * index) as a variable already in scope. Returns `{ restore, readCount }`;
+ * callers must invoke `restore` (ideally in a `finally`) even when the
+ * assertion throws.
+ */
+function stubGhWithCounter(scriptBody: string): {
+  restore: () => void;
+  readCount: () => number;
+} {
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-discover-roadmap-graph-retry-'),
+  );
+  const ghPath = join(tempRoot, 'gh');
+  const counterFile = join(tempRoot, 'count');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const counterFile = ${JSON.stringify(counterFile)};
+let count = 0;
+try {
+  count = Number(fs.readFileSync(counterFile, 'utf8').trim()) || 0;
+} catch {}
+count += 1;
+fs.writeFileSync(counterFile, String(count));
+const args = process.argv.slice(2);
+${scriptBody}
+process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${tempRoot}:${originalPath ?? ''}`;
+  return {
+    restore: () => {
+      process.env.PATH = originalPath;
+    },
+    readCount: () => Number(readFileSync(counterFile, 'utf8').trim()),
+  };
+}
 
 /** Run `body` with `process.stderr.write` captured; return the joined output. */
 function captureStderr(body: () => void): string {
@@ -2413,4 +2463,144 @@ test('normalizeConcurrency keeps integers >= 1 and falls back otherwise (#1136)'
   assert.equal(normalizeConcurrency('2.5'), DEFAULT);
   assert.equal(normalizeConcurrency('3px'), DEFAULT);
   assert.equal(normalizeConcurrency(''), DEFAULT);
+});
+
+test('buildIssueLoader retries once past a truncated-JSON transient failure, then succeeds (#1394)', async () => {
+  const { restore, readCount } = stubGhWithCounter(`
+if (args[0] === 'api' && args[1] === 'repos/o/r/issues/900') {
+  if (count === 1) {
+    // Truncated captured stdout (the field evidence's "unexpected end of
+    // JSON input"): gh itself exits cleanly, but the body is cut short.
+    process.stdout.write('{"number": 900, "tit');
+    process.exit(0);
+  }
+  process.stdout.write(JSON.stringify({ number: 900, title: 'issue 900' }));
+  process.exit(0);
+}
+`);
+  try {
+    const result = await buildIssueLoader('o', 'r')(900);
+    assert.deepEqual(result, { number: 900, title: 'issue 900' });
+    assert.equal(readCount(), 2);
+  } finally {
+    restore();
+  }
+});
+
+test('buildIssueLoader still rethrows after exhausting bounded attempts on a persistent failure (#1394)', async () => {
+  const { restore, readCount } = stubGhWithCounter(`
+process.stderr.write('HTTP 500 (simulated persistent failure)');
+process.exit(1);
+`);
+  try {
+    await assert.rejects(
+      () => buildIssueLoader('o', 'r')(900),
+      (error: unknown) => {
+        // Fail-closed AND unwrapped: still the plain gh-exec failure shape,
+        // not re-wrapped by the retry layer.
+        assert.match((error as Error).message, /HTTP 500/);
+        assert.equal(
+          (error as { stderr?: string }).stderr,
+          'HTTP 500 (simulated persistent failure)',
+        );
+        return true;
+      },
+    );
+    assert.equal(readCount(), 3);
+  } finally {
+    restore();
+  }
+});
+
+test('buildIssueLoader resolves an existing 404 immediately, without any retry (#1394)', async () => {
+  const { restore, readCount } = stubGhWithCounter(`
+process.stderr.write('HTTP 404: Not Found (https://api.github.com/repos/o/r/issues/900)');
+process.exit(1);
+`);
+  try {
+    const result = await buildIssueLoader('o', 'r')(900);
+    assert.equal(result, null);
+    // The 404 classifier short-circuits on the FIRST attempt: byte-identical
+    // to having no retry wrapper at all.
+    assert.equal(readCount(), 1);
+  } finally {
+    restore();
+  }
+});
+
+test('buildSubIssueLoader retries once past a transient GraphQL failure, then succeeds (#1394)', async () => {
+  const { restore, readCount } = stubGhWithCounter(`
+if (args[0] === 'api' && args[1] === 'graphql') {
+  if (count === 1) {
+    // Same transient shape: a truncated stdout body surfaces as a
+    // JSON.parse failure inside runGraphqlQuery.
+    process.stdout.write('{"data": {"repository": {"issue": {"sub');
+    process.exit(0);
+  }
+  process.stdout.write(JSON.stringify({
+    data: {
+      repository: {
+        issue: {
+          subIssues: {
+            nodes: [{ number: 701 }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    },
+  }));
+  process.exit(0);
+}
+`);
+  try {
+    const result = await buildSubIssueLoader('o', 'r')(700);
+    assert.deepEqual(result, [701]);
+    assert.equal(readCount(), 2);
+  } finally {
+    restore();
+  }
+});
+
+test('buildSubIssueLoader still rethrows after exhausting bounded attempts on a persistent failure (#1394)', async () => {
+  const { restore, readCount } = stubGhWithCounter(`
+process.stderr.write('rate limited (simulated persistent failure)');
+process.exit(1);
+`);
+  try {
+    await assert.rejects(
+      () => buildSubIssueLoader('o', 'r')(700),
+      /rate limited/,
+    );
+    assert.equal(readCount(), 3);
+  } finally {
+    restore();
+  }
+});
+
+test('buildCommentLoader retries once past a transient page-fetch failure, then succeeds (#1394)', async () => {
+  const { restore, readCount } = stubGhWithCounter(`
+if (args[0] === 'api' && String(args[1]).startsWith('repos/o/r/issues/900/comments')) {
+  if (count === 1) {
+    process.stdout.write('[{"body": "trunca');
+    process.exit(0);
+  }
+  process.stdout.write(JSON.stringify([
+    { body: 'hello', createdAt: '2026-01-01T00:00:00Z', author: { login: 'kurone-kito' } },
+  ]));
+  process.exit(0);
+}
+`);
+  try {
+    const result = await buildCommentLoader('o', 'r')(900);
+    assert.deepEqual(result, [
+      {
+        body: 'hello',
+        createdAt: '2026-01-01T00:00:00Z',
+        author: { login: 'kurone-kito' },
+      },
+    ]);
+    assert.equal(readCount(), 2);
+  } finally {
+    restore();
+  }
 });

--- a/tests/gh-exec.test.mts
+++ b/tests/gh-exec.test.mts
@@ -11,6 +11,7 @@ import {
   ghText,
   isCliExecution,
   safeGhText,
+  withBoundedRetry,
 } from '../src/scripts/gh-exec.mts';
 
 // Stub `gh` on PATH (the discover-roadmap-graph.test.mts / post-idd-marker.test.mts
@@ -284,4 +285,65 @@ test('isCliExecution is false for an unrelated moduleUrl or a missing argv[1]', 
   } finally {
     process.argv[1] = originalArgv1;
   }
+});
+
+test('withBoundedRetry succeeds after transient failures within the attempt budget', async () => {
+  let calls = 0;
+  const result = await withBoundedRetry(
+    async () => {
+      calls += 1;
+      if (calls < 3) {
+        throw new Error(`transient failure ${calls}`);
+      }
+      return 'ok';
+    },
+    { baseDelayMs: 1 },
+  );
+  assert.equal(result, 'ok');
+  assert.equal(calls, 3);
+});
+
+test('withBoundedRetry rethrows immediately, without retrying, when isRetryable returns false', async () => {
+  let calls = 0;
+  const thrown = new Error('not retryable');
+  let caught: unknown;
+  try {
+    await withBoundedRetry(
+      async () => {
+        calls += 1;
+        throw thrown;
+      },
+      { baseDelayMs: 1, isRetryable: () => false },
+    );
+    assert.fail('expected withBoundedRetry to reject');
+  } catch (error) {
+    caught = error;
+  }
+  // Same instance, never re-wrapped, and called exactly once (no wasted
+  // attempt or backoff wait once isRetryable says no).
+  assert.equal(caught, thrown);
+  assert.equal(calls, 1);
+});
+
+test('withBoundedRetry exhausts bounded attempts and rethrows the final error unchanged', async () => {
+  let calls = 0;
+  let lastError: Error | undefined;
+  let caught: unknown;
+  try {
+    await withBoundedRetry(
+      async () => {
+        calls += 1;
+        lastError = new Error(`persistent failure ${calls}`);
+        throw lastError;
+      },
+      { attempts: 3, baseDelayMs: 1 },
+    );
+    assert.fail('expected withBoundedRetry to reject');
+  } catch (error) {
+    caught = error;
+  }
+  // Bounded to exactly `attempts` tries, and the rethrown error is the same
+  // instance the final attempt threw (fail-closed, never re-wrapped).
+  assert.equal(calls, 3);
+  assert.equal(caught, lastError);
 });

--- a/tests/gh-exec.test.mts
+++ b/tests/gh-exec.test.mts
@@ -347,3 +347,48 @@ test('withBoundedRetry exhausts bounded attempts and rethrows the final error un
   assert.equal(calls, 3);
   assert.equal(caught, lastError);
 });
+
+test('withBoundedRetry falls back to the default attempt bound on a non-finite attempts value (#1394 Copilot + Codex review)', async () => {
+  for (const nonFiniteAttempts of [Number.NaN, Number.POSITIVE_INFINITY]) {
+    let calls = 0;
+    let caught: unknown;
+    try {
+      await withBoundedRetry(
+        async () => {
+          calls += 1;
+          throw new Error(`persistent failure ${calls}`);
+        },
+        { attempts: nonFiniteAttempts, baseDelayMs: 1 },
+      );
+      assert.fail('expected withBoundedRetry to reject');
+    } catch (error) {
+      caught = error;
+    }
+    // Without the Number.isFinite guard, `Math.max(1, Math.trunc(NaN))` is
+    // `NaN` and `Math.max(1, Math.trunc(Infinity))` is `Infinity`; either
+    // way `attempt >= totalAttempts` is never true, so the loop never
+    // terminates. Asserting a bounded call count (the default of 3, not an
+    // unbounded count) is the actual regression check.
+    assert.ok(caught instanceof Error);
+    assert.equal(calls, 3);
+  }
+});
+
+test('withBoundedRetry falls back to the default backoff on a non-finite baseDelayMs value', async () => {
+  let calls = 0;
+  const result = await withBoundedRetry(
+    async () => {
+      calls += 1;
+      if (calls < 2) {
+        throw new Error('transient failure');
+      }
+      return 'ok';
+    },
+    { baseDelayMs: Number.NaN },
+  );
+  // A non-finite baseDelayMs cannot hang the suite (setTimeout would clamp
+  // it), but should not silently disable backoff either; this only proves
+  // the call still completes and resolves normally under the fallback.
+  assert.equal(result, 'ok');
+  assert.equal(calls, 2);
+});


### PR DESCRIPTION
# Summary

Adds a small bounded-retry-with-backoff utility (`withBoundedRetry` in
`gh-exec.mts`) and wraps `discover-roadmap-graph.mts`'s three traversal
loaders (`buildIssueLoader`, `buildSubIssueLoader`, `buildCommentLoader`)
so a transient `gh`/API hiccup no longer aborts a whole roadmap-graph
enumeration when an immediate retry would have succeeded.

## Linked issue

Closes #1394

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Field evidence (batch-6 roadmap #1386): with six-plus concurrent sessions
against one repository, the roadmap-graph discovery helper aborted three
separate times in one Discover pass with `gh api ... failed: unexpected
end of JSON input`; an isolated re-run of the exact same call succeeded
immediately every time -- consistent with transient gh/API contention
under heavy concurrent load, not a systemic defect.

`buildIssueLoader` retries only around its existing 404/access-style
classification (`isNotFoundIssueLookupError` / `isInaccessibleIssueLookupError`):
an already-classified failure still short-circuits on the very first
attempt, byte-identical to before this change. `buildSubIssueLoader` and
`buildCommentLoader` retry every failure by default, since neither had a
pre-existing classification to preserve -- a genuinely persistent failure
still rethrows the exact same error instance unchanged, just after up to
2 extra bounded round-trips instead of 0 (a small, deliberate latency
cost documented in code comments, not a fail-closed regression).

No flag/env override was added (the issue marks it optional); the fixed
default (3 attempts, linear-ish backoff + jitter) keeps scope small, so
no helper-docs update was needed.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed