### PR TITLE
fix(issue-authoring): scope every nested sibling to its parent

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -603,14 +603,17 @@ without ending the title early and losing the rest of the link. An empty
 or whitespace-only `--current-repo` (or `$GITHUB_REPOSITORY`) is treated
 the same as omitting it entirely, rather than as a known repository that
 can never match. A nested/child list item's reference is evaluated
-together with its parent bullet's coordination-language text instead of
-being scoped away from it, while a sibling bullet at the same
+together with its full ancestor chain's coordination-language text
+instead of being scoped away from it, while a sibling bullet at the same
 indentation — nested or top-level — still starts its own separate scope,
 preserving the tight-list sentence-conflation fix mentioned above. This
-holds for the first nested child under a given parent; a parent with two
-or more nested children currently keeps only the first one scoped with
-it — a known, tracked limitation, not a guarantee for every nested
-child. Unlike every other check above, a
+holds for every nested child under a given parent, at any depth — not
+only the first. A known, tracked limitation remains for a tight list
+only: a continuation line resuming at an ancestor's own indentation
+after a deeper child has already opened is still attributed to that
+child rather than the ancestor, and a loose list (a blank line between
+sibling items) resets scope at the paragraph boundary before this check
+ever sees it. Unlike every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -459,12 +459,16 @@ quoted link title may contain a backslash-escaped quote matching its own
 delimiter without ending the title early. An empty or whitespace-only
 `--current-repo` (or `$GITHUB_REPOSITORY`) is treated the same as
 omitting it, not as a known repository that can never match. A
