### PR TITLE
feat(idd): detect base advancement in branch-conflict-state

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -45,12 +45,9 @@ This check is read-only — F1 does not rebase, merge, or push.
 
 - **`clean`** (`mergeable` is `MERGEABLE` and `mergeStateStatus` is
   `CLEAN`) or **`behind-no-conflict`** when no up-to-date-head policy
-  applies: proceed to F2. Note: `clean` is textual conflict-freeness only,
-  not whole-tree CI-invariant freedom — when the helper reports
-  `baseAdvancedSinceMergeBase: true`, base has moved since this branch's
-  merge-base and a `pull_request`-triggered CI result may be pinned to a
-  stale merge-ref; this does not block F2 by itself, but prefer a fresh CI
-  result over trusting an old green check in that case.
+  applies: proceed to F2. `clean` is conflict-freeness only; if
+  `baseAdvancedSinceMergeBase: true`, prefer a fresh CI result over an
+  old green check (base may have moved since the merge-base).
 - **`behind-no-conflict`** when branch protection or recorded repository
   policy requires an up-to-date head, or **`content-conflict`**
   (`mergeable` is `CONFLICTING`): return to the E-phase branch-sync check

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -45,7 +45,12 @@ This check is read-only — F1 does not rebase, merge, or push.
 
 - **`clean`** (`mergeable` is `MERGEABLE` and `mergeStateStatus` is
   `CLEAN`) or **`behind-no-conflict`** when no up-to-date-head policy
-  applies: proceed to F2.
+  applies: proceed to F2. Note: `clean` is textual conflict-freeness only,
+  not whole-tree CI-invariant freedom — when the helper reports
+  `baseAdvancedSinceMergeBase: true`, base has moved since this branch's
+  merge-base and a `pull_request`-triggered CI result may be pinned to a
+  stale merge-ref; this does not block F2 by itself, but prefer a fresh CI
+  result over trusting an old green check in that case.
 - **`behind-no-conflict`** when branch protection or recorded repository
   policy requires an up-to-date head, or **`content-conflict`**
   (`mergeable` is `CONFLICTING`): return to the E-phase branch-sync check

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -422,7 +422,9 @@ Route based on `branchState` from the helper (or `mergeable` /
   new reviewer activity; without the refresh F2's review-currency treats
   them as newer activity and returns to E1 for an avoidable cycle. Do
   **not** refresh on the sync path (it re-snapshots at E1 after merging
-  `main`) or on a hold (it stops without proceeding to F-phase).
+  `main`) or on a hold (it stops without proceeding to F-phase). `clean`
+  here is conflict-freeness only — see the `baseAdvancedSinceMergeBase`
+  note under F1 in `idd-pre-merge.instructions.md`.
 - **`behind-no-conflict`** when branch protection or recorded repository
   policy requires an up-to-date head: → **sync path** below.
 - **`content-conflict`** (`mergeable` is `CONFLICTING`): → **sync path**

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1287,8 +1287,12 @@ Interpretation rules:
   `computing`)
 - `baseAdvancedSinceMergeBase` (boolean): `true` when the base ref has moved
   past this PR's merge-base, computed independently of `syncRecommendation` so
-  it does not change any existing `syncRecommendation` value. A `clean` /
-  `none` verdict is textual conflict-freeness only, not whole-tree
+  it does not change any existing `syncRecommendation` value. `false` is
+  **overloaded**: it means either a confirmed-unmoved base, or that the
+  check was skipped / the merge-base could not be resolved (e.g. missing
+  local history); the two are distinguished only via `diagnostics.notes`
+  (an "undetermined" entry marks the latter), never by this field alone. A
+  `clean` / `none` verdict is textual conflict-freeness only, not whole-tree
   CI-invariant freedom (line-count budgets, generated-file drift, lockfile
   consistency, and similar checks a full test suite enforces against the
   whole tree); when this field is `true` alongside `syncRecommendation: none`,

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1267,6 +1267,7 @@ Interpretation rules:
     "mergeStateStatus": "CLEAN",
     "branchState": "clean",
     "syncRecommendation": "none",
