### PR TITLE
feat(issue-authoring): recognize more prose-dependency reference shapes

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -578,7 +578,20 @@ without that context, a full-URL reference is still flagged by
 default (unchanged behavior) — unless its issue/PR number happens to
 already appear as a local `Blocked by` / `Depends on` / task-list
 marker elsewhere in the body, in which case it is treated as already
-encoded like any other match. Unlike every other check above, a
+encoded like any other match. A Markdown link's target may carry
+trailing content after the issue/PR number and before the link's
+closing paren — a URL fragment (`#issuecomment-123`), a trailing `/`,
+or a quoted link title (`"..."` or `'...'`) — and the link is still
+recognized as one match; without this, the label's own bare `#NNN`
+would otherwise leak through to the bare-`#` check and be misjudged
+independently of the link's (possibly cross-repo) target. A local
+`owner/repo#N` shorthand (e.g. `kurone-kito/idd-skill#4321`) is also
+recognized, but with the reverse default from the full-URL case above:
+it is flagged only when `--current-repo` is supplied **and**
+case-insensitively matches `owner/repo`; naming a different repository,
+or omitting `--current-repo`, always excludes it, since this shorthand
+was never recognized at all before and a bare `owner/repo` cannot be
+assumed local without confirmation. Unlike every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -440,7 +440,17 @@ CI) — a cross-repo dependency cannot be encoded with these
 repository-local markers, so flagging it would recommend an impossible
 fix; without that context a full-URL reference is still flagged by
 default, unless its number happens to already match a local dependency
-marker elsewhere in the body. A
+marker elsewhere in the body. A Markdown link's target may also carry
+trailing content between the issue/PR number and the link's closing
+paren — a URL fragment (`#issuecomment-123`), a trailing `/`, or a
+quoted link title (`"..."` or `'...'`) — and is still recognized as one
+link match rather than leaking its label's bare `#NNN` through to the
+bare-`#` check. A local `owner/repo#N` shorthand (e.g.
+`kurone-kito/idd-skill#4321`) is recognized too, but with the reverse
+default from the full-URL case: it is flagged only when
+`--current-repo` is supplied and case-insensitively matches
+`owner/repo`; a different repository, or no `--current-repo` at all,
+always excludes it. A
 `prose-dependency` warning never flips `passed` to
 `false` and never changes the linter's exit code; it prompts the author
 to convert the prose into a proper dependency marker or consciously

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -122,7 +122,7 @@ const PROSE_DEPENDENCY_KEYWORDS = [
 // token boundary rather than mid-path (e.g. inside a 3-segment
 // slash-separated path that happens to end in `#123`).
 const ISSUE_OR_PR_REFERENCE_PATTERN =
-  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[\w-]+)?(?:\s+(?:"[^"\n]*"|'[^'\n]*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
+  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"[^"\n]*"|'[^'\n]*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
 // Matches a Markdown list item marker at the start of a line (unordered
 // `-`/`*`/`+`, or ordered `1.`/`1)`), optionally indented and optionally
 // followed by a task-list checkbox. Declared here (before the CLI entry

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -85,25 +85,44 @@ const PROSE_DEPENDENCY_KEYWORDS = [
 ];
 // Matches a Markdown link whose target is a full GitHub issue/PR URL (e.g.
 // `[PR #1391](https://github.com/owner/repo/pull/1391)`), a bare `#123`
