### PR TITLE
docs(idd): harden PR-body and claim-scan instruction text

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -515,8 +515,9 @@ in ascending issue-number order:
   shared claim-state rules in `idd-claim.instructions.md` — including
   forced-handoff and legacy markers, not just
   `claimed-by`/`unclaimed-by`. No current bulk helper
-  (`discover-roadmap-graph.mjs` / `discover-orphan-filter.mjs`
-  `--with-claim-state`) is forced-handoff-aware, so a multi-candidate
+  (`discover-roadmap-graph.mjs --with-claim-state` /
+  `discover-orphan-filter.mjs --with-claim-state`) is
+  forced-handoff-aware, so a multi-candidate
   survey here must either loop the single-issue
   `resume-claim-routing.mjs --fresh-claim-gate` resolver per candidate
   or apply `idd-claim.instructions.md`'s full parsing rules manually. A

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -512,7 +512,14 @@ in ascending issue-number order:
   where `N` is `.github/idd/config.json`
   `discover.activeClaimPreScanBatchSize` (distributed default: `10`).
 - For each candidate, fetch the issue and parse comments per the
-  shared claim-state rules in `idd-claim.instructions.md`. A
+  shared claim-state rules in `idd-claim.instructions.md` — including
+  forced-handoff and legacy markers, not just
+  `claimed-by`/`unclaimed-by`. No current bulk helper
+  (`discover-roadmap-graph.mjs` / `discover-orphan-filter.mjs`
+  `--with-claim-state`) is forced-handoff-aware, so a multi-candidate
+  survey here must either loop the single-issue
+  `resume-claim-routing.mjs --fresh-claim-gate` resolver per candidate
+  or apply `idd-claim.instructions.md`'s full parsing rules manually. A
   candidate is **ineligible** when parsing yields an **active claim**
   whose latest valid `claimed-by` comment (matching the documented
   format, authored by a trusted marker actor) has GitHub `created_at`

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -34,7 +34,10 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 **Important**: operational marker bodies are HTML comments. Some tools
 (e.g., `gh issue comment`, `gh api -f body=`) silently reject
 HTML-only bodies — always include the visible note and post via direct
-HTTP `POST` with a JSON body for reliability. When helper runtime is enabled,
+HTTP `POST` with a JSON body for reliability. `-f` also treats a leading
+`@` as a literal character — only `-F` reads `@file` contents, so
+`gh api -f body=@file` never posts the file's contents either. When
+helper runtime is enabled,
 the `post-idd-marker` helper (`--type claim --target issue <number> --apply`
 plus the claim fields; see `docs/idd-helper-scripts.md`) posts this marker
 through that JSON path (dry-run, posting nothing, without `--apply`); the direct

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -253,23 +253,30 @@ completion.
    block-quote prefix) and apply the same edit-and-recheck path
    as step 4.
 
-6. **Confirm no unintended extra closes**: GitHub's
+6. **Confirm the closing set matches exactly**: GitHub's
    `closingIssuesReferences` field on the PR
    (`gh pr view <pr-number> --json closingIssuesReferences --jq
    '.closingIssuesReferences[].number'`) lists every issue GitHub plans
    to close when the PR merges. Compare it against the deliberate
    closing set from D3 — normally just the claimed issue `<N>`, or the
