### PR TITLE
fix(claim): thread prFirstCommitAt through the PR-target claim gate

### DIFF
--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -63,6 +63,7 @@ import {
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   resolveAdvisoryBotLogins,
+  resolvePrFirstCommitAt,
   resolveTrustedMarkerActors,
   summarizeClaimValidation,
   summarizeDispositionEvidenceForGate,
@@ -833,35 +834,6 @@ function resolveTrustedCollaboratorMarkerLogins(
       permission === 'write'
     );
   });
-}
-/**
- * Resolve the PR's first-commit time as an ISO string -- mirrors
- * `pre-merge-readiness.mts`'s `resolvePrFirstCommitAt` verbatim (the
- * minimum across all commits of each commit's committer date, falling
- * back to author date). Returns `null` when no commit carries a
- * parseable date, which fails the Part B (#1058) allowance closed
- * (an `issue-only` handoff against a PR-backed claim stays rejected).
- */
-function resolvePrFirstCommitAt(commits) {
-  let earliestMs = null;
-  let earliestIso = null;
-  for (const commit of commits) {
-    const date =
-      String(commit?.commit?.committer?.date ?? '').trim() ||
-      String(commit?.commit?.author?.date ?? '').trim();
-    if (!date) {
-      continue;
-    }
-    const ms = Date.parse(date);
-    if (!Number.isFinite(ms)) {
-      continue;
-    }
-    if (earliestMs === null || ms < earliestMs) {
-      earliestMs = ms;
-      earliestIso = date;
-    }
-  }
-  return earliestIso;
 }
 function ghGraphql(query, variables) {
   const args = ['api', 'graphql', '-f', `query=${query}`];

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -12,13 +12,14 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mjs';
-import { isCliExecution } from './gh-exec.mjs';
+import { ghApiJson, isCliExecution } from './gh-exec.mjs';
 import { resolveCollaboratorMarkerTrust } from './policy-helpers.mjs';
 import {
   applyDigestUpsert,
   normalizeTrustedMarkerLogins,
   parsePaginatedGhNdjson,
   planLiveStatusDigestUpsert,
+  resolvePrFirstCommitAt,
   resolveTrustedMarkerActors,
   summarizeClaimValidation,
 } from './protocol-helpers.mjs';
@@ -77,6 +78,11 @@ function main() {
     targetType === 'pr'
       ? {
           expectedLinkedPrs: buildExpectedLinkedPrReferences(
+            owner,
+            repo,
+            targetNumber,
+          ),
+          prFirstCommitAt: resolvePrFirstCommitAtForPr(
             owner,
             repo,
             targetNumber,
@@ -266,6 +272,7 @@ function readActiveClaim(owner, repo, issueNumber, options = {}) {
     trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
     forcedHandoffEnabled: readForcedHandoffMode() === 'human-gated',
     expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
     isAuthorizedForcedHandoff: (forcedBy) =>
       isAuthorizedForcedHandoffActor(
         owner,
@@ -295,6 +302,30 @@ function buildExpectedLinkedPrReferences(owner, repo, prNumber) {
     `#${normalized}`,
     `https://github.com/${owner}/${repo}/pull/${normalized}`,
   ];
+}
+// The PR's first-commit time backs the Part B forced-handoff rule (#1058): a
+// legitimate issue-only handoff that predates the PR is honored even against
+// a PR-backed claim -- see `buildForcedHandoffEnableGate` in
+// protocol-helpers.mts. Resolve it only when forced handoffs are enabled, and
+// fail closed to `null` (reject) on any lookup/parse error so a transient
+// commits-API failure never widens what the gate accepts. Mirrors
+// `pre-merge-readiness.mts` / `advisory-convergence.mts`'s identical
+// resolution, sharing `resolvePrFirstCommitAt`'s date computation with both.
+function resolvePrFirstCommitAtForPr(owner, repo, prNumber) {
+  if (readForcedHandoffMode() !== 'human-gated') {
+    return null;
+  }
+  try {
+    const prCommits = ghApiJson(
+      `repos/${owner}/${repo}/pulls/${prNumber}/commits`,
+      {
+        paginate: true,
+      },
+    );
+    return resolvePrFirstCommitAt(prCommits);
+  } catch {
+    return null;
+  }
 }
 export function isTrustedMarkerAuthor(owner, repo, login) {
   if (!login) {

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -74,15 +74,19 @@ function main() {
     args.issue ?? args.pr,
     `--${targetType}`,
   );
+  // `expectedLinkedPrs` is a pure, local computation, so building it
+  // eagerly is free. `prFirstCommitAt` is not: resolving it makes a
+  // paginated `gh api pulls/{pr}/commits` call. `claimContext` is only
+  // consumed inside the `assertClaim` callback below, which
+  // `applyDigestUpsert` invokes only for a real `--apply` claim check (never
+  // for a dry-run, a duplicate-plan exit, or `--apply --skip-claim-check`),
+  // so resolve `prFirstCommitAt` lazily at that same call site instead of
+  // paying for it on every invocation regardless of whether anything ends
+  // up consuming it.
   const claimContext =
     targetType === 'pr'
       ? {
           expectedLinkedPrs: buildExpectedLinkedPrReferences(
-            owner,
-            repo,
-            targetNumber,
-          ),
-          prFirstCommitAt: resolvePrFirstCommitAtForPr(
             owner,
             repo,
             targetNumber,
@@ -151,7 +155,13 @@ function main() {
             args.claimIssue,
             args.agentId,
             args.claimId,
-            claimContext,
+            {
+              ...claimContext,
+              prFirstCommitAt:
+                targetType === 'pr'
+                  ? resolvePrFirstCommitAtForPr(owner, repo, targetNumber)
+                  : null,
+            },
           ),
         createComment: (body) =>
           createIssueComment(owner, repo, targetNumber, body),

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -33,6 +33,7 @@ import {
   parsePaginatedGhNdjson,
   resolveAdvisoryBotLogins,
   resolveCodeownersForFiles,
+  resolvePrFirstCommitAt,
   resolveRulesetDetailPath,
   resolveTrustedMarkerActors,
   selectCodeownersText,
@@ -788,35 +789,6 @@ function ghApiJson(path, paginate = false, extraArgs = [], options = {}) {
     return parsePaginatedGhNdjson(raw);
   }
   return JSON.parse(raw);
-}
-/**
- * Resolve the PR's first-commit time as an ISO string: the minimum across all
- * commits of each commit's committer date (falling back to author date). The
- * GitHub `pulls/{pr}/commits` listing is chronological, but compute the
- * minimum defensively rather than relying on order. Returns `null` when no
- * commit carries a parseable date, which makes the Part B gate fail closed
- * (issue-only handoffs against a PR-backed claim stay rejected).
- */
-function resolvePrFirstCommitAt(commits) {
-  let earliestMs = null;
-  let earliestIso = null;
-  for (const commit of commits) {
-    const date =
-      String(commit?.commit?.committer?.date ?? '').trim() ||
-      String(commit?.commit?.author?.date ?? '').trim();
-    if (!date) {
-      continue;
-    }
-    const ms = Date.parse(date);
-    if (!Number.isFinite(ms)) {
-      continue;
-    }
-    if (earliestMs === null || ms < earliestMs) {
-      earliestMs = ms;
-      earliestIso = date;
-    }
-  }
-  return earliestIso;
 }
 /**
  * Decide how a thrown `gh` failure is tolerated, returning the string result to

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3407,6 +3407,39 @@ export function resolveRulesetDetailPath(owner, repo, rule, rulesetId) {
   return `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/rulesets/${rulesetId}`;
 }
 /**
+ * Resolve a PR's first-commit time as an ISO string -- the minimum across all
+ * commits of each commit's committer date, falling back to author date. A
+ * GitHub `pulls/{pr}/commits` listing is chronological, but compute the
+ * minimum defensively rather than relying on order. Returns `null` when no
+ * commit carries a parseable date, which makes the Part B gate below fail
+ * closed (an `issue-only` handoff against a PR-backed claim stays rejected).
+ *
+ * Shared by every `prFirstCommitAt` resolver (`pre-merge-readiness.mts`,
+ * `advisory-convergence.mts`, `live-status-digest.mts`) so the Part B
+ * allowance's date computation has one implementation, not three.
+ */
+export function resolvePrFirstCommitAt(commits) {
+  let earliestMs = null;
+  let earliestIso = null;
+  for (const commit of commits) {
+    const date =
+      String(commit?.commit?.committer?.date ?? '').trim() ||
+      String(commit?.commit?.author?.date ?? '').trim();
+    if (!date) {
+      continue;
+    }
+    const ms = Date.parse(date);
+    if (!Number.isFinite(ms)) {
+      continue;
+    }
+    if (earliestMs === null || ms < earliestMs) {
+      earliestMs = ms;
+      earliestIso = date;
+    }
+  }
+  return earliestIso;
+}
+/**
  * Build the `isForcedHandoffEnabled` gate shared by every claim-revalidation
  * path (resume routing, the merge-gate, and the write-side helpers).
  *

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -60,12 +60,14 @@ import {
   parseIsoDurationToMs,
   resolveCollaboratorMarkerTrust,
 } from './policy-helpers.mts';
+import type { PrCommitPayload } from './protocol-helpers.mts';
 import {
   DEFAULT_STALE_AGE_MS,
   isCopilotReviewerLogin,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   resolveAdvisoryBotLogins,
+  resolvePrFirstCommitAt,
   resolveTrustedMarkerActors,
   summarizeClaimValidation,
   summarizeDispositionEvidenceForGate,
@@ -139,16 +141,6 @@ interface ReviewThreadsConnectionPayload {
 /** `gh pr view --json closingIssuesReferences` entry. */
 interface ClosingIssueRefPayload {
   number?: number | null;
-}
-
-/** Commit payload fields consumed by the Part B (#1058) first-commit-time
- * resolver -- mirrors `pre-merge-readiness.mts`'s `PrCommitPayload`
- * verbatim. */
-interface PrCommitPayload {
-  commit?: {
-    author?: { date?: string | null } | null;
-    committer?: { date?: string | null } | null;
-  } | null;
 }
 
 /** Latest-review clause evidence (Clause 1 of the `converged` definition). */
@@ -1139,36 +1131,6 @@ function resolveTrustedCollaboratorMarkerLogins(
       permission === 'write'
     );
   });
-}
-
-/**
- * Resolve the PR's first-commit time as an ISO string -- mirrors
- * `pre-merge-readiness.mts`'s `resolvePrFirstCommitAt` verbatim (the
- * minimum across all commits of each commit's committer date, falling
- * back to author date). Returns `null` when no commit carries a
- * parseable date, which fails the Part B (#1058) allowance closed
- * (an `issue-only` handoff against a PR-backed claim stays rejected).
- */
-function resolvePrFirstCommitAt(commits: PrCommitPayload[]): string | null {
-  let earliestMs: number | null = null;
-  let earliestIso: string | null = null;
-  for (const commit of commits) {
-    const date =
-      String(commit?.commit?.committer?.date ?? '').trim() ||
-      String(commit?.commit?.author?.date ?? '').trim();
-    if (!date) {
-      continue;
-    }
-    const ms = Date.parse(date);
-    if (!Number.isFinite(ms)) {
-      continue;
-    }
-    if (earliestMs === null || ms < earliestMs) {
-      earliestMs = ms;
-      earliestIso = date;
-    }
-  }
-  return earliestIso;
 }
 
 function ghGraphql(

--- a/src/scripts/live-status-digest.mts
+++ b/src/scripts/live-status-digest.mts
@@ -159,15 +159,19 @@ function main(): void {
     args.issue ?? args.pr,
     `--${targetType}`,
   );
+  // `expectedLinkedPrs` is a pure, local computation, so building it
+  // eagerly is free. `prFirstCommitAt` is not: resolving it makes a
+  // paginated `gh api pulls/{pr}/commits` call. `claimContext` is only
+  // consumed inside the `assertClaim` callback below, which
+  // `applyDigestUpsert` invokes only for a real `--apply` claim check (never
+  // for a dry-run, a duplicate-plan exit, or `--apply --skip-claim-check`),
+  // so resolve `prFirstCommitAt` lazily at that same call site instead of
+  // paying for it on every invocation regardless of whether anything ends
+  // up consuming it.
   const claimContext =
     targetType === 'pr'
       ? {
           expectedLinkedPrs: buildExpectedLinkedPrReferences(
-            owner,
-            repo,
-            targetNumber,
-          ),
-          prFirstCommitAt: resolvePrFirstCommitAtForPr(
             owner,
             repo,
             targetNumber,
@@ -241,7 +245,13 @@ function main(): void {
             args.claimIssue,
             args.agentId,
             args.claimId,
-            claimContext,
+            {
+              ...claimContext,
+              prFirstCommitAt:
+                targetType === 'pr'
+                  ? resolvePrFirstCommitAtForPr(owner, repo, targetNumber)
+                  : null,
+            },
           ),
         createComment: (body) =>
           createIssueComment(owner, repo, targetNumber, body),

--- a/src/scripts/live-status-digest.mts
+++ b/src/scripts/live-status-digest.mts
@@ -14,14 +14,16 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mts';
-import { isCliExecution } from './gh-exec.mts';
+import { ghApiJson, isCliExecution } from './gh-exec.mts';
 import { resolveCollaboratorMarkerTrust } from './policy-helpers.mts';
+import type { PrCommitPayload } from './protocol-helpers.mts';
 import {
   applyDigestUpsert,
   type DigestUpsertOutcome,
   normalizeTrustedMarkerLogins,
   parsePaginatedGhNdjson,
   planLiveStatusDigestUpsert,
+  resolvePrFirstCommitAt,
   resolveTrustedMarkerActors,
   summarizeClaimValidation,
 } from './protocol-helpers.mts';
@@ -161,6 +163,11 @@ function main(): void {
     targetType === 'pr'
       ? {
           expectedLinkedPrs: buildExpectedLinkedPrReferences(
+            owner,
+            repo,
+            targetNumber,
+          ),
+          prFirstCommitAt: resolvePrFirstCommitAtForPr(
             owner,
             repo,
             targetNumber,
@@ -355,7 +362,10 @@ function assertActiveClaim(
   issueNumber: string | undefined,
   agentId: string | undefined,
   claimId: string | undefined,
-  options: { expectedLinkedPrs?: string[] } = {},
+  options: {
+    expectedLinkedPrs?: string[];
+    prFirstCommitAt?: string | null;
+  } = {},
 ): void {
   const active = readActiveClaim(owner, repo, issueNumber, options);
   if (
@@ -374,7 +384,10 @@ function readActiveClaim(
   owner: string,
   repo: string,
   issueNumber: string | undefined,
-  options: { expectedLinkedPrs?: string[] } = {},
+  options: {
+    expectedLinkedPrs?: string[];
+    prFirstCommitAt?: string | null;
+  } = {},
 ) {
   const comments = fetchIssueComments(owner, repo, issueNumber).map(
     (comment) => {
@@ -395,6 +408,7 @@ function readActiveClaim(
     trustedMarkerLogins: resolveTrustedMarkerLogins(owner, repo, comments),
     forcedHandoffEnabled: readForcedHandoffMode() === 'human-gated',
     expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+    prFirstCommitAt: options.prFirstCommitAt ?? null,
     isAuthorizedForcedHandoff: (forcedBy) =>
       isAuthorizedForcedHandoffActor(
         owner,
@@ -435,6 +449,35 @@ function buildExpectedLinkedPrReferences(
     `#${normalized}`,
     `https://github.com/${owner}/${repo}/pull/${normalized}`,
   ];
+}
+
+// The PR's first-commit time backs the Part B forced-handoff rule (#1058): a
+// legitimate issue-only handoff that predates the PR is honored even against
+// a PR-backed claim -- see `buildForcedHandoffEnableGate` in
+// protocol-helpers.mts. Resolve it only when forced handoffs are enabled, and
+// fail closed to `null` (reject) on any lookup/parse error so a transient
+// commits-API failure never widens what the gate accepts. Mirrors
+// `pre-merge-readiness.mts` / `advisory-convergence.mts`'s identical
+// resolution, sharing `resolvePrFirstCommitAt`'s date computation with both.
+function resolvePrFirstCommitAtForPr(
+  owner: string,
+  repo: string,
+  prNumber: number,
+): string | null {
+  if (readForcedHandoffMode() !== 'human-gated') {
+    return null;
+  }
+  try {
+    const prCommits = ghApiJson(
+      `repos/${owner}/${repo}/pulls/${prNumber}/commits`,
+      {
+        paginate: true,
+      },
+    ) as PrCommitPayload[];
+    return resolvePrFirstCommitAt(prCommits);
+  } catch {
+    return null;
+  }
 }
 
 export function isTrustedMarkerAuthor(

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -27,7 +27,10 @@ import {
   parseIsoDurationToMs,
   resolveCollaboratorMarkerTrust,
 } from './policy-helpers.mts';
-import type { TrustedMarkerActorResolution } from './protocol-helpers.mts';
+import type {
+  PrCommitPayload,
+  TrustedMarkerActorResolution,
+} from './protocol-helpers.mts';
 import {
   buildPreMergeReadinessSummary,
   DEFAULT_STALE_AGE_MS,
@@ -37,6 +40,7 @@ import {
   parsePaginatedGhNdjson,
   resolveAdvisoryBotLogins,
   resolveCodeownersForFiles,
+  resolvePrFirstCommitAt,
   resolveRulesetDetailPath,
   resolveTrustedMarkerActors,
   selectCodeownersText,
@@ -70,14 +74,6 @@ interface CheckPayload {
   name?: string | null;
   state?: string | null;
   completedAt?: string | null;
-}
-
-/** Commit payload fields consumed by the Part B first-commit-time resolver. */
-interface PrCommitPayload {
-  commit?: {
-    author?: { date?: string | null } | null;
-    committer?: { date?: string | null } | null;
-  } | null;
 }
 
 /** Timeline event payload fields consumed by the Copilot coverage check. */
@@ -1047,36 +1043,6 @@ function ghApiJson(
     return parsePaginatedGhNdjson(raw);
   }
   return JSON.parse(raw);
-}
-
-/**
- * Resolve the PR's first-commit time as an ISO string: the minimum across all
- * commits of each commit's committer date (falling back to author date). The
- * GitHub `pulls/{pr}/commits` listing is chronological, but compute the
- * minimum defensively rather than relying on order. Returns `null` when no
- * commit carries a parseable date, which makes the Part B gate fail closed
- * (issue-only handoffs against a PR-backed claim stay rejected).
- */
-function resolvePrFirstCommitAt(commits: PrCommitPayload[]): string | null {
-  let earliestMs: number | null = null;
-  let earliestIso: string | null = null;
-  for (const commit of commits) {
-    const date =
-      String(commit?.commit?.committer?.date ?? '').trim() ||
-      String(commit?.commit?.author?.date ?? '').trim();
-    if (!date) {
-      continue;
-    }
-    const ms = Date.parse(date);
-    if (!Number.isFinite(ms)) {
-      continue;
-    }
-    if (earliestMs === null || ms < earliestMs) {
-      earliestMs = ms;
-      earliestIso = date;
-    }
-  }
-  return earliestIso;
 }
 
 /**

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4325,6 +4325,51 @@ export function resolveRulesetDetailPath(
   return `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/rulesets/${rulesetId}`;
 }
 
+/** GitHub `pulls/{pr}/commits` REST payload fields `resolvePrFirstCommitAt`
+ * consumes. */
+export interface PrCommitPayload {
+  commit?: {
+    author?: { date?: string | null } | null;
+    committer?: { date?: string | null } | null;
+  } | null;
+}
+
+/**
+ * Resolve a PR's first-commit time as an ISO string -- the minimum across all
+ * commits of each commit's committer date, falling back to author date. A
+ * GitHub `pulls/{pr}/commits` listing is chronological, but compute the
+ * minimum defensively rather than relying on order. Returns `null` when no
+ * commit carries a parseable date, which makes the Part B gate below fail
+ * closed (an `issue-only` handoff against a PR-backed claim stays rejected).
+ *
+ * Shared by every `prFirstCommitAt` resolver (`pre-merge-readiness.mts`,
+ * `advisory-convergence.mts`, `live-status-digest.mts`) so the Part B
+ * allowance's date computation has one implementation, not three.
+ */
+export function resolvePrFirstCommitAt(
+  commits: PrCommitPayload[],
+): string | null {
+  let earliestMs: number | null = null;
+  let earliestIso: string | null = null;
+  for (const commit of commits) {
+    const date =
+      String(commit?.commit?.committer?.date ?? '').trim() ||
+      String(commit?.commit?.author?.date ?? '').trim();
+    if (!date) {
+      continue;
+    }
+    const ms = Date.parse(date);
+    if (!Number.isFinite(ms)) {
+      continue;
+    }
+    if (earliestMs === null || ms < earliestMs) {
+      earliestMs = ms;
+      earliestIso = date;
+    }
+  }
+  return earliestIso;
+}
+
 /**
  * Build the `isForcedHandoffEnabled` gate shared by every claim-revalidation
  * path (resume routing, the merge-gate, and the write-side helpers).

--- a/tests/live-status-digest.test.mts
+++ b/tests/live-status-digest.test.mts
@@ -475,9 +475,9 @@ test('PR-target + issue-only handoff predating the PR resolves to the successor'
 
 test('PR-target + issue-only handoff NOT predating the PR stays rejected', () => {
   const summary = summarizePrTargetClaim({
-    // Handoff at 2026-06-05 is AFTER this prFirstCommitAt, so Part B does
-    // not apply -- the pre-handoff claim stays active, matching today's
-    // (pre-fix) behavior for this specific input.
+    // Handoff at 2026-06-11 is AFTER PR_TARGET_PR_FIRST_COMMIT_AT
+    // (2026-06-10), so Part B does not apply -- the pre-handoff claim stays
+    // active, matching today's (pre-fix) behavior for this specific input.
     handoffComment: prTargetForcedHandoffComment({
       createdAt: '2026-06-11T00:00:00Z',
     }),
@@ -494,11 +494,12 @@ test('PR-target + issue-plus-pr handoff resolves via the linked-PR match, unaffe
     handoffComment: prTargetForcedHandoffComment({
       contextScope: 'issue-plus-pr',
       linkedPr: '1435',
-      // Deliberately AFTER the handoff, proving acceptance here comes from
-      // the linked-PR match, not the Part B predates-PR rule.
       createdAt: '2026-06-01T12:00:00Z',
     }),
     expectedLinkedPrs: ['1435'],
+    // Deliberately null: `issue-plus-pr` accepts via the linked-PR match,
+    // a path independent of the Part B predates-PR rule, so this proves
+    // acceptance here does not come from prFirstCommitAt.
     prFirstCommitAt: null,
   });
   assert.equal(summary.activeClaimPresent, true);

--- a/tests/live-status-digest.test.mts
+++ b/tests/live-status-digest.test.mts
@@ -15,7 +15,9 @@ import {
   LIVE_STATUS_DIGEST_MARKER,
   planLiveStatusDigestUpsert,
   renderLiveStatusDigest,
+  resolvePrFirstCommitAt,
   resolveTrustedMarkerActors,
+  summarizeClaimValidation,
 } from '../src/scripts/protocol-helpers.mts';
 
 const fields = {
@@ -350,4 +352,170 @@ test('isTrustedMarkerAuthor matches the seeded current viewer login', () => {
   // Case-insensitive against the normalized viewer login.
   assert.equal(isTrustedMarkerAuthor('o', 'r', 'Me-The-Viewer'), true);
   __resetTrustedMarkerCachesForTest();
+});
+
+// --- #1437: PR-target mode was silently rejecting an issue-only
+// forced-handoff successor's claim, because `prFirstCommitAt` was never
+// computed or threaded into `summarizeClaimValidation` -- the Part B (#1058)
+// allowance defaulted closed. `resolvePrFirstCommitAt` is the shared,
+// extracted date computation (also used by `pre-merge-readiness.mts` and
+// `advisory-convergence.mts`); the scenarios below exercise it directly and
+// then prove the claim-resolution contract this file's `readActiveClaim` now
+// participates in, entirely via injected fixtures -- no live network.
+
+test('resolvePrFirstCommitAt: empty commit list resolves to null', () => {
+  assert.equal(resolvePrFirstCommitAt([]), null);
+});
+
+test('resolvePrFirstCommitAt: a single commit resolves to its committer date', () => {
+  assert.equal(
+    resolvePrFirstCommitAt([
+      { commit: { committer: { date: '2026-06-10T00:00:00Z' } } },
+    ]),
+    '2026-06-10T00:00:00Z',
+  );
+});
+
+test('resolvePrFirstCommitAt: picks the earliest commit regardless of array order', () => {
+  const commits = [
+    { commit: { committer: { date: '2026-06-12T00:00:00Z' } } },
+    { commit: { committer: { date: '2026-06-10T00:00:00Z' } } },
+    { commit: { committer: { date: '2026-06-11T00:00:00Z' } } },
+  ];
+  assert.equal(resolvePrFirstCommitAt(commits), '2026-06-10T00:00:00Z');
+});
+
+test('resolvePrFirstCommitAt: falls back to the author date when committer date is absent', () => {
+  assert.equal(
+    resolvePrFirstCommitAt([
+      { commit: { author: { date: '2026-06-09T00:00:00Z' } } },
+    ]),
+    '2026-06-09T00:00:00Z',
+  );
+});
+
+test('resolvePrFirstCommitAt: skips unparseable dates instead of letting them win the minimum', () => {
+  const commits = [
+    { commit: { committer: { date: 'not-a-date' } } },
+    { commit: { committer: { date: '2026-06-10T00:00:00Z' } } },
+  ];
+  assert.equal(resolvePrFirstCommitAt(commits), '2026-06-10T00:00:00Z');
+});
+
+const PR_TARGET_TRUSTED = 'kurone-kito';
+const PR_TARGET_OLD_AGENT_ID = 'claude-old';
+const PR_TARGET_OLD_CLAIM_ID = 'claim-old';
+const PR_TARGET_NEW_AGENT_ID = 'claude-successor';
+const PR_TARGET_NEW_CLAIM_ID = 'claim-successor';
+const PR_TARGET_PR_FIRST_COMMIT_AT = '2026-06-10T00:00:00Z';
+
+function prTargetClaimComment() {
+  return {
+    author: { login: PR_TARGET_TRUSTED },
+    body: `<!-- claimed-by: ${PR_TARGET_OLD_AGENT_ID} ${PR_TARGET_OLD_CLAIM_ID} supersedes: none 2026-06-01T00:00:00Z branch: issue/1435-test -->\n\n_${PR_TARGET_OLD_AGENT_ID}: issue claim — IDD automation marker. Do not edit._`,
+    createdAt: '2026-06-01T00:00:00Z',
+  };
+}
+
+function prTargetForcedHandoffComment({
+  contextScope = 'issue-only',
+  linkedPr,
+  createdAt = '2026-06-05T00:00:00Z',
+}: {
+  contextScope?: string;
+  linkedPr?: string;
+  createdAt?: string;
+} = {}) {
+  const payload = {
+    'old-agent-id': PR_TARGET_OLD_AGENT_ID,
+    'old-claim-id': PR_TARGET_OLD_CLAIM_ID,
+    'new-agent-id': PR_TARGET_NEW_AGENT_ID,
+    'new-claim-id': PR_TARGET_NEW_CLAIM_ID,
+    branch: 'issue/1435-test',
+    'forced-by': PR_TARGET_TRUSTED,
+    reason: 'operator-approved-recovery',
+    timestamp: createdAt,
+    'context-scope': contextScope,
+    ...(linkedPr ? { 'linked-pr': linkedPr } : {}),
+  };
+  return {
+    author: { login: PR_TARGET_TRUSTED },
+    body: `<!-- forced-handoff: ${JSON.stringify(payload)} -->\n\nForced handoff approved by ${PR_TARGET_TRUSTED}.`,
+    createdAt,
+  };
+}
+
+function summarizePrTargetClaim(options: {
+  handoffComment: ReturnType<typeof prTargetForcedHandoffComment>;
+  expectedLinkedPrs: string[];
+  prFirstCommitAt?: string | null;
+}) {
+  return summarizeClaimValidation(
+    [prTargetClaimComment(), options.handoffComment],
+    {
+      trustedMarkerLogins: [PR_TARGET_TRUSTED],
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: options.expectedLinkedPrs,
+      prFirstCommitAt: options.prFirstCommitAt ?? null,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === PR_TARGET_TRUSTED,
+    },
+  );
+}
+
+test('PR-target + issue-only handoff predating the PR resolves to the successor', () => {
+  const summary = summarizePrTargetClaim({
+    handoffComment: prTargetForcedHandoffComment(),
+    expectedLinkedPrs: ['1435'],
+    prFirstCommitAt: PR_TARGET_PR_FIRST_COMMIT_AT,
+  });
+  assert.equal(summary.activeClaimPresent, true);
+  assert.equal(summary.activeClaim?.claimId, PR_TARGET_NEW_CLAIM_ID);
+  assert.equal(summary.activeClaim?.agentId, PR_TARGET_NEW_AGENT_ID);
+});
+
+test('PR-target + issue-only handoff NOT predating the PR stays rejected', () => {
+  const summary = summarizePrTargetClaim({
+    // Handoff at 2026-06-05 is AFTER this prFirstCommitAt, so Part B does
+    // not apply -- the pre-handoff claim stays active, matching today's
+    // (pre-fix) behavior for this specific input.
+    handoffComment: prTargetForcedHandoffComment({
+      createdAt: '2026-06-11T00:00:00Z',
+    }),
+    expectedLinkedPrs: ['1435'],
+    prFirstCommitAt: PR_TARGET_PR_FIRST_COMMIT_AT,
+  });
+  assert.equal(summary.activeClaimPresent, true);
+  assert.equal(summary.activeClaim?.claimId, PR_TARGET_OLD_CLAIM_ID);
+  assert.equal(summary.activeClaim?.agentId, PR_TARGET_OLD_AGENT_ID);
+});
+
+test('PR-target + issue-plus-pr handoff resolves via the linked-PR match, unaffected by prFirstCommitAt', () => {
+  const summary = summarizePrTargetClaim({
+    handoffComment: prTargetForcedHandoffComment({
+      contextScope: 'issue-plus-pr',
+      linkedPr: '1435',
+      // Deliberately AFTER the handoff, proving acceptance here comes from
+      // the linked-PR match, not the Part B predates-PR rule.
+      createdAt: '2026-06-01T12:00:00Z',
+    }),
+    expectedLinkedPrs: ['1435'],
+    prFirstCommitAt: null,
+  });
+  assert.equal(summary.activeClaimPresent, true);
+  assert.equal(summary.activeClaim?.claimId, PR_TARGET_NEW_CLAIM_ID);
+});
+
+test('issue-target mode (no expectedLinkedPrs) honors the handoff unconditionally, unaffected by prFirstCommitAt', () => {
+  const summary = summarizeClaimValidation(
+    [prTargetClaimComment(), prTargetForcedHandoffComment()],
+    {
+      trustedMarkerLogins: [PR_TARGET_TRUSTED],
+      forcedHandoffEnabled: true,
+      expectedLinkedPrs: [],
+      prFirstCommitAt: null,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === PR_TARGET_TRUSTED,
+    },
+  );
+  assert.equal(summary.activeClaimPresent, true);
+  assert.equal(summary.activeClaim?.claimId, PR_TARGET_NEW_CLAIM_ID);
 });


### PR DESCRIPTION
## Summary

`live-status-digest.mjs --pr <number>` resolved the active claim to the
pre-forced-handoff claim instead of the verified successor whenever the
forced-handoff marker was `issue-only`-scoped — the common case, since
`idd-force-handoff` normally runs before a PR exists. In PR-target mode,
`expectedLinkedPrs` is non-empty, so `buildForcedHandoffEnableGate`'s Part B
allowance (#1058) requires `prFirstCommitAt` to accept an issue-only
handoff; this file never computed or passed it, so the value defaulted to
`null` and every issue-only handoff against a PR-backed claim was silently
rejected. Hit live while resuming issue #1387 after an operator-approved
forced handoff (`pre-merge-readiness.mjs` correctly resolved the successor
for the same PR; `live-status-digest.mjs` did not), forcing a manual
workaround.

Extracted the previously-duplicated `PrCommitPayload` type and
`resolvePrFirstCommitAt` (byte-identical in `pre-merge-readiness.mts` and
`advisory-convergence.mts`) into `protocol-helpers.mts` as a single shared,
exported implementation, and updated both existing call sites to import it
instead of carrying their own copy — their own gh-fetch call sites are
otherwise unchanged. Wired the same resolution into
`live-status-digest.mts`'s PR-target `claimContext` construction, gated on
`forcedHandoffEnabled` and failing closed to `null` on any lookup/parse
error, matching the two reference implementations. Issue-target mode is
unaffected — `expectedLinkedPrs` stays absent there, so the gate keeps
returning `true` unconditionally as before.

## Test plan

- [x] Direct unit tests for the extracted `resolvePrFirstCommitAt`
      (empty/single/multiple commits, committer-vs-author-date fallback,
      unparseable-date skipping)
- [x] Tests proving the claim-resolution contract this file's
      `readActiveClaim` now correctly participates in — PR-target
      issue-only handoff predating vs. not predating the PR, issue-plus-pr
      unaffected, issue-target mode unaffected — via injected comment
      fixtures against the shared `summarizeClaimValidation`, no live
      network, matching this codebase's established testing pattern for
      the same Part B logic in the two reference files
- [x] `npx tsc --noEmit` — clean
- [x] Full test suite (`node --experimental-strip-types --test tests/*.test.mts`) — 1998/1998 pass, zero regression from the `protocol-helpers.mts` extraction
- [x] `pnpm run build` output committed
- [x] `node scripts/idd-doctor.mjs` — passes (pre-existing warnings only, unrelated)
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell) — all pass

Closes #1437