### PR TITLE
fix(roadmap-audit-execute): harden gh calls, viewer lookup, reasons

### DIFF
--- a/schemas/idd-roadmap-audit-execute.schema.json
+++ b/schemas/idd-roadmap-audit-execute.schema.json
@@ -87,6 +87,7 @@
     },
     "viewerLoginUnavailable": {
       "type": "boolean",
+      "enum": [true],
       "description": "Present (and true) only when the production viewer-login lookup (gh api user) failed for this run; absent when it succeeded."
     }
   },

--- a/schemas/idd-roadmap-audit-execute.schema.json
+++ b/schemas/idd-roadmap-audit-execute.schema.json
@@ -84,6 +84,10 @@
     },
     "result": {
       "type": "string"
+    },
+    "viewerLoginUnavailable": {
+      "type": "boolean",
+      "description": "Present (and true) only when the production viewer-login lookup (gh api user) failed for this run; absent when it succeeded."
     }
   },
   "additionalProperties": false

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -1292,7 +1292,7 @@ function printHelp() {
   an unexpected blank response) is reported as { viewerLoginUnavailable: true }
   on the verdict, and any not-owned "result" message gets a trailing NOTE, so a
   failed lookup is never silently indistinguishable from a real not-owned
-  claim. Absent (or false) whenever the lookup succeeded normally.
+  claim. Absent (never explicitly false) whenever the lookup succeeded.
 
   SCOPE: this helper gates only the MECHANICAL completion preconditions (all
   descendants closed/complete; no open / unresolved / inaccessible / linked-PR

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -27,7 +27,7 @@ import {
   isClaimStaleByAge,
   parseClaimStaleAgeMs,
 } from './discover-roadmap-graph.mjs';
-import { ghText, safeGhText } from './gh-exec.mjs';
+import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 import {
   renderUnclaimedByMarker,
@@ -412,6 +412,62 @@ export function evaluateRoadmapClaim(comments, options) {
   };
 }
 /**
+ * Fallback explanation for a {@link RoadmapClaimVerdict.reason} /
+ * {@link ClaimValidationSummary} `reason` code this map does not (yet)
+ * recognize. Keeps {@link explainRoadmapClaimReason} total instead of
+ * throwing or returning an empty string for a future/unlisted code.
+ */
+const UNKNOWN_CLAIM_REASON_EXPLANATION =
+  'unrecognized claim-verification reason code';
+/**
+ * Human-readable explanation for every `reason` code {@link evaluateRoadmapClaim}
+ * (and the `summarizeClaimValidation` it wraps) can produce (#1396). The codes
+ * themselves stay stable, machine-readable strings — several are asserted by
+ * exact equality in tests — so this map is additive: it never replaces
+ * `RoadmapClaimVerdict.reason`, it only makes the CLI's human-facing `result`
+ * messages self-describing, so a policy rejection (e.g. a normal execution
+ * claim rejected for lacking the roadmap-audit coordination branch) is never
+ * misread as an unexplained fetch failure.
+ */
+const CLAIM_REASON_EXPLANATIONS = {
+  match:
+    'the claim is owned: claim-id, agent-id, branch, and staleness all match',
+  'missing-active-claim':
+    'no active claim is present on the roadmap issue (no trusted claimed-by comment, or it was released/superseded)',
+  'claim-id-mismatch':
+    "the active claim's claim-id does not match the claim-id this run expected to own",
+  'agent-id-mismatch':
+    "the active claim's agent-id does not match the agent-id this run expected to own",
+  'claim-branch-mismatch':
+    'the audit only accepts roadmap-audit/<n>-* coordination claims; a normal execution claim (e.g. issue/<n>-...) on the roadmap issue does not authorize closure',
+  'claim-stale':
+    'the active claim is older than the configured stale age and is takeover-eligible, so it cannot prove ongoing ownership',
+};
+/**
+ * Resolve the human-readable explanation for a claim-verification `reason`
+ * code. Total: an unrecognized code (never emitted by the current
+ * `evaluateRoadmapClaim` / `summarizeClaimValidation` vocabulary, but a safe
+ * default for any future addition) reports
+ * {@link UNKNOWN_CLAIM_REASON_EXPLANATION} instead of throwing or silently
+ * omitting an explanation.
+ */
+export function explainRoadmapClaimReason(reason) {
+  return CLAIM_REASON_EXPLANATIONS[reason] ?? UNKNOWN_CLAIM_REASON_EXPLANATION;
+}
+/**
+ * Trailing caveat appended to a claim-not-owned `result` message when the
+ * production viewer-login lookup failed (#1396). Empty string when the
+ * lookup succeeded (or was never attempted, e.g. injected test deps), so the
+ * common-case message is unaffected. Kept as its own function so all three
+ * not-owned call sites in {@link runRoadmapAuditExecute} render the exact
+ * same caveat text.
+ */
+function viewerLoginUnavailableCaveat(viewerLoginUnavailable) {
+  return viewerLoginUnavailable
+    ? ' NOTE: the viewer-login lookup failed for this run, so trusted-author resolution may be incomplete — this not-owned result could stem from that instead of a genuine claim conflict.'
+    : '';
+}
+/**
  * Detect the helper's own canonical `IDD roadmap completion audit` evidence
  * comment (the exact heading `buildRoadmapCompletionAuditBody` emits) among
  * `comments`, posted by an author for which `isTrustedAuthor` is true. Used
@@ -497,6 +553,11 @@ export async function runRoadmapAuditExecute(argv, deps) {
     closed: false,
     claimReleased: false,
     result: '',
+    // Present only when the lookup genuinely failed (#1396): keeps the
+    // common healthy-path JSON byte-identical to before this field existed.
+    ...(resolvedDeps.viewerLoginUnavailable
+      ? { viewerLoginUnavailable: true }
+      : {}),
   };
   if (!args.apply) {
     // Dry-run: read-only. Never mutate. Surface the scope caveat so a caller
@@ -562,7 +623,7 @@ export async function runRoadmapAuditExecute(argv, deps) {
       verdict.result = `already-complete: roadmap #${roadmapNumber} is already closed with a trusted IDD roadmap completion audit evidence comment (claim reason="${earlyClaim.reason}"); idempotent no-op, no mutation performed`;
       return { verdict, exitCode: 0 };
     }
-    verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}"); no mutation`;
+    verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}": ${explainRoadmapClaimReason(earlyClaim.reason)}); no mutation${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
     return { verdict, exitCode: 1 };
   }
   // Re-fetch the roadmap + child state and confirm the audit input still
@@ -595,7 +656,7 @@ export async function runRoadmapAuditExecute(argv, deps) {
     nowIso,
   });
   if (!claim.owned) {
-    verdict.result = `claim not owned immediately before mutation (reason="${claim.reason}"); no mutation`;
+    verdict.result = `claim not owned immediately before mutation (reason="${claim.reason}": ${explainRoadmapClaimReason(claim.reason)}); no mutation${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
     return { verdict, exitCode: 1 };
   }
   // Post the evidence comment (non-destructive), THEN re-validate ownership one
@@ -614,7 +675,7 @@ export async function runRoadmapAuditExecute(argv, deps) {
     nowIso,
   });
   if (!preCloseClaim.owned) {
-    verdict.result = `claim lost in the comment→close gap (reason="${preCloseClaim.reason}"); evidence comment posted but roadmap NOT closed`;
+    verdict.result = `claim lost in the comment→close gap (reason="${preCloseClaim.reason}": ${explainRoadmapClaimReason(preCloseClaim.reason)}); evidence comment posted but roadmap NOT closed${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
     return { verdict, exitCode: 1 };
   }
   // Ownership held through the comment: close, then release using the last
@@ -664,17 +725,64 @@ function normalizeApplyNow(raw) {
 // ---------------------------------------------------------------------------
 // Production dependency wiring (live gh + roadmap-graph traversal).
 // ---------------------------------------------------------------------------
+/**
+ * Fetch the authenticated actor's own GitHub login via `gh api user`, or
+ * `null` on any failure (e.g. an under-scoped or expired token). Uses the
+ * throwing {@link ghText} (not `safeGhText`) wrapped in a local try/catch so
+ * a genuine failure is distinguishable from a merely-empty response — the
+ * distinction {@link resolveViewerLogin} needs to report
+ * `viewerLoginUnavailable` instead of silently treating a failed lookup the
+ * same as an anonymous one (#1396).
+ */
+function fetchViewerLogin() {
+  try {
+    return ghText(['api', 'user', '--jq', '.login'], GH_TEXT_LOOP_OPTIONS);
+  } catch {
+    return null;
+  }
+}
+/**
+ * Resolve the viewer login used to always-trust the current claimant (see
+ * {@link buildTrustedAuthorPredicate}), distinguishing a genuinely failed
+ * lookup from an empty one instead of collapsing both to `''` (#1396). A
+ * previously silent failure here excluded the real claimant from the
+ * trusted-author set with no signal that the LOOKUP, not the claim itself,
+ * was the problem, so a `not owned` verdict could be misread as a genuine
+ * claim conflict.
+ *
+ * `fetchLogin` defaults to the real {@link fetchViewerLogin} network call but
+ * is injectable so both outcomes (success and failure) are unit-testable
+ * without shelling out to `gh`. A successful-but-blank response (`''` or
+ * whitespace-only) is also reported as unavailable: an authenticated `gh api
+ * user` call should never legitimately return an empty login, so a blank
+ * result signals a degraded response rather than a real anonymous viewer.
+ */
+export function resolveViewerLogin(fetchLogin = fetchViewerLogin) {
+  const raw = fetchLogin();
+  const normalized = String(raw ?? '')
+    .trim()
+    .toLowerCase();
+  if (raw === null || normalized === '') {
+    return { viewerLogin: '', viewerLoginUnavailable: true };
+  }
+  return { viewerLogin: normalized, viewerLoginUnavailable: false };
+}
 function createProductionDeps(args) {
   const owner =
     args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
   const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
   const rawConfig = loadPolicy(args.policy);
   const markerPrefix = normalizeMarkerPrefix(rawConfig.markerPrefix);
-  const viewerLogin = String(safeGhText(['api', 'user', '--jq', '.login']))
-    .trim()
-    .toLowerCase();
+  const { viewerLogin, viewerLoginUnavailable } = resolveViewerLogin();
   const isTrustedAuthor = buildTrustedAuthorPredicate({
     owner,
     viewerLogin,
@@ -703,6 +811,7 @@ function createProductionDeps(args) {
       resolveOpenLinkedPrIssues(owner, repo, issueNumbers),
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    viewerLoginUnavailable,
     revalidateClaim: ({
       issueNumber,
       roadmapNumber,
@@ -728,15 +837,18 @@ function createProductionDeps(args) {
     postEvidenceComment: (issueNumber, body) =>
       postIssueComment(owner, repo, issueNumber, body),
     closeRoadmap: (issueNumber) =>
-      ghText([
-        'issue',
-        'close',
-        String(issueNumber),
-        '--repo',
-        `${owner}/${repo}`,
-        '--reason',
-        'completed',
-      ]),
+      ghText(
+        [
+          'issue',
+          'close',
+          String(issueNumber),
+          '--repo',
+          `${owner}/${repo}`,
+          '--reason',
+          'completed',
+        ],
+        GH_TEXT_LOOP_OPTIONS,
+      ),
     releaseClaim: (issueNumber, fields) =>
       postIssueComment(
         owner,
@@ -778,12 +890,15 @@ function loadIssueComments(owner, repo, issueNumber) {
   const comments = [];
   const pageSize = 100;
   for (let page = 1; ; page += 1) {
-    const raw = ghText([
-      'api',
-      `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
-      '--jq',
-      '.',
-    ]);
+    const raw = ghText(
+      [
+        'api',
+        `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+        '--jq',
+        '.',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    );
     const pageItems = raw && raw !== 'null' ? JSON.parse(raw) : [];
     if (!Array.isArray(pageItems) || pageItems.length === 0) {
       break;
@@ -958,7 +1073,14 @@ function hasOpenConnectedPr(owner, repo, issueNumber, runGraphql) {
   }
   return reconcileConnectedOpenPrs(events).length > 0;
 }
-/** Run one `gh api graphql` page, passing `after` only when set. */
+/**
+ * Run one `gh api graphql` page, passing `after` only when set.
+ *
+ * Stdin-safe (#1396): called from a per-issue pagination loop
+ * (`resolveOpenLinkedPrIssues` → `hasOpenClosingPr` / `hasOpenConnectedPr`),
+ * the exact tight-loop hazard `GH_TEXT_LOOP_OPTIONS` exists for — this call
+ * site was missed by the initial pass over the file's other `ghText` calls.
+ */
 function ghGraphql(query, owner, repo, issueNumber, after) {
   const apiArgs = [
     'api',
@@ -975,7 +1097,7 @@ function ghGraphql(query, owner, repo, issueNumber, after) {
   if (after) {
     apiArgs.push('-f', `after=${after}`);
   }
-  return JSON.parse(ghText(apiArgs));
+  return JSON.parse(ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
 }
 /** Coerce raw CONNECTED/DISCONNECTED timeline nodes into reconcile events. */
 function parseConnectedPrEvents(nodes) {
@@ -1148,6 +1270,29 @@ function printHelp() {
   (branch roadmap-audit/<roadmap>-<slug>) and match --claim-id (required under
   --apply) and, when given, --agent-id. --owner and --repo must be passed
   together or not at all.
+
+  CLAIM REJECTION REASONS: a not-owned result's "reason" code is one of:
+    match                 the claim is owned (not a rejection)
+    missing-active-claim  no active claim is present on the roadmap issue
+    claim-id-mismatch     the active claim's claim-id is not the expected one
+    agent-id-mismatch     the active claim's agent-id is not the expected one
+    claim-branch-mismatch the active claim's branch is not a roadmap-audit
+                           coordination claim (roadmap-audit/<roadmap>-<slug>)
+                           for THIS roadmap -- a normal execution claim on the
+                           roadmap issue does not authorize closure
+    claim-stale           the active claim is older than the configured stale
+                           age and is takeover-eligible, so it cannot prove
+                           ongoing ownership
+  Each not-owned "result" message embeds both the code and this explanation,
+  so a policy rejection (e.g. claim-branch-mismatch) is never misread as an
+  unexplained fetch failure.
+
+  VIEWER-LOGIN LOOKUP: the trusted-author check needs this run's own GitHub
+  login (via "gh api user"). A genuinely FAILED lookup (network/auth error, or
+  an unexpected blank response) is reported as { viewerLoginUnavailable: true }
+  on the verdict, and any not-owned "result" message gets a trailing NOTE, so a
+  failed lookup is never silently indistinguishable from a real not-owned
+  claim. Absent (or false) whenever the lookup succeeded normally.
 
   SCOPE: this helper gates only the MECHANICAL completion preconditions (all
   descendants closed/complete; no open / unresolved / inaccessible / linked-PR

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -1631,7 +1631,7 @@ function printHelp(): void {
   an unexpected blank response) is reported as { viewerLoginUnavailable: true }
   on the verdict, and any not-owned "result" message gets a trailing NOTE, so a
   failed lookup is never silently indistinguishable from a real not-owned
-  claim. Absent (or false) whenever the lookup succeeded normally.
+  claim. Absent (never explicitly false) whenever the lookup succeeded.
 
   SCOPE: this helper gates only the MECHANICAL completion preconditions (all
   descendants closed/complete; no open / unresolved / inaccessible / linked-PR

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -29,7 +29,7 @@ import {
   parseClaimStaleAgeMs,
   type RoadmapGraphReport,
 } from './discover-roadmap-graph.mts';
-import { ghText, safeGhText } from './gh-exec.mts';
+import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 import type { ClaimValidationSummary } from './protocol-helpers.mts';
 import {
@@ -109,6 +109,17 @@ export interface IddRoadmapAuditExecuteVerdict {
   closed: boolean;
   claimReleased: boolean;
   result: string;
+  /**
+   * Present (and `true`) only when the production `gh api user` viewer-login
+   * lookup failed (#1396). Absent whenever the lookup succeeded, so the
+   * common healthy-path JSON stays byte-identical to before this field
+   * existed. A silently-failed lookup previously excluded the real claimant
+   * from the trusted-author set with no visible signal, so a `not owned`
+   * verdict could be misread as a genuine claim conflict instead of a
+   * lookup failure; callers should treat any not-owned result alongside
+   * this flag as inconclusive rather than a confirmed claim loss.
+   */
+  viewerLoginUnavailable?: boolean;
 }
 
 /** Outcome of re-validating the roadmap-audit claim before any mutation. */
@@ -539,6 +550,68 @@ export function evaluateRoadmapClaim(
 }
 
 /**
+ * Fallback explanation for a {@link RoadmapClaimVerdict.reason} /
+ * {@link ClaimValidationSummary} `reason` code this map does not (yet)
+ * recognize. Keeps {@link explainRoadmapClaimReason} total instead of
+ * throwing or returning an empty string for a future/unlisted code.
+ */
+const UNKNOWN_CLAIM_REASON_EXPLANATION =
+  'unrecognized claim-verification reason code';
+
+/**
+ * Human-readable explanation for every `reason` code {@link evaluateRoadmapClaim}
+ * (and the `summarizeClaimValidation` it wraps) can produce (#1396). The codes
+ * themselves stay stable, machine-readable strings — several are asserted by
+ * exact equality in tests — so this map is additive: it never replaces
+ * `RoadmapClaimVerdict.reason`, it only makes the CLI's human-facing `result`
+ * messages self-describing, so a policy rejection (e.g. a normal execution
+ * claim rejected for lacking the roadmap-audit coordination branch) is never
+ * misread as an unexplained fetch failure.
+ */
+const CLAIM_REASON_EXPLANATIONS: Record<string, string> = {
+  match:
+    'the claim is owned: claim-id, agent-id, branch, and staleness all match',
+  'missing-active-claim':
+    'no active claim is present on the roadmap issue (no trusted claimed-by comment, or it was released/superseded)',
+  'claim-id-mismatch':
+    "the active claim's claim-id does not match the claim-id this run expected to own",
+  'agent-id-mismatch':
+    "the active claim's agent-id does not match the agent-id this run expected to own",
+  'claim-branch-mismatch':
+    'the audit only accepts roadmap-audit/<n>-* coordination claims; a normal execution claim (e.g. issue/<n>-...) on the roadmap issue does not authorize closure',
+  'claim-stale':
+    'the active claim is older than the configured stale age and is takeover-eligible, so it cannot prove ongoing ownership',
+};
+
+/**
+ * Resolve the human-readable explanation for a claim-verification `reason`
+ * code. Total: an unrecognized code (never emitted by the current
+ * `evaluateRoadmapClaim` / `summarizeClaimValidation` vocabulary, but a safe
+ * default for any future addition) reports
+ * {@link UNKNOWN_CLAIM_REASON_EXPLANATION} instead of throwing or silently
+ * omitting an explanation.
+ */
+export function explainRoadmapClaimReason(reason: string): string {
+  return CLAIM_REASON_EXPLANATIONS[reason] ?? UNKNOWN_CLAIM_REASON_EXPLANATION;
+}
+
+/**
+ * Trailing caveat appended to a claim-not-owned `result` message when the
+ * production viewer-login lookup failed (#1396). Empty string when the
+ * lookup succeeded (or was never attempted, e.g. injected test deps), so the
+ * common-case message is unaffected. Kept as its own function so all three
+ * not-owned call sites in {@link runRoadmapAuditExecute} render the exact
+ * same caveat text.
+ */
+function viewerLoginUnavailableCaveat(
+  viewerLoginUnavailable?: boolean,
+): string {
+  return viewerLoginUnavailable
+    ? ' NOTE: the viewer-login lookup failed for this run, so trusted-author resolution may be incomplete — this not-owned result could stem from that instead of a genuine claim conflict.'
+    : '';
+}
+
+/**
  * Detect the helper's own canonical `IDD roadmap completion audit` evidence
  * comment (the exact heading `buildRoadmapCompletionAuditBody` emits) among
  * `comments`, posted by an author for which `isTrustedAuthor` is true. Used
@@ -633,6 +706,14 @@ export interface RoadmapAuditExecuteDeps {
   blockedByHumanLabelName?: string;
   /** Configured `labels.needsDecisionLabelName` (#1273). */
   needsDecisionLabelName?: string;
+  /**
+   * True when the production viewer-login lookup failed (#1396). Static
+   * context resolved once in {@link createProductionDeps}, mirroring the
+   * `blockedByHumanLabelName` / `needsDecisionLabelName` fields above; copied
+   * onto the verdict's `viewerLoginUnavailable` field so a failed lookup is
+   * never silently indistinguishable from a genuine not-owned claim.
+   */
+  viewerLoginUnavailable?: boolean;
 }
 
 /**
@@ -688,6 +769,11 @@ export async function runRoadmapAuditExecute(
     closed: false,
     claimReleased: false,
     result: '',
+    // Present only when the lookup genuinely failed (#1396): keeps the
+    // common healthy-path JSON byte-identical to before this field existed.
+    ...(resolvedDeps.viewerLoginUnavailable
+      ? { viewerLoginUnavailable: true }
+      : {}),
   };
 
   if (!args.apply) {
@@ -759,7 +845,7 @@ export async function runRoadmapAuditExecute(
       verdict.result = `already-complete: roadmap #${roadmapNumber} is already closed with a trusted IDD roadmap completion audit evidence comment (claim reason="${earlyClaim.reason}"); idempotent no-op, no mutation performed`;
       return { verdict, exitCode: 0 };
     }
-    verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}"); no mutation`;
+    verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}": ${explainRoadmapClaimReason(earlyClaim.reason)}); no mutation${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
     return { verdict, exitCode: 1 };
   }
 
@@ -794,7 +880,7 @@ export async function runRoadmapAuditExecute(
     nowIso,
   });
   if (!claim.owned) {
-    verdict.result = `claim not owned immediately before mutation (reason="${claim.reason}"); no mutation`;
+    verdict.result = `claim not owned immediately before mutation (reason="${claim.reason}": ${explainRoadmapClaimReason(claim.reason)}); no mutation${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
     return { verdict, exitCode: 1 };
   }
 
@@ -815,7 +901,7 @@ export async function runRoadmapAuditExecute(
     nowIso,
   });
   if (!preCloseClaim.owned) {
-    verdict.result = `claim lost in the comment→close gap (reason="${preCloseClaim.reason}"); evidence comment posted but roadmap NOT closed`;
+    verdict.result = `claim lost in the comment→close gap (reason="${preCloseClaim.reason}": ${explainRoadmapClaimReason(preCloseClaim.reason)}); evidence comment posted but roadmap NOT closed${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
     return { verdict, exitCode: 1 };
   }
 
@@ -872,21 +958,72 @@ function normalizeApplyNow(raw: string): string | null {
 // Production dependency wiring (live gh + roadmap-graph traversal).
 // ---------------------------------------------------------------------------
 
+/**
+ * Fetch the authenticated actor's own GitHub login via `gh api user`, or
+ * `null` on any failure (e.g. an under-scoped or expired token). Uses the
+ * throwing {@link ghText} (not `safeGhText`) wrapped in a local try/catch so
+ * a genuine failure is distinguishable from a merely-empty response — the
+ * distinction {@link resolveViewerLogin} needs to report
+ * `viewerLoginUnavailable` instead of silently treating a failed lookup the
+ * same as an anonymous one (#1396).
+ */
+function fetchViewerLogin(): string | null {
+  try {
+    return ghText(['api', 'user', '--jq', '.login'], GH_TEXT_LOOP_OPTIONS);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the viewer login used to always-trust the current claimant (see
+ * {@link buildTrustedAuthorPredicate}), distinguishing a genuinely failed
+ * lookup from an empty one instead of collapsing both to `''` (#1396). A
+ * previously silent failure here excluded the real claimant from the
+ * trusted-author set with no signal that the LOOKUP, not the claim itself,
+ * was the problem, so a `not owned` verdict could be misread as a genuine
+ * claim conflict.
+ *
+ * `fetchLogin` defaults to the real {@link fetchViewerLogin} network call but
+ * is injectable so both outcomes (success and failure) are unit-testable
+ * without shelling out to `gh`. A successful-but-blank response (`''` or
+ * whitespace-only) is also reported as unavailable: an authenticated `gh api
+ * user` call should never legitimately return an empty login, so a blank
+ * result signals a degraded response rather than a real anonymous viewer.
+ */
+export function resolveViewerLogin(
+  fetchLogin: () => string | null = fetchViewerLogin,
+): { viewerLogin: string; viewerLoginUnavailable: boolean } {
+  const raw = fetchLogin();
+  const normalized = String(raw ?? '')
+    .trim()
+    .toLowerCase();
+  if (raw === null || normalized === '') {
+    return { viewerLogin: '', viewerLoginUnavailable: true };
+  }
+  return { viewerLogin: normalized, viewerLoginUnavailable: false };
+}
+
 function createProductionDeps(
   args: RoadmapAuditExecuteArgs,
 ): RoadmapAuditExecuteDeps {
   const owner =
     args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
   const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+    args.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_OPTIONS,
+    );
   const rawConfig = loadPolicy(args.policy);
   const markerPrefix = normalizeMarkerPrefix(
     (rawConfig as { markerPrefix?: unknown }).markerPrefix,
   );
-  const viewerLogin = String(safeGhText(['api', 'user', '--jq', '.login']))
-    .trim()
-    .toLowerCase();
+  const { viewerLogin, viewerLoginUnavailable } = resolveViewerLogin();
   const isTrustedAuthor = buildTrustedAuthorPredicate({
     owner,
     viewerLogin,
@@ -918,6 +1055,7 @@ function createProductionDeps(
       resolveOpenLinkedPrIssues(owner, repo, issueNumbers),
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    viewerLoginUnavailable,
     revalidateClaim: ({
       issueNumber,
       roadmapNumber,
@@ -943,15 +1081,18 @@ function createProductionDeps(
     postEvidenceComment: (issueNumber, body) =>
       postIssueComment(owner, repo, issueNumber, body),
     closeRoadmap: (issueNumber) =>
-      ghText([
-        'issue',
-        'close',
-        String(issueNumber),
-        '--repo',
-        `${owner}/${repo}`,
-        '--reason',
-        'completed',
-      ]),
+      ghText(
+        [
+          'issue',
+          'close',
+          String(issueNumber),
+          '--repo',
+          `${owner}/${repo}`,
+          '--reason',
+          'completed',
+        ],
+        GH_TEXT_LOOP_OPTIONS,
+      ),
     releaseClaim: (issueNumber, fields) =>
       postIssueComment(
         owner,
@@ -1007,12 +1148,15 @@ function loadIssueComments(
   const comments: unknown[] = [];
   const pageSize = 100;
   for (let page = 1; ; page += 1) {
-    const raw = ghText([
-      'api',
-      `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
-      '--jq',
-      '.',
-    ]);
+    const raw = ghText(
+      [
+        'api',
+        `repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+        '--jq',
+        '.',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    );
     const pageItems = raw && raw !== 'null' ? JSON.parse(raw) : [];
     if (!Array.isArray(pageItems) || pageItems.length === 0) {
       break;
@@ -1239,7 +1383,14 @@ function hasOpenConnectedPr(
   return reconcileConnectedOpenPrs(events).length > 0;
 }
 
-/** Run one `gh api graphql` page, passing `after` only when set. */
+/**
+ * Run one `gh api graphql` page, passing `after` only when set.
+ *
+ * Stdin-safe (#1396): called from a per-issue pagination loop
+ * (`resolveOpenLinkedPrIssues` → `hasOpenClosingPr` / `hasOpenConnectedPr`),
+ * the exact tight-loop hazard `GH_TEXT_LOOP_OPTIONS` exists for — this call
+ * site was missed by the initial pass over the file's other `ghText` calls.
+ */
 function ghGraphql(
   query: string,
   owner: string,
@@ -1262,7 +1413,7 @@ function ghGraphql(
   if (after) {
     apiArgs.push('-f', `after=${after}`);
   }
-  return JSON.parse(ghText(apiArgs));
+  return JSON.parse(ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
 }
 
 /** Coerce raw CONNECTED/DISCONNECTED timeline nodes into reconcile events. */
@@ -1458,6 +1609,29 @@ function printHelp(): void {
   (branch roadmap-audit/<roadmap>-<slug>) and match --claim-id (required under
   --apply) and, when given, --agent-id. --owner and --repo must be passed
   together or not at all.
+
+  CLAIM REJECTION REASONS: a not-owned result's "reason" code is one of:
+    match                 the claim is owned (not a rejection)
+    missing-active-claim  no active claim is present on the roadmap issue
+    claim-id-mismatch     the active claim's claim-id is not the expected one
+    agent-id-mismatch     the active claim's agent-id is not the expected one
+    claim-branch-mismatch the active claim's branch is not a roadmap-audit
+                           coordination claim (roadmap-audit/<roadmap>-<slug>)
+                           for THIS roadmap -- a normal execution claim on the
+                           roadmap issue does not authorize closure
+    claim-stale           the active claim is older than the configured stale
+                           age and is takeover-eligible, so it cannot prove
+                           ongoing ownership
+  Each not-owned "result" message embeds both the code and this explanation,
+  so a policy rejection (e.g. claim-branch-mismatch) is never misread as an
+  unexplained fetch failure.
+
+  VIEWER-LOGIN LOOKUP: the trusted-author check needs this run's own GitHub
+  login (via "gh api user"). A genuinely FAILED lookup (network/auth error, or
+  an unexpected blank response) is reported as { viewerLoginUnavailable: true }
+  on the verdict, and any not-owned "result" message gets a trailing NOTE, so a
+  failed lookup is never silently indistinguishable from a real not-owned
+  claim. Absent (or false) whenever the lookup succeeded normally.
 
   SCOPE: this helper gates only the MECHANICAL completion preconditions (all
   descendants closed/complete; no open / unresolved / inaccessible / linked-PR

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -119,7 +119,7 @@ export interface IddRoadmapAuditExecuteVerdict {
    * lookup failure; callers should treat any not-owned result alongside
    * this flag as inconclusive rather than a confirmed claim loss.
    */
-  viewerLoginUnavailable?: boolean;
+  viewerLoginUnavailable?: true;
 }
 
 /** Outcome of re-validating the roadmap-audit claim before any mutation. */

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -1093,7 +1093,7 @@ test('resolveViewerLogin normalizes a successful login to lowercase', () => {
   });
 });
 
-test('resolveViewerLogin reports unavailable when the lookup throws (caught as null)', () => {
+test('resolveViewerLogin reports unavailable when fetchLogin returns null (production already caught a throw)', () => {
   const result = resolveViewerLogin(() => null);
   assert.deepEqual(result, { viewerLogin: '', viewerLoginUnavailable: true });
 });

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -1107,7 +1107,15 @@ test('resolveViewerLogin reports unavailable on a blank-but-successful response'
 // explainRoadmapClaimReason (#1396)
 // ---------------------------------------------------------------------------
 
-test('explainRoadmapClaimReason covers every reason code evaluateRoadmapClaim can emit', () => {
+// This list is hand-maintained against evaluateRoadmapClaim / (the
+// summarizeClaimValidation it wraps) as of #1396 — it does NOT introspect
+// the reason-emitting source, so it cannot by itself catch a future reason
+// code added there without a matching CLAIM_REASON_EXPLANATIONS entry (C1
+// review, #1396). explainRoadmapClaimReason() degrades gracefully in that
+// case (UNKNOWN_CLAIM_REASON_EXPLANATION, exercised by the test below), so
+// the gap is cosmetic, not a crash risk; the vocabulary itself stays
+// pinned by the exact-equality reason assertions elsewhere in this file.
+test('explainRoadmapClaimReason maps each of the six currently-known reason codes to a distinct explanation (#1396)', () => {
   const knownReasons = [
     'match',
     'missing-active-claim',

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -10,10 +10,12 @@ import {
   type ConnectedPrEvent,
   evaluateRoadmapAuditGates,
   evaluateRoadmapClaim,
+  explainRoadmapClaimReason,
   hasTrustedCompletionEvidenceComment,
   type RoadmapAuditExecuteDeps,
   reconcileConnectedOpenPrs,
   resolveOpenLinkedPrIssues,
+  resolveViewerLogin,
   runRoadmapAuditExecute,
   safeHasTrustedCompletionEvidence,
 } from '../src/scripts/idd-roadmap-audit-execute.mts';
@@ -1000,6 +1002,134 @@ test('--apply fails closed (no close) when the claim is lost / not owned', async
   assert.equal(exitCode, 1);
   assert.deepEqual(calls.closed, []);
   assert.deepEqual(calls.comments, []);
+});
+
+test('a not-owned result explains the reason code inline (#1396)', async () => {
+  const { deps } = makeDeps(readyReport(), {
+    revalidateClaim: () => ({
+      owned: false,
+      reason: 'claim-branch-mismatch',
+      stale: false,
+      activeClaim: {
+        agentId: '',
+        claimId: '',
+        supersedes: '',
+        branch: '',
+        createdAt: '',
+      },
+    }),
+  });
+  const { verdict } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.match(verdict.result, /reason="claim-branch-mismatch"/);
+  assert.equal(
+    verdict.result.includes(explainRoadmapClaimReason('claim-branch-mismatch')),
+    true,
+  );
+  // Explanation names the coordination-branch policy, not a fetch failure.
+  assert.match(verdict.result, /roadmap-audit\/<n>-\*/);
+});
+
+// ---------------------------------------------------------------------------
+// viewerLoginUnavailable — fail-noisy viewer-login lookup surfacing (#1396)
+// ---------------------------------------------------------------------------
+
+test('verdict.viewerLoginUnavailable is absent on the healthy default path', async () => {
+  const { deps } = makeDeps(readyReport());
+  const { verdict } = await runRoadmapAuditExecute(
+    ['--roadmap', String(ROADMAP)],
+    deps,
+  );
+
+  assert.equal(Object.hasOwn(verdict, 'viewerLoginUnavailable'), false);
+});
+
+test('a failed viewer-login lookup surfaces viewerLoginUnavailable and a caveat on a not-owned result', async () => {
+  const { deps } = makeDeps(readyReport(), {
+    viewerLoginUnavailable: true,
+    revalidateClaim: () => ({
+      owned: false,
+      reason: 'missing-active-claim',
+      stale: false,
+      activeClaim: {
+        agentId: '',
+        claimId: '',
+        supersedes: '',
+        branch: '',
+        createdAt: '',
+      },
+    }),
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+
+  assert.equal(verdict.viewerLoginUnavailable, true);
+  assert.equal(exitCode, 1);
+  assert.match(verdict.result, /viewer-login lookup failed/);
+  assert.match(
+    verdict.result,
+    /could stem from that instead of a genuine claim conflict/,
+  );
+});
+
+test('viewerLoginUnavailable: true does not appear when the lookup succeeded', async () => {
+  const { deps } = makeDeps(readyReport(), { viewerLoginUnavailable: false });
+  const { verdict } = await runRoadmapAuditExecute(
+    ['--roadmap', String(ROADMAP)],
+    deps,
+  );
+
+  assert.equal(Object.hasOwn(verdict, 'viewerLoginUnavailable'), false);
+});
+
+// ---------------------------------------------------------------------------
+// resolveViewerLogin (injectable viewer-login lookup, #1396)
+// ---------------------------------------------------------------------------
+
+test('resolveViewerLogin normalizes a successful login to lowercase', () => {
+  const result = resolveViewerLogin(() => 'Some-User');
+  assert.deepEqual(result, {
+    viewerLogin: 'some-user',
+    viewerLoginUnavailable: false,
+  });
+});
+
+test('resolveViewerLogin reports unavailable when the lookup throws (caught as null)', () => {
+  const result = resolveViewerLogin(() => null);
+  assert.deepEqual(result, { viewerLogin: '', viewerLoginUnavailable: true });
+});
+
+test('resolveViewerLogin reports unavailable on a blank-but-successful response', () => {
+  const result = resolveViewerLogin(() => '   ');
+  assert.deepEqual(result, { viewerLogin: '', viewerLoginUnavailable: true });
+});
+
+// ---------------------------------------------------------------------------
+// explainRoadmapClaimReason (#1396)
+// ---------------------------------------------------------------------------
+
+test('explainRoadmapClaimReason covers every reason code evaluateRoadmapClaim can emit', () => {
+  const knownReasons = [
+    'match',
+    'missing-active-claim',
+    'claim-id-mismatch',
+    'agent-id-mismatch',
+    'claim-branch-mismatch',
+    'claim-stale',
+  ];
+  const explanations = knownReasons.map((reason) =>
+    explainRoadmapClaimReason(reason),
+  );
+  // Every known code gets a distinct, non-empty explanation.
+  assert.equal(
+    explanations.every((text) => text.length > 0),
+    true,
+  );
+  assert.equal(new Set(explanations).size, knownReasons.length);
+});
+
+test('explainRoadmapClaimReason falls back to a generic explanation for an unrecognized code', () => {
+  const explanation = explainRoadmapClaimReason('some-future-reason-code');
+  assert.match(explanation, /unrecognized/);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -337,6 +337,7 @@ export const iddRoadmapAuditExecuteKeys = [
   'closed',
   'claimReleased',
   'result',
+  'viewerLoginUnavailable',
 ] as const satisfies readonly (keyof IddRoadmapAuditExecuteVerdict)[];
 
 export const forcedHandoffMarkerKeys = [


### PR DESCRIPTION
# Summary

Hardens the A1.5 roadmap-completion-audit CLI helper
(`src/scripts/idd-roadmap-audit-execute.mts`) per three field-reported
gaps:

1. **stdin-safe `gh` calls**: every audit-side `gh` invocation now
   passes `GH_TEXT_LOOP_OPTIONS`, including the `ghGraphql()` page
   runner used by `resolveOpenLinkedPrIssues`'s per-issue pagination
   loop — a tight-loop stdin hazard the file's other call sites had
   already been given the fix for, but this one was missed.
2. **Fail-noisy viewer-login lookup**: `resolveViewerLogin()`
   distinguishes a genuinely failed `gh api user` lookup (thrown
   error, or a successful-but-blank response) from a legitimate empty
   viewer, surfaced as `viewerLoginUnavailable` on the verdict
   (present only on failure, so the healthy-path JSON stays
   byte-identical) plus a trailing caveat on any not-owned result.
3. **Self-describing claim-rejection reasons**: `explainRoadmapClaimReason()`
   maps every reason code `evaluateRoadmapClaim` /
   `summarizeClaimValidation` can emit to a human-readable explanation,
   appended to all three not-owned result messages and documented in
   `--help`.

## Linked issue

Closes #1396

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This session resumed #1396 via an operator-approved forced-handoff
after the prior session stalled ~20h with zero commits but a
substantial (~186-line) uncommitted diff already in the worktree. That
diff already implemented most of criteria 1-2 well but had three real
gaps closed here: the missed `ghGraphql()` call site (criterion 1), no
test coverage at all (criterion 2 explicitly requires one — added an
end-to-end test injecting a failed lookup and asserting both the
verdict field and the caveat text, plus direct unit tests for
`resolveViewerLogin`/`explainRoadmapClaimReason`), and no `--help`
documentation of the reason vocabulary (criterion 3). Also discovered
and fixed a real regression the new field caused: the new
`viewerLoginUnavailable` verdict field broke this repo's `#874`
compile-time schema/type exhaustiveness guard
(`tests/schema-type-reconciliation.test.mts`) and needed registering
in both the key-exhaustiveness list and
`schemas/idd-roadmap-audit-execute.schema.json` (optional property,
not required).

Verified no interaction with #1425 (which made the *advisory-convergence*
viewer probe silent-in-CI, since a GitHub Actions installation token
has no authenticated user there): this helper has zero
`.github/workflows/` invocations and is exclusively agent/CLI-invoked
under a real user token, so a failed lookup here is never a legitimate
empty-viewer case — the two changes are complementary, not
contradictory.

Two independent C1 critique passes found no High/Medium issues. Three
Low findings came up on the first pass; two (a test title that
overclaimed source-exhaustiveness, and imprecise `--help` wording) are
fixed in the third commit. The third (scoping the not-owned caveat to
only the 2 of 6 reason codes actually reachable through a failed
lookup) was explicitly assessed as an optional refinement with zero
safety impact and left as-is — the current single shared
caveat-rendering path is simpler and the extra precision has no
behavioral upside.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

`schemas/idd-roadmap-audit-execute.schema.json` (this helper's own
output schema, not the IDD policy config schema) gained one optional
property. "Security / credential / merge behavior" is checked out of
caution because the viewer-login lookup feeds trusted-author
resolution on a mutation-gating path (roadmap closure) — the change
only makes a silent failure there *observable*, it does not loosen or
change who gets trusted.

## Verification

- [x] `pnpm lint` (ran the underlying `lint:minimum` pieces individually: typecheck, build:check, biome, dprint, full test suite, workshop-integrity, cspell, markdownlint — all green)
- [x] `pnpm test` (1998/1998 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; 4 pre-existing environmental warnings unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claim rejection verdicts now add human-readable explanations alongside the specific verification reason code.
  * CLI JSON verdicts can include `viewerLoginUnavailable: true` when the production viewer-login lookup fails.
  * Expanded CLI help with detailed claim rejection reasons and viewer-login lookup behavior.

* **Bug Fixes**
  * Improved claim-not-owned / claim-lost reporting to include `reason="<code>": <explanation>` and a viewer-login lookup caveat when relevant.
  * Viewer-login handling is now normalized and consistently reported for failure, blank, or whitespace results.

* **Tests**
  * Added/updated coverage for reason explanations and viewer-login failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->