+    "baseAdvancedSinceMergeBase": false,
     "readOnly": true,
     "worktreeUnchanged": true,
     "diagnostics": {
@@ -1284,6 +1285,16 @@ Interpretation rules:
 - `syncRecommendation` values: `none`, `merge-main`, `policy-required-update`,
   `force-push-exception`, `recheck`, `hold-unknown` (`recheck` pairs with
   `computing`)
+- `baseAdvancedSinceMergeBase` (boolean): `true` when the base ref has moved
+  past this PR's merge-base, computed independently of `syncRecommendation` so
+  it does not change any existing `syncRecommendation` value. A `clean` /
+  `none` verdict is textual conflict-freeness only, not whole-tree
+  CI-invariant freedom (line-count budgets, generated-file drift, lockfile
+  consistency, and similar checks a full test suite enforces against the
+  whole tree); when this field is `true` alongside `syncRecommendation: none`,
+  `diagnostics.notes` also carries an advisory note naming the blind spot. A
+  `pull_request`-triggered CI run is pinned to a merge-ref computed at trigger
+  time, so a bare rerun after base moves can replay that stale state.
 - Stable fields consumed by D/E/F routing: `branchState`,
   `syncRecommendation`, `published`, `readOnly`, `worktreeUnchanged`
 - Read-only boundary: the helper never runs `git merge`, `git rebase`, or

--- a/fixtures/schemas/branch-conflict-state.valid.json
+++ b/fixtures/schemas/branch-conflict-state.valid.json
@@ -8,6 +8,7 @@
   "mergeStateStatus": "CLEAN",
   "branchState": "clean",
   "syncRecommendation": "none",
+  "baseAdvancedSinceMergeBase": false,
   "readOnly": true,
   "worktreeUnchanged": true,
   "diagnostics": {

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -40,12 +40,9 @@ This check is read-only — F1 does not rebase, merge, or push.
 
 - **`clean`** (`mergeable` is `MERGEABLE` and `mergeStateStatus` is
   `CLEAN`) or **`behind-no-conflict`** when no up-to-date-head policy
-  applies: proceed to F2. Note: `clean` is textual conflict-freeness only,
-  not whole-tree CI-invariant freedom — when the helper reports
-  `baseAdvancedSinceMergeBase: true`, base has moved since this branch's
-  merge-base and a `pull_request`-triggered CI result may be pinned to a
-  stale merge-ref; this does not block F2 by itself, but prefer a fresh CI
-  result over trusting an old green check in that case.
+  applies: proceed to F2. `clean` is conflict-freeness only; if
+  `baseAdvancedSinceMergeBase: true`, prefer a fresh CI result over an
+  old green check (base may have moved since the merge-base).
 - **`behind-no-conflict`** when branch protection or recorded repository
   policy requires an up-to-date head, or **`content-conflict`**
   (`mergeable` is `CONFLICTING`): return to the E-phase branch-sync check

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -40,7 +40,12 @@ This check is read-only — F1 does not rebase, merge, or push.
 
 - **`clean`** (`mergeable` is `MERGEABLE` and `mergeStateStatus` is
   `CLEAN`) or **`behind-no-conflict`** when no up-to-date-head policy
-  applies: proceed to F2.
+  applies: proceed to F2. Note: `clean` is textual conflict-freeness only,
+  not whole-tree CI-invariant freedom — when the helper reports
+  `baseAdvancedSinceMergeBase: true`, base has moved since this branch's
+  merge-base and a `pull_request`-triggered CI result may be pinned to a
+  stale merge-ref; this does not block F2 by itself, but prefer a fresh CI
+  result over trusting an old green check in that case.
 - **`behind-no-conflict`** when branch protection or recorded repository
   policy requires an up-to-date head, or **`content-conflict`**
   (`mergeable` is `CONFLICTING`): return to the E-phase branch-sync check

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -417,7 +417,9 @@ Route based on `branchState` from the helper (or `mergeable` /
   new reviewer activity; without the refresh F2's review-currency treats
   them as newer activity and returns to E1 for an avoidable cycle. Do
   **not** refresh on the sync path (it re-snapshots at E1 after merging
-  `main`) or on a hold (it stops without proceeding to F-phase).
+  `main`) or on a hold (it stops without proceeding to F-phase). `clean`
+  here is conflict-freeness only — see the `baseAdvancedSinceMergeBase`
+  note under F1 in `idd-pre-merge.instructions.md`.
 - **`behind-no-conflict`** when branch protection or recorded repository
   policy requires an up-to-date head: → **sync path** below.
 - **`content-conflict`** (`mergeable` is `CONFLICTING`): → **sync path**

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1287,8 +1287,12 @@ Interpretation rules:
   `computing`)
 - `baseAdvancedSinceMergeBase` (boolean): `true` when the base ref has moved
   past this PR's merge-base, computed independently of `syncRecommendation` so
-  it does not change any existing `syncRecommendation` value. A `clean` /
-  `none` verdict is textual conflict-freeness only, not whole-tree
+  it does not change any existing `syncRecommendation` value. `false` is
+  **overloaded**: it means either a confirmed-unmoved base, or that the
+  check was skipped / the merge-base could not be resolved (e.g. missing
+  local history); the two are distinguished only via `diagnostics.notes`
+  (an "undetermined" entry marks the latter), never by this field alone. A
+  `clean` / `none` verdict is textual conflict-freeness only, not whole-tree
   CI-invariant freedom (line-count budgets, generated-file drift, lockfile
   consistency, and similar checks a full test suite enforces against the
   whole tree); when this field is `true` alongside `syncRecommendation: none`,

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1267,6 +1267,7 @@ Interpretation rules:
     "mergeStateStatus": "CLEAN",
     "branchState": "clean",
     "syncRecommendation": "none",
+    "baseAdvancedSinceMergeBase": false,
     "readOnly": true,
     "worktreeUnchanged": true,
     "diagnostics": {
@@ -1284,6 +1285,16 @@ Interpretation rules:
 - `syncRecommendation` values: `none`, `merge-main`, `policy-required-update`,
   `force-push-exception`, `recheck`, `hold-unknown` (`recheck` pairs with
   `computing`)
+- `baseAdvancedSinceMergeBase` (boolean): `true` when the base ref has moved
+  past this PR's merge-base, computed independently of `syncRecommendation` so
+  it does not change any existing `syncRecommendation` value. A `clean` /
+  `none` verdict is textual conflict-freeness only, not whole-tree
+  CI-invariant freedom (line-count budgets, generated-file drift, lockfile
+  consistency, and similar checks a full test suite enforces against the
+  whole tree); when this field is `true` alongside `syncRecommendation: none`,
+  `diagnostics.notes` also carries an advisory note naming the blind spot. A
+  `pull_request`-triggered CI run is pinned to a merge-ref computed at trigger
+  time, so a bare rerun after base moves can replay that stale state.
 - Stable fields consumed by D/E/F routing: `branchState`,
   `syncRecommendation`, `published`, `readOnly`, `worktreeUnchanged`
 - Read-only boundary: the helper never runs `git merge`, `git rebase`, or

--- a/schemas/branch-conflict-state.schema.json
+++ b/schemas/branch-conflict-state.schema.json
@@ -14,6 +14,7 @@
     "mergeStateStatus",
     "branchState",
     "syncRecommendation",
+    "baseAdvancedSinceMergeBase",
     "readOnly",
     "worktreeUnchanged"
   ],
@@ -65,6 +66,9 @@
         "recheck",
         "hold-unknown"
       ]