-   full deliberate multi-issue set when "Multiple closing issues"
-   above applies. The two sets must be **exactly** equal; the steps
-   above only confirm the claimed issue is present; they do not catch
-   an extra unintended entry. Any `closingIssuesReferences` entry
-   outside the deliberate set is a spurious extra close — most often
-   the negation-blind false-positive documented above, where an
-   unrelated `#M` reference ends up adjacent to a recognized keyword
-   elsewhere in the body. If an unintended entry is found, edit the PR
-   body to separate the keyword from that `#M` reference and repeat
-   this step once. If it still fails, post a hold note on the issue
-   citing the PR URL and stop. Do not proceed to D4.
+   full deliberate multi-issue set when "Multiple closing issues" above
+   applies. The two sets must be **exactly** equal; steps 1-5 above
+   only confirm the claimed issue `<N>` is present, so this step is the
+   only one that catches either direction of mismatch:
+
+   - **An extra entry** (a `closingIssuesReferences` issue outside the
+     deliberate set) is most often the negation-blind false-positive
+     documented above, where an unrelated `#M` reference ends up
+     adjacent to a recognized keyword elsewhere in the body. Edit the
+     PR body to separate the keyword from that `#M` reference.
+   - **A missing entry** (a deliberate multi-issue-close target absent
+     from `closingIssuesReferences`) means its keyword did not
+     register — apply the same edit-and-recheck path as step 4 for
+     that issue number.
+
+   Repeat this step once after either fix. If it still fails, post a
+   hold note on the issue citing the PR URL and stop. Do not proceed to
+   D4.
 
 ## D4 — Wait for CI
 

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -167,6 +167,30 @@ When detection fails, GitHub will not auto-close the linked issue on
 merge and the issue↔PR linking surfaces (sidebar, timeline) will not
 populate.
 
+**Mirror false-positive — negation-blind detection**: the same literal
+matching runs in the other direction too. GitHub's detector matches a
+recognized keyword form immediately adjacent to a `#N` reference and
+has no concept of negation — wrapping the keyword in surrounding
+"not" / "deliberately" / "isn't" wording does not stop detection when
+the keyword itself still sits next to the `#N` it must not close. Keep
+every recognized keyword form (`close`, `closes`, `closed`, `fix`,
+`fixes`, `fixed`, `resolve`, `resolves`, `resolved`) structurally apart
+from any reference it must not close:
+
+- Risky — a keyword sits directly before the reference, even inside a
+  negation clause: "this PR does not close #42" (`close` is
+  immediately adjacent to `#42`; GitHub cannot see the "not").
+- Safe — reorder so no recognized keyword is adjacent to the
+  reference: "Refs #42 (deliberately not a closing keyword — see the
+  discussion there for why this PR does not resolve it directly)".
+  Here `resolve` is followed by "it", not a `#N` token, so nothing
+  adjacent to `#42` matches.
+
+Do not rely on careful phrasing alone as the only safeguard — the
+strengthened check in D3.5 below verifies `closingIssuesReferences`
+against the deliberate closing set exactly, catching a spurious extra
+close even if phrasing slips.
+
 #### Multiple closing issues
 
 When the PR closes more than one issue, repeat the keyword for each
@@ -229,11 +253,23 @@ completion.
    block-quote prefix) and apply the same edit-and-recheck path
    as step 4.
 
-GitHub's `closingIssuesReferences` field on the PR
-(`gh pr view <pr-number> --json closingIssuesReferences`) can also
-confirm detection: it lists every issue GitHub plans to close when
-the PR merges. If that list is non-empty and contains the claimed
-issue, the regex check above is redundant but still safe to run.
+6. **Confirm no unintended extra closes**: GitHub's
+   `closingIssuesReferences` field on the PR
+   (`gh pr view <pr-number> --json closingIssuesReferences --jq
+   '.closingIssuesReferences[].number'`) lists every issue GitHub plans
+   to close when the PR merges. Compare it against the deliberate
+   closing set from D3 — normally just the claimed issue `<N>`, or the
+   full deliberate multi-issue set when "Multiple closing issues"
+   above applies. The two sets must be **exactly** equal; the steps
+   above only confirm the claimed issue is present; they do not catch
+   an extra unintended entry. Any `closingIssuesReferences` entry
+   outside the deliberate set is a spurious extra close — most often
+   the negation-blind false-positive documented above, where an
+   unrelated `#M` reference ends up adjacent to a recognized keyword
+   elsewhere in the body. If an unintended entry is found, edit the PR
+   body to separate the keyword from that `#M` reference and repeat
+   this step once. If it still fails, post a hold note on the issue
+   citing the PR URL and stop. Do not proceed to D4.
 
 ## D4 — Wait for CI
 

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -168,10 +168,10 @@ reject bodies that consist entirely of HTML comments; this format
 includes visible text so that is not an issue, but the HTTP `POST` path
 is still recommended for reliability (`curl` with
 `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->\n\n_note_"}'`). `-f` also treats a leading
