### PR TITLE
fix(issue-authoring): recognize more prose-dependency edge cases

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -591,7 +591,23 @@ it is flagged only when `--current-repo` is supplied **and**
 case-insensitively matches `owner/repo`; naming a different repository,
 or omitting `--current-repo`, always excludes it, since this shorthand
 was never recognized at all before and a bare `owner/repo` cannot be
-assumed local without confirmation. Unlike every other check above, a
+assumed local without confirmation. A reference-style Markdown link
+(`[text][ref]` with a separate `[ref]: target` definition elsewhere in
+the body) is recognized the same way as the inline-link form above,
+including the same `currentRepo`-based local/cross-repo comparison; a
+`ref` with no matching definition is left as literal text and falls
+through to the bare-`#` check like any other unrecognized shape. A
+quoted link title may contain a backslash-escaped quote matching its own
+delimiter (`\"` inside a `"..."` title, or `\'` inside a `'...'` title)
+without ending the title early and losing the rest of the link. An empty
+or whitespace-only `--current-repo` (or `$GITHUB_REPOSITORY`) is treated
+the same as omitting it entirely, rather than as a known repository that
+can never match. A nested/child list item's reference is evaluated
+together with its parent bullet's coordination-language text instead of
+being scoped away from it, while a sibling bullet at the same
+indentation — nested or top-level — still starts its own separate scope,
+preserving the tight-list sentence-conflation fix mentioned above. Unlike
+every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -606,8 +606,11 @@ can never match. A nested/child list item's reference is evaluated
 together with its parent bullet's coordination-language text instead of
 being scoped away from it, while a sibling bullet at the same
 indentation — nested or top-level — still starts its own separate scope,
-preserving the tight-list sentence-conflation fix mentioned above. Unlike
-every other check above, a
+preserving the tight-list sentence-conflation fix mentioned above. This
+holds for the first nested child under a given parent; a parent with two
+or more nested children currently keeps only the first one scoped with
+it — a known, tracked limitation, not a guarantee for every nested
+child. Unlike every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -462,7 +462,9 @@ omitting it, not as a known repository that can never match. A
 nested/child list item's reference is evaluated together with its parent
 bullet's coordination-language text instead of being scoped away from
 it, while a same-depth sibling bullet still starts its own separate
