### PR TITLE
fix(issue-authoring): close remaining prose-dependency scoping gaps

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -614,10 +614,13 @@ that ancestor rather than the deepest open child. A loose list (a blank
 line between sibling items) preserves the same ancestor scope across
 the blank line, as long as the following item's own marker is no deeper
 than whatever is still open at the end of the preceding item — a
-same-depth sibling, or a resumption at a shallower ancestor's own level;
-a blank line directly followed by a more deeply indented marker is not
-bridged, to avoid grafting an unrelated item onto an open ancestor as a
-false child. Unlike every other check above, a
+same-depth sibling, or a resumption at a shallower ancestor's own
+level — and the preceding item ends in a list marker rather than
+trailing plain prose (once plain prose follows the last marker, the
+list reads as already having ended, so the blank line is not bridged).
+A blank line directly followed by a more deeply indented marker is also
+not bridged, to avoid grafting an unrelated item onto an open ancestor
+as a false child. Unlike every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -608,12 +608,16 @@ instead of being scoped away from it, while a sibling bullet at the same
 indentation — nested or top-level — still starts its own separate scope,
 preserving the tight-list sentence-conflation fix mentioned above. This
 holds for every nested child under a given parent, at any depth — not
-only the first. A known, tracked limitation remains for a tight list
-only: a continuation line resuming at an ancestor's own indentation
-after a deeper child has already opened is still attributed to that
-child rather than the ancestor, and a loose list (a blank line between
-sibling items) resets scope at the paragraph boundary before this check
-ever sees it. Unlike every other check above, a
+only the first. A continuation line resuming at an ancestor's own
+indentation, after a deeper child has already opened, is attributed to
+that ancestor rather than the deepest open child. A loose list (a blank
+line between sibling items) preserves the same ancestor scope across
+the blank line, as long as the following item's own marker is no deeper
+than whatever is still open at the end of the preceding item — a
+same-depth sibling, or a resumption at a shallower ancestor's own level;
+a blank line directly followed by a more deeply indented marker is not
+bridged, to avoid grafting an unrelated item onto an open ancestor as a
+false child. Unlike every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -470,9 +470,12 @@ list (a blank line between sibling items) preserves the same ancestor
 scope across the blank line, as long as the following item's own marker
 is no deeper than whatever is still open at the end of the preceding
 item -- a same-depth sibling, or a resumption at a shallower ancestor's
-own level; a blank line directly followed by a more deeply indented
-marker is not bridged, to avoid grafting an unrelated item onto an open
-ancestor as a false child. A
+own level -- and the preceding item ends in a list marker rather than
+trailing plain prose (once plain prose follows the last marker, the
+list reads as already having ended, so the blank line is not bridged).
+A blank line directly followed by a more deeply indented marker is also
+not bridged, to avoid grafting an unrelated item onto an open ancestor
+as a false child. A
 `prose-dependency` warning never flips `passed` to
 `false` and never changes the linter's exit code; it prompts the author
 to convert the prose into a proper dependency marker or consciously

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -463,12 +463,16 @@ nested/child list item's reference is evaluated together with its full
 ancestor chain's coordination-language text instead of being scoped away
 from it, while a same-depth sibling bullet still starts its own separate
 scope. This holds for every nested child under a given parent, at any
