### PR TITLE
fix(merged-pr-feedback-sweep): reuse the CodeRabbit summary classifier

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1420,13 +1420,21 @@ Interpretation rules:
     `**Awaiting maintainer decision**`). Trusted IDD operational markers, IDD
     disposition comments, any HTML comment beginning with `<!-- idd-` (for
     example cleanup-evidence, excluded regardless of author — including CI
-    automation such as `github-actions[bot]`), and a CodeRabbit
-    summary-walkthrough comment (recognized via the shared
-    `isReviewSummaryComment` classifier — the same single-sourced predicate
-    E6's `disposition-non-review-notices` uses to auto-`**Accepted**` it) are
-    all excluded from the feedback set unconditionally, regardless of
-    disposition state, so the sweep and E6 classify it identically instead of
-    disagreeing. Advisory non-review notices (rate/usage-limit) are
+    automation such as `github-actions[bot]`), and a genuine CodeRabbit
+    summary-walkthrough comment are all excluded from the feedback set
+    unconditionally, regardless of disposition state, so the sweep and E6
+    classify a CodeRabbit summary-walkthrough comment identically instead of
+    disagreeing. The summary-walkthrough exclusion requires **all three** of:
+    `isCodeRabbitLogin(author)` (the marker string is body-only with no author
+    check baked in, so gating on the actual CodeRabbit login keeps a
+    non-CodeRabbit comment that merely starts with the same literal text from
+    being wrongly dropped), the shared `isReviewSummaryComment` classifier —
+    the same single-sourced predicate E6's `disposition-non-review-notices`
+    uses to auto-`**Accepted**` a summary — and `!isAdvisoryNonReviewNotice`
+    (a CodeRabbit comment can carry both the summary marker and a
+    rate/usage-limit notice; E6 classifies that combination as a non-review
+    notice, never a summary acceptance, so the sweep must not exclude it
+    either). Advisory non-review notices (rate/usage-limit) are
     deliberately **not** excluded this way — an undispositioned one left on a
     merged PR still indicates a skipped E6 disposition and stays a genuine
     signal. Each finding carries an `advisoryBot` flag (`isKnownReviewBot` or a

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1418,10 +1418,18 @@ Interpretation rules:
     `CHANGES_REQUESTED` review bodies from non-IDD-agent authors that have
     **no later IDD-agent disposition** (`**Accepted**` / `**Rejected**` /
     `**Awaiting maintainer decision**`). Trusted IDD operational markers, IDD
-    disposition comments, and any HTML comment beginning with `<!-- idd-` (for
+    disposition comments, any HTML comment beginning with `<!-- idd-` (for
     example cleanup-evidence, excluded regardless of author — including CI
-    automation such as `github-actions[bot]`) are excluded from the feedback
-    set. Each finding carries an `advisoryBot` flag (`isKnownReviewBot` or a
+    automation such as `github-actions[bot]`), and a CodeRabbit
+    summary-walkthrough comment (recognized via the shared
+    `isReviewSummaryComment` classifier — the same single-sourced predicate
+    E6's `disposition-non-review-notices` uses to auto-`**Accepted**` it) are
+    all excluded from the feedback set unconditionally, regardless of
+    disposition state, so the sweep and E6 classify it identically instead of
+    disagreeing. Advisory non-review notices (rate/usage-limit) are
+    deliberately **not** excluded this way — an undispositioned one left on a
+    merged PR still indicates a skipped E6 disposition and stays a genuine
+    signal. Each finding carries an `advisoryBot` flag (`isKnownReviewBot` or a
     configured `advisoryBotLogins` author) so the operator can prioritize human
     feedback over capricious advisory-bot noise.
 - JSON output keys: `sweepWindow`, `trustedMarkerActors`,

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1425,16 +1425,21 @@ Interpretation rules:
     unconditionally, regardless of disposition state, so the sweep and E6
     classify a CodeRabbit summary-walkthrough comment identically instead of
     disagreeing. The summary-walkthrough exclusion requires **all three** of:
-    `isCodeRabbitLogin(author)` (the marker string is body-only with no author
-    check baked in, so gating on the actual CodeRabbit login keeps a
-    non-CodeRabbit comment that merely starts with the same literal text from
-    being wrongly dropped), the shared `isReviewSummaryComment` classifier —
-    the same single-sourced predicate E6's `disposition-non-review-notices`
-    uses to auto-`**Accepted**` a summary — and `!isAdvisoryNonReviewNotice`
-    (a CodeRabbit comment can carry both the summary marker and a
-    rate/usage-limit notice; E6 classifies that combination as a non-review
-    notice, never a summary acceptance, so the sweep must not exclude it
-    either). Advisory non-review notices (rate/usage-limit) are
+    the author matching the _configured_ advisory-bot identity set (the same
+    `--advisory-bot-logins` / `IDD_ADVISORY_BOT_LOGINS` / config resolution as
+    above, falling back to the CodeRabbit/Codex defaults when nothing is
+    configured — the same fallback E6 itself applies, and deliberately
+    narrower than the broader `isKnownReviewBot` recognition used for the
+    `advisoryBot` flag below, so a repo that configures `advisoryBotLogins` to
+    omit CodeRabbit makes both the sweep and E6 leave a CodeRabbit summary
+    undispositioned rather than only E6), the shared `isReviewSummaryComment`
+    classifier — the same single-sourced predicate E6's
+    `disposition-non-review-notices` uses to auto-`**Accepted**` a summary —
+    and `!isAdvisoryNonReviewNotice` (a CodeRabbit comment can carry both the
+    summary marker and a rate/usage-limit notice; E6 classifies that
+    combination as a non-review notice, never a summary acceptance, so the
+    sweep must not exclude it either). Advisory non-review notices
+    (rate/usage-limit) are
     deliberately **not** excluded this way — an undispositioned one left on a
     merged PR still indicates a skipped E6 disposition and stays a genuine
     signal. Each finding carries an `advisoryBot` flag (`isKnownReviewBot` or a

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1420,13 +1420,21 @@ Interpretation rules:
     `**Awaiting maintainer decision**`). Trusted IDD operational markers, IDD
     disposition comments, any HTML comment beginning with `<!-- idd-` (for
     example cleanup-evidence, excluded regardless of author — including CI
-    automation such as `github-actions[bot]`), and a CodeRabbit
-    summary-walkthrough comment (recognized via the shared
-    `isReviewSummaryComment` classifier — the same single-sourced predicate
-    E6's `disposition-non-review-notices` uses to auto-`**Accepted**` it) are
-    all excluded from the feedback set unconditionally, regardless of
-    disposition state, so the sweep and E6 classify it identically instead of
-    disagreeing. Advisory non-review notices (rate/usage-limit) are
+    automation such as `github-actions[bot]`), and a genuine CodeRabbit
+    summary-walkthrough comment are all excluded from the feedback set
+    unconditionally, regardless of disposition state, so the sweep and E6
+    classify a CodeRabbit summary-walkthrough comment identically instead of
+    disagreeing. The summary-walkthrough exclusion requires **all three** of:
+    `isCodeRabbitLogin(author)` (the marker string is body-only with no author
+    check baked in, so gating on the actual CodeRabbit login keeps a
+    non-CodeRabbit comment that merely starts with the same literal text from
+    being wrongly dropped), the shared `isReviewSummaryComment` classifier —
+    the same single-sourced predicate E6's `disposition-non-review-notices`
+    uses to auto-`**Accepted**` a summary — and `!isAdvisoryNonReviewNotice`
+    (a CodeRabbit comment can carry both the summary marker and a
+    rate/usage-limit notice; E6 classifies that combination as a non-review
+    notice, never a summary acceptance, so the sweep must not exclude it
+    either). Advisory non-review notices (rate/usage-limit) are
     deliberately **not** excluded this way — an undispositioned one left on a
     merged PR still indicates a skipped E6 disposition and stays a genuine
     signal. Each finding carries an `advisoryBot` flag (`isKnownReviewBot` or a

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1418,10 +1418,18 @@ Interpretation rules:
     `CHANGES_REQUESTED` review bodies from non-IDD-agent authors that have
     **no later IDD-agent disposition** (`**Accepted**` / `**Rejected**` /
     `**Awaiting maintainer decision**`). Trusted IDD operational markers, IDD
-    disposition comments, and any HTML comment beginning with `<!-- idd-` (for
+    disposition comments, any HTML comment beginning with `<!-- idd-` (for
     example cleanup-evidence, excluded regardless of author — including CI
-    automation such as `github-actions[bot]`) are excluded from the feedback
-    set. Each finding carries an `advisoryBot` flag (`isKnownReviewBot` or a
+    automation such as `github-actions[bot]`), and a CodeRabbit
+    summary-walkthrough comment (recognized via the shared
+    `isReviewSummaryComment` classifier — the same single-sourced predicate
+    E6's `disposition-non-review-notices` uses to auto-`**Accepted**` it) are
+    all excluded from the feedback set unconditionally, regardless of
+    disposition state, so the sweep and E6 classify it identically instead of
+    disagreeing. Advisory non-review notices (rate/usage-limit) are
+    deliberately **not** excluded this way — an undispositioned one left on a
+    merged PR still indicates a skipped E6 disposition and stays a genuine
+    signal. Each finding carries an `advisoryBot` flag (`isKnownReviewBot` or a
     configured `advisoryBotLogins` author) so the operator can prioritize human
     feedback over capricious advisory-bot noise.
 - JSON output keys: `sweepWindow`, `trustedMarkerActors`,

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1425,16 +1425,21 @@ Interpretation rules:
     unconditionally, regardless of disposition state, so the sweep and E6
     classify a CodeRabbit summary-walkthrough comment identically instead of
     disagreeing. The summary-walkthrough exclusion requires **all three** of:
-    `isCodeRabbitLogin(author)` (the marker string is body-only with no author
-    check baked in, so gating on the actual CodeRabbit login keeps a
-    non-CodeRabbit comment that merely starts with the same literal text from
-    being wrongly dropped), the shared `isReviewSummaryComment` classifier —
-    the same single-sourced predicate E6's `disposition-non-review-notices`
-    uses to auto-`**Accepted**` a summary — and `!isAdvisoryNonReviewNotice`
-    (a CodeRabbit comment can carry both the summary marker and a
-    rate/usage-limit notice; E6 classifies that combination as a non-review
-    notice, never a summary acceptance, so the sweep must not exclude it
-    either). Advisory non-review notices (rate/usage-limit) are
+    the author matching the _configured_ advisory-bot identity set (the same
+    `--advisory-bot-logins` / `IDD_ADVISORY_BOT_LOGINS` / config resolution as
+    above, falling back to the CodeRabbit/Codex defaults when nothing is
+    configured — the same fallback E6 itself applies, and deliberately
+    narrower than the broader `isKnownReviewBot` recognition used for the
+    `advisoryBot` flag below, so a repo that configures `advisoryBotLogins` to
+    omit CodeRabbit makes both the sweep and E6 leave a CodeRabbit summary
+    undispositioned rather than only E6), the shared `isReviewSummaryComment`
+    classifier — the same single-sourced predicate E6's
+    `disposition-non-review-notices` uses to auto-`**Accepted**` a summary —
+    and `!isAdvisoryNonReviewNotice` (a CodeRabbit comment can carry both the
+    summary marker and a rate/usage-limit notice; E6 classifies that
+    combination as a non-review notice, never a summary acceptance, so the
+    sweep must not exclude it either). Advisory non-review notices
+    (rate/usage-limit) are
     deliberately **not** excluded this way — an undispositioned one left on a
     merged PR still indicates a skipped E6 disposition and stays a genuine
     signal. Each finding carries an `advisoryBot` flag (`isKnownReviewBot` or a

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -10,6 +10,16 @@ export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
 export const DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES = 10;
 export const DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES = 2;
 export const DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN = 'copilot';
+// Shared last-resort fallback for the plural `advisoryBotLogins` config key
+// (distinct from the singular primary-bot-login default above): used by both
+// `merged-pr-feedback-sweep.mts` and `disposition-non-review-notices.mts` so
+// the two stay aligned on which identities count as advisory bots when
+// `.github/idd/config.json` configures none. A single source avoids the
+// drift risk of two independently-maintained literals (see PR #1490 review).
+export const DEFAULT_ADVISORY_BOT_LOGINS = [
+  'coderabbitai[bot]',
+  'chatgpt-codex-connector[bot]',
+];
 // 24h, matching the `claim-stale-age` and external-check-waiver
 // `maxValidity` defaults so this gate uses a familiar timescale.
 export const DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES = 1440;

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -37,6 +37,7 @@ import { loadIddConfig } from './idd-config.mjs';
 import {
   advisoryBotIdentityToken,
   compareIsoTimestamps,
+  DEFAULT_ADVISORY_BOT_LOGINS,
   dispositionNamesAdvisoryBot,
   effectiveRegularCommentActivityAt,
   isAdvisoryNonReviewNotice,
@@ -47,11 +48,6 @@ import {
   resolveActiveClaimForWriteGate,
   resolveAdvisoryBotLogins,
 } from './protocol-helpers.mjs';
-
-const DEFAULT_ADVISORY_BOT_LOGINS = [
-  'coderabbitai[bot]',
-  'chatgpt-codex-connector[bot]',
-];
 /**
  * Derive the short `({reason})` clause for a non-review notice from its body.
  * Tightly tied to the categories `isAdvisoryNonReviewNotice` recognizes; falls

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -19,6 +19,8 @@ import { parseCliArgs } from './cli-args.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
   hasFreshDisposition,
+  isAdvisoryNonReviewNotice,
+  isCodeRabbitLogin,
   isDispositionComment,
   isKnownReviewBot,
   isReviewSummaryComment,
@@ -258,10 +260,27 @@ function collectUnaddressedComments(
     // The CodeRabbit summary-walkthrough comment is auto-generated
     // boilerplate, not reviewer feedback: E6 (disposition-non-review-notices)
     // already auto-`**Accepted**`s it via this same single-sourced
-    // classifier. Exclude it unconditionally here too — the same tier as IDD
-    // bookkeeping, not gated on `latestDispositionAt` — so the sweep and E6
-    // classify it identically instead of disagreeing (#1488).
-    if (isReviewSummaryComment(comment.body)) {
+    // `isReviewSummaryComment` classifier. Exclude it unconditionally here
+    // too — the same tier as IDD bookkeeping, not gated on
+    // `latestDispositionAt` — so the sweep and E6 classify it identically
+    // instead of disagreeing (#1488). Two guards keep this narrow, matching
+    // E6's own gate exactly (`disposition-non-review-notices.mts`):
+    // - `isCodeRabbitLogin(author)`: the marker is body-only (no author
+    //   check baked in), so without this a non-CodeRabbit author whose
+    //   comment happens to start with the same literal HTML-comment text
+    //   would be wrongly treated as inert boilerplate and dropped.
+    // - `!isAdvisoryNonReviewNotice(comment.body)`: a CodeRabbit comment can
+    //   carry both this summary marker and a rate/usage-limit notice; E6
+    //   classifies that combination as a non-review notice (a `**Rejected**`
+    //   disposition), never as a summary acceptance. Excluding it here
+    //   before that classification would hide an undispositioned notice
+    //   from the sweep, contrary to advisory non-review notices staying a
+    //   genuine signal.
+    if (
+      isCodeRabbitLogin(author) &&
+      isReviewSummaryComment(comment.body) &&
+      !isAdvisoryNonReviewNotice(comment.body)
+    ) {
       continue;
     }
     if (isLaterThan(latestDispositionAt, commentTimestamp(comment))) {

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -18,9 +18,9 @@ import { execFileSync } from 'node:child_process';
 import { parseCliArgs } from './cli-args.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
+  advisoryBotIdentityToken,
   hasFreshDisposition,
   isAdvisoryNonReviewNotice,
-  isCodeRabbitLogin,
   isDispositionComment,
   isKnownReviewBot,
   isReviewSummaryComment,
@@ -123,10 +123,26 @@ export function buildMergedPrFeedbackSweep(prs, options) {
   const advisory = new Set(
     options.advisoryBotLogins.map((login) => login.toLowerCase()),
   );
+  // Distinct from `advisory` above: E6 (disposition-non-review-notices.mts)
+  // gates its summary-walkthrough auto-acceptance on membership in the
+  // *configured* `advisoryBotLogins` set alone (identity-token compared, so
+  // `coderabbitai` and `coderabbitai[bot]` collapse to the same entry) --
+  // never on the broader `isKnownReviewBot` recognition `advisory` folds in
+  // here. A repo that deliberately configures advisoryBotLogins to omit
+  // CodeRabbit (e.g. a Codex-only advisory policy) makes E6 leave a
+  // CodeRabbit summary undispositioned; matching that exactly (not
+  // `isKnownReviewBot`, which would keep recognizing CodeRabbit regardless of
+  // that config) is what keeps the sweep's summary exclusion from disagreeing
+  // with E6 in that configuration.
+  const advisoryIdentities = new Set(
+    options.advisoryBotLogins.map(advisoryBotIdentityToken),
+  );
   const isIdd = (login) => idd.has(login);
   const isTrusted = (login) => trusted.has(login);
   const isAdvisoryBot = (login) =>
     isKnownReviewBot(login) || advisory.has(login);
+  const isConfiguredAdvisoryBotIdentity = (login) =>
+    advisoryIdentities.has(advisoryBotIdentityToken(login));
   const findings = [];
   for (const pr of prs) {
     const unresolvedThreads = collectUnresolvedThreads(
@@ -141,6 +157,7 @@ export function buildMergedPrFeedbackSweep(prs, options) {
       isIdd,
       isTrusted,
       isAdvisoryBot,
+      isConfiguredAdvisoryBotIdentity,
     );
     if (unresolvedThreads.length === 0 && unaddressedComments.length === 0) {
       continue;
@@ -217,6 +234,7 @@ function collectUnaddressedComments(
   isIdd,
   isTrusted,
   isAdvisoryBot,
+  isConfiguredAdvisoryBotIdentity,
 ) {
   // A non-IDD item counts as addressed only when a later IDD-agent
   // *disposition* (Accepted / Rejected / Awaiting maintainer decision)
@@ -265,10 +283,16 @@ function collectUnaddressedComments(
     // `latestDispositionAt` — so the sweep and E6 classify it identically
     // instead of disagreeing (#1488). Two guards keep this narrow, matching
     // E6's own gate exactly (`disposition-non-review-notices.mts`):
-    // - `isCodeRabbitLogin(author)`: the marker is body-only (no author
-    //   check baked in), so without this a non-CodeRabbit author whose
-    //   comment happens to start with the same literal HTML-comment text
-    //   would be wrongly treated as inert boilerplate and dropped.
+    // - `isConfiguredAdvisoryBotIdentity(author)`: the marker is body-only
+    //   (no author check baked in), so without this a non-advisory-bot
+    //   author whose comment happens to start with the same literal
+    //   HTML-comment text would be wrongly treated as inert boilerplate and
+    //   dropped. Gated on the *configured* advisory-bot set specifically
+    //   (not the broader `isAdvisoryBot` / `isKnownReviewBot` recognition)
+    //   because that is what E6 itself gates on: a repo that configures
+    //   `advisoryBotLogins` to omit CodeRabbit makes E6 leave a CodeRabbit
+    //   summary undispositioned, and this exclusion must agree rather than
+    //   still silently dropping it.
     // - `!isAdvisoryNonReviewNotice(comment.body)`: a CodeRabbit comment can
     //   carry both this summary marker and a rate/usage-limit notice; E6
     //   classifies that combination as a non-review notice (a `**Rejected**`
@@ -277,7 +301,7 @@ function collectUnaddressedComments(
     //   from the sweep, contrary to advisory non-review notices staying a
     //   genuine signal.
     if (
-      isCodeRabbitLogin(author) &&
+      isConfiguredAdvisoryBotIdentity(author) &&
       isReviewSummaryComment(comment.body) &&
       !isAdvisoryNonReviewNotice(comment.body)
     ) {
@@ -317,6 +341,20 @@ function collectUnaddressedComments(
   }
   return out;
 }
+// ---------------------------------------------------------------------------
+// CLI / I/O (not unit-tested; the detection lives in the pure builder above)
+// ---------------------------------------------------------------------------
+// Mirrors disposition-non-review-notices.mts (E6)'s own default exactly: a
+// repo with no --advisory-bot-logins flag, no IDD_ADVISORY_BOT_LOGINS env,
+// and no advisoryBotLogins in .github/idd/config.json still recognizes
+// CodeRabbit/Codex as advisory-bot identities for the summary-walkthrough
+// exclusion, matching what E6 falls back to by default -- instead of that
+// exclusion (gated on `isConfiguredAdvisoryBotIdentity`) silently never
+// firing when resolution yields an empty list.
+const DEFAULT_ADVISORY_BOT_LOGINS = [
+  'coderabbitai[bot]',
+  'chatgpt-codex-connector[bot]',
+];
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `since:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
 // .mjs source text for quoted flag literals such as the --since spec key
@@ -602,11 +640,15 @@ function main() {
     envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
     config: iddConfig,
   });
-  const { logins: advisoryBotLogins } = resolveAdvisoryBotLogins({
+  const resolvedAdvisoryBotLogins = resolveAdvisoryBotLogins({
     flagValue: args.advisoryBotLogins,
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config: iddConfig,
-  });
+  }).logins;
+  const advisoryBotLogins =
+    resolvedAdvisoryBotLogins.length > 0
+      ? resolvedAdvisoryBotLogins
+      : DEFAULT_ADVISORY_BOT_LOGINS;
   // The IDD agent accounts whose comments are treated as dispositions and
   // whose own comments are not feedback. Distinct from trusted-marker actors:
   // a human maintainer can be a trusted-marker actor whose review feedback we

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -21,6 +21,7 @@ import {
   hasFreshDisposition,
   isDispositionComment,
   isKnownReviewBot,
+  isReviewSummaryComment,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   resolveAdvisoryBotLogins,
@@ -252,6 +253,15 @@ function collectUnaddressedComments(
     // or any `<!-- idd-… -->` comment (e.g. cleanup-evidence / plan / digest,
     // which CI automation such as github-actions also posts).
     if (isIddBookkeeping(comment.body, author, isTrusted)) {
+      continue;
+    }
+    // The CodeRabbit summary-walkthrough comment is auto-generated
+    // boilerplate, not reviewer feedback: E6 (disposition-non-review-notices)
+    // already auto-`**Accepted**`s it via this same single-sourced
+    // classifier. Exclude it unconditionally here too — the same tier as IDD
+    // bookkeeping, not gated on `latestDispositionAt` — so the sweep and E6
+    // classify it identically instead of disagreeing (#1488).
+    if (isReviewSummaryComment(comment.body)) {
       continue;
     }
     if (isLaterThan(latestDispositionAt, commentTimestamp(comment))) {

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -19,6 +19,7 @@ import { parseCliArgs } from './cli-args.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
   advisoryBotIdentityToken,
+  DEFAULT_ADVISORY_BOT_LOGINS,
   hasFreshDisposition,
   isAdvisoryNonReviewNotice,
   isDispositionComment,
@@ -341,20 +342,6 @@ function collectUnaddressedComments(
   }
   return out;
 }
-// ---------------------------------------------------------------------------
-// CLI / I/O (not unit-tested; the detection lives in the pure builder above)
-// ---------------------------------------------------------------------------
-// Mirrors disposition-non-review-notices.mts (E6)'s own default exactly: a
-// repo with no --advisory-bot-logins flag, no IDD_ADVISORY_BOT_LOGINS env,
-// and no advisoryBotLogins in .github/idd/config.json still recognizes
-// CodeRabbit/Codex as advisory-bot identities for the summary-walkthrough
-// exclusion, matching what E6 falls back to by default -- instead of that
-// exclusion (gated on `isConfiguredAdvisoryBotIdentity`) silently never
-// firing when resolution yields an empty list.
-const DEFAULT_ADVISORY_BOT_LOGINS = [
-  'coderabbitai[bot]',
-  'chatgpt-codex-connector[bot]',
-];
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `since:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
 // .mjs source text for quoted flag literals such as the --since spec key

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -9,6 +9,12 @@ import {
   normalizeAdvisoryWaitRuntimeOptions,
 } from './advisory-wait-policy.mjs';
 
+// Re-exported so callers that already import advisory-bot-identity helpers
+// from this façade (merged-pr-feedback-sweep.mts,
+// disposition-non-review-notices.mts) can get the shared default-logins list
+// from the same module instead of reaching into advisory-wait-policy.mts
+// directly.
+export { DEFAULT_ADVISORY_BOT_LOGINS } from './advisory-wait-policy.mjs';
 // Façade re-export (wave 1 of the protocol-helpers split; see #1209): every
 // marker render/parse primitive now lives in the marker-helpers module.
 // Re-exporting it here keeps every existing call site importing from

--- a/src/scripts/advisory-wait-policy.mts
+++ b/src/scripts/advisory-wait-policy.mts
@@ -13,6 +13,16 @@ export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
 export const DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES = 10;
 export const DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES = 2;
 export const DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN = 'copilot';
+// Shared last-resort fallback for the plural `advisoryBotLogins` config key
+// (distinct from the singular primary-bot-login default above): used by both
+// `merged-pr-feedback-sweep.mts` and `disposition-non-review-notices.mts` so
+// the two stay aligned on which identities count as advisory bots when
+// `.github/idd/config.json` configures none. A single source avoids the
+// drift risk of two independently-maintained literals (see PR #1490 review).
+export const DEFAULT_ADVISORY_BOT_LOGINS = [
+  'coderabbitai[bot]',
+  'chatgpt-codex-connector[bot]',
+];
 // 24h, matching the `claim-stale-age` and external-check-waiver
 // `maxValidity` defaults so this gate uses a familiar timescale.
 export const DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES = 1440;

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -39,6 +39,7 @@ import { loadIddConfig } from './idd-config.mts';
 import {
   advisoryBotIdentityToken,
   compareIsoTimestamps,
+  DEFAULT_ADVISORY_BOT_LOGINS,
   dispositionNamesAdvisoryBot,
   effectiveRegularCommentActivityAt,
   isAdvisoryNonReviewNotice,
@@ -49,11 +50,6 @@ import {
   resolveActiveClaimForWriteGate,
   resolveAdvisoryBotLogins,
 } from './protocol-helpers.mts';
-
-const DEFAULT_ADVISORY_BOT_LOGINS = [
-  'coderabbitai[bot]',
-  'chatgpt-codex-connector[bot]',
-];
 
 export interface NoticeComment {
   id: number;

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -20,6 +20,8 @@ import { parseCliArgs } from './cli-args.mts';
 import { loadIddConfig } from './idd-config.mts';
 import {
   hasFreshDisposition,
+  isAdvisoryNonReviewNotice,
+  isCodeRabbitLogin,
   isDispositionComment,
   isKnownReviewBot,
   isReviewSummaryComment,
@@ -390,10 +392,27 @@ function collectUnaddressedComments(
     // The CodeRabbit summary-walkthrough comment is auto-generated
     // boilerplate, not reviewer feedback: E6 (disposition-non-review-notices)
     // already auto-`**Accepted**`s it via this same single-sourced
-    // classifier. Exclude it unconditionally here too — the same tier as IDD
-    // bookkeeping, not gated on `latestDispositionAt` — so the sweep and E6
-    // classify it identically instead of disagreeing (#1488).
-    if (isReviewSummaryComment(comment.body)) {
+    // `isReviewSummaryComment` classifier. Exclude it unconditionally here
+    // too — the same tier as IDD bookkeeping, not gated on
+    // `latestDispositionAt` — so the sweep and E6 classify it identically
+    // instead of disagreeing (#1488). Two guards keep this narrow, matching
+    // E6's own gate exactly (`disposition-non-review-notices.mts`):
+    // - `isCodeRabbitLogin(author)`: the marker is body-only (no author
+    //   check baked in), so without this a non-CodeRabbit author whose
+    //   comment happens to start with the same literal HTML-comment text
+    //   would be wrongly treated as inert boilerplate and dropped.
+    // - `!isAdvisoryNonReviewNotice(comment.body)`: a CodeRabbit comment can
+    //   carry both this summary marker and a rate/usage-limit notice; E6
+    //   classifies that combination as a non-review notice (a `**Rejected**`
+    //   disposition), never as a summary acceptance. Excluding it here
+    //   before that classification would hide an undispositioned notice
+    //   from the sweep, contrary to advisory non-review notices staying a
+    //   genuine signal.
+    if (
+      isCodeRabbitLogin(author) &&
+      isReviewSummaryComment(comment.body) &&
+      !isAdvisoryNonReviewNotice(comment.body)
+    ) {
       continue;
     }
     if (isLaterThan(latestDispositionAt, commentTimestamp(comment))) {

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -20,6 +20,7 @@ import { parseCliArgs } from './cli-args.mts';
 import { loadIddConfig } from './idd-config.mts';
 import {
   advisoryBotIdentityToken,
+  DEFAULT_ADVISORY_BOT_LOGINS,
   hasFreshDisposition,
   isAdvisoryNonReviewNotice,
   isDispositionComment,
@@ -479,18 +480,6 @@ function collectUnaddressedComments(
 // ---------------------------------------------------------------------------
 // CLI / I/O (not unit-tested; the detection lives in the pure builder above)
 // ---------------------------------------------------------------------------
-
-// Mirrors disposition-non-review-notices.mts (E6)'s own default exactly: a
-// repo with no --advisory-bot-logins flag, no IDD_ADVISORY_BOT_LOGINS env,
-// and no advisoryBotLogins in .github/idd/config.json still recognizes
-// CodeRabbit/Codex as advisory-bot identities for the summary-walkthrough
-// exclusion, matching what E6 falls back to by default -- instead of that
-// exclusion (gated on `isConfiguredAdvisoryBotIdentity`) silently never
-// firing when resolution yields an empty list.
-const DEFAULT_ADVISORY_BOT_LOGINS = [
-  'coderabbitai[bot]',
-  'chatgpt-codex-connector[bot]',
-];
 
 interface SweepArgs {
   since: string | null;

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -22,6 +22,7 @@ import {
   hasFreshDisposition,
   isDispositionComment,
   isKnownReviewBot,
+  isReviewSummaryComment,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   resolveAdvisoryBotLogins,
@@ -384,6 +385,15 @@ function collectUnaddressedComments(
     // or any `<!-- idd-… -->` comment (e.g. cleanup-evidence / plan / digest,
     // which CI automation such as github-actions also posts).
     if (isIddBookkeeping(comment.body, author, isTrusted)) {
+      continue;
+    }
+    // The CodeRabbit summary-walkthrough comment is auto-generated
+    // boilerplate, not reviewer feedback: E6 (disposition-non-review-notices)
+    // already auto-`**Accepted**`s it via this same single-sourced
+    // classifier. Exclude it unconditionally here too — the same tier as IDD
+    // bookkeeping, not gated on `latestDispositionAt` — so the sweep and E6
+    // classify it identically instead of disagreeing (#1488).
+    if (isReviewSummaryComment(comment.body)) {
       continue;
     }
     if (isLaterThan(latestDispositionAt, commentTimestamp(comment))) {

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -19,9 +19,9 @@ import { execFileSync } from 'node:child_process';
 import { parseCliArgs } from './cli-args.mts';
 import { loadIddConfig } from './idd-config.mts';
 import {
+  advisoryBotIdentityToken,
   hasFreshDisposition,
   isAdvisoryNonReviewNotice,
-  isCodeRabbitLogin,
   isDispositionComment,
   isKnownReviewBot,
   isReviewSummaryComment,
@@ -241,10 +241,26 @@ export function buildMergedPrFeedbackSweep(
   const advisory = new Set(
     options.advisoryBotLogins.map((login) => login.toLowerCase()),
   );
+  // Distinct from `advisory` above: E6 (disposition-non-review-notices.mts)
+  // gates its summary-walkthrough auto-acceptance on membership in the
+  // *configured* `advisoryBotLogins` set alone (identity-token compared, so
+  // `coderabbitai` and `coderabbitai[bot]` collapse to the same entry) --
+  // never on the broader `isKnownReviewBot` recognition `advisory` folds in
+  // here. A repo that deliberately configures advisoryBotLogins to omit
+  // CodeRabbit (e.g. a Codex-only advisory policy) makes E6 leave a
+  // CodeRabbit summary undispositioned; matching that exactly (not
+  // `isKnownReviewBot`, which would keep recognizing CodeRabbit regardless of
+  // that config) is what keeps the sweep's summary exclusion from disagreeing
+  // with E6 in that configuration.
+  const advisoryIdentities = new Set(
+    options.advisoryBotLogins.map(advisoryBotIdentityToken),
+  );
   const isIdd = (login: string): boolean => idd.has(login);
   const isTrusted = (login: string): boolean => trusted.has(login);
   const isAdvisoryBot = (login: string): boolean =>
     isKnownReviewBot(login) || advisory.has(login);
+  const isConfiguredAdvisoryBotIdentity = (login: string): boolean =>
+    advisoryIdentities.has(advisoryBotIdentityToken(login));
 
   const findings: SweepPrFinding[] = [];
   for (const pr of prs) {
@@ -260,6 +276,7 @@ export function buildMergedPrFeedbackSweep(
       isIdd,
       isTrusted,
       isAdvisoryBot,
+      isConfiguredAdvisoryBotIdentity,
     );
     if (unresolvedThreads.length === 0 && unaddressedComments.length === 0) {
       continue;
@@ -347,6 +364,7 @@ function collectUnaddressedComments(
   isIdd: (login: string) => boolean,
   isTrusted: (login: string) => boolean,
   isAdvisoryBot: (login: string) => boolean,
+  isConfiguredAdvisoryBotIdentity: (login: string) => boolean,
 ): SweepCommentFinding[] {
   // A non-IDD item counts as addressed only when a later IDD-agent
   // *disposition* (Accepted / Rejected / Awaiting maintainer decision)
@@ -397,10 +415,16 @@ function collectUnaddressedComments(
     // `latestDispositionAt` — so the sweep and E6 classify it identically
     // instead of disagreeing (#1488). Two guards keep this narrow, matching
     // E6's own gate exactly (`disposition-non-review-notices.mts`):
-    // - `isCodeRabbitLogin(author)`: the marker is body-only (no author
-    //   check baked in), so without this a non-CodeRabbit author whose
-    //   comment happens to start with the same literal HTML-comment text
-    //   would be wrongly treated as inert boilerplate and dropped.
+    // - `isConfiguredAdvisoryBotIdentity(author)`: the marker is body-only
+    //   (no author check baked in), so without this a non-advisory-bot
+    //   author whose comment happens to start with the same literal
+    //   HTML-comment text would be wrongly treated as inert boilerplate and
+    //   dropped. Gated on the *configured* advisory-bot set specifically
+    //   (not the broader `isAdvisoryBot` / `isKnownReviewBot` recognition)
+    //   because that is what E6 itself gates on: a repo that configures
+    //   `advisoryBotLogins` to omit CodeRabbit makes E6 leave a CodeRabbit
+    //   summary undispositioned, and this exclusion must agree rather than
+    //   still silently dropping it.
     // - `!isAdvisoryNonReviewNotice(comment.body)`: a CodeRabbit comment can
     //   carry both this summary marker and a rate/usage-limit notice; E6
     //   classifies that combination as a non-review notice (a `**Rejected**`
@@ -409,7 +433,7 @@ function collectUnaddressedComments(
     //   from the sweep, contrary to advisory non-review notices staying a
     //   genuine signal.
     if (
-      isCodeRabbitLogin(author) &&
+      isConfiguredAdvisoryBotIdentity(author) &&
       isReviewSummaryComment(comment.body) &&
       !isAdvisoryNonReviewNotice(comment.body)
     ) {
@@ -455,6 +479,18 @@ function collectUnaddressedComments(
 // ---------------------------------------------------------------------------
 // CLI / I/O (not unit-tested; the detection lives in the pure builder above)
 // ---------------------------------------------------------------------------
+
+// Mirrors disposition-non-review-notices.mts (E6)'s own default exactly: a
+// repo with no --advisory-bot-logins flag, no IDD_ADVISORY_BOT_LOGINS env,
+// and no advisoryBotLogins in .github/idd/config.json still recognizes
+// CodeRabbit/Codex as advisory-bot identities for the summary-walkthrough
+// exclusion, matching what E6 falls back to by default -- instead of that
+// exclusion (gated on `isConfiguredAdvisoryBotIdentity`) silently never
+// firing when resolution yields an empty list.
+const DEFAULT_ADVISORY_BOT_LOGINS = [
+  'coderabbitai[bot]',
+  'chatgpt-codex-connector[bot]',
+];
 
 interface SweepArgs {
   since: string | null;
@@ -817,11 +853,15 @@ function main(): void {
     envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
     config: iddConfig,
   });
-  const { logins: advisoryBotLogins } = resolveAdvisoryBotLogins({
+  const resolvedAdvisoryBotLogins = resolveAdvisoryBotLogins({
     flagValue: args.advisoryBotLogins,
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config: iddConfig,
-  });
+  }).logins;
+  const advisoryBotLogins =
+    resolvedAdvisoryBotLogins.length > 0
+      ? resolvedAdvisoryBotLogins
+      : DEFAULT_ADVISORY_BOT_LOGINS;
   // The IDD agent accounts whose comments are treated as dispositions and
   // whose own comments are not feedback. Distinct from trusted-marker actors:
   // a human maintainer can be a trusted-marker actor whose review feedback we

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -10,6 +10,13 @@ import {
   normalizeAdvisoryWaitRuntimeOptions,
 } from './advisory-wait-policy.mts';
 
+// Re-exported so callers that already import advisory-bot-identity helpers
+// from this façade (merged-pr-feedback-sweep.mts,
+// disposition-non-review-notices.mts) can get the shared default-logins list
+// from the same module instead of reaching into advisory-wait-policy.mts
+// directly.
+export { DEFAULT_ADVISORY_BOT_LOGINS } from './advisory-wait-policy.mts';
+
 // Façade re-export (wave 1 of the protocol-helpers split; see #1209): every
 // marker render/parse primitive now lives in the marker-helpers module.
 // Re-exporting it here keeps every existing call site importing from

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -435,7 +435,9 @@ test('a non-CodeRabbit author whose comment starts with the summary marker is st
   // Codex review finding on #1488's own PR: isReviewSummaryComment matches by
   // body prefix alone, so without an author gate a human (or any other bot)
   // could evade the sweep by starting a comment with CodeRabbit's literal
-  // marker text. Only coderabbitai[bot] gets the exclusion.
+  // marker text. Only a login in the configured advisory-bot identity set
+  // (default: CodeRabbit/Codex) gets the exclusion -- a human posting the
+  // same marker text does not qualify.
   const prs: MergedPrInput[] = [
     {
       number: 20,

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -431,6 +431,56 @@ test('the summary exclusion is comment-scoped: a genuine comment and an unresolv
   );
 });
 
+test('a non-CodeRabbit author whose comment starts with the summary marker is still surfaced', () => {
+  // Codex review finding on #1488's own PR: isReviewSummaryComment matches by
+  // body prefix alone, so without an author gate a human (or any other bot)
+  // could evade the sweep by starting a comment with CodeRabbit's literal
+  // marker text. Only coderabbitai[bot] gets the exclusion.
+  const prs: MergedPrInput[] = [
+    {
+      number: 20,
+      comments: [
+        {
+          body: `${CODERABBIT_SUMMARY_MARKER}\n\nNot actually CodeRabbit.`,
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'a-human' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unaddressedComments.length, 1);
+  assert.equal(result.prs[0].unaddressedComments[0].author, 'a-human');
+});
+
+test('a CodeRabbit comment carrying both the summary marker and a rate-limit notice is still surfaced', () => {
+  // Second Codex finding: E6 (disposition-non-review-notices) classifies a
+  // combined summary+rate-limit comment as a non-review notice -- rejected,
+  // never accepted as a summary -- so the sweep must not silently drop it
+  // via the summary exclusion either (it would otherwise hide an
+  // undispositioned notice, contrary to notices staying a genuine signal).
+  const prs: MergedPrInput[] = [
+    {
+      number: 21,
+      comments: [
+        {
+          body: `${CODERABBIT_SUMMARY_MARKER}\n\n> ## Review limit reached`,
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unaddressedComments.length, 1);
+  assert.equal(
+    result.prs[0].unaddressedComments[0].author,
+    'coderabbitai[bot]',
+  );
+});
+
 test('surfaces an unaddressed CHANGES_REQUESTED review body', () => {
   const prs: MergedPrInput[] = [
     {

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -481,6 +481,39 @@ test('a CodeRabbit comment carrying both the summary marker and a rate-limit not
   );
 });
 
+test('a CodeRabbit summary is still surfaced when advisoryBotLogins is configured to omit CodeRabbit', () => {
+  // Third Codex finding (raised on this PR's own second review round): the
+  // exclusion gates on the *configured* advisoryBotLogins set, not the
+  // broader isKnownReviewBot recognition -- matching E6, which requires the
+  // author to be in its own configured advisory-bot identities. A Codex-only
+  // advisory policy (CodeRabbit deliberately not configured) makes E6 leave a
+  // CodeRabbit summary undispositioned, so the sweep must surface it too
+  // instead of still excluding it via a hardcoded/broader bot recognition.
+  const codexOnlyOptions = {
+    ...OPTIONS,
+    advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+  };
+  const prs: MergedPrInput[] = [
+    {
+      number: 22,
+      comments: [
+        {
+          body: `${CODERABBIT_SUMMARY_MARKER}\n\n## Walkthrough\n\nRefactors X.`,
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, codexOnlyOptions);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unaddressedComments.length, 1);
+  assert.equal(
+    result.prs[0].unaddressedComments[0].author,
+    'coderabbitai[bot]',
+  );
+});
+
 test('surfaces an unaddressed CHANGES_REQUESTED review body', () => {
   const prs: MergedPrInput[] = [
     {

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -6,6 +6,7 @@ import {
   type MergedPrInput,
   parseArgs,
 } from '../src/scripts/merged-pr-feedback-sweep.mts';
+import { CODERABBIT_SUMMARY_MARKER } from '../src/scripts/protocol-helpers.mts';
 import { buildCommentThread } from './test-utils.mts';
 
 const OPTIONS = {
@@ -372,6 +373,62 @@ test('excludes an IDD bookkeeping marker even from CI automation', () => {
   ];
   const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
   assert.equal(result.prs.length, 0);
+});
+
+// --- #1488: reuse isReviewSummaryComment so the sweep and E6 agree --------
+
+test('excludes a CodeRabbit summary-walkthrough comment from unaddressedComments', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 18,
+      comments: [
+        {
+          body: `${CODERABBIT_SUMMARY_MARKER}\n\n## Walkthrough\n\nRefactors X.`,
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
+test('the summary exclusion is comment-scoped: a genuine comment and an unresolved thread in the same PR are still surfaced', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 19,
+      threads: [
+        buildCommentThread(false, [
+          {
+            login: 'coderabbitai[bot]',
+            body: 'This loop can deadlock.',
+            createdAt: '2026-06-09T00:00:00Z',
+          },
+        ]),
+      ],
+      comments: [
+        {
+          body: `${CODERABBIT_SUMMARY_MARKER}\n\n## Walkthrough\n\nRefactors X.`,
+          createdAt: '2026-06-09T00:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+        {
+          body: 'Did you consider X?',
+          createdAt: '2026-06-09T00:05:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unresolvedThreads.length, 1);
+  assert.equal(result.prs[0].unaddressedComments.length, 1);
+  assert.equal(
+    result.prs[0].unaddressedComments[0].bodyExcerpt,
+    'Did you consider X?',
+  );
 });
 
 test('surfaces an unaddressed CHANGES_REQUESTED review body', () => {


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`merged-pr-feedback-sweep` never imported `protocol-helpers`'
`isReviewSummaryComment`, so it classified CodeRabbit's auto-generated
summary-walkthrough comment as unaddressed reviewer feedback — the same
comment E6 (`disposition-non-review-notices`) already
auto-`**Accepted**`s via that single-sourced classifier. Live runs on this
repo flagged 90-100% of merged PRs on pure boilerplate, burying the one
signal (`unresolvedThreadCount`) the sweep exists to surface.

This PR reuses `isReviewSummaryComment` in `collectUnaddressedComments`'s
comment loop, excluding a matched comment unconditionally (same tier as
IDD bookkeeping, not gated on a later disposition), regenerates the
compiled `.mjs`, adds test coverage, and syncs the helper-scripts doc.

## Linked issue

Closes #1488

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

- Scoped to the summary-walkthrough exclusion only, per the issue:
  `isAdvisoryNonReviewNotice` is deliberately **not** also excluded — an
  undispositioned rate/usage-limit notice left on a merged PR still
  indicates a skipped E6 disposition and stays a genuine signal.
- No merge-gate change: the sweep is a read-only, manually-invoked
  detector; the E6 mis-classification / E7 self-attested-disposition
  merge-gate fail-open remains the decided, accepted risk under
  `fully_autonomous_merge` (#909, reaffirmed on #1352).
- `idd-template/docs/idd-helper-scripts.md` is the canonical **source**
  for this doc (per `audit/sync-manifest.json`'s `idd-helper-scripts-doc`
  pair); `docs/idd-helper-scripts.md` is the generated mirror, regenerated
  via `node scripts/sync-docs.mjs --apply`.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merged pull request feedback sweeps now exclude recognized CodeRabbit review-summary walkthroughs from unresolved feedback.
  * Advisory rate-limit and usage notices remain visible when they appear alongside summary markers.
  * Other unresolved comments in the same pull request continue to be reported correctly.

* **Tests**
  * Added coverage for author-specific filtering, mixed comments, and summary walkthrough handling.

* **Documentation**
  * Updated guidance to reflect the refined feedback exclusion rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->