-scope. A
+scope. This holds for the first nested child under a given parent; a
+parent with two or more nested children currently keeps only the first
+one scoped with it -- a known, tracked limitation. A
 `prose-dependency` warning never flips `passed` to
 `false` and never changes the linter's exit code; it prompts the author
 to convert the prose into a proper dependency marker or consciously

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -450,7 +450,19 @@ bare-`#` check. A local `owner/repo#N` shorthand (e.g.
 default from the full-URL case: it is flagged only when
 `--current-repo` is supplied and case-insensitively matches
 `owner/repo`; a different repository, or no `--current-repo` at all,
-always excludes it. A
+always excludes it. A reference-style Markdown link (`[text][ref]` with
+a separate `[ref]: target` definition elsewhere in the body) is
+recognized the same way as the inline-link form, including the same
+`currentRepo` comparison; a `ref` with no matching definition falls
+through to the bare-`#` check like any other unrecognized shape. A
+quoted link title may contain a backslash-escaped quote matching its own
+delimiter without ending the title early. An empty or whitespace-only
+`--current-repo` (or `$GITHUB_REPOSITORY`) is treated the same as
+omitting it, not as a known repository that can never match. A
+nested/child list item's reference is evaluated together with its parent
+bullet's coordination-language text instead of being scoped away from
+it, while a same-depth sibling bullet still starts its own separate
+scope. A
 `prose-dependency` warning never flips `passed` to
 `false` and never changes the linter's exit code; it prompts the author
 to convert the prose into a proper dependency marker or consciously

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -125,19 +125,36 @@ const PROSE_DEPENDENCY_KEYWORDS = [
 // The quoted-title sub-pattern tolerates a backslash-escaped quote
 // matching the title's own delimiter (`\"` inside a `"..."` title, or
 // `\'` inside a `'...'` title) as content instead of letting it close the
-// title early: `(?:\\.|[^"\n])*` (and the single-quote equivalent) tries
-// consuming a backslash plus the character right after it as one unit
-// before falling back to "any non-quote, non-newline character", so an
-// escaped quote is never mistaken for the real closing delimiter. Without
-// this, a title like `"reviewed \"API\""` would close at the first
-// escaped quote, leave the rest of the title as unconsumed content before
-// the link's real closing paren, fail the whole Markdown-link
-// alternative, and re-leak the label's own bare `#N` to the bare-`#`
-// alternative — the same failure mode the trailing-content tolerances
-// above already guard against, just triggered by escaping instead of an
-// unhandled trailing shape.
+// title early: `(?:\\.|[^"\\\n])*` (and the single-quote equivalent)
+// tries consuming a backslash plus the character right after it as one
+// unit before falling back to "any character that is not the quote, a
+// backslash, or a newline", so an escaped quote is never mistaken for the
+// real closing delimiter. Without this, a title like `"reviewed
+// \"API\""` would close at the first escaped quote, leave the rest of
+// the title as unconsumed content before the link's real closing paren,
+// fail the whole Markdown-link alternative, and re-leak the label's own
+// bare `#N` to the bare-`#` alternative — the same failure mode the
+// trailing-content tolerances above already guard against, just
+// triggered by escaping instead of an unhandled trailing shape.
+//
+// The character class excludes a literal backslash (not just the quote
+// and newline) so the two alternatives never overlap on the same input
+// character: `\\.` is the only alternative that can ever consume a `\`,
+// and the class-based alternative is the only one that can consume
+// anything else. A version that let the class also match a bare `\`
+// (`[^"\n]` alone) would let the engine choose, for every backslash in a
+// run of them, between pairing it with the next character via `\\.` or
+// consuming it alone via the class — an ambiguity that multiplies
+// combinatorially (Fibonacci-many partitions of an N-backslash run) and
+// causes catastrophic backtracking once the overall match fails, i.e.
+// exponential-time behavior on a long run of backslashes with no closing
+// quote (confirmed empirically: a ~30-character adversarial input took
+// several seconds under the ambiguous form; a ~10,000-character one
+// resolves in under a millisecond after excluding the backslash from the
+// class). This is the standard non-overlapping idiom for a
+// backslash-escaped quoted string and applies to both quote styles.
 const ISSUE_OR_PR_REFERENCE_PATTERN =
-  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"(?:\\.|[^"\n])*"|'(?:\\.|[^'\n])*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
+  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"(?:\\.|[^"\\\n])*"|'(?:\\.|[^'\\\n])*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
 // Matches a Markdown list item marker at the start of a line (unordered
 // `-`/`*`/`+`, or ordered `1.`/`1)`), optionally indented and optionally
 // followed by a task-list checkbox. Captures the leading indentation

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -670,6 +670,21 @@ function checkProseOnlyDependency(text, currentRepo) {
 function normalizeLinkReferenceLabel(label) {
   return label.trim().toLowerCase().replace(/\s+/g, ' ');
 }
+// CommonMark §6.6 allows a reference definition's destination to be
+// wrapped in angle brackets (`[ref]: <https://...>`), captured verbatim
+// (brackets included) by LINK_REFERENCE_DEFINITION_PATTERN's `\S+`.
+// Without unwrapping, resolveReferenceStyleLinks would rewrite a usage to
+// `[text](<https://...>)`, which ISSUE_OR_PR_REFERENCE_PATTERN's
+// Markdown-link alternative does not recognize (it expects the URL
+// immediately after the opening paren, no angle brackets) — silently
+// leaving the reference-style link unresolved and re-leaking the label's
+// bare `#N` to the bare-`#` alternative, the same failure mode item 1
+// exists to prevent.
+function unwrapAngleBracketDestination(target) {
+  return target.startsWith('<') && target.endsWith('>')
+    ? target.slice(1, -1)
+    : target;
+}
 /**
  * Resolves every `[text][ref]` reference-style link usage in `text`
  * against its `[ref]: target` definition — which may appear anywhere else
@@ -686,7 +701,7 @@ function resolveReferenceStyleLinks(text) {
   for (const match of text.matchAll(LINK_REFERENCE_DEFINITION_PATTERN)) {
     const key = normalizeLinkReferenceLabel(match[1]);
     if (!definitions.has(key)) {
-      definitions.set(key, match[2]);
+      definitions.set(key, unwrapAngleBracketDestination(match[2]));
     }
   }
   if (definitions.size === 0) {

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -121,17 +121,56 @@ const PROSE_DEPENDENCY_KEYWORDS = [
 // `(?<![\w/])` lookbehind so it, too, only starts matching at a natural
 // token boundary rather than mid-path (e.g. inside a 3-segment
 // slash-separated path that happens to end in `#123`).
+//
+// The quoted-title sub-pattern tolerates a backslash-escaped quote
+// matching the title's own delimiter (`\"` inside a `"..."` title, or
+// `\'` inside a `'...'` title) as content instead of letting it close the
+// title early: `(?:\\.|[^"\n])*` (and the single-quote equivalent) tries
+// consuming a backslash plus the character right after it as one unit
+// before falling back to "any non-quote, non-newline character", so an
+// escaped quote is never mistaken for the real closing delimiter. Without
+// this, a title like `"reviewed \"API\""` would close at the first
+// escaped quote, leave the rest of the title as unconsumed content before
+// the link's real closing paren, fail the whole Markdown-link
+// alternative, and re-leak the label's own bare `#N` to the bare-`#`
+// alternative — the same failure mode the trailing-content tolerances
+// above already guard against, just triggered by escaping instead of an
+// unhandled trailing shape.
 const ISSUE_OR_PR_REFERENCE_PATTERN =
-  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"[^"\n]*"|'[^'\n]*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
+  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"(?:\\.|[^"\n])*"|'(?:\\.|[^'\n])*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
 // Matches a Markdown list item marker at the start of a line (unordered
 // `-`/`*`/`+`, or ordered `1.`/`1)`), optionally indented and optionally
-// followed by a task-list checkbox. Declared here (before the CLI entry
+// followed by a task-list checkbox. Captures the leading indentation
+// (group 1) so splitIntoListItemBlocks can tell a deeper-indented
+// nested/child marker from a new marker at the same or shallower
+// indentation as the most recently seen one — see that function for how
+// the two are told apart. Declared here (before the CLI entry
 // block below), not next to splitIntoSentences/splitIntoListItemBlocks
 // that use it, because those are hoisted function declarations but this
 // is a module-level `const` — declaring it after the entry block would be
 // a TDZ risk under the CLI path, which calls main() synchronously at this
 // point in module evaluation (see tests/cli-entry-smoke.test.mts).
-const LIST_ITEM_MARKER_PATTERN = /^\s*(?:[-*+]|\d+[.)])\s+/;
+const LIST_ITEM_MARKER_PATTERN = /^(\s*)(?:[-*+]|\d+[.)])\s+/;
+// Matches a Markdown reference-style link *usage*: `[text][ref]`, where a
+// separate `[ref]: <target>` definition (matched by
+// LINK_REFERENCE_DEFINITION_PATTERN below) supplies the actual target
+// elsewhere in the document — commonly far from the usage, so this is
+// resolved as a whole-document pre-processing step (see
+// resolveReferenceStyleLinks) rather than as a fifth alternative inside
+// ISSUE_OR_PR_REFERENCE_PATTERN, which cannot look outside its own match
+// to find the target. The ref label must be non-empty — this
+// deliberately excludes the shortcut forms `[text][]` and bare `[text]`
+// (which would resolve the ref from the label text itself); only the
+// explicit-ref shape named in issue #1472 is in scope here. Same
+// TDZ-avoidance placement rationale as LIST_ITEM_MARKER_PATTERN above.
+const REFERENCE_STYLE_LINK_USAGE_PATTERN = /\[([^\]\n]*)\]\[([^\]\n]+)\]/g;
+// Matches a Markdown link reference definition line: optionally indented
+// (up to 3 spaces, per CommonMark), `[label]: target`, with the target
+// read up to the first whitespace. An optional title on the same
+// definition line (e.g. `[ref]: <url> "title"`) is intentionally not
+// captured — only the destination matters for resolving a reference-style
+// link to a GitHub issue/PR URL.
+const LINK_REFERENCE_DEFINITION_PATTERN = /^ {0,3}\[([^\]\n]+)\]:\s*(\S+)/gm;
 if (import.meta.main) {
   main();
 }
@@ -182,7 +221,7 @@ export function auditAuthoredIssue(body, options) {
     checkDependencyMarkerRule(text, markerPrefix, shape),
     checkSuitabilityVisibleLineAgreement(text, markerPrefix, suitability),
     checkEffortVisibleLineAgreement(text, markerPrefix),
-    checkProseOnlyDependency(text, options.currentRepo),
+    checkProseOnlyDependency(text, normalizeCurrentRepo(options.currentRepo)),
   ];
   return {
     shape,
@@ -468,6 +507,25 @@ function checkEffortVisibleLineAgreement(text, markerPrefix) {
     `visible line agrees with marker value ${effort.value}`,
   );
 }
+// An empty or whitespace-only currentRepo (reachable via an explicit
+// `--current-repo ''`, or an environment where `$GITHUB_REPOSITORY`
+// resolves to an empty string) must be treated the same as it being
+// unset. Without this, `currentRepo !== undefined` is true for `''`, but
+// `${owner}/${repo}` built from a regex match is never empty, so it can
+// never equal `''` — every full-URL/cross-repo-shorthand match would then
+// be silently treated as "known and different" (cross-repo) and excluded,
+// even when the reference is actually local. Returning the *trimmed*
+// value (not the original) when it is non-empty is a free, strictly more
+// correct bonus: a currentRepo with stray leading/trailing whitespace
+// would otherwise never case-insensitively equal a match's own untrimmed
+// `owner/repo` either.
+function normalizeCurrentRepo(currentRepo) {
+  if (currentRepo === undefined) {
+    return undefined;
+  }
+  const trimmed = currentRepo.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
 function checkProseOnlyDependency(text, currentRepo) {
   const id = 'prose-dependency';
   const name =
@@ -485,7 +543,14 @@ function checkProseOnlyDependency(text, currentRepo) {
     'i',
   );
   const flagged = new Set();
-  for (const paragraph of text.split(/\n\s*\n/)) {
+  // Resolve reference-style Markdown links (`[text][ref]` + a separate
+  // `[ref]: target` definition elsewhere in the body) to the equivalent
+  // inline-link shape before splitting into paragraphs/sentences, so the
+  // existing Markdown-link alternative below — and its currentRepo /
+  // trailing-content handling — recognizes it with no duplicated matching
+  // logic. Scoped to this check only; other checks keep using `text`.
+  const resolvedText = resolveReferenceStyleLinks(text);
+  for (const paragraph of resolvedText.split(/\n\s*\n/)) {
     for (const sentence of splitIntoSentences(paragraph)) {
       // Scope proximity to one sentence, not the whole paragraph: a long
       // paragraph can legitimately combine an unrelated coordination word
@@ -582,6 +647,42 @@ function checkProseOnlyDependency(text, currentRepo) {
       'only',
   };
 }
+// CommonMark reference labels are compared case-insensitively after
+// collapsing internal whitespace and trimming, so `[Upstream PR]` and
+// `[upstream  pr]` refer to the same definition.
+function normalizeLinkReferenceLabel(label) {
+  return label.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+/**
+ * Resolves every `[text][ref]` reference-style link usage in `text`
+ * against its `[ref]: target` definition — which may appear anywhere else
+ * in the document, commonly far from the usage — by rewriting the usage
+ * to the equivalent inline-link shape `[text](target)`. A usage whose ref
+ * does not resolve to any definition is left unchanged: it falls through
+ * to the bare-`#` alternative like any other unrecognized bracket shape,
+ * the same fallback that already applies today. Duplicate labels keep the
+ * first definition, matching CommonMark's rule for duplicate link
+ * reference definitions.
+ */
+function resolveReferenceStyleLinks(text) {
+  const definitions = new Map();
+  for (const match of text.matchAll(LINK_REFERENCE_DEFINITION_PATTERN)) {
+    const key = normalizeLinkReferenceLabel(match[1]);
+    if (!definitions.has(key)) {
+      definitions.set(key, match[2]);
+    }
+  }
+  if (definitions.size === 0) {
+    return text;
+  }
+  return text.replace(
+    REFERENCE_STYLE_LINK_USAGE_PATTERN,
+    (whole, label, ref) => {
+      const target = definitions.get(normalizeLinkReferenceLabel(ref));
+      return target === undefined ? whole : `[${label}](${target})`;
+    },
+  );
+}
 /**
  * Split a paragraph into sentences on `.`/`!`/`?` followed by whitespace,
  * after collapsing internal newlines to spaces (so a sentence that wraps
@@ -611,16 +712,45 @@ function splitIntoSentences(paragraph) {
  * of its own) onto the item it continues. A paragraph with no list items
  * at all yields exactly one block spanning every line, preserving prior
  * behavior for plain prose.
+ *
+ * A marker line's indentation is compared against the *most recently
+ * seen* marker line's indentation (not the current block's own starting
+ * indentation): a *deeper* indentation is a nested/child item and stays
+ * part of the running block, so a parent bullet's coordination language
+ * and a nested child's reference are scoped together instead of being
+ * split into unrelated blocks (see issue #1472). A marker at the *same or
+ * shallower* indentation as the most recently seen marker still starts a
+ * new block, preserving the original tight-list sentence-conflation fix
+ * this function exists for — separate sibling bullets, at any shared
+ * indentation depth, never merge with each other.
+ *
+ * Known, accepted residual gap: a parent bullet with two or more nested
+ * children only keeps the *first* child merged with the parent's text — a
+ * later same-depth sibling still starts its own new block (indistinguishable
+ * here from a same-depth sibling of the parent itself, without tracking a
+ * full indentation stack). Not a regression: today, every nested child is
+ * already split away from its parent unconditionally, so this is
+ * strictly no worse for the second-and-later children while fixing the
+ * common single-child case.
  */
 function splitIntoListItemBlocks(paragraph) {
   const blocks = [];
   let current = [];
+  let lastMarkerIndent = null;
   for (const line of paragraph.split('\n')) {
-    if (LIST_ITEM_MARKER_PATTERN.test(line) && current.length > 0) {
+    const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
+    const startsNewBlock =
+      marker !== null &&
+      current.length > 0 &&
+      (lastMarkerIndent === null || marker[1].length <= lastMarkerIndent);
+    if (startsNewBlock) {
       blocks.push(current.join('\n'));
       current = [line];
     } else {
       current.push(line);
+    }
+    if (marker !== null) {
+      lastMarkerIndent = marker[1].length;
     }
   }
   if (current.length > 0) {

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -738,6 +738,23 @@ function splitIntoSentences(paragraph) {
     return flattened.length === 0 ? [] : flattened.split(/(?<=[.!?])\s+/);
   });
 }
+// CommonMark expands a tab to the next column that is a multiple of 4
+// when it participates in block structure (e.g. list-item indentation),
+// rather than counting as a single character. Comparing raw
+// `.length` would undercount a tab-indented marker's effective depth,
+// wrongly treating a tab-indented nested child as shallower than (or
+// equal to) a same-or-deeper space-indented parent and starting a new
+// block instead of keeping the child scoped with its parent — the same
+// loss-of-parent-scope splitIntoListItemBlocks exists to prevent, just
+// triggered by mixed tab/space indentation instead of an indentation
+// depth mismatch.
+function indentColumnWidth(indent) {
+  let column = 0;
+  for (const char of indent) {
+    column = char === '\t' ? (Math.floor(column / 4) + 1) * 4 : column + 1;
+  }
+  return column;
+}
 /**
  * Split a paragraph into blocks at each Markdown list item boundary, while
  * still joining a soft-wrapped continuation line (one with no list marker
@@ -771,18 +788,19 @@ function splitIntoListItemBlocks(paragraph) {
   let lastMarkerIndent = null;
   for (const line of paragraph.split('\n')) {
     const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
+    const indent = marker === null ? null : indentColumnWidth(marker[1]);
     const startsNewBlock =
-      marker !== null &&
+      indent !== null &&
       current.length > 0 &&
-      (lastMarkerIndent === null || marker[1].length <= lastMarkerIndent);
+      (lastMarkerIndent === null || indent <= lastMarkerIndent);
     if (startsNewBlock) {
       blocks.push(current.join('\n'));
       current = [line];
     } else {
       current.push(line);
     }
-    if (marker !== null) {
-      lastMarkerIndent = marker[1].length;
+    if (indent !== null) {
+      lastMarkerIndent = indent;
     }
   }
   if (current.length > 0) {

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -591,7 +591,23 @@ it is flagged only when `--current-repo` is supplied **and**
 case-insensitively matches `owner/repo`; naming a different repository,
 or omitting `--current-repo`, always excludes it, since this shorthand
 was never recognized at all before and a bare `owner/repo` cannot be
-assumed local without confirmation. Unlike every other check above, a
+assumed local without confirmation. A reference-style Markdown link
+(`[text][ref]` with a separate `[ref]: target` definition elsewhere in
+the body) is recognized the same way as the inline-link form above,
+including the same `currentRepo`-based local/cross-repo comparison; a
+`ref` with no matching definition is left as literal text and falls
+through to the bare-`#` check like any other unrecognized shape. A
+quoted link title may contain a backslash-escaped quote matching its own
+delimiter (`\"` inside a `"..."` title, or `\'` inside a `'...'` title)
+without ending the title early and losing the rest of the link. An empty
+or whitespace-only `--current-repo` (or `$GITHUB_REPOSITORY`) is treated
+the same as omitting it entirely, rather than as a known repository that
+can never match. A nested/child list item's reference is evaluated
+together with its parent bullet's coordination-language text instead of
+being scoped away from it, while a sibling bullet at the same
+indentation — nested or top-level — still starts its own separate scope,
+preserving the tight-list sentence-conflation fix mentioned above. Unlike
+every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -606,8 +606,11 @@ can never match. A nested/child list item's reference is evaluated
 together with its parent bullet's coordination-language text instead of
 being scoped away from it, while a sibling bullet at the same
 indentation — nested or top-level — still starts its own separate scope,
-preserving the tight-list sentence-conflation fix mentioned above. Unlike
-every other check above, a
+preserving the tight-list sentence-conflation fix mentioned above. This
+holds for the first nested child under a given parent; a parent with two
+or more nested children currently keeps only the first one scoped with
+it — a known, tracked limitation, not a guarantee for every nested
+child. Unlike every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -120,6 +120,10 @@ export interface AuditOptions {
    * matches the reference's `owner/repo` always flags it (subject to the
    * existing dependency-marker exclusion), and one that differs always
    * excludes it.
+   *
+   * An empty or whitespace-only value is normalized to `undefined` before
+   * this comparison runs, so it is treated the same as omitting this
+   * option entirely — never as a known, non-matching repo.
    */
   currentRepo?: string;
 }
@@ -206,18 +210,59 @@ const PROSE_DEPENDENCY_KEYWORDS = [
 // `(?<![\w/])` lookbehind so it, too, only starts matching at a natural
 // token boundary rather than mid-path (e.g. inside a 3-segment
 // slash-separated path that happens to end in `#123`).
+//
+// The quoted-title sub-pattern tolerates a backslash-escaped quote
+// matching the title's own delimiter (`\"` inside a `"..."` title, or
+// `\'` inside a `'...'` title) as content instead of letting it close the
+// title early: `(?:\\.|[^"\n])*` (and the single-quote equivalent) tries
+// consuming a backslash plus the character right after it as one unit
+// before falling back to "any non-quote, non-newline character", so an
+// escaped quote is never mistaken for the real closing delimiter. Without
+// this, a title like `"reviewed \"API\""` would close at the first
+// escaped quote, leave the rest of the title as unconsumed content before
+// the link's real closing paren, fail the whole Markdown-link
+// alternative, and re-leak the label's own bare `#N` to the bare-`#`
+// alternative — the same failure mode the trailing-content tolerances
+// above already guard against, just triggered by escaping instead of an
+// unhandled trailing shape.
 const ISSUE_OR_PR_REFERENCE_PATTERN =
-  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"[^"\n]*"|'[^'\n]*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
+  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"(?:\\.|[^"\n])*"|'(?:\\.|[^'\n])*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
 
 // Matches a Markdown list item marker at the start of a line (unordered
 // `-`/`*`/`+`, or ordered `1.`/`1)`), optionally indented and optionally