+    },
+    "baseAdvancedSinceMergeBase": {
+      "type": "boolean"
     },
     "readOnly": {
       "type": "boolean"

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -7,6 +7,16 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { ghText } from './gh-exec.mjs';
 
+/** One-line advisory attached to `notes` alongside a `true` result. */
+const BASE_ADVANCED_BLIND_SPOT_NOTE =
+  'Base has advanced since the merge-base for this branch ' +
+  '(baseAdvancedSinceMergeBase); a textually clean/mergeable verdict is ' +
+  'conflict-freeness only, not whole-tree CI-invariant freedom (e.g. ' +
+  'line-count budgets, generated-file drift, lockfile consistency) against ' +
+  'the current base tip, and a pull_request-triggered CI result may be ' +
+  'pinned to a merge-ref computed at an earlier trigger time. Consider ' +
+  're-validating against current base before relying on a pre-existing ' +
+  'green check.';
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -49,6 +59,7 @@ export async function classifyBranchConflictState(prNumber, options = {}) {
       mergeStateStatus: null,
       branchState: 'unknown',
       syncRecommendation: 'hold-unknown',
+      baseAdvancedSinceMergeBase: false,
       readOnly: true,
       worktreeUnchanged: true,
       diagnostics: {
@@ -60,19 +71,24 @@ export async function classifyBranchConflictState(prNumber, options = {}) {
       },
     };
   }
-  const { branchState, syncRecommendation, conflictFiles, mergeableSource } =
-    deriveBranchState({
-      prHeadSha,
-      prBaseSha,
-      prHeadRef,
-      prBaseRef,
-      mergeable,
-      mergeStateStatus,
-      notes,
-      owner,
-      repo,
-      skipGitProbe: Boolean(_skipGitProbe),
-    });
+  const {
+    branchState,
+    syncRecommendation,
+    conflictFiles,
+    mergeableSource,
+    baseAdvancedSinceMergeBase,
+  } = deriveBranchState({
+    prHeadSha,
+    prBaseSha,
+    prHeadRef,
+    prBaseRef,
+    mergeable,
+    mergeStateStatus,
+    notes,
+    owner,
+    repo,
+    skipGitProbe: Boolean(_skipGitProbe),
+  });
   return {
     protocolVersion: '1',
     prNumber: Number(prNumber),
@@ -83,6 +99,7 @@ export async function classifyBranchConflictState(prNumber, options = {}) {
     mergeStateStatus: normalizeNullable(mergeStateStatus),
     branchState,
     syncRecommendation,
+    baseAdvancedSinceMergeBase,
     readOnly: true,
     worktreeUnchanged: true,
     diagnostics: {
@@ -121,6 +138,10 @@ function deriveBranchState({
       syncRecommendation: 'hold-unknown',
       conflictFiles: probeResult ?? [],
       mergeableSource: 'github-mergeable',
+      // A real textual conflict already forces a hold; whether base also
+      // advanced past the merge-base is not an independently useful signal
+      // here, so this is not computed for this branch.
+      baseAdvancedSinceMergeBase: false,
     };
   }
   if (mergeStateNorm === 'DIRTY') {
@@ -129,23 +150,42 @@ function deriveBranchState({
       syncRecommendation: 'hold-unknown',
       conflictFiles: [],
       mergeableSource: 'github-merge-state',
+      baseAdvancedSinceMergeBase: false,
     };
   }
   if (mergeableNorm === 'MERGEABLE' && mergeStateNorm === 'CLEAN') {
+    const baseAdvancedSinceMergeBase = computeBaseAdvanced(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      owner,
+      repo,
+      notes,
+      skipGitProbe,
+    );
+    if (baseAdvancedSinceMergeBase) {
+      notes.push(BASE_ADVANCED_BLIND_SPOT_NOTE);
+    }
     return {
       branchState: 'clean',
       syncRecommendation: 'none',
       conflictFiles: [],
       mergeableSource: 'github-mergeable',
+      baseAdvancedSinceMergeBase,
     };
   }
   if (mergeStateNorm === 'BEHIND') {
+    // GitHub's BEHIND state is definitional: the base has already advanced
+    // past this branch's merge-base (that is what "behind" means), so this
+    // is known for free without an extra git probe, for every return below.
+    const baseAdvancedSinceMergeBase = true;
     if (skipGitProbe) {
       return {
         branchState: 'behind-no-conflict',
         syncRecommendation: 'merge-main',
         conflictFiles: [],
         mergeableSource: 'github-merge-state',
+        baseAdvancedSinceMergeBase,
       };
     }
     const probeResult = probeConflictFilesReadOnly(
@@ -162,6 +202,7 @@ function deriveBranchState({
         syncRecommendation: 'hold-unknown',
         conflictFiles: [],
         mergeableSource: 'git-merge-tree',
+        baseAdvancedSinceMergeBase,
       };
     }
     if (probeResult.length > 0) {
@@ -170,6 +211,7 @@ function deriveBranchState({
         syncRecommendation: 'hold-unknown',
         conflictFiles: probeResult,
         mergeableSource: 'git-merge-tree',
+        baseAdvancedSinceMergeBase,
       };
     }
     return {
@@ -177,14 +219,28 @@ function deriveBranchState({
       syncRecommendation: 'merge-main',
       conflictFiles: [],
       mergeableSource: 'git-merge-tree',
+      baseAdvancedSinceMergeBase,
     };
   }
   if (mergeableNorm === 'MERGEABLE') {
+    const baseAdvancedSinceMergeBase = computeBaseAdvanced(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      owner,
+      repo,
+      notes,
+      skipGitProbe,
+    );
+    if (baseAdvancedSinceMergeBase) {
+      notes.push(BASE_ADVANCED_BLIND_SPOT_NOTE);
+    }
     return {
       branchState: 'clean',
       syncRecommendation: 'none',
       conflictFiles: [],
       mergeableSource: 'github-mergeable',
+      baseAdvancedSinceMergeBase,
     };
   }
   if (mergeableNorm === 'UNKNOWN' || !mergeableNorm) {
@@ -196,6 +252,7 @@ function deriveBranchState({
       syncRecommendation: 'recheck',
       conflictFiles: [],
       mergeableSource: 'none',
+      baseAdvancedSinceMergeBase: false,
     };
   }
   notes.push(
@@ -206,7 +263,66 @@ function deriveBranchState({
     syncRecommendation: 'hold-unknown',
     conflictFiles: [],
     mergeableSource: 'none',
+    baseAdvancedSinceMergeBase: false,
   };
+}
+/**
+ * Read-only local `git merge-base` lookup, falling back to a shallow fetch
+ * of the base ref when the base commit is not yet present locally (e.g. a
+ * shallow CI checkout that only has the PR head). Returns `null` when the
+ * merge-base still cannot be resolved after the fallback fetch; callers
+ * decide how to report that indeterminate outcome, since "conflict probe"
+ * and "base-advancement" callers need different diagnostics wording for the
+ * same underlying null.
+ */
+function computeMergeBase(prHeadSha, prBaseSha, prBaseRef, owner, repo, notes) {
+  let mergeBase = gitText(['merge-base', prHeadSha, prBaseSha]);
+  if (!mergeBase) {
+    tryFetchBase(prBaseRef, owner, repo, notes);
+    mergeBase = gitText(['merge-base', prHeadSha, prBaseSha]);
+  }
+  return mergeBase || null;
+}
+/**
+ * True when the base ref has moved past this PR's merge-base, independent of
+ * `syncRecommendation` -- the blind spot this field exists to close. Returns
+ * `false` both when base genuinely has not advanced and when the merge-base
+ * could not be resolved at all; the latter, indeterminate case is
+ * distinguished only via a `notes` entry, never silently reported as a
+ * confirmed "no" (see the `computeMergeBase` doc comment above).
+ */
+function computeBaseAdvanced(
+  prHeadSha,
+  prBaseSha,
+  prBaseRef,
+  owner,
+  repo,
+  notes,
+  skipGitProbe,
+) {
+  if (skipGitProbe) return false;
+  try {
+    const mergeBase = computeMergeBase(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      owner,
+      repo,
+      notes,
+    );
+    if (!mergeBase) {
+      notes.push(
+        'merge-base not found; base-advancement since merge-base is undetermined (reported as false).',
+      );
+      return false;
+    }
+    return mergeBase !== prBaseSha;
+  } catch {
+    notes.push(
+      'git merge-base unavailable; base-advancement since merge-base is undetermined (reported as false).',
+    );
+    return false;
+  }
 }
 function probeConflictFilesReadOnly(
   prHeadSha,
@@ -217,16 +333,19 @@ function probeConflictFilesReadOnly(
   notes,
 ) {
   try {
-    let mergeBase = gitText(['merge-base', prHeadSha, prBaseSha]);
+    const mergeBase = computeMergeBase(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      owner,
+      repo,
+      notes,
+    );
     if (!mergeBase) {
-      tryFetchBase(prBaseRef, owner, repo, notes);
-      mergeBase = gitText(['merge-base', prHeadSha, prBaseSha]);
-      if (!mergeBase) {
-        notes.push(
-          'merge-base not found; cannot prove conflict-free; holding unknown.',
-        );
-        return null;
-      }
+      notes.push(
+        'merge-base not found; cannot prove conflict-free; holding unknown.',
+      );
+      return null;
     }
     const result = spawnSync(
       'git',

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -378,6 +378,12 @@ function probeConflictFilesReadOnly(
 }
 function tryFetchBase(prBaseRef, owner, repo, notes) {
   if (!prBaseRef) return;
+  if (!owner || !repo) {
+    notes.push(
+      'Skipped base-ref fetch fallback: owner/repo not provided; merge-base probe may be incomplete.',
+    );
+    return;
+  }
   try {
     const remote = `https://github.com/${owner}/${repo}.git`;
     execFileSync(

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -475,6 +475,12 @@ function tryFetchBase(
   notes: string[],
 ): void {
   if (!prBaseRef) return;
+  if (!owner || !repo) {
+    notes.push(
+      'Skipped base-ref fetch fallback: owner/repo not provided; merge-base probe may be incomplete.',
+    );
+    return;
+  }
   try {
     const remote = `https://github.com/${owner}/${repo}.git`;
     execFileSync(

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -23,6 +23,7 @@ interface BranchStateDerivation {
   syncRecommendation: string;
   conflictFiles: string[];
   mergeableSource: string;
+  baseAdvancedSinceMergeBase: boolean;
 }
 
 /**
@@ -40,6 +41,7 @@ export interface BranchConflictResult {
   mergeStateStatus: string | null;
   branchState: string;
   syncRecommendation: string;
+  baseAdvancedSinceMergeBase: boolean;
   readOnly: boolean;
   worktreeUnchanged: boolean;
   diagnostics: {
@@ -55,6 +57,17 @@ interface ClassifyOptions {
   _testPrData?: PrData;
   _skipGitProbe?: boolean;
 }
+
+/** One-line advisory attached to `notes` alongside a `true` result. */
+const BASE_ADVANCED_BLIND_SPOT_NOTE =
+  'Base has advanced since the merge-base for this branch ' +
+  '(baseAdvancedSinceMergeBase); a textually clean/mergeable verdict is ' +
+  'conflict-freeness only, not whole-tree CI-invariant freedom (e.g. ' +
+  'line-count budgets, generated-file drift, lockfile consistency) against ' +
+  'the current base tip, and a pull_request-triggered CI result may be ' +
+  'pinned to a merge-ref computed at an earlier trigger time. Consider ' +
+  're-validating against current base before relying on a pre-existing ' +
+  'green check.';
 
 if (isMainModule(import.meta.url)) {
   const args = parseArgs(process.argv.slice(2));
@@ -106,6 +119,7 @@ export async function classifyBranchConflictState(
       mergeStateStatus: null,
       branchState: 'unknown',
       syncRecommendation: 'hold-unknown',
+      baseAdvancedSinceMergeBase: false,
       readOnly: true,
       worktreeUnchanged: true,
       diagnostics: {
@@ -118,19 +132,24 @@ export async function classifyBranchConflictState(
     };
   }
 
-  const { branchState, syncRecommendation, conflictFiles, mergeableSource } =
-    deriveBranchState({
-      prHeadSha,
-      prBaseSha,
-      prHeadRef,
-      prBaseRef,
-      mergeable,
-      mergeStateStatus,
-      notes,
-      owner,
-      repo,
-      skipGitProbe: Boolean(_skipGitProbe),
-    });
+  const {
+    branchState,
+    syncRecommendation,
+    conflictFiles,
+    mergeableSource,
+    baseAdvancedSinceMergeBase,
+  } = deriveBranchState({
+    prHeadSha,
+    prBaseSha,
+    prHeadRef,
+    prBaseRef,
+    mergeable,
+    mergeStateStatus,
+    notes,
+    owner,
+    repo,
+    skipGitProbe: Boolean(_skipGitProbe),
+  });
 
   return {
     protocolVersion: '1',
@@ -142,6 +161,7 @@ export async function classifyBranchConflictState(
     mergeStateStatus: normalizeNullable(mergeStateStatus),
     branchState,
     syncRecommendation,
+    baseAdvancedSinceMergeBase,
     readOnly: true,
     worktreeUnchanged: true,
     diagnostics: {
@@ -193,6 +213,10 @@ function deriveBranchState({
       syncRecommendation: 'hold-unknown',
       conflictFiles: probeResult ?? [],
       mergeableSource: 'github-mergeable',
+      // A real textual conflict already forces a hold; whether base also
+      // advanced past the merge-base is not an independently useful signal
+      // here, so this is not computed for this branch.
+      baseAdvancedSinceMergeBase: false,
     };
   }
 
@@ -202,25 +226,44 @@ function deriveBranchState({
       syncRecommendation: 'hold-unknown',
       conflictFiles: [],
       mergeableSource: 'github-merge-state',
+      baseAdvancedSinceMergeBase: false,
     };
   }
 
   if (mergeableNorm === 'MERGEABLE' && mergeStateNorm === 'CLEAN') {
+    const baseAdvancedSinceMergeBase = computeBaseAdvanced(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      owner,
+      repo,
+      notes,
+      skipGitProbe,
+    );
+    if (baseAdvancedSinceMergeBase) {
+      notes.push(BASE_ADVANCED_BLIND_SPOT_NOTE);
+    }
     return {
       branchState: 'clean',
       syncRecommendation: 'none',
       conflictFiles: [],
       mergeableSource: 'github-mergeable',
+      baseAdvancedSinceMergeBase,
     };
   }
 
   if (mergeStateNorm === 'BEHIND') {
+    // GitHub's BEHIND state is definitional: the base has already advanced
+    // past this branch's merge-base (that is what "behind" means), so this
+    // is known for free without an extra git probe, for every return below.
+    const baseAdvancedSinceMergeBase = true;
     if (skipGitProbe) {
       return {
         branchState: 'behind-no-conflict',
         syncRecommendation: 'merge-main',
         conflictFiles: [],
         mergeableSource: 'github-merge-state',
+        baseAdvancedSinceMergeBase,
       };
     }
     const probeResult = probeConflictFilesReadOnly(
@@ -237,6 +280,7 @@ function deriveBranchState({
         syncRecommendation: 'hold-unknown',
         conflictFiles: [],
         mergeableSource: 'git-merge-tree',
+        baseAdvancedSinceMergeBase,
       };
     }
     if (probeResult.length > 0) {
@@ -245,6 +289,7 @@ function deriveBranchState({
         syncRecommendation: 'hold-unknown',
         conflictFiles: probeResult,
         mergeableSource: 'git-merge-tree',
+        baseAdvancedSinceMergeBase,
       };
     }
     return {
@@ -252,15 +297,29 @@ function deriveBranchState({
       syncRecommendation: 'merge-main',
       conflictFiles: [],
       mergeableSource: 'git-merge-tree',
+      baseAdvancedSinceMergeBase,
     };
   }
 
   if (mergeableNorm === 'MERGEABLE') {
+    const baseAdvancedSinceMergeBase = computeBaseAdvanced(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      owner,
+      repo,
+      notes,
+      skipGitProbe,
+    );
+    if (baseAdvancedSinceMergeBase) {
+      notes.push(BASE_ADVANCED_BLIND_SPOT_NOTE);
+    }
     return {
       branchState: 'clean',
       syncRecommendation: 'none',
       conflictFiles: [],
       mergeableSource: 'github-mergeable',
+      baseAdvancedSinceMergeBase,
     };
   }
 
@@ -273,6 +332,7 @@ function deriveBranchState({
       syncRecommendation: 'recheck',
       conflictFiles: [],
       mergeableSource: 'none',
+      baseAdvancedSinceMergeBase: false,
     };
   }
 
@@ -284,7 +344,75 @@ function deriveBranchState({
     syncRecommendation: 'hold-unknown',
     conflictFiles: [],
     mergeableSource: 'none',
+    baseAdvancedSinceMergeBase: false,
   };
+}
+
+/**
+ * Read-only local `git merge-base` lookup, falling back to a shallow fetch
+ * of the base ref when the base commit is not yet present locally (e.g. a
+ * shallow CI checkout that only has the PR head). Returns `null` when the
+ * merge-base still cannot be resolved after the fallback fetch; callers
+ * decide how to report that indeterminate outcome, since "conflict probe"
+ * and "base-advancement" callers need different diagnostics wording for the
+ * same underlying null.
+ */
+function computeMergeBase(
+  prHeadSha: string,
+  prBaseSha: string,
+  prBaseRef: string,
+  owner: string | undefined,
+  repo: string | undefined,
+  notes: string[],
+): string | null {
+  let mergeBase = gitText(['merge-base', prHeadSha, prBaseSha]);
+  if (!mergeBase) {
+    tryFetchBase(prBaseRef, owner, repo, notes);
+    mergeBase = gitText(['merge-base', prHeadSha, prBaseSha]);
+  }
+  return mergeBase || null;
+}
+
+/**
+ * True when the base ref has moved past this PR's merge-base, independent of
+ * `syncRecommendation` -- the blind spot this field exists to close. Returns
+ * `false` both when base genuinely has not advanced and when the merge-base
+ * could not be resolved at all; the latter, indeterminate case is
+ * distinguished only via a `notes` entry, never silently reported as a
+ * confirmed "no" (see the `computeMergeBase` doc comment above).
+ */
+function computeBaseAdvanced(
+  prHeadSha: string,
+  prBaseSha: string,
+  prBaseRef: string,
+  owner: string | undefined,
+  repo: string | undefined,
+  notes: string[],
+  skipGitProbe: boolean,
+): boolean {
+  if (skipGitProbe) return false;
+  try {
+    const mergeBase = computeMergeBase(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      owner,
+      repo,
+      notes,
+    );
+    if (!mergeBase) {
+      notes.push(
+        'merge-base not found; base-advancement since merge-base is undetermined (reported as false).',
+      );
+      return false;
+    }
+    return mergeBase !== prBaseSha;
+  } catch {
+    notes.push(
+      'git merge-base unavailable; base-advancement since merge-base is undetermined (reported as false).',
+    );
+    return false;
+  }
 }
 
 function probeConflictFilesReadOnly(
@@ -296,16 +424,19 @@ function probeConflictFilesReadOnly(
   notes: string[],
 ): string[] | null {
   try {
-    let mergeBase = gitText(['merge-base', prHeadSha, prBaseSha]);
+    const mergeBase = computeMergeBase(
+      prHeadSha,
+      prBaseSha,
+      prBaseRef,
+      owner,
+      repo,
+      notes,
+    );
     if (!mergeBase) {
-      tryFetchBase(prBaseRef, owner, repo, notes);
-      mergeBase = gitText(['merge-base', prHeadSha, prBaseSha]);
-      if (!mergeBase) {
-        notes.push(
-          'merge-base not found; cannot prove conflict-free; holding unknown.',
-        );
-        return null;
-      }
+      notes.push(
+        'merge-base not found; cannot prove conflict-free; holding unknown.',
+      );
+      return null;
     }
     const result = spawnSync(
       'git',

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -377,11 +377,15 @@ test('classifyBranchConflictState: CLEAN with an unresolvable merge-base reports
     owner: 'test-owner',
     repo: 'test-repo',
     // Deliberately no _skipGitProbe: the fixture's placeholder SHAs are not
-    // real git objects, so the merge-base lookup (and its fallback fetch)
-    // both fail. baseAdvancedSinceMergeBase must still read `false`, but
-    // must NOT read the same as a confirmed base-unmoved result -- a
-    // distinguishing note is required (see computeBaseAdvanced doc comment).
-    _testPrData: fixture.prData,
+    // real git objects, so the initial merge-base lookup fails.
+    // baseRefName is overridden to '' so the fallback-fetch guard
+    // (`if (!prBaseRef) return;`) short-circuits before attempting a real
+    // network fetch -- keeping this test hermetic and fast -- while still
+    // exercising the "merge-base not found" path: baseAdvancedSinceMergeBase
+    // must still read `false`, but must NOT read the same as a confirmed
+    // base-unmoved result -- a distinguishing note is required (see the
+    // computeBaseAdvanced doc comment).
+    _testPrData: { ...fixture.prData, baseRefName: '' },
   });
   assert.equal(result.baseAdvancedSinceMergeBase, false);
   assert.ok(

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
 import {
@@ -50,12 +53,50 @@ async function _classifyFromFixture(fixture: ConflictFixture) {
   });
 }
 
+let sharedTwoCommitRepo: { dir: string; older: string; newer: string } | null =
+  null;
+
+/**
+ * Builds (once, memoized) a hermetic two-commit git repository in a fresh
+ * temp directory and returns the SHAs of both commits, oldest first. Real
+ * local objects let `git merge-base` resolve deterministically with no
+ * network fetch, so `baseAdvancedSinceMergeBase` tests don't depend on the
+ * ambient checkout's history or depth (this project's own CI uses shallow,
+ * `fetch-depth: 1` checkouts in places, so relying on e.g. `HEAD~3` here
+ * would be fragile). Every caller only reads this fixture via `merge-base`
+ * afterward, so sharing one instance across tests is safe and avoids paying
+ * `git init` + two commits repeatedly.
+ */
+function createTwoCommitRepo(): { dir: string; older: string; newer: string } {
+  if (sharedTwoCommitRepo) return sharedTwoCommitRepo;
+  const dir = mkdtempSync(join(tmpdir(), 'idd-branch-conflict-state-'));
+  const git = (args: string[]) =>
+    execFileSync('git', args, { cwd: dir, encoding: 'utf8' }).trim();
+  git(['init', '-q']);
+  git(['config', 'user.email', 'test@example.invalid']);
+  git(['config', 'user.name', 'Test']);
+  writeFileSync(join(dir, 'a.txt'), 'a\n');
+  git(['add', 'a.txt']);
+  git(['commit', '-q', '-m', 'older']);
+  const older = git(['rev-parse', 'HEAD']);
+  writeFileSync(join(dir, 'b.txt'), 'b\n');
+  git(['add', 'b.txt']);
+  git(['commit', '-q', '-m', 'newer']);
+  const newer = git(['rev-parse', 'HEAD']);
+  sharedTwoCommitRepo = { dir, older, newer };
+  return sharedTwoCommitRepo;
+}
+
 test('classifyBranchConflictState: clean PR returns clean state', async () => {
   const fixture = loadFixture('clean');
   const result = await classifyBranchConflictState(fixture.prData.number, {
     owner: 'test-owner',
     repo: 'test-repo',
     _testPrData: fixture.prData,
+    // The fixture's SHAs are placeholders, not real git objects; skip the
+    // new baseAdvancedSinceMergeBase probe so this pre-existing test stays
+    // fast and offline (dedicated tests below cover the probe itself).
+    _skipGitProbe: true,
   });
   assert.equal(result.branchState, fixture.expected.branchState);
   assert.equal(result.syncRecommendation, fixture.expected.syncRecommendation);
@@ -63,6 +104,7 @@ test('classifyBranchConflictState: clean PR returns clean state', async () => {
     result.diagnostics.mergeableSource,
     fixture.expected.mergeableSource,
   );
+  assert.equal(result.baseAdvancedSinceMergeBase, false);
   assert.equal(result.readOnly, true);
   assert.equal(result.worktreeUnchanged, true);
   assert.equal(result.protocolVersion, '1');
@@ -77,6 +119,7 @@ test('classifyBranchConflictState: CONFLICTING returns content-conflict', async 
   });
   assert.equal(result.branchState, fixture.expected.branchState);
   assert.equal(result.syncRecommendation, fixture.expected.syncRecommendation);
+  assert.equal(result.baseAdvancedSinceMergeBase, false);
 });
 
 test('classifyBranchConflictState: DIRTY returns dirty state', async () => {
@@ -92,6 +135,7 @@ test('classifyBranchConflictState: DIRTY returns dirty state', async () => {
     result.diagnostics.mergeableSource,
     fixture.expected.mergeableSource,
   );
+  assert.equal(result.baseAdvancedSinceMergeBase, false);
 });
 
 test('classifyBranchConflictState: UNKNOWN returns transient computing state', async () => {
@@ -103,6 +147,7 @@ test('classifyBranchConflictState: UNKNOWN returns transient computing state', a
   });
   assert.equal(result.branchState, 'computing');
   assert.equal(result.syncRecommendation, 'recheck');
+  assert.equal(result.baseAdvancedSinceMergeBase, false);
 });
 
 test('classifyBranchConflictState: unrecognized mergeable returns terminal unknown', async () => {
@@ -114,6 +159,7 @@ test('classifyBranchConflictState: unrecognized mergeable returns terminal unkno
   });
   assert.equal(result.branchState, 'unknown');
   assert.equal(result.syncRecommendation, 'hold-unknown');
+  assert.equal(result.baseAdvancedSinceMergeBase, false);
 });
 
 test('classifyBranchConflictState: missing SHA returns unknown with hold-unknown', async () => {
@@ -126,6 +172,7 @@ test('classifyBranchConflictState: missing SHA returns unknown with hold-unknown
   assert.equal(result.branchState, 'unknown');
   assert.equal(result.syncRecommendation, 'hold-unknown');
   assert.equal(result.prHeadSha, '');
+  assert.equal(result.baseAdvancedSinceMergeBase, false);
   assert.ok(result.diagnostics.notes.length > 0);
 });
 
@@ -135,6 +182,7 @@ test('classifyBranchConflictState: result always reports readOnly and worktreeUn
     owner: 'test-owner',
     repo: 'test-repo',
     _testPrData: fixture.prData,
+    _skipGitProbe: true,
   });
   assert.equal(result.readOnly, true);
   assert.equal(result.worktreeUnchanged, true);
@@ -159,6 +207,9 @@ test('classifyBranchConflictState: BEHIND without conflict recommends merge-main
   });
   assert.equal(result.branchState, 'behind-no-conflict');
   assert.equal(result.syncRecommendation, 'merge-main');
+  // BEHIND is definitional: base has already advanced past the merge-base,
+  // so this is `true` even though the git probe itself was skipped.
+  assert.equal(result.baseAdvancedSinceMergeBase, true);
 });
 
 test('parseConflictFiles: parses content conflict lines', () => {
@@ -213,6 +264,130 @@ test('classifyBranchConflictState: post-push merge recommendation for BEHIND is 
     _skipGitProbe: true,
   });
   assert.equal(result.syncRecommendation, 'merge-main');
+  assert.equal(result.baseAdvancedSinceMergeBase, true);
+});
+
+test('classifyBranchConflictState: CLEAN with base advanced past merge-base reports true with an advisory note', async () => {
+  const { dir, older, newer } = createTwoCommitRepo();
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  try {
+    const prData = {
+      number: 301,
+      // Head is stuck at the older commit; base has moved on to the
+      // newer one -- textually clean/mergeable, yet base advanced past
+      // the merge-base. This is the exact blind spot the issue reports.
+      headRefOid: older,
+      baseRefOid: newer,
+      headRefName: 'feature/stale-clean',
+      baseRefName: 'main',
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'CLEAN',
+      headRepository: { id: 'R_test', name: 'test-repo' },
+    };
+    const result = await classifyBranchConflictState(301, {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      _testPrData: prData,
+    });
+    assert.equal(result.branchState, 'clean');
+    assert.equal(result.syncRecommendation, 'none');
+    assert.equal(result.baseAdvancedSinceMergeBase, true);
+    assert.ok(
+      result.diagnostics.notes.some((note) =>
+        note.includes('baseAdvancedSinceMergeBase'),
+      ),
+      'expected an advisory note naming the blind spot',
+    );
+  } finally {
+    process.chdir(originalCwd);
+  }
+});
+
+test('classifyBranchConflictState: CLEAN with base unmoved since merge-base reports false with no advisory note', async () => {
+  const { dir, older, newer } = createTwoCommitRepo();
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  try {
+    const prData = {
+      number: 302,
+      // Head has moved ahead with its own commit; base is still the
+      // older commit it forked from -- base has not advanced.
+      headRefOid: newer,
+      baseRefOid: older,
+      headRefName: 'feature/genuinely-clean',
+      baseRefName: 'main',
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'CLEAN',
+      headRepository: { id: 'R_test', name: 'test-repo' },
+    };
+    const result = await classifyBranchConflictState(302, {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      _testPrData: prData,
+    });
+    assert.equal(result.branchState, 'clean');
+    assert.equal(result.syncRecommendation, 'none');
+    assert.equal(result.baseAdvancedSinceMergeBase, false);
+    assert.ok(
+      !result.diagnostics.notes.some((note) =>
+        note.includes('baseAdvancedSinceMergeBase'),
+      ),
+      'did not expect an advisory note when base has not advanced',
+    );
+  } finally {
+    process.chdir(originalCwd);
+  }
+});
+
+test('classifyBranchConflictState: bare MERGEABLE (non-CLEAN state) also computes baseAdvancedSinceMergeBase', async () => {
+  const { dir, older, newer } = createTwoCommitRepo();
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  try {
+    const prData = {
+      number: 303,
+      headRefOid: older,
+      baseRefOid: newer,
+      headRefName: 'feature/stale-unstable',
+      baseRefName: 'main',
+      mergeable: 'MERGEABLE',
+      // Any merge state other than CLEAN/DIRTY/BEHIND falls through to
+      // the bare-MERGEABLE branch (line ~293 in the source), which is
+      // the second `none`-producing branch the issue names.
+      mergeStateStatus: 'UNSTABLE',
+      headRepository: { id: 'R_test', name: 'test-repo' },
+    };
+    const result = await classifyBranchConflictState(303, {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      _testPrData: prData,
+    });
+    assert.equal(result.branchState, 'clean');
+    assert.equal(result.syncRecommendation, 'none');
+    assert.equal(result.baseAdvancedSinceMergeBase, true);
+  } finally {
+    process.chdir(originalCwd);
+  }
+});
+
+test('classifyBranchConflictState: CLEAN with an unresolvable merge-base reports false with an undetermined note, never a silent false-negative', async () => {
+  const fixture = loadFixture('clean');
+  const result = await classifyBranchConflictState(fixture.prData.number, {
+    owner: 'test-owner',
+    repo: 'test-repo',
+    // Deliberately no _skipGitProbe: the fixture's placeholder SHAs are not
+    // real git objects, so the merge-base lookup (and its fallback fetch)
+    // both fail. baseAdvancedSinceMergeBase must still read `false`, but
+    // must NOT read the same as a confirmed base-unmoved result -- a
+    // distinguishing note is required (see computeBaseAdvanced doc comment).
+    _testPrData: fixture.prData,
+  });
+  assert.equal(result.baseAdvancedSinceMergeBase, false);
+  assert.ok(
+    result.diagnostics.notes.some((note) => note.includes('undetermined')),
+    'expected a note distinguishing "undetermined" from a confirmed unmoved base',
+  );
 });
 
 test('classifyBranchConflictState: published is true when head SHA is present', async () => {

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -292,6 +292,7 @@ export const branchConflictStateKeys = [
   'mergeStateStatus',
   'branchState',
   'syncRecommendation',
+  'baseAdvancedSinceMergeBase',
   'readOnly',
   'worktreeUnchanged',
   'diagnostics',
@@ -614,6 +615,7 @@ const branchConflictStateFixture = {
   mergeStateStatus: 'CLEAN',
   branchState: 'clean',
   syncRecommendation: 'none',
+  baseAdvancedSinceMergeBase: false,
   readOnly: true,
   worktreeUnchanged: true,
   diagnostics: {


### PR DESCRIPTION
# Summary

`branch-conflict-state` derived `syncRecommendation` purely from
GitHub's `mergeable` / `mergeStateStatus` plus a read-only
`git merge-tree` conflict probe, with no signal for whether base
moved past this branch's merge-base. Field evidence surfaced two
symptoms of the same gap: two individually-green PRs broke a
whole-tree line-count guard for every other open PR once merged
together, and a still-open PR's "clean, no sync recommended" verdict
stayed green even though its head would fail CI, because the fix
landed on base after that PR's last sync point (`pull_request`-triggered
CI is pinned to a merge-ref computed at trigger time, so a bare rerun
replays the stale state). GitHub only reports `mergeStateStatus: BEHIND`
when "require branches up to date" is enabled — otherwise a
stale-but-textually-clean head reads as `MERGEABLE`.

This PR adds `baseAdvancedSinceMergeBase: boolean` to the helper's
output, computed via a local `git merge-base` probe (reusing the
existing conflict-probe fallback-fetch pattern via a new shared
`computeMergeBase` helper) for the two `syncRecommendation: none`
branches (`MERGEABLE`+`CLEAN`, and bare `MERGEABLE`), and known for
free (`true`) for `BEHIND`, since that state is definitional. An
unresolvable merge-base reports `false` but is distinguished from a
confirmed-unmoved base via a `diagnostics.notes` entry, so an
indeterminate result is never silently reported the same as a
confirmed negative. Existing `syncRecommendation` values and
`branchState` routing are unchanged.

Docs updated at both consuming instruction surfaces (F1 in
`idd-pre-merge.instructions.md`, the E-phase branch-sync check in
`idd-review-triage.instructions.md`) and in the helper's field
reference (`docs/idd-helper-scripts.md`), edited at their
`idd-template/` source and synced.

## Linked issue

Closes #1398

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`baseAdvancedSinceMergeBase` is scoped to the two `none`-producing
branches (plus the free `true` for `BEHIND`) rather than computed
universally, since those are exactly the blind-spot cases the issue
reports; `CONFLICTING` / `DIRTY` / `computing` / terminal `unknown`
already carry accurate, non-`none` recommendations and report `false`
(not computed) to keep the change proportionate to the reported gap.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed (helper output schema
      `schemas/branch-conflict-state.schema.json` changed; the adopter
      policy schema/config is untouched)
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (2011/2011 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed, 4 pre-existing environmental warnings unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Branch status results now indicate whether the base branch advanced since the merge base.
  - Added advisory diagnostics when branch status may rely on stale CI information.

- **Bug Fixes**
  - Improved routing to prioritize fresh CI results when the base branch has advanced.
  - Clarified that a “clean” status confirms conflict-freeness only.

- **Documentation**
  - Updated helper-script guidance, schemas, and workflow instructions to explain the new branch-status information and CI freshness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->