### PR TITLE
fix(idd): derive tryFetchBase remote host, not hardcoded github.com

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -54,3 +54,6 @@ words:
   - minimizable
   - waivable
   - rollup
+  - GHES
+  - ghes
+  - WHATWG

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -55,5 +55,4 @@ words:
   - waivable
   - rollup
   - GHES
-  - ghes
   - WHATWG

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -417,8 +417,11 @@ export function parseGitHostFromUrl(url) {
       return null;
     }
   }
-  // scp-like shorthand: [user@]host:path (no scheme, so URL() can't parse it).
-  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?([^:/\s]+):/);
+  // scp-like shorthand: user@host:path (no scheme, so URL() can't parse
+  // it). The `user@` prefix is required, not just conventional: without
+  // it, a Windows-style local path such as `C:\Users\foo\repo.git` would
+  // otherwise match with `C` misread as a host.
+  const scpMatch = trimmed.match(/^[^@\s]+@([^:/\s]+):/);
   return scpMatch ? scpMatch[1].toLowerCase() : null;
 }
 /**
@@ -431,9 +434,10 @@ export function parseGitHostFromUrl(url) {
  * 1. The `GH_HOST` environment variable — the same override `gh` itself
  *    honors — when set and non-blank.
  * 2. The host parsed from the local checkout's `origin` remote URL. This
- *    assumes the fetch-worthy remote is named `origin`, matching every
- *    other git probe in this file; an unusual multi-remote checkout that
- *    names its GHES remote something else falls through to (3).
+ *    assumes the fetch-worthy remote is named `origin`, the conventional
+ *    default for a single-remote checkout; an unusual multi-remote
+ *    checkout that names its GHES remote something else falls through
+ *    to (3).
  * 3. `github.com`, the pre-existing default, when neither signal
  *    resolves.
  */
