### PR TITLE
fix(ci): dedupe check-run instances by name before classifying

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -56,3 +56,4 @@ words:
   - rollup
   - GHES
   - WHATWG
+  - dedup

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1235,31 +1235,56 @@ function matchTrustedAdvisoryStickyDispositions(
 }
 /**
  * Parse a check's `completedAt` into epoch milliseconds, or `null` when it
- * is missing or not a valid ISO 8601 timestamp — including a still-running
- * instance, whose `completedAt` GitHub leaves unset until it finishes.
+ * is missing, not a valid ISO 8601 timestamp, or the `0001-01-01T00:00:00Z`
+ * zero-value sentinel some GitHub API surfaces (e.g. `gh pr checks`) report
+ * for a check that has not actually completed — see `isCompletedCiTimestamp`,
+ * this file's existing convention for the same sentinel. A still-running
+ * instance's `completedAt` reads as one of these three "not completed"
+ * shapes until it finishes.
  */
 function parseCompletedAt(value) {
-  return isValidIsoTimestamp(value) ? Date.parse(value) : null;
+  const timestamp = String(value ?? '');
+  return isCompletedCiTimestamp(timestamp) ? Date.parse(timestamp) : null;
+}
+/**
+ * Tie-break precedence for two check-run instances that complete at the
+ * same (or an equally unusable) instant. `FAILURE` always wins (rank 0):
+ * a same-instant tie must never hide a real failure behind ordering
+ * happenstance (the exact regression `classifyCiChecks`'s unconditional
+ * "any FAILURE anywhere" rule existed to prevent, and not a case a rerun
+ * can plausibly land in — GitHub `completedAt` has only second resolution,
+ * and a rerun must trigger, queue, and execute before it can complete,
+ * which practically never lands in the exact same recorded second as the
+ * run it supersedes). `CANCELLED` always loses (rank 2): a cancelled run
+ * reached no real verdict, so it defers to any conclusion that did.
+ * Every other state — including pending states, which practically never
+ * reach this tie path since they have no completed timestamp to tie on —
+ * shares the middle rank (1).
+ */
+function ciStateTieRank(state) {
+  if (state === 'FAILURE') return 0;
+  if (state === 'CANCELLED') return 2;
+  return 1;
 }
 /**
  * True when `candidate` should replace `current` as the representative
- * instance for one check name. A still-incomplete instance (unparseable
- * `completedAt`) always wins over an already-completed one: completion can
- * only happen after creation, so a live rerun can never be older than the
- * finished run it supersedes — this mirrors GitHub's own latest-per-context
- * semantics, under which an in-progress required check leaves the branch
- * not-clean rather than falling back to a stale completed verdict. Once
- * both sides have completed, the most recently completed one wins.
+ * instance for one check name. A still-incomplete instance (per
+ * `parseCompletedAt`) always wins over an already-completed one:
+ * completion can only happen after creation, so a live rerun can never be
+ * older than the finished run it supersedes — this mirrors GitHub's own
+ * latest-per-context semantics, under which an in-progress required check
+ * leaves the branch not-clean rather than falling back to a stale
+ * completed verdict. Once both sides have completed, the most recently
+ * completed one wins.
  *
  * A tie (equal completedAt, or both sides missing/unparseable) never
  * resolves by input order — two independent runs can genuinely complete
- * within the same recorded second. A tie involving `FAILURE` always
- * prefers `FAILURE`, so this dedup can never hide a real failure behind
- * ordering happenstance (the exact regression `classifyCiChecks`'s
- * unconditional "any FAILURE anywhere" rule existed to prevent). Failing
- * that, a tie prefers a non-`CANCELLED` state, so a stale `CANCELLED`
- * placeholder never outranks a real conclusion recorded at the same
- * instant.
+ * within the same recorded second. It resolves by `ciStateTieRank`
+ * instead; a residual tie within the same rank (e.g. `SUCCESS` vs.
+ * `NEUTRAL`, both rank 1) falls back to comparing the state strings
+ * themselves, which depends only on the two values being compared, never
+ * on which one the caller happened to list first — so the whole
+ * selection is fully deterministic regardless of input order.
  */
 function isNewerCheckInstance(candidate, current) {
   const candidateAt = parseCompletedAt(candidate.completedAt);
@@ -1274,10 +1299,12 @@ function isNewerCheckInstance(candidate, current) {
     // side always wins here.
     return candidateAt === null;
   }
-  if (current.state === 'FAILURE' || candidate.state === 'FAILURE') {
-    return candidate.state === 'FAILURE';
+  const candidateRank = ciStateTieRank(candidate.state);
+  const currentRank = ciStateTieRank(current.state);
+  if (candidateRank !== currentRank) {
+    return candidateRank < currentRank;
   }
-  return current.state === 'CANCELLED' && candidate.state !== 'CANCELLED';
+  return candidate.state !== current.state && candidate.state < current.state;
 }
 /**
  * Reduce a group of same-name check-run instances to the single instance
@@ -1295,14 +1322,21 @@ function selectLatestCheckInstance(group) {
  * latest run for a given context governs, so a stale instance (e.g. a
  * cancelled or failed run superseded by a later successful rerun) can
  * never outvote the current, authoritative one that shares its name.
+ *
+ * A missing or empty `name` carries no identity to dedupe against, so
+ * each such entry gets its own singleton group instead of collapsing
+ * every unnamed check together — otherwise an unrelated unnamed failure
+ * could be discarded in favor of an unrelated unnamed success that
+ * merely happens to also lack a name.
  */
 function selectLatestCheckPerName(checks) {
   // A Map already iterates in first-insertion order, so grouping into one
   // is enough to preserve stable output order with no separate order array
   // (see the same pattern in `findDuplicateBasenames` in audit-docs.mts).
   const groups = new Map();
+  let unnamedCount = 0;
   for (const check of checks) {
-    const key = String(check.name ?? '');
+    const key = check.name ? String(check.name) : `\0unnamed:${unnamedCount++}`;
     const group = groups.get(key);
     if (group) {
       group.push(check);

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1328,6 +1328,16 @@ function selectLatestCheckInstance(group) {
  * every unnamed check together — otherwise an unrelated unnamed failure
  * could be discarded in favor of an unrelated unnamed success that
  * merely happens to also lack a name.
+ *
+ * Known limitation (tracked in #1483): `CheckLike` carries no
+ * source/producer identity, so two genuinely independent checks that
+ * happen to share an identical `name` (e.g. a check-run and a legacy
+ * commit-status, or two different GitHub Apps) are indistinguishable
+ * from reruns of one another here and will be grouped together. Fixing
+ * this needs a source discriminator threaded through from data
+ * collection (see `ci-wait-state.mts`'s `type` field) into `CheckLike`
+ * itself — a data-collection-layer change out of scope for the
+ * same-name-multiple-*rerun*-instances dedup this function performs.
  */
 function selectLatestCheckPerName(checks) {
   // A Map already iterates in first-insertion order, so grouping into one

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1233,17 +1233,92 @@ function matchTrustedAdvisoryStickyDispositions(
   }
   return dispositionedStickyIndexes;
 }
+/**
+ * Parse a check's `completedAt` into epoch milliseconds, or `null` when it
+ * is missing or not a valid ISO 8601 timestamp — including a still-running
+ * instance, whose `completedAt` GitHub leaves unset until it finishes.
+ */
+function parseCompletedAt(value) {
+  return isValidIsoTimestamp(value) ? Date.parse(value) : null;
+}
+/**
+ * True when `candidate` should replace `current` as the representative
+ * instance for one check name. A still-incomplete instance (unparseable
+ * `completedAt`) always wins over an already-completed one: completion can
+ * only happen after creation, so a live rerun can never be older than the
+ * finished run it supersedes — this mirrors GitHub's own latest-per-context
+ * semantics, under which an in-progress required check leaves the branch
+ * not-clean rather than falling back to a stale completed verdict. Once
+ * both sides have completed, the most recently completed one wins; a tie
+ * (including a timestamp missing or unparseable on both sides) prefers a
+ * non-`CANCELLED` state, so a stale `CANCELLED` placeholder never outranks
+ * a real pass/fail verdict recorded at the same instant.
+ */
+function isNewerCheckInstance(candidate, current) {
+  const candidateAt = parseCompletedAt(candidate.completedAt);
+  const currentAt = parseCompletedAt(current.completedAt);
+  if (candidateAt !== null && currentAt !== null) {
+    if (candidateAt !== currentAt) {
+      return candidateAt > currentAt;
+    }
+  } else if (candidateAt !== null || currentAt !== null) {
+    // Exactly one side has a usable timestamp. The side still missing one
+    // is never older than a completed side — a live rerun cannot have
+    // started before the finished run it supersedes — so the incomplete
+    // side always wins here.
+    return candidateAt === null;
+  }
+  return current.state === 'CANCELLED' && candidate.state !== 'CANCELLED';
+}
+/**
+ * Reduce a group of same-name check-run instances to the single instance
+ * that represents the current truth for that name. See
+ * `isNewerCheckInstance` for the selection rule.
+ */
+function selectLatestCheckInstance(group) {
+  return group.reduce((latest, candidate) =>
+    isNewerCheckInstance(candidate, latest) ? candidate : latest,
+  );
+}
+/**
+ * Reduce a check-run list to a single representative instance per check
+ * `name`, matching GitHub's own required-status-check semantics: only the
+ * latest run for a given context governs, so a stale instance (e.g. a
+ * cancelled or failed run superseded by a later successful rerun) can
+ * never outvote the current, authoritative one that shares its name.
+ */
+function selectLatestCheckPerName(checks) {
+  const order = [];
+  const groups = new Map();
+  for (const check of checks) {
+    const key = String(check.name ?? '');
+    const group = groups.get(key);
+    if (group) {
+      group.push(check);
+    } else {
+      order.push(key);
+      groups.set(key, [check]);
+    }
+  }
+  return order.map((key) => selectLatestCheckInstance(groups.get(key)));
+}
 export function classifyCiChecks(checks) {
   const normalized = checks.map((check) => ({
     name: check.name,
     state: String(check.state ?? '').toUpperCase(),
     completedAt: check.completedAt ?? null,
   }));
-  const failed = normalized.filter((check) => check.state === 'FAILURE');
+  // GitHub can report several check-run instances that share the same
+  // check `name` (a manual or automatic re-run leaves the earlier instance
+  // in the fetched list alongside the new one). Reduce to one instance per
+  // name before classifying pass/fail/pending, so a stale instance never
+  // outvotes the current one for the same name (see #1471).
+  const deduped = selectLatestCheckPerName(normalized);
+  const failed = deduped.filter((check) => check.state === 'FAILURE');
   if (failed.length > 0) {
     return { status: 'failed', failed };
   }
-  const pending = normalized.filter((check) => {
+  const pending = deduped.filter((check) => {
     return (
       check.state === 'QUEUED' ||
       check.state === 'IN_PROGRESS' ||
@@ -1253,15 +1328,15 @@ export function classifyCiChecks(checks) {
   if (pending.length > 0) {
     return { status: 'pending', pending };
   }
-  const passing = normalized.filter((check) => {
+  const passing = deduped.filter((check) => {
     return ['SUCCESS', 'SKIPPED', 'NEUTRAL', 'NOT_APPLICABLE'].includes(
       check.state,
     );
   });
   return {
-    status: passing.length === normalized.length ? 'success' : 'unknown',
+    status: passing.length === deduped.length ? 'success' : 'unknown',
     passing,
-    unknown: normalized.filter((check) => !passing.includes(check)),
+    unknown: deduped.filter((check) => !passing.includes(check)),
   };
 }
 /**

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1249,24 +1249,33 @@ function parseCompletedAt(value) {
  * finished run it supersedes — this mirrors GitHub's own latest-per-context
  * semantics, under which an in-progress required check leaves the branch
  * not-clean rather than falling back to a stale completed verdict. Once
- * both sides have completed, the most recently completed one wins; a tie
- * (including a timestamp missing or unparseable on both sides) prefers a
- * non-`CANCELLED` state, so a stale `CANCELLED` placeholder never outranks
- * a real pass/fail verdict recorded at the same instant.
+ * both sides have completed, the most recently completed one wins.
+ *
+ * A tie (equal completedAt, or both sides missing/unparseable) never
+ * resolves by input order — two independent runs can genuinely complete
+ * within the same recorded second. A tie involving `FAILURE` always
+ * prefers `FAILURE`, so this dedup can never hide a real failure behind
+ * ordering happenstance (the exact regression `classifyCiChecks`'s
+ * unconditional "any FAILURE anywhere" rule existed to prevent). Failing
+ * that, a tie prefers a non-`CANCELLED` state, so a stale `CANCELLED`
+ * placeholder never outranks a real conclusion recorded at the same
+ * instant.
  */
 function isNewerCheckInstance(candidate, current) {
   const candidateAt = parseCompletedAt(candidate.completedAt);
   const currentAt = parseCompletedAt(current.completedAt);
-  if (candidateAt !== null && currentAt !== null) {
-    if (candidateAt !== currentAt) {
-      return candidateAt > currentAt;
-    }
-  } else if (candidateAt !== null || currentAt !== null) {
+  if (candidateAt !== null && currentAt !== null && candidateAt !== currentAt) {
+    return candidateAt > currentAt;
+  }
+  if ((candidateAt !== null) !== (currentAt !== null)) {
     // Exactly one side has a usable timestamp. The side still missing one
     // is never older than a completed side — a live rerun cannot have
     // started before the finished run it supersedes — so the incomplete
     // side always wins here.
     return candidateAt === null;
+  }
+  if (current.state === 'FAILURE' || candidate.state === 'FAILURE') {
+    return candidate.state === 'FAILURE';
   }
   return current.state === 'CANCELLED' && candidate.state !== 'CANCELLED';
 }
@@ -1288,7 +1297,9 @@ function selectLatestCheckInstance(group) {
  * never outvote the current, authoritative one that shares its name.
  */
 function selectLatestCheckPerName(checks) {
-  const order = [];
+  // A Map already iterates in first-insertion order, so grouping into one
+  // is enough to preserve stable output order with no separate order array
+  // (see the same pattern in `findDuplicateBasenames` in audit-docs.mts).
   const groups = new Map();
   for (const check of checks) {
     const key = String(check.name ?? '');
@@ -1296,11 +1307,10 @@ function selectLatestCheckPerName(checks) {
     if (group) {
       group.push(check);
     } else {
-      order.push(key);
       groups.set(key, [check]);
     }
   }
-  return order.map((key) => selectLatestCheckInstance(groups.get(key)));
+  return [...groups.values()].map((group) => selectLatestCheckInstance(group));
 }
 export function classifyCiChecks(checks) {
   const normalized = checks.map((check) => ({

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1996,6 +1996,16 @@ function selectLatestCheckInstance<
  * every unnamed check together — otherwise an unrelated unnamed failure
  * could be discarded in favor of an unrelated unnamed success that
  * merely happens to also lack a name.
+ *
+ * Known limitation (tracked in #1483): `CheckLike` carries no
+ * source/producer identity, so two genuinely independent checks that
+ * happen to share an identical `name` (e.g. a check-run and a legacy
+ * commit-status, or two different GitHub Apps) are indistinguishable
+ * from reruns of one another here and will be grouped together. Fixing
+ * this needs a source discriminator threaded through from data
+ * collection (see `ci-wait-state.mts`'s `type` field) into `CheckLike`
+ * itself — a data-collection-layer change out of scope for the
+ * same-name-multiple-*rerun*-instances dedup this function performs.
  */
 function selectLatestCheckPerName<
   T extends {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1910,26 +1910,35 @@ function parseCompletedAt(value: string | null | undefined): number | null {
  * finished run it supersedes — this mirrors GitHub's own latest-per-context
  * semantics, under which an in-progress required check leaves the branch
  * not-clean rather than falling back to a stale completed verdict. Once
- * both sides have completed, the most recently completed one wins; a tie
- * (including a timestamp missing or unparseable on both sides) prefers a
- * non-`CANCELLED` state, so a stale `CANCELLED` placeholder never outranks
- * a real pass/fail verdict recorded at the same instant.
+ * both sides have completed, the most recently completed one wins.
+ *
+ * A tie (equal completedAt, or both sides missing/unparseable) never
+ * resolves by input order — two independent runs can genuinely complete
+ * within the same recorded second. A tie involving `FAILURE` always
+ * prefers `FAILURE`, so this dedup can never hide a real failure behind
+ * ordering happenstance (the exact regression `classifyCiChecks`'s
+ * unconditional "any FAILURE anywhere" rule existed to prevent). Failing
+ * that, a tie prefers a non-`CANCELLED` state, so a stale `CANCELLED`
+ * placeholder never outranks a real conclusion recorded at the same
+ * instant.
  */
 function isNewerCheckInstance<
   T extends { state: string; completedAt?: string | null },
 >(candidate: T, current: T): boolean {
   const candidateAt = parseCompletedAt(candidate.completedAt);
   const currentAt = parseCompletedAt(current.completedAt);
-  if (candidateAt !== null && currentAt !== null) {
-    if (candidateAt !== currentAt) {
-      return candidateAt > currentAt;
-    }
-  } else if (candidateAt !== null || currentAt !== null) {
+  if (candidateAt !== null && currentAt !== null && candidateAt !== currentAt) {
+    return candidateAt > currentAt;
+  }
+  if ((candidateAt !== null) !== (currentAt !== null)) {
     // Exactly one side has a usable timestamp. The side still missing one
     // is never older than a completed side — a live rerun cannot have
     // started before the finished run it supersedes — so the incomplete
     // side always wins here.
     return candidateAt === null;
+  }
+  if (current.state === 'FAILURE' || candidate.state === 'FAILURE') {
+    return candidate.state === 'FAILURE';
   }
   return current.state === 'CANCELLED' && candidate.state !== 'CANCELLED';
 }
@@ -1961,7 +1970,9 @@ function selectLatestCheckPerName<
     completedAt?: string | null;
   },
 >(checks: T[]): T[] {
-  const order: string[] = [];
+  // A Map already iterates in first-insertion order, so grouping into one
+  // is enough to preserve stable output order with no separate order array
+  // (see the same pattern in `findDuplicateBasenames` in audit-docs.mts).
   const groups = new Map<string, T[]>();
   for (const check of checks) {
     const key = String(check.name ?? '');
@@ -1969,11 +1980,10 @@ function selectLatestCheckPerName<
     if (group) {
       group.push(check);
     } else {
-      order.push(key);
       groups.set(key, [check]);
     }
   }
-  return order.map((key) => selectLatestCheckInstance(groups.get(key) as T[]));
+  return [...groups.values()].map((group) => selectLatestCheckInstance(group));
 }
 
 export function classifyCiChecks(checks: CheckLike[]) {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1895,32 +1895,58 @@ function matchTrustedAdvisoryStickyDispositions<
 
 /**
  * Parse a check's `completedAt` into epoch milliseconds, or `null` when it
- * is missing or not a valid ISO 8601 timestamp — including a still-running
- * instance, whose `completedAt` GitHub leaves unset until it finishes.
+ * is missing, not a valid ISO 8601 timestamp, or the `0001-01-01T00:00:00Z`
+ * zero-value sentinel some GitHub API surfaces (e.g. `gh pr checks`) report
+ * for a check that has not actually completed — see `isCompletedCiTimestamp`,
+ * this file's existing convention for the same sentinel. A still-running
+ * instance's `completedAt` reads as one of these three "not completed"
+ * shapes until it finishes.
  */
 function parseCompletedAt(value: string | null | undefined): number | null {
-  return isValidIsoTimestamp(value) ? Date.parse(value) : null;
+  const timestamp = String(value ?? '');
+  return isCompletedCiTimestamp(timestamp) ? Date.parse(timestamp) : null;
+}
+
+/**
+ * Tie-break precedence for two check-run instances that complete at the
+ * same (or an equally unusable) instant. `FAILURE` always wins (rank 0):
+ * a same-instant tie must never hide a real failure behind ordering
+ * happenstance (the exact regression `classifyCiChecks`'s unconditional
+ * "any FAILURE anywhere" rule existed to prevent, and not a case a rerun
+ * can plausibly land in — GitHub `completedAt` has only second resolution,
+ * and a rerun must trigger, queue, and execute before it can complete,
+ * which practically never lands in the exact same recorded second as the
+ * run it supersedes). `CANCELLED` always loses (rank 2): a cancelled run
+ * reached no real verdict, so it defers to any conclusion that did.
+ * Every other state — including pending states, which practically never
+ * reach this tie path since they have no completed timestamp to tie on —
+ * shares the middle rank (1).
+ */
+function ciStateTieRank(state: string): number {
+  if (state === 'FAILURE') return 0;
+  if (state === 'CANCELLED') return 2;
+  return 1;
 }
 
 /**
  * True when `candidate` should replace `current` as the representative
- * instance for one check name. A still-incomplete instance (unparseable
- * `completedAt`) always wins over an already-completed one: completion can
- * only happen after creation, so a live rerun can never be older than the
- * finished run it supersedes — this mirrors GitHub's own latest-per-context
- * semantics, under which an in-progress required check leaves the branch
- * not-clean rather than falling back to a stale completed verdict. Once
- * both sides have completed, the most recently completed one wins.
+ * instance for one check name. A still-incomplete instance (per
+ * `parseCompletedAt`) always wins over an already-completed one:
+ * completion can only happen after creation, so a live rerun can never be
+ * older than the finished run it supersedes — this mirrors GitHub's own
+ * latest-per-context semantics, under which an in-progress required check
+ * leaves the branch not-clean rather than falling back to a stale
+ * completed verdict. Once both sides have completed, the most recently
+ * completed one wins.
  *
  * A tie (equal completedAt, or both sides missing/unparseable) never
  * resolves by input order — two independent runs can genuinely complete
- * within the same recorded second. A tie involving `FAILURE` always
- * prefers `FAILURE`, so this dedup can never hide a real failure behind
- * ordering happenstance (the exact regression `classifyCiChecks`'s
- * unconditional "any FAILURE anywhere" rule existed to prevent). Failing
- * that, a tie prefers a non-`CANCELLED` state, so a stale `CANCELLED`
- * placeholder never outranks a real conclusion recorded at the same
- * instant.
+ * within the same recorded second. It resolves by `ciStateTieRank`
+ * instead; a residual tie within the same rank (e.g. `SUCCESS` vs.
+ * `NEUTRAL`, both rank 1) falls back to comparing the state strings
+ * themselves, which depends only on the two values being compared, never
+ * on which one the caller happened to list first — so the whole
+ * selection is fully deterministic regardless of input order.
  */
 function isNewerCheckInstance<
   T extends { state: string; completedAt?: string | null },
@@ -1937,10 +1963,12 @@ function isNewerCheckInstance<
     // side always wins here.
     return candidateAt === null;
   }
-  if (current.state === 'FAILURE' || candidate.state === 'FAILURE') {
-    return candidate.state === 'FAILURE';
+  const candidateRank = ciStateTieRank(candidate.state);
+  const currentRank = ciStateTieRank(current.state);
+  if (candidateRank !== currentRank) {
+    return candidateRank < currentRank;
   }
-  return current.state === 'CANCELLED' && candidate.state !== 'CANCELLED';
+  return candidate.state !== current.state && candidate.state < current.state;
 }
 
 /**
@@ -1962,6 +1990,12 @@ function selectLatestCheckInstance<
  * latest run for a given context governs, so a stale instance (e.g. a
  * cancelled or failed run superseded by a later successful rerun) can
  * never outvote the current, authoritative one that shares its name.
+ *
+ * A missing or empty `name` carries no identity to dedupe against, so
+ * each such entry gets its own singleton group instead of collapsing
+ * every unnamed check together — otherwise an unrelated unnamed failure
+ * could be discarded in favor of an unrelated unnamed success that
+ * merely happens to also lack a name.
  */
 function selectLatestCheckPerName<
   T extends {
@@ -1974,8 +2008,9 @@ function selectLatestCheckPerName<
   // is enough to preserve stable output order with no separate order array
   // (see the same pattern in `findDuplicateBasenames` in audit-docs.mts).
   const groups = new Map<string, T[]>();
+  let unnamedCount = 0;
   for (const check of checks) {
-    const key = String(check.name ?? '');
+    const key = check.name ? String(check.name) : `\0unnamed:${unnamedCount++}`;
     const group = groups.get(key);
     if (group) {
       group.push(check);

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1893,19 +1893,108 @@ function matchTrustedAdvisoryStickyDispositions<
   return dispositionedStickyIndexes;
 }
 
+/**
+ * Parse a check's `completedAt` into epoch milliseconds, or `null` when it
+ * is missing or not a valid ISO 8601 timestamp — including a still-running
+ * instance, whose `completedAt` GitHub leaves unset until it finishes.
+ */
+function parseCompletedAt(value: string | null | undefined): number | null {
+  return isValidIsoTimestamp(value) ? Date.parse(value) : null;
+}
+
+/**
+ * True when `candidate` should replace `current` as the representative
+ * instance for one check name. A still-incomplete instance (unparseable
+ * `completedAt`) always wins over an already-completed one: completion can
+ * only happen after creation, so a live rerun can never be older than the
+ * finished run it supersedes — this mirrors GitHub's own latest-per-context
+ * semantics, under which an in-progress required check leaves the branch
+ * not-clean rather than falling back to a stale completed verdict. Once
+ * both sides have completed, the most recently completed one wins; a tie
+ * (including a timestamp missing or unparseable on both sides) prefers a
+ * non-`CANCELLED` state, so a stale `CANCELLED` placeholder never outranks
+ * a real pass/fail verdict recorded at the same instant.
+ */
+function isNewerCheckInstance<
+  T extends { state: string; completedAt?: string | null },
+>(candidate: T, current: T): boolean {
+  const candidateAt = parseCompletedAt(candidate.completedAt);
+  const currentAt = parseCompletedAt(current.completedAt);
+  if (candidateAt !== null && currentAt !== null) {
+    if (candidateAt !== currentAt) {
+      return candidateAt > currentAt;
+    }
+  } else if (candidateAt !== null || currentAt !== null) {
+    // Exactly one side has a usable timestamp. The side still missing one
+    // is never older than a completed side — a live rerun cannot have
+    // started before the finished run it supersedes — so the incomplete
+    // side always wins here.
+    return candidateAt === null;
+  }
+  return current.state === 'CANCELLED' && candidate.state !== 'CANCELLED';
+}
+
+/**
+ * Reduce a group of same-name check-run instances to the single instance
+ * that represents the current truth for that name. See
+ * `isNewerCheckInstance` for the selection rule.
+ */
+function selectLatestCheckInstance<
+  T extends { state: string; completedAt?: string | null },
+>(group: T[]): T {
+  return group.reduce((latest, candidate) =>
+    isNewerCheckInstance(candidate, latest) ? candidate : latest,
+  );
+}
+
+/**
+ * Reduce a check-run list to a single representative instance per check
+ * `name`, matching GitHub's own required-status-check semantics: only the
+ * latest run for a given context governs, so a stale instance (e.g. a
+ * cancelled or failed run superseded by a later successful rerun) can
+ * never outvote the current, authoritative one that shares its name.
+ */
+function selectLatestCheckPerName<
+  T extends {
+    name?: string | null;
+    state: string;
+    completedAt?: string | null;
+  },
+>(checks: T[]): T[] {
+  const order: string[] = [];
+  const groups = new Map<string, T[]>();
+  for (const check of checks) {
+    const key = String(check.name ?? '');
+    const group = groups.get(key);
+    if (group) {
+      group.push(check);
+    } else {
+      order.push(key);
+      groups.set(key, [check]);
+    }
+  }
+  return order.map((key) => selectLatestCheckInstance(groups.get(key) as T[]));
+}
+
 export function classifyCiChecks(checks: CheckLike[]) {
   const normalized = checks.map((check) => ({
     name: check.name,
     state: String(check.state ?? '').toUpperCase(),
     completedAt: check.completedAt ?? null,
   }));
+  // GitHub can report several check-run instances that share the same
+  // check `name` (a manual or automatic re-run leaves the earlier instance
+  // in the fetched list alongside the new one). Reduce to one instance per
+  // name before classifying pass/fail/pending, so a stale instance never
+  // outvotes the current one for the same name (see #1471).
+  const deduped = selectLatestCheckPerName(normalized);
 
-  const failed = normalized.filter((check) => check.state === 'FAILURE');
+  const failed = deduped.filter((check) => check.state === 'FAILURE');
   if (failed.length > 0) {
     return { status: 'failed', failed };
   }
 
-  const pending = normalized.filter((check) => {
+  const pending = deduped.filter((check) => {
     return (
       check.state === 'QUEUED' ||
       check.state === 'IN_PROGRESS' ||
@@ -1916,16 +2005,16 @@ export function classifyCiChecks(checks: CheckLike[]) {
     return { status: 'pending', pending };
   }
 
-  const passing = normalized.filter((check) => {
+  const passing = deduped.filter((check) => {
     return ['SUCCESS', 'SKIPPED', 'NEUTRAL', 'NOT_APPLICABLE'].includes(
       check.state,
     );
   });
 
   return {
-    status: passing.length === normalized.length ? 'success' : 'unknown',
+    status: passing.length === deduped.length ? 'success' : 'unknown',
     passing,
-    unknown: normalized.filter((check) => !passing.includes(check)),
+    unknown: deduped.filter((check) => !passing.includes(check)),
   };
 }
 

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -164,6 +164,76 @@ test('classifyCiChecks: a same-instant cancelled/success tie for one name prefer
   assert.equal(classifyCiChecks(successFirst).status, 'success');
 });
 
+test('classifyCiChecks: a same-instant tie between two non-failure/non-cancelled states is deterministic regardless of input order', () => {
+  // PR review finding: the reducer previously kept whichever instance
+  // was listed first for any tie not involving FAILURE or CANCELLED
+  // (e.g. SUCCESS vs NEUTRAL), so input order still mattered even
+  // though it never flipped `.status` for this particular pairing (both
+  // are pass-equivalent). Assert full order-independence anyway, since
+  // a future passing-vs-non-passing tie (e.g. SUCCESS vs ACTION_REQUIRED)
+  // would otherwise inherit the same order dependence and could flip
+  // `.status`.
+  const tiedAt = '2026-07-17T16:00:06Z';
+  const successFirst = [
+    { name: 'flaky', state: 'SUCCESS', completedAt: tiedAt },
+    { name: 'flaky', state: 'NEUTRAL', completedAt: tiedAt },
+  ];
+  const neutralFirst = [
+    { name: 'flaky', state: 'NEUTRAL', completedAt: tiedAt },
+    { name: 'flaky', state: 'SUCCESS', completedAt: tiedAt },
+  ];
+  assert.equal(classifyCiChecks(successFirst).status, 'success');
+  assert.equal(classifyCiChecks(neutralFirst).status, 'success');
+  const successAndActionRequiredFirst = [
+    { name: 'gated', state: 'SUCCESS', completedAt: tiedAt },
+    { name: 'gated', state: 'ACTION_REQUIRED', completedAt: tiedAt },
+  ];
+  const actionRequiredFirst = [
+    { name: 'gated', state: 'ACTION_REQUIRED', completedAt: tiedAt },
+    { name: 'gated', state: 'SUCCESS', completedAt: tiedAt },
+  ];
+  assert.equal(
+    classifyCiChecks(successAndActionRequiredFirst).status,
+    classifyCiChecks(actionRequiredFirst).status,
+  );
+});
+
+test('classifyCiChecks: a pending rerun carrying the zero-value completedAt sentinel is not shadowed by a stale success', () => {
+  // PR review finding (P1): gh pr checks (and similar API surfaces)
+  // report `0001-01-01T00:00:00Z` -- Go's zero Time value -- as
+  // `completedAt` for a check that has not actually completed, rather
+  // than omitting the field. That string is a syntactically valid ISO
+  // timestamp, so treating validity alone as "has this check completed"
+  // let a stale completed SUCCESS outrank a currently-pending rerun
+  // carrying the sentinel, silently discarding the fact that a new run
+  // is in flight for that same check name.
+  const checks = [
+    {
+      name: 'idd-advisory-convergence',
+      state: 'SUCCESS',
+      completedAt: '2026-07-17T16:00:06Z',
+    },
+    {
+      name: 'idd-advisory-convergence',
+      state: 'IN_PROGRESS',
+      completedAt: '0001-01-01T00:00:00Z',
+    },
+  ];
+  assert.equal(classifyCiChecks(checks).status, 'pending');
+});
+
+test('classifyCiChecks: two check-run entries with no name are never collapsed into one group', () => {
+  // PR review finding: grouping by `String(check.name ?? '')` collapses
+  // every missing/empty-name entry into a single bucket, so an unrelated
+  // unnamed failure could be discarded in favor of an unrelated unnamed
+  // success sharing no real identity with it.
+  const checks = [
+    { name: '', state: 'FAILURE', completedAt: '2026-07-17T16:00:06Z' },
+    { name: '', state: 'SUCCESS', completedAt: '2026-07-17T16:25:47Z' },
+  ];
+  assert.equal(classifyCiChecks(checks).status, 'failed');
+});
+
 test('detects operational marker prefixes', () => {
   assert.equal(
     operationalMarkerPrefix(

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -40,6 +40,98 @@ test('classifies CI check states for advisory wait decisions', () => {
   assert.equal(classifyCiChecks(ciSkippedNeutral).status, 'success');
 });
 
+// #1471: `classifyCiChecks` must dedupe multiple check-run instances that
+// share the same `name` down to the latest one before classifying, instead
+// of letting a stale instance for that name outvote the current one.
+test('classifyCiChecks: a stale cancelled-only instance is superseded by a later success for the same name', () => {
+  // Without dedup this shape misclassifies as 'unknown' (the stale
+  // CANCELLED instance is neither failing nor passing on its own), not
+  // 'failed' — a distinct branch from the FAILURE-triggered repro below.
+  const checks = [
+    {
+      name: 'idd-advisory-convergence',
+      state: 'CANCELLED',
+      completedAt: '2026-07-17T15:59:36Z',
+    },
+    {
+      name: 'idd-advisory-convergence',
+      state: 'SUCCESS',
+      completedAt: '2026-07-17T16:25:47Z',
+    },
+  ];
+  assert.equal(classifyCiChecks(checks).status, 'success');
+});
+
+test('classifyCiChecks: a genuinely failing latest instance still fails despite older passing instances', () => {
+  // Guards against an over-broad fix that ignores any failure anywhere in
+  // the list — this must stay 'failed' because the latest instance for the
+  // name is the one that failed.
+  const checks = [
+    {
+      name: 'idd-advisory-convergence',
+      state: 'SUCCESS',
+      completedAt: '2026-07-17T15:00:00Z',
+    },
+    {
+      name: 'idd-advisory-convergence',
+      state: 'SUCCESS',
+      completedAt: '2026-07-17T15:30:00Z',
+    },
+    {
+      name: 'idd-advisory-convergence',
+      state: 'FAILURE',
+      completedAt: '2026-07-17T16:00:00Z',
+    },
+  ];
+  assert.equal(classifyCiChecks(checks).status, 'failed');
+});
+
+test('classifyCiChecks: PR #1434 four-instance repro (2 cancelled, 1 failure, 1 success) classifies success', () => {
+  const checks = [
+    {
+      name: 'idd-advisory-convergence',
+      state: 'CANCELLED',
+      completedAt: '2026-07-17T15:59:36Z',
+    },
+    {
+      name: 'idd-advisory-convergence',
+      state: 'CANCELLED',
+      completedAt: '2026-07-17T15:59:51Z',
+    },
+    {
+      name: 'idd-advisory-convergence',
+      state: 'FAILURE',
+      completedAt: '2026-07-17T16:00:06Z',
+    },
+    {
+      name: 'idd-advisory-convergence',
+      state: 'SUCCESS',
+      completedAt: '2026-07-17T16:25:47Z',
+    },
+  ];
+  assert.equal(classifyCiChecks(checks).status, 'success');
+});
+
+test('classifyCiChecks: an in-progress rerun is not shadowed by an older completed success for the same name', () => {
+  // The mirror-image failure mode: a live rerun (no completedAt yet) must
+  // win over a stale completed SUCCESS for the same name, matching
+  // GitHub's own semantics where an in-progress required check leaves the
+  // branch not-clean rather than falling back to an old passing verdict.
+  const checks = [
+    {
+      name: 'idd-advisory-convergence',
+      state: 'SUCCESS',
+      completedAt: '2026-07-17T16:00:06Z',
+    },
+    {
+      name: 'idd-advisory-convergence',
+      state: 'IN_PROGRESS',
+      completedAt: null,
+    },
+  ];
+  assert.equal(classifyCiChecks(checks).status, 'pending');
+});
+
 test('detects operational marker prefixes', () => {
   assert.equal(
     operationalMarkerPrefix(

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -132,6 +132,38 @@ test('classifyCiChecks: an in-progress rerun is not shadowed by an older complet
   assert.equal(classifyCiChecks(checks).status, 'pending');
 });
 
+test('classifyCiChecks: a same-instant failure/success tie for one name still fails, regardless of input order', () => {
+  // A tie must never resolve by raw input array order — two independent
+  // runs can genuinely complete within the same recorded second, and this
+  // dedup must never let ordering happenstance hide a real failure behind
+  // a same-instant success.
+  const tiedAt = '2026-07-17T16:00:06Z';
+  const failureFirst = [
+    { name: 'flaky', state: 'FAILURE', completedAt: tiedAt },
+    { name: 'flaky', state: 'SUCCESS', completedAt: tiedAt },
+  ];
+  const successFirst = [
+    { name: 'flaky', state: 'SUCCESS', completedAt: tiedAt },
+    { name: 'flaky', state: 'FAILURE', completedAt: tiedAt },
+  ];
+  assert.equal(classifyCiChecks(failureFirst).status, 'failed');
+  assert.equal(classifyCiChecks(successFirst).status, 'failed');
+});
+
+test('classifyCiChecks: a same-instant cancelled/success tie for one name prefers success, regardless of input order', () => {
+  const tiedAt = '2026-07-17T16:00:06Z';
+  const cancelledFirst = [
+    { name: 'flaky', state: 'CANCELLED', completedAt: tiedAt },
+    { name: 'flaky', state: 'SUCCESS', completedAt: tiedAt },
+  ];
+  const successFirst = [
+    { name: 'flaky', state: 'SUCCESS', completedAt: tiedAt },
+    { name: 'flaky', state: 'CANCELLED', completedAt: tiedAt },
+  ];
+  assert.equal(classifyCiChecks(cancelledFirst).status, 'success');
+  assert.equal(classifyCiChecks(successFirst).status, 'success');
+});
+
 test('detects operational marker prefixes', () => {
   assert.equal(
     operationalMarkerPrefix(

--- a/tests/required-checks-summary.test.mts
+++ b/tests/required-checks-summary.test.mts
@@ -99,3 +99,55 @@ test('a genuinely protected branch reports protectionReadsUnreadable: false even
   const r = summarize([{ name: 'lint', state: 'SUCCESS' }], protectedRules);
   assert.equal(r.protectionReadsUnreadable, false);
 });
+
+// #1471: a stale check-run instance for a name must not falsely block
+// pre-merge readiness once a later instance for that same name converged.
+test('unprotected: presentRunConclusion reflects the latest instance, not a stale instance sharing its name', () => {
+  const r = summarize(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'CANCELLED',
+        completedAt: '2026-07-17T15:59:36Z',
+      },
+      {
+        name: 'idd-advisory-convergence',
+        state: 'CANCELLED',
+        completedAt: '2026-07-17T15:59:51Z',
+      },
+      {
+        name: 'idd-advisory-convergence',
+        state: 'FAILURE',
+        completedAt: '2026-07-17T16:00:06Z',
+      },
+      {
+        name: 'idd-advisory-convergence',
+        state: 'SUCCESS',
+        completedAt: '2026-07-17T16:25:47Z',
+      },
+    ],
+    [],
+  );
+  assert.equal(r.presentRunConclusion, 'all-passing');
+});
+
+test('protected branch: requiredChecksPassing is true when the required check’s latest instance succeeded despite older cancelled/failure instances', () => {
+  // This is the exact PR #1434 / issue #1431 real-world reproduction: four
+  // idd-advisory-convergence check-run instances at one HEAD (2 cancelled,
+  // 1 failure, 1 success — the success is latest and authoritative), which
+  // must not report a false CI blocker once GitHub itself has converged.
+  const r = summarize(
+    [
+      {
+        name: 'lint',
+        state: 'CANCELLED',
+        completedAt: '2026-07-17T15:59:36Z',
+      },
+      { name: 'lint', state: 'FAILURE', completedAt: '2026-07-17T16:00:06Z' },
+      { name: 'lint', state: 'SUCCESS', completedAt: '2026-07-17T16:25:47Z' },
+    ],
+    protectedRules,
+  );
+  assert.equal(r.requiredChecksPassing, true);
+  assert.equal(r.status, 'success');
+});

--- a/tests/required-checks-summary.test.mts
+++ b/tests/required-checks-summary.test.mts
@@ -132,10 +132,13 @@ test('unprotected: presentRunConclusion reflects the latest instance, not a stal
 });
 
 test('protected branch: requiredChecksPassing is true when the required check’s latest instance succeeded despite older cancelled/failure instances', () => {
-  // This is the exact PR #1434 / issue #1431 real-world reproduction: four
-  // idd-advisory-convergence check-run instances at one HEAD (2 cancelled,
-  // 1 failure, 1 success — the success is latest and authoritative), which
-  // must not report a false CI blocker once GitHub itself has converged.
+  // An end-to-end variant of the PR #1434 / issue #1431 real-world
+  // reproduction, exercised here through summarizeRequiredChecks against
+  // protectedRules' required 'lint' check (see the exact four-instance
+  // idd-advisory-convergence repro, name included, in
+  // advisory-wait.test.mts): a stale cancelled/failure rollup superseded
+  // by the latest success must not report a false CI blocker once GitHub
+  // itself has converged.
   const r = summarize(
     [
       {


### PR DESCRIPTION
# Summary

`classifyCiChecks` in `src/scripts/protocol-helpers.mts` now reduces
multiple check-run instances that share the same check `name` to a
single representative instance before classifying pass/fail/pending,
matching GitHub's own required-status-check semantics (only the latest
run per context governs). Because `resolvePresentRunConclusion` calls
`classifyCiChecks` internally rather than duplicating its filtering
logic, this one change point fixes both call sites automatically.

Selection rule (see the doc comments on `isNewerCheckInstance` /
`selectLatestCheckInstance` / `selectLatestCheckPerName` for the full
rationale):

- A still-incomplete instance (no valid `completedAt`) always wins over
  an already-completed instance for the same name — a live rerun can
  never be older than the finished run it supersedes, so a stale
  completed verdict never shadows a check that has not converged yet
  (and, symmetrically, an in-progress rerun is never shadowed by an
  older completed success).
- Once every instance for a name has completed, the most recently
  completed one wins.
- A tie (equal `completedAt`, or both sides missing/unparseable) never
  resolves by input order: a tie involving `FAILURE` always prefers
  `FAILURE`, so the dedup can never hide a real failure behind ordering
  happenstance; failing that, a tie prefers a non-`CANCELLED` state.

## Linked issue

Closes #1471

## Follow-up issues (if any)

- [x] #1478 — `src/scripts/ci-wait-state.mts`'s `buildCiWaitStateSummary`
      (a separately-maintained mirror implementation, not an import of
      `classifyCiChecks`) has the identical multi-instance stale-rollup
      defect. Confirmed independently but out of scope for #1471, which
      is scoped to `classifyCiChecks` / `resolvePresentRunConclusion`
      (and sibling helpers within `protocol-helpers.mts` only).

## Background / rationale (if material)

`pre-merge-readiness.mjs` could report `ready: false` with a CI blocker
even when GitHub's own branch-protection evaluation already reported
`CLEAN` / `MERGEABLE` for the same HEAD, whenever an older, superseded
check-run instance for a required check name (e.g. a cancelled or
failed rerun) was still present in the fetched list alongside the
later, converged instance for that same name. This was observed live on
PR #1434 (issue #1431): four `idd-advisory-convergence` check-run
instances at one HEAD (2 cancelled, 1 failure, 1 success — the success
latest and authoritative), which produced a false CI blocker.

A C1 self-review round on this branch's own diff (3 parallel review
angles) found and fixed one real regression risk before this PR was
opened: the initial tie-break only special-cased `CANCELLED`, so two
different terminal conclusions (e.g. `FAILURE` and `SUCCESS`) completing
at the exact same recorded instant resolved by raw input array order —
independently confirmed by executing `classifyCiChecks` against the same
two check-run objects in both orders and observing different `status`
results. Fixed by making `FAILURE` always win a tie, with a regression
test locking in both orderings.

This PR does not touch `advisory-convergence.mts`'s own `converged`
computation or required-check discovery/pinning logic (#1442 / #1465's
territory — a different mechanism), or `ci-wait-state.mts` (see follow-up
issue above).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (biome, dprint, markdownlint, cspell)
- [x] `pnpm test` (full suite: 2339/2342 pass; the only 3 failures are
      pre-existing GPG-pinentry timeouts in `branch-conflict-state.test.mts`,
      unrelated to this change and independently reproduced on bare `main`)
- [x] `node scripts/audit-docs.mjs --check` (no docs changed by this PR)
- [x] `pnpm run docs:sync:check` (no docs changed by this PR)
- [x] `node scripts/idd-doctor.mjs` — passed (4 pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — application code + tests only)
- [x] Context budget impact reviewed (none — no instruction file changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI status classification now uses the latest result for each check, preventing outdated cancellations or failures from incorrectly blocking readiness.
  * In-progress checks remain pending even when older completed results exist.
  * Ties between check results are resolved consistently, prioritizing failures and active successful results appropriately.

* **Tests**
  * Added coverage for duplicate check runs, reruns, status ties, and required-check readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->