-`@` as a literal character — only `-F` reads `@file` contents. The
-post-idd-marker helper referenced above performs exactly this JSON
-`POST` under `--apply`.
+`-d '{"body":"<!-- ... -->\n\n_note_"}'`). For `gh api` specifically
+(not `curl`), `-f` also treats a leading `@` as a literal character —
+only `-F` reads `@file` contents. The post-idd-marker helper
+referenced above performs exactly this JSON `POST` under `--apply`.
 
 On resume or restart, read the latest
 `<!-- review-watermark: {agent-id} {claim-id} … -->` comment whose

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -168,8 +168,10 @@ reject bodies that consist entirely of HTML comments; this format
 includes visible text so that is not an issue, but the HTTP `POST` path
 is still recommended for reliability (`curl` with
 `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->\n\n_note_"}'`). The post-idd-marker helper
-referenced above performs exactly this JSON `POST` under `--apply`.
+`-d '{"body":"<!-- ... -->\n\n_note_"}'`). `-f` also treats a leading
+`@` as a literal character — only `-F` reads `@file` contents. The
+post-idd-marker helper referenced above performs exactly this JSON
+`POST` under `--apply`.
 
 On resume or restart, read the latest
 `<!-- review-watermark: {agent-id} {claim-id} … -->` comment whose

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -268,8 +268,14 @@ default below is unchanged.
     eligibility is unknown and treated as non-blocking). `authoringHeld`
     reports label **presence** only — `--with-readiness` does not compute the
     stale-authoring warning (it would cost a discarded per-leaf timeline fetch
-    and does not change startability). Both annotations are **soft** discovery
-    hints — the A3/A4/A4.5/A5 gates remain authoritative.
+    and does not change startability). `--with-claim-state` itself is not
+    forced-handoff-aware — it intentionally excludes forced-handoff and
+    legacy markers as a best-effort **soft signal**; a discovery-time survey
+    across many candidates must either loop the single-issue
+    `resume-claim-routing.mjs --fresh-claim-gate` resolver per candidate or
+    apply `idd-claim.instructions.md`'s full parsing rules manually to catch
+    a more-recent forced-handoff transfer. Both annotations are **soft**
+    discovery hints — the A3/A4/A4.5/A5 gates remain authoritative.
   - `diagnostics`: same four buckets as single-root mode, deduped across
     every per-root enumeration.
   - `summary`: `{ rootCount: number, leafCount: number,`

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -946,7 +946,8 @@ Interpretation rules:
   `protocol-helpers` renderers, then POSTs it as a JSON document
   (`{"body": …}`) via `gh api --method POST .../comments --input -`. The JSON
   path is mandatory because `gh issue comment` / `gh api -f body=` silently
-  reject the HTML-comment-first claim-family bodies.
+  reject the HTML-comment-first claim-family bodies. `-f` also treats a
+  leading `@` as a literal character — only `-F` reads `@file` contents.
 - The `claim` / `unclaim` / `watermark` / `baseline` bodies are
   HTML-comment-first with a visible "Do not edit" note; `advisory` /
   `advisory-recovery` are the **plain-text** `advisory-wait:` /

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -539,7 +539,14 @@ in ascending issue-number order:
   where `N` is `.github/idd/config.json`
   `discover.activeClaimPreScanBatchSize` (distributed default: `10`).
 - For each candidate, fetch the issue and parse comments per the
-  shared claim-state rules in `idd-claim.instructions.md`. A
+  shared claim-state rules in `idd-claim.instructions.md` — including
+  forced-handoff and legacy markers, not just
+  `claimed-by`/`unclaimed-by`. No current bulk helper
+  (`discover-roadmap-graph.mjs` / `discover-orphan-filter.mjs`
+  `--with-claim-state`) is forced-handoff-aware, so a multi-candidate
+  survey here must either loop the single-issue
+  `resume-claim-routing.mjs --fresh-claim-gate` resolver per candidate
+  or apply `idd-claim.instructions.md`'s full parsing rules manually. A
   candidate is **ineligible** when parsing yields an **active claim**
   whose latest valid `claimed-by` comment (matching the documented
   format, authored by a trusted marker actor) has GitHub `created_at`

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -542,8 +542,9 @@ in ascending issue-number order:
   shared claim-state rules in `idd-claim.instructions.md` — including
   forced-handoff and legacy markers, not just
   `claimed-by`/`unclaimed-by`. No current bulk helper