-// issue/PR reference, or a bare full GitHub issue/PR URL — in that order,
-// capturing each URL alternative's owner and repo so callers can tell a
-// local reference from a cross-repo one (see `currentRepo` handling in
-// checkProseOnlyDependency below). The Markdown-link alternative is tried
-// (and, being anchored at the label's own `[`, wins) first specifically so
-// that a cross-repo link's *label* text — which often repeats the same
-// `#N` the URL already names, e.g. the `#1391` above — is consumed as part
-// of that one link match rather than separately re-matched by the bare-`#`
-// alternative and misread as a local reference once the link's URL itself
-// is correctly filtered out as cross-repo. `#` alone (as in an ATX
-// heading) never matches without trailing digits. The bare-`#` alternative
-// excludes a `#` immediately preceded by a word character or `/` (a
-// negative lookbehind), so cross-repo shorthand like `other/repo#123`
-// does not match on its trailing `#123` — a cross-repo reference cannot be
-// encoded with this repository's local `Blocked by` / `Depends on`
-// markers, so flagging it here would be misleading rather than
-// actionable.
+// issue/PR reference, a bare full GitHub issue/PR URL, or a local
+// `owner/repo#123` shorthand — in that order, capturing each URL/shorthand
+// alternative's owner and repo so callers can tell a local reference from
+// a cross-repo one (see `currentRepo` handling in checkProseOnlyDependency
+// below). The Markdown-link alternative is tried (and, being anchored at
+// the label's own `[`, wins) first specifically so that a cross-repo
+// link's *label* text — which often repeats the same `#N` the URL already
+// names, e.g. the `#1391` above — is consumed as part of that one link
+// match rather than separately re-matched by the bare-`#` alternative and
+// misread as a local reference once the link's URL itself is correctly
+// filtered out as cross-repo. Between the issue/PR number and the link's
+// closing `)`, the Markdown-link alternative also tolerates an optional
+// trailing `/`, an optional URL fragment (`#issuecomment-123`), and an
+// optional quoted title (`"..."` or `'...'`) — each bounded tightly enough
+// (a matching quote character, or a fragment charset that excludes `)`,
+// quotes, and whitespace) that none of them can consume past the link's
+// real closing paren the way a naive `.*\)` would. Without this, any of
+// those three trailing forms would break the Markdown-link match and let
+// the label's own bare `#N` leak through to the bare-`#` alternative
+// below, reintroducing the label-leak false positive the Markdown-link
+// alternative exists to prevent. `#` alone (as in an ATX heading) never
+// matches without trailing digits. The bare-`#` alternative excludes a `#`
+// immediately preceded by a word character or `/` (a negative lookbehind),
+// so cross-repo shorthand like `other/repo#123` does not match on its
+// trailing `#123` — a cross-repo reference cannot be encoded with this
+// repository's local `Blocked by` / `Depends on` markers, so flagging it
+// here would be misleading rather than actionable. The final `owner/repo#N`
+// shorthand alternative recognizes that same shape as a *distinct*,
+// dedicated match (rather than leaving it permanently unmatched) so
+// checkProseOnlyDependency can apply the currentRepo comparison to it —
+// flagging it only when the shorthand names the current repository (see
+// the `currentRepo` JSDoc on `AuditOptions` for the reversed-default-
+// polarity rationale). It reuses the bare-`#` alternative's own
+// `(?<![\w/])` lookbehind so it, too, only starts matching at a natural
+// token boundary rather than mid-path (e.g. inside a 3-segment
+// slash-separated path that happens to end in `#123`).
 const ISSUE_OR_PR_REFERENCE_PATTERN =