-depth -- not only the first. A known, tracked limitation remains for a
-tight list only: a continuation line resuming at an ancestor's own
-indentation after a deeper child has already opened is still attributed
-to that child rather than the ancestor, and a loose list (a blank line
-between sibling items) resets scope at the paragraph boundary before
-this check ever sees it. A
+depth -- not only the first. A continuation line resuming at an
+ancestor's own indentation, after a deeper child has already opened, is
+attributed to that ancestor rather than the deepest open child. A loose
+list (a blank line between sibling items) preserves the same ancestor
+scope across the blank line, as long as the following item's own marker
+is no deeper than whatever is still open at the end of the preceding
+item -- a same-depth sibling, or a resumption at a shallower ancestor's
+own level; a blank line directly followed by a more deeply indented
+marker is not bridged, to avoid grafting an unrelated item onto an open
+ancestor as a false child. A
 `prose-dependency` warning never flips `passed` to
 `false` and never changes the linter's exit code; it prompts the author
 to convert the prose into a proper dependency marker or consciously

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -749,13 +749,19 @@ function isSingleBlankLine(separator) {
 // having ended before the blank line, even though the algorithm's stack
 // still shows a node open (the trailing prose is a continuation line
 // attached via the ancestry walk, not a marker, so nothing closes it).
-// Bridging across the blank line in that shape would scope "Before"
-// onto a reference in the next chunk that the source never associated
-// with it. Rather than trying to re-derive CommonMark's real
-// list-termination rule, require the last marker line to *be* the run's
-// last line -- any trailing continuation line makes "is this list still
-// open" ambiguous enough that refusing to bridge (a missed advisory,
-// not a false one) is the safer default, matching the same
+// CommonMark's own lazy-continuation rule technically disagrees --
+// "Independent prose" is absorbed into "child"'s own paragraph rather
+// than ending the list -- but that is a well-known surprising edge case
+// that misleads readers (this PR's own Codex review included) far more
+// often than it helps them, so this heuristic follows the visual
+// reading over the stricter spec rule. Bridging across the blank line
+// in that shape would scope "Before" onto a reference in the next chunk
+// that a human author would not expect it to reach. Rather than trying
+// to fully re-derive CommonMark's real list-termination semantics,
+// require the last marker line to *be* the run's last line -- any
+// trailing continuation line makes "is this list still open" ambiguous
+// enough that refusing to bridge (a missed advisory, not a false one)
+// is the safer default, matching the same
 // prefer-a-miss-over-a-false-positive stance the indentation guard below
 // already takes for a too-deep right-hand marker.
 //

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -734,23 +734,45 @@ function isSingleBlankLine(separator) {
   return (separator.match(/\n/g)?.length ?? 0) === 2;
 }
 // Once any list-item marker line appears in a blank-line-free run of
-// text, only a *later* marker line can close its node (a continuation
-// line never does -- see splitIntoListItemBlocks). So the *last* marker
-// line anywhere in such a run is necessarily still open at the run's
-// end, and that marker's own indentation is an exact, cheap proxy for
-// "the indentation of whatever node is still open right before the
-// blank line" -- without re-running the full ancestry-stack simulation
-// just to find out. Returns undefined when `text` has no marker line at
-// all.
+// text, only a *later* marker line can close its node in
+// splitIntoListItemBlocks's own stack bookkeeping (a continuation line
+// never does). So, structurally, the *last* marker line anywhere in such
+// a run is necessarily still open at the run's end, and that marker's
+// own indentation is a cheap proxy for "the indentation of whatever node
+// is still open right before the blank line" -- without re-running the
+// full ancestry-stack simulation just to find out.
+//
+// That structural fact is not the same as the list still being open in
+// the Markdown a human reader sees, though (found on this PR's own
+// review, Codex): a marker followed by unindented plain prose --
+// `- Before merging\n  - child\nIndependent prose` -- reads as the list
+// having ended before the blank line, even though the algorithm's stack
+// still shows a node open (the trailing prose is a continuation line
+// attached via the ancestry walk, not a marker, so nothing closes it).
+// Bridging across the blank line in that shape would scope "Before"
+// onto a reference in the next chunk that the source never associated
+// with it. Rather than trying to re-derive CommonMark's real
+// list-termination rule, require the last marker line to *be* the run's
+// last line -- any trailing continuation line makes "is this list still
+// open" ambiguous enough that refusing to bridge (a missed advisory,
+// not a false one) is the safer default, matching the same
+// prefer-a-miss-over-a-false-positive stance the indentation guard below
+// already takes for a too-deep right-hand marker.
+//
+// Returns undefined when `text` has no marker line at all, or when a
+// continuation line follows the last marker line.
 function lastListItemMarkerIndent(text) {
-  let last;
-  for (const line of text.split('\n')) {
-    const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
+  const lines = text.split('\n');
+  let lastMarkerIndex = -1;
+  let lastMarkerIndent;
+  for (let index = 0; index < lines.length; index += 1) {
+    const marker = LIST_ITEM_MARKER_PATTERN.exec(lines[index]);
     if (marker !== null) {
-      last = indentColumnWidth(marker[1]);
+      lastMarkerIndex = index;
+      lastMarkerIndent = indentColumnWidth(marker[1]);
     }
   }
-  return last;
+  return lastMarkerIndex === lines.length - 1 ? lastMarkerIndent : undefined;
 }
 // Two adjacent blank-line-delimited chunks bridge into one loose-list
 // paragraph only when the right chunk's first marker is no deeper than

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -169,6 +169,15 @@ const ISSUE_OR_PR_REFERENCE_PATTERN =
 // a TDZ risk under the CLI path, which calls main() synchronously at this
 // point in module evaluation (see tests/cli-entry-smoke.test.mts).
 const LIST_ITEM_MARKER_PATTERN = /^(\s*)(?:[-*+]|\d+[.)])\s+/;
+// A continuation line (no list-item marker of its own) has no
+// LIST_ITEM_MARKER_PATTERN capture group to read an indentation from,
+// unlike a marker line — its own leading whitespace has to be measured
+// directly (see `lineIndentColumn`, used by splitIntoListItemBlocks's
+// continuation-line branch, #1476). Declared here for the same
+// TDZ reason as LIST_ITEM_MARKER_PATTERN immediately above: this is a
+// module-level `const` reached by the same synchronous CLI call path,
+// not a hoisted function declaration.
+const LEADING_WHITESPACE_PATTERN = /^\s*/;
 // Matches a Markdown reference-style link *usage*: `[text][ref]`, where a
 // separate `[ref]: <target>` definition (matched by
 // LINK_REFERENCE_DEFINITION_PATTERN below) supplies the actual target
@@ -568,7 +577,7 @@ function checkProseOnlyDependency(text, currentRepo) {
   // trailing-content handling — recognizes it with no duplicated matching
   // logic. Scoped to this check only; other checks keep using `text`.
   const resolvedText = resolveReferenceStyleLinks(text);
-  for (const paragraph of resolvedText.split(/\n\s*\n/)) {
+  for (const paragraph of splitIntoParagraphs(resolvedText)) {
     for (const sentence of splitIntoSentences(paragraph)) {
       // Scope proximity to one sentence, not the whole paragraph: a long
       // paragraph can legitimately combine an unrelated coordination word
@@ -716,6 +725,98 @@ function resolveReferenceStyleLinks(text) {
     },
   );
 }
+// Exactly one blank line between two lines of content is two newline
+// characters (the left line's own terminator, then the blank line's
+// own terminator). Two or more blank lines means three or more, which
+// splitIntoParagraphs deliberately treats as a harder break -- see its
+// own doc comment.
+function isSingleBlankLine(separator) {
+  return (separator.match(/\n/g)?.length ?? 0) === 2;
+}
+// Once any list-item marker line appears in a blank-line-free run of
+// text, only a *later* marker line can close its node (a continuation
+// line never does -- see splitIntoListItemBlocks). So the *last* marker
+// line anywhere in such a run is necessarily still open at the run's
+// end, and that marker's own indentation is an exact, cheap proxy for
+// "the indentation of whatever node is still open right before the
+// blank line" -- without re-running the full ancestry-stack simulation
+// just to find out. Returns undefined when `text` has no marker line at
+// all.
+function lastListItemMarkerIndent(text) {
+  let last;
+  for (const line of text.split('\n')) {
+    const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
+    if (marker !== null) {
+      last = indentColumnWidth(marker[1]);
+    }
+  }
+  return last;
+}
+// Two adjacent blank-line-delimited chunks bridge into one loose-list
+// paragraph only when the right chunk's first marker is no deeper than
+// whatever is still open at the end of the left chunk -- a same-depth
+// sibling continuation, or a resumption at a shallower ancestor's own
+// level, both legitimate loose-list shapes that splitIntoListItemBlocks's
+// existing same-or-shallower sibling-closing logic already re-separates
+// correctly when they are not actually related. A *strictly deeper*
+// right-hand marker is refused: bridging it would invent a parent/child
+// relationship across a blank line the source never expressed -- for
+// example a punctuation-free, keyword-bearing checklist item directly
+// followed by an unrelated, more-indented bullet, which would otherwise
+// flatten into one false-positive "sentence" (see #1476).
+function isBridgeableLooseListBoundary(left, separator, right) {
+  if (!isSingleBlankLine(separator)) {
+    return false;
+  }
+  const leftTailIndent = lastListItemMarkerIndent(left);
+  if (leftTailIndent === undefined) {
+    return false;
+  }
+  const rightMarker = LIST_ITEM_MARKER_PATTERN.exec(right.split('\n')[0] ?? '');
+  return (
+    rightMarker !== null && indentColumnWidth(rightMarker[1]) <= leftTailIndent
+  );
+}
+/**
+ * Splits `text` into paragraphs the same way as `text.split(/\n\s*\n/)`,
+ * except that two adjacent blank-line-delimited chunks are re-joined
+ * into one paragraph when the blank line between them sits inside what
+ * reads as a single loose Markdown list (see `isBridgeableLooseListBoundary`
+ * and #1476). Without this, a loose list -- its sibling items separated
+ * by a blank line, which is ordinary, valid CommonMark -- silently loses
+ * every earlier sibling's ancestor-scoped coordination language the
+ * moment `splitIntoListItemBlocks` runs on each paragraph independently.
+ *
+ * The blank line itself is preserved verbatim in the merged text rather
+ * than dropped: `splitIntoListItemBlocks` treats it like any other
+ * continuation line (no marker of its own), which never closes a node,
+ * so it is inert other than contributing a single collapsed space once
+ * `splitIntoSentences` later flattens the block.
+ *
+ * Merge decisions fold left-to-right against the *running accumulator*,
+ * not the original first chunk, so a loose list of three or more sibling
+ * items (blank line before the second, blank line before the third, and
+ * so on) keeps bridging correctly -- each decision re-derives the
+ * accumulator's own trailing indentation from whatever has already been
+ * merged in.
+ */
+function splitIntoParagraphs(text) {
+  const parts = text.split(/(\n\s*\n)/);
+  const paragraphs = [];
+  let current = parts[0] ?? '';
+  for (let index = 1; index < parts.length; index += 2) {
+    const separator = parts[index] ?? '';
+    const next = parts[index + 1] ?? '';
+    if (isBridgeableLooseListBoundary(current, separator, next)) {
+      current += separator + next;
+    } else {
+      paragraphs.push(current);
+      current = next;
+    }
+  }
+  paragraphs.push(current);
+  return paragraphs;
+}
 /**
  * Split a paragraph into sentences on `.`/`!`/`?` followed by whitespace,
  * after collapsing internal newlines to spaces (so a sentence that wraps
@@ -756,6 +857,9 @@ function indentColumnWidth(indent) {
   }
   return column;
 }
+function lineIndentColumn(line) {
+  return indentColumnWidth(LEADING_WHITESPACE_PATTERN.exec(line)?.[0] ?? '');
+}
 /**
  * Split a paragraph into blocks at each Markdown list item boundary, while
  * still joining a soft-wrapped continuation line (one with no list marker
@@ -795,15 +899,16 @@ function indentColumnWidth(indent) {
  * the first list item), or as the paragraph's sole block if no marker
  * ever appears.
  *
- * Known, tracked residual gaps (tracked in #1476, distinct from the
- * marker-ancestry scoping this function fixes): a continuation line
- * resuming at an ancestor's own indentation after a deeper child has
- * already opened is still attributed to that child rather than the
- * ancestor (see the `top.lines.push(line)` continuation-line branch
- * below), and a loose list — sibling items separated by a blank
- * line — resets scope at the paragraph boundary before this function
- * ever runs, since its caller (`checkProseOnlyDependency`) splits on
- * blank lines first.
+ * Two further gaps in the same area, both distinct from the
+ * marker-ancestry scoping above, were closed by #1476: a continuation
+ * line resuming at an ancestor's own indentation after a deeper child
+ * has already opened is now attributed to that ancestor rather than the
+ * deepest open child (see the ancestry walk in the continuation-line
+ * branch below, using `lineIndentColumn`), and a loose list — sibling
+ * items separated by a blank line — no longer resets scope at the
+ * paragraph boundary, because its caller (`checkProseOnlyDependency`)
+ * now bridges a single blank line between two loose-list chunks via
+ * `splitIntoParagraphs` before this function ever runs.
  */
 function splitIntoListItemBlocks(paragraph) {
   const blocks = [];
@@ -820,14 +925,30 @@ function splitIntoListItemBlocks(paragraph) {
     const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
     const indent = marker === null ? null : indentColumnWidth(marker[1]);
     if (indent === null) {
-      // Continuation line: attach to the deepest open node, or to the
-      // pre-first-marker preamble if no node is open yet.
+      // Continuation line: attach to the deepest open node whose own
+      // indentation is strictly less than this line's own indentation --
+      // the innermost node this line still reads as nested inside of. A
+      // continuation at or above an already-open child's own marker
+      // indentation is not deep enough to be that child's content; walk
+      // up the ancestry until a strictly shallower owner is found,
+      // falling back to the shallowest (root) node when none is
+      // strictly shallower (#1476: this is what lets a continuation
+      // that resumes at an ancestor's own indentation, after a deeper
+      // child already opened, land on that ancestor instead of
+      // unconditionally on the deepest open child). A continuation
+      // genuinely deeper than every open node still resolves at the
+      // first (deepest) comparison, so the normal, unambiguous case is
+      // unchanged. When no node is open yet, keep attaching to the
+      // pre-first-marker preamble.
       const top = stack.at(-1);
       if (top === undefined) {
         preamble.push(line);
-      } else {
-        top.lines.push(line);
+        continue;
       }
+      const ownIndent = lineIndentColumn(line);
+      const owner =
+        stack.findLast((node) => node.indent < ownIndent) ?? stack[0];
+      owner.lines.push(line);
       continue;
     }
     // A same-or-shallower marker closes every open node at this depth or

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -614,10 +614,13 @@ that ancestor rather than the deepest open child. A loose list (a blank
 line between sibling items) preserves the same ancestor scope across
 the blank line, as long as the following item's own marker is no deeper
 than whatever is still open at the end of the preceding item — a
-same-depth sibling, or a resumption at a shallower ancestor's own level;
-a blank line directly followed by a more deeply indented marker is not
-bridged, to avoid grafting an unrelated item onto an open ancestor as a
-false child. Unlike every other check above, a
+same-depth sibling, or a resumption at a shallower ancestor's own
+level — and the preceding item ends in a list marker rather than
+trailing plain prose (once plain prose follows the last marker, the
+list reads as already having ended, so the blank line is not bridged).
+A blank line directly followed by a more deeply indented marker is also
+not bridged, to avoid grafting an unrelated item onto an open ancestor
+as a false child. Unlike every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -608,12 +608,16 @@ instead of being scoped away from it, while a sibling bullet at the same
 indentation — nested or top-level — still starts its own separate scope,
 preserving the tight-list sentence-conflation fix mentioned above. This
 holds for every nested child under a given parent, at any depth — not
-only the first. A known, tracked limitation remains for a tight list
-only: a continuation line resuming at an ancestor's own indentation
-after a deeper child has already opened is still attributed to that
-child rather than the ancestor, and a loose list (a blank line between
-sibling items) resets scope at the paragraph boundary before this check
-ever sees it. Unlike every other check above, a
+only the first. A continuation line resuming at an ancestor's own
+indentation, after a deeper child has already opened, is attributed to
+that ancestor rather than the deepest open child. A loose list (a blank
+line between sibling items) preserves the same ancestor scope across
+the blank line, as long as the following item's own marker is no deeper
+than whatever is still open at the end of the preceding item — a
+same-depth sibling, or a resumption at a shallower ancestor's own level;
+a blank line directly followed by a more deeply indented marker is not
+bridged, to avoid grafting an unrelated item onto an open ancestor as a
+false child. Unlike every other check above, a
 `prose-dependency` warning never flips `passed` to `false` and never
 changes the linter's exit code: it prompts the author to either
 convert the prose into a proper dependency marker or consciously

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -260,6 +260,16 @@ const ISSUE_OR_PR_REFERENCE_PATTERN =
 // point in module evaluation (see tests/cli-entry-smoke.test.mts).
 const LIST_ITEM_MARKER_PATTERN = /^(\s*)(?:[-*+]|\d+[.)])\s+/;
 
+// A continuation line (no list-item marker of its own) has no
+// LIST_ITEM_MARKER_PATTERN capture group to read an indentation from,
+// unlike a marker line — its own leading whitespace has to be measured
+// directly (see `lineIndentColumn`, used by splitIntoListItemBlocks's
+// continuation-line branch, #1476). Declared here for the same
+// TDZ reason as LIST_ITEM_MARKER_PATTERN immediately above: this is a
+// module-level `const` reached by the same synchronous CLI call path,
+// not a hoisted function declaration.
+const LEADING_WHITESPACE_PATTERN = /^\s*/;
+
 // Matches a Markdown reference-style link *usage*: `[text][ref]`, where a
 // separate `[ref]: <target>` definition (matched by
 // LINK_REFERENCE_DEFINITION_PATTERN below) supplies the actual target
@@ -704,7 +714,7 @@ function checkProseOnlyDependency(
   // trailing-content handling — recognizes it with no duplicated matching
   // logic. Scoped to this check only; other checks keep using `text`.
   const resolvedText = resolveReferenceStyleLinks(text);
-  for (const paragraph of resolvedText.split(/\n\s*\n/)) {
+  for (const paragraph of splitIntoParagraphs(resolvedText)) {
     for (const sentence of splitIntoSentences(paragraph)) {
       // Scope proximity to one sentence, not the whole paragraph: a long
       // paragraph can legitimately combine an unrelated coordination word
@@ -856,6 +866,106 @@ function resolveReferenceStyleLinks(text: string): string {
   );
 }
 
+// Exactly one blank line between two lines of content is two newline
+// characters (the left line's own terminator, then the blank line's
+// own terminator). Two or more blank lines means three or more, which
+// splitIntoParagraphs deliberately treats as a harder break -- see its
+// own doc comment.
+function isSingleBlankLine(separator: string): boolean {
+  return (separator.match(/\n/g)?.length ?? 0) === 2;
+}
+
+// Once any list-item marker line appears in a blank-line-free run of
+// text, only a *later* marker line can close its node (a continuation
+// line never does -- see splitIntoListItemBlocks). So the *last* marker
+// line anywhere in such a run is necessarily still open at the run's
+// end, and that marker's own indentation is an exact, cheap proxy for
+// "the indentation of whatever node is still open right before the
+// blank line" -- without re-running the full ancestry-stack simulation
+// just to find out. Returns undefined when `text` has no marker line at
+// all.
+function lastListItemMarkerIndent(text: string): number | undefined {
+  let last: number | undefined;
+  for (const line of text.split('\n')) {
+    const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
+    if (marker !== null) {
+      last = indentColumnWidth(marker[1]);
+    }
+  }
+  return last;
+}
+
+// Two adjacent blank-line-delimited chunks bridge into one loose-list
+// paragraph only when the right chunk's first marker is no deeper than
+// whatever is still open at the end of the left chunk -- a same-depth
+// sibling continuation, or a resumption at a shallower ancestor's own
+// level, both legitimate loose-list shapes that splitIntoListItemBlocks's
+// existing same-or-shallower sibling-closing logic already re-separates
+// correctly when they are not actually related. A *strictly deeper*
+// right-hand marker is refused: bridging it would invent a parent/child
+// relationship across a blank line the source never expressed -- for
+// example a punctuation-free, keyword-bearing checklist item directly
+// followed by an unrelated, more-indented bullet, which would otherwise
+// flatten into one false-positive "sentence" (see #1476).
+function isBridgeableLooseListBoundary(
+  left: string,
+  separator: string,
+  right: string,
+): boolean {
+  if (!isSingleBlankLine(separator)) {
+    return false;
+  }
+  const leftTailIndent = lastListItemMarkerIndent(left);
+  if (leftTailIndent === undefined) {
+    return false;
+  }
+  const rightMarker = LIST_ITEM_MARKER_PATTERN.exec(right.split('\n')[0] ?? '');
+  return (
+    rightMarker !== null && indentColumnWidth(rightMarker[1]) <= leftTailIndent
+  );
+}
+
+/**
+ * Splits `text` into paragraphs the same way as `text.split(/\n\s*\n/)`,
+ * except that two adjacent blank-line-delimited chunks are re-joined
+ * into one paragraph when the blank line between them sits inside what
+ * reads as a single loose Markdown list (see `isBridgeableLooseListBoundary`
+ * and #1476). Without this, a loose list -- its sibling items separated
+ * by a blank line, which is ordinary, valid CommonMark -- silently loses
+ * every earlier sibling's ancestor-scoped coordination language the
+ * moment `splitIntoListItemBlocks` runs on each paragraph independently.
+ *
+ * The blank line itself is preserved verbatim in the merged text rather
+ * than dropped: `splitIntoListItemBlocks` treats it like any other
+ * continuation line (no marker of its own), which never closes a node,
+ * so it is inert other than contributing a single collapsed space once
+ * `splitIntoSentences` later flattens the block.
+ *
+ * Merge decisions fold left-to-right against the *running accumulator*,
+ * not the original first chunk, so a loose list of three or more sibling
+ * items (blank line before the second, blank line before the third, and
+ * so on) keeps bridging correctly -- each decision re-derives the
+ * accumulator's own trailing indentation from whatever has already been
+ * merged in.
+ */
+function splitIntoParagraphs(text: string): string[] {
+  const parts = text.split(/(\n\s*\n)/);
+  const paragraphs: string[] = [];
+  let current = parts[0] ?? '';
+  for (let index = 1; index < parts.length; index += 2) {
+    const separator = parts[index] ?? '';
+    const next = parts[index + 1] ?? '';
+    if (isBridgeableLooseListBoundary(current, separator, next)) {
+      current += separator + next;
+    } else {
+      paragraphs.push(current);
+      current = next;
+    }
+  }
+  paragraphs.push(current);
+  return paragraphs;
+}
+
 /**
  * Split a paragraph into sentences on `.`/`!`/`?` followed by whitespace,
  * after collapsing internal newlines to spaces (so a sentence that wraps
@@ -896,6 +1006,10 @@ function indentColumnWidth(indent: string): number {
     column = char === '\t' ? (Math.floor(column / 4) + 1) * 4 : column + 1;
   }
   return column;
+}
+
+function lineIndentColumn(line: string): number {
+  return indentColumnWidth(LEADING_WHITESPACE_PATTERN.exec(line)?.[0] ?? '');
 }
 
 // One open Markdown list-item node in splitIntoListItemBlocks's
@@ -950,15 +1064,16 @@ interface ListItemNode {
  * the first list item), or as the paragraph's sole block if no marker
  * ever appears.
  *
- * Known, tracked residual gaps (tracked in #1476, distinct from the
- * marker-ancestry scoping this function fixes): a continuation line
- * resuming at an ancestor's own indentation after a deeper child has
- * already opened is still attributed to that child rather than the
- * ancestor (see the `top.lines.push(line)` continuation-line branch
- * below), and a loose list — sibling items separated by a blank
- * line — resets scope at the paragraph boundary before this function
- * ever runs, since its caller (`checkProseOnlyDependency`) splits on
- * blank lines first.
+ * Two further gaps in the same area, both distinct from the
+ * marker-ancestry scoping above, were closed by #1476: a continuation
+ * line resuming at an ancestor's own indentation after a deeper child
+ * has already opened is now attributed to that ancestor rather than the
+ * deepest open child (see the ancestry walk in the continuation-line
+ * branch below, using `lineIndentColumn`), and a loose list — sibling
+ * items separated by a blank line — no longer resets scope at the
+ * paragraph boundary, because its caller (`checkProseOnlyDependency`)
+ * now bridges a single blank line between two loose-list chunks via
+ * `splitIntoParagraphs` before this function ever runs.
  */
 function splitIntoListItemBlocks(paragraph: string): string[] {
   const blocks: string[] = [];
@@ -977,14 +1092,30 @@ function splitIntoListItemBlocks(paragraph: string): string[] {
     const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
     const indent = marker === null ? null : indentColumnWidth(marker[1]);
     if (indent === null) {
-      // Continuation line: attach to the deepest open node, or to the
-      // pre-first-marker preamble if no node is open yet.
+      // Continuation line: attach to the deepest open node whose own
+      // indentation is strictly less than this line's own indentation --
+      // the innermost node this line still reads as nested inside of. A
+      // continuation at or above an already-open child's own marker
+      // indentation is not deep enough to be that child's content; walk
+      // up the ancestry until a strictly shallower owner is found,
+      // falling back to the shallowest (root) node when none is
+      // strictly shallower (#1476: this is what lets a continuation
+      // that resumes at an ancestor's own indentation, after a deeper
+      // child already opened, land on that ancestor instead of
+      // unconditionally on the deepest open child). A continuation
+      // genuinely deeper than every open node still resolves at the
+      // first (deepest) comparison, so the normal, unambiguous case is
+      // unchanged. When no node is open yet, keep attaching to the
+      // pre-first-marker preamble.
       const top = stack.at(-1);
       if (top === undefined) {
         preamble.push(line);
-      } else {
-        top.lines.push(line);
+        continue;
       }
+      const ownIndent = lineIndentColumn(line);
+      const owner =
+        stack.findLast((node) => node.indent < ownIndent) ?? stack[0];
+      owner.lines.push(line);
       continue;
     }
     // A same-or-shallower marker closes every open node at this depth or

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -891,13 +891,19 @@ function isSingleBlankLine(separator: string): boolean {
 // having ended before the blank line, even though the algorithm's stack
 // still shows a node open (the trailing prose is a continuation line
 // attached via the ancestry walk, not a marker, so nothing closes it).
-// Bridging across the blank line in that shape would scope "Before"
-// onto a reference in the next chunk that the source never associated
-// with it. Rather than trying to re-derive CommonMark's real
-// list-termination rule, require the last marker line to *be* the run's
-// last line -- any trailing continuation line makes "is this list still
-// open" ambiguous enough that refusing to bridge (a missed advisory,
-// not a false one) is the safer default, matching the same
+// CommonMark's own lazy-continuation rule technically disagrees --
+// "Independent prose" is absorbed into "child"'s own paragraph rather
+// than ending the list -- but that is a well-known surprising edge case
+// that misleads readers (this PR's own Codex review included) far more
+// often than it helps them, so this heuristic follows the visual
+// reading over the stricter spec rule. Bridging across the blank line
+// in that shape would scope "Before" onto a reference in the next chunk
+// that a human author would not expect it to reach. Rather than trying
+// to fully re-derive CommonMark's real list-termination semantics,
+// require the last marker line to *be* the run's last line -- any
+// trailing continuation line makes "is this list still open" ambiguous
+// enough that refusing to bridge (a missed advisory, not a false one)
+// is the safer default, matching the same
 // prefer-a-miss-over-a-false-positive stance the indentation guard below
 // already takes for a too-deep right-hand marker.
 //

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -876,23 +876,45 @@ function isSingleBlankLine(separator: string): boolean {
 }
 
 // Once any list-item marker line appears in a blank-line-free run of
-// text, only a *later* marker line can close its node (a continuation
-// line never does -- see splitIntoListItemBlocks). So the *last* marker
-// line anywhere in such a run is necessarily still open at the run's
-// end, and that marker's own indentation is an exact, cheap proxy for
-// "the indentation of whatever node is still open right before the
-// blank line" -- without re-running the full ancestry-stack simulation
-// just to find out. Returns undefined when `text` has no marker line at
-// all.
+// text, only a *later* marker line can close its node in
+// splitIntoListItemBlocks's own stack bookkeeping (a continuation line
+// never does). So, structurally, the *last* marker line anywhere in such
+// a run is necessarily still open at the run's end, and that marker's
+// own indentation is a cheap proxy for "the indentation of whatever node
+// is still open right before the blank line" -- without re-running the
+// full ancestry-stack simulation just to find out.
+//
+// That structural fact is not the same as the list still being open in
+// the Markdown a human reader sees, though (found on this PR's own
+// review, Codex): a marker followed by unindented plain prose --
+// `- Before merging\n  - child\nIndependent prose` -- reads as the list
+// having ended before the blank line, even though the algorithm's stack
+// still shows a node open (the trailing prose is a continuation line
+// attached via the ancestry walk, not a marker, so nothing closes it).
+// Bridging across the blank line in that shape would scope "Before"
+// onto a reference in the next chunk that the source never associated
+// with it. Rather than trying to re-derive CommonMark's real
+// list-termination rule, require the last marker line to *be* the run's
+// last line -- any trailing continuation line makes "is this list still
+// open" ambiguous enough that refusing to bridge (a missed advisory,
+// not a false one) is the safer default, matching the same
+// prefer-a-miss-over-a-false-positive stance the indentation guard below
+// already takes for a too-deep right-hand marker.
+//
+// Returns undefined when `text` has no marker line at all, or when a
+// continuation line follows the last marker line.
 function lastListItemMarkerIndent(text: string): number | undefined {
-  let last: number | undefined;
-  for (const line of text.split('\n')) {
-    const marker = LIST_ITEM_MARKER_PATTERN.exec(line);
+  const lines = text.split('\n');
+  let lastMarkerIndex = -1;
+  let lastMarkerIndent: number | undefined;
+  for (let index = 0; index < lines.length; index += 1) {
+    const marker = LIST_ITEM_MARKER_PATTERN.exec(lines[index]);
     if (marker !== null) {
-      last = indentColumnWidth(marker[1]);
+      lastMarkerIndex = index;
+      lastMarkerIndent = indentColumnWidth(marker[1]);
     }
   }
-  return last;
+  return lastMarkerIndex === lines.length - 1 ? lastMarkerIndent : undefined;
 }
 
 // Two adjacent blank-line-delimited chunks bridge into one loose-list

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1664,6 +1664,33 @@ test('prose-dependency does not bridge a blank line between plain prose and a fo
   assert.equal(finding.severity, undefined);
 });
 
+test('prose-dependency bridges a loose-list blank line to a shallower open ancestor, not just the same depth', () => {
+  // Regression test for a CodeRabbit review nitpick on this PR: every
+  // other loose-list positive test above resumes at exactly the same
+  // depth as the left chunk's tail node (rightHeadIndent === leftTailIndent),
+  // never exercising the genuinely-shallower branch of the
+  // `rightHeadIndent <= leftTailIndent` guard in
+  // isBridgeableLooseListBoundary. Here the left chunk ends three levels
+  // deep ("Sub-detail" at indent 4), and the item after the blank line
+  // resumes at "Gather context"'s own (shallower, indent-2) level --
+  // strictly less than 4, not equal to it. The bridge must still fire so
+  // "Before starting:" (the root) reaches "PR #1391".
+  const body = childBody({
+    extraMarkers:
+      '- Before starting:\n' +
+      '  - Gather context\n' +
+      '    - Sub-detail\n' +
+      '\n' +
+      '  - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
 // --- prose-dependency: empty-string currentRepo (#1472) ---
 
 test('prose-dependency treats an empty-string currentRepo as unknown', () => {

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1518,6 +1518,152 @@ test('prose-dependency does not merge plain prose directly followed by a list it
   assert.equal(finding.severity, undefined);
 });
 
+// --- prose-dependency: continuation-line and loose-list ancestor
+// scoping gaps (#1476) ---
+
+test('prose-dependency attributes a continuation line to its true ancestor, not the deepest open child', () => {
+  // Regression test for the exact gap #1476 tracks: a continuation line
+  // (no list marker of its own) resuming at an ancestor's own
+  // indentation -- after a deeper child has already opened -- was
+  // always glued to whatever child happened to be deepest-open at that
+  // point, regardless of the continuation's own indentation. Here
+  // "Before starting, confirm scope" sits at the SAME 2-space
+  // indentation as the two children's own markers, which is also where
+  // continuation text belonging to the (0-indent) parent's own body
+  // would land; the fix walks the ancestry stack to find the deepest
+  // node whose indent is still strictly less than the continuation's
+  // own, so the coordination language lands on the parent -- reaching
+  // the later sibling "PR #1391" -- not on "Gather context" alone.
+  const body = childBody({
+    extraMarkers:
+      '- Parent task\n' +
+      '  - Gather context\n' +
+      '  Before starting, confirm scope\n' +
+      '  - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency preserves ancestor scope across a loose list blank line between sibling items', () => {
+  // Regression test for the second gap #1476 tracks: checkProseOnlyDependency
+  // split text into paragraphs on every blank line, so a loose list
+  // (blank line between sibling items, ordinary valid CommonMark) lost
+  // the earlier paragraph's still-open ancestor ("Before starting:")
+  // the moment splitIntoListItemBlocks ran on the second item's
+  // paragraph independently. splitIntoParagraphs now bridges exactly
+  // one blank line between two loose-list chunks before
+  // splitIntoListItemBlocks ever runs, so this behaves the same as the
+  // already-passing tight-list case above.
+  const body = childBody({
+    extraMarkers:
+      '- Before starting:\n' +
+      '  - Gather context\n' +
+      '\n' +
+      '  - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency preserves ancestor scope across a loose list spanning three sibling items', () => {
+  // Generalizes the loose-list fix to a THIRD sibling (blank line
+  // before both the second and third items), mirroring the existing
+  // tight-list third-child test above -- proves the merge in
+  // splitIntoParagraphs folds left-to-right against the running
+  // accumulator rather than only handling a single pairwise merge.
+  const body = childBody({
+    extraMarkers:
+      '- Before starting this work:\n' +
+      '  - Gather context\n' +
+      '\n' +
+      '  - Draft the plan\n' +
+      '\n' +
+      '  - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
+test('prose-dependency does not graft a deeper-indented unrelated item onto a keyword-bearing item across a loose-list blank line', () => {
+  // Regression guard for a false positive the loose-list merge must
+  // not introduce: bridging is only safe when the right chunk's first
+  // marker is no deeper than whatever is still open at the end of the
+  // left chunk (a genuine sibling/ancestor continuation). Without that
+  // indentation guard, this RIGHT chunk -- indented deeper than the
+  // left chunk's only (0-indent) item -- would be grafted on as a
+  // fresh CHILD instead of staying a wholly separate, unrelated
+  // bullet. Because the left item has no terminal punctuation, the
+  // flattened block would become one "sentence" that spuriously pairs
+  // the left item's own coordination language ("before") with the
+  // right item's unrelated reference.
+  const body = childBody({
+    extraMarkers:
+      '- Before merging confirm CI is green\n' +
+      '\n' +
+      '  - Unrelated aside mentioning PR #1391, no coordination language here',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency does not bridge two blank lines between list items as one loose list', () => {
+  // Guard: the loose-list merge is scoped to EXACTLY one blank line
+  // (matching the issue's own "a loose list (blank line between
+  // sibling items)" framing) -- two or more blank lines is a harder
+  // paragraph break and is not bridged, keeping today's behavior for
+  // that stronger separator.
+  const body = childBody({
+    extraMarkers:
+      '- Before starting this work:\n' +
+      '  - Gather context\n' +
+      '\n\n' +
+      '  - PR #1391 must land',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency does not bridge a blank line between plain prose and a following unrelated list item', () => {
+  // Guard: the loose-list merge requires the left chunk to contain a
+  // list-item marker; a chunk of plain prose (no marker at all) is
+  // never a bridge candidate, so a coordination keyword in ordinary
+  // prose does not reach across a blank line into an unrelated
+  // following bullet's reference either.
+  const body = childBody({
+    extraMarkers:
+      'Confirm before merging this section\n' +
+      '\n' +
+      '- PR #1391 is an unrelated bullet',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
 // --- prose-dependency: empty-string currentRepo (#1472) ---
 
 test('prose-dependency treats an empty-string currentRepo as unknown', () => {

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1693,19 +1693,25 @@ test('prose-dependency bridges a loose-list blank line to a shallower open ances
 
 test('prose-dependency does not bridge a loose-list blank line when the left chunk ends in plain prose, not a marker', () => {
   // Regression test for a Codex review finding on this PR: `- Before
-  // merging\n  - child\nIndependent prose` reads, under CommonMark, as
-  // the nested list having ended before the blank line -- "Independent
-  // prose" is unindented plain text, not a continuation of "child".
-  // lastListItemMarkerIndent previously found "child" as the left
+  // merging\n  - child\nIndependent prose` visually reads as the nested
+  // list having ended before the blank line -- "Independent prose" sits
+  // unindented at column 0, directly under "child"'s own bullet.
+  // (CommonMark's lazy-continuation rule technically still absorbs it
+  // into "child"'s own paragraph rather than ending the list -- verified
+  // against three independent renderers, including GitHub's own
+  // `/markdown` API -- but that is a well-known surprising edge case;
+  // this advisory-only check follows the same reading a human author (and
+  // this PR's own Codex review) would give it, not the stricter spec
+  // rule.) lastListItemMarkerIndent previously found "child" as the left
   // chunk's last MARKER line and used its indentation as "whatever is
-  // still open", ignoring that a later continuation line (attached via
+  // still open", ignoring the trailing continuation line (attached via
   // the ancestry walk, since nothing but a marker line closes a node)
-  // followed it. That let the bridge fire and incorrectly scope
-  // "Before" onto the next chunk's "#1391" -- a reference the source
-  // never associated with it. A trailing continuation line after the
-  // left chunk's last marker now blocks the bridge entirely, matching
-  // the pre-#1476 behavior for this shape (paragraph splitting already
-  // kept the two references apart).
+  // that followed it. That let the bridge fire and scope "Before" onto
+  // the next chunk's "#1391" -- a reference a human author reading this
+  // shape would not expect it to reach. A trailing continuation line
+  // after the left chunk's last marker now blocks the bridge entirely,
+  // matching the pre-#1476 behavior for this shape (paragraph splitting
+  // already kept the two references apart).
   const body = childBody({
     extraMarkers:
       '- Before merging\n' +

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1691,6 +1691,37 @@ test('prose-dependency bridges a loose-list blank line to a shallower open ances
   assert.match(finding?.detail ?? '', /#1391/);
 });
 
+test('prose-dependency does not bridge a loose-list blank line when the left chunk ends in plain prose, not a marker', () => {
+  // Regression test for a Codex review finding on this PR: `- Before
+  // merging\n  - child\nIndependent prose` reads, under CommonMark, as
+  // the nested list having ended before the blank line -- "Independent
+  // prose" is unindented plain text, not a continuation of "child".
+  // lastListItemMarkerIndent previously found "child" as the left
+  // chunk's last MARKER line and used its indentation as "whatever is
+  // still open", ignoring that a later continuation line (attached via
+  // the ancestry walk, since nothing but a marker line closes a node)
+  // followed it. That let the bridge fire and incorrectly scope
+  // "Before" onto the next chunk's "#1391" -- a reference the source
+  // never associated with it. A trailing continuation line after the
+  // left chunk's last marker now blocks the bridge entirely, matching
+  // the pre-#1476 behavior for this shape (paragraph splitting already
+  // kept the two references apart).
+  const body = childBody({
+    extraMarkers:
+      '- Before merging\n' +
+      '  - child\n' +
+      'Independent prose\n' +
+      '\n' +
+      '  - PR #1391',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
 // --- prose-dependency: empty-string currentRepo (#1472) ---
 
 test('prose-dependency treats an empty-string currentRepo as unknown', () => {


### PR DESCRIPTION
# Summary

Closes two further, distinct gaps in `prose-dependency`'s ancestor-chain
scoping (`src/scripts/audit-authored-issue.mts`), both found on #1474's
own review and explicitly deferred to this follow-up rather than chased
in that PR.

**1. Continuation-line ancestor misattribution.** A continuation line
(no list marker of its own) resuming at an ancestor's own indentation,
after a deeper child has already opened, was always glued to whatever
child happened to be deepest-open — regardless of the continuation's
own indentation:

```markdown
- Parent
  - Gather context
  Before starting
  - PR #1391 must land
```

`Before starting` used to attach to `Gather context`, not `Parent`, so
`PR #1391` (the second child) never saw it as coordination language.
`splitIntoListItemBlocks`'s continuation-line branch now walks the
indentation-ancestry stack and attaches the line to the deepest node
whose indentation is strictly less than the continuation's own,
falling back to the shallowest node — a continuation genuinely deeper
than every open node still resolves at the very first comparison, so
the normal/unambiguous case is unchanged.

**2. Loose-list paragraph-boundary loss.** `checkProseOnlyDependency`
split text into paragraphs on every blank line and ran
`splitIntoListItemBlocks` once per paragraph independently, so a loose
list (blank line between sibling items — ordinary, valid CommonMark)
lost the earlier item's ancestor scope entirely:

```markdown
- Before starting:
  - Gather context

  - PR #1391 must land
```

A new `splitIntoParagraphs` bridges exactly one blank line between two
chunks when the left chunk contains a list-marker line and the right
chunk's first line is a marker at no deeper an indentation than
whatever is still open at the left chunk's end (a same-depth sibling,
or a resumption at a shallower ancestor's level). A strictly deeper
right-hand marker is never bridged — merging it would invent a
parent/child relationship the source never expressed. This guard was
added after a design-stage critique pass caught a concrete false
positive the unguarded version would have produced (a punctuation-free,
keyword-bearing checklist item directly followed by an unrelated,
more-indented bullet); see the code comments on
`isBridgeableLooseListBoundary` for the full reasoning.

Both fixes are independently unit-tested against the exact Markdown
shapes above, plus guard tests proving the loose-list bridge does not
over-merge (two-or-more blank lines, or a marker-free left chunk, are
never bridged) and does not graft an unrelated deeper item onto a
keyword-bearing one.

## Linked issue

Closes #1476

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This is the fifth generation of a deferral chain
(#1399 → #1468 → #1472 → #1474 → #1476). Per the same discipline every
prior generation applied, this PR implements exactly the two items
#1476 scopes and stops there.

The loose-list bridge is intentionally narrower than full tight-list
parity: it only bridges a right-hand marker that is no deeper than
whatever is still open at the left chunk's end. A loose list whose next
item is genuinely *deeper*-indented after the blank line is not
bridged — indentation alone cannot distinguish a legitimate deeper
child from an unrelated one across a paragraph gap, so the guard
prefers a missed advisory (false negative) over a false positive. This
is a deliberate, narrower-than-symmetric scope boundary for an
advisory-only check, not an oversight.

Two independent critique passes ran during this PR: one on the design
before implementation (caught the false-positive risk above, before
any code was written) and one on the landed diff (hand-traced both
fixes against the issue's own examples, confirmed test coverage,
confirmed no scope creep, and flagged that the contract docs still
described both gaps as a "known, tracked limitation" — fixed in a
separate, atomic `docs:` commit).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (typecheck, `build:check`, biome, dprint, `node --test`,
      workshop-integrity, cspell, markdownlint — equivalent commands run
      individually, see below)
- [x] `pnpm test` — `node --test tests/audit-authored-issue.test.mts`:
      108/108 pass (102 pre-existing + 6 new regression tests, 3 of them
      confirmed to fail against the pre-fix code before this change).
      Full suite `node --test tests/*.test.mts`: 2329/2332 pass; the 3
      failures are all in `tests/branch-conflict-state.test.mts`
      (`classifyBranchConflictState: ...`), a pre-existing fixture
      GPG-pinentry-timeout issue in this local environment, unrelated to
      this diff (confirmed by file/test name — this diff does not touch
      that file).
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (pre-existing, unrelated warnings only)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “prose-dependency” advisory so Markdown list scoping no longer resets incorrectly across loose-list boundaries.
  * Fixed continuation-line association to use the correct ancestor indentation level after nested children open.
  * Prevented unrelated list content from being incorrectly associated across single-blank-line and list-boundary edge cases.

* **Documentation**
  * Updated the Mechanical pre-publish gate guidance to reflect the revised list-scoping behavior.

* **Tests**
  * Expanded regression coverage for nested lists, loose lists, continuation lines, and blank-line merging/non-bridging scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->