-  (`discover-roadmap-graph.mjs` / `discover-orphan-filter.mjs`
-  `--with-claim-state`) is forced-handoff-aware, so a multi-candidate
+  (`discover-roadmap-graph.mjs --with-claim-state` /
+  `discover-orphan-filter.mjs --with-claim-state`) is
+  forced-handoff-aware, so a multi-candidate
   survey here must either loop the single-issue
   `resume-claim-routing.mjs --fresh-claim-gate` resolver per candidate
   or apply `idd-claim.instructions.md`'s full parsing rules manually. A

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -29,7 +29,10 @@ _{agent-id}: issue claim — IDD automation marker. Do not edit._
 **Important**: operational marker bodies are HTML comments. Some tools
 (e.g., `gh issue comment`, `gh api -f body=`) silently reject
 HTML-only bodies — always include the visible note and post via direct
-HTTP `POST` with a JSON body for reliability. When helper runtime is enabled,
+HTTP `POST` with a JSON body for reliability. `-f` also treats a leading
+`@` as a literal character — only `-F` reads `@file` contents, so
+`gh api -f body=@file` never posts the file's contents either. When
+helper runtime is enabled,
 the `post-idd-marker` helper (`--type claim --target issue <number> --apply`
 plus the claim fields; see `docs/idd-helper-scripts.md`) posts this marker
 through that JSON path (dry-run, posting nothing, without `--apply`); the direct

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -248,23 +248,30 @@ completion.
    block-quote prefix) and apply the same edit-and-recheck path
    as step 4.
 
-6. **Confirm no unintended extra closes**: GitHub's
+6. **Confirm the closing set matches exactly**: GitHub's
    `closingIssuesReferences` field on the PR
    (`gh pr view <pr-number> --json closingIssuesReferences --jq
    '.closingIssuesReferences[].number'`) lists every issue GitHub plans
    to close when the PR merges. Compare it against the deliberate
    closing set from D3 — normally just the claimed issue `<N>`, or the
-   full deliberate multi-issue set when "Multiple closing issues"
-   above applies. The two sets must be **exactly** equal; the steps
-   above only confirm the claimed issue is present; they do not catch
-   an extra unintended entry. Any `closingIssuesReferences` entry
-   outside the deliberate set is a spurious extra close — most often
-   the negation-blind false-positive documented above, where an
-   unrelated `#M` reference ends up adjacent to a recognized keyword
-   elsewhere in the body. If an unintended entry is found, edit the PR
-   body to separate the keyword from that `#M` reference and repeat
-   this step once. If it still fails, post a hold note on the issue
-   citing the PR URL and stop. Do not proceed to D4.
+   full deliberate multi-issue set when "Multiple closing issues" above
+   applies. The two sets must be **exactly** equal; steps 1-5 above
+   only confirm the claimed issue `<N>` is present, so this step is the
+   only one that catches either direction of mismatch:
+
+   - **An extra entry** (a `closingIssuesReferences` issue outside the
+     deliberate set) is most often the negation-blind false-positive
+     documented above, where an unrelated `#M` reference ends up
+     adjacent to a recognized keyword elsewhere in the body. Edit the
+     PR body to separate the keyword from that `#M` reference.
+   - **A missing entry** (a deliberate multi-issue-close target absent
+     from `closingIssuesReferences`) means its keyword did not
+     register — apply the same edit-and-recheck path as step 4 for
+     that issue number.
+
+   Repeat this step once after either fix. If it still fails, post a
+   hold note on the issue citing the PR URL and stop. Do not proceed to
+   D4.
 
 ## D4 — Wait for CI
 

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -162,6 +162,30 @@ When detection fails, GitHub will not auto-close the linked issue on
 merge and the issue↔PR linking surfaces (sidebar, timeline) will not
 populate.
 