-  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b/gi;
+  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[\w-]+)?(?:\s+(?:"[^"\n]*"|'[^'\n]*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
 // Matches a Markdown list item marker at the start of a line (unordered
 // `-`/`*`/`+`, or ordered `1.`/`1)`), optionally indented and optionally
 // followed by a task-list checkbox. Declared here (before the CLI entry
@@ -487,6 +506,9 @@ function checkProseOnlyDependency(text, currentRepo) {
           urlOwner,
           urlRepo,
           urlNumber,
+          shorthandOwner,
+          shorthandRepo,
+          shorthandNumber,
         ] = match;
         // Whichever of the two URL-bearing alternatives matched (a
         // Markdown-link target or a bare URL) supplies the owner/repo/number
@@ -513,7 +535,24 @@ function checkProseOnlyDependency(text, currentRepo) {
         ) {
           continue;
         }
-        const numberText = bareNumber ?? linkNumber ?? urlNumber;
+        // The owner/repo#N shorthand alternative uses the *opposite*
+        // default from the URL-bearing alternatives above: it is excluded
+        // unless currentRepo is both known and a case-insensitive match.
+        // Unlike a full URL (which was always flaggable pre-#1399), this
+        // shorthand was never recognized at all before this alternative
+        // existed, so there is no prior "flag by default" behavior to
+        // preserve when locality can't be confirmed — see the
+        // `currentRepo` JSDoc on `AuditOptions`.
+        if (
+          shorthandOwner !== undefined &&
+          (currentRepo === undefined ||
+            `${shorthandOwner}/${shorthandRepo}`.toLowerCase() !==
+              currentRepo.toLowerCase())
+        ) {
+          continue;
+        }
+        const numberText =
+          bareNumber ?? linkNumber ?? urlNumber ?? shorthandNumber;
         const number = Number.parseInt(numberText, 10);
         if (!encoded.has(number)) {
           flagged.add(number);

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -578,7 +578,20 @@ without that context, a full-URL reference is still flagged by
 default (unchanged behavior) — unless its issue/PR number happens to
 already appear as a local `Blocked by` / `Depends on` / task-list
 marker elsewhere in the body, in which case it is treated as already
-encoded like any other match. Unlike every other check above, a
+encoded like any other match. A Markdown link's target may carry
+trailing content after the issue/PR number and before the link's
+closing paren — a URL fragment (`#issuecomment-123`), a trailing `/`,
+or a quoted link title (`"..."` or `'...'`) — and the link is still
+recognized as one match; without this, the label's own bare `#NNN`
+would otherwise leak through to the bare-`#` check and be misjudged
+independently of the link's (possibly cross-repo) target. A local
+`owner/repo#N` shorthand (e.g. `kurone-kito/idd-skill#4321`) is also
+recognized, but with the reverse default from the full-URL case above:
+it is flagged only when `--current-repo` is supplied **and**
+case-insensitively matches `owner/repo`; naming a different repository,
+or omitting `--current-repo`, always excludes it, since this shorthand
+was never recognized at all before and a bare `owner/repo` cannot be
+assumed local without confirmation. Unlike every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -99,13 +99,27 @@ export interface AuditOptions {
   /**
    * The repository the drafted body belongs to, as `owner/repo` (matching
    * the `GITHUB_REPOSITORY` env var's own format). Used only by the
-   * advisory `prose-dependency` check to tell a local full-URL issue/PR
-   * reference from a cross-repo one: the encodings it recommends
-   * (`Blocked by #N` / `Depends on #N`) are inherently local, so a
-   * cross-repo URL would otherwise get the same, actively-wrong advice.
-   * When omitted, every full-URL reference is still treated as flaggable
-   * (the pre-#1399-fix default), since a bare `owner/repo` cannot be
-   * inferred from the body text alone.
+   * advisory `prose-dependency` check to tell a local issue/PR reference
+   * from a cross-repo one: the encodings it recommends (`Blocked by #N` /
+   * `Depends on #N`) are inherently local, so a cross-repo reference would
+   * otherwise get the same, actively-wrong advice.
+   *
+   * The two reference forms this option affects default in **opposite**
+   * directions when it is omitted:
+   *
+   * - **Full-URL / Markdown-link-to-a-full-URL** references: every match
+   *   is still treated as flaggable (the pre-#1399-fix default), since a
+   *   bare `owner/repo` cannot be inferred from the body text alone.
+   * - **`owner/repo#N` shorthand** references: every match is excluded
+   *   (never flagged), since this shorthand was never recognized at all
+   *   before this option existed — there is no legacy "flag by default"
+   *   behavior to preserve, and a shorthand naming an unconfirmed repo is
+   *   not assumed local.
+   *
+   * In both forms, an explicit `currentRepo` that case-insensitively
+   * matches the reference's `owner/repo` always flags it (subject to the
+   * existing dependency-marker exclusion), and one that differs always
+   * excludes it.
    */
   currentRepo?: string;
 }
@@ -156,25 +170,44 @@ const PROSE_DEPENDENCY_KEYWORDS = [
 
 // Matches a Markdown link whose target is a full GitHub issue/PR URL (e.g.
 // `[PR #1391](https://github.com/owner/repo/pull/1391)`), a bare `#123`
-// issue/PR reference, or a bare full GitHub issue/PR URL — in that order,
-// capturing each URL alternative's owner and repo so callers can tell a
-// local reference from a cross-repo one (see `currentRepo` handling in
-// checkProseOnlyDependency below). The Markdown-link alternative is tried
-// (and, being anchored at the label's own `[`, wins) first specifically so
-// that a cross-repo link's *label* text — which often repeats the same
-// `#N` the URL already names, e.g. the `#1391` above — is consumed as part
-// of that one link match rather than separately re-matched by the bare-`#`
-// alternative and misread as a local reference once the link's URL itself
-// is correctly filtered out as cross-repo. `#` alone (as in an ATX
-// heading) never matches without trailing digits. The bare-`#` alternative
-// excludes a `#` immediately preceded by a word character or `/` (a
-// negative lookbehind), so cross-repo shorthand like `other/repo#123`
-// does not match on its trailing `#123` — a cross-repo reference cannot be
-// encoded with this repository's local `Blocked by` / `Depends on`
-// markers, so flagging it here would be misleading rather than
-// actionable.
+// issue/PR reference, a bare full GitHub issue/PR URL, or a local
+// `owner/repo#123` shorthand — in that order, capturing each URL/shorthand
+// alternative's owner and repo so callers can tell a local reference from
+// a cross-repo one (see `currentRepo` handling in checkProseOnlyDependency
+// below). The Markdown-link alternative is tried (and, being anchored at
+// the label's own `[`, wins) first specifically so that a cross-repo
+// link's *label* text — which often repeats the same `#N` the URL already
+// names, e.g. the `#1391` above — is consumed as part of that one link
+// match rather than separately re-matched by the bare-`#` alternative and
+// misread as a local reference once the link's URL itself is correctly
+// filtered out as cross-repo. Between the issue/PR number and the link's
+// closing `)`, the Markdown-link alternative also tolerates an optional
+// trailing `/`, an optional URL fragment (`#issuecomment-123`), and an
+// optional quoted title (`"..."` or `'...'`) — each bounded tightly enough
+// (a matching quote character, or a fragment charset that excludes `)`,
+// quotes, and whitespace) that none of them can consume past the link's
+// real closing paren the way a naive `.*\)` would. Without this, any of
+// those three trailing forms would break the Markdown-link match and let
+// the label's own bare `#N` leak through to the bare-`#` alternative
+// below, reintroducing the label-leak false positive the Markdown-link
+// alternative exists to prevent. `#` alone (as in an ATX heading) never
+// matches without trailing digits. The bare-`#` alternative excludes a `#`
+// immediately preceded by a word character or `/` (a negative lookbehind),
+// so cross-repo shorthand like `other/repo#123` does not match on its
+// trailing `#123` — a cross-repo reference cannot be encoded with this
+// repository's local `Blocked by` / `Depends on` markers, so flagging it
+// here would be misleading rather than actionable. The final `owner/repo#N`
+// shorthand alternative recognizes that same shape as a *distinct*,
+// dedicated match (rather than leaving it permanently unmatched) so
+// checkProseOnlyDependency can apply the currentRepo comparison to it —
+// flagging it only when the shorthand names the current repository (see
+// the `currentRepo` JSDoc on `AuditOptions` for the reversed-default-
+// polarity rationale). It reuses the bare-`#` alternative's own
+// `(?<![\w/])` lookbehind so it, too, only starts matching at a natural
+// token boundary rather than mid-path (e.g. inside a 3-segment
+// slash-separated path that happens to end in `#123`).
 const ISSUE_OR_PR_REFERENCE_PATTERN =
-  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b/gi;
+  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[\w-]+)?(?:\s+(?:"[^"\n]*"|'[^'\n]*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
 
 // Matches a Markdown list item marker at the start of a line (unordered
 // `-`/`*`/`+`, or ordered `1.`/`1)`), optionally indented and optionally
@@ -600,6 +633,9 @@ function checkProseOnlyDependency(
           urlOwner,
           urlRepo,
           urlNumber,
+          shorthandOwner,
+          shorthandRepo,
+          shorthandNumber,
         ] = match;
         // Whichever of the two URL-bearing alternatives matched (a
         // Markdown-link target or a bare URL) supplies the owner/repo/number
@@ -626,7 +662,24 @@ function checkProseOnlyDependency(
         ) {
           continue;
         }
-        const numberText = bareNumber ?? linkNumber ?? urlNumber;
+        // The owner/repo#N shorthand alternative uses the *opposite*
+        // default from the URL-bearing alternatives above: it is excluded
+        // unless currentRepo is both known and a case-insensitive match.
+        // Unlike a full URL (which was always flaggable pre-#1399), this
+        // shorthand was never recognized at all before this alternative
+        // existed, so there is no prior "flag by default" behavior to
+        // preserve when locality can't be confirmed — see the
+        // `currentRepo` JSDoc on `AuditOptions`.
+        if (
+          shorthandOwner !== undefined &&
+          (currentRepo === undefined ||
+            `${shorthandOwner}/${shorthandRepo}`.toLowerCase() !==
+              currentRepo.toLowerCase())
+        ) {
+          continue;
+        }
+        const numberText =
+          bareNumber ?? linkNumber ?? urlNumber ?? shorthandNumber;
         const number = Number.parseInt(numberText, 10);
         if (!encoded.has(number)) {
           flagged.add(number);

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -207,7 +207,7 @@ const PROSE_DEPENDENCY_KEYWORDS = [
 // token boundary rather than mid-path (e.g. inside a 3-segment
 // slash-separated path that happens to end in `#123`).
 const ISSUE_OR_PR_REFERENCE_PATTERN =
-  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[\w-]+)?(?:\s+(?:"[^"\n]*"|'[^'\n]*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
+  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"[^"\n]*"|'[^'\n]*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
 
 // Matches a Markdown list item marker at the start of a line (unordered
 // `-`/`*`/`+`, or ordered `1.`/`1)`), optionally indented and optionally

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -969,7 +969,7 @@ test('prose-dependency does not warn on a cross-repo Markdown link whose fragmen
   // fragment charset restricted to [\w-]+ rejects a fragment containing a
   // `.` (e.g. a heading-anchor-style fragment), which fails the whole
   // Markdown-link alternative and reintroduces the exact label-leak this
-  // shape exists to prevent -- the same failure mode as an untolerated
+  // shape exists to prevent -- the same failure mode as not tolerating a
   // fragment at all, just triggered by an overly narrow charset instead.
   const body = childBody({
     extraMarkers:

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -926,6 +926,252 @@ test('prose-dependency ignores a coordination word and reference that only appea
   assert.equal(finding.severity, undefined);
 });
 
+// --- prose-dependency: trailing Markdown-link content (#1468) ---
+
+test('prose-dependency recognizes a Markdown link whose target has a trailing URL fragment', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/idd-skill/pull/1391#issuecomment-123) has merged.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency does not warn on a cross-repo Markdown link with a trailing URL fragment when currentRepo is known', () => {
+  // Regression test for the exact label-leak false positive this issue's
+  // Background describes: without trailing-content support, this link
+  // would fail the Markdown-link alternative and let its label's bare
+  // `#1391` leak through to the bare-`#` alternative, wrongly flagging a
+  // cross-repo reference as local.
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/other-repo/pull/1391#issuecomment-123) has shipped.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency recognizes a Markdown link whose target has a trailing slash', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/idd-skill/pull/1391/) has merged.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency does not warn on a cross-repo Markdown link with a trailing slash when currentRepo is known', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/other-repo/pull/1391/) has shipped.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency recognizes a Markdown link whose target has a double-quoted title', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/idd-skill/pull/1391 "Merge base change") has merged.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency recognizes a Markdown link whose target has a single-quoted title', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      "[PR #1391](https://github.com/kurone-kito/idd-skill/pull/1391 'Merge base change') has merged.",
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency does not warn on a cross-repo Markdown link with a quoted title when currentRepo is known', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/other-repo/pull/1391 "Merge base change") has shipped.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency does not warn on a Markdown link with a trailing URL fragment when the number already has a Blocked by encoding', () => {
+  const body = childBody({
+    extraMarkers:
+      'Blocked by #1391\n\nBefore this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/idd-skill/pull/1391#issuecomment-123) has merged.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency does not warn on a Markdown link with a quoted title when the number already has a task-list encoding', () => {
+  const body = childBody({
+    extraMarkers:
+      '- [ ] #1391\n\nBefore this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/idd-skill/pull/1391 "Merge base change") has merged.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+// --- prose-dependency: owner/repo#N shorthand (#1468) ---
+
+test('prose-dependency flags an owner/repo#N shorthand naming currentRepo', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before starting, confirm kurone-kito/idd-skill#4321 has shipped.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#4321/);
+});
+
+test('prose-dependency does not warn on an owner/repo#N shorthand naming a different repo', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before starting, confirm kurone-kito/other-repo#4321 has shipped.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency does not warn on an owner/repo#N shorthand when currentRepo is unknown', () => {
+  // No behavior change from before this issue: this shorthand was never
+  // recognized at all pre-#1468, so the default without currentRepo stays
+  // "excluded" — the opposite default from the full-URL alternatives,
+  // which stay flagged-by-default when currentRepo is unknown.
+  const body = childBody({
+    extraMarkers:
+      'Before starting, confirm kurone-kito/idd-skill#4321 has shipped.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency owner/repo#N shorthand currentRepo comparison is case-insensitive', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before starting, confirm Kurone-Kito/IDD-Skill#4321 has shipped.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#4321/);
+});
+
+test('prose-dependency does not warn on an owner/repo#N shorthand when the number already has a Depends on encoding', () => {
+  const body = childBody({
+    extraMarkers:
+      'Depends on #4321\n\nBefore starting, confirm ' +
+      'kurone-kito/idd-skill#4321 has shipped.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency does not misparse a three-segment slash path ending in #N as an owner/repo#N shorthand', () => {
+  // Regression test for the new alternative's own false-positive risk: a
+  // greedy owner/repo#N match starting mid-path (e.g. the "b/c#123" tail of
+  // "a/b/c#123") would misread an unrelated multi-segment path as a
+  // shorthand reference. The shared (?<![\w/]) lookbehind must reject
+  // starting the match right after another `/`.
+  const body = childBody({
+    extraMarkers: 'Before starting, see a/b/c#4321 for details.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
 // --- shape / markerPrefix pass-through ---
 
 test('the report echoes the declared shape and resolved markerPrefix', () => {

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -964,6 +964,50 @@ test('prose-dependency does not warn on a cross-repo Markdown link with a traili
   assert.equal(finding.severity, undefined);
 });
 
+test('prose-dependency does not warn on a cross-repo Markdown link whose fragment contains a dot', () => {
+  // Regression test for a review finding on this same PR (#1469): a
+  // fragment charset restricted to [\w-]+ rejects a fragment containing a
+  // `.` (e.g. a heading-anchor-style fragment), which fails the whole
+  // Markdown-link alternative and reintroduces the exact label-leak this
+  // shape exists to prevent -- the same failure mode as an untolerated
+  // fragment at all, just triggered by an overly narrow charset instead.
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      '[PR #12](https://github.com/kurone-kito/other-repo/pull/12#foo.bar) has shipped.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency does not warn on a cross-repo Markdown link with a non-ASCII fragment', () => {
+  // Regression test for a review finding on this same PR (#1469): a
+  // fragment charset restricted to ASCII \w rejects a non-ASCII fragment
+  // (realistic for this repository, whose docs/issues carry Japanese
+  // content routinely), with the same label-leak failure mode as above.
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/other-repo/pull/1391#背景) has shipped.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
 test('prose-dependency recognizes a Markdown link whose target has a trailing slash', () => {
   const body = childBody({
     extraMarkers:


### PR DESCRIPTION
# Summary

Extends `checkProseOnlyDependency` / `ISSUE_OR_PR_REFERENCE_PATTERN` in
`src/scripts/audit-authored-issue.mts` to recognize the three
reference shapes this issue's `## Proposed change` names:

1. A Markdown link's target may now carry trailing content between the
   issue/PR number and the link's closing paren — a URL fragment
   (`#issuecomment-123`), a trailing `/`, or a quoted link title
   (`"..."` / `'...'`) — without breaking the Markdown-link match. Any
   of these previously fell through to the bare-`#` alternative,
   reintroducing the label-leak false positive for cross-repo links
   the Markdown-link alternative exists to prevent.
2. A dedicated `owner/repo#N` shorthand alternative is added, applying
   the `currentRepo` comparison with **reversed default polarity**
   from the full-URL case: flagged only when `currentRepo` is known
   and matches; excluded when unknown or different (this shorthand was
   never recognized at all before, so "unknown" stays excluded rather
   than flagged-by-default).

## Linked issue

Closes #1468

## Follow-up issues (if any)

- [x] none

This issue also carries two addendum comments from the issue author
(items 4-6: reference-style Markdown links `[text][ref]`, nested-list
scope loss, and an empty-string `currentRepo` edge case), explicitly
described as "deferred here rather than fixed, for the same reason."
Those are intentionally **not** addressed by this PR — they're already
recorded on #1468 for a possible future follow-up, consistent with how
#1468 itself was spun out of #1399 rather than chased there.

## Background / rationale (if material)

#1399's review kept surfacing new reference-shape edge cases round
after round; rather than repeat that open-ended chase, #1468 bounded
the remaining work to exactly the three shapes above. This PR
implements exactly those three and stops there.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (ran as separate components: `node scripts/audit-docs.mjs --check`,
      `pnpm run typecheck`, `pnpm run build:check`, `biome check`,
      `dprint check`, `markdownlint-cli2`, `cspell lint`,
      `node scripts/verify-workshop-integrity.mjs` — all pass)
- [x] `pnpm test` — `tests/audit-authored-issue.test.mts`: 76/76 pass
      (61 pre-existing + 15 new). Full suite: 2081/2084 pass; the 3
      failures are `tests/branch-conflict-state.test.mts` fixture
      commits hitting a GPG pinentry timeout from this local
      environment's ambient `commit.gpgsign=true` — unrelated to this
      diff (module untouched here) and reproduced identically on
      unmodified `main`. Expected to pass on hosted CI.
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable) — passed, 4
      pre-existing environmental warnings unrelated to this diff

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