@@ -453,6 +457,12 @@ function tryFetchBase(prBaseRef, owner, repo, notes) {
     return;
   }
   try {
+    // resolveFetchHost()'s own branching (GH_HOST / origin-remote / default)
+    // is unit-tested directly; this URL-assembly line and the real `git
+    // fetch` below stay deliberately untested at this call site, matching
+    // this file's existing test-suite convention of never letting a test
+    // reach a live network fetch (see the "unresolvable merge-base" test's
+    // `baseRefName: ''` short-circuit).
     const remote = `https://${resolveFetchHost()}/${owner}/${repo}.git`;
     execFileSync(
       'git',

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -385,23 +385,32 @@ function readOriginRemoteUrl() {
 }
 /**
  * Parse the scheme and host (hostname, plus `:port` when meaningful) from
- * a git remote URL. Supports both URL-scheme forms parseable by the
- * WHATWG URL parser (`http(s)://host[:port]/owner/repo.git`,
- * `ssh://git@host[:port]/owner/repo.git`) and the scp-like SSH shorthand
+ * a git remote URL. Supports the `http://` / `https://` URL-scheme forms
+ * (parseable by the WHATWG URL parser) and the scp-like SSH shorthand
  * (`[user@]host:path`, which has no `://` scheme and is not
  * `URL`-parseable; per git's own URL syntax the `user@` prefix is
  * optional, e.g. a bare `ghes.example.com:owner/repo.git` is valid).
  *
- * The returned `scheme` always matches the origin's own scheme for an
- * `http://` or `https://` origin — an `http://`-only GHES instance (no
- * TLS, e.g. behind a private network boundary) must stay `http`, since
- * silently upgrading to `https` on the same port would target a port
- * that is not serving TLS and the fetch would fail. An `ssh://` origin or
- * the scp-like shorthand has no reusable scheme for this always-anonymous
- * fetch, so both resolve to `https`; the same reasoning drops an
- * `ssh://` origin's port (frequently unrelated to a GHES instance's
- * HTTPS port behind a reverse proxy), while an `http(s)://` origin's port
- * is preserved, since it is directly reusable here.
+ * The returned `scheme` always matches an `http://` or `https://` origin's
+ * own scheme — an `http://`-only GHES instance (no TLS, e.g. behind a
+ * private network boundary) must stay `http`, since silently upgrading to
+ * `https` on the same port would target a port that is not serving TLS
+ * and the fetch would fail; that origin's port is preserved too, since it
+ * is directly reusable here.
+ *
+ * An `ssh://` URL-scheme origin (or any other non-`http(s)` scheme)
+ * deliberately returns `null` rather than reusing its hostname: an SSH
+ * hostname is sometimes an alias with no HTTPS service of its own —
+ * GitHub's own documented `ssh.github.com` (used for SSH-over-443
+ * firewall traversal) accepts SSH, not HTTPS, on that hostname, and a
+ * local `~/.ssh/config` `Host` alias may not resolve via DNS at all.
+ * Guessing wrong here would regress a previously-working `github.com`
+ * fallback into a broken fetch, so this signal is treated as unusable
+ * rather than guessed at. The scp-like shorthand keeps reusing its host,
+ * since that syntax has no port field of its own and is therefore not
+ * used for GitHub's SSH-over-443 workaround in practice — the same
+ * hostname is the overwhelmingly common real-world case for a GHES
+ * remote's SSH and HTTPS endpoints.
  *
  * Returns `null` for empty, unparseable, or host-less input (e.g. a
  * `file://` URL, whose `hostname` is `''`) so callers fall back to
@@ -421,9 +430,9 @@ export function parseGitFetchOrigin(url) {
       if (parsed.protocol === 'https:') {
         return { scheme: 'https', host: parsed.host.toLowerCase() };
       }
-      // ssh:// (or any other scheme): no reusable scheme or port -- see
-      // the doc comment above.
-      return { scheme: 'https', host: parsed.hostname.toLowerCase() };
+      // ssh:// (or any other scheme): no reusable host -- see the doc
+      // comment above.
+      return null;
     } catch {
       return null;
     }

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -376,6 +376,74 @@ function probeConflictFilesReadOnly(
     return null;
   }
 }
+/** Default `origin` URL reader: `git remote get-url origin` in the current
+ * working directory (this file's other git probes are likewise un-scoped
+ * to a `-C <dir>`, since they always run from inside the target checkout).
+ * `gitText` already swallows any git failure and returns `''`. */
+function readOriginRemoteUrl() {
+  return gitText(['remote', 'get-url', 'origin']);
+}
+/**
+ * Parse the host (hostname, plus `:port` when meaningful) from a git
+ * remote URL. Supports both URL-scheme forms parseable by the WHATWG URL
+ * parser (`https://host[:port]/owner/repo.git`,
+ * `ssh://git@host[:port]/owner/repo.git`) and the scp-like SSH shorthand
+ * (`git@host:owner/repo.git`, which has no `://` scheme and is not
+ * `URL`-parseable).
+ *
+ * Port handling is scheme-aware: an `http(s)://` origin's port is
+ * preserved, since it is directly reusable for the `https://` fetch URL
+ * this resolves for; an `ssh://` origin's port is dropped, since an SSH
+ * port is frequently unrelated to a GHES instance's HTTPS port behind a
+ * reverse proxy, and carrying it over would silently build a wrong URL.
+ * The scp-like shorthand has no port syntax of its own.
+ *
+ * Returns `null` for empty, unparseable, or host-less input (e.g. a
+ * `file://` URL, whose `hostname` is `''`) so callers fall back to
+ * another signal. The host is lowercased for consistent comparison —
+ * DNS/HTTP hosts are case-insensitive.
+ */
+export function parseGitHostFromUrl(url) {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes('://')) {
+    try {
+      const parsed = new URL(trimmed);
+      if (!parsed.hostname) return null;
+      const isHttp =
+        parsed.protocol === 'http:' || parsed.protocol === 'https:';
+      return (isHttp ? parsed.host : parsed.hostname).toLowerCase();
+    } catch {
+      return null;
+    }
+  }
+  // scp-like shorthand: [user@]host:path (no scheme, so URL() can't parse it).
+  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?([^:/\s]+):/);
+  return scpMatch ? scpMatch[1].toLowerCase() : null;
+}
+/**
+ * Resolve the git host to use for the read-only base-ref fetch fallback in
+ * {@link tryFetchBase}, instead of hardcoding `github.com` (#1454) — a
+ * GitHub Enterprise Server (GHES) checkout must fetch from its own host,
+ * or the fallback silently targets an unrelated github.com repo of the
+ * same owner/repo name (or just fails outright). Preference order:
+ *
+ * 1. The `GH_HOST` environment variable — the same override `gh` itself
+ *    honors — when set and non-blank.
+ * 2. The host parsed from the local checkout's `origin` remote URL. This
+ *    assumes the fetch-worthy remote is named `origin`, matching every
+ *    other git probe in this file; an unusual multi-remote checkout that
+ *    names its GHES remote something else falls through to (3).
+ * 3. `github.com`, the pre-existing default, when neither signal
+ *    resolves.
+ */
+export function resolveFetchHost(env = process.env, readers = {}) {
+  const ghHost = env.GH_HOST?.trim();
+  if (ghHost) return ghHost;
+  const readOriginUrl = readers.readOriginUrl ?? readOriginRemoteUrl;
+  const originHost = parseGitHostFromUrl(readOriginUrl());
+  return originHost || 'github.com';
+}
 function tryFetchBase(prBaseRef, owner, repo, notes) {
   if (!prBaseRef) return;
   if (!owner || !repo) {
@@ -385,7 +453,7 @@ function tryFetchBase(prBaseRef, owner, repo, notes) {
     return;
   }
   try {
-    const remote = `https://github.com/${owner}/${repo}.git`;
+    const remote = `https://${resolveFetchHost()}/${owner}/${repo}.git`;
     execFileSync(
       'git',
       ['fetch', '--no-tags', '--depth=1', remote, prBaseRef],

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -467,7 +467,10 @@ export function parseGitFetchOrigin(url) {
  */
 export function resolveFetchOrigin(env = process.env, readers = {}) {
   const ghHost = env.GH_HOST?.trim();
-  if (ghHost) return { scheme: 'https', host: ghHost };
+  // Lowercased for consistency with the origin-derived path below (DNS/HTTP
+  // hosts are case-insensitive either way, so this does not change fetch
+  // behavior -- only comparison/display consistency).
+  if (ghHost) return { scheme: 'https', host: ghHost.toLowerCase() };
   const readOriginUrl = readers.readOriginUrl ?? readOriginRemoteUrl;
   return (
     parseGitFetchOrigin(readOriginUrl()) ?? {

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -384,69 +384,92 @@ function readOriginRemoteUrl() {
   return gitText(['remote', 'get-url', 'origin']);
 }
 /**
- * Parse the host (hostname, plus `:port` when meaningful) from a git
- * remote URL. Supports both URL-scheme forms parseable by the WHATWG URL
- * parser (`https://host[:port]/owner/repo.git`,
+ * Parse the scheme and host (hostname, plus `:port` when meaningful) from
+ * a git remote URL. Supports both URL-scheme forms parseable by the
+ * WHATWG URL parser (`http(s)://host[:port]/owner/repo.git`,
  * `ssh://git@host[:port]/owner/repo.git`) and the scp-like SSH shorthand
- * (`git@host:owner/repo.git`, which has no `://` scheme and is not
- * `URL`-parseable).
+ * (`[user@]host:path`, which has no `://` scheme and is not
+ * `URL`-parseable; per git's own URL syntax the `user@` prefix is
+ * optional, e.g. a bare `ghes.example.com:owner/repo.git` is valid).
  *
- * Port handling is scheme-aware: an `http(s)://` origin's port is
- * preserved, since it is directly reusable for the `https://` fetch URL
- * this resolves for; an `ssh://` origin's port is dropped, since an SSH
- * port is frequently unrelated to a GHES instance's HTTPS port behind a
- * reverse proxy, and carrying it over would silently build a wrong URL.
- * The scp-like shorthand has no port syntax of its own.
+ * The returned `scheme` always matches the origin's own scheme for an
+ * `http://` or `https://` origin — an `http://`-only GHES instance (no
+ * TLS, e.g. behind a private network boundary) must stay `http`, since
+ * silently upgrading to `https` on the same port would target a port
+ * that is not serving TLS and the fetch would fail. An `ssh://` origin or
+ * the scp-like shorthand has no reusable scheme for this always-anonymous
+ * fetch, so both resolve to `https`; the same reasoning drops an
+ * `ssh://` origin's port (frequently unrelated to a GHES instance's
+ * HTTPS port behind a reverse proxy), while an `http(s)://` origin's port
+ * is preserved, since it is directly reusable here.
  *
  * Returns `null` for empty, unparseable, or host-less input (e.g. a
  * `file://` URL, whose `hostname` is `''`) so callers fall back to
  * another signal. The host is lowercased for consistent comparison —
  * DNS/HTTP hosts are case-insensitive.
  */
-export function parseGitHostFromUrl(url) {
+export function parseGitFetchOrigin(url) {
   const trimmed = url.trim();
   if (!trimmed) return null;
   if (trimmed.includes('://')) {
     try {
       const parsed = new URL(trimmed);
       if (!parsed.hostname) return null;
-      const isHttp =
-        parsed.protocol === 'http:' || parsed.protocol === 'https:';
-      return (isHttp ? parsed.host : parsed.hostname).toLowerCase();
+      if (parsed.protocol === 'http:') {
+        return { scheme: 'http', host: parsed.host.toLowerCase() };
+      }
+      if (parsed.protocol === 'https:') {
+        return { scheme: 'https', host: parsed.host.toLowerCase() };
+      }
+      // ssh:// (or any other scheme): no reusable scheme or port -- see
+      // the doc comment above.
+      return { scheme: 'https', host: parsed.hostname.toLowerCase() };
     } catch {
       return null;
     }
   }
-  // scp-like shorthand: user@host:path (no scheme, so URL() can't parse
-  // it). The `user@` prefix is required, not just conventional: without
-  // it, a Windows-style local path such as `C:\Users\foo\repo.git` would
-  // otherwise match with `C` misread as a host.
-  const scpMatch = trimmed.match(/^[^@\s]+@([^:/\s]+):/);
-  return scpMatch ? scpMatch[1].toLowerCase() : null;
+  // scp-like shorthand: [user@]host:path (no scheme, so URL() can't parse
+  // it). A single-character "host" is excluded rather than requiring
+  // `user@`: git's own scp-like syntax makes the username optional (a
+  // real GHES remote can validly omit it), but no real git host is a
+  // single letter, so this is almost always a Windows drive-letter path
+  // (`C:\Users\...`, `C:repo.git`) rather than a real host.
+  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?([^:/\s]+):/);
+  const host = scpMatch?.[1];
+  return host && host.length > 1
+    ? { scheme: 'https', host: host.toLowerCase() }
+    : null;
 }
 /**
- * Resolve the git host to use for the read-only base-ref fetch fallback in
- * {@link tryFetchBase}, instead of hardcoding `github.com` (#1454) — a
- * GitHub Enterprise Server (GHES) checkout must fetch from its own host,
- * or the fallback silently targets an unrelated github.com repo of the
- * same owner/repo name (or just fails outright). Preference order:
+ * Resolve the scheme + host to use for the read-only base-ref fetch
+ * fallback in {@link tryFetchBase}, instead of hardcoding
+ * `https://github.com` (#1454) — a GitHub Enterprise Server (GHES)
+ * checkout must fetch from its own host, or the fallback silently targets
+ * an unrelated github.com repo of the same owner/repo name (or just
+ * fails outright). Preference order:
  *
  * 1. The `GH_HOST` environment variable — the same override `gh` itself
- *    honors — when set and non-blank.
- * 2. The host parsed from the local checkout's `origin` remote URL. This
- *    assumes the fetch-worthy remote is named `origin`, the conventional
- *    default for a single-remote checkout; an unusual multi-remote
- *    checkout that names its GHES remote something else falls through
- *    to (3).
- * 3. `github.com`, the pre-existing default, when neither signal
+ *    honors — when set and non-blank. `GH_HOST` never carries a scheme,
+ *    so this always resolves to `https` (the same assumption `gh` itself
+ *    makes for its own HTTPS operations).
+ * 2. The scheme and host parsed from the local checkout's `origin`
+ *    remote URL. This assumes the fetch-worthy remote is named `origin`,
+ *    the conventional default for a single-remote checkout; an unusual
+ *    multi-remote checkout that names its GHES remote something else
+ *    falls through to (3).
+ * 3. `https://github.com`, the pre-existing default, when neither signal
  *    resolves.
  */
-export function resolveFetchHost(env = process.env, readers = {}) {
+export function resolveFetchOrigin(env = process.env, readers = {}) {
   const ghHost = env.GH_HOST?.trim();
-  if (ghHost) return ghHost;
+  if (ghHost) return { scheme: 'https', host: ghHost };
   const readOriginUrl = readers.readOriginUrl ?? readOriginRemoteUrl;
-  const originHost = parseGitHostFromUrl(readOriginUrl());
-  return originHost || 'github.com';
+  return (
+    parseGitFetchOrigin(readOriginUrl()) ?? {
+      scheme: 'https',
+      host: 'github.com',
+    }
+  );
 }
 function tryFetchBase(prBaseRef, owner, repo, notes) {
   if (!prBaseRef) return;
@@ -457,13 +480,14 @@ function tryFetchBase(prBaseRef, owner, repo, notes) {
     return;
   }
   try {
-    // resolveFetchHost()'s own branching (GH_HOST / origin-remote / default)
-    // is unit-tested directly; this URL-assembly line and the real `git
-    // fetch` below stay deliberately untested at this call site, matching
-    // this file's existing test-suite convention of never letting a test
-    // reach a live network fetch (see the "unresolvable merge-base" test's
-    // `baseRefName: ''` short-circuit).
-    const remote = `https://${resolveFetchHost()}/${owner}/${repo}.git`;
+    // resolveFetchOrigin()'s own branching (GH_HOST / origin-remote /
+    // default) is unit-tested directly; this URL-assembly line and the
+    // real `git fetch` below stay deliberately untested at this call
+    // site, matching this file's existing test-suite convention of never
+    // letting a test reach a live network fetch (see the "unresolvable
+    // merge-base" test's `baseRefName: ''` short-circuit).
+    const { scheme, host } = resolveFetchOrigin();
+    const remote = `${scheme}://${host}/${owner}/${repo}.git`;
     execFileSync(
       'git',
       ['fetch', '--no-tags', '--depth=1', remote, prBaseRef],

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -434,7 +434,12 @@ export function parseGitFetchOrigin(url) {
   // real GHES remote can validly omit it), but no real git host is a
   // single letter, so this is almost always a Windows drive-letter path
   // (`C:\Users\...`, `C:repo.git`) rather than a real host.
-  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?([^:/\s]+):/);
+  //
+  // A bracketed IPv6 literal host (`[2001:db8::1]`) is matched before the
+  // generic host pattern: IPv6 literals contain colons of their own, so
+  // the generic `[^:/\s]+` alternative would otherwise stop at the first
+  // one and capture only a truncated fragment (e.g. `[2001`).
+  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?(\[[^\]\s]+\]|[^:/\s]+):/);
   const host = scpMatch?.[1];
   return host && host.length > 1
     ? { scheme: 'https', host: host.toLowerCase() }

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -487,73 +487,108 @@ function readOriginRemoteUrl(): string {
 }
 
 /**
- * Parse the host (hostname, plus `:port` when meaningful) from a git
- * remote URL. Supports both URL-scheme forms parseable by the WHATWG URL
- * parser (`https://host[:port]/owner/repo.git`,
+ * The scheme + host (plus `:port` when meaningful) to use for the
+ * `tryFetchBase` fallback fetch URL. `tryFetchBase` always performs an
+ * anonymous, credential-helper-backed fetch (never SSH), so `scheme` is
+ * only ever `http` or `https` even when the source signal was an
+ * `ssh://` URL or the scp-like shorthand.
+ */
+export interface FetchOrigin {
+  scheme: 'http' | 'https';
+  host: string;
+}
+
+/**
+ * Parse the scheme and host (hostname, plus `:port` when meaningful) from
+ * a git remote URL. Supports both URL-scheme forms parseable by the
+ * WHATWG URL parser (`http(s)://host[:port]/owner/repo.git`,
  * `ssh://git@host[:port]/owner/repo.git`) and the scp-like SSH shorthand
- * (`git@host:owner/repo.git`, which has no `://` scheme and is not
- * `URL`-parseable).
+ * (`[user@]host:path`, which has no `://` scheme and is not
+ * `URL`-parseable; per git's own URL syntax the `user@` prefix is
+ * optional, e.g. a bare `ghes.example.com:owner/repo.git` is valid).
  *
- * Port handling is scheme-aware: an `http(s)://` origin's port is
- * preserved, since it is directly reusable for the `https://` fetch URL
- * this resolves for; an `ssh://` origin's port is dropped, since an SSH
- * port is frequently unrelated to a GHES instance's HTTPS port behind a
- * reverse proxy, and carrying it over would silently build a wrong URL.
- * The scp-like shorthand has no port syntax of its own.
+ * The returned `scheme` always matches the origin's own scheme for an
+ * `http://` or `https://` origin — an `http://`-only GHES instance (no
+ * TLS, e.g. behind a private network boundary) must stay `http`, since
+ * silently upgrading to `https` on the same port would target a port
+ * that is not serving TLS and the fetch would fail. An `ssh://` origin or
+ * the scp-like shorthand has no reusable scheme for this always-anonymous
+ * fetch, so both resolve to `https`; the same reasoning drops an
+ * `ssh://` origin's port (frequently unrelated to a GHES instance's
+ * HTTPS port behind a reverse proxy), while an `http(s)://` origin's port
+ * is preserved, since it is directly reusable here.
  *
  * Returns `null` for empty, unparseable, or host-less input (e.g. a
  * `file://` URL, whose `hostname` is `''`) so callers fall back to
  * another signal. The host is lowercased for consistent comparison —
  * DNS/HTTP hosts are case-insensitive.
  */
-export function parseGitHostFromUrl(url: string): string | null {
+export function parseGitFetchOrigin(url: string): FetchOrigin | null {
   const trimmed = url.trim();
   if (!trimmed) return null;
   if (trimmed.includes('://')) {
     try {
       const parsed = new URL(trimmed);
       if (!parsed.hostname) return null;
-      const isHttp =
-        parsed.protocol === 'http:' || parsed.protocol === 'https:';
-      return (isHttp ? parsed.host : parsed.hostname).toLowerCase();
+      if (parsed.protocol === 'http:') {
+        return { scheme: 'http', host: parsed.host.toLowerCase() };
+      }
+      if (parsed.protocol === 'https:') {
+        return { scheme: 'https', host: parsed.host.toLowerCase() };
+      }
+      // ssh:// (or any other scheme): no reusable scheme or port -- see
+      // the doc comment above.
+      return { scheme: 'https', host: parsed.hostname.toLowerCase() };
     } catch {
       return null;
     }
   }
-  // scp-like shorthand: user@host:path (no scheme, so URL() can't parse
-  // it). The `user@` prefix is required, not just conventional: without
-  // it, a Windows-style local path such as `C:\Users\foo\repo.git` would
-  // otherwise match with `C` misread as a host.
-  const scpMatch = trimmed.match(/^[^@\s]+@([^:/\s]+):/);
-  return scpMatch ? scpMatch[1].toLowerCase() : null;
+  // scp-like shorthand: [user@]host:path (no scheme, so URL() can't parse
+  // it). A single-character "host" is excluded rather than requiring
+  // `user@`: git's own scp-like syntax makes the username optional (a
+  // real GHES remote can validly omit it), but no real git host is a
+  // single letter, so this is almost always a Windows drive-letter path
+  // (`C:\Users\...`, `C:repo.git`) rather than a real host.
+  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?([^:/\s]+):/);
+  const host = scpMatch?.[1];
+  return host && host.length > 1
+    ? { scheme: 'https', host: host.toLowerCase() }
+    : null;
 }
 
 /**
- * Resolve the git host to use for the read-only base-ref fetch fallback in
- * {@link tryFetchBase}, instead of hardcoding `github.com` (#1454) — a
- * GitHub Enterprise Server (GHES) checkout must fetch from its own host,
- * or the fallback silently targets an unrelated github.com repo of the
- * same owner/repo name (or just fails outright). Preference order:
+ * Resolve the scheme + host to use for the read-only base-ref fetch
+ * fallback in {@link tryFetchBase}, instead of hardcoding
+ * `https://github.com` (#1454) — a GitHub Enterprise Server (GHES)
+ * checkout must fetch from its own host, or the fallback silently targets
+ * an unrelated github.com repo of the same owner/repo name (or just
+ * fails outright). Preference order:
  *
  * 1. The `GH_HOST` environment variable — the same override `gh` itself
- *    honors — when set and non-blank.
- * 2. The host parsed from the local checkout's `origin` remote URL. This
- *    assumes the fetch-worthy remote is named `origin`, the conventional
- *    default for a single-remote checkout; an unusual multi-remote
- *    checkout that names its GHES remote something else falls through
- *    to (3).
- * 3. `github.com`, the pre-existing default, when neither signal
+ *    honors — when set and non-blank. `GH_HOST` never carries a scheme,
+ *    so this always resolves to `https` (the same assumption `gh` itself
+ *    makes for its own HTTPS operations).
+ * 2. The scheme and host parsed from the local checkout's `origin`
+ *    remote URL. This assumes the fetch-worthy remote is named `origin`,
+ *    the conventional default for a single-remote checkout; an unusual
+ *    multi-remote checkout that names its GHES remote something else
+ *    falls through to (3).
+ * 3. `https://github.com`, the pre-existing default, when neither signal
  *    resolves.
  */
-export function resolveFetchHost(
+export function resolveFetchOrigin(
   env: NodeJS.ProcessEnv = process.env,
   readers: FetchHostReaders = {},
-): string {
+): FetchOrigin {
   const ghHost = env.GH_HOST?.trim();
-  if (ghHost) return ghHost;
+  if (ghHost) return { scheme: 'https', host: ghHost };
   const readOriginUrl = readers.readOriginUrl ?? readOriginRemoteUrl;
-  const originHost = parseGitHostFromUrl(readOriginUrl());
-  return originHost || 'github.com';
+  return (
+    parseGitFetchOrigin(readOriginUrl()) ?? {
+      scheme: 'https',
+      host: 'github.com',
+    }
+  );
 }
 
 function tryFetchBase(
@@ -570,13 +605,14 @@ function tryFetchBase(
     return;
   }
   try {
-    // resolveFetchHost()'s own branching (GH_HOST / origin-remote / default)
-    // is unit-tested directly; this URL-assembly line and the real `git
-    // fetch` below stay deliberately untested at this call site, matching
-    // this file's existing test-suite convention of never letting a test
-    // reach a live network fetch (see the "unresolvable merge-base" test's
-    // `baseRefName: ''` short-circuit).
-    const remote = `https://${resolveFetchHost()}/${owner}/${repo}.git`;
+    // resolveFetchOrigin()'s own branching (GH_HOST / origin-remote /
+    // default) is unit-tested directly; this URL-assembly line and the
+    // real `git fetch` below stay deliberately untested at this call
+    // site, matching this file's existing test-suite convention of never
+    // letting a test reach a live network fetch (see the "unresolvable
+    // merge-base" test's `baseRefName: ''` short-circuit).
+    const { scheme, host } = resolveFetchOrigin();
+    const remote = `${scheme}://${host}/${owner}/${repo}.git`;
     execFileSync(
       'git',
       ['fetch', '--no-tags', '--depth=1', remote, prBaseRef],

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -468,7 +468,7 @@ function probeConflictFilesReadOnly(
   }
 }
 
-/** Injectable evidence reader for {@link resolveFetchHost}, so host
+/** Injectable evidence reader for {@link resolveFetchOrigin}, so host
  * resolution stays unit-testable without shelling out to git or mutating
  * `process.env`. Mirrors the `OnboardEvidenceReaders` convention in
  * `idd-onboard.mts`. */
@@ -549,7 +549,12 @@ export function parseGitFetchOrigin(url: string): FetchOrigin | null {
   // real GHES remote can validly omit it), but no real git host is a
   // single letter, so this is almost always a Windows drive-letter path
   // (`C:\Users\...`, `C:repo.git`) rather than a real host.
-  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?([^:/\s]+):/);
+  //
+  // A bracketed IPv6 literal host (`[2001:db8::1]`) is matched before the
+  // generic host pattern: IPv6 literals contain colons of their own, so
+  // the generic `[^:/\s]+` alternative would otherwise stop at the first
+  // one and capture only a truncated fragment (e.g. `[2001`).
+  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?(\[[^\]\s]+\]|[^:/\s]+):/);
   const host = scpMatch?.[1];
   return host && host.length > 1
     ? { scheme: 'https', host: host.toLowerCase() }

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -586,7 +586,10 @@ export function resolveFetchOrigin(
   readers: FetchHostReaders = {},
 ): FetchOrigin {
   const ghHost = env.GH_HOST?.trim();
-  if (ghHost) return { scheme: 'https', host: ghHost };
+  // Lowercased for consistency with the origin-derived path below (DNS/HTTP
+  // hosts are case-insensitive either way, so this does not change fetch
+  // behavior -- only comparison/display consistency).
+  if (ghHost) return { scheme: 'https', host: ghHost.toLowerCase() };
   const readOriginUrl = readers.readOriginUrl ?? readOriginRemoteUrl;
   return (
     parseGitFetchOrigin(readOriginUrl()) ?? {

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -490,8 +490,8 @@ function readOriginRemoteUrl(): string {
  * The scheme + host (plus `:port` when meaningful) to use for the
  * `tryFetchBase` fallback fetch URL. `tryFetchBase` always performs an
  * anonymous, credential-helper-backed fetch (never SSH), so `scheme` is
- * only ever `http` or `https` even when the source signal was an
- * `ssh://` URL or the scp-like shorthand.
+ * only ever `http` or `https` — including when the source signal was the
+ * scp-like SSH shorthand, which carries no scheme of its own.
  */
 export interface FetchOrigin {
   scheme: 'http' | 'https';
@@ -500,23 +500,32 @@ export interface FetchOrigin {
 
 /**
  * Parse the scheme and host (hostname, plus `:port` when meaningful) from
- * a git remote URL. Supports both URL-scheme forms parseable by the
- * WHATWG URL parser (`http(s)://host[:port]/owner/repo.git`,
- * `ssh://git@host[:port]/owner/repo.git`) and the scp-like SSH shorthand
+ * a git remote URL. Supports the `http://` / `https://` URL-scheme forms
+ * (parseable by the WHATWG URL parser) and the scp-like SSH shorthand
  * (`[user@]host:path`, which has no `://` scheme and is not
  * `URL`-parseable; per git's own URL syntax the `user@` prefix is
  * optional, e.g. a bare `ghes.example.com:owner/repo.git` is valid).
  *
- * The returned `scheme` always matches the origin's own scheme for an
- * `http://` or `https://` origin — an `http://`-only GHES instance (no
- * TLS, e.g. behind a private network boundary) must stay `http`, since
- * silently upgrading to `https` on the same port would target a port
- * that is not serving TLS and the fetch would fail. An `ssh://` origin or
- * the scp-like shorthand has no reusable scheme for this always-anonymous
- * fetch, so both resolve to `https`; the same reasoning drops an
- * `ssh://` origin's port (frequently unrelated to a GHES instance's
- * HTTPS port behind a reverse proxy), while an `http(s)://` origin's port
- * is preserved, since it is directly reusable here.
+ * The returned `scheme` always matches an `http://` or `https://` origin's
+ * own scheme — an `http://`-only GHES instance (no TLS, e.g. behind a
+ * private network boundary) must stay `http`, since silently upgrading to
+ * `https` on the same port would target a port that is not serving TLS
+ * and the fetch would fail; that origin's port is preserved too, since it
+ * is directly reusable here.
+ *
+ * An `ssh://` URL-scheme origin (or any other non-`http(s)` scheme)
+ * deliberately returns `null` rather than reusing its hostname: an SSH
+ * hostname is sometimes an alias with no HTTPS service of its own —
+ * GitHub's own documented `ssh.github.com` (used for SSH-over-443
+ * firewall traversal) accepts SSH, not HTTPS, on that hostname, and a
+ * local `~/.ssh/config` `Host` alias may not resolve via DNS at all.
+ * Guessing wrong here would regress a previously-working `github.com`
+ * fallback into a broken fetch, so this signal is treated as unusable
+ * rather than guessed at. The scp-like shorthand keeps reusing its host,
+ * since that syntax has no port field of its own and is therefore not
+ * used for GitHub's SSH-over-443 workaround in practice — the same
+ * hostname is the overwhelmingly common real-world case for a GHES
+ * remote's SSH and HTTPS endpoints.
  *
  * Returns `null` for empty, unparseable, or host-less input (e.g. a
  * `file://` URL, whose `hostname` is `''`) so callers fall back to
@@ -536,9 +545,9 @@ export function parseGitFetchOrigin(url: string): FetchOrigin | null {
       if (parsed.protocol === 'https:') {
         return { scheme: 'https', host: parsed.host.toLowerCase() };
       }
-      // ssh:// (or any other scheme): no reusable scheme or port -- see
-      // the doc comment above.
-      return { scheme: 'https', host: parsed.hostname.toLowerCase() };
+      // ssh:// (or any other scheme): no reusable host -- see the doc
+      // comment above.
+      return null;
     } catch {
       return null;
     }

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -520,8 +520,11 @@ export function parseGitHostFromUrl(url: string): string | null {
       return null;
     }
   }
-  // scp-like shorthand: [user@]host:path (no scheme, so URL() can't parse it).
-  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?([^:/\s]+):/);
+  // scp-like shorthand: user@host:path (no scheme, so URL() can't parse
+  // it). The `user@` prefix is required, not just conventional: without
+  // it, a Windows-style local path such as `C:\Users\foo\repo.git` would
+  // otherwise match with `C` misread as a host.
+  const scpMatch = trimmed.match(/^[^@\s]+@([^:/\s]+):/);
   return scpMatch ? scpMatch[1].toLowerCase() : null;
 }
 
@@ -535,9 +538,10 @@ export function parseGitHostFromUrl(url: string): string | null {
  * 1. The `GH_HOST` environment variable — the same override `gh` itself
  *    honors — when set and non-blank.
  * 2. The host parsed from the local checkout's `origin` remote URL. This
- *    assumes the fetch-worthy remote is named `origin`, matching every
- *    other git probe in this file; an unusual multi-remote checkout that
- *    names its GHES remote something else falls through to (3).
+ *    assumes the fetch-worthy remote is named `origin`, the conventional
+ *    default for a single-remote checkout; an unusual multi-remote
+ *    checkout that names its GHES remote something else falls through
+ *    to (3).
  * 3. `github.com`, the pre-existing default, when neither signal
  *    resolves.
  */
@@ -566,6 +570,12 @@ function tryFetchBase(
     return;
   }
   try {
+    // resolveFetchHost()'s own branching (GH_HOST / origin-remote / default)
+    // is unit-tested directly; this URL-assembly line and the real `git
+    // fetch` below stay deliberately untested at this call site, matching
+    // this file's existing test-suite convention of never letting a test
+    // reach a live network fetch (see the "unresolvable merge-base" test's
+    // `baseRefName: ''` short-circuit).
     const remote = `https://${resolveFetchHost()}/${owner}/${repo}.git`;
     execFileSync(
       'git',

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -468,6 +468,90 @@ function probeConflictFilesReadOnly(
   }
 }
 
+/** Injectable evidence reader for {@link resolveFetchHost}, so host
+ * resolution stays unit-testable without shelling out to git or mutating
+ * `process.env`. Mirrors the `OnboardEvidenceReaders` convention in
+ * `idd-onboard.mts`. */
+export interface FetchHostReaders {
+  /** Returns the local checkout's `origin` remote URL, or `''` when
+   * unavailable. Defaults to `git remote get-url origin`. */
+  readOriginUrl?: () => string;
+}
+
+/** Default `origin` URL reader: `git remote get-url origin` in the current
+ * working directory (this file's other git probes are likewise un-scoped
+ * to a `-C <dir>`, since they always run from inside the target checkout).
+ * `gitText` already swallows any git failure and returns `''`. */
+function readOriginRemoteUrl(): string {
+  return gitText(['remote', 'get-url', 'origin']);
+}
+
+/**
+ * Parse the host (hostname, plus `:port` when meaningful) from a git
+ * remote URL. Supports both URL-scheme forms parseable by the WHATWG URL
+ * parser (`https://host[:port]/owner/repo.git`,
+ * `ssh://git@host[:port]/owner/repo.git`) and the scp-like SSH shorthand
+ * (`git@host:owner/repo.git`, which has no `://` scheme and is not
+ * `URL`-parseable).
+ *
+ * Port handling is scheme-aware: an `http(s)://` origin's port is
+ * preserved, since it is directly reusable for the `https://` fetch URL
+ * this resolves for; an `ssh://` origin's port is dropped, since an SSH
+ * port is frequently unrelated to a GHES instance's HTTPS port behind a
+ * reverse proxy, and carrying it over would silently build a wrong URL.
+ * The scp-like shorthand has no port syntax of its own.
+ *
+ * Returns `null` for empty, unparseable, or host-less input (e.g. a
+ * `file://` URL, whose `hostname` is `''`) so callers fall back to
+ * another signal. The host is lowercased for consistent comparison —
+ * DNS/HTTP hosts are case-insensitive.
+ */
+export function parseGitHostFromUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes('://')) {
+    try {
+      const parsed = new URL(trimmed);
+      if (!parsed.hostname) return null;
+      const isHttp =
+        parsed.protocol === 'http:' || parsed.protocol === 'https:';
+      return (isHttp ? parsed.host : parsed.hostname).toLowerCase();
+    } catch {
+      return null;
+    }
+  }
+  // scp-like shorthand: [user@]host:path (no scheme, so URL() can't parse it).
+  const scpMatch = trimmed.match(/^(?:[^@\s]+@)?([^:/\s]+):/);
+  return scpMatch ? scpMatch[1].toLowerCase() : null;
+}
+
+/**
+ * Resolve the git host to use for the read-only base-ref fetch fallback in
+ * {@link tryFetchBase}, instead of hardcoding `github.com` (#1454) — a
+ * GitHub Enterprise Server (GHES) checkout must fetch from its own host,
+ * or the fallback silently targets an unrelated github.com repo of the
+ * same owner/repo name (or just fails outright). Preference order:
+ *
+ * 1. The `GH_HOST` environment variable — the same override `gh` itself
+ *    honors — when set and non-blank.
+ * 2. The host parsed from the local checkout's `origin` remote URL. This
+ *    assumes the fetch-worthy remote is named `origin`, matching every
+ *    other git probe in this file; an unusual multi-remote checkout that
+ *    names its GHES remote something else falls through to (3).
+ * 3. `github.com`, the pre-existing default, when neither signal
+ *    resolves.
+ */
+export function resolveFetchHost(
+  env: NodeJS.ProcessEnv = process.env,
+  readers: FetchHostReaders = {},
+): string {
+  const ghHost = env.GH_HOST?.trim();
+  if (ghHost) return ghHost;
+  const readOriginUrl = readers.readOriginUrl ?? readOriginRemoteUrl;
+  const originHost = parseGitHostFromUrl(readOriginUrl());
+  return originHost || 'github.com';
+}
+
 function tryFetchBase(
   prBaseRef: string,
   owner: string | undefined,
@@ -482,7 +566,7 @@ function tryFetchBase(
     return;
   }
   try {
-    const remote = `https://github.com/${owner}/${repo}.git`;
+    const remote = `https://${resolveFetchHost()}/${owner}/${repo}.git`;
     execFileSync(
       'git',
       ['fetch', '--no-tags', '--depth=1', remote, prBaseRef],

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -482,6 +482,16 @@ test('parseGitFetchOrigin: extracts host from the scp-like SSH shorthand without
   });
 });
 
+test('parseGitFetchOrigin: extracts a bracketed IPv6 host from the scp-like shorthand', () => {
+  // The generic scp-like host pattern stops at the first colon, which
+  // would otherwise truncate an IPv6 literal (`[2001:db8::1]`) to
+  // `[2001`; the bracketed form must be matched before the generic one.
+  assert.deepEqual(parseGitFetchOrigin('git@[2001:db8::1]:owner/repo.git'), {
+    scheme: 'https',
+    host: '[2001:db8::1]',
+  });
+});
+
 test('parseGitFetchOrigin: extracts github.com from the pre-existing HTTPS form, lowercased', () => {
   assert.deepEqual(parseGitFetchOrigin('https://GitHub.com/owner/repo.git'), {
     scheme: 'https',

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -428,6 +428,19 @@ test('parseGitHostFromUrl: extracts host from an HTTPS GHES remote, preserving a
   );
 });
 
+test('parseGitHostFromUrl: strips embedded credentials from an actions/checkout-style origin, keeping only the host', () => {
+  // actions/checkout writes `origin` as
+  // `https://x-access-token:<token>@host/owner/repo` -- the real-world CI
+  // shape this fix targets. URL() parses the token into userinfo, not the
+  // host, so it never leaks into the constructed fetch URL.
+  assert.equal(
+    parseGitHostFromUrl(
+      'https://x-access-token:ghs_abc123@ghes.example.com/owner/repo',
+    ),
+    'ghes.example.com',
+  );
+});
+
 test('parseGitHostFromUrl: extracts host from an ssh:// GHES remote, dropping the SSH-specific port', () => {
   // The SSH port is frequently unrelated to the HTTPS port behind a
   // reverse proxy, so it must not leak into the https:// fetch URL.

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -543,6 +543,16 @@ test('resolveFetchOrigin: honors a GH_HOST override to a non-github.com host, al
   );
 });
 
+test('resolveFetchOrigin: lowercases a mixed-case GH_HOST for consistency with the origin-derived path', () => {
+  assert.deepEqual(
+    resolveFetchOrigin(
+      { GH_HOST: 'GHES.Example.COM' },
+      { readOriginUrl: () => '' },
+    ),
+    { scheme: 'https', host: 'ghes.example.com' },
+  );
+});
+
 test('resolveFetchOrigin: falls back to a non-github.com origin remote when GH_HOST is unset', () => {
   assert.deepEqual(
     resolveFetchOrigin(

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -454,14 +454,30 @@ test('parseGitFetchOrigin: strips embedded credentials from an actions/checkout-
   );
 });
 
-test('parseGitFetchOrigin: resolves an ssh:// GHES remote to https, dropping the SSH-specific port', () => {
-  // The SSH port is frequently unrelated to the HTTPS port behind a
-  // reverse proxy, so it must not leak into the https:// fetch URL; the
-  // ssh:// scheme itself cannot be reused since tryFetchBase's fetch is
-  // always anonymous HTTPS.
-  assert.deepEqual(
+test('parseGitFetchOrigin: returns null for an ssh:// origin instead of guessing an HTTPS host', () => {
+  // An ssh:// hostname is sometimes an SSH-only alias with no HTTPS
+  // service of its own -- guessing wrong would regress a
+  // previously-working github.com fallback into a broken fetch, so this
+  // signal is unusable rather than guessed at (see the dedicated
+  // ssh.github.com regression test below for the concrete case this
+  // protects against).
+  assert.equal(
     parseGitFetchOrigin('ssh://git@ghes.example.com:2222/owner/repo.git'),
-    { scheme: 'https', host: 'ghes.example.com' },
+    null,
+  );
+});
+
+test("parseGitFetchOrigin: returns null for GitHub's documented SSH-over-443 endpoint, not a broken HTTPS host", () => {
+  // ssh.github.com is GitHub's own documented alias for SSH traffic over
+  // the HTTPS port (firewall traversal); it accepts SSH, not HTTPS, on
+  // that hostname. Before #1454, this checkout shape already worked via
+  // the hardcoded github.com default -- treating the ssh:// origin's
+  // hostname as reusable for HTTPS would have silently regressed it to
+  // an unreachable https://ssh.github.com fetch (found by Codex review on
+  // PR #1470).
+  assert.equal(
+    parseGitFetchOrigin('ssh://git@ssh.github.com:443/owner/repo.git'),
+    null,
   );
 });
 
@@ -560,6 +576,21 @@ test('resolveFetchOrigin: falls back to a non-github.com origin remote when GH_H
       { readOriginUrl: () => 'http://ghes.example.com/owner/repo.git' },
     ),
     { scheme: 'http', host: 'ghes.example.com' },
+  );
+});
+
+test('resolveFetchOrigin: falls through to the github.com default for an ssh:// origin, not a guessed host', () => {
+  // End-to-end confirmation of the ssh.github.com regression fix: an
+  // ssh:// origin (unresolvable per parseGitFetchOrigin) must not block
+  // or corrupt resolution -- it falls through to the same github.com
+  // default as no origin at all, exactly matching this checkout shape's
+  // pre-#1454 behavior.
+  assert.deepEqual(
+    resolveFetchOrigin(
+      {},
+      { readOriginUrl: () => 'ssh://git@ssh.github.com:443/owner/repo.git' },
+    ),
+    { scheme: 'https', host: 'github.com' },
   );
 });
 

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -9,8 +9,8 @@ import {
   classifyBranchConflictState,
   parseArgs,
   parseConflictFiles,
-  parseGitHostFromUrl,
-  resolveFetchHost,
+  parseGitFetchOrigin,
+  resolveFetchOrigin,
 } from '../src/scripts/branch-conflict-state.mts';
 
 type ClassifyOptions = NonNullable<
@@ -418,117 +418,148 @@ test('classifyBranchConflictState: published is false when head SHA is absent', 
 
 // #1454: tryFetchBase hardcoded `https://github.com/...` as the base-ref
 // fetch fallback remote, breaking (or worse, silently mis-targeting) GHES
-// checkouts. parseGitHostFromUrl / resolveFetchHost are the extracted,
-// independently unit-testable pieces of that fix.
+// checkouts. parseGitFetchOrigin / resolveFetchOrigin are the extracted,
+// independently unit-testable pieces of that fix. Both findings below
+// (HTTP-scheme preservation, username-less scp-like remotes) came from an
+// independent Codex review pass on the PR.
 
-test('parseGitHostFromUrl: extracts host from an HTTPS GHES remote, preserving a non-default port', () => {
-  assert.equal(
-    parseGitHostFromUrl('https://ghes.example.com:8443/owner/repo.git'),
-    'ghes.example.com:8443',
+test('parseGitFetchOrigin: extracts scheme+host from an HTTPS GHES remote, preserving a non-default port', () => {
+  assert.deepEqual(
+    parseGitFetchOrigin('https://ghes.example.com:8443/owner/repo.git'),
+    { scheme: 'https', host: 'ghes.example.com:8443' },
   );
 });
 
-test('parseGitHostFromUrl: strips embedded credentials from an actions/checkout-style origin, keeping only the host', () => {
+test('parseGitFetchOrigin: preserves http (not https) for a plain HTTP GHES remote', () => {
+  // An http://-only GHES instance (no TLS) must stay http: silently
+  // upgrading to https on the same port would target a port that is not
+  // serving TLS, and the fetch would fail even though the configured
+  // remote is reachable over plain HTTP.
+  assert.deepEqual(
+    parseGitFetchOrigin('http://ghes.example.com:8080/owner/repo.git'),
+    { scheme: 'http', host: 'ghes.example.com:8080' },
+  );
+});
+
+test('parseGitFetchOrigin: strips embedded credentials from an actions/checkout-style origin, keeping only the host', () => {
   // actions/checkout writes `origin` as
   // `https://x-access-token:<token>@host/owner/repo` -- the real-world CI
   // shape this fix targets. URL() parses the token into userinfo, not the
   // host, so it never leaks into the constructed fetch URL.
-  assert.equal(
-    parseGitHostFromUrl(
+  assert.deepEqual(
+    parseGitFetchOrigin(
       'https://x-access-token:ghs_abc123@ghes.example.com/owner/repo',
     ),
-    'ghes.example.com',
+    { scheme: 'https', host: 'ghes.example.com' },
   );
 });
 
-test('parseGitHostFromUrl: extracts host from an ssh:// GHES remote, dropping the SSH-specific port', () => {
+test('parseGitFetchOrigin: resolves an ssh:// GHES remote to https, dropping the SSH-specific port', () => {
   // The SSH port is frequently unrelated to the HTTPS port behind a
-  // reverse proxy, so it must not leak into the https:// fetch URL.
-  assert.equal(
-    parseGitHostFromUrl('ssh://git@ghes.example.com:2222/owner/repo.git'),
-    'ghes.example.com',
+  // reverse proxy, so it must not leak into the https:// fetch URL; the
+  // ssh:// scheme itself cannot be reused since tryFetchBase's fetch is
+  // always anonymous HTTPS.
+  assert.deepEqual(
+    parseGitFetchOrigin('ssh://git@ghes.example.com:2222/owner/repo.git'),
+    { scheme: 'https', host: 'ghes.example.com' },
   );
 });
 
-test('parseGitHostFromUrl: extracts host from the scp-like SSH shorthand', () => {
-  assert.equal(
-    parseGitHostFromUrl('git@ghes.example.com:owner/repo.git'),
-    'ghes.example.com',
-  );
+test('parseGitFetchOrigin: extracts host from the scp-like SSH shorthand with a username', () => {
+  assert.deepEqual(parseGitFetchOrigin('git@ghes.example.com:owner/repo.git'), {
+    scheme: 'https',
+    host: 'ghes.example.com',
+  });
 });
 
-test('parseGitHostFromUrl: extracts github.com from the pre-existing HTTPS form, lowercased', () => {
-  assert.equal(
-    parseGitHostFromUrl('https://GitHub.com/owner/repo.git'),
-    'github.com',
-  );
+test('parseGitFetchOrigin: extracts host from the scp-like SSH shorthand without a username', () => {
+  // Git's documented scp-like URL form is `[user@]host:path` -- the
+  // username is optional, so a bare `ghes.example.com:owner/repo.git`
+  // (no `user@` prefix) is a valid, real-world GHES remote.
+  assert.deepEqual(parseGitFetchOrigin('ghes.example.com:owner/repo.git'), {
+    scheme: 'https',
+    host: 'ghes.example.com',
+  });
 });
 
-test('parseGitHostFromUrl: returns null for empty or whitespace-only input', () => {
-  assert.equal(parseGitHostFromUrl(''), null);
-  assert.equal(parseGitHostFromUrl('   '), null);
+test('parseGitFetchOrigin: extracts github.com from the pre-existing HTTPS form, lowercased', () => {
+  assert.deepEqual(parseGitFetchOrigin('https://GitHub.com/owner/repo.git'), {
+    scheme: 'https',
+    host: 'github.com',
+  });
 });
 
-test('parseGitHostFromUrl: returns null for a host-less file:// URL', () => {
-  assert.equal(parseGitHostFromUrl('file:///some/local/path.git'), null);
+test('parseGitFetchOrigin: returns null for empty or whitespace-only input', () => {
+  assert.equal(parseGitFetchOrigin(''), null);
+  assert.equal(parseGitFetchOrigin('   '), null);
 });
 
-test('parseGitHostFromUrl: returns null for an unparseable, scheme-less, colon-less string', () => {
-  assert.equal(parseGitHostFromUrl('not a url'), null);
+test('parseGitFetchOrigin: returns null for a host-less file:// URL', () => {
+  assert.equal(parseGitFetchOrigin('file:///some/local/path.git'), null);
 });
 
-test('parseGitHostFromUrl: returns null for a Windows-style local path, not the drive letter as a host', () => {
-  // A bare `C:\...` path has no `user@` prefix, unlike real scp-like git
-  // remotes (`git@host:owner/repo.git`); without requiring `@`, the
-  // scp-like regex would otherwise misread the drive letter `C` as a host.
-  assert.equal(parseGitHostFromUrl('C:\\Users\\foo\\repo.git'), null);
+test('parseGitFetchOrigin: returns null for an unparseable, scheme-less, colon-less string', () => {
+  assert.equal(parseGitFetchOrigin('not a url'), null);
 });
 
-test('resolveFetchHost: regression -- returns github.com when GH_HOST is unset and origin does not resolve', () => {
+test('parseGitFetchOrigin: returns null for a Windows-style local path, not the drive letter as a host', () => {
+  // A single-character "host" (`C:\Users\...`, `C:repo.git`) is almost
+  // certainly a Windows drive letter, never a real git host -- excluded
+  // explicitly rather than by requiring a `user@` prefix, since that
+  // would also reject the valid username-less scp-like form covered
+  // above.
+  assert.equal(parseGitFetchOrigin('C:\\Users\\foo\\repo.git'), null);
+  assert.equal(parseGitFetchOrigin('C:repo.git'), null);
+});
+
+test('resolveFetchOrigin: regression -- resolves to https://github.com when GH_HOST is unset and origin does not resolve', () => {
   // Existing github.com-hosted behavior must stay unchanged. Injecting an
   // empty-returning reader exercises the literal `github.com` fallback
   // constant directly, rather than incidentally depending on whatever
   // this checkout's own real `origin` remote happens to be.
-  assert.equal(resolveFetchHost({}, { readOriginUrl: () => '' }), 'github.com');
+  assert.deepEqual(resolveFetchOrigin({}, { readOriginUrl: () => '' }), {
+    scheme: 'https',
+    host: 'github.com',
+  });
 });
 
-test('resolveFetchHost: honors a GH_HOST override to a non-github.com host', () => {
-  assert.equal(
-    resolveFetchHost(
+test('resolveFetchOrigin: honors a GH_HOST override to a non-github.com host, always as https', () => {
+  assert.deepEqual(
+    resolveFetchOrigin(
       { GH_HOST: 'ghes.example.com' },
       { readOriginUrl: () => '' },
     ),
-    'ghes.example.com',
+    { scheme: 'https', host: 'ghes.example.com' },
   );
 });
 
-test('resolveFetchHost: falls back to a non-github.com origin remote host when GH_HOST is unset', () => {
-  assert.equal(
-    resolveFetchHost(
+test('resolveFetchOrigin: falls back to a non-github.com origin remote when GH_HOST is unset', () => {
+  assert.deepEqual(
+    resolveFetchOrigin(
       {},
-      { readOriginUrl: () => 'https://ghes.example.com/owner/repo.git' },
+      { readOriginUrl: () => 'http://ghes.example.com/owner/repo.git' },
     ),
-    'ghes.example.com',
+    { scheme: 'http', host: 'ghes.example.com' },
   );
 });
 
-test('resolveFetchHost: GH_HOST takes precedence over a resolvable non-github.com origin', () => {
-  assert.equal(
-    resolveFetchHost(
+test('resolveFetchOrigin: GH_HOST takes precedence over a resolvable non-github.com origin', () => {
+  assert.deepEqual(
+    resolveFetchOrigin(
       { GH_HOST: 'override.example.com' },
       { readOriginUrl: () => 'https://ghes.example.com/owner/repo.git' },
     ),
-    'override.example.com',
+    { scheme: 'https', host: 'override.example.com' },
   );
 });
 
-test('resolveFetchHost: a whitespace-only GH_HOST is ignored, falling through to origin resolution', () => {
-  assert.equal(
-    resolveFetchHost(
+test('resolveFetchOrigin: a whitespace-only GH_HOST is ignored, falling through to origin resolution', () => {
+  assert.deepEqual(
+    resolveFetchOrigin(
       { GH_HOST: '   ' },
       { readOriginUrl: () => 'https://ghes.example.com/owner/repo.git' },
     ),
-    'ghes.example.com',
+    { scheme: 'https', host: 'ghes.example.com' },
   );
 });
 

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -464,6 +464,13 @@ test('parseGitHostFromUrl: returns null for an unparseable, scheme-less, colon-l
   assert.equal(parseGitHostFromUrl('not a url'), null);
 });
 
+test('parseGitHostFromUrl: returns null for a Windows-style local path, not the drive letter as a host', () => {
+  // A bare `C:\...` path has no `user@` prefix, unlike real scp-like git
+  // remotes (`git@host:owner/repo.git`); without requiring `@`, the
+  // scp-like regex would otherwise misread the drive letter `C` as a host.
+  assert.equal(parseGitHostFromUrl('C:\\Users\\foo\\repo.git'), null);
+});
+
 test('resolveFetchHost: regression -- returns github.com when GH_HOST is unset and origin does not resolve', () => {
   // Existing github.com-hosted behavior must stay unchanged. Injecting an
   // empty-returning reader exercises the literal `github.com` fallback

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -9,6 +9,8 @@ import {
   classifyBranchConflictState,
   parseArgs,
   parseConflictFiles,
+  parseGitHostFromUrl,
+  resolveFetchHost,
 } from '../src/scripts/branch-conflict-state.mts';
 
 type ClassifyOptions = NonNullable<
@@ -412,6 +414,102 @@ test('classifyBranchConflictState: published is false when head SHA is absent', 
     _testPrData: fixture.prData,
   });
   assert.equal(result.published, false);
+});
+
+// #1454: tryFetchBase hardcoded `https://github.com/...` as the base-ref
+// fetch fallback remote, breaking (or worse, silently mis-targeting) GHES
+// checkouts. parseGitHostFromUrl / resolveFetchHost are the extracted,
+// independently unit-testable pieces of that fix.
+
+test('parseGitHostFromUrl: extracts host from an HTTPS GHES remote, preserving a non-default port', () => {
+  assert.equal(
+    parseGitHostFromUrl('https://ghes.example.com:8443/owner/repo.git'),
+    'ghes.example.com:8443',
+  );
+});
+
+test('parseGitHostFromUrl: extracts host from an ssh:// GHES remote, dropping the SSH-specific port', () => {
+  // The SSH port is frequently unrelated to the HTTPS port behind a
+  // reverse proxy, so it must not leak into the https:// fetch URL.
+  assert.equal(
+    parseGitHostFromUrl('ssh://git@ghes.example.com:2222/owner/repo.git'),
+    'ghes.example.com',
+  );
+});
+
+test('parseGitHostFromUrl: extracts host from the scp-like SSH shorthand', () => {
+  assert.equal(
+    parseGitHostFromUrl('git@ghes.example.com:owner/repo.git'),
+    'ghes.example.com',
+  );
+});
+
+test('parseGitHostFromUrl: extracts github.com from the pre-existing HTTPS form, lowercased', () => {
+  assert.equal(
+    parseGitHostFromUrl('https://GitHub.com/owner/repo.git'),
+    'github.com',
+  );
+});
+
+test('parseGitHostFromUrl: returns null for empty or whitespace-only input', () => {
+  assert.equal(parseGitHostFromUrl(''), null);
+  assert.equal(parseGitHostFromUrl('   '), null);
+});
+
+test('parseGitHostFromUrl: returns null for a host-less file:// URL', () => {
+  assert.equal(parseGitHostFromUrl('file:///some/local/path.git'), null);
+});
+
+test('parseGitHostFromUrl: returns null for an unparseable, scheme-less, colon-less string', () => {
+  assert.equal(parseGitHostFromUrl('not a url'), null);
+});
+
+test('resolveFetchHost: regression -- returns github.com when GH_HOST is unset and origin does not resolve', () => {
+  // Existing github.com-hosted behavior must stay unchanged. Injecting an
+  // empty-returning reader exercises the literal `github.com` fallback
+  // constant directly, rather than incidentally depending on whatever
+  // this checkout's own real `origin` remote happens to be.
+  assert.equal(resolveFetchHost({}, { readOriginUrl: () => '' }), 'github.com');
+});
+
+test('resolveFetchHost: honors a GH_HOST override to a non-github.com host', () => {
+  assert.equal(
+    resolveFetchHost(
+      { GH_HOST: 'ghes.example.com' },
+      { readOriginUrl: () => '' },
+    ),
+    'ghes.example.com',
+  );
+});
+
+test('resolveFetchHost: falls back to a non-github.com origin remote host when GH_HOST is unset', () => {
+  assert.equal(
+    resolveFetchHost(
+      {},
+      { readOriginUrl: () => 'https://ghes.example.com/owner/repo.git' },
+    ),
+    'ghes.example.com',
+  );
+});
+
+test('resolveFetchHost: GH_HOST takes precedence over a resolvable non-github.com origin', () => {
+  assert.equal(
+    resolveFetchHost(
+      { GH_HOST: 'override.example.com' },
+      { readOriginUrl: () => 'https://ghes.example.com/owner/repo.git' },
+    ),
+    'override.example.com',
+  );
+});
+
+test('resolveFetchHost: a whitespace-only GH_HOST is ignored, falling through to origin resolution', () => {
+  assert.equal(
+    resolveFetchHost(
+      { GH_HOST: '   ' },
+      { readOriginUrl: () => 'https://ghes.example.com/owner/repo.git' },
+    ),
+    'ghes.example.com',
+  );
 });
 
 test('parseArgs: valid --pr parses to a positive-integer string', () => {


### PR DESCRIPTION
# Summary

`tryFetchBase` in `src/scripts/branch-conflict-state.mts` hardcoded the
base-ref fallback-fetch remote as `https://github.com/${owner}/${repo}.git`,
so a GitHub Enterprise Server (GHES) checkout's fallback fetch always
targeted github.com instead of the actual configured host -- the fetch
fails, or worse could silently address an unrelated public github.com
repo of the same owner/repo name. This shared fallback-fetch path backs
both the pre-existing conflict probe (`CONFLICTING` / `BEHIND` states)
and the `baseAdvancedSinceMergeBase` computation added by #1398 / PR #1452.

This PR adds `resolveFetchOrigin()` / `parseGitFetchOrigin()` to
`branch-conflict-state.mts`, resolving the fetch scheme + host in this
order:

1. `GH_HOST` environment variable (the same override `gh` itself
   honors), lowercased for consistency with the origin-derived path
   below.
2. The scheme + host parsed from the local checkout's `origin` remote
   URL -- supports `http://` / `https://` (scheme and port preserved)
   and the scp-like `[user@]host:owner/repo` shorthand (always resolved
   as `https`, no port field). An `ssh://` origin (or any other
   non-http(s) scheme) resolves to `null` here rather than reusing its
   hostname for HTTPS: GitHub's own documented SSH-over-443 endpoint
   (`ssh://git@ssh.github.com:443/...`) accepts SSH only, so treating
   it as an HTTPS host would regress a previously-working checkout into
   a broken fetch. `null` falls through to step 3.
3. `github.com`, the pre-existing default, when neither signal resolves.

`tryFetchBase` now builds its remote URL from `resolveFetchOrigin()`
instead of the hardcoded string; no other change to its control flow,
guard clauses, or error/notes handling, and no change to
`computeMergeBase` / `computeBaseAdvanced` / `probeConflictFilesReadOnly`.

Both new functions are exported and unit-tested via an injectable-reader
dependency-injection shape (`FetchHostReaders.readOriginUrl?`) mirroring
the existing `OnboardEvidenceReaders` convention in
`src/scripts/idd-onboard.mts`, so the added tests never shell out to
git, mutate real `process.env`, or need a temp git repo.

## Linked issue

Closes #1454

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

- **Acceptance criteria mapping**: (1) host now derives from `GH_HOST` /
  local `origin`, never hardcoded -- see `resolveFetchOrigin`; (2)
  regression test asserts the literal `github.com` fallback constant
  directly (via an injected empty-origin reader, not incidental ambient
  state); (3) multiple new tests cover non-github.com host resolution,
  including the actual production shape this bug manifests in --
  `actions/checkout`'s `origin` written as
  `https://x-access-token:<token>@host/owner/repo` (confirms the token
  lands in URL userinfo, never leaking into the constructed fetch URL).
- **Self-review pass**: an independent critique pass on the first draft
  caught that the scp-like shorthand regex's optional `user@` prefix let
  a Windows-style local path (`C:\Users\foo\repo.git`) misparse as host
  `c`. The `user@` prefix stays optional in the shipped parser -- git's
  own scp-like syntax (`[user@]host:path`) allows a real GHES remote to
  validly omit it, e.g. `ghes.example.com:owner/repo.git` -- so the fix
  instead excludes any single-character "host" (no real git host is one
  letter, so a single-character match is almost always a Windows
  drive-letter path, not a real host). It also flagged that `.hostname`
  (used in an earlier draft) would have silently dropped a real HTTPS
  port on a GHES instance behind a reverse proxy -- fixed via the
  scheme-aware `.host` handling described above.
- **Review-driven hardening (several rounds)**: fresh Copilot/Codex
  passes after each push found, and this PR fixed: a bracketed-IPv6
  scp-like host (`git@[2001:db8::1]:owner/repo.git`) truncating at the
  first `:`; a stale `{@link}` doc reference from an earlier rename;
  `GH_HOST` not being lowercased to match the origin-derived path; and
  the `ssh://`-scheme regression described above, where an earlier
  draft of this PR *did* derive a host from `ssh://` origins and Codex
  caught that this breaks GitHub's SSH-over-443 endpoint -- fixed by
  having `parseGitFetchOrigin` return `null` for any non-http(s) scheme
  instead of guessing.
- **Unrelated environment note** (not a code change in this PR): while
  verifying locally, `tests/branch-conflict-state.test.mts`'s existing
  `createTwoCommitRepo()` helper (predates this PR, from #1398 / PR
  #1452) was found to hang indefinitely in a sandbox where the operator's
  global `commit.gpgsign=true` is set without a usable non-interactive
  signer -- its real `git commit` calls block on a pinentry prompt that
  never resolves. Confirmed via `git stash` bisection against the
  pre-existing baseline (same hang, unrelated to this diff) and worked
  around locally with a process-scoped `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`
  override (no config file touched). Elsewhere in this repo's test suite
  there is already a hardening pattern for exactly this class of issue
  ("fixture commits ignore a signing-enabled global git config"); this
  file's fixture predates that pattern and was not in scope to change
  here. Flagging for awareness rather than opening a separate issue.
- **Commit signing**: local commits on this branch used the repository's
  documented GPG-pinentry -> SSH-fallback ladder -- configured GPG
  signing was attempted once per commit and hung on the same pinentry
  condition noted above, so each commit was signed via the project's
  `git commit-ssh` alias (SSH signing, cryptographically valid; may show
  as GitHub-"Unverified" per the ladder's own caveat about signing-key
  registration).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`, all clean)
- [x] `pnpm test` (2302/2302 passing; 45 tests in
      `tests/branch-conflict-state.test.mts`)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed, 4 pre-existing environmental warnings unrelated to this change)
- [x] `pnpm run typecheck` (`tsc -p tsconfig.json`, clean)
- [x] `npx cspell lint "**"` (clean; added `GHES` / `WHATWG` to the project word list)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback branch fetching for GitHub Enterprise and custom Git hosts.
  * Preserves the configured connection protocol and host when resolving remote repositories.
  * Supports host overrides through environment configuration and handles additional remote URL formats.

* **Tests**
  * Added coverage for enterprise hosts, SSH remotes, custom ports, credentials, IPv6 addresses, and invalid local paths.

* **Chores**
  * Updated spelling recognition for `GHES` and `WHATWG`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