+**Mirror false-positive — negation-blind detection**: the same literal
+matching runs in the other direction too. GitHub's detector matches a
+recognized keyword form immediately adjacent to a `#N` reference and
+has no concept of negation — wrapping the keyword in surrounding
+"not" / "deliberately" / "isn't" wording does not stop detection when
+the keyword itself still sits next to the `#N` it must not close. Keep
+every recognized keyword form (`close`, `closes`, `closed`, `fix`,
+`fixes`, `fixed`, `resolve`, `resolves`, `resolved`) structurally apart
+from any reference it must not close:
+
+- Risky — a keyword sits directly before the reference, even inside a
+  negation clause: "this PR does not close #42" (`close` is
+  immediately adjacent to `#42`; GitHub cannot see the "not").
+- Safe — reorder so no recognized keyword is adjacent to the
+  reference: "Refs #42 (deliberately not a closing keyword — see the
+  discussion there for why this PR does not resolve it directly)".
+  Here `resolve` is followed by "it", not a `#N` token, so nothing
+  adjacent to `#42` matches.
+
+Do not rely on careful phrasing alone as the only safeguard — the
+strengthened check in D3.5 below verifies `closingIssuesReferences`
+against the deliberate closing set exactly, catching a spurious extra
+close even if phrasing slips.
+
 #### Multiple closing issues
 
 When the PR closes more than one issue, repeat the keyword for each
@@ -224,11 +248,23 @@ completion.
    block-quote prefix) and apply the same edit-and-recheck path
    as step 4.
 
-GitHub's `closingIssuesReferences` field on the PR
-(`gh pr view <pr-number> --json closingIssuesReferences`) can also
-confirm detection: it lists every issue GitHub plans to close when
-the PR merges. If that list is non-empty and contains the claimed
-issue, the regex check above is redundant but still safe to run.
+6. **Confirm no unintended extra closes**: GitHub's
+   `closingIssuesReferences` field on the PR
+   (`gh pr view <pr-number> --json closingIssuesReferences --jq
+   '.closingIssuesReferences[].number'`) lists every issue GitHub plans
+   to close when the PR merges. Compare it against the deliberate
+   closing set from D3 — normally just the claimed issue `<N>`, or the
+   full deliberate multi-issue set when "Multiple closing issues"
+   above applies. The two sets must be **exactly** equal; the steps
+   above only confirm the claimed issue is present; they do not catch
+   an extra unintended entry. Any `closingIssuesReferences` entry
+   outside the deliberate set is a spurious extra close — most often
+   the negation-blind false-positive documented above, where an
+   unrelated `#M` reference ends up adjacent to a recognized keyword
+   elsewhere in the body. If an unintended entry is found, edit the PR
+   body to separate the keyword from that `#M` reference and repeat
+   this step once. If it still fails, post a hold note on the issue
+   citing the PR URL and stop. Do not proceed to D4.
 
 ## D4 — Wait for CI
 

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -163,10 +163,10 @@ reject bodies that consist entirely of HTML comments; this format
 includes visible text so that is not an issue, but the HTTP `POST` path
 is still recommended for reliability (`curl` with
 `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->\n\n_note_"}'`). `-f` also treats a leading
-`@` as a literal character — only `-F` reads `@file` contents. The
-post-idd-marker helper referenced above performs exactly this JSON
-`POST` under `--apply`.
+`-d '{"body":"<!-- ... -->\n\n_note_"}'`). For `gh api` specifically
+(not `curl`), `-f` also treats a leading `@` as a literal character —
+only `-F` reads `@file` contents. The post-idd-marker helper
+referenced above performs exactly this JSON `POST` under `--apply`.
 
 On resume or restart, read the latest
 `<!-- review-watermark: {agent-id} {claim-id} … -->` comment whose

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -163,8 +163,10 @@ reject bodies that consist entirely of HTML comments; this format
 includes visible text so that is not an issue, but the HTTP `POST` path
 is still recommended for reliability (`curl` with
 `-H "Content-Type: application/json"` and
-`-d '{"body":"<!-- ... -->\n\n_note_"}'`). The post-idd-marker helper
-referenced above performs exactly this JSON `POST` under `--apply`.
+`-d '{"body":"<!-- ... -->\n\n_note_"}'`). `-f` also treats a leading
+`@` as a literal character — only `-F` reads `@file` contents. The
+post-idd-marker helper referenced above performs exactly this JSON
+`POST` under `--apply`.
 
 On resume or restart, read the latest
 `<!-- review-watermark: {agent-id} {claim-id} … -->` comment whose

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -268,8 +268,14 @@ default below is unchanged.
     eligibility is unknown and treated as non-blocking). `authoringHeld`
     reports label **presence** only — `--with-readiness` does not compute the
     stale-authoring warning (it would cost a discarded per-leaf timeline fetch
-    and does not change startability). Both annotations are **soft** discovery
-    hints — the A3/A4/A4.5/A5 gates remain authoritative.
+    and does not change startability). `--with-claim-state` itself is not
+    forced-handoff-aware — it intentionally excludes forced-handoff and
+    legacy markers as a best-effort **soft signal**; a discovery-time survey
+    across many candidates must either loop the single-issue
+    `resume-claim-routing.mjs --fresh-claim-gate` resolver per candidate or
+    apply `idd-claim.instructions.md`'s full parsing rules manually to catch
+    a more-recent forced-handoff transfer. Both annotations are **soft**
+    discovery hints — the A3/A4/A4.5/A5 gates remain authoritative.
   - `diagnostics`: same four buckets as single-root mode, deduped across
     every per-root enumeration.
   - `summary`: `{ rootCount: number, leafCount: number,`

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -946,7 +946,8 @@ Interpretation rules:
   `protocol-helpers` renderers, then POSTs it as a JSON document
   (`{"body": …}`) via `gh api --method POST .../comments --input -`. The JSON
   path is mandatory because `gh issue comment` / `gh api -f body=` silently
-  reject the HTML-comment-first claim-family bodies.
+  reject the HTML-comment-first claim-family bodies. `-f` also treats a
+  leading `@` as a literal character — only `-F` reads `@file` contents.
 - The `claim` / `unclaim` / `watermark` / `baseline` bodies are
   HTML-comment-first with a visible "Do not edit" note; `advisory` /
   `advisory-recovery` are the **plain-text** `advisory-wait:` /


### PR DESCRIPTION
## Summary

Three independent, verified documentation-precision hardenings to IDD
instruction text, per issue #1481:

- **A** (`idd-pr-submit.instructions.md`): documents the
  closing-keyword negation-blindness anti-pattern (GitHub matches
  literal `keyword + #N` adjacency and ignores negation wording) with a
  worked safe-phrasing example, and strengthens D3.5's
  `closingIssuesReferences` check to assert the field equals exactly
  the deliberate closing set rather than merely containing it.
- **B** (`idd-overview-core`, `idd-review-snapshot`,
  `idd-helper-scripts.md`): adds the `-f` vs `-F` `@file`-reading
  clause to all three existing `gh api -f body=` warnings.
- **C** (`idd-discover.instructions.md` Step 1.5,
  `idd-helper-scripts.md`): names forced-handoff explicitly and states
  the bulk-helper gap, so a multi-candidate discovery-time survey knows
  to loop `resume-claim-routing.mjs --fresh-claim-gate` or apply the
  full parsing rules manually.

All edits are documentation-only, in canonical `idd-template/` sources
with generated `.github/instructions/`/`docs/` mirrors kept in sync via
`sync-docs.mjs --apply` (except `idd-discover.instructions.md`, whose
mirror pair uses `structure` mode in `audit/sync-manifest.json` and was
hand-edited to match, since that mode is not auto-generated).

Closes #1481

## Test plan

- [x] `node scripts/sync-docs.mjs --apply`
- [x] `node scripts/audit-docs.mjs --check` -- zero drift
- [x] `node scripts/idd-doctor.mjs` -- passes
- [x] pre-push-validate (biome, dprint, markdownlint, cspell) -- clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified claim-state guidance to account for forced-handoff and legacy markers.
  * Documented limitations of bulk claim-state discovery annotations and recommended authoritative verification steps.
  * Updated GitHub API examples to clarify `-f` versus `-F` file handling and JSON marker posting.
  * Strengthened pull request closing-keyword guidance, including exact verification of intended issue closures.
  * Refined review watermark posting examples and instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->