-nested/child list item's reference is evaluated together with its parent
-bullet's coordination-language text instead of being scoped away from
-it, while a same-depth sibling bullet still starts its own separate
-scope. This holds for the first nested child under a given parent; a
-parent with two or more nested children currently keeps only the first
-one scoped with it -- a known, tracked limitation. A
+nested/child list item's reference is evaluated together with its full
+ancestor chain's coordination-language text instead of being scoped away
+from it, while a same-depth sibling bullet still starts its own separate
+scope. This holds for every nested child under a given parent, at any
+depth -- not only the first. A known, tracked limitation remains for a
+tight list only: a continuation line resuming at an ancestor's own
+indentation after a deeper child has already opened is still attributed
+to that child rather than the ancestor, and a loose list (a blank line
+between sibling items) resets scope at the paragraph boundary before
+this check ever sees it. A
 `prose-dependency` warning never flips `passed` to
 `false` and never changes the linter's exit code; it prompts the author
 to convert the prose into a proper dependency marker or consciously

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -794,6 +794,16 @@ function indentColumnWidth(indent) {
  * (preserving the existing behavior that leading prose never merges with
  * the first list item), or as the paragraph's sole block if no marker
  * ever appears.
+ *
+ * Known, tracked residual gaps (tracked in #1476, distinct from the
+ * marker-ancestry scoping this function fixes): a continuation line
+ * resuming at an ancestor's own indentation after a deeper child has
+ * already opened is still attributed to that child rather than the
+ * ancestor (see the `top.lines.push(line)` continuation-line branch
+ * below), and a loose list — sibling items separated by a blank
+ * line — resets scope at the paragraph boundary before this function
+ * ever runs, since its caller (`checkProseOnlyDependency`) splits on
+ * blank lines first.
  */
 function splitIntoListItemBlocks(paragraph) {
   const blocks = [];

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -160,8 +160,9 @@ const ISSUE_OR_PR_REFERENCE_PATTERN =
 // followed by a task-list checkbox. Captures the leading indentation
 // (group 1) so splitIntoListItemBlocks can tell a deeper-indented
 // nested/child marker from a new marker at the same or shallower
-// indentation as the most recently seen one — see that function for how
-// the two are told apart. Declared here (before the CLI entry
+// indentation as the currently open node at that depth in its
+// indentation-ancestry stack — see that function for how the two are
+// told apart. Declared here (before the CLI entry
 // block below), not next to splitIntoSentences/splitIntoListItemBlocks
 // that use it, because those are hoisted function declarations but this
 // is a module-level `const` — declaring it after the entry block would be
@@ -762,49 +763,90 @@ function indentColumnWidth(indent) {
  * at all yields exactly one block spanning every line, preserving prior
  * behavior for plain prose.
  *
- * A marker line's indentation is compared against the *most recently
- * seen* marker line's indentation (not the current block's own starting
- * indentation): a *deeper* indentation is a nested/child item and stays
- * part of the running block, so a parent bullet's coordination language
- * and a nested child's reference are scoped together instead of being
- * split into unrelated blocks (see issue #1472). A marker at the *same or
- * shallower* indentation as the most recently seen marker still starts a
- * new block, preserving the original tight-list sentence-conflation fix
- * this function exists for — separate sibling bullets, at any shared
- * indentation depth, never merge with each other.
+ * Tracks a full indentation-ancestry stack of open `ListItemNode`s rather
+ * than a single most-recently-seen marker indentation (see issue #1474):
+ * a marker line strictly *deeper* than the stack's top is pushed as a new
+ * child node, nested under it. A marker at the *same or shallower*
+ * indentation pops nodes off the stack — closing each one — until the top
+ * is strictly shallower (or the stack empties), then pushes the new
+ * marker as a fresh node at that level.
  *
- * Known, accepted residual gap: a parent bullet with two or more nested
- * children only keeps the *first* child merged with the parent's text — a
- * later same-depth sibling still starts its own new block (indistinguishable
- * here from a same-depth sibling of the parent itself, without tracking a
- * full indentation stack). Not a regression: today, every nested child is
- * already split away from its parent unconditionally, so this is
- * strictly no worse for the second-and-later children while fixing the
- * common single-child case.
+ * Closing a node emits it as its own block *only when it never acquired a
+ * child* (a leaf): the block is that leaf's still-open ancestors' own
+ * lines (root through parent, in document order) followed by the leaf's
+ * own lines. A node that did acquire a child is never emitted standalone
+ * — its own lines already appear as the ancestor prefix of every one of
+ * its descendant leaf blocks, so nothing is lost. Net effect: every
+ * root-to-leaf path down the tree emits exactly one block containing
+ * every node on that path, and every node lies on at least one such path.
+ * That scopes a parent bullet's coordination language together with
+ * *every* nested child's reference at any depth — not only the first
+ * child under a given parent, fixing the residual gap #1472 left behind
+ * — while same-depth sibling bullets never share a leaf block with each
+ * other, preserving the original tight-list sentence-conflation fix this
+ * function exists for.
+ *
+ * Lines seen before any node has opened (a plain-prose preamble, or an
+ * entire paragraph with no markers at all) accumulate in a separate
+ * `preamble` buffer rather than the stack — there is no ancestor above
+ * pre-first-marker prose to scope it with. `preamble` is flushed as its
+ * own standalone block as soon as the first marker line opens a node
+ * (preserving the existing behavior that leading prose never merges with
+ * the first list item), or as the paragraph's sole block if no marker
+ * ever appears.
  */
 function splitIntoListItemBlocks(paragraph) {
   const blocks = [];
-  let current = [];
-  let lastMarkerIndent = null;
+  const stack = [];
+  let preamble = [];
+  const closeNode = (node) => {
+    if (node.hasChild) {
+      return;
+    }
+    const ancestorLines = stack.flatMap((ancestor) => ancestor.lines);
+    blocks.push([...ancestorLines, ...node.lines].join('\n'));
+  };
   for (const line of paragraph.split('\n')) {
     const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
     const indent = marker === null ? null : indentColumnWidth(marker[1]);
-    const startsNewBlock =
-      indent !== null &&
-      current.length > 0 &&
-      (lastMarkerIndent === null || indent <= lastMarkerIndent);
-    if (startsNewBlock) {
-      blocks.push(current.join('\n'));
-      current = [line];
-    } else {
-      current.push(line);
+    if (indent === null) {
+      // Continuation line: attach to the deepest open node, or to the
+      // pre-first-marker preamble if no node is open yet.
+      const top = stack.at(-1);
+      if (top === undefined) {
+        preamble.push(line);
+      } else {
+        top.lines.push(line);
+      }
+      continue;
     }
-    if (indent !== null) {
-      lastMarkerIndent = indent;
+    // A same-or-shallower marker closes every open node at this depth or
+    // deeper — one level at a time — before the new marker starts its own
+    // node, mirroring the original single-value comparison per stack
+    // level instead of once against a single flattened scalar.
+    for (
+      let top = stack.at(-1);
+      top !== undefined && indent <= top.indent;
+      top = stack.at(-1)
+    ) {
+      stack.pop();
+      closeNode(top);
     }
+    const parent = stack.at(-1);
+    if (parent !== undefined) {
+      parent.hasChild = true;
+    } else if (preamble.length > 0) {
+      blocks.push(preamble.join('\n'));
+      preamble = [];
+    }
+    stack.push({ indent, lines: [line], hasChild: false });
   }
-  if (current.length > 0) {
-    blocks.push(current.join('\n'));
+  for (let top = stack.at(-1); top !== undefined; top = stack.at(-1)) {
+    stack.pop();
+    closeNode(top);
+  }
+  if (preamble.length > 0) {
+    blocks.push(preamble.join('\n'));
   }
   return blocks;
 }

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -603,14 +603,17 @@ without ending the title early and losing the rest of the link. An empty
 or whitespace-only `--current-repo` (or `$GITHUB_REPOSITORY`) is treated
 the same as omitting it entirely, rather than as a known repository that
 can never match. A nested/child list item's reference is evaluated
-together with its parent bullet's coordination-language text instead of
-being scoped away from it, while a sibling bullet at the same
+together with its full ancestor chain's coordination-language text
+instead of being scoped away from it, while a sibling bullet at the same
 indentation — nested or top-level — still starts its own separate scope,
 preserving the tight-list sentence-conflation fix mentioned above. This
-holds for the first nested child under a given parent; a parent with two
-or more nested children currently keeps only the first one scoped with
-it — a known, tracked limitation, not a guarantee for every nested
-child. Unlike every other check above, a
+holds for every nested child under a given parent, at any depth — not
+only the first. A known, tracked limitation remains for a tight list
+only: a continuation line resuming at an ancestor's own indentation
+after a deeper child has already opened is still attributed to that
+child rather than the ancestor, and a loose list (a blank line between
+sibling items) resets scope at the paragraph boundary before this check
+ever sees it. Unlike every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -949,6 +949,16 @@ interface ListItemNode {
  * (preserving the existing behavior that leading prose never merges with
  * the first list item), or as the paragraph's sole block if no marker
  * ever appears.
+ *
+ * Known, tracked residual gaps (tracked in #1476, distinct from the
+ * marker-ancestry scoping this function fixes): a continuation line
+ * resuming at an ancestor's own indentation after a deeper child has
+ * already opened is still attributed to that child rather than the
+ * ancestor (see the `top.lines.push(line)` continuation-line branch
+ * below), and a loose list — sibling items separated by a blank
+ * line — resets scope at the paragraph boundary before this function
+ * ever runs, since its caller (`checkProseOnlyDependency`) splits on
+ * blank lines first.
  */
 function splitIntoListItemBlocks(paragraph: string): string[] {
   const blocks: string[] = [];

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -250,8 +250,9 @@ const ISSUE_OR_PR_REFERENCE_PATTERN =
 // followed by a task-list checkbox. Captures the leading indentation
 // (group 1) so splitIntoListItemBlocks can tell a deeper-indented
 // nested/child marker from a new marker at the same or shallower
-// indentation as the most recently seen one — see that function for how
-// the two are told apart. Declared here (before the CLI entry
+// indentation as the currently open node at that depth in its
+// indentation-ancestry stack — see that function for how the two are
+// told apart. Declared here (before the CLI entry
 // block below), not next to splitIntoSentences/splitIntoListItemBlocks
 // that use it, because those are hoisted function declarations but this
 // is a module-level `const` — declaring it after the entry block would be
@@ -897,6 +898,19 @@ function indentColumnWidth(indent: string): number {
   return column;
 }
 
+// One open Markdown list-item node in splitIntoListItemBlocks's
+// indentation-ancestry stack. `lines` accumulates the node's own marker
+// line plus any soft-wrapped continuation lines that belong directly to
+// it (before any deeper child of its own begins). `hasChild` records
+// whether a deeper node was ever pushed on top of this one — see
+// splitIntoListItemBlocks for why that suppresses this node's own
+// standalone block.
+interface ListItemNode {
+  indent: number;
+  lines: string[];
+  hasChild: boolean;
+}
+
 /**
  * Split a paragraph into blocks at each Markdown list item boundary, while
  * still joining a soft-wrapped continuation line (one with no list marker
@@ -904,49 +918,92 @@ function indentColumnWidth(indent: string): number {
  * at all yields exactly one block spanning every line, preserving prior
  * behavior for plain prose.
  *
- * A marker line's indentation is compared against the *most recently
- * seen* marker line's indentation (not the current block's own starting
- * indentation): a *deeper* indentation is a nested/child item and stays
- * part of the running block, so a parent bullet's coordination language
- * and a nested child's reference are scoped together instead of being
- * split into unrelated blocks (see issue #1472). A marker at the *same or
- * shallower* indentation as the most recently seen marker still starts a
- * new block, preserving the original tight-list sentence-conflation fix
- * this function exists for — separate sibling bullets, at any shared
- * indentation depth, never merge with each other.
+ * Tracks a full indentation-ancestry stack of open `ListItemNode`s rather
+ * than a single most-recently-seen marker indentation (see issue #1474):
+ * a marker line strictly *deeper* than the stack's top is pushed as a new
+ * child node, nested under it. A marker at the *same or shallower*
+ * indentation pops nodes off the stack — closing each one — until the top
+ * is strictly shallower (or the stack empties), then pushes the new
+ * marker as a fresh node at that level.
  *
- * Known, accepted residual gap: a parent bullet with two or more nested
- * children only keeps the *first* child merged with the parent's text — a
- * later same-depth sibling still starts its own new block (indistinguishable
- * here from a same-depth sibling of the parent itself, without tracking a
- * full indentation stack). Not a regression: today, every nested child is
- * already split away from its parent unconditionally, so this is
- * strictly no worse for the second-and-later children while fixing the
- * common single-child case.
+ * Closing a node emits it as its own block *only when it never acquired a
+ * child* (a leaf): the block is that leaf's still-open ancestors' own
+ * lines (root through parent, in document order) followed by the leaf's
+ * own lines. A node that did acquire a child is never emitted standalone
+ * — its own lines already appear as the ancestor prefix of every one of
+ * its descendant leaf blocks, so nothing is lost. Net effect: every
+ * root-to-leaf path down the tree emits exactly one block containing
+ * every node on that path, and every node lies on at least one such path.
+ * That scopes a parent bullet's coordination language together with
+ * *every* nested child's reference at any depth — not only the first
+ * child under a given parent, fixing the residual gap #1472 left behind
+ * — while same-depth sibling bullets never share a leaf block with each
+ * other, preserving the original tight-list sentence-conflation fix this
+ * function exists for.
+ *
+ * Lines seen before any node has opened (a plain-prose preamble, or an
+ * entire paragraph with no markers at all) accumulate in a separate
+ * `preamble` buffer rather than the stack — there is no ancestor above
+ * pre-first-marker prose to scope it with. `preamble` is flushed as its
+ * own standalone block as soon as the first marker line opens a node
+ * (preserving the existing behavior that leading prose never merges with
+ * the first list item), or as the paragraph's sole block if no marker
+ * ever appears.
  */
 function splitIntoListItemBlocks(paragraph: string): string[] {
   const blocks: string[] = [];
-  let current: string[] = [];
-  let lastMarkerIndent: number | null = null;
+  const stack: ListItemNode[] = [];
+  let preamble: string[] = [];
+
+  const closeNode = (node: ListItemNode) => {
+    if (node.hasChild) {
+      return;
+    }
+    const ancestorLines = stack.flatMap((ancestor) => ancestor.lines);
+    blocks.push([...ancestorLines, ...node.lines].join('\n'));
+  };
+
   for (const line of paragraph.split('\n')) {
     const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
     const indent = marker === null ? null : indentColumnWidth(marker[1]);
-    const startsNewBlock =
-      indent !== null &&
-      current.length > 0 &&
-      (lastMarkerIndent === null || indent <= lastMarkerIndent);
-    if (startsNewBlock) {
-      blocks.push(current.join('\n'));
-      current = [line];
-    } else {
-      current.push(line);
+    if (indent === null) {
+      // Continuation line: attach to the deepest open node, or to the
+      // pre-first-marker preamble if no node is open yet.
+      const top = stack.at(-1);
+      if (top === undefined) {
+        preamble.push(line);
+      } else {
+        top.lines.push(line);
+      }
+      continue;
     }
-    if (indent !== null) {
-      lastMarkerIndent = indent;
+    // A same-or-shallower marker closes every open node at this depth or
+    // deeper — one level at a time — before the new marker starts its own
+    // node, mirroring the original single-value comparison per stack
+    // level instead of once against a single flattened scalar.
+    for (
+      let top = stack.at(-1);
+      top !== undefined && indent <= top.indent;
+      top = stack.at(-1)
+    ) {
+      stack.pop();
+      closeNode(top);
     }
+    const parent = stack.at(-1);
+    if (parent !== undefined) {
+      parent.hasChild = true;
+    } else if (preamble.length > 0) {
+      blocks.push(preamble.join('\n'));
+      preamble = [];
+    }
+    stack.push({ indent, lines: [line], hasChild: false });
   }
-  if (current.length > 0) {
-    blocks.push(current.join('\n'));
+  for (let top = stack.at(-1); top !== undefined; top = stack.at(-1)) {
+    stack.pop();
+    closeNode(top);
+  }
+  if (preamble.length > 0) {
+    blocks.push(preamble.join('\n'));
   }
   return blocks;
 }

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1424,6 +1424,100 @@ test('prose-dependency recognizes a tab-indented nested child as deeper than its
   assert.match(finding?.detail ?? '', /#1391/);
 });
 
+// --- prose-dependency: every nested sibling under one parent, not just
+// the first (#1474) ---
+
+test('prose-dependency recognizes a reference in the second nested child under one parent, not only the first', () => {
+  // Regression test for the exact gap #1474 tracks: the pre-#1474
+  // single-most-recently-seen-marker comparison kept only the FIRST
+  // child merged with the parent's block -- once that first child was
+  // processed, the comparison value became the child's own (deeper)
+  // indentation, so the second same-depth child compared against that
+  // instead of the parent and started a fresh block, losing the
+  // parent's coordination language exactly like every child did before
+  // #1472 shipped.
+  const body = childBody({
+    extraMarkers:
+      '- Before starting this work:\n' +
+      '  - Gather context\n' +
+      '  - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency recognizes a reference in the third nested child under one parent', () => {
+  // Generalizes the second-child case above to a third sibling, proving
+  // the indentation-ancestry stack scopes every child at a given depth
+  // with the parent -- not merely the first two.
+  const body = childBody({
+    extraMarkers:
+      '- Before starting this work:\n' +
+      '  - Gather context\n' +
+      '  - Draft the plan\n' +
+      '  - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency recognizes a reference nested under a non-first branch of a multi-level list', () => {
+  // Multi-level nesting (grandparent / two sibling parent branches /
+  // child), reference in a child under the SECOND (non-first) branch.
+  // Under the pre-#1474 single-most-recently-seen-marker comparison,
+  // once the first branch's own child was processed, the comparison
+  // value sat at that child's depth; the second branch's marker (same
+  // depth as the first branch) started a fresh block with nothing
+  // carried over, so the grandparent's coordination language never
+  // reached the second branch's own child -- the reference was silently
+  // never flagged. The indentation-ancestry stack fixes this: every
+  // node still open above the current one (grandparent, and this
+  // branch) prefixes the leaf block, regardless of what an earlier
+  // sibling branch already consumed.
+  const body = childBody({
+    extraMarkers:
+      '- Before this release:\n' +
+      '  - First branch: nothing notable here\n' +
+      '  - Second branch:\n' +
+      '    - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency does not merge plain prose directly followed by a list item with no blank line', () => {
+  // Regression guard for the preamble-flush rule the #1474 rework
+  // introduces: lines seen before any list marker opens must still be
+  // flushed as their OWN block the moment the first marker appears
+  // (matching pre-#1474 behavior), not merged into the first list
+  // item's block. No terminal punctuation is used deliberately -- an
+  // incorrect merge of the preamble into the following list item's
+  // block would put the keyword and the reference in the same
+  // sentence (nothing else would split them apart), which would wrongly
+  // flag it.
+  const body = childBody({
+    extraMarkers: 'Confirm before merging\n- PR #1391 is an unrelated bullet',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
 // --- prose-dependency: empty-string currentRepo (#1472) ---
 
 test('prose-dependency treats an empty-string currentRepo as unknown', () => {


### PR DESCRIPTION
# Summary

Reworks `splitIntoListItemBlocks` in `src/scripts/audit-authored-issue.mts`
to track a full indentation-ancestry stack instead of a single
most-recently-seen marker indentation, so **every** nested child under a
parent bullet — not only the first — stays scoped with its ancestor
chain's coordination language:

```markdown
- Before starting:
  - Gather context
  - PR #1391 must land
```

Before this change, `#1391` was not flagged: #1472's fix merged only the
*first* child ("Gather context") into the parent's block; the second
child reset the comparison to its own depth and started a fresh block,
losing "Before starting" — the same loss-of-parent-scope #1472 fixed for
the single-child case, recurring for every child after the first.

The new design: every root-to-leaf path down the list tree emits exactly
one block containing every node on that path (a leaf's still-open
ancestors' lines, in document order, followed by its own), and a node
that acquired a child is never emitted standalone — its lines already
prefix every one of its descendant leaf blocks, so nothing is lost. Same-
depth sibling bullets still never share a leaf block with each other,
preserving the original tight-list sentence-conflation fix this function
exists for. The function's signature and contract
(`(paragraph: string) => string[]`) are unchanged, so its callers
(`splitIntoSentences`, `checkProseOnlyDependency`) need no changes.

This check remains advisory-only (never flips `passed` or the exit
code).

## Linked issue

Closes #1474

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This is the fourth generation of a deferral chain (#1399 → #1468 → #1472
→ #1474), but unlike its predecessors (surface-level regex edge cases),
#1474 was explicitly filed as the deferred architectural fix that
#1472's own scope note left behind, so it is implemented in full here
rather than deferred again.

The design was validated by hand-tracing it against all 4 existing
codified regression tests (single-child nested scoping, `Blocked by`-
encoded suppression, top-level-sibling separation with a nested child,
tab-indented depth comparison) before writing any code, plus the new
cases below. A critique pass on the plan (before implementation) caught
one real gap: the plan's prose asserted a "preamble" (pre-first-marker
prose) flush rule without specifying its mechanism, which a literal
reading would have broken for every zero-marker-paragraph test in the
suite. The plan was revised to state the flush rule explicitly, and a
dedicated regression test (below) now covers the specific "prose
immediately followed by a list item, no blank line" case that gap would
have silently missed.

New regression tests added, each confirmed to **fail against the
prior implementation** before this fix (except the last, a non-regression
guard confirmed to already pass on both):

- A reference in the **second** nested child under one parent.
- A reference in the **third** nested child under one parent (generalizes
  beyond just "second").
- Multi-level nesting (grandparent / two sibling branches / child), with
  the reference in a child under the **second** (non-first) branch.
- Plain prose immediately followed by a list item with no blank line
  (preamble-flush non-regression guard).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (typecheck, `build:check`, biome, dprint, `node --test`,
      workshop-integrity, cspell, markdownlint — equivalent commands run
      individually, see below)
- [x] `pnpm test` — `node --test tests/audit-authored-issue.test.mts`:
      102/102 pass (98 pre-existing + 4 new regression tests). Full suite
      `node --test tests/*.test.mts`: 2323/2326 pass; the 3 failures are
      all in `tests/branch-conflict-state.test.mts`
      (`classifyBranchConflictState: ...`), a pre-existing fixture
      GPG-pinentry-timeout issue in this local environment, unrelated to
      this diff (confirmed by file/test name — this diff does not touch
      that file).
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (pre-existing, unrelated warnings only)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