-// followed by a task-list checkbox. Declared here (before the CLI entry
+// followed by a task-list checkbox. Captures the leading indentation
+// (group 1) so splitIntoListItemBlocks can tell a deeper-indented
+// nested/child marker from a new marker at the same or shallower
+// indentation as the most recently seen one — see that function for how
+// the two are told apart. Declared here (before the CLI entry
 // block below), not next to splitIntoSentences/splitIntoListItemBlocks
 // that use it, because those are hoisted function declarations but this
 // is a module-level `const` — declaring it after the entry block would be
 // a TDZ risk under the CLI path, which calls main() synchronously at this
 // point in module evaluation (see tests/cli-entry-smoke.test.mts).
-const LIST_ITEM_MARKER_PATTERN = /^\s*(?:[-*+]|\d+[.)])\s+/;
+const LIST_ITEM_MARKER_PATTERN = /^(\s*)(?:[-*+]|\d+[.)])\s+/;
+
+// Matches a Markdown reference-style link *usage*: `[text][ref]`, where a
+// separate `[ref]: <target>` definition (matched by
+// LINK_REFERENCE_DEFINITION_PATTERN below) supplies the actual target
+// elsewhere in the document — commonly far from the usage, so this is
+// resolved as a whole-document pre-processing step (see
+// resolveReferenceStyleLinks) rather than as a fifth alternative inside
+// ISSUE_OR_PR_REFERENCE_PATTERN, which cannot look outside its own match
+// to find the target. The ref label must be non-empty — this
+// deliberately excludes the shortcut forms `[text][]` and bare `[text]`
+// (which would resolve the ref from the label text itself); only the
+// explicit-ref shape named in issue #1472 is in scope here. Same
+// TDZ-avoidance placement rationale as LIST_ITEM_MARKER_PATTERN above.
+const REFERENCE_STYLE_LINK_USAGE_PATTERN = /\[([^\]\n]*)\]\[([^\]\n]+)\]/g;
+
+// Matches a Markdown link reference definition line: optionally indented
+// (up to 3 spaces, per CommonMark), `[label]: target`, with the target
+// read up to the first whitespace. An optional title on the same
+// definition line (e.g. `[ref]: <url> "title"`) is intentionally not
+// captured — only the destination matters for resolving a reference-style
+// link to a GitHub issue/PR URL.
+const LINK_REFERENCE_DEFINITION_PATTERN = /^ {0,3}\[([^\]\n]+)\]:\s*(\S+)/gm;
 
 if (import.meta.main) {
   main();
@@ -275,7 +320,7 @@ export function auditAuthoredIssue(
     checkDependencyMarkerRule(text, markerPrefix, shape),
     checkSuitabilityVisibleLineAgreement(text, markerPrefix, suitability),
     checkEffortVisibleLineAgreement(text, markerPrefix),
-    checkProseOnlyDependency(text, options.currentRepo),
+    checkProseOnlyDependency(text, normalizeCurrentRepo(options.currentRepo)),
   ];
 
   return {
@@ -592,6 +637,28 @@ function checkEffortVisibleLineAgreement(
   );
 }
 
+// An empty or whitespace-only currentRepo (reachable via an explicit
+// `--current-repo ''`, or an environment where `$GITHUB_REPOSITORY`
+// resolves to an empty string) must be treated the same as it being
+// unset. Without this, `currentRepo !== undefined` is true for `''`, but
+// `${owner}/${repo}` built from a regex match is never empty, so it can
+// never equal `''` — every full-URL/cross-repo-shorthand match would then
+// be silently treated as "known and different" (cross-repo) and excluded,
+// even when the reference is actually local. Returning the *trimmed*
+// value (not the original) when it is non-empty is a free, strictly more
+// correct bonus: a currentRepo with stray leading/trailing whitespace
+// would otherwise never case-insensitively equal a match's own untrimmed
+// `owner/repo` either.
+function normalizeCurrentRepo(
+  currentRepo: string | undefined,
+): string | undefined {
+  if (currentRepo === undefined) {
+    return undefined;
+  }
+  const trimmed = currentRepo.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
 function checkProseOnlyDependency(
   text: string,
   currentRepo: string | undefined,
@@ -612,7 +679,14 @@ function checkProseOnlyDependency(
     'i',
   );
   const flagged = new Set<number>();
-  for (const paragraph of text.split(/\n\s*\n/)) {
+  // Resolve reference-style Markdown links (`[text][ref]` + a separate
+  // `[ref]: target` definition elsewhere in the body) to the equivalent
+  // inline-link shape before splitting into paragraphs/sentences, so the
+  // existing Markdown-link alternative below — and its currentRepo /
+  // trailing-content handling — recognizes it with no duplicated matching
+  // logic. Scoped to this check only; other checks keep using `text`.
+  const resolvedText = resolveReferenceStyleLinks(text);
+  for (const paragraph of resolvedText.split(/\n\s*\n/)) {
     for (const sentence of splitIntoSentences(paragraph)) {
       // Scope proximity to one sentence, not the whole paragraph: a long
       // paragraph can legitimately combine an unrelated coordination word
@@ -710,6 +784,44 @@ function checkProseOnlyDependency(
   };
 }
 
+// CommonMark reference labels are compared case-insensitively after
+// collapsing internal whitespace and trimming, so `[Upstream PR]` and
+// `[upstream  pr]` refer to the same definition.
+function normalizeLinkReferenceLabel(label: string): string {
+  return label.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/**
+ * Resolves every `[text][ref]` reference-style link usage in `text`
+ * against its `[ref]: target` definition — which may appear anywhere else
+ * in the document, commonly far from the usage — by rewriting the usage
+ * to the equivalent inline-link shape `[text](target)`. A usage whose ref
+ * does not resolve to any definition is left unchanged: it falls through
+ * to the bare-`#` alternative like any other unrecognized bracket shape,
+ * the same fallback that already applies today. Duplicate labels keep the
+ * first definition, matching CommonMark's rule for duplicate link
+ * reference definitions.
+ */
+function resolveReferenceStyleLinks(text: string): string {
+  const definitions = new Map<string, string>();
+  for (const match of text.matchAll(LINK_REFERENCE_DEFINITION_PATTERN)) {
+    const key = normalizeLinkReferenceLabel(match[1]);
+    if (!definitions.has(key)) {
+      definitions.set(key, match[2]);
+    }
+  }
+  if (definitions.size === 0) {
+    return text;
+  }
+  return text.replace(
+    REFERENCE_STYLE_LINK_USAGE_PATTERN,
+    (whole: string, label: string, ref: string) => {
+      const target = definitions.get(normalizeLinkReferenceLabel(ref));
+      return target === undefined ? whole : `[${label}](${target})`;
+    },
+  );
+}
+
 /**
  * Split a paragraph into sentences on `.`/`!`/`?` followed by whitespace,
  * after collapsing internal newlines to spaces (so a sentence that wraps
@@ -740,16 +852,45 @@ function splitIntoSentences(paragraph: string): string[] {
  * of its own) onto the item it continues. A paragraph with no list items
  * at all yields exactly one block spanning every line, preserving prior
  * behavior for plain prose.
+ *
+ * A marker line's indentation is compared against the *most recently
+ * seen* marker line's indentation (not the current block's own starting
+ * indentation): a *deeper* indentation is a nested/child item and stays
+ * part of the running block, so a parent bullet's coordination language
+ * and a nested child's reference are scoped together instead of being
+ * split into unrelated blocks (see issue #1472). A marker at the *same or
+ * shallower* indentation as the most recently seen marker still starts a
+ * new block, preserving the original tight-list sentence-conflation fix
+ * this function exists for — separate sibling bullets, at any shared
+ * indentation depth, never merge with each other.
+ *
+ * Known, accepted residual gap: a parent bullet with two or more nested
+ * children only keeps the *first* child merged with the parent's text — a
+ * later same-depth sibling still starts its own new block (indistinguishable
+ * here from a same-depth sibling of the parent itself, without tracking a
+ * full indentation stack). Not a regression: today, every nested child is
+ * already split away from its parent unconditionally, so this is
+ * strictly no worse for the second-and-later children while fixing the
+ * common single-child case.
  */
 function splitIntoListItemBlocks(paragraph: string): string[] {
   const blocks: string[] = [];
   let current: string[] = [];
+  let lastMarkerIndent: number | null = null;
   for (const line of paragraph.split('\n')) {
-    if (LIST_ITEM_MARKER_PATTERN.test(line) && current.length > 0) {
+    const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
+    const startsNewBlock =
+      marker !== null &&
+      current.length > 0 &&
+      (lastMarkerIndent === null || marker[1].length <= lastMarkerIndent);
+    if (startsNewBlock) {
       blocks.push(current.join('\n'));
       current = [line];
     } else {
       current.push(line);
+    }
+    if (marker !== null) {
+      lastMarkerIndent = marker[1].length;
     }
   }
   if (current.length > 0) {

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -879,6 +879,24 @@ function splitIntoSentences(paragraph: string): string[] {
   });
 }
 
+// CommonMark expands a tab to the next column that is a multiple of 4
+// when it participates in block structure (e.g. list-item indentation),
+// rather than counting as a single character. Comparing raw
+// `.length` would undercount a tab-indented marker's effective depth,
+// wrongly treating a tab-indented nested child as shallower than (or
+// equal to) a same-or-deeper space-indented parent and starting a new
+// block instead of keeping the child scoped with its parent — the same
+// loss-of-parent-scope splitIntoListItemBlocks exists to prevent, just
+// triggered by mixed tab/space indentation instead of an indentation
+// depth mismatch.
+function indentColumnWidth(indent: string): number {
+  let column = 0;
+  for (const char of indent) {
+    column = char === '\t' ? (Math.floor(column / 4) + 1) * 4 : column + 1;
+  }
+  return column;
+}
+
 /**
  * Split a paragraph into blocks at each Markdown list item boundary, while
  * still joining a soft-wrapped continuation line (one with no list marker
@@ -912,18 +930,19 @@ function splitIntoListItemBlocks(paragraph: string): string[] {
   let lastMarkerIndent: number | null = null;
   for (const line of paragraph.split('\n')) {
     const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
+    const indent = marker === null ? null : indentColumnWidth(marker[1]);
     const startsNewBlock =
-      marker !== null &&
+      indent !== null &&
       current.length > 0 &&
-      (lastMarkerIndent === null || marker[1].length <= lastMarkerIndent);
+      (lastMarkerIndent === null || indent <= lastMarkerIndent);
     if (startsNewBlock) {
       blocks.push(current.join('\n'));
       current = [line];
     } else {
       current.push(line);
     }
-    if (marker !== null) {
-      lastMarkerIndent = marker[1].length;
+    if (indent !== null) {
+      lastMarkerIndent = indent;
     }
   }
   if (current.length > 0) {

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -808,6 +808,22 @@ function normalizeLinkReferenceLabel(label: string): string {
   return label.trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
+// CommonMark §6.6 allows a reference definition's destination to be
+// wrapped in angle brackets (`[ref]: <https://...>`), captured verbatim
+// (brackets included) by LINK_REFERENCE_DEFINITION_PATTERN's `\S+`.
+// Without unwrapping, resolveReferenceStyleLinks would rewrite a usage to
+// `[text](<https://...>)`, which ISSUE_OR_PR_REFERENCE_PATTERN's
+// Markdown-link alternative does not recognize (it expects the URL
+// immediately after the opening paren, no angle brackets) — silently
+// leaving the reference-style link unresolved and re-leaking the label's
+// bare `#N` to the bare-`#` alternative, the same failure mode item 1
+// exists to prevent.
+function unwrapAngleBracketDestination(target: string): string {
+  return target.startsWith('<') && target.endsWith('>')
+    ? target.slice(1, -1)
+    : target;
+}
+
 /**
  * Resolves every `[text][ref]` reference-style link usage in `text`
  * against its `[ref]: target` definition — which may appear anywhere else
@@ -824,7 +840,7 @@ function resolveReferenceStyleLinks(text: string): string {
   for (const match of text.matchAll(LINK_REFERENCE_DEFINITION_PATTERN)) {
     const key = normalizeLinkReferenceLabel(match[1]);
     if (!definitions.has(key)) {
-      definitions.set(key, match[2]);
+      definitions.set(key, unwrapAngleBracketDestination(match[2]));
     }
   }
   if (definitions.size === 0) {

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -214,19 +214,36 @@ const PROSE_DEPENDENCY_KEYWORDS = [
 // The quoted-title sub-pattern tolerates a backslash-escaped quote
 // matching the title's own delimiter (`\"` inside a `"..."` title, or
 // `\'` inside a `'...'` title) as content instead of letting it close the
-// title early: `(?:\\.|[^"\n])*` (and the single-quote equivalent) tries
-// consuming a backslash plus the character right after it as one unit
-// before falling back to "any non-quote, non-newline character", so an
-// escaped quote is never mistaken for the real closing delimiter. Without
-// this, a title like `"reviewed \"API\""` would close at the first
-// escaped quote, leave the rest of the title as unconsumed content before
-// the link's real closing paren, fail the whole Markdown-link
-// alternative, and re-leak the label's own bare `#N` to the bare-`#`
-// alternative — the same failure mode the trailing-content tolerances
-// above already guard against, just triggered by escaping instead of an
-// unhandled trailing shape.
+// title early: `(?:\\.|[^"\\\n])*` (and the single-quote equivalent)
+// tries consuming a backslash plus the character right after it as one
+// unit before falling back to "any character that is not the quote, a
+// backslash, or a newline", so an escaped quote is never mistaken for the
+// real closing delimiter. Without this, a title like `"reviewed
+// \"API\""` would close at the first escaped quote, leave the rest of
+// the title as unconsumed content before the link's real closing paren,
+// fail the whole Markdown-link alternative, and re-leak the label's own
+// bare `#N` to the bare-`#` alternative — the same failure mode the
+// trailing-content tolerances above already guard against, just
+// triggered by escaping instead of an unhandled trailing shape.
+//
+// The character class excludes a literal backslash (not just the quote
+// and newline) so the two alternatives never overlap on the same input
+// character: `\\.` is the only alternative that can ever consume a `\`,
+// and the class-based alternative is the only one that can consume
+// anything else. A version that let the class also match a bare `\`
+// (`[^"\n]` alone) would let the engine choose, for every backslash in a
+// run of them, between pairing it with the next character via `\\.` or
+// consuming it alone via the class — an ambiguity that multiplies
+// combinatorially (Fibonacci-many partitions of an N-backslash run) and
+// causes catastrophic backtracking once the overall match fails, i.e.
+// exponential-time behavior on a long run of backslashes with no closing
+// quote (confirmed empirically: a ~30-character adversarial input took
+// several seconds under the ambiguous form; a ~10,000-character one
+// resolves in under a millisecond after excluding the backslash from the
+// class). This is the standard non-overlapping idiom for a
+// backslash-escaped quoted string and applies to both quote styles.
 const ISSUE_OR_PR_REFERENCE_PATTERN =
-  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"(?:\\.|[^"\n])*"|'(?:\\.|[^'\n])*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
+  /\[[^\]\n]*\]\(https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)(?:\/)?(?:#[^)\s"']+)?(?:\s+(?:"(?:\\.|[^"\\\n])*"|'(?:\\.|[^'\\\n])*'))?\)|(?<![\w/])#(\d+)\b|https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(?:issues|pull)\/(\d+)\b|(?<![\w/])([\w.-]+)\/([\w.-]+)#(\d+)\b/gi;
 
 // Matches a Markdown list item marker at the start of a line (unordered
 // `-`/`*`/`+`, or ordered `1.`/`1)`), optionally indented and optionally

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1326,6 +1326,35 @@ test('prose-dependency does not resolve a reference-style link whose ref has no 
   assert.match(finding?.detail ?? '', /#1391/);
 });
 
+test('prose-dependency resolves a reference-style link whose ref label differs in case and whitespace from its definition', () => {
+  // CommonMark compares reference labels case-insensitively after
+  // trimming and collapsing internal whitespace (normalizeLinkReferenceLabel).
+  // Every other reference-style test uses an identical single-word label
+  // on both sides, which would still resolve-and-flag correctly (via the
+  // bare-`#` fallback) even if label normalization were entirely broken --
+  // not a discriminating test. A *cross-repo* definition with currentRepo
+  // known is: if normalization fails to match "Upstream  PR" to "upstream
+  // pr", the usage is left unresolved, falls through to the bare-`#`
+  // alternative (which has no owner/repo of its own and is therefore
+  // always treated as local, unlike the resolved Markdown-link form),
+  // and gets wrongly flagged -- only correct label resolution lets the
+  // cross-repo exclusion apply.
+  const body = childBody({
+    extraMarkers:
+      'Before starting, [PR #1391][Upstream  PR] must land.\n\n' +
+      '[upstream pr]: https://github.com/acme/other-repo/pull/1391',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
 // --- prose-dependency: nested list item parent-scope loss (#1472) ---
 
 test('prose-dependency recognizes a nested list item reference alongside its parent bullet coordination language', () => {
@@ -1403,6 +1432,31 @@ test('prose-dependency treats a whitespace-only currentRepo as unknown', () => {
   const report = auditAuthoredIssue(body, {
     shape: 'child',
     currentRepo: '   ',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency trims a currentRepo with incidental leading/trailing whitespace before comparing', () => {
+  // normalizeCurrentRepo's non-empty branch returns the trimmed value, not
+  // the original string. A *local* URL reference is the discriminating
+  // case: an explicit currentRepo that matches the reference's owner/repo
+  // is still flagged by design (see the AuditOptions.currentRepo JSDoc),
+  // so if trimming were broken -- comparing the padded string as-is --
+  // the padded value would never equal the unpadded local repo, the
+  // reference would be wrongly treated as cross-repo, and this would
+  // silently NOT warn instead.
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      'https://github.com/kurone-kito/idd-skill/pull/1391 has merged.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: '  kurone-kito/idd-skill  ',
   });
   const finding = report.findings.find(
     (entry) => entry.id === 'prose-dependency',

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1403,6 +1403,27 @@ test('prose-dependency still separates top-level sibling list items sharing a ti
   assert.doesNotMatch(finding.detail, /#1386/);
 });
 
+test('prose-dependency recognizes a tab-indented nested child as deeper than its space-indented parent', () => {
+  // Regression test for a real review finding on this same PR (Codex):
+  // CommonMark expands a tab to the next column that is a multiple of 4
+  // when it participates in block structure, so a tab-indented marker
+  // (raw length 1) can still be a deeper nested child than a 2-space
+  // parent (raw length 2) once expanded (column 4 vs. column 2). A raw
+  // character-count comparison would undercount the tab and wrongly
+  // treat this as a same-or-shallower marker, starting a new block and
+  // losing the parent's coordination language -- the same failure mode
+  // the nested-scoping fix above exists to prevent.
+  const body = childBody({
+    extraMarkers: '  - Before starting this work:\n\t- PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
 // --- prose-dependency: empty-string currentRepo (#1472) ---
 
 test('prose-dependency treats an empty-string currentRepo as unknown', () => {

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1466,6 +1466,34 @@ test('prose-dependency does not warn on a Markdown link with an escaped-quote ti
   assert.equal(finding.severity, undefined);
 });
 
+test('prose-dependency does not exhibit catastrophic backtracking on an adversarial escaped-quote-like run', () => {
+  // Regression test for a real exponential-backtracking vulnerability
+  // CodeQL caught in this PR's first draft of the escaped-quote fix: an
+  // earlier version of the title sub-pattern let its "any non-quote,
+  // non-newline character" alternative also match a bare backslash,
+  // overlapping with the "backslash + any character" escape alternative.
+  // That overlap gives the engine a combinatorially large (Fibonacci-many)
+  // number of ways to partition a long run of backslashes before
+  // concluding no match is possible, once no real closing quote/paren
+  // follows -- an unbounded-length adversarial title is plausible input
+  // (e.g. a pasted issue body). The fixed pattern excludes a literal
+  // backslash from that character class, making the two alternatives
+  // non-overlapping, so this must stay linear-time regardless of run
+  // length.
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      `[x](https://github.com/o/r/pull/1 "${'\\!'.repeat(5000)}`,
+  });
+  const start = Date.now();
+  auditAuthoredIssue(body, { shape: 'child' });
+  const elapsedMs = Date.now() - start;
+  assert.ok(
+    elapsedMs < 2000,
+    `expected linear-time evaluation, took ${elapsedMs}ms`,
+  );
+});
+
 // --- shape / markerPrefix pass-through ---
 
 test('the report echoes the declared shape and resolved markerPrefix', () => {

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1285,6 +1285,31 @@ test('prose-dependency does not warn on a reference-style Markdown link when the
   assert.equal(finding.severity, undefined);
 });
 
+test('prose-dependency resolves a reference-style link whose definition uses an angle-bracket destination', () => {
+  // Regression test for a real review finding on this same PR (Copilot):
+  // CommonMark (section 6.6) allows a reference definition's destination
+  // to be wrapped in angle brackets (`[ref]: <https://...>`). Without
+  // stripping the brackets before rewriting, the usage would become
+  // `[text](<https://...>)`, which the Markdown-link alternative does not
+  // recognize, silently leaving the reference-style link unresolved and
+  // re-leaking the label's bare `#N` -- the same failure mode this item
+  // exists to prevent, just for this one destination-encoding shape.
+  const body = childBody({
+    extraMarkers:
+      'Before starting, [PR #1391][upstream] must land.\n\n' +
+      '[upstream]: <https://github.com/acme/other-repo/pull/1391>',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
 test('prose-dependency does not resolve a reference-style link whose ref has no matching definition', () => {
   // A dangling ref (no matching `[ref]: target` definition anywhere in
   // the body) is left as literal text -- it falls through to the bare-`#`

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1216,6 +1216,256 @@ test('prose-dependency does not misparse a three-segment slash path ending in #N
   assert.equal(finding.severity, undefined);
 });
 
+// --- prose-dependency: reference-style Markdown links (#1472) ---
+
+test('prose-dependency recognizes a reference-style Markdown link target', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before starting, [PR #1391][upstream] must land.\n\n' +
+      '[upstream]: https://github.com/kurone-kito/idd-skill/pull/1391',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency does not warn on a cross-repo reference-style Markdown link when currentRepo is known', () => {
+  // Regression test for the exact scenario #1472 describes: without
+  // resolving the reference-style link to its definition's URL, the
+  // label's own bare `#1391` leaks through to the bare-`#` alternative and
+  // gets wrongly flagged as local even though the definition targets
+  // another repository.
+  const body = childBody({
+    extraMarkers:
+      'Before starting, [PR #1391][upstream] must land.\n\n' +
+      '[upstream]: https://github.com/acme/other-repo/pull/1391',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency still warns on a cross-repo reference-style Markdown link when currentRepo is unknown', () => {
+  // Preserves the same default polarity as the full-URL and Markdown-link
+  // alternatives: without repo context, a reference-style link is still
+  // flagged by default.
+  const body = childBody({
+    extraMarkers:
+      'Before starting, [PR #1391][upstream] must land.\n\n' +
+      '[upstream]: https://github.com/acme/other-repo/pull/1391',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency does not warn on a reference-style Markdown link when the number already has a Blocked by encoding', () => {
+  const body = childBody({
+    extraMarkers:
+      'Blocked by #1391\n\nBefore starting, [PR #1391][upstream] must land.\n\n' +
+      '[upstream]: https://github.com/kurone-kito/idd-skill/pull/1391',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency does not resolve a reference-style link whose ref has no matching definition', () => {
+  // A dangling ref (no matching `[ref]: target` definition anywhere in
+  // the body) is left as literal text -- it falls through to the bare-`#`
+  // alternative like any other unrecognized bracket shape, the same
+  // fallback that already applies to every other unmatched shape.
+  const body = childBody({
+    extraMarkers: 'Before starting, [PR #1391][missing-ref] must land.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+// --- prose-dependency: nested list item parent-scope loss (#1472) ---
+
+test('prose-dependency recognizes a nested list item reference alongside its parent bullet coordination language', () => {
+  const body = childBody({
+    extraMarkers: '- Before starting this work:\n  - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency does not warn on a nested list item reference when the number already has a Blocked by encoding', () => {
+  const body = childBody({
+    extraMarkers:
+      'Blocked by #1391\n\n- Before starting this work:\n  - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency still separates top-level sibling list items sharing a tight list with a nested child', () => {
+  // Regression guard: the nested-scoping fix above must not regress the
+  // original tight-list sentence-conflation fix for TOP-LEVEL siblings --
+  // a nested child's own reference must not leak into an unrelated
+  // top-level sibling bullet's block.
+  const body = childBody({
+    extraMarkers:
+      '- Part of roadmap #1386\n' +
+      '- Before starting this work:\n' +
+      '  - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, 'warning');
+  assert.match(finding.detail, /#1391/);
+  assert.doesNotMatch(finding.detail, /#1386/);
+});
+
+// --- prose-dependency: empty-string currentRepo (#1472) ---
+
+test('prose-dependency treats an empty-string currentRepo as unknown', () => {
+  // Regression test for the exact bug #1472 describes: `currentRepo !==
+  // undefined` is true for `''`, so a local full-URL reference was
+  // silently excluded (misread as cross-repo) instead of flagged by the
+  // "unknown repo" default.
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      'https://github.com/kurone-kito/idd-skill/pull/1391 has merged.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child', currentRepo: '' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency treats a whitespace-only currentRepo as unknown', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      'https://github.com/kurone-kito/idd-skill/pull/1391 has merged.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: '   ',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency does not warn with an empty-string currentRepo when the number already has a Blocked by encoding', () => {
+  const body = childBody({
+    extraMarkers:
+      'Blocked by #1391\n\nBefore this can start, confirm ' +
+      'https://github.com/kurone-kito/idd-skill/pull/1391 has merged.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child', currentRepo: '' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+// --- prose-dependency: escaped quotes in a Markdown link title (#1472) ---
+
+test('prose-dependency recognizes a Markdown link whose quoted title contains an escaped double quote', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/idd-skill/pull/1391 "reviewed \\"API\\"") has merged.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency recognizes a Markdown link whose quoted title contains an escaped single quote', () => {
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      "[PR #1391](https://github.com/kurone-kito/idd-skill/pull/1391 'reviewed \\'API\\'') has merged.",
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency does not warn on a cross-repo Markdown link with an escaped-quote title when currentRepo is known', () => {
+  // Regression test for the exact label-leak #1472 describes: without
+  // tolerating the escaped quote, the title sub-pattern closes early, the
+  // whole Markdown-link alternative fails, and the label's own bare
+  // `#1391` leaks through to the bare-`#` alternative and gets wrongly
+  // flagged as local even though the link targets another repository.
+  const body = childBody({
+    extraMarkers:
+      'Before this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/other-repo/pull/1391 "reviewed \\"API\\"") has shipped.',
+  });
+  const report = auditAuthoredIssue(body, {
+    shape: 'child',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency does not warn on a Markdown link with an escaped-quote title when the number already has a Blocked by encoding', () => {
+  const body = childBody({
+    extraMarkers:
+      'Blocked by #1391\n\nBefore this can start, confirm ' +
+      '[PR #1391](https://github.com/kurone-kito/idd-skill/pull/1391 "reviewed \\"API\\"") has merged.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
 // --- shape / markerPrefix pass-through ---
 
 test('the report echoes the declared shape and resolved markerPrefix', () => {


### PR DESCRIPTION
# Summary

Implements the four prose-dependency edge cases consolidated by #1472
(after #1468/#1469's own review, and #1399's before that, kept finding
related gaps in this same advisory check):

- **Reference-style Markdown links.** `[text][ref]` + a separate
  `[ref]: target` definition is now resolved to the equivalent
  inline-link shape before matching, so the existing Markdown-link
  alternative (and its `currentRepo` comparison) recognizes it with no
  duplicated logic. A `ref` with no matching definition falls through
  to the bare-`#` alternative like any other unrecognized shape.
- **Nested list items losing parent scope.** `splitIntoListItemBlocks`
  now compares each marker line's indentation against the *most
  recently seen* marker's indentation instead of splitting at every
  marker unconditionally: a strictly deeper marker (nested/child) stays
  merged with the running block, while same-depth markers (nested or
  top-level) still start a new block — preserving the existing
  tight-list sentence-conflation fix this function exists for.
- **Empty-string `currentRepo`.** `currentRepo !== undefined` was true
  for `''`, so every full-URL/shorthand match was silently treated as
  cross-repo and excluded. An empty or whitespace-only value is now
  normalized to `undefined` before it reaches the check.
- **Escaped quotes in a Markdown link title.** The quoted-title
  sub-pattern now tolerates a backslash-escaped quote matching its own
  delimiter (`\"` / `\'`) as content instead of treating it as the
  closing quote, which previously failed the whole Markdown-link
  alternative and re-leaked the label's bare `#N` to the bare-`#`
  alternative.

This check remains advisory-only (never flips `passed` or the exit
code).

## Linked issue

Closes #1472

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Per the issue's own scope note, only these four items are implemented
in this PR. Item 2 (nested-list scoping) carries the most regression
risk — it was validated against the existing tight-list sentence-
conflation regression test plus new sibling-still-separates and
multi-child-residual checks (see test file). It was not split into a
separate issue since this task requires landing all four together in
one PR; a documented, accepted residual limitation remains for a parent
bullet with two or more nested children (only the first child stays
merged with the parent — no worse than today's behavior, which merges
none).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (typecheck, `build:check`, biome, dprint, `node --test`,
      workshop-integrity, cspell, markdownlint — equivalent commands run
      individually, see below)
- [x] `pnpm test` — `node --test tests/audit-authored-issue.test.mts`:
      93/93 pass (78 pre-existing + 15 new regression tests covering
      each of the 4 items individually, cross-repo/unknown-currentRepo
      polarity, and combination with an existing `Blocked by` encoding).
      Full suite `node --test tests/*.test.mts`: 2294/2297 pass; the 3
      failures are all in `tests/branch-conflict-state.test.mts`
      (`classifyBranchConflictState: ...`), reproduced independently in
      complete isolation — a pre-existing fixture GPG-pinentry-timeout
      issue in this local environment, unrelated to this diff.
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (pre-existing, unrelated warnings only)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of issue and pull request references in Markdown, including reference-style links and link titles with escaped quotes.
  * Corrected local vs cross-repository reference handling when repository context is missing or whitespace-only.
  * Improved advisory sentence-scoping for nested list items to prevent incorrect warnings.

* **Documentation**
  * Expanded guidance for `prose-dependency` advisory behavior, including reference matching rules, `--current-repo` handling, and nested list scope limitations.

* **Tests**
  * Added coverage for reference-style link resolution, escaping edge cases, repository context trimming/unknown behavior, and nested list